### PR TITLE
Remove sticky-menu class preventing full admin page scroll

### DIFF
--- a/packages/edit-post/src/components/fullscreen-mode/index.js
+++ b/packages/edit-post/src/components/fullscreen-mode/index.js
@@ -4,15 +4,25 @@
 import { Component } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 
-class FullscreenMode extends Component {
+export class FullscreenMode extends Component {
 	componentDidMount() {
+		this.isSticky = false;
 		this.sync();
 
 		// `is-fullscreen-mode` is set in PHP as a body class by Gutenberg, and this causes
 		// `sticky-menu` to be applied by WordPress and prevents the admin menu being scrolled
 		// even if `is-fullscreen-mode` is then removed. Let's remove `sticky-menu` here as
 		// a consequence of the FullscreenMode setup
-		document.body.classList.remove( 'sticky-menu' );
+		if ( document.body.classList.contains( 'sticky-menu' ) ) {
+			this.isSticky = true;
+			document.body.classList.remove( 'sticky-menu' );
+		}
+	}
+
+	componentWillUnmount() {
+		if ( this.isSticky ) {
+			document.body.classList.add( 'sticky-menu' );
+		}
 	}
 
 	componentDidUpdate( prevProps ) {

--- a/packages/edit-post/src/components/fullscreen-mode/index.js
+++ b/packages/edit-post/src/components/fullscreen-mode/index.js
@@ -7,6 +7,12 @@ import { withSelect } from '@wordpress/data';
 class FullscreenMode extends Component {
 	componentDidMount() {
 		this.sync();
+
+		// `is-fullscreen-mode` is set in PHP as a body class by Gutenberg, and this causes
+		// `sticky-menu` to be applied by WordPress and prevents the admin menu being scrolled
+		// even if `is-fullscreen-mode` is then removed. Let's remove `sticky-menu` here as
+		// a consequence of the FullscreenMode setup
+		document.body.classList.remove( 'sticky-menu' );
 	}
 
 	componentDidUpdate( prevProps ) {

--- a/packages/edit-post/src/components/fullscreen-mode/test/index.js
+++ b/packages/edit-post/src/components/fullscreen-mode/test/index.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies.
+ */
+import { FullscreenMode } from '..';
+
+describe( 'FullscreenMode', () => {
+	it( 'fullscreen mode to be added to document body when active', () => {
+		shallow( <FullscreenMode isActive={ true } /> );
+
+		expect( document.body.classList.contains( 'is-fullscreen-mode' ) ).toBe( true );
+	} );
+
+	it( 'fullscreen mode not to be added to document body when active', () => {
+		shallow( <FullscreenMode isActive={ false } /> );
+
+		expect( document.body.classList.contains( 'is-fullscreen-mode' ) ).toBe( false );
+	} );
+
+	it( 'sticky-menu to be removed from the body class if present', () => {
+		document.body.classList.add( 'sticky-menu' );
+
+		shallow( <FullscreenMode isActive={ false } /> );
+
+		expect( document.body.classList.contains( 'sticky-menu' ) ).toBe( false );
+	} );
+
+	it( 'sticky-menu to be restored when component unmounted and originally present', () => {
+		document.body.classList.add( 'sticky-menu' );
+
+		const mode = shallow( <FullscreenMode isActive={ false } /> );
+		mode.unmount();
+
+		expect( document.body.classList.contains( 'sticky-menu' ) ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
If you have a long admin menu it's not possible to scroll down when Gutenberg first loads.

![edit_post_ _wordpress_latest_ _wordpress_and_gutenberg_ _fix_fullscreen-sticky-menu__8244_commits__and_gutenberg_index_js_ _gutenberg](https://user-images.githubusercontent.com/1277682/47795189-ff2f2200-dd19-11e8-896f-c4a3b7557ef2.jpg)

This is caused because of #9567 adding `is-fullscreen-mode` to the page body class. This causes [core WordPress](https://core.svn.wordpress.org/trunk/wp-admin/js/common.js) to add `sticky-menu` to the page, which sets the admin menu to `position: fixed`.

Resizing the window causes Gutenberg to re-apply body class values, and `sticky-menu` is then lost.

More information can be found in this [comment](https://github.com/WordPress/gutenberg/issues/9996#issuecomment-434630485).

This PR modifies the `FullscreenMode` component to remove `sticky-menu` when it first starts to counteract [adding](https://github.com/WordPress/gutenberg/blob/master/gutenberg.php#L500) `is-fullscreen-mode` in PHP.

Fixes #9996

## How has this been tested?
1. Create plugin described [here](https://github.com/WordPress/gutenberg/issues/9996#issuecomment-434621869) to extend your admin menu
2. Verify that on page load it's possible to scroll to the bottom of the admin menu

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
