### PR TITLE
Editor: Use correct content retrieval in error boundary

### DIFF
--- a/packages/editor/src/components/error-boundary/index.js
+++ b/packages/editor/src/components/error-boundary/index.js
@@ -1,20 +1,15 @@
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button, ClipboardButton } from '@wordpress/components';
+import { select } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { Warning } from '../';
-import { getEditedPostContent } from '../../store/selectors';
 
 class ErrorBoundary extends Component {
 	constructor() {
@@ -38,7 +33,13 @@ class ErrorBoundary extends Component {
 
 	getContent() {
 		try {
-			return getEditedPostContent( this.context.store.getState() );
+			// While `select` in a component is generally discouraged, it is
+			// used here because it (a) reduces the chance of data loss in the
+			// case of additional errors by performing a direct retrieval and
+			// (b) avoids the performance cost associated with unnecessary
+			// content serialization throughout the lifetime of a non-erroring
+			// application.
+			return select( 'core/editor' ).getEditedPostContent();
 		} catch ( error ) {}
 	}
 
@@ -68,9 +69,5 @@ class ErrorBoundary extends Component {
 		);
 	}
 }
-
-ErrorBoundary.contextTypes = {
-	store: noop,
-};
 
 export default ErrorBoundary;


### PR DESCRIPTION
This pull request seeks to resolve an issue where the "Copy Post Text" button in the error boundary would not actually copy post text, since it used a legacy retrieval method for post content.

**Implementation notes:**

There should probably be an end-to-end test for these behaviors, though it's unclear to me how we could predictably cause an error to occur in the application. Suggestions welcome.

**Testing instructions:**

Since there should ideally not be any existing error workflows in the application, introduce one by applying the following patch:

```diff
diff --git a/packages/editor/src/components/inserter/menu.js b/packages/editor/src/components/inserter/menu.js
index 21f8279c8..93e842d93 100644
--- a/packages/editor/src/components/inserter/menu.js
+++ b/packages/editor/src/components/inserter/menu.js
@@ -229,7 +229,7 @@ export class InserterMenu extends Component {
 	}
 
 	render() {
-		const { instanceId, onSelect, rootClientId } = this.props;
+		const { instanceId, onSelect, rootClientId } = this.props.error;
 		const { childItems, filterValue, hoveredItem, suggestedItems, reusableItems, itemsPerCategory, openPanels } = this.state;
 		const isPanelOpen = ( panel ) => openPanels.indexOf( panel ) !== -1;
 		const isSearching = !! filterValue;
```

An error will occur when opening the inserter menu. Ensure that upon proceeding to click "Copy Post Text", the post text is copied to the clipboard.