### PR TITLE
Components: Remove redundant onClickOutside handler from Dropdown

### DIFF
--- a/packages/components/src/dropdown/index.js
+++ b/packages/components/src/dropdown/index.js
@@ -11,12 +11,13 @@ import Popover from '../popover';
 class Dropdown extends Component {
 	constructor() {
 		super( ...arguments );
+
 		this.toggle = this.toggle.bind( this );
 		this.close = this.close.bind( this );
-		this.clickOutside = this.clickOutside.bind( this );
-		this.bindContainer = this.bindContainer.bind( this );
 		this.refresh = this.refresh.bind( this );
+
 		this.popoverRef = createRef();
+
 		this.state = {
 			isOpen: false,
 		};
@@ -38,10 +39,6 @@ class Dropdown extends Component {
 		}
 	}
 
-	bindContainer( ref ) {
-		this.container = ref;
-	}
-
 	/**
 	 * When contents change height due to user interaction,
 	 * `refresh` can be called to re-render Popover with correct
@@ -57,12 +54,6 @@ class Dropdown extends Component {
 		this.setState( ( state ) => ( {
 			isOpen: ! state.isOpen,
 		} ) );
-	}
-
-	clickOutside( event ) {
-		if ( ! this.container.contains( event.target ) ) {
-			this.close();
-		}
 	}
 
 	close() {
@@ -84,7 +75,7 @@ class Dropdown extends Component {
 		const args = { isOpen, onToggle: this.toggle, onClose: this.close };
 
 		return (
-			<div className={ className } ref={ this.bindContainer }>
+			<div className={ className }>
 				{ renderToggle( args ) }
 				{ isOpen && (
 					<Popover
@@ -92,7 +83,6 @@ class Dropdown extends Component {
 						ref={ this.popoverRef }
 						position={ position }
 						onClose={ this.close }
-						onClickOutside={ this.clickOutside }
 						expandOnMobile={ expandOnMobile }
 						headerTitle={ headerTitle }
 					>


### PR DESCRIPTION
Related: #2888

This pull request seeks to simplify the Dropdown component, removing redundant handling of "click outside" behavior which is otherwise already encapsulated in the rendered Popover's `onClose` handling, also handled by Dropdown to perform the `close` action.

https://github.com/WordPress/gutenberg/blob/393f5baa1cb640ea142c70458fdd22b8d8d2334e/packages/components/src/popover/index.js#L224
https://github.com/WordPress/gutenberg/blob/master/packages/components/src/popover/detect-outside.js

**Testing instructions:**

Verify there are no regressions in the behavior of Dropdown (e.g. Inserter), notably click-outside behavior.