### PR TITLE
Shortcode: Move label above input to make more room for input

### DIFF
--- a/packages/block-library/src/shortcode/editor.scss
+++ b/packages/block-library/src/shortcode/editor.scss
@@ -1,6 +1,6 @@
 .wp-block-shortcode {
 	display: flex;
-	flex-direction: row;
+	flex-direction: column;
 	padding: $block-padding;
 	background-color: $light-gray-100;
 	font-size: $default-font-size;
@@ -9,7 +9,7 @@
 	label {
 		display: flex;
 		align-items: center;
-		margin-right: $grid-size;
+		margin-bottom: $grid-size;
 		white-space: nowrap;
 		font-weight: 600;
 		flex-shrink: 0;


### PR DESCRIPTION
## Description

This PR attempts to fix #11079. 

When 3 or more shortcode blocks are used inside a column block, the input region is seen to be very narrow.

This PR attempts to move the shortcode label from the left to above the input region, to make more room for input, as suggested by @billerickson on the issue. I feel that it's a nice solution as well. 

## Before

<img width="697" alt="screenshot 2018-10-26 at 16 42 19" src="https://user-images.githubusercontent.com/18581859/47566360-25834500-d949-11e8-8997-62109e364d4a.png">
<sup>Image indicating three shortcode blocks inside the column block that are having a very narrow space for input</sup> 

## After

<img width="663" alt="screenshot 2018-10-26 at 16 41 26" src="https://user-images.githubusercontent.com/18581859/47566367-29af6280-d949-11e8-8073-3292dfa87258.png">
<sup>Image indicating three shortcode blocks inside the column block that are having more space for input</sup> 

## How has this been tested?

- ✅ Tested by adding the shortcode block on all available columns, 6 in total
- ✅ Tested on Google Chrome Version 70.0.3538.67 (Official Build) (64-bit) for macOS 10.14 - Mac OS Mojave

## Types of changes

Minor change that moves the placement of the `Shortcode` label on the shortcode block, from left of the input to above the input.