### PR TITLE
Fix icon size regression.

### DIFF
--- a/packages/editor/src/components/block-icon/index.js
+++ b/packages/editor/src/components/block-icon/index.js
@@ -9,16 +9,6 @@ import classnames from 'classnames';
 import { Dashicon, SVG } from '@wordpress/components';
 import { createElement, Component } from '@wordpress/element';
 
-function isSVGIcon( icon ) {
-	if ( icon && icon.type === 'svg' ) {
-		return true;
-	} else if ( icon && icon.type.name === 'SVG' ) {
-		return true;
-	}
-
-	return false;
-}
-
 function renderIcon( icon ) {
 	if ( 'string' === typeof icon ) {
 		return <Dashicon icon={ icon } size={ 20 } />;
@@ -28,7 +18,7 @@ function renderIcon( icon ) {
 		}
 
 		return icon();
-	} else if ( isSVGIcon( icon ) ) {
+	} else if ( icon && ( icon.type === 'svg' || icon.type === SVG ) ) {
 		const appliedProps = {
 			...icon.props,
 			width: icon.props.width || 24,

--- a/packages/editor/src/components/block-icon/index.js
+++ b/packages/editor/src/components/block-icon/index.js
@@ -9,6 +9,16 @@ import classnames from 'classnames';
 import { Dashicon, SVG } from '@wordpress/components';
 import { createElement, Component } from '@wordpress/element';
 
+function isSVGIcon( icon ) {
+	if ( icon && icon.type === 'svg' ) {
+		return true;
+	} else if ( icon && icon.type.name === 'SVG' ) {
+		return true;
+	}
+
+	return false;
+}
+
 function renderIcon( icon ) {
 	if ( 'string' === typeof icon ) {
 		return <Dashicon icon={ icon } size={ 20 } />;
@@ -18,13 +28,12 @@ function renderIcon( icon ) {
 		}
 
 		return icon();
-	} else if ( icon && icon.type === 'svg' ) {
+	} else if ( isSVGIcon( icon ) ) {
 		const appliedProps = {
 			...icon.props,
 			width: icon.props.width || 24,
 			height: icon.props.height || 24,
 		};
-
 		return <SVG { ...appliedProps } />;
 	}
 


### PR DESCRIPTION
This is an alternative to #10938 which for whatever reason I can't rebase. The purpose is the same:

This PR fixes an icon size regression that was introduced in #9828. Basically SVG icons are _between 20 and 24px_.

If an SVG has an explicit width, it uses that width, within the boundaries of those extremes. But unfortunately it also means if the SVG _doesn't_ have an explicit width or height, it collapses to the min-width and min-height.

This PR updates documentation, and adds explicit dimensions for all block icons used.

Before:

![screen shot 2018-10-23 at 11 34 25](https://user-images.githubusercontent.com/1204802/47352448-32d6d000-d6ba-11e8-8ab8-c83fea8e8b07.png)

After:

![screen shot 2018-10-23 at 11 39 07](https://user-images.githubusercontent.com/1204802/47352456-35392a00-d6ba-11e8-832e-a45f3772389c.png)