### PR TITLE
Parsing: Use full parser in `do_blocks` with nested block support

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -166,14 +166,14 @@ function gutenberg_render_block( $block ) {
 		$inner_content = '';
 
 		if ( $has_blocks ) {
-			$index  = 0;
+			$index = 0;
 			foreach ( $block['innerContent'] as $chunk ) {
 				$inner_content .= is_string( $chunk ) ? $chunk : gutenberg_render_block( $block['innerBlocks'][ $index++ ] );
 			}
 		} else {
 			$inner_content = $block['innerHTML'];
 		}
-		
+
 		$global_post = $post;
 		$output      = $block_type->render( $attributes, $inner_content );
 		$post        = $global_post;

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -195,8 +195,7 @@ if ( ! function_exists( 'do_blocks' ) ) {
 	 */
 	function do_blocks( $content ) {
 		$without_trailing_newlines = preg_replace( '/(<!--\s+\/?wp:.*?-->)\r?\n?/m', '$1', $content );
-		$without_final_newline     = preg_replace( '/[\n]$/', '', $without_trailing_newlines );
-		$blocks                    = gutenberg_parse_blocks( $without_final_newline );
+		$blocks                    = gutenberg_parse_blocks( $without_trailing_newlines );
 		$output                    = '';
 
 		foreach ( $blocks as $block ) {

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -58,21 +58,6 @@ if ( ! function_exists( 'gutenberg_parse_blocks' ) ) {
 	 * @return array  Array of parsed block objects.
 	 */
 	function gutenberg_parse_blocks( $content ) {
-		/*
-		 * If there are no blocks in the content, return a single block, rather
-		 * than wasting time trying to parse the string.
-		 */
-		if ( ! has_blocks( $content ) ) {
-			return array(
-				array(
-					'blockName'   => null,
-					'attrs'       => array(),
-					'innerBlocks' => array(),
-					'innerHTML'   => $content,
-				),
-			);
-		}
-
 		/**
 		 * Filter to allow plugins to replace the server-side block parser
 		 *

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -194,9 +194,8 @@ if ( ! function_exists( 'do_blocks' ) ) {
 	 * @return string          Updated post content.
 	 */
 	function do_blocks( $content ) {
-		$without_trailing_newlines = preg_replace( '/(<!--\s+\/?wp:.*?-->)\r?\n?/m', '$1', $content );
-		$blocks                    = gutenberg_parse_blocks( $without_trailing_newlines );
-		$output                    = '';
+		$blocks = gutenberg_parse_blocks( $content );
+		$output = '';
 
 		foreach ( $blocks as $block ) {
 			$output .= gutenberg_render_block( $block );

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -157,22 +157,17 @@ if ( ! function_exists( 'get_dynamic_blocks_regex' ) ) {
 function gutenberg_render_block( $block ) {
 	global $post;
 
-	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
-	$is_dynamic = $block['blockName'] && null !== $block_type && $block_type->is_dynamic();
-	$has_blocks = ! empty( $block['innerBlocks'] );
+	$block_type    = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
+	$is_dynamic    = $block['blockName'] && null !== $block_type && $block_type->is_dynamic();
+	$inner_content = '';
+	$index         = 0;
+
+	foreach ( $block['innerContent'] as $chunk ) {
+		$inner_content .= is_string( $chunk ) ? $chunk : gutenberg_render_block( $block['innerBlocks'][ $index++ ] );
+	}
 
 	if ( $is_dynamic ) {
 		$attributes    = is_array( $block['attrs'] ) ? (array) $block['attrs'] : array();
-		$inner_content = '';
-
-		if ( $has_blocks ) {
-			$index = 0;
-			foreach ( $block['innerContent'] as $chunk ) {
-				$inner_content .= is_string( $chunk ) ? $chunk : gutenberg_render_block( $block['innerBlocks'][ $index++ ] );
-			}
-		} else {
-			$inner_content = $block['innerHTML'];
-		}
 
 		$global_post = $post;
 		$output      = $block_type->render( $attributes, $inner_content );
@@ -181,17 +176,7 @@ function gutenberg_render_block( $block ) {
 		return $output;
 	}
 
-	if ( ! $has_blocks ) {
-		return $block['innerHTML'];
-	}
-
-	$output = '';
-	$index  = 0;
-	foreach ( $block['innerContent'] as $chunk ) {
-		$output .= is_string( $chunk ) ? $chunk : gutenberg_render_block( $block['innerBlocks'][ $index++ ] );
-	}
-
-	return $output;
+	return $inner_content;
 }
 
 if ( ! function_exists( 'do_blocks' ) ) {

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -148,27 +148,39 @@ if ( ! function_exists( 'get_dynamic_blocks_regex' ) ) {
  * Renders a single block into a HTML string.
  *
  * @since 1.9.0
+ * @since 4.4.0 renders full nested tree of blocks before reassembling into HTML string
+ * @global WP_Post $post The post to edit.
  *
  * @param  array $block A single parsed block object.
  * @return string String of rendered HTML.
  */
 function gutenberg_render_block( $block ) {
-	$block_name  = isset( $block['blockName'] ) ? $block['blockName'] : null;
-	$attributes  = is_array( $block['attrs'] ) ? $block['attrs'] : array();
-	$raw_content = isset( $block['innerHTML'] ) ? $block['innerHTML'] : null;
+	global $post;
 
-	if ( $block_name ) {
-		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
-		if ( null !== $block_type && $block_type->is_dynamic() ) {
-			return $block_type->render( $attributes );
-		}
+	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
+	$is_dynamic = $block['blockName'] && null !== $block_type && $block_type->is_dynamic();
+	$has_blocks = ! empty( $block['innerBlocks'] );
+
+	if ( $is_dynamic ) {
+		$attributes  = is_array( $block['attrs'] ) ? (array) $block['attrs'] : array();
+		$global_post = $post;
+		$output      = $block_type->render( $attributes, $block['innerHTML'] );
+		$post        = $global_post;
+
+		return $output;
 	}
 
-	if ( $raw_content ) {
-		return $raw_content;
+	if ( ! $has_blocks ) {
+		return $block['innerHTML'];
 	}
 
-	return '';
+	$output = '';
+	$index  = 0;
+	foreach ( $block['innerContent'] as $chunk ) {
+		$output .= is_string( $chunk ) ? $chunk : gutenberg_render_block( $block['innerBlocks'][ $index++ ] );
+	}
+
+	return $output;
 }
 
 if ( ! function_exists( 'do_blocks' ) ) {
@@ -176,91 +188,22 @@ if ( ! function_exists( 'do_blocks' ) ) {
 	 * Parses dynamic blocks out of `post_content` and re-renders them.
 	 *
 	 * @since 0.1.0
-	 * @global WP_Post $post The post to edit.
+	 * @since 4.4.0 performs full parse on input post content
 	 *
 	 * @param  string $content Post content.
 	 * @return string          Updated post content.
 	 */
 	function do_blocks( $content ) {
-		global $post;
+		$without_trailing_newlines = preg_replace( '/(<!--\s+\/?wp:.*?-->)\r?\n?/m', '$1', $content );
+		$without_final_newline     = preg_replace( '/[\n]$/', '', $without_trailing_newlines );
+		$blocks                    = gutenberg_parse_blocks( $without_final_newline );
+		$output                    = '';
 
-		$rendered_content      = '';
-		$dynamic_block_pattern = get_dynamic_blocks_regex();
-
-		/*
-		 * Back up global post, to restore after render callback.
-		 * Allows callbacks to run new WP_Query instances without breaking the global post.
-		 */
-		$global_post = $post;
-
-		while ( preg_match( $dynamic_block_pattern, $content, $block_match, PREG_OFFSET_CAPTURE ) ) {
-			$opening_tag     = $block_match[0][0];
-			$offset          = $block_match[0][1];
-			$block_name      = $block_match[1][0];
-			$is_self_closing = isset( $block_match[4] );
-
-			// Reset attributes JSON to prevent scope bleed from last iteration.
-			$block_attributes_json = null;
-			if ( isset( $block_match[3] ) ) {
-				$block_attributes_json = $block_match[3][0];
-			}
-
-			// Since content is a working copy since the last match, append to
-			// rendered content up to the matched offset...
-			$rendered_content .= substr( $content, 0, $offset );
-
-			// ...then update the working copy of content.
-			$content = substr( $content, $offset + strlen( $opening_tag ) );
-
-			// Make implicit core namespace explicit.
-			$is_implicit_core_namespace = ( false === strpos( $block_name, '/' ) );
-			$normalized_block_name      = $is_implicit_core_namespace ? 'core/' . $block_name : $block_name;
-
-			// Find registered block type. We can assume it exists since we use the
-			// `get_dynamic_block_names` function as a source for pattern matching.
-			$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $normalized_block_name );
-
-			// Attempt to parse attributes JSON, if available.
-			$attributes = array();
-			if ( ! empty( $block_attributes_json ) ) {
-				$decoded_attributes = json_decode( $block_attributes_json, true );
-				if ( ! is_null( $decoded_attributes ) ) {
-					$attributes = $decoded_attributes;
-				}
-			}
-
-			$inner_content = '';
-
-			if ( ! $is_self_closing ) {
-				$end_tag_pattern = '/<!--\s+\/wp:' . preg_quote( $block_name, '/' ) . '\s+-->/';
-				if ( ! preg_match( $end_tag_pattern, $content, $block_match_end, PREG_OFFSET_CAPTURE ) ) {
-					// If no closing tag is found, abort all matching, and continue
-					// to append remainder of content to rendered output.
-					break;
-				}
-
-				// Update content to omit text up to and including closing tag.
-				$end_tag    = $block_match_end[0][0];
-				$end_offset = $block_match_end[0][1];
-
-				$inner_content = substr( $content, 0, $end_offset );
-				$content       = substr( $content, $end_offset + strlen( $end_tag ) );
-			}
-
-			// Replace dynamic block with server-rendered output.
-			$rendered_content .= $block_type->render( $attributes, $inner_content );
-
-			// Restore global $post.
-			$post = $global_post;
+		foreach ( $blocks as $block ) {
+			$output .= gutenberg_render_block( $block );
 		}
 
-		// Append remaining unmatched content.
-		$rendered_content .= $content;
-
-		// Strip remaining block comment demarcations.
-		$rendered_content = preg_replace( '/<!--\s+\/?wp:.*?-->\r?\n?/m', '', $rendered_content );
-
-		return $rendered_content;
+		return $output;
 	}
 
 	add_filter( 'the_content', 'do_blocks', 7 ); // BEFORE do_shortcode() and oembed.

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -162,9 +162,20 @@ function gutenberg_render_block( $block ) {
 	$has_blocks = ! empty( $block['innerBlocks'] );
 
 	if ( $is_dynamic ) {
-		$attributes  = is_array( $block['attrs'] ) ? (array) $block['attrs'] : array();
+		$attributes    = is_array( $block['attrs'] ) ? (array) $block['attrs'] : array();
+		$inner_content = '';
+
+		if ( $has_blocks ) {
+			$index  = 0;
+			foreach ( $block['innerContent'] as $chunk ) {
+				$inner_content .= is_string( $chunk ) ? $chunk : gutenberg_render_block( $block['innerBlocks'][ $index++ ] );
+			}
+		} else {
+			$inner_content = $block['innerHTML'];
+		}
+		
 		$global_post = $post;
-		$output      = $block_type->render( $attributes, $block['innerHTML'] );
+		$output      = $block_type->render( $attributes, $inner_content );
 		$post        = $global_post;
 
 		return $output;

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -167,8 +167,7 @@ function gutenberg_render_block( $block ) {
 	}
 
 	if ( $is_dynamic ) {
-		$attributes    = is_array( $block['attrs'] ) ? (array) $block['attrs'] : array();
-
+		$attributes  = is_array( $block['attrs'] ) ? (array) $block['attrs'] : array();
 		$global_post = $post;
 		$output      = $block_type->render( $attributes, $inner_content );
 		$post        = $global_post;

--- a/phpunit/class-do-blocks-test.php
+++ b/phpunit/class-do-blocks-test.php
@@ -79,7 +79,7 @@ class Do_Blocks_Test extends WP_UnitTestCase {
 				'render_callback' => array(
 					$this,
 					'render_dynamic_incrementer',
-				)
+				),
 			)
 		);
 

--- a/phpunit/class-do-blocks-test.php
+++ b/phpunit/class-do-blocks-test.php
@@ -30,7 +30,7 @@ class Do_Blocks_Test extends WP_UnitTestCase {
 		add_shortcode( 'someshortcode', array( $this, 'handle_shortcode' ) );
 
 		$classic_content = "Foo\n\n[someshortcode]\n\nBar\n\n[/someshortcode]\n\nBaz";
-		$block_content   = "<!-- wp:core/paragraph -->\n<p>Foo</p>\n<!-- /wp:core/paragraph -->\n\n<!-- wp:core/shortcode -->[someshortcode]\n\nBar\n\n[/someshortcode]<!-- /wp:core/shortcode -->\n\n<!-- wp:core/paragraph -->\n<p>Baz</p>\n<!-- /wp:core/paragraph -->";
+		$block_content   = "<!-- wp:core/paragraph --><p>Foo</p>\n<!-- /wp:core/paragraph -->\n\n<!-- wp:core/shortcode -->[someshortcode]\n\nBar\n\n[/someshortcode]<!-- /wp:core/shortcode -->\n\n<!-- wp:core/paragraph -->\n<p>Baz</p>\n<!-- /wp:core/paragraph -->";
 
 		$classic_filtered_content = apply_filters( 'the_content', $classic_content );
 		$block_filtered_content   = apply_filters( 'the_content', $block_content );

--- a/phpunit/class-dynamic-blocks-render-test.php
+++ b/phpunit/class-dynamic-blocks-render-test.php
@@ -171,7 +171,8 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 
 	function test_dynamic_block_gets_inner_html() {
 		register_block_type(
-			'core/dynamic', array(
+			'core/dynamic',
+			array(
 				'render_callback' => array(
 					$this,
 					'render_serialize_dynamic_block'
@@ -179,8 +180,8 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$output = do_blocks( '<!-- wp:dynamic -->inner<!-- /wp:dynamic -->' );
-		list( /* attrs */, $content ) = unserialize( base64_decode( $output ) );
+		$output  = do_blocks( '<!-- wp:dynamic -->inner<!-- /wp:dynamic -->' );
+		$content = unserialize( base64_decode( $output ) )[1];
 
 		$this->assertEquals( 'inner', $content );
 	}
@@ -205,8 +206,8 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$output = do_blocks( '<!-- wp:dynamic -->before<!-- wp:dummy /-->after<!-- /wp:dynamic -->' );
-		list( /* attrs */, $content ) = unserialize( base64_decode( $output ) );
+		$output  = do_blocks( '<!-- wp:dynamic -->before<!-- wp:dummy /-->after<!-- /wp:dynamic -->' );
+		$content = unserialize( base64_decode( $output ) )[ 1 ];
 
 		$this->assertEquals( 'before10after', $content );
 	}
@@ -222,8 +223,8 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$output = do_blocks( '<!-- wp:dynamic -->before<!-- wp:dynamic -->deep inner<!-- /wp:dynamic -->after<!-- /wp:dynamic -->' );
-		list( /* attrs */, $content ) = unserialize( base64_decode( $output ) );
+		$output  = do_blocks( '<!-- wp:dynamic -->before<!-- wp:dynamic -->deep inner<!-- /wp:dynamic -->after<!-- /wp:dynamic -->' );
+		$content = unserialize( base64_decode( $output ) )[ 1 ];
 
 		$inner = $this->render_serialize_dynamic_block( array(), 'deep inner' );
 

--- a/phpunit/class-dynamic-blocks-render-test.php
+++ b/phpunit/class-dynamic-blocks-render-test.php
@@ -79,6 +79,7 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 
 		$registry = WP_Block_Type_Registry::get_instance();
 		$registry->unregister( 'core/dummy' );
+		$registry->unregister( 'core/dynamic' );
 	}
 
 	/**

--- a/phpunit/class-dynamic-blocks-render-test.php
+++ b/phpunit/class-dynamic-blocks-render-test.php
@@ -177,7 +177,7 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 		$output = do_blocks( '<!-- wp:dynamic -->inner<!-- /wp:dynamic -->' );
 		list( /* attrs */, $content ) = unserialize( base64_decode( $output ) );
 
-		$this->assertEqual( 'inner', $content );
+		$this->assertEquals( 'inner', $content );
 	}
 
 	function test_dynamic_block_gets_rendered_inner_blocks() {
@@ -191,7 +191,7 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 		$output = do_blocks( '<!-- wp:dynamic -->before<!-- wp:dummy /-->after<!-- /wp:dynamic -->' );
 		list( /* attrs */, $content ) = unserialize( base64_decode( $output ) );
 
-		$this->assertEqual( 'before10after', $content );
+		$this->assertEquals( 'before10after', $content );
 	}
 
 	function test_dynamic_block_gets_rendered_inner_dynamic_blocks() {
@@ -204,6 +204,6 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 
 		$inner = $this->render_serialize_dynamic_block( [], 'deep inner' );
 
-		$this->assertEqual( $content, 'before' . $inner . 'after' );
+		$this->assertEquals( $content, 'before' . $inner . 'after' );
 	}
 }

--- a/phpunit/class-dynamic-blocks-render-test.php
+++ b/phpunit/class-dynamic-blocks-render-test.php
@@ -78,8 +78,14 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 		$this->dummy_block_instance_number = 0;
 
 		$registry = WP_Block_Type_Registry::get_instance();
-		$registry->unregister( 'core/dummy' );
-		$registry->unregister( 'core/dynamic' );
+
+		if ( $registry->is_registered( 'core/dummy' ) ) {
+			$registry->unregister( 'core/dummy' );
+		}
+
+		if ( $registry->is_registered( 'core/dynamic' ) ) {
+			$registry->unregister( 'core/dynamic' );
+		}
 	}
 
 	/**

--- a/phpunit/class-dynamic-blocks-render-test.php
+++ b/phpunit/class-dynamic-blocks-render-test.php
@@ -38,6 +38,10 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 		return 10;
 	}
 
+	function render_serialize_dynamic_block( $attributes, $content ) {
+		return base64_encode( serialize( array( $attributes, $content ) ) );
+	}
+
 	/**
 	 * Dummy block rendering function, creating a new WP_Query instance.
 	 *
@@ -163,5 +167,46 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 
 		$this->assertSame( '10', $rendered );
 		$this->assertInternalType( 'string', $rendered );
+	}
+
+	function test_dynamic_block_gets_inner_html() {
+		register_block_type( 'core/dynamic', array(
+			'render_callback' => array( $this, 'render_serialize_dynamic_block' ),
+		) );
+
+		$output = do_blocks( '<!-- wp:dynamic -->inner<!-- /wp:dynamic -->' );
+		list( /* attrs */, $content ) = unserialize( base64_decode( $output ) );
+
+		$this->assertEqual( $content, 'inner' );
+	}
+
+	function test_dynamic_block_gets_rendered_inner_blocks() {
+		register_block_type( 'core/dummy', array(
+			'render_callback' => array( $this, 'render_dummy_block_numeric' ),
+		) );
+		register_block_type( 'core/dynamic', array(
+			'render_callback' => array( $this, 'render_serialize_dynamic_block' ),
+		) );
+
+		$output = do_blocks( '<!-- wp:dynamic -->before<!-- wp:dummy /-->after<!-- /wp:dynamic -->' );
+		list( /* attrs */, $content ) = unserialize( base64_decode( $output ) );
+
+		$this->assertEqual( $content, 'before10after' );
+	}
+
+	function test_dynamic_block_gets_rendered_inner_dynamic_blocks() {
+		register_block_type( 'core/dynamic', array(
+			'render_callback' => array( $this, 'render_serialize_dynamic_block' ),
+		) );
+
+		$output = do_blocks( '<!-- wp:dynamic -->before<!-- wp:dynamic -->deep inner<!-- /wp:dynamic -->after<!-- /wp:dynamic -->' );
+		list( /* attrs */, $content ) = unserialize( base64_decode( $output ) );
+
+		$this->assertStringStartsWith( 'before', $content );
+		$this->assertStringEndWith( 'after', $content );
+
+		list( /* attrs */, $content ) = unserialize( base64_decode( $content ) );
+
+		$this->assertEqual( $content, 'deep inner' );
 	}
 }

--- a/phpunit/class-dynamic-blocks-render-test.php
+++ b/phpunit/class-dynamic-blocks-render-test.php
@@ -170,9 +170,14 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 	}
 
 	function test_dynamic_block_gets_inner_html() {
-		register_block_type( 'core/dynamic', array(
-			'render_callback' => array( $this, 'render_serialize_dynamic_block' ),
-		) );
+		register_block_type(
+			'core/dynamic', array(
+				'render_callback' => array(
+					$this,
+					'render_serialize_dynamic_block'
+				),
+			)
+		);
 
 		$output = do_blocks( '<!-- wp:dynamic -->inner<!-- /wp:dynamic -->' );
 		list( /* attrs */, $content ) = unserialize( base64_decode( $output ) );
@@ -181,12 +186,24 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 	}
 
 	function test_dynamic_block_gets_rendered_inner_blocks() {
-		register_block_type( 'core/dummy', array(
-			'render_callback' => array( $this, 'render_dummy_block_numeric' ),
-		) );
-		register_block_type( 'core/dynamic', array(
-			'render_callback' => array( $this, 'render_serialize_dynamic_block' ),
-		) );
+		register_block_type(
+			'core/dummy',
+			array(
+				'render_callback' => array(
+					$this,
+					'render_dummy_block_numeric'
+				),
+			)
+		);
+		register_block_type(
+			'core/dynamic',
+			array(
+				'render_callback' => array(
+					$this,
+					'render_serialize_dynamic_block'
+				),
+			)
+		);
 
 		$output = do_blocks( '<!-- wp:dynamic -->before<!-- wp:dummy /-->after<!-- /wp:dynamic -->' );
 		list( /* attrs */, $content ) = unserialize( base64_decode( $output ) );
@@ -195,14 +212,20 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 	}
 
 	function test_dynamic_block_gets_rendered_inner_dynamic_blocks() {
-		register_block_type( 'core/dynamic', array(
-			'render_callback' => array( $this, 'render_serialize_dynamic_block' ),
-		) );
+		register_block_type(
+			'core/dynamic',
+			array(
+				'render_callback' => array(
+					$this,
+					'render_serialize_dynamic_block'
+				),
+			)
+		);
 
 		$output = do_blocks( '<!-- wp:dynamic -->before<!-- wp:dynamic -->deep inner<!-- /wp:dynamic -->after<!-- /wp:dynamic -->' );
 		list( /* attrs */, $content ) = unserialize( base64_decode( $output ) );
 
-		$inner = $this->render_serialize_dynamic_block( [], 'deep inner' );
+		$inner = $this->render_serialize_dynamic_block( array(), 'deep inner' );
 
 		$this->assertEquals( $content, 'before' . $inner . 'after' );
 	}

--- a/phpunit/class-dynamic-blocks-render-test.php
+++ b/phpunit/class-dynamic-blocks-render-test.php
@@ -202,11 +202,8 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 		$output = do_blocks( '<!-- wp:dynamic -->before<!-- wp:dynamic -->deep inner<!-- /wp:dynamic -->after<!-- /wp:dynamic -->' );
 		list( /* attrs */, $content ) = unserialize( base64_decode( $output ) );
 
-		$this->assertStringStartsWith( 'before', $content );
-		$this->assertStringEndWith( 'after', $content );
+		$inner = $this->render_serialize_dynamic_block( [], 'deep inner' );
 
-		list( /* attrs */, $content ) = unserialize( base64_decode( $content ) );
-
-		$this->assertEqual( $content, 'deep inner' );
+		$this->assertEqual( $content, 'before' . $inner . 'after' );
 	}
 }

--- a/phpunit/class-dynamic-blocks-render-test.php
+++ b/phpunit/class-dynamic-blocks-render-test.php
@@ -180,8 +180,9 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$output  = do_blocks( '<!-- wp:dynamic -->inner<!-- /wp:dynamic -->' );
-		$content = unserialize( base64_decode( $output ) )[1];
+		$output = do_blocks( '<!-- wp:dynamic -->inner<!-- /wp:dynamic -->' );
+
+		list( /* attrs */, $content ) = unserialize( base64_decode( $output ) );
 
 		$this->assertEquals( 'inner', $content );
 	}
@@ -206,8 +207,9 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$output  = do_blocks( '<!-- wp:dynamic -->before<!-- wp:dummy /-->after<!-- /wp:dynamic -->' );
-		$content = unserialize( base64_decode( $output ) )[ 1 ];
+		$output = do_blocks( '<!-- wp:dynamic -->before<!-- wp:dummy /-->after<!-- /wp:dynamic -->' );
+
+		list( /* attrs */, $content ) = unserialize( base64_decode( $output ) );
 
 		$this->assertEquals( 'before10after', $content );
 	}
@@ -223,8 +225,9 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$output  = do_blocks( '<!-- wp:dynamic -->before<!-- wp:dynamic -->deep inner<!-- /wp:dynamic -->after<!-- /wp:dynamic -->' );
-		$content = unserialize( base64_decode( $output ) )[ 1 ];
+		$output = do_blocks( '<!-- wp:dynamic -->before<!-- wp:dynamic -->deep inner<!-- /wp:dynamic -->after<!-- /wp:dynamic -->' );
+		
+		list( /* attrs */, $content ) = unserialize( base64_decode( $output ) );
 
 		$inner = $this->render_serialize_dynamic_block( array(), 'deep inner' );
 

--- a/phpunit/class-dynamic-blocks-render-test.php
+++ b/phpunit/class-dynamic-blocks-render-test.php
@@ -175,7 +175,7 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 			array(
 				'render_callback' => array(
 					$this,
-					'render_serialize_dynamic_block'
+					'render_serialize_dynamic_block',
 				),
 			)
 		);
@@ -193,7 +193,7 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 			array(
 				'render_callback' => array(
 					$this,
-					'render_dummy_block_numeric'
+					'render_dummy_block_numeric',
 				),
 			)
 		);
@@ -202,7 +202,7 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 			array(
 				'render_callback' => array(
 					$this,
-					'render_serialize_dynamic_block'
+					'render_serialize_dynamic_block',
 				),
 			)
 		);
@@ -220,13 +220,13 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 			array(
 				'render_callback' => array(
 					$this,
-					'render_serialize_dynamic_block'
+					'render_serialize_dynamic_block',
 				),
 			)
 		);
 
 		$output = do_blocks( '<!-- wp:dynamic -->before<!-- wp:dynamic -->deep inner<!-- /wp:dynamic -->after<!-- /wp:dynamic -->' );
-		
+
 		list( /* attrs */, $content ) = unserialize( base64_decode( $output ) );
 
 		$inner = $this->render_serialize_dynamic_block( array(), 'deep inner' );

--- a/phpunit/class-dynamic-blocks-render-test.php
+++ b/phpunit/class-dynamic-blocks-render-test.php
@@ -177,7 +177,7 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 		$output = do_blocks( '<!-- wp:dynamic -->inner<!-- /wp:dynamic -->' );
 		list( /* attrs */, $content ) = unserialize( base64_decode( $output ) );
 
-		$this->assertEqual( $content, 'inner' );
+		$this->assertEqual( 'inner', $content );
 	}
 
 	function test_dynamic_block_gets_rendered_inner_blocks() {
@@ -191,7 +191,7 @@ class Dynamic_Blocks_Render_Test extends WP_UnitTestCase {
 		$output = do_blocks( '<!-- wp:dynamic -->before<!-- wp:dummy /-->after<!-- /wp:dynamic -->' );
 		list( /* attrs */, $content ) = unserialize( base64_decode( $output ) );
 
-		$this->assertEqual( $content, 'before10after' );
+		$this->assertEqual( 'before10after', $content );
 	}
 
 	function test_dynamic_block_gets_rendered_inner_dynamic_blocks() {

--- a/phpunit/fixtures/do-blocks-expected.html
+++ b/phpunit/fixtures/do-blocks-expected.html
@@ -14,4 +14,3 @@
 <p>[someshortcode]</p>
 <p>And some content?!</p>
 <p>[/someshortcode]</p>
-

--- a/phpunit/fixtures/do-blocks-expected.html
+++ b/phpunit/fixtures/do-blocks-expected.html
@@ -2,6 +2,7 @@
 
 <!--more-->
 
+
 <p>First Gutenberg Paragraph</p>
 
 <p>Second Auto Paragraph</p>

--- a/phpunit/fixtures/do-blocks-expected.html
+++ b/phpunit/fixtures/do-blocks-expected.html
@@ -5,13 +5,18 @@
 
 <p>First Gutenberg Paragraph</p>
 
+
 <p>Second Auto Paragraph</p>
 
 
+
+
 <p>Third Gutenberg Paragraph</p>
+
 
 <p>Third Auto Paragraph</p>
 
 <p>[someshortcode]</p>
 <p>And some content?!</p>
 <p>[/someshortcode]</p>
+


### PR DESCRIPTION
Updates `do_blocks()` and `gutenberg_render_block()` so that we can support nested blocks inside of dynamic blocks. This replaces the use of the partial parser which extracts registered dynamic blocks with the full parser.

This change will allow dynamic blocks which contain nested blocks inside of them and it will pave the way for a filtering API to structurally process blocks.

The partial parser came about at a time before the default parser was written; it was faster than the spec parser and was a tradeoff to get dynamic blocks rendering. The default parser, however, has been fast enough for a while to run on page render and so this PR exists to finally get it into the pipeline.

## Status

### Iteration

<del>The `RecursiveIteratorIterator` should provide us a way of performing the depth-first block traversal without risking a stack overflow. We keep rendered blocks on a stack and pop them off as we go.</del>

Interestingly enough I did some testing and `RecursiveIteratorIterator` was a let-down. There's one important thing it does which is bypass the `xdebug.max_nesting_level` which limits recursion depth when `xdebug` is running; sadly it's much much slower than basic recursion.

With the `RecursiveIteratorIterator` we can continue to nest into blocks until we run out of memory but the runtime performance is exponential. With recursion we hit the same memory limit if `xdebug` is disabled but hit it usually around 100 if it is. That means that for massive posts we could run into unexpected failures when debugging if we go the recursion route.

What is the memory limit? In my testing back to PHP 5.6 on my local laptop it was at around 100,000 levels of nesting - this should be obviously sufficient - I can't imagine an editor showing that many levels of nesting. With the recursive version and a limit of 100 that's still almost equally viable as 100,000. I'd recommend we stick with this recursive approach then unless we get bug reports of failures when debugging, at which point we can discuss bringing back the `RecursiveIteratorIterator` version.

On the other hand I may simply have been writing the `WP_Block_Tree_Iterator` in a stupid way that was way too slow. It would be worth running an experiment where I make a custom tree iterator without using the SPL functions and see if the performance characteristics are similar.

**Update**

After running some tests I made ended up with [a basic tree iterator](https://repl.it/@dmsnell/SickGreedyShockwave) and it hit hard performance issues long before the recursive version. I think that the memory churning of the stacks required to track nodes in the tree is far less efficient than using the built-in argument passing in functions and closures provided by PHP with the recursive method.

In other words, I am currently unable to come close to the recursive version in terms of performance. Does this matter with small nesting? Probably not. Should we then prefer the safe version that won't break with low `max_nesting_depth`? I don't know. Probably not since anything over 100 levels of nested blocks is somewhat of an insane construction.

### Testing and Review
The patch needs testing, but this can be hard because we don't have too many deeply-nested blocks. It's best to try with things like columns.

👉 I would greatly appreciate some help adding the appropriate deprecation messages for `get_dynamic_blocks_regex()` and friends!