### PR TITLE
SelectControl: Update with Core styles

### DIFF
--- a/packages/components/src/select-control/style.scss
+++ b/packages/components/src/select-control/style.scss
@@ -1,3 +1,20 @@
 .components-select-control__input {
+	background: $white;
+	height: 36px;
+	line-height: 36px;
+	margin: 1px;
+	outline: 0;
 	width: 100%;
+	-webkit-tap-highlight-color: rgba(0, 0, 0, 0) !important;
+
+	@include break-medium() {
+		height: 28px;
+		line-height: 28px;
+	}
+}
+
+@media (max-width: #{ ($break-medium) }) {
+	.components-base-control .components-base-control__field .components-select-control__input {
+		font-size: 16px;
+	}
 }

--- a/packages/editor/src/components/post-format/index.js
+++ b/packages/editor/src/components/post-format/index.js
@@ -7,7 +7,7 @@ import { find, get, includes, union } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { Button, SelectControl } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { withInstanceId, compose } from '@wordpress/compose';
 
@@ -42,15 +42,15 @@ function PostFormat( { onUpdatePostFormat, postFormat = 'standard', supportedFor
 			<div className="editor-post-format">
 				<div className="editor-post-format__content">
 					<label htmlFor={ postFormatSelectorId }>{ __( 'Post Format' ) }</label>
-					<select
+					<SelectControl
 						value={ postFormat }
-						onChange={ ( event ) => onUpdatePostFormat( event.target.value ) }
+						onChange={ ( format ) => onUpdatePostFormat( format ) }
 						id={ postFormatSelectorId }
-					>
-						{ formats.map( ( format ) => (
-							<option key={ format.id } value={ format.id }>{ format.caption }</option>
-						) ) }
-					</select>
+						options={ formats.map( ( format ) => ( {
+							label: format.caption,
+							value: format.id,
+						} ) ) }
+					/>
 				</div>
 
 				{ suggestion && suggestion.id !== postFormat && (


### PR DESCRIPTION
## Description

Add to the `SelectControl` stylesheet all the Core styles it uses, so that, when using Gutenberg outside of WordPress, `SelectControl` keeps the same design.

To test this, we've also replaced the Post Format simple `select` with a `SelectControl`.

cc @mmtr 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tested locally.
To load Gutenberg without Core styles, it's enough to add the following snippet into [`gutenberg.php`](https://github.com/WordPress/gutenberg/blob/master/gutenberg.php):

```php
function remove_default_stylesheets() {
  wp_deregister_style('wp-admin');
}
add_action('admin_init','remove_default_stylesheets');
```

## Screenshots <!-- if applicable -->

| Before | Before w/o Core Styles | After w/o Core Styles | After |
| --- | --- | --- | --- |
| <img width="252" alt="screenshot 2018-10-23 at 15 55 43" src="https://user-images.githubusercontent.com/2070010/47369755-44c96a80-d6dc-11e8-8375-89e2d0d56faa.png"> | <img width="255" alt="screenshot 2018-10-23 at 15 52 22" src="https://user-images.githubusercontent.com/2070010/47369788-5579e080-d6dc-11e8-8a1f-3b2183d6aea9.png"> | <img width="251" alt="screenshot 2018-10-23 at 15 50 01" src="https://user-images.githubusercontent.com/2070010/47369798-59a5fe00-d6dc-11e8-8412-422b4035a249.png"> | <img width="252" alt="screenshot 2018-10-23 at 15 55 43" src="https://user-images.githubusercontent.com/2070010/47369755-44c96a80-d6dc-11e8-8375-89e2d0d56faa.png"> |


## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
