### PR TITLE
Data: Refactor and optimize withSelect, withDispatch handling of registry change

### DIFF
--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -1,9 +1,11 @@
 Gutenberg's deprecation policy is intended to support backwards-compatibility for releases, when possible. The current deprecations are listed below and are grouped by _the version at which they will be removed completely_. If your plugin depends on these behaviors, you must update to the recommended alternative before the noted version.
 
-# 4.4.0
- - `wp.date.getSettings` has been removed. Please use `wp.date.__experimentalGetSettings` instead.
+## 4.4.0
 
-# 4.3.0
+- `wp.date.getSettings` has been removed. Please use `wp.date.__experimentalGetSettings` instead.
+- `wp.compose.remountOnPropChange` has been removed.
+
+## 4.3.0
 
 - `isEditorSidebarPanelOpened` selector (`core/edit-post`) has been removed. Please use `isEditorPanelEnabled` instead.
 - `toggleGeneralSidebarEditorPanel` action (`core/edit-post`) has been removed. Please use `toggleEditorPanelOpened` instead.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -269,7 +269,13 @@ function gutenberg_register_scripts_and_styles() {
 	gutenberg_override_script(
 		'wp-compose',
 		gutenberg_url( 'build/compose/index.js' ),
-		array( 'lodash', 'wp-element', 'wp-is-shallow-equal', 'wp-polyfill' ),
+		array(
+			'lodash',
+			'wp-deprecated',
+			'wp-element',
+			'wp-is-shallow-equal',
+			'wp-polyfill',
+		),
 		filemtime( gutenberg_dir_path() . 'build/compose/index.js' ),
 		true
 	);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2152,6 +2152,7 @@
 			"version": "file:packages/compose",
 			"requires": {
 				"@babel/runtime": "^7.0.0",
+				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"lodash": "^4.17.10"

--- a/packages/compose/CHANGELOG.md
+++ b/packages/compose/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.0 (Unreleased)
+
+### Deprecation
+
+- `remountOnPropChange` has been deprecated.
+
 ## 2.0.5 (2018-10-19)
 
 ## 2.0.4 (2018-10-18)

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -22,6 +22,7 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.0.0",
+		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/element": "file:../element",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"lodash": "^4.17.10"

--- a/packages/compose/src/remount-on-prop-change/index.js
+++ b/packages/compose/src/remount-on-prop-change/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -16,8 +17,13 @@ import createHigherOrderComponent from '../create-higher-order-component';
  *
  * @return {Function} Higher-order component.
  */
-const remountOnPropChange = ( propName ) => createHigherOrderComponent(
-	( WrappedComponent ) => class extends Component {
+const remountOnPropChange = ( propName ) => createHigherOrderComponent( ( WrappedComponent ) => {
+	deprecated( 'remountOnPropChange', {
+		plugin: 'Gutenberg',
+		version: '4.4.0',
+	} );
+
+	return class extends Component {
 		constructor( props ) {
 			super( ...arguments );
 			this.state = {
@@ -40,8 +46,7 @@ const remountOnPropChange = ( propName ) => createHigherOrderComponent(
 		render() {
 			return <WrappedComponent key={ this.state.propChangeId } { ...this.props } />;
 		}
-	},
-	'remountOnPropChange'
-);
+	};
+}, 'remountOnPropChange' );
 
 export default remountOnPropChange;

--- a/packages/compose/src/remount-on-prop-change/test/index.js
+++ b/packages/compose/src/remount-on-prop-change/test/index.js
@@ -7,11 +7,14 @@ import TestRenderer from 'react-test-renderer';
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
  */
 import remountOnPropChange from '../';
+
+jest.mock( '@wordpress/deprecated', () => jest.fn() );
 
 describe( 'remountOnPropChange', () => {
 	let count = 0;
@@ -52,6 +55,8 @@ describe( 'remountOnPropChange', () => {
 			<Wrapped monitor="unchanged" other="2" />
 		);
 		expect( testRenderer.toJSON() ).toBe( '1' );
+
+		expect( deprecated ).toHaveBeenCalled();
 	} );
 
 	it( 'Should remount the inner component if the prop value changes', () => {
@@ -67,5 +72,7 @@ describe( 'remountOnPropChange', () => {
 			<Wrapped monitor="updated" />
 		);
 		expect( testRenderer.toJSON() ).toBe( '2' );
+
+		expect( deprecated ).toHaveBeenCalled();
 	} );
 } );

--- a/packages/data/src/components/with-dispatch/index.js
+++ b/packages/data/src/components/with-dispatch/index.js
@@ -7,7 +7,7 @@ import { mapValues } from 'lodash';
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { pure, compose, remountOnPropChange, createHigherOrderComponent } from '@wordpress/compose';
+import { pure, compose, createHigherOrderComponent } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -30,7 +30,7 @@ const withDispatch = ( mapDispatchToProps ) => createHigherOrderComponent(
 	compose( [
 		pure,
 		( WrappedComponent ) => {
-			const ComponentWithDispatch = remountOnPropChange( 'registry' )( class extends Component {
+			class ComponentWithDispatch extends Component {
 				constructor( props ) {
 					super( ...arguments );
 
@@ -48,8 +48,12 @@ const withDispatch = ( mapDispatchToProps ) => createHigherOrderComponent(
 				}
 
 				setProxyProps( props ) {
-					// Assign as instance property so that in reconciling subsequent
-					// renders, the assigned prop values are referentially equal.
+					// Assign as instance property so that in subsequent render
+					// reconciliation, the prop values are referentially equal.
+					// Importantly, note that while `mapDispatchToProps` is
+					// called, it is done only to determine the keys for which
+					// proxy functions should be created. The actual registry
+					// dispatch does not occur until the function is called.
 					const propsToDispatchers = mapDispatchToProps( this.props.registry.dispatch, props.ownProps );
 					this.proxyProps = mapValues( propsToDispatchers, ( dispatcher, propName ) => {
 						// Prebind with prop name so we have reference to the original
@@ -66,7 +70,7 @@ const withDispatch = ( mapDispatchToProps ) => createHigherOrderComponent(
 				render() {
 					return <WrappedComponent { ...this.props.ownProps } { ...this.proxyProps } />;
 				}
-			} );
+			}
 
 			return ( ownProps ) => (
 				<RegistryConsumer>

--- a/packages/data/src/components/with-select/test/index.js
+++ b/packages/data/src/components/with-select/test/index.js
@@ -11,10 +11,41 @@ import { compose } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import withSelect from '../';
+import withSelect, { getUniqueKeyByObject } from '../';
 import withDispatch from '../../with-dispatch';
 import { createRegistry } from '../../../registry';
 import RegistryProvider from '../../registry-provider';
+
+describe( 'getUniqueKeyByObject', () => {
+	it( 'returns a string', () => {
+		expect( typeof getUniqueKeyByObject( {} ) ).toBe( 'string' );
+	} );
+
+	it( 'returns the same id on repeated call with same value', () => {
+		const value = {};
+		let lastId = getUniqueKeyByObject( value );
+		let id;
+
+		id = getUniqueKeyByObject( value );
+		expect( id ).toBe( lastId );
+		lastId = id;
+
+		id = getUniqueKeyByObject( value );
+		expect( id ).toBe( lastId );
+	} );
+
+	it( 'returns the unique id on repeated call with differing value', () => {
+		let lastId = getUniqueKeyByObject( {} );
+		let id;
+
+		id = getUniqueKeyByObject( {} );
+		expect( id ).not.toBe( lastId );
+		lastId = id;
+
+		id = getUniqueKeyByObject( {} );
+		expect( id ).not.toBe( lastId );
+	} );
+} );
 
 describe( 'withSelect', () => {
 	let registry;
@@ -446,5 +477,60 @@ describe( 'withSelect', () => {
 		expect( parentMapSelectToProps ).toHaveBeenCalledTimes( 2 );
 		expect( ChildOriginalComponent ).toHaveBeenCalledTimes( 1 );
 		expect( ParentOriginalComponent ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'should rerun selection on registry change', () => {
+		const firstRegistry = registry;
+		firstRegistry.registerStore( 'demo', {
+			reducer: ( state = 'first' ) => state,
+			selectors: {
+				getValue: ( state ) => state,
+			},
+		} );
+
+		const mapSelectToProps = jest.fn().mockImplementation( ( _select ) => ( {
+			value: _select( 'demo' ).getValue(),
+		} ) );
+
+		const OriginalComponent = jest.fn().mockImplementation( ( props ) => (
+			<div>{ props.value }</div>
+		) );
+
+		const Component = withSelect( mapSelectToProps )( OriginalComponent );
+
+		const testRenderer = TestRenderer.create(
+			<RegistryProvider value={ firstRegistry }>
+				<Component />
+			</RegistryProvider>
+		);
+		const testInstance = testRenderer.root;
+
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 1 );
+		expect( OriginalComponent ).toHaveBeenCalledTimes( 1 );
+
+		expect( testInstance.findByType( 'div' ).props ).toEqual( {
+			children: 'first',
+		} );
+
+		const secondRegistry = createRegistry();
+		secondRegistry.registerStore( 'demo', {
+			reducer: ( state = 'second' ) => state,
+			selectors: {
+				getValue: ( state ) => state,
+			},
+		} );
+
+		testRenderer.update(
+			<RegistryProvider value={ secondRegistry }>
+				<Component />
+			</RegistryProvider>
+		);
+
+		expect( mapSelectToProps ).toHaveBeenCalledTimes( 2 );
+		expect( OriginalComponent ).toHaveBeenCalledTimes( 2 );
+
+		expect( testInstance.findByType( 'div' ).props ).toEqual( {
+			children: 'second',
+		} );
 	} );
 } );

--- a/packages/data/src/components/with-select/test/index.js
+++ b/packages/data/src/components/with-select/test/index.js
@@ -11,41 +11,10 @@ import { compose } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import withSelect, { getUniqueKeyByObject } from '../';
+import withSelect from '../';
 import withDispatch from '../../with-dispatch';
 import { createRegistry } from '../../../registry';
 import RegistryProvider from '../../registry-provider';
-
-describe( 'getUniqueKeyByObject', () => {
-	it( 'returns a string', () => {
-		expect( typeof getUniqueKeyByObject( {} ) ).toBe( 'string' );
-	} );
-
-	it( 'returns the same id on repeated call with same value', () => {
-		const value = {};
-		let lastId = getUniqueKeyByObject( value );
-		let id;
-
-		id = getUniqueKeyByObject( value );
-		expect( id ).toBe( lastId );
-		lastId = id;
-
-		id = getUniqueKeyByObject( value );
-		expect( id ).toBe( lastId );
-	} );
-
-	it( 'returns the unique id on repeated call with differing value', () => {
-		let lastId = getUniqueKeyByObject( {} );
-		let id;
-
-		id = getUniqueKeyByObject( {} );
-		expect( id ).not.toBe( lastId );
-		lastId = id;
-
-		id = getUniqueKeyByObject( {} );
-		expect( id ).not.toBe( lastId );
-	} );
-} );
 
 describe( 'withSelect', () => {
 	let registry;


### PR DESCRIPTION
This pull request seeks to refactor the implementations of `withSelect` and `withDispatch` to avoid dependency upon -- and thus enable the deprecation of -- the `remountOnPropChange` higher-order component.

A few notes as to the rationale:

- `remountOnPropChange` used broadly outside this specific context could serve as a "footgun", since it can have negative effects in focus loss ([example](https://codepen.io/aduth/pen/qJQVQe))
- Higher-order components are considered to be performance-impacting ([reference](https://github.com/acdlite/recompose/blob/master/docs/performance.md)). `withSelect` and `withDispatch` are two of the hottest code paths, and as implemented prior to these changes would each have a `remountOnPropChange` wrapper
- The `remountOnPropChange` wrapper for `withDispatch` is actually not necessary, due to its behavior of proxying function calls to resolve `registry.dispatch` only when the mapped prop is called.

**Testing Instructions:**

This is a refactoring change. There should be no impact on usage.

Ensure unit tests pass:

```
npm run test-unit packages/data
```