### PR TITLE
Filter DropZone and MediaPlaceholder components

### DIFF
--- a/packages/editor/src/components/block-drop-zone/README.md
+++ b/packages/editor/src/components/block-drop-zone/README.md
@@ -1,0 +1,30 @@
+BlockDropZone
+===========
+
+`BlockDropZone` is a React component that renders a container which allows a user to drag media into the editor and immediately place it.
+
+## Setup
+
+It includes a `wp.hooks` filter `editor.BlockDropZone` that enables developers to replace or extend it.
+
+_Example:_
+
+Replace the contents of the panel:
+
+```js
+function replaceBlockDropZone() { 
+	return function() { 
+		return wp.element.createElement( 
+			'div', 
+			{}, 
+			'The replacement contents or components.' 
+		); 
+	} 
+} 
+
+wp.hooks.addFilter( 
+	'editor.BlockDropZone', 
+	'my-plugin/replace-block-drop-zone', 
+	replaceBlockDropZone
+);
+```

--- a/packages/editor/src/components/block-drop-zone/README.md
+++ b/packages/editor/src/components/block-drop-zone/README.md
@@ -9,7 +9,7 @@ It includes a `wp.hooks` filter `editor.BlockDropZone` that enables developers t
 
 _Example:_
 
-Replace the contents of the panel:
+Replace implementation of the drop zone:
 
 ```js
 function replaceBlockDropZone() { 

--- a/packages/editor/src/components/block-drop-zone/index.js
+++ b/packages/editor/src/components/block-drop-zone/index.js
@@ -164,5 +164,6 @@ export default compose(
 			isLocked: !! getTemplateLock( rootClientId ),
 			getClientIdsOfDescendants,
 		};
-	} )
-)( withFilters( 'editor.BlockDropZone' )( BlockDropZone ) );
+	} ),
+	withFilters( 'editor.BlockDropZone' )
+)( BlockDropZone );

--- a/packages/editor/src/components/block-drop-zone/index.js
+++ b/packages/editor/src/components/block-drop-zone/index.js
@@ -165,4 +165,4 @@ export default compose(
 			getClientIdsOfDescendants,
 		};
 	} )
-)( withFilters( 'editor.MediaPlaceholder' )( BlockDropZone ) );
+)( withFilters( 'editor.BlockDropZone' )( BlockDropZone ) );

--- a/packages/editor/src/components/block-drop-zone/index.js
+++ b/packages/editor/src/components/block-drop-zone/index.js
@@ -7,7 +7,10 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { DropZone } from '@wordpress/components';
+import {
+	DropZone,
+	withFilters,
+} from '@wordpress/components';
 import {
 	rawHandler,
 	cloneBlock,
@@ -162,4 +165,4 @@ export default compose(
 			getClientIdsOfDescendants,
 		};
 	} )
-)( BlockDropZone );
+)( withFilters( 'editor.MediaPlaceholder' )( BlockDropZone ) );

--- a/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
   className="editor-default-block-appender"
   data-root-client-id=""
 >
-  <WithDispatch(WithSelect(BlockDropZone)) />
+  <WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
   <input
     aria-label="Add block"
     className="editor-default-block-appender__content"
@@ -34,7 +34,7 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
   className="editor-default-block-appender"
   data-root-client-id=""
 >
-  <WithDispatch(WithSelect(BlockDropZone)) />
+  <WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
   <input
     aria-label="Add block"
     className="editor-default-block-appender__content"
@@ -56,7 +56,7 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
   className="editor-default-block-appender"
   data-root-client-id=""
 >
-  <WithDispatch(WithSelect(BlockDropZone)) />
+  <WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
   <input
     aria-label="Add block"
     className="editor-default-block-appender__content"

--- a/packages/editor/src/components/media-placeholder/README.md
+++ b/packages/editor/src/components/media-placeholder/README.md
@@ -1,0 +1,30 @@
+MediaPlaceholder
+===========
+
+`MediaPlaceholder` is a React component used to render either the media associated with a block, or an editing interface to replace the media for a block.
+
+## Setup
+
+It includes a `wp.hooks` filter `editor.MediaPlaceholder` that enables developers to replace or extend it.
+
+_Example:_
+
+Replace the contents of the panel:
+
+```js
+function replaceMediaPlaceholder() { 
+	return function() { 
+		return wp.element.createElement( 
+			'div', 
+			{}, 
+			'The replacement contents or components.' 
+		); 
+	} 
+} 
+
+wp.hooks.addFilter( 
+	'editor.MediaPlaceholder', 
+	'my-plugin/replace-media-placeholder-component', 
+	replaceMediaPlaceholder
+);
+```

--- a/packages/editor/src/components/media-placeholder/README.md
+++ b/packages/editor/src/components/media-placeholder/README.md
@@ -9,7 +9,7 @@ It includes a `wp.hooks` filter `editor.MediaPlaceholder` that enables developer
 
 _Example:_
 
-Replace the contents of the panel:
+Replace implementation of the placeholder:
 
 ```js
 function replaceMediaPlaceholder() { 
@@ -24,7 +24,7 @@ function replaceMediaPlaceholder() {
 
 wp.hooks.addFilter( 
 	'editor.MediaPlaceholder', 
-	'my-plugin/replace-media-placeholder-component', 
+	'my-plugin/replace-media-placeholder',
 	replaceMediaPlaceholder
 );
 ```

--- a/packages/editor/src/components/media-placeholder/index.js
+++ b/packages/editor/src/components/media-placeholder/index.js
@@ -13,6 +13,7 @@ import {
 	Placeholder,
 	DropZone,
 	IconButton,
+	withFilters,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
@@ -221,4 +222,4 @@ class MediaPlaceholder extends Component {
 	}
 }
 
-export default MediaPlaceholder;
+export default withFilters( 'editor.MediaPlaceholder' )( MediaPlaceholder );


### PR DESCRIPTION
## Description

Resolves #10177.

<!-- Please describe what you have changed or added -->
Export both the `DropZone` and `MediaPlaceholder` editor components with the `withFilters` HOC. This makes those components overridable on a more granular basis and makes the media components easier to modify.

See https://github.com/WordPress/gutenberg/issues/10177#issuecomment-429806799 for more context.

## How has this been tested?
I tested the behavior of the components in a default WP install using the Docker container provided by the install/setup script. I ran the test suite using `npm test` and updated the snapshot tests to match the new level of HOC wrappers.

I have dragged an image into the DropZone and used the MediaUploader to create an image block for the Image, Gallery, Cover, and File blocks.

Apologies for the poorly-named branch, I missed the instructions on branch naming 🤦‍♂️ 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
