### PR TITLE
Hooks: Remove redundant hooks initialization

### DIFF
--- a/packages/hooks/src/createRunHook.js
+++ b/packages/hooks/src/createRunHook.js
@@ -43,13 +43,6 @@ function createRunHook( hooks, returnFirstArg ) {
 
 		hooks.__current.push( hookInfo );
 
-		if ( ! hooks[ hookName ] ) {
-			hooks[ hookName ] = {
-				runs: 0,
-				handlers: [],
-			};
-		}
-
 		while ( hookInfo.currentIndex < handlers.length ) {
 			const handler = handlers[ hookInfo.currentIndex ];
 


### PR DESCRIPTION
Related: https://github.com/WordPress/packages/pull/134 (https://github.com/WordPress/packages/pull/134#discussion_r193403441)

This pull request seeks to remove a redundant condition to initialization a hooks entry. In https://github.com/WordPress/packages/pull/134, an identical condition was hoisted to the top of the function. Thus, the condition here will never be satisfied and is effectively dead code.

**Testing instructions:**

Run unit tests:

```
npm run test-unit packages/hooks
```