### PR TITLE
Fix link popover keyboard accessibility

### DIFF
--- a/docs/data/data-core-editor.md
+++ b/docs/data/data-core-editor.md
@@ -1777,3 +1777,5 @@ Returns an action object signaling that a new term is added to the edited post.
 
  * slug: Taxonomy slug.
  * term: Term object.
+
+### createNotice

--- a/docs/data/data-core-editor.md
+++ b/docs/data/data-core-editor.md
@@ -907,6 +907,18 @@ Returns true if the user is typing, or false otherwise.
 
 Whether user is typing.
 
+### isCaretWithinFormattedText
+
+Returns true if the caret is within formatted text, or false otherwise.
+
+*Parameters*
+
+ * state: Global application state.
+
+*Returns*
+
+Whether the caret is within formatted text.
+
 ### getBlockInsertionPoint
 
 Returns the insertion point, the index at which the new inserted block would
@@ -1623,6 +1635,34 @@ Returns an action object used in signalling that the user has begun to type.
 
 Returns an action object used in signalling that the user has stopped typing.
 
+### enterFormattedText
+
+Returns an action object used in signalling that the caret has entered formatted text.
+
+### leaveFormattedText
+
+Returns an action object used in signalling that the user caret has left formatted text.
+
+### createNotice
+
+Returns an action object used to create a notice.
+
+*Parameters*
+
+ * status: The notice status.
+ * content: The notice content.
+ * options: The notice options.  Available options:
+                             `id` (string; default auto-generated)
+                             `isDismissible` (boolean; default `true`).
+
+### removeNotice
+
+Returns an action object used to remove a notice.
+
+*Parameters*
+
+ * id: The notice id.
+
 ### updatePostLock
 
 Returns an action object used to lock the editor.
@@ -1757,5 +1797,3 @@ Returns an action object signaling that a new term is added to the edited post.
 
  * slug: Taxonomy slug.
  * term: Term object.
-
-### createNotice

--- a/docs/data/data-core-editor.md
+++ b/docs/data/data-core-editor.md
@@ -1639,9 +1639,9 @@ Returns an action object used in signalling that the user has stopped typing.
 
 Returns an action object used in signalling that the caret has entered formatted text.
 
-### leaveFormattedText
+### exitFormattedText
 
-Returns an action object used in signalling that the user caret has left formatted text.
+Returns an action object used in signalling that the user caret has exited formatted text.
 
 ### createNotice
 

--- a/docs/data/data-core-editor.md
+++ b/docs/data/data-core-editor.md
@@ -1643,26 +1643,6 @@ Returns an action object used in signalling that the caret has entered formatted
 
 Returns an action object used in signalling that the user caret has exited formatted text.
 
-### createNotice
-
-Returns an action object used to create a notice.
-
-*Parameters*
-
- * status: The notice status.
- * content: The notice content.
- * options: The notice options.  Available options:
-                             `id` (string; default auto-generated)
-                             `isDismissible` (boolean; default `true`).
-
-### removeNotice
-
-Returns an action object used to remove a notice.
-
-*Parameters*
-
- * id: The notice id.
-
 ### updatePostLock
 
 Returns an action object used to lock the editor.

--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -372,6 +372,7 @@ export class BlockListBlock extends Component {
 			isPartOfMultiSelection,
 			isFirstMultiSelected,
 			isTypingWithinBlock,
+			isCaretWithinFormattedText,
 			isMultiSelecting,
 			hoverArea,
 			isEmptyDefaultBlock,
@@ -399,7 +400,7 @@ export class BlockListBlock extends Component {
 		// We render block movers and block settings to keep them tabbale even if hidden
 		const shouldRenderMovers = ! isFocusMode && ( isSelected || hoverArea === 'left' ) && ! showEmptyBlockSideInserter && ! isMultiSelecting && ! isPartOfMultiSelection && ! isTypingWithinBlock;
 		const shouldShowBreadcrumb = ! isFocusMode && isHovered && ! isEmptyDefaultBlock;
-		const shouldShowContextualToolbar = ! hasFixedToolbar && ! showSideInserter && ( ( isSelected && ! isTypingWithinBlock ) || isFirstMultiSelected );
+		const shouldShowContextualToolbar = ! hasFixedToolbar && ! showSideInserter && ( ( isSelected && ( ! isTypingWithinBlock || isCaretWithinFormattedText ) ) || isFirstMultiSelected );
 		const shouldShowMobileToolbar = shouldAppearSelected;
 		const { error, dragging } = this.state;
 
@@ -588,6 +589,7 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId, isLargeV
 		isFirstMultiSelectedBlock,
 		isMultiSelecting,
 		isTyping,
+		isCaretWithinFormattedText,
 		getBlockIndex,
 		getEditedPostAttribute,
 		getBlockMode,
@@ -613,6 +615,7 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId, isLargeV
 		// We only care about this prop when the block is selected
 		// Thus to avoid unnecessary rerenders we avoid updating the prop if the block is not selected.
 		isTypingWithinBlock: ( isSelected || isParentOfSelectedBlock ) && isTyping(),
+		isCaretWithinFormattedText: isCaretWithinFormattedText(),
 		order: getBlockIndex( clientId, rootClientId ),
 		meta: getEditedPostAttribute( 'meta' ),
 		mode: getBlockMode( clientId ),

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -429,7 +429,7 @@ export class RichText extends Component {
 		if ( formats[ start ] ) {
 			this.props.onEnterFormattedText();
 		} else {
-			this.props.onLeaveFormattedText();
+			this.props.onExitFormattedText();
 		}
 
 		if ( start !== this.state.start || end !== this.state.end ) {
@@ -969,7 +969,7 @@ const RichTextContainer = compose( [
 			redo,
 			undo,
 			enterFormattedText,
-			leaveFormattedText,
+			exitFormattedText,
 		} = dispatch( 'core/editor' );
 
 		return {
@@ -977,7 +977,7 @@ const RichTextContainer = compose( [
 			onRedo: redo,
 			onUndo: undo,
 			onEnterFormattedText: enterFormattedText,
-			onLeaveFormattedText: leaveFormattedText,
+			onExitFormattedText: exitFormattedText,
 		};
 	} ),
 	withSafeTimeout,

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -424,7 +424,13 @@ export class RichText extends Component {
 			return;
 		}
 
-		const { start, end } = this.createRecord();
+		const { start, end, formats } = this.createRecord();
+
+		if ( formats[ start ] ) {
+			this.props.onEnterFormattedText();
+		} else {
+			this.props.onLeaveFormattedText();
+		}
 
 		if ( start !== this.state.start || end !== this.state.end ) {
 			this.setState( { start, end } );
@@ -962,12 +968,16 @@ const RichTextContainer = compose( [
 			createUndoLevel,
 			redo,
 			undo,
+			enterFormattedText,
+			leaveFormattedText,
 		} = dispatch( 'core/editor' );
 
 		return {
 			onCreateUndoLevel: createUndoLevel,
 			onRedo: redo,
 			onUndo: undo,
+			onEnterFormattedText: enterFormattedText,
+			onLeaveFormattedText: leaveFormattedText,
 		};
 	} ),
 	withSafeTimeout,

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -558,49 +558,6 @@ export function exitFormattedText() {
 }
 
 /**
- * Returns an action object used to create a notice.
- *
- * @param {string}    status  The notice status.
- * @param {WPElement} content The notice content.
- * @param {?Object}   options The notice options.  Available options:
- *                              `id` (string; default auto-generated)
- *                              `isDismissible` (boolean; default `true`).
- *
- * @return {Object} Action object.
- */
-export function createNotice( status, content, options = {} ) {
-	const {
-		id = uuid(),
-		isDismissible = true,
-		spokenMessage,
-	} = options;
-	return {
-		type: 'CREATE_NOTICE',
-		notice: {
-			id,
-			status,
-			content,
-			isDismissible,
-			spokenMessage,
-		},
-	};
-}
-
-/**
- * Returns an action object used to remove a notice.
- *
- * @param {string} id The notice id.
- *
- * @return {Object} Action object.
- */
-export function removeNotice( id ) {
-	return {
-		type: 'REMOVE_NOTICE',
-		noticeId: id,
-	};
-}
-
-/**
  * Returns an action object used to lock the editor.
  *
  * @param {Object}  lock Details about the post lock status, user, and nonce.

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -547,13 +547,13 @@ export function enterFormattedText() {
 }
 
 /**
- * Returns an action object used in signalling that the user caret has left formatted text.
+ * Returns an action object used in signalling that the user caret has exited formatted text.
  *
  * @return {Object} Action object.
  */
-export function leaveFormattedText() {
+export function exitFormattedText() {
 	return {
-		type: 'LEAVE_FORMATTED_TEXT',
+		type: 'EXIT_FORMATTED_TEXT',
 	};
 }
 

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -536,6 +536,71 @@ export function stopTyping() {
 }
 
 /**
+ * Returns an action object used in signalling that the caret has entered formatted text.
+ *
+ * @return {Object} Action object.
+ */
+export function enterFormattedText() {
+	return {
+		type: 'ENTER_FORMATTED_TEXT',
+	};
+}
+
+/**
+ * Returns an action object used in signalling that the user caret has left formatted text.
+ *
+ * @return {Object} Action object.
+ */
+export function leaveFormattedText() {
+	return {
+		type: 'LEAVE_FORMATTED_TEXT',
+	};
+}
+
+/**
+ * Returns an action object used to create a notice.
+ *
+ * @param {string}    status  The notice status.
+ * @param {WPElement} content The notice content.
+ * @param {?Object}   options The notice options.  Available options:
+ *                              `id` (string; default auto-generated)
+ *                              `isDismissible` (boolean; default `true`).
+ *
+ * @return {Object} Action object.
+ */
+export function createNotice( status, content, options = {} ) {
+	const {
+		id = uuid(),
+		isDismissible = true,
+		spokenMessage,
+	} = options;
+	return {
+		type: 'CREATE_NOTICE',
+		notice: {
+			id,
+			status,
+			content,
+			isDismissible,
+			spokenMessage,
+		},
+	};
+}
+
+/**
+ * Returns an action object used to remove a notice.
+ *
+ * @param {string} id The notice id.
+ *
+ * @return {Object} Action object.
+ */
+export function removeNotice( id ) {
+	return {
+		type: 'REMOVE_NOTICE',
+		noticeId: id,
+	};
+}
+
+/**
  * Returns an action object used to lock the editor.
  *
  * @param {Object}  lock Details about the post lock status, user, and nonce.

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -597,7 +597,7 @@ export function isCaretWithinFormattedText( state = false, action ) {
 		case 'ENTER_FORMATTED_TEXT':
 			return true;
 
-		case 'LEAVE_FORMATTED_TEXT':
+		case 'EXIT_FORMATTED_TEXT':
 			return false;
 	}
 

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -585,6 +585,26 @@ export function isTyping( state = false, action ) {
 }
 
 /**
+ * Reducer returning whether the caret is within formatted text.
+ *
+ * @param {boolean} state  Current state.
+ * @param {Object}  action Dispatched action.
+ *
+ * @return {boolean} Updated state.
+ */
+export function isCaretWithinFormattedText( state = false, action ) {
+	switch ( action.type ) {
+		case 'ENTER_FORMATTED_TEXT':
+			return true;
+
+		case 'LEAVE_FORMATTED_TEXT':
+			return false;
+	}
+
+	return state;
+}
+
+/**
  * Reducer returning the block selection's state.
  *
  * @param {Object} state  Current state.
@@ -1093,6 +1113,7 @@ export default optimist( combineReducers( {
 	editor,
 	currentPost,
 	isTyping,
+	isCaretWithinFormattedText,
 	blockSelection,
 	blocksMode,
 	blockListSettings,

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1256,6 +1256,17 @@ export function isTyping( state ) {
 }
 
 /**
+ * Returns true if the caret is within formatted text, or false otherwise.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {boolean} Whether the caret is within formatted text.
+ */
+export function isCaretWithinFormattedText( state ) {
+	return state.isCaretWithinFormattedText;
+}
+
+/**
  * Returns the insertion point, the index at which the new inserted block would
  * be placed. Defaults to the last index.
  *

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -5,6 +5,14 @@ import {
 	replaceBlocks,
 	startTyping,
 	stopTyping,
+	createNotice,
+	createErrorNotice,
+	createInfoNotice,
+	createSuccessNotice,
+	createWarningNotice,
+	removeNotice,
+	enterFormattedText,
+	leaveFormattedText,
 	fetchReusableBlocks,
 	saveReusableBlock,
 	deleteReusableBlock,
@@ -340,6 +348,130 @@ describe( 'actions', () => {
 		it( 'should return the STOP_TYPING action', () => {
 			expect( stopTyping() ).toEqual( {
 				type: 'STOP_TYPING',
+			} );
+		} );
+	} );
+
+	describe( 'enterFormattedText', () => {
+		it( 'should return the ENTER_FORMATTED_TEXT action', () => {
+			expect( enterFormattedText() ).toEqual( {
+				type: 'ENTER_FORMATTED_TEXT',
+			} );
+		} );
+	} );
+
+	describe( 'leaveFormattedText', () => {
+		it( 'should return the LEAVE_FORMATTED_TEXT action', () => {
+			expect( leaveFormattedText() ).toEqual( {
+				type: 'LEAVE_FORMATTED_TEXT',
+			} );
+		} );
+	} );
+
+	describe( 'createNotice', () => {
+		const status = 'status';
+		const content = <p>element</p>;
+		it( 'should return CREATE_NOTICE action when options is empty', () => {
+			const result = createNotice( status, content );
+			expect( result ).toMatchObject( {
+				type: 'CREATE_NOTICE',
+				notice: {
+					status,
+					content,
+					isDismissible: true,
+					id: expect.any( String ),
+				},
+			} );
+		} );
+		it( 'should return CREATE_NOTICE action when options is desined', () => {
+			const id = 'my-id';
+			const options = {
+				id,
+				isDismissible: false,
+			};
+			const result = createNotice( status, content, options );
+			expect( result ).toEqual( {
+				type: 'CREATE_NOTICE',
+				notice: {
+					id,
+					status,
+					content,
+					isDismissible: false,
+				},
+			} );
+		} );
+	} );
+
+	describe( 'createSuccessNotice', () => {
+		it( 'should return CREATE_NOTICE action', () => {
+			const content = <p>element</p>;
+			const result = createSuccessNotice( content );
+			expect( result ).toMatchObject( {
+				type: 'CREATE_NOTICE',
+				notice: {
+					status: 'success',
+					content,
+					isDismissible: true,
+					id: expect.any( String ),
+				},
+			} );
+		} );
+	} );
+
+	describe( 'createInfoNotice', () => {
+		it( 'should return CREATE_NOTICE action', () => {
+			const content = <p>element</p>;
+			const result = createInfoNotice( content );
+			expect( result ).toMatchObject( {
+				type: 'CREATE_NOTICE',
+				notice: {
+					status: 'info',
+					content,
+					isDismissible: true,
+					id: expect.any( String ),
+				},
+			} );
+		} );
+	} );
+
+	describe( 'createErrorNotice', () => {
+		it( 'should return CREATE_NOTICE action', () => {
+			const content = <p>element</p>;
+			const result = createErrorNotice( content );
+			expect( result ).toMatchObject( {
+				type: 'CREATE_NOTICE',
+				notice: {
+					status: 'error',
+					content,
+					isDismissible: true,
+					id: expect.any( String ),
+				},
+			} );
+		} );
+	} );
+
+	describe( 'createWarningNotice', () => {
+		it( 'should return CREATE_NOTICE action', () => {
+			const content = <p>element</p>;
+			const result = createWarningNotice( content );
+			expect( result ).toMatchObject( {
+				type: 'CREATE_NOTICE',
+				notice: {
+					status: 'warning',
+					content,
+					isDismissible: true,
+					id: expect.any( String ),
+				},
+			} );
+		} );
+	} );
+
+	describe( 'removeNotice', () => {
+		it( 'should return REMOVE_NOTICE actions', () => {
+			const noticeId = 'id';
+			expect( removeNotice( noticeId ) ).toEqual( {
+				type: 'REMOVE_NOTICE',
+				noticeId,
 			} );
 		} );
 	} );

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -5,12 +5,6 @@ import {
 	replaceBlocks,
 	startTyping,
 	stopTyping,
-	createNotice,
-	createErrorNotice,
-	createInfoNotice,
-	createSuccessNotice,
-	createWarningNotice,
-	removeNotice,
 	enterFormattedText,
 	exitFormattedText,
 	fetchReusableBlocks,
@@ -364,114 +358,6 @@ describe( 'actions', () => {
 		it( 'should return the EXIT_FORMATTED_TEXT action', () => {
 			expect( exitFormattedText() ).toEqual( {
 				type: 'EXIT_FORMATTED_TEXT',
-			} );
-		} );
-	} );
-
-	describe( 'createNotice', () => {
-		const status = 'status';
-		const content = <p>element</p>;
-		it( 'should return CREATE_NOTICE action when options is empty', () => {
-			const result = createNotice( status, content );
-			expect( result ).toMatchObject( {
-				type: 'CREATE_NOTICE',
-				notice: {
-					status,
-					content,
-					isDismissible: true,
-					id: expect.any( String ),
-				},
-			} );
-		} );
-		it( 'should return CREATE_NOTICE action when options is desined', () => {
-			const id = 'my-id';
-			const options = {
-				id,
-				isDismissible: false,
-			};
-			const result = createNotice( status, content, options );
-			expect( result ).toEqual( {
-				type: 'CREATE_NOTICE',
-				notice: {
-					id,
-					status,
-					content,
-					isDismissible: false,
-				},
-			} );
-		} );
-	} );
-
-	describe( 'createSuccessNotice', () => {
-		it( 'should return CREATE_NOTICE action', () => {
-			const content = <p>element</p>;
-			const result = createSuccessNotice( content );
-			expect( result ).toMatchObject( {
-				type: 'CREATE_NOTICE',
-				notice: {
-					status: 'success',
-					content,
-					isDismissible: true,
-					id: expect.any( String ),
-				},
-			} );
-		} );
-	} );
-
-	describe( 'createInfoNotice', () => {
-		it( 'should return CREATE_NOTICE action', () => {
-			const content = <p>element</p>;
-			const result = createInfoNotice( content );
-			expect( result ).toMatchObject( {
-				type: 'CREATE_NOTICE',
-				notice: {
-					status: 'info',
-					content,
-					isDismissible: true,
-					id: expect.any( String ),
-				},
-			} );
-		} );
-	} );
-
-	describe( 'createErrorNotice', () => {
-		it( 'should return CREATE_NOTICE action', () => {
-			const content = <p>element</p>;
-			const result = createErrorNotice( content );
-			expect( result ).toMatchObject( {
-				type: 'CREATE_NOTICE',
-				notice: {
-					status: 'error',
-					content,
-					isDismissible: true,
-					id: expect.any( String ),
-				},
-			} );
-		} );
-	} );
-
-	describe( 'createWarningNotice', () => {
-		it( 'should return CREATE_NOTICE action', () => {
-			const content = <p>element</p>;
-			const result = createWarningNotice( content );
-			expect( result ).toMatchObject( {
-				type: 'CREATE_NOTICE',
-				notice: {
-					status: 'warning',
-					content,
-					isDismissible: true,
-					id: expect.any( String ),
-				},
-			} );
-		} );
-	} );
-
-	describe( 'removeNotice', () => {
-		it( 'should return REMOVE_NOTICE actions', () => {
-			const noticeId = 'id';
-			expect( removeNotice( noticeId ) ).toEqual( {
-				type: 'REMOVE_NOTICE',
-				noticeId,
 			} );
 		} );
 	} );

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -12,7 +12,7 @@ import {
 	createWarningNotice,
 	removeNotice,
 	enterFormattedText,
-	leaveFormattedText,
+	exitFormattedText,
 	fetchReusableBlocks,
 	saveReusableBlock,
 	deleteReusableBlock,
@@ -360,10 +360,10 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( 'leaveFormattedText', () => {
-		it( 'should return the LEAVE_FORMATTED_TEXT action', () => {
-			expect( leaveFormattedText() ).toEqual( {
-				type: 'LEAVE_FORMATTED_TEXT',
+	describe( 'exitFormattedText', () => {
+		it( 'should return the EXIT_FORMATTED_TEXT action', () => {
+			expect( exitFormattedText() ).toEqual( {
+				type: 'EXIT_FORMATTED_TEXT',
 			} );
 		} );
 	} );

--- a/packages/editor/src/store/test/reducer.js
+++ b/packages/editor/src/store/test/reducer.js
@@ -1327,7 +1327,7 @@ describe( 'state', () => {
 
 		it( 'should set the flag to false', () => {
 			const state = isCaretWithinFormattedText( true, {
-				type: 'LEAVE_FORMATTED_TEXT',
+				type: 'EXIT_FORMATTED_TEXT',
 			} );
 
 			expect( state ).toBe( false );

--- a/packages/editor/src/store/test/reducer.js
+++ b/packages/editor/src/store/test/reducer.js
@@ -25,6 +25,7 @@ import {
 	editor,
 	currentPost,
 	isTyping,
+	isCaretWithinFormattedText,
 	blockSelection,
 	preferences,
 	saving,
@@ -1309,6 +1310,24 @@ describe( 'state', () => {
 		it( 'should set the typing flag to false', () => {
 			const state = isTyping( false, {
 				type: 'STOP_TYPING',
+			} );
+
+			expect( state ).toBe( false );
+		} );
+	} );
+
+	describe( 'isCaretWithinFormattedText()', () => {
+		it( 'should set the flag to true', () => {
+			const state = isCaretWithinFormattedText( false, {
+				type: 'ENTER_FORMATTED_TEXT',
+			} );
+
+			expect( state ).toBe( true );
+		} );
+
+		it( 'should set the flag to false', () => {
+			const state = isCaretWithinFormattedText( true, {
+				type: 'LEAVE_FORMATTED_TEXT',
 			} );
 
 			expect( state ).toBe( false );

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -82,6 +82,7 @@ const {
 	isFirstMultiSelectedBlock,
 	getBlockMode,
 	isTyping,
+	isCaretWithinFormattedText,
 	getBlockInsertionPoint,
 	isBlockInsertionPointVisible,
 	isSavingPost,
@@ -2716,6 +2717,24 @@ describe( 'selectors', () => {
 			};
 
 			expect( isTyping( state ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isCaretWithinFormattedText', () => {
+		it( 'returns true if the isCaretWithinFormattedText state is also true', () => {
+			const state = {
+				isCaretWithinFormattedText: true,
+			};
+
+			expect( isCaretWithinFormattedText( state ) ).toBe( true );
+		} );
+
+		it( 'returns false if the isCaretWithinFormattedText state is also false', () => {
+			const state = {
+				isCaretWithinFormattedText: false,
+			};
+
+			expect( isCaretWithinFormattedText( state ) ).toBe( false );
 		} );
 	} );
 

--- a/test/e2e/specs/links.test.js
+++ b/test/e2e/specs/links.test.js
@@ -388,4 +388,36 @@ describe( 'Links', () => {
 		await page.keyboard.press( 'Escape' );
 		expect( await page.$( '.editor-url-popover' ) ).toBeNull();
 	} );
+
+	it( 'can be modified using the keyboard once a link has been set', async () => {
+		const URL = 'https://wordpress.org/gutenberg';
+
+		// Create a block with some text and format it as a link.
+		await clickBlockAppender();
+		await page.keyboard.type( 'This is Gutenberg' );
+		await pressWithModifier( SELECT_WORD_MODIFIER_KEYS, 'ArrowLeft' );
+		await pressWithModifier( META_KEY, 'K' );
+		await waitForAutoFocus();
+		await page.keyboard.type( URL );
+		await page.keyboard.press( 'Enter' );
+
+		// Deselect the link text by moving the caret to the end of the line
+		// and the link popover should not be displayed.
+		await page.keyboard.press( 'End' );
+		expect( await page.$( '.editor-url-popover' ) ).toBeNull();
+
+		// Move the caret back into the link text and the link popover
+		// should be displayed.
+		await page.keyboard.press( 'ArrowLeft' );
+		expect( await page.$( '.editor-url-popover' ) ).not.toBeNull();
+
+		// Press Cmd+K to edit the link and the url-input should become
+		// focused with the value previously inserted.
+		await pressWithModifier( META_KEY, 'K' );
+		await waitForAutoFocus();
+		const activeElementParentClasses = await page.evaluate( () => Object.values( document.activeElement.parentElement.classList ) );
+		expect( activeElementParentClasses ).toContain( 'editor-url-input' );
+		const activeElementValue = await page.evaluate( () => document.activeElement.value );
+		expect( activeElementValue ).toBe( URL );
+	} );
 } );


### PR DESCRIPTION
## Description
 Fixes #8266 by displaying the link popover whenever the caret is positioned within link formatting. As discussed in the issue, the agreed upon approach also involved displaying the toolbar whenever the caret is positioned within any formatting.

Also fixes #3350.

Changes:
- Add core/editor state handling for storing whether caret is positioned within formatting.
- Adjust toolbar rendering logic to show toolbar when caret is positioned within formatting.
- Add e2e tests to ensure regressions don't occur.

## How has this been tested?
- e2e tests
- manual testing

## Screenshots <!-- if applicable -->
![toolbar-formatting](https://user-images.githubusercontent.com/677833/47415540-3c3d6680-d7a6-11e8-94e8-940f8810956f.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
