### PR TITLE
Pasting text with link into RichText for file name makes block invalid #10967

### DIFF
--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -21,6 +21,7 @@ import {
 	MediaPlaceholder,
 	BlockControls,
 	RichText,
+    PlainText,
 	mediaUpload,
 } from '@wordpress/editor';
 import { compose } from '@wordpress/compose';
@@ -182,7 +183,7 @@ class FileEdit extends Component {
 				</BlockControls>
 				<div className={ classes }>
 					<div className={ `${ className }__content-wrapper` }>
-						<RichText
+						<PlainText
 							wrapperClassName={ `${ className }__textlink` }
 							tagName="div" // must be block-level or else cursor disappears
 							value={ fileName }

--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -10,8 +10,9 @@ import { __, _x } from '@wordpress/i18n';
 import { createBlobURL } from '@wordpress/blob';
 import { createBlock } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
-import { RichText } from '@wordpress/editor';
+import { RichText, PlainText } from '@wordpress/editor';
 import { SVG, Path } from '@wordpress/components';
+import { RawHTML } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -200,33 +201,71 @@ export const settings = {
 			showDownloadButton,
 			downloadButtonText,
 		} = attributes;
-
-		return ( href &&
+        return ( href &&
 			<div>
-				{ ! RichText.isEmpty( fileName ) &&
-					<a
-						href={ textLinkHref }
-						target={ textLinkTarget }
-						rel={ textLinkTarget ? 'noreferrer noopener' : false }
-					>
-						<RichText.Content
-							value={ fileName }
-						/>
-					</a>
-				}
-				{ showDownloadButton &&
-					<a
-						href={ href }
-						className="wp-block-file__button"
-						download={ true }
-					>
-						<RichText.Content
-							value={ downloadButtonText }
-						/>
-					</a>
-				}
+                { fileName !== null &&
+				<a
+					href={ textLinkHref }
+					target={ textLinkTarget }
+					rel={ textLinkTarget ? 'noreferrer noopener' : false }
+				>
+					<RawHTML>{ fileName }</RawHTML>
+				</a>
+                }
+                { showDownloadButton &&
+				<a
+					href={ href }
+					className="wp-block-file__button"
+					download={ true }
+				>
+					<RichText.Content
+						value={ downloadButtonText }
+					/>
+				</a>
+                }
 			</div>
-		);
+        );
+    },
+
+    deprecated: [ {
+        save( { attributes } ) {
+            const {
+                href,
+                fileName,
+                textLinkHref,
+                textLinkTarget,
+                showDownloadButton,
+                downloadButtonText,
+            } = attributes;
+
+            return ( href &&
+                <div>
+                    { ! RichText.isEmpty( fileName ) &&
+                        <a
+                            href={ textLinkHref }
+                            target={ textLinkTarget }
+                            rel={ textLinkTarget ? 'noreferrer noopener' : false }
+                        >
+                            <RichText.Content
+                                value={ fileName }
+                            />
+                        </a>
+                    }
+                    { showDownloadButton &&
+                        <a
+                            href={ href }
+                            className="wp-block-file__button"
+                            download={ true }
+                        >
+                            <RichText.Content
+                                value={ downloadButtonText }
+                            />
+                        </a>
+                    }
+                </div>
+            );
+        },
 	},
+    ],
 
 };

--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -10,7 +10,7 @@ import { __, _x } from '@wordpress/i18n';
 import { createBlobURL } from '@wordpress/blob';
 import { createBlock } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
-import { RichText, PlainText } from '@wordpress/editor';
+import { RichText } from '@wordpress/editor';
 import { SVG, Path } from '@wordpress/components';
 import { RawHTML } from '@wordpress/element';
 


### PR DESCRIPTION
## Description
Fixes #10967.

Solution for pasting text with link into RichText for file name makes block invalid #10967
<!-- Please describe what you have changed or added -->

## How has this been tested?
Ran `npm run test`
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
Added PlainText control instead of RichText control and also added deprecation function.
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
