### PR TITLE
API Fetch: Handle 204 Response Code

### DIFF
--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -55,6 +55,10 @@ function apiFetch( options ) {
 
 		const parseResponse = ( response ) => {
 			if ( parse ) {
+				if ( response.status === 204 ) {
+					return null;
+				}
+
 				return response.json ? response.json() : Promise.reject( response );
 			}
 

--- a/packages/api-fetch/src/test/index.js
+++ b/packages/api-fetch/src/test/index.js
@@ -74,6 +74,16 @@ describe( 'apiFetch', () => {
 		} );
 	} );
 
+	it( 'should return null if response has no content status code', () => {
+		window.fetch.mockReturnValue( Promise.resolve( {
+			status: 204,
+		} ) );
+
+		return apiFetch( { path: '/random' } ).catch( ( body ) => {
+			expect( body ).toEqual( null );
+		} );
+	} );
+
 	it( 'should not try to parse the response', () => {
 		window.fetch.mockReturnValue( Promise.resolve( {
 			status: 200,


### PR DESCRIPTION
Fixes #11179. Previously, API Fetch would try to always get the response body
as JSON, even if the Response Status Code indicated that an empty response body
was expected.

## Description
Check if the response status code is 204 before parsing the response as JSON and return null instead.

## How has this been tested?
- Manually with an API endpoint that returns 204.
- With a unit test.

## Types of changes
New feature/Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
