### PR TITLE
Remove findDOMNode from Tooltip component

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.0.2 (Unreleased)
+
+### Polish
+
+- Tooltip are no longer removed when Button becomes disabled, it's left to the component rendering the Tooltip.
+
 ## 5.0.1 (2018-10-30)
 
 ## 5.0.0 (2018-10-29)

--- a/packages/components/src/icon-button/index.js
+++ b/packages/components/src/icon-button/index.js
@@ -25,7 +25,7 @@ class IconButton extends Component {
 		const tooltipText = tooltip || label;
 
 		// Should show the tooltip if...
-		const showTooltip = (
+		const showTooltip = ! additionalProps.disabled && (
 			// an explicit tooltip is passed or...
 			tooltip ||
 			// there's a shortcut or...
@@ -49,7 +49,10 @@ class IconButton extends Component {
 
 		if ( showTooltip ) {
 			element = (
-				<Tooltip text={ tooltipText } shortcut={ shortcut }>
+				<Tooltip
+					text={ tooltipText }
+					shortcut={ shortcut }
+				>
 					{ element }
 				</Tooltip>
 			);


### PR DESCRIPTION
This PR removes the deprecated findDOMNode call from the Tooltip component. It changes the behavior of the tooltip component a little bit though. It doesn't try to catch whether the wrapper component is disabled or not to set/unset the tooltip but it leaves this responsibility to the caller: The tooltip shouldn't be applied on disabled elements. It can have a small impact on third-party usage but I think it's a fine compromise.