### PR TITLE
Improve the style variation control aria-label

### DIFF
--- a/packages/editor/src/components/block-styles/index.js
+++ b/packages/editor/src/components/block-styles/index.js
@@ -107,7 +107,8 @@ function BlockStyles( {
 						onMouseLeave={ () => onHoverClassName( null ) }
 						role="button"
 						tabIndex="0"
-						aria-label={ sprintf( __( 'Apply style variation "%s"' ), style.label || style.name ) }
+						/* translators: %s: style variation name */
+						aria-label={ sprintf( __( '%s style' ), style.label || style.name ) }
 					>
 						<div className="editor-block-styles__item-preview">
 							<BlockPreviewContent

--- a/packages/editor/src/components/block-styles/index.js
+++ b/packages/editor/src/components/block-styles/index.js
@@ -10,7 +10,6 @@ import classnames from 'classnames';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { getBlockType } from '@wordpress/blocks';
-import { __, sprintf } from '@wordpress/i18n';
 import TokenList from '@wordpress/token-list';
 import { ENTER, SPACE } from '@wordpress/keycodes';
 
@@ -107,8 +106,7 @@ function BlockStyles( {
 						onMouseLeave={ () => onHoverClassName( null ) }
 						role="button"
 						tabIndex="0"
-						/* translators: %s: style variation name */
-						aria-label={ sprintf( __( '%s style' ), style.label || style.name ) }
+						aria-label={ style.label || style.name }
 					>
 						<div className="editor-block-styles__item-preview">
 							<BlockPreviewContent


### PR DESCRIPTION
Fixes #11044.

The accessible name of an UI control should match (or at least start with) the visible label. For more details please refer to the related issue #11044.

- changes the `aria-label` from `Apply style variation "%s"` to `%s style`
- this way, the visible label is at the beginning of the accessible name
- simplifies the wording, "apply" and "variation" are a bit redundant: we're already in a group identified as "Block Styles" so simplifying to, for example "Regular style" and "Large style", reduces noise for screen reader users
- adds a missing translators comment

From a l10n perspective, the variable at the beginning may not be ideal but it's essential for a11y reasons. I also wonder if we should add some info in the translators comment to inform translators to not move the variable and keep it at the beginning. /Cc @SergeyBiryukov @ocean90 