### PR TITLE
WIP: Parser: Add tokens for inner blocks in inner HTML

### DIFF
--- a/packages/block-serialization-default-parser/parser.php
+++ b/packages/block-serialization-default-parser/parser.php
@@ -440,8 +440,9 @@ class WP_Block_Parser {
 	 */
 	function add_inner_block( WP_Block_Parser_Block $block, $token_start, $token_length, $last_offset = null ) {
 		$parent = $this->stack[ count( $this->stack ) - 1 ];
+		$next_html = substr( $this->document, $parent->prev_offset, $token_start - $parent->prev_offset );
+		$parent->block->innerHTML .= $next_html . '<!-- {' . count( $parent->block->innerBlocks ) . '} -->';
 		$parent->block->innerBlocks[] = $block;
-		$parent->block->innerHTML .= substr( $this->document, $parent->prev_offset, $token_start - $parent->prev_offset );
 		$parent->prev_offset = $last_offset ? $last_offset : $token_start + $token_length;
 	}
 

--- a/packages/block-serialization-default-parser/src/index.js
+++ b/packages/block-serialization-default-parser/src/index.js
@@ -229,11 +229,10 @@ function addFreeform( rawLength ) {
 
 function addInnerBlock( block, tokenStart, tokenLength, lastOffset ) {
 	const parent = stack[ stack.length - 1 ];
-	parent.block.innerBlocks.push( block );
-	parent.block.innerHTML += document.substr(
-		parent.prevOffset,
-		tokenStart - parent.prevOffset,
-	);
+	const parentBlock = parent.block;
+	const nextHTML = document.substr( parent.prevOffset, tokenStart - parent.prevOffset );
+	parentBlock.innerHTML += `${ nextHTML }<!-- {${ parentBlock.innerBlocks.length }} -->`;
+	parentBlock.innerBlocks.push( block );
 	parent.prevOffset = lastOffset ? lastOffset : tokenStart + tokenLength;
 }
 

--- a/packages/block-serialization-default-parser/test/__snapshots__/index.js.snap
+++ b/packages/block-serialization-default-parser/test/__snapshots__/index.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`block-serialization-default-parser-js basic parsing parse() works properly 1`] = `
+Array [
+  Object {
+    "attrs": Object {},
+    "blockName": "core/more",
+    "innerBlocks": Array [],
+    "innerHTML": "<!--more-->",
+  },
+]
+`;
+
+exports[`block-serialization-default-parser-php basic parsing parse() works properly 1`] = `
+Array [
+  Object {
+    "attrs": Object {},
+    "blockName": "core/more",
+    "innerBlocks": Array [],
+    "innerHTML": "<!--more-->",
+  },
+]
+`;

--- a/packages/block-serialization-default-parser/test/index.js
+++ b/packages/block-serialization-default-parser/test/index.js
@@ -1,73 +1,24 @@
 /**
+ * External dependencies
+ */
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+/**
  * Internal dependencies
  */
+import { testParser } from '../../block-serialization-spec-parser/shared-tests';
 import { parse } from '../';
 
-describe( 'block-serialization-spec-parser', () => {
-	test( 'parse() accepts inputs with multiple Reusable blocks', () => {
-		const result = parse(
-			'<!-- wp:block {"ref":313} /--><!-- wp:block {"ref":482} /-->'
-		);
+describe( 'block-serialization-default-parser-js', testParser( parse ) );
 
-		expect( result ).toEqual( [
-			{
-				blockName: 'core/block',
-				attrs: { ref: 313 },
-				innerBlocks: [],
-				innerHTML: '',
-			},
-			{
-				blockName: 'core/block',
-				attrs: { ref: 482 },
-				innerBlocks: [],
-				innerHTML: '',
-			},
-		] );
-	} );
-
-	test( 'treats void blocks and empty blocks identically', () => {
-		expect( parse(
-			'<!-- wp:block /-->'
-		) ).toEqual( parse(
-			'<!-- wp:block --><!-- /wp:block -->'
-		) );
-
-		expect( parse(
-			'<!-- wp:my/bus { "is": "fast" } /-->'
-		) ).toEqual( parse(
-			'<!-- wp:my/bus { "is": "fast" } --><!-- /wp:my/bus -->'
-		) );
-	} );
-
-	test( 'should grab HTML soup before block openers', () => {
-		[
-			'<p>Break me</p><!-- wp:block /-->',
-			'<p>Break me</p><!-- wp:block --><!-- /wp:block -->',
-		].forEach( ( input ) => expect( parse( input ) ).toEqual( [
-			expect.objectContaining( { innerHTML: '<p>Break me</p>' } ),
-			expect.objectContaining( { blockName: 'core/block', innerHTML: '' } ),
-		] ) );
-	} );
-
-	test( 'should grab HTML soup before inner block openers', () => {
-		[
-			'<!-- wp:outer --><p>Break me</p><!-- wp:block /--><!-- /wp:outer -->',
-			'<!-- wp:outer --><p>Break me</p><!-- wp:block --><!-- /wp:block --><!-- /wp:outer -->',
-		].forEach( ( input ) => expect( parse( input ) ).toEqual( [
-			expect.objectContaining( {
-				innerBlocks: [ expect.objectContaining( { blockName: 'core/block', innerHTML: '' } ) ],
-				innerHTML: '<p>Break me</p>',
-			} ),
-		] ) );
-	} );
-
-	test( 'should grab HTML soup after blocks', () => {
-		[
-			'<!-- wp:block /--><p>Break me</p>',
-			'<!-- wp:block --><!-- /wp:block --><p>Break me</p>',
-		].forEach( ( input ) => expect( parse( input ) ).toEqual( [
-			expect.objectContaining( { blockName: 'core/block', innerHTML: '' } ),
-			expect.objectContaining( { innerHTML: '<p>Break me</p>' } ),
-		] ) );
-	} );
-} );
+describe( 'block-serialization-default-parser-php', testParser( ( document ) => JSON.parse(
+	spawnSync(
+		'php',
+		[ '-f', path.join( __dirname, 'test-parser.php' ) ],
+		{
+			input: document,
+			encoding: 'utf8',
+		}
+	).stdout
+) ) );

--- a/packages/block-serialization-default-parser/test/test-parser.php
+++ b/packages/block-serialization-default-parser/test/test-parser.php
@@ -1,0 +1,7 @@
+<?php
+
+require_once __DIR__ . '/../parser.php';
+
+$parser = new WP_Block_Parser();
+
+echo json_encode( $parser->parse( file_get_contents( 'php://stdin' ) ) );

--- a/packages/block-serialization-spec-parser/grammar.pegjs
+++ b/packages/block-serialization-spec-parser/grammar.pegjs
@@ -51,18 +51,21 @@
 // are the same as `json_decode`
 
 // array arguments are backwards because of PHP
-if ( ! function_exists( 'peg_array_partition' ) ) {
-    function peg_array_partition( $array, $predicate ) {
-        $truthy = array();
-        $falsey = array();
+if ( ! function_exists( 'peg_process_inner_content' ) ) {
+    function peg_process_inner_content( $array ) {
+        $innerHTML = '';
+        $innerBlocks = array();
 
         foreach ( $array as $item ) {
-            call_user_func( $predicate, $item )
-                ? $truthy[] = $item
-                : $falsey[] = $item;
+            if ( is_string( $item ) ) {
+                $innerHTML .= $item;
+            } else {
+                $innerHTML .= '<!-- {' . count( $innerBlocks ) . '} -->';
+                $innerBlocks[] = $item;
+            }
         }
 
-        return array( $truthy, $falsey );
+        return array( $innerHTML, $innerBlocks );
     }
 }
 
@@ -151,22 +154,25 @@ function maybeJSON( s ) {
     }
 }
 
-function partition( predicate, list ) {
+function processInnerContent( list ) {
     var i, l, item;
-    var truthy = [];
-    var falsey = [];
+    var innerHTML = '';
+    var innerBlocks = [];
 
     // nod to performance over a simpler reduce
     // and clone model we could have taken here
     for ( i = 0, l = list.length; i < l; i++ ) {
         item = list[ i ];
 
-        predicate( item )
-            ? truthy.push( item )
-            : falsey.push( item )
-    };
+        if ( 'string' === typeof item ) {
+            innerHTML += item;
+        } else {
+            innerHTML += '<!-- {' + innerBlocks.length + '} -->';
+            innerBlocks.push( item );
+        }
+    }
 
-    return [ truthy, falsey ];
+    return [ innerHTML, innerBlocks ];
 }
 
 }
@@ -216,17 +222,17 @@ Block_Balanced
   = s:Block_Start children:(Block / $(!Block_End .))* e:Block_End
   {
     /** <?php
-    list( $innerHTML, $innerBlocks ) = peg_array_partition( $children, 'is_string' );
+    list( $innerHTML, $innerBlocks ) = peg_process_inner_content( $children );
 
     return array(
       'blockName'    => $s['blockName'],
       'attrs'        => $s['attrs'],
       'innerBlocks'  => $innerBlocks,
-      'innerHTML'    => implode( '', $innerHTML ),
+      'innerHTML'    => $innerHTML,
     );
     ?> **/
 
-    var innerContent = partition( function( a ) { return 'string' === typeof a }, children );
+    var innerContent = processInnerContent( children );
     var innerHTML = innerContent[ 0 ];
     var innerBlocks = innerContent[ 1 ];
 
@@ -234,7 +240,7 @@ Block_Balanced
       blockName: s.blockName,
       attrs: s.attrs,
       innerBlocks: innerBlocks,
-      innerHTML: innerHTML.join( '' )
+      innerHTML: innerHTML
     };
   }
 

--- a/packages/block-serialization-spec-parser/shared-tests.js
+++ b/packages/block-serialization-spec-parser/shared-tests.js
@@ -1,0 +1,85 @@
+export const testParser = ( parse ) => () => {
+	describe( 'basic parsing', () => {
+		test( 'parse() works properly', () => {
+			expect( parse( '<!-- wp:core/more --><!--more--><!-- /wp:core/more -->' ) ).toMatchSnapshot();
+		} );
+	} );
+
+	describe( 'generic tests', () => {
+		test( 'parse() accepts inputs with multiple Reusable blocks', () => {
+			expect( parse( '<!-- wp:block {"ref":313} /--><!-- wp:block {"ref":482} /-->' ) ).toEqual( [
+				expect.objectContaining( {
+					blockName: 'core/block',
+					attrs: { ref: 313 },
+				} ),
+				expect.objectContaining( {
+					blockName: 'core/block',
+					attrs: { ref: 482 },
+				} ),
+			] );
+		} );
+
+		test( 'treats void blocks and empty blocks identically', () => {
+			expect( parse(
+				'<!-- wp:block /-->'
+			) ).toEqual( parse(
+				'<!-- wp:block --><!-- /wp:block -->'
+			) );
+
+			expect( parse(
+				'<!-- wp:my/bus { "is": "fast" } /-->'
+			) ).toEqual( parse(
+				'<!-- wp:my/bus { "is": "fast" } --><!-- /wp:my/bus -->'
+			) );
+		} );
+
+		test( 'should grab HTML soup before block openers', () => {
+			[
+				'<p>Break me</p><!-- wp:block /-->',
+				'<p>Break me</p><!-- wp:block --><!-- /wp:block -->',
+			].forEach( ( input ) => expect( parse( input ) ).toEqual( [
+				expect.objectContaining( { innerHTML: '<p>Break me</p>' } ),
+				expect.objectContaining( { blockName: 'core/block', innerHTML: '' } ),
+			] ) );
+		} );
+
+		test( 'should grab HTML soup before inner block openers', () => [
+			'<!-- wp:outer --><p>Break me</p><!-- wp:block /--><!-- /wp:outer -->',
+			'<!-- wp:outer --><p>Break me</p><!-- wp:block --><!-- /wp:block --><!-- /wp:outer -->',
+		].forEach( ( input ) => expect( parse( input ) ).toEqual( [
+			expect.objectContaining( {
+				innerBlocks: [ expect.objectContaining( { blockName: 'core/block', innerHTML: '' } ) ],
+				innerHTML: '<p>Break me</p><!-- {0} -->',
+			} ),
+		] ) ) );
+
+		test( 'should grab HTML soup after blocks', () => [
+			'<!-- wp:block /--><p>Break me</p>',
+			'<!-- wp:block --><!-- /wp:block --><p>Break me</p>',
+		].forEach( ( input ) => expect( parse( input ) ).toEqual( [
+			expect.objectContaining( { blockName: 'core/block', innerHTML: '' } ),
+			expect.objectContaining( { innerHTML: '<p>Break me</p>' } ),
+		] ) ) );
+	} );
+
+	describe( 'innerBlock tokenization', () => {
+		test( 'adds token to empty innerHTML', () => {
+			expect( parse( '<!-- wp:block --><!-- wp:void /--><!-- /wp:block -->' )[ 0 ] ).toHaveProperty( 'innerHTML', '<!-- {0} -->' );
+		} );
+
+		test( 'adds token before HTML soup', () => {
+			expect( parse( '<!-- wp:block --><!-- wp:void /-->after<!-- /wp:block -->' )[ 0 ] ).toHaveProperty( 'innerHTML', '<!-- {0} -->after' );
+		} );
+
+		test( 'adds token after HTML soup', () => {
+			expect( parse( '<!-- wp:block -->before<!-- wp:void /-->after<!-- /wp:block -->' )[ 0 ] ).toHaveProperty( 'innerHTML', 'before<!-- {0} -->after' );
+		} );
+
+		test( 'nests tokens with their respective blocks', () => {
+			const block = parse( '<!-- wp:outer -->before<!-- wp:inner -->deep before<!-- wp:deep -->inside<!-- /wp:deep -->deep after<!-- /wp:inner -->after<!-- /wp:outer -->' )[ 0 ];
+
+			expect( block ).toHaveProperty( 'innerHTML', 'before<!-- {0} -->after' );
+			expect( block.innerBlocks[ 0 ] ).toHaveProperty( 'innerHTML', 'deep before<!-- {0} -->deep after' );
+		} );
+	} );
+};

--- a/packages/block-serialization-spec-parser/test/__snapshots__/index.js.snap
+++ b/packages/block-serialization-spec-parser/test/__snapshots__/index.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`block-serialization-spec-parser parse() works properly 1`] = `
+exports[`block-serialization-spec-parser basic parsing parse() works properly 1`] = `
 Array [
   Object {
     "attrs": Object {},

--- a/packages/block-serialization-spec-parser/test/index.js
+++ b/packages/block-serialization-spec-parser/test/index.js
@@ -1,14 +1,7 @@
 /**
  * Internal dependencies
  */
+import { testParser } from '../shared-tests';
 import { parse } from '../';
 
-describe( 'block-serialization-spec-parser', () => {
-	test( 'parse() works properly', () => {
-		const result = parse(
-			'<!-- wp:core/more --><!--more--><!-- /wp:core/more -->'
-		);
-
-		expect( result ).toMatchSnapshot();
-	} );
-} );
+describe( 'block-serialization-spec-parser', testParser( parse ) );


### PR DESCRIPTION
> **DO NOT MERGE**

Motivated by #8760
Necessary for #10463, #10108

## Abstract
Add tokens in `innerHTML` of parsed `post_content` indicating where each of a block's `innerBlocks` came from. e.g. `innerHTML: "Before <!-- {0} --> Middle <!-- {1} --> After"`

## Status

 - the code editor for posts is showing the tokens currently which means that we have to update the full parsing stack to make this PR ready to merge

## Summary
Inner blocks, or nested blocks, or blocks-within-blocks, can exist in Gutenberg posts. They are serialized in `post_content` in-place as normal blocks which exist in between another block's comment delimiters.

```html
<!-- wp:outerBlock -->
Check out my
<!-- wp:voidInnerBlock /-->
and my other
<!-- wp:innerBlock -->
with its own content.
<!-- /wp:innerBlock -->
<!-- /wp:outerBlock -->
```

The way this gets parsed leaves us in a quandary: we cannot reconstruct the original `post_content` after parsing because we lose the origin location information for each inner block since they are only passed as an array of inner blocks.

```json
{
	"blockName": "core/outerBlock",
	"attrs": {},
	"innerBlocks": [
		{
			"blockName": "core/voidInnerBlock",
			"attrs": {},
			"innerBlocks": [],
			"innerHTML": ""
		},
		{
			"blockName": "core/innerBlock",
			"attrs": {},
			"innerBlocks": [],
			"innerHTML": "\nwith its own content.\n"
		}
	],
	"innerHTML": "\nCheck out my\n\nand my other\n\n"
}
```

At this point we have parsed the blocks and prepared them for attaching into the JavaScript block code that interprets them but we have lost our reverse transformation.

In this PR I'd like to introduce a new mechanism which should only marginally break existing functionality but which will enable us to go back and forth isomorphically between the `post_content` and first stage of parsing. If we can tear apart a Gutenberg post and reassemble then it will let us to structurally-informed processing of the posts without needing to be aware of all the block JavaScript.

The proposed mechanism is a form of tombstone or **token inserted into `innerHTML` where the `innerBlocks` were found**.

```json
{
	"blockName": "core/outerBlock",
	"attrs": {},
	"innerBlocks": [
		{
			"blockName": "core/voidInnerBlock",
			"attrs": {},
			"innerBlocks": [],
			"blockMarkers": [],
			"innerHTML": ""
		},
		{
			"blockName": "core/innerBlock",
			"attrs": {},
			"innerBlocks": [],
			"blockMarkers": [],
			"innerHTML": "\nwith its own content.\n"
		}
	],
	"innerHTML": "\nCheck out my\n<!-- {0} -->\nand my other\n<!-- {1} -->\n"
}
```

The token is a normal HTML comment of trivial structure which (if accidentally not removed before rendering) should not display in the rendered page, which should be trivial to substitute with a RegEx-based replacement, and which should remain straightforward for plugin authors and translators to deal with.

These tokens won't exist in `post_content` and they will be stripped before rendering the page. They exist only to restore isomorphism to the parser/printer pair.