### PR TITLE
Don't set a value on the file block download attribute

### DIFF
--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -217,8 +217,7 @@ export const settings = {
 					<a
 						href={ href }
 						className="wp-block-file__button"
-						// Using '' here as `true` leaves the attribute unset.
-						download=""
+						download={ true }
 					>
 						<RichText.Content
 							value={ downloadButtonText }

--- a/packages/blocks/src/api/validation.js
+++ b/packages/blocks/src/api/validation.js
@@ -57,6 +57,7 @@ const BOOLEAN_ATTRIBUTES = [
 	'default',
 	'defer',
 	'disabled',
+	'download',
 	'formnovalidate',
 	'hidden',
 	'ismap',

--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -116,6 +116,7 @@ const BOOLEAN_ATTRIBUTES = new Set( [
 	'default',
 	'defer',
 	'disabled',
+	'download',
 	'formnovalidate',
 	'hidden',
 	'ismap',

--- a/test/integration/full-content/fixtures/core__file__new-window.html
+++ b/test/integration/full-content/fixtures/core__file__new-window.html
@@ -1,3 +1,3 @@
 <!-- wp:file {"href":"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js","showDownloadButton":true,"id":176} -->
-<div class="wp-block-file"><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" target="_blank" rel="noreferrer noopener">6546</a><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" class="wp-block-file__button" download="">Download</a></div>
+<div class="wp-block-file"><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" target="_blank" rel="noreferrer noopener">6546</a><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" class="wp-block-file__button" download>Download</a></div>
 <!-- /wp:file -->

--- a/test/integration/full-content/fixtures/core__file__new-window.json
+++ b/test/integration/full-content/fixtures/core__file__new-window.json
@@ -13,6 +13,6 @@
             "downloadButtonText": "Download"
         },
         "innerBlocks": [],
-        "originalContent": "<div class=\"wp-block-file\"><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" target=\"_blank\" rel=\"noreferrer noopener\">6546</a><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" class=\"wp-block-file__button\" download=\"\">Download</a></div>"
+        "originalContent": "<div class=\"wp-block-file\"><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" target=\"_blank\" rel=\"noreferrer noopener\">6546</a><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" class=\"wp-block-file__button\" download=>Download</a></div>"
     }
 ]

--- a/test/integration/full-content/fixtures/core__file__new-window.json
+++ b/test/integration/full-content/fixtures/core__file__new-window.json
@@ -13,6 +13,6 @@
             "downloadButtonText": "Download"
         },
         "innerBlocks": [],
-        "originalContent": "<div class=\"wp-block-file\"><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" target=\"_blank\" rel=\"noreferrer noopener\">6546</a><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" class=\"wp-block-file__button\" download=>Download</a></div>"
+        "originalContent": "<div class=\"wp-block-file\"><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" target=\"_blank\" rel=\"noreferrer noopener\">6546</a><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" class=\"wp-block-file__button\" download>Download</a></div>"
     }
 ]

--- a/test/integration/full-content/fixtures/core__file__new-window.parsed.json
+++ b/test/integration/full-content/fixtures/core__file__new-window.parsed.json
@@ -7,7 +7,7 @@
             "id": 176
         },
         "innerBlocks": [],
-        "innerHTML": "\n<div class=\"wp-block-file\"><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" target=\"_blank\" rel=\"noreferrer noopener\">6546</a><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" class=\"wp-block-file__button\" download=\"\">Download</a></div>\n"
+        "innerHTML": "\n<div class=\"wp-block-file\"><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" target=\"_blank\" rel=\"noreferrer noopener\">6546</a><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" class=\"wp-block-file__button\" download>Download</a></div>\n"
     },
     {
         "blockName": null,

--- a/test/integration/full-content/fixtures/core__file__new-window.serialized.html
+++ b/test/integration/full-content/fixtures/core__file__new-window.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:file {"id":176,"href":"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js"} -->
-<div class="wp-block-file"><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" target="_blank" rel="noreferrer noopener">6546</a><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" class="wp-block-file__button" download="">Download</a></div>
+<div class="wp-block-file"><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" target="_blank" rel="noreferrer noopener">6546</a><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" class="wp-block-file__button" download>Download</a></div>
 <!-- /wp:file -->

--- a/test/integration/full-content/fixtures/core__file__no-text-link.html
+++ b/test/integration/full-content/fixtures/core__file__no-text-link.html
@@ -1,3 +1,3 @@
 <!-- wp:file {"href":"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js","showDownloadButton":true,"id":176} -->
-<div class="wp-block-file"><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" class="wp-block-file__button" download="">Download</a></div>
+<div class="wp-block-file"><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" class="wp-block-file__button" download>Download</a></div>
 <!-- /wp:file -->

--- a/test/integration/full-content/fixtures/core__file__no-text-link.json
+++ b/test/integration/full-content/fixtures/core__file__no-text-link.json
@@ -11,6 +11,6 @@
             "downloadButtonText": "Download"
         },
         "innerBlocks": [],
-        "originalContent": "<div class=\"wp-block-file\"><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" class=\"wp-block-file__button\" download=\"\">Download</a></div>"
+        "originalContent": "<div class=\"wp-block-file\"><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" class=\"wp-block-file__button\" download>Download</a></div>"
     }
 ]

--- a/test/integration/full-content/fixtures/core__file__no-text-link.parsed.json
+++ b/test/integration/full-content/fixtures/core__file__no-text-link.parsed.json
@@ -7,7 +7,7 @@
             "id": 176
         },
         "innerBlocks": [],
-        "innerHTML": "\n<div class=\"wp-block-file\"><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" class=\"wp-block-file__button\" download=\"\">Download</a></div>\n"
+        "innerHTML": "\n<div class=\"wp-block-file\"><a href=\"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js\" class=\"wp-block-file__button\" download>Download</a></div>\n"
     },
     {
         "blockName": null,

--- a/test/integration/full-content/fixtures/core__file__no-text-link.serialized.html
+++ b/test/integration/full-content/fixtures/core__file__no-text-link.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:file {"id":176,"href":"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js"} -->
-<div class="wp-block-file"><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" class="wp-block-file__button" downloa>Download</a></div>
+<div class="wp-block-file"><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" class="wp-block-file__button" download>Download</a></div>
 <!-- /wp:file -->

--- a/test/integration/full-content/fixtures/core__file__no-text-link.serialized.html
+++ b/test/integration/full-content/fixtures/core__file__no-text-link.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:file {"id":176,"href":"http://localhost:8888/wp-content/uploads/2018/05/keycodes.js"} -->
-<div class="wp-block-file"><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" class="wp-block-file__button" download="">Download</a></div>
+<div class="wp-block-file"><a href="http://localhost:8888/wp-content/uploads/2018/05/keycodes.js" class="wp-block-file__button" downloa>Download</a></div>
 <!-- /wp:file -->


### PR DESCRIPTION
## Description

This is a followup to #10948.

KSES now allows the `download` attribute, but only if it is set as a valueless attribute. Ie, it only allows `<a download>`, not `<a download="">`.

This PR updates the parser to add `download` as a valueless attribute, and uses that form for the file block download button.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.