### PR TITLE
Fix converting a reusable block with nested blocks into a static block

### DIFF
--- a/packages/editor/src/store/effects/reusable-blocks.js
+++ b/packages/editor/src/store/effects/reusable-blocks.js
@@ -237,11 +237,7 @@ export const convertBlockToStatic = ( action, store ) => {
 	if ( referencedBlock.name === 'core/template' ) {
 		newBlocks = referencedBlock.innerBlocks.map( ( innerBlock ) => cloneBlock( innerBlock ) );
 	} else {
-		newBlocks = [ createBlock(
-			referencedBlock.name,
-			referencedBlock.attributes,
-			referencedBlock.innerBlocks
-		) ];
+		newBlocks = [ cloneBlock( referencedBlock ) ];
 	}
 	store.dispatch( replaceBlocks( oldBlock.clientId, newBlocks ) );
 };

--- a/packages/editor/src/store/effects/reusable-blocks.js
+++ b/packages/editor/src/store/effects/reusable-blocks.js
@@ -237,7 +237,11 @@ export const convertBlockToStatic = ( action, store ) => {
 	if ( referencedBlock.name === 'core/template' ) {
 		newBlocks = referencedBlock.innerBlocks.map( ( innerBlock ) => cloneBlock( innerBlock ) );
 	} else {
-		newBlocks = [ createBlock( referencedBlock.name, referencedBlock.attributes ) ];
+		newBlocks = [ createBlock(
+			referencedBlock.name,
+			referencedBlock.attributes,
+			referencedBlock.innerBlocks
+		) ];
 	}
 	store.dispatch( replaceBlocks( oldBlock.clientId, newBlocks ) );
 };

--- a/packages/editor/src/store/effects/test/reusable-blocks.js
+++ b/packages/editor/src/store/effects/test/reusable-blocks.js
@@ -404,6 +404,46 @@ describe( 'reusable blocks effects', () => {
 				time: expect.any( Number ),
 			} );
 		} );
+
+		it( 'should convert a reusable block with nested blocks into a static block', () => {
+			const associatedBlock = createBlock( 'core/block', { ref: 123 } );
+			const reusableBlock = { id: 123, title: 'My cool block' };
+			const parsedBlock = createBlock( 'core/test-block', { name: 'Big Bird' }, [
+				createBlock( 'core/test-block', { name: 'Oscar the Grouch' } ),
+				createBlock( 'core/test-block', { name: 'Cookie Monster' } ),
+			] );
+
+			const state = reduce( [
+				resetBlocks( [ associatedBlock ] ),
+				receiveReusableBlocksAction( [ { reusableBlock, parsedBlock } ] ),
+				receiveBlocks( [ parsedBlock ] ),
+			], reducer, undefined );
+
+			const dispatch = jest.fn();
+			const store = { getState: () => state, dispatch };
+
+			convertBlockToStatic( convertBlockToStaticAction( associatedBlock.clientId ), store );
+
+			expect( dispatch ).toHaveBeenCalledWith( {
+				type: 'REPLACE_BLOCKS',
+				clientIds: [ associatedBlock.clientId ],
+				blocks: [
+					expect.objectContaining( {
+						name: 'core/test-block',
+						attributes: { name: 'Big Bird' },
+						innerBlocks: [
+							expect.objectContaining( {
+								attributes: { name: 'Oscar the Grouch' },
+							} ),
+							expect.objectContaining( {
+								attributes: { name: 'Cookie Monster' },
+							} ),
+						],
+					} ),
+				],
+				time: expect.any( Number ),
+			} );
+		} );
 	} );
 
 	describe( 'convertBlockToReusable', () => {


### PR DESCRIPTION
Fixes #9278.

The `CONVERT_BLOCK_TO_STATIC` effect needs to handle the case where the block being converted has inner blocks.

#### Testing

1. Insert a Columns block.
2. Insert some other block into the Columns block.
3. Open the ellipsis (<kbd><samp>More Options</samp></kbd>) menu and choose <kbd><samp>Add to Reusable Blocks</samp></kbd>.
4. Finish naming and saving the Reusable Block.
5. Notice that the nested blocks are saved in the Reusable Block as expected.
6. Open the ellipsis menu again and choose <kbd><samp>Convert to Regular Block</samp></kbd>.
7. The nested blocks should not have disappeared.