### PR TITLE
Update dropzone context API

### DIFF
--- a/packages/components/src/drop-zone/index.js
+++ b/packages/components/src/drop-zone/index.js
@@ -27,7 +27,7 @@ class DropZoneComponent extends Component {
 
 		this.ref = createRef();
 		this.dropZone = {
-			element: this.ref,
+			element: null,
 			onDrop: this.props.onDrop,
 			onFilesDrop: this.props.onFilesDrop,
 			onHTMLDrop: this.props.onHTMLDrop,
@@ -35,6 +35,8 @@ class DropZoneComponent extends Component {
 	}
 
 	componentDidMount() {
+		// Set element after the component has a node assigned in the DOM
+		this.dropZone.element = this.ref.current;
 		this.props.context.addDropZone( this.dropZone );
 	}
 

--- a/packages/components/src/drop-zone/index.js
+++ b/packages/components/src/drop-zone/index.js
@@ -31,6 +31,13 @@ class DropZoneComponent extends Component {
 			onDrop: this.props.onDrop,
 			onFilesDrop: this.props.onFilesDrop,
 			onHTMLDrop: this.props.onHTMLDrop,
+			setState: this.setState,
+		};
+		this.state = {
+			isDraggingOverDocument: false,
+			isDraggingOverElement: false,
+			position: null,
+			type: null,
 		};
 	}
 
@@ -45,16 +52,8 @@ class DropZoneComponent extends Component {
 	}
 
 	render() {
-		const {
-			className,
-			label,
-			context: {
-				isDraggingOverDocument,
-				isDraggingOverElement,
-				position,
-				type,
-			},
-		} = this.props;
+		const { className, label } = this.props;
+		const { isDraggingOverDocument, isDraggingOverElement, position, type } = this.state;
 		const classes = classnames( 'components-drop-zone', className, {
 			'is-active': isDraggingOverDocument || isDraggingOverElement,
 			'is-dragging-over-document': isDraggingOverDocument,

--- a/packages/components/src/drop-zone/index.js
+++ b/packages/components/src/drop-zone/index.js
@@ -31,7 +31,7 @@ class DropZoneComponent extends Component {
 	constructor() {
 		super( ...arguments );
 
-		this.ref = createRef();
+		this.dropZoneElement = createRef();
 		this.dropZone = {
 			element: null,
 			onDrop: this.props.onDrop,
@@ -49,7 +49,7 @@ class DropZoneComponent extends Component {
 
 	componentDidMount() {
 		// Set element after the component has a node assigned in the DOM
-		this.dropZone.element = this.ref.current;
+		this.dropZone.element = this.dropZoneElement.current;
 		this.props.addDropZone( this.dropZone );
 	}
 
@@ -72,7 +72,7 @@ class DropZoneComponent extends Component {
 		} );
 
 		return (
-			<div ref={ this.ref } className={ classes }>
+			<div ref={ this.dropZoneElement } className={ classes }>
 				<div className="components-drop-zone__content">
 					{ [
 						<Dashicon

--- a/packages/components/src/drop-zone/index.js
+++ b/packages/components/src/drop-zone/index.js
@@ -2,54 +2,59 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
+import { Component, createRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import Dashicon from '../dashicon';
+import { DropZoneConsumer } from './provider';
 
-class DropZone extends Component {
+const DropZone = ( props ) => (
+	<DropZoneConsumer>
+		{ ( context ) => ( <DropZoneComponent contex={ context } { ...props } /> ) }
+	</DropZoneConsumer>
+);
+
+class DropZoneComponent extends Component {
 	constructor() {
 		super( ...arguments );
 
 		this.setZoneNode = this.setZoneNode.bind( this );
 
-		this.state = {
-			isDraggingOverDocument: false,
-			isDraggingOverElement: false,
-			position: null,
-			type: null,
+		this.ref = createRef();
+		this.dropZone = {
+			element: this.ref,
+			onDrop: this.props.onDrop,
+			onFilesDrop: this.props.onFilesDrop,
+			onHTMLDrop: this.props.onHTMLDrop,
 		};
 	}
 
 	componentDidMount() {
-		this.context.dropzones.add( {
-			element: this.zone,
-			updateState: this.setState.bind( this ),
-			onDrop: this.props.onDrop,
-			onFilesDrop: this.props.onFilesDrop,
-			onHTMLDrop: this.props.onHTMLDrop,
-		} );
+		this.props.context.addDropZone( this.dropZone );
 	}
 
 	componentWillUnmount() {
-		this.context.dropzones.remove( this.zone );
-	}
-
-	setZoneNode( node ) {
-		this.zone = node;
+		this.props.context.removeDropZone( this.dropZone );
 	}
 
 	render() {
-		const { className, label } = this.props;
-		const { isDraggingOverDocument, isDraggingOverElement, position, type } = this.state;
+		const {
+			className,
+			label,
+			context: {
+				isDraggingOverDocument,
+				isDraggingOverElement,
+				position,
+				type,
+			},
+		} = this.props;
 		const classes = classnames( 'components-drop-zone', className, {
 			'is-active': isDraggingOverDocument || isDraggingOverElement,
 			'is-dragging-over-document': isDraggingOverDocument,
@@ -62,7 +67,7 @@ class DropZone extends Component {
 		} );
 
 		return (
-			<div ref={ this.setZoneNode } className={ classes }>
+			<div ref={ this.ref } className={ classes }>
 				<div className="components-drop-zone__content">
 					{ [
 						<Dashicon
@@ -84,9 +89,4 @@ class DropZone extends Component {
 	}
 }
 
-DropZone.contextTypes = {
-	dropzones: noop,
-};
-
 export default DropZone;
-

--- a/packages/components/src/drop-zone/index.js
+++ b/packages/components/src/drop-zone/index.js
@@ -25,8 +25,6 @@ class DropZoneComponent extends Component {
 	constructor() {
 		super( ...arguments );
 
-		this.setZoneNode = this.setZoneNode.bind( this );
-
 		this.ref = createRef();
 		this.dropZone = {
 			element: this.ref,

--- a/packages/components/src/drop-zone/index.js
+++ b/packages/components/src/drop-zone/index.js
@@ -17,7 +17,7 @@ import { DropZoneConsumer } from './provider';
 
 const DropZone = ( props ) => (
 	<DropZoneConsumer>
-		{ ( context ) => ( <DropZoneComponent contex={ context } { ...props } /> ) }
+		{ ( context ) => ( <DropZoneComponent context={ context } { ...props } /> ) }
 	</DropZoneConsumer>
 );
 

--- a/packages/components/src/drop-zone/index.js
+++ b/packages/components/src/drop-zone/index.js
@@ -37,7 +37,7 @@ class DropZoneComponent extends Component {
 			onDrop: this.props.onDrop,
 			onFilesDrop: this.props.onFilesDrop,
 			onHTMLDrop: this.props.onHTMLDrop,
-			setState: this.setState,
+			setState: this.setState.bind( this ),
 		};
 		this.state = {
 			isDraggingOverDocument: false,

--- a/packages/components/src/drop-zone/index.js
+++ b/packages/components/src/drop-zone/index.js
@@ -17,7 +17,13 @@ import { DropZoneConsumer } from './provider';
 
 const DropZone = ( props ) => (
 	<DropZoneConsumer>
-		{ ( context ) => ( <DropZoneComponent context={ context } { ...props } /> ) }
+		{ ( { addDropZone, removeDropZone } ) => (
+			<DropZoneComponent
+				addDropZone={ addDropZone }
+				removeDropZone={ removeDropZone }
+				{ ...props }
+			/>
+		) }
 	</DropZoneConsumer>
 );
 
@@ -44,11 +50,11 @@ class DropZoneComponent extends Component {
 	componentDidMount() {
 		// Set element after the component has a node assigned in the DOM
 		this.dropZone.element = this.ref.current;
-		this.props.context.addDropZone( this.dropZone );
+		this.props.addDropZone( this.dropZone );
 	}
 
 	componentWillUnmount() {
-		this.props.context.removeDropZone( this.dropZone );
+		this.props.removeDropZone( this.dropZone );
 	}
 
 	render() {

--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -25,17 +25,22 @@ class DropZoneProvider extends Component {
 		// Event listeners
 		this.onDragOver = this.onDragOver.bind( this );
 		this.onDrop = this.onDrop.bind( this );
+		// Context methods so this component can receive data from consumers
+		this.addDropZone = this.addDropZone.bind( this );
+		this.removeDropZone = this.removeDropZone.bind( this );
 		// Utility methods
 		this.resetDragState = this.resetDragState.bind( this );
 		this.toggleDraggingOverDocument = throttle( this.toggleDraggingOverDocument.bind( this ), 200 );
 		this.isWithinZoneBounds = this.isWithinZoneBounds.bind( this );
 
+		this.dropzones = [];
 		this.state = {
+			addDropZone: this.addDropZone,
+			removeDropZone: this.removeDropZone,
 			isDraggingOverDocument: false,
 			hoveredDropZone: -1,
 			position: null,
 		};
-		this.dropzones = [];
 	}
 
 	getChildContext() {
@@ -65,6 +70,14 @@ class DropZoneProvider extends Component {
 		window.removeEventListener( 'dragover', this.onDragOver );
 		window.removeEventListener( 'drop', this.onDrop );
 		window.removeEventListener( 'mouseup', this.resetDragState );
+	}
+
+	addDropZone( dropZone ) {
+		this.dropzones.push( dropZone );
+	}
+
+	removeDropZone( dropZone ) {
+		this.dropzones = filter( this.dropzones, ( dz ) => dz !== dropZone );
 	}
 
 	resetDragState() {

--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -62,7 +62,7 @@ class DropZoneProvider extends Component {
 		this.toggleDraggingOverDocument = throttle( this.toggleDraggingOverDocument.bind( this ), 200 );
 
 		this.dropZones = [];
-		this.context = {
+		this.dropZoneCallbacks = {
 			addDropZone: this.addDropZone,
 			removeDropZone: this.removeDropZone,
 		};
@@ -235,7 +235,7 @@ class DropZoneProvider extends Component {
 
 	render() {
 		return (
-			<Provider value={ this.context }>
+			<Provider value={ this.dropZoneCallbacks }>
 				{ this.props.children }
 			</Provider>
 		);

--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -22,11 +22,13 @@ class DropZoneProvider extends Component {
 	constructor() {
 		super( ...arguments );
 
+		// Event listeners
+		this.onDragOver = this.onDragOver.bind( this );
+		this.onDrop = this.onDrop.bind( this );
+		// Utility methods
 		this.resetDragState = this.resetDragState.bind( this );
 		this.toggleDraggingOverDocument = throttle( this.toggleDraggingOverDocument.bind( this ), 200 );
-		this.dragOverListener = this.dragOverListener.bind( this );
 		this.isWithinZoneBounds = this.isWithinZoneBounds.bind( this );
-		this.onDrop = this.onDrop.bind( this );
 
 		this.state = {
 			isDraggingOverDocument: false,
@@ -36,7 +38,7 @@ class DropZoneProvider extends Component {
 		this.dropzones = [];
 	}
 
-	dragOverListener( event ) {
+	onDragOver( event ) {
 		this.toggleDraggingOverDocument( event, this.getDragEventType( event ) );
 		event.preventDefault();
 	}
@@ -55,7 +57,7 @@ class DropZoneProvider extends Component {
 	}
 
 	componentDidMount() {
-		window.addEventListener( 'dragover', this.dragOverListener );
+		window.addEventListener( 'dragover', this.onDragOver );
 		window.addEventListener( 'drop', this.onDrop );
 		window.addEventListener( 'mouseup', this.resetDragState );
 
@@ -65,7 +67,7 @@ class DropZoneProvider extends Component {
 	}
 
 	componentWillUnmount() {
-		window.removeEventListener( 'dragover', this.dragOverListener );
+		window.removeEventListener( 'dragover', this.onDragOver );
 		window.removeEventListener( 'drop', this.onDrop );
 		window.removeEventListener( 'mouseup', this.resetDragState );
 	}

--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -134,10 +134,9 @@ class DropZoneProvider extends Component {
 		const detail = window.CustomEvent && event instanceof window.CustomEvent ? event.detail : event;
 
 		// Index of hovered dropzone.
-
-		const hoveredDropZones = filter( this.dropZones, ( dropzone ) =>
-			isTypeSupported( dragEventType, dropzone ) &&
-			isWithinElementBounds( dropzone.element, detail.clientX, detail.clientY )
+		const hoveredDropZones = filter( this.dropZones, ( dropZone ) =>
+			isTypeSupported( dragEventType, dropZone ) &&
+			isWithinElementBounds( dropZone.element, detail.clientX, detail.clientY )
 		);
 
 		// Find the leaf dropzone not containing another dropzone
@@ -179,11 +178,11 @@ class DropZoneProvider extends Component {
 		}
 
 		// Notifying the dropzones
-		toUpdate.map( ( dropzone ) => {
-			const index = this.dropZones.indexOf( dropzone );
+		toUpdate.map( ( dropZone ) => {
+			const index = this.dropZones.indexOf( dropZone );
 			const isDraggingOverDropZone = index === hoveredDropZoneIndex;
-			dropzone.setState( {
-				isDraggingOverDocument: isTypeSupported( dragEventType, dropzone ),
+			dropZone.setState( {
+				isDraggingOverDocument: isTypeSupported( dragEventType, dropZone ),
 				isDraggingOverElement: isDraggingOverDropZone,
 				position: isDraggingOverDropZone ? position : null,
 				type: isDraggingOverDropZone ? dragEventType : null,
@@ -212,20 +211,20 @@ class DropZoneProvider extends Component {
 
 		const { position, hoveredDropZone } = this.state;
 		const dragEventType = getDragEventType( event );
-		const dropzone = this.dropZones[ hoveredDropZone ];
-		const isValidDropzone = !! dropzone && this.container.contains( event.target );
+		const dropZone = this.dropZones[ hoveredDropZone ];
+		const isValidDropzone = !! dropZone && this.container.contains( event.target );
 		this.resetDragState();
 
 		if ( isValidDropzone ) {
 			switch ( dragEventType ) {
 				case 'file':
-					dropzone.onFilesDrop( [ ...event.dataTransfer.files ], position );
+					dropZone.onFilesDrop( [ ...event.dataTransfer.files ], position );
 					break;
 				case 'html':
-					dropzone.onHTMLDrop( event.dataTransfer.getData( 'text/html' ), position );
+					dropZone.onHTMLDrop( event.dataTransfer.getData( 'text/html' ), position );
 					break;
 				case 'default':
-					dropzone.onDrop( event, position );
+					dropZone.onDrop( event, position );
 			}
 		}
 

--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -31,10 +31,10 @@ const getDragEventType = ( { dataTransfer } ) => {
 	return 'default';
 };
 
-const isTypeSupported = ( type, typesSupported ) => {
-	return ( type === 'file' && typesSupported.onFilesDrop ) ||
-		( type === 'html' && typesSupported.onHTMLDrop ) ||
-		( type === 'default' && typesSupported.onDrop );
+const isTypeSupportedByDropZone = ( type, dropZone ) => {
+	return ( type === 'file' && dropZone.onFilesDrop ) ||
+		( type === 'html' && dropZone.onHTMLDrop ) ||
+		( type === 'default' && dropZone.onDrop );
 };
 
 const isWithinElementBounds = ( element, x, y ) => {
@@ -135,7 +135,7 @@ class DropZoneProvider extends Component {
 
 		// Index of hovered dropzone.
 		const hoveredDropZones = filter( this.dropZones, ( dropZone ) =>
-			isTypeSupported( dragEventType, dropZone ) &&
+			isTypeSupportedByDropZone( dragEventType, dropZone ) &&
 			isWithinElementBounds( dropZone.element, detail.clientX, detail.clientY )
 		);
 
@@ -182,7 +182,7 @@ class DropZoneProvider extends Component {
 			const index = this.dropZones.indexOf( dropZone );
 			const isDraggingOverDropZone = index === hoveredDropZoneIndex;
 			dropZone.setState( {
-				isDraggingOverDocument: isTypeSupported( dragEventType, dropZone ),
+				isDraggingOverDocument: isTypeSupportedByDropZone( dragEventType, dropZone ),
 				isDraggingOverElement: isDraggingOverDropZone,
 				position: isDraggingOverDropZone ? position : null,
 				type: isDraggingOverDropZone ? dragEventType : null,

--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEqual, find, some, filter, noop, throttle, includes } from 'lodash';
+import { isEqual, find, some, filter, throttle, includes } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -9,7 +9,7 @@ import { isEqual, find, some, filter, noop, throttle, includes } from 'lodash';
 import { Component, createContext, findDOMNode } from '@wordpress/element';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 
-const Context = createContext( {
+const { Provider } = createContext( {
 	addDropZone: () => {},
 	removeDropZone: () => {},
 	isDraggingOverDocument: false,
@@ -75,19 +75,6 @@ class DropZoneProvider extends Component {
 		};
 	}
 
-	getChildContext() {
-		return {
-			dropzones: {
-				add: ( { element, updateState, onDrop, onFilesDrop, onHTMLDrop } ) => {
-					this.dropZones.push( { element, updateState, onDrop, onFilesDrop, onHTMLDrop } );
-				},
-				remove: ( element ) => {
-					this.dropZones = filter( this.dropZones, ( dropzone ) => dropzone.element !== element );
-				},
-			},
-		};
-	}
-
 	componentDidMount() {
 		window.addEventListener( 'dragover', this.onDragOver );
 		window.addEventListener( 'drop', this.onDrop );
@@ -125,15 +112,6 @@ class DropZoneProvider extends Component {
 			isDraggingOverDocument: false,
 			hoveredDropZone: -1,
 			position: null,
-		} );
-
-		this.dropZones.forEach( ( { updateState } ) => {
-			updateState( {
-				isDraggingOverDocument: false,
-				isDraggingOverElement: false,
-				position: null,
-				type: null,
-			} );
 		} );
 	}
 
@@ -247,13 +225,12 @@ class DropZoneProvider extends Component {
 	}
 
 	render() {
-		const { children } = this.props;
-		return children;
+		return (
+			<Provider value={ this.state }>
+				{ this.props.children }
+			</Provider>
+		);
 	}
 }
-
-DropZoneProvider.childContextTypes = {
-	dropzones: noop,
-};
 
 export default DropZoneProvider;

--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -35,6 +35,12 @@ const getDragEventType = ( { dataTransfer } ) => {
 	return 'default';
 };
 
+const isTypeSupported = ( type, typesSupported ) => {
+	return ( type === 'file' && typesSupported.onFilesDrop ) ||
+		( type === 'html' && typesSupported.onHTMLDrop ) ||
+		( type === 'default' && typesSupported.onDrop );
+};
+
 class DropZoneProvider extends Component {
 	constructor() {
 		super( ...arguments );
@@ -122,14 +128,6 @@ class DropZoneProvider extends Component {
 		} );
 	}
 
-	doesDropzoneSupportType( dropzone, type ) {
-		return (
-			( type === 'file' && dropzone.onFilesDrop ) ||
-			( type === 'html' && dropzone.onHTMLDrop ) ||
-			( type === 'default' && dropzone.onDrop )
-		);
-	}
-
 	toggleDraggingOverDocument( event, dragEventType ) {
 		// In some contexts, it may be necessary to capture and redirect the
 		// drag event (e.g. atop an `iframe`). To accommodate this, you can
@@ -142,7 +140,7 @@ class DropZoneProvider extends Component {
 		// Index of hovered dropzone.
 
 		const hoveredDropZones = filter( this.dropZones, ( dropzone ) =>
-			this.doesDropzoneSupportType( dropzone, dragEventType ) &&
+			isTypeSupported( dragEventType, dropzone ) &&
 			this.isWithinZoneBounds( dropzone.element, detail.clientX, detail.clientY )
 		);
 
@@ -191,7 +189,7 @@ class DropZoneProvider extends Component {
 			dropzone.updateState( {
 				isDraggingOverElement: isDraggingOverDropZone,
 				position: isDraggingOverDropZone ? position : null,
-				isDraggingOverDocument: this.doesDropzoneSupportType( dropzone, dragEventType ),
+				isDraggingOverDocument: isTypeSupported( dragEventType, dropzone ),
 				type: isDraggingOverDropZone ? dragEventType : null,
 			} );
 		} );

--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -41,6 +41,16 @@ const isTypeSupported = ( type, typesSupported ) => {
 		( type === 'default' && typesSupported.onDrop );
 };
 
+const isWithinElementBounds = ( element, x, y ) => {
+	const rect = element.getBoundingClientRect();
+	/// make sure the rect is a valid rect
+	if ( rect.bottom === rect.top || rect.left === rect.right ) {
+		return false;
+	}
+
+	return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+};
+
 class DropZoneProvider extends Component {
 	constructor() {
 		super( ...arguments );
@@ -54,7 +64,6 @@ class DropZoneProvider extends Component {
 		// Utility methods
 		this.resetDragState = this.resetDragState.bind( this );
 		this.toggleDraggingOverDocument = throttle( this.toggleDraggingOverDocument.bind( this ), 200 );
-		this.isWithinZoneBounds = this.isWithinZoneBounds.bind( this );
 
 		this.dropZones = [];
 		this.state = {
@@ -141,7 +150,7 @@ class DropZoneProvider extends Component {
 
 		const hoveredDropZones = filter( this.dropZones, ( dropzone ) =>
 			isTypeSupported( dragEventType, dropzone ) &&
-			this.isWithinZoneBounds( dropzone.element, detail.clientX, detail.clientY )
+			isWithinElementBounds( dropzone.element, detail.clientX, detail.clientY )
 		);
 
 		// Find the leaf dropzone not containing another dropzone
@@ -202,23 +211,6 @@ class DropZoneProvider extends Component {
 		if ( ! isShallowEqual( newState, this.state ) ) {
 			this.setState( newState );
 		}
-	}
-
-	isWithinZoneBounds( dropzone, x, y ) {
-		const isWithinElement = ( element ) => {
-			const rect = element.getBoundingClientRect();
-			/// make sure the rect is a valid rect
-			if ( rect.bottom === rect.top || rect.left === rect.right ) {
-				return false;
-			}
-
-			return (
-				x >= rect.left && x <= rect.right &&
-				y >= rect.top && y <= rect.bottom
-			);
-		};
-
-		return isWithinElement( dropzone );
 	}
 
 	onDragOver( event ) {

--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -9,7 +9,7 @@ import { isEqual, find, some, filter, throttle, includes } from 'lodash';
 import { Component, createContext, findDOMNode } from '@wordpress/element';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 
-const { Provider } = createContext( {
+const { Provider, Consumer } = createContext( {
 	addDropZone: () => {},
 	removeDropZone: () => {},
 	isDraggingOverDocument: false,
@@ -234,3 +234,4 @@ class DropZoneProvider extends Component {
 }
 
 export default DropZoneProvider;
+export { Consumer as DropZoneConsumer };

--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -18,6 +18,23 @@ const Context = createContext( {
 	type: null,
 } );
 
+const getDragEventType = ( { dataTransfer } ) => {
+	if ( dataTransfer ) {
+		// Use lodash `includes` here as in the Edge browser `types` is implemented
+		// as a DomStringList, whereas in other browsers it's an array. `includes`
+		// happily works with both types.
+		if ( includes( dataTransfer.types, 'Files' ) ) {
+			return 'file';
+		}
+
+		if ( includes( dataTransfer.types, 'text/html' ) ) {
+			return 'html';
+		}
+	}
+
+	return 'default';
+};
+
 class DropZoneProvider extends Component {
 	constructor() {
 		super( ...arguments );
@@ -103,23 +120,6 @@ class DropZoneProvider extends Component {
 				type: null,
 			} );
 		} );
-	}
-
-	getDragEventType( event ) {
-		if ( event.dataTransfer ) {
-			// Use lodash `includes` here as in the Edge browser `types` is implemented
-			// as a DomStringList, whereas in other browsers it's an array. `includes`
-			// happily works with both types.
-			if ( includes( event.dataTransfer.types, 'Files' ) ) {
-				return 'file';
-			}
-
-			if ( includes( event.dataTransfer.types, 'text/html' ) ) {
-				return 'html';
-			}
-		}
-
-		return 'default';
 	}
 
 	doesDropzoneSupportType( dropzone, type ) {
@@ -224,7 +224,7 @@ class DropZoneProvider extends Component {
 	}
 
 	onDragOver( event ) {
-		this.toggleDraggingOverDocument( event, this.getDragEventType( event ) );
+		this.toggleDraggingOverDocument( event, getDragEventType( event ) );
 		event.preventDefault();
 	}
 
@@ -234,7 +234,7 @@ class DropZoneProvider extends Component {
 		event.dataTransfer && event.dataTransfer.files.length; // eslint-disable-line no-unused-expressions
 
 		const { position, hoveredDropZone } = this.state;
-		const dragEventType = this.getDragEventType( event );
+		const dragEventType = getDragEventType( event );
 		const dropzone = this.dropZones[ hoveredDropZone ];
 		const isValidDropzone = !! dropzone && this.container.contains( event.target );
 		this.resetDragState();

--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -38,11 +38,6 @@ class DropZoneProvider extends Component {
 		this.dropzones = [];
 	}
 
-	onDragOver( event ) {
-		this.toggleDraggingOverDocument( event, this.getDragEventType( event ) );
-		event.preventDefault();
-	}
-
 	getChildContext() {
 		return {
 			dropzones: {
@@ -213,6 +208,11 @@ class DropZoneProvider extends Component {
 		};
 
 		return isWithinElement( dropzone );
+	}
+
+	onDragOver( event ) {
+		this.toggleDraggingOverDocument( event, this.getDragEventType( event ) );
+		event.preventDefault();
 	}
 
 	onDrop( event ) {

--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -33,7 +33,7 @@ class DropZoneProvider extends Component {
 		this.toggleDraggingOverDocument = throttle( this.toggleDraggingOverDocument.bind( this ), 200 );
 		this.isWithinZoneBounds = this.isWithinZoneBounds.bind( this );
 
-		this.dropzones = [];
+		this.dropZones = [];
 		this.state = {
 			addDropZone: this.addDropZone,
 			removeDropZone: this.removeDropZone,
@@ -47,10 +47,10 @@ class DropZoneProvider extends Component {
 		return {
 			dropzones: {
 				add: ( { element, updateState, onDrop, onFilesDrop, onHTMLDrop } ) => {
-					this.dropzones.push( { element, updateState, onDrop, onFilesDrop, onHTMLDrop } );
+					this.dropZones.push( { element, updateState, onDrop, onFilesDrop, onHTMLDrop } );
 				},
 				remove: ( element ) => {
-					this.dropzones = filter( this.dropzones, ( dropzone ) => dropzone.element !== element );
+					this.dropZones = filter( this.dropZones, ( dropzone ) => dropzone.element !== element );
 				},
 			},
 		};
@@ -73,11 +73,11 @@ class DropZoneProvider extends Component {
 	}
 
 	addDropZone( dropZone ) {
-		this.dropzones.push( dropZone );
+		this.dropZones.push( dropZone );
 	}
 
 	removeDropZone( dropZone ) {
-		this.dropzones = filter( this.dropzones, ( dz ) => dz !== dropZone );
+		this.dropZones = filter( this.dropZones, ( dz ) => dz !== dropZone );
 	}
 
 	resetDragState() {
@@ -95,7 +95,7 @@ class DropZoneProvider extends Component {
 			position: null,
 		} );
 
-		this.dropzones.forEach( ( { updateState } ) => {
+		this.dropZones.forEach( ( { updateState } ) => {
 			updateState( {
 				isDraggingOverDocument: false,
 				isDraggingOverElement: false,
@@ -141,7 +141,7 @@ class DropZoneProvider extends Component {
 
 		// Index of hovered dropzone.
 
-		const hoveredDropZones = filter( this.dropzones, ( dropzone ) =>
+		const hoveredDropZones = filter( this.dropZones, ( dropzone ) =>
 			this.doesDropzoneSupportType( dropzone, dragEventType ) &&
 			this.isWithinZoneBounds( dropzone.element, detail.clientX, detail.clientY )
 		);
@@ -151,7 +151,7 @@ class DropZoneProvider extends Component {
 			! some( hoveredDropZones, ( subZone ) => subZone !== zone && zone.element.parentElement.contains( subZone.element ) )
 		) );
 
-		const hoveredDropZoneIndex = this.dropzones.indexOf( hoveredDropZone );
+		const hoveredDropZoneIndex = this.dropZones.indexOf( hoveredDropZone );
 
 		let position = null;
 
@@ -168,10 +168,10 @@ class DropZoneProvider extends Component {
 		let dropzonesToUpdate = [];
 
 		if ( ! this.state.isDraggingOverDocument ) {
-			dropzonesToUpdate = this.dropzones;
+			dropzonesToUpdate = this.dropZones;
 		} else if ( hoveredDropZoneIndex !== this.state.hoveredDropZone ) {
 			if ( this.state.hoveredDropZone !== -1 ) {
-				dropzonesToUpdate.push( this.dropzones[ this.state.hoveredDropZone ] );
+				dropzonesToUpdate.push( this.dropZones[ this.state.hoveredDropZone ] );
 			}
 			if ( hoveredDropZone ) {
 				dropzonesToUpdate.push( hoveredDropZone );
@@ -186,7 +186,7 @@ class DropZoneProvider extends Component {
 
 		// Notifying the dropzones
 		dropzonesToUpdate.map( ( dropzone ) => {
-			const index = this.dropzones.indexOf( dropzone );
+			const index = this.dropZones.indexOf( dropzone );
 			const isDraggingOverDropZone = index === hoveredDropZoneIndex;
 			dropzone.updateState( {
 				isDraggingOverElement: isDraggingOverDropZone,
@@ -235,7 +235,7 @@ class DropZoneProvider extends Component {
 
 		const { position, hoveredDropZone } = this.state;
 		const dragEventType = this.getDragEventType( event );
-		const dropzone = this.dropzones[ hoveredDropZone ];
+		const dropzone = this.dropZones[ hoveredDropZone ];
 		const isValidDropzone = !! dropzone && this.container.contains( event.target );
 		this.resetDragState();
 

--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -6,8 +6,17 @@ import { isEqual, find, some, filter, noop, throttle, includes } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component, findDOMNode } from '@wordpress/element';
+import { Component, createContext, findDOMNode } from '@wordpress/element';
 import isShallowEqual from '@wordpress/is-shallow-equal';
+
+const Context = createContext( {
+	addDropZone: () => {},
+	removeDropZone: () => {},
+	isDraggingOverDocument: false,
+	isDraggingOverElement: false,
+	position: null,
+	type: null,
+} );
 
 class DropZoneProvider extends Component {
 	constructor() {


### PR DESCRIPTION
The DropZoneProvider is using the React's [legacy context API](https://reactjs.org/docs/legacy-context.html) which will be removed in the next major version and was added as a [deprecation in StrictMode](https://reactjs.org/blog/2018/10/23/react-v-16-6.html#deprecations-in-strictmode) in 16.6.0. 

This PR updates the DropZoneProvider to the stable React's context API. Note that DropZone functionality has remained untouched and works as it used to.

