### PR TITLE
Fix usage of `preg_quote()`

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -232,7 +232,7 @@ if ( ! function_exists( 'do_blocks' ) ) {
 			$inner_content = '';
 
 			if ( ! $is_self_closing ) {
-				$end_tag_pattern = '/<!--\s+\/wp:' . str_replace( '/', '\/', preg_quote( $block_name ) ) . '\s+-->/';
+				$end_tag_pattern = '/<!--\s+\/wp:' . preg_quote( $block_name, '/' ) . '\s+-->/';
 				if ( ! preg_match( $end_tag_pattern, $content, $block_match_end, PREG_OFFSET_CAPTURE ) ) {
 					// If no closing tag is found, abort all matching, and continue
 					// to append remainder of content to rendered output.


### PR DESCRIPTION
The end tag pattern is currently generated like this:
```
$end_tag_pattern = '/<!--\s+\/wp:' . str_replace( '/', '\/', preg_quote( $block_name ) ) . '\s+-->/';
```

Instead of separately using a string replace to replace `/` with `\/`, it is preferable to use the second argument `$delimiter` that the `preg_quote()` function provides.

See http://php.net/manual/en/function.preg-quote.php

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->


<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->