### PR TITLE
Add `has-background` classes to pullquote and Media & Text blocks

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -130,13 +130,14 @@ class MediaTextEdit extends Component {
 		const classNames = classnames( className, {
 			'has-media-on-the-right': 'right' === mediaPosition,
 			'is-selected': isSelected,
+			'has-background': ( backgroundColor.class || backgroundColor.color ),
 			[ backgroundColor.class ]: backgroundColor.class,
 			'is-stacked-on-mobile': isStackedOnMobile,
 		} );
 		const widthString = `${ temporaryMediaWidth || mediaWidth }%`;
 		const style = {
 			gridTemplateColumns: 'right' === mediaPosition ? `auto ${ widthString }` : `${ widthString } auto`,
-			backgroundColor: backgroundColor.color,
+			backgroundColor: backgroundColor.class ? undefined : backgroundColor.color,
 		};
 		const colorSettings = [ {
 			value: backgroundColor.color,

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -137,7 +137,7 @@ class MediaTextEdit extends Component {
 		const widthString = `${ temporaryMediaWidth || mediaWidth }%`;
 		const style = {
 			gridTemplateColumns: 'right' === mediaPosition ? `auto ${ widthString }` : `${ widthString } auto`,
-			backgroundColor: backgroundColor.class ? undefined : backgroundColor.color,
+			backgroundColor: backgroundColor.color,
 		};
 		const colorSettings = [ {
 			value: backgroundColor.color,

--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -202,6 +202,51 @@ export const settings = {
 					mediaType,
 					mediaUrl,
 					mediaWidth,
+					mediaId,
+				} = attributes;
+				const mediaTypeRenders = {
+					image: () => <img src={ mediaUrl } alt={ mediaAlt } className={ ( mediaId && mediaType === 'image' ) ? `wp-image-${ mediaId }` : null } />,
+					video: () => <video controls src={ mediaUrl } />,
+				};
+				const backgroundClass = getColorClassName( 'background-color', backgroundColor );
+				const className = classnames( {
+					'has-media-on-the-right': 'right' === mediaPosition,
+					[ backgroundClass ]: backgroundClass,
+					'is-stacked-on-mobile': isStackedOnMobile,
+				} );
+
+				let gridTemplateColumns;
+				if ( mediaWidth !== DEFAULT_MEDIA_WIDTH ) {
+					gridTemplateColumns = 'right' === mediaPosition ? `auto ${ mediaWidth }%` : `${ mediaWidth }% auto`;
+				}
+				const style = {
+					backgroundColor: backgroundClass ? undefined : customBackgroundColor,
+					gridTemplateColumns,
+				};
+				return (
+					<div className={ className } style={ style }>
+						<figure className="wp-block-media-text__media" >
+							{ ( mediaTypeRenders[ mediaType ] || noop )() }
+						</figure>
+						<div className="wp-block-media-text__content">
+							<InnerBlocks.Content />
+						</div>
+					</div>
+				);
+			},
+		},
+		{
+			attributes: blockAttributes,
+			save( { attributes } ) {
+				const {
+					backgroundColor,
+					customBackgroundColor,
+					isStackedOnMobile,
+					mediaAlt,
+					mediaPosition,
+					mediaType,
+					mediaUrl,
+					mediaWidth,
 				} = attributes;
 				const mediaTypeRenders = {
 					image: () => <img src={ mediaUrl } alt={ mediaAlt } />,

--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -164,6 +164,7 @@ export const settings = {
 		const backgroundClass = getColorClassName( 'background-color', backgroundColor );
 		const className = classnames( {
 			'has-media-on-the-right': 'right' === mediaPosition,
+			'has-background': ( backgroundClass || customBackgroundColor ),
 			[ backgroundClass ]: backgroundClass,
 			'is-stacked-on-mobile': isStackedOnMobile,
 		} );

--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -66,7 +66,7 @@ class PullQuoteEdit extends Component {
 		const isSolidColorStyle = includes( className, SOLID_COLOR_CLASS );
 
 		const figureStyles = isSolidColorStyle ?
-			{ backgroundColor: mainColor.class ? undefined : mainColor.color } :
+			{ backgroundColor: mainColor.color } :
 			{ borderColor: mainColor.color };
 
 		const figureClasses = classnames( className, {
@@ -75,13 +75,13 @@ class PullQuoteEdit extends Component {
 		} );
 
 		const blockquoteStyles = {
-			color: textColor.class ? undefined : textColor.color,
+			color: textColor.color,
 		};
 
-		const blockquoteClasses = textColor.color && classnames( {
-			'has-text-color': textColor.color,
-			[ textColor.class ]: textColor.class,
-		} );
+		const blockquoteClasses = textColor.color && classnames(
+			'has-text-color',
+			{ [ textColor.class ]: textColor.class }
+		);
 
 		return (
 			<Fragment>

--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -64,22 +64,29 @@ class PullQuoteEdit extends Component {
 		const { value, citation } = attributes;
 
 		const isSolidColorStyle = includes( className, SOLID_COLOR_CLASS );
-		const figureStyle = isSolidColorStyle ?
-			{ backgroundColor: mainColor.color } :
+
+		const figureStyles = isSolidColorStyle ?
+			{ backgroundColor: mainColor.class ? undefined : mainColor.color } :
 			{ borderColor: mainColor.color };
-		const blockquoteStyle = {
-			color: textColor.color,
+
+		const figureClasses = classnames( className, {
+			'has-background': isSolidColorStyle && mainColor.color,
+			[ mainColor.class ]: isSolidColorStyle && mainColor.class,
+		} );
+
+		const blockquoteStyles = {
+			color: textColor.class ? undefined : textColor.color,
 		};
-		const blockquoteClasses = textColor.color ? classnames( 'has-text-color', {
+
+		const blockquoteClasses = textColor.color && classnames( {
+			'has-text-color': textColor.color,
 			[ textColor.class ]: textColor.class,
-		} ) : undefined;
+		} );
+
 		return (
 			<Fragment>
-				<figure style={ figureStyle } className={ classnames(
-					className, {
-						[ mainColor.class ]: isSolidColorStyle && mainColor.class,
-					} ) }>
-					<blockquote style={ blockquoteStyle } className={ blockquoteClasses }>
+				<figure className={ figureClasses } style={ figureStyles }>
+					<blockquote className={ blockquoteClasses } style={ blockquoteStyles }>
 						<RichText
 							multiline
 							value={ value }

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -80,24 +80,38 @@ export const settings = {
 	edit,
 
 	save( { attributes } ) {
-		const { mainColor, customMainColor, textColor, customTextColor, value, citation, className } = attributes;
+		const {
+			mainColor,
+			customMainColor,
+			textColor,
+			customTextColor,
+			value,
+			citation,
+			className,
+		} = attributes;
+
 		const isSolidColorStyle = includes( className, SOLID_COLOR_CLASS );
 
-		let figureClass, figureStyles;
+		let figureClasses, figureStyles;
+
 		// Is solid color style
 		if ( isSolidColorStyle ) {
-			figureClass = getColorClassName( 'background-color', mainColor );
-			if ( ! figureClass ) {
-				figureStyles = {
-					backgroundColor: customMainColor,
-				};
-			}
+			const backgroundClass = getColorClassName( 'background-color', mainColor );
+
+			figureClasses = classnames( {
+				'has-background': ( backgroundClass || customMainColor ),
+				[ backgroundClass ]: backgroundClass,
+			} );
+
+			figureStyles = {
+				backgroundColor: backgroundClass ? undefined : customMainColor,
+			};
 		// Is normal style and a custom color is being used ( we can set a style directly with its value)
 		} else if ( customMainColor ) {
 			figureStyles = {
 				borderColor: customMainColor,
 			};
-		// Is normal style and a named color is being used, we need to retrieve the color value to set the style,
+		// If normal style and a named color are being used, we need to retrieve the color value to set the style,
 		// as there is no expectation that themes create classes that set border colors.
 		} else if ( mainColor ) {
 			const colors = get( select( 'core/editor' ).getEditorSettings(), [ 'colors' ], [] );
@@ -108,13 +122,15 @@ export const settings = {
 		}
 
 		const blockquoteTextColorClass = getColorClassName( 'color', textColor );
-		const blockquoteClasses = textColor || customTextColor ? classnames( 'has-text-color', {
+		const blockquoteClasses = ( textColor || customTextColor ) && classnames( 'has-text-color', {
 			[ blockquoteTextColorClass ]: blockquoteTextColorClass,
-		} ) : undefined;
-		const blockquoteStyle = blockquoteTextColorClass ? undefined : { color: customTextColor };
+		} );
+
+		const blockquoteStyles = blockquoteTextColorClass ? undefined : { color: customTextColor };
+
 		return (
-			<figure className={ figureClass } style={ figureStyles }>
-				<blockquote className={ blockquoteClasses } style={ blockquoteStyle } >
+			<figure className={ figureClasses } style={ figureStyles }>
+				<blockquote className={ blockquoteClasses } style={ blockquoteStyles } >
 					<RichText.Content value={ value } multiline />
 					{ ! RichText.isEmpty( citation ) && <RichText.Content tagName="cite" value={ citation } /> }
 				</blockquote>

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -143,6 +143,52 @@ export const settings = {
 			...blockAttributes,
 		},
 		save( { attributes } ) {
+			const { mainColor, customMainColor, textColor, customTextColor, value, citation, className } = attributes;
+			const isSolidColorStyle = includes( className, SOLID_COLOR_CLASS );
+
+			let figureClass, figureStyles;
+			// Is solid color style
+			if ( isSolidColorStyle ) {
+				figureClass = getColorClassName( 'background-color', mainColor );
+				if ( ! figureClass ) {
+					figureStyles = {
+						backgroundColor: customMainColor,
+					};
+				}
+			// Is normal style and a custom color is being used ( we can set a style directly with its value)
+			} else if ( customMainColor ) {
+				figureStyles = {
+					borderColor: customMainColor,
+				};
+			// Is normal style and a named color is being used, we need to retrieve the color value to set the style,
+			// as there is no expectation that themes create classes that set border colors.
+			} else if ( mainColor ) {
+				const colors = get( select( 'core/editor' ).getEditorSettings(), [ 'colors' ], [] );
+				const colorObject = getColorObjectByAttributeValues( colors, mainColor );
+				figureStyles = {
+					borderColor: colorObject.color,
+				};
+			}
+
+			const blockquoteTextColorClass = getColorClassName( 'color', textColor );
+			const blockquoteClasses = textColor || customTextColor ? classnames( 'has-text-color', {
+				[ blockquoteTextColorClass ]: blockquoteTextColorClass,
+			} ) : undefined;
+			const blockquoteStyle = blockquoteTextColorClass ? undefined : { color: customTextColor };
+			return (
+				<figure className={ figureClass } style={ figureStyles }>
+					<blockquote className={ blockquoteClasses } style={ blockquoteStyle } >
+						<RichText.Content value={ value } multiline />
+						{ ! RichText.isEmpty( citation ) && <RichText.Content tagName="cite" value={ citation } /> }
+					</blockquote>
+				</figure>
+			);
+		},
+	}, {
+		attributes: {
+			...blockAttributes,
+		},
+		save( { attributes } ) {
 			const { value, citation } = attributes;
 			return (
 				<blockquote>


### PR DESCRIPTION
Fixes #11172.

This adds `has-background` classes to the pullquote and Media & Text blocks which makes them more consistent with the paragraph block.

I also did some light refactoring to try to make the code easier to read (which did make it easier to write the PR) and made it so neither block has an inline `background-color` style if using a named color value.

There should be no visual changes in the editor or front-end.

I expect the tests on this are going to fail because I didn't update any snapshots; I plan to fix that up in the morning.