### PR TITLE
Expose setUnregisteredTypeHandlerName/getUnregisteredTypeHandlerName for mobile

### DIFF
--- a/packages/blocks/src/api/index.native.js
+++ b/packages/blocks/src/api/index.native.js
@@ -15,6 +15,8 @@ export {
 	registerBlockType,
 	setUnknownTypeHandlerName,
 	getUnknownTypeHandlerName,
+	setUnregisteredTypeHandlerName,
+	getUnregisteredTypeHandlerName,
 	getBlockType,
 	getBlockTypes,
 	hasBlockSupport,


### PR DESCRIPTION
This will allow us to replace setUnknownTypeHandlerName and getUnregisteredTypeHandlerName as they're deprecated.

Should unblock https://github.com/wordpress-mobile/gutenberg-mobile/pull/186