### PR TITLE
RichText: fix buggy enter/delete behaviour

### DIFF
--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -769,6 +769,18 @@ export class RichText extends Component {
 			this.applyRecord( record );
 			this.savedContent = value;
 		}
+
+		// If blocks are merged, but the content remains the same, e.g. merging
+		// an empty paragraph into another, then also set the selection to the
+		// end.
+		if ( isSelected && ! prevProps.isSelected && ! this.isActive() ) {
+			const record = this.formatToValue( value );
+			const prevRecord = this.formatToValue( prevProps.value );
+			const length = getTextContent( prevRecord ).length;
+			record.start = length;
+			record.end = length;
+			this.applyRecord( record );
+		}
 	}
 
 	formatToValue( value ) {

--- a/packages/editor/src/components/rich-text/tinymce.js
+++ b/packages/editor/src/components/rich-text/tinymce.js
@@ -250,7 +250,7 @@ export default class TinyMCE extends Component {
 	onKeyDown( event ) {
 		const { keyCode } = event;
 
-		// Disable TinyMCE behaviour.
+		// Disables TinyMCE behaviour.
 		if ( keyCode === ENTER || keyCode === BACKSPACE || keyCode === DELETE ) {
 			event.preventDefault();
 			// For some reason this is needed to also prevent the insertion of
@@ -258,6 +258,16 @@ export default class TinyMCE extends Component {
 			return false;
 		}
 
+		// Handles a horizontal navigation key down event to handle the case
+		// where TinyMCE attempts to preventDefault when on the outside edge of
+		// an inline boundary when arrowing _away_ from the boundary, not within
+		// it. Replaces the TinyMCE event `preventDefault` behavior with a noop,
+		// such that those relying on `defaultPrevented` are not misinformed
+		// about the arrow event.
+		//
+		// If TinyMCE#4476 is resolved, this handling may be removed.
+		//
+		// @see https://github.com/tinymce/tinymce/issues/4476
 		if ( keyCode !== LEFT && keyCode !== RIGHT ) {
 			return;
 		}

--- a/test/e2e/specs/block-deletion.test.js
+++ b/test/e2e/specs/block-deletion.test.js
@@ -7,7 +7,6 @@ import {
 	newPost,
 	pressWithModifier,
 	ACCESS_MODIFIER_KEYS,
-	waitForRichTextInitialization,
 } from '../support/utils';
 
 const addThreeParagraphsToNewPost = async () => {
@@ -17,10 +16,8 @@ const addThreeParagraphsToNewPost = async () => {
 	await clickBlockAppender();
 	await page.keyboard.type( 'First paragraph' );
 	await page.keyboard.press( 'Enter' );
-	await waitForRichTextInitialization();
 	await page.keyboard.type( 'Second paragraph' );
 	await page.keyboard.press( 'Enter' );
-	await waitForRichTextInitialization();
 };
 
 const clickOnBlockSettingsMenuItem = async ( buttonLabel ) => {
@@ -99,7 +96,6 @@ describe( 'block deletion -', () => {
 			// Add a third paragraph for this test.
 			await page.keyboard.type( 'Third paragraph' );
 			await page.keyboard.press( 'Enter' );
-			await waitForRichTextInitialization();
 
 			// Press the up arrow once to select the third and fourth blocks.
 			await pressWithModifier( 'Shift', 'ArrowUp' );

--- a/test/e2e/specs/splitting-merging.test.js
+++ b/test/e2e/specs/splitting-merging.test.js
@@ -8,7 +8,6 @@ import {
 	pressTimes,
 	pressWithModifier,
 	META_KEY,
-	waitForRichTextInitialization,
 } from '../support/utils';
 
 describe( 'splitting and merging blocks', () => {
@@ -133,9 +132,7 @@ describe( 'splitting and merging blocks', () => {
 		await pressWithModifier( META_KEY, 'b' );
 		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.press( 'Enter' );
-		await waitForRichTextInitialization();
 		await page.keyboard.press( 'Enter' );
-		await waitForRichTextInitialization();
 
 		await page.keyboard.press( 'Backspace' );
 
@@ -175,11 +172,8 @@ describe( 'splitting and merging blocks', () => {
 		await insertBlock( 'Paragraph' );
 		await page.keyboard.type( 'First' );
 		await page.keyboard.press( 'Enter' );
-		await waitForRichTextInitialization();
 		await page.keyboard.press( 'Enter' );
-		await waitForRichTextInitialization();
 		await page.keyboard.press( 'Enter' );
-		await waitForRichTextInitialization();
 		await page.keyboard.type( 'Second' );
 		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.press( 'ArrowUp' );

--- a/test/e2e/support/utils.js
+++ b/test/e2e/support/utils.js
@@ -86,34 +86,6 @@ async function login() {
 	] );
 }
 
-/**
- * Returns a promise which resolves once it's determined that the active DOM
- * element is not within a RichText field, or the RichText field's TinyMCE has
- * completed initialization. This is an unfortunate workaround to address an
- * issue where TinyMCE takes its time to become ready for user input.
- *
- * TODO: This is a code smell, indicating that "too fast" resulting in breakage
- * could be equally problematic for a fast human. It should be explored whether
- * all event bindings we assign to TinyMCE to handle could be handled through
- * the DOM directly instead.
- *
- * @return {Promise} Promise resolving once RichText is initialized, or is
- *                   determined to not be a container of the active element.
- */
-export async function waitForRichTextInitialization() {
-	const isInRichText = await page.evaluate( () => {
-		return !! document.activeElement.closest( '.editor-rich-text__tinymce' );
-	} );
-
-	if ( ! isInRichText ) {
-		return;
-	}
-
-	return page.waitForFunction( () => {
-		return !! document.activeElement.closest( '.mce-content-body' );
-	} );
-}
-
 export async function visitAdmin( adminPath, query ) {
 	await goToWPPath( join( 'wp-admin', adminPath ), query );
 
@@ -238,7 +210,6 @@ export async function ensureSidebarOpened() {
  */
 export async function clickBlockAppender() {
 	await page.click( '.editor-default-block-appender__content' );
-	await waitForRichTextInitialization();
 }
 
 /**
@@ -268,7 +239,6 @@ export async function insertBlock( searchTerm, panelName = null ) {
 		await panelButton.click();
 	}
 	await page.click( `button[aria-label="${ searchTerm }"]` );
-	await waitForRichTextInitialization();
 }
 
 export async function convertBlock( name ) {
@@ -276,7 +246,6 @@ export async function convertBlock( name ) {
 	await page.mouse.move( 250, 350, { steps: 10 } );
 	await page.click( '.editor-block-switcher__toggle' );
 	await page.click( `.editor-block-types-list__item[aria-label="${ name }"]` );
-	await waitForRichTextInitialization();
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes #6021, #11348, #10484 and #9905.

In master, keep enter pressed in a paragraph, and observe blocks with too many BR elements, or nested paragraph elements, or BR elements around existing text. This is caused by attaching the keydown handler too late (during TinyMCE setup), resulting in default browser behaviour executing. The solution is to attach handler on the content editable element with React as soon as the element is created.

Also removes `waitForRichTextInitialization` entirely from all tests, because the `contentEditable` area is immediately available for input.

## How has this been tested?
When keeping enter pressed in a paragraph, it should create a bunch a clean, empty paragraphs.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->