### PR TITLE
Fix rich-text package dependencies

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -427,6 +427,7 @@ function gutenberg_register_scripts_and_styles() {
 		array(
 			'lodash',
 			'wp-polyfill',
+			'wp-blocks',
 			'wp-data',
 			'wp-escape-html',
 		),

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -21,6 +21,7 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.0.0",
+		"@wordpress/blocks": "file:../data",
 		"@wordpress/data": "file:../data",
 		"@wordpress/escape-html": "file:../escape-html",
 		"lodash": "^4.17.10",


### PR DESCRIPTION
## Description
Currently `@wordpress/blocks` is not added as a dependency. @nosolosw does this fix your issue?

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
