### PR TITLE
Rename wp-polyfill-ecmascript

### DIFF
--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -66,4 +66,4 @@ It is recommened to use the main `wp-polyfill` script handle which takes care of
 | [Formdata Polyfill](https://www.npmjs.com/package/formdata-polyfill) | wp-polyfill-formdata| Polyfill conditionally replaces the native implementation |
 | [Node Contains Polyfill](https://polyfill.io) | wp-polyfill-node-contains |Polyfill for Node.contains |
 | [Element Closest Polyfill](https://www.npmjs.com/package/element-closest) | wp-polyfill-element-closest| Return the closest element matching a selector up the DOM tree |
-| [ECMAScript Polyfill](https://babeljs.io/docs/en/babel-polyfill) | wp-polyfill-ecmascript | Emulate a full ES2015+ environment |
+| [ECMAScript Polyfill](https://babeljs.io/docs/en/babel-polyfill) | wp-babel-polyfill | Emulate a full ES2015+ environment |

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -60,10 +60,9 @@ It is recommened to use the main `wp-polyfill` script handle which takes care of
 
 | Script Name | Handle | Description |
 |-------------|--------|-------------|
-| polyfill | wp-polyfill | Main script to load all the below mentioned polyfills |
+| [Babel Polyfill](https://babeljs.io/docs/en/babel-polyfill) | wp-polyfill | Emulate a full ES2015+ environment. Main script to load all the below mentioned additional polyfills |
 | [Fetch Polyfill](https://www.npmjs.com/package/whatwg-fetch) | wp-polyfill-fetch | Polyfill that implements a subset of the standard Fetch specification |
 | [Promise Polyfill](https://www.npmjs.com/package/promise-polyfill) | wp-polyfill-promise| Lightweight ES6 Promise polyfill for the browser and node |
 | [Formdata Polyfill](https://www.npmjs.com/package/formdata-polyfill) | wp-polyfill-formdata| Polyfill conditionally replaces the native implementation |
 | [Node Contains Polyfill](https://polyfill.io) | wp-polyfill-node-contains |Polyfill for Node.contains |
 | [Element Closest Polyfill](https://www.npmjs.com/package/element-closest) | wp-polyfill-element-closest| Return the closest element matching a selector up the DOM tree |
-| [ECMAScript Polyfill](https://babeljs.io/docs/en/babel-polyfill) | wp-babel-polyfill | Emulate a full ES2015+ environment |

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -144,6 +144,7 @@ function gutenberg_register_scripts_and_styles() {
 
 	register_tinymce_scripts();
 
+	$suffix = SCRIPT_DEBUG ? '' : '.min';
 	gutenberg_override_script(
 		'wp-polyfill',
 		'https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.0.0/polyfill' . $suffix . '.js'

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -981,7 +981,13 @@ function gutenberg_register_vendor_scripts() {
 		null,
 		array(
 			'wp-polyfill',
+			'wp-deprecated',
 		)
+	);
+	wp_script_add_data(
+		'wp-polyfill-ecmascript',
+		'data',
+		'wp.deprecated( "wp-polyfill-ecmascript script handle", { plugin: "Gutenberg", version: "4.5" } );'
 	);
 }
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -146,10 +146,7 @@ function gutenberg_register_scripts_and_styles() {
 
 	gutenberg_override_script(
 		'wp-polyfill',
-		null,
-		array(
-			'wp-babel-polyfill',
-		)
+		'https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.0.0/polyfill' . $suffix . '.js'
 	);
 	wp_script_add_data(
 		'wp-polyfill',
@@ -485,7 +482,7 @@ function gutenberg_register_scripts_and_styles() {
 			'lodash',
 			'wp-a11y',
 			'wp-data',
-			'wp-babel-polyfill',
+			'wp-polyfill',
 		),
 		filemtime( gutenberg_dir_path() . 'build/notices/index.js' ),
 		true
@@ -751,7 +748,7 @@ function gutenberg_register_scripts_and_styles() {
 			'wp-compose',
 			'wp-element',
 			'wp-i18n',
-			'wp-babel-polyfill',
+			'wp-polyfill',
 		),
 		filemtime( gutenberg_dir_path() . 'build/list-reusable-blocks/index.js' ),
 		true
@@ -977,10 +974,6 @@ function gutenberg_register_vendor_scripts() {
 	gutenberg_register_vendor_script(
 		'wp-polyfill-element-closest',
 		'https://unpkg.com/element-closest@2.0.2/element-closest.js'
-	);
-	gutenberg_register_vendor_script(
-		'wp-babel-polyfill',
-		'https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.0.0/polyfill' . $suffix . '.js'
 	);
 }
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -144,16 +144,12 @@ function gutenberg_register_scripts_and_styles() {
 
 	register_tinymce_scripts();
 
-	$suffix = SCRIPT_DEBUG ? '' : '.min';
-	gutenberg_override_script(
-		'wp-polyfill',
-		'https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.0.0/polyfill' . $suffix . '.js'
-	);
 	wp_script_add_data(
 		'wp-polyfill',
 		'data',
 		gutenberg_get_script_polyfill(
 			array(
+				'false'               => 'wp-polyfill-ecmascript',
 				'\'fetch\' in window' => 'wp-polyfill-fetch',
 				'document.contains'   => 'wp-polyfill-node-contains',
 				'window.FormData && window.FormData.prototype.keys' => 'wp-polyfill-formdata',
@@ -975,6 +971,10 @@ function gutenberg_register_vendor_scripts() {
 	gutenberg_register_vendor_script(
 		'wp-polyfill-element-closest',
 		'https://unpkg.com/element-closest@2.0.2/element-closest.js'
+	);
+	gutenberg_register_vendor_script(
+		'wp-polyfill',
+		'https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.0.0/polyfill' . $suffix . '.js'
 	);
 }
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -976,7 +976,7 @@ function gutenberg_register_vendor_scripts() {
 		'wp-polyfill',
 		'https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.0.0/polyfill' . $suffix . '.js'
 	);
-	// Ensure backwards compatibility after renaming to wp-polyfill
+	// Ensure backwards compatibility after renaming to wp-polyfill.
 	gutenberg_override_script(
 		'wp-polyfill-ecmascript',
 		null,

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -148,7 +148,7 @@ function gutenberg_register_scripts_and_styles() {
 		'wp-polyfill',
 		null,
 		array(
-			'wp-polyfill-ecmascript',
+			'wp-babel-polyfill',
 		)
 	);
 	wp_script_add_data(
@@ -485,7 +485,7 @@ function gutenberg_register_scripts_and_styles() {
 			'lodash',
 			'wp-a11y',
 			'wp-data',
-			'wp-polyfill-ecmascript',
+			'wp-babel-polyfill',
 		),
 		filemtime( gutenberg_dir_path() . 'build/notices/index.js' ),
 		true
@@ -751,7 +751,7 @@ function gutenberg_register_scripts_and_styles() {
 			'wp-compose',
 			'wp-element',
 			'wp-i18n',
-			'wp-polyfill-ecmascript',
+			'wp-babel-polyfill',
 		),
 		filemtime( gutenberg_dir_path() . 'build/list-reusable-blocks/index.js' ),
 		true
@@ -979,7 +979,7 @@ function gutenberg_register_vendor_scripts() {
 		'https://unpkg.com/element-closest@2.0.2/element-closest.js'
 	);
 	gutenberg_register_vendor_script(
-		'wp-polyfill-ecmascript',
+		'wp-babel-polyfill',
 		'https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.0.0/polyfill' . $suffix . '.js'
 	);
 }

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -149,7 +149,6 @@ function gutenberg_register_scripts_and_styles() {
 		'data',
 		gutenberg_get_script_polyfill(
 			array(
-				'false'               => 'wp-polyfill-ecmascript',
 				'\'fetch\' in window' => 'wp-polyfill-fetch',
 				'document.contains'   => 'wp-polyfill-node-contains',
 				'window.FormData && window.FormData.prototype.keys' => 'wp-polyfill-formdata',

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -976,6 +976,14 @@ function gutenberg_register_vendor_scripts() {
 		'wp-polyfill',
 		'https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.0.0/polyfill' . $suffix . '.js'
 	);
+	// Ensure backwards compatibility after renaming to wp-polyfill
+	gutenberg_override_script(
+		'wp-polyfill-ecmascript',
+		null,
+		array(
+			'wp-polyfill',
+		)
+	);
 }
 
 /**


### PR DESCRIPTION
We're continuing to see reports of issues with ModSecurity due to a very common ruleset including a rule that blocks files with `ecmascript` in the filename. The polyfill file uses the name `wp-polyfill-ecmascript.min.js`, so it ends up getting blocked by the rule, resulting in the editor breaking completely. See #10075 for more details.

It seems unreasonable to expect all hosts to put an exception rule in ahead of 5.0 to make sure this doesn't happen. Any reason why we can't just rename the file? 

I went with `wp-babel-polyfill` on this PR, but not stuck to that. Just used it because [that's where the polyfill originates from](https://github.com/WordPress/gutenberg/pull/9171#issuecomment-419163250). 
