### PR TITLE
Fix: "View as" link is not updated after the post is updated and the permalink is changed

### DIFF
--- a/packages/edit-post/src/store/effects.js
+++ b/packages/edit-post/src/store/effects.js
@@ -27,6 +27,8 @@ import {
 import { getMetaBoxContainer } from '../utils/meta-boxes';
 import { onChangeListener } from './utils';
 
+const VIEW_AS_LINK_SELECTOR = '#wp-admin-bar-view a';
+
 const effects = {
 	SET_META_BOXES_PER_LOCATIONS( action, store ) {
 		// Allow toggling metaboxes panels
@@ -154,6 +156,26 @@ const effects = {
 		// Collapse sidebar when viewport shrinks.
 		// Reopen sidebar it if viewport expands and it was closed because of a previous shrink.
 		subscribe( onChangeListener( isMobileViewPort, adjustSidebar ) );
+
+		// Update View as link when currentPost link changes
+		const updateViewAsLink = ( newPermalink ) => {
+			if ( ! newPermalink ) {
+				return;
+			}
+
+			const nodeToUpdate = document.querySelector(
+				VIEW_AS_LINK_SELECTOR
+			);
+			if ( ! nodeToUpdate ) {
+				return;
+			}
+			nodeToUpdate.setAttribute( 'href', newPermalink );
+		};
+
+		subscribe( onChangeListener(
+			() => select( 'core/editor' ).getCurrentPost().link,
+			updateViewAsLink
+		) );
 	},
 
 };


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/7275

The editor contains a "View as" pointing to the post permalink on the top bar.
This link comes from the page rendered on the server. When the post is updated with a permalink change the page is not rendered again so the "View as" link continued to be the same.
This PR adds an effect to update the dom of the "View as" link to contain the new permalink when the post is saved with success and the permalink was changed.


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Create a new post, and publish it.
Reload the editor and verify we have a "View as" link in the top bar.
Change the post permalink and press update, verify that when the post is saved with success the View as link points to the new permalink.
