### PR TITLE
Improve the header toolbar aria-label

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -22,10 +22,12 @@ import {
 import FullscreenModeClose from '../fullscreen-mode-close';
 
 function HeaderToolbar( { hasFixedToolbar, isLargeViewport, mode } ) {
+	const toolbarAriaLabel = hasFixedToolbar ? __( 'Document and block tools' ) : __( 'Document tools' );
+
 	return (
 		<NavigableToolbar
 			className="edit-post-header-toolbar"
-			aria-label={ __( 'Editor Toolbar' ) }
+			aria-label={ toolbarAriaLabel }
 		>
 			<FullscreenModeClose />
 			<div>


### PR DESCRIPTION
## Description

See #2387.

The header toolbar (the one with `role="toolbar"`) is currently labelled as "Editor toolbar". However, screen readers already announce "toolbar" when they encounter a `role="toolbar"` so what they actually announce is:

`Editor toolbar, toolbar`

It's a bit noisy and doesn't help in clarifying what this toolbar purpose is. A complete audit of the various `aria-labels` used in Gutenberg was the aim of #2387. I'd like to propose to refer to that issue (maybe reopen it?).

This PR tries to improve the toolbar aria label leveraging the wording used for the "Unified Toolbar" setting:

<img width="281" alt="screen shot 2018-10-27 at 17 18 23" src="https://user-images.githubusercontent.com/1682452/47606653-7c0a8500-da16-11e8-838b-a1aa30ac67bd.png">

For consistency and clarity, I'd tend to think the best option is to refer to the toolbar as a place with tools that change based on the "Unified Toolbar" setting:
- removes the word "toolbar" from the aria-label
- uses `Document tools` when "Unified Toolbar" is disabled
- uses `Document and block tools` when "Unified Toolbar" is enabled

Screenshots:

<img width="650" alt="screen shot 2018-10-27 at 17 24 00" src="https://user-images.githubusercontent.com/1682452/47606673-d4418700-da16-11e8-8103-5058f4eebb0b.png">
<img width="648" alt="screen shot 2018-10-27 at 17 26 12" src="https://user-images.githubusercontent.com/1682452/47606674-d4418700-da16-11e8-8590-dd8d955c8bef.png">
