### PR TITLE
Always check selection range when creating undo levels

### DIFF
--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -227,7 +227,8 @@ export class RichText extends Component {
 	}
 
 	createRecord() {
-		const range = getSelection().getRangeAt( 0 );
+		const selection = getSelection();
+		const range = selection.rangeCount > 0 ? selection.getRangeAt( 0 ) : null;
 
 		return create( {
 			element: this.editableRef,


### PR DESCRIPTION
Occasionally I see an error being thrown when clicking around a rich text editor:

![devtools_-_latest_local_wp-admin_post_php_post_195_action_edit](https://user-images.githubusercontent.com/1277682/47660867-d7ac4e00-db8f-11e8-84ff-fce46bfa884c.jpg)

I'm not entirely sure what triggers it, but I've got the steps down to a vague:

1. Quickly create a bunch of paragraphs
2. Click inside the paragraph blocks, but not on the text
3. Maybe get an error

Not the best steps, but hopefully this shows it better:

![range](https://user-images.githubusercontent.com/1277682/47661118-4ee1e200-db90-11e8-95c0-9627cce63062.gif)

The problem seems to be a `mousedown` event triggering an undo history event, and the `window.getSelection()` not having any range.

In this PR I've added a check to `window.getSelection()` so it looks at `rangeCount`, as well as adds checks for all uses of `createRecord`.

I'm not entirely sure if this is the best solution, but it fixes the problem at hand. The error may indicate another problem I'm unaware of (with a better solution!)

The error only happens for me in Chrome (tested with 70.0.3538.77). It doesn't happen in Firefox 63 or Safari 12. The error is triggered more easily with the Unified Toolbar option enabled, although I've had it happen without.

Using Gutenberg master

## Types of changes
Additional checks added for selection range in rich text editor

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
