### PR TITLE
Fixing color picker accessibility

### DIFF
--- a/packages/components/src/color-picker/inputs.js
+++ b/packages/components/src/color-picker/inputs.js
@@ -174,10 +174,11 @@ export class Inputs extends Component {
 				<fieldset>
 					<legend className="screen-reader-text">
 						{ __( 'Color value in RGB' ) }
+						<abbr title={ __( 'Red Green Blue' ) }>RGB</abbr>
 					</legend>
 					<div className="components-color-picker__inputs-fields">
 						<Input
-							label="r"
+							label={ __( 'Red' ) }
 							valueKey="r"
 							value={ this.props.rgb.r }
 							onChange={ this.handleChange }
@@ -186,7 +187,7 @@ export class Inputs extends Component {
 							max="255"
 						/>
 						<Input
-							label="g"
+							label={ __( 'Green' ) }
 							valueKey="g"
 							value={ this.props.rgb.g }
 							onChange={ this.handleChange }
@@ -195,7 +196,7 @@ export class Inputs extends Component {
 							max="255"
 						/>
 						<Input
-							label="b"
+							label={ __( 'Blue' ) }
 							valueKey="b"
 							value={ this.props.rgb.b }
 							onChange={ this.handleChange }
@@ -205,7 +206,7 @@ export class Inputs extends Component {
 						/>
 						{ disableAlpha ? null : (
 							<Input
-								label="a"
+								label={ __( 'Alpha' ) }
 								valueKey="a"
 								value={ this.props.rgb.a }
 								onChange={ this.handleChange }
@@ -222,11 +223,12 @@ export class Inputs extends Component {
 			return (
 				<fieldset>
 					<legend className="screen-reader-text">
-						{ __( 'Color value in HSL' ) }
+						{ __( 'Color value in' ) }
+						<abbr title={ 'Hue Saturation Lightness' }>{ __( 'HSL' ) }</abbr>
 					</legend>
 					<div className="components-color-picker__inputs-fields">
 						<Input
-							label="h"
+							label={ __( 'Hue' ) }
 							valueKey="h"
 							value={ this.props.hsl.h }
 							onChange={ this.handleChange }
@@ -235,7 +237,7 @@ export class Inputs extends Component {
 							max="359"
 						/>
 						<Input
-							label="s"
+							label={ __( 'Saturation' ) }
 							valueKey="s"
 							value={ this.props.hsl.s }
 							onChange={ this.handleChange }
@@ -244,7 +246,7 @@ export class Inputs extends Component {
 							max="100"
 						/>
 						<Input
-							label="l"
+							label={ __( 'Lightness' ) }
 							valueKey="l"
 							value={ this.props.hsl.l }
 							onChange={ this.handleChange }
@@ -254,7 +256,7 @@ export class Inputs extends Component {
 						/>
 						{ disableAlpha ? null : (
 							<Input
-								label="a"
+								label={ __( 'Alpha' ) }
 								valueKey="a"
 								value={ this.props.hsl.a }
 								onChange={ this.handleChange }


### PR DESCRIPTION
## Description
Attempts to cover part 1 of #10975.

* Replacing some abbriviations with proper abbr tags
* Other abbriviations have been replaced with full names

## How has this been tested?
Manual testing. I did not attempt to fix the VoiceOver bug in #10975

## Screenshots
<img width="282" alt="screenshot 2018-10-31 at 14 22 10" src="https://user-images.githubusercontent.com/191583/47790847-7bc10100-dd18-11e8-9532-dcd46834ee04.png">
<img width="284" alt="screenshot 2018-10-31 at 14 22 24" src="https://user-images.githubusercontent.com/191583/47790860-84193c00-dd18-11e8-8071-a517e4399b61.png">

## Types of changes
No breaking changes. Those are only markup-related. No testing required as far as I know, unless the CI breaks. 🤞

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
