### PR TITLE
Override `createElement` to map svg elements to `react-native-svg` ones

### DIFF
--- a/packages/babel-plugin-import-jsx-pragma/test/index.js
+++ b/packages/babel-plugin-import-jsx-pragma/test/index.js
@@ -28,8 +28,15 @@ describe( 'babel-plugin-import-jsx-pragma', () => {
 		expect( string ).toBe( original );
 	} );
 
-	it( 'does nothing if there scope variable already imported', () => {
+	it( 'does nothing if the scope variable is already imported', () => {
 		const original = 'import React from "react";\nlet foo = <bar />;';
+		const string = getTransformedCode( original );
+
+		expect( string ).toBe( original );
+	} );
+
+	it( 'does nothing if the scope variable is already defined', () => {
+		const original = 'const React = require("react");\n\nlet foo = <bar />;';
 		const string = getTransformedCode( original );
 
 		expect( string ).toBe( original );
@@ -40,6 +47,20 @@ describe( 'babel-plugin-import-jsx-pragma', () => {
 		const string = getTransformedCode( original );
 
 		expect( string ).toBe( 'import React from "react";\nlet foo = <bar />;' );
+	} );
+
+	it( 'adds import for scope variable even if library is required', () => {
+		const original = 'const OtherReact = require("react");\n\nlet foo = <bar />;';
+		const string = getTransformedCode( original );
+
+		expect( string ).toBe( 'import React from "react";\n\nconst OtherReact = require("react");\n\nlet foo = <bar />;' );
+	} );
+
+	it( 'adds import for scope variable even if variable is defined in a child scope is required', () => {
+		const original = 'let foo = <bar />;\n\nfunction x() { const React = require("react"); }';
+		const string = getTransformedCode( original );
+
+		expect( string ).toBe( 'import React from "react";\nlet foo = <bar />;\n\nfunction x() {\n  const React = require("react");\n}' );
 	} );
 
 	it( 'allows options customization', () => {

--- a/packages/block-library/src/code/index.js
+++ b/packages/block-library/src/code/index.js
@@ -3,10 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
-import {
-	Path,
-	SVG,
-} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -20,7 +16,7 @@ export const settings = {
 
 	description: __( 'Add text that respects your spacing and tabs -- perfect for displaying code.' ),
 
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Path d="M9.4,16.6L4.8,12l4.6-4.6L8,6l-6,6l6,6L9.4,16.6z M14.6,16.6l4.6-4.6l-4.6-4.6L16,6l6,6l-6,6L14.6,16.6z" /></SVG>,
+	icon: <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M0,0h24v24H0V0z" fill="none" /><path d="M9.4,16.6L4.8,12l4.6-4.6L8,6l-6,6l6,6L9.4,16.6z M14.6,16.6l4.6-4.6l-4.6-4.6L16,6l6,6l-6,6L14.6,16.6z" /></svg>,
 
 	category: 'formatting',
 

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -14,10 +14,6 @@ import {
 	getBlockType,
 } from '@wordpress/blocks';
 import { RichText } from '@wordpress/editor';
-import {
-	Path,
-	SVG,
-} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -64,7 +60,7 @@ export const settings = {
 
 	description: __( 'Introduce topics and help visitors (and search engines!) understand how your content is organized.' ),
 
-	icon: <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M5 4v3h5.5v12h3V7H19V4z" /><Path fill="none" d="M0 0h24v24H0V0z" /></SVG>,
+	icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M5 4v3h5.5v12h3V7H19V4z" /><path fill="none" d="M0 0h24v24H0V0z" /></svg>,
 
 	category: 'common',
 

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -16,10 +16,6 @@ import {
 } from '@wordpress/blocks';
 import { RichText } from '@wordpress/editor';
 import { createBlobURL } from '@wordpress/blob';
-import {
-	Path,
-	SVG,
-} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -98,7 +94,7 @@ export const settings = {
 
 	description: __( 'They’re worth 1,000 words! Insert a single image.' ),
 
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Path d="m19 5v14h-14v-14h14m0-2h-14c-1.1 0-2 0.9-2 2v14c0 1.1 0.9 2 2 2h14c1.1 0 2-0.9 2-2v-14c0-1.1-0.9-2-2-2z" /><Path d="m14.14 11.86l-3 3.87-2.14-2.59-3 3.86h12l-3.86-5.14z" /></SVG>,
+	icon: <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M0,0h24v24H0V0z" fill="none" /><path d="m19 5v14h-14v-14h14m0-2h-14c-1.1 0-2 0.9-2 2v14c0 1.1 0.9 2 2 2h14c1.1 0 2-0.9 2-2v-14c0-1.1-0.9-2-2-2z" /><path d="m14.14 11.86l-3 3.87-2.14-2.59-3 3.86h12l-3.86-5.14z" /></svg>,
 
 	category: 'common',
 

--- a/packages/block-library/src/more/index.js
+++ b/packages/block-library/src/more/index.js
@@ -9,11 +9,6 @@ import { compact } from 'lodash';
 import { __, _x } from '@wordpress/i18n';
 import { RawHTML } from '@wordpress/element';
 import { createBlock } from '@wordpress/blocks';
-import {
-	Path,
-	G,
-	SVG,
-} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -27,7 +22,7 @@ export const settings = {
 
 	description: __( 'Want to show only part of this post on your blog’s home page? Insert a "More" block where you want the split.' ),
 
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M2 9v2h19V9H2zm0 6h5v-2H2v2zm7 0h5v-2H9v2zm7 0h5v-2h-5v2z" /></G></SVG>,
+	icon: <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="none" d="M0 0h24v24H0V0z" /><g><path d="M2 9v2h19V9H2zm0 6h5v-2H2v2zm7 0h5v-2H9v2zm7 0h5v-2h-5v2z" /></g></svg>,
 
 	category: 'layout',
 

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -17,10 +17,6 @@ import {
 	RichText,
 } from '@wordpress/editor';
 import { getPhrasingContentSchema } from '@wordpress/blocks';
-import {
-	Path,
-	SVG,
-} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -78,7 +74,7 @@ export const settings = {
 
 	description: __( 'Add some basic text.' ),
 
-	icon: <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M11 5v7H9.5C7.6 12 6 10.4 6 8.5S7.6 5 9.5 5H11m8-2H9.5C6.5 3 4 5.5 4 8.5S6.5 14 9.5 14H11v7h2V5h2v16h2V5h2V3z" /></SVG>,
+	icon: <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M11 5v7H9.5C7.6 12 6 10.4 6 8.5S7.6 5 9.5 5H11m8-2H9.5C6.5 3 4 5.5 4 8.5S6.5 14 9.5 14H11v7h2V5h2v16h2V5h2V3z" /></svg>,
 
 	category: 'common',
 

--- a/packages/blocks/src/api/index.native.js
+++ b/packages/blocks/src/api/index.native.js
@@ -15,6 +15,8 @@ export {
 	registerBlockType,
 	setUnknownTypeHandlerName,
 	getUnknownTypeHandlerName,
+	setUnregisteredTypeHandlerName,
+	getUnregisteredTypeHandlerName,
 	getBlockType,
 	getBlockTypes,
 	hasBlockSupport,

--- a/packages/components/src/dashicon/index.js
+++ b/packages/components/src/dashicon/index.js
@@ -13,7 +13,6 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { Path, SVG } from '../primitives';
 
 export default class Dashicon extends Component {
 	shouldComponentUpdate( nextProps ) {
@@ -899,7 +898,7 @@ export default class Dashicon extends Component {
 		const iconClass = [ 'dashicon', 'dashicons-' + icon, className ].filter( Boolean ).join( ' ' );
 
 		return (
-			<SVG
+			<svg
 				aria-hidden
 				role="img"
 				focusable="false"
@@ -909,8 +908,8 @@ export default class Dashicon extends Component {
 				height={ size }
 				viewBox="0 0 20 20"
 			>
-				<Path d={ path } />
-			</SVG>
+				<path d={ path } />
+			</svg>
 		);
 	}
 }

--- a/packages/components/src/dashicon/test/index.js
+++ b/packages/components/src/dashicon/test/index.js
@@ -7,7 +7,6 @@ import { shallow } from 'enzyme';
  * Internal dependencies
  */
 import Dashicon from '../';
-import { SVG } from '../../primitives';
 
 describe( 'Dashicon', () => {
 	describe( 'basic rendering', () => {
@@ -27,7 +26,7 @@ describe( 'Dashicon', () => {
 			const dashicon = shallow( <Dashicon icon="wordpress" /> );
 			expect( dashicon.hasClass( 'dashicon' ) ).toBe( true );
 			expect( dashicon.hasClass( 'dashicons-wordpress' ) ).toBe( true );
-			expect( dashicon.type() ).toBe( SVG );
+			expect( dashicon.type() ).toBe( 'svg' );
 			expect( dashicon.prop( 'xmlns' ) ).toBe( 'http://www.w3.org/2000/svg' );
 			expect( dashicon.prop( 'width' ) ).toBe( 20 );
 			expect( dashicon.prop( 'height' ) ).toBe( 20 );

--- a/packages/components/src/form-toggle/index.js
+++ b/packages/components/src/form-toggle/index.js
@@ -7,7 +7,6 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import { Path, SVG } from '../primitives';
 
 function FormToggle( { className, checked, id, onChange = noop, ...props } ) {
 	const wrapperClasses = classnames(
@@ -29,8 +28,8 @@ function FormToggle( { className, checked, id, onChange = noop, ...props } ) {
 			<span className="components-form-toggle__track"></span>
 			<span className="components-form-toggle__thumb"></span>
 			{ checked ?
-				<SVG className="components-form-toggle__on" width="2" height="6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2 6"><Path d="M0 0h2v6H0z" /></SVG> :
-				<SVG className="components-form-toggle__off" width="6" height="6" aria-hidden="true" role="img" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6 6"><Path d="M3 1.5c.8 0 1.5.7 1.5 1.5S3.8 4.5 3 4.5 1.5 3.8 1.5 3 2.2 1.5 3 1.5M3 0C1.3 0 0 1.3 0 3s1.3 3 3 3 3-1.3 3-3-1.3-3-3-3z" /></SVG>
+				<svg className="components-form-toggle__on" width="2" height="6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2 6"><path d="M0 0h2v6H0z" /></svg> :
+				<svg className="components-form-toggle__off" width="6" height="6" aria-hidden="true" role="img" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6 6"><path d="M3 1.5c.8 0 1.5.7 1.5 1.5S3.8 4.5 3 4.5 1.5 3.8 1.5 3 2.2 1.5 3 1.5M3 0C1.3 0 0 1.3 0 3s1.3 3 3 3 3-1.3 3-3-1.3-3-3-3z" /></svg>
 			}
 		</span>
 	);

--- a/packages/components/src/panel/body.js
+++ b/packages/components/src/panel/body.js
@@ -13,7 +13,6 @@ import { Component } from '@wordpress/element';
  */
 import Button from '../button';
 import Dashicon from '../dashicon';
-import { G, Path, SVG } from '../primitives';
 
 class PanelBody extends Component {
 	constructor( props ) {
@@ -52,14 +51,14 @@ class PanelBody extends Component {
 							aria-expanded={ isOpened }
 						>
 							{ isOpened ?
-								<SVG className="components-panel__arrow" width="24px" height="24px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-									<G><Path fill="none" d="M0,0h24v24H0V0z" /></G>
-									<G><Path d="M12,8l-6,6l1.41,1.41L12,10.83l4.59,4.58L18,14L12,8z" /></G>
-								</SVG> :
-								<SVG className="components-panel__arrow" width="24px" height="24px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-									<G><Path fill="none" d="M0,0h24v24H0V0z" /></G>
-									<G><Path d="M7.41,8.59L12,13.17l4.59-4.58L18,10l-6,6l-6-6L7.41,8.59z" /></G>
-								</SVG>
+								<svg className="components-panel__arrow" width="24px" height="24px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+									<g><path fill="none" d="M0,0h24v24H0V0z" /></g>
+									<g><path d="M12,8l-6,6l1.41,1.41L12,10.83l4.59,4.58L18,14L12,8z" /></g>
+								</svg> :
+								<svg className="components-panel__arrow" width="24px" height="24px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+									<g><path fill="none" d="M0,0h24v24H0V0z" /></g>
+									<g><path d="M7.41,8.59L12,13.17l4.59-4.58L18,10l-6,6l-6-6L7.41,8.59z" /></g>
+								</svg>
 							}
 							{ icon && <Dashicon icon={ icon } className="components-panel__icon" /> }
 							{ title }

--- a/packages/components/src/panel/test/body.js
+++ b/packages/components/src/panel/test/body.js
@@ -24,7 +24,7 @@ describe( 'PanelBody', () => {
 			expect( panelBody.hasClass( 'is-opened' ) ).toBe( true );
 			expect( panelBody.state( 'opened' ) ).toBe( true );
 			expect( button.prop( 'onClick' ) ).toBe( panelBody.instance().toggle );
-			expect( button.childAt( 0 ).name() ).toBe( 'SVG' );
+			expect( button.childAt( 0 ).name() ).toBe( 'svg' );
 			expect( button.childAt( 1 ).text() ).toBe( 'Some Text' );
 		} );
 

--- a/packages/components/src/primitives/svg/index.js
+++ b/packages/components/src/primitives/svg/index.js
@@ -8,11 +8,41 @@ import { createElement } from '@wordpress/element';
  */
 import deprecated from '@wordpress/deprecated';
 
-export const G = ( props ) => createElement( 'g', props );
-export const Path = ( props ) => createElement( 'path', props );
-export const Polygon = ( props ) => createElement( 'polygon', props );
+// deprecations
+export const G = ( props ) => {
+	deprecated( 'wp.components.G', {
+		version: '4.2',
+		alternative: 'g',
+		plugin: 'Gutenberg',
+	} );
+	return createElement( 'g', props );
+}
+
+export const Path = ( props ) => {
+	deprecated( 'wp.components.Path', {
+		version: '4.2',
+		alternative: 'path',
+		plugin: 'Gutenberg',
+	} );
+	return createElement( 'path', props );
+}
+
+export const Polygon = ( props ) => {
+	deprecated( 'wp.components.Polygon', {
+		version: '4.2',
+		alternative: 'polygon',
+		plugin: 'Gutenberg',
+	} );
+	return createElement( 'polygon', props );
+}
 
 export const SVG = ( props ) => {
+	deprecated( 'wp.components.SVG', {
+		version: '4.2',
+		alternative: 'svg',
+		plugin: 'Gutenberg',
+	} );
+
 	const appliedProps = {
 		...props,
 		role: 'img',
@@ -23,12 +53,11 @@ export const SVG = ( props ) => {
 	return <svg { ...appliedProps } />;
 };
 
-// deprecations
 export const AccessibleSVG = ( props ) => {
 	deprecated( 'wp.components.AccessibleSVG', {
 		version: '4.2',
-		alternative: 'wp.components.SVG',
+		alternative: 'svg',
 		plugin: 'Gutenberg',
 	} );
-	return <SVG { ...props } />;
+	return <svg { ...props } />;
 };

--- a/packages/edit-post/src/components/header/more-menu/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/header/more-menu/test/__snapshots__/index.js.snap
@@ -46,7 +46,7 @@ exports[`MoreMenu should match snapshot 1`] = `
                 icon="ellipsis"
                 key="0,0"
               >
-                <SVG
+                <svg
                   aria-hidden={true}
                   className="dashicon dashicons-ellipsis"
                   focusable="false"
@@ -66,15 +66,15 @@ exports[`MoreMenu should match snapshot 1`] = `
                     width={20}
                     xmlns="http://www.w3.org/2000/svg"
                   >
-                    <Path
+                    <path
                       d="M5 10c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm12-2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-7 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
                     >
                       <path
                         d="M5 10c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm12-2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-7 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
                       />
-                    </Path>
+                    </path>
                   </svg>
-                </SVG>
+                </svg>
               </Dashicon>
             </button>
           </Button>

--- a/packages/edit-post/src/components/sidebar/plugin-post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/sidebar/plugin-post-publish-panel/test/__snapshots__/index.js.snap
@@ -24,7 +24,7 @@ exports[`PluginPostPublishPanel renders fill properly 1`] = `
           onClick={[Function]}
           type="button"
         >
-          <SVG
+          <svg
             className="components-panel__arrow"
             height="24px"
             viewBox="0 0 24 24"
@@ -41,9 +41,9 @@ exports[`PluginPostPublishPanel renders fill properly 1`] = `
               width="24px"
               xmlns="http://www.w3.org/2000/svg"
             >
-              <G>
+              <g>
                 <g>
-                  <Path
+                  <path
                     d="M0,0h24v24H0V0z"
                     fill="none"
                   >
@@ -51,22 +51,22 @@ exports[`PluginPostPublishPanel renders fill properly 1`] = `
                       d="M0,0h24v24H0V0z"
                       fill="none"
                     />
-                  </Path>
+                  </path>
                 </g>
-              </G>
-              <G>
+              </g>
+              <g>
                 <g>
-                  <Path
+                  <path
                     d="M12,8l-6,6l1.41,1.41L12,10.83l4.59,4.58L18,14L12,8z"
                   >
                     <path
                       d="M12,8l-6,6l1.41,1.41L12,10.83l4.59,4.58L18,14L12,8z"
                     />
-                  </Path>
+                  </path>
                 </g>
-              </G>
+              </g>
             </svg>
-          </SVG>
+          </svg>
           My panel title
         </button>
       </Button>

--- a/packages/edit-post/src/components/sidebar/plugin-pre-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/sidebar/plugin-pre-publish-panel/test/__snapshots__/index.js.snap
@@ -24,7 +24,7 @@ exports[`PluginPrePublishPanel renders fill properly 1`] = `
           onClick={[Function]}
           type="button"
         >
-          <SVG
+          <svg
             className="components-panel__arrow"
             height="24px"
             viewBox="0 0 24 24"
@@ -41,9 +41,9 @@ exports[`PluginPrePublishPanel renders fill properly 1`] = `
               width="24px"
               xmlns="http://www.w3.org/2000/svg"
             >
-              <G>
+              <g>
                 <g>
-                  <Path
+                  <path
                     d="M0,0h24v24H0V0z"
                     fill="none"
                   >
@@ -51,22 +51,22 @@ exports[`PluginPrePublishPanel renders fill properly 1`] = `
                       d="M0,0h24v24H0V0z"
                       fill="none"
                     />
-                  </Path>
+                  </path>
                 </g>
-              </G>
-              <G>
+              </g>
+              <g>
                 <g>
-                  <Path
+                  <path
                     d="M12,8l-6,6l1.41,1.41L12,10.83l4.59,4.58L18,14L12,8z"
                   >
                     <path
                       d="M12,8l-6,6l1.41,1.41L12,10.83l4.59,4.58L18,14L12,8z"
                     />
-                  </Path>
+                  </path>
                 </g>
-              </G>
+              </g>
             </svg>
-          </SVG>
+          </svg>
           My panel title
         </button>
       </Button>

--- a/packages/editor/src/components/block-icon/index.js
+++ b/packages/editor/src/components/block-icon/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Dashicon, SVG } from '@wordpress/components';
+import { Dashicon } from '@wordpress/components';
 import { createElement, Component } from '@wordpress/element';
 
 function renderIcon( icon ) {
@@ -25,7 +25,7 @@ function renderIcon( icon ) {
 			height: icon.props.height || 24,
 		};
 
-		return <SVG { ...appliedProps } />;
+		return <svg { ...appliedProps } />;
 	}
 
 	return icon || null;

--- a/packages/editor/src/components/block-mover/icons.js
+++ b/packages/editor/src/components/block-mover/icons.js
@@ -1,24 +1,20 @@
-/**
- * WordPress dependencies
- */
-import { Path, Polygon, SVG } from '@wordpress/components';
 
 export const upArrow = (
-	<SVG width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18">
-		<Polygon points="9,4.5 3.3,10.1 4.8,11.5 9,7.3 13.2,11.5 14.7,10.1 " />
-	</SVG>
+	<svg width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18">
+		<polygon points="9,4.5 3.3,10.1 4.8,11.5 9,7.3 13.2,11.5 14.7,10.1 " />
+	</svg>
 );
 
 export const downArrow = (
-	<SVG width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18">
-		<Polygon points="9,13.5 14.7,7.9 13.2,6.5 9,10.7 4.8,6.5 3.3,7.9 " />
-	</SVG>
+	<svg width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18">
+		<polygon points="9,13.5 14.7,7.9 13.2,6.5 9,10.7 4.8,6.5 3.3,7.9 " />
+	</svg>
 );
 
 export const dragHandle = (
-	<SVG width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18">
-		<Path d="M13,8c0.6,0,1-0.4,1-1s-0.4-1-1-1s-1,0.4-1,1S12.4,8,13,8z M5,6C4.4,6,4,6.4,4,7s0.4,1,1,1s1-0.4,1-1S5.6,6,5,6z M5,10
+	<svg width="18" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18">
+		<path d="M13,8c0.6,0,1-0.4,1-1s-0.4-1-1-1s-1,0.4-1,1S12.4,8,13,8z M5,6C4.4,6,4,6.4,4,7s0.4,1,1,1s1-0.4,1-1S5.6,6,5,6z M5,10
 			c-0.6,0-1,0.4-1,1s0.4,1,1,1s1-0.4,1-1S5.6,10,5,10z M13,10c-0.6,0-1,0.4-1,1s0.4,1,1,1s1-0.4,1-1S13.6,10,13,10z M9,6
 			C8.4,6,8,6.4,8,7s0.4,1,1,1s1-0.4,1-1S9.6,6,9,6z M9,10c-0.6,0-1,0.4-1,1s0.4,1,1,1s1-0.4,1-1S9.6,10,9,10z" />
-	</SVG>
+	</svg>
 );

--- a/packages/editor/src/components/block-navigation/dropdown.js
+++ b/packages/editor/src/components/block-navigation/dropdown.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Fragment } from '@wordpress/element';
-import { IconButton, Dropdown, SVG, Path, KeyboardShortcuts } from '@wordpress/components';
+import { IconButton, Dropdown, KeyboardShortcuts } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { rawShortcut } from '@wordpress/keycodes';
 
@@ -12,9 +12,9 @@ import { rawShortcut } from '@wordpress/keycodes';
 import BlockNavigation from './';
 
 const menuIcon = (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20">
-		<Path d="M5 5H3v2h2V5zm3 8h11v-2H8v2zm9-8H6v2h11V5zM7 11H5v2h2v-2zm0 8h2v-2H7v2zm3-2v2h11v-2H10z" />
-	</SVG>
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20">
+		<path d="M5 5H3v2h2V5zm3 8h11v-2H8v2zm9-8H6v2h11V5zM7 11H5v2h2v-2zm0 8h2v-2H7v2zm3-2v2h11v-2H10z" />
+	</svg>
 );
 
 function BlockNavigationDropdown() {

--- a/packages/editor/src/components/block-switcher/index.js
+++ b/packages/editor/src/components/block-switcher/index.js
@@ -7,7 +7,7 @@ import { castArray, filter, first, get, mapKeys, orderBy } from 'lodash';
  * WordPress dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Dropdown, IconButton, Toolbar, PanelBody, Path, SVG } from '@wordpress/components';
+import { Dropdown, IconButton, Toolbar, PanelBody } from '@wordpress/components';
 import { getBlockType, getPossibleBlockTransformations, switchToBlockType, hasChildBlocksWithInserterSupport } from '@wordpress/blocks';
 import { Component, Fragment } from '@wordpress/element';
 import { DOWN } from '@wordpress/keycodes';
@@ -99,7 +99,7 @@ export class BlockSwitcher extends Component {
 								onKeyDown={ openOnArrowDown }
 							>
 								<BlockIcon icon={ blockType.icon && blockType.icon.src } showColors />
-								<SVG className="editor-block-switcher__transform" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M6.5 8.9c.6-.6 1.4-.9 2.2-.9h6.9l-1.3 1.3 1.4 1.4L19.4 7l-3.7-3.7-1.4 1.4L15.6 6H8.7c-1.4 0-2.6.5-3.6 1.5l-2.8 2.8 1.4 1.4 2.8-2.8zm13.8 2.4l-2.8 2.8c-.6.6-1.3.9-2.1.9h-7l1.3-1.3-1.4-1.4L4.6 16l3.7 3.7 1.4-1.4L8.4 17h6.9c1.3 0 2.6-.5 3.5-1.5l2.8-2.8-1.3-1.4z" /></SVG>
+								<svg className="editor-block-switcher__transform" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M6.5 8.9c.6-.6 1.4-.9 2.2-.9h6.9l-1.3 1.3 1.4 1.4L19.4 7l-3.7-3.7-1.4 1.4L15.6 6H8.7c-1.4 0-2.6.5-3.6 1.5l-2.8 2.8 1.4 1.4 2.8-2.8zm13.8 2.4l-2.8 2.8c-.6.6-1.3.9-2.1.9h-7l1.3-1.3-1.4-1.4L4.6 16l3.7 3.7 1.4-1.4L8.4 17h6.9c1.3 0 2.6-.5 3.5-1.5l2.8-2.8-1.3-1.4z" /></svg>
 							</IconButton>
 						</Toolbar>
 					);

--- a/packages/element/src/create-element.js
+++ b/packages/element/src/create-element.js
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { createElement } from 'react';
+
+/**
+ * Returns a new element of given type. Type can be either a string tag name or
+ * another function which itself returns an element.
+ *
+ * @param {?(string|Function)} type     Tag name or element creator.
+ * @param {Object}             props    Element properties, either attribute
+ *                                       set to apply to node or values to
+ *                                       pass through to element creator.
+ * @param {...WPElement}       children Descendant elements.
+ *
+ * @return {WPElement} Element.
+ */
+export default createElement;

--- a/packages/element/src/create-element.native.js
+++ b/packages/element/src/create-element.native.js
@@ -1,42 +1,15 @@
 /**
  * External dependencies
  */
-import { get, isString } from 'lodash';
+import { get, isString, lowerFirst, reduce } from 'lodash';
 import { createElement as createElementDefault } from 'react';
-import {
-	Circle,
-	Defs,
-	Ellipse,
-	G,
-	Line,
-	Path,
-	Polygon,
-	TextPath,
-	TSpan,
-	Svg,
-} from 'react-native-svg';
+import * as SVGComponents from 'react-native-svg';
 
 const htmlTagToNativeComponent = {
-	circle: Circle,
-	defs: Defs,
-	ellipse: Ellipse,
-	g: G,
-	line: Line,
-	path: Path,
-	polygon: Polygon,
-	svg: Svg,
-	textPath: TextPath,
-	tspan: TSpan,
-	/*Polyline,
-	Text,
-	Rect,
-	Use,
-	Image,
-	Symbol,
-	LinearGradient,
-	RadialGradient,
-	Stop,
-	ClipPath*/
+	...reduce( SVGComponents, ( result, component, componentName ) => {
+		result[ lowerFirst( componentName ) ] = component;
+		return result;
+	}, {} ),
 };
 
 const mapHTMLTagToNativeComponent = ( type ) => {

--- a/packages/element/src/create-element.native.js
+++ b/packages/element/src/create-element.native.js
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import { get, isString } from 'lodash';
+import { createElement as createElementDefault } from 'react';
+import {
+	Circle,
+	Defs,
+	Ellipse,
+	G,
+	Line,
+	Path,
+	Polygon,
+	TextPath,
+	TSpan,
+	Svg,
+} from 'react-native-svg';
+
+const htmlTagToNativeComponent = {
+	circle: Circle,
+	defs: Defs,
+	ellipse: Ellipse,
+	g: G,
+	line: Line,
+	path: Path,
+	polygon: Polygon,
+	svg: Svg,
+	textPath: TextPath,
+	tspan: TSpan,
+	/*Polyline,
+	Text,
+	Rect,
+	Use,
+	Image,
+	Symbol,
+	LinearGradient,
+	RadialGradient,
+	Stop,
+	ClipPath*/
+};
+
+const mapHTMLTagToNativeComponent = ( type ) => {
+	if ( ! isString( type ) ) {
+		return type;
+	}
+
+	return get( htmlTagToNativeComponent, [ type ], type );
+};
+
+/**
+ * Returns a new element of given type. Type can be either a string tag name or
+ * another function which itself returns an element.
+ *
+ * @param {?(string|Function)} type     Tag name or element creator.
+ * @param {Object}             props    Element properties, either attribute
+ *                                       set to apply to node or values to
+ *                                       pass through to element creator.
+ * @param {...WPElement}       children Descendant elements.
+ *
+ * @return {WPElement} Element.
+ */
+const createElement = ( type, props, ...children ) => {
+	return createElementDefault(
+		mapHTMLTagToNativeComponent( type ),
+		props,
+		...children
+	);
+};
+
+export default createElement;

--- a/packages/element/src/index.js
+++ b/packages/element/src/index.js
@@ -1,3 +1,5 @@
+import * as React from './react';
+export default React;
 export * from './react';
 export * from './react-platform';
 export * from './utils';

--- a/packages/element/src/index.js
+++ b/packages/element/src/index.js
@@ -3,3 +3,4 @@ export * from './react-platform';
 export * from './utils';
 export { default as renderToString } from './serialize';
 export { default as RawHTML } from './raw-html';
+export { default as createElement } from './create-element';

--- a/packages/element/src/react.js
+++ b/packages/element/src/react.js
@@ -6,7 +6,6 @@ import {
 	cloneElement,
 	Component,
 	createContext,
-	createElement,
 	createRef,
 	forwardRef,
 	Fragment,
@@ -14,7 +13,7 @@ import {
 	StrictMode,
 } from 'react';
 import { isString } from 'lodash';
-
+import createElement from './create-element';
 export { Children };
 
 /**


### PR DESCRIPTION
## Description
This PR reverts to using string versions of `svg` elements and introduces a custom `createElement` function for react-native which will be able to map those to native svg elements.
It will also be useful to have a custom `createElement` function in other case, such as having a failover for `<div>`, `<span>`... 

## How has this been tested?
To be tested along with https://github.com/wordpress-mobile/gutenberg-mobile/pull/184
WIP

## Types of changes
Build changes

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
