### PR TITLE
Data: Use turbo-combine-reducers in place of Redux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2189,7 +2189,8 @@
 				"equivalent-key-map": "^0.2.2",
 				"is-promise": "^2.1.0",
 				"lodash": "^4.17.10",
-				"redux": "^4.0.0"
+				"redux": "^4.0.0",
+				"turbo-combine-reducers": "^1.0.2"
 			}
 		},
 		"@wordpress/date": {
@@ -19932,6 +19933,11 @@
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
+		},
+		"turbo-combine-reducers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/turbo-combine-reducers/-/turbo-combine-reducers-1.0.2.tgz",
+			"integrity": "sha512-gHbdMZlA6Ym6Ur5pSH/UWrNQMIM9IqTH6SoL1DbHpqEdQ8i+cFunSmSlFykPt0eGQwZ4d/XTHOl74H0/kFBVWw=="
 		},
 		"tweetnacl": {
 			"version": "0.14.5",

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.1 (Unreleased)
+
+### Internal
+
+- Replace Redux implementation of `combineReducers` with in-place-compatible `turbo-combine-reducers`.
+
 ## 3.0.0 (2018-10-29)
 
 ### Breaking Changes
@@ -10,7 +16,7 @@
 
 ## 2.1.0 (2018-09-30)
 
-## New Features
+### New Features
 
 - Adding support for using controls in resolvers using the controls plugin.
 
@@ -22,7 +28,7 @@
 
 - Writing resolvers as async generators has been deprecated. Use the controls plugin instead.
 
-## Bug Fixes
+### Bug Fixes
 
 - Fix the promise middleware in Firefox.
 

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -29,7 +29,8 @@
 		"equivalent-key-map": "^0.2.2",
 		"is-promise": "^2.1.0",
 		"lodash": "^4.17.10",
-		"redux": "^4.0.0"
+		"redux": "^4.0.0",
+		"turbo-combine-reducers": "^1.0.2"
 	},
 	"devDependencies": {
 		"deep-freeze": "^0.0.1",

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
+import combineReducers from 'turbo-combine-reducers';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
Extracted from: #10844

This pull request seeks to swap the implementation of `combineReducers` from Redux to a performance-optimized drop-in variant [turbo-combine-reducers](https://github.com/aduth/turbo-combine-reducers), a side-project maintained by myself. Benchmarks demonstrate improvement in the range of 92x over Redux on the high-end (Firefox, Chrome) and 10x on the low-end (Safari). [Try benchmark yourself](https://jsbin.com/beyocup/edit?html,js,console,output).

**Implementation notes:**

Since this export is already abstracted under `@wordpress/data`, there should be zero impact of the drop-in replacement on implementers. The only difference is the lack of "friendly" validations otherwise offered through Redux's implementations (the undesirable nature of the validations is what led to its development for #10844).

**Testing instructions:**

There should be no notable impact on behaviors.

Ensure tests pass:

```
npm test
```