### PR TITLE
Add styles to stop classic block editor buttons from inheriting italics from themes

### DIFF
--- a/packages/block-library/src/classic/editor.scss
+++ b/packages/block-library/src/classic/editor.scss
@@ -124,6 +124,11 @@
 		color: $dark-gray-800;
 	}
 
+	// Prevent i tags in buttons from picking up theme editor styles.
+	.mce-btn i {
+		font-style: normal;
+	}
+
 	// Adjust padding to not cause a jump.
 	.mce-toolbar-grp > div {
 		padding: 1px 3px;


### PR DESCRIPTION
## Description

When a theme includes style for the `i` tag in the classic editor CSS, and that stylesheet is pulled into Gutenberg via `add_theme_support( 'editor-styles' )`, it can cause the buttons in the classic block to be italicized. This is because the classic editor styles are added inline, overriding the `font-style: normal` added to the `.mce-ico` class in the TinyMCE styles. 

Admittedly, this is kind of an odd case -- the `i` tag is deprecated in the HTML spec, and is usually used for icons because of that: it's usually not styled. But since the default themes are built with backwards compatibility in mind, most do include some reset styles for this tag. And because of the nature of default themes, how they do this is often copied as a best practice for other themes.

This issue was brought up in #11034, and was moved to be a default theme issue (https://core.trac.wordpress.org/ticket/45188) because it seemed specific to Twenty Seventeen. It turns out it's present in all older default themes but Twenty Thirteen.

## Screenshots 

Before (from #11034):

![twenty-seventeen-editor-buttons](https://user-images.githubusercontent.com/177561/47583920-a6bce680-d90d-11e8-9e88-744a21273ff4.png)

After:

![twenty-seventeen-editor-buttons-after](https://user-images.githubusercontent.com/177561/47583933-ae7c8b00-d90d-11e8-88f8-2d88e8f6fb8d.png)

## Types of changes
This change updates CSS, to reiterate some styles already present in Gutenberg, but with a more specific selector so they can't be overwritten by something inline.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
