### PR TITLE
Add "img" as a keyword for the image block

### DIFF
--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -103,7 +103,7 @@ export const settings = {
 	category: 'common',
 
 	keywords: [
-		'img',
+		'img', // "img" is not translated as it is intended to reflect the HTML <img> tag.
 		__( 'photo' ),
 	],
 

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -102,7 +102,10 @@ export const settings = {
 
 	category: 'common',
 
-	keywords: [ __( 'photo' ) ],
+	keywords: [
+		'img',
+		__( 'photo' ),
+	],
 
 	attributes: blockAttributes,
 


### PR DESCRIPTION
This adds "img" as a keyword for the image block, mirroring the HTML `<img>` tag.

Because this is intended to mirror the HTML tag, I did not wrap this string in a translation method as HTML doesn't translate.

This is in response to Jeff Chandler's [feedback on Twitter](https://twitter.com/jeffr0/status/1054550924541210625_:

> Well, I created a new block and was doing that / shortcut thing but when I typed /img Imgur showed up instead of image block.

We already support `h*` keywords for the Heading block and the `blockquote` keyword for the Quote block; this is a natural extension of that behavior.