### PR TITLE
Fix dynamic blocks not rendering in the frontend

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -312,7 +312,7 @@ if ( ! function_exists( 'strip_dynamic_blocks_remove_filter' ) ) {
 	 * @return string
 	 */
 	function strip_dynamic_blocks_remove_filter( $text ) {
-		remove_filter( 'the_content', 'strip_dynamic_blocks', 8 );
+		remove_filter( 'the_content', 'strip_dynamic_blocks', 6 );
 
 		return $text;
 	}

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -265,6 +265,8 @@ if ( ! function_exists( 'do_blocks' ) ) {
 
 		return $rendered_content;
 	}
+
+	global $the_content_priority_do_blocks;
 	add_filter( 'the_content', 'do_blocks', $the_content_priority_do_blocks ); // BEFORE do_shortcode() and oembed.
 }
 
@@ -295,6 +297,7 @@ if ( ! function_exists( 'strip_dynamic_blocks_add_filter' ) ) {
 	 * @return string
 	 */
 	function strip_dynamic_blocks_add_filter( $text ) {
+		global $the_content_priority_strip_dynamic_blocks;
 		add_filter( 'the_content', 'strip_dynamic_blocks', $the_content_priority_strip_dynamic_blocks );
 
 		return $text;
@@ -315,6 +318,7 @@ if ( ! function_exists( 'strip_dynamic_blocks_remove_filter' ) ) {
 	 * @return string
 	 */
 	function strip_dynamic_blocks_remove_filter( $text ) {
+		global $the_content_priority_strip_dynamic_blocks;
 		remove_filter( 'the_content', 'strip_dynamic_blocks', $the_content_priority_strip_dynamic_blocks );
 
 		return $text;

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -9,6 +9,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Silence is golden.' );
 }
 
+$the_content_priority_strip_dynamic_blocks = 6; // Before do_blocks
+$the_content_priority_do_blocks = 7; // Before do_shortcodes
+
 if ( ! function_exists( 'register_block_type' ) ) {
 	/**
 	 * Registers a block type.
@@ -262,7 +265,7 @@ if ( ! function_exists( 'do_blocks' ) ) {
 
 		return $rendered_content;
 	}
-	add_filter( 'the_content', 'do_blocks', 7 ); // BEFORE do_shortcode() and oembed.
+	add_filter( 'the_content', 'do_blocks', $the_content_priority_do_blocks ); // BEFORE do_shortcode() and oembed.
 }
 
 if ( ! function_exists( 'strip_dynamic_blocks' ) ) {
@@ -292,7 +295,7 @@ if ( ! function_exists( 'strip_dynamic_blocks_add_filter' ) ) {
 	 * @return string
 	 */
 	function strip_dynamic_blocks_add_filter( $text ) {
-		add_filter( 'the_content', 'strip_dynamic_blocks', 6 ); // Before do_blocks().
+		add_filter( 'the_content', 'strip_dynamic_blocks', $the_content_priority_strip_dynamic_blocks );
 
 		return $text;
 	}
@@ -312,7 +315,7 @@ if ( ! function_exists( 'strip_dynamic_blocks_remove_filter' ) ) {
 	 * @return string
 	 */
 	function strip_dynamic_blocks_remove_filter( $text ) {
-		remove_filter( 'the_content', 'strip_dynamic_blocks', 6 );
+		remove_filter( 'the_content', 'strip_dynamic_blocks', $the_content_priority_strip_dynamic_blocks );
 
 		return $text;
 	}

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -9,8 +9,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Silence is golden.' );
 }
 
-$the_content_priority_strip_dynamic_blocks = 6; // Before do_blocks
-$the_content_priority_do_blocks = 7; // Before do_shortcodes
+$the_content_priority_strip_dynamic_blocks = 6; // Before do_blocks.
+$the_content_priority_do_blocks            = 7; // Before do_shortcodes.
 
 if ( ! function_exists( 'register_block_type' ) ) {
 	/**

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -9,9 +9,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Silence is golden.' );
 }
 
-$the_content_priority_strip_dynamic_blocks = 6; // Before do_blocks.
-$the_content_priority_do_blocks            = 7; // Before do_shortcodes.
-
 if ( ! function_exists( 'register_block_type' ) ) {
 	/**
 	 * Registers a block type.
@@ -266,8 +263,7 @@ if ( ! function_exists( 'do_blocks' ) ) {
 		return $rendered_content;
 	}
 
-	global $the_content_priority_do_blocks;
-	add_filter( 'the_content', 'do_blocks', $the_content_priority_do_blocks ); // BEFORE do_shortcode() and oembed.
+	add_filter( 'the_content', 'do_blocks', 7 ); // BEFORE do_shortcode() and oembed.
 }
 
 if ( ! function_exists( 'strip_dynamic_blocks' ) ) {
@@ -297,8 +293,7 @@ if ( ! function_exists( 'strip_dynamic_blocks_add_filter' ) ) {
 	 * @return string
 	 */
 	function strip_dynamic_blocks_add_filter( $text ) {
-		global $the_content_priority_strip_dynamic_blocks;
-		add_filter( 'the_content', 'strip_dynamic_blocks', $the_content_priority_strip_dynamic_blocks );
+		add_filter( 'the_content', 'strip_dynamic_blocks', 6 );
 
 		return $text;
 	}
@@ -318,8 +313,7 @@ if ( ! function_exists( 'strip_dynamic_blocks_remove_filter' ) ) {
 	 * @return string
 	 */
 	function strip_dynamic_blocks_remove_filter( $text ) {
-		global $the_content_priority_strip_dynamic_blocks;
-		remove_filter( 'the_content', 'strip_dynamic_blocks', $the_content_priority_strip_dynamic_blocks );
+		remove_filter( 'the_content', 'strip_dynamic_blocks', 6 );
 
 		return $text;
 	}

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Silence is golden.' );
 }
 
-$the_content_priority_gutenberg_wpautop = 8;
+$the_content_priority_gutenberg_wpautop = 5 // Before do_blocks;
 
 /**
  * Splits a UTF-8 string into an array of UTF-8-encoded codepoints.

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -10,8 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Silence is golden.' );
 }
 
-$the_content_priority_gutenberg_wpautop = 5; // Before do_blocks.
-
 /**
  * Splits a UTF-8 string into an array of UTF-8-encoded codepoints.
  *
@@ -116,7 +114,7 @@ function gutenberg_wpautop( $content ) {
 	return wpautop( $content );
 }
 remove_filter( 'the_content', 'wpautop' );
-add_filter( 'the_content', 'gutenberg_wpautop', $the_content_priority_gutenberg_wpautop );
+add_filter( 'the_content', 'gutenberg_wpautop', 6 );
 
 
 /**

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -10,6 +10,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Silence is golden.' );
 }
 
+$the_content_priority_gutenberg_wpautop = 8;
+
 /**
  * Splits a UTF-8 string into an array of UTF-8-encoded codepoints.
  *
@@ -114,7 +116,7 @@ function gutenberg_wpautop( $content ) {
 	return wpautop( $content );
 }
 remove_filter( 'the_content', 'wpautop' );
-add_filter( 'the_content', 'gutenberg_wpautop', 8 );
+add_filter( 'the_content', 'gutenberg_wpautop', $the_content_priority_gutenberg_wpautop );
 
 
 /**

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Silence is golden.' );
 }
 
-$the_content_priority_gutenberg_wpautop = 5 // Before do_blocks;
+$the_content_priority_gutenberg_wpautop = 5 // Before do_blocks.
 
 /**
  * Splits a UTF-8 string into an array of UTF-8-encoded codepoints.

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Silence is golden.' );
 }
 
-$the_content_priority_gutenberg_wpautop = 5 // Before do_blocks.
+$the_content_priority_gutenberg_wpautop = 5; // Before do_blocks.
 
 /**
  * Splits a UTF-8 string into an array of UTF-8-encoded codepoints.

--- a/test/e2e/specs/__snapshots__/compatibility-classic-editor.test.js.snap
+++ b/test/e2e/specs/__snapshots__/compatibility-classic-editor.test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Compatibility with Classic Editor Should not apply autop when rendering blocks 1`] = `
+"
+		
+<a>
+Random Link
+</a>
+	"
+`;

--- a/test/e2e/specs/__snapshots__/compatibility-classic-editor.test.js.snap
+++ b/test/e2e/specs/__snapshots__/compatibility-classic-editor.test.js.snap
@@ -1,10 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Compatibility with Classic Editor Should not apply autop when rendering blocks 1`] = `
-"
-		
-<a>
+"<a>
 Random Link
-</a>
-	"
+</a>"
 `;

--- a/test/e2e/specs/compatibility-classic-editor.test.js
+++ b/test/e2e/specs/compatibility-classic-editor.test.js
@@ -23,6 +23,7 @@ describe( 'Compatibility with Classic Editor', () => {
 		await page.waitForNavigation();
 
 		// Check the the content doesn't contain <p> tags
+		await page.waitForSelector( '.entry-content' );
 		const content = await page.$eval( '.entry-content', ( element ) => element.innerHTML );
 		expect( content ).toMatchSnapshot();
 	} );

--- a/test/e2e/specs/compatibility-classic-editor.test.js
+++ b/test/e2e/specs/compatibility-classic-editor.test.js
@@ -9,10 +9,6 @@ describe( 'Compatibility with Classic Editor', () => {
 	} );
 
 	it( 'Should not apply autop when rendering blocks', async () => {
-		// Save should not be an option for new empty post.
-		expect( await page.$( '.editor-post-save-draft' ) ).toBe( null );
-
-		// Add title to enable valid non-empty post save.
 		await insertBlock( 'Custom HTML' );
 		await page.keyboard.type( '<a>' );
 		await page.keyboard.press( 'Enter' );
@@ -26,7 +22,7 @@ describe( 'Compatibility with Classic Editor', () => {
 		await viewPostLinks[ 0 ].click();
 		await page.waitForNavigation();
 
-		// Check the the dynamic block appears.
+		// Check the the content doesn't contain <p> tags
 		const content = await page.$eval( '.entry-content', ( element ) => element.innerHTML );
 		expect( content ).toMatchSnapshot();
 	} );

--- a/test/e2e/specs/compatibility-classic-editor.test.js
+++ b/test/e2e/specs/compatibility-classic-editor.test.js
@@ -24,7 +24,7 @@ describe( 'Compatibility with Classic Editor', () => {
 
 		// Check the the content doesn't contain <p> tags
 		await page.waitForSelector( '.entry-content' );
-		const content = await page.$eval( '.entry-content', ( element ) => element.innerHTML );
+		const content = await page.$eval( '.entry-content', ( element ) => element.innerHTML.trim() );
 		expect( content ).toMatchSnapshot();
 	} );
 } );

--- a/test/e2e/specs/compatibility-classic-editor.test.js
+++ b/test/e2e/specs/compatibility-classic-editor.test.js
@@ -1,0 +1,33 @@
+/**
+ * Internal dependencies
+ */
+import { newPost, insertBlock, publishPost } from '../support/utils';
+
+describe( 'Compatibility with Classic Editor', () => {
+	beforeEach( async () => {
+		await newPost();
+	} );
+
+	it( 'Should not apply autop when rendering blocks', async () => {
+		// Save should not be an option for new empty post.
+		expect( await page.$( '.editor-post-save-draft' ) ).toBe( null );
+
+		// Add title to enable valid non-empty post save.
+		await insertBlock( 'Custom HTML' );
+		await page.keyboard.type( '<a>' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Random Link' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '</a>' );
+		await publishPost();
+
+		// View the post.
+		const viewPostLinks = await page.$x( "//a[contains(text(), 'View Post')]" );
+		await viewPostLinks[ 0 ].click();
+		await page.waitForNavigation();
+
+		// Check the the dynamic block appears.
+		const content = await page.$eval( '.entry-content', ( element ) => element.innerHTML );
+		expect( content ).toMatchSnapshot();
+	} );
+} );

--- a/test/e2e/specs/meta-boxes.test.js
+++ b/test/e2e/specs/meta-boxes.test.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { newPost } from '../support/utils';
+import { newPost, insertBlock, publishPost } from '../support/utils';
 import { activatePlugin, deactivatePlugin } from '../support/plugins';
 
 describe( 'Meta boxes', () => {
@@ -34,5 +34,28 @@ describe( 'Meta boxes', () => {
 			page.keyboard.press( 'S' ),
 			page.keyboard.up( 'Meta' ),
 		] );
+	} );
+
+	it( 'Should render dynamic blocks when the meta box uses the excerpt for front end rendering', async () => {
+		// Publish a post so there's something for the latest posts dynamic block to render.
+		await newPost();
+		await page.type( '.editor-post-title__input', 'A published post' );
+		await insertBlock( 'Paragraph' );
+		await page.keyboard.type( 'Hello there!' );
+		await publishPost();
+
+		// Publish a post with the latest posts dynamic block.
+		await newPost();
+		await page.type( '.editor-post-title__input', 'Dynamic block test' );
+		await insertBlock( 'Latest Posts' );
+		await publishPost();
+
+		// View the post.
+		const viewPostLinks = await page.$x( "//a[contains(text(), 'View Post')]" );
+		await viewPostLinks[ 0 ].click();
+		await page.waitForNavigation();
+
+		// Check the the dynamic block appears.
+		await page.waitForSelector( '.wp-block-latest-posts' );
 	} );
 } );

--- a/test/e2e/test-plugins/meta-box.php
+++ b/test/e2e/test-plugins/meta-box.php
@@ -23,3 +23,15 @@ function gutenberg_test_meta_box_add_meta_box() {
 	);
 }
 add_action( 'add_meta_boxes', 'gutenberg_test_meta_box_add_meta_box' );
+
+
+function gutenberg_test_meta_box_render_head() {
+	// Emulates what plugins like Yoast do with meta data on the front end.
+	// Tests that our excerpt processing does not interfere with dynamic blocks.
+	$excerpt = wp_strip_all_tags( get_the_excerpt() );
+	?>
+	<meta property="gutenberg:hello" content="<?php echo esc_attr( $excerpt ); ?>" />
+	<?php
+}
+
+add_action( 'wp_head', 'gutenberg_test_meta_box_render_head' );


### PR DESCRIPTION
Regression in 4.1 when you have dynamic blocks in your post and a meta box (like yoast). The dynamic blocks get stripped from the frontend.

In this PR https://github.com/WordPress/gutenberg/pull/10035/files#r228107590 we changed the priority of the different `the_content` hooks but we forgot to update the hook removal properly?

**Testing instructions**

 - Install Yoast
 - Add a dynamic block (latest posts)
 - The block should show up in the frontend
 - Would be good to check that the excerpts are still stripping the dynamic blocks.

Related #8984