### PR TITLE
Fix vanilla stylesheet

### DIFF
--- a/packages/editor/src/editor-styles.scss
+++ b/packages/editor/src/editor-styles.scss
@@ -1,5 +1,13 @@
+body {
+	font-family: $editor-font;
+	font-size: $editor-font-size;
+	line-height: $editor-line-height;
+	color: $dark-gray-900;
+}
+
 p {
 	font-size: $editor-font-size;
+	line-height: $editor-line-height;
 }
 
 ul,


### PR DESCRIPTION
Recent changes to the editor styles appear to have broken the vanilla stylesheet ever so slightly. To clarify, the vanilla stylesheet is the stylesheet the editor loads when a theme itself does not provide an editor style.

This PR fixes:

- Font size issue in lists
- Font family issue in all text
- Line height issue in blockquote
- Font color in all text
- An issue with heading sizes (they are sized in ems, so the body element needs a size)

To test, please verify that the editor looks right (Noto serif, 16px, 1.8 lineheight) with a theme that does not provide an editor style, and verify that themes that DO provide editor styles are also okay.

Before:

![localhost_8888_wp-admin_post php_post 692 action edit 1](https://user-images.githubusercontent.com/1204802/47638512-09f18780-db5f-11e8-8907-1f6b437ba4e1.png)

After:

![localhost_8888_wp-admin_post php_post 692 action edit](https://user-images.githubusercontent.com/1204802/47638488-fc3c0200-db5e-11e8-9c1e-018fbcfc6c18.png)
