### PR TITLE
Pass the post being edited to the enqueue_block_editor_assets action

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1687,8 +1687,10 @@ JS;
 	 * `wp_enqueue_style` to add your functionality to the Gutenberg editor.
 	 *
 	 * @since 0.4.0
+	 *
+	 * @param WP_Post $post Post being edited.
 	 */
-	do_action( 'enqueue_block_editor_assets' );
+	do_action( 'enqueue_block_editor_assets', $post );
 }
 
 /**

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1688,7 +1688,7 @@ JS;
 	 *
 	 * @since 0.4.0
 	 *
-	 * @param WP_Post $post Post being edited.
+	 * @param WP_Post $post Post being edited (added in 4.1.1).
 	 */
 	do_action( 'enqueue_block_editor_assets', $post );
 }

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1687,8 +1687,9 @@ JS;
 	 * `wp_enqueue_style` to add your functionality to the Gutenberg editor.
 	 *
 	 * @since 0.4.0
+	 * @since 4.1.1 Added the `$post` parameter.
 	 *
-	 * @param WP_Post $post Post being edited (added in 4.1.1).
+	 * @param WP_Post $post Post being edited.
 	 */
 	do_action( 'enqueue_block_editor_assets', $post );
 }


### PR DESCRIPTION
## Description
Passes the post being edited to the enqueue_block_editor_assets action.

## How has this been tested?
These changes have not been tested.

## Checklist:
- [ ] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
