### PR TITLE
Improve a11y of settings sidebar tabs

### DIFF
--- a/packages/edit-post/src/components/sidebar/settings-header/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-header/index.js
@@ -17,27 +17,46 @@ const SettingsHeader = ( { count, openDocumentSettings, openBlockSettings, sideb
 		__( 'Block' ) :
 		sprintf( _n( '%d Block', '%d Blocks', blockCount ), blockCount );
 
+	const [ documentAriaLabel, documentActiveClass ] = sidebarName === 'edit-post/document' ?
+		// translators: ARIA label for the Document Settings sidebar tab, selected.
+		[ __( 'Document settings (selected)' ), 'is-active' ] :
+		// translators: ARIA label for the Document Settings sidebar tab, not selected.
+		[ __( 'Document settings' ), '' ];
+
+	const [ blockAriaLabel, blockActiveClass ] = sidebarName === 'edit-post/block' ?
+		// translators: ARIA label for the Block Settings sidebar tab, selected.
+		[ __( 'Block settings (selected)' ), 'is-active' ] :
+		// translators: ARIA label for the Block Settings sidebar tab, not selected.
+		[ __( 'Block settings' ), '' ];
+
 	return (
 		<SidebarHeader
 			className="edit-post-sidebar__panel-tabs"
 			closeLabel={ __( 'Close settings' ) }
 		>
-			<button
-				onClick={ openDocumentSettings }
-				className={ `edit-post-sidebar__panel-tab ${ sidebarName === 'edit-post/document' ? 'is-active' : '' }` }
-				aria-label={ __( 'Document settings' ) }
-				data-label={ __( 'Document' ) }
-			>
-				{ __( 'Document' ) }
-			</button>
-			<button
-				onClick={ openBlockSettings }
-				className={ `edit-post-sidebar__panel-tab ${ sidebarName === 'edit-post/block' ? 'is-active' : '' }` }
-				aria-label={ __( 'Block settings' ) }
-				data-label={ blockLabel }
-			>
-				{ blockLabel }
-			</button>
+			{ /* Use a list so screen readers will announce how many tabs there are. */ }
+			<ul>
+				<li>
+					<button
+						onClick={ openDocumentSettings }
+						className={ `edit-post-sidebar__panel-tab ${ documentActiveClass }` }
+						aria-label={ documentAriaLabel }
+						data-label={ __( 'Document' ) }
+					>
+						{ __( 'Document' ) }
+					</button>
+				</li>
+				<li>
+					<button
+						onClick={ openBlockSettings }
+						className={ `edit-post-sidebar__panel-tab ${ blockActiveClass }` }
+						aria-label={ blockAriaLabel }
+						data-label={ blockLabel }
+					>
+						{ blockLabel }
+					</button>
+				</li>
+			</ul>
 		</SidebarHeader>
 	);
 };

--- a/packages/edit-post/src/components/sidebar/settings-header/style.scss
+++ b/packages/edit-post/src/components/sidebar/settings-header/style.scss
@@ -6,6 +6,13 @@
 	position: sticky;
 	z-index: z-index(".components-panel__header.edit-post-sidebar__panel-tabs");
 	top: 0;
+
+	ul {
+		display: flex;
+	}
+	li {
+		margin: 0;
+	}
 }
 
 .edit-post-sidebar__panel-tab {

--- a/test/e2e/specs/editor-modes.test.js
+++ b/test/e2e/specs/editor-modes.test.js
@@ -91,18 +91,18 @@ describe( 'Editing modes (visual/HTML)', () => {
 		expect( title ).toBe( 'Paragraph' );
 
 		// The Block inspector should be active
-		let blockInspectorTab = await page.$( '.edit-post-sidebar__panel-tab.is-active[aria-label="Block settings"]' );
+		let blockInspectorTab = await page.$( '.edit-post-sidebar__panel-tab.is-active[data-label="Block"]' );
 		expect( blockInspectorTab ).not.toBeNull();
 
 		// Switch to Code Editor
 		await switchToEditor( 'Code' );
 
 		// The Block inspector should not be active anymore
-		blockInspectorTab = await page.$( '.edit-post-sidebar__panel-tab.is-active[aria-label="Block settings"]' );
+		blockInspectorTab = await page.$( '.edit-post-sidebar__panel-tab.is-active[data-label="Block"]' );
 		expect( blockInspectorTab ).toBeNull();
 
 		// No block is selected
-		await page.click( '.edit-post-sidebar__panel-tab[aria-label="Block settings"]' );
+		await page.click( '.edit-post-sidebar__panel-tab[data-label="Block"]' );
 		const noBlocksElement = await page.$( '.editor-block-inspector__no-blocks' );
 		expect( noBlocksElement ).not.toBeNull();
 


### PR DESCRIPTION
## Description
The purpose of this PR is to improve the accessibility of settings sidebar tabs by:
* Providing the tabs as a list so screen readers will announce the tab count.
* Updating the ARIA label of the selected tab to include "(selected)".

Contributes to #8079.

## How has this been tested?

* Ran automated tests.
* Opened Gutenberg in Chrome, Firefox, macOS Safari, iOS Safari, IE11, and Edge and observed the tabs behaved normally.
* Opened Gutenberg in Chrome with Voice Over enabled in macOS and observed the tab count being announced and the ARIA label changing on buttons after they were selected.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
