### PR TITLE
Add Alt + F10 (navigate to the nearest toolbar) to the shortcut docs and modal

### DIFF
--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -111,6 +111,11 @@ This is the canonical list of keyboard shortcuts:
 			<td><kbd>⇧</kbd><kbd>⌥</kbd><kbd>P</kbd></td>
 		</tr>
 		<tr>
+			<td>Navigate to the nearest toolbar.</td>
+			<td><kbd>Alt</kbd>+<kbd>F10</kbd></td>
+			<td><kbd>⌥</kbd><kbd>F10</kbd></td>
+		</tr>
+		<tr>
 			<td>Switch between Visual Editor and Code Editor.</td>
 			<td><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Alt</kbd>+<kbd>M</kbd></td>
 			<td><kbd>⇧</kbd><kbd>⌥</kbd><kbd>⌘</kbd><kbd>M</kbd></td>

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/config.js
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/config.js
@@ -16,6 +16,7 @@ const {
 	// Ctrl+Alt+<key> on a mac, Shift+Alt+<key> elsewhere.
 	access,
 	ctrl,
+	alt,
 	ctrlShift,
 	shiftAlt,
 } = displayShortcutList;
@@ -65,6 +66,10 @@ const globalShortcuts = {
 		{
 			keyCombination: shiftAlt( 'p' ),
 			description: __( 'Navigate to the previous part of the editor (alternative).' ),
+		},
+		{
+			keyCombination: alt( 'F10' ),
+			description: __( 'Navigate to the nearest toolbar.' ),
 		},
 		{
 			keyCombination: secondary( 'm' ),

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
@@ -124,6 +124,14 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
             ],
           },
           Object {
+            "description": "Navigate to the nearest toolbar.",
+            "keyCombination": Array [
+              "Alt",
+              "+",
+              "F10",
+            ],
+          },
+          Object {
             "description": "Switch between Visual Editor and Code Editor.",
             "keyCombination": Array [
               "Ctrl",

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -50,6 +50,7 @@ const modifiers = {
 	secondary: ( _isApple ) => _isApple() ? [ SHIFT, ALT, COMMAND ] : [ CTRL, SHIFT, ALT ],
 	access: ( _isApple ) => _isApple() ? [ CTRL, ALT ] : [ SHIFT, ALT ],
 	ctrl: () => [ CTRL ],
+	alt: () => [ ALT ],
 	ctrlShift: () => [ CTRL, SHIFT ],
 	shift: () => [ SHIFT ],
 	shiftAlt: () => [ SHIFT, ALT ],


### PR DESCRIPTION
## Description
Found this undocumented keyboard shortcut the other day, it seems to still work absolutely fine. This PR adds it to our docs and the shortcut modal.

## How has this been tested?
- Manual testing

## Screenshots <!-- if applicable -->
![screen shot 2018-10-26 at 5 26 32 pm](https://user-images.githubusercontent.com/677833/47557861-544aec80-d944-11e8-8249-66d9c2cacb03.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
