### PR TITLE
Fix: Pressing add new category before categories are loaded crashes the editor

### DIFF
--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -27,6 +27,7 @@ const DEFAULT_QUERY = {
 };
 
 const MIN_TERMS_COUNT_FOR_FILTER = 8;
+const EMPTY_AVAILABLE_TERMS = [];
 
 class HierarchicalTermSelector extends Component {
 	constructor() {
@@ -285,7 +286,7 @@ class HierarchicalTermSelector extends Component {
 				slug === 'category' ? __( 'Categories' ) : __( 'Terms' )
 			)
 		);
-		const showFilter = availableTerms && ( availableTerms.length >= MIN_TERMS_COUNT_FOR_FILTER );
+		const showFilter = availableTerms.length >= MIN_TERMS_COUNT_FOR_FILTER;
 
 		return [
 			showFilter && <label
@@ -366,7 +367,8 @@ export default compose( [
 		const { getTaxonomy, getEntityRecords } = select( 'core' );
 		const { isResolving } = select( 'core/data' );
 		const taxonomy = getTaxonomy( slug );
-		const availableTerms = getEntityRecords( 'taxonomy', slug, DEFAULT_QUERY );
+		const availableTerms = getEntityRecords( 'taxonomy', slug, DEFAULT_QUERY ) ||
+			EMPTY_AVAILABLE_TERMS;
 		const availableTermsTree = buildTermsTree( availableTerms );
 		return {
 			hasCreateAction: taxonomy ? get( getCurrentPost(), [ '_links', 'wp:action-create-' + taxonomy.rest_base ], false ) : false,


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/11279

Previously availableTerms was part of the state and initialized to an empty array while a request for the terms was not finished. During https://github.com/WordPress/gutenberg/pull/10089 availableTerms started being a prop but if the terms were not yet requested it was null, some changes were made to handle null values in availableTerms but one case where we just checked the length was missing.

This PR just makes sure while the terms are not requested availableTerms is an empty array. This simplifies the code and solves the crash.

## Description
I created a new post.
I collapsed the categories.
I reloaded the post.
I edited WordPress index.php and added a sleep( 5 ); to make a request take at least 5 seconds, makes things easier to reproduce.
I expanded the categories and I pressed the add new button. I checked that after 5 seconds are passed the categories appear without any crash. On master, we have a crash.
