### PR TITLE
Media & Text: Fixing vertical alignment of the image

### DIFF
--- a/packages/block-library/src/media-text/editor.scss
+++ b/packages/block-library/src/media-text/editor.scss
@@ -43,7 +43,7 @@ figure.block-library-media-text__media-container {
 
 .wp-block-media-text .block-library-media-text__media-container img,
 .wp-block-media-text .block-library-media-text__media-container video {
-	margin-bottom: -8px;
+	vertical-align: middle;
 	width: 100%;
 }
 

--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -31,5 +31,5 @@
 .wp-block-media-text > figure > video {
 	max-width: unset;
 	width: 100%;
-	margin-bottom: -6px;
+	vertical-align: middle;
 }


### PR DESCRIPTION
Fixes #11024

Potentially could be even fixed with `vertical-align: top;`