### PR TITLE
Editor: Move `normalizeIconObject` to `BlockEdit` component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2443,6 +2443,7 @@
 			"requires": {
 				"@babel/runtime": "^7.0.0",
 				"@wordpress/data": "file:packages/data",
+				"@wordpress/element": "file:packages/element",
 				"@wordpress/escape-html": "file:packages/escape-html",
 				"lodash": "^4.17.10",
 				"rememo": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
 		"publish:dev": "npm run build:packages && lerna publish --npm-tag next",
 		"publish:prod": "npm run build:packages && lerna publish",
 		"test": "concurrently \"npm run lint && npm run test-unit\" \"npm run test-mobile\"",
-		"pretest-e2e": "concurrently \"./bin/reset-e2e-tests.sh\"",
+		"pretest-e2e": "concurrently \"./bin/reset-e2e-tests.sh\" \"npm run build\"",
 		"test-e2e": "cross-env JEST_PUPPETEER_CONFIG=test/e2e/puppeteer.config.js wp-scripts test-unit-js --config test/e2e/jest.config.json --runInBand",
 		"test-e2e:watch": "npm run test-e2e -- --watch",
 		"test-mobile": "yarn --cwd gutenberg-mobile test:inside-gb",

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
 		"publish:dev": "npm run build:packages && lerna publish --npm-tag next",
 		"publish:prod": "npm run build:packages && lerna publish",
 		"test": "concurrently \"npm run lint && npm run test-unit\" \"npm run test-mobile\"",
-		"pretest-e2e": "concurrently \"./bin/reset-e2e-tests.sh\" \"npm run build\"",
+		"pretest-e2e": "concurrently \"./bin/reset-e2e-tests.sh\"",
 		"test-e2e": "cross-env JEST_PUPPETEER_CONFIG=test/e2e/puppeteer.config.js wp-scripts test-unit-js --config test/e2e/jest.config.json --runInBand",
 		"test-e2e:watch": "npm run test-e2e -- --watch",
 		"test-mobile": "yarn --cwd gutenberg-mobile test:inside-gb",

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -14,7 +14,7 @@ import { select, dispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { isValidIcon, normalizeIconObject } from './utils';
+import { isValidIcon } from './utils';
 
 /**
  * Defined behavior of a block type.
@@ -66,6 +66,7 @@ export function unstable__bootstrapServerSideBlockDefinitions( definitions ) { /
 export function registerBlockType( name, settings ) {
 	settings = {
 		name,
+		icon: 'block-default',
 		...get( serverSideBlockDefinitions, name ),
 		...settings,
 	};
@@ -137,8 +138,7 @@ export function registerBlockType( name, settings ) {
 		return;
 	}
 
-	settings.icon = normalizeIconObject( settings.icon );
-	if ( ! isValidIcon( settings.icon.src ) ) {
+	if ( ! isValidIcon( settings.icon ) ) {
 		console.error(
 			'The icon passed is invalid. ' +
 			'The icon should be a string, an element, a function, or an object following the specifications documented in https://wordpress.org/gutenberg/handbook/block-api/#icon-optional'

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -92,9 +92,7 @@ describe( 'blocks', () => {
 			expect( console ).not.toHaveErrored();
 			expect( block ).toEqual( {
 				name: 'my-plugin/fancy-block-4',
-				icon: {
-					src: 'block-default',
-				},
+				icon: 'block-default',
 				save: noop,
 				category: 'common',
 				title: 'block title',
@@ -177,9 +175,7 @@ describe( 'blocks', () => {
 				save: noop,
 				category: 'common',
 				title: 'block title',
-				icon: {
-					src: 'block-default',
-				},
+				icon: 'block-default',
 				attributes: {
 					ok: {
 						type: 'boolean',
@@ -216,12 +212,12 @@ describe( 'blocks', () => {
 				save: noop,
 				category: 'common',
 				title: 'block title',
-				icon: {
-					src: ( <svg width="20" height="20" viewBox="0 0 20 20">
+				icon: (
+					<svg width="20" height="20" viewBox="0 0 20 20">
 						<circle cx="10" cy="10" r="10"
 							fill="red" stroke="blue" strokeWidth="10" />
-					</svg> ),
-				},
+					</svg>
+				),
 			} );
 		} );
 
@@ -238,9 +234,7 @@ describe( 'blocks', () => {
 				save: noop,
 				category: 'common',
 				title: 'block title',
-				icon: {
-					src: 'foo',
-				},
+				icon: 'foo',
 			} );
 		} );
 
@@ -263,9 +257,7 @@ describe( 'blocks', () => {
 				save: noop,
 				category: 'common',
 				title: 'block title',
-				icon: {
-					src: MyTestIcon,
-				},
+				icon: MyTestIcon,
 			} );
 		} );
 
@@ -282,16 +274,14 @@ describe( 'blocks', () => {
 					</svg> ),
 				},
 			};
-			registerBlockType( 'core/test-block-icon-normalize-background', blockType );
-			expect( getBlockType( 'core/test-block-icon-normalize-background' ) ).toEqual( {
-				name: 'core/test-block-icon-normalize-background',
+			registerBlockType( 'core/test-block-icon-svg-with-background', blockType );
+			expect( getBlockType( 'core/test-block-icon-svg-with-background' ) ).toEqual( {
+				name: 'core/test-block-icon-svg-with-background',
 				save: noop,
 				category: 'common',
 				title: 'block title',
 				icon: {
 					background: '#f00',
-					foreground: '#191e23',
-					shadowColor: 'rgba(255, 0, 0, 0.3)',
 					src: ( <svg width="20" height="20" viewBox="0 0 20 20">
 						<circle cx="10" cy="10" r="10"
 							fill="red" stroke="blue" strokeWidth="10" />
@@ -310,9 +300,7 @@ describe( 'blocks', () => {
 				save: noop,
 				category: 'common',
 				title: 'block title',
-				icon: {
-					src: 'block-default',
-				},
+				icon: 'block-default',
 			} );
 		} );
 
@@ -350,9 +338,7 @@ describe( 'blocks', () => {
 					save: noop,
 					category: 'common',
 					title: 'block title',
-					icon: {
-						src: 'block-default',
-					},
+					icon: 'block-default',
 				},
 			] );
 			const oldBlock = unregisterBlockType( 'core/test-block' );
@@ -362,9 +348,7 @@ describe( 'blocks', () => {
 				save: noop,
 				category: 'common',
 				title: 'block title',
-				icon: {
-					src: 'block-default',
-				},
+				icon: 'block-default',
 			} );
 			expect( getBlockTypes() ).toEqual( [] );
 		} );
@@ -420,9 +404,7 @@ describe( 'blocks', () => {
 				save: noop,
 				category: 'common',
 				title: 'block title',
-				icon: {
-					src: 'block-default',
-				},
+				icon: 'block-default',
 			} );
 		} );
 
@@ -435,9 +417,7 @@ describe( 'blocks', () => {
 				save: noop,
 				category: 'common',
 				title: 'block title',
-				icon: {
-					src: 'block-default',
-				},
+				icon: 'block-default',
 			} );
 		} );
 	} );
@@ -457,9 +437,7 @@ describe( 'blocks', () => {
 					save: noop,
 					category: 'common',
 					title: 'block title',
-					icon: {
-						src: 'block-default',
-					},
+					icon: 'block-default',
 				},
 				{
 					name: 'core/test-block-with-settings',
@@ -467,9 +445,7 @@ describe( 'blocks', () => {
 					save: noop,
 					category: 'common',
 					title: 'block title',
-					icon: {
-						src: 'block-default',
-					},
+					icon: 'block-default',
 				},
 			] );
 		} );

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -64,7 +64,8 @@ export function isValidIcon( icon ) {
 		isString( icon ) ||
 		isValidElement( icon ) ||
 		isFunction( icon ) ||
-		icon instanceof Component
+		icon instanceof Component ||
+		isValidIcon( icon.src )
 	);
 }
 

--- a/packages/editor/src/components/autocompleters/block.js
+++ b/packages/editor/src/components/autocompleters/block.js
@@ -73,7 +73,7 @@ export function createBlockCompleter( {
 		getOptionLabel( inserterItem ) {
 			const { icon, title } = inserterItem;
 			return [
-				<BlockIcon key="icon" icon={ icon && icon.src } showColors />,
+				<BlockIcon key="icon" icon={ icon } showColors />,
 				title,
 			];
 		},

--- a/packages/editor/src/components/autocompleters/test/block.js
+++ b/packages/editor/src/components/autocompleters/test/block.js
@@ -69,9 +69,7 @@ describe( 'block', () => {
 	it( 'should render a block option label', () => {
 		const labelComponents = shallow( <div>
 			{ blockCompleter.getOptionLabel( {
-				icon: {
-					src: 'expected-icon',
-				},
+				icon: 'expected-icon',
 				title: 'expected-text',
 			} ) }
 		</div> ).children();

--- a/packages/editor/src/components/block-icon/index.js
+++ b/packages/editor/src/components/block-icon/index.js
@@ -8,15 +8,21 @@ import classnames from 'classnames';
  */
 import { Path, Icon, SVG } from '@wordpress/components';
 
+/**
+ * Internal dependencies
+ */
+import { normalizeIconObject } from '../../utils/icon';
+
 export default function BlockIcon( { icon, showColors = false, className } ) {
 	if ( icon === 'block-default' ) {
 		return <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M19 7h-1V5h-4v2h-4V5H6v2H5c-1.1 0-2 .9-2 2v10h18V9c0-1.1-.9-2-2-2zm0 10H5V9h14v8z" /></SVG>;
 	}
 
-	const renderedIcon = <Icon icon={ icon && icon.src ? icon.src : icon } />;
+	const normalizedIcon = normalizeIconObject( icon );
+	const renderedIcon = <Icon icon={ normalizedIcon.src } />;
 	const style = showColors ? {
-		backgroundColor: icon && icon.background,
-		color: icon && icon.foreground,
+		backgroundColor: normalizedIcon.background,
+		color: normalizedIcon.foreground,
 	} : {};
 
 	return (

--- a/packages/editor/src/components/block-icon/test/index.js
+++ b/packages/editor/src/components/block-icon/test/index.js
@@ -6,7 +6,7 @@ import { shallow } from 'enzyme';
 /**
  * WordPress dependencies
  */
-import { Icon } from '@wordpress/components';
+import { Circle, Icon, SVG } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -44,6 +44,23 @@ describe( 'BlockIcon', () => {
 		expect( wrapper.find( 'div' ).prop( 'style' ) ).toEqual( {
 			backgroundColor: 'white',
 			color: 'black',
+		} );
+	} );
+
+	it( 'adds background and foreground styles when an icon with background and a custom svg', () => {
+		const icon = {
+			background: '#f00',
+			src: (
+				<SVG width="20" height="20" viewBox="0 0 20 20">
+					<Circle cx="10" cy="10" r="10" fill="red" stroke="blue" strokeWidth="10" />
+				</SVG>
+			),
+		};
+		const wrapper = shallow( <BlockIcon icon={ icon } showColors /> );
+
+		expect( wrapper.find( 'div' ).prop( 'style' ) ).toEqual( {
+			backgroundColor: '#f00',
+			color: '#191e23',
 		} );
 	} );
 } );

--- a/packages/editor/src/components/block-switcher/index.js
+++ b/packages/editor/src/components/block-switcher/index.js
@@ -98,7 +98,7 @@ export class BlockSwitcher extends Component {
 								tooltip={ label }
 								onKeyDown={ openOnArrowDown }
 							>
-								<BlockIcon icon={ blockType.icon && blockType.icon.src } showColors />
+								<BlockIcon icon={ blockType.icon } showColors />
 								<SVG className="editor-block-switcher__transform" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M6.5 8.9c.6-.6 1.4-.9 2.2-.9h6.9l-1.3 1.3 1.4 1.4L19.4 7l-3.7-3.7-1.4 1.4L15.6 6H8.7c-1.4 0-2.6.5-3.6 1.5l-2.8 2.8 1.4 1.4 2.8-2.8zm13.8 2.4l-2.8 2.8c-.6.6-1.3.9-2.1.9h-7l1.3-1.3-1.4-1.4L4.6 16l3.7 3.7 1.4-1.4L8.4 17h6.9c1.3 0 2.6-.5 3.5-1.5l2.8-2.8-1.3-1.4z" /></SVG>
 							</IconButton>
 						</Toolbar>

--- a/packages/editor/src/components/inserter-list-item/index.js
+++ b/packages/editor/src/components/inserter-list-item/index.js
@@ -4,14 +4,10 @@
 import classnames from 'classnames';
 
 /**
- * WordPress dependencies
- */
-import { normalizeIconObject } from '@wordpress/blocks';
-
-/**
  * Internal dependencies
  */
 import BlockIcon from '../block-icon';
+import { normalizeIconObject } from '../../utils/icon';
 
 function InserterListItem( {
 	icon,
@@ -22,14 +18,14 @@ function InserterListItem( {
 	className,
 	...props
 } ) {
-	icon = normalizeIconObject( icon );
+	const normalizedIcon = normalizeIconObject( icon );
 
-	const itemIconStyle = icon ? {
-		backgroundColor: icon.background,
-		color: icon.foreground,
+	const itemIconStyle = normalizedIcon ? {
+		backgroundColor: normalizedIcon.background,
+		color: normalizedIcon.foreground,
 	} : {};
-	const itemIconStackStyle = icon && icon.shadowColor ? {
-		backgroundColor: icon.shadowColor,
+	const itemIconStackStyle = normalizedIcon && normalizedIcon.shadowColor ? {
+		backgroundColor: normalizedIcon.shadowColor,
 	} : {};
 
 	return (
@@ -57,7 +53,7 @@ function InserterListItem( {
 					className="editor-block-types-list__item-icon"
 					style={ itemIconStyle }
 				>
-					<BlockIcon icon={ icon && icon.src } showColors />
+					<BlockIcon icon={ normalizedIcon } showColors />
 					{ hasChildBlocksWithInserterSupport &&
 						<span
 							className="editor-block-types-list__item-icon-stack"

--- a/packages/editor/src/components/inserter-with-shortcuts/index.js
+++ b/packages/editor/src/components/inserter-with-shortcuts/index.js
@@ -39,7 +39,7 @@ function InserterWithShortcuts( { items, isLocked, onInsert } ) {
 					// translators: %s: block title/name to be added
 					label={ sprintf( __( 'Add %s' ), item.title ) }
 					icon={ (
-						<BlockIcon icon={ item.icon && item.icon.src } />
+						<BlockIcon icon={ item.icon } />
 					) }
 				/>
 			) ) }

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -3490,9 +3490,7 @@ describe( 'selectors', () => {
 				name: 'core/test-block-a',
 				initialAttributes: {},
 				title: 'Test Block A',
-				icon: {
-					src: 'test',
-				},
+				icon: 'test',
 				category: 'formatting',
 				keywords: [ 'testing' ],
 				isDisabled: false,
@@ -3506,9 +3504,7 @@ describe( 'selectors', () => {
 				name: 'core/block',
 				initialAttributes: { ref: 1 },
 				title: 'Reusable Block 1',
-				icon: {
-					src: 'test',
-				},
+				icon: 'test',
 				category: 'reusable',
 				keywords: [],
 				isDisabled: false,

--- a/packages/editor/src/utils/icon.js
+++ b/packages/editor/src/utils/icon.js
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ */
+import { isFunction, isObject, isString } from 'lodash';
+import { default as tinycolor, mostReadable } from 'tinycolor2';
+
+/**
+ * WordPress dependencies
+ */
+import { Component, isValidElement } from '@wordpress/element';
+
+/**
+ * Array of icon colors containing a color to be used if the icon color
+ * was not explicitly set but the icon background color was.
+ *
+ * @type {Object}
+ */
+const ICON_COLORS = [ '#191e23', '#f8f9f9' ];
+
+/**
+ * Function that checks if the parameter is a valid icon object.
+ *
+ * For more information:
+ * @see https://wordpress.org/gutenberg/handbook/block-api/#icon-optional
+ *
+ * @param {*} icon  Parameter to be checked.
+ *
+ * @return {boolean} True if the parameter is a valid icon object and false otherwise.
+ */
+
+function isValidIconObject( icon ) {
+	const src = isObject( icon ) && icon.src;
+
+	return !! src && (
+		isString( src ) ||
+		isValidElement( src ) ||
+		isFunction( src ) ||
+		src instanceof Component
+	);
+}
+
+/**
+ * Function that receives an icon as set by the blocks during the registration
+ * and returns a new icon object that is normalized so we can rely on just on possible icon structure
+ * in the codebase.
+ *
+ * @param {(Object|string|WPElement)} icon  Slug of the Dashicon to be shown
+ *                                          as the icon for the block in the
+ *                                          inserter, or element or an object describing the icon.
+ *
+ * @return {Object} Object describing the icon.
+ */
+export function normalizeIconObject( icon ) {
+	if ( isValidIconObject( icon ) ) {
+		if ( icon.background ) {
+			const normalizedIcon = { ...icon };
+			const tinyBgColor = tinycolor( icon.background );
+			if ( ! icon.foreground ) {
+				normalizedIcon.foreground = mostReadable(
+					tinyBgColor,
+					ICON_COLORS,
+					{ includeFallbackColors: true, level: 'AA', size: 'large' }
+				).toHexString();
+			}
+			normalizedIcon.shadowColor = tinyBgColor.setAlpha( 0.3 ).toRgbString();
+
+			return normalizedIcon;
+		}
+		return icon;
+	}
+
+	return {
+		src: icon,
+	};
+}

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -22,6 +22,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.0.0",
 		"@wordpress/data": "file:../data",
+		"@wordpress/element": "file:../element",
 		"@wordpress/escape-html": "file:../escape-html",
 		"lodash": "^4.17.10",
 		"rememo": "^3.0.0"

--- a/packages/rich-text/src/register-format-type.js
+++ b/packages/rich-text/src/register-format-type.js
@@ -1,13 +1,31 @@
 /**
  * External dependencies
  */
-import { isFunction } from 'lodash';
+import { isFunction, isString } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { select, dispatch } from '@wordpress/data';
-import { isValidIcon, normalizeIconObject } from '@wordpress/blocks';
+import { Component, isValidElement } from '@wordpress/element';
+
+/**
+ * Function that checks if the parameter is a valid icon.
+ *
+ * @param {*} icon  Parameter to be checked.
+ *
+ * @return {boolean} True if the parameter is a valid icon and false otherwise.
+ */
+
+export function isValidIcon( icon ) {
+	return !! icon && (
+		isString( icon ) ||
+		isValidElement( icon ) ||
+		isFunction( icon ) ||
+		icon instanceof Component ||
+		isValidIcon( icon.src )
+	);
+}
 
 /**
  * Registers a new format provided a unique name and an object defining its
@@ -22,6 +40,7 @@ import { isValidIcon, normalizeIconObject } from '@wordpress/blocks';
 export function registerFormatType( name, settings ) {
 	settings = {
 		name,
+		icon: 'block-default',
 		...settings,
 	};
 
@@ -74,9 +93,7 @@ export function registerFormatType( name, settings ) {
 		return;
 	}
 
-	settings.icon = normalizeIconObject( settings.icon );
-
-	if ( ! isValidIcon( settings.icon.src ) ) {
+	if ( ! isValidIcon( settings.icon ) ) {
 		window.console.error(
 			'The icon passed is invalid. ' +
 			'The icon should be a string, an element, a function, or an object following the specifications documented in https://wordpress.org/gutenberg/handbook/format-api/#icon-optional'


### PR DESCRIPTION
## Description
Supersedes: #11122.

> Currently @wordpress/blocks is not added as a dependency.

This PR removes this dependency completely by moving `normalizeIconObject` to `@wordpress/editor` and copying `isValidIcon` logic to `@wordpress/rich-text`.

## How has this been tested?
`npm test` & `npm run test-e2e`

Block icons have pretty good coverage in e2e test (props to @jorgefilipecosta).
You also install manually `Gutenberg Test Block Icons` plugin bundled with Gutenberg Docker instance and verify that all icons are properly rendered in all types of inserters.

## TODO

Deprecate `normalizeIconObject` inside `@wordpress/blocks` and maybe make `isValidIcon` private. 

## Types of changes
Refactoring.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
