### PR TITLE
Update plugin version to 4.1.0

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -3,7 +3,7 @@
  * Plugin Name: Gutenberg
  * Plugin URI: https://github.com/WordPress/gutenberg
  * Description: Printing since 1440. This is the development plugin for the new block editor in core.
- * Version: 4.1.0-rc.2
+ * Version: 4.1.0
  * Author: Gutenberg Team
  *
  * @package gutenberg

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "4.1.0-rc.2",
+	"version": "4.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "4.1.0-rc.2",
+	"version": "4.1.0",
 	"private": true,
 	"description": "A new WordPress editor experience",
 	"repository": "git+https://github.com/WordPress/gutenberg.git",


### PR DESCRIPTION
**Changelog**

 - Removes the keyword half from the Media & Text block.
 - Fix: Show resizer on "Media & Text" block on unified toolbar mode
 - Fix RichText shortcuts
 - Fix Slash autocomplete: Support non-Latin inputs
 - Add WordPress logo animation for preview

