### PR TITLE
File Block: Set the download attribute as empty

### DIFF
--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -11,7 +11,6 @@ import { createBlobURL } from '@wordpress/blob';
 import { createBlock } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
 import { RichText } from '@wordpress/editor';
-import { create, getTextContent } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -218,10 +217,8 @@ export const settings = {
 					<a
 						href={ href }
 						className="wp-block-file__button"
-						// ensure download attribute is still set when fileName
-						// is undefined. Using '' here as `true` still leaves
-						// the attribute unset.
-						download={ getTextContent( create( { html: fileName } ) ) }
+						// Using '' here as `true` leaves the attribute unset.
+						download=""
 					>
 						<RichText.Content
 							value={ downloadButtonText }

--- a/test/integration/full-content/fixtures/core__categories.json
+++ b/test/integration/full-content/fixtures/core__categories.json
@@ -4,9 +4,9 @@
         "name": "core/categories",
         "isValid": true,
         "attributes": {
-            "showPostCounts": false,
             "displayAsDropdown": false,
-            "showHierarchy": false
+            "showHierarchy": false,
+            "showPostCounts": false
         },
         "innerBlocks": [],
         "originalContent": ""

--- a/test/integration/full-content/fixtures/core__file__new-window.html
+++ b/test/integration/full-content/fixtures/core__file__new-window.html
@@ -1,3 +1,3 @@
 <!-- wp:file {"href":"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js","showDownloadButton":true,"id":176} -->
-<div class="wp-block-file"><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" target="_blank" rel="noreferrer noopener">6546</a><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" class="wp-block-file__button" download="6546">Download</a></div>
+<div class="wp-block-file"><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" target="_blank" rel="noreferrer noopener">6546</a><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" class="wp-block-file__button" download="">Download</a></div>
 <!-- /wp:file -->

--- a/test/integration/full-content/fixtures/core__file__new-window.json
+++ b/test/integration/full-content/fixtures/core__file__new-window.json
@@ -13,6 +13,6 @@
             "downloadButtonText": "Download"
         },
         "innerBlocks": [],
-        "originalContent": "<div class=\"wp-block-file\"><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" target=\"_blank\" rel=\"noreferrer noopener\">6546</a><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" class=\"wp-block-file__button\" download=\"6546\">Download</a></div>"
+        "originalContent": "<div class=\"wp-block-file\"><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" target=\"_blank\" rel=\"noreferrer noopener\">6546</a><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" class=\"wp-block-file__button\" download=\"\">Download</a></div>"
     }
 ]

--- a/test/integration/full-content/fixtures/core__file__new-window.parsed.json
+++ b/test/integration/full-content/fixtures/core__file__new-window.parsed.json
@@ -7,7 +7,7 @@
             "id": 176
         },
         "innerBlocks": [],
-        "innerHTML": "\n<div class=\"wp-block-file\"><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" target=\"_blank\" rel=\"noreferrer noopener\">6546</a><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" class=\"wp-block-file__button\" download=\"6546\">Download</a></div>\n"
+        "innerHTML": "\n<div class=\"wp-block-file\"><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" target=\"_blank\" rel=\"noreferrer noopener\">6546</a><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" class=\"wp-block-file__button\" download=\"\">Download</a></div>\n"
     },
     {
         "blockName": null,

--- a/test/integration/full-content/fixtures/core__file__new-window.serialized.html
+++ b/test/integration/full-content/fixtures/core__file__new-window.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:file {"id":176,"href":"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js"} -->
-<div class="wp-block-file"><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" target="_blank" rel="noreferrer noopener">6546</a><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" class="wp-block-file__button" download="6546">Download</a></div>
+<div class="wp-block-file"><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" target="_blank" rel="noreferrer noopener">6546</a><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" class="wp-block-file__button" download="">Download</a></div>
 <!-- /wp:file -->

--- a/test/integration/full-content/fixtures/core__freeform__undelimited.parsed.json
+++ b/test/integration/full-content/fixtures/core__freeform__undelimited.parsed.json
@@ -1,7 +1,7 @@
 [
     {
-        "attrs": {},
         "blockName": null,
+        "attrs": {},
         "innerBlocks": [],
         "innerHTML": "Testing freeform block with some\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>\n"
     }

--- a/test/integration/full-content/fixtures/core__missing.json
+++ b/test/integration/full-content/fixtures/core__missing.json
@@ -4,9 +4,9 @@
         "name": "core/missing",
         "isValid": true,
         "attributes": {
-			"originalContent": "<!-- wp:unregistered/example {\"attr1\":\"One\",\"attr2\":\"Two\"} -->\n<p>Testing missing block with some</p>\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>\n<!-- /wp:unregistered/example -->",
-			"originalName": "unregistered/example",
-			"originalUndelimitedContent": "<p>Testing missing block with some</p>\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>"
+            "originalName": "unregistered/example",
+            "originalUndelimitedContent": "<p>Testing missing block with some</p>\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>",
+            "originalContent": "<!-- wp:unregistered/example {\"attr1\":\"One\",\"attr2\":\"Two\"} -->\n<p>Testing missing block with some</p>\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>\n<!-- /wp:unregistered/example -->"
         },
         "innerBlocks": [],
         "originalContent": "<!-- wp:unregistered/example {\"attr1\":\"One\",\"attr2\":\"Two\"} -->\n<p>Testing missing block with some</p>\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>\n<!-- /wp:unregistered/example -->"

--- a/test/integration/full-content/fixtures/core__missing.parsed.json
+++ b/test/integration/full-content/fixtures/core__missing.parsed.json
@@ -2,16 +2,16 @@
     {
         "blockName": "unregistered/example",
         "attrs": {
-			"attr1": "One",
-			"attr2": "Two"
-		},
+            "attr1": "One",
+            "attr2": "Two"
+        },
         "innerBlocks": [],
         "innerHTML": "\n<p>Testing missing block with some</p>\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>\n"
     },
     {
-		"blockName": null,
-		"attrs": {},
-		"innerBlocks": [],
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
         "innerHTML": "\n"
     }
 ]


### PR DESCRIPTION
## Description

Replaces #10693 

Set the File Block's "Download" button's `download` attribute as empty.

The addition of the `download` attribute for `a` tags to the `wp_kses` whitelist has been [recently blocked](https://core.trac.wordpress.org/ticket/44724#comment:11) (cc @pento):

> The `download` attribute doesn't work on cross-origin links (eg, any site that uses a CDN for hosting uploads). I don't know that we necessarily need to account for this, but it is something to consider.
>
> It's also a risk to allow the download filename to be set: for example, an author could upload `my_definitely_not_suspicious_file.txt`, but then set the download attribute to be `CLICK_ME.bat`, which isn't great. If we do allow the `download` attribute, it should only be allowed with no value.

#### Note

The attribute has been set as empty string (`download=""`) instead of valueless (`download` or `download={ true }`) because in the latter case it was always stripped away at the first block update, breaking it altogether.

## How has this been tested?
Manually on a local environment, checking for regressions.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
