### PR TITLE
Try different block descriptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2443,6 +2443,7 @@
 			"requires": {
 				"@babel/runtime": "^7.0.0",
 				"@wordpress/data": "file:packages/data",
+				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/escape-html": "file:packages/escape-html",
 				"lodash": "^4.17.10",
 				"rememo": "^3.0.0"

--- a/packages/block-library/src/archives/index.js
+++ b/packages/block-library/src/archives/index.js
@@ -14,7 +14,7 @@ export const name = 'core/archives';
 export const settings = {
 	title: __( 'Archives' ),
 
-	description: __( 'Display a monthly archive of your site’s Posts.' ),
+	description: __( 'Display a monthly archive of your posts.' ),
 
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M7 11h2v2H7v-2zm14-5v14l-2 2H5l-2-2V6l2-2h1V2h2v2h8V2h2v2h1l2 2zM5 8h14V6H5v2zm14 12V10H5v10h14zm-4-7h2v-2h-2v2zm-4 0h2v-2h-2v2z" /></G></SVG>,
 

--- a/packages/block-library/src/audio/index.js
+++ b/packages/block-library/src/audio/index.js
@@ -17,7 +17,7 @@ export const name = 'core/audio';
 export const settings = {
 	title: __( 'Audio' ),
 
-	description: __( 'Embed an audio file and a simple audio player.' ),
+	description: __( 'Embed a simple audio player.' ),
 
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Path d="m12 3l0.01 10.55c-0.59-0.34-1.27-0.55-2-0.55-2.22 0-4.01 1.79-4.01 4s1.79 4 4.01 4 3.99-1.79 3.99-4v-10h4v-4h-6zm-1.99 16c-1.1 0-2-0.9-2-2s0.9-2 2-2 2 0.9 2 2-0.9 2-2 2z" /></SVG>,
 

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -64,7 +64,7 @@ const colorsMigration = ( attributes ) => {
 export const settings = {
 	title: __( 'Button' ),
 
-	description: __( 'Want visitors to click to subscribe, buy, or read more? Get their attention with a button.' ),
+	description: __( 'Prompt visitors to take action with a custom button.' ),
 
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M19 6H5L3 8v8l2 2h14l2-2V8l-2-2zm0 10H5V8h14v8z" /></G></SVG>,
 

--- a/packages/block-library/src/categories/index.js
+++ b/packages/block-library/src/categories/index.js
@@ -14,7 +14,7 @@ export const name = 'core/categories';
 export const settings = {
 	title: __( 'Categories' ),
 
-	description: __( 'Display a list of all your site’s categories.' ),
+	description: __( 'Display a list of all categories.' ),
 
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Path d="M12,2l-5.5,9h11L12,2z M12,5.84L13.93,9h-3.87L12,5.84z" /><Path d="m17.5 13c-2.49 0-4.5 2.01-4.5 4.5s2.01 4.5 4.5 4.5 4.5-2.01 4.5-4.5-2.01-4.5-4.5-4.5zm0 7c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z" /><Path d="m3 21.5h8v-8h-8v8zm2-6h4v4h-4v-4z" /></SVG>,
 

--- a/packages/block-library/src/classic/index.js
+++ b/packages/block-library/src/classic/index.js
@@ -15,7 +15,7 @@ export const name = 'core/freeform';
 export const settings = {
 	title: _x( 'Classic', 'block title' ),
 
-	description: __( 'It’s the classic WordPress editor and it’s a block! Drop the editor right in.' ),
+	description: __( 'Use the classic WordPress editor.' ),
 
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z M0,0h24v24H0V0z" fill="none" /><Path d="m20 7v10h-16v-10h16m0-2h-16c-1.1 0-1.99 0.9-1.99 2l-0.01 10c0 1.1 0.9 2 2 2h16c1.1 0 2-0.9 2-2v-10c0-1.1-0.9-2-2-2z" /><Rect x="11" y="8" width="2" height="2" /><Rect x="11" y="11" width="2" height="2" /><Rect x="8" y="8" width="2" height="2" /><Rect x="8" y="11" width="2" height="2" /><Rect x="5" y="11" width="2" height="2" /><Rect x="5" y="8" width="2" height="2" /><Rect x="8" y="14" width="8" height="2" /><Rect x="14" y="11" width="2" height="2" /><Rect x="14" y="8" width="2" height="2" /><Rect x="17" y="11" width="2" height="2" /><Rect x="17" y="8" width="2" height="2" /></SVG>,
 

--- a/packages/block-library/src/code/index.js
+++ b/packages/block-library/src/code/index.js
@@ -18,7 +18,7 @@ export const name = 'core/code';
 export const settings = {
 	title: __( 'Code' ),
 
-	description: __( 'Add text that respects your spacing and tabs -- perfect for displaying code.' ),
+	description: __( 'Display code snippets that respect your spacing and tabs.' ),
 
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Path d="M9.4,16.6L4.8,12l4.6-4.6L8,6l-6,6l6,6L9.4,16.6z M14.6,16.6l4.6-4.6l-4.6-4.6L16,6l6,6l-6,6L14.6,16.6z" /></SVG>,
 

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -83,7 +83,7 @@ const VIDEO_BACKGROUND_TYPE = 'video';
 export const settings = {
 	title: __( 'Cover' ),
 
-	description: __( 'Add a full-width image or video, and layer text over it — great for headers.' ),
+	description: __( 'Add an image or video with a text overlay — great for headers.' ),
 
 	icon: <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M4 4h7V2H4c-1.1 0-2 .9-2 2v7h2V4zm6 9l-4 5h12l-3-4-2.03 2.71L10 13zm7-4.5c0-.83-.67-1.5-1.5-1.5S14 7.67 14 8.5s.67 1.5 1.5 1.5S17 9.33 17 8.5zM20 2h-7v2h7v7h2V4c0-1.1-.9-2-2-2zm0 18h-7v2h7c1.1 0 2-.9 2-2v-7h-2v7zM4 13H2v7c0 1.1.9 2 2 2h7v-2H4v-7z" /><Path d="M0 0h24v24H0z" fill="none" /></SVG>,
 

--- a/packages/block-library/src/embed/core-embeds.js
+++ b/packages/block-library/src/embed/core-embeds.js
@@ -31,6 +31,7 @@ export const common = [
 			title: 'Twitter',
 			icon: embedTwitterIcon,
 			keywords: [ 'tweet' ],
+			description: __( 'Embed a tweet' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?twitter\.com\/.+/i ],
 	},
@@ -40,6 +41,7 @@ export const common = [
 			title: 'YouTube',
 			icon: embedYouTubeIcon,
 			keywords: [ __( 'music' ), __( 'video' ) ],
+			description: __( 'Embed a YouTube video' ),
 		},
 		patterns: [ /^https?:\/\/((m|www)\.)?youtube\.com\/.+/i, /^https?:\/\/youtu\.be\/.+/i ],
 	},
@@ -48,6 +50,7 @@ export const common = [
 		settings: {
 			title: 'Facebook',
 			icon: embedFacebookIcon,
+			description: __( 'Embed a Facebook post' ),
 		},
 		patterns: [ /^https?:\/\/www\.facebook.com\/.+/i ],
 	},
@@ -57,6 +60,7 @@ export const common = [
 			title: 'Instagram',
 			icon: embedInstagramIcon,
 			keywords: [ __( 'image' ) ],
+			description: __( 'Embed an Instagram post' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?instagr(\.am|am\.com)\/.+/i ],
 	},
@@ -67,6 +71,7 @@ export const common = [
 			icon: embedWordPressIcon,
 			keywords: [ __( 'post' ), __( 'blog' ) ],
 			responsive: false,
+			description: __( 'Embed a WordPress post' ),
 		},
 	},
 	{
@@ -75,6 +80,7 @@ export const common = [
 			title: 'SoundCloud',
 			icon: embedAudioIcon,
 			keywords: [ __( 'music' ), __( 'audio' ) ],
+			description: __( 'Embed SoundCloud content' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?soundcloud\.com\/.+/i ],
 	},
@@ -84,6 +90,7 @@ export const common = [
 			title: 'Spotify',
 			icon: embedSpotifyIcon,
 			keywords: [ __( 'music' ), __( 'audio' ) ],
+			description: __( 'Embed Spotify content' ),
 		},
 		patterns: [ /^https?:\/\/(open|play)\.spotify\.com\/.+/i ],
 	},
@@ -93,6 +100,7 @@ export const common = [
 			title: 'Flickr',
 			icon: embedFlickrIcon,
 			keywords: [ __( 'image' ) ],
+			description: __( 'Embed Flickr content' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?flickr\.com\/.+/i, /^https?:\/\/flic\.kr\/.+/i ],
 	},
@@ -102,6 +110,7 @@ export const common = [
 			title: 'Vimeo',
 			icon: embedVimeoIcon,
 			keywords: [ __( 'video' ) ],
+			description: __( 'Embed a Vimeo video' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?vimeo\.com\/.+/i ],
 	},
@@ -113,6 +122,7 @@ export const others = [
 		settings: {
 			title: 'Animoto',
 			icon: embedVideoIcon,
+			description: __( 'Embed an Animoto video' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?(animoto|video214)\.com\/.+/i ],
 	},
@@ -121,6 +131,7 @@ export const others = [
 		settings: {
 			title: 'Cloudup',
 			icon: embedContentIcon,
+			description: __( 'Embed Cloudup content' ),
 		},
 		patterns: [ /^https?:\/\/cloudup\.com\/.+/i ],
 	},
@@ -129,6 +140,7 @@ export const others = [
 		settings: {
 			title: 'CollegeHumor',
 			icon: embedVideoIcon,
+			description: __( 'Embed CollegeHumor content' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?collegehumor\.com\/.+/i ],
 	},
@@ -137,6 +149,7 @@ export const others = [
 		settings: {
 			title: 'Dailymotion',
 			icon: embedVideoIcon,
+			description: __( 'Embed a Dailymotion video' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?dailymotion\.com\/.+/i ],
 	},
@@ -145,6 +158,7 @@ export const others = [
 		settings: {
 			title: 'Funny or Die',
 			icon: embedVideoIcon,
+			description: __( 'Embed Funny or Die content' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?funnyordie\.com\/.+/i ],
 	},
@@ -153,6 +167,7 @@ export const others = [
 		settings: {
 			title: 'Hulu',
 			icon: embedVideoIcon,
+			description: __( 'Embed Hulu content' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?hulu\.com\/.+/i ],
 	},
@@ -161,6 +176,7 @@ export const others = [
 		settings: {
 			title: 'Imgur',
 			icon: embedPhotoIcon,
+			description: __( 'Embed Imgur content' ),
 		},
 		patterns: [ /^https?:\/\/(.+\.)?imgur\.com\/.+/i ],
 	},
@@ -169,6 +185,7 @@ export const others = [
 		settings: {
 			title: 'Issuu',
 			icon: embedContentIcon,
+			description: __( 'Embed Issuu content' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?issuu\.com\/.+/i ],
 	},
@@ -177,6 +194,7 @@ export const others = [
 		settings: {
 			title: 'Kickstarter',
 			icon: embedContentIcon,
+			description: __( 'Embed Kickstarter content' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?kickstarter\.com\/.+/i, /^https?:\/\/kck\.st\/.+/i ],
 	},
@@ -185,6 +203,7 @@ export const others = [
 		settings: {
 			title: 'Meetup.com',
 			icon: embedContentIcon,
+			description: __( 'Embed Meetup.com content' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?meetu(\.ps|p\.com)\/.+/i ],
 	},
@@ -194,6 +213,7 @@ export const others = [
 			title: 'Mixcloud',
 			icon: embedAudioIcon,
 			keywords: [ __( 'music' ), __( 'audio' ) ],
+			description: __( 'Embed Mixcloud content' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?mixcloud\.com\/.+/i ],
 	},
@@ -202,6 +222,7 @@ export const others = [
 		settings: {
 			title: 'Photobucket',
 			icon: embedPhotoIcon,
+			description: __( 'Embed a Photobucket image' ),
 		},
 		patterns: [ /^http:\/\/g?i*\.photobucket\.com\/.+/i ],
 	},
@@ -210,6 +231,7 @@ export const others = [
 		settings: {
 			title: 'Polldaddy',
 			icon: embedContentIcon,
+			description: __( 'Embed Polldaddy content' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?polldaddy\.com\/.+/i ],
 	},
@@ -218,6 +240,7 @@ export const others = [
 		settings: {
 			title: 'Reddit',
 			icon: embedRedditIcon,
+			description: __( 'Embed a Reddit thread' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?reddit\.com\/.+/i ],
 	},
@@ -226,6 +249,7 @@ export const others = [
 		settings: {
 			title: 'ReverbNation',
 			icon: embedAudioIcon,
+			description: __( 'Embed ReverbNation content' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?reverbnation\.com\/.+/i ],
 	},
@@ -234,6 +258,7 @@ export const others = [
 		settings: {
 			title: 'Screencast',
 			icon: embedVideoIcon,
+			description: __( 'Embed Screencast content' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?screencast\.com\/.+/i ],
 	},
@@ -242,6 +267,7 @@ export const others = [
 		settings: {
 			title: 'Scribd',
 			icon: embedContentIcon,
+			description: __( 'Embed Scribd content' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?scribd\.com\/.+/i ],
 	},
@@ -250,6 +276,7 @@ export const others = [
 		settings: {
 			title: 'Slideshare',
 			icon: embedContentIcon,
+			description: __( 'Embed Slideshare content' ),
 		},
 		patterns: [ /^https?:\/\/(.+?\.)?slideshare\.net\/.+/i ],
 	},
@@ -258,6 +285,7 @@ export const others = [
 		settings: {
 			title: 'SmugMug',
 			icon: embedPhotoIcon,
+			description: __( 'Embed SmugMug content' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?smugmug\.com\/.+/i ],
 	},
@@ -287,6 +315,7 @@ export const others = [
 					} );
 				},
 			} ],
+			description: __( 'Embed Speaker Deck content' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?speakerdeck\.com\/.+/i ],
 	},
@@ -295,6 +324,7 @@ export const others = [
 		settings: {
 			title: 'TED',
 			icon: embedVideoIcon,
+			description: __( 'Embed a TED video' ),
 		},
 		patterns: [ /^https?:\/\/(www\.|embed\.)?ted\.com\/.+/i ],
 	},
@@ -303,6 +333,7 @@ export const others = [
 		settings: {
 			title: 'Tumblr',
 			icon: embedTumbrIcon,
+			description: __( 'Embed a Tumblr post' ),
 		},
 		patterns: [ /^https?:\/\/(www\.)?tumblr\.com\/.+/i ],
 	},
@@ -312,6 +343,7 @@ export const others = [
 			title: 'VideoPress',
 			icon: embedVideoIcon,
 			keywords: [ __( 'video' ) ],
+			description: __( 'Embed a VideoPress video' ),
 		},
 		patterns: [ /^https?:\/\/videopress\.com\/.+/i ],
 	},
@@ -320,6 +352,7 @@ export const others = [
 		settings: {
 			title: 'WordPress.tv',
 			icon: embedVideoIcon,
+			description: __( 'Embed a WordPress.tv video' ),
 		},
 		patterns: [ /^https?:\/\/wordpress\.tv\/.+/i ],
 	},

--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -15,7 +15,7 @@ export const name = 'core/embed';
 
 export const settings = getEmbedBlockSettings( {
 	title: _x( 'Embed', 'block title' ),
-	description: __( 'The Embed block allows you to easily add videos, images, tweets, audio, and other content to your post or page.' ),
+	description: __( 'Embed videos, images, tweets, audio, and other content from external sources.' ),
 	icon: embedContentIcon,
 	// Unknown embeds should not be responsive by default.
 	responsive: false,

--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -23,7 +23,7 @@ export const name = 'core/file';
 export const settings = {
 	title: __( 'File' ),
 
-	description: __( 'Add a link to a file that visitors can download.' ),
+	description: __( 'Add a link to a downloadable file.' ),
 
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><Path d="M9 6l2 2h9v10H4V6h5m1-2H4L2 6v12l2 2h16l2-2V8l-2-2h-8l-2-2z" /></SVG>,
 

--- a/packages/block-library/src/gallery/index.js
+++ b/packages/block-library/src/gallery/index.js
@@ -69,7 +69,7 @@ export const name = 'core/gallery';
 
 export const settings = {
 	title: __( 'Gallery' ),
-	description: __( 'Display multiple images in an elegantly organized tiled layout.' ),
+	description: __( 'Display multiple images in a rich gallery.' ),
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M20 4v12H8V4h12m0-2H8L6 4v12l2 2h12l2-2V4l-2-2z" /><Path d="M12 12l1 2 3-3 3 4H9z" /><Path d="M2 6v14l2 2h14v-2H4V6H2z" /></G></SVG>,
 	category: 'common',
 	keywords: [ __( 'images' ), __( 'photos' ) ],

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -64,7 +64,7 @@ export const name = 'core/heading';
 export const settings = {
 	title: __( 'Heading' ),
 
-	description: __( 'Introduce topics and help visitors (and search engines!) understand how your content is organized.' ),
+	description: __( 'Introduce new sections and organize content.' ),
 
 	icon: <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M5 4v3h5.5v12h3V7H19V4z" /><Path fill="none" d="M0 0h24v24H0V0z" /></SVG>,
 

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -64,7 +64,7 @@ export const name = 'core/heading';
 export const settings = {
 	title: __( 'Heading' ),
 
-	description: __( 'Introduce new sections and organize content.' ),
+	description: __( 'Introduce new sections and organize content to help visitors (and search engines) understand the structure of your content.' ),
 
 	icon: <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M5 4v3h5.5v12h3V7H19V4z" /><Path fill="none" d="M0 0h24v24H0V0z" /></SVG>,
 

--- a/packages/block-library/src/html/index.js
+++ b/packages/block-library/src/html/index.js
@@ -13,7 +13,7 @@ export const name = 'core/html';
 export const settings = {
 	title: __( 'Custom HTML' ),
 
-	description: __( 'Add your own HTML (and view it right here as you edit!).' ),
+	description: __( 'Add custom HTML code and preview it as you edit.' ),
 
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M4.5,11h-2V9H1v6h1.5v-2.5h2V15H6V9H4.5V11z M7,10.5h1.5V15H10v-4.5h1.5V9H7V10.5z M14.5,10l-1-1H12v6h1.5v-3.9  l1,1l1-1V15H17V9h-1.5L14.5,10z M19.5,13.5V9H18v6h5v-1.5H19.5z" /></SVG>,
 

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -103,7 +103,7 @@ const schema = {
 export const settings = {
 	title: __( 'Image' ),
 
-	description: __( 'They’re worth 1,000 words! Insert a single image.' ),
+	description: __( 'Insert an image for visual color.' ),
 
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Path d="m19 5v14h-14v-14h14m0-2h-14c-1.1 0-2 0.9-2 2v14c0 1.1 0.9 2 2 2h14c1.1 0 2-0.9 2-2v-14c0-1.1-0.9-2-2-2z" /><Path d="m14.14 11.86l-3 3.87-2.14-2.59-3 3.86h12l-3.86-5.14z" /></SVG>,
 

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -103,7 +103,7 @@ const schema = {
 export const settings = {
 	title: __( 'Image' ),
 
-	description: __( 'Insert an image for visual color.' ),
+	description: __( 'Insert an image to make a visual statement.' ),
 
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Path d="m19 5v14h-14v-14h14m0-2h-14c-1.1 0-2 0.9-2 2v14c0 1.1 0.9 2 2 2h14c1.1 0 2-0.9 2-2v-14c0-1.1-0.9-2-2-2z" /><Path d="m14.14 11.86l-3 3.87-2.14-2.59-3 3.86h12l-3.86-5.14z" /></SVG>,
 

--- a/packages/block-library/src/latest-comments/index.js
+++ b/packages/block-library/src/latest-comments/index.js
@@ -14,7 +14,7 @@ export const name = 'core/latest-comments';
 export const settings = {
 	title: __( 'Latest Comments' ),
 
-	description: __( 'Show a list of your site’s most recent comments.' ),
+	description: __( 'Display a list of your most recent comments.' ),
 
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M22 4l-2-2H4L2 4v12l2 2h14l4 4V4zm-2 0v13l-1-1H4V4h16z" /><Path d="M6 12h12v2H6zM6 9h12v2H6zM6 6h12v2H6z" /></G></SVG>,
 

--- a/packages/block-library/src/list/index.js
+++ b/packages/block-library/src/list/index.js
@@ -60,7 +60,7 @@ export const name = 'core/list';
 
 export const settings = {
 	title: __( 'List' ),
-	description: __( 'Numbers, bullets, up to you. Add a list of items.' ),
+	description: __( 'Create a bulleted or numbered list.' ),
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><G><Path d="M9 19h12v-2H9v2zm0-6h12v-2H9v2zm0-8v2h12V5H9zm-4-.5c-.828 0-1.5.672-1.5 1.5S4.172 7.5 5 7.5 6.5 6.828 6.5 6 5.828 4.5 5 4.5zm0 6c-.828 0-1.5.672-1.5 1.5s.672 1.5 1.5 1.5 1.5-.672 1.5-1.5-.672-1.5-1.5-1.5zm0 6c-.828 0-1.5.672-1.5 1.5s.672 1.5 1.5 1.5 1.5-.672 1.5-1.5-.672-1.5-1.5-1.5z" /></G></SVG>,
 	category: 'common',
 	keywords: [ __( 'bullet list' ), __( 'ordered list' ), __( 'numbered list' ) ],

--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -26,6 +26,8 @@ export const name = 'core/media-text';
 export const settings = {
 	title: __( 'Media & Text' ),
 
+	description: __( 'Set media and words side-by-side media for a richer layout.' ),
+
 	icon: <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M13 17h8v-2h-8v2zM3 19h8V5H3v14zM13 9h8V7h-8v2zm0 4h8v-2h-8v2z" /></SVG>,
 
 	category: 'layout',

--- a/packages/block-library/src/more/index.js
+++ b/packages/block-library/src/more/index.js
@@ -25,7 +25,7 @@ export const name = 'core/more';
 export const settings = {
 	title: _x( 'More', 'block name' ),
 
-	description: __( 'Want to show only part of this post on your blog’s home page? Insert a "More" block where you want the split.' ),
+	description: __( 'Want to show only an excerpt of this post on your home page? Use this block to define where you want the separation.' ),
 
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M2 9v2h19V9H2zm0 6h5v-2H2v2zm7 0h5v-2H9v2zm7 0h5v-2h-5v2z" /></G></SVG>,
 

--- a/packages/block-library/src/nextpage/index.js
+++ b/packages/block-library/src/nextpage/index.js
@@ -11,7 +11,7 @@ export const name = 'core/nextpage';
 export const settings = {
 	title: __( 'Page break' ),
 
-	description: __( 'This block allows you to set break points on your post. Visitors of your blog are then presented with content split into multiple pages.' ),
+	description: __( 'Separate your content into a multi-page experience.' ),
 
 	icon: <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><G><Path d="M9 12h6v-2H9zm-7 0h5v-2H2zm15 0h5v-2h-5zm3 2v2l-6 6H6a2 2 0 0 1-2-2v-6h2v6h6v-4a2 2 0 0 1 2-2h6zM4 8V4a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v4h-2V4H6v4z" /></G></SVG>,
 

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -77,7 +77,7 @@ export const name = 'core/paragraph';
 export const settings = {
 	title: __( 'Paragraph' ),
 
-	description: __( 'Add some basic text.' ),
+	description: __( 'Start with the building block of all narrative.' ),
 
 	icon: <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M11 5v7H9.5C7.6 12 6 10.4 6 8.5S7.6 5 9.5 5H11m8-2H9.5C6.5 3 4 5.5 4 8.5S6.5 14 9.5 14H11v7h2V5h2v16h2V5h2V3z" /></SVG>,
 

--- a/packages/block-library/src/preformatted/index.js
+++ b/packages/block-library/src/preformatted/index.js
@@ -11,7 +11,7 @@ export const name = 'core/preformatted';
 export const settings = {
 	title: __( 'Preformatted' ),
 
-	description: __( 'Add text that respects your spacing and tabs, and also allows styling.' ),
+	description: __( 'Add custom HTML code and preview it as you edit.' ),
 
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Path d="M20,4H4C2.9,4,2,4.9,2,6v12c0,1.1,0.9,2,2,2h16c1.1,0,2-0.9,2-2V6C22,4.9,21.1,4,20,4z M20,18H4V6h16V18z" /><Rect x="6" y="10" width="2" height="2" /><Rect x="6" y="14" width="8" height="2" /><Rect x="16" y="14" width="2" height="2" /><Rect x="10" y="10" width="8" height="2" /></SVG>,
 

--- a/packages/block-library/src/preformatted/index.js
+++ b/packages/block-library/src/preformatted/index.js
@@ -11,7 +11,7 @@ export const name = 'core/preformatted';
 export const settings = {
 	title: __( 'Preformatted' ),
 
-	description: __( 'Add custom HTML code and preview it as you edit.' ),
+	description: __( 'Add text that respects your spacing and tabs, and also allows styling.' ),
 
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Path d="M20,4H4C2.9,4,2,4.9,2,6v12c0,1.1,0.9,2,2,2h16c1.1,0,2-0.9,2-2V6C22,4.9,21.1,4,20,4z M20,18H4V6h16V18z" /><Rect x="6" y="10" width="2" height="2" /><Rect x="6" y="14" width="8" height="2" /><Rect x="16" y="14" width="2" height="2" /><Rect x="10" y="10" width="8" height="2" /></SVG>,
 

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -57,7 +57,7 @@ export const settings = {
 
 	title: __( 'Pullquote' ),
 
-	description: __( 'Highlight a quote from your post or page by displaying it as a graphic element.' ),
+	description: __( 'Give special visual emphasis to a quote from your text.' ),
 
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Polygon points="21 18 2 18 2 20 21 20" /><Path d="m19 10v4h-15v-4h15m1-2h-17c-0.55 0-1 0.45-1 1v6c0 0.55 0.45 1 1 1h17c0.55 0 1-0.45 1-1v-6c0-0.55-0.45-1-1-1z" /><Polygon points="21 4 2 4 2 6 21 6" /></SVG>,
 

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -40,7 +40,7 @@ export const name = 'core/quote';
 
 export const settings = {
 	title: __( 'Quote' ),
-	description: __( 'Give quoted text visual emphasis.' ),
+	description: __( 'Give quoted text visual emphasis. "In quoting others, we cite ourselves." — Julio Cortázar' ),
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M19 18h-6l2-4h-2V6h8v7l-2 5zm-2-2l2-3V8h-4v4h4l-2 4zm-8 2H3l2-4H3V6h8v7l-2 5zm-2-2l2-3V8H5v4h4l-2 4z" /></G></SVG>,
 	category: 'common',
 	keywords: [ __( 'blockquote' ) ],

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -40,7 +40,7 @@ export const name = 'core/quote';
 
 export const settings = {
 	title: __( 'Quote' ),
-	description: __( 'Maybe someone else said it better -- add some quoted text.' ),
+	description: __( 'Give quoted text visual emphasis.' ),
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M19 18h-6l2-4h-2V6h8v7l-2 5zm-2-2l2-3V8h-4v4h4l-2 4zm-8 2H3l2-4H3V6h8v7l-2 5zm-2-2l2-3V8H5v4h4l-2 4z" /></G></SVG>,
 	category: 'common',
 	keywords: [ __( 'blockquote' ) ],

--- a/packages/block-library/src/separator/index.js
+++ b/packages/block-library/src/separator/index.js
@@ -10,7 +10,7 @@ export const name = 'core/separator';
 export const settings = {
 	title: __( 'Separator' ),
 
-	description: __( 'Insert a horizontal line where you want to create a break between ideas.' ),
+	description: __( 'Create a break between ideas or sections with a horizontal line.' ),
 
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><Path d="M19 13H5v-2h14v2z" /></SVG>,
 

--- a/packages/block-library/src/separator/index.js
+++ b/packages/block-library/src/separator/index.js
@@ -10,7 +10,7 @@ export const name = 'core/separator';
 export const settings = {
 	title: __( 'Separator' ),
 
-	description: __( 'Create a break between ideas or sections with a horizontal line.' ),
+	description: __( 'Create a break between ideas or sections with a horizontal separator.' ),
 
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><Path d="M19 13H5v-2h14v2z" /></SVG>,
 

--- a/packages/block-library/src/shortcode/index.js
+++ b/packages/block-library/src/shortcode/index.js
@@ -13,7 +13,7 @@ export const name = 'core/shortcode';
 export const settings = {
 	title: __( 'Shortcode' ),
 
-	description: __( 'Add a shortcode -- a WordPress-specific snippet of code written between square brackets.' ),
+	description: __( 'Insert additional custom elements with a WordPress shortcode.' ),
 
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M8.5,21.4l1.9,0.5l5.2-19.3l-1.9-0.5L8.5,21.4z M3,19h4v-2H5V7h2V5H3V19z M17,5v2h2v10h-2v2h4V5H17z" /></SVG>,
 

--- a/packages/block-library/src/spacer/index.js
+++ b/packages/block-library/src/spacer/index.js
@@ -17,7 +17,7 @@ export const name = 'core/spacer';
 export const settings = {
 	title: __( 'Spacer' ),
 
-	description: __( 'Add an element with empty space and custom height.' ),
+	description: __( 'Add white space between blocks and customize its height.' ),
 
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><G><Path d="M13 4v2h3.59L6 16.59V13H4v7h7v-2H7.41L18 7.41V11h2V4h-7" /></G></SVG>,
 

--- a/packages/block-library/src/table/index.js
+++ b/packages/block-library/src/table/index.js
@@ -77,7 +77,7 @@ export const name = 'core/table';
 
 export const settings = {
 	title: __( 'Table' ),
-	description: __( 'Insert a table -- perfect for sharing charts and data.' ),
+	description: __( 'Insert a table — perfect for sharing charts and data.' ),
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M20 3H5L3 5v14l2 2h15l2-2V5l-2-2zm0 2v3H5V5h15zm-5 14h-5v-9h5v9zM5 10h3v9H5v-9zm12 9v-9h3v9h-3z" /></G></SVG>,
 	category: 'formatting',
 

--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -16,7 +16,7 @@ export const name = 'core/verse';
 export const settings = {
 	title: __( 'Verse' ),
 
-	description: __( 'A block for haiku? Why not? Blocks for all the things! (See what we did here?)' ),
+	description: __( 'Insert haiku. Use special spacing formats. Or quote song lyrics. (See what we did here?)' ),
 
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><Path d="M3 17v4h4l11-11-4-4L3 17zm3 2H5v-1l9-9 1 1-9 9zM21 6l-3-3h-1l-2 2 4 4 2-2V6z" /></SVG>,
 

--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -16,7 +16,7 @@ export const name = 'core/verse';
 export const settings = {
 	title: __( 'Verse' ),
 
-	description: __( 'Insert haiku. Use special spacing formats. Or quote song lyrics. (See what we did here?)' ),
+	description: __( 'Insert poetry. Use special spacing formats. Or quote song lyrics.' ),
 
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><Path d="M3 17v4h4l11-11-4-4L3 17zm3 2H5v-1l9-9 1 1-9 9zM21 6l-3-3h-1l-2 2 4 4 2-2V6z" /></SVG>,
 

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -17,7 +17,7 @@ export const name = 'core/video';
 export const settings = {
 	title: __( 'Video' ),
 
-	description: __( 'Embed a video file and a simple video player.' ),
+	description: __( 'Embed a video from your media library or upload a new one.' ),
 
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><Path d="M4 6l2 4h14v8H4V6m18-2h-4l2 4h-3l-2-4h-2l2 4h-3l-2-4H8l2 4H7L5 4H4L2 6v12l2 2h16l2-2V4z" /></SVG>,
 


### PR DESCRIPTION
This follows the latest suggestions by @alexislloyd in #10919.

The section it doesn't do is this:

> If the content format has its own noun, then use "Embed a tweet", "embed a Facebook post", etc. If not, then default to "Embed Kickstarter content", "embed Mixcloud content", etc.

I think this needs some dev help to make happen. @mtias looping you in just incase here.