### PR TITLE
Restore displaying formatting shortcuts in toolbar

### DIFF
--- a/packages/editor/src/components/rich-text/format-edit.js
+++ b/packages/editor/src/components/rich-text/format-edit.js
@@ -4,7 +4,7 @@
 import { Component, Fragment } from '@wordpress/element';
 import { getActiveFormat, getFormatTypes } from '@wordpress/rich-text';
 import { Fill, KeyboardShortcuts, ToolbarButton } from '@wordpress/components';
-import { rawShortcut } from '@wordpress/keycodes';
+import { rawShortcut, displayShortcut } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -18,10 +18,19 @@ function isResult( { title, keywords = [] }, filterValue ) {
 	return matchSearch( title ) || keywords.some( matchSearch );
 }
 
-function FillToolbarButton( { name, ...props } ) {
+function FillToolbarButton( { name, shortcutType, shortcutCharacter, ...props } ) {
+	let shortcut;
+
+	if ( shortcutType && shortcutCharacter ) {
+		shortcut = displayShortcut[ shortcutType ]( shortcutCharacter );
+	}
+
 	return (
 		<Fill name={ `RichText.ToolbarControls.${ name }` }>
-			<ToolbarButton { ...props } />
+			<ToolbarButton
+				{ ...props }
+				shortcut={ shortcut }
+			/>
 		</Fill>
 	);
 }

--- a/packages/format-library/src/bold/index.js
+++ b/packages/format-library/src/bold/index.js
@@ -29,6 +29,8 @@ export const bold = {
 					title={ __( 'Bold' ) }
 					onClick={ onToggle }
 					isActive={ isActive }
+					shortcutType="primary"
+					shortcutCharacter="b"
 				/>
 			</Fragment>
 		);

--- a/packages/format-library/src/italic/index.js
+++ b/packages/format-library/src/italic/index.js
@@ -29,6 +29,8 @@ export const italic = {
 					title={ __( 'Italic' ) }
 					onClick={ onToggle }
 					isActive={ isActive }
+					shortcutType="primary"
+					shortcutCharacter="i"
 				/>
 			</Fragment>
 		);

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -94,6 +94,8 @@ export const link = {
 						title={ __( 'Unlink' ) }
 						onClick={ this.onRemoveFormat }
 						isActive={ isActive }
+						shortcutType="primaryShift"
+						shortcutCharacter="k"
 					/> }
 					{ ! isActive && <ToolbarButton
 						name="link"
@@ -101,6 +103,8 @@ export const link = {
 						title={ __( 'Link' ) }
 						onClick={ this.addLink }
 						isActive={ isActive }
+						shortcutType="primary"
+						shortcutCharacter="k"
 					/> }
 					<InlineLinkUI
 						addingLink={ this.state.addingLink }

--- a/packages/format-library/src/strikethrough/index.js
+++ b/packages/format-library/src/strikethrough/index.js
@@ -29,6 +29,8 @@ export const strikethrough = {
 					title={ __( 'Strikethrough' ) }
 					onClick={ onToggle }
 					isActive={ isActive }
+					shortcutType="access"
+					shortcutCharacter="d"
 				/>
 			</Fragment>
 		);


### PR DESCRIPTION
## Description
After #10209, shortcuts no longer display in the tooltips of the formatting toolbar. This branch adds extra props on `ToolbarButton` to display the wanted combination (there can be more than one, e.g. link).

## How has this been tested?
Check the formatting buttons' tooltips.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->