### PR TITLE
Slash autocomplete: Support non-Latin inputs

### DIFF
--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -399,7 +399,7 @@ export class Autocomplete extends Component {
 						return false;
 					}
 
-					return /^\w*$/.test( text.slice( index + triggerPrefix.length ) );
+					return /^\S*$/.test( text.slice( index + triggerPrefix.length ) );
 				} );
 
 				if ( ! open ) {
@@ -408,7 +408,7 @@ export class Autocomplete extends Component {
 				}
 
 				const safeTrigger = escapeRegExp( open.triggerPrefix );
-				const match = text.match( new RegExp( `${ safeTrigger }(\\w*)$` ) );
+				const match = text.match( new RegExp( `${ safeTrigger }(\\S*)$` ) );
 				const query = match && match[ 1 ];
 				const { open: wasOpen, suppress: wasSuppress, query: wasQuery } = this.state;
 


### PR DESCRIPTION
Fixes #10775 

## Description

Fix the `/` autocompleter for non-Latin scripts, i.e. make sure a block type whose name is registered in a non-Latin script (e.g. _Список_ for the List block in Russian) can be chosen from the completer by typing `/сп`.

## Context

In JavaScript regular expressions, `\w` and `\W` only match ASCII-based characters; for example, "a" to "z", "A" to "Z", "0" to "9" and "_". `\w` was used presumably to weed out any whitespace-containing
autocompleter inputs. Instead, look for non-whitespace characters.

## How has this been tested?

1. Set WordPress to Russian.
2. Make sure you have the translation for the plugin: navigate to `/wp-admin/update-core.php` and click on the Upgrade button (can be found in the DOM under ID `upgrade`).
3. Start a new post.
4. In a blank paragraph block, type `/сп`

You should see the List block (_Список_) as the primary result.

Make sure the functionality is kept intact with Latin, and that the autocomplete feature doesn't pop up or disappear at unexpected times.

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->