### PR TITLE
Do not add isDirty prop to DOM

### DIFF
--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -56,7 +56,7 @@ export class PostPublishPanel extends Component {
 			...additionalProps
 		} = this.props;
 		const isPublishedOrScheduled = isPublished || ( isScheduled && isBeingScheduled );
-		const propsForPanel = omit( additionalProps, [ 'hasPublishAction' ] );
+		const propsForPanel = omit( additionalProps, [ 'hasPublishAction', 'isDirty' ] );
 		return (
 			<div className="editor-post-publish-panel" { ...propsForPanel }>
 				<div className="editor-post-publish-panel__header">


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/10875

Having `isDirty` prop in the DOM was making React unhappy.