### PR TITLE
Improve handling of centered 1-col galleries with small images

### DIFF
--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -148,4 +148,12 @@
 	&.alignright {
 		display: flex;
 	}
+
+	// If the gallery is centered, center the content inside as well.
+	[data-align="center"] &,
+	&.aligncenter {
+		.blocks-gallery-item figure {
+			justify-content: center;
+		}
+	}
 }

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -133,8 +133,6 @@
 	}
 
 	// Apply max-width to floated items that have no intrinsic width.
-	[data-align="left"] &,
-	[data-align="right"] &,
 	&.alignleft,
 	&.alignright {
 		max-width: $content-width / 2;
@@ -150,7 +148,6 @@
 	}
 
 	// If the gallery is centered, center the content inside as well.
-	[data-align="center"] &,
 	&.aligncenter {
 		.blocks-gallery-item figure {
 			justify-content: center;


### PR DESCRIPTION
If you insert a gallery that has a single column, and multiple smallish images, then center it, the images inside do not appear centered.

This is technically correct, since the _gallery itself_ is centered, but because it's full width and because the images might vary in widths, this doesn't appear to make any difference to the content inside. So although "correct", it's not a good user experience.

This PR simply centers the content also.

This fixes #9531. 

Centered 1 column gallery with small images before:

<img width="776" alt="before" src="https://user-images.githubusercontent.com/1204802/47484026-f2eb2680-d83a-11e8-8c46-8d72d6931d86.png">

After:

<img width="878" alt="after" src="https://user-images.githubusercontent.com/1204802/47484035-fa123480-d83a-11e8-9aed-3c8bf01dd562.png">

Note this also has the following effect if you apply more than one column, while centered:

<img width="851" alt="screen shot 2018-10-25 at 09 44 59" src="https://user-images.githubusercontent.com/1204802/47484050-05656000-d83b-11e8-9553-c19cef973fb1.png">

But that's fun! And remember, that's only if you disable cropping. If you enable cropping again, you get this recognizable friend:

<img width="844" alt="screen shot 2018-10-25 at 09 45 04" src="https://user-images.githubusercontent.com/1204802/47484061-101ff500-d83b-11e8-9f34-abb469283c0e.png">
