### PR TITLE
Fix issue with unified toolbar not fitting

### DIFF
--- a/assets/stylesheets/_breakpoints.scss
+++ b/assets/stylesheets/_breakpoints.scss
@@ -5,6 +5,8 @@
 // Most used breakpoints
 $break-huge: 1440px;
 $break-wide: 1280px;
+$break-xlarge: 1080px;
+$break-large: 960px;	// admin sidebar auto folds
 $break-large: 960px;	// admin sidebar auto folds
 $break-medium: 782px;	// adminbar goes big
 $break-small: 600px;

--- a/assets/stylesheets/_mixins.scss
+++ b/assets/stylesheets/_mixins.scss
@@ -14,6 +14,12 @@
 	}
 }
 
+@mixin break-xlarge() {
+	@media (min-width: #{ ($break-xlarge) }) {
+		@content;
+	}
+}
+
 @mixin break-large() {
 	@media (min-width: #{ ($break-large) }) {
 		@content;

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -64,16 +64,11 @@
 		}
 
 		.editor-block-toolbar {
-			margin: 0;
+			margin: -($grid-size + $border-width) 0;
 		}
 
 		.editor-block-toolbar .components-toolbar {
-			padding: 0 $grid-size-small;
-		}
-
-		// Hide the right border on the ellipsis menu.
-		.editor-block-toolbar > div:last-child .components-toolbar {
-			border-right: none;
+			padding: ($grid-size + $border-width + $border-width) $grid-size-small ($grid-size + $border-width);
 		}
 	}
 }

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -50,7 +50,7 @@
 	}
 
 	// Move toolbar into top Editor Bar.
-	@include break-large {
+	@include break-xlarge {
 		padding-left: $grid-size;
 		position: static;
 		left: auto;
@@ -64,11 +64,16 @@
 		}
 
 		.editor-block-toolbar {
-			margin: -9px 0;
+			margin: 0;
 		}
 
 		.editor-block-toolbar .components-toolbar {
-			padding: 9px;
+			padding: 0 $grid-size-small;
+		}
+
+		// Hide the right border on the ellipsis menu.
+		.editor-block-toolbar > div:last-child .components-toolbar {
+			border-right: none;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #10959.

This PR fixes an issue where at certain viewport widths, there wouldn't be room for the unified toolbar between the icons on the left, and the buttons on the right, in the editor bar. It does so by:

- Reducing the padding between toolbar segments
- Introducing a new breakpoint, xlarge (1080px), that allows the toolbar to stay in the editor bar for longer, before it stacks.

Note, it also changes the design a smidgeon. CC @youknowriad for opinions, I know this reverts a decision you made earlier:

<img width="501" alt="after option 2" src="https://user-images.githubusercontent.com/1204802/47419507-a80ad980-d77c-11e8-8c05-6a7784c146f1.png">

The reason being: the edge to edge borders are there to imply _regions of the interface_. This change makes them more like separators between chunks of content, which I feel speaks better to what it is. CC: @alexislloyd and @karmatosed for thoughts.

But my opinion on this is not STRONG, and I can also trivially change it to this, if that's preferred — in fact it may be necessary due to the UI freeze:

<img width="505" alt="after option 1" src="https://user-images.githubusercontent.com/1204802/47419612-dab4d200-d77c-11e8-959e-89c4c371f8d1.png">

How it looked before:

<img src="https://user-images.githubusercontent.com/583546/47375930-b4962000-d6f1-11e8-8168-8ac595c9bb6a.png" />

GIF of the fix:

![fix](https://user-images.githubusercontent.com/1204802/47419625-e1dbe000-d77c-11e8-9bb2-3b8ee58556e4.gif)
