### PR TITLE
Editor: Reshape blocks state under own key

### DIFF
--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -86,7 +86,7 @@ function getFlattenedBlocks( blocks ) {
 	const stack = [ ...blocks ];
 	while ( stack.length ) {
 		// `innerBlocks` is redundant data which can fall out of sync, since
-		// this is reflected in `blockOrder`, so exclude from appended block.
+		// this is reflected in `blocks.order`, so exclude from appended block.
 		const { innerBlocks, ...block } = stack.shift();
 
 		stack.push( ...innerBlocks );
@@ -181,7 +181,7 @@ const withInnerBlocksRemoveCascade = ( reducer ) => ( state, action ) => {
 		// For each removed client ID, include its inner blocks to remove,
 		// recursing into those so long as inner blocks exist.
 		for ( let i = 0; i < clientIds.length; i++ ) {
-			clientIds.push( ...state.blockOrder[ clientIds[ i ] ] );
+			clientIds.push( ...state.blocks.order[ clientIds[ i ] ] );
 		}
 
 		action = { ...action, clientIds };
@@ -197,9 +197,7 @@ const withInnerBlocksRemoveCascade = ( reducer ) => ( state, action ) => {
  * Handles the following state keys:
  *  - edits: an object describing changes to be made to the current post, in
  *           the format accepted by the WP REST API
- *  - blocksByClientId: post content blocks keyed by client ID
- *  - blockOrder: object where each key is a client ID, its value an array of
- *                client IDs representing the order of its inner blocks
+ *  - blocks: post content blocks
  *
  * @param {Object} state  Current state.
  * @param {Object} action Dispatched action.
@@ -277,242 +275,244 @@ export const editor = flow( [
 		return state;
 	},
 
-	blocksByClientId( state = {}, action ) {
-		switch ( action.type ) {
-			case 'RESET_BLOCKS':
-			case 'SETUP_EDITOR_STATE':
-				return getFlattenedBlocks( action.blocks );
+	blocks: combineReducers( {
+		byClientId( state = {}, action ) {
+			switch ( action.type ) {
+				case 'RESET_BLOCKS':
+				case 'SETUP_EDITOR_STATE':
+					return getFlattenedBlocks( action.blocks );
 
-			case 'RECEIVE_BLOCKS':
-				return {
-					...state,
-					...getFlattenedBlocks( action.blocks ),
-				};
-
-			case 'UPDATE_BLOCK_ATTRIBUTES':
-				// Ignore updates if block isn't known
-				if ( ! state[ action.clientId ] ) {
-					return state;
-				}
-
-				// Consider as updates only changed values
-				const nextAttributes = reduce( action.attributes, ( result, value, key ) => {
-					if ( value !== result[ key ] ) {
-						// Avoid mutating original block by creating shallow clone
-						if ( result === state[ action.clientId ].attributes ) {
-							result = { ...result };
-						}
-
-						result[ key ] = value;
-					}
-
-					return result;
-				}, state[ action.clientId ].attributes );
-
-				// Skip update if nothing has been changed. The reference will
-				// match the original block if `reduce` had no changed values.
-				if ( nextAttributes === state[ action.clientId ].attributes ) {
-					return state;
-				}
-
-				// Otherwise merge attributes into state
-				return {
-					...state,
-					[ action.clientId ]: {
-						...state[ action.clientId ],
-						attributes: nextAttributes,
-					},
-				};
-
-			case 'UPDATE_BLOCK':
-				// Ignore updates if block isn't known
-				if ( ! state[ action.clientId ] ) {
-					return state;
-				}
-
-				return {
-					...state,
-					[ action.clientId ]: {
-						...state[ action.clientId ],
-						...action.updates,
-					},
-				};
-
-			case 'INSERT_BLOCKS':
-				return {
-					...state,
-					...getFlattenedBlocks( action.blocks ),
-				};
-
-			case 'REPLACE_BLOCKS':
-				if ( ! action.blocks ) {
-					return state;
-				}
-
-				return {
-					...omit( state, action.clientIds ),
-					...getFlattenedBlocks( action.blocks ),
-				};
-
-			case 'REMOVE_BLOCKS':
-				return omit( state, action.clientIds );
-
-			case 'SAVE_REUSABLE_BLOCK_SUCCESS': {
-				const { id, updatedId } = action;
-
-				// If a temporary reusable block is saved, we swap the temporary id with the final one
-				if ( id === updatedId ) {
-					return state;
-				}
-
-				return mapValues( state, ( block ) => {
-					if ( block.name === 'core/block' && block.attributes.ref === id ) {
-						return {
-							...block,
-							attributes: {
-								...block.attributes,
-								ref: updatedId,
-							},
-						};
-					}
-
-					return block;
-				} );
-			}
-		}
-
-		return state;
-	},
-
-	blockOrder( state = {}, action ) {
-		switch ( action.type ) {
-			case 'RESET_BLOCKS':
-			case 'SETUP_EDITOR_STATE':
-				return mapBlockOrder( action.blocks );
-
-			case 'RECEIVE_BLOCKS':
-				return {
-					...state,
-					...omit( mapBlockOrder( action.blocks ), '' ),
-				};
-
-			case 'INSERT_BLOCKS': {
-				const { rootClientId = '', blocks } = action;
-				const subState = state[ rootClientId ] || [];
-				const mappedBlocks = mapBlockOrder( blocks, rootClientId );
-				const { index = subState.length } = action;
-
-				return {
-					...state,
-					...mappedBlocks,
-					[ rootClientId ]: insertAt( subState, mappedBlocks[ rootClientId ], index ),
-				};
-			}
-
-			case 'MOVE_BLOCK_TO_POSITION': {
-				const { fromRootClientId = '', toRootClientId = '', clientId } = action;
-				const { index = state[ toRootClientId ].length } = action;
-
-				// Moving inside the same parent block
-				if ( fromRootClientId === toRootClientId ) {
-					const subState = state[ toRootClientId ];
-					const fromIndex = subState.indexOf( clientId );
+				case 'RECEIVE_BLOCKS':
 					return {
 						...state,
-						[ toRootClientId ]: moveTo( state[ toRootClientId ], fromIndex, index ),
+						...getFlattenedBlocks( action.blocks ),
+					};
+
+				case 'UPDATE_BLOCK_ATTRIBUTES':
+					// Ignore updates if block isn't known
+					if ( ! state[ action.clientId ] ) {
+						return state;
+					}
+
+					// Consider as updates only changed values
+					const nextAttributes = reduce( action.attributes, ( result, value, key ) => {
+						if ( value !== result[ key ] ) {
+							// Avoid mutating original block by creating shallow clone
+							if ( result === state[ action.clientId ].attributes ) {
+								result = { ...result };
+							}
+
+							result[ key ] = value;
+						}
+
+						return result;
+					}, state[ action.clientId ].attributes );
+
+					// Skip update if nothing has been changed. The reference will
+					// match the original block if `reduce` had no changed values.
+					if ( nextAttributes === state[ action.clientId ].attributes ) {
+						return state;
+					}
+
+					// Otherwise merge attributes into state
+					return {
+						...state,
+						[ action.clientId ]: {
+							...state[ action.clientId ],
+							attributes: nextAttributes,
+						},
+					};
+
+				case 'UPDATE_BLOCK':
+					// Ignore updates if block isn't known
+					if ( ! state[ action.clientId ] ) {
+						return state;
+					}
+
+					return {
+						...state,
+						[ action.clientId ]: {
+							...state[ action.clientId ],
+							...action.updates,
+						},
+					};
+
+				case 'INSERT_BLOCKS':
+					return {
+						...state,
+						...getFlattenedBlocks( action.blocks ),
+					};
+
+				case 'REPLACE_BLOCKS':
+					if ( ! action.blocks ) {
+						return state;
+					}
+
+					return {
+						...omit( state, action.clientIds ),
+						...getFlattenedBlocks( action.blocks ),
+					};
+
+				case 'REMOVE_BLOCKS':
+					return omit( state, action.clientIds );
+
+				case 'SAVE_REUSABLE_BLOCK_SUCCESS': {
+					const { id, updatedId } = action;
+
+					// If a temporary reusable block is saved, we swap the temporary id with the final one
+					if ( id === updatedId ) {
+						return state;
+					}
+
+					return mapValues( state, ( block ) => {
+						if ( block.name === 'core/block' && block.attributes.ref === id ) {
+							return {
+								...block,
+								attributes: {
+									...block.attributes,
+									ref: updatedId,
+								},
+							};
+						}
+
+						return block;
+					} );
+				}
+			}
+
+			return state;
+		},
+
+		order( state = {}, action ) {
+			switch ( action.type ) {
+				case 'RESET_BLOCKS':
+				case 'SETUP_EDITOR_STATE':
+					return mapBlockOrder( action.blocks );
+
+				case 'RECEIVE_BLOCKS':
+					return {
+						...state,
+						...omit( mapBlockOrder( action.blocks ), '' ),
+					};
+
+				case 'INSERT_BLOCKS': {
+					const { rootClientId = '', blocks } = action;
+					const subState = state[ rootClientId ] || [];
+					const mappedBlocks = mapBlockOrder( blocks, rootClientId );
+					const { index = subState.length } = action;
+
+					return {
+						...state,
+						...mappedBlocks,
+						[ rootClientId ]: insertAt( subState, mappedBlocks[ rootClientId ], index ),
 					};
 				}
 
-				// Moving from a parent block to another
-				return {
-					...state,
-					[ fromRootClientId ]: without( state[ fromRootClientId ], clientId ),
-					[ toRootClientId ]: insertAt( state[ toRootClientId ], clientId, index ),
-				};
-			}
+				case 'MOVE_BLOCK_TO_POSITION': {
+					const { fromRootClientId = '', toRootClientId = '', clientId } = action;
+					const { index = state[ toRootClientId ].length } = action;
 
-			case 'MOVE_BLOCKS_UP': {
-				const { clientIds, rootClientId = '' } = action;
-				const firstClientId = first( clientIds );
-				const subState = state[ rootClientId ];
+					// Moving inside the same parent block
+					if ( fromRootClientId === toRootClientId ) {
+						const subState = state[ toRootClientId ];
+						const fromIndex = subState.indexOf( clientId );
+						return {
+							...state,
+							[ toRootClientId ]: moveTo( state[ toRootClientId ], fromIndex, index ),
+						};
+					}
 
-				if ( ! subState.length || firstClientId === first( subState ) ) {
-					return state;
+					// Moving from a parent block to another
+					return {
+						...state,
+						[ fromRootClientId ]: without( state[ fromRootClientId ], clientId ),
+						[ toRootClientId ]: insertAt( state[ toRootClientId ], clientId, index ),
+					};
 				}
 
-				const firstIndex = subState.indexOf( firstClientId );
+				case 'MOVE_BLOCKS_UP': {
+					const { clientIds, rootClientId = '' } = action;
+					const firstClientId = first( clientIds );
+					const subState = state[ rootClientId ];
 
-				return {
-					...state,
-					[ rootClientId ]: moveTo( subState, firstIndex, firstIndex - 1, clientIds.length ),
-				};
-			}
+					if ( ! subState.length || firstClientId === first( subState ) ) {
+						return state;
+					}
 
-			case 'MOVE_BLOCKS_DOWN': {
-				const { clientIds, rootClientId = '' } = action;
-				const firstClientId = first( clientIds );
-				const lastClientId = last( clientIds );
-				const subState = state[ rootClientId ];
+					const firstIndex = subState.indexOf( firstClientId );
 
-				if ( ! subState.length || lastClientId === last( subState ) ) {
-					return state;
+					return {
+						...state,
+						[ rootClientId ]: moveTo( subState, firstIndex, firstIndex - 1, clientIds.length ),
+					};
 				}
 
-				const firstIndex = subState.indexOf( firstClientId );
+				case 'MOVE_BLOCKS_DOWN': {
+					const { clientIds, rootClientId = '' } = action;
+					const firstClientId = first( clientIds );
+					const lastClientId = last( clientIds );
+					const subState = state[ rootClientId ];
 
-				return {
-					...state,
-					[ rootClientId ]: moveTo( subState, firstIndex, firstIndex + 1, clientIds.length ),
-				};
-			}
+					if ( ! subState.length || lastClientId === last( subState ) ) {
+						return state;
+					}
 
-			case 'REPLACE_BLOCKS': {
-				const { blocks, clientIds } = action;
-				if ( ! blocks ) {
-					return state;
+					const firstIndex = subState.indexOf( firstClientId );
+
+					return {
+						...state,
+						[ rootClientId ]: moveTo( subState, firstIndex, firstIndex + 1, clientIds.length ),
+					};
 				}
 
-				const mappedBlocks = mapBlockOrder( blocks );
+				case 'REPLACE_BLOCKS': {
+					const { blocks, clientIds } = action;
+					if ( ! blocks ) {
+						return state;
+					}
 
-				return flow( [
-					( nextState ) => omit( nextState, clientIds ),
-					( nextState ) => ( {
-						...nextState,
-						...omit( mappedBlocks, '' ),
-					} ),
-					( nextState ) => mapValues( nextState, ( subState ) => (
-						reduce( subState, ( result, clientId ) => {
-							if ( clientId === clientIds[ 0 ] ) {
-								return [
-									...result,
-									...mappedBlocks[ '' ],
-								];
-							}
+					const mappedBlocks = mapBlockOrder( blocks );
 
-							if ( clientIds.indexOf( clientId ) === -1 ) {
-								result.push( clientId );
-							}
+					return flow( [
+						( nextState ) => omit( nextState, clientIds ),
+						( nextState ) => ( {
+							...nextState,
+							...omit( mappedBlocks, '' ),
+						} ),
+						( nextState ) => mapValues( nextState, ( subState ) => (
+							reduce( subState, ( result, clientId ) => {
+								if ( clientId === clientIds[ 0 ] ) {
+									return [
+										...result,
+										...mappedBlocks[ '' ],
+									];
+								}
 
-							return result;
-						}, [] )
-					) ),
-				] )( state );
+								if ( clientIds.indexOf( clientId ) === -1 ) {
+									result.push( clientId );
+								}
+
+								return result;
+							}, [] )
+						) ),
+					] )( state );
+				}
+
+				case 'REMOVE_BLOCKS':
+					return flow( [
+						// Remove inner block ordering for removed blocks
+						( nextState ) => omit( nextState, action.clientIds ),
+
+						// Remove deleted blocks from other blocks' orderings
+						( nextState ) => mapValues( nextState, ( subState ) => (
+							without( subState, ...action.clientIds )
+						) ),
+					] )( state );
 			}
 
-			case 'REMOVE_BLOCKS':
-				return flow( [
-					// Remove inner block ordering for removed blocks
-					( nextState ) => omit( nextState, action.clientIds ),
-
-					// Remove deleted blocks from other blocks' orderings
-					( nextState ) => mapValues( nextState, ( subState ) => (
-						without( subState, ...action.clientIds )
-					) ),
-				] )( state );
-		}
-
-		return state;
-	},
+			return state;
+		},
+	} ),
 } );
 
 /**

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -502,7 +502,7 @@ export const getBlockDependantsCacheBust = createSelector(
  * @return {string} Block name.
  */
 export function getBlockName( state, clientId ) {
-	const block = state.editor.present.blocksByClientId[ clientId ];
+	const block = state.editor.present.blocks.byClientId[ clientId ];
 	return block ? block.name : null;
 }
 
@@ -519,7 +519,7 @@ export function getBlockName( state, clientId ) {
  */
 export const getBlock = createSelector(
 	( state, clientId ) => {
-		const block = state.editor.present.blocksByClientId[ clientId ];
+		const block = state.editor.present.blocks.byClientId[ clientId ];
 		if ( ! block ) {
 			return null;
 		}
@@ -552,7 +552,7 @@ export const getBlock = createSelector(
 		};
 	},
 	( state, clientId ) => [
-		state.editor.present.blocksByClientId[ clientId ],
+		state.editor.present.blocks.byClientId[ clientId ],
 		getBlockDependantsCacheBust( state, clientId ),
 		state.editor.present.edits.meta,
 		state.currentPost.meta,
@@ -585,8 +585,7 @@ export const getBlocks = createSelector(
 		);
 	},
 	( state ) => [
-		state.editor.present.blockOrder,
-		state.editor.present.blocksByClientId,
+		state.editor.present.blocks,
 	]
 );
 
@@ -618,7 +617,7 @@ export const getClientIdsWithDescendants = createSelector(
 		return [ ...topLevelIds, ...getClientIdsOfDescendants( state, topLevelIds ) ];
 	},
 	( state ) => [
-		state.editor.present.blockOrder,
+		state.editor.present.blocks.order,
 	]
 );
 
@@ -634,16 +633,16 @@ export const getClientIdsWithDescendants = createSelector(
 export const getGlobalBlockCount = createSelector(
 	( state, blockName ) => {
 		if ( ! blockName ) {
-			return size( state.editor.present.blocksByClientId );
+			return size( state.editor.present.blocks.byClientId );
 		}
 		return reduce(
-			state.editor.present.blocksByClientId,
+			state.editor.present.blocks.byClientId,
 			( count, block ) => block.name === blockName ? count + 1 : count,
 			0
 		);
 	},
 	( state ) => [
-		state.editor.present.blocksByClientId,
+		state.editor.present.blocks.byClientId,
 	]
 );
 
@@ -662,11 +661,9 @@ export const getBlocksByClientId = createSelector(
 		( clientId ) => getBlock( state, clientId )
 	),
 	( state ) => [
-		state.editor.present.blocksByClientId,
-		state.editor.present.blockOrder,
 		state.editor.present.edits.meta,
 		state.currentPost.meta,
-		state.editor.present.blocksByClientId,
+		state.editor.present.blocks,
 	]
 );
 
@@ -774,10 +771,10 @@ export function getSelectedBlock( state ) {
  */
 export const getBlockRootClientId = createSelector(
 	( state, clientId ) => {
-		const { blockOrder } = state.editor.present;
+		const { order } = state.editor.present.blocks;
 
-		for ( const rootClientId in blockOrder ) {
-			if ( includes( blockOrder[ rootClientId ], clientId ) ) {
+		for ( const rootClientId in order ) {
+			if ( includes( order[ rootClientId ], clientId ) ) {
 				return rootClientId;
 			}
 		}
@@ -785,7 +782,7 @@ export const getBlockRootClientId = createSelector(
 		return null;
 	},
 	( state ) => [
-		state.editor.present.blockOrder,
+		state.editor.present.blocks.order,
 	]
 );
 
@@ -809,7 +806,7 @@ export const getBlockHierarchyRootClientId = createSelector(
 		return current;
 	},
 	( state ) => [
-		state.editor.present.blockOrder,
+		state.editor.present.blocks.order,
 	]
 );
 
@@ -854,8 +851,8 @@ export function getAdjacentBlockClientId( state, startClientId, modifier = 1 ) {
 		return null;
 	}
 
-	const { blockOrder } = state.editor.present;
-	const orderSet = blockOrder[ rootClientId ];
+	const { order } = state.editor.present.blocks;
+	const orderSet = order[ rootClientId ];
 	const index = orderSet.indexOf( startClientId );
 	const nextIndex = ( index + ( 1 * modifier ) );
 
@@ -954,7 +951,7 @@ export const getMultiSelectedBlockClientIds = createSelector(
 		return blockOrder.slice( startIndex, endIndex + 1 );
 	},
 	( state ) => [
-		state.editor.present.blockOrder,
+		state.editor.present.blocks.order,
 		state.blockSelection.start,
 		state.blockSelection.end,
 	],
@@ -978,10 +975,10 @@ export const getMultiSelectedBlocks = createSelector(
 		return multiSelectedBlockClientIds.map( ( clientId ) => getBlock( state, clientId ) );
 	},
 	( state ) => [
-		state.editor.present.blockOrder,
+		state.editor.present.blocks.order,
 		state.blockSelection.start,
 		state.blockSelection.end,
-		state.editor.present.blocksByClientId,
+		state.editor.present.blocks.byClientId,
 		state.editor.present.edits.meta,
 		state.currentPost.meta,
 	]
@@ -1059,7 +1056,7 @@ export const isAncestorMultiSelected = createSelector(
 		return isMultiSelected;
 	},
 	( state ) => [
-		state.editor.present.blockOrder,
+		state.editor.present.blocks.order,
 		state.blockSelection.start,
 		state.blockSelection.end,
 	],
@@ -1115,7 +1112,7 @@ export function getMultiSelectedBlocksEndClientId( state ) {
  * @return {Array} Ordered client IDs of editor blocks.
  */
 export function getBlockOrder( state, rootClientId ) {
-	return state.editor.present.blockOrder[ rootClientId || '' ] || EMPTY_ARRAY;
+	return state.editor.present.blocks.order[ rootClientId || '' ] || EMPTY_ARRAY;
 }
 
 /**
@@ -1500,8 +1497,7 @@ export const getEditedPostContent = createSelector(
 	},
 	( state ) => [
 		state.editor.present.edits.content,
-		state.editor.present.blocksByClientId,
-		state.editor.present.blockOrder,
+		state.editor.present.blocks,
 	],
 );
 
@@ -1563,7 +1559,7 @@ export const canInsertBlockType = createSelector(
 	},
 	( state, blockName, rootClientId ) => [
 		state.blockListSettings[ rootClientId ],
-		state.editor.present.blocksByClientId[ rootClientId ],
+		state.editor.present.blocks.byClientId[ rootClientId ],
 		state.settings.allowedBlockTypes,
 		state.settings.templateLock,
 	],
@@ -1751,8 +1747,7 @@ export const getInserterItems = createSelector(
 	},
 	( state, rootClientId ) => [
 		state.blockListSettings[ rootClientId ],
-		state.editor.present.blockOrder,
-		state.editor.present.blocksByClientId,
+		state.editor.present.blocks,
 		state.preferences.insertUsage,
 		state.settings.allowedBlockTypes,
 		state.settings.templateLock,

--- a/packages/editor/src/store/test/reducer.js
+++ b/packages/editor/src/store/test/reducer.js
@@ -277,14 +277,14 @@ describe( 'state', () => {
 			unregisterBlockType( 'core/test-block' );
 		} );
 
-		it( 'should return history (empty edits, blocksByClientId, blockOrder), dirty flag by default', () => {
+		it( 'should return history (empty edits, blocks), dirty flag by default', () => {
 			const state = editor( undefined, {} );
 
 			expect( state.past ).toEqual( [] );
 			expect( state.future ).toEqual( [] );
 			expect( state.present.edits ).toEqual( {} );
-			expect( state.present.blocksByClientId ).toEqual( {} );
-			expect( state.present.blockOrder ).toEqual( {} );
+			expect( state.present.blocks.byClientId ).toEqual( {} );
+			expect( state.present.blocks.order ).toEqual( {} );
 			expect( state.isDirty ).toBe( false );
 		} );
 
@@ -295,9 +295,9 @@ describe( 'state', () => {
 				blocks: [ { clientId: 'bananas', innerBlocks: [] } ],
 			} );
 
-			expect( Object.keys( state.present.blocksByClientId ) ).toHaveLength( 1 );
-			expect( values( state.present.blocksByClientId )[ 0 ].clientId ).toBe( 'bananas' );
-			expect( state.present.blockOrder ).toEqual( {
+			expect( Object.keys( state.present.blocks.byClientId ) ).toHaveLength( 1 );
+			expect( values( state.present.blocks.byClientId )[ 0 ].clientId ).toBe( 'bananas' );
+			expect( state.present.blocks.order ).toEqual( {
 				'': [ 'bananas' ],
 				bananas: [],
 			} );
@@ -313,8 +313,8 @@ describe( 'state', () => {
 				} ],
 			} );
 
-			expect( Object.keys( state.present.blocksByClientId ) ).toHaveLength( 2 );
-			expect( state.present.blockOrder ).toEqual( {
+			expect( Object.keys( state.present.blocks.byClientId ) ).toHaveLength( 2 );
+			expect( state.present.blocks.order ).toEqual( {
 				'': [ 'bananas' ],
 				apples: [],
 				bananas: [ 'apples' ],
@@ -340,9 +340,9 @@ describe( 'state', () => {
 				} ],
 			} );
 
-			expect( Object.keys( state.present.blocksByClientId ) ).toHaveLength( 2 );
-			expect( values( state.present.blocksByClientId )[ 1 ].clientId ).toBe( 'ribs' );
-			expect( state.present.blockOrder ).toEqual( {
+			expect( Object.keys( state.present.blocks.byClientId ) ).toHaveLength( 2 );
+			expect( values( state.present.blocks.byClientId )[ 1 ].clientId ).toBe( 'ribs' );
+			expect( state.present.blocks.order ).toEqual( {
 				'': [ 'chicken', 'ribs' ],
 				chicken: [],
 				ribs: [],
@@ -369,10 +369,10 @@ describe( 'state', () => {
 				} ],
 			} );
 
-			expect( Object.keys( state.present.blocksByClientId ) ).toHaveLength( 1 );
-			expect( values( state.present.blocksByClientId )[ 0 ].name ).toBe( 'core/freeform' );
-			expect( values( state.present.blocksByClientId )[ 0 ].clientId ).toBe( 'wings' );
-			expect( state.present.blockOrder ).toEqual( {
+			expect( Object.keys( state.present.blocks.byClientId ) ).toHaveLength( 1 );
+			expect( values( state.present.blocks.byClientId )[ 0 ].name ).toBe( 'core/freeform' );
+			expect( values( state.present.blocks.byClientId )[ 0 ].clientId ).toBe( 'wings' );
+			expect( state.present.blocks.order ).toEqual( {
 				'': [ 'wings' ],
 				wings: [],
 			} );
@@ -393,7 +393,7 @@ describe( 'state', () => {
 				blocks: [ replacementBlock ],
 			} );
 
-			expect( state.present.blockOrder ).toEqual( {
+			expect( state.present.blocks.order ).toEqual( {
 				'': [ wrapperBlock.clientId ],
 				[ wrapperBlock.clientId ]: [ replacementBlock.clientId ],
 				[ replacementBlock.clientId ]: [],
@@ -420,11 +420,11 @@ describe( 'state', () => {
 				} ],
 			} );
 
-			expect( Object.keys( replacedState.present.blocksByClientId ) ).toHaveLength( 1 );
-			expect( values( originalState.present.blocksByClientId )[ 0 ].name ).toBe( 'core/test-block' );
-			expect( values( replacedState.present.blocksByClientId )[ 0 ].name ).toBe( 'core/freeform' );
-			expect( values( replacedState.present.blocksByClientId )[ 0 ].clientId ).toBe( 'chicken' );
-			expect( replacedState.present.blockOrder ).toEqual( {
+			expect( Object.keys( replacedState.present.blocks.byClientId ) ).toHaveLength( 1 );
+			expect( values( originalState.present.blocks.byClientId )[ 0 ].name ).toBe( 'core/test-block' );
+			expect( values( replacedState.present.blocks.byClientId )[ 0 ].name ).toBe( 'core/freeform' );
+			expect( values( replacedState.present.blocks.byClientId )[ 0 ].clientId ).toBe( 'chicken' );
+			expect( replacedState.present.blocks.order ).toEqual( {
 				'': [ 'chicken' ],
 				chicken: [],
 			} );
@@ -454,14 +454,14 @@ describe( 'state', () => {
 				blocks: [ replacementNestedBlock ],
 			} );
 
-			expect( replacedNestedState.present.blockOrder ).toEqual( {
+			expect( replacedNestedState.present.blocks.order ).toEqual( {
 				'': [ wrapperBlock.clientId ],
 				[ wrapperBlock.clientId ]: [ replacementNestedBlock.clientId ],
 				[ replacementNestedBlock.clientId ]: [],
 			} );
 
-			expect( originalNestedState.present.blocksByClientId.chicken.name ).toBe( 'core/test-block' );
-			expect( replacedNestedState.present.blocksByClientId.chicken.name ).toBe( 'core/freeform' );
+			expect( originalNestedState.present.blocks.byClientId.chicken.name ).toBe( 'core/test-block' );
+			expect( replacedNestedState.present.blocks.byClientId.chicken.name ).toBe( 'core/freeform' );
 		} );
 
 		it( 'should update the block', () => {
@@ -484,7 +484,7 @@ describe( 'state', () => {
 				},
 			} );
 
-			expect( state.present.blocksByClientId.chicken ).toEqual( {
+			expect( state.present.blocks.byClientId.chicken ).toEqual( {
 				clientId: 'chicken',
 				name: 'core/test-block',
 				attributes: { content: 'ribs' },
@@ -512,7 +512,7 @@ describe( 'state', () => {
 				updatedId: 3,
 			} );
 
-			expect( state.present.blocksByClientId.chicken ).toEqual( {
+			expect( state.present.blocks.byClientId.chicken ).toEqual( {
 				clientId: 'chicken',
 				name: 'core/block',
 				attributes: {
@@ -542,7 +542,7 @@ describe( 'state', () => {
 				clientIds: [ 'ribs' ],
 			} );
 
-			expect( state.present.blockOrder[ '' ] ).toEqual( [ 'ribs', 'chicken' ] );
+			expect( state.present.blocks.order[ '' ] ).toEqual( [ 'ribs', 'chicken' ] );
 		} );
 
 		it( 'should move the nested block up', () => {
@@ -559,7 +559,7 @@ describe( 'state', () => {
 				rootClientId: wrapperBlock.clientId,
 			} );
 
-			expect( state.present.blockOrder ).toEqual( {
+			expect( state.present.blocks.order ).toEqual( {
 				'': [ wrapperBlock.clientId ],
 				[ wrapperBlock.clientId ]: [ movedBlock.clientId, siblingBlock.clientId ],
 				[ movedBlock.clientId ]: [],
@@ -592,7 +592,7 @@ describe( 'state', () => {
 				clientIds: [ 'ribs', 'veggies' ],
 			} );
 
-			expect( state.present.blockOrder[ '' ] ).toEqual( [ 'ribs', 'veggies', 'chicken' ] );
+			expect( state.present.blocks.order[ '' ] ).toEqual( [ 'ribs', 'veggies', 'chicken' ] );
 		} );
 
 		it( 'should move multiple nested blocks up', () => {
@@ -610,7 +610,7 @@ describe( 'state', () => {
 				rootClientId: wrapperBlock.clientId,
 			} );
 
-			expect( state.present.blockOrder ).toEqual( {
+			expect( state.present.blocks.order ).toEqual( {
 				'': [ wrapperBlock.clientId ],
 				[ wrapperBlock.clientId ]: [ movedBlockA.clientId, movedBlockB.clientId, siblingBlock.clientId ],
 				[ movedBlockA.clientId ]: [],
@@ -639,7 +639,7 @@ describe( 'state', () => {
 				clientIds: [ 'chicken' ],
 			} );
 
-			expect( state.present.blockOrder ).toBe( original.present.blockOrder );
+			expect( state.present.blocks.order ).toBe( original.present.blocks.order );
 		} );
 
 		it( 'should move the block down', () => {
@@ -662,7 +662,7 @@ describe( 'state', () => {
 				clientIds: [ 'chicken' ],
 			} );
 
-			expect( state.present.blockOrder[ '' ] ).toEqual( [ 'ribs', 'chicken' ] );
+			expect( state.present.blocks.order[ '' ] ).toEqual( [ 'ribs', 'chicken' ] );
 		} );
 
 		it( 'should move the nested block down', () => {
@@ -679,7 +679,7 @@ describe( 'state', () => {
 				rootClientId: wrapperBlock.clientId,
 			} );
 
-			expect( state.present.blockOrder ).toEqual( {
+			expect( state.present.blocks.order ).toEqual( {
 				'': [ wrapperBlock.clientId ],
 				[ wrapperBlock.clientId ]: [ siblingBlock.clientId, movedBlock.clientId ],
 				[ movedBlock.clientId ]: [],
@@ -712,7 +712,7 @@ describe( 'state', () => {
 				clientIds: [ 'chicken', 'ribs' ],
 			} );
 
-			expect( state.present.blockOrder[ '' ] ).toEqual( [ 'veggies', 'chicken', 'ribs' ] );
+			expect( state.present.blocks.order[ '' ] ).toEqual( [ 'veggies', 'chicken', 'ribs' ] );
 		} );
 
 		it( 'should move multiple nested blocks down', () => {
@@ -730,7 +730,7 @@ describe( 'state', () => {
 				rootClientId: wrapperBlock.clientId,
 			} );
 
-			expect( state.present.blockOrder ).toEqual( {
+			expect( state.present.blocks.order ).toEqual( {
 				'': [ wrapperBlock.clientId ],
 				[ wrapperBlock.clientId ]: [ siblingBlock.clientId, movedBlockA.clientId, movedBlockB.clientId ],
 				[ movedBlockA.clientId ]: [],
@@ -759,7 +759,7 @@ describe( 'state', () => {
 				clientIds: [ 'ribs' ],
 			} );
 
-			expect( state.present.blockOrder ).toBe( original.present.blockOrder );
+			expect( state.present.blocks.order ).toBe( original.present.blocks.order );
 		} );
 
 		it( 'should remove the block', () => {
@@ -782,9 +782,9 @@ describe( 'state', () => {
 				clientIds: [ 'chicken' ],
 			} );
 
-			expect( state.present.blockOrder[ '' ] ).toEqual( [ 'ribs' ] );
-			expect( state.present.blockOrder ).not.toHaveProperty( 'chicken' );
-			expect( state.present.blocksByClientId ).toEqual( {
+			expect( state.present.blocks.order[ '' ] ).toEqual( [ 'ribs' ] );
+			expect( state.present.blocks.order ).not.toHaveProperty( 'chicken' );
+			expect( state.present.blocks.byClientId ).toEqual( {
 				ribs: {
 					clientId: 'ribs',
 					name: 'core/test-block',
@@ -818,10 +818,10 @@ describe( 'state', () => {
 				clientIds: [ 'chicken', 'veggies' ],
 			} );
 
-			expect( state.present.blockOrder[ '' ] ).toEqual( [ 'ribs' ] );
-			expect( state.present.blockOrder ).not.toHaveProperty( 'chicken' );
-			expect( state.present.blockOrder ).not.toHaveProperty( 'veggies' );
-			expect( state.present.blocksByClientId ).toEqual( {
+			expect( state.present.blocks.order[ '' ] ).toEqual( [ 'ribs' ] );
+			expect( state.present.blocks.order ).not.toHaveProperty( 'chicken' );
+			expect( state.present.blocks.order ).not.toHaveProperty( 'veggies' );
+			expect( state.present.blocks.byClientId ).toEqual( {
 				ribs: {
 					clientId: 'ribs',
 					name: 'core/test-block',
@@ -847,8 +847,8 @@ describe( 'state', () => {
 				clientIds: [ block.clientId ],
 			} );
 
-			expect( state.present.blocksByClientId ).toEqual( {} );
-			expect( state.present.blockOrder ).toEqual( {
+			expect( state.present.blocks.byClientId ).toEqual( {} );
+			expect( state.present.blocks.order ).toEqual( {
 				'': [],
 			} );
 		} );
@@ -879,8 +879,8 @@ describe( 'state', () => {
 				} ],
 			} );
 
-			expect( Object.keys( state.present.blocksByClientId ) ).toHaveLength( 3 );
-			expect( state.present.blockOrder[ '' ] ).toEqual( [ 'kumquat', 'persimmon', 'loquat' ] );
+			expect( Object.keys( state.present.blocks.byClientId ) ).toHaveLength( 3 );
+			expect( state.present.blocks.order[ '' ] ).toEqual( [ 'kumquat', 'persimmon', 'loquat' ] );
 		} );
 
 		it( 'should move block to lower index', () => {
@@ -909,7 +909,7 @@ describe( 'state', () => {
 				index: 0,
 			} );
 
-			expect( state.present.blockOrder[ '' ] ).toEqual( [ 'ribs', 'chicken', 'veggies' ] );
+			expect( state.present.blocks.order[ '' ] ).toEqual( [ 'ribs', 'chicken', 'veggies' ] );
 		} );
 
 		it( 'should move block to higher index', () => {
@@ -938,7 +938,7 @@ describe( 'state', () => {
 				index: 2,
 			} );
 
-			expect( state.present.blockOrder[ '' ] ).toEqual( [ 'chicken', 'veggies', 'ribs' ] );
+			expect( state.present.blocks.order[ '' ] ).toEqual( [ 'chicken', 'veggies', 'ribs' ] );
 		} );
 
 		it( 'should not move block if passed same index', () => {
@@ -967,7 +967,7 @@ describe( 'state', () => {
 				index: 1,
 			} );
 
-			expect( state.present.blockOrder[ '' ] ).toEqual( [ 'chicken', 'ribs', 'veggies' ] );
+			expect( state.present.blocks.order[ '' ] ).toEqual( [ 'chicken', 'ribs', 'veggies' ] );
 		} );
 
 		describe( 'edits()', () => {
@@ -1087,88 +1087,90 @@ describe( 'state', () => {
 			} );
 		} );
 
-		describe( 'blocksByClientId', () => {
-			it( 'should return with attribute block updates', () => {
-				const original = deepFreeze( editor( undefined, {
-					type: 'RESET_BLOCKS',
-					blocks: [ {
-						clientId: 'kumquat',
-						attributes: {},
-						innerBlocks: [],
-					} ],
-				} ) );
-				const state = editor( original, {
-					type: 'UPDATE_BLOCK_ATTRIBUTES',
-					clientId: 'kumquat',
-					attributes: {
-						updated: true,
-					},
-				} );
-
-				expect( state.present.blocksByClientId.kumquat.attributes.updated ).toBe( true );
-			} );
-
-			it( 'should accumulate attribute block updates', () => {
-				const original = deepFreeze( editor( undefined, {
-					type: 'RESET_BLOCKS',
-					blocks: [ {
+		describe( 'blocks', () => {
+			describe( 'byClientId', () => {
+				it( 'should return with attribute block updates', () => {
+					const original = deepFreeze( editor( undefined, {
+						type: 'RESET_BLOCKS',
+						blocks: [ {
+							clientId: 'kumquat',
+							attributes: {},
+							innerBlocks: [],
+						} ],
+					} ) );
+					const state = editor( original, {
+						type: 'UPDATE_BLOCK_ATTRIBUTES',
 						clientId: 'kumquat',
 						attributes: {
 							updated: true,
 						},
-						innerBlocks: [],
-					} ],
-				} ) );
-				const state = editor( original, {
-					type: 'UPDATE_BLOCK_ATTRIBUTES',
-					clientId: 'kumquat',
-					attributes: {
+					} );
+
+					expect( state.present.blocks.byClientId.kumquat.attributes.updated ).toBe( true );
+				} );
+
+				it( 'should accumulate attribute block updates', () => {
+					const original = deepFreeze( editor( undefined, {
+						type: 'RESET_BLOCKS',
+						blocks: [ {
+							clientId: 'kumquat',
+							attributes: {
+								updated: true,
+							},
+							innerBlocks: [],
+						} ],
+					} ) );
+					const state = editor( original, {
+						type: 'UPDATE_BLOCK_ATTRIBUTES',
+						clientId: 'kumquat',
+						attributes: {
+							moreUpdated: true,
+						},
+					} );
+
+					expect( state.present.blocks.byClientId.kumquat.attributes ).toEqual( {
+						updated: true,
 						moreUpdated: true,
-					},
+					} );
 				} );
 
-				expect( state.present.blocksByClientId.kumquat.attributes ).toEqual( {
-					updated: true,
-					moreUpdated: true,
-				} );
-			} );
-
-			it( 'should ignore updates to non-existent block', () => {
-				const original = deepFreeze( editor( undefined, {
-					type: 'RESET_BLOCKS',
-					blocks: [],
-				} ) );
-				const state = editor( original, {
-					type: 'UPDATE_BLOCK_ATTRIBUTES',
-					clientId: 'kumquat',
-					attributes: {
-						updated: true,
-					},
-				} );
-
-				expect( state.present.blocksByClientId ).toBe( original.present.blocksByClientId );
-			} );
-
-			it( 'should return with same reference if no changes in updates', () => {
-				const original = deepFreeze( editor( undefined, {
-					type: 'RESET_BLOCKS',
-					blocks: [ {
+				it( 'should ignore updates to non-existent block', () => {
+					const original = deepFreeze( editor( undefined, {
+						type: 'RESET_BLOCKS',
+						blocks: [],
+					} ) );
+					const state = editor( original, {
+						type: 'UPDATE_BLOCK_ATTRIBUTES',
 						clientId: 'kumquat',
 						attributes: {
 							updated: true,
 						},
-						innerBlocks: [],
-					} ],
-				} ) );
-				const state = editor( original, {
-					type: 'UPDATE_BLOCK_ATTRIBUTES',
-					clientId: 'kumquat',
-					attributes: {
-						updated: true,
-					},
+					} );
+
+					expect( state.present.blocks.byClientId ).toBe( original.present.blocks.byClientId );
 				} );
 
-				expect( state.present.blocksByClientId ).toBe( state.present.blocksByClientId );
+				it( 'should return with same reference if no changes in updates', () => {
+					const original = deepFreeze( editor( undefined, {
+						type: 'RESET_BLOCKS',
+						blocks: [ {
+							clientId: 'kumquat',
+							attributes: {
+								updated: true,
+							},
+							innerBlocks: [],
+						} ],
+					} ) );
+					const state = editor( original, {
+						type: 'UPDATE_BLOCK_ATTRIBUTES',
+						clientId: 'kumquat',
+						attributes: {
+							updated: true,
+						},
+					} );
+
+					expect( state.present.blocks.byClientId ).toBe( state.present.blocks.byClientId );
+				} );
 			} );
 		} );
 

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -919,8 +919,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {},
-						blockOrder: {},
+						blocks: {
+							byClientId: {},
+							order: {},
+						},
 						edits: {},
 					},
 				},
@@ -935,8 +937,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {},
-						blockOrder: {},
+						blocks: {
+							byClientId: {},
+							order: {},
+						},
 						edits: {},
 					},
 				},
@@ -955,8 +959,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {},
-						blockOrder: {},
+						blocks: {
+							byClientId: {},
+							order: {},
+						},
 						edits: {},
 					},
 				},
@@ -973,8 +979,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {},
-						blockOrder: {},
+						blocks: {
+							byClientId: {},
+							order: {},
+						},
 						edits: {},
 					},
 				},
@@ -991,17 +999,19 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {
-							123: {
-								clientId: 123,
-								name: 'core/test-block',
-								attributes: {
-									text: '',
+						blocks: {
+							byClientId: {
+								123: {
+									clientId: 123,
+									name: 'core/test-block',
+									attributes: {
+										text: '',
+									},
 								},
 							},
-						},
-						blockOrder: {
-							'': [ 123 ],
+							order: {
+								'': [ 123 ],
+							},
 						},
 						edits: {},
 					},
@@ -1019,8 +1029,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {},
-						blockOrder: {},
+						blocks: {
+							byClientId: {},
+							order: {},
+						},
 						edits: {},
 					},
 				},
@@ -1042,8 +1054,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {},
-						blockOrder: {},
+						blocks: {
+							byClientId: {},
+							order: {},
+						},
 						edits: {},
 					},
 				},
@@ -1061,8 +1075,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {},
-						blockOrder: {},
+						blocks: {
+							byClientId: {},
+							order: {},
+						},
 						edits: {
 							content: 'foo',
 						},
@@ -1090,8 +1106,10 @@ describe( 'selectors', () => {
 					const state = {
 						editor: {
 							present: {
-								blocksByClientId: {},
-								blockOrder: {},
+								blocks: {
+									byClientId: {},
+									order: {},
+								},
 								edits: {
 									content: 'foo',
 								},
@@ -1163,8 +1181,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {},
-						blockOrder: {},
+						blocks: {
+							byClientId: {},
+							order: {},
+						},
 						edits: {},
 					},
 				},
@@ -1178,17 +1198,19 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {
-							123: {
-								clientId: 123,
-								name: 'core/test-block',
-								attributes: {
-									text: '',
+						blocks: {
+							byClientId: {
+								123: {
+									clientId: 123,
+									name: 'core/test-block',
+									attributes: {
+										text: '',
+									},
 								},
 							},
-						},
-						blockOrder: {
-							'': [ 123 ],
+							order: {
+								'': [ 123 ],
+							},
 						},
 						edits: {},
 					},
@@ -1203,8 +1225,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {},
-						blockOrder: {},
+						blocks: {
+							byClientId: {},
+							order: {},
+						},
 						edits: {},
 					},
 				},
@@ -1220,8 +1244,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {},
-						blockOrder: {},
+						blocks: {
+							byClientId: {},
+							order: {},
+						},
 						edits: {
 							content: 'sassel',
 						},
@@ -1348,12 +1374,14 @@ describe( 'selectors', () => {
 				currentPost: {},
 				editor: {
 					present: {
-						blocksByClientId: {
-							123: rootBlock,
-						},
-						blockOrder: {
-							'': rootOrder,
-							123: rootBlockOrder,
+						blocks: {
+							byClientId: {
+								123: rootBlock,
+							},
+							order: {
+								'': rootOrder,
+								123: rootBlockOrder,
+							},
 						},
 						edits: {},
 					},
@@ -1364,12 +1392,14 @@ describe( 'selectors', () => {
 				currentPost: {},
 				editor: {
 					present: {
-						blocksByClientId: {
-							123: rootBlock,
-						},
-						blockOrder: {
-							'': rootOrder,
-							123: rootBlockOrder,
+						blocks: {
+							byClientId: {
+								123: rootBlock,
+							},
+							order: {
+								'': rootOrder,
+								123: rootBlockOrder,
+							},
 						},
 						edits: {},
 					},
@@ -1386,12 +1416,14 @@ describe( 'selectors', () => {
 				currentPost: {},
 				editor: {
 					present: {
-						blocksByClientId: {
-							123: rootBlock,
-						},
-						blockOrder: {
-							'': rootOrder,
-							123: [],
+						blocks: {
+							byClientId: {
+								123: rootBlock,
+							},
+							order: {
+								'': rootOrder,
+								123: [],
+							},
 						},
 						edits: {},
 					},
@@ -1402,14 +1434,16 @@ describe( 'selectors', () => {
 				currentPost: {},
 				editor: {
 					present: {
-						blocksByClientId: {
-							123: rootBlock,
-							456: { clientId: 456, name: 'core/paragraph', attributes: {} },
-						},
-						blockOrder: {
-							'': rootOrder,
-							123: [ 456 ],
-							456: [],
+						blocks: {
+							byClientId: {
+								123: rootBlock,
+								456: { clientId: 456, name: 'core/paragraph', attributes: {} },
+							},
+							order: {
+								'': rootOrder,
+								123: [ 456 ],
+								456: [],
+							},
 						},
 						edits: {},
 					},
@@ -1430,14 +1464,16 @@ describe( 'selectors', () => {
 				currentPost: {},
 				editor: {
 					present: {
-						blocksByClientId: {
-							123: rootBlock,
-							456: childBlock,
-						},
-						blockOrder: {
-							'': rootOrder,
-							123: rootBlockOrder,
-							456: childBlockOrder,
+						blocks: {
+							byClientId: {
+								123: rootBlock,
+								456: childBlock,
+							},
+							order: {
+								'': rootOrder,
+								123: rootBlockOrder,
+								456: childBlockOrder,
+							},
 						},
 						edits: {},
 					},
@@ -1448,14 +1484,16 @@ describe( 'selectors', () => {
 				currentPost: {},
 				editor: {
 					present: {
-						blocksByClientId: {
-							123: rootBlock,
-							456: childBlock,
-						},
-						blockOrder: {
-							'': rootOrder,
-							123: rootBlockOrder,
-							456: childBlockOrder,
+						blocks: {
+							byClientId: {
+								123: rootBlock,
+								456: childBlock,
+							},
+							order: {
+								'': rootOrder,
+								123: rootBlockOrder,
+								456: childBlockOrder,
+							},
 						},
 						edits: {},
 					},
@@ -1475,14 +1513,16 @@ describe( 'selectors', () => {
 				currentPost: {},
 				editor: {
 					present: {
-						blocksByClientId: {
-							123: rootBlock,
-							456: { clientId: 456, name: 'core/paragraph', attributes: {} },
-						},
-						blockOrder: {
-							'': rootOrder,
-							123: rootBlockOrder,
-							456: childBlockOrder,
+						blocks: {
+							byClientId: {
+								123: rootBlock,
+								456: { clientId: 456, name: 'core/paragraph', attributes: {} },
+							},
+							order: {
+								'': rootOrder,
+								123: rootBlockOrder,
+								456: childBlockOrder,
+							},
 						},
 						edits: {},
 					},
@@ -1493,14 +1533,16 @@ describe( 'selectors', () => {
 				currentPost: {},
 				editor: {
 					present: {
-						blocksByClientId: {
-							123: rootBlock,
-							456: { clientId: 456, name: 'core/paragraph', attributes: { content: [ 'foo' ] } },
-						},
-						blockOrder: {
-							'': rootOrder,
-							123: rootBlockOrder,
-							456: childBlockOrder,
+						blocks: {
+							byClientId: {
+								123: rootBlock,
+								456: { clientId: 456, name: 'core/paragraph', attributes: { content: [ 'foo' ] } },
+							},
+							order: {
+								'': rootOrder,
+								123: rootBlockOrder,
+								456: childBlockOrder,
+							},
 						},
 						edits: {},
 					},
@@ -1522,16 +1564,18 @@ describe( 'selectors', () => {
 				currentPost: {},
 				editor: {
 					present: {
-						blocksByClientId: {
-							123: rootBlock,
-							456: childBlock,
-							789: { clientId: 789, name: 'core/paragraph', attributes: {} },
-						},
-						blockOrder: {
-							'': rootOrder,
-							123: rootBlockOrder,
-							456: childBlockOrder,
-							789: grandChildBlockOrder,
+						blocks: {
+							byClientId: {
+								123: rootBlock,
+								456: childBlock,
+								789: { clientId: 789, name: 'core/paragraph', attributes: {} },
+							},
+							order: {
+								'': rootOrder,
+								123: rootBlockOrder,
+								456: childBlockOrder,
+								789: grandChildBlockOrder,
+							},
 						},
 						edits: {},
 					},
@@ -1542,16 +1586,18 @@ describe( 'selectors', () => {
 				currentPost: {},
 				editor: {
 					present: {
-						blocksByClientId: {
-							123: rootBlock,
-							456: childBlock,
-							789: { clientId: 789, name: 'core/paragraph', attributes: { content: [ 'foo' ] } },
-						},
-						blockOrder: {
-							'': rootOrder,
-							123: rootBlockOrder,
-							456: childBlockOrder,
-							789: grandChildBlockOrder,
+						blocks: {
+							byClientId: {
+								123: rootBlock,
+								456: childBlock,
+								789: { clientId: 789, name: 'core/paragraph', attributes: { content: [ 'foo' ] } },
+							},
+							order: {
+								'': rootOrder,
+								123: rootBlockOrder,
+								456: childBlockOrder,
+								789: grandChildBlockOrder,
+							},
 						},
 						edits: {},
 					},
@@ -1570,8 +1616,10 @@ describe( 'selectors', () => {
 				currentPost: {},
 				editor: {
 					present: {
-						blocksByClientId: {},
-						blockOrder: {},
+						blocks: {
+							byClientId: {},
+							order: {},
+						},
 						edits: {},
 					},
 				},
@@ -1587,16 +1635,18 @@ describe( 'selectors', () => {
 				currentPost: {},
 				editor: {
 					present: {
-						blocksByClientId: {
-							'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': {
-								clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
-								name: 'core/paragraph',
-								attributes: {},
+						blocks: {
+							byClientId: {
+								'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': {
+									clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1',
+									name: 'core/paragraph',
+									attributes: {},
+								},
 							},
-						},
-						blockOrder: {
-							'': [ 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' ],
-							'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': [],
+							order: {
+								'': [ 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' ],
+								'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': [],
+							},
 						},
 						edits: {},
 					},
@@ -1615,12 +1665,14 @@ describe( 'selectors', () => {
 				currentPost: {},
 				editor: {
 					present: {
-						blocksByClientId: {
-							123: { clientId: 123, name: 'core/paragraph', attributes: {} },
-						},
-						blockOrder: {
-							'': [ 123 ],
-							123: [],
+						blocks: {
+							byClientId: {
+								123: { clientId: 123, name: 'core/paragraph', attributes: {} },
+							},
+							order: {
+								'': [ 123 ],
+								123: [],
+							},
 						},
 						edits: {},
 					},
@@ -1640,8 +1692,10 @@ describe( 'selectors', () => {
 				currentPost: {},
 				editor: {
 					present: {
-						blocksByClientId: {},
-						blockOrder: {},
+						blocks: {
+							byClientId: {},
+							order: {},
+						},
 						edits: {},
 					},
 				},
@@ -1655,14 +1709,16 @@ describe( 'selectors', () => {
 				currentPost: {},
 				editor: {
 					present: {
-						blocksByClientId: {
-							123: { clientId: 123, name: 'core/paragraph', attributes: {} },
-							456: { clientId: 456, name: 'core/paragraph', attributes: {} },
-						},
-						blockOrder: {
-							'': [ 123 ],
-							123: [ 456 ],
-							456: [],
+						blocks: {
+							byClientId: {
+								123: { clientId: 123, name: 'core/paragraph', attributes: {} },
+								456: { clientId: 456, name: 'core/paragraph', attributes: {} },
+							},
+							order: {
+								'': [ 123 ],
+								123: [ 456 ],
+								456: [],
+							},
 						},
 						edits: {},
 					},
@@ -1704,12 +1760,14 @@ describe( 'selectors', () => {
 				},
 				editor: {
 					present: {
-						blocksByClientId: {
-							123: { clientId: 123, name: 'core/meta-block', attributes: {} },
-						},
-						blockOrder: {
-							'': [ 123 ],
-							123: [],
+						blocks: {
+							byClientId: {
+								123: { clientId: 123, name: 'core/meta-block', attributes: {} },
+							},
+							order: {
+								'': [ 123 ],
+								123: [],
+							},
 						},
 						edits: {},
 					},
@@ -1735,12 +1793,14 @@ describe( 'selectors', () => {
 				currentPost: {},
 				editor: {
 					present: {
-						blocksByClientId: {
-							23: { clientId: 23, name: 'core/heading', attributes: {} },
-							123: { clientId: 123, name: 'core/paragraph', attributes: {} },
-						},
-						blockOrder: {
-							'': [ 123, 23 ],
+						blocks: {
+							byClientId: {
+								23: { clientId: 23, name: 'core/heading', attributes: {} },
+								123: { clientId: 123, name: 'core/paragraph', attributes: {} },
+							},
+							order: {
+								'': [ 123, 23 ],
+							},
 						},
 						edits: {},
 					},
@@ -1760,39 +1820,41 @@ describe( 'selectors', () => {
 				currentPost: {},
 				editor: {
 					present: {
-						blocksByClientId: {
-							'uuid-2': { clientId: 'uuid-2', name: 'core/image', attributes: {} },
-							'uuid-4': { clientId: 'uuid-4', name: 'core/paragraph', attributes: {} },
-							'uuid-6': { clientId: 'uuid-6', name: 'core/paragraph', attributes: {} },
-							'uuid-8': { clientId: 'uuid-8', name: 'core/block', attributes: {} },
-							'uuid-10': { clientId: 'uuid-10', name: 'core/columns', attributes: {} },
-							'uuid-12': { clientId: 'uuid-12', name: 'core/column', attributes: {} },
-							'uuid-14': { clientId: 'uuid-14', name: 'core/column', attributes: {} },
-							'uuid-16': { clientId: 'uuid-16', name: 'core/quote', attributes: {} },
-							'uuid-18': { clientId: 'uuid-18', name: 'core/block', attributes: {} },
-							'uuid-20': { clientId: 'uuid-20', name: 'core/gallery', attributes: {} },
-							'uuid-22': { clientId: 'uuid-22', name: 'core/block', attributes: {} },
-							'uuid-24': { clientId: 'uuid-24', name: 'core/columns', attributes: {} },
-							'uuid-26': { clientId: 'uuid-26', name: 'core/column', attributes: {} },
-							'uuid-28': { clientId: 'uuid-28', name: 'core/column', attributes: {} },
-							'uuid-30': { clientId: 'uuid-30', name: 'core/paragraph', attributes: {} },
-						},
-						blockOrder: {
-							'': [ 'uuid-6', 'uuid-8', 'uuid-10', 'uuid-22' ],
-							'uuid-2': [ ],
-							'uuid-4': [ ],
-							'uuid-6': [ ],
-							'uuid-8': [ ],
-							'uuid-10': [ 'uuid-12', 'uuid-14' ],
-							'uuid-12': [ 'uuid-16' ],
-							'uuid-14': [ 'uuid-18' ],
-							'uuid-16': [ ],
-							'uuid-18': [ 'uuid-24' ],
-							'uuid-20': [ ],
-							'uuid-22': [ ],
-							'uuid-24': [ 'uuid-26', 'uuid-28' ],
-							'uuid-26': [ ],
-							'uuid-28': [ 'uuid-30' ],
+						blocks: {
+							byClientId: {
+								'uuid-2': { clientId: 'uuid-2', name: 'core/image', attributes: {} },
+								'uuid-4': { clientId: 'uuid-4', name: 'core/paragraph', attributes: {} },
+								'uuid-6': { clientId: 'uuid-6', name: 'core/paragraph', attributes: {} },
+								'uuid-8': { clientId: 'uuid-8', name: 'core/block', attributes: {} },
+								'uuid-10': { clientId: 'uuid-10', name: 'core/columns', attributes: {} },
+								'uuid-12': { clientId: 'uuid-12', name: 'core/column', attributes: {} },
+								'uuid-14': { clientId: 'uuid-14', name: 'core/column', attributes: {} },
+								'uuid-16': { clientId: 'uuid-16', name: 'core/quote', attributes: {} },
+								'uuid-18': { clientId: 'uuid-18', name: 'core/block', attributes: {} },
+								'uuid-20': { clientId: 'uuid-20', name: 'core/gallery', attributes: {} },
+								'uuid-22': { clientId: 'uuid-22', name: 'core/block', attributes: {} },
+								'uuid-24': { clientId: 'uuid-24', name: 'core/columns', attributes: {} },
+								'uuid-26': { clientId: 'uuid-26', name: 'core/column', attributes: {} },
+								'uuid-28': { clientId: 'uuid-28', name: 'core/column', attributes: {} },
+								'uuid-30': { clientId: 'uuid-30', name: 'core/paragraph', attributes: {} },
+							},
+							order: {
+								'': [ 'uuid-6', 'uuid-8', 'uuid-10', 'uuid-22' ],
+								'uuid-2': [ ],
+								'uuid-4': [ ],
+								'uuid-6': [ ],
+								'uuid-8': [ ],
+								'uuid-10': [ 'uuid-12', 'uuid-14' ],
+								'uuid-12': [ 'uuid-16' ],
+								'uuid-14': [ 'uuid-18' ],
+								'uuid-16': [ ],
+								'uuid-18': [ 'uuid-24' ],
+								'uuid-20': [ ],
+								'uuid-22': [ ],
+								'uuid-24': [ 'uuid-26', 'uuid-28' ],
+								'uuid-26': [ ],
+								'uuid-28': [ 'uuid-30' ],
+							},
 						},
 						edits: {},
 					},
@@ -1817,39 +1879,41 @@ describe( 'selectors', () => {
 				currentPost: {},
 				editor: {
 					present: {
-						blocksByClientId: {
-							'uuid-2': { clientId: 'uuid-2', name: 'core/image', attributes: {} },
-							'uuid-4': { clientId: 'uuid-4', name: 'core/paragraph', attributes: {} },
-							'uuid-6': { clientId: 'uuid-6', name: 'core/paragraph', attributes: {} },
-							'uuid-8': { clientId: 'uuid-8', name: 'core/block', attributes: {} },
-							'uuid-10': { clientId: 'uuid-10', name: 'core/columns', attributes: {} },
-							'uuid-12': { clientId: 'uuid-12', name: 'core/column', attributes: {} },
-							'uuid-14': { clientId: 'uuid-14', name: 'core/column', attributes: {} },
-							'uuid-16': { clientId: 'uuid-16', name: 'core/quote', attributes: {} },
-							'uuid-18': { clientId: 'uuid-18', name: 'core/block', attributes: {} },
-							'uuid-20': { clientId: 'uuid-20', name: 'core/gallery', attributes: {} },
-							'uuid-22': { clientId: 'uuid-22', name: 'core/block', attributes: {} },
-							'uuid-24': { clientId: 'uuid-24', name: 'core/columns', attributes: {} },
-							'uuid-26': { clientId: 'uuid-26', name: 'core/column', attributes: {} },
-							'uuid-28': { clientId: 'uuid-28', name: 'core/column', attributes: {} },
-							'uuid-30': { clientId: 'uuid-30', name: 'core/paragraph', attributes: {} },
-						},
-						blockOrder: {
-							'': [ 'uuid-6', 'uuid-8', 'uuid-10', 'uuid-22' ],
-							'uuid-2': [ ],
-							'uuid-4': [ ],
-							'uuid-6': [ ],
-							'uuid-8': [ ],
-							'uuid-10': [ 'uuid-12', 'uuid-14' ],
-							'uuid-12': [ 'uuid-16' ],
-							'uuid-14': [ 'uuid-18' ],
-							'uuid-16': [ ],
-							'uuid-18': [ 'uuid-24' ],
-							'uuid-20': [ ],
-							'uuid-22': [ ],
-							'uuid-24': [ 'uuid-26', 'uuid-28' ],
-							'uuid-26': [ ],
-							'uuid-28': [ 'uuid-30' ],
+						blocks: {
+							byClientId: {
+								'uuid-2': { clientId: 'uuid-2', name: 'core/image', attributes: {} },
+								'uuid-4': { clientId: 'uuid-4', name: 'core/paragraph', attributes: {} },
+								'uuid-6': { clientId: 'uuid-6', name: 'core/paragraph', attributes: {} },
+								'uuid-8': { clientId: 'uuid-8', name: 'core/block', attributes: {} },
+								'uuid-10': { clientId: 'uuid-10', name: 'core/columns', attributes: {} },
+								'uuid-12': { clientId: 'uuid-12', name: 'core/column', attributes: {} },
+								'uuid-14': { clientId: 'uuid-14', name: 'core/column', attributes: {} },
+								'uuid-16': { clientId: 'uuid-16', name: 'core/quote', attributes: {} },
+								'uuid-18': { clientId: 'uuid-18', name: 'core/block', attributes: {} },
+								'uuid-20': { clientId: 'uuid-20', name: 'core/gallery', attributes: {} },
+								'uuid-22': { clientId: 'uuid-22', name: 'core/block', attributes: {} },
+								'uuid-24': { clientId: 'uuid-24', name: 'core/columns', attributes: {} },
+								'uuid-26': { clientId: 'uuid-26', name: 'core/column', attributes: {} },
+								'uuid-28': { clientId: 'uuid-28', name: 'core/column', attributes: {} },
+								'uuid-30': { clientId: 'uuid-30', name: 'core/paragraph', attributes: {} },
+							},
+							order: {
+								'': [ 'uuid-6', 'uuid-8', 'uuid-10', 'uuid-22' ],
+								'uuid-2': [ ],
+								'uuid-4': [ ],
+								'uuid-6': [ ],
+								'uuid-8': [ ],
+								'uuid-10': [ 'uuid-12', 'uuid-14' ],
+								'uuid-12': [ 'uuid-16' ],
+								'uuid-14': [ 'uuid-18' ],
+								'uuid-16': [ ],
+								'uuid-18': [ 'uuid-24' ],
+								'uuid-20': [ ],
+								'uuid-22': [ ],
+								'uuid-24': [ 'uuid-26', 'uuid-28' ],
+								'uuid-26': [ ],
+								'uuid-28': [ 'uuid-30' ],
+							},
 						},
 						edits: {},
 					},
@@ -1877,12 +1941,14 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {
-							23: { clientId: 23, name: 'core/heading', attributes: {} },
-							123: { clientId: 123, name: 'core/paragraph', attributes: {} },
-						},
-						blockOrder: {
-							'': [ 123, 23 ],
+						blocks: {
+							byClientId: {
+								23: { clientId: 23, name: 'core/heading', attributes: {} },
+								123: { clientId: 123, name: 'core/paragraph', attributes: {} },
+							},
+							order: {
+								'': [ 123, 23 ],
+							},
 						},
 					},
 				},
@@ -1895,14 +1961,16 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {
-							123: { clientId: 123, name: 'core/columns', attributes: {} },
-							456: { clientId: 456, name: 'core/paragraph', attributes: {} },
-							789: { clientId: 789, name: 'core/paragraph', attributes: {} },
-						},
-						blockOrder: {
-							'': [ 123 ],
-							123: [ 456, 789 ],
+						blocks: {
+							byClientId: {
+								123: { clientId: 123, name: 'core/columns', attributes: {} },
+								456: { clientId: 456, name: 'core/paragraph', attributes: {} },
+								789: { clientId: 789, name: 'core/paragraph', attributes: {} },
+							},
+							order: {
+								'': [ 123 ],
+								123: [ 456, 789 ],
+							},
 						},
 					},
 				},
@@ -1952,9 +2020,11 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {
-							23: { clientId: 23, name: 'core/heading', attributes: {} },
-							123: { clientId: 123, name: 'core/paragraph', attributes: {} },
+						blocks: {
+							byClientId: {
+								23: { clientId: 23, name: 'core/heading', attributes: {} },
+								123: { clientId: 123, name: 'core/paragraph', attributes: {} },
+							},
 						},
 					},
 				},
@@ -1967,11 +2037,13 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {
-							123: { clientId: 123, name: 'core/columns', attributes: {} },
-							456: { clientId: 456, name: 'core/paragraph', attributes: {} },
-							789: { clientId: 789, name: 'core/paragraph', attributes: {} },
-							124: { clientId: 123, name: 'core/heading', attributes: {} },
+						blocks: {
+							byClientId: {
+								123: { clientId: 123, name: 'core/columns', attributes: {} },
+								456: { clientId: 456, name: 'core/paragraph', attributes: {} },
+								789: { clientId: 789, name: 'core/paragraph', attributes: {} },
+								124: { clientId: 123, name: 'core/heading', attributes: {} },
+							},
 						},
 					},
 				},
@@ -1984,7 +2056,8 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {
+						blocks: {
+							byClientId: {},
 						},
 					},
 				},
@@ -2026,14 +2099,16 @@ describe( 'selectors', () => {
 				currentPost: {},
 				editor: {
 					present: {
-						blocksByClientId: {
-							23: { clientId: 23, name: 'core/heading', attributes: {} },
-							123: { clientId: 123, name: 'core/paragraph', attributes: {} },
-						},
-						blockOrder: {
-							'': [ 23, 123 ],
-							23: [],
-							123: [],
+						blocks: {
+							byClientId: {
+								23: { clientId: 23, name: 'core/heading', attributes: {} },
+								123: { clientId: 123, name: 'core/paragraph', attributes: {} },
+							},
+							order: {
+								'': [ 23, 123 ],
+								23: [],
+								123: [],
+							},
 						},
 						edits: {},
 					},
@@ -2049,14 +2124,16 @@ describe( 'selectors', () => {
 				currentPost: {},
 				editor: {
 					present: {
-						blocksByClientId: {
-							23: { clientId: 23, name: 'core/heading', attributes: {} },
-							123: { clientId: 123, name: 'core/paragraph', attributes: {} },
-						},
-						blockOrder: {
-							'': [ 23, 123 ],
-							23: [],
-							123: [],
+						blocks: {
+							byClientId: {
+								23: { clientId: 23, name: 'core/heading', attributes: {} },
+								123: { clientId: 123, name: 'core/paragraph', attributes: {} },
+							},
+							order: {
+								'': [ 23, 123 ],
+								23: [],
+								123: [],
+							},
 						},
 						edits: {},
 					},
@@ -2072,14 +2149,16 @@ describe( 'selectors', () => {
 				currentPost: {},
 				editor: {
 					present: {
-						blocksByClientId: {
-							23: { clientId: 23, name: 'core/heading', attributes: {} },
-							123: { clientId: 123, name: 'core/paragraph', attributes: {} },
-						},
-						blockOrder: {
-							'': [ 23, 123 ],
-							23: [],
-							123: [],
+						blocks: {
+							byClientId: {
+								23: { clientId: 23, name: 'core/heading', attributes: {} },
+								123: { clientId: 123, name: 'core/paragraph', attributes: {} },
+							},
+							order: {
+								'': [ 23, 123 ],
+								23: [],
+								123: [],
+							},
 						},
 						edits: {},
 					},
@@ -2101,7 +2180,9 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {},
+						blocks: {
+							order: {},
+						},
 					},
 				},
 			};
@@ -2113,9 +2194,11 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 123, 23 ],
-							123: [ 456, 56 ],
+						blocks: {
+							order: {
+								'': [ 123, 23 ],
+								123: [ 456, 56 ],
+							},
 						},
 					},
 				},
@@ -2130,7 +2213,9 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {},
+						blocks: {
+							order: {},
+						},
 					},
 				},
 			};
@@ -2142,9 +2227,11 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 123, 23 ],
-							123: [ 456, 56 ],
+						blocks: {
+							order: {
+								'': [ 123, 23 ],
+								123: [ 456, 56 ],
+							},
 						},
 					},
 				},
@@ -2157,10 +2244,12 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ '123', '23' ],
-							123: [ '456', '56' ],
-							56: [ '12' ],
+						blocks: {
+							order: {
+								'': [ '123', '23' ],
+								123: [ '456', '56' ],
+								56: [ '12' ],
+							},
 						},
 					},
 				},
@@ -2175,8 +2264,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 123, 23 ],
+						blocks: {
+							order: {
+								'': [ 123, 23 ],
+							},
 						},
 					},
 				},
@@ -2190,8 +2281,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 5, 4, 3, 2, 1 ],
+						blocks: {
+							order: {
+								'': [ 5, 4, 3, 2, 1 ],
+							},
 						},
 					},
 				},
@@ -2205,9 +2298,11 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 5, 4, 3, 2, 1 ],
-							4: [ 9, 8, 7, 6 ],
+						blocks: {
+							order: {
+								'': [ 5, 4, 3, 2, 1 ],
+								4: [ 9, 8, 7, 6 ],
+							},
 						},
 					},
 				},
@@ -2223,8 +2318,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {},
-						blockOrder: {},
+						blocks: {
+							byClientId: {},
+							order: {},
+						},
 						edits: {},
 					},
 				},
@@ -2279,8 +2376,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 123, 23 ],
+						blocks: {
+							order: {
+								'': [ 123, 23 ],
+							},
 						},
 					},
 				},
@@ -2293,9 +2392,11 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 123, 23 ],
-							123: [ 456 ],
+						blocks: {
+							order: {
+								'': [ 123, 23 ],
+								123: [ 456 ],
+							},
 						},
 					},
 				},
@@ -2310,8 +2411,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 123, 23 ],
+						blocks: {
+							order: {
+								'': [ 123, 23 ],
+							},
 						},
 					},
 				},
@@ -2324,9 +2427,11 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 123, 23 ],
-							123: [ 456, 56 ],
+						blocks: {
+							order: {
+								'': [ 123, 23 ],
+								123: [ 456, 56 ],
+							},
 						},
 					},
 				},
@@ -2341,8 +2446,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 123, 23 ],
+						blocks: {
+							order: {
+								'': [ 123, 23 ],
+							},
 						},
 					},
 				},
@@ -2355,9 +2462,11 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 123, 23 ],
-							123: [ 456, 56 ],
+						blocks: {
+							order: {
+								'': [ 123, 23 ],
+								123: [ 456, 56 ],
+							},
 						},
 					},
 				},
@@ -2370,8 +2479,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 123, 23 ],
+						blocks: {
+							order: {
+								'': [ 123, 23 ],
+							},
 						},
 					},
 				},
@@ -2384,9 +2495,11 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 123, 23 ],
-							123: [ 456, 56 ],
+						blocks: {
+							order: {
+								'': [ 123, 23 ],
+								123: [ 456, 56 ],
+							},
 						},
 					},
 				},
@@ -2401,8 +2514,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 123, 23 ],
+						blocks: {
+							order: {
+								'': [ 123, 23 ],
+							},
 						},
 					},
 				},
@@ -2415,9 +2530,11 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 123, 23 ],
-							123: [ 456, 56 ],
+						blocks: {
+							order: {
+								'': [ 123, 23 ],
+								123: [ 456, 56 ],
+							},
 						},
 					},
 				},
@@ -2430,8 +2547,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 123, 23 ],
+						blocks: {
+							order: {
+								'': [ 123, 23 ],
+							},
 						},
 					},
 				},
@@ -2444,9 +2563,11 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 123, 23 ],
-							123: [ 456, 56 ],
+						blocks: {
+							order: {
+								'': [ 123, 23 ],
+								123: [ 456, 56 ],
+							},
 						},
 					},
 				},
@@ -2488,8 +2609,10 @@ describe( 'selectors', () => {
 				blockSelection: { start: 5, end: 5 },
 				editor: {
 					present: {
-						blockOrder: {
-							4: [ 3, 2, 1 ],
+						blocks: {
+							order: {
+								4: [ 3, 2, 1 ],
+							},
 						},
 					},
 				},
@@ -2503,8 +2626,10 @@ describe( 'selectors', () => {
 				blockSelection: { start: 3, end: 3 },
 				editor: {
 					present: {
-						blockOrder: {
-							4: [ 3, 2, 1 ],
+						blocks: {
+							order: {
+								4: [ 3, 2, 1 ],
+							},
 						},
 					},
 				},
@@ -2517,8 +2642,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							6: [ 5, 4, 3, 2, 1 ],
+						blocks: {
+							order: {
+								6: [ 5, 4, 3, 2, 1 ],
+							},
 						},
 					},
 				},
@@ -2531,9 +2658,11 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							3: [ 2, 1 ],
-							6: [ 5, 4 ],
+						blocks: {
+							order: {
+								3: [ 2, 1 ],
+								6: [ 5, 4 ],
+							},
 						},
 					},
 				},
@@ -2549,8 +2678,10 @@ describe( 'selectors', () => {
 				blockSelection: { start: 5, end: 3 },
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 5, 4, 3, 2, 1 ],
+						blocks: {
+							order: {
+								'': [ 5, 4, 3, 2, 1 ],
+							},
 						},
 					},
 				},
@@ -2564,8 +2695,10 @@ describe( 'selectors', () => {
 				blockSelection: { start: 5, end: 3 },
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 5, 4, 3, 2, 1 ],
+						blocks: {
+							order: {
+								'': [ 5, 4, 3, 2, 1 ],
+							},
 						},
 					},
 				},
@@ -2579,8 +2712,10 @@ describe( 'selectors', () => {
 				blockSelection: { start: 5, end: 3 },
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 5, 4, 3, 2, 1 ],
+						blocks: {
+							order: {
+								'': [ 5, 4, 3, 2, 1 ],
+							},
 						},
 					},
 				},
@@ -2594,8 +2729,10 @@ describe( 'selectors', () => {
 				blockSelection: {},
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 5, 4, 3, 2, 1 ],
+						blocks: {
+							order: {
+								'': [ 5, 4, 3, 2, 1 ],
+							},
 						},
 					},
 				},
@@ -2644,8 +2781,10 @@ describe( 'selectors', () => {
 		const state = {
 			editor: {
 				present: {
-					blockOrder: {
-						'': [ 5, 4, 3, 2, 1 ],
+					blocks: {
+						order: {
+							'': [ 5, 4, 3, 2, 1 ],
+						},
 					},
 				},
 			},
@@ -2665,8 +2804,10 @@ describe( 'selectors', () => {
 		const state = {
 			editor: {
 				present: {
-					blockOrder: {
-						'': [ 5, 4, 3, 2, 1 ],
+					blocks: {
+						order: {
+							'': [ 5, 4, 3, 2, 1 ],
+						},
 					},
 				},
 			},
@@ -2771,14 +2912,16 @@ describe( 'selectors', () => {
 				},
 				editor: {
 					present: {
-						blocksByClientId: {
-							clientId1: { clientId: 'clientId1' },
-							clientId2: { clientId: 'clientId2' },
-						},
-						blockOrder: {
-							'': [ 'clientId1' ],
-							clientId1: [ 'clientId2' ],
-							clientId2: [],
+						blocks: {
+							byClientId: {
+								clientId1: { clientId: 'clientId1' },
+								clientId2: { clientId: 'clientId2' },
+							},
+							order: {
+								'': [ 'clientId1' ],
+								clientId1: [ 'clientId2' ],
+								clientId2: [],
+							},
 						},
 						edits: {},
 					},
@@ -2805,12 +2948,14 @@ describe( 'selectors', () => {
 				},
 				editor: {
 					present: {
-						blocksByClientId: {
-							clientId1: { clientId: 'clientId1' },
-						},
-						blockOrder: {
-							'': [ 'clientId1' ],
-							clientId1: [],
+						blocks: {
+							byClientId: {
+								clientId1: { clientId: 'clientId1' },
+							},
+							order: {
+								'': [ 'clientId1' ],
+								clientId1: [],
+							},
 						},
 						edits: {},
 					},
@@ -2834,14 +2979,16 @@ describe( 'selectors', () => {
 				},
 				editor: {
 					present: {
-						blocksByClientId: {
-							clientId1: { clientId: 'clientId1' },
-							clientId2: { clientId: 'clientId2' },
-						},
-						blockOrder: {
-							'': [ 'clientId1' ],
-							clientId1: [ 'clientId2' ],
-							clientId2: [],
+						blocks: {
+							byClientId: {
+								clientId1: { clientId: 'clientId1' },
+								clientId2: { clientId: 'clientId2' },
+							},
+							order: {
+								'': [ 'clientId1' ],
+								clientId1: [ 'clientId2' ],
+								clientId2: [],
+							},
 						},
 						edits: {},
 					},
@@ -2865,14 +3012,16 @@ describe( 'selectors', () => {
 				},
 				editor: {
 					present: {
-						blocksByClientId: {
-							clientId1: { clientId: 'clientId1' },
-							clientId2: { clientId: 'clientId2' },
-						},
-						blockOrder: {
-							'': [ 'clientId1', 'clientId2' ],
-							clientId1: [],
-							clientId2: [],
+						blocks: {
+							byClientId: {
+								clientId1: { clientId: 'clientId1' },
+								clientId2: { clientId: 'clientId2' },
+							},
+							order: {
+								'': [ 'clientId1', 'clientId2' ],
+								clientId1: [],
+								clientId2: [],
+							},
 						},
 						edits: {},
 					},
@@ -2896,14 +3045,16 @@ describe( 'selectors', () => {
 				},
 				editor: {
 					present: {
-						blocksByClientId: {
-							clientId1: { clientId: 'clientId1' },
-							clientId2: { clientId: 'clientId2' },
-						},
-						blockOrder: {
-							'': [ 'clientId1', 'clientId2' ],
-							clientId1: [],
-							clientId2: [],
+						blocks: {
+							byClientId: {
+								clientId1: { clientId: 'clientId1' },
+								clientId2: { clientId: 'clientId2' },
+							},
+							order: {
+								'': [ 'clientId1', 'clientId2' ],
+								clientId1: [],
+								clientId2: [],
+							},
 						},
 						edits: {},
 					},
@@ -3010,8 +3161,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {},
-						blocksByClientId: {},
+						blocks: {
+							byClientId: {},
+							order: {},
+						},
 						edits: {},
 					},
 				},
@@ -3025,12 +3178,14 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 123, 456 ],
-						},
-						blocksByClientId: {
-							123: { clientId: 123, name: 'core/image', attributes: {} },
-							456: { clientId: 456, name: 'core/quote', attributes: {} },
+						blocks: {
+							byClientId: {
+								123: { clientId: 123, name: 'core/image', attributes: {} },
+								456: { clientId: 456, name: 'core/quote', attributes: {} },
+							},
+							order: {
+								'': [ 123, 456 ],
+							},
 						},
 						edits: {},
 					},
@@ -3045,11 +3200,13 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 123 ],
-						},
-						blocksByClientId: {
-							123: { clientId: 123, name: 'core/image', attributes: {} },
+						blocks: {
+							byClientId: {
+								123: { clientId: 123, name: 'core/image', attributes: {} },
+							},
+							order: {
+								'': [ 123 ],
+							},
 						},
 						edits: {},
 					},
@@ -3064,11 +3221,13 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 456 ],
-						},
-						blocksByClientId: {
-							456: { clientId: 456, name: 'core/quote', attributes: {} },
+						blocks: {
+							byClientId: {
+								456: { clientId: 456, name: 'core/quote', attributes: {} },
+							},
+							order: {
+								'': [ 456 ],
+							},
 						},
 						edits: {},
 					},
@@ -3083,11 +3242,13 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 567 ],
-						},
-						blocksByClientId: {
-							567: { clientId: 567, name: 'core-embed/youtube', attributes: {} },
+						blocks: {
+							byClientId: {
+								567: { clientId: 567, name: 'core-embed/youtube', attributes: {} },
+							},
+							order: {
+								'': [ 567 ],
+							},
 						},
 						edits: {},
 					},
@@ -3102,12 +3263,14 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ 456, 789 ],
-						},
-						blocksByClientId: {
-							456: { clientId: 456, name: 'core/quote', attributes: {} },
-							789: { clientId: 789, name: 'core/paragraph', attributes: {} },
+						blocks: {
+							byClientId: {
+								456: { clientId: 456, name: 'core/quote', attributes: {} },
+								789: { clientId: 789, name: 'core/paragraph', attributes: {} },
+							},
+							order: {
+								'': [ 456, 789 ],
+							},
 						},
 						edits: {},
 					},
@@ -3165,11 +3328,13 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ block.clientId ],
-						},
-						blocksByClientId: {
-							[ block.clientId ]: block,
+						blocks: {
+							byClientId: {
+								[ block.clientId ]: block,
+							},
+							order: {
+								'': [ block.clientId ],
+							},
 						},
 						edits: {
 							content: 'custom edit',
@@ -3190,11 +3355,13 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ block.clientId ],
-						},
-						blocksByClientId: {
-							[ block.clientId ]: block,
+						blocks: {
+							byClientId: {
+								[ block.clientId ]: block,
+							},
+							order: {
+								'': [ block.clientId ],
+							},
 						},
 						edits: {},
 					},
@@ -3214,11 +3381,13 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ unknownBlock.clientId ],
-						},
-						blocksByClientId: {
-							[ unknownBlock.clientId ]: unknownBlock,
+						blocks: {
+							byClientId: {
+								[ unknownBlock.clientId ]: unknownBlock,
+							},
+							order: {
+								'': [ unknownBlock.clientId ],
+							},
 						},
 						edits: {},
 					},
@@ -3241,12 +3410,14 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ firstUnknown.clientId, secondUnknown.clientId ],
-						},
-						blocksByClientId: {
-							[ firstUnknown.clientId ]: firstUnknown,
-							[ secondUnknown.clientId ]: secondUnknown,
+						blocks: {
+							byClientId: {
+								[ firstUnknown.clientId ]: firstUnknown,
+								[ secondUnknown.clientId ]: secondUnknown,
+							},
+							order: {
+								'': [ firstUnknown.clientId, secondUnknown.clientId ],
+							},
 						},
 						edits: {},
 					},
@@ -3264,11 +3435,13 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ defaultBlock.clientId ],
-						},
-						blocksByClientId: {
-							[ defaultBlock.clientId ]: defaultBlock,
+						blocks: {
+							byClientId: {
+								[ defaultBlock.clientId ]: defaultBlock,
+							},
+							order: {
+								'': [ defaultBlock.clientId ],
+							},
 						},
 						edits: {},
 					},
@@ -3286,16 +3459,18 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blockOrder: {
-							'': [ defaultBlock.clientId ],
-						},
-						blocksByClientId: {
-							[ defaultBlock.clientId ]: {
-								...defaultBlock,
-								attributes: {
-									...defaultBlock.attributes,
-									modified: true,
+						blocks: {
+							byClientId: {
+								[ defaultBlock.clientId ]: {
+									...defaultBlock,
+									attributes: {
+										...defaultBlock.attributes,
+										modified: true,
+									},
 								},
+							},
+							order: {
+								'': [ defaultBlock.clientId ],
 							},
 						},
 						edits: {},
@@ -3315,7 +3490,9 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {},
+						blocks: {
+							byClientId: {},
+						},
 					},
 				},
 				blockListSettings: {},
@@ -3328,7 +3505,9 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {},
+						blocks: {
+							byClientId: {},
+						},
 					},
 				},
 				blockListSettings: {},
@@ -3343,7 +3522,9 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {},
+						blocks: {
+							byClientId: {},
+						},
 					},
 				},
 				blockListSettings: {},
@@ -3358,7 +3539,9 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {},
+						blocks: {
+							byClientId: {},
+						},
 					},
 				},
 				blockListSettings: {},
@@ -3373,7 +3556,9 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {},
+						blocks: {
+							byClientId: {},
+						},
 					},
 				},
 				blockListSettings: {},
@@ -3386,8 +3571,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {
-							block1: { name: 'core/test-block-a' },
+						blocks: {
+							byClientId: {
+								block1: { name: 'core/test-block-a' },
+							},
 						},
 					},
 				},
@@ -3401,8 +3588,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {
-							block1: { name: 'core/test-block-b' },
+						blocks: {
+							byClientId: {
+								block1: { name: 'core/test-block-b' },
+							},
 						},
 					},
 				},
@@ -3416,8 +3605,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {
-							block1: { name: 'core/test-block-a' },
+						blocks: {
+							byClientId: {
+								block1: { name: 'core/test-block-a' },
+							},
 						},
 					},
 				},
@@ -3435,8 +3626,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {
-							block1: { name: 'core/test-block-a' },
+						blocks: {
+							byClientId: {
+								block1: { name: 'core/test-block-a' },
+							},
 						},
 					},
 				},
@@ -3454,8 +3647,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {
-							block1: { name: 'core/test-block-b' },
+						blocks: {
+							byClientId: {
+								block1: { name: 'core/test-block-b' },
+							},
 						},
 					},
 				},
@@ -3475,10 +3670,12 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {
-							block1: { name: 'core/test-block-a' },
+						blocks: {
+							byClientId: {
+								block1: { name: 'core/test-block-a' },
+							},
+							order: {},
 						},
-						blockOrder: {},
 						edits: {},
 					},
 				},
@@ -3532,11 +3729,13 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {
-							block1: { name: 'core/test-block-a' },
-							block2: { name: 'core/test-block-a' },
+						blocks: {
+							byClientId: {
+								block1: { name: 'core/test-block-a' },
+								block2: { name: 'core/test-block-a' },
+							},
+							order: {},
 						},
-						blockOrder: {},
 						edits: {},
 					},
 				},
@@ -3569,11 +3768,13 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {
-							block1: { name: 'core/test-block-a' },
-							block2: { name: 'core/test-block-a' },
+						blocks: {
+							byClientId: {
+								block1: { name: 'core/test-block-a' },
+								block2: { name: 'core/test-block-a' },
+							},
+							order: {},
 						},
-						blockOrder: {},
 						edits: {},
 					},
 				},
@@ -3627,11 +3828,13 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {
-							block1: { clientId: 'block1', name: 'core/test-block-b' },
-						},
-						blockOrder: {
-							'': [ 'block1' ],
+						blocks: {
+							byClientId: {
+								block1: { clientId: 'block1', name: 'core/test-block-b' },
+							},
+							order: {
+								'': [ 'block1' ],
+							},
 						},
 						edits: {},
 					},
@@ -3655,8 +3858,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {},
-						blockOrder: {},
+						blocks: {
+							byClientId: {},
+							order: {},
+						},
 						edits: {},
 					},
 				},
@@ -3679,8 +3884,10 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {},
-						blockOrder: {},
+						blocks: {
+							byClientId: {},
+							order: {},
+						},
 						edits: {},
 					},
 				},
@@ -3706,11 +3913,13 @@ describe( 'selectors', () => {
 			const state = {
 				editor: {
 					present: {
-						blocksByClientId: {
-							block1: { name: 'core/test-block-b' },
-						},
-						blockOrder: {
-							'': [ 'block1' ],
+						blocks: {
+							byClientId: {
+								block1: { name: 'core/test-block-b' },
+							},
+							order: {
+								'': [ 'block1' ],
+							},
 						},
 						edits: {},
 					},


### PR DESCRIPTION
Extracted from #10844

This pull request seeks to refactor blocks state to track blocks state as a single subtree within the `editor` reducer.

*Before:*

- `editor`
   - `edits`
   - `blocksByClientId`
   - `blockOrder`

*After:*

- `editor`
   - `edits`
   - `blocks`
      - `byClientId`
      - `order`

The rationale for this change is in better representing treatment the two as a collective unit, facilitating work in #10844 to shift the `isDirty` tracking from `editor` to `blocks`, and enabling the simplification of e.g. memoized selector cache-busting, which can reference the single `editor.blocks` (where previously it would enumerate both `blocksByClientId` and `blockOrder`).

**Testing instructions:**

This is a refactoring change. There should be no notable impact on behavior.