### PR TITLE
Implement more generic pre-publish prompts; fixes #10750.

### DIFF
--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -33,10 +33,10 @@ function PostPublishPanelPrepublish( {
 		prePublishBodyText = __( 'When you’re ready, submit your work for review, and an Editor will be able to approve it for you.' );
 	} else if ( isBeingScheduled ) {
 		prePublishTitle = __( 'Are you ready to schedule?' );
-		prePublishBodyText = __( 'Your post will be published at the specified date and time.' );
+		prePublishBodyText = __( 'Your work will be published at the specified date and time.' );
 	} else {
 		prePublishTitle = __( 'Are you ready to publish?' );
-		prePublishBodyText = __( 'Double-check your settings, then use the button to publish your post.' );
+		prePublishBodyText = __( 'Double-check your settings before publishing.' );
 	}
 
 	return (


### PR DESCRIPTION
This fixes #10750 by reworking the pre-publish prompts to be a wee bit more generic, so they make sense with any type of content being published:

Before:
<img width="294" alt="screenshot 2018-10-24 14 05 48" src="https://user-images.githubusercontent.com/376315/47432387-eeb8fd80-d795-11e8-870b-6fe57b55fb11.png">

After:
<img width="293" alt="screenshot 2018-10-24 14 05 12" src="https://user-images.githubusercontent.com/376315/47432393-f24c8480-d795-11e8-9460-1982c0786ae4.png">

