### PR TITLE
Update post grammar to include markers for inner blocks

### DIFF
--- a/packages/block-serialization-default-parser/test/__snapshots__/index.js.snap
+++ b/packages/block-serialization-default-parser/test/__snapshots__/index.js.snap
@@ -4,6 +4,7 @@ exports[`block-serialization-default-parser-js basic parsing parse() works prope
 Array [
   Object {
     "attrs": Object {},
+    "blockMarkers": Array [],
     "blockName": "core/more",
     "innerBlocks": Array [],
     "innerHTML": "<!--more-->",
@@ -15,6 +16,7 @@ exports[`block-serialization-default-parser-php basic parsing parse() works prop
 Array [
   Object {
     "attrs": Object {},
+    "blockMarkers": Array [],
     "blockName": "core/more",
     "innerBlocks": Array [],
     "innerHTML": "<!--more-->",

--- a/packages/block-serialization-spec-parser/parser.js
+++ b/packages/block-serialization-spec-parser/parser.js
@@ -165,10 +165,11 @@
         peg$c10 = function(blockName, attrs) {
             /** <?php
             return array(
-              'blockName'   => $blockName,
-              'attrs'       => isset( $attrs ) ? $attrs : array(),
-              'innerBlocks' => array(),
-              'innerHTML'   => '',
+              'blockName'    => $blockName,
+              'attrs'        => isset( $attrs ) ? $attrs : array(),
+              'innerBlocks'  => array(),
+              'innerHTML'    => '',
+              'blockMarkers' => array(),
             );
             ?> **/
 
@@ -176,30 +177,34 @@
               blockName: blockName,
               attrs: attrs || {},
               innerBlocks: [],
-              innerHTML: ''
+              innerHTML: '',
+              blockMarkers: [],
             };
           },
         peg$c11 = function(s, children, e) {
             /** <?php
-            list( $innerHTML, $innerBlocks ) = peg_array_partition( $children, 'is_string' );
+            list( $innerHTML, $innerBlocks, $blockMarkers ) = peg_split_inner_content( $children );
 
             return array(
               'blockName'    => $s['blockName'],
               'attrs'        => $s['attrs'],
               'innerBlocks'  => $innerBlocks,
               'innerHTML'    => implode( '', $innerHTML ),
+              'blockMarkers' => $blockMarkers,
             );
             ?> **/
 
-            var innerContent = partition( function( a ) { return 'string' === typeof a }, children );
+            var innerContent = splitInnerContent( children );
             var innerHTML = innerContent[ 0 ];
             var innerBlocks = innerContent[ 1 ];
+            var blockMarkers = innerContent[ 2 ];
 
             return {
               blockName: s.blockName,
               attrs: s.attrs,
               innerBlocks: innerBlocks,
-              innerHTML: innerHTML.join( '' )
+              innerHTML: innerHTML.join( '' ),
+              blockMarkers: blockMarkers,
             };
           },
         peg$c12 = "-->",
@@ -1478,18 +1483,31 @@
     // are the same as `json_decode`
 
     // array arguments are backwards because of PHP
-    if ( ! function_exists( 'peg_array_partition' ) ) {
-        function peg_array_partition( $array, $predicate ) {
-            $truthy = array();
-            $falsey = array();
+    if ( ! function_exists( 'peg_split_inner_content' ) ) {
+        function peg_split_inner_content( $array ) {
+            $strings  = array();
+            $blocks   = array();
+            $markers  = array();
+            $offset   = 0;
+            $string   = '';
 
             foreach ( $array as $item ) {
-                call_user_func( $predicate, $item )
-                    ? $truthy[] = $item
-                    : $falsey[] = $item;
+                if ( is_string( $item ) ) {
+                    $string .= $item;
+                } else {
+                    $offset   += strlen( $string );
+                    $strings[] = $string;
+                    $markers[] = $offset;
+                    $blocks[]  = $item;
+                    $string    = '';
+                }
             }
 
-            return array( $truthy, $falsey );
+            if ( $string !== '' ) {
+                $strings[] = $string;
+            }
+
+            return array( $strings, $blocks, $markers );
         }
     }
 
@@ -1499,10 +1517,10 @@
 
             if ( ! empty( $pre ) ) {
                 $blocks[] = array(
-                    'blockName' => null,
-                    'attrs' => array(),
+                    'blockName'   => null,
+                    'attrs'       => array(),
                     'innerBlocks' => array(),
-                    'innerHTML' => $pre
+                    'innerHTML'   => $pre
                 );
             }
 
@@ -1513,20 +1531,20 @@
 
                 if ( ! empty( $html ) ) {
                     $blocks[] = array(
-                        'blockName' => null,
-                        'attrs' => array(),
+                        'blockName'   => null,
+                        'attrs'       => array(),
                         'innerBlocks' => array(),
-                        'innerHTML' => $html
+                        'innerHTML'   => $html
                     );
                 }
             }
 
             if ( ! empty( $post ) ) {
                 $blocks[] = array(
-                    'blockName' => null,
-                    'attrs' => array(),
+                    'blockName'   => null,
+                    'attrs'       => array(),
                     'innerBlocks' => array(),
-                    'innerHTML' => $post
+                    'innerHTML'   => $post
                 );
             }
 
@@ -1578,22 +1596,86 @@
         }
     }
 
-    function partition( predicate, list ) {
+    /**
+     * Returns bytes required to represent given string in UTF8
+     *
+     * Assumes input is encoded in UCS2 or UTF16 according to the ECMAScript spec
+     * @see: https://www.ecma-international.org/ecma-262/9.0/index.html#sec-ecmascript-language-types-string-type
+     *
+     * Transparently counts bytes for invalid encodings:
+     * e.g. unpaired surrogate pair characters count as three bytes
+     *
+     * @cite: https://stackoverflow.com/a/34920444
+     *
+     * @param {string} s input string
+     * @return {number} how many bytes are in the UTF8 representation of the given string
+     */
+    function utf8bytes( s ) {
+        var i, l, n = 0;
+
+        for ( i = 0, l = s.length; i < l; i++ ) {
+            var lo, hi = s.charCodeAt( i );
+
+            if ( hi < 0x0080) { // [0x0000, 0x007F]
+                n += 1;
+            } else if ( hi < 0x0800 ) { // [0x0080, 0x07FF]
+                n += 2;
+            } else if ( hi < 0xD800 ) { // [0x0800, 0xD7FF]
+                n += 3;
+            } else if ( hi < 0xDC00 ) { // [0xD800, 0xDBFF]
+                lo = s.charCodeAt( ++i );
+
+                if ( i < l && lo >= 0xDC00 && lo <= 0xDFFF ) { //followed by [0xDC00, 0xDFFF]
+                    n += 4;
+                } else {
+                    // this is an invalid string with an unpaired surrogate.
+                    // transparently pass it through for byte counts
+                    // and back up to restart processing at the next character.
+                    n += 3;
+                    i -= 1;
+                }
+            } else if ( hi < 0xE000 ) { //[0xDC00, 0xDFFF]
+                // these are invalid encodings in the Unicode standard
+                // because they are reserved for encoding surrogate pairs.
+                // transparently pass them through here for byte counts.
+                n += 3;
+            } else { // [0xE000, 0xFFFF]
+                n += 3;
+            }
+        }
+
+        return n;
+    }
+
+    function splitInnerContent( list ) {
         var i, l, item;
-        var truthy = [];
-        var falsey = [];
+        var strings = [];
+        var blocks = [];
+        var markers = [];
+        var offset = 0;
+        var string = '';
 
         // nod to performance over a simpler reduce
         // and clone model we could have taken here
         for ( i = 0, l = list.length; i < l; i++ ) {
             item = list[ i ];
 
-            predicate( item )
-                ? truthy.push( item )
-                : falsey.push( item )
+            if ( 'string' === typeof item ) {
+                string += item;
+            } else {
+                offset += utf8bytes( string );
+                strings.push( string );
+                markers.push( offset );
+                blocks.push( item );
+                string = '';
+            }
         };
 
-        return [ truthy, falsey ];
+        if ( string !== '' ) {
+            strings.push( string );
+        }
+
+        return [ strings, blocks, markers ];
     }
 
 

--- a/packages/block-serialization-spec-parser/shared-tests.js
+++ b/packages/block-serialization-spec-parser/shared-tests.js
@@ -61,6 +61,70 @@ export const jsTester = ( parse ) => () => {
 			expect.objectContaining( { innerHTML: '<p>Break me</p>' } ),
 		] ) ) );
 	} );
+
+	describe( 'blockMarkers', () => {
+		test( 'adds empty block markers when no inner blocks exist', () => {
+			expect( parse( '<!-- wp:void /-->' )[ 0 ] ).toHaveProperty( 'blockMarkers', [] );
+			expect( parse( '<!-- wp:block --><!-- /wp:block -->' )[ 0 ] ).toHaveProperty( 'blockMarkers', [] );
+			expect( parse( '<!-- wp:block -->with content<!-- /wp:block -->' )[ 0 ] ).toHaveProperty( 'blockMarkers', [] );
+		} );
+
+		test( 'adds block markers for inner blocks', () => {
+			expect( parse( '<!-- wp:block --><!-- wp:void /--><!-- /wp:block -->' )[ 0 ] ).toHaveProperty( 'blockMarkers', [ 0 ] );
+			expect( parse( '<!-- wp:block -->aa<!-- wp:void /-->bb<!-- /wp:block -->' )[ 0 ] ).toHaveProperty( 'blockMarkers', [ 2 ] );
+			expect( parse( '<!-- wp:block -->aa<!-- wp:inner -->bb<!-- /wp:inner -->cc<!-- /wp:block -->' )[ 0 ] ).toHaveProperty( 'blockMarkers', [ 2 ] );
+			expect( parse( '<!-- wp:block --><!-- wp:start /-->aa<!-- wp:inner -->bb<!-- /wp:inner -->cc<!-- wp:end /--><!-- /wp:block -->' )[ 0 ] ).toHaveProperty( 'blockMarkers', [ 0, 2, 4 ] );
+		} );
+
+		test( 'block markers report UTF-8 encoding byte-length', () => {
+			const run = ( c ) => parse( `<!-- wp:block -->${ c }<!-- wp:void /--><!-- /wp:block -->` )[ 0 ];
+
+			// normal conditions
+			expect( run( '\u{0024}' ) ).toHaveProperty( 'blockMarkers', [ 1 ] ); // $ U+0000 - U+007F
+			expect( run( '\u{00a2}' ) ).toHaveProperty( 'blockMarkers', [ 2 ] ); // ¢ U+0080 - U+07FF
+			expect( run( '\u{20ac}' ) ).toHaveProperty( 'blockMarkers', [ 3 ] ); // € U+0800 - U+7FFF
+			expect( run( '\u{f8ff}' ) ).toHaveProperty( 'blockMarkers', [ 3 ] ); //  U+8000 - U+FFFF
+			expect( run( '\u{10348}' ) ).toHaveProperty( 'blockMarkers', [ 4 ] ); // 𐍈 U+10000 - U+1FFFF
+
+			expect( run( '$' ) ).toHaveProperty( 'blockMarkers', [ 1 ] ); // $ U+0000 - U+007F
+			expect( run( '¢' ) ).toHaveProperty( 'blockMarkers', [ 2 ] ); // ¢ U+0080 - U+07FF
+			expect( run( '€' ) ).toHaveProperty( 'blockMarkers', [ 3 ] ); // € U+0800 - U+7FFF
+			expect( run( '' ) ).toHaveProperty( 'blockMarkers', [ 3 ] ); //  U+8000 - U+FFFF
+			expect( run( '𐍈' ) ).toHaveProperty( 'blockMarkers', [ 4 ] ); // 𐍈 U+10000 - U+1FFFF
+
+			// surrogate pairs
+			expect( run( '\u{d800}' ) ).toHaveProperty( 'blockMarkers', [ 3 ] ); // invalid unpaired surrogate
+			expect( run( '\u{dc00}' ) ).toHaveProperty( 'blockMarkers', [ 3 ] ); // invalid unpaired surrogate
+			expect( run( '\u{10000}' ) ).toHaveProperty( 'blockMarkers', [ 4 ] ); // 𐀀 surrogate pair U+D800 U+DC00
+			expect( run( '\ud800\udc00' ) ).toHaveProperty( 'blockMarkers', [ 4 ] ); // 𐀀 surrogate pair U+D800 U+DC00
+			expect( run( '𐀀' ) ).toHaveProperty( 'blockMarkers', [ 4 ] ); // 𐀀 surrogate pair U+D800 U+DC00
+
+			// variations
+			expect( run( '\u{845b}' ) ).toHaveProperty( 'blockMarkers', [ 3 ] ); // edible bean; surname
+			expect( run( '\u{845b}\u{e0100}' ) ).toHaveProperty( 'blockMarkers', [ 7 ] ); // edible bean; surname + variation
+
+			// NOTE: The next two run() strings _are not the same_ - check the encoding/raw bytes
+			// The first is the character by itself
+			// The second is the character plus the variation
+			expect( run( '葛' ) ).toHaveProperty( 'blockMarkers', [ 3 ] ); // edible bean; surname
+			expect( run( '葛󠄀' ) ).toHaveProperty( 'blockMarkers', [ 7 ] ); // edible bean; surname + variation
+
+			// higher planes
+			expect( run( '\u{24b62}' ) ).toHaveProperty( 'blockMarkers', [ 4 ] );
+			expect( run( '𤭢' ) ).toHaveProperty( 'blockMarkers', [ 4 ] );
+
+			// invalids
+			expect( run( '\u{fffd}' ) ).toHaveProperty( 'blockMarkers', [ 3 ] ); // replacement character
+			expect( run( '\u{80}' ) ).toHaveProperty( 'blockMarkers', [ 2 ] ); // unexpected continuation byte
+			expect( run( '\u{fe}' ) ).toHaveProperty( 'blockMarkers', [ 2 ] ); // invalid byte
+
+			// emoji
+			expect( run( '\u{1f4a9}' ) ).toHaveProperty( 'blockMarkers', [ 4 ] ); // 💩 pile of poo
+			expect( run( '💩' ) ).toHaveProperty( 'blockMarkers', [ 4 ] ); // 💩 pile of poo
+			expect( run( '\u{2764}\u{fe0f}' ) ).toHaveProperty( 'blockMarkers', [ 6 ] ); // ❤️ black heart + variation 16
+			expect( run( '❤️' ) ).toHaveProperty( 'blockMarkers', [ 6 ] ); // ❤️ black heart + variation 16
+		} );
+	} );
 };
 
 const hasPHP = 'test' === process.env.NODE_ENV ? ( () => {

--- a/packages/block-serialization-spec-parser/test/__snapshots__/index.js.snap
+++ b/packages/block-serialization-spec-parser/test/__snapshots__/index.js.snap
@@ -4,6 +4,7 @@ exports[`block-serialization-spec-parser-js basic parsing parse() works properly
 Array [
   Object {
     "attrs": Object {},
+    "blockMarkers": Array [],
     "blockName": "core/more",
     "innerBlocks": Array [],
     "innerHTML": "<!--more-->",
@@ -15,6 +16,7 @@ exports[`block-serialization-spec-parser-php basic parsing parse() works properl
 Array [
   Object {
     "attrs": Array [],
+    "blockMarkers": Array [],
     "blockName": "core/more",
     "innerBlocks": Array [],
     "innerHTML": "<!--more-->",


### PR DESCRIPTION
Motivated by #8760
Necessary for #10463, #10108

## Abstract
Add new property to parsed block object indicating where in the `innerHTML` each `innerBlock` was found.

## Summary
Inner blocks, or nested blocks, or blocks-within-blocks, can exist in Gutenberg posts. They are serialized in `post_content` in place as normal blocks which exist in between another block's comment delimiters.

```html
<!-- wp:outerBlock -->
Check out my
<!-- wp:voidInnerBlock /-->
and my other
<!-- wp:innerBlock -->
with its own content.
<!-- /wp:innerBlock -->
<!-- /wp:outerBlock -->
```

The way this gets parsed leaves us in a quandary: we cannot reconstruct the original `post_content` after parsing because we lose the origin location information for each inner block since they are only passed as an array of inner blocks.

```json
{
	"blockName": "core/outerBlock",
	"attrs": {},
	"innerBlocks": [
		{
			"blockName": "core/voidInnerBlock",
			"attrs": {},
			"innerBlocks": [],
			"innerHTML": ""
		},
		{
			"blockName": "core/innerBlock",
			"attrs": {},
			"innerBlocks": [],
			"innerHTML": "\nwith its own content.\n"
		}
	],
	"innerHTML": "\nCheck out my\n\nand my other\n\n"
}
```

At this point we have parsed the blocks and prepared them for attaching into the JavaScript block code that interprets them but we have lost our reverse transformation.

In this PR I'd like to introduce a new mechanism which shouldn't break existing functionality but which will enable us to go back and forth isomorphically between the `post_content` and first stage of parsing. If we can tear apart a Gutenberg post and reassemble then it will let us to structurally-informed processing of the posts without needing to be aware of all the block JavaScript.

The proposed mechanism is a form of tombstone or `blockMarkers` that **specify the index into `innerHTML` where the `innerBlocks` were found**.

```json
{
	"blockName": "core/outerBlock",
	"attrs": {},
	"innerBlocks": [
		{
			"blockName": "core/voidInnerBlock",
			"attrs": {},
			"innerBlocks": [],
			"blockMarkers": [],
			"innerHTML": ""
		},
		{
			"blockName": "core/innerBlock",
			"attrs": {},
			"innerBlocks": [],
			"blockMarkers": [],
			"innerHTML": "\nwith its own content.\n"
		}
	],
	"blockMarkers": [ 14, 28 ],
	"innerHTML": "\nCheck out my\n\nand my other\n\n"
}
```

The block markers represent the ~UCS-2 index~ UTF-8 byte-length into the `innerHTML` where the block was found and where it should be replaced if we reserialize. ~UCS-2 has its own quirks that become important to recognize when dealing with Unicode strings.~ That is, we get the value by taking the portion of `innerHTML` preceding that inner block and then compute how many bytes are required to represent it in UTF-8, then that count is our index.

The array of markers is of the same length as the array of `innerBlocks` and each location index corresponds to the block at the same array index in `innerBlocks`.

Simplified, `aa[1]bb[2]cc` would correspond to `text: "aabbcc", blocks: [1,2], markers: [2, 4 ]`