### PR TITLE
renamed _wpGutenbergCodeEditorSettings to _wpCodeEditorSettings

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1509,7 +1509,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	wp_add_inline_script(
 		'wp-editor',
 		sprintf(
-			'window._wpGutenbergCodeEditorSettings = %s;',
+			'window._wpCodeEditorSettings = %s;',
 			wp_json_encode( $gutenberg_captured_code_editor_settings )
 		)
 	);


### PR DESCRIPTION
## Description
renamed _wpGutenbergCodeEditorSettings to _wpCodeEditorSettings

Fix: #10847 
