### PR TITLE
Rename parentClientId to rootClientId for consistency

### DIFF
--- a/docs/data/data-core-editor.md
+++ b/docs/data/data-core-editor.md
@@ -1074,17 +1074,13 @@ Post content.
 
 ### canInsertBlockType
 
-Determines if the given block type is allowed to be inserted, and, if
-parentClientId is provided, whether it is allowed to be nested within the
-given parent.
+Determines if the given block type is allowed to be inserted into the block list.
 
 *Parameters*
 
  * state: Editor state.
- * blockName: The name of the given block type, e.g.
-                                'core/paragraph'.
- * parentClientId: The parent that the given block is to be
-                                nested within, or null.
+ * blockName: The name of the block type, e.g.' core/paragraph'.
+ * rootClientId: Optional root client ID of block list.
 
 *Returns*
 
@@ -1114,7 +1110,7 @@ Items are returned ordered descendingly by their 'utility' and 'frecency'.
 *Parameters*
 
  * state: Editor state.
- * parentClientId: The block we are inserting into, if any.
+ * rootClientId: Optional root client ID of block list.
 
 *Returns*
 

--- a/packages/editor/src/components/autocompleters/block.js
+++ b/packages/editor/src/components/autocompleters/block.js
@@ -23,14 +23,14 @@ function defaultGetBlockInsertionParentClientId() {
 /**
  * Returns the inserter items for the specified parent block.
  *
- * @param {string} parentClientId Client ID of the block for which to retrieve
- *                                inserter items.
+ * @param {string} rootClientId Client ID of the block for which to retrieve
+ *                              inserter items.
  *
  * @return {Array<Editor.InserterItem>} The inserter items for the specified
  *                                      parent.
  */
-function defaultGetInserterItems( parentClientId ) {
-	return select( 'core/editor' ).getInserterItems( parentClientId );
+function defaultGetInserterItems( rootClientId ) {
+	return select( 'core/editor' ).getInserterItems( rootClientId );
 }
 
 /**

--- a/packages/editor/src/components/inner-blocks/index.js
+++ b/packages/editor/src/components/inner-blocks/index.js
@@ -128,12 +128,12 @@ InnerBlocks = compose( [
 			getTemplateLock,
 		} = select( 'core/editor' );
 		const { clientId } = ownProps;
-		const parentClientId = getBlockRootClientId( clientId );
+		const rootClientId = getBlockRootClientId( clientId );
 		return {
 			isSelectedBlockInRoot: isBlockSelected( clientId ) || hasSelectedInnerBlock( clientId ),
 			block: getBlock( clientId ),
 			blockListSettings: getBlockListSettings( clientId ),
-			parentLock: getTemplateLock( parentClientId ),
+			parentLock: getTemplateLock( rootClientId ),
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {


### PR DESCRIPTION
We refer to the same concept as `rootClientId` elsewhere in the application.