### PR TITLE
Ensure buttons on end of row in media-placeholder have no margin-right

### DIFF
--- a/packages/editor/src/components/media-placeholder/style.scss
+++ b/packages/editor/src/components/media-placeholder/style.scss
@@ -30,7 +30,6 @@
 }
 
 .editor-media-placeholder__button {
-	margin-right: 5px;
 	margin-bottom: 0.5rem;
 
 	.dashicon {
@@ -41,4 +40,8 @@
 	&:hover {
 		color: $dark-gray-800;
 	}
+}
+
+.components-form-file-upload .editor-media-placeholder__button {
+	margin-right: 5px;
 }

--- a/packages/editor/src/components/media-placeholder/style.scss
+++ b/packages/editor/src/components/media-placeholder/style.scss
@@ -43,5 +43,5 @@
 }
 
 .components-form-file-upload .editor-media-placeholder__button {
-	margin-right: 5px;
+	margin-right: $grid-size-small;
 }


### PR DESCRIPTION
## Description
I noticed the buttons in the media placeholder are very subtly off-centre.

This is a tiny css tweak to make sure the buttons at the end of the row in the media placeholder do not have margin-right.

## How has this been tested?
- Manual inspection of css.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
**Before**
![screen shot 2018-10-24 at 10 43 10 am](https://user-images.githubusercontent.com/677833/47402887-fcf92080-d779-11e8-9d93-97d27e07b6f3.png)

**After**
![screen shot 2018-10-24 at 10 44 38 am](https://user-images.githubusercontent.com/677833/47402881-f2d72200-d779-11e8-9134-b19179ce9264.png)

## Types of changes
Non-breaking minor CSS Adjustment
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
