### PR TITLE
Fix RTL block alignments

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -29,6 +29,7 @@ $blocks-button__line-height: $big-font-size + 6px;
 	}
 
 	&.alignright {
+		/*rtl:ignore*/
 		text-align: right;
 	}
 }

--- a/packages/block-library/src/categories/style.scss
+++ b/packages/block-library/src/categories/style.scss
@@ -1,8 +1,10 @@
 .wp-block-categories {
 	&.alignleft {
+		/*rtl:ignore*/
 		margin-right: 2em;
 	}
 	&.alignright {
+		/*rtl:ignore*/
 		margin-left: 2em;
 	}
 }

--- a/packages/block-library/src/classic/editor.scss
+++ b/packages/block-library/src/classic/editor.scss
@@ -88,12 +88,16 @@
 	}
 
 	.alignright {
+		/*rtl:ignore*/
 		float: right;
+		/*rtl:ignore*/
 		margin: 0.5em 0 0.5em 1em;
 	}
 
 	.alignleft {
+		/*rtl:ignore*/
 		float: left;
+		/*rtl:ignore*/
 		margin: 0.5em 1em 0.5em 0;
 	}
 

--- a/packages/block-library/src/file/style.scss
+++ b/packages/block-library/src/file/style.scss
@@ -6,6 +6,7 @@
 	}
 
 	&.alignright {
+		/*rtl:ignore*/
 		text-align: right;
 	}
 

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -41,12 +41,16 @@
 	}
 
 	.alignleft {
+		/*rtl:ignore*/
 		float: left;
+		/*rtl:ignore*/
 		margin-right: 1em;
 	}
 
 	.alignright {
+		/*rtl:ignore*/
 		float: right;
+		/*rtl:ignore*/
 		margin-left: 1em;
 	}
 

--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -1,8 +1,10 @@
 .wp-block-latest-posts {
 	&.alignleft {
+		/*rtl:ignore*/
 		margin-right: 2em;
 	}
 	&.alignright {
+		/*rtl:ignore*/
 		margin-left: 2em;
 	}
 	&.is-grid {

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -814,12 +814,23 @@
 			// It behaves as relative, in other words, until it reaches an edge and then behaves as fixed.
 			// But by applying a float, we take it out of this flow. The benefit is that we don't need to compensate for margins.
 			// In turn, this allows margins on sibling elements to collapse to parent elements.
+			// RTL note: this rule does need to be auto-flipped based on direction.
+			float: left;
+		}
+	}
+
+	.editor-block-list__block[data-align="left"] & {
+		@include break-small() {
+			// RTL note: this rule should not be auto-flipped based on direction.
+			/*rtl:ignore*/
 			float: left;
 		}
 	}
 
 	.editor-block-list__block[data-align="right"] & {
 		@include break-small() {
+			// RTL note: this rule should not be auto-flipped based on direction.
+			/*rtl:ignore*/
 			float: right;
 		}
 	}


### PR DESCRIPTION
When you explicitly pick an alignment in the editor, this alignment should be respected regardless of text direction.

"Align left" is always _align left_. This PR fixes that by adding ignore comments to the auto RTL prefixer.

Steps to reproduce:

- Set WordPress to an RTL language
- Explicitly left or right align a block, and verify that this alignment looks right in both the editor and the frontend.

Before:

<img width="905" alt="screenshot 2018-10-31 at 12 04 04" src="https://user-images.githubusercontent.com/1204802/47784290-6c848800-dd05-11e8-8d8a-f2b36151652b.png">

After:

<img width="876" alt="screenshot 2018-10-31 at 12 04 10" src="https://user-images.githubusercontent.com/1204802/47784294-6f7f7880-dd05-11e8-8e4c-1e08e39d7029.png">