### PR TITLE
Editor: Optimize Inserter props generation and reconciliation

### DIFF
--- a/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -23,7 +23,7 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
     value="Write your story"
   />
   <WithSelect(WithDispatch(InserterWithShortcuts)) />
-  <WithSelect(WithDispatch(Inserter))
+  <WithSelect(IfCondition(Inserter))
     position="top right"
   />
 </div>
@@ -45,7 +45,7 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
     value="Write your story"
   />
   <WithSelect(WithDispatch(InserterWithShortcuts)) />
-  <WithSelect(WithDispatch(Inserter))
+  <WithSelect(IfCondition(Inserter))
     position="top right"
   />
 </div>
@@ -67,7 +67,7 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
     value=""
   />
   <WithSelect(WithDispatch(InserterWithShortcuts)) />
-  <WithSelect(WithDispatch(Inserter))
+  <WithSelect(IfCondition(Inserter))
     position="top right"
   />
 </div>

--- a/packages/editor/src/components/inserter/index.js
+++ b/packages/editor/src/components/inserter/index.js
@@ -3,10 +3,9 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Dropdown, IconButton } from '@wordpress/components';
-import { createBlock, isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import { Component } from '@wordpress/element';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
+import { compose, ifCondition } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -30,6 +29,8 @@ class Inserter extends Component {
 		super( ...arguments );
 
 		this.onToggle = this.onToggle.bind( this );
+		this.renderToggle = this.renderToggle.bind( this );
+		this.renderContent = this.renderContent.bind( this );
 	}
 
 	onToggle( isOpen ) {
@@ -41,20 +42,46 @@ class Inserter extends Component {
 		}
 	}
 
-	render() {
+	/**
+	 * Render callback to display Dropdown toggle element.
+	 *
+	 * @param {Function} options.onToggle Callback to invoke when toggle is
+	 *                                    pressed.
+	 * @param {boolean}  options.isOpen   Whether dropdown is currently open.
+	 *
+	 * @return {WPElement} Dropdown toggle element.
+	 */
+	renderToggle( { onToggle, isOpen } ) {
 		const {
-			items,
-			position,
-			title,
-			onInsertBlock,
-			rootClientId,
 			disabled,
 			renderToggle = defaultRenderToggle,
 		} = this.props;
 
-		if ( items.length === 0 ) {
-			return null;
-		}
+		return renderToggle( { onToggle, isOpen, disabled } );
+	}
+
+	/**
+	 * Render callback to display Dropdown content element.
+	 *
+	 * @param {Function} options.onClose Callback to invoke when dropdown is
+	 *                                   closed.
+	 *
+	 * @return {WPElement} Dropdown content element.
+	 */
+	renderContent( { onClose } ) {
+		const { rootClientId, index } = this.props;
+
+		return (
+			<InserterMenu
+				onSelect={ onClose }
+				rootClientId={ rootClientId }
+				index={ index }
+			/>
+		);
+	}
+
+	render() {
+		const { position, title } = this.props;
 
 		return (
 			<Dropdown
@@ -64,22 +91,8 @@ class Inserter extends Component {
 				onToggle={ this.onToggle }
 				expandOnMobile
 				headerTitle={ title }
-				renderToggle={ ( { onToggle, isOpen } ) => renderToggle( { onToggle, isOpen, disabled } ) }
-				renderContent={ ( { onClose } ) => {
-					const onSelect = ( item ) => {
-						onInsertBlock( item );
-
-						onClose();
-					};
-
-					return (
-						<InserterMenu
-							items={ items }
-							onSelect={ onSelect }
-							rootClientId={ rootClientId }
-						/>
-					);
-				} }
+				renderToggle={ this.renderToggle }
+				renderContent={ this.renderContent }
 			/>
 		);
 	}
@@ -90,7 +103,6 @@ export default compose( [
 		const {
 			getEditedPostAttribute,
 			getBlockInsertionPoint,
-			getSelectedBlock,
 			getInserterItems,
 		} = select( 'core/editor' );
 
@@ -106,21 +118,10 @@ export default compose( [
 
 		return {
 			title: getEditedPostAttribute( 'title' ),
-			selectedBlock: getSelectedBlock(),
-			items: getInserterItems( rootClientId ),
-			index,
+			hasItems: getInserterItems( rootClientId ).length > 0,
 			rootClientId,
+			index,
 		};
 	} ),
-	withDispatch( ( dispatch, ownProps ) => ( {
-		onInsertBlock: ( item ) => {
-			const { selectedBlock, index, rootClientId } = ownProps;
-			const { name, initialAttributes } = item;
-			const insertedBlock = createBlock( name, initialAttributes );
-			if ( selectedBlock && isUnmodifiedDefaultBlock( selectedBlock ) ) {
-				return dispatch( 'core/editor' ).replaceBlocks( selectedBlock.clientId, insertedBlock );
-			}
-			return dispatch( 'core/editor' ).insertBlock( insertedBlock, index, rootClientId );
-		},
-	} ) ),
+	ifCondition( ( { hasItems } ) => hasItems ),
 ] )( Inserter );


### PR DESCRIPTION
Related (potentially blocks): #11018

This pull request seeks to apply minor refactoring to the Inserter to optimize its rendering:

- Avoid passing `selectedBlock` to the root component, as its reference changes frequently (i.e. every keystroke in the selected paragraph) and is only needed for the opened menu.
   - Similarly, avoid passing `items` array to the root component, and pass only the simple boolean reference of `hasItems` for use in considering whether the inserter should be rendered at all (via `ifCondition`)
- Assign toggle and content renderers as a consistent bound reference on the root component class, avoiding reconciliation which would otherwise occur in the changing function references on each render.

Further optimization could be achieved in simplifying how `hasItems` is calculated, since `getInserterItems` is easily the most complex / convoluted selector we have in the `core/editor` store. This has not been done here, but I foresee one or more of:

- Splitting `getInserterItems` into more granular memoized selectors
- Creating a separate `hasInserterItems` selector which performs the more simple filtering (not mapping) operations
- Defer the internal "build" operations of `getInserterItems` to the inserter component itself, passing instead the minimal raw data necessary.

**Testing instructions:**

Verify there are no regressions in the behavior of the inserter, with notable variations:

- With and without a block selected
- Inserter in header and empty-paragraph-adjacent

Using React DevTools "Highlight Updates" option, verify that the Inserter does not re-render when typing within a paragraph.

![image](https://user-images.githubusercontent.com/1779930/47723231-784f4c00-dc2a-11e8-876b-324d42abed20.png)
