### PR TITLE
Media & Text: Remove keyword `half`

### DIFF
--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -29,7 +29,7 @@ export const settings = {
 
 	category: 'layout',
 
-	keywords: [ __( 'image' ), __( 'video' ), __( 'half' ) ],
+	keywords: [ __( 'image' ), __( 'video' ) ],
 
 	attributes: {
 		align: {


### PR DESCRIPTION
## Description
This PR removes the keyword `half` from the Media & Text block.
Fixes #10856