### PR TITLE
Add "Image Title Attribute" as an editable attribute on the image block

### DIFF
--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -23,6 +23,12 @@
 			"source": "html",
 			"selector": "figcaption"
 		},
+		"title": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "img",
+			"attribute": "title"
+		},
 		"href": {
 			"type": "string",
 			"source": "attribute",

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -783,9 +783,13 @@ export class ImageEdit extends Component {
 						value={ title || '' }
 						onChange={ this.onSetTitle }
 						help={
-							<ExternalLink href="https://www.w3.org/TR/html52/dom.html#the-title-attribute">
-								{ __( 'Provide an optional description for this image.' ) }
-							</ExternalLink>
+							<>
+								{ __( 'Describe the role of this image on the page.' ) }
+								<br />
+								<ExternalLink href="https://www.w3.org/TR/html52/dom.html#the-title-attribute">
+									{ __( '(Note: many devices and browsers do not display this text.)' ) }
+								</ExternalLink>
+							</>
 						}
 					/>
 				</InspectorAdvancedControls>

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -782,7 +782,11 @@ export class ImageEdit extends Component {
 						label={ __( 'Title Attribute' ) }
 						value={ title || '' }
 						onChange={ this.onSetTitle }
-						help={ __( 'Provide a clear name for this image.' ) }
+						help={
+							<ExternalLink href="https://www.w3.org/TR/html52/dom.html#the-title-attribute">
+								{ __( 'Provide an optional description for this image.' ) }
+							</ExternalLink>
+						}
 					/>
 				</InspectorAdvancedControls>
 			</>

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -51,6 +51,7 @@ import {
 	BlockControls,
 	BlockIcon,
 	InspectorControls,
+	InspectorAdvancedControls,
 	MediaPlaceholder,
 	URLPopover,
 	RichText,
@@ -281,6 +282,7 @@ export class ImageEdit extends Component {
 		this.onSetLinkClass = this.onSetLinkClass.bind( this );
 		this.onSetLinkRel = this.onSetLinkRel.bind( this );
 		this.onSetNewTab = this.onSetNewTab.bind( this );
+		this.onSetTitle = this.onSetTitle.bind( this );
 		this.getFilename = this.getFilename.bind( this );
 		this.toggleIsEditing = this.toggleIsEditing.bind( this );
 		this.onUploadError = this.onUploadError.bind( this );
@@ -350,6 +352,7 @@ export class ImageEdit extends Component {
 				url: undefined,
 				alt: undefined,
 				id: undefined,
+				title: undefined,
 				caption: undefined,
 			} );
 			return;
@@ -442,6 +445,11 @@ export class ImageEdit extends Component {
 			return;
 		}
 		this.props.setAttributes( { href: value } );
+	}
+
+	onSetTitle( value ) {
+		// This is the HTML title attribute, separate from the media object title
+		this.props.setAttributes( { title: value } );
 	}
 
 	onSetLinkClass( value ) {
@@ -579,6 +587,7 @@ export class ImageEdit extends Component {
 			rel,
 			linkClass,
 			linkDestination,
+			title,
 			width,
 			height,
 			linkTarget,
@@ -689,84 +698,94 @@ export class ImageEdit extends Component {
 		const imageSizeOptions = this.getImageSizeOptions();
 
 		const getInspectorControls = ( imageWidth, imageHeight ) => (
-			<InspectorControls>
-				<PanelBody title={ __( 'Image Settings' ) }>
-					<TextareaControl
-						label={ __( 'Alt Text (Alternative Text)' ) }
-						value={ alt }
-						onChange={ this.updateAlt }
-						help={
-							<>
-								<ExternalLink href="https://www.w3.org/WAI/tutorials/images/decision-tree">
-									{ __( 'Describe the purpose of the image' ) }
-								</ExternalLink>
-								{ __( 'Leave empty if the image is purely decorative.' ) }
-							</>
-						}
-					/>
-					{ ! isEmpty( imageSizeOptions ) && (
-						<SelectControl
-							label={ __( 'Image Size' ) }
-							value={ sizeSlug }
-							options={ imageSizeOptions }
-							onChange={ this.updateImage }
+			<>
+				<InspectorControls>
+					<PanelBody title={ __( 'Image Settings' ) }>
+						<TextareaControl
+							label={ __( 'Alt Text (Alternative Text)' ) }
+							value={ alt }
+							onChange={ this.updateAlt }
+							help={
+								<>
+									<ExternalLink href="https://www.w3.org/WAI/tutorials/images/decision-tree">
+										{ __( 'Describe the purpose of the image' ) }
+									</ExternalLink>
+									{ __( 'Leave empty if the image is purely decorative.' ) }
+								</>
+							}
 						/>
-					) }
-					{ isResizable && (
-						<div className="block-library-image__dimensions">
-							<p className="block-library-image__dimensions__row">
-								{ __( 'Image Dimensions' ) }
-							</p>
-							<div className="block-library-image__dimensions__row">
-								<TextControl
-									type="number"
-									className="block-library-image__dimensions__width"
-									label={ __( 'Width' ) }
-									value={ width || imageWidth || '' }
-									min={ 1 }
-									onChange={ this.updateWidth }
-								/>
-								<TextControl
-									type="number"
-									className="block-library-image__dimensions__height"
-									label={ __( 'Height' ) }
-									value={ height || imageHeight || '' }
-									min={ 1 }
-									onChange={ this.updateHeight }
-								/>
-							</div>
-							<div className="block-library-image__dimensions__row">
-								<ButtonGroup aria-label={ __( 'Image Size' ) }>
-									{ [ 25, 50, 75, 100 ].map( ( scale ) => {
-										const scaledWidth = Math.round( imageWidth * ( scale / 100 ) );
-										const scaledHeight = Math.round( imageHeight * ( scale / 100 ) );
+						{ ! isEmpty( imageSizeOptions ) && (
+							<SelectControl
+								label={ __( 'Image Size' ) }
+								value={ sizeSlug }
+								options={ imageSizeOptions }
+								onChange={ this.updateImage }
+							/>
+						) }
+						{ isResizable && (
+							<div className="block-library-image__dimensions">
+								<p className="block-library-image__dimensions__row">
+									{ __( 'Image Dimensions' ) }
+								</p>
+								<div className="block-library-image__dimensions__row">
+									<TextControl
+										type="number"
+										className="block-library-image__dimensions__width"
+										label={ __( 'Width' ) }
+										value={ width || imageWidth || '' }
+										min={ 1 }
+										onChange={ this.updateWidth }
+									/>
+									<TextControl
+										type="number"
+										className="block-library-image__dimensions__height"
+										label={ __( 'Height' ) }
+										value={ height || imageHeight || '' }
+										min={ 1 }
+										onChange={ this.updateHeight }
+									/>
+								</div>
+								<div className="block-library-image__dimensions__row">
+									<ButtonGroup aria-label={ __( 'Image Size' ) }>
+										{ [ 25, 50, 75, 100 ].map( ( scale ) => {
+											const scaledWidth = Math.round( imageWidth * ( scale / 100 ) );
+											const scaledHeight = Math.round( imageHeight * ( scale / 100 ) );
 
-										const isCurrent = width === scaledWidth && height === scaledHeight;
+											const isCurrent = width === scaledWidth && height === scaledHeight;
 
-										return (
-											<Button
-												key={ scale }
-												isSmall
-												isPrimary={ isCurrent }
-												aria-pressed={ isCurrent }
-												onClick={ this.updateDimensions( scaledWidth, scaledHeight ) }
-											>
-												{ scale }%
-											</Button>
-										);
-									} ) }
-								</ButtonGroup>
-								<Button
-									isSmall
-									onClick={ this.updateDimensions() }
-								>
-									{ __( 'Reset' ) }
-								</Button>
+											return (
+												<Button
+													key={ scale }
+													isSmall
+													isPrimary={ isCurrent }
+													aria-pressed={ isCurrent }
+													onClick={ this.updateDimensions( scaledWidth, scaledHeight ) }
+												>
+													{ scale }%
+												</Button>
+											);
+										} ) }
+									</ButtonGroup>
+									<Button
+										isSmall
+										onClick={ this.updateDimensions() }
+									>
+										{ __( 'Reset' ) }
+									</Button>
+								</div>
 							</div>
-						</div>
-					) }
-				</PanelBody>
-			</InspectorControls>
+						) }
+					</PanelBody>
+				</InspectorControls>
+				<InspectorAdvancedControls>
+					<TextControl
+						label={ __( 'Title Attribute' ) }
+						value={ title || '' }
+						onChange={ this.onSetTitle }
+						help={ __( 'Provide a clear name for this image.' ) }
+					/>
+				</InspectorAdvancedControls>
+			</>
 		);
 
 		// Disable reason: Each block can be selected by clicking on it

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -785,7 +785,6 @@ export class ImageEdit extends Component {
 						help={
 							<>
 								{ __( 'Describe the role of this image on the page.' ) }
-								<br />
 								<ExternalLink href="https://www.w3.org/TR/html52/dom.html#the-title-attribute">
 									{ __( '(Note: many devices and browsers do not display this text.)' ) }
 								</ExternalLink>

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -23,6 +23,7 @@ export default function save( { attributes } ) {
 		id,
 		linkTarget,
 		sizeSlug,
+		title,
 	} = attributes;
 
 	const newRel = isEmpty( rel ) ? undefined : rel;
@@ -40,6 +41,7 @@ export default function save( { attributes } ) {
 			className={ id ? `wp-image-${ id }` : null }
 			width={ width }
 			height={ height }
+			title={ title }
 		/>
 	);
 

--- a/packages/block-library/src/image/transforms.js
+++ b/packages/block-library/src/image/transforms.js
@@ -44,7 +44,7 @@ function getFirstAnchorAttributeFormHTML( html, attributeName ) {
 
 const imageSchema = {
 	img: {
-		attributes: [ 'src', 'alt' ],
+		attributes: [ 'src', 'alt', 'title' ],
 		classes: [ 'alignleft', 'aligncenter', 'alignright', 'alignnone', /^wp-image-\d+$/ ],
 	},
 };


### PR DESCRIPTION
## Description
Closes #11054.

Adds a title attribute to the image block, as requestions in #11054, although I think there may be some more discussion needed, I will follow up there. 

## How has this been tested?
Add a new image block to the page either via dropping a file of the media library
Open the settings for that block.
See that there is now a "title" attribute that is defaulted to the current title attribute in the media library
Save and view post, see that the title attribute exists on the image unless it was set to blank.

## Screenshots
![edit_post_ _gutenberg_dev_ _wordpress](https://user-images.githubusercontent.com/6653970/47513220-c7246c80-d84b-11e8-9351-e17cbd770222.png)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
