### PR TITLE
Add createCustomColorsHOC HOC builder

### DIFF
--- a/packages/editor/src/components/colors/index.js
+++ b/packages/editor/src/components/colors/index.js
@@ -3,4 +3,7 @@ export {
 	getColorObjectByAttributeValues,
 	getColorObjectByColorValue,
 } from './utils';
-export { default as withColors } from './with-colors';
+export {
+	createCustomColorsHOC,
+	default as withColors,
+} from './with-colors';

--- a/packages/editor/src/components/colors/test/__snapshots__/with-colors.js.snap
+++ b/packages/editor/src/components/colors/test/__snapshots__/with-colors.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createCustomColorsHOC provides the the wrapped component with color values and setter functions as props 1`] = `
+<Component
+  attributes={
+    Object {
+      "backgroundColor": null,
+    }
+  }
+  backgroundColor={
+    Object {
+      "class": undefined,
+      "color": undefined,
+    }
+  }
+  colorUtils={
+    Object {
+      "getMostReadableColor": [Function],
+    }
+  }
+  setBackgroundColor={[Function]}
+/>
+`;

--- a/packages/editor/src/components/colors/test/with-colors.js
+++ b/packages/editor/src/components/colors/test/with-colors.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import { shallow, mount } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { createCustomColorsHOC } from '../with-colors';
+
+describe( 'createCustomColorsHOC', () => {
+	it( 'provides the the wrapped component with color values and setter functions as props', () => {
+		const withCustomColors = createCustomColorsHOC( [ { name: 'Red', slug: 'red', color: 'ff0000' } ] );
+		const EnhancedComponent = withCustomColors( 'backgroundColor' )( () => (
+			<div />
+		) );
+
+		const wrapper = shallow(
+			<EnhancedComponent attributes={ { backgroundColor: null } } />
+		);
+
+		expect( wrapper.dive() ).toMatchSnapshot();
+	} );
+
+	it( 'setting the color to a value in the provided custom color array updated the backgroundColor attribute', () => {
+		const withCustomColors = createCustomColorsHOC( [ { name: 'Red', slug: 'red', color: 'ff0000' } ] );
+		const EnhancedComponent = withCustomColors( 'backgroundColor' )( ( props ) => (
+			<button onClick={ () => props.setBackgroundColor( 'ff0000' ) }>Test Me</button>
+		) );
+
+		const setAttributes = jest.fn();
+
+		const wrapper = mount(
+			<EnhancedComponent attributes={ { backgroundColor: null } } setAttributes={ setAttributes } />
+		);
+
+		wrapper.find( 'button' ).simulate( 'click' );
+		expect( setAttributes ).toHaveBeenCalledWith( { backgroundColor: 'red', customBackgroundColor: undefined } );
+	} );
+
+	it( 'setting the color to a value not in the provided custom color array updates customBackgroundColor attribute', () => {
+		const withCustomColors = createCustomColorsHOC( [ { name: 'Red', slug: 'red', color: 'ff0000' } ] );
+		const EnhancedComponent = withCustomColors( 'backgroundColor' )( ( props ) => (
+			<button onClick={ () => props.setBackgroundColor( '000000' ) }>Test Me</button>
+		) );
+
+		const setAttributes = jest.fn();
+
+		const wrapper = mount(
+			<EnhancedComponent attributes={ { backgroundColor: null } } setAttributes={ setAttributes } />
+		);
+
+		wrapper.find( 'button' ).simulate( 'click' );
+		expect( setAttributes ).toHaveBeenCalledWith( { backgroundColor: undefined, customBackgroundColor: '000000' } );
+	} );
+} );

--- a/packages/editor/src/components/colors/with-colors.js
+++ b/packages/editor/src/components/colors/with-colors.js
@@ -18,21 +18,24 @@ import { getColorClassName, getColorObjectByColorValue, getColorObjectByAttribut
 const DEFAULT_COLORS = [];
 
 /**
- * Higher-order component, which handles color logic for class generation
+ * A Higher-order component builder, which handles color logic for class generation
  * color value, retrieval and color attribute setting.
  *
- * @param {...(object|string)} args The arguments can be strings or objects. If the argument is an object,
- *                                  it should contain the color attribute name as key and the color context as value.
- *                                  If the argument is a string the value should be the color attribute name,
- *                                  the color context is computed by applying a kebab case transform to the value.
- *                                  Color context represents the context/place where the color is going to be used.
- *                                  The class name of the color is generated using 'has' followed by the color name
- *                                  and ending with the color context all in kebab case e.g: has-green-background-color.
+ * @param {?Array}             colorsArray The array of color objects (name, slug, color, etc... ), if not passed,
+ *                                         the array is queried from the editor state to retrieve the colors array set by the theme,
+ *                                         if the colors array was not set by the theme the default colors are used.
+ * @param {...(object|string)} args        The arguments can be strings or objects. If the argument is an object,
+ *                                         it should contain the color attribute name as key and the color context as value.
+ *                                         If the argument is a string the value should be the color attribute name,
+ *                                         the color context is computed by applying a kebab case transform to the value.
+ *                                         Color context represents the context/place where the color is going to be used.
+ *                                         The class name of the color is generated using 'has' followed by the color name
+ *                                         and ending with the color context all in kebab case e.g: has-green-background-color.
  *
  *
  * @return {Function} Higher-order component.
  */
-export default ( ...args ) => {
+export const createCustomColorsHOC = ( colorsArray ) => ( ...args ) => {
 	const colorMap = reduce( args, ( colorObject, arg ) => {
 		return {
 			...colorObject,
@@ -43,6 +46,11 @@ export default ( ...args ) => {
 	return createHigherOrderComponent(
 		compose( [
 			withSelect( ( select ) => {
+				if ( colorsArray ) {
+					return {
+						colors: colorsArray,
+					};
+				}
 				const settings = select( 'core/editor' ).getEditorSettings();
 				return {
 					colors: get( settings, [ 'colors' ], DEFAULT_COLORS ),
@@ -132,3 +140,5 @@ export default ( ...args ) => {
 		'withColors'
 	);
 };
+
+export default createCustomColorsHOC();

--- a/packages/editor/src/components/colors/with-colors.js
+++ b/packages/editor/src/components/colors/with-colors.js
@@ -18,127 +18,186 @@ import { getColorClassName, getColorObjectByColorValue, getColorObjectByAttribut
 const DEFAULT_COLORS = [];
 
 /**
- * A Higher-order component builder, which handles color logic for class generation
- * color value, retrieval and color attribute setting.
+ * Higher order component factory for injecting the `colorsArray` argument as
+ * the colors prop in the `withCustomColors` HOC.
  *
- * @param {?Array}             colorsArray The array of color objects (name, slug, color, etc... ), if not passed,
- *                                         the array is queried from the editor state to retrieve the colors array set by the theme,
- *                                         if the colors array was not set by the theme the default colors are used.
- * @param {...(object|string)} args        The arguments can be strings or objects. If the argument is an object,
- *                                         it should contain the color attribute name as key and the color context as value.
- *                                         If the argument is a string the value should be the color attribute name,
- *                                         the color context is computed by applying a kebab case transform to the value.
- *                                         Color context represents the context/place where the color is going to be used.
- *                                         The class name of the color is generated using 'has' followed by the color name
- *                                         and ending with the color context all in kebab case e.g: has-green-background-color.
+ * @param {Array} colorsArray An array of color objects.
  *
- *
- * @return {Function} Higher-order component.
+ * @return {function} The higher order component.
  */
-export const createCustomColorsHOC = ( colorsArray ) => ( ...args ) => {
-	const colorMap = reduce( args, ( colorObject, arg ) => {
+const withCustomColorPalette = ( colorsArray ) => createHigherOrderComponent( ( WrappedComponent ) => ( props ) => (
+	<WrappedComponent { ...props } colors={ colorsArray } />
+), 'withCustomColorPalette' );
+
+/**
+ * Higher order component factory for injecting the editor colors as the
+ * `colors` prop in the `withColors` HOC.
+ *
+ * @return {function} The higher order component.
+ */
+const withEditorColorPalette = () => withSelect( ( select ) => {
+	const settings = select( 'core/editor' ).getEditorSettings();
+	return {
+		colors: get( settings, [ 'colors' ], DEFAULT_COLORS ),
+	};
+} );
+
+/**
+ * Helper function used with `createHigherOrderComponent` to create
+ * higher order components for managing color logic.
+ *
+ * @param {Array}    colorTypes       An array of color types (e.g. 'backgroundColor, borderColor).
+ * @param {Function} withColorPalette A HOC for injecting the 'colors' prop into the WrappedComponent.
+ *
+ * @return {Component} The component that can be used as a HOC.
+ */
+function createColorHOC( colorTypes, withColorPalette ) {
+	const colorMap = reduce( colorTypes, ( colorObject, colorType ) => {
 		return {
 			...colorObject,
-			...( isString( arg ) ? { [ arg ]: kebabCase( arg ) } : arg ),
+			...( isString( colorType ) ? { [ colorType ]: kebabCase( colorType ) } : colorType ),
 		};
 	}, {} );
 
-	return createHigherOrderComponent(
-		compose( [
-			withSelect( ( select ) => {
-				if ( colorsArray ) {
-					return {
-						colors: colorsArray,
+	return compose( [
+		withColorPalette,
+		( WrappedComponent ) => {
+			return class extends Component {
+				constructor( props ) {
+					super( props );
+
+					this.setters = this.createSetters();
+					this.colorUtils = {
+						getMostReadableColor: this.getMostReadableColor.bind( this ),
+					};
+
+					this.state = {};
+				}
+
+				getMostReadableColor( colorValue ) {
+					const { colors } = this.props;
+					return getMostReadableColor( colors, colorValue );
+				}
+
+				createSetters() {
+					return reduce( colorMap, ( settersAccumulator, colorContext, colorAttributeName ) => {
+						const upperFirstColorAttributeName = upperFirst( colorAttributeName );
+						const customColorAttributeName = `custom${ upperFirstColorAttributeName }`;
+						settersAccumulator[ `set${ upperFirstColorAttributeName }` ] =
+							this.createSetColor( colorAttributeName, customColorAttributeName );
+						return settersAccumulator;
+					}, {} );
+				}
+
+				createSetColor( colorAttributeName, customColorAttributeName ) {
+					return ( colorValue ) => {
+						const colorObject = getColorObjectByColorValue( this.props.colors, colorValue );
+						this.props.setAttributes( {
+							[ colorAttributeName ]: colorObject && colorObject.slug ? colorObject.slug : undefined,
+							[ customColorAttributeName ]: colorObject && colorObject.slug ? undefined : colorValue,
+						} );
 					};
 				}
-				const settings = select( 'core/editor' ).getEditorSettings();
-				return {
-					colors: get( settings, [ 'colors' ], DEFAULT_COLORS ),
-				};
-			} ),
-			( WrappedComponent ) => {
-				return class extends Component {
-					constructor( props ) {
-						super( props );
 
-						this.setters = this.createSetters();
-						this.colorUtils = {
-							getMostReadableColor: this.getMostReadableColor.bind( this ),
-						};
-
-						this.state = {};
-					}
-
-					getMostReadableColor( colorValue ) {
-						const { colors } = this.props;
-						return getMostReadableColor( colors, colorValue );
-					}
-
-					createSetters() {
-						return reduce( colorMap, ( settersAccumulator, colorContext, colorAttributeName ) => {
-							const upperFirstColorAttributeName = upperFirst( colorAttributeName );
-							const customColorAttributeName = `custom${ upperFirstColorAttributeName }`;
-							settersAccumulator[ `set${ upperFirstColorAttributeName }` ] =
-								this.createSetColor( colorAttributeName, customColorAttributeName );
-							return settersAccumulator;
-						}, {} );
-					}
-
-					createSetColor( colorAttributeName, customColorAttributeName ) {
-						return ( colorValue ) => {
-							const colorObject = getColorObjectByColorValue( this.props.colors, colorValue );
-							this.props.setAttributes( {
-								[ colorAttributeName ]: colorObject && colorObject.slug ? colorObject.slug : undefined,
-								[ customColorAttributeName ]: colorObject && colorObject.slug ? undefined : colorValue,
-							} );
-						};
-					}
-
-					static getDerivedStateFromProps( { attributes, colors }, previousState ) {
-						return reduce( colorMap, ( newState, colorContext, colorAttributeName ) => {
-							const colorObject = getColorObjectByAttributeValues(
-								colors,
-								attributes[ colorAttributeName ],
-								attributes[ `custom${ upperFirst( colorAttributeName ) }` ],
-							);
-
-							const previousColorObject = previousState[ colorAttributeName ];
-							const previousColor = get( previousColorObject, [ 'color' ] );
-							/**
-							* The "and previousColorObject" condition checks that a previous color object was already computed.
-							* At the start previousColorObject and colorValue are both equal to undefined
-							* bus as previousColorObject does not exist we should compute the object.
-							*/
-							if ( previousColor === colorObject.color && previousColorObject ) {
-								newState[ colorAttributeName ] = previousColorObject;
-							} else {
-								newState[ colorAttributeName ] = {
-									...colorObject,
-									class: getColorClassName( colorContext, colorObject.slug ),
-								};
-							}
-							return newState;
-						}, {} );
-					}
-
-					render() {
-						return (
-							<WrappedComponent
-								{ ...{
-									...this.props,
-									colors: undefined,
-									...this.state,
-									...this.setters,
-									colorUtils: this.colorUtils,
-								} }
-							/>
+				static getDerivedStateFromProps( { attributes, colors }, previousState ) {
+					return reduce( colorMap, ( newState, colorContext, colorAttributeName ) => {
+						const colorObject = getColorObjectByAttributeValues(
+							colors,
+							attributes[ colorAttributeName ],
+							attributes[ `custom${ upperFirst( colorAttributeName ) }` ],
 						);
-					}
-				};
-			},
-		] ),
-		'withColors'
-	);
-};
 
-export default createCustomColorsHOC();
+						const previousColorObject = previousState[ colorAttributeName ];
+						const previousColor = get( previousColorObject, [ 'color' ] );
+						/**
+						* The "and previousColorObject" condition checks that a previous color object was already computed.
+						* At the start previousColorObject and colorValue are both equal to undefined
+						* bus as previousColorObject does not exist we should compute the object.
+						*/
+						if ( previousColor === colorObject.color && previousColorObject ) {
+							newState[ colorAttributeName ] = previousColorObject;
+						} else {
+							newState[ colorAttributeName ] = {
+								...colorObject,
+								class: getColorClassName( colorContext, colorObject.slug ),
+							};
+						}
+						return newState;
+					}, {} );
+				}
+
+				render() {
+					return (
+						<WrappedComponent
+							{ ...{
+								...this.props,
+								colors: undefined,
+								...this.state,
+								...this.setters,
+								colorUtils: this.colorUtils,
+							} }
+						/>
+					);
+				}
+			};
+		},
+	] );
+}
+
+/**
+ * A higher-order component factory for creating a 'withCustomColors' HOC, which handles color logic
+ * for class generation color value, retrieval and color attribute setting.
+ *
+ * Use this higher-order component to work with a custom set of colors.
+ *
+ * @example
+ *
+ * ```jsx
+ * const CUSTOM_COLORS = [ { name: 'Red', slug: 'red', color: '#ff0000' }, { name: 'Blue', slug: 'blue', color: '#0000ff' } ];
+ * const withCustomColors = createCustomColorsHOC( CUSTOM_COLORS );
+ * // ...
+ * export default compose(
+ *     withCustomColors( 'backgroundColor', 'borderColor' ),
+ *     MyColorfulComponent,
+ * );
+ * ```
+ *
+ * @param {Array} colorsArray The array of color objects (name, slug, color, etc... ).
+ *
+ * @return {Function} Higher-order component.
+ */
+export function createCustomColorsHOC( colorsArray ) {
+	return ( ...colorTypes ) => {
+		const withColorPalette = withCustomColorPalette( colorsArray );
+		return createHigherOrderComponent( createColorHOC( colorTypes, withColorPalette ), 'withCustomColors' );
+	};
+}
+
+/**
+ * A higher-order component, which handles color logic for class generation color value, retrieval and color attribute setting.
+ *
+ * For use with the default editor/theme color palette.
+ *
+ * @example
+ *
+ * ```jsx
+ * export default compose(
+ *     withColors( 'backgroundColor', { textColor: 'color' } ),
+ *     MyColorfulComponent,
+ * );
+ * ```
+ *
+ * @param {...(object|string)} colorTypes The arguments can be strings or objects. If the argument is an object,
+ *                                        it should contain the color attribute name as key and the color context as value.
+ *                                        If the argument is a string the value should be the color attribute name,
+ *                                        the color context is computed by applying a kebab case transform to the value.
+ *                                        Color context represents the context/place where the color is going to be used.
+ *                                        The class name of the color is generated using 'has' followed by the color name
+ *                                        and ending with the color context all in kebab case e.g: has-green-background-color.
+ *
+ * @return {Function} Higher-order component.
+ */
+export default function withColors( ...colorTypes ) {
+	const withColorPalette = withEditorColorPalette();
+	return createHigherOrderComponent( createColorHOC( colorTypes, withColorPalette ), 'withColors' );
+}


### PR DESCRIPTION
This PR is useful for #10611.
Supersedes: https://github.com/WordPress/gutenberg/pull/10765

createCustomColorsHOC builds a HOC equivalent to withColors but that has a static color array instead of using the color array provided by the theme or the default colors.

Props to @talldan for suggesting this feature/interface.

Sample:
```
 var BORDER_COLORS = [ {
            slug: 'green',
            name: 'Green',
            color: '#00ff00'
        },{
            slug: 'yellow',
            name: 'Yellow',
            color: '#ffff00'
    } ];
var withBorderColors = createCustomColorsHOC( BORDER_COLORS );
// ...
compose( [ 
	withColors( 'backgroundColor', 'textColor' ),
	withBorderColors( 'borderBottomColor', 'borderTopColor' )
] );
```
In the previous sample backgroundColor and textColor use the color palette provided by the editor/theme while borderBottomColor and borderTopColor use the static colors provided by the block.
The block is responsible for implementing the following classes: .has-green-border-top-color, has-yellow-border-top-color, has-green-border-bottom-color, .has-yellow-border-bottom-color;
This is useful in a context where there are no expectations themes should provide classes e.g: border colors, or if the block only makes sense with a given set of colors and we want to avoid inline styles.


## How has this been tested?
I added the test bock available in https://gist.github.com/jorgefilipecosta/74ba266ed16a6759c85e1a13effe447c.

I checked that for border colors we can choose between a specified set, and classes are used for border colors with the logic being handled by the component created by createCustomColorsHOC (equivalent to) withColors.
I checked that background and text color still present the expected behavior.
I checked that existing blocks that use colors ( cover, paragraph, button etc...) still work as expected.
