### PR TITLE
RichText: Remove top-level ARIA props picking

### DIFF
--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -49,7 +49,6 @@ import BlockFormatControls from '../block-format-controls';
 import FormatEdit from './format-edit';
 import FormatToolbar from './format-toolbar';
 import TinyMCE from './tinymce';
-import { pickAriaProps } from './aria';
 import { getPatterns } from './patterns';
 import { withBlockEditContext } from '../block-edit/context';
 
@@ -858,7 +857,6 @@ export class RichText extends Component {
 		} = this.props;
 
 		const MultilineTag = this.multilineTag;
-		const ariaProps = pickAriaProps( this.props );
 
 		// Generating a key that includes `tagName` ensures that if the tag
 		// changes, we unmount and destroy the previous TinyMCE element, then
@@ -903,7 +901,6 @@ export class RichText extends Component {
 								aria-expanded={ isExpanded }
 								aria-owns={ listBoxId }
 								aria-activedescendant={ activeId }
-								{ ...ariaProps }
 								className={ className }
 								key={ key }
 								onPaste={ this.onPaste }


### PR DESCRIPTION
This pull request seeks to remove specific picking for ARIA props from the top-level `RichText` interface. This is not currently used anywhere in the core codebase. As done in #7432, the expectation would be that any ARIA props which must be applied to the rendered `contenteditable` field should be done so internal to RichText, inferred by incoming props if necessary for variation.

This is both a simplification of the expected maintained API surface of the component, and may marginally improve performance by avoiding (often redundant) iterations over incoming props to the RichText field. It also avoids setting false expectations surrounding the ability to apply any DOM property to the rendered `contenteditable`, which has not been and is not expected to be the case.

Internally, the component does and will continue to assign its own ARIA props to the rendered contenteditable. This is not expected to change, though its implementation of could probably be improved further (particularly in applying diff of ARIA prop values during component lifecycle).

**Testing instructions:**

Verify there are no regressions in the behavior of RichText (i.e. paragraph field).