### PR TITLE
Fixed Typo in Documentation

### DIFF
--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -140,7 +140,7 @@ styles: [
 ],
 ```
 
-Plugins and Themes can also register [custom block style](../docs/extensibility/extending-blocks/#block-style-variations) for exisiting blocks.
+Plugins and Themes can also register [custom block style](../docs/extensibility/extending-blocks/#block-style-variations) for existing blocks.
 
 #### Attributes (optional)
 
@@ -490,7 +490,7 @@ className: false,
 html: false,
 ```
 
-- `inserter` (default `true`): By default, all blocks will appear in the Gutenberg inserter. To hide a block so that it can only be inserted programatically, set `inserter` to `false`.
+- `inserter` (default `true`): By default, all blocks will appear in the Gutenberg inserter. To hide a block so that it can only be inserted programmatically, set `inserter` to `false`.
 
 ```js
 // Hide this block from the inserter.


### PR DESCRIPTION
## Description
Fixed two typos in docs/block-api.md

## How has this been tested?
Spell checker

## Types of changes
Corrected spelling

## Checklist:
- [ x ] My code is tested.
- [ x ] My code follows the WordPress code style.
- [ x ] My code follows the accessibility standards.
- [ x ] My code has proper inline documentation.
