### PR TITLE
DateTimePicker component: Use color function for defining the background

### DIFF
--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -40,7 +40,7 @@
 		background: theme(primary);
 
 		&:hover {
-			background: theme(primary) shade(15%);
+			background: color(theme(primary) shade(15%));
 		}
 	}
 


### PR DESCRIPTION
## Description
The last version of the `@wordpress/components` package provides an CSS file with invalid syntax because there is `background` property with a wrong value for the `DateTimePicker` component. 

It seems that it was forgotten to include the `color` function on WordPress/gutenberg#7621, as this function will create a new color by adjusting it with the given `shade`.

This PR adds that function, so we can solve the [import problems](https://github.com/Automattic/wp-calypso/pull/28000#pullrequestreview-167146438) we have on Calypso using the latest packages.

## How has this been tested?
I tested locally by generating a build and checking that the built CSS include a valid background value.

### Testing instructions
- Build the packages with `npm run build:packages`
- Check that the generated file `packages/components/build-style/style.css` doesn't include any `shade`, specially the `background` properties between lines 1615 and 1629.
- Check that the generated CSS can be imported using SCSS

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. 
- [x] My code follows the accessibility standards. 
- [x] My code has proper inline documentation. 
