### PR TITLE
Docs: Update extensibility docs for Editor's UI

### DIFF
--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -59,6 +59,8 @@ Extending the editor UI can be accomplished with the `registerPlugin` API, allow
 
 Refer to the [Plugins](https://github.com/WordPress/gutenberg/blob/master/packages/plugins/README.md) and [Edit Post](https://github.com/WordPress/gutenberg/blob/master/packages/edit-post/README.md) section for more information.
 
+Learn also more in the [Extending editor UI](../docs/extensibility/extending-editor.md) section.
+
 ## Meta Boxes
 
 **Porting PHP meta boxes to blocks is highly encouraged!**

--- a/docs/extensibility/extending-blocks.md
+++ b/docs/extensibility/extending-blocks.md
@@ -1,4 +1,4 @@
-# Extending Blocks (Experimental)
+# Extending Blocks
 
 [Hooks](https://developer.wordpress.org/plugins/hooks/) are a way for one piece of code to interact/modify another piece of code. They make up the foundation for how plugins and themes interact with Gutenberg, but they’re also used extensively by WordPress Core itself. There are two types of hooks: [Actions](https://developer.wordpress.org/plugins/hooks/actions/) and [Filters](https://developer.wordpress.org/plugins/hooks/filters/). They were initially implemented in PHP, but for the purpose of Gutenberg they were ported to JavaScript and published to npm as [@wordpress/hooks](https://www.npmjs.com/package/@wordpress/hooks) package for general purpose use. You can also learn more about both APIs: [PHP](https://codex.wordpress.org/Plugin_API/) and [JavaScript](https://github.com/WordPress/packages/tree/master/packages/hooks).
 

--- a/docs/extensibility/extending-editor.md
+++ b/docs/extensibility/extending-editor.md
@@ -8,6 +8,8 @@
 
 To modify the behavior of the editor experience, Gutenberg exposes the following Filters:
 
+#### `editor.BlockDropZone`
+
 #### `editor.BlockEdit`
 
 See [Extending Blocks](../docs/extensibility/extending-blocks.md#editorblockedit) section.
@@ -15,6 +17,8 @@ See [Extending Blocks](../docs/extensibility/extending-blocks.md#editorblockedit
 #### `editor.BlockListBlock`
 
 See [Extending Blocks](../docs/extensibility/extending-blocks.md#editorblocklistblock) section.
+
+#### `editor.MediaPlaceholder`
 
 #### `editor.MediaUpload`
 

--- a/docs/extensibility/extending-editor.md
+++ b/docs/extensibility/extending-editor.md
@@ -1,12 +1,26 @@
-# Extending Editor (Experimental)
+# Extending Editor
 
 [Hooks](https://developer.wordpress.org/plugins/hooks/) are a way for one piece of code to interact/modify another piece of code. They make up the foundation for how plugins and themes interact with Gutenberg, but they’re also used extensively by WordPress Core itself. There are two types of hooks: [Actions](https://developer.wordpress.org/plugins/hooks/actions/) and [Filters](https://developer.wordpress.org/plugins/hooks/filters/). They were initially implemented in PHP, but for the purpose of Gutenberg they were ported to JavaScript and published to npm as [@wordpress/hooks](https://www.npmjs.com/package/@wordpress/hooks) package for general purpose use. You can also learn more about both APIs: [PHP](https://codex.wordpress.org/Plugin_API/) and [JavaScript](https://github.com/WordPress/packages/tree/master/packages/hooks).
 
 ## Modifying Editor
 
+### Filters
+
 To modify the behavior of the editor experience, Gutenberg exposes the following Filters:
 
-### `editor.PostFeaturedImage.imageSize`
+#### `editor.BlockEdit`
+
+See [Extending Blocks](../docs/extensibility/extending-blocks.md#editorblockedit) section.
+
+#### `editor.BlockListBlock`
+
+See [Extending Blocks](../docs/extensibility/extending-blocks.md#editorblocklistblock) section.
+
+#### `editor.MediaUpload`
+
+#### `editor.PostFeaturedImage`
+
+#### `editor.PostFeaturedImage.imageSize`
 
 Used to modify the image size displayed in the Post Featured Image component. It defaults to `'post-thumbnail'`, and will fail back to the `full` image size when the specified image size doesn't exist in the media object. It's modeled after the `admin_post_thumbnail_size` filter in the Classic Editor.
 
@@ -19,3 +33,5 @@ var withImageSize = function( size, mediaId, postId ) {
 
 wp.hooks.addFilter( 'editor.PostFeaturedImage.imageSize', 'my-plugin/with-image-size', withImageSize );
 ```
+
+#### `editor.PostTaxonomyType`


### PR DESCRIPTION
## Description
I noticed that we don't have a reference to Editor's UI extensibility docs and we obviously don't have all filters documented. I bet we have more features that should be documented here. Let's work collectively to make it happen. Feel free to take over this PR and improve this content. I'm happy to help to move it forwards with reviews. However, I might not have time to spent too much time on it in the upcoming days.
