### PR TITLE
Try: Link galleries to media file by default

### DIFF
--- a/packages/block-library/src/gallery/index.js
+++ b/packages/block-library/src/gallery/index.js
@@ -61,7 +61,7 @@ const blockAttributes = {
 	},
 	linkTo: {
 		type: 'string',
-		default: 'none',
+		default: 'media',
 	},
 };
 


### PR DESCRIPTION
When you insert a gallery in Gutenberg, images are not linked anywhere. If you open the inspector, you can choose to link to the media files, or to attachment pages.

In other words, the default is to link to "none".

While Gutenberg galleries can be used in a more decorative way than previously (like showing just two images in a gallery, full-wide, side by side) and not need to be linked, every once in a while a quick gallery thrown together will cause many of the images to show up in thumbnail size. In those situations, it feels a bit off that those thumbnails do not link to larger versions. Even if clicking to see them is not a smooth lightbox-esque experience.

This PR simply changes that default, so that if you insert a gallery and don't customize the link property, thumnails link to their full-size counterparts. This is similar to galleries created in the classic editor, which also link to the media file by default.

There's one downside, though. Old galleries now show this warning:

<img width="572" alt="screenshot 2018-10-30 at 11 04 04" src="https://user-images.githubusercontent.com/1204802/47711559-cd448f80-dc35-11e8-99c3-541b506c3416.png">

Can we create a deprecation handler for this or other way to handle this more gracefully? This fact also suggests we should make a decision pre 5.0.