### PR TITLE
Editor: Flatten Inserter mapSelectToProps to optimize rendering

### DIFF
--- a/packages/editor/src/components/inserter/index.js
+++ b/packages/editor/src/components/inserter/index.js
@@ -96,24 +96,24 @@ export default compose( [
 			getInserterItems,
 			getBlockOrder,
 		} = select( 'core/editor' );
+
 		const insertionPoint = getBlockInsertionPoint();
-		const parentId = rootClientId || insertionPoint.rootClientId;
+		if ( rootClientId === undefined ) {
+			rootClientId = insertionPoint.rootClientId;
+		}
+
 		return {
 			title: getEditedPostAttribute( 'title' ),
-			insertionPoint: {
-				rootClientId: parentId,
-				layout: rootClientId ? layout : insertionPoint.layout,
-				index: rootClientId ? getBlockOrder( rootClientId ).length : insertionPoint.index,
-			},
+			layout: rootClientId ? layout : insertionPoint.layout,
+			index: rootClientId ? getBlockOrder( rootClientId ).length : insertionPoint.index,
 			selectedBlock: getSelectedBlock(),
-			items: getInserterItems( parentId ),
-			rootClientId: parentId,
+			items: getInserterItems( rootClientId ),
+			rootClientId,
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => ( {
 		onInsertBlock: ( item ) => {
-			const { selectedBlock, insertionPoint } = ownProps;
-			const { index, rootClientId, layout } = insertionPoint;
+			const { selectedBlock, index, rootClientId, layout } = ownProps;
 			const { name, initialAttributes } = item;
 			const insertedBlock = createBlock( name, { ...initialAttributes, layout } );
 			if ( selectedBlock && isUnmodifiedDefaultBlock( selectedBlock ) ) {

--- a/packages/editor/src/components/inserter/index.js
+++ b/packages/editor/src/components/inserter/index.js
@@ -94,20 +94,24 @@ export default compose( [
 			getBlockInsertionPoint,
 			getSelectedBlock,
 			getInserterItems,
-			getBlockOrder,
 		} = select( 'core/editor' );
 
-		const insertionPoint = getBlockInsertionPoint();
+		let index;
 		if ( rootClientId === undefined ) {
-			rootClientId = insertionPoint.rootClientId;
+			// Unless explicitly provided, the default insertion point provided
+			// by the store occurs immediately following the selected block.
+			// Otherwise, the default behavior for an undefined index is to
+			// append block to the end of the rootClientId context.
+			const insertionPoint = getBlockInsertionPoint();
+			( { rootClientId, layout, index } = insertionPoint );
 		}
 
 		return {
 			title: getEditedPostAttribute( 'title' ),
-			layout: rootClientId ? layout : insertionPoint.layout,
-			index: rootClientId ? getBlockOrder( rootClientId ).length : insertionPoint.index,
 			selectedBlock: getSelectedBlock(),
 			items: getInserterItems( rootClientId ),
+			layout,
+			index,
 			rootClientId,
 		};
 	} ),


### PR DESCRIPTION
This pull request seeks to optimize the rendering of the `Inserter` component by avoiding the return of a new reference object which had been returned previously in each call to its `withSelect` `mapSelectToProps`. It does so by merely flattening the `insertionPoint` object it had been creating. 

As a general rule of thumb, `mapSelectToProps` should never create new objects used in values of its return object.

This has the impact of reducing the number of render calls on `Inserter` for a new post from **~50 to 4**.

**Testing instructions:**

This is a refactoring change. There is expected to be no effective changes.

Ensure unit tests pass.

```
npm run test-unit packages/editor/src/components/inserter/test/index.js
```

Verify basic usage of the inserter.