### PR TITLE
Small followup fix to options modal tweaks

### DIFF
--- a/packages/edit-post/src/components/options-modal/style.scss
+++ b/packages/edit-post/src/components/options-modal/style.scss
@@ -1,6 +1,4 @@
 .edit-post-options-modal {
-	min-width: 320px;
-
 	&__title {
 		font-size: 1rem;
 		font-weight: bold;


### PR DESCRIPTION
In https://github.com/WordPress/gutenberg/pull/10944 the options modal was made mobile friendly. This PR follows up and in fact removes the min width rule because it was redundant.