### PR TITLE
Fix embedding and demo tests

### DIFF
--- a/test/e2e/specs/demo.test.js
+++ b/test/e2e/specs/demo.test.js
@@ -23,8 +23,7 @@ describe( 'new editor state', () => {
 		// cannot leave errors in the console and cause the test to fail.
 		await page.setRequestInterception( true );
 		page.on( 'request', async ( request ) => {
-			console.log( request.url() );
-			if ( request.url().indexOf( 'oembed/1.0/proxy' ) !== -1 ) {
+			if ( request.url().indexOf( 'oembed%2F1.0%2Fproxy' ) !== -1 ) {
 				// Because we can't get the responses to requests and modify them on the fly,
 				// we have to make our own request, get the response, modify it, then use the
 				// modified values to respond to the request.

--- a/test/e2e/specs/demo.test.js
+++ b/test/e2e/specs/demo.test.js
@@ -23,6 +23,7 @@ describe( 'new editor state', () => {
 		// cannot leave errors in the console and cause the test to fail.
 		await page.setRequestInterception( true );
 		page.on( 'request', async ( request ) => {
+			console.log( request.url() );
 			if ( request.url().indexOf( 'oembed/1.0/proxy' ) !== -1 ) {
 				// Because we can't get the responses to requests and modify them on the fly,
 				// we have to make our own request, get the response, modify it, then use the
@@ -61,7 +62,7 @@ describe( 'new editor state', () => {
 		await visitAdmin( 'post-new.php', 'gutenberg-demo' );
 	} );
 
-	it.skip( 'content should load without making the post dirty', async () => {
+	it( 'content should load without making the post dirty', async () => {
 		const isDirty = await page.evaluate( () => {
 			const { select } = window.wp.data;
 			return select( 'core/editor' ).isEditedPostDirty();

--- a/test/e2e/specs/embedding.test.js
+++ b/test/e2e/specs/embedding.test.js
@@ -146,7 +146,7 @@ const setUp = async () => {
 describe( 'Embedding content', () => {
 	beforeEach( setUp );
 
-	it.skip( 'should render embeds in the correct state', async () => {
+	it( 'should render embeds in the correct state', async () => {
 		// The successful embeds should be in a correctly classed figure element.
 		// This tests that they have switched to the correct block.
 		await page.waitForSelector( 'figure.wp-block-embed-twitter' );

--- a/test/e2e/specs/embedding.test.js
+++ b/test/e2e/specs/embedding.test.js
@@ -67,7 +67,7 @@ const setupEmbedRequestInterception = async () => {
 	await page.setRequestInterception( true );
 	page.on( 'request', async ( request ) => {
 		const requestUrl = request.url();
-		const isEmbeddingUrl = -1 !== requestUrl.indexOf( 'oembed/1.0/proxy' );
+		const isEmbeddingUrl = -1 !== requestUrl.indexOf( 'oembed%2F1.0%2Fproxy' );
 		if ( isEmbeddingUrl ) {
 			const embedUrl = decodeURIComponent( /.*url=([^&]+).*/.exec( requestUrl )[ 1 ] );
 			const mockResponse = MOCK_RESPONSES[ embedUrl ];


### PR DESCRIPTION
## Description

The rest_route is now encoded as a URIComponent, so we needed to update the matching in the intercept code that applies mocks.

The reason this did not show up locally in our branches, but did in Travis, is that Travis merges master before it runs the test. That caused surprise failures in branches, and made this difficult to track down because I could not push up an older revision to test, because when it came time to run the tests, master got merged and it was back to the broken state.

## How has this been tested?

Run the tests *on Travis*. They pass.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
