### PR TITLE
RichText: Append registered toolbar buttons

### DIFF
--- a/packages/editor/src/components/rich-text/format-edit.js
+++ b/packages/editor/src/components/rich-text/format-edit.js
@@ -20,13 +20,18 @@ function isResult( { title, keywords = [] }, filterValue ) {
 
 function FillToolbarButton( { name, shortcutType, shortcutCharacter, ...props } ) {
 	let shortcut;
+	let fillName = 'RichText.ToolbarControls';
+
+	if ( name ) {
+		fillName += `.${ name }`;
+	}
 
 	if ( shortcutType && shortcutCharacter ) {
 		shortcut = displayShortcut[ shortcutType ]( shortcutCharacter );
 	}
 
 	return (
-		<Fill name={ `RichText.ToolbarControls.${ name }` }>
+		<Fill name={ fillName }>
 			<ToolbarButton
 				{ ...props }
 				shortcut={ shortcut }

--- a/packages/editor/src/components/rich-text/format-toolbar/index.js
+++ b/packages/editor/src/components/rich-text/format-toolbar/index.js
@@ -11,6 +11,7 @@ const FormatToolbar = ( { controls } ) => {
 				{ controls.map( ( format ) =>
 					<Slot name={ `RichText.ToolbarControls.${ format }` } key={ format } />
 				) }
+				<Slot name="RichText.ToolbarControls" />
 			</Toolbar>
 		</div>
 	);


### PR DESCRIPTION
## Description
With this branch any registered toolbar buttons will be appended to the formatting toolbar. Fixes #11114.

## How has this been tested?
Register a button and see if it appears.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->