### PR TITLE
Fix focus issue on gallery remove button

### DIFF
--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -108,6 +108,10 @@ ul.wp-block-gallery li {
 
 .blocks-gallery-item__remove {
 	padding: 0;
+
+	&.components-button:focus {
+		color: inherit;
+	}
 }
 
 .blocks-gallery-item .components-spinner {


### PR DESCRIPTION
This fixes #11158.

Before:

![screenshot 2018-10-29 at 13 30 46](https://user-images.githubusercontent.com/1204802/47650005-34ebd380-db7f-11e8-86e4-3778a2b81303.png)

After:

![screenshot 2018-10-29 at 13 32 32](https://user-images.githubusercontent.com/1204802/47650008-36b59700-db7f-11e8-9771-768e6981c121.png)
