### PR TITLE
NUX package: fix incorrect named deprecated import

### DIFF
--- a/packages/nux/src/components/dot-tip/index.js
+++ b/packages/nux/src/components/dot-tip/index.js
@@ -5,7 +5,7 @@ import { compose } from '@wordpress/compose';
 import { Popover, Button, IconButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { deprecated } from '@wordpress/deprecated';
+import deprecated from '@wordpress/deprecated';
 
 function getAnchorRect( anchor ) {
 	// The default getAnchorRect() excludes an element's top and bottom padding


### PR DESCRIPTION
## Description

`DotTip` component was attempting to import a named export of `deprecated` which
is not provided by `@wordpress/deprecated` package. This switches it to use the
default export instead.

Fixes https://github.com/WordPress/gutenberg/issues/11282

See `deprecated` docs for correct usage: https://github.com/WordPress/gutenberg/tree/master/packages/deprecated#usage

## How has this been tested?
- Editor smoke test.

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
