### PR TITLE
Revert addition of icon to Common block category

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1306,7 +1306,7 @@ function gutenberg_get_block_categories( $post ) {
 		array(
 			'slug'  => 'common',
 			'title' => __( 'Common Blocks', 'gutenberg' ),
-			'icon'  => 'screenoptions',
+			'icon'  => null,
 		),
 		array(
 			'slug'  => 'formatting',


### PR DESCRIPTION
## Description
In #10651 we inadvertently merged a commit that had to be deleted before merging  (https://github.com/WordPress/gutenberg/pull/10651/commits/fa4cd682dc6e0f2e16767ab32a001194ad6c8483). Its purpose was to demonstrate registration of a block category icon on the server side, but was never meant to be merged.

So this PR essentially reverts this commit.

cc @youknowriad 

## How has this been tested?
* Checkout this PR.
* Open the inserter in a post.
* Look at the "Common" category.
* Verify you can't see an icon to the right of the "Common" category name.

## Types of changes
* Revert adding a dummy icon to the Common block category.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
