### PR TITLE
Media & Text: Add field that allows changing image alt text from the sidebar

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -15,7 +15,11 @@ import {
 	withColors,
 } from '@wordpress/editor';
 import { Component, Fragment } from '@wordpress/element';
-import { Toolbar } from '@wordpress/components';
+import {
+	PanelBody,
+	TextareaControl,
+	Toolbar,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -108,7 +112,7 @@ class MediaTextEdit extends Component {
 			setAttributes,
 			setBackgroundColor,
 		} = this.props;
-		const { mediaPosition, mediaWidth } = attributes;
+		const { mediaAlt, mediaPosition, mediaType, mediaWidth } = attributes;
 		const temporaryMediaWidth = this.state.mediaWidth;
 		const classNames = classnames( className, {
 			'has-media-on-the-right': 'right' === mediaPosition,
@@ -136,9 +140,23 @@ class MediaTextEdit extends Component {
 			isActive: mediaPosition === 'right',
 			onClick: () => setAttributes( { mediaPosition: 'right' } ),
 		} ];
+		const onMediaAltChange = ( newMediaAlt ) => {
+			setAttributes( { mediaAlt: newMediaAlt } );
+		};
+		const mediaTextGeneralSettings = mediaType === 'image' && (
+			<PanelBody title={ __( 'Media & Text Settings' ) }>
+				<TextareaControl
+					label={ __( 'Alt Text (Alternative Text)' ) }
+					value={ mediaAlt }
+					onChange={ onMediaAltChange }
+					help={ __( 'Alternative text describes your image to people who can’t see it. Add a short description with its key details.' ) }
+				/>
+			</PanelBody>
+		);
 		return (
 			<Fragment>
 				<InspectorControls>
+					{ mediaTextGeneralSettings }
 					<PanelColorSettings
 						title={ __( 'Color Settings' ) }
 						initialOpen={ false }


### PR DESCRIPTION
This PR adds a field that allows changing the alt of the selected image on Media & Text block from the sidebar.

Fixes: https://github.com/WordPress/gutenberg/issues/10924

## How has this been tested?
I checked that I can correctly change the alt text of the image from the sidebar.
I checked that when a video is selected the alt text input field does not appear.

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/11271197/47516159-a7596c80-d87c-11e8-9e11-85366a610ac6.png)

