### PR TITLE
Docs: custom block category add icon info

### DIFF
--- a/docs/extensibility/extending-blocks.md
+++ b/docs/extensibility/extending-blocks.md
@@ -333,7 +333,7 @@ function my_plugin_block_categories( $categories, $post ) {
 			array(
 				'slug' => 'my-category',
 				'title' => __( 'My category', 'my-plugin' ),
-				'icon'  => 'screenoptions',
+				'icon'  => '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="none" d="M0 0h24v24H0V0z" /><path d="M19 13H5v-2h14v2z" /></svg>',
 			),
 		)
 	);

--- a/docs/extensibility/extending-blocks.md
+++ b/docs/extensibility/extending-blocks.md
@@ -333,9 +333,13 @@ function my_plugin_block_categories( $categories, $post ) {
 			array(
 				'slug' => 'my-category',
 				'title' => __( 'My category', 'my-plugin' ),
+				'icon'  => 'screenoptions',
 			),
 		)
 	);
 }
 add_filter( 'block_categories', 'my_plugin_block_categories', 10, 2 );
 ```
+
+An icon key/value can be specified to add an icon to block category. These can be any of [WordPress Dashicons](https://developer.wordpress.org/resource/dashicons/), or a custom `svg` element.
+

--- a/docs/extensibility/extending-blocks.md
+++ b/docs/extensibility/extending-blocks.md
@@ -341,5 +341,5 @@ function my_plugin_block_categories( $categories, $post ) {
 add_filter( 'block_categories', 'my_plugin_block_categories', 10, 2 );
 ```
 
-An icon key/value can be specified to add an icon to block category. These can be any of [WordPress Dashicons](https://developer.wordpress.org/resource/dashicons/), or a custom `svg` element.
+You can also display an icon with your block category by setting an `icon` attribute. The value can be the slug of a [WordPress Dashicon](https://developer.wordpress.org/resource/dashicons/), or a custom `svg` element.
 


### PR DESCRIPTION
With https://github.com/WordPress/gutenberg/pull/10651 custom block categories can have a custom icon.

This PR adds the same to docs https://wordpress.org/gutenberg/handbook/extensibility/extending-blocks/#managing-block-categories

cc: @tyxla 