### PR TITLE
Gallery, Image: Move attributes to block boundary (JSON)

### DIFF
--- a/packages/block-library/src/gallery/index.js
+++ b/packages/block-library/src/gallery/index.js
@@ -17,12 +17,12 @@ import { G, Path, SVG } from '@wordpress/components';
  */
 import { default as edit, defaultColumnsNumber, pickRelevantMediaFiles } from './edit';
 
+// Attributes are to be saved as JSON in the block boundary for easier
+// server-side access.
 const blockAttributes = {
 	images: {
 		type: 'array',
 		default: [],
-		source: 'query',
-		selector: 'ul.wp-block-gallery .blocks-gallery-item',
 		query: {
 			url: {
 				source: 'attribute',
@@ -61,6 +61,17 @@ const blockAttributes = {
 	linkTo: {
 		type: 'string',
 		default: 'none',
+	},
+};
+
+// Identical schema, but wherein `images` are not saved in the block boundary,
+// and instead are sourced in the block's inner HTML.
+const deprecatedBlockAttributes = {
+	...blockAttributes,
+	images: {
+		...blockAttributes.images,
+		source: 'query',
+		selector: 'ul.wp-block-gallery .blocks-gallery-item',
 	},
 };
 
@@ -199,7 +210,42 @@ export const settings = {
 
 	deprecated: [
 		{
-			attributes: blockAttributes,
+			attributes: deprecatedBlockAttributes,
+			save( { attributes } ) {
+				const { images, columns = defaultColumnsNumber( attributes ), imageCrop, linkTo } = attributes;
+				return (
+					<ul className={ `columns-${ columns } ${ imageCrop ? 'is-cropped' : '' }` } >
+						{ images.map( ( image ) => {
+							let href;
+
+							switch ( linkTo ) {
+								case 'media':
+									href = image.url;
+									break;
+								case 'attachment':
+									href = image.link;
+									break;
+							}
+
+							const img = <img src={ image.url } alt={ image.alt } data-id={ image.id } data-link={ image.link } className={ image.id ? `wp-image-${ image.id }` : null } />;
+
+							return (
+								<li key={ image.id || image.url } className="blocks-gallery-item">
+									<figure>
+										{ href ? <a href={ href }>{ img }</a> : img }
+										{ image.caption && image.caption.length > 0 && (
+											<RichText.Content tagName="figcaption" value={ image.caption } />
+										) }
+									</figure>
+								</li>
+							);
+						} ) }
+					</ul>
+				);
+			},
+		},
+		{
+			attributes: deprecatedBlockAttributes,
 			save( { attributes } ) {
 				const { images, columns = defaultColumnsNumber( attributes ), imageCrop, linkTo } = attributes;
 				return (
@@ -235,9 +281,9 @@ export const settings = {
 		},
 		{
 			attributes: {
-				...blockAttributes,
+				...deprecatedBlockAttributes,
 				images: {
-					...blockAttributes.images,
+					...deprecatedBlockAttributes.images,
 					selector: 'div.wp-block-gallery figure.blocks-gallery-image img',
 				},
 				align: {

--- a/packages/block-library/src/gallery/index.js
+++ b/packages/block-library/src/gallery/index.js
@@ -75,6 +75,39 @@ const deprecatedBlockAttributes = {
 	},
 };
 
+function save( { attributes } ) {
+	const { images, columns = defaultColumnsNumber( attributes ), imageCrop, linkTo } = attributes;
+	return (
+		<ul className={ `columns-${ columns } ${ imageCrop ? 'is-cropped' : '' }` } >
+			{ images.map( ( image ) => {
+				let href;
+
+				switch ( linkTo ) {
+					case 'media':
+						href = image.url;
+						break;
+					case 'attachment':
+						href = image.link;
+						break;
+				}
+
+				const img = <img src={ image.url } alt={ image.alt } data-id={ image.id } data-link={ image.link } className={ image.id ? `wp-image-${ image.id }` : null } />;
+
+				return (
+					<li key={ image.id || image.url } className="blocks-gallery-item">
+						<figure>
+							{ href ? <a href={ href }>{ img }</a> : img }
+							{ image.caption && image.caption.length > 0 && (
+								<RichText.Content tagName="figcaption" value={ image.caption } />
+							) }
+						</figure>
+					</li>
+				);
+			} ) }
+		</ul>
+	);
+}
+
 export const name = 'core/gallery';
 
 export const settings = {
@@ -175,74 +208,12 @@ export const settings = {
 
 	edit,
 
-	save( { attributes } ) {
-		const { images, columns = defaultColumnsNumber( attributes ), imageCrop, linkTo } = attributes;
-		return (
-			<ul className={ `columns-${ columns } ${ imageCrop ? 'is-cropped' : '' }` } >
-				{ images.map( ( image ) => {
-					let href;
-
-					switch ( linkTo ) {
-						case 'media':
-							href = image.url;
-							break;
-						case 'attachment':
-							href = image.link;
-							break;
-					}
-
-					const img = <img src={ image.url } alt={ image.alt } data-id={ image.id } data-link={ image.link } className={ image.id ? `wp-image-${ image.id }` : null } />;
-
-					return (
-						<li key={ image.id || image.url } className="blocks-gallery-item">
-							<figure>
-								{ href ? <a href={ href }>{ img }</a> : img }
-								{ image.caption && image.caption.length > 0 && (
-									<RichText.Content tagName="figcaption" value={ image.caption } />
-								) }
-							</figure>
-						</li>
-					);
-				} ) }
-			</ul>
-		);
-	},
+	save,
 
 	deprecated: [
 		{
 			attributes: deprecatedBlockAttributes,
-			save( { attributes } ) {
-				const { images, columns = defaultColumnsNumber( attributes ), imageCrop, linkTo } = attributes;
-				return (
-					<ul className={ `columns-${ columns } ${ imageCrop ? 'is-cropped' : '' }` } >
-						{ images.map( ( image ) => {
-							let href;
-
-							switch ( linkTo ) {
-								case 'media':
-									href = image.url;
-									break;
-								case 'attachment':
-									href = image.link;
-									break;
-							}
-
-							const img = <img src={ image.url } alt={ image.alt } data-id={ image.id } data-link={ image.link } className={ image.id ? `wp-image-${ image.id }` : null } />;
-
-							return (
-								<li key={ image.id || image.url } className="blocks-gallery-item">
-									<figure>
-										{ href ? <a href={ href }>{ img }</a> : img }
-										{ image.caption && image.caption.length > 0 && (
-											<RichText.Content tagName="figcaption" value={ image.caption } />
-										) }
-									</figure>
-								</li>
-							);
-						} ) }
-					</ul>
-				);
-			},
+			save,
 		},
 		{
 			attributes: deprecatedBlockAttributes,

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -31,26 +31,16 @@ export const name = 'core/image';
 const blockAttributes = {
 	url: {
 		type: 'string',
-		source: 'attribute',
-		selector: 'img',
-		attribute: 'src',
 	},
 	alt: {
 		type: 'string',
-		source: 'attribute',
-		selector: 'img',
-		attribute: 'alt',
 		default: '',
 	},
 	caption: {
-		source: 'html',
-		selector: 'figcaption',
+		type: 'string',
 	},
 	href: {
 		type: 'string',
-		source: 'attribute',
-		selector: 'figure > a',
-		attribute: 'href',
 	},
 	id: {
 		type: 'number',
@@ -70,6 +60,37 @@ const blockAttributes = {
 	},
 	linkTarget: {
 		type: 'string',
+	},
+};
+
+const deprecatedBlockAttributes = {
+	...blockAttributes,
+	url: {
+		...blockAttributes.url,
+		source: 'attribute',
+		selector: 'img',
+		attribute: 'src',
+	},
+	alt: {
+		...blockAttributes.alt,
+		source: 'attribute',
+		selector: 'img',
+		attribute: 'alt',
+	},
+	caption: {
+		...blockAttributes.caption,
+		type: undefined,
+		source: 'html',
+		selector: 'figcaption',
+	},
+	href: {
+		...blockAttributes.href,
+		source: 'attribute',
+		selector: 'figure > a',
+		attribute: 'href',
+	},
+	linkTarget: {
+		...blockAttributes.linkTarget,
 		source: 'attribute',
 		selector: 'figure > a',
 		attribute: 'target',
@@ -98,6 +119,48 @@ const schema = {
 		},
 	},
 };
+
+function save( { attributes } ) {
+	const { url, alt, caption, align, href, width, height, id, linkTarget } = attributes;
+
+	const classes = classnames( {
+		[ `align${ align }` ]: align,
+		'is-resized': width || height,
+	} );
+
+	const image = (
+		<img
+			src={ url }
+			alt={ alt }
+			className={ id ? `wp-image-${ id }` : null }
+			width={ width }
+			height={ height }
+		/>
+	);
+
+	const figure = (
+		<Fragment>
+			{ href ? <a href={ href } target={ linkTarget } rel={ linkTarget === '_blank' ? 'noreferrer noopener' : undefined }>{ image }</a> : image }
+			{ ! RichText.isEmpty( caption ) && <RichText.Content tagName="figcaption" value={ caption } /> }
+		</Fragment>
+	);
+
+	if ( 'left' === align || 'right' === align || 'center' === align ) {
+		return (
+			<div>
+				<figure className={ classes }>
+					{ figure }
+				</figure>
+			</div>
+		);
+	}
+
+	return (
+		<figure className={ classes }>
+			{ figure }
+		</figure>
+	);
+}
 
 export const settings = {
 	title: __( 'Image' ),
@@ -212,51 +275,15 @@ export const settings = {
 
 	edit,
 
-	save( { attributes } ) {
-		const { url, alt, caption, align, href, width, height, id, linkTarget } = attributes;
-
-		const classes = classnames( {
-			[ `align${ align }` ]: align,
-			'is-resized': width || height,
-		} );
-
-		const image = (
-			<img
-				src={ url }
-				alt={ alt }
-				className={ id ? `wp-image-${ id }` : null }
-				width={ width }
-				height={ height }
-			/>
-		);
-
-		const figure = (
-			<Fragment>
-				{ href ? <a href={ href } target={ linkTarget } rel={ linkTarget === '_blank' ? 'noreferrer noopener' : undefined }>{ image }</a> : image }
-				{ ! RichText.isEmpty( caption ) && <RichText.Content tagName="figcaption" value={ caption } /> }
-			</Fragment>
-		);
-
-		if ( 'left' === align || 'right' === align || 'center' === align ) {
-			return (
-				<div>
-					<figure className={ classes }>
-						{ figure }
-					</figure>
-				</div>
-			);
-		}
-
-		return (
-			<figure className={ classes }>
-				{ figure }
-			</figure>
-		);
-	},
+	save,
 
 	deprecated: [
 		{
-			attributes: blockAttributes,
+			attributes: deprecatedBlockAttributes,
+			save,
+		},
+		{
+			attributes: deprecatedBlockAttributes,
 			save( { attributes } ) {
 				const { url, alt, caption, align, href, width, height, id } = attributes;
 
@@ -284,7 +311,7 @@ export const settings = {
 			},
 		},
 		{
-			attributes: blockAttributes,
+			attributes: deprecatedBlockAttributes,
 			save( { attributes } ) {
 				const { url, alt, caption, align, href, width, height, id } = attributes;
 
@@ -307,7 +334,7 @@ export const settings = {
 			},
 		},
 		{
-			attributes: blockAttributes,
+			attributes: deprecatedBlockAttributes,
 			save( { attributes } ) {
 				const { url, alt, caption, align, href, width, height } = attributes;
 				const extraImageProps = width || height ? { width, height } : {};

--- a/test/integration/full-content/fixtures/core__gallery.html
+++ b/test/integration/full-content/fixtures/core__gallery.html
@@ -1,4 +1,4 @@
-<!-- wp:core/gallery -->
+<!-- wp:core/gallery {"images":[{"url":"https://cldup.com/uuUqE_dXzy.jpg","alt":"title","caption":""},{"url":"http://google.com/hi.png","alt":"title","caption":""}]} -->
 <ul class="wp-block-gallery columns-2 is-cropped">
 	<li class="blocks-gallery-item">
 		<figure>

--- a/test/integration/full-content/fixtures/core__gallery.parsed.json
+++ b/test/integration/full-content/fixtures/core__gallery.parsed.json
@@ -1,7 +1,7 @@
 [
     {
         "blockName": "core/gallery",
-        "attrs": {},
+        "attrs": {"images":[{"url":"https://cldup.com/uuUqE_dXzy.jpg","alt":"title","caption":""},{"url":"http://google.com/hi.png","alt":"title","caption":""}]},
         "innerBlocks": [],
         "innerHTML": "\n<ul class=\"wp-block-gallery columns-2 is-cropped\">\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n</ul>\n"
     },

--- a/test/integration/full-content/fixtures/core__gallery.serialized.html
+++ b/test/integration/full-content/fixtures/core__gallery.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:gallery -->
+<!-- wp:gallery {"images":[{"url":"https://cldup.com/uuUqE_dXzy.jpg","alt":"title","caption":""},{"url":"http://google.com/hi.png","alt":"title","caption":""}]} -->
 <ul class="wp-block-gallery columns-2 is-cropped"><li class="blocks-gallery-item"><figure><img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title"/></figure></li><li class="blocks-gallery-item"><figure><img src="http://google.com/hi.png" alt="title"/></figure></li></ul>
 <!-- /wp:gallery -->

--- a/test/integration/full-content/fixtures/core__gallery__columns.html
+++ b/test/integration/full-content/fixtures/core__gallery__columns.html
@@ -1,4 +1,4 @@
-<!-- wp:core/gallery {"columns":1} -->
+<!-- wp:core/gallery {"images":[{"url":"https://cldup.com/uuUqE_dXzy.jpg","alt":"title","caption":""},{"url":"http://google.com/hi.png","alt":"title","caption":""}],"columns":1} -->
 <ul class="wp-block-gallery columns-1 is-cropped">
 	<li class="blocks-gallery-item">
 		<figure>

--- a/test/integration/full-content/fixtures/core__gallery__columns.parsed.json
+++ b/test/integration/full-content/fixtures/core__gallery__columns.parsed.json
@@ -2,6 +2,10 @@
     {
         "blockName": "core/gallery",
         "attrs": {
+			"images": [
+				{"url":"https://cldup.com/uuUqE_dXzy.jpg","alt":"title","caption":""},
+				{"url":"http://google.com/hi.png","alt":"title","caption":""}
+			],
             "columns": 1
         },
         "innerBlocks": [],

--- a/test/integration/full-content/fixtures/core__gallery__columns.serialized.html
+++ b/test/integration/full-content/fixtures/core__gallery__columns.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:gallery {"columns":1} -->
+<!-- wp:gallery {"images":[{"url":"https://cldup.com/uuUqE_dXzy.jpg","alt":"title","caption":""},{"url":"http://google.com/hi.png","alt":"title","caption":""}],"columns":1} -->
 <ul class="wp-block-gallery columns-1 is-cropped"><li class="blocks-gallery-item"><figure><img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title"/></figure></li><li class="blocks-gallery-item"><figure><img src="http://google.com/hi.png" alt="title"/></figure></li></ul>
 <!-- /wp:gallery -->

--- a/test/integration/full-content/fixtures/core__image.html
+++ b/test/integration/full-content/fixtures/core__image.html
@@ -1,3 +1,3 @@
-<!-- wp:core/image -->
+<!-- wp:core/image {"url":"https://cldup.com/uuUqE_dXzy.jpg","caption":""} -->
 <figure class="wp-block-image"><img src="https://cldup.com/uuUqE_dXzy.jpg" alt="" /></figure>
 <!-- /wp:core/image -->

--- a/test/integration/full-content/fixtures/core__image.parsed.json
+++ b/test/integration/full-content/fixtures/core__image.parsed.json
@@ -1,7 +1,10 @@
 [
     {
         "blockName": "core/image",
-        "attrs": {},
+        "attrs": {
+			"url": "https://cldup.com/uuUqE_dXzy.jpg",
+			"caption": ""
+		},
         "innerBlocks": [],
         "innerHTML": "\n<figure class=\"wp-block-image\"><img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"\" /></figure>\n"
     },

--- a/test/integration/full-content/fixtures/core__image.serialized.html
+++ b/test/integration/full-content/fixtures/core__image.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:image -->
+<!-- wp:image {"url":"https://cldup.com/uuUqE_dXzy.jpg","caption":""} -->
 <figure class="wp-block-image"><img src="https://cldup.com/uuUqE_dXzy.jpg" alt=""/></figure>
 <!-- /wp:image -->

--- a/test/integration/full-content/fixtures/core__image__attachment-link.html
+++ b/test/integration/full-content/fixtures/core__image__attachment-link.html
@@ -1,3 +1,3 @@
-<!-- wp:core/image {"linkDestination":"attachment"}  -->
+<!-- wp:core/image {"url":"https://cldup.com/uuUqE_dXzy.jpg","caption":"","href":"http://localhost:8888/?attachment_id=7","linkDestination":"attachment"} -->
 <figure class="wp-block-image"><a href="http://localhost:8888/?attachment_id=7"><img src="https://cldup.com/uuUqE_dXzy.jpg" alt="" /></a></figure>
 <!-- /wp:core/image -->

--- a/test/integration/full-content/fixtures/core__image__attachment-link.parsed.json
+++ b/test/integration/full-content/fixtures/core__image__attachment-link.parsed.json
@@ -2,6 +2,9 @@
     {
         "blockName": "core/image",
         "attrs": {
+			"url":"https://cldup.com/uuUqE_dXzy.jpg",
+			"caption":"",
+			"href":"http://localhost:8888/?attachment_id=7",
             "linkDestination": "attachment"
         },
         "innerBlocks": [],

--- a/test/integration/full-content/fixtures/core__image__attachment-link.serialized.html
+++ b/test/integration/full-content/fixtures/core__image__attachment-link.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:image {"linkDestination":"attachment"} -->
+<!-- wp:image {"url":"https://cldup.com/uuUqE_dXzy.jpg","caption":"","href":"http://localhost:8888/?attachment_id=7","linkDestination":"attachment"} -->
 <figure class="wp-block-image"><a href="http://localhost:8888/?attachment_id=7"><img src="https://cldup.com/uuUqE_dXzy.jpg" alt=""/></a></figure>
 <!-- /wp:image -->

--- a/test/integration/full-content/fixtures/core__image__center-caption.html
+++ b/test/integration/full-content/fixtures/core__image__center-caption.html
@@ -1,3 +1,3 @@
-<!-- wp:core/image {"align":"center"} -->
+<!-- wp:core/image {"url":"https://cldup.com/YLYhpou2oq.jpg","caption":"Give it a try. Press the \u0022really wide\u0022 button on the image toolbar.","align":"center"} -->
 <div class="wp-block-image"><figure class="aligncenter"><img src="https://cldup.com/YLYhpou2oq.jpg" alt="" /><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure></div>
 <!-- /wp:core/image -->

--- a/test/integration/full-content/fixtures/core__image__center-caption.parsed.json
+++ b/test/integration/full-content/fixtures/core__image__center-caption.parsed.json
@@ -2,6 +2,8 @@
     {
         "blockName": "core/image",
         "attrs": {
+			"url":"https://cldup.com/YLYhpou2oq.jpg",
+			"caption":"Give it a try. Press the \u0022really wide\u0022 button on the image toolbar.",
             "align": "center"
         },
         "innerBlocks": [],

--- a/test/integration/full-content/fixtures/core__image__center-caption.serialized.html
+++ b/test/integration/full-content/fixtures/core__image__center-caption.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:image {"align":"center"} -->
+<!-- wp:image {"url":"https://cldup.com/YLYhpou2oq.jpg","caption":"Give it a try. Press the \u0022really wide\u0022 button on the image toolbar.","align":"center"} -->
 <div class="wp-block-image"><figure class="aligncenter"><img src="https://cldup.com/YLYhpou2oq.jpg" alt=""/><figcaption>Give it a try. Press the "really wide" button on the image toolbar.</figcaption></figure></div>
 <!-- /wp:image -->

--- a/test/integration/full-content/fixtures/core__image__custom-link.html
+++ b/test/integration/full-content/fixtures/core__image__custom-link.html
@@ -1,3 +1,3 @@
-<!-- wp:core/image {"linkDestination":"custom"}  -->
+<!-- wp:core/image {"url":"https://cldup.com/uuUqE_dXzy.jpg","caption":"","href":"https://wordpress.org/","linkDestination":"custom"} -->
 <figure class="wp-block-image"><a href="https://wordpress.org/"><img src="https://cldup.com/uuUqE_dXzy.jpg" alt="" /></a></figure>
 <!-- /wp:core/image -->

--- a/test/integration/full-content/fixtures/core__image__custom-link.parsed.json
+++ b/test/integration/full-content/fixtures/core__image__custom-link.parsed.json
@@ -2,6 +2,9 @@
     {
         "blockName": "core/image",
         "attrs": {
+			"url":"https://cldup.com/uuUqE_dXzy.jpg",
+			"caption":"",
+			"href":"https://wordpress.org/",
             "linkDestination": "custom"
         },
         "innerBlocks": [],

--- a/test/integration/full-content/fixtures/core__image__custom-link.serialized.html
+++ b/test/integration/full-content/fixtures/core__image__custom-link.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:image {"linkDestination":"custom"} -->
+<!-- wp:image {"url":"https://cldup.com/uuUqE_dXzy.jpg","caption":"","href":"https://wordpress.org/","linkDestination":"custom"} -->
 <figure class="wp-block-image"><a href="https://wordpress.org/"><img src="https://cldup.com/uuUqE_dXzy.jpg" alt=""/></a></figure>
 <!-- /wp:image -->

--- a/test/integration/full-content/fixtures/core__image__media-link.html
+++ b/test/integration/full-content/fixtures/core__image__media-link.html
@@ -1,3 +1,3 @@
-<!-- wp:core/image {"linkDestination":"media"}  -->
+<!-- wp:core/image {"url":"https://cldup.com/uuUqE_dXzy.jpg","caption":"","href":"https://cldup.com/uuUqE_dXzy.jpg","linkDestination":"media"} -->
 <figure class="wp-block-image"><a href="https://cldup.com/uuUqE_dXzy.jpg"><img src="https://cldup.com/uuUqE_dXzy.jpg" alt="" /></a></figure>
 <!-- /wp:core/image -->

--- a/test/integration/full-content/fixtures/core__image__media-link.parsed.json
+++ b/test/integration/full-content/fixtures/core__image__media-link.parsed.json
@@ -2,6 +2,9 @@
     {
         "blockName": "core/image",
         "attrs": {
+			"url":"https://cldup.com/uuUqE_dXzy.jpg",
+			"caption":"",
+			"href":"https://cldup.com/uuUqE_dXzy.jpg",
             "linkDestination": "media"
         },
         "innerBlocks": [],

--- a/test/integration/full-content/fixtures/core__image__media-link.serialized.html
+++ b/test/integration/full-content/fixtures/core__image__media-link.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:image {"linkDestination":"media"} -->
+<!-- wp:image {"url":"https://cldup.com/uuUqE_dXzy.jpg","caption":"","href":"https://cldup.com/uuUqE_dXzy.jpg","linkDestination":"media"} -->
 <figure class="wp-block-image"><a href="https://cldup.com/uuUqE_dXzy.jpg"><img src="https://cldup.com/uuUqE_dXzy.jpg" alt=""/></a></figure>
 <!-- /wp:image -->


### PR DESCRIPTION
## Description

Fixes #8193. See issue for context. In short: in order to allow easy server-side inspection and interception of Gallery and Image blocks, move away from sourced attributes — that would require server-side HTML-parsing tools that we don't yet have — towards "plain" attributes that are duplicated in the HTML comments of blocks.

## How has this been tested?

- Make sure that any new block of Gallery and Image types is saved unaltered inner HTML but added JSON in its boundary.
- Make sure that any pre-existing block of said types properly automatically migrates when a post is edited and saved.

A Gallery is henceforth saved as:

```html
<!-- wp:gallery {"images":[{"url":"MY_URL","link":"https://example.org","alt":"","id":"711","caption":""}]} -->
<ul class="wp-block-gallery columns-2 is-cropped"><li class="blocks-gallery-item"><figure><img src="MY_URL" alt="" data-id="711" data-link="https://example.org" class="wp-image-711"/></figure></li></ul>
<!-- /wp:gallery -->
```

and an Image:

```html
<!-- wp:image {"url":"MY_URL","alt":"Some alt text.","caption":"A caption.","href":"https://example.org","id":712,"linkDestination":"custom"} -->
<figure class="wp-block-image"><a href="https://example.org"><img src="MY_URL" alt="Some alt text." class="wp-image-712"/></a><figcaption>A caption.</figcaption></figure>
<!-- /wp:image -->
```

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->