### PR TITLE
Don't load PHP classes in WP5+

### DIFF
--- a/lib/load.php
+++ b/lib/load.php
@@ -9,41 +9,49 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Silence is golden.' );
 }
 
-// These files only need to be loaded if within a rest server instance
-// which this class will exist if that is the case.
-if ( class_exists( 'WP_REST_Controller' ) ) {
-	if ( ! class_exists( 'WP_REST_Blocks_Controller' ) ) {
-		require dirname( __FILE__ ) . '/class-wp-rest-blocks-controller.php';
-	}
-	if ( ! class_exists( 'WP_REST_Autosaves_Controller' ) ) {
-		require dirname( __FILE__ ) . '/class-wp-rest-autosaves-controller.php';
-	}
-	if ( ! class_exists( 'WP_REST_Themes_Controller' ) ) {
-		require dirname( __FILE__ ) . '/class-wp-rest-themes-controller.php';
-	}
-	if ( ! class_exists( 'WP_REST_Block_Renderer_Controller' ) ) {
-		require dirname( __FILE__ ) . '/class-wp-rest-block-renderer-controller.php';
-	}
-	if ( ! class_exists( 'WP_REST_Search_Controller' ) ) {
-		require dirname( __FILE__ ) . '/class-wp-rest-search-controller.php';
-	}
-	if ( ! class_exists( 'WP_REST_Search_Handler' ) ) {
-		require dirname( __FILE__ ) . '/class-wp-rest-search-handler.php';
-	}
-	if ( ! class_exists( 'WP_REST_Post_Search_Handler' ) ) {
-		require dirname( __FILE__ ) . '/class-wp-rest-post-search-handler.php';
+// These PHP entities are already declared in WordPress 5.0. Merely
+// depending on `class_exists` can easily fail is the plugin declares a
+// class before core, so instead we only load if the WP version matches 4.*
+// (the plugin's current minimum version is 4.9.8).
+global $wp_version;
+if ( 0 === strpos( $wp_version, '4.' ) ) {
+
+	// These files only need to be loaded if within a rest server instance
+	// which this class will exist if that is the case.
+	if ( class_exists( 'WP_REST_Controller' ) ) {
+		if ( ! class_exists( 'WP_REST_Blocks_Controller' ) ) {
+			require dirname( __FILE__ ) . '/class-wp-rest-blocks-controller.php';
+		}
+		if ( ! class_exists( 'WP_REST_Autosaves_Controller' ) ) {
+			require dirname( __FILE__ ) . '/class-wp-rest-autosaves-controller.php';
+		}
+		if ( ! class_exists( 'WP_REST_Themes_Controller' ) ) {
+			require dirname( __FILE__ ) . '/class-wp-rest-themes-controller.php';
+		}
+		if ( ! class_exists( 'WP_REST_Block_Renderer_Controller' ) ) {
+			require dirname( __FILE__ ) . '/class-wp-rest-block-renderer-controller.php';
+		}
+		if ( ! class_exists( 'WP_REST_Search_Controller' ) ) {
+			require dirname( __FILE__ ) . '/class-wp-rest-search-controller.php';
+		}
+		if ( ! class_exists( 'WP_REST_Search_Handler' ) ) {
+			require dirname( __FILE__ ) . '/class-wp-rest-search-handler.php';
+		}
+		if ( ! class_exists( 'WP_REST_Post_Search_Handler' ) ) {
+			require dirname( __FILE__ ) . '/class-wp-rest-post-search-handler.php';
+		}
 	}
 
-	require dirname( __FILE__ ) . '/rest-api.php';
+	if ( ! class_exists( 'WP_Block_Type' ) ) {
+		require dirname( __FILE__ ) . '/class-wp-block-type.php';
+	}
+	if ( ! class_exists( 'WP_Block_Type_Registry' ) ) {
+		require dirname( __FILE__ ) . '/class-wp-block-type-registry.php';
+	}
 }
 
+require dirname( __FILE__ ) . '/rest-api.php';
 require dirname( __FILE__ ) . '/meta-box-partial-page.php';
-if ( ! class_exists( 'WP_Block_Type' ) ) {
-	require dirname( __FILE__ ) . '/class-wp-block-type.php';
-}
-if ( ! class_exists( 'WP_Block_Type_Registry' ) ) {
-	require dirname( __FILE__ ) . '/class-wp-block-type-registry.php';
-}
 require dirname( __FILE__ ) . '/blocks.php';
 require dirname( __FILE__ ) . '/client-assets.php';
 require dirname( __FILE__ ) . '/compat.php';


### PR DESCRIPTION
## Description
See report in Core: https://core.trac.wordpress.org/ticket/45157

**Edit:** Superseded by #11375.

[See diff with no whitespace changes](https://github.com/WordPress/gutenberg/pull/11019/files?utf8=✓&diff=unified&w=1).

After a lot of back-and-forth, I suspect any failure we may see here is due to interactions caused by Gutenberg-dependent plugins. The `class_exists` guards should be more than enough to allow the plugin to run on both 4.9.8 and 5.0. In any case, we can try to shield the user even more by checking that we're running 4.9.x before loading classes in the plugin.

## How has this been tested?
Plugin should work in 4.9 and 5.0. Test server-side interactions, like editing Latest Posts, viewing Latest Posts on the frontend. If you have a plugin using server-side knowledge of blocks, try that too.

Note: Latest Comments *seems* to be having problems in core regardless of the plugin.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->