### PR TITLE
NUX: Make tips collapsed by default

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -39,7 +39,7 @@ function HeaderToolbar( { hasFixedToolbar, isLargeViewport, showInserter } ) {
 				<DotTip
 					tipId="core/editor.inserter"
 					isCollapsible
-					label={ ( isOpen ) => isOpen ? __( 'Close tip for ‘Add block’' ) : __( 'Open tip for ‘Add block’' ) }
+					label={ ( isOpen ) => isOpen ? __( 'Close tip for “Add block”' ) : __( 'Open tip for “Add block”' ) }
 					className="edit-post-header-toolbar__inserter-button-tip"
 				>
 					{ __( 'Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to add a new block. There are blocks available for all kinds of content: you can insert text, headings, images, lists, and lots more!' ) }

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -15,6 +15,7 @@ import {
 	NavigableToolbar,
 	BlockNavigationDropdown,
 } from '@wordpress/editor';
+import { rawShortcut, shortcutAriaLabel } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -38,9 +39,13 @@ function HeaderToolbar( { hasFixedToolbar, isLargeViewport, showInserter } ) {
 				<Inserter disabled={ ! showInserter } position="bottom right" />
 				<DotTip
 					tipId="core/editor.inserter"
-					isCollapsible
-					label={ ( isOpen ) => isOpen ? __( 'Close tip for “Add block”' ) : __( 'Open tip for “Add block”' ) }
 					className="edit-post-header-toolbar__inserter-button-tip"
+					isCollapsible
+					label="Add block"
+					shortcut={ {
+						raw: rawShortcut.access( 't' ),
+						ariaLabel: shortcutAriaLabel.access( 't' ),
+					} }
 				>
 					{ __( 'Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to add a new block. There are blocks available for all kinds of content: you can insert text, headings, images, lists, and lots more!' ) }
 				</DotTip>

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -36,7 +36,12 @@ function HeaderToolbar( { hasFixedToolbar, isLargeViewport, showInserter } ) {
 			<FullscreenModeClose />
 			<div className="edit-post-header-toolbar__inserter-button-wrapper">
 				<Inserter disabled={ ! showInserter } position="bottom right" />
-				<DotTip tipId="core/editor.inserter" isCollapsible className="edit-post-header-toolbar__inserter-button-tip">
+				<DotTip
+					tipId="core/editor.inserter"
+					isCollapsible
+					label={ ( isOpen ) => isOpen ? __( 'Close tip for ‘Add block’' ) : __( 'Open tip for ‘Add block’' ) }
+					className="edit-post-header-toolbar__inserter-button-tip"
+				>
 					{ __( 'Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to add a new block. There are blocks available for all kinds of content: you can insert text, headings, images, lists, and lots more!' ) }
 				</DotTip>
 			</div>

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -15,7 +15,7 @@ import {
 	NavigableToolbar,
 	BlockNavigationDropdown,
 } from '@wordpress/editor';
-import { rawShortcut, shortcutAriaLabel } from '@wordpress/keycodes';
+import { rawShortcut, displayShortcut, shortcutAriaLabel } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -41,9 +41,10 @@ function HeaderToolbar( { hasFixedToolbar, isLargeViewport, showInserter } ) {
 					tipId="core/editor.inserter"
 					className="edit-post-header-toolbar__inserter-button-tip"
 					isCollapsible
-					label="Add block"
+					title="Add block"
 					shortcut={ {
 						raw: rawShortcut.access( 't' ),
+						display: displayShortcut.access( 't' ),
 						ariaLabel: shortcutAriaLabel.access( 't' ),
 					} }
 				>

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -34,9 +34,9 @@ function HeaderToolbar( { hasFixedToolbar, isLargeViewport, showInserter } ) {
 			aria-label={ toolbarAriaLabel }
 		>
 			<FullscreenModeClose />
-			<div>
+			<div className="edit-post-header-toolbar__inserter-button-wrapper">
 				<Inserter disabled={ ! showInserter } position="bottom right" />
-				<DotTip tipId="core/editor.inserter">
+				<DotTip tipId="core/editor.inserter" isCollapsible className="edit-post-header-toolbar__inserter-button-tip">
 					{ __( 'Welcome to the wonderful world of blocks! Click the “+” (“Add block”) button to add a new block. There are blocks available for all kinds of content: you can insert text, headings, images, lists, and lots more!' ) }
 				</DotTip>
 			</div>

--- a/packages/edit-post/src/components/header/header-toolbar/style.scss
+++ b/packages/edit-post/src/components/header/header-toolbar/style.scss
@@ -22,6 +22,17 @@
 	}
 }
 
+.edit-post-header-toolbar__inserter-button-wrapper {
+	align-items: center;
+	display: flex;
+	position: relative;
+}
+
+.edit-post-header-toolbar__inserter-button-tip {
+	position: absolute;
+	right: -17px;
+}
+
 // Block toolbar when fixed to the top of the screen.
 .edit-post-header-toolbar__block-toolbar {
 	// Stack toolbar below Editor Bar.

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -59,7 +59,7 @@ function Header( {
 					forceIsDirty={ hasActiveMetaboxes }
 					forceIsSaving={ isSaving }
 				/>
-				<div>
+				<div className="edit-post-header__settings-button-wrapper">
 					<IconButton
 						icon="admin-generic"
 						label={ __( 'Settings' ) }
@@ -68,7 +68,7 @@ function Header( {
 						aria-expanded={ isEditorSidebarOpened }
 						shortcut={ shortcuts.toggleSidebar }
 					/>
-					<DotTip tipId="core/editor.settings">
+					<DotTip tipId="core/editor.settings" className="edit-post-header__settings-button-tip">
 						{ __( 'You’ll find more settings for your page and blocks in the sidebar. Click “Settings” to open it.' ) }
 					</DotTip>
 				</div>

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -63,9 +63,19 @@
 
 @include editor-left(".edit-post-header");
 
-.edit-post-header__settings {
+.edit-post-header__settings,
+.edit-post-header__settings-button-wrapper {
 	display: inline-flex;
 	align-items: center;
+}
+
+.edit-post-header__settings-button-wrapper {
+	position: relative;
+}
+
+.edit-post-header__settings-button-tip {
+	left: -17px;
+	position: absolute;
 }
 
 .edit-post-header .components-button {

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -182,7 +182,7 @@ export class PostPreviewButton extends Component {
 						__( '(opens in a new tab)' )
 					}
 				</span>
-				<DotTip tipId="core/editor.preview">
+				<DotTip tipId="core/editor.preview" className="editor-post-preview__tip">
 					{ __( 'Click “Preview” to load a preview of this page, so you can make sure you’re happy with your blocks.' ) }
 				</DotTip>
 			</Button>

--- a/packages/editor/src/components/post-preview-button/style.scss
+++ b/packages/editor/src/components/post-preview-button/style.scss
@@ -1,0 +1,10 @@
+.editor-post-preview {
+	align-items: center;
+	display: flex;
+	position: relative;
+}
+
+.editor-post-preview__tip {
+	left: -17px;
+	position: absolute;
+}

--- a/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
@@ -16,6 +16,7 @@ exports[`PostPreviewButton render() should render currentPostLink otherwise 1`] 
     (opens in a new tab)
   </span>
   <WithSelect(WithDispatch(DotTip))
+    className="editor-post-preview__tip"
     tipId="core/editor.preview"
   >
     Click “Preview” to load a preview of this page, so you can make sure you’re happy with your blocks.
@@ -39,6 +40,7 @@ exports[`PostPreviewButton render() should render previewLink if provided 1`] = 
     (opens in a new tab)
   </span>
   <WithSelect(WithDispatch(DotTip))
+    className="editor-post-preview__tip"
     tipId="core/editor.preview"
   >
     Click “Preview” to load a preview of this page, so you can make sure you’re happy with your blocks.

--- a/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-preview-button/test/__snapshots__/index.js.snap
@@ -15,12 +15,12 @@ exports[`PostPreviewButton render() should render currentPostLink otherwise 1`] 
   >
     (opens in a new tab)
   </span>
-  <WithSelect(WithDispatch(DotTip))
+  <WithSelect(WithDispatch(WithSpokenMessages(DotTip)))
     className="editor-post-preview__tip"
     tipId="core/editor.preview"
   >
     Click “Preview” to load a preview of this page, so you can make sure you’re happy with your blocks.
-  </WithSelect(WithDispatch(DotTip))>
+  </WithSelect(WithDispatch(WithSpokenMessages(DotTip)))>
 </Button>
 `;
 
@@ -39,11 +39,11 @@ exports[`PostPreviewButton render() should render previewLink if provided 1`] = 
   >
     (opens in a new tab)
   </span>
-  <WithSelect(WithDispatch(DotTip))
+  <WithSelect(WithDispatch(WithSpokenMessages(DotTip)))
     className="editor-post-preview__tip"
     tipId="core/editor.preview"
   >
     Click “Preview” to load a preview of this page, so you can make sure you’re happy with your blocks.
-  </WithSelect(WithDispatch(DotTip))>
+  </WithSelect(WithDispatch(WithSpokenMessages(DotTip)))>
 </Button>
 `;

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -107,7 +107,7 @@ export class PostPublishButton extends Component {
 				{ ...componentProps }
 			>
 				{ componentChildren }
-				<DotTip tipId="core/editor.publish">
+				<DotTip tipId="core/editor.publish" className="editor-post-publish-panel__toggle-tip">
 					{ __( 'Finished writing? That’s great, let’s get this published right now. Just click “Publish” and you’re good to go.' ) }
 				</DotTip>
 			</Button>

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -40,6 +40,15 @@
 	padding: 16px;
 }
 
+.editor-post-publish-panel__toggle {
+	position: relative;
+}
+
+.editor-post-publish-panel__toggle-tip {
+	left: -17px;
+	position: absolute;
+}
+
 .components-button.editor-post-publish-panel__toggle.is-primary {
 	display: inline-flex;
 	align-items: center;

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -33,6 +33,7 @@
 @import "./components/post-last-revision/style.scss";
 @import "./components/post-locked-modal/style.scss";
 @import "./components/post-permalink/style.scss";
+@import "./components/post-preview-button/style.scss";
 @import "./components/post-publish-panel/style.scss";
 @import "./components/post-saved-state/style.scss";
 @import "./components/post-taxonomies/style.scss";

--- a/packages/nux/CHANGELOG.md
+++ b/packages/nux/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 4.0.0 (Unreleased)
+
+### New Features
+
+- `DotTip`s can now be made collapsible using the `isCollapsible` prop.
+
+### Breaking Changes
+
+- `DotTip` will no longer automatically position its indicator next to the parent component. Instead, users of `DotTip` should manually position the indicator by applying a `className` or styling `.nux-dot-tip`.
+
 ## 3.0.4 (2018-11-30)
 
 ## 3.0.3 (2018-11-22)
@@ -28,7 +38,7 @@
 
 ### Deprecations
 
-- The id prop of DotTip has been deprecated. Please use the tipId prop instead.
+- The `id` prop of `DotTip` has been deprecated. Please use the `tipId` prop instead.
 
 ## 2.0.6 (2018-10-22)
 
@@ -38,6 +48,6 @@
 
 ## 2.0.0 (2018-09-05)
 
-### Breaking Change
+### Breaking Changes
 
 - Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)). If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.

--- a/packages/nux/src/components/dot-tip/README.md
+++ b/packages/nux/src/components/dot-tip/README.md
@@ -39,12 +39,12 @@ Defaults to `false`.
 - Type: `boolean`
 - Required: No
 
-### label
+### title
 
 A short string which describes the tip. This is used to label the button which expands or collapses the tip if it is collapsible.
 
 ```jsx
-<DotTip tipId="acme/add-to-cart" label="Add to Cart">
+<DotTip tipId="acme/add-to-cart" title="Add to Cart">
 	Click here to add the product to your shopping cart.
 </DotTip>
 ```
@@ -57,6 +57,8 @@ A short string which describes the tip. This is used to label the button which e
 An object which, if specified, configures a keyboard shortcut which will expand or collapse the tip if it is collapsible.
 
 The object must contain a `raw` property which is the keyboard shortcut to bind to.
+
+Optionally, the object can contain a `display` property which is a textual description of the shortcut used for the button tooltip.
 
 Optionally, the object can contain an `ariaLabel` property which is a textual description of the shortcut used for screen readers.
 

--- a/packages/nux/src/components/dot-tip/README.md
+++ b/packages/nux/src/components/dot-tip/README.md
@@ -41,15 +41,30 @@ Defaults to `false`.
 
 ### label
 
-The ARIA label used to describe the button that opens or closes a collapsible tip.
-
-If a function is provided then it will be invoked with `isOpen` as the argument, allowing one to change the label depeneding on whether the button opens or closes the tip.
+A short string which describes the tip. This is used to label the button which expands or collapses the tip if it is collapsible.
 
 ```jsx
-<DotTip tipId="acme/add-to-cart" label={ ( isOpen ) => isOpen ? 'Close tip' : 'Open tip' }>
+<DotTip tipId="acme/add-to-cart" label="Add to Cart">
 	Click here to add the product to your shopping cart.
 </DotTip>
 ```
 
-- Type: `string` or `Function`
+- Type: `string`
+- Required: No
+
+### shortcut
+
+An object which, if specified, configures a keyboard shortcut which will expand or collapse the tip if it is collapsible.
+
+The object must contain a `raw` property which is the keyboard shortcut to bind to.
+
+Optionally, the object can contain an `ariaLabel` property which is a textual description of the shortcut used for screen readers.
+
+```jsx
+<DotTip tipId="acme/add-to-cart" shortcut={ { raw: 'ctrl+alt+t' } }>
+	Click here to add the product to your shopping cart.
+</DotTip>
+```
+
+- Type: `Object`
 - Required: No

--- a/packages/nux/src/components/dot-tip/README.md
+++ b/packages/nux/src/components/dot-tip/README.md
@@ -29,3 +29,27 @@ A string that uniquely identifies the tip. Identifiers should be prefixed with t
 ### children
 
 Any React element or elements can be passed as children. They will be rendered within the tip bubble.
+
+### isCollapsible
+
+Marks a tip as being collapsible. Collapsible tips show a pulsating indicator and nothing else. Clicking on the indicator will expand or collapse the tip.
+
+Defaults to `false`.
+
+- Type: `boolean`
+- Required: No
+
+### label
+
+The ARIA label used to describe the button that opens or closes a collapsible tip.
+
+If a function is provided then it will be invoked with `isOpen` as the argument, allowing one to change the label depeneding on whether the button opens or closes the tip.
+
+```jsx
+<DotTip tipId="acme/add-to-cart" label={ ( isOpen ) => isOpen ? 'Close tip' : 'Open tip' }>
+	Click here to add the product to your shopping cart.
+</DotTip>
+```
+
+- Type: `string` or `Function`
+- Required: No

--- a/packages/nux/src/components/dot-tip/index.js
+++ b/packages/nux/src/components/dot-tip/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { isFunction } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
@@ -11,6 +16,10 @@ function stopEventPropagation( event ) {
 	// Tips are often nested within buttons. We stop propagation so that clicking
 	// on a tip doesn't result in the button being clicked.
 	event.stopPropagation();
+}
+
+function defaultLabel( isOpen ) {
+	return isOpen ? __( 'Close tip' ) : __( 'Open tip' );
 }
 
 export class DotTip extends Component {
@@ -39,6 +48,7 @@ export class DotTip extends Component {
 			hasNextTip,
 			isCollapsible,
 			isVisible,
+			label = defaultLabel,
 			onDisable,
 			onDismiss,
 		} = this.props;
@@ -84,7 +94,7 @@ export class DotTip extends Component {
 		return isCollapsible ? (
 			<button
 				className={ classes }
-				aria-label={ isOpen ? __( 'Close tip' ) : __( 'Open tip' ) }
+				aria-label={ isFunction( label ) ? label( isOpen ) : label }
 				onClick={ this.toggleIsOpen }
 			>
 				{ popover }

--- a/packages/nux/src/components/dot-tip/index.js
+++ b/packages/nux/src/components/dot-tip/index.js
@@ -1,60 +1,98 @@
 /**
  * WordPress dependencies
  */
+import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { Popover, Button, IconButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 
-function getAnchorRect( anchor ) {
-	// The default getAnchorRect() excludes an element's top and bottom padding
-	// from its calculation. We want tips to point to the outer margin of an
-	// element, so we override getAnchorRect() to include all padding.
-	return anchor.parentNode.getBoundingClientRect();
-}
-
-function onClick( event ) {
+function stopEventPropagation( event ) {
 	// Tips are often nested within buttons. We stop propagation so that clicking
 	// on a tip doesn't result in the button being clicked.
 	event.stopPropagation();
 }
 
-export function DotTip( {
-	children,
-	isVisible,
-	hasNextTip,
-	onDismiss,
-	onDisable,
-} ) {
-	if ( ! isVisible ) {
-		return null;
+export class DotTip extends Component {
+	constructor( { isCollapsible } ) {
+		super( ...arguments );
+
+		this.toggleIsOpen = this.toggleIsOpen.bind( this );
+
+		this.state = {
+			isOpen: ! isCollapsible,
+		};
 	}
 
-	return (
-		<Popover
-			className="nux-dot-tip"
-			position="middle right"
-			noArrow
-			focusOnMount="container"
-			getAnchorRect={ getAnchorRect }
-			role="dialog"
-			aria-label={ __( 'Editor tips' ) }
-			onClick={ onClick }
-		>
-			<p>{ children }</p>
-			<p>
-				<Button isLink onClick={ onDismiss }>
-					{ hasNextTip ? __( 'See next tip' ) : __( 'Got it' ) }
-				</Button>
-			</p>
-			<IconButton
-				className="nux-dot-tip__disable"
-				icon="no-alt"
-				label={ __( 'Disable tips' ) }
-				onClick={ onDisable }
-			/>
-		</Popover>
-	);
+	toggleIsOpen( event ) {
+		stopEventPropagation( event );
+
+		if ( this.props.isCollapsible ) {
+			this.setState( { isOpen: ! this.state.isOpen } );
+		}
+	}
+
+	render() {
+		const {
+			children,
+			className,
+			hasNextTip,
+			isCollapsible,
+			isVisible,
+			onDisable,
+			onDismiss,
+		} = this.props;
+		const { isOpen } = this.state;
+
+		if ( ! isVisible ) {
+			return null;
+		}
+
+		let classes = 'nux-dot-tip';
+		if ( className ) {
+			classes += ` ${ className }`;
+		}
+
+		let popover = null;
+		if ( isOpen ) {
+			popover = (
+				<Popover
+					className="nux-dot-tip__popover"
+					position="middle right"
+					noArrow
+					focusOnMount="container"
+					role="dialog"
+					aria-label={ __( 'Editor tips' ) }
+					onClick={ stopEventPropagation }
+				>
+					<p>{ children }</p>
+					<p>
+						<Button isLink onClick={ onDismiss }>
+							{ hasNextTip ? __( 'See next tip' ) : __( 'Got it' ) }
+						</Button>
+					</p>
+					<IconButton
+						className="nux-dot-tip__disable"
+						icon="no-alt"
+						label={ __( 'Disable tips' ) }
+						onClick={ onDisable }
+					/>
+				</Popover>
+			);
+		}
+
+		return isCollapsible ? (
+			<button
+				className={ classes }
+				aria-label={ isOpen ? __( 'Close tip' ) : __( 'Open tip' ) }
+				onClick={ this.toggleIsOpen }
+			>
+				{ popover }
+			</button>
+		) : (
+			<div className={ classes }>{ popover }</div>
+		);
+	}
 }
 
 export default compose(
@@ -76,5 +114,5 @@ export default compose(
 				disableTips();
 			},
 		};
-	} ),
+	} )
 )( DotTip );

--- a/packages/nux/src/components/dot-tip/index.js
+++ b/packages/nux/src/components/dot-tip/index.js
@@ -8,6 +8,7 @@ import {
 	IconButton,
 	KeyboardShortcuts,
 	Popover,
+	Tooltip,
 	withSpokenMessages,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
@@ -17,15 +18,6 @@ function stopEventPropagation( event ) {
 	// Tips are often nested within buttons. We stop propagation so that clicking
 	// on a tip doesn't result in the button being clicked.
 	event.stopPropagation();
-}
-
-function buildLabel( isOpen, label ) {
-	if ( label ) {
-		return isOpen ?
-			sprintf( __( 'Close tip for “%s”' ), label ) :
-			sprintf( __( 'Open tip for “%s”' ), label );
-	}
-	return isOpen ? __( 'Close tip' ) : __( 'Open tip' );
 }
 
 export class DotTip extends Component {
@@ -40,11 +32,11 @@ export class DotTip extends Component {
 	}
 
 	componentDidMount() {
-		const { isCollapsible, shortcut, label, debouncedSpeak } = this.props;
+		const { isCollapsible, shortcut, title, debouncedSpeak } = this.props;
 
-		if ( isCollapsible && shortcut && shortcut.raw && shortcut.ariaLabel && label ) {
+		if ( isCollapsible && shortcut && shortcut.raw && shortcut.ariaLabel && title ) {
 			debouncedSpeak(
-				sprintf( __( 'Press “%s” to open the tip for “%s”.' ), shortcut.ariaLabel, label )
+				sprintf( __( 'Press “%s” to open the tip for “%s”.' ), shortcut.ariaLabel, title )
 			);
 		}
 	}
@@ -64,7 +56,7 @@ export class DotTip extends Component {
 			hasNextTip,
 			isCollapsible,
 			isVisible,
-			label,
+			title,
 			onDisable,
 			onDismiss,
 			shortcut,
@@ -78,6 +70,15 @@ export class DotTip extends Component {
 		let classes = 'nux-dot-tip';
 		if ( className ) {
 			classes += ` ${ className }`;
+		}
+
+		let label;
+		if ( title ) {
+			label = isOpen ?
+				sprintf( __( 'Close tip for “%s”' ), title ) :
+				sprintf( __( 'Open tip for “%s”' ), title );
+		} else {
+			label = isOpen ? __( 'Close tip' ) : __( 'Open tip' );
 		}
 
 		let popover = null;
@@ -109,21 +110,18 @@ export class DotTip extends Component {
 		}
 
 		return isCollapsible ? (
-			<button
-				className={ classes }
-				aria-label={ buildLabel( isOpen, label ) }
-				onClick={ this.toggleIsOpen }
-			>
-				{ shortcut &&
-					shortcut.raw && (
-					<KeyboardShortcuts
-						shortcuts={ {
-							[ shortcut.raw ]: this.toggleIsOpen,
-						} }
-					/>
-				) }
-				{ popover }
-			</button>
+			<Tooltip text={ label } shortcut={ shortcut && shortcut.display }>
+				<button className={ classes } aria-label={ label } onClick={ this.toggleIsOpen }>
+					{ shortcut && shortcut.raw && (
+						<KeyboardShortcuts
+							shortcuts={ {
+								[ shortcut.raw ]: this.toggleIsOpen,
+							} }
+						/>
+					) }
+					{ popover }
+				</button>
+			</Tooltip>
 		) : (
 			<div className={ classes }>{ popover }</div>
 		);

--- a/packages/nux/src/components/dot-tip/style.scss
+++ b/packages/nux/src/components/dot-tip/style.scss
@@ -1,40 +1,53 @@
-$dot-size: 8px; // Size of the indicator dot
+$dot-size: 12px; // Size of the indicator dot
 $dot-scale: 3;  // How much the pulse animation should scale up by in size
 
 .nux-dot-tip {
-	&::before,
-	&::after {
-		border-radius: 100%;
-		content: " ";
-		pointer-events: none;
-		position: absolute;
+	background: $blue-medium-800;
+	border-radius: 100%;
+	border: none;
+	height: $dot-size;
+	outline: none;
+	padding: 0;
+	position: relative;
+	width: $dot-size;
+	z-index: z-index(".nux-dot-tip");
+
+	&:active {
+		outline: none;
+	}
+
+	&:focus {
+		// TODO: Would look nicer if this focus outline were a circle.
+		outline-offset: ($dot-size * $dot-scale - $dot-size) / 2;
+		outline: 1px solid $dark-gray-300;
 	}
 
 	&::before {
 		animation: nux-pulse 1.6s infinite cubic-bezier(0.17, 0.67, 0.92, 0.62);
 		background: rgba($blue-medium-800, 0.9);
+		border-radius: 100%;
+		content: " ";
 		height: $dot-size * $dot-scale;
-		left: -($dot-size * $dot-scale) / 2;
-		top: -($dot-size * $dot-scale) / 2;
-		transform: scale((1 / $dot-scale));
+		left: -$dot-size;
+		position: absolute;
+		top: -$dot-size;
+		transform: scale(1 / $dot-scale);
 		width: $dot-size * $dot-scale;
 	}
+}
 
-	&::after {
-		background: $blue-medium-800;
-		height: $dot-size;
-		left: -$dot-size / 2;
-		top: -$dot-size / 2;
-		width: $dot-size;
+button.nux-dot-tip {
+	cursor: pointer;
+}
+
+@keyframes nux-pulse {
+	100% {
+		background: rgba($blue-medium-800, 0);
+		transform: scale(1);
 	}
+}
 
-	@keyframes nux-pulse {
-		100% {
-			background: rgba($blue-medium-800, 0);
-			transform: scale(1);
-		}
-	}
-
+.nux-dot-tip__popover {
 	.components-popover__content {
 		padding: 5px (36px + 5px) 5px 20px;
 		width: 350px;
@@ -48,20 +61,6 @@ $dot-scale: 3;  // How much the pulse animation should scale up by in size
 			right: 0;
 			top: 0;
 		}
-	}
-
-	// Position the dot right next to the edge of the button
-	&.is-top {
-		margin-top: -$dot-size / 2;
-	}
-	&.is-bottom {
-		margin-top: $dot-size / 2;
-	}
-	&.is-middle.is-left {
-		margin-left: -$dot-size / 2;
-	}
-	&.is-middle.is-right {
-		margin-left: $dot-size / 2;
 	}
 
 	// Position the tip content away from the dot

--- a/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
@@ -1,53 +1,65 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DotTip should render a button when collapsible 1`] = `
-<button
-  aria-label="Open tip"
-  className="nux-dot-tip"
-  onClick={[Function]}
-/>
+<Tooltip
+  text="Open tip"
+>
+  <button
+    aria-label="Open tip"
+    className="nux-dot-tip"
+    onClick={[Function]}
+  />
+</Tooltip>
 `;
 
 exports[`DotTip should render a custom label when collapsible 1`] = `
-<button
-  aria-label="Open tip for “Writing a Letter”"
-  className="nux-dot-tip"
-  onClick={[Function]}
-/>
+<Tooltip
+  text="Open tip for “Writing a Letter”"
+>
+  <button
+    aria-label="Open tip for “Writing a Letter”"
+    className="nux-dot-tip"
+    onClick={[Function]}
+  />
+</Tooltip>
 `;
 
 exports[`DotTip should render the tip after being clicked when collapsible 1`] = `
-<button
-  aria-label="Close tip"
-  className="nux-dot-tip"
-  onClick={[Function]}
+<Tooltip
+  text="Close tip"
 >
-  <Popover
-    aria-label="Editor tips"
-    className="nux-dot-tip__popover"
-    focusOnMount="container"
-    noArrow={true}
+  <button
+    aria-label="Close tip"
+    className="nux-dot-tip"
     onClick={[Function]}
-    position="middle right"
-    role="dialog"
   >
-    <p>
-      It looks like you’re writing a letter. Would you like help?
-    </p>
-    <p>
-      <Button
-        isLink={true}
-      >
-        Got it
-      </Button>
-    </p>
-    <IconButton
-      className="nux-dot-tip__disable"
-      icon="no-alt"
-      label="Disable tips"
-    />
-  </Popover>
-</button>
+    <Popover
+      aria-label="Editor tips"
+      className="nux-dot-tip__popover"
+      focusOnMount="container"
+      noArrow={true}
+      onClick={[Function]}
+      position="middle right"
+      role="dialog"
+    >
+      <p>
+        It looks like you’re writing a letter. Would you like help?
+      </p>
+      <p>
+        <Button
+          isLink={true}
+        >
+          Got it
+        </Button>
+      </p>
+      <IconButton
+        className="nux-dot-tip__disable"
+        icon="no-alt"
+        label="Disable tips"
+      />
+    </Popover>
+  </button>
+</Tooltip>
 `;
 
 exports[`DotTip should render the tip when non-collapsible 1`] = `

--- a/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
@@ -8,6 +8,14 @@ exports[`DotTip should render a button when collapsible 1`] = `
 />
 `;
 
+exports[`DotTip should render a custom label when collapsible 1`] = `
+<button
+  aria-label="Toggle tip"
+  className="nux-dot-tip"
+  onClick={[Function]}
+/>
+`;
+
 exports[`DotTip should render the tip after being clicked when collapsible 1`] = `
 <button
   aria-label="Close tip"

--- a/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
@@ -1,30 +1,75 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DotTip should render correctly 1`] = `
-<Popover
-  aria-label="Editor tips"
+exports[`DotTip should render a button when collapsible 1`] = `
+<button
+  aria-label="Open tip"
   className="nux-dot-tip"
-  focusOnMount="container"
-  getAnchorRect={[Function]}
-  noArrow={true}
   onClick={[Function]}
-  position="middle right"
-  role="dialog"
+/>
+`;
+
+exports[`DotTip should render the tip after being clicked when collapsible 1`] = `
+<button
+  aria-label="Close tip"
+  className="nux-dot-tip"
+  onClick={[Function]}
 >
-  <p>
-    It looks like you’re writing a letter. Would you like help?
-  </p>
-  <p>
-    <Button
-      isLink={true}
-    >
-      Got it
-    </Button>
-  </p>
-  <IconButton
-    className="nux-dot-tip__disable"
-    icon="no-alt"
-    label="Disable tips"
-  />
-</Popover>
+  <Popover
+    aria-label="Editor tips"
+    className="nux-dot-tip__popover"
+    focusOnMount="container"
+    noArrow={true}
+    onClick={[Function]}
+    position="middle right"
+    role="dialog"
+  >
+    <p>
+      It looks like you’re writing a letter. Would you like help?
+    </p>
+    <p>
+      <Button
+        isLink={true}
+      >
+        Got it
+      </Button>
+    </p>
+    <IconButton
+      className="nux-dot-tip__disable"
+      icon="no-alt"
+      label="Disable tips"
+    />
+  </Popover>
+</button>
+`;
+
+exports[`DotTip should render the tip when non-collapsible 1`] = `
+<div
+  className="nux-dot-tip"
+>
+  <Popover
+    aria-label="Editor tips"
+    className="nux-dot-tip__popover"
+    focusOnMount="container"
+    noArrow={true}
+    onClick={[Function]}
+    position="middle right"
+    role="dialog"
+  >
+    <p>
+      It looks like you’re writing a letter. Would you like help?
+    </p>
+    <p>
+      <Button
+        isLink={true}
+      >
+        Got it
+      </Button>
+    </p>
+    <IconButton
+      className="nux-dot-tip__disable"
+      icon="no-alt"
+      label="Disable tips"
+    />
+  </Popover>
+</div>
 `;

--- a/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
@@ -10,7 +10,7 @@ exports[`DotTip should render a button when collapsible 1`] = `
 
 exports[`DotTip should render a custom label when collapsible 1`] = `
 <button
-  aria-label="Toggle tip"
+  aria-label="Open tip for “Writing a Letter”"
   className="nux-dot-tip"
   onClick={[Function]}
 />

--- a/packages/nux/src/components/dot-tip/test/index.js
+++ b/packages/nux/src/components/dot-tip/test/index.js
@@ -40,7 +40,7 @@ describe( 'DotTip', () => {
 
 	it( 'should render a custom label when collapsible', () => {
 		const wrapper = shallow(
-			<DotTip isCollapsible label="Writing a Letter" isVisible>
+			<DotTip isCollapsible title="Writing a Letter" isVisible>
 				It looks like you’re writing a letter. Would you like help?
 			</DotTip>
 		);
@@ -55,7 +55,7 @@ describe( 'DotTip', () => {
 		);
 
 		const stopPropagation = jest.fn();
-		wrapper.simulate( 'click', { stopPropagation } );
+		wrapper.find( 'button' ).simulate( 'click', { stopPropagation } );
 		wrapper.update();
 
 		expect( wrapper ).toMatchSnapshot();

--- a/packages/nux/src/components/dot-tip/test/index.js
+++ b/packages/nux/src/components/dot-tip/test/index.js
@@ -40,7 +40,7 @@ describe( 'DotTip', () => {
 
 	it( 'should render a custom label when collapsible', () => {
 		const wrapper = shallow(
-			<DotTip isCollapsible label="Toggle tip" isVisible>
+			<DotTip isCollapsible label="Writing a Letter" isVisible>
 				It looks like you’re writing a letter. Would you like help?
 			</DotTip>
 		);

--- a/packages/nux/src/components/dot-tip/test/index.js
+++ b/packages/nux/src/components/dot-tip/test/index.js
@@ -38,6 +38,15 @@ describe( 'DotTip', () => {
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
+	it( 'should render a custom label when collapsible', () => {
+		const wrapper = shallow(
+			<DotTip isCollapsible label="Toggle tip" isVisible>
+				It looks like you’re writing a letter. Would you like help?
+			</DotTip>
+		);
+		expect( wrapper ).toMatchSnapshot();
+	} );
+
 	it( 'should render the tip after being clicked when collapsible', () => {
 		const wrapper = shallow(
 			<DotTip isCollapsible isVisible>

--- a/packages/nux/src/components/dot-tip/test/index.js
+++ b/packages/nux/src/components/dot-tip/test/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { shallow } from 'enzyme';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,19 +20,43 @@ describe( 'DotTip', () => {
 		expect( wrapper.isEmptyRender() ).toBe( true );
 	} );
 
-	it( 'should render correctly', () => {
+	it( 'should render the tip when non-collapsible', () => {
 		const wrapper = shallow(
-			<DotTip isVisible setTimeout={ noop }>
+			<DotTip isVisible>
 				It looks like you’re writing a letter. Would you like help?
 			</DotTip>
 		);
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
+	it( 'should render a button when collapsible', () => {
+		const wrapper = shallow(
+			<DotTip isCollapsible isVisible>
+				It looks like you’re writing a letter. Would you like help?
+			</DotTip>
+		);
+		expect( wrapper ).toMatchSnapshot();
+	} );
+
+	it( 'should render the tip after being clicked when collapsible', () => {
+		const wrapper = shallow(
+			<DotTip isCollapsible isVisible>
+				It looks like you’re writing a letter. Would you like help?
+			</DotTip>
+		);
+
+		const stopPropagation = jest.fn();
+		wrapper.simulate( 'click', { stopPropagation } );
+		wrapper.update();
+
+		expect( wrapper ).toMatchSnapshot();
+		expect( stopPropagation ).toHaveBeenCalled();
+	} );
+
 	it( 'should call onDismiss when the dismiss button is clicked', () => {
 		const onDismiss = jest.fn();
 		const wrapper = shallow(
-			<DotTip isVisible onDismiss={ onDismiss } setTimeout={ noop }>
+			<DotTip isVisible onDismiss={ onDismiss }>
 				It looks like you’re writing a letter. Would you like help?
 			</DotTip>
 		);
@@ -44,7 +67,7 @@ describe( 'DotTip', () => {
 	it( 'should call onDisable when the X button is clicked', () => {
 		const onDisable = jest.fn();
 		const wrapper = shallow(
-			<DotTip isVisible onDisable={ onDisable } setTimeout={ noop }>
+			<DotTip isVisible onDisable={ onDisable }>
 				It looks like you’re writing a letter. Would you like help?
 			</DotTip>
 		);

--- a/test/e2e/specs/nux.test.js
+++ b/test/e2e/specs/nux.test.js
@@ -11,12 +11,15 @@ import {
 
 describe( 'New User Experience (NUX)', () => {
 	async function clickAllTips( page ) {
-		// Click through all available tips.
 		const tips = await getTips( page );
 		const numberOfTips = tips.tipIds.length;
 
+		// Open up the first tip.
+		await page.click( '.nux-dot-tip' );
+
+		// Click through all of the tips.
 		for ( let i = 1; i < numberOfTips; i++ ) {
-			await page.click( '.nux-dot-tip .components-button.is-link' );
+			await page.click( '.nux-dot-tip__popover .components-button.is-link' );
 		}
 
 		return { numberOfTips, tips };
@@ -39,13 +42,19 @@ describe( 'New User Experience (NUX)', () => {
 	} );
 
 	it( 'should show tips to a first-time user', async () => {
-		const firstTipText = await page.$eval( '.nux-dot-tip', ( element ) => element.innerText );
+		// Click on the tip indicator to open the first tip.
+		await page.click( '.nux-dot-tip' );
+
+		// Check that we see the first tip.
+		const firstTipText = await page.$eval( '.nux-dot-tip__popover', ( element ) => element.innerText );
 		expect( firstTipText ).toContain( 'Welcome to the wonderful world of blocks!' );
 
+		// Go to the next tip.
 		const [ nextTipButton ] = await page.$x( "//button[contains(text(), 'See next tip')]" );
 		await nextTipButton.click();
 
-		const secondTipText = await page.$eval( '.nux-dot-tip', ( element ) => element.innerText );
+		// Check that we see the second tip.
+		const secondTipText = await page.$eval( '.nux-dot-tip__popover', ( element ) => element.innerText );
 		expect( secondTipText ).toContain( 'You’ll find more settings for your page and blocks in the sidebar.' );
 	} );
 
@@ -57,7 +66,7 @@ describe( 'New User Experience (NUX)', () => {
 		expect( gotItButton ).toHaveLength( 1 );
 
 		// Click the "Got it button".
-		await page.click( '.nux-dot-tip .components-button.is-link' );
+		await page.click( '.nux-dot-tip__popover .components-button.is-link' );
 
 		// Verify no more tips are visible on the page.
 		const nuxTipElements = await page.$$( '.nux-dot-tip' );
@@ -70,6 +79,10 @@ describe( 'New User Experience (NUX)', () => {
 	} );
 
 	it( 'should hide and disable tips if "disable tips" button is clicked', async () => {
+		// Click on the tip indicator to open the first tip.
+		await page.click( '.nux-dot-tip' );
+
+		// Click the X.
 		await page.click( '.nux-dot-tip__disable' );
 
 		// Verify no more tips are visible on the page.
@@ -88,7 +101,10 @@ describe( 'New User Experience (NUX)', () => {
 	} );
 
 	it( 'should enable tips when the "Enable tips" option is toggled on', async () => {
-		// Start by disabling tips.
+		// Click on the tip indicator to open the first tip.
+		await page.click( '.nux-dot-tip' );
+
+		// Click the X to disable tips.
 		await page.click( '.nux-dot-tip__disable' );
 
 		// Verify no more tips are visible on the page.


### PR DESCRIPTION
Closes #9242. Fixes #12358.

![nux](https://user-images.githubusercontent.com/612155/48600251-44f91500-e9bf-11e8-90fe-9b417a595904.gif)

Makes the NUX guide less overwhelming by collapsing the first tip in the guide.

What's changed:

- `DotTip` has a new `isCollapsible` prop which marks it as being a collapsible tip
  - Collapsible tips are opened and closed by clicking on the indicator
  - I've increased the size of the indicator so that it's easier to click
  - The first tip is marked as `isCollapsible`
- Dismissing and disabling tips works as before

#### How to test

1. Clear out your local storage or re-enable tips
2. Note that the first tip is now a collapsed pulsating dot
3. Click on it to open up the first tip
4. Click through the rest of the tips