### PR TITLE
Fix documentation for openModal() and closeModal()

### DIFF
--- a/docs/data/data-core-edit-post.md
+++ b/docs/data/data-core-edit-post.md
@@ -275,7 +275,7 @@ Returns an action object signalling that the user closed the sidebar.
 
 ### openModal
 
-Returns an action object used in signalling that the user opened an editor sidebar.
+Returns an action object used in signalling that the user opened a modal.
 
 *Parameters*
 
@@ -283,7 +283,7 @@ Returns an action object used in signalling that the user opened an editor sideb
 
 ### closeModal
 
-Returns an action object signalling that the user closed the sidebar.
+Returns an action object signalling that the user closed a modal.
 
 ### openPublishSidebar
 

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -29,7 +29,7 @@ export function closeGeneralSidebar() {
 }
 
 /**
- * Returns an action object used in signalling that the user opened an editor sidebar.
+ * Returns an action object used in signalling that the user opened a modal.
  *
  * @param {string} name A string that uniquely identifies the modal.
  *
@@ -43,7 +43,7 @@ export function openModal( name ) {
 }
 
 /**
- * Returns an action object signalling that the user closed the sidebar.
+ * Returns an action object signalling that the user closed a modal.
  *
  * @return {Object} Action object.
  */


### PR DESCRIPTION
The docblock for the `openModal()` and `closeModal()` funtions were duplicates of the `openGeneralSidebar()` and `closeGeneralSidebar()` functions.