### PR TITLE
added a gutenberg_loaded action

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -169,6 +169,13 @@ function gutenberg_pre_init() {
 	}
 
 	add_filter( 'replace_editor', 'gutenberg_init', 10, 2 );
+
+	/**
+	 * This hook is fired once the Gutenberg files are loaded.
+	 *
+	 * @since 4.1.1
+	 */
+	do_action( 'gutenberg_loaded' );
 }
 
 /**


### PR DESCRIPTION
## Description
Added a `gutenberg_loaded` action at the end of `gutenberg_pre_init()`. Similar to the `rest_api_init` action, this will allow themes and plugins to know when they can access various Gutenberg functions (ex: `register_block_type()`) 

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
