### PR TITLE
RTL: Set code editor as RTL

### DIFF
--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -73,7 +73,7 @@ export class PostTextEditor extends Component {
 				</label>
 				<Textarea
 					autoComplete="off"
-					dir="ltr"
+					dir="auto"
 					value={ value }
 					onChange={ this.edit }
 					onBlur={ this.stopEditing }

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -73,6 +73,7 @@ export class PostTextEditor extends Component {
 				</label>
 				<Textarea
 					autoComplete="off"
+					dir="ltr"
 					value={ value }
 					onChange={ this.edit }
 					onBlur={ this.stopEditing }


### PR DESCRIPTION
The code editor is an odd beast when it comes to text direction.
There's a confusing interplay of stored bytes, styling, and
internal directionality in the display of text.

If we set `dir="rtl"` on the code editor, which happens when chaining
down from the same attribute on the `<html>` tag, then the block
comments display incorrectly. The browser is smart enough to handle
text and HTML tags/attributes but gets confused in the comments.

With this change we force the browser to treat the textarea for the
code editor as `auto` for its display to preserve the ability to interact
with the block delimiters. It's noteworthy that the browser still
properly handles RTL text snippets.

This change may mean that the cursor doesn't appear on the right side
of the code editor when an RTL language is set, but once we start
typing characters associated with RTL directions they should display
fine, maybe left-aligned.

There is a tradeoff here in semantics, which is more appropriate: that
RTL languages display right-aligned or that structural content is
preserved. I think that the preservation of the block comments in the
code view is most important. Since this is a display issue it's worth
pointing out that the underlying stream of bytes doesn't change and so
no block comments are broken with the `rtl` value, but they _look_
broken and become hard to work with.

![code-editor-rtl mov](https://user-images.githubusercontent.com/5431237/47393452-5a3a9680-d6d4-11e8-825d-e34644bc5f03.gif)
