### PR TITLE
Use source_url for media file link URL in image block

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -168,7 +168,7 @@ class ImageEdit extends Component {
 		if ( value === LINK_DESTINATION_NONE ) {
 			href = undefined;
 		} else if ( value === LINK_DESTINATION_MEDIA ) {
-			href = this.props.attributes.url;
+			href = this.props.image.source_url;
 		} else if ( value === LINK_DESTINATION_ATTACHMENT ) {
 			href = this.props.image && this.props.image.link;
 		} else {

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -168,7 +168,7 @@ class ImageEdit extends Component {
 		if ( value === LINK_DESTINATION_NONE ) {
 			href = undefined;
 		} else if ( value === LINK_DESTINATION_MEDIA ) {
-			href = this.props.image.source_url;
+			href = ( this.props.image && this.props.image.source_url ) || this.props.attributes.url;
 		} else if ( value === LINK_DESTINATION_ATTACHMENT ) {
 			href = this.props.image && this.props.image.link;
 		} else {


### PR DESCRIPTION
## Description
When inserting an image with the image block, you can set its link to "Media file". In the Classic Editor, this has traditionally been the original full-size image. In Gutenberg currently, this ends up just pointing to the file for the size of the image that is inserted into the post. 

For example, if you insert the thumbnail size and select Media file for the link, it will just link to the thumbnail. That's not particularly helpful, since it's already loaded in the post body.

This PR just switches the link to use the original source_url for the image instead of the URL for the same size that is inserted into the post. 

Fixes: #11046

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
