### PR TITLE
Archives: Add class for -dropdown/-list

### DIFF
--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -29,6 +29,8 @@ function render_block_core_archives( $attributes ) {
 
 	if ( ! empty( $attributes['displayAsDropdown'] ) ) {
 
+		$class .= ' wp-block-archives-dropdown';
+
 		$dropdown_id = esc_attr( uniqid( 'wp-block-archives-' ) );
 		$title       = __( 'Archives', 'gutenberg' );
 
@@ -76,6 +78,8 @@ function render_block_core_archives( $attributes ) {
 			$block_content
 		);
 	} else {
+
+		$class .= ' wp-block-archives-list';
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-archives.php */
 		$archives_args = apply_filters(


### PR DESCRIPTION
## Description
Fixes #11075
To become consistent with the categories block, this PR adds a type class (-dropdown/-list) to the archives block.

![bildschirmfoto 2018-10-25 um 19 49 01](https://user-images.githubusercontent.com/695201/47519997-3e2f2480-d88f-11e8-909d-4a200fefc987.png)
![bildschirmfoto 2018-10-25 um 19 50 01](https://user-images.githubusercontent.com/695201/47519998-3e2f2480-d88f-11e8-881a-e0144738daad.png)
