### PR TITLE
Use better help text for ALT text input

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -355,7 +355,7 @@ class ImageEdit extends Component {
 						label={ __( 'Alt Text (Alternative Text)' ) }
 						value={ alt }
 						onChange={ this.updateAlt }
-						help={ __( 'Describe the purpose of the image. Leave empty if the image is not a key part of the content.' ) }
+						help={ __( 'Alternative text describes your image to people who can’t see it. Add a short description with its key details.' ) }
 					/>
 					{ ! isEmpty( availableSizes ) && (
 						<SelectControl


### PR DESCRIPTION
This is just a wee tweak to the description for the accessibility text input, to clarify its purpose and ideally help users build content that's more accessible. I considered using a link for more information but I'm not sure of a good resource to link to that would be evergreen, so I decided to leave it as-is.

Before:
<img width="274" alt="screenshot 2018-10-25 11 30 52" src="https://user-images.githubusercontent.com/376315/47494965-e53d9d00-d84a-11e8-87ad-727cc46bcb49.png">

After:
<img width="272" alt="screenshot 2018-10-25 11 31 13" src="https://user-images.githubusercontent.com/376315/47494968-e5d63380-d84a-11e8-923b-629a61c64345.png">

We may also want to include text that indicates to leave the text blank if the image isn't a key part of content, but I've opted for the phrasing suggested in #8391. 