### PR TITLE
Editor: Factor initial edits to own state

### DIFF
--- a/docs/data/data-core-editor.md
+++ b/docs/data/data-core-editor.md
@@ -1391,6 +1391,7 @@ the specified post object and editor settings.
 *Parameters*
 
  * post: Post object.
+ * edits: Initial edited attributes object.
 
 ### resetPost
 
@@ -1427,7 +1428,6 @@ Returns an action object used to setup the editor state when first opening an ed
 
  * post: Post object.
  * blocks: Array of blocks.
- * edits: Initial edited attributes object.
 
 ### resetBlocks
 
@@ -1573,6 +1573,15 @@ Returns an action object resetting the template validity.
 ### synchronizeTemplate
 
 Returns an action object synchronize the template with the list of blocks
+
+### editPost
+
+Returns an action object used in signalling that attributes of the post have
+been edited.
+
+*Parameters*
+
+ * edits: Post attributes to edit.
 
 ### savePost
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1467,26 +1467,16 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		$demo_content = ob_get_clean();
 
 		$initial_edits = array(
-			'title'   => array(
-				'raw' => __( 'Welcome to the Gutenberg Editor', 'gutenberg' ),
-			),
-			'content' => array(
-				'raw' => $demo_content,
-			),
+			'title'   => __( 'Welcome to the Gutenberg Editor', 'gutenberg' ),
+			'content' => $demo_content,
 		);
 	} elseif ( $is_new_post ) {
 		// Override "(Auto Draft)" new post default title with empty string,
 		// or filtered value.
 		$initial_edits = array(
-			'title'   => array(
-				'raw' => $post->post_title,
-			),
-			'content' => array(
-				'raw' => $post->post_content,
-			),
-			'excerpt' => array(
-				'raw' => $post->post_excerpt,
-			),
+			'title'   => $post->post_title,
+			'content' => $post->post_content,
+			'excerpt' => $post->post_excerpt,
 		);
 	} else {
 		$initial_edits = null;

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -14,7 +14,7 @@ function Editor( {
 	hasFixedToolbar,
 	focusMode,
 	post,
-	overridePost,
+	initialEdits,
 	onError,
 	...props
 } ) {
@@ -32,7 +32,8 @@ function Editor( {
 		<StrictMode>
 			<EditorProvider
 				settings={ editorSettings }
-				post={ { ...post, ...overridePost } }
+				post={ post }
+				initialEdits={ initialEdits }
 				{ ...props }
 			>
 				<ErrorBoundary onError={ onError }>

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -22,18 +22,27 @@ import Editor from './editor';
  * an unhandled error occurs, replacing previously mounted editor element using
  * an initial state from prior to the crash.
  *
- * @param {Object}  postType       Post type of the post to edit.
- * @param {Object}  postId         ID of the post to edit.
- * @param {Element} target         DOM node in which editor is rendered.
- * @param {?Object} settings       Editor settings object.
- * @param {Object}  overridePost   Post properties to override.
+ * @param {Object}  postType     Post type of the post to edit.
+ * @param {Object}  postId       ID of the post to edit.
+ * @param {Element} target       DOM node in which editor is rendered.
+ * @param {?Object} settings     Editor settings object.
+ * @param {Object}  initialEdits Programmatic edits to apply initially, to be
+ *                               considered as non-user-initiated (bypass for
+ *                               unsaved changes prompt).
  */
-export function reinitializeEditor( postType, postId, target, settings, overridePost ) {
+export function reinitializeEditor( postType, postId, target, settings, initialEdits ) {
 	unmountComponentAtNode( target );
-	const reboot = reinitializeEditor.bind( null, postType, postId, target, settings, overridePost );
+	const reboot = reinitializeEditor.bind( null, postType, postId, target, settings, initialEdits );
 
 	render(
-		<Editor settings={ settings } onError={ reboot } postId={ postId } postType={ postType } overridePost={ overridePost } recovery />,
+		<Editor
+			settings={ settings }
+			onError={ reboot }
+			postId={ postId }
+			postType={ postType }
+			initialEdits={ initialEdits }
+			recovery
+		/>,
 		target
 	);
 }
@@ -44,15 +53,17 @@ export function reinitializeEditor( postType, postId, target, settings, override
  * The return value of this function is not necessary if we change where we
  * call initializeEditor(). This is due to metaBox timing.
  *
- * @param {string}  id            Unique identifier for editor instance.
- * @param {Object}  postType      Post type of the post to edit.
- * @param {Object}  postId        ID of the post to edit.
- * @param {?Object} settings      Editor settings object.
- * @param {Object}  overridePost  Post properties to override.
+ * @param {string}  id           Unique identifier for editor instance.
+ * @param {Object}  postType     Post type of the post to edit.
+ * @param {Object}  postId       ID of the post to edit.
+ * @param {?Object} settings     Editor settings object.
+ * @param {Object}  initialEdits Programmatic edits to apply initially, to be
+ *                               considered as non-user-initiated (bypass for
+ *                               unsaved changes prompt).
  */
-export function initializeEditor( id, postType, postId, settings, overridePost ) {
+export function initializeEditor( id, postType, postId, settings, initialEdits ) {
 	const target = document.getElementById( id );
-	const reboot = reinitializeEditor.bind( null, postType, postId, target, settings, overridePost );
+	const reboot = reinitializeEditor.bind( null, postType, postId, target, settings, initialEdits );
 
 	registerCoreBlocks();
 
@@ -64,7 +75,13 @@ export function initializeEditor( id, postType, postId, settings, overridePost )
 	] );
 
 	render(
-		<Editor settings={ settings } onError={ reboot } postId={ postId } postType={ postType } overridePost={ overridePost } />,
+		<Editor
+			settings={ settings }
+			onError={ reboot }
+			postId={ postId }
+			postType={ postType }
+			initialEdits={ initialEdits }
+		/>,
 		target
 	);
 }

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -28,7 +28,7 @@ class EditorProvider extends Component {
 
 		props.updateEditorSettings( props.settings );
 		props.updatePostLock( props.settings.postLock );
-		props.setupEditor( props.post );
+		props.setupEditor( props.post, props.initialEdits );
 
 		if ( props.settings.autosave ) {
 			props.createWarningNotice(

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -17,14 +17,16 @@ import { dispatch } from '@wordpress/data';
  * Returns an action object used in signalling that editor has initialized with
  * the specified post object and editor settings.
  *
- * @param {Object} post Post object.
+ * @param {Object} post  Post object.
+ * @param {Object} edits Initial edited attributes object.
  *
  * @return {Object} Action object.
  */
-export function setupEditor( post ) {
+export function setupEditor( post, edits ) {
 	return {
 		type: 'SETUP_EDITOR',
 		post,
+		edits,
 	};
 }
 
@@ -76,18 +78,16 @@ export function updatePost( edits ) {
 /**
  * Returns an action object used to setup the editor state when first opening an editor.
  *
- * @param {Object}  post            Post object.
- * @param {Array}   blocks          Array of blocks.
- * @param {Object}  edits           Initial edited attributes object.
+ * @param {Object} post   Post object.
+ * @param {Array}  blocks Array of blocks.
  *
  * @return {Object} Action object.
  */
-export function setupEditorState( post, blocks, edits ) {
+export function setupEditorState( post, blocks ) {
 	return {
 		type: 'SETUP_EDITOR_STATE',
 		post,
 		blocks,
-		edits,
 	};
 }
 
@@ -381,6 +381,14 @@ export function synchronizeTemplate() {
 	};
 }
 
+/**
+ * Returns an action object used in signalling that attributes of the post have
+ * been edited.
+ *
+ * @param {Object} edits Post attributes to edit.
+ *
+ * @return {Object} Action object.
+ */
 export function editPost( edits ) {
 	return {
 		type: 'EDIT_POST',

--- a/packages/editor/src/store/defaults.js
+++ b/packages/editor/src/store/defaults.js
@@ -127,3 +127,10 @@ export const EDITOR_SETTINGS_DEFAULTS = {
 	// List of allowed mime types and file extensions.
 	allowedMimeTypes: null,
 };
+
+/**
+ * Default initial edits state.
+ *
+ * @type {Object}
+ */
+export const INITIAL_EDITS_DEFAULTS = {};

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -28,7 +28,11 @@ import { combineReducers } from '@wordpress/data';
  */
 import withHistory from '../utils/with-history';
 import withChangeDetection from '../utils/with-change-detection';
-import { PREFERENCES_DEFAULTS, EDITOR_SETTINGS_DEFAULTS } from './defaults';
+import {
+	PREFERENCES_DEFAULTS,
+	EDITOR_SETTINGS_DEFAULTS,
+	INITIAL_EDITS_DEFAULTS,
+} from './defaults';
 import { insertAt, moveTo } from './array';
 
 /**
@@ -95,6 +99,23 @@ function getFlattenedBlocks( blocks ) {
 	}
 
 	return flattenedBlocks;
+}
+
+/**
+ * Returns an object against which it is safe to perform mutating operations,
+ * given the original object and its current working copy.
+ *
+ * @param {Object} original Original object.
+ * @param {Object} working  Working object.
+ *
+ * @return {Object} Mutation-safe object.
+ */
+function getMutateSafeObject( original, working ) {
+	if ( original === working ) {
+		return { ...original };
+	}
+
+	return working;
 }
 
 /**
@@ -226,16 +247,10 @@ export const editor = flow( [
 	edits( state = {}, action ) {
 		switch ( action.type ) {
 			case 'EDIT_POST':
-			case 'SETUP_EDITOR_STATE':
 				return reduce( action.edits, ( result, value, key ) => {
 					// Only assign into result if not already same value
 					if ( value !== state[ key ] ) {
-						// Avoid mutating original state by creating shallow
-						// clone. Should only occur once per reduce.
-						if ( result === state ) {
-							result = { ...state };
-						}
-
+						result = getMutateSafeObject( state, result );
 						result[ key ] = value;
 					}
 
@@ -263,10 +278,7 @@ export const editor = flow( [
 						return result;
 					}
 
-					if ( state === result ) {
-						result = { ...state };
-					}
-
+					result = getMutateSafeObject( state, result );
 					delete result[ key ];
 					return result;
 				}, state );
@@ -297,11 +309,7 @@ export const editor = flow( [
 					// Consider as updates only changed values
 					const nextAttributes = reduce( action.attributes, ( result, value, key ) => {
 						if ( value !== result[ key ] ) {
-							// Avoid mutating original block by creating shallow clone
-							if ( result === state[ action.clientId ].attributes ) {
-								result = { ...result };
-							}
-
+							result = getMutateSafeObject( state[ action.clientId ].attributes, result );
 							result[ key ] = value;
 						}
 
@@ -514,6 +522,51 @@ export const editor = flow( [
 		},
 	} ),
 } );
+
+/**
+ * Reducer returning the initial edits state. With matching shape to that of
+ * `editor.edits`, the initial edits are those applied programmatically, are
+ * not considered in prmopting the user for unsaved changes, and are included
+ * in (and reset by) the next save payload.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Action object.
+ *
+ * @return {Object} Next state.
+ */
+export function initialEdits( state = INITIAL_EDITS_DEFAULTS, action ) {
+	switch ( action.type ) {
+		case 'SETUP_EDITOR':
+			if ( ! action.edits ) {
+				break;
+			}
+
+			return action.edits;
+
+		case 'SETUP_EDITOR_STATE':
+			if ( 'content' in state ) {
+				return omit( state, 'content' );
+			}
+
+			return state;
+
+		case 'UPDATE_POST':
+			return reduce( action.edits, ( result, value, key ) => {
+				if ( ! result.hasOwnProperty( key ) ) {
+					return result;
+				}
+
+				result = getMutateSafeObject( state, result );
+				delete result[ key ];
+				return result;
+			}, state );
+
+		case 'RESET_POST':
+			return INITIAL_EDITS_DEFAULTS;
+	}
+
+	return state;
+}
 
 /**
  * Reducer returning the last-known state of the current post, in the format
@@ -924,10 +977,7 @@ export const reusableBlocks = combineReducers( {
 					const value = { clientId, title };
 
 					if ( ! isEqual( nextState[ id ], value ) ) {
-						if ( nextState === state ) {
-							nextState = { ...nextState };
-						}
-
+						nextState = getMutateSafeObject( state, nextState );
 						nextState[ id ] = value;
 					}
 
@@ -1096,6 +1146,7 @@ export function autosave( state = null, action ) {
 
 export default optimist( combineReducers( {
 	editor,
+	initialEdits,
 	currentPost,
 	isTyping,
 	isCaretWithinFormattedText,

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -193,9 +193,18 @@ export function getCurrentPostLastRevisionId( state ) {
  *
  * @return {Object} Object of key value pairs comprising unsaved edits.
  */
-export function getPostEdits( state ) {
-	return state.editor.present.edits;
-}
+export const getPostEdits = createSelector(
+	( state ) => {
+		return {
+			...state.initialEdits,
+			...state.editor.present.edits,
+		};
+	},
+	( state ) => [
+		state.editor.present.edits,
+		state.initialEdits,
+	]
+);
 
 /**
  * Returns a new reference when edited values have changed. This is useful in
@@ -597,6 +606,7 @@ export const getBlock = createSelector(
 		state.editor.present.blocks.byClientId[ clientId ],
 		getBlockDependantsCacheBust( state, clientId ),
 		state.editor.present.edits.meta,
+		state.initialEdits.meta,
 		state.currentPost.meta,
 	]
 );
@@ -704,6 +714,7 @@ export const getBlocksByClientId = createSelector(
 	),
 	( state ) => [
 		state.editor.present.edits.meta,
+		state.initialEdits.meta,
 		state.currentPost.meta,
 		state.editor.present.blocks,
 	]
@@ -1022,6 +1033,7 @@ export const getMultiSelectedBlocks = createSelector(
 		state.blockSelection.end,
 		state.editor.present.blocks.byClientId,
 		state.editor.present.edits.meta,
+		state.initialEdits.meta,
 		state.currentPost.meta,
 	]
 );
@@ -1538,8 +1550,9 @@ export const getEditedPostContent = createSelector(
 		return content;
 	},
 	( state ) => [
-		state.editor.present.edits.content,
 		state.editor.present.blocks,
+		state.editor.present.edits.content,
+		state.initialEdits.content,
 	],
 );
 

--- a/packages/editor/src/store/test/reducer.js
+++ b/packages/editor/src/store/test/reducer.js
@@ -23,6 +23,7 @@ import {
 	shouldOverwriteState,
 	getPostRawValue,
 	editor,
+	initialEdits,
 	currentPost,
 	isTyping,
 	isCaretWithinFormattedText,
@@ -37,6 +38,7 @@ import {
 	autosave,
 	postSavingLock,
 } from '../reducer';
+import { INITIAL_EDITS_DEFAULTS } from '../defaults';
 
 describe( 'state', () => {
 	describe( 'hasSameKeys()', () => {
@@ -1038,22 +1040,6 @@ describe( 'state', () => {
 				} );
 			} );
 
-			it( 'should save initial post state', () => {
-				const state = editor( undefined, {
-					type: 'SETUP_EDITOR_STATE',
-					edits: {
-						status: 'draft',
-						title: 'post title',
-					},
-					blocks: [],
-				} );
-
-				expect( state.present.edits ).toEqual( {
-					status: 'draft',
-					title: 'post title',
-				} );
-			} );
-
 			it( 'should omit content when resetting', () => {
 				// Use case: When editing in Text mode, we defer to content on
 				// the property, but we reset blocks by parse when switching
@@ -1240,6 +1226,88 @@ describe( 'state', () => {
 
 				expect( state.past ).toHaveLength( 3 );
 			} );
+		} );
+	} );
+
+	describe( 'initialEdits', () => {
+		it( 'should default to initial edits', () => {
+			const state = initialEdits( undefined, {} );
+
+			expect( state ).toBe( INITIAL_EDITS_DEFAULTS );
+		} );
+
+		it( 'should return initial edits on post reset', () => {
+			const state = initialEdits( undefined, {
+				type: 'RESET_POST',
+			} );
+
+			expect( state ).toBe( INITIAL_EDITS_DEFAULTS );
+		} );
+
+		it( 'should return referentially equal state if setup includes no edits', () => {
+			const original = initialEdits( undefined, {} );
+			const state = initialEdits( deepFreeze( original ), {
+				type: 'SETUP_EDITOR',
+			} );
+
+			expect( state ).toBe( original );
+		} );
+
+		it( 'should return referentially equal state if reset while having made no edits', () => {
+			const original = initialEdits( undefined, {} );
+			const state = initialEdits( deepFreeze( original ), {
+				type: 'RESET_POST',
+			} );
+
+			expect( state ).toBe( original );
+		} );
+
+		it( 'should return setup edits', () => {
+			const original = initialEdits( undefined, {} );
+			const state = initialEdits( deepFreeze( original ), {
+				type: 'SETUP_EDITOR',
+				edits: {
+					title: '',
+					content: '',
+				},
+			} );
+
+			expect( state ).toEqual( {
+				title: '',
+				content: '',
+			} );
+		} );
+
+		it( 'should unset content on editor setup', () => {
+			const original = initialEdits( undefined, {
+				type: 'SETUP_EDITOR',
+				edits: {
+					title: '',
+					content: '',
+				},
+			} );
+			const state = initialEdits( deepFreeze( original ), {
+				type: 'SETUP_EDITOR_STATE',
+			} );
+
+			expect( state ).toEqual( { title: '' } );
+		} );
+
+		it( 'should unset values on post update', () => {
+			const original = initialEdits( undefined, {
+				type: 'SETUP_EDITOR',
+				edits: {
+					title: '',
+				},
+			} );
+			const state = initialEdits( deepFreeze( original ), {
+				type: 'UPDATE_POST',
+				edits: {
+					title: '',
+				},
+			} );
+
+			expect( state ).toEqual( {} );
 		} );
 	} );
 

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -246,6 +246,7 @@ describe( 'selectors', () => {
 						},
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect( isEditedPostNew( state ) ).toBe( true );
@@ -263,6 +264,7 @@ describe( 'selectors', () => {
 						},
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect( isEditedPostNew( state ) ).toBe( false );
@@ -434,6 +436,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect( getEditedPostAttribute( state, 'slug' ) ).toBe( 'post slug' );
@@ -449,6 +452,7 @@ describe( 'selectors', () => {
 						},
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect( getEditedPostAttribute( state, 'slug' ) ).toBe( 'new slug' );
@@ -464,6 +468,7 @@ describe( 'selectors', () => {
 						edits: { status: 'private' },
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect( getEditedPostAttribute( state, 'title' ) ).toBe( 'sassel' );
@@ -479,6 +484,7 @@ describe( 'selectors', () => {
 						edits: { title: 'youcha' },
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect( getEditedPostAttribute( state, 'title' ) ).toBe( 'youcha' );
@@ -492,6 +498,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect( getEditedPostAttribute( state, 'valueOf' ) ).toBeUndefined();
@@ -606,9 +613,36 @@ describe( 'selectors', () => {
 						edits: { title: 'terga' },
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect( getPostEdits( state ) ).toEqual( { title: 'terga' } );
+		} );
+
+		it( 'should return value from initial edits', () => {
+			const state = {
+				editor: {
+					present: {
+						edits: {},
+					},
+				},
+				initialEdits: { title: 'terga' },
+			};
+
+			expect( getPostEdits( state ) ).toEqual( { title: 'terga' } );
+		} );
+
+		it( 'should prefer value from edits over initial edits', () => {
+			const state = {
+				editor: {
+					present: {
+						edits: { title: 'werga' },
+					},
+				},
+				initialEdits: { title: 'terga' },
+			};
+
+			expect( getPostEdits( state ) ).toEqual( { title: 'werga' } );
 		} );
 	} );
 
@@ -638,6 +672,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect( getEditedPostVisibility( state ) ).toBe( 'public' );
@@ -653,6 +688,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect( getEditedPostVisibility( state ) ).toBe( 'private' );
@@ -669,6 +705,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect( getEditedPostVisibility( state ) ).toBe( 'password' );
@@ -688,6 +725,7 @@ describe( 'selectors', () => {
 						},
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect( getEditedPostVisibility( state ) ).toBe( 'private' );
@@ -957,6 +995,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				currentPost: {},
 				saving: {},
 			};
@@ -975,6 +1014,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				currentPost: {
 					title: 'sassel',
 				},
@@ -997,6 +1037,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				currentPost: {
 					title: 'sassel',
 				},
@@ -1017,6 +1058,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				currentPost: {
 					excerpt: 'sassel',
 				},
@@ -1048,6 +1090,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				currentPost: {},
 				saving: {},
 			};
@@ -1076,6 +1119,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				currentPost: {},
 				saving: {},
 			};
@@ -1105,6 +1149,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				currentPost: {
 					title: 'sassel',
 				},
@@ -1127,6 +1172,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				currentPost: {
 					title: 'sassel',
 				},
@@ -1152,6 +1198,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				currentPost: {
 					title: 'sassel',
 				},
@@ -1175,6 +1222,7 @@ describe( 'selectors', () => {
 						},
 					},
 				},
+				initialEdits: {},
 				currentPost: {
 					title: 'foo',
 					content: 'foo',
@@ -1206,6 +1254,7 @@ describe( 'selectors', () => {
 								},
 							},
 						},
+						initialEdits: {},
 						currentPost: {
 							title: 'foo',
 							content: 'foo',
@@ -1279,6 +1328,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				currentPost: {},
 			};
 
@@ -1307,6 +1357,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				currentPost: {},
 			};
 
@@ -1337,6 +1388,7 @@ describe( 'selectors', () => {
 						},
 					},
 				},
+				initialEdits: {},
 				currentPost: {
 					content: '',
 				},
@@ -1356,6 +1408,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				currentPost: {
 					content: '',
 				},
@@ -1377,6 +1430,7 @@ describe( 'selectors', () => {
 						},
 					},
 				},
+				initialEdits: {},
 				currentPost: {},
 			};
 
@@ -1405,6 +1459,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				currentPost: {},
 			};
 
@@ -1433,6 +1488,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				currentPost: {
 					content: '',
 				},
@@ -1463,6 +1519,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				currentPost: {
 					content: 'Test Data',
 				},
@@ -1501,6 +1558,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				currentPost: {
 					content: '\n\n',
 				},
@@ -1520,6 +1578,7 @@ describe( 'selectors', () => {
 						edits: { date: date.toUTCString() },
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect( isEditedPostBeingScheduled( state ) ).toBe( true );
@@ -1532,6 +1591,7 @@ describe( 'selectors', () => {
 						edits: { date: '2016-05-30T17:21:39' },
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect( isEditedPostBeingScheduled( state ) ).toBe( false );
@@ -1539,16 +1599,6 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'isEditedPostDateFloating', () => {
-		let editor;
-
-		beforeEach( () => {
-			editor = {
-				present: {
-					edits: {},
-				},
-			};
-		} );
-
 		it( 'should return true for draft posts where the date matches the modified date', () => {
 			const state = {
 				currentPost: {
@@ -1556,7 +1606,12 @@ describe( 'selectors', () => {
 					modified: '2018-09-27T01:23:45.678Z',
 					status: 'draft',
 				},
-				editor,
+				editor: {
+					present: {
+						edits: {},
+					},
+				},
+				initialEdits: {},
 			};
 
 			expect( isEditedPostDateFloating( state ) ).toBe( true );
@@ -1569,7 +1624,12 @@ describe( 'selectors', () => {
 					modified: '2018-09-27T01:23:45.678Z',
 					status: 'auto-draft',
 				},
-				editor,
+				editor: {
+					present: {
+						edits: {},
+					},
+				},
+				initialEdits: {},
 			};
 
 			expect( isEditedPostDateFloating( state ) ).toBe( true );
@@ -1582,7 +1642,12 @@ describe( 'selectors', () => {
 					modified: '1970-01-01T00:00:00.000Z',
 					status: 'draft',
 				},
-				editor,
+				editor: {
+					present: {
+						edits: {},
+					},
+				},
+				initialEdits: {},
 			};
 
 			expect( isEditedPostDateFloating( state ) ).toBe( false );
@@ -1595,7 +1660,12 @@ describe( 'selectors', () => {
 					modified: '1970-01-01T00:00:00.000Z',
 					status: 'auto-draft',
 				},
-				editor,
+				editor: {
+					present: {
+						edits: {},
+					},
+				},
+				initialEdits: {},
 			};
 
 			expect( isEditedPostDateFloating( state ) ).toBe( false );
@@ -1608,7 +1678,12 @@ describe( 'selectors', () => {
 					modified: '2018-09-27T01:23:45.678Z',
 					status: 'publish',
 				},
-				editor,
+				editor: {
+					present: {
+						edits: {},
+					},
+				},
+				initialEdits: {},
 			};
 
 			expect( isEditedPostDateFloating( state ) ).toBe( false );
@@ -1638,6 +1713,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			const nextState = {
@@ -1656,6 +1732,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect(
@@ -1680,6 +1757,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			const nextState = {
@@ -1700,6 +1778,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect(
@@ -1730,6 +1809,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			const nextState = {
@@ -1750,6 +1830,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect(
@@ -1779,6 +1860,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			const nextState = {
@@ -1799,6 +1881,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect(
@@ -1832,6 +1915,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			const nextState = {
@@ -1854,6 +1938,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect(
@@ -1875,6 +1960,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			const name = getBlockName( state, 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' );
@@ -1903,6 +1989,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			const name = getBlockName( state, 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' );
@@ -1929,6 +2016,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect( getBlock( state, 123 ) ).toEqual( {
@@ -1951,6 +2039,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect( getBlock( state, 123 ) ).toBe( null );
@@ -1975,6 +2064,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect( getBlock( state, 123 ) ).toEqual( {
@@ -2024,6 +2114,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect( getBlock( state, 123 ) ).toEqual( {
@@ -2057,6 +2148,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect( getBlocks( state ) ).toEqual( [
@@ -2111,6 +2203,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 			expect( getClientIdsOfDescendants( state, [ 'uuid-10' ] ) ).toEqual( [
 				'uuid-12',
@@ -2170,6 +2263,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 			expect( getClientIdsWithDescendants( state ) ).toEqual( [
 				'uuid-6',
@@ -2365,6 +2459,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				blockSelection: { start: null, end: null },
 			};
 
@@ -2390,6 +2485,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				blockSelection: { start: 23, end: 123 },
 			};
 
@@ -2415,6 +2511,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				blockSelection: { start: 23, end: 23 },
 			};
 
@@ -2577,6 +2674,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				blockSelection: { start: null, end: null },
 				currentPost: {},
 			};
@@ -3178,6 +3276,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				insertionPoint: {
 					rootClientId: undefined,
 					index: 0,
@@ -3212,6 +3311,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				insertionPoint: null,
 			};
 
@@ -3245,6 +3345,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				insertionPoint: null,
 			};
 
@@ -3278,6 +3379,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				insertionPoint: null,
 			};
 
@@ -3311,6 +3413,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				insertionPoint: null,
 			};
 
@@ -3420,6 +3523,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				currentPost: {},
 			};
 
@@ -3442,6 +3546,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				currentPost: {},
 			};
 
@@ -3463,6 +3568,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				currentPost: {},
 			};
 
@@ -3484,6 +3590,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				currentPost: {},
 			};
 
@@ -3505,6 +3612,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				currentPost: {},
 			};
 
@@ -3527,6 +3635,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				currentPost: {},
 			};
 
@@ -3580,6 +3689,7 @@ describe( 'selectors', () => {
 						},
 					},
 				},
+				initialEdits: {},
 				currentPost: {},
 			};
 
@@ -3605,6 +3715,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				currentPost: {},
 			};
 
@@ -3631,6 +3742,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				currentPost: {},
 			};
 
@@ -3661,6 +3773,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				currentPost: {},
 			};
 
@@ -3685,6 +3798,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				currentPost: {},
 			};
 
@@ -3715,6 +3829,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				currentPost: {},
 			};
 
@@ -3918,6 +4033,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				reusableBlocks: {
 					data: {
 						1: { clientId: 'block1', title: 'Reusable Block 1' },
@@ -3978,6 +4094,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				reusableBlocks: {
 					data: {
 						1: { clientId: 'block1', title: 'Reusable Block 1' },
@@ -4018,6 +4135,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				reusableBlocks: {
 					data: {
 						1: { clientId: 'block1', title: 'Reusable Block 1' },
@@ -4081,6 +4199,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				reusableBlocks: {
 					data: {},
 				},
@@ -4107,6 +4226,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				reusableBlocks: {
 					data: {},
 				},
@@ -4133,6 +4253,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				reusableBlocks: {
 					data: {},
 				},
@@ -4166,6 +4287,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 				reusableBlocks: {
 					data: {},
 				},
@@ -4397,9 +4519,6 @@ describe( 'selectors', () => {
 				saving: {
 					requesting: false,
 				},
-				editor: {
-					edits: {},
-				},
 				currentPost: {
 					status: 'publish',
 				},
@@ -4414,9 +4533,6 @@ describe( 'selectors', () => {
 				saving: {
 					requesting: true,
 				},
-				editor: {
-					edits: {},
-				},
 				currentPost: {
 					status: 'draft',
 				},
@@ -4430,9 +4546,6 @@ describe( 'selectors', () => {
 				optimist: [],
 				saving: {
 					requesting: true,
-				},
-				editor: {
-					edits: {},
 				},
 				currentPost: {
 					status: 'publish',
@@ -4450,9 +4563,6 @@ describe( 'selectors', () => {
 							saving: {
 								requesting: false,
 							},
-							editor: {
-								edits: {},
-							},
 							currentPost: {
 								status: 'publish',
 							},
@@ -4466,9 +4576,6 @@ describe( 'selectors', () => {
 				],
 				saving: {
 					requesting: true,
-				},
-				editor: {
-					edits: {},
 				},
 				currentPost: {
 					status: 'publish',
@@ -4486,11 +4593,6 @@ describe( 'selectors', () => {
 							saving: {
 								requesting: false,
 							},
-							editor: {
-								edits: {
-									status: 'publish',
-								},
-							},
 							currentPost: {
 								status: 'draft',
 							},
@@ -4504,9 +4606,6 @@ describe( 'selectors', () => {
 				],
 				saving: {
 					requesting: true,
-				},
-				editor: {
-					edits: {},
 				},
 				currentPost: {
 					status: 'publish',
@@ -4604,6 +4703,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect( isPermalinkEditable( state ) ).toBe( false );
@@ -4617,6 +4717,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect( isPermalinkEditable( state ) ).toBe( false );
@@ -4630,6 +4731,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect( isPermalinkEditable( state ) ).toBe( true );
@@ -4643,6 +4745,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect( isPermalinkEditable( state ) ).toBe( true );
@@ -4659,6 +4762,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect( getPermalink( state ) ).toBe( url );
@@ -4675,6 +4779,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect( getPermalink( state ) ).toBe( 'http://foo.test/bar/baz/' );
@@ -4698,6 +4803,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect( getPermalinkParts( state ) ).toEqual( parts );
@@ -4718,6 +4824,7 @@ describe( 'selectors', () => {
 						edits: {},
 					},
 				},
+				initialEdits: {},
 			};
 
 			expect( getPermalinkParts( state ) ).toEqual( parts );

--- a/packages/url/src/test/index.test.js
+++ b/packages/url/src/test/index.test.js
@@ -71,6 +71,13 @@ describe( 'addQueryArgs', () => {
 
 		expect( safeDecodeURI( addQueryArgs( url, args ) ) ).toBe( 'https://andalouses.example/beach?time[0]=10&time[1]=11&beach[0]=sand&beach[1]=rock' );
 	} );
+
+	it( 'should disregard keys with undefined values', () => {
+		const url = 'https://andalouses.example/beach';
+		const args = { sun: 'true', sand: undefined };
+
+		expect( addQueryArgs( url, args ) ).toBe( 'https://andalouses.example/beach?sun=true' );
+	} );
 } );
 
 describe( 'getQueryArg', () => {

--- a/packages/url/src/test/index.test.js
+++ b/packages/url/src/test/index.test.js
@@ -78,6 +78,13 @@ describe( 'addQueryArgs', () => {
 
 		expect( addQueryArgs( url, args ) ).toBe( 'https://andalouses.example/beach?sun=true' );
 	} );
+
+	it( 'should encodes spaces by RFC 3986', () => {
+		const url = 'https://andalouses.example/beach';
+		const args = { activity: 'fun in the sun' };
+
+		expect( addQueryArgs( url, args ) ).toBe( 'https://andalouses.example/beach?activity=fun%20in%20the%20sun' );
+	} );
 } );
 
 describe( 'getQueryArg', () => {

--- a/test/e2e/specs/change-detection.test.js
+++ b/test/e2e/specs/change-detection.test.js
@@ -130,7 +130,17 @@ describe( 'Change detection', () => {
 		await assertIsDirty( true );
 	} );
 
-	it( 'Should not prompt to confirm unsaved changes', async () => {
+	it( 'Should not prompt to confirm unsaved changes for new post', async () => {
+		await assertIsDirty( false );
+	} );
+
+	it( 'Should not prompt to confirm unsaved changes for new post with initial edits', async () => {
+		await newPost( {
+			title: 'My New Post',
+			content: 'My content',
+			excerpt: 'My excerpt',
+		} );
+
 		await assertIsDirty( false );
 	} );
 

--- a/test/e2e/specs/demo.test.js
+++ b/test/e2e/specs/demo.test.js
@@ -38,4 +38,8 @@ describe( 'new editor state', () => {
 		} );
 		expect( isDirty ).toBeFalsy();
 	} );
+
+	it( 'should be immediately saveable', async () => {
+		await page.$( 'button.editor-post-save-draft' );
+	} );
 } );

--- a/test/e2e/specs/new-post.test.js
+++ b/test/e2e/specs/new-post.test.js
@@ -73,4 +73,11 @@ describe( 'new editor state', () => {
 		// focused by default when a post already has a title.
 		expect( activeElementTagName ).toEqual( 'body' );
 	} );
+
+	it( 'should be saveable with sufficient initial edits', async () => {
+		await newPost( { title: 'Here is the title' } );
+
+		// Verify saveable by presence of the Save Draft button.
+		await page.$( 'button.editor-post-save-draft' );
+	} );
 } );

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -8,13 +8,18 @@ import { URL } from 'url';
  * External dependencies
  */
 import { times, castArray } from 'lodash';
+import fetch from 'node-fetch';
+
+/**
+ * WordPress dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
 
 const {
 	WP_BASE_URL = 'http://localhost:8889',
 	WP_USERNAME = 'admin',
 	WP_PASSWORD = 'password',
 } = process.env;
-import fetch from 'node-fetch';
 
 /**
  * Platform-specific meta key.
@@ -96,8 +101,20 @@ export async function visitAdmin( adminPath, query ) {
 	}
 }
 
-export async function newPost( { postType, enableTips = false } = {} ) {
-	await visitAdmin( 'post-new.php', postType ? 'post_type=' + postType : '' );
+export async function newPost( {
+	postType,
+	title,
+	content,
+	excerpt,
+	enableTips = false,
+} = {} ) {
+	const query = addQueryArgs( '', {
+		post_type: postType,
+		post_title: title,
+		content,
+		excerpt,
+	} ).slice( 1 );
+	await visitAdmin( 'post-new.php', query );
 
 	await page.evaluate( ( _enableTips ) => {
 		const action = _enableTips ? 'enableTips' : 'disableTips';


### PR DESCRIPTION
Extracted from / complements: #10844
Partially addresses: #7409

This pull request seeks to refactor the treatment of "initial edits" out of the `state.editor.present.edits` to allow for the existing `edits` state to represent only user-initiated edits to be considered for change detection. This will enable some simplification of change detection reset conditions, and works toward #10844's goal of considering "dirtiness" as a condition of a non-empty `edits` state.

**Implementation notes:**

While I think this partly moves away from a goal of eliminating the editor setup actions, it concedes in acknowledging that there should be at most a single parse which occurs at the start of an editing session, with consideration of both edits and content. Thus, it is implemented here as part of the effect handler for `SETUP_EDITOR`. I still have some faith this could be refactored in the future, but have chosen the most direct option to supporting #10844 here.

**Testing instructions:**

Verify there are no regressions in the behavior of "initial edits", notably:

- Saving a new draft with an empty title does not show "Auto Draft" upon reload
- The demo content works as expected

Ensure tests pass:

```
npm test
```

**Follow-up tasks:**

- [ ] With improvements here to initial edits, [assignment of draft status during first auto-draft save](https://github.com/WordPress/gutenberg/blob/3600c88fda01b62463769b5e8c3e795b064e12c1/packages/editor/src/store/effects/posts.js#L69-L82) could be easily moved to the server-side setup of a new draft.
- [ ] `SETUP_EDITOR` handling of blocks should be eliminated in favor of a consistent, single `RESET_BLOCKS` action.