### PR TITLE
Handle metabox warning exceptions

### DIFF
--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -232,10 +232,15 @@ function gutenberg_show_meta_box_warning( $callback ) {
 		return;
 	}
 
-	if ( is_array( $callback ) ) {
-		$reflection = new ReflectionMethod( $callback[0], $callback[1] );
-	} else {
-		$reflection = new ReflectionFunction( $callback );
+	try {
+		if ( is_array( $callback ) ) {
+			$reflection = new ReflectionMethod( $callback[0], $callback[1] );
+		} else {
+			$reflection = new ReflectionFunction( $callback );
+		}
+	} catch ( ReflectionException $exception ) {
+		// We could not properly reflect on the callable, so we abort here.
+		return;
 	}
 
 	if ( $reflection->isInternal() ) {


### PR DESCRIPTION
The constructor of the `ReflectionMethod` and `ReflectionFunction` classes can throw a `ReflectionException` if they are passed an invalid or broken `$callable`.

We should catch these exceptions and make sure they don't propagate and take the server down, just to stay on the safe side.

See http://php.net/manual/en/reflectionmethod.construct.php & http://php.net/manual/en/reflectionfunction.construct.php

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->


<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->