### PR TITLE
Request mocking helpers for e2e tests

### DIFF
--- a/test/e2e/specs/demo.test.js
+++ b/test/e2e/specs/demo.test.js
@@ -12,12 +12,12 @@ const MOCK_VIMEO_RESPONSE = {
 	version: '1.0',
 };
 
-const couldNotBePreviewed = ( obj ) => {
-	return 'Embed Handler' === obj.provider_name;
+const couldNotBePreviewed = ( embedObject ) => {
+	return 'Embed Handler' === embedObject.provider_name;
 };
 
-const stripIframeFromEmbed = ( obj ) => {
-	return { ...obj, html: obj.html.replace( /src=[^\s]+/, '' ) };
+const stripIframeFromEmbed = ( embedObject ) => {
+	return { ...embedObject, html: embedObject.html.replace( /src=[^\s]+/, '' ) };
 };
 
 describe( 'new editor state', () => {

--- a/test/e2e/specs/demo.test.js
+++ b/test/e2e/specs/demo.test.js
@@ -1,12 +1,7 @@
 /**
- * External dependencies
- */
-import fetch from 'node-fetch';
-
-/**
  * Internal dependencies
  */
-import { visitAdmin } from '../support/utils';
+import { visitAdmin, matchURL, setUpResponseMocking, mockOrTransform } from '../support/utils';
 
 const MOCK_VIMEO_RESPONSE = {
 	url: 'https://vimeo.com/22439234',
@@ -17,47 +12,22 @@ const MOCK_VIMEO_RESPONSE = {
 	version: '1.0',
 };
 
+const couldNotBePreviewed = ( obj ) => {
+	return 'Embed Handler' === obj.provider_name;
+};
+
+const stripIframeFromEmbed = ( obj ) => {
+	return { ...obj, html: obj.html.replace( /src=[^\s]+/, '' ) };
+};
+
 describe( 'new editor state', () => {
 	beforeAll( async () => {
-		// Intercept embed requests so that scripts loaded from third parties
-		// cannot leave errors in the console and cause the test to fail.
-		await page.setRequestInterception( true );
-		page.on( 'request', async ( request ) => {
-			if ( request.url().indexOf( 'oembed%2F1.0%2Fproxy' ) !== -1 ) {
-				// Because we can't get the responses to requests and modify them on the fly,
-				// we have to make our own request, get the response, modify it, then use the
-				// modified values to respond to the request.
-				const response = await fetch(
-					request.url(),
-					{
-						headers: request.headers(),
-						method: request.method(),
-						body: request.postData(),
-					}
-				);
-				const preview = await response.json();
-				let responseBody;
-				if ( 'Embed Handler' === preview.provider_name ) {
-					// If Vimeo is down, that would make this test fail. So if we get a
-					// response from 'Embed Handler' instead of 'Vimeo', respond with a mock
-					// response, so we don't hold up development while Vimeo is down.
-					responseBody = MOCK_VIMEO_RESPONSE;
-				} else {
-					// Remove the first src attribute. This stops the Vimeo iframe loading the actual
-					// embedded content, but the height and width are preserved so layout related
-					// attributes, like aspect ratio CSS classes, remain the same.
-					preview.html = preview.html.replace( /src=[^\s]+/, '' );
-					responseBody = preview;
-				}
-				request.respond( {
-					content: 'application/json',
-					body: JSON.stringify( responseBody ),
-				} );
-			} else {
-				request.continue();
-			}
-		} );
-
+		setUpResponseMocking( [
+			{
+				match: matchURL( 'oembed%2F1.0%2Fproxy' ),
+				onRequestMatch: mockOrTransform( couldNotBePreviewed, MOCK_VIMEO_RESPONSE, stripIframeFromEmbed ),
+			},
+		] );
 		await visitAdmin( 'post-new.php', 'gutenberg-demo' );
 	} );
 

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -14,6 +14,7 @@ const {
 	WP_USERNAME = 'admin',
 	WP_PASSWORD = 'password',
 } = process.env;
+import fetch from 'node-fetch';
 
 /**
  * Platform-specific meta key.
@@ -473,5 +474,129 @@ export function observeFocusLoss() {
 				}
 			} );
 		} );
+	} );
+}
+
+/**
+ * Creates a function to determine if a request is embedding a certain URL.
+ *
+ * @param {string} url The URL to check against a request.
+ * @return {function} Function that determines if a request is for the embed API, embedding a specific URL.
+ */
+export function isEmbedding( url ) {
+	return ( request ) => matchURL( 'oembed%2F1.0%2Fproxy' )( request ) && parameterEquals( 'url', url )( request );
+}
+
+/**
+ * Respond to a request with a JSON response.
+ *
+ * @param {string} mockResponse The mock object to wrap in a JSON response.
+ * @return {Promise} Promise that responds to a request with the mock JSON response.
+ */
+export function JSONResponse( mockResponse ) {
+	return async ( request ) => request.respond( getJSONResponse( mockResponse ) );
+}
+
+/**
+ * Creates a function to determine if a request is calling a URL with the substring present.
+ *
+ * @param {string} substring The substring to check for.
+ * @return {function} Function that determines if a request's URL contains substring.
+ */
+export function matchURL( substring ) {
+	return ( request ) => -1 !== request.url().indexOf( substring );
+}
+
+/**
+ * Creates a function to determine if a request has a parameter with a certain value.
+ *
+ * @param {string} parameterName The query parameter to check.
+ * @param {string} value The value to check for.
+ * @return {function} Function that determines if a request's query parameter is the specified value.
+ */
+export function parameterEquals( parameterName, value ) {
+	return ( request ) => {
+		const url = request.url();
+		return value === decodeURIComponent( new RegExp( '.*' + parameterName + '=([^&]+).*' ).exec( url )[ 1 ] );
+	};
+}
+
+/**
+ * Get a JSON response for the passed in object, for use with `request.respond`.
+ *
+ * @param {Object} obj Object to seralise for response.
+ * @return {Object} Response for use with `request.respond`.
+ */
+export function getJSONResponse( obj ) {
+	return {
+		content: 'application/json',
+		body: JSON.stringify( obj ),
+	};
+}
+
+/**
+ * Mocks a request with the supplied mock object, or allows it to run with an optional transform, based on the
+ * deserialised JSON response for the request.
+ *
+ * @param {function} mockCheck function that returns true if the request should be mocked.
+ * @param {Object} mock A mock object to wrap in a JSON response, if the request should be mocked.
+ * @param {function|undefined} responseObjectTransform An optional function that transforms the response's object before the response is used.
+ * @return {Promise} Promise that uses `mockCheck` to see if a request should be mocked with `mock`, and optionally transforms the response with `responseObjectTransform`.
+ */
+export function mockOrTransform( mockCheck, mock, responseObjectTransform = ( obj ) => obj ) {
+	return async ( request ) => {
+		// Because we can't get the responses to requests and modify them on the fly,
+		// we have to make our own request and get the response, then apply the
+		// optional transform to the json encoded object.
+		const response = await fetch(
+			request.url(),
+			{
+				headers: request.headers(),
+				method: request.method(),
+				body: request.postData(),
+			}
+		);
+		const obj = await response.json();
+		if ( mockCheck( obj ) ) {
+			request.respond( getJSONResponse( mock ) );
+		} else {
+			request.respond( getJSONResponse( responseObjectTransform( obj ) ) );
+		}
+	};
+}
+
+/**
+ * Sets up mock checks and responses. Accepts a list of mock settings with the following properties:
+ *   - match: function to check if a request should be mocked.
+ *   - onRequestMatch: async function to respond to the request.
+ *
+ * Example:
+ *   const MOCK_RESPONSES = [
+ *     {
+ *       match: isEmbedding( 'https://wordpress.org/gutenberg/handbook/' ),
+ *       onRequestMatch: JSONResponse( MOCK_BAD_WORDPRESS_RESPONSE ),
+ *     },
+ *     {
+ *       match: isEmbedding( 'https://wordpress.org/gutenberg/handbook/block-api/attributes/' ),
+ *       onRequestMatch: JSONResponse( MOCK_EMBED_WORDPRESS_SUCCESS_RESPONSE ),
+ *     }
+ *  ];
+ *  setUpResponseMocking( MOCK_RESPONSES );
+ *
+ * If none of the mock settings match the request, the request is allowed to continue.
+ *
+ * @param {Array} mocks Array of mock settings.
+ */
+export async function setUpResponseMocking( mocks ) {
+	await page.setRequestInterception( true );
+	page.on( 'request', async ( request ) => {
+		for ( let i = 0; i < mocks.length; i++ ) {
+			const mock = mocks[ i ];
+			if ( mock.match( request ) ) {
+				await mock.onRequestMatch( request );
+				return;
+			}
+		}
+		request.continue();
 	} );
 }

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -517,7 +517,11 @@ export function matchURL( substring ) {
 export function parameterEquals( parameterName, value ) {
 	return ( request ) => {
 		const url = request.url();
-		return value === decodeURIComponent( new RegExp( '.*' + parameterName + '=([^&]+).*' ).exec( url )[ 1 ] );
+		const match = new RegExp( `.*${ parameterName }=([^&]+).*` ).exec( url );
+		if ( ! match ) {
+			return false;
+		}
+		return value === decodeURIComponent( match[ 1 ] );
 	};
 }
 
@@ -556,11 +560,11 @@ export function mockOrTransform( mockCheck, mock, responseObjectTransform = ( ob
 				body: request.postData(),
 			}
 		);
-		const obj = await response.json();
-		if ( mockCheck( obj ) ) {
+		const responseObject = await response.json();
+		if ( mockCheck( responseObject ) ) {
 			request.respond( getJSONResponse( mock ) );
 		} else {
-			request.respond( getJSONResponse( responseObjectTransform( obj ) ) );
+			request.respond( getJSONResponse( responseObjectTransform( responseObject ) ) );
 		}
 	};
 }


### PR DESCRIPTION
## Description

Adds new helper functions for mocking requests in e2e tests.

The aim is to simplify mocking for people writing e2e tests, while keeping
the flexibility needed to deal with the demo page.

I find the embedding test in particular is much easier to read and extend with
these changes.

## How has this been tested?

e2e tests still pass.

## Types of changes
Refactor

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
