### PR TITLE
Fix submit for review button

### DIFF
--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -124,5 +124,5 @@ export default compose(
 			hasBlockSelection: undefined,
 		};
 	} ),
-	withViewportMatch( { isMobileViewport: '< small' } ),
+	withViewportMatch( { isMobileViewport: '< medium' } ),
 )( Header );

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -17,6 +17,7 @@ import {
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { DotTip } from '@wordpress/nux';
+import { withViewportMatch } from '@wordpress/viewport';
 
 /**
  * Internal dependencies
@@ -40,6 +41,7 @@ function Header( {
 	isScheduled,
 	isBeingScheduled,
 	isPending,
+	isMobileViewport,
 } ) {
 	const toggleGeneralSidebar = isEditorSidebarOpened ? closeGeneralSidebar : openGeneralSidebar;
 
@@ -47,7 +49,7 @@ function Header( {
 		! isPublishSidebarEnabled ||
 		isPublished ||
 		( isScheduled && isBeingScheduled ) ||
-		( isPending && ! hasPublishAction )
+		( isPending && ! hasPublishAction && ! isMobileViewport )
 	);
 	return (
 		<div
@@ -122,4 +124,5 @@ export default compose(
 			hasBlockSelection: undefined,
 		};
 	} ),
+	withViewportMatch( { isMobileViewport: '< small' } ),
 )( Header );

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -41,7 +41,7 @@ function Header( {
 	isScheduled,
 	isBeingScheduled,
 	isPending,
-	isMobileViewport,
+	isSmallViewport,
 } ) {
 	const toggleGeneralSidebar = isEditorSidebarOpened ? closeGeneralSidebar : openGeneralSidebar;
 
@@ -49,7 +49,7 @@ function Header( {
 		! isPublishSidebarEnabled ||
 		isPublished ||
 		( isScheduled && isBeingScheduled ) ||
-		( isPending && ! hasPublishAction && ! isMobileViewport )
+		( isPending && ! hasPublishAction && ! isSmallViewport )
 	);
 	return (
 		<div
@@ -124,5 +124,5 @@ export default compose(
 			hasBlockSelection: undefined,
 		};
 	} ),
-	withViewportMatch( { isMobileViewport: '< medium' } ),
+	withViewportMatch( { isSmallViewport: '< medium' } ),
 )( Header );

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -49,15 +49,15 @@ function Header( {
 						forceIsSaving={ isSaving }
 					/>
 					<PostPreviewButton />
-					{ isPublishSidebarEnabled ? (
-						<PostPublishPanelToggle
-							isOpen={ isPublishSidebarOpened }
-							onToggle={ togglePublishSidebar }
+					{ ! isPublishSidebarEnabled ? (
+						<PostPublishButton
 							forceIsDirty={ hasActiveMetaboxes }
 							forceIsSaving={ isSaving }
 						/>
 					) : (
-						<PostPublishButton
+						<PostPublishPanelToggle
+							isOpen={ isPublishSidebarOpened }
+							onToggle={ togglePublishSidebar }
 							forceIsDirty={ hasActiveMetaboxes }
 							forceIsSaving={ isSaving }
 						/>

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -1,9 +1,4 @@
 /**
- * External Dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -11,13 +6,10 @@ import { IconButton } from '@wordpress/components';
 import {
 	PostPreviewButton,
 	PostSavedState,
-	PostPublishPanelToggle,
-	PostPublishButton,
 } from '@wordpress/editor';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { DotTip } from '@wordpress/nux';
-import { withViewportMatch } from '@wordpress/viewport';
 
 /**
  * Internal dependencies
@@ -26,31 +18,18 @@ import MoreMenu from './more-menu';
 import HeaderToolbar from './header-toolbar';
 import PinnedPlugins from './pinned-plugins';
 import shortcuts from '../../keyboard-shortcuts';
+import PostPublishButtonOrToggle from './post-publish-button-or-toggle';
 
 function Header( {
-	isEditorSidebarOpened,
-	openGeneralSidebar,
 	closeGeneralSidebar,
-	isPublishSidebarOpened,
-	isPublishSidebarEnabled,
-	togglePublishSidebar,
 	hasActiveMetaboxes,
-	hasPublishAction,
+	isEditorSidebarOpened,
+	isPublishSidebarOpened,
 	isSaving,
-	isPublished,
-	isScheduled,
-	isBeingScheduled,
-	isPending,
-	isSmallViewport,
+	openGeneralSidebar,
 } ) {
 	const toggleGeneralSidebar = isEditorSidebarOpened ? closeGeneralSidebar : openGeneralSidebar;
 
-	const shouldShowButton = (
-		( ! isPublishSidebarEnabled && ! isSmallViewport ) ||
-		isPublished ||
-		( isScheduled && isBeingScheduled ) ||
-		( isPending && ! hasPublishAction && ! isSmallViewport )
-	);
 	return (
 		<div
 			role="region"
@@ -67,18 +46,10 @@ function Header( {
 						forceIsSaving={ isSaving }
 					/>
 					<PostPreviewButton />
-					{ shouldShowButton ? (
-						<PostPublishButton
-							forceIsDirty={ hasActiveMetaboxes }
-							forceIsSaving={ isSaving }
-						/>
-					) : (
-						<PostPublishPanelToggle
-							isOpen={ isPublishSidebarOpened }
-							onToggle={ togglePublishSidebar }
-							forceIsSaving={ isSaving }
-						/>
-					) }
+					<PostPublishButtonOrToggle
+						forceIsDirty={ hasActiveMetaboxes }
+						forceIsSaving={ isSaving }
+					/>
 					<div>
 						<IconButton
 							icon="admin-generic"
@@ -102,27 +73,18 @@ function Header( {
 
 export default compose(
 	withSelect( ( select ) => ( {
+		hasBlockSelection: !! select( 'core/editor' ).getBlockSelectionStart(),
 		isEditorSidebarOpened: select( 'core/edit-post' ).isEditorSidebarOpened(),
 		isPublishSidebarOpened: select( 'core/edit-post' ).isPublishSidebarOpened(),
-		isPublishSidebarEnabled: select( 'core/editor' ).isPublishSidebarEnabled(),
-		hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
 		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
-		hasBlockSelection: !! select( 'core/editor' ).getBlockSelectionStart(),
-		hasPublishAction: get( select( 'core/editor' ).getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
-		isPublished: select( 'core/editor' ).isCurrentPostPublished(),
-		isScheduled: select( 'core/editor' ).isCurrentPostScheduled(),
-		isBeingScheduled: select( 'core/editor' ).isEditedPostBeingScheduled(),
-		isPending: select( 'core/editor' ).isCurrentPostPending(),
 	} ) ),
 	withDispatch( ( dispatch, { hasBlockSelection } ) => {
-		const { openGeneralSidebar, closeGeneralSidebar, togglePublishSidebar } = dispatch( 'core/edit-post' );
+		const { openGeneralSidebar, closeGeneralSidebar } = dispatch( 'core/edit-post' );
 		const sidebarToOpen = hasBlockSelection ? 'edit-post/block' : 'edit-post/document';
 		return {
 			openGeneralSidebar: () => openGeneralSidebar( sidebarToOpen ),
 			closeGeneralSidebar: closeGeneralSidebar,
-			togglePublishSidebar: togglePublishSidebar,
 			hasBlockSelection: undefined,
 		};
 	} ),
-	withViewportMatch( { isSmallViewport: '< medium' } ),
 )( Header );

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -1,4 +1,9 @@
 /**
+ * External Dependencies
+ */
+import { get } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -29,17 +34,20 @@ function Header( {
 	isPublishSidebarEnabled,
 	togglePublishSidebar,
 	hasActiveMetaboxes,
+	hasPublishAction,
 	isSaving,
 	isPublished,
 	isScheduled,
 	isBeingScheduled,
+	isPending,
 } ) {
 	const toggleGeneralSidebar = isEditorSidebarOpened ? closeGeneralSidebar : openGeneralSidebar;
 
 	const shouldShowButton = (
 		! isPublishSidebarEnabled ||
 		isPublished ||
-		( isScheduled && isBeingScheduled )
+		( isScheduled && isBeingScheduled ) ||
+		( isPending && ! hasPublishAction )
 	);
 	return (
 		<div
@@ -99,9 +107,11 @@ export default compose(
 		hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
 		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
 		hasBlockSelection: !! select( 'core/editor' ).getBlockSelectionStart(),
+		hasPublishAction: get( select( 'core/editor' ).getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
 		isPublished: select( 'core/editor' ).isCurrentPostPublished(),
 		isScheduled: select( 'core/editor' ).isCurrentPostScheduled(),
 		isBeingScheduled: select( 'core/editor' ).isEditedPostBeingScheduled(),
+		isPending: select( 'core/editor' ).isCurrentPostPending(),
 	} ) ),
 	withDispatch( ( dispatch, { hasBlockSelection } ) => {
 		const { openGeneralSidebar, closeGeneralSidebar, togglePublishSidebar } = dispatch( 'core/edit-post' );

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -30,9 +30,11 @@ function Header( {
 	togglePublishSidebar,
 	hasActiveMetaboxes,
 	isSaving,
+	isPublished,
 } ) {
 	const toggleGeneralSidebar = isEditorSidebarOpened ? closeGeneralSidebar : openGeneralSidebar;
 
+	const shouldShowButton = ( ! isPublishSidebarEnabled || isPublished );
 	return (
 		<div
 			role="region"
@@ -49,7 +51,7 @@ function Header( {
 						forceIsSaving={ isSaving }
 					/>
 					<PostPreviewButton />
-					{ ! isPublishSidebarEnabled ? (
+					{ shouldShowButton ? (
 						<PostPublishButton
 							forceIsDirty={ hasActiveMetaboxes }
 							forceIsSaving={ isSaving }
@@ -91,6 +93,7 @@ export default compose(
 		hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
 		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
 		hasBlockSelection: !! select( 'core/editor' ).getBlockSelectionStart(),
+		isPublished: select( 'core/editor' ).isCurrentPostPublished(),
 	} ) ),
 	withDispatch( ( dispatch, { hasBlockSelection } ) => {
 		const { openGeneralSidebar, closeGeneralSidebar, togglePublishSidebar } = dispatch( 'core/edit-post' );

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -31,10 +31,16 @@ function Header( {
 	hasActiveMetaboxes,
 	isSaving,
 	isPublished,
+	isScheduled,
+	isBeingScheduled,
 } ) {
 	const toggleGeneralSidebar = isEditorSidebarOpened ? closeGeneralSidebar : openGeneralSidebar;
 
-	const shouldShowButton = ( ! isPublishSidebarEnabled || isPublished );
+	const shouldShowButton = (
+		! isPublishSidebarEnabled ||
+		isPublished ||
+		( isScheduled && isBeingScheduled )
+	);
 	return (
 		<div
 			role="region"
@@ -94,6 +100,8 @@ export default compose(
 		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
 		hasBlockSelection: !! select( 'core/editor' ).getBlockSelectionStart(),
 		isPublished: select( 'core/editor' ).isCurrentPostPublished(),
+		isScheduled: select( 'core/editor' ).isCurrentPostScheduled(),
+		isBeingScheduled: select( 'core/editor' ).isEditedPostBeingScheduled(),
 	} ) ),
 	withDispatch( ( dispatch, { hasBlockSelection } ) => {
 		const { openGeneralSidebar, closeGeneralSidebar, togglePublishSidebar } = dispatch( 'core/edit-post' );

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -73,6 +73,7 @@ function Header( {
 
 export default compose(
 	withSelect( ( select ) => ( {
+		hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
 		hasBlockSelection: !! select( 'core/editor' ).getBlockSelectionStart(),
 		isEditorSidebarOpened: select( 'core/edit-post' ).isEditorSidebarOpened(),
 		isPublishSidebarOpened: select( 'core/edit-post' ).isPublishSidebarOpened(),

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -74,7 +74,6 @@ function Header( {
 						<PostPublishPanelToggle
 							isOpen={ isPublishSidebarOpened }
 							onToggle={ togglePublishSidebar }
-							forceIsDirty={ hasActiveMetaboxes }
 							forceIsSaving={ isSaving }
 						/>
 					) }

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -46,7 +46,7 @@ function Header( {
 	const toggleGeneralSidebar = isEditorSidebarOpened ? closeGeneralSidebar : openGeneralSidebar;
 
 	const shouldShowButton = (
-		! isPublishSidebarEnabled ||
+		( ! isPublishSidebarEnabled && ! isSmallViewport ) ||
 		isPublished ||
 		( isScheduled && isBeingScheduled ) ||
 		( isPending && ! hasPublishAction && ! isSmallViewport )

--- a/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
+++ b/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
@@ -14,7 +14,7 @@ import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { withViewportMatch } from '@wordpress/viewport';
 
-function PostPublishButtonOrToggle( {
+export function PostPublishButtonOrToggle( {
 	hasPublishAction,
 	isBeingScheduled,
 	isPending,

--- a/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
+++ b/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
@@ -1,0 +1,69 @@
+/**
+ * External Dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * WordPress dependencies.
+ */
+import {
+	PostPublishPanelToggle,
+	PostPublishButton,
+} from '@wordpress/editor';
+import { compose } from '@wordpress/compose';
+import { withDispatch, withSelect } from '@wordpress/data';
+import { withViewportMatch } from '@wordpress/viewport';
+
+function PostPublishButtonOrToggle( {
+	hasPublishAction,
+	isBeingScheduled,
+	isPending,
+	isPublished,
+	isPublishSidebarEnabled,
+	isPublishSidebarOpened,
+	isScheduled,
+	isSmallViewport,
+	forceIsDirty,
+	forceIsSaving,
+	togglePublishSidebar,
+} ) {
+	const shouldShowButton = (
+		( ! isPublishSidebarEnabled && ! isSmallViewport ) ||
+		isPublished ||
+		( isScheduled && isBeingScheduled ) ||
+		( isPending && ! hasPublishAction && ! isSmallViewport )
+	);
+
+	const component = shouldShowButton ? (
+		<PostPublishButton
+			forceIsDirty={ forceIsDirty }
+			forceIsSaving={ forceIsSaving }
+		/>
+	) : (
+		<PostPublishPanelToggle
+			isOpen={ isPublishSidebarOpened }
+			onToggle={ togglePublishSidebar }
+			forceIsSaving={ forceIsSaving }
+		/>
+	);
+	return component;
+}
+
+export default compose(
+	withSelect( ( select ) => ( {
+		hasPublishAction: get( select( 'core/editor' ).getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
+		isBeingScheduled: select( 'core/editor' ).isEditedPostBeingScheduled(),
+		isPending: select( 'core/editor' ).isCurrentPostPending(),
+		isPublished: select( 'core/editor' ).isCurrentPostPublished(),
+		isPublishSidebarEnabled: select( 'core/editor' ).isPublishSidebarEnabled(),
+		isPublishSidebarOpened: select( 'core/edit-post' ).isPublishSidebarOpened(),
+		isScheduled: select( 'core/editor' ).isCurrentPostScheduled(),
+	} ) ),
+	withDispatch( ( dispatch ) => {
+		const { togglePublishSidebar } = dispatch( 'core/edit-post' );
+		return {
+			togglePublishSidebar,
+		};
+	} ),
+	withViewportMatch( { isSmallViewport: '< medium' } ),
+)( PostPublishButtonOrToggle );

--- a/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
+++ b/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
@@ -15,7 +15,9 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import { withViewportMatch } from '@wordpress/viewport';
 
 export function PostPublishButtonOrToggle( {
+	hasPublishAction,
 	isBeingScheduled,
+	isPending,
 	isPublished,
 	isPublishSidebarEnabled,
 	isPublishSidebarOpened,
@@ -39,14 +41,22 @@ export function PostPublishButtonOrToggle( {
 	);
 
 	/**
-     * We want to show a BUTTON when the post status is:
+     * We want to show a BUTTON when the post status is at the _final stage_
+     * for a particular role (see https://codex.wordpress.org/Post_Status):
      *
-     * - 'publish': isPublished will be true.
-     * - 'private': isPublished will be true.
-     * - 'future' and post date before now: isPublished will be true.
-     * - 'future' and post date equals or after now: isScheduled will be true.
+     * - is published
+     * - is scheduled to be published
+     * - is pending and can't be published (but only for viewports > small)
+     *
+     * Originally we considered showing a button for pending posts
+     * that couldn't be published (for ex, for a contributor role).
+     * Some languages can have really long translations for "Submit for review",
+     * so given the lack of UI real state we decided to take into account the viewport
+     * in that particular case.
      */
-	if ( isPublished || ( isScheduled && isBeingScheduled ) ) {
+	if ( isPublished ||
+        ( isScheduled && isBeingScheduled ) ||
+        ( isPending && ! hasPublishAction && ! isSmallViewport ) ) {
 		return button;
 	}
 

--- a/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
+++ b/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
@@ -15,16 +15,16 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import { withViewportMatch } from '@wordpress/viewport';
 
 export function PostPublishButtonOrToggle( {
+	forceIsDirty,
+	forceIsSaving,
 	hasPublishAction,
 	isBeingScheduled,
+	isLessThanMediumViewport,
 	isPending,
 	isPublished,
 	isPublishSidebarEnabled,
 	isPublishSidebarOpened,
 	isScheduled,
-	isSmallViewport,
-	forceIsDirty,
-	forceIsSaving,
 	togglePublishSidebar,
 } ) {
 	const button = (
@@ -46,7 +46,7 @@ export function PostPublishButtonOrToggle( {
      *
      * - is published
      * - is scheduled to be published
-     * - is pending and can't be published (but only for viewports > small)
+     * - is pending and can't be published (but only for viewports >= medium)
      *
      * Originally we considered showing a button for pending posts
      * that couldn't be published (for ex, for a contributor role).
@@ -56,7 +56,7 @@ export function PostPublishButtonOrToggle( {
      */
 	if ( isPublished ||
         ( isScheduled && isBeingScheduled ) ||
-        ( isPending && ! hasPublishAction && ! isSmallViewport ) ) {
+        ( isPending && ! hasPublishAction && ! isLessThanMediumViewport ) ) {
 		return button;
 	}
 
@@ -66,7 +66,7 @@ export function PostPublishButtonOrToggle( {
      * - Show TOGGLE if it is small viewport.
      * - Otherwise, use publish sidebar status to decide - TOGGLE if enabled, BUTTON if not.
      */
-	if ( isSmallViewport ) {
+	if ( isLessThanMediumViewport ) {
 		return toggle;
 	}
 
@@ -89,5 +89,5 @@ export default compose(
 			togglePublishSidebar,
 		};
 	} ),
-	withViewportMatch( { isSmallViewport: '< medium' } ),
+	withViewportMatch( { isLessThanMediumViewport: '< medium' } ),
 )( PostPublishButtonOrToggle );

--- a/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
+++ b/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
@@ -15,9 +15,7 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import { withViewportMatch } from '@wordpress/viewport';
 
 export function PostPublishButtonOrToggle( {
-	hasPublishAction,
 	isBeingScheduled,
-	isPending,
 	isPublished,
 	isPublishSidebarEnabled,
 	isPublishSidebarOpened,
@@ -27,26 +25,42 @@ export function PostPublishButtonOrToggle( {
 	forceIsSaving,
 	togglePublishSidebar,
 } ) {
-	const shouldUseButton = (
-		( ! isPublishSidebarEnabled && ! isSmallViewport ) ||
-		isPublished ||
-		( isScheduled && isBeingScheduled ) ||
-		( isPending && ! hasPublishAction && ! isSmallViewport )
-	);
-
-	const component = shouldUseButton ? (
+	const button = (
 		<PostPublishButton
 			forceIsDirty={ forceIsDirty }
-			forceIsSaving={ forceIsSaving }
-		/>
-	) : (
+			forceIsSaving={ forceIsSaving } />
+	);
+	const toggle = (
 		<PostPublishPanelToggle
 			isOpen={ isPublishSidebarOpened }
 			onToggle={ togglePublishSidebar }
 			forceIsSaving={ forceIsSaving }
 		/>
 	);
-	return component;
+
+	/**
+     * We want to show a BUTTON when the post status is:
+     *
+     * - 'publish': isPublished will be true.
+     * - 'private': isPublished will be true.
+     * - 'future' and post date before now: isPublished will be true.
+     * - 'future' and post date equals or after now: isScheduled will be true.
+     */
+	if ( isPublished || ( isScheduled && isBeingScheduled ) ) {
+		return button;
+	}
+
+	/**
+     * Then, we take other things into account:
+     *
+     * - Show TOGGLE if it is small viewport.
+     * - Otherwise, use publish sidebar status to decide - TOGGLE if enabled, BUTTON if not.
+     */
+	if ( isSmallViewport ) {
+		return toggle;
+	}
+
+	return isPublishSidebarEnabled ? toggle : button;
 }
 
 export default compose(

--- a/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
+++ b/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
@@ -6,10 +6,7 @@ import { get } from 'lodash';
 /**
  * WordPress dependencies.
  */
-import {
-	PostPublishPanelToggle,
-	PostPublishButton,
-} from '@wordpress/editor';
+import { PostPublishPanelToggle, PostPublishButton } from '@wordpress/editor';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { withViewportMatch } from '@wordpress/viewport';
@@ -30,7 +27,8 @@ export function PostPublishButtonOrToggle( {
 	const button = (
 		<PostPublishButton
 			forceIsDirty={ forceIsDirty }
-			forceIsSaving={ forceIsSaving } />
+			forceIsSaving={ forceIsSaving }
+		/>
 	);
 	const toggle = (
 		<PostPublishPanelToggle
@@ -41,31 +39,33 @@ export function PostPublishButtonOrToggle( {
 	);
 
 	/**
-     * We want to show a BUTTON when the post status is at the _final stage_
-     * for a particular role (see https://codex.wordpress.org/Post_Status):
-     *
-     * - is published
-     * - is scheduled to be published
-     * - is pending and can't be published (but only for viewports >= medium)
-     *
-     * Originally we considered showing a button for pending posts
-     * that couldn't be published (for ex, for a contributor role).
-     * Some languages can have really long translations for "Submit for review",
-     * so given the lack of UI real state we decided to take into account the viewport
-     * in that particular case.
-     */
-	if ( isPublished ||
-        ( isScheduled && isBeingScheduled ) ||
-        ( isPending && ! hasPublishAction && ! isLessThanMediumViewport ) ) {
+	 * We want to show a BUTTON when the post status is at the _final stage_
+	 * for a particular role (see https://codex.wordpress.org/Post_Status):
+	 *
+	 * - is published
+	 * - is scheduled to be published
+	 * - is pending and can't be published (but only for viewports >= medium)
+	 *
+	 * Originally we considered showing a button for pending posts
+	 * that couldn't be published (for ex, for a contributor role).
+	 * Some languages can have really long translations for "Submit for review",
+	 * so given the lack of UI real state we decided to take into account the viewport
+	 * in that particular case.
+	 */
+	if (
+		isPublished ||
+		( isScheduled && isBeingScheduled ) ||
+		( isPending && ! hasPublishAction && ! isLessThanMediumViewport )
+	) {
 		return button;
 	}
 
 	/**
-     * Then, we take other things into account:
-     *
-     * - Show TOGGLE if it is small viewport.
-     * - Otherwise, use publish sidebar status to decide - TOGGLE if enabled, BUTTON if not.
-     */
+	 * Then, we take other things into account:
+	 *
+	 * - Show TOGGLE if it is small viewport.
+	 * - Otherwise, use publish sidebar status to decide - TOGGLE if enabled, BUTTON if not.
+	 */
 	if ( isLessThanMediumViewport ) {
 		return toggle;
 	}
@@ -75,7 +75,11 @@ export function PostPublishButtonOrToggle( {
 
 export default compose(
 	withSelect( ( select ) => ( {
-		hasPublishAction: get( select( 'core/editor' ).getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
+		hasPublishAction: get(
+			select( 'core/editor' ).getCurrentPost(),
+			[ '_links', 'wp:action-publish' ],
+			false
+		),
 		isBeingScheduled: select( 'core/editor' ).isEditedPostBeingScheduled(),
 		isPending: select( 'core/editor' ).isCurrentPostPending(),
 		isPublished: select( 'core/editor' ).isCurrentPostPublished(),

--- a/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
+++ b/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
@@ -27,14 +27,14 @@ function PostPublishButtonOrToggle( {
 	forceIsSaving,
 	togglePublishSidebar,
 } ) {
-	const shouldShowButton = (
+	const shouldUseButton = (
 		( ! isPublishSidebarEnabled && ! isSmallViewport ) ||
 		isPublished ||
 		( isScheduled && isBeingScheduled ) ||
 		( isPending && ! hasPublishAction && ! isSmallViewport )
 	);
 
-	const component = shouldShowButton ? (
+	const component = shouldUseButton ? (
 		<PostPublishButton
 			forceIsDirty={ forceIsDirty }
 			forceIsSaving={ forceIsSaving }

--- a/packages/edit-post/src/components/header/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/header/test/__snapshots__/index.js.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PostPublishButtonOrToggle should render a  button when post is not published or scheduled, the viewport is not small, and the publish sidebar is disabled 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
+exports[`PostPublishButtonOrToggle should render a button when post is not (1), (2), (3), the viewport is >= medium, and the publish sidebar is disabled 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
 
-exports[`PostPublishButtonOrToggle should render a  button when the post is pending and cannot be published but the viewport is > small 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
+exports[`PostPublishButtonOrToggle should render a button when the post is pending and cannot be published but the viewport is >= medium (3) 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
 
-exports[`PostPublishButtonOrToggle should render a  button when the post is published 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
+exports[`PostPublishButtonOrToggle should render a button when the post is published (1) 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
 
-exports[`PostPublishButtonOrToggle should render a  button when the post is scheduled 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
+exports[`PostPublishButtonOrToggle should render a button when the post is scheduled (2) 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
 
-exports[`PostPublishButtonOrToggle should render a  toggle when post is not published or scheduled and the viewport is small 1`] = `<WithSelect(PostPublishPanelToggle) />`;
+exports[`PostPublishButtonOrToggle should render a toggle when post is not (1), (2), (3), the viewport is >= medium, and the publish sidebar is enabled 1`] = `<WithSelect(PostPublishPanelToggle) />`;
 
-exports[`PostPublishButtonOrToggle should render a  toggle when post is not published or scheduled, the viewport is not small, and the publish sidebar is enabled 1`] = `<WithSelect(PostPublishPanelToggle) />`;
+exports[`PostPublishButtonOrToggle should render a toggle when post is not published or scheduled and the viewport is < medium 1`] = `<WithSelect(PostPublishPanelToggle) />`;

--- a/packages/edit-post/src/components/header/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/header/test/__snapshots__/index.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PostPublishButtonOrToggle should render button when the post is published 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;

--- a/packages/edit-post/src/components/header/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/header/test/__snapshots__/index.js.snap
@@ -2,6 +2,8 @@
 
 exports[`PostPublishButtonOrToggle should render a  button when post is not published or scheduled, the viewport is not small, and the publish sidebar is disabled 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
 
+exports[`PostPublishButtonOrToggle should render a  button when the post is pending and cannot be published but the viewport is > small 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
+
 exports[`PostPublishButtonOrToggle should render a  button when the post is published 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
 
 exports[`PostPublishButtonOrToggle should render a  button when the post is scheduled 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;

--- a/packages/edit-post/src/components/header/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/header/test/__snapshots__/index.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`PostPublishButtonOrToggle should render button when the post is being scheduled 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
+
 exports[`PostPublishButtonOrToggle should render button when the post is published 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
 
 exports[`PostPublishButtonOrToggle should render button when the publish sidebar is not enabled and the viewport is > small 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;

--- a/packages/edit-post/src/components/header/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/header/test/__snapshots__/index.js.snap
@@ -1,13 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PostPublishButtonOrToggle should render button when the post is being scheduled 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
+exports[`PostPublishButtonOrToggle should render a  button when post is not published or scheduled, the viewport is not small, and the publish sidebar is disabled 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
 
-exports[`PostPublishButtonOrToggle should render button when the post is pending, it cannot be published, and the viewport is not small  1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
+exports[`PostPublishButtonOrToggle should render a  button when the post is published 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
 
-exports[`PostPublishButtonOrToggle should render button when the post is published 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
+exports[`PostPublishButtonOrToggle should render a  button when the post is scheduled 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
 
-exports[`PostPublishButtonOrToggle should render button when the publish sidebar is not enabled and the viewport is > small 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
+exports[`PostPublishButtonOrToggle should render a  toggle when post is not published or scheduled and the viewport is small 1`] = `<WithSelect(PostPublishPanelToggle) />`;
 
-exports[`PostPublishButtonOrToggle should render toggle when the post is pending, it cannot be published, and the viewport is small  1`] = `<WithSelect(PostPublishPanelToggle) />`;
-
-exports[`PostPublishButtonOrToggle should render toggle when the publish sidebar is not enabled and the viewport is <= small 1`] = `<WithSelect(PostPublishPanelToggle) />`;
+exports[`PostPublishButtonOrToggle should render a  toggle when post is not published or scheduled, the viewport is not small, and the publish sidebar is enabled 1`] = `<WithSelect(PostPublishPanelToggle) />`;

--- a/packages/edit-post/src/components/header/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/header/test/__snapshots__/index.js.snap
@@ -2,8 +2,12 @@
 
 exports[`PostPublishButtonOrToggle should render button when the post is being scheduled 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
 
+exports[`PostPublishButtonOrToggle should render button when the post is pending, it cannot be published, and the viewport is not small  1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
+
 exports[`PostPublishButtonOrToggle should render button when the post is published 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
 
 exports[`PostPublishButtonOrToggle should render button when the publish sidebar is not enabled and the viewport is > small 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
+
+exports[`PostPublishButtonOrToggle should render toggle when the post is pending, it cannot be published, and the viewport is small  1`] = `<WithSelect(PostPublishPanelToggle) />`;
 
 exports[`PostPublishButtonOrToggle should render toggle when the publish sidebar is not enabled and the viewport is <= small 1`] = `<WithSelect(PostPublishPanelToggle) />`;

--- a/packages/edit-post/src/components/header/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/header/test/__snapshots__/index.js.snap
@@ -1,3 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PostPublishButtonOrToggle should render button when the post is published 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
+
+exports[`PostPublishButtonOrToggle should render button when the publish sidebar is not enabled and the viewport is > small 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
+
+exports[`PostPublishButtonOrToggle should render toggle when the publish sidebar is not enabled and the viewport is <= small 1`] = `<WithSelect(PostPublishPanelToggle) />`;

--- a/packages/edit-post/src/components/header/test/index.js
+++ b/packages/edit-post/src/components/header/test/index.js
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies.
+ */
+import { PostPublishButtonOrToggle } from '../post-publish-button-or-toggle';
+
+describe( 'PostPublishButtonOrToggle', () => {
+	it( 'should render button when the post is published', () => {
+		const wrapper = shallow( <PostPublishButtonOrToggle isPublished={ true } /> );
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );

--- a/packages/edit-post/src/components/header/test/index.js
+++ b/packages/edit-post/src/components/header/test/index.js
@@ -37,4 +37,22 @@ describe( 'PostPublishButtonOrToggle', () => {
 		/> );
 		expect( wrapper ).toMatchSnapshot();
 	} );
+
+	it( 'should render button when the post is pending, it cannot be published, and the viewport is not small ', () => {
+		const wrapper = shallow( <PostPublishButtonOrToggle
+			isPending={ true }
+			hasPublishAction={ false }
+			isSmallViewport={ false }
+		/> );
+		expect( wrapper ).toMatchSnapshot();
+	} );
+
+	it( 'should render toggle when the post is pending, it cannot be published, and the viewport is small ', () => {
+		const wrapper = shallow( <PostPublishButtonOrToggle
+			isPending={ true }
+			hasPublishAction={ false }
+			isSmallViewport={ true }
+		/> );
+		expect( wrapper ).toMatchSnapshot();
+	} );
 } );

--- a/packages/edit-post/src/components/header/test/index.js
+++ b/packages/edit-post/src/components/header/test/index.js
@@ -9,22 +9,6 @@ import { shallow } from 'enzyme';
 import { PostPublishButtonOrToggle } from '../post-publish-button-or-toggle';
 
 describe( 'PostPublishButtonOrToggle should render a ', () => {
-	it( 'button when the publish sidebar is not enabled and the viewport is > small', () => {
-		const wrapper = shallow( <PostPublishButtonOrToggle
-			isPublishSidebarEnabled={ false }
-			isSmallViewport={ false }
-		/> );
-		expect( wrapper ).toMatchSnapshot();
-	} );
-
-	it( 'toggle when the publish sidebar is not enabled and the viewport is <= small', () => {
-		const wrapper = shallow( <PostPublishButtonOrToggle
-			isPublishSidebarEnabled={ false }
-			isSmallViewport={ true }
-		/> );
-		expect( wrapper ).toMatchSnapshot();
-	} );
-
 	it( 'button when the post is published', () => {
 		const wrapper = shallow( <PostPublishButtonOrToggle isPublished={ true } /> );
 		expect( wrapper ).toMatchSnapshot();
@@ -38,20 +22,31 @@ describe( 'PostPublishButtonOrToggle should render a ', () => {
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
-	it( 'button when the post is pending, it cannot be published, and the viewport is not small ', () => {
+	it( 'toggle when post is not published or scheduled and the viewport is small', () => {
 		const wrapper = shallow( <PostPublishButtonOrToggle
-			isPending={ true }
-			hasPublishAction={ false }
-			isSmallViewport={ false }
+			isScheduled={ false }
+			isPublished={ false }
+			isSmallViewport={ true }
 		/> );
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
-	it( 'toggle when the post is pending, it cannot be published, and the viewport is small ', () => {
+	it( 'toggle when post is not published or scheduled, the viewport is not small, and the publish sidebar is enabled', () => {
 		const wrapper = shallow( <PostPublishButtonOrToggle
-			isPending={ true }
-			hasPublishAction={ false }
-			isSmallViewport={ true }
+			isScheduled={ false }
+			isPublished={ false }
+			isSmallViewport={ false }
+			isPublishSidebarEnabled={ true }
+		/> );
+		expect( wrapper ).toMatchSnapshot();
+	} );
+
+	it( 'button when post is not published or scheduled, the viewport is not small, and the publish sidebar is disabled', () => {
+		const wrapper = shallow( <PostPublishButtonOrToggle
+			isScheduled={ false }
+			isPublished={ false }
+			isSmallViewport={ false }
+			isPublishSidebarEnabled={ false }
 		/> );
 		expect( wrapper ).toMatchSnapshot();
 	} );

--- a/packages/edit-post/src/components/header/test/index.js
+++ b/packages/edit-post/src/components/header/test/index.js
@@ -8,13 +8,13 @@ import { shallow } from 'enzyme';
  */
 import { PostPublishButtonOrToggle } from '../post-publish-button-or-toggle';
 
-describe( 'PostPublishButtonOrToggle should render a ', () => {
-	it( 'button when the post is published', () => {
+describe( 'PostPublishButtonOrToggle should render a', () => {
+	it( 'button when the post is published (1)', () => {
 		const wrapper = shallow( <PostPublishButtonOrToggle isPublished={ true } /> );
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
-	it( 'button when the post is scheduled', () => {
+	it( 'button when the post is scheduled (2)', () => {
 		const wrapper = shallow( <PostPublishButtonOrToggle
 			isScheduled={ true }
 			isBeingScheduled={ true }
@@ -22,41 +22,27 @@ describe( 'PostPublishButtonOrToggle should render a ', () => {
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
-	it( 'button when the post is pending and cannot be published but the viewport is > small', () => {
+	it( 'button when the post is pending and cannot be published but the viewport is >= medium (3)', () => {
 		const wrapper = shallow( <PostPublishButtonOrToggle
 			isPending={ true }
 			hasPublishAction={ false }
-			isSmallViewport={ false }
+			isLessThanMediumViewport={ false }
 		/> );
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
-	it( 'toggle when post is not published or scheduled and the viewport is small', () => {
-		const wrapper = shallow( <PostPublishButtonOrToggle
-			isScheduled={ false }
-			isPublished={ false }
-			isSmallViewport={ true }
-		/> );
+	it( 'toggle when post is not published or scheduled and the viewport is < medium', () => {
+		const wrapper = shallow( <PostPublishButtonOrToggle isLessThanMediumViewport={ true } /> );
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
-	it( 'toggle when post is not published or scheduled, the viewport is not small, and the publish sidebar is enabled', () => {
-		const wrapper = shallow( <PostPublishButtonOrToggle
-			isScheduled={ false }
-			isPublished={ false }
-			isSmallViewport={ false }
-			isPublishSidebarEnabled={ true }
-		/> );
+	it( 'toggle when post is not (1), (2), (3), the viewport is >= medium, and the publish sidebar is enabled', () => {
+		const wrapper = shallow( <PostPublishButtonOrToggle isPublishSidebarEnabled={ true } /> );
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
-	it( 'button when post is not published or scheduled, the viewport is not small, and the publish sidebar is disabled', () => {
-		const wrapper = shallow( <PostPublishButtonOrToggle
-			isScheduled={ false }
-			isPublished={ false }
-			isSmallViewport={ false }
-			isPublishSidebarEnabled={ false }
-		/> );
+	it( 'button when post is not (1), (2), (3), the viewport is >= medium, and the publish sidebar is disabled', () => {
+		const wrapper = shallow( <PostPublishButtonOrToggle isPublishSidebarEnabled={ false } /> );
 		expect( wrapper ).toMatchSnapshot();
 	} );
 } );

--- a/packages/edit-post/src/components/header/test/index.js
+++ b/packages/edit-post/src/components/header/test/index.js
@@ -30,7 +30,7 @@ describe( 'PostPublishButtonOrToggle should render a ', () => {
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
-	it( 'button when the post is being scheduled', () => {
+	it( 'button when the post is scheduled', () => {
 		const wrapper = shallow( <PostPublishButtonOrToggle
 			isScheduled={ true }
 			isBeingScheduled={ true }

--- a/packages/edit-post/src/components/header/test/index.js
+++ b/packages/edit-post/src/components/header/test/index.js
@@ -29,4 +29,12 @@ describe( 'PostPublishButtonOrToggle', () => {
 		const wrapper = shallow( <PostPublishButtonOrToggle isPublished={ true } /> );
 		expect( wrapper ).toMatchSnapshot();
 	} );
+
+	it( 'should render button when the post is being scheduled', () => {
+		const wrapper = shallow( <PostPublishButtonOrToggle
+			isScheduled={ true }
+			isBeingScheduled={ true }
+		/> );
+		expect( wrapper ).toMatchSnapshot();
+	} );
 } );

--- a/packages/edit-post/src/components/header/test/index.js
+++ b/packages/edit-post/src/components/header/test/index.js
@@ -9,6 +9,22 @@ import { shallow } from 'enzyme';
 import { PostPublishButtonOrToggle } from '../post-publish-button-or-toggle';
 
 describe( 'PostPublishButtonOrToggle', () => {
+	it( 'should render button when the publish sidebar is not enabled and the viewport is > small', () => {
+		const wrapper = shallow( <PostPublishButtonOrToggle
+			isPublishSidebarEnabled={ false }
+			isSmallViewport={ false }
+		/> );
+		expect( wrapper ).toMatchSnapshot();
+	} );
+
+	it( 'should render toggle when the publish sidebar is not enabled and the viewport is <= small', () => {
+		const wrapper = shallow( <PostPublishButtonOrToggle
+			isPublishSidebarEnabled={ false }
+			isSmallViewport={ true }
+		/> );
+		expect( wrapper ).toMatchSnapshot();
+	} );
+
 	it( 'should render button when the post is published', () => {
 		const wrapper = shallow( <PostPublishButtonOrToggle isPublished={ true } /> );
 		expect( wrapper ).toMatchSnapshot();

--- a/packages/edit-post/src/components/header/test/index.js
+++ b/packages/edit-post/src/components/header/test/index.js
@@ -8,8 +8,8 @@ import { shallow } from 'enzyme';
  */
 import { PostPublishButtonOrToggle } from '../post-publish-button-or-toggle';
 
-describe( 'PostPublishButtonOrToggle', () => {
-	it( 'should render button when the publish sidebar is not enabled and the viewport is > small', () => {
+describe( 'PostPublishButtonOrToggle should render a ', () => {
+	it( 'button when the publish sidebar is not enabled and the viewport is > small', () => {
 		const wrapper = shallow( <PostPublishButtonOrToggle
 			isPublishSidebarEnabled={ false }
 			isSmallViewport={ false }
@@ -17,7 +17,7 @@ describe( 'PostPublishButtonOrToggle', () => {
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
-	it( 'should render toggle when the publish sidebar is not enabled and the viewport is <= small', () => {
+	it( 'toggle when the publish sidebar is not enabled and the viewport is <= small', () => {
 		const wrapper = shallow( <PostPublishButtonOrToggle
 			isPublishSidebarEnabled={ false }
 			isSmallViewport={ true }
@@ -25,12 +25,12 @@ describe( 'PostPublishButtonOrToggle', () => {
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
-	it( 'should render button when the post is published', () => {
+	it( 'button when the post is published', () => {
 		const wrapper = shallow( <PostPublishButtonOrToggle isPublished={ true } /> );
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
-	it( 'should render button when the post is being scheduled', () => {
+	it( 'button when the post is being scheduled', () => {
 		const wrapper = shallow( <PostPublishButtonOrToggle
 			isScheduled={ true }
 			isBeingScheduled={ true }
@@ -38,7 +38,7 @@ describe( 'PostPublishButtonOrToggle', () => {
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
-	it( 'should render button when the post is pending, it cannot be published, and the viewport is not small ', () => {
+	it( 'button when the post is pending, it cannot be published, and the viewport is not small ', () => {
 		const wrapper = shallow( <PostPublishButtonOrToggle
 			isPending={ true }
 			hasPublishAction={ false }
@@ -47,7 +47,7 @@ describe( 'PostPublishButtonOrToggle', () => {
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
-	it( 'should render toggle when the post is pending, it cannot be published, and the viewport is small ', () => {
+	it( 'toggle when the post is pending, it cannot be published, and the viewport is small ', () => {
 		const wrapper = shallow( <PostPublishButtonOrToggle
 			isPending={ true }
 			hasPublishAction={ false }

--- a/packages/edit-post/src/components/header/test/index.js
+++ b/packages/edit-post/src/components/header/test/index.js
@@ -22,6 +22,15 @@ describe( 'PostPublishButtonOrToggle should render a ', () => {
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
+	it( 'button when the post is pending and cannot be published but the viewport is > small', () => {
+		const wrapper = shallow( <PostPublishButtonOrToggle
+			isPending={ true }
+			hasPublishAction={ false }
+			isSmallViewport={ false }
+		/> );
+		expect( wrapper ).toMatchSnapshot();
+	} );
+
 	it( 'toggle when post is not published or scheduled and the viewport is small', () => {
 		const wrapper = shallow( <PostPublishButtonOrToggle
 			isScheduled={ false }

--- a/packages/edit-post/src/components/options-modal/options.js
+++ b/packages/edit-post/src/components/options-modal/options.js
@@ -5,6 +5,7 @@ import { CheckboxControl } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
+import { ifViewportMatches } from '@wordpress/viewport';
 
 function Option( { label, isChecked, onChange } ) {
 	return (
@@ -51,7 +52,8 @@ export const EnablePublishSidebarOption = compose(
 		return {
 			onChange: ( isEnabled ) => ( isEnabled ? enablePublishSidebar() : disablePublishSidebar() ),
 		};
-	} )
+	} ),
+	ifViewportMatches( 'medium' ),
 )( Option );
 
 export const EnableTipsOption = compose(

--- a/packages/edit-post/src/components/options-modal/options.js
+++ b/packages/edit-post/src/components/options-modal/options.js
@@ -53,6 +53,8 @@ export const EnablePublishSidebarOption = compose(
 			onChange: ( isEnabled ) => ( isEnabled ? enablePublishSidebar() : disablePublishSidebar() ),
 		};
 	} ),
+	// In < medium viewports we override this option and always show the publish sidebar.
+	// See the edit-post's header component for the specific logic.
 	ifViewportMatches( 'medium' ),
 )( Option );
 

--- a/packages/edit-post/src/components/options-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/options-modal/test/__snapshots__/index.js.snap
@@ -15,7 +15,7 @@ exports[`OptionsModal should match snapshot when the modal is active 1`] = `
   <Section
     title="General"
   >
-    <WithSelect(WithDispatch(Option))
+    <WithSelect(WithDispatch(IfViewportMatches(Option)))
       label="Enable Pre-publish Checks"
     />
     <WithSelect(WithDispatch(DeferredOption))

--- a/packages/editor/src/components/post-publish-panel/toggle.js
+++ b/packages/editor/src/components/post-publish-panel/toggle.js
@@ -1,9 +1,4 @@
 /**
- * External Dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress Dependencies
  */
 import { Button } from '@wordpress/components';
@@ -12,34 +7,19 @@ import { __ } from '@wordpress/i18n';
 import { withSelect } from '@wordpress/data';
 import { DotTip } from '@wordpress/nux';
 
-/**
- * Internal Dependencies
- */
-import PostPublishButton from '../post-publish-button';
-
 export function PostPublishPanelToggle( {
-	hasPublishAction,
 	isSaving,
 	isPublishable,
 	isSaveable,
 	isPublished,
 	isBeingScheduled,
-	isPending,
-	isScheduled,
 	onToggle,
 	isOpen,
-	forceIsDirty,
 	forceIsSaving,
 } ) {
 	const isButtonEnabled = (
 		! isSaving && ! forceIsSaving && isPublishable && isSaveable
 	) || isPublished;
-
-	const showToggle = ! isPublished && ! ( isScheduled && isBeingScheduled ) && ! ( isPending && ! hasPublishAction );
-
-	if ( ! showToggle ) {
-		return <PostPublishButton forceIsDirty={ forceIsDirty } forceIsSaving={ forceIsSaving } />;
-	}
 
 	return (
 		<Button
@@ -64,23 +44,15 @@ export default compose( [
 			isSavingPost,
 			isEditedPostSaveable,
 			isEditedPostPublishable,
-			isCurrentPostPending,
 			isCurrentPostPublished,
 			isEditedPostBeingScheduled,
-			isCurrentPostScheduled,
-			getCurrentPost,
-			getCurrentPostType,
 		} = select( 'core/editor' );
 		return {
-			hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
 			isSaving: isSavingPost(),
 			isSaveable: isEditedPostSaveable(),
 			isPublishable: isEditedPostPublishable(),
-			isPending: isCurrentPostPending(),
 			isPublished: isCurrentPostPublished(),
-			isScheduled: isCurrentPostScheduled(),
 			isBeingScheduled: isEditedPostBeingScheduled(),
-			postType: getCurrentPostType(),
 		};
 	} ),
 ] )( PostPublishPanelToggle );

--- a/test/e2e/specs/publishing.test.js
+++ b/test/e2e/specs/publishing.test.js
@@ -8,6 +8,7 @@ import {
 	enablePrePublishChecks,
 	disablePrePublishChecks,
 	arePrePublishChecksEnabled,
+	setViewport,
 } from '../support/utils';
 
 describe( 'Publishing', () => {
@@ -73,6 +74,32 @@ describe( 'Publishing', () => {
 
 				// The post-publishing panel should have been not shown.
 				expect( await page.$( '.editor-post-publish-panel' ) ).toBeNull();
+			} );
+		} );
+	} );
+
+	[ 'post', 'page' ].forEach( ( postType ) => {
+		let werePrePublishChecksEnabled;
+		describe( `a ${ postType } in small viewports`, () => {
+			beforeEach( async () => {
+				await newPost( postType );
+				werePrePublishChecksEnabled = await arePrePublishChecksEnabled();
+				if ( werePrePublishChecksEnabled ) {
+					await disablePrePublishChecks();
+				}
+				await setViewport( 'small' );
+			} );
+
+			afterEach( async () => {
+				await setViewport( 'large' );
+				if ( werePrePublishChecksEnabled ) {
+					await enablePrePublishChecks();
+				}
+			} );
+
+			it( `should ignore the pre-publish checks and show the Publish... toggle instead of the Publish button`, async () => {
+				expect( await page.$( '.editor-post-publish-panel__toggle' ) ).not.toBeNull();
+				expect( await page.$( '.editor-post-publish-button' ) ).toBeNull();
 			} );
 		} );
 	} );


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/10475

This PR takes the viewport size into account when it comes to decide whether we show the button or toggle logic. Here's how this PR modifies the logic (changes in bold):

Logic | Before | After 
--- | --- | ---
Post status is `publish` or `private` | Button | Button
Post status is `future` and the (scheduled) date is after now | Button | Button
Post status is `pending`, cannot be published and the viewport is < medium  | **Button** | **Toggle**
Post status is `pending`, cannot be published and the viewport >= medium | Button | Button
Publish sidebar is enabled | Toggle | Toggle
Publish sidebar is disabled and viewport is < medium | **Button** | **Toggle**
Publish sidebar is disabled and viewport is >= medium | Button | Button

### TODO

- [x] Show the "Publish..." button below medium viewports overriding the pre-publish checks option if necessary.
- [x] Hide pre-publish checks option on the general settings modal below medium viewports.
- [x] Update/Add e2e tests.
