### PR TITLE
Experiment how React hooks can improve our codebase

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -937,11 +937,11 @@ function gutenberg_register_vendor_scripts() {
 
 	gutenberg_register_vendor_script(
 		'react',
-		'https://unpkg.com/react@16.4.1/umd/react' . $react_suffix . '.js'
+		'https://unpkg.com/react@16.7.0-alpha.0/umd/react' . $react_suffix . '.js'
 	);
 	gutenberg_register_vendor_script(
 		'react-dom',
-		'https://unpkg.com/react-dom@16.4.1/umd/react-dom' . $react_suffix . '.js',
+		'https://unpkg.com/react-dom@16.7.0-alpha.0/umd/react-dom' . $react_suffix . '.js',
 		array( 'react' )
 	);
 	$moment_script = SCRIPT_DEBUG ? 'moment.js' : 'min/moment.min.js';

--- a/packages/block-library/src/image/image-size.js
+++ b/packages/block-library/src/image/image-size.js
@@ -1,85 +1,39 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
+import { useRef, useMemo } from 'react';
 
 /**
  * WordPress dependencies
  */
-import { withGlobalEvents } from '@wordpress/compose';
-import { Component } from '@wordpress/element';
+import { useImageSize, useElementSize } from '@wordpress/compose';
 
-class ImageSize extends Component {
-	constructor() {
-		super( ...arguments );
-		this.state = {
-			width: undefined,
-			height: undefined,
+function ImageSize( { src, dirtynessTrigger, children } ) {
+	const container = useRef( null );
+	const [ imageWidth, imageHeight ] = useImageSize( src );
+	const [ containerWidth, containerHeight ] = useElementSize( container.current, dirtynessTrigger );
+	const sizes = useMemo( () => {
+		const maxWidth = containerWidth;
+		const exceedMaxWidth = imageWidth > maxWidth;
+		const ratio = imageHeight / imageWidth;
+		const width = exceedMaxWidth ? maxWidth : imageWidth;
+		const height = exceedMaxWidth ? maxWidth * ratio : imageHeight;
+
+		return {
+			imageWidthWithinContainer: width,
+			imageHeightWithinContainer: height,
+			imageWidth,
+			imageHeight,
+			containerWidth,
+			containerHeight,
 		};
-		this.bindContainer = this.bindContainer.bind( this );
-		this.calculateSize = this.calculateSize.bind( this );
-	}
+	}, [ imageWidth, imageHeight, containerWidth, containerHeight ] );
 
-	bindContainer( ref ) {
-		this.container = ref;
-	}
-
-	componentDidUpdate( prevProps ) {
-		if ( this.props.src !== prevProps.src ) {
-			this.setState( {
-				width: undefined,
-				height: undefined,
-			} );
-			this.fetchImageSize();
-		}
-
-		if ( this.props.dirtynessTrigger !== prevProps.dirtynessTrigger ) {
-			this.calculateSize();
-		}
-	}
-
-	componentDidMount() {
-		this.fetchImageSize();
-	}
-
-	componentWillUnmount() {
-		if ( this.image ) {
-			this.image.onload = noop;
-		}
-	}
-
-	fetchImageSize() {
-		this.image = new window.Image();
-		this.image.onload = this.calculateSize;
-		this.image.src = this.props.src;
-	}
-
-	calculateSize() {
-		const maxWidth = this.container.clientWidth;
-		const exceedMaxWidth = this.image.width > maxWidth;
-		const ratio = this.image.height / this.image.width;
-		const width = exceedMaxWidth ? maxWidth : this.image.width;
-		const height = exceedMaxWidth ? maxWidth * ratio : this.image.height;
-		this.setState( { width, height } );
-	}
-
-	render() {
-		const sizes = {
-			imageWidth: this.image && this.image.width,
-			imageHeight: this.image && this.image.height,
-			containerWidth: this.container && this.container.clientWidth,
-			containerHeight: this.container && this.container.clientHeight,
-			imageWidthWithinContainer: this.state.width,
-			imageHeightWithinContainer: this.state.height,
-		};
-		return (
-			<div ref={ this.bindContainer }>
-				{ this.props.children( sizes ) }
-			</div>
-		);
-	}
+	return (
+		<div ref={ container }>
+			{ children( sizes ) }
+		</div>
+	);
 }
 
-export default withGlobalEvents( {
-	resize: 'calculateSize',
-} )( ImageSize );
+export default ImageSize;

--- a/packages/compose/src/index.js
+++ b/packages/compose/src/index.js
@@ -12,6 +12,9 @@ export { default as withInstanceId } from './with-instance-id';
 export { default as withSafeTimeout } from './with-safe-timeout';
 export { default as withState } from './with-state';
 
+export { default as useImageSize } from './use-image-size';
+export { default as useElementSize } from './use-element-size';
+
 /**
  * Composes multiple higher-order components into a single higher-order component. Performs right-to-left function
  * composition, where each successive invocation is supplied the return value of the previous.

--- a/packages/compose/src/use-element-size/index.js
+++ b/packages/compose/src/use-element-size/index.js
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+function useElementSize( element, dirtynessTrigger ) {
+	const [ { width, height }, updateSize ] = useState( {} );
+
+	const updateContainerSize = () => {
+		updateSize( {
+			width: element ? element.clientWidth : undefined,
+			height: element ? element.clientHeight : undefined,
+		} );
+	};
+	useEffect( updateContainerSize, [ element, dirtynessTrigger ] );
+
+	// This could be refactored using a `useGlobalEvent`
+	// to avoid subscribing multiple times to the same event
+	// Similar to withGlobalEvent.
+	useEffect( () => {
+		window.addEventListener( 'resize', updateContainerSize );
+		return () => window.removeEventListener( 'resize', updateContainerSize );
+	}, [] );
+
+	return [ width, height ];
+}
+
+export default useElementSize;

--- a/packages/compose/src/use-image-size/index.js
+++ b/packages/compose/src/use-image-size/index.js
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+function useImageSize( src ) {
+	const [ { width, height }, updateSize ] = useState( {} );
+
+	useEffect( () => {
+		const image = new window.Image();
+		image.onload = () => {
+			updateSize( { width: image.width, height: image.height } );
+		};
+		image.src = src;
+	}, [ src ] );
+
+	return [ width, height ];
+}
+
+export default useImageSize;


### PR DESCRIPTION
React 16.7 introduces this concept of [hooks](https://reactjs.org/docs/hooks-intro.html). In this PR, I'm creating some hooks to explore this API and how it can improve or not our codebase and APIs.

So far, I'm thinking that it's a great API, I like how you can reason about discrete behaviors and combine them later in components without having to wrap your components or create extra DOM nodes you don't really need.

 - See how I created two simple hooks `useImageSize` to retrieve the image size and height, `useElementSize` to retrieve the size of an element and refresh it if the window is resized.
 - See how I refactored our current `ImageWidth` component to combine the two hooks above instead of a complex component class.
 - I think the `ImageWidth` component can be eliminated entirely (in favor of using the hooks directly in the image block) but I didn't want to push the refactor further.