### PR TITLE
Fix: Image dimensions label on image block

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -42,6 +42,7 @@
 	margin-bottom: 1em;
 
 	.block-library-image__dimensions__row {
+		width: 100%;
 		display: flex;
 		justify-content: space-between;
 


### PR DESCRIPTION
## Description
This just contains a CSS fix to "Image Dimensions" label on image block.

## How has this been tested?
I checked that the "Image Dimensions" label now appears correctly.

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/11271197/47514122-8d695b00-d877-11e8-8677-8f6af2496445.png)


After:
![image](https://user-images.githubusercontent.com/11271197/47514060-6b6fd880-d877-11e8-9ca5-6ce2bafc8d59.png)
