### PR TITLE
Add validation to link format in RichText component 

### DIFF
--- a/packages/format-library/src/link/style.scss
+++ b/packages/format-library/src/link/style.scss
@@ -11,4 +11,8 @@
 	white-space: nowrap;
 	min-width: 150px;
 	max-width: 500px;
+
+	&.has-invalid-link {
+		color: $alert-red;
+	}
 }

--- a/packages/format-library/src/link/test/utils.js
+++ b/packages/format-library/src/link/test/utils.js
@@ -1,0 +1,76 @@
+
+/**
+ * Internal dependencies
+ */
+import {
+	isValidHref,
+} from '../utils';
+
+describe( 'isValidHref', () => {
+	it( 'returns true if the href cannot be recognised as a url or an anchor link', () => {
+		expect( isValidHref( 'notaurloranchorlink' ) ).toBe( true );
+	} );
+
+	it( 'returns false if the href is not specified', () => {
+		expect( isValidHref() ).toBe( false );
+		expect( isValidHref( '' ) ).toBe( false );
+		expect( isValidHref( ' ' ) ).toBe( false );
+	} );
+
+	describe( 'URLs beginning with a protocol', () => {
+		it( 'returns true for valid URLs', () => {
+			expect( isValidHref( 'tel:+123456789' ) ).toBe( true );
+			expect( isValidHref( 'mailto:test@somewhere.com' ) ).toBe( true );
+			expect( isValidHref( 'file:///c:/WINDOWS/winamp.exe' ) ).toBe( true );
+			expect( isValidHref( 'http://test.com' ) ).toBe( true );
+			expect( isValidHref( 'https://test.com' ) ).toBe( true );
+			expect( isValidHref( 'http://test-with-hyphen.com' ) ).toBe( true );
+			expect( isValidHref( 'http://test.com/' ) ).toBe( true );
+			expect( isValidHref( 'http://test.com/with/path/separators' ) ).toBe( true );
+			expect( isValidHref( 'http://test.com/with?query=string&params' ) ).toBe( true );
+		} );
+
+		it( 'returns false for invalid urls', () => {
+			expect( isValidHref( 'tel:+12 345 6789' ) ).toBe( false );
+			expect( isValidHref( 'mailto:test @ somewhere.com' ) ).toBe( false );
+			expect( isValidHref( 'mailto: test@somewhere.com' ) ).toBe( false );
+			expect( isValidHref( 'ht#tp://this/is/invalid' ) ).toBe( false );
+			expect( isValidHref( 'ht#tp://th&is/is/invalid' ) ).toBe( false );
+			expect( isValidHref( 'http://?test.com' ) ).toBe( false );
+			expect( isValidHref( 'http://#test.com' ) ).toBe( false );
+			expect( isValidHref( 'http://test.com?double?params' ) ).toBe( false );
+			expect( isValidHref( 'http://test.com#double#anchor' ) ).toBe( false );
+			expect( isValidHref( 'http://test.com?path/after/params' ) ).toBe( false );
+			expect( isValidHref( 'http://test.com#path/after/fragment' ) ).toBe( false );
+		} );
+
+		it( 'returns false if the URL has whitespace', () => {
+			expect( isValidHref( 'http:/ /test.com' ) ).toBe( false );
+			expect( isValidHref( 'http://te st.com' ) ).toBe( false );
+			expect( isValidHref( 'http:// test.com' ) ).toBe( false );
+			expect( isValidHref( 'http://test.c om' ) ).toBe( false );
+			expect( isValidHref( 'http://test.com/ee ee/' ) ).toBe( false );
+			expect( isValidHref( 'http://test.com/eeee?qwd qwdw' ) ).toBe( false );
+			expect( isValidHref( 'http://test.com/eeee#qwd qwdw' ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'Anchor links', () => {
+		it( 'returns true for valid anchor links', () => {
+			expect( isValidHref( '#yesitis' ) ).toBe( true );
+			expect( isValidHref( '#yes_it_is' ) ).toBe( true );
+			expect( isValidHref( '#yes~it~is' ) ).toBe( true );
+			expect( isValidHref( '#yes-it-is' ) ).toBe( true );
+		} );
+
+		it( 'returns false for invalid anchor links', () => {
+			expect( isValidHref( '' ) ).toBe( false );
+			expect( isValidHref( '#no-it-isnt#' ) ).toBe( false );
+			expect( isValidHref( '#no-it-#isnt' ) ).toBe( false );
+			expect( isValidHref( '#no-it-isnt?' ) ).toBe( false );
+			expect( isValidHref( '#no-it isnt' ) ).toBe( false );
+			expect( isValidHref( '#no-it-isnt/' ) ).toBe( false );
+		} );
+	} );
+} );
+

--- a/packages/format-library/src/link/utils.js
+++ b/packages/format-library/src/link/utils.js
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import { startsWith } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	getProtocol,
+	isValidProtocol,
+	getAuthority,
+	isValidAuthority,
+	getPath,
+	isValidPath,
+	getQueryString,
+	isValidQueryString,
+	getFragment,
+	isValidFragment,
+} from '@wordpress/url';
+
+/**
+ * Check for issues with the provided href.
+ *
+ * @param {string} href The href.
+ *
+ * @return {boolean} Is the href invalid?
+ */
+export function isValidHref( href ) {
+	if ( ! href ) {
+		return false;
+	}
+
+	const trimmedHref = href.trim();
+
+	if ( ! trimmedHref ) {
+		return false;
+	}
+
+	// Does the href start with something that looks like a url protocol?
+	if ( /^\S+:/.test( trimmedHref ) ) {
+		const protocol = getProtocol( trimmedHref );
+		if ( ! isValidProtocol( protocol ) ) {
+			return false;
+		}
+
+		const authority = getAuthority( trimmedHref );
+		if ( ! isValidAuthority( authority ) ) {
+			return false;
+		}
+
+		const path = getPath( trimmedHref );
+		if ( path && ! isValidPath( path ) ) {
+			return false;
+		}
+
+		const queryString = getQueryString( trimmedHref );
+		if ( queryString && ! isValidQueryString( queryString ) ) {
+			return false;
+		}
+
+		const fragment = getFragment( trimmedHref );
+		if ( fragment && ! isValidFragment( trimmedHref ) ) {
+			return false;
+		}
+	}
+
+	// Validate anchor links.
+	if ( startsWith( trimmedHref, '#' ) && ! isValidFragment( trimmedHref ) ) {
+		return false;
+	}
+
+	return true;
+}

--- a/packages/url/CHANGELOG.md
+++ b/packages/url/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 2.3.0 (Unreleased)
+
+### Features
+
+- Added `getProtocol`
+- Added `isValidProtocol`
+- Added `getAuthority`
+- Added `isValidAuthority`
+- Added `getPath`
+- Added `isValidPath`
+- Added `getQueryString`
+- Added `isValidQueryString`
+- Added `getFragment`
+- Added `isValidFragment`
+
 ## 2.2.0 (2018-10-29)
 
 ### Features

--- a/packages/url/CHANGELOG.md
+++ b/packages/url/CHANGELOG.md
@@ -1,21 +1,21 @@
 ## 2.3.0 (Unreleased)
 
-### Features
+### New Features
 
-- Added `getProtocol`
-- Added `isValidProtocol`
+- Added `getProtocol`.
+- Added `isValidProtocol`.
 - Added `getAuthority`
-- Added `isValidAuthority`
-- Added `getPath`
-- Added `isValidPath`
-- Added `getQueryString`
-- Added `isValidQueryString`
-- Added `getFragment`
-- Added `isValidFragment`
+- Added `isValidAuthority`.
+- Added `getPath`.
+- Added `isValidPath`.
+- Added `getQueryString`.
+- Added `isValidQueryString`.
+- Added `getFragment`.
+- Added `isValidFragment`.
 
 ## 2.2.0 (2018-10-29)
 
-### Features
+### New Features
 
 - Added `getQueryArg`.
 - Added `hasQueryArg`.
@@ -23,13 +23,13 @@
 
 ## 2.1.0 (2018-10-16)
 
-### Features
+### New Feature
 
 - Added `safeDecodeURI`.
 
 ## 2.0.1 (2018-09-30)
 
-### Bug Fixes
+### Bug Fix
 
 - Fix typo in the `qs` dependency definition in the `package.json`
 

--- a/packages/url/README.md
+++ b/packages/url/README.md
@@ -14,26 +14,157 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 
 ## Usage
 
-```JS
-import { isURL, addQueryArgs, prependHTTP } from '@wordpress/url';
+### isURL
 
-// Checks if the argument looks like a URL
+```js
 const isURL = isURL( 'https://wordpress.org' ); // true
+```
 
-// Appends arguments to the query string of a given url
+Checks whether the URL is an HTTP or HTTPS URL.
+
+
+### getProtocol
+
+```js
+const protocol1 = getProtocol( 'tel:012345678' ); // 'tel:'
+const protocol2 = getProtocol( 'https://wordpress.org' ); // 'https:'
+```
+
+Returns the protocol part of the provided URL.
+
+
+### isValidProtocol
+
+```js
+const isValid = isValidProtocol( 'https:' ); // true
+const isNotValid = isValidProtocol( 'https :' ); // false
+```
+
+Returns true if the provided protocol is valid. Returns false if the protocol contains invalid characters.
+
+
+### getAuthority
+
+```js
+const authority1 = getAuthority( 'https://wordpress.org/help/' ); // 'wordpress.org'
+const authority2 = getAuthority( 'https://localhost:8080/test/' ); // 'localhost:8080'
+```
+
+Returns the authority part of the provided URL.
+
+
+### isValidAuthority
+
+```js
+const isValid = isValidAuthority( 'wordpress.org' ); // true
+const isNotValid = isValidAuthority( 'wordpress#org' ); // false
+```
+
+Returns true if the provided authority is valid. Returns false if the protocol contains invalid characters.
+
+
+### getPath
+
+```js
+const path1 = getPath( 'http://localhost:8080/this/is/a/test?query=true' ); // 'this/is/a/test'
+const path2 = getPath( 'https://wordpress.org/help/faq/' ); // 'help/faq'
+```
+
+Returns the path part of the provided URL.
+
+
+### isValidPath
+
+```js
+const isValid = isValidPath( 'test/path/' ); // true
+const isNotValid = isValidPath( '/invalid?test/path/' ); // false
+```
+
+Returns true if the provided path is valid. Returns false if the path contains invalid characters.
+
+
+### getQueryString
+
+```js
+const queryString1 = getQueryString( 'http://localhost:8080/this/is/a/test?query=true#fragment' ); // 'query=true'
+const queryString2 = getQueryString( 'https://wordpress.org#fragment?query=false&search=hello' ); // 'query=false&search=hello'
+```
+
+Returns the query string part of the provided URL.
+
+
+### isValidQueryString
+
+```js
+const isValid = isValidQueryString( 'query=true&another=false' ); // true
+const isNotValid = isValidQueryString( 'query=true?another=false' ); // false
+```
+
+Returns true if the provided query string is valid. Returns false if the query string contains invalid characters.
+
+
+### getFragment
+
+```js
+const fragment1 = getFragment( 'http://localhost:8080/this/is/a/test?query=true#fragment' ); // '#fragment'
+const fragment2 = getFragment( 'https://wordpress.org#another-fragment?query=true' ); // '#another-fragment'
+```
+
+Returns the fragment part of the provided URL.
+
+
+### isValidFragment
+
+```js
+const isValid = isValidFragment( '#valid-fragment' ); // true
+const isNotValid = isValidFragment( '#invalid-#fragment' ); // false
+```
+
+Returns true if the provided fragment is valid. Returns false if the fragment contains invalid characters.
+
+
+### addQueryArgs
+
+```js
 const newURL = addQueryArgs( 'https://google.com', { q: 'test' } ); // https://google.com/?q=test
+```
 
-// Prepends 'http://' to URLs that are probably mean to have them
+Adds a query string argument to the provided URL.
+
+
+### prependHTTP
+
+```js
 const actualURL = prependHTTP( 'wordpress.org' ); // http://wordpress.org
+```
 
-// Gets a single query arg from the given URL.
+Prepends the provided partial URL with the http:// protocol.
+
+### getQueryArg
+
+```js
 const foo = getQueryArg( 'https://wordpress.org?foo=bar&bar=baz', 'foo' ); // bar
+```
 
-// Checks whether a URL contains a given query arg.
+Retrieve a query string argument from the provided URL.
+
+
+### hasQueryArg
+
+```js
 const hasBar = hasQueryArg( 'https://wordpress.org?foo=bar&bar=baz', 'bar' ); // true
+```
 
-// Removes one or more query args from the given URL.
+Checks whether a URL contains the given query string argument.
+
+
+### removeQueryArgs
+
+```js
 const newUrl = removeQueryArgs( 'https://wordpress.org?foo=bar&bar=baz&baz=foobar', 'foo', 'bar' ); // https://wordpress.org?baz=foobar
 ```
+
+Removes one or more query string arguments from the given URL.
+
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/url/src/index.js
+++ b/packages/url/src/index.js
@@ -19,6 +19,146 @@ export function isURL( url ) {
 }
 
 /**
+ * Returns the protocol part of the URL.
+ *
+ * @param {string} url The full URL.
+ *
+ * @return {?string} The protocol part of the URL.
+ */
+export function getProtocol( url ) {
+	const matches = /^([^\s:]+:)/.exec( url );
+	if ( matches ) {
+		return matches[ 1 ];
+	}
+}
+
+/**
+ * Tests if a url protocol is valid.
+ *
+ * @param {string} protocol The url protocol.
+ *
+ * @return {boolean} True if the argument is a valid protocol (e.g. http://, tel:).
+ */
+export function isValidProtocol( protocol ) {
+	if ( ! protocol ) {
+		return false;
+	}
+	return /^[a-z\-.\+]+[0-9]*:(?:\/\/)?\/?$/i.test( protocol );
+}
+
+/**
+ * Returns the authority part of the URL.
+ *
+ * @param {string} url The full URL.
+ *
+ * @return {?string} The authority part of the URL.
+ */
+export function getAuthority( url ) {
+	const matches = /^[^\/\s:]+:(?:\/\/)?\/?([^\/\s#?]+)[\/#?]{0,1}\S*$/.exec( url );
+	if ( matches ) {
+		return matches[ 1 ];
+	}
+}
+
+/**
+ * Checks for invalid characters within the provided authority.
+ *
+ * @param {string} authority A string containing the URL authority.
+ *
+ * @return {boolean} True if the argument contains a valid authority.
+ */
+export function isValidAuthority( authority ) {
+	if ( ! authority ) {
+		return false;
+	}
+	return /^[^\s#?]+$/.test( authority );
+}
+
+/**
+ * Returns the path part of the URL.
+ *
+ * @param {string} url The full URL.
+ *
+ * @return {?string} The path part of the URL.
+ */
+export function getPath( url ) {
+	const matches = /^[^\/\s:]+:(?:\/\/)?[^\/\s#?]+[\/]([^\s#?]+)[#?]{0,1}\S*$/.exec( url );
+	if ( matches ) {
+		return matches[ 1 ];
+	}
+}
+
+/**
+ * Checks for invalid characters within the provided path.
+ *
+ * @param {string} path The URL path.
+ *
+ * @return {boolean} True if the argument contains a valid path
+ */
+export function isValidPath( path ) {
+	if ( ! path ) {
+		return false;
+	}
+	return /^[^\s#?]+$/.test( path );
+}
+
+/**
+ * Returns the query string part of the URL.
+ *
+ * @param {string} url The full URL.
+ *
+ * @return {?string} The query string part of the URL.
+ */
+export function getQueryString( url ) {
+	const matches = /^\S+?\?([^\s#]+)/.exec( url );
+	if ( matches ) {
+		return matches[ 1 ];
+	}
+}
+
+/**
+ * Checks for invalid characters within the provided query string.
+ *
+ * @param {string} queryString The url query string.
+ *
+ * @return {boolean} True if the argument contains a valid query string.
+ */
+export function isValidQueryString( queryString ) {
+	if ( ! queryString ) {
+		return false;
+	}
+	return /^[^\s#?\/]+$/.test( queryString );
+}
+
+/**
+ * Returns the fragment part of the URL.
+ *
+ * @param {string} url The full URL
+ *
+ * @return {?string} The fragment part of the URL.
+ */
+export function getFragment( url ) {
+	const matches = /^\S+(#[^\s\?]*)/.exec( url );
+	if ( matches ) {
+		return matches[ 1 ];
+	}
+}
+
+/**
+ * Checks for invalid characters within the provided fragment.
+ *
+ * @param {string} fragment The url fragment.
+ *
+ * @return {boolean} True if the argument contains a valid fragment.
+ */
+export function isValidFragment( fragment ) {
+	if ( ! fragment ) {
+		return false;
+	}
+	return /^#[^\s#?\/]*$/.test( fragment );
+}
+
+/**
  * Appends arguments to the query string of the url
  *
  * @param {string} url  URL

--- a/packages/url/src/index.js
+++ b/packages/url/src/index.js
@@ -119,7 +119,7 @@ export function getQueryString( url ) {
 /**
  * Checks for invalid characters within the provided query string.
  *
- * @param {string} queryString The url query string.
+ * @param {string} queryString The query string.
  *
  * @return {boolean} True if the argument contains a valid query string.
  */

--- a/packages/url/src/test/index.test.js
+++ b/packages/url/src/test/index.test.js
@@ -8,6 +8,16 @@ import { every } from 'lodash';
  */
 import {
 	isURL,
+	getProtocol,
+	isValidProtocol,
+	getAuthority,
+	isValidAuthority,
+	getPath,
+	isValidPath,
+	getQueryString,
+	isValidQueryString,
+	getFragment,
+	isValidFragment,
 	addQueryArgs,
 	getQueryArg,
 	hasQueryArg,
@@ -40,6 +50,239 @@ describe( 'isURL', () => {
 		];
 
 		expect( every( urls, isURL ) ).toBe( false );
+	} );
+} );
+
+describe( 'getProtocol', () => {
+	it( 'returns the protocol part of a URL', () => {
+		expect( getProtocol( 'http://user:password@www.test-this.com:1020/test-path/file.extension#anchor?query=params&more' ) ).toBe( 'http:' );
+		expect( getProtocol( 'https://user:password@www.test-this.com:1020/test-path/file.extension#anchor?query=params&more' ) ).toBe( 'https:' );
+		expect( getProtocol( 'https://wordpress.org#test' ) ).toBe( 'https:' );
+		expect( getProtocol( 'https://wordpress.org/' ) ).toBe( 'https:' );
+		expect( getProtocol( 'https://wordpress.org?test' ) ).toBe( 'https:' );
+		expect( getProtocol( 'https://localhost:8080' ) ).toBe( 'https:' );
+		expect( getProtocol( 'tel:1234' ) ).toBe( 'tel:' );
+		expect( getProtocol( 'blob:data' ) ).toBe( 'blob:' );
+	} );
+
+	it( 'returns undefined when the provided value does not contain a URL protocol', () => {
+		expect( getProtocol( '' ) ).toBeUndefined();
+		expect( getProtocol( 'https' ) ).toBeUndefined();
+		expect( getProtocol( 'test.com' ) ).toBeUndefined();
+		expect( getProtocol( ' https:// ' ) ).toBeUndefined();
+	} );
+} );
+
+describe( 'isValidProtocol', () => {
+	it( 'returns true if the protocol is valid', () => {
+		expect( isValidProtocol( 'tel:' ) ).toBe( true );
+		expect( isValidProtocol( 'http:' ) ).toBe( true );
+		expect( isValidProtocol( 'https:' ) ).toBe( true );
+		expect( isValidProtocol( 'http://' ) ).toBe( true );
+		expect( isValidProtocol( 'https://' ) ).toBe( true );
+		expect( isValidProtocol( 'file:///' ) ).toBe( true );
+		expect( isValidProtocol( 'test.protocol:' ) ).toBe( true );
+		expect( isValidProtocol( 'test-protocol:' ) ).toBe( true );
+		expect( isValidProtocol( 'test+protocol:' ) ).toBe( true );
+		expect( isValidProtocol( 'test+protocol123:' ) ).toBe( true );
+	} );
+
+	it( 'returns false if the protocol is invalid', () => {
+		expect( isValidProtocol() ).toBe( false );
+		expect( isValidProtocol( '' ) ).toBe( false );
+		expect( isValidProtocol( ' http: ' ) ).toBe( false );
+		expect( isValidProtocol( 'http :' ) ).toBe( false );
+		expect( isValidProtocol( 'http: //' ) ).toBe( false );
+		expect( isValidProtocol( 'test protocol:' ) ).toBe( false );
+		expect( isValidProtocol( 'test#protocol:' ) ).toBe( false );
+		expect( isValidProtocol( 'test?protocol:' ) ).toBe( false );
+		expect( isValidProtocol( '123test+protocol:' ) ).toBe( false );
+	} );
+} );
+
+describe( 'getAuthority', () => {
+	it( 'returns the authority part of a URL', () => {
+		expect( getAuthority( 'https://user:password@www.test-this.com:1020/test-path/file.extension#anchor?query=params&more' ) ).toBe( 'user:password@www.test-this.com:1020' );
+		expect( getAuthority( 'http://user:password@www.test-this.com:1020/test-path/file.extension#anchor?query=params&more' ) ).toBe( 'user:password@www.test-this.com:1020' );
+		expect( getAuthority( 'https://wordpress.org#test' ) ).toBe( 'wordpress.org' );
+		expect( getAuthority( 'https://wordpress.org/' ) ).toBe( 'wordpress.org' );
+		expect( getAuthority( 'https://wordpress.org?test' ) ).toBe( 'wordpress.org' );
+		expect( getAuthority( 'https://localhost:8080' ) ).toBe( 'localhost:8080' );
+	} );
+
+	it( 'returns undefined when the provided value does not contain a URL authority', () => {
+		expect( getAuthority( '' ) ).toBeUndefined();
+		expect( getAuthority( 'https://' ) ).toBeUndefined();
+		expect( getAuthority( 'https:///' ) ).toBeUndefined();
+		expect( getAuthority( 'https://#' ) ).toBeUndefined();
+		expect( getAuthority( 'https://?' ) ).toBeUndefined();
+		expect( getAuthority( 'test.com' ) ).toBeUndefined();
+		expect( getAuthority( 'https://#?hello' ) ).toBeUndefined();
+	} );
+} );
+
+describe( 'isValidAuthority', () => {
+	it( 'returns true if the authority is valid', () => {
+		expect( isValidAuthority( 'user:password@www.test-this.com:1020' ) ).toBe( true );
+		expect( isValidAuthority( 'wordpress.org' ) ).toBe( true );
+		expect( isValidAuthority( 'localhost' ) ).toBe( true );
+		expect( isValidAuthority( 'localhost:8080' ) ).toBe( true );
+		expect( isValidAuthority( 'www.the-best-website.co.uk' ) ).toBe( true );
+		expect( isValidAuthority( 'WWW.VERYLOUD.COM' ) ).toBe( true );
+	} );
+
+	it( 'returns false if the authority is invalid', () => {
+		expect( isValidAuthority() ).toBe( false );
+		expect( isValidAuthority( '' ) ).toBe( false );
+		expect( isValidAuthority( 'inv alid.website.com' ) ).toBe( false );
+		expect( isValidAuthority( 'test#.com' ) ).toBe( false );
+		expect( isValidAuthority( 'test?.com' ) ).toBe( false );
+	} );
+} );
+
+describe( 'getPath', () => {
+	it( 'returns the path part of a URL', () => {
+		expect( getPath( 'https://user:password@www.test-this.com:1020/test-path/file.extension#anchor?query=params&more' ) ).toBe( 'test-path/file.extension' );
+		expect( getPath( 'http://user:password@www.test-this.com:1020/test-path/file.extension#anchor?query=params&more' ) ).toBe( 'test-path/file.extension' );
+		expect( getPath( 'https://wordpress.org/test-path#anchor' ) ).toBe( 'test-path' );
+		expect( getPath( 'https://wordpress.org/test-path?query' ) ).toBe( 'test-path' );
+		expect( getPath( 'https://www.google.com/search?source=hp&ei=tP7kW8-_FoK89QORoa2QBQ&q=test+url&oq=test+url&gs_l=psy-ab.3..0l10' ) ).toBe( 'search' );
+		expect( getPath( 'https://wordpress.org/this%20is%20a%20test' ) ).toBe( 'this%20is%20a%20test' );
+		expect( getPath( 'https://wordpress.org/this%20is%20a%20test?query' ) ).toBe( 'this%20is%20a%20test' );
+	} );
+
+	it( 'returns undefined when the provided value does not contain a URL path', () => {
+		expect( getPath() ).toBeUndefined();
+		expect( getPath( '' ) ).toBeUndefined();
+		expect( getPath( 'https://wordpress.org#test' ) ).toBeUndefined();
+		expect( getPath( 'https://wordpress.org/' ) ).toBeUndefined();
+		expect( getPath( 'https://wordpress.org?test' ) ).toBeUndefined();
+		expect( getPath( 'https://localhost:8080' ) ).toBeUndefined();
+		expect( getPath( 'https://' ) ).toBeUndefined();
+		expect( getPath( 'https:///test' ) ).toBeUndefined();
+		expect( getPath( 'https://#' ) ).toBeUndefined();
+		expect( getPath( 'https://?' ) ).toBeUndefined();
+		expect( getPath( 'test.com' ) ).toBeUndefined();
+		expect( getPath( 'https://#?hello' ) ).toBeUndefined();
+		expect( getPath( 'https' ) ).toBeUndefined();
+	} );
+} );
+
+describe( 'isValidPath', () => {
+	it( 'returns true if the path is valid', () => {
+		expect( isValidPath( 'test-path/file.extension' ) ).toBe( true );
+		expect( isValidPath( '/absolute/path' ) ).toBe( true );
+		expect( isValidPath( 'relative/path' ) ).toBe( true );
+		expect( isValidPath( 'slightly/longer/path/' ) ).toBe( true );
+		expect( isValidPath( 'path/with/percent%20encoding' ) ).toBe( true );
+	} );
+
+	it( 'returns false if the path is invalid', () => {
+		expect( isValidPath() ).toBe( false );
+		expect( isValidPath( '' ) ).toBe( false );
+		expect( isValidPath( 'path /with/spaces' ) ).toBe( false );
+		expect( isValidPath( 'path/with/number/symbol#' ) ).toBe( false );
+		expect( isValidPath( 'path/with/question/mark?' ) ).toBe( false );
+		expect( isValidPath( ' path/with/padding ' ) ).toBe( false );
+	} );
+} );
+
+describe( 'getQueryString', () => {
+	it( 'returns the query string of a URL', () => {
+		expect( getQueryString( 'https://user:password@www.test-this.com:1020/test-path/file.extension#anchor?query=params&more' ) ).toBe( 'query=params&more' );
+		expect( getQueryString( 'http://user:password@www.test-this.com:1020/test-path/file.extension?query=params&more#anchor' ) ).toBe( 'query=params&more' );
+		expect( getQueryString( 'https://wordpress.org/test-path?query' ) ).toBe( 'query' );
+		expect( getQueryString( 'https://www.google.com/search?source=hp&ei=tP7kW8-_FoK89QORoa2QBQ&q=test+url&oq=test+url&gs_l=psy-ab.3..0l10' ) )
+			.toBe( 'source=hp&ei=tP7kW8-_FoK89QORoa2QBQ&q=test+url&oq=test+url&gs_l=psy-ab.3..0l10' );
+		expect( getQueryString( 'https://wordpress.org/this%20is%20a%20test?query' ) ).toBe( 'query' );
+		expect( getQueryString( 'https://wordpress.org/test?query=something%20with%20spaces' ) ).toBe( 'query=something%20with%20spaces' );
+		expect( getQueryString( 'https://andalouses.example/beach?foo[]=bar&foo[]=baz' ) ).toBe( 'foo[]=bar&foo[]=baz' );
+		expect( getQueryString( 'test.com?foo[]=bar&foo[]=baz' ) ).toBe( 'foo[]=bar&foo[]=baz' );
+		expect( getQueryString( 'test.com?foo=bar&foo=baz?test' ) ).toBe( 'foo=bar&foo=baz?test' );
+	} );
+
+	it( 'returns undefined when the provided does not contain a url query string', () => {
+		expect( getQueryString( '' ) ).toBeUndefined();
+		expect( getQueryString( 'https://wordpress.org/test-path#anchor' ) ).toBeUndefined();
+		expect( getQueryString( 'https://wordpress.org/this%20is%20a%20test' ) ).toBeUndefined();
+		expect( getQueryString( 'https://wordpress.org#test' ) ).toBeUndefined();
+		expect( getQueryString( 'https://wordpress.org/' ) ).toBeUndefined();
+		expect( getQueryString( 'https://localhost:8080' ) ).toBeUndefined();
+		expect( getQueryString( 'https://' ) ).toBeUndefined();
+		expect( getQueryString( 'https:///test' ) ).toBeUndefined();
+		expect( getQueryString( 'https://#' ) ).toBeUndefined();
+		expect( getQueryString( 'https://?' ) ).toBeUndefined();
+		expect( getQueryString( 'test.com' ) ).toBeUndefined();
+	} );
+} );
+
+describe( 'isValidQueryString', () => {
+	it( 'returns true if the query string is valid', () => {
+		expect( isValidQueryString( 'test' ) ).toBe( true );
+		expect( isValidQueryString( 'test=true' ) ).toBe( true );
+		expect( isValidQueryString( 'test=true&another' ) ).toBe( true );
+		expect( isValidQueryString( 'test=true&another=false' ) ).toBe( true );
+		expect( isValidQueryString( 'test[]=true&another[]=false' ) ).toBe( true );
+		expect( isValidQueryString( 'query=something%20with%20spaces' ) ).toBe( true );
+		expect( isValidQueryString( 'source=hp&ei=tP7kW8-_FoK89QORoa2QBQ&q=test+url&oq=test+url&gs_l=psy-ab.3..0l10' ) ).toBe( true );
+	} );
+
+	it( 'returns false if the query string is invalid', () => {
+		expect( isValidQueryString() ).toBe( false );
+		expect( isValidQueryString( '' ) ).toBe( false );
+		expect( isValidQueryString( '?test=false' ) ).toBe( false );
+		expect( isValidQueryString( ' test=false ' ) ).toBe( false );
+		expect( isValidQueryString( 'test = false' ) ).toBe( false );
+		expect( isValidQueryString( 'test=f?alse' ) ).toBe( false );
+		expect( isValidQueryString( 'test=f#alse' ) ).toBe( false );
+		expect( isValidQueryString( 'test=f/alse' ) ).toBe( false );
+		expect( isValidQueryString( 'test=f?alse' ) ).toBe( false );
+		expect( isValidQueryString( '/test=false' ) ).toBe( false );
+		expect( isValidQueryString( 'test=false/' ) ).toBe( false );
+	} );
+} );
+
+describe( 'getFragment', () => {
+	it( 'returns the fragment of a URL', () => {
+		expect( getFragment( 'https://user:password@www.test-this.com:1020/test-path/file.extension#fragment?query=params&more' ) ).toBe( '#fragment' );
+		expect( getFragment( 'http://user:password@www.test-this.com:1020/test-path/file.extension?query=params&more#fragment' ) ).toBe( '#fragment' );
+		expect( getFragment( 'relative/url/#fragment' ) ).toBe( '#fragment' );
+		expect( getFragment( '/absolute/url/#fragment' ) ).toBe( '#fragment' );
+	} );
+
+	it( 'returns undefined when the provided does not contain a url fragment', () => {
+		expect( getFragment( '' ) ).toBeUndefined();
+		expect( getFragment( 'https://wordpress.org/test-path?query' ) ).toBeUndefined();
+		expect( getFragment( 'https://wordpress.org/test-path' ) ).toBeUndefined();
+		expect( getFragment( 'https://wordpress.org/this%20is%20a%20test' ) ).toBeUndefined();
+		expect( getFragment( 'https://www.google.com/search?source=hp&ei=tP7kW8-_FoK89QORoa2QBQ&q=test+url&oq=test+url&gs_l=psy-ab.3..0l10' ) ).toBeUndefined();
+		expect( getFragment( 'https://wordpress.org' ) ).toBeUndefined();
+		expect( getFragment( 'https://localhost:8080' ) ).toBeUndefined();
+		expect( getFragment( 'https://' ) ).toBeUndefined();
+		expect( getFragment( 'https:///test' ) ).toBeUndefined();
+		expect( getFragment( 'https://?' ) ).toBeUndefined();
+		expect( getFragment( 'test.com' ) ).toBeUndefined();
+	} );
+} );
+
+describe( 'isValidFragment', () => {
+	it( 'returns true if the fragment is valid', () => {
+		expect( isValidFragment( '#' ) ).toBe( true );
+		expect( isValidFragment( '#yesitis' ) ).toBe( true );
+		expect( isValidFragment( '#yes_it_is' ) ).toBe( true );
+		expect( isValidFragment( '#yes~it~is' ) ).toBe( true );
+		expect( isValidFragment( '#yes-it-is' ) ).toBe( true );
+	} );
+
+	it( 'returns false if the fragment is invalid', () => {
+		expect( isValidFragment( '' ) ).toBe( false );
+		expect( isValidFragment( ' #no-it-isnt ' ) ).toBe( false );
+		expect( isValidFragment( '#no-it-isnt#' ) ).toBe( false );
+		expect( isValidFragment( '#no-it-#isnt' ) ).toBe( false );
+		expect( isValidFragment( '#no-it-isnt?' ) ).toBe( false );
+		expect( isValidFragment( '#no-it isnt' ) ).toBe( false );
+		expect( isValidFragment( '/#no-it-isnt' ) ).toBe( false );
+		expect( isValidFragment( '#no-it-isnt/' ) ).toBe( false );
 	} );
 } );
 
@@ -104,6 +347,12 @@ describe( 'getQueryArg', () => {
 		const url = 'https://andalouses.example/beach?foo[]=bar&foo[]=baz';
 
 		expect( getQueryArg( url, 'foo' ) ).toEqual( [ 'bar', 'baz' ] );
+	} );
+
+	it( 'continues to work when an anchor follows the query string', () => {
+		const url = 'https://andalouses.example/beach?foo=bar&bar=baz#foo';
+
+		expect( getQueryArg( url, 'foo' ) ).toEqual( 'bar' );
 	} );
 } );
 

--- a/test/e2e/specs/links.test.js
+++ b/test/e2e/specs/links.test.js
@@ -420,4 +420,16 @@ describe( 'Links', () => {
 		const activeElementValue = await page.evaluate( () => document.activeElement.value );
 		expect( activeElementValue ).toBe( URL );
 	} );
+
+	it( 'adds an assertive message for screenreader users when an invalid link is set', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'This is Gutenberg' );
+		await pressWithModifier( SELECT_WORD_MODIFIER_KEYS, 'ArrowLeft' );
+		await pressWithModifier( META_KEY, 'K' );
+		await waitForAutoFocus();
+		await page.keyboard.type( 'http://#test.com' );
+		await page.keyboard.press( 'Enter' );
+		const assertiveContent = await page.evaluate( () => document.querySelector( '#a11y-speak-assertive' ).textContent );
+		expect( assertiveContent ).toBe( 'Warning: the link has been inserted but may have errors. Please test it.' );
+	} );
 } );

--- a/test/e2e/specs/links.test.js
+++ b/test/e2e/specs/links.test.js
@@ -430,6 +430,6 @@ describe( 'Links', () => {
 		await page.keyboard.type( 'http://#test.com' );
 		await page.keyboard.press( 'Enter' );
 		const assertiveContent = await page.evaluate( () => document.querySelector( '#a11y-speak-assertive' ).textContent );
-		expect( assertiveContent ).toBe( 'Warning: the link has been inserted but may have errors. Please test it.' );
+		expect( assertiveContent.trim() ).toBe( 'Warning: the link has been inserted but may have errors. Please test it.' );
 	} );
 } );


### PR DESCRIPTION
## Description
First step at addressing #1838.

**Changes:**
- Adds basic link validation following the same rules used in the classic editor
- Highlights link text in red when the link validation fails
- Speaks an assertive screenreader message ("Warning: the link has been inserted but may have errors. Please test it.") when link validation fails.

**What's missing**
Highlighting the invalid link in the paragraph like the classic editor does:
![screen shot 2018-10-31 at 3 19 55 pm](https://user-images.githubusercontent.com/677833/47772482-c8f5a080-dd21-11e8-826a-59a998530a11.png)

The new format api (#10209) landed just as I started looking into this. We need a way to set error states for formatting in the format api in order to highlight text in the same way the classic editor does. Issue to cover this: #11484.

## How has this been tested?
- Unit tests for the validation function
- E2E tests to catch regressions of the screenreader message
- Manual testing:
1. Enable a screenreader.
2. Try inserting a variety of invalid links (e.g. http:// test.com/, htt#p://test.com)
3. Observe that the link text turns red in the popover once the link is applied
4. Hear the message ""Warning: the link has been inserted but may have errors. Please test it." read by the screenreader
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
![screen shot 2018-11-09 at 6 40 06 pm](https://user-images.githubusercontent.com/677833/48257987-0b6c5b00-e44f-11e8-9df9-ad7d4f2987b9.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
