### PR TITLE
RichText: Remove unused `ref` assignment to RichText

### DIFF
--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -15,7 +15,7 @@ import memize from 'memize';
 /**
  * WordPress dependencies
  */
-import { Component, Fragment, RawHTML, createRef } from '@wordpress/element';
+import { Component, Fragment, RawHTML } from '@wordpress/element';
 import {
 	isHorizontalEdge,
 	getRectangleFromRange,
@@ -104,7 +104,6 @@ export class RichText extends Component {
 		this.formatToValue = memize( this.formatToValue.bind( this ), { size: 1 } );
 
 		this.savedContent = value;
-		this.containerRef = createRef();
 		this.patterns = getPatterns( {
 			onReplace,
 			multilineTag: this.multilineTag,
@@ -870,7 +869,6 @@ export class RichText extends Component {
 
 		return (
 			<div className={ classes }
-				ref={ this.containerRef }
 				onFocus={ this.setFocusedElement }
 			>
 				{ isSelected && ! inlineToolbar && (


### PR DESCRIPTION
This pull request seeks to remove an unused `ref` assignment from the `RichText` wrapper element.

Originally I had intended to try toward removing the wrapper altogether. It may not be necessary, though the `className` and `focus` behavior compatibilities may require further effort to recreate.

**Testing instructions:**

Nothing had used this `ref` assignment.

Verify there are no regressions in the behavior of the `RichText` component.