### PR TITLE
Fix navigation in inserter menu triggering writing flow

### DIFF
--- a/packages/editor/src/components/inserter/menu.js
+++ b/packages/editor/src/components/inserter/menu.js
@@ -26,6 +26,7 @@ import { withSpokenMessages, PanelBody } from '@wordpress/components';
 import { getCategories, isReusableBlock } from '@wordpress/blocks';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { withInstanceId, compose, withSafeTimeout } from '@wordpress/compose';
+import { LEFT, RIGHT, UP, DOWN, BACKSPACE, ENTER } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -36,6 +37,8 @@ import ChildBlocks from './child-blocks';
 import InserterInlineElements from './inline-elements';
 
 const MAX_SUGGESTED_ITEMS = 9;
+
+const stopKeyPropagation = ( event ) => event.stopPropagation();
 
 /**
  * Filters an item list given a search term.
@@ -218,19 +221,31 @@ export class InserterMenu extends Component {
 		debouncedSpeak( resultsFoundMessage, 'assertive' );
 	}
 
+	onKeyDown( event ) {
+		if ( includes( [ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ], event.keyCode ) ) {
+			// Stop the key event from propagating up to ObserveTyping.startTypingInTextField.
+			event.stopPropagation();
+		}
+	}
+
 	render() {
 		const { instanceId, onSelect, rootClientId } = this.props;
 		const { childItems, filterValue, hoveredItem, suggestedItems, reusableItems, itemsPerCategory, openPanels } = this.state;
 		const isPanelOpen = ( panel ) => openPanels.indexOf( panel ) !== -1;
 		const isSearching = !! filterValue;
 
-		// Disable reason: The inserter menu is a modal display, not one which
-		// is always visible, and one which already incurs this behavior of
-		// autoFocus via Popover's focusOnMount.
-
-		/* eslint-disable jsx-a11y/no-autofocus */
+		// Disable reason (no-autofocus): The inserter menu is a modal display, not one which
+		// is always visible, and one which already incurs this behavior of autoFocus via
+		// Popover's focusOnMount.
+		// Disable reason (no-static-element-interactions): Navigational key-presses within
+		// the menu are prevented from triggering WritingFlow and ObserveTyping interactions.
+		/* eslint-disable jsx-a11y/no-autofocus, jsx-a11y/no-static-element-interactions */
 		return (
-			<div className="editor-inserter__menu">
+			<div
+				className="editor-inserter__menu"
+				onKeyPress={ stopKeyPropagation }
+				onKeyDown={ this.onKeyDown }
+			>
 				<label htmlFor={ `editor-inserter__search-${ instanceId }` } className="screen-reader-text">
 					{ __( 'Search for a block' ) }
 				</label>
@@ -317,7 +332,7 @@ export class InserterMenu extends Component {
 				}
 			</div>
 		);
-		/* eslint-enable jsx-a11y/no-autofocus */
+		/* eslint-enable jsx-a11y/no-autofocus, jsx-a11y/no-noninteractive-element-interactions */
 	}
 }
 

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -123,7 +123,7 @@ class InlineLinkUI extends Component {
 		}
 
 		if ( [ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].indexOf( event.keyCode ) > -1 ) {
-			// Stop the key event from propagating up to maybeStartTyping in BlockListBlock.
+			// Stop the key event from propagating up to ObserveTyping.startTypingInTextField.
 			event.stopPropagation();
 		}
 	}


### PR DESCRIPTION
## Description
Fixes #9583

Particular keyboard interaction (up/down arrow keys) was causing focus to transfer out of the default block's insertion menu.

**What causes this?**
As far as I can tell, the ObserveTyping component is receiving those events and triggering the START_TYPING action, potentially causing focus to transfer to a block:
https://github.com/WordPress/gutenberg/blob/a696e508ad5d3566b447fc48f355e91953a17c4a/packages/editor/src/components/observe-typing/index.js#L165-L171

There might also be other event handlers acting on those events, but if so I haven't been able to determine what they are.

**The fix**
In this PR I've used the same technique as used in the LinkContainer to prevent this:
https://github.com/WordPress/gutenberg/blob/a696e508ad5d3566b447fc48f355e91953a17c4a/packages/editor/src/components/rich-text/format-toolbar/link-container.js#L59-L64

☝️ Here onKeyPress and onKeyDown events are used to prevent propagation of keyboard events outside of the popover. I've applied the same to the block insertion menu.

## How has this been tested?
- Manual testing
    1 - Open the inserter menu from the default block
    2 - Press the up or down arrow key
    Expected - focus should remain within the inserter search input
    Actual - focus is taken to a block

- Added an e2e test to catch regressions
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
