### PR TITLE
Remove cover image ‘strong’ style

### DIFF
--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -12,10 +12,6 @@
 		background: rgba(255, 255, 255, 0.3);
 	}
 
-	.editor-rich-text strong {
-		font-weight: 300;
-	}
-
 	&.components-placeholder h2 {
 		color: inherit;
 	}


### PR DESCRIPTION
The bold style on a cover image has no effect on the preview. Here the first word is made bold and has the same weight (300) as the second word:

![edit_post_ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/47450182-77e32b00-d7bc-11e8-8bc1-ee65e143c0a0.jpg)

The reason for this is that the cover block overrides the standard `strong` weight and specifically sets it to 300. There may have been a reason for this in the past but it's one of the few places in Gutenberg where `strong` is changed, and removing it fixes the problem. As the CSS is only scoped to the cover block within the rich text editor I don't think it will affect anything else.

![edit_post_ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/47478544-8d3e7080-d821-11e8-801c-0b96e82ffd5e.jpg)

Fixes #8202

## How has this been tested?
1. Add a cover image and try to make the cover text bold
2. Note that bold text should look visually different, and using a browser inspector it has a weight of 600

## Types of changes
Removes CSS override for `.wp-block-cover .editor-rich-text strong`

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
