### PR TITLE
Fix: Embeds: Clicking on a WordPress embed does not select the block.

### DIFF
--- a/packages/block-library/src/embed/embed-preview.js
+++ b/packages/block-library/src/embed/embed-preview.js
@@ -18,6 +18,11 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Placeholder, SandBox } from '@wordpress/components';
 import { RichText, BlockIcon } from '@wordpress/editor';
 
+/**
+ * Internal dependencies
+ */
+import WpEmbedPreview from './wp-embed-preview';
+
 const EmbedPreview = ( props ) => {
 	const { preview, url, type, caption, onCaptionChange, isSelected, className, icon, label } = props;
 	const { scripts } = preview;
@@ -30,9 +35,8 @@ const EmbedPreview = ( props ) => {
 	const sandboxClassnames = classnames( type, className, 'wp-block-embed__wrapper' );
 
 	const embedWrapper = 'wp-embed' === type ? (
-		<div
-			className={ sandboxClassnames }
-			dangerouslySetInnerHTML={ { __html: html } }
+		<WpEmbedPreview
+			html={ html }
 		/>
 	) : (
 		<div className="wp-block-embed__wrapper">

--- a/packages/block-library/src/embed/wp-embed-preview.js
+++ b/packages/block-library/src/embed/wp-embed-preview.js
@@ -1,0 +1,53 @@
+/**
+ * WordPress dependencies
+ */
+import { Component, createRef } from '@wordpress/element';
+import { withGlobalEvents } from '@wordpress/compose';
+
+/**
+ * Browser dependencies
+ */
+
+const { FocusEvent } = window;
+
+class WpEmbedPreview extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.checkFocus = this.checkFocus.bind( this );
+		this.node = createRef();
+	}
+
+	/**
+	 * Checks whether the wp embed iframe is the activeElement,
+	 * if it is dispatch a focus event.
+	 */
+	checkFocus() {
+		const { activeElement } = document;
+
+		if (
+			activeElement.tagName !== 'IFRAME' ||
+			activeElement.parentNode !== this.node.current
+		) {
+			return;
+		}
+
+		const focusEvent = new FocusEvent( 'focus', { bubbles: true } );
+		activeElement.dispatchEvent( focusEvent );
+	}
+
+	render() {
+		const { html } = this.props;
+		return (
+			<div
+				ref={ this.node }
+				className="wp-block-embed__wrapper"
+				dangerouslySetInnerHTML={ { __html: html } }
+			/>
+		);
+	}
+}
+
+export default withGlobalEvents( {
+	blur: 'checkFocus',
+} )( WpEmbedPreview );


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/10632

Clicking on embed from a WordPress website (even the local test site) does not select the embed block.
This PR fixes this behavior.
It implements a local component WpEmbedContainer inspired on FocusableIframe. Using FocusableIframe was on possible it looks like we need to use an iframe as returned from the embed API with data-secret and other custom attributes.

Todo: add end 2 end test case.

## How has this been tested?
I added a WordPress embed (https://make.wordpress.org/core/2018/10/24/wordpress-5-0-beta-1-update/).
I verified when I click on the content of the embed the block gets selected.
I repeated the test with another post from the test site.

## Screenshots <!-- if applicable -->
Before:

![oct-29-2018 19-09-07](https://user-images.githubusercontent.com/11271197/47674040-44cedc00-dbae-11e8-80cf-5e78e476ef2c.gif)

After:
![oct-29-2018 19-09-47](https://user-images.githubusercontent.com/11271197/47674059-4ef0da80-dbae-11e8-8ef3-62f80176eb87.gif)

