### PR TITLE
Add: Stack on mobile option on Media & Text block.

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -18,9 +18,9 @@ import { Component, Fragment } from '@wordpress/element';
 import {
 	PanelBody,
 	TextareaControl,
+	ToggleControl,
 	Toolbar,
 } from '@wordpress/components';
-
 /**
  * Internal dependencies
  */
@@ -112,12 +112,19 @@ class MediaTextEdit extends Component {
 			setAttributes,
 			setBackgroundColor,
 		} = this.props;
-		const { mediaAlt, mediaPosition, mediaType, mediaWidth } = attributes;
+		const {
+			isStackedOnMobile,
+			mediaAlt,
+			mediaPosition,
+			mediaType,
+			mediaWidth,
+		} = attributes;
 		const temporaryMediaWidth = this.state.mediaWidth;
 		const classNames = classnames( className, {
 			'has-media-on-the-right': 'right' === mediaPosition,
 			'is-selected': isSelected,
 			[ backgroundColor.class ]: backgroundColor.class,
+			'is-stacked-on-mobile': isStackedOnMobile,
 		} );
 		const widthString = `${ temporaryMediaWidth || mediaWidth }%`;
 		const style = {
@@ -143,14 +150,21 @@ class MediaTextEdit extends Component {
 		const onMediaAltChange = ( newMediaAlt ) => {
 			setAttributes( { mediaAlt: newMediaAlt } );
 		};
-		const mediaTextGeneralSettings = mediaType === 'image' && (
+		const mediaTextGeneralSettings = (
 			<PanelBody title={ __( 'Media & Text Settings' ) }>
-				<TextareaControl
+				<ToggleControl
+					label={ __( 'Stack on mobile' ) }
+					checked={ isStackedOnMobile }
+					onChange={ () => setAttributes( {
+						isStackedOnMobile: ! isStackedOnMobile,
+					} ) }
+				/>
+				{ mediaType === 'image' && ( <TextareaControl
 					label={ __( 'Alt Text (Alternative Text)' ) }
 					value={ mediaAlt }
 					onChange={ onMediaAltChange }
 					help={ __( 'Alternative text describes your image to people who can’t see it. Add a short description with its key details.' ) }
-				/>
+				/> ) }
 			</PanelBody>
 		);
 		return (

--- a/packages/block-library/src/media-text/editor.scss
+++ b/packages/block-library/src/media-text/editor.scss
@@ -1,12 +1,10 @@
-.wp-block-media-text,
-.wp-block-media-text.aligncenter {
+.wp-block-media-text {
 	grid-template-areas:
 		"media-text-media media-text-content"
 		"resizer resizer";
 }
 
-.wp-block-media-text.has-media-on-the-right,
-.wp-block-media-text.has-media-on-the-right.aligncenter {
+.wp-block-media-text.has-media-on-the-right {
 	grid-template-areas:
 		"media-text-content media-text-media"
 		"resizer resizer";
@@ -51,8 +49,17 @@ figure.block-library-media-text__media-container {
 	display: none;
 }
 
-.wp-block-media-text.is-selected {
+.wp-block-media-text.is-selected:not(.is-stacked-on-mobile) {
 	.editor-media-container__resizer .components-resizable-box__handle {
 		display: block;
 	}
 }
+
+@include break-small {
+	.wp-block-media-text.is-selected.is-stacked-on-mobile {
+		.editor-media-container__resizer .components-resizable-box__handle {
+			display: block;
+		}
+	}
+}
+

--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -70,6 +70,10 @@ export const settings = {
 			type: 'number',
 			default: 50,
 		},
+		isStackedOnMobile: {
+			type: 'boolean',
+			default: false,
+		},
 	},
 
 	supports: {
@@ -82,6 +86,7 @@ export const settings = {
 		const {
 			backgroundColor,
 			customBackgroundColor,
+			isStackedOnMobile,
 			mediaAlt,
 			mediaPosition,
 			mediaType,
@@ -97,6 +102,7 @@ export const settings = {
 		const className = classnames( {
 			'has-media-on-the-right': 'right' === mediaPosition,
 			[ backgroundClass ]: backgroundClass,
+			'is-stacked-on-mobile': isStackedOnMobile,
 		} );
 
 		let gridTemplateColumns;

--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -1,14 +1,14 @@
-.wp-block-media-text,
-.wp-block-media-text.aligncenter {
+.wp-block-media-text {
 	display: grid;
 }
 
 .wp-block-media-text {
 	grid-template-rows: auto;
-	grid-template-areas: "media-text-media media-text-content";
 	align-items: center;
+	grid-template-areas: "media-text-media media-text-content";
 	grid-template-columns: 50% auto;
 	.has-media-on-the-right {
+		grid-template-areas: "media-text-content media-text-media";
 		grid-template-columns: auto 50%;
 	}
 }
@@ -23,13 +23,32 @@
 	grid-area: media-text-content;
 	padding: 0 8% 0 8%;
 }
-.wp-block-media-text.has-media-on-the-right {
-	grid-template-areas: "media-text-content media-text-media";
-}
 
 .wp-block-media-text > figure > img,
 .wp-block-media-text > figure > video {
 	max-width: unset;
 	width: 100%;
 	vertical-align: middle;
+}
+
+/*
+* Here we here not able to use a mobile first CSS approach.
+* Custom widths are set using inline styles, and on mobile,
+* we need 100% width, so we use important to overwrite the inline style.
+* If the style were set on mobile first, on desktop styles,
+* we would have no way of setting the style again to the inline style.
+*/
+@media (max-width: #{ ($break-small) }) {
+	.wp-block-media-text.is-stacked-on-mobile {
+		grid-template-columns: 100% !important;
+		grid-template-areas:
+			"media-text-media"
+			"media-text-content";
+	}
+
+	.wp-block-media-text.is-stacked-on-mobile.has-media-on-the-right {
+		grid-template-areas:
+			"media-text-content"
+			"media-text-media";
+	}
 }

--- a/test/integration/full-content/fixtures/core__media-text__image-alt-no-align.json
+++ b/test/integration/full-content/fixtures/core__media-text__image-alt-no-align.json
@@ -10,7 +10,8 @@
             "mediaId": 17985,
             "mediaUrl": "http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg",
             "mediaType": "image",
-            "mediaWidth": 50
+            "mediaWidth": 50,
+            "isStackedOnMobile": false
         },
         "innerBlocks": [
             {

--- a/test/integration/full-content/fixtures/core__media-text__is-stacked-on-mobile.html
+++ b/test/integration/full-content/fixtures/core__media-text__is-stacked-on-mobile.html
@@ -1,0 +1,12 @@
+<!-- wp:media-text {"mediaId":17897,"mediaType":"video", "isStackedOnMobile": true} -->
+<div class="wp-block-media-text alignwide is-stacked-on-mobile">
+	<figure class="wp-block-media-text__media">
+		<video controls src="http://localhost/wp-content/uploads/2018/09/Jul-26-2018-11-34-54.mp4"></video>
+	</figure>
+	<div class="wp-block-media-text__content">
+		<!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->
+		<p class="has-large-font-size">My Content</p>
+		<!-- /wp:paragraph -->
+	</div>
+</div>
+<!-- /wp:media-text -->

--- a/test/integration/full-content/fixtures/core__media-text__is-stacked-on-mobile.json
+++ b/test/integration/full-content/fixtures/core__media-text__is-stacked-on-mobile.json
@@ -7,11 +7,11 @@
             "align": "wide",
             "mediaAlt": "",
             "mediaPosition": "left",
-            "mediaId": 17985,
-            "mediaUrl": "http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg",
-            "mediaType": "image",
+            "mediaId": 17897,
+            "mediaUrl": "http://localhost/wp-content/uploads/2018/09/Jul-26-2018-11-34-54.mp4",
+            "mediaType": "video",
             "mediaWidth": 50,
-            "isStackedOnMobile": false
+            "isStackedOnMobile": true
         },
         "innerBlocks": [
             {
@@ -28,6 +28,6 @@
                 "originalContent": "<p class=\"has-large-font-size\">My Content</p>"
             }
         ],
-        "originalContent": "<div class=\"wp-block-media-text alignwide\">\n\t<figure class=\"wp-block-media-text__media\">\n\t\t<img src=\"http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg\" alt=\"\"/>\n\t</figure>\n\t<div class=\"wp-block-media-text__content\">\n\t\t\n\t</div>\n</div>"
+        "originalContent": "<div class=\"wp-block-media-text alignwide is-stacked-on-mobile\">\n\t<figure class=\"wp-block-media-text__media\">\n\t\t<video controls src=\"http://localhost/wp-content/uploads/2018/09/Jul-26-2018-11-34-54.mp4\"></video>\n\t</figure>\n\t<div class=\"wp-block-media-text__content\">\n\t\t\n\t</div>\n</div>"
     }
 ]

--- a/test/integration/full-content/fixtures/core__media-text__is-stacked-on-mobile.parsed.json
+++ b/test/integration/full-content/fixtures/core__media-text__is-stacked-on-mobile.parsed.json
@@ -1,0 +1,28 @@
+[
+    {
+        "blockName": "core/media-text",
+        "attrs": {
+            "mediaId": 17897,
+            "mediaType": "video",
+            "isStackedOnMobile": true
+        },
+        "innerBlocks": [
+            {
+                "blockName": "core/paragraph",
+                "attrs": {
+                    "placeholder": "Content…",
+                    "fontSize": "large"
+                },
+                "innerBlocks": [],
+                "innerHTML": "\n\t\t<p class=\"has-large-font-size\">My Content</p>\n\t\t"
+            }
+        ],
+        "innerHTML": "\n<div class=\"wp-block-media-text alignwide is-stacked-on-mobile\">\n\t<figure class=\"wp-block-media-text__media\">\n\t\t<video controls src=\"http://localhost/wp-content/uploads/2018/09/Jul-26-2018-11-34-54.mp4\"></video>\n\t</figure>\n\t<div class=\"wp-block-media-text__content\">\n\t\t\n\t</div>\n</div>\n"
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n"
+    }
+]

--- a/test/integration/full-content/fixtures/core__media-text__is-stacked-on-mobile.serialized.html
+++ b/test/integration/full-content/fixtures/core__media-text__is-stacked-on-mobile.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:media-text {"mediaId":17897,"mediaType":"video","isStackedOnMobile":true} -->
+<div class="wp-block-media-text alignwide is-stacked-on-mobile"><figure class="wp-block-media-text__media"><video controls src="http://localhost/wp-content/uploads/2018/09/Jul-26-2018-11-34-54.mp4"></video></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->
+<p class="has-large-font-size">My Content</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:media-text -->

--- a/test/integration/full-content/fixtures/core__media-text__media-right-custom-width.json
+++ b/test/integration/full-content/fixtures/core__media-text__media-right-custom-width.json
@@ -10,7 +10,8 @@
             "mediaId": 17897,
             "mediaUrl": "http://localhost/wp-content/uploads/2018/09/Jul-26-2018-11-34-54.mp4",
             "mediaType": "video",
-            "mediaWidth": 41
+            "mediaWidth": 41,
+            "isStackedOnMobile": false
         },
         "innerBlocks": [
             {

--- a/test/integration/full-content/fixtures/core__media-text__video.json
+++ b/test/integration/full-content/fixtures/core__media-text__video.json
@@ -10,7 +10,8 @@
             "mediaId": 17897,
             "mediaUrl": "http://localhost/wp-content/uploads/2018/09/Jul-26-2018-11-34-54.mp4",
             "mediaType": "video",
-            "mediaWidth": 50
+            "mediaWidth": 50,
+            "isStackedOnMobile": false
         },
         "innerBlocks": [
             {


### PR DESCRIPTION
## Description
Closes: https://github.com/WordPress/gutenberg/issues/10798

This PR adds a "Stack on mobile" option on media & text block.
If this option is enabled, on mobile instead of the Media & content area appearing side by side they appear stacked up.

## How has this been tested?
I checked media & text block continues to work as before.
I checked that of "Stack on mobile" options is true contents appear stacked up on mobile but on large screens continue to appear side by side.
## Screenshots <!-- if applicable -->
![oct-23-2018 20-08-55](https://user-images.githubusercontent.com/11271197/47384774-26756600-d700-11e8-9a34-89c72b56d76f.gif)
