### PR TITLE
RichText: fix format placeholder

### DIFF
--- a/packages/rich-text/src/apply-format.js
+++ b/packages/rich-text/src/apply-format.js
@@ -2,15 +2,13 @@
  * External dependencies
  */
 
-import { find, reject } from 'lodash';
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
  */
 
 import { normaliseFormats } from './normalise-formats';
-import { insert } from './insert';
-import { ZERO_WIDTH_NO_BREAK_SPACE } from './special-characters';
 
 /**
  * Apply a format object to a Rich Text value from the given `startIndex` to the
@@ -56,10 +54,16 @@ export function applyFormat(
 			const previousFormat = newFormats[ startIndex - 1 ] || [];
 			const hasType = find( previousFormat, { type: format.type } );
 
-			return insert( { formats, text, start, end }, {
-				formats: hasType ? [ reject( previousFormat, { type: format.type } ) ] : [ [ ...previousFormat, format ] ],
-				text: ZERO_WIDTH_NO_BREAK_SPACE,
-			} );
+			return {
+				formats,
+				text,
+				start,
+				end,
+				formatPlaceholder: {
+					index: startIndex,
+					format: hasType ? undefined : format,
+				},
+			};
 		}
 	} else {
 		for ( let index = startIndex; index < endIndex; index++ ) {

--- a/packages/rich-text/src/test/apply-format.js
+++ b/packages/rich-text/src/test/apply-format.js
@@ -8,7 +8,6 @@ import deepFreeze from 'deep-freeze';
  */
 
 import { applyFormat } from '../apply-format';
-import { ZERO_WIDTH_NO_BREAK_SPACE } from '../special-characters';
 import { getSparseArrayLength } from './helpers';
 
 describe( 'applyFormat', () => {
@@ -61,16 +60,17 @@ describe( 'applyFormat', () => {
 			end: 0,
 		};
 		const expected = {
-			formats: [ [ a2 ], , , , , [ a ], [ a ], [ a ], , , , , , , ],
-			text: `${ ZERO_WIDTH_NO_BREAK_SPACE }one two three`,
-			start: 1,
-			end: 1,
+			...record,
+			formatPlaceholder: {
+				format: a2,
+				index: 0,
+			},
 		};
 		const result = applyFormat( deepFreeze( record ), a2 );
 
 		expect( result ).toEqual( expected );
 		expect( result ).not.toBe( record );
-		expect( getSparseArrayLength( result.formats ) ).toBe( 4 );
+		expect( getSparseArrayLength( result.formats ) ).toBe( 3 );
 	} );
 
 	it( 'should apply format on existing format if selection is collapsed', () => {

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -159,6 +159,7 @@ export function toDom( {
 		onEndIndex( body, pointer ) {
 			endPath = createPathToNode( pointer, body, [ pointer.nodeValue.length ] );
 		},
+		isEditableTree: true,
 	} );
 
 	if ( createLinePadding ) {

--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -75,6 +75,22 @@ export function toTree( {
 		append( tree, '' );
 	}
 
+	function setFormatPlaceholder( pointer, index ) {
+		if ( isEditableTree && formatPlaceholder && formatPlaceholder.index === index ) {
+			const parent = getParent( pointer );
+
+			if ( formatPlaceholder.format === undefined ) {
+				pointer = getParent( parent );
+			} else {
+				pointer = append( parent, fromFormat( formatPlaceholder.format ) );
+			}
+
+			pointer = append( pointer, ZERO_WIDTH_NO_BREAK_SPACE );
+		}
+
+		return pointer;
+	}
+
 	for ( let i = 0; i < formatsLength; i++ ) {
 		const character = text.charAt( i );
 		let characterFormats = formats[ i ];
@@ -148,17 +164,7 @@ export function toTree( {
 			continue;
 		}
 
-		if ( isEditableTree && formatPlaceholder && formatPlaceholder.index === 0 ) {
-			const parent = getParent( pointer );
-
-			if ( formatPlaceholder.format === undefined ) {
-				pointer = getParent( parent );
-			} else {
-				pointer = append( parent, fromFormat( formatPlaceholder.format ) );
-			}
-
-			pointer = append( pointer, ZERO_WIDTH_NO_BREAK_SPACE );
-		}
+		pointer = setFormatPlaceholder( pointer, 0 );
 
 		// If there is selection at 0, handle it before characters are inserted.
 		if ( i === 0 ) {
@@ -183,17 +189,7 @@ export function toTree( {
 			}
 		}
 
-		if ( isEditableTree && formatPlaceholder && formatPlaceholder.index === i + 1 ) {
-			const parent = getParent( pointer );
-
-			if ( formatPlaceholder.format === undefined ) {
-				pointer = getParent( parent );
-			} else {
-				pointer = append( parent, fromFormat( formatPlaceholder.format ) );
-			}
-
-			pointer = append( pointer, ZERO_WIDTH_NO_BREAK_SPACE );
-		}
+		pointer = setFormatPlaceholder( pointer, i + 1 );
 
 		if ( onStartIndex && start === i + 1 ) {
 			onStartIndex( tree, pointer );

--- a/test/e2e/specs/__snapshots__/rich-text.test.js.snap
+++ b/test/e2e/specs/__snapshots__/rich-text.test.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`RichText should apply formatting when selection is collapsed 1`] = `
+"<!-- wp:paragraph -->
+<p>Some <strong>bold</strong>.</p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`RichText should apply formatting with access shortcut 1`] = `
 "<!-- wp:paragraph -->
 <p><del>test</del></p>

--- a/test/e2e/specs/rich-text.test.js
+++ b/test/e2e/specs/rich-text.test.js
@@ -45,4 +45,17 @@ describe( 'RichText', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should apply formatting when selection is collapsed', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'Some ' );
+		// All following characters should now be bold.
+		await pressWithModifier( META_KEY, 'b' );
+		await page.keyboard.type( 'bold' );
+		// All following characters should no longer be bold.
+		await pressWithModifier( META_KEY, 'b' );
+		await page.keyboard.type( '.' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );


### PR DESCRIPTION
## Description

This branch fixes a few related issues:

* The issue described at https://github.com/WordPress/gutenberg/pull/10209#issuecomment-433108480.
* Inserting a non breaking zero-width space in the *value* is not a good thing, as it will break e.g. a search for text.
* The non breaking zero-width space is kept around longer than it should.

The only solution for applying a format placeholder is to temporarily store an extra property on the value object that indicates to the editable tree creator that a format placeholder should appear there with the caret.

I added an e2e test to verify it works.

## How has this been tested?

Ensure you can type while using formatting shortcuts (see e2e test). Ensure https://github.com/WordPress/gutenberg/pull/10209#issuecomment-433108480 is not reproducible. 

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->