### PR TITLE
Try hiding output from incompatible plugins

### DIFF
--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -80,6 +80,11 @@ body.block-editor-page {
 
 	#wpbody-content {
 		padding-bottom: 0;
+
+		// Hide any element output on this screen that isn't the editor.
+		> *:not(#screen-meta):not(.block-editor):not(.clear) {
+			display: none;
+		}
 	}
 
 	/* We hide legacy notices in Gutenberg, because they were not designed in a way that scaled well.


### PR DESCRIPTION
This PR intends to hide output from classic plugins that output into the `admin_notices` filter.

Intentionally labelled "Try", because this doesn't feel like the right approach, but your thoughts are appreciated.

Example, try activating the "Hello Dolly" plugin, verify in the markup that it's hidden.