### PR TITLE
RichText: Update registration method signature

### DIFF
--- a/packages/format-library/src/index.js
+++ b/packages/format-library/src/index.js
@@ -22,4 +22,4 @@ import {
 	italic,
 	link,
 	strikethrough,
-].forEach( registerFormatType );
+].forEach( ( { name, ...settings } ) => registerFormatType( name, settings ) );

--- a/packages/rich-text/src/register-format-type.js
+++ b/packages/rich-text/src/register-format-type.js
@@ -13,12 +13,18 @@ import { isValidIcon, normalizeIconObject } from '@wordpress/blocks';
  * Registers a new format provided a unique name and an object defining its
  * behavior.
  *
+ * @param {string} name     Format name.
  * @param {Object} settings Format settings.
  *
  * @return {?WPFormat} The format, if it has been successfully registered;
  *                     otherwise `undefined`.
  */
-export function registerFormatType( settings ) {
+export function registerFormatType( name, settings ) {
+	settings = {
+		name,
+		...settings,
+	};
+
 	if ( typeof settings.name !== 'string' ) {
 		window.console.error(
 			'Format names must be strings.'


### PR DESCRIPTION
## Description
I missed it when reviewing #10209.

This PR changes the signature of `registerFormatType` to use `name` param. This change is introduced only for consistency with `registerBlockType` and `registerPlugin`.

There should be no visual changes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
