### PR TITLE
Docs: Fix "Mac OS" typo + use fancy quotes consistently

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -2,7 +2,7 @@
 
 Gutenberg began as a transformation of the WordPress editor — a new interface for adding, editing, and manipulating content. It seeks to make it easy for anyone to create rich, flexible content layouts with a block-based UI. All types of page components are represented as modular blocks, which means they can be accessed from a unified block menu, dropped anywhere on a page, and directly edited to create the custom presentation the user wants.
 
-It is a fundamental modernization and transformation of how the WordPress experience works, creating new opportunities for both users and developers. Gutenberg introduces new frameworks, interaction patterns, functionality, and user experiences for WordPress. And similar to a new Mac OS version, we will talk about "Gutenberg", and all the new possibilities it enables, until eventually the idea of Gutenberg as a separate entity will fade and it will simply be WordPress.
+It is a fundamental modernization and transformation of how the WordPress experience works, creating new opportunities for both users and developers. Gutenberg introduces new frameworks, interaction patterns, functionality, and user experiences for WordPress. And similar to a new macOS version, we will talk about “Gutenberg”, and all the new possibilities it enables, until eventually the idea of Gutenberg as a separate entity will fade and it will simply be WordPress.
 
 ![Gutenberg Demo](https://cldup.com/kZXGDcGPMU.gif)
 


### PR DESCRIPTION
## Description
Fixed a typo in `docs/readme.md` and switched a usage of neutral quotation marks to fancy quotation marks, since they were being used elsewhere in the same file and should be consistent with other user-facing text.