### PR TITLE
Block List: Use default Inserter for sibling insertion

### DIFF
--- a/docs/data/data-core-editor.md
+++ b/docs/data/data-core-editor.md
@@ -707,7 +707,7 @@ otherwise.
 
 *Returns*
 
-Whether block is first in mult-selection.
+Whether block is first in multi-selection.
 
 ### isBlockMultiSelected
 
@@ -1534,13 +1534,19 @@ be inserted, optionally at a specific index respective a root block list.
 
  * blocks: Block objects to insert.
  * index: Index at which block should be inserted.
- * rootClientId: Optional root cliente ID of block list on
+ * rootClientId: Optional root client ID of block list on
                                which to insert.
 
 ### showInsertionPoint
 
 Returns an action object used in signalling that the insertion point should
 be shown.
+
+*Parameters*
+
+ * rootClientId: Optional root client ID of block list on
+                              which to insert.
+ * index: Index at which block should be inserted.
 
 ### hideInsertionPoint
 

--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -379,13 +379,13 @@ export class BlockListBlock extends Component {
 			isSelected,
 			isPartOfMultiSelection,
 			isFirstMultiSelected,
-			isLastMultiSelected,
 			isTypingWithinBlock,
 			isCaretWithinFormattedText,
 			isMultiSelecting,
 			hoverArea,
 			isEmptyDefaultBlock,
 			isMovable,
+			isPreviousBlockADefaultEmptyBlock,
 			isParentOfSelectedBlock,
 			isDraggable,
 		} = this.props;
@@ -414,8 +414,8 @@ export class BlockListBlock extends Component {
 
 		// Insertion point can only be made visible if the block is at the
 		// the extent of a multi-selection, or not in a multi-selection.
-		const shouldShowInsertionPoint = ( isPartOfMultiSelection && isLastMultiSelected ) || ! isPartOfMultiSelection;
-		const canShowInBetweenInserter = ! isEmptyDefaultBlock;
+		const shouldShowInsertionPoint = ( isPartOfMultiSelection && isFirstMultiSelected ) || ! isPartOfMultiSelection;
+		const canShowInBetweenInserter = ! isEmptyDefaultBlock && ! isPreviousBlockADefaultEmptyBlock;
 
 		// The wp-block className is important for editor styles.
 		// Generate the wrapper class names handling the different states of the block.
@@ -495,6 +495,13 @@ export class BlockListBlock extends Component {
 				] }
 				{ ...wrapperProps }
 			>
+				{ shouldShowInsertionPoint && (
+					<BlockInsertionPoint
+						clientId={ clientId }
+						rootClientId={ rootClientId }
+						canShowInserter={ canShowInBetweenInserter }
+					/>
+				) }
 				<BlockDropZone
 					index={ order }
 					clientId={ clientId }
@@ -568,13 +575,6 @@ export class BlockListBlock extends Component {
 						</div>
 					</Fragment>
 				) }
-				{ shouldShowInsertionPoint && (
-					<BlockInsertionPoint
-						clientId={ clientId }
-						rootClientId={ rootClientId }
-						canShowInserter={ canShowInBetweenInserter }
-					/>
-				) }
 			</IgnoreNestedEvents>
 		);
 		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
@@ -590,7 +590,6 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId, isLargeV
 		isAncestorMultiSelected,
 		isBlockMultiSelected,
 		isFirstMultiSelectedBlock,
-		isLastMultiSelectedBlock,
 		isMultiSelecting,
 		isTyping,
 		isCaretWithinFormattedText,
@@ -607,6 +606,7 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId, isLargeV
 	const { hasFixedToolbar, focusMode } = getEditorSettings();
 	const block = getBlock( clientId );
 	const previousBlockClientId = getPreviousBlockClientId( clientId );
+	const previousBlock = getBlock( previousBlockClientId );
 	const templateLock = getTemplateLock( rootClientId );
 	const isParentOfSelectedBlock = hasSelectedInnerBlock( clientId, true );
 
@@ -614,7 +614,6 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId, isLargeV
 		nextBlockClientId: getNextBlockClientId( clientId ),
 		isPartOfMultiSelection: isBlockMultiSelected( clientId ) || isAncestorMultiSelected( clientId ),
 		isFirstMultiSelected: isFirstMultiSelectedBlock( clientId ),
-		isLastMultiSelected: isLastMultiSelectedBlock( clientId ),
 		isMultiSelecting: isMultiSelecting(),
 		// We only care about this prop when the block is selected
 		// Thus to avoid unnecessary rerenders we avoid updating the prop if the block is not selected.
@@ -626,6 +625,7 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId, isLargeV
 		isSelectionEnabled: isSelectionEnabled(),
 		initialPosition: getSelectedBlocksInitialCaretPosition(),
 		isEmptyDefaultBlock: block && isUnmodifiedDefaultBlock( block ),
+		isPreviousBlockADefaultEmptyBlock: previousBlock && isUnmodifiedDefaultBlock( previousBlock ),
 		isMovable: 'all' !== templateLock,
 		isLocked: !! templateLock,
 		isFocusMode: focusMode && isLargeViewport,

--- a/packages/editor/src/components/block-list/insertion-point.js
+++ b/packages/editor/src/components/block-list/insertion-point.js
@@ -6,12 +6,14 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import { Component } from '@wordpress/element';
-import { IconButton } from '@wordpress/components';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { ifCondition, compose } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import Inserter from '../inserter';
 
 class BlockInsertionPoint extends Component {
 	constructor() {
@@ -22,14 +24,9 @@ class BlockInsertionPoint extends Component {
 
 		this.onBlurInserter = this.onBlurInserter.bind( this );
 		this.onFocusInserter = this.onFocusInserter.bind( this );
-		this.onClick = this.onClick.bind( this );
 	}
 
-	onFocusInserter( event ) {
-		// We stop propagation of the focus event to avoid selecting the current block
-		// While we're trying to insert a new block
-		event.stopPropagation();
-
+	onFocusInserter() {
 		this.setState( {
 			isInserterFocused: true,
 		} );
@@ -41,77 +38,47 @@ class BlockInsertionPoint extends Component {
 		} );
 	}
 
-	onClick() {
-		const { rootClientId, index, ...props } = this.props;
-		props.insertDefaultBlock( undefined, rootClientId, index );
-		props.startTyping();
-		this.onBlurInserter();
-		if ( props.onInsert ) {
-			this.props.onInsert();
-		}
-	}
-
 	render() {
 		const { isInserterFocused } = this.state;
-		const { showInsertionPoint, showInserter } = this.props;
+		const { showInsertionPoint, canShowInserter } = this.props;
 
 		return (
 			<div className="editor-block-list__insertion-point">
 				{ showInsertionPoint && <div className="editor-block-list__insertion-point-indicator" /> }
-				{ showInserter && (
-					<div className={ classnames( 'editor-block-list__insertion-point-inserter', { 'is-visible': isInserterFocused } ) }>
-						<IconButton
-							icon="insert"
-							className="editor-block-list__insertion-point-button"
-							onClick={ this.onClick }
-							label={ __( 'Insert block' ) }
-							onFocus={ this.onFocusInserter }
-							onBlur={ this.onBlurInserter }
-						/>
+				{ canShowInserter && (
+					<div
+						onFocus={ this.onFocusInserter }
+						onBlur={ this.onBlurInserter }
+						className={
+							classnames( 'editor-block-list__insertion-point-inserter', {
+								'is-visible': isInserterFocused,
+							} )
+						}
+					>
+						<Inserter />
 					</div>
 				) }
 			</div>
 		);
 	}
 }
-export default compose(
-	withSelect( ( select, { clientId, rootClientId, canShowInserter } ) => {
-		const {
-			canInsertBlockType,
-			getBlockIndex,
-			getBlockInsertionPoint,
-			getBlock,
-			isBlockInsertionPointVisible,
-			isTyping,
-		} = select( 'core/editor' );
-		const {
-			getDefaultBlockName,
-		} = select( 'core/blocks' );
-		const blockIndex = clientId ? getBlockIndex( clientId, rootClientId ) : -1;
-		const insertIndex = blockIndex;
-		const insertionPoint = getBlockInsertionPoint();
-		const block = clientId ? getBlock( clientId ) : null;
-		const showInsertionPoint = (
-			isBlockInsertionPointVisible() &&
-			insertionPoint.index === insertIndex &&
-			insertionPoint.rootClientId === rootClientId &&
-			( ! block || ! isUnmodifiedDefaultBlock( block ) )
-		);
+export default withSelect( ( select, { clientId, rootClientId } ) => {
+	const {
+		getBlockIndex,
+		getBlockInsertionPoint,
+		getBlock,
+		isBlockInsertionPointVisible,
+	} = select( 'core/editor' );
+	const blockIndex = getBlockIndex( clientId, rootClientId );
+	const insertIndex = blockIndex + 1;
+	const insertionPoint = getBlockInsertionPoint();
+	const block = getBlock( clientId );
+	const showInsertionPoint = (
+		isBlockInsertionPointVisible() &&
+		insertionPoint.index === insertIndex &&
+		insertionPoint.rootClientId === rootClientId &&
+		! isUnmodifiedDefaultBlock( block )
+	);
 
-		const defaultBlockName = getDefaultBlockName();
-		return {
-			canInsertDefaultBlock: canInsertBlockType( defaultBlockName, rootClientId ),
-			showInserter: ! isTyping() && canShowInserter,
-			index: insertIndex,
-			showInsertionPoint,
-		};
-	} ),
-	ifCondition( ( { canInsertDefaultBlock } ) => canInsertDefaultBlock ),
-	withDispatch( ( dispatch ) => {
-		const { insertDefaultBlock, startTyping } = dispatch( 'core/editor' );
-		return {
-			insertDefaultBlock,
-			startTyping,
-		};
-	} )
-)( BlockInsertionPoint );
+	return { showInsertionPoint };
+} )( BlockInsertionPoint );

--- a/packages/editor/src/components/block-list/insertion-point.js
+++ b/packages/editor/src/components/block-list/insertion-point.js
@@ -26,7 +26,12 @@ class BlockInsertionPoint extends Component {
 		this.onFocusInserter = this.onFocusInserter.bind( this );
 	}
 
-	onFocusInserter() {
+	onFocusInserter( event ) {
+		// Stop propagation of the focus event to avoid selecting the current
+		// block while inserting a new block, as it is not relevant to sibling
+		// insertion and conflicts with contextual toolbar placement.
+		event.stopPropagation();
+
 		this.setState( {
 			isInserterFocused: true,
 		} );
@@ -40,11 +45,18 @@ class BlockInsertionPoint extends Component {
 
 	render() {
 		const { isInserterFocused } = this.state;
-		const { showInsertionPoint, canShowInserter } = this.props;
+		const {
+			showInsertionPoint,
+			canShowInserter,
+			rootClientId,
+			insertIndex,
+		} = this.props;
 
 		return (
 			<div className="editor-block-list__insertion-point">
-				{ showInsertionPoint && <div className="editor-block-list__insertion-point-indicator" /> }
+				{ showInsertionPoint && (
+					<div className="editor-block-list__insertion-point-indicator" />
+				) }
 				{ canShowInserter && (
 					<div
 						onFocus={ this.onFocusInserter }
@@ -55,7 +67,10 @@ class BlockInsertionPoint extends Component {
 							} )
 						}
 					>
-						<Inserter />
+						<Inserter
+							rootClientId={ rootClientId }
+							index={ insertIndex }
+						/>
 					</div>
 				) }
 			</div>
@@ -70,7 +85,7 @@ export default withSelect( ( select, { clientId, rootClientId } ) => {
 		isBlockInsertionPointVisible,
 	} = select( 'core/editor' );
 	const blockIndex = getBlockIndex( clientId, rootClientId );
-	const insertIndex = blockIndex + 1;
+	const insertIndex = blockIndex;
 	const insertionPoint = getBlockInsertionPoint();
 	const block = getBlock( clientId );
 	const showInsertionPoint = (
@@ -80,5 +95,5 @@ export default withSelect( ( select, { clientId, rootClientId } ) => {
 		! isUnmodifiedDefaultBlock( block )
 	);
 
-	return { showInsertionPoint };
+	return { showInsertionPoint, insertIndex };
 } )( BlockInsertionPoint );

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -613,7 +613,7 @@
 .editor-block-list__insertion-point {
 	position: relative;
 	z-index: z-index(".editor-block-list__insertion-point");
-	margin-bottom: -$block-padding;
+	margin-top: -$block-padding;
 }
 
 .editor-block-list__insertion-point-indicator {
@@ -663,14 +663,30 @@
 	}
 }
 
+// Don't show the sibling inserter before the selected block.
+.edit-post-layout:not(.has-fixed-toolbar) {
+	// The child selector is necessary for this to work properly in nested contexts.
+	.is-selected > .editor-block-list__insertion-point .editor-inserter__toggle {
+		opacity: 0;
+		pointer-events: none;
+
+		&:hover,
+		&.is-visible {
+			opacity: 1;
+			pointer-events: auto;
+		}
+	}
+}
+
 // This is the edge-to-edge hover area that contains the plus.
 .editor-block-list__block {
 	> .editor-block-list__insertion-point {
 		position: absolute;
-		bottom: -$block-padding - $block-spacing / 2;
+		top: -$block-padding - $block-spacing / 2;
 
 		// Matches the whole empty space between two blocks.
 		height: $block-padding * 2;
+		bottom: auto;
 
 		// Go edge to edge on mobile.
 		left: 0;

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -613,7 +613,7 @@
 .editor-block-list__insertion-point {
 	position: relative;
 	z-index: z-index(".editor-block-list__insertion-point");
-	margin-top: -$block-padding;
+	margin-bottom: -$block-padding;
 }
 
 .editor-block-list__insertion-point-indicator {
@@ -640,7 +640,7 @@
 	justify-content: center;
 
 	// Show a clickable plus.
-	.editor-block-list__insertion-point-button {
+	.editor-inserter__toggle {
 		margin-top: -4px;
 		border-radius: 50%;
 		color: $blue-medium-focus;
@@ -663,30 +663,14 @@
 	}
 }
 
-// Don't show the sibling inserter before the selected block.
-.edit-post-layout:not(.has-fixed-toolbar) {
-	// The child selector is necessary for this to work properly in nested contexts.
-	.is-selected > .editor-block-list__insertion-point > .editor-block-list__insertion-point-inserter {
-		opacity: 0;
-		pointer-events: none;
-
-		&:hover,
-		&.is-visible {
-			opacity: 1;
-			pointer-events: auto;
-		}
-	}
-}
-
 // This is the edge-to-edge hover area that contains the plus.
 .editor-block-list__block {
 	> .editor-block-list__insertion-point {
 		position: absolute;
-		top: -$block-padding - $block-spacing / 2;
+		bottom: -$block-padding - $block-spacing / 2;
 
 		// Matches the whole empty space between two blocks.
 		height: $block-padding * 2;
-		bottom: auto;
 
 		// Go edge to edge on mobile.
 		left: 0;

--- a/packages/editor/src/components/inserter/index.js
+++ b/packages/editor/src/components/inserter/index.js
@@ -99,15 +99,14 @@ class Inserter extends Component {
 }
 
 export default compose( [
-	withSelect( ( select, { rootClientId } ) => {
+	withSelect( ( select, { rootClientId, index } ) => {
 		const {
 			getEditedPostAttribute,
 			getBlockInsertionPoint,
 			getInserterItems,
 		} = select( 'core/editor' );
 
-		let index;
-		if ( rootClientId === undefined ) {
+		if ( rootClientId === undefined && index === undefined ) {
 			// Unless explicitly provided, the default insertion point provided
 			// by the store occurs immediately following the selected block.
 			// Otherwise, the default behavior for an undefined index is to

--- a/packages/editor/src/components/inserter/menu.js
+++ b/packages/editor/src/components/inserter/menu.js
@@ -130,10 +130,12 @@ export class InserterMenu extends Component {
 			hoveredItem: item,
 		} );
 
+		const { showInsertionPoint, hideInsertionPoint } = this.props;
 		if ( item ) {
-			this.props.showInsertionPoint();
+			const { rootClientId, index } = this.props;
+			showInsertionPoint( rootClientId, index );
 		} else {
-			this.props.hideInsertionPoint();
+			hideInsertionPoint();
 		}
 	}
 

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -312,7 +312,7 @@ export function insertBlock( block, index, rootClientId ) {
  *
  * @param {Object[]} blocks       Block objects to insert.
  * @param {?number}  index        Index at which block should be inserted.
- * @param {?string}  rootClientId Optional root cliente ID of block list on
+ * @param {?string}  rootClientId Optional root client ID of block list on
  *                                which to insert.
  *
  * @return {Object} Action object.
@@ -331,11 +331,17 @@ export function insertBlocks( blocks, index, rootClientId ) {
  * Returns an action object used in signalling that the insertion point should
  * be shown.
  *
+ * @param {?string} rootClientId Optional root client ID of block list on
+ *                               which to insert.
+ * @param {?number} index        Index at which block should be inserted.
+ *
  * @return {Object} Action object.
  */
-export function showInsertionPoint() {
+export function showInsertionPoint( rootClientId, index ) {
 	return {
 		type: 'SHOW_INSERTION_POINT',
+		rootClientId,
+		index,
 	};
 }
 

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -710,21 +710,23 @@ export function blocksMode( state = {}, action ) {
 }
 
 /**
- * Reducer returning the block insertion point visibility, a boolean value
- * reflecting whether the insertion point should be shown.
+ * Reducer returning the block insertion point visibility, either null if there
+ * is not an explicit insertion point assigned, or an object of its `index` and
+ * `rootClientId`.
  *
  * @param {Object} state  Current state.
  * @param {Object} action Dispatched action.
  *
  * @return {Object} Updated state.
  */
-export function isInsertionPointVisible( state = false, action ) {
+export function insertionPoint( state = null, action ) {
 	switch ( action.type ) {
 		case 'SHOW_INSERTION_POINT':
-			return true;
+			const { rootClientId, index } = action;
+			return { rootClientId, index };
 
 		case 'HIDE_INSERTION_POINT':
-			return false;
+			return null;
 	}
 
 	return state;
@@ -1100,7 +1102,7 @@ export default optimist( combineReducers( {
 	blockSelection,
 	blocksMode,
 	blockListSettings,
-	isInsertionPointVisible,
+	insertionPoint,
 	preferences,
 	saving,
 	postLock,

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1026,20 +1026,6 @@ export function isFirstMultiSelectedBlock( state, clientId ) {
 }
 
 /**
- * Returns true if a multi-selection exists, and the block corresponding to the
- * specified client ID is the last block of the multi-selection set, or false
- * otherwise.
- *
- * @param {Object} state    Editor state.
- * @param {string} clientId Block client ID.
- *
- * @return {boolean} Whether block is last in mult-selection.
- */
-export function isLastMultiSelectedBlock( state, clientId ) {
-	return getLastMultiSelectedBlockClientId( state ) === clientId;
-}
-
-/**
  * Returns true if the client ID occurs within the block multi-selection, or
  * false otherwise.
  *

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1016,13 +1016,27 @@ export function getLastMultiSelectedBlockClientId( state ) {
  * specified client ID is the first block of the multi-selection set, or false
  * otherwise.
  *
- * @param {Object} state      Editor state.
- * @param {string} clientId   Block client ID.
+ * @param {Object} state    Editor state.
+ * @param {string} clientId Block client ID.
  *
- * @return {boolean} Whether block is first in mult-selection.
+ * @return {boolean} Whether block is first in multi-selection.
  */
 export function isFirstMultiSelectedBlock( state, clientId ) {
 	return getFirstMultiSelectedBlockClientId( state ) === clientId;
+}
+
+/**
+ * Returns true if a multi-selection exists, and the block corresponding to the
+ * specified client ID is the last block of the multi-selection set, or false
+ * otherwise.
+ *
+ * @param {Object} state    Editor state.
+ * @param {string} clientId Block client ID.
+ *
+ * @return {boolean} Whether block is last in mult-selection.
+ */
+export function isLastMultiSelectedBlock( state, clientId ) {
+	return getLastMultiSelectedBlockClientId( state ) === clientId;
 }
 
 /**

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1291,7 +1291,12 @@ export function isCaretWithinFormattedText( state ) {
 export function getBlockInsertionPoint( state ) {
 	let rootClientId, index;
 
-	const { end } = state.blockSelection;
+	const { insertionPoint, blockSelection } = state;
+	if ( insertionPoint !== null ) {
+		return insertionPoint;
+	}
+
+	const { end } = blockSelection;
 	if ( end ) {
 		rootClientId = getBlockRootClientId( state, end ) || undefined;
 		index = getBlockIndex( state, end, rootClientId ) + 1;
@@ -1310,7 +1315,7 @@ export function getBlockInsertionPoint( state ) {
  * @return {?boolean} Whether the insertion point is visible or not.
  */
 export function isBlockInsertionPointVisible( state ) {
-	return state.isInsertionPointVisible;
+	return state.insertionPoint !== null;
 }
 
 /**

--- a/packages/editor/src/store/test/reducer.js
+++ b/packages/editor/src/store/test/reducer.js
@@ -30,7 +30,7 @@ import {
 	preferences,
 	saving,
 	blocksMode,
-	isInsertionPointVisible,
+	insertionPoint,
 	reusableBlocks,
 	template,
 	blockListSettings,
@@ -1274,27 +1274,36 @@ describe( 'state', () => {
 		} );
 	} );
 
-	describe( 'isInsertionPointVisible', () => {
-		it( 'should default to false', () => {
-			const state = isInsertionPointVisible( undefined, {} );
+	describe( 'insertionPoint', () => {
+		it( 'should default to null', () => {
+			const state = insertionPoint( undefined, {} );
 
-			expect( state ).toBe( false );
+			expect( state ).toBe( null );
 		} );
 
-		it( 'should set insertion point visible', () => {
-			const state = isInsertionPointVisible( false, {
+		it( 'should set insertion point', () => {
+			const state = insertionPoint( null, {
 				type: 'SHOW_INSERTION_POINT',
+				rootClientId: 'clientId1',
+				index: 0,
 			} );
 
-			expect( state ).toBe( true );
+			expect( state ).toEqual( {
+				rootClientId: 'clientId1',
+				index: 0,
+			} );
 		} );
 
 		it( 'should clear the insertion point', () => {
-			const state = isInsertionPointVisible( true, {
+			const original = deepFreeze( {
+				rootClientId: 'clientId1',
+				index: 0,
+			} );
+			const state = insertionPoint( original, {
 				type: 'HIDE_INSERTION_POINT',
 			} );
 
-			expect( state ).toBe( false );
+			expect( state ).toBe( null );
 		} );
 	} );
 

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -2761,6 +2761,40 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'getBlockInsertionPoint', () => {
+		it( 'should return the explicitly assigned insertion point', () => {
+			const state = {
+				currentPost: {},
+				preferences: { mode: 'visual' },
+				blockSelection: {
+					start: 'clientId2',
+					end: 'clientId2',
+				},
+				editor: {
+					present: {
+						blocksByClientId: {
+							clientId1: { clientId: 'clientId1' },
+							clientId2: { clientId: 'clientId2' },
+						},
+						blockOrder: {
+							'': [ 'clientId1' ],
+							clientId1: [ 'clientId2' ],
+							clientId2: [],
+						},
+						edits: {},
+					},
+				},
+				insertionPoint: {
+					rootClientId: undefined,
+					index: 0,
+				},
+			};
+
+			expect( getBlockInsertionPoint( state ) ).toEqual( {
+				rootClientId: undefined,
+				index: 0,
+			} );
+		} );
+
 		it( 'should return an object for the selected block', () => {
 			const state = {
 				currentPost: {},
@@ -2781,7 +2815,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
-				isInsertionPointVisible: false,
+				insertionPoint: null,
 			};
 
 			expect( getBlockInsertionPoint( state ) ).toEqual( {
@@ -2812,7 +2846,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
-				isInsertionPointVisible: false,
+				insertionPoint: null,
 			};
 
 			expect( getBlockInsertionPoint( state ) ).toEqual( {
@@ -2843,7 +2877,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
-				isInsertionPointVisible: false,
+				insertionPoint: null,
 			};
 
 			expect( getBlockInsertionPoint( state ) ).toEqual( {
@@ -2874,7 +2908,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
-				isInsertionPointVisible: false,
+				insertionPoint: null,
 			};
 
 			expect( getBlockInsertionPoint( state ) ).toEqual( {
@@ -2885,9 +2919,20 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'isBlockInsertionPointVisible', () => {
-		it( 'should return the value in state', () => {
+		it( 'should return false if no assigned insertion point', () => {
 			const state = {
-				isInsertionPointVisible: true,
+				insertionPoint: null,
+			};
+
+			expect( isBlockInsertionPointVisible( state ) ).toBe( false );
+		} );
+
+		it( 'should return true if assigned insertion point', () => {
+			const state = {
+				insertionPoint: {
+					rootClientId: undefined,
+					index: 5,
+				},
 			};
 
 			expect( isBlockInsertionPointVisible( state ) ).toBe( true );

--- a/test/e2e/specs/adding-blocks.test.js
+++ b/test/e2e/specs/adding-blocks.test.js
@@ -67,11 +67,20 @@ describe( 'adding blocks', () => {
 		await page.click( '.editor-post-title__input' );
 
 		// Using the between inserter
-		const insertionPoint = await page.$( '[data-type="core/quote"] .editor-block-list__insertion-point-button' );
+		const insertionPoint = await page.$( '[data-type="core/quote"] .editor-inserter__toggle' );
 		const rect = await insertionPoint.boundingBox();
 		await page.mouse.move( rect.x + ( rect.width / 2 ), rect.y + ( rect.height / 2 ), { steps: 10 } );
-		await page.waitForSelector( '[data-type="core/quote"] .editor-block-list__insertion-point-button' );
-		await page.click( '[data-type="core/quote"] .editor-block-list__insertion-point-button' );
+		await page.waitForSelector( '[data-type="core/quote"] .editor-inserter__toggle' );
+		await page.click( '[data-type="core/quote"] .editor-inserter__toggle' );
+		// [TODO]: Search input should be focused immediately. It shouldn't be
+		// necessary to have `waitForFunction`.
+		await page.waitForFunction( () => (
+			document.activeElement &&
+			document.activeElement.classList.contains( 'editor-inserter__search' )
+		) );
+		await page.keyboard.type( 'para' );
+		await pressTimes( 'Tab', 3 );
+		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'Second paragraph' );
 
 		// Switch to Text Mode to check HTML Output


### PR DESCRIPTION
Partially addresses: #10519

This pull request seeks to change the behavior of the sibling inserter to display the same Inserter menu which appears in the header toolbar. This replaces the current behavior which inserts a new empty paragraph block.

**Implementation notes:**

As implemented, it's not yet a faithful recreation of the cases where the previous sibling inserter would have been shown. This is partly to do with the need to reposition the inserter from the top of the block to the bottom, effectively changing from an "insert before" to an "insert after" action, since the Inserter is currently architected to only fully support the latter.

Notably, the following divergences exist:

- An inserter is not shown before the first block
- An inserter is wrongly shown in block contexts where no blocks can be inserted, e.g. columns (related: #7301).
   - This will require some enhancements to the Inserter component to accept not just `rootClientId`, but index at which to insert.
- An inserter is shown adjacent the selected block
   - I don't even know why this was disabled previously
- An inserter can be shown while `isTyping` is active
   - I don't even know why this was disabled previously. And, if I understand correctly, it would prevent tabbing to the sibling inserter while typing. Is that meant to be the intended behavior? How would someone reach the sibling inserter while typing if they _wanted_ to reach it? 

I'm not sure if it's worth tackling some of these here or separately.