### PR TITLE
Display correct custom taxonomy labels

### DIFF
--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -174,12 +174,12 @@ class FlatTermSelector extends Component {
 		const termNames = availableTerms.map( ( term ) => term.name );
 		const newTermLabel = get(
 			taxonomy,
-			[ 'data', 'labels', 'add_new_item' ],
+			[ 'labels', 'add_new_item' ],
 			slug === 'post_tag' ? __( 'Add New Tag' ) : __( 'Add New Term' )
 		);
 		const singularName = get(
 			taxonomy,
-			[ 'data', 'labels', 'singular_name' ],
+			[ 'labels', 'singular_name' ],
 			slug === 'post_tag' ? __( 'Tag' ) : __( 'Term' )
 		);
 		const termAddedLabel = sprintf( _x( '%s added', 'term' ), singularName );

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -348,7 +348,7 @@ class HierarchicalTermSelector extends Component {
 		const { availableTermsTree, availableTerms, filteredTermsTree, formName, formParent, loading, showForm, filterValue } = this.state;
 		const labelWithFallback = ( labelProperty, fallbackIsCategory, fallbackIsNotCategory ) => get(
 			taxonomy,
-			[ 'data', 'labels', labelProperty ],
+			[ 'labels', labelProperty ],
 			slug === 'category' ? fallbackIsCategory : fallbackIsNotCategory
 		);
 		const newTermButtonLabel = labelWithFallback(


### PR DESCRIPTION
## Description
The check for taxonomy labels supplied by the REST API used an incorrect property path, so was always falling back to `term` for custom taxonomies. 

Fixes #8448

Tested with a custom taxonomy called "Models" supplying it's own labels. 

### Flat
<img width="284" alt="screen shot 2018-10-23 at 1 38 25 pm" src="https://user-images.githubusercontent.com/4267290/47380377-49d1ee00-d6cb-11e8-91dc-4cea95245a1b.png">
<img width="281" alt="screen shot 2018-10-23 at 1 38 35 pm" src="https://user-images.githubusercontent.com/4267290/47380378-49d1ee00-d6cb-11e8-9ada-2542edd303f1.png">

### Hierarchical
<img width="285" alt="screen shot 2018-10-23 at 2 04 59 pm" src="https://user-images.githubusercontent.com/4267290/47380962-b4cff480-d6cc-11e8-89e7-7c8b011656f5.png">


