### PR TITLE
Make options modal mobile friendly.

### DIFF
--- a/packages/edit-post/src/components/options-modal/style.scss
+++ b/packages/edit-post/src/components/options-modal/style.scss
@@ -1,5 +1,5 @@
 .edit-post-options-modal {
-	min-width: 450px;
+	min-width: 320px;
 
 	&__title {
 		font-size: 1rem;

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -171,7 +171,8 @@ body.block-editor-page {
 .edit-post-sidebar,
 .editor-post-publish-panel,
 .editor-block-list__block,
-.components-popover {
+.components-popover,
+.components-modal__content {
 	.input-control, // Upstream name is `.regular-text`.
 	input[type="text"],
 	input[type="search"],


### PR DESCRIPTION
This PR makes the options modal fit on mobile. Fixes #10894.

It also makes the checkboxes nice:

<img width="654" alt="screen shot 2018-10-23 at 13 04 42" src="https://user-images.githubusercontent.com/1204802/47356492-86e6b200-d6c4-11e8-978f-07f6dcfdb857.png">
