### PR TITLE
Make anchor always render after Additional CSS class

### DIFF
--- a/packages/editor/src/hooks/index.js
+++ b/packages/editor/src/hooks/index.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import './align';
-import './anchor';
 import './custom-class-name';
+import './anchor';
 import './default-autocompleters';
 import './generated-class-name';


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/7964