### PR TITLE
[RNMobile] Export `switchToBlockType` function to native

### DIFF
--- a/packages/blocks/src/api/index.native.js
+++ b/packages/blocks/src/api/index.native.js
@@ -1,5 +1,6 @@
 export {
 	createBlock,
+	switchToBlockType,
 } from './factory';
 export {
 	default as parse,


### PR DESCRIPTION
This is a very simple PR that exposes `switchToBlockType` to native side. We need it when merging blocks of 2 different types.