### PR TITLE
Fix: Pasting a tag that is part of a transform and not matched ignores the content.

### DIFF
--- a/test/integration/non-matched-tags-handling.spec.js
+++ b/test/integration/non-matched-tags-handling.spec.js
@@ -1,0 +1,37 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	pasteHandler,
+	unregisterBlockType,
+} from '@wordpress/blocks';
+import { registerCoreBlocks } from '@wordpress/block-library';
+
+describe( 'Handling of non matched tags in block transforms', () => {
+	beforeAll( () => {
+		// Load all hooks that modify blocks
+		require( '../../packages/editor/src/hooks' );
+		registerCoreBlocks();
+	} );
+	it( 'correctly pastes preformatted tag even if preformatted block is removed', () => {
+		unregisterBlockType( 'core/preformatted' );
+		const simplePreformattedResult = pasteHandler( {
+			HTML: '<pre>Pre</pre>',
+			mode: 'AUTO',
+		} );
+
+		expect( simplePreformattedResult ).toHaveLength( 1 );
+		expect( simplePreformattedResult[ 0 ].name ).toBe( 'core/paragraph' );
+		expect( simplePreformattedResult[ 0 ].attributes.content ).toBe( 'Pre' );
+
+		const codeResult = pasteHandler( {
+			HTML: '<pre><code>code</code></pre>',
+			mode: 'AUTO',
+		} );
+
+		expect( codeResult ).toHaveLength( 1 );
+		expect( codeResult[ 0 ].name ).toBe( 'core/code' );
+		expect( codeResult[ 0 ].attributes.content ).toBe( 'code' );
+		expect( console ).toHaveLogged();
+	} );
+} );


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/11057

On https://github.com/WordPress/gutenberg/issues/11057 @jrmd discovered that if we remove the preformatted block (wp.blocks.unregisterBlockType('core/preformatted')) when pasting some content inside the pre tag e.g `<pre>Pre</pre>`the content is simply ignored.

What happens is that we have other blocks that implement a transform for the PRE tag (the code block) but simple pre-content is not matched by the code block raw handler so in this case, we just returned nothing and ignored the content.

This PR changes the situation when a tag contains a transform that handles it but does not match its content we now create an HTML block to contain that content (filtered to make sure it is something the user can insert on the site).

## How has this been tested?
I removed the preformatted block `wp.blocks.unregisterBlockType('core/preformatted')`.
I pasted some HTML content inside a PRE tag e.g:`<pre>Pre</pre>` and checked it was added inside an HTML block.
