### PR TITLE
Fix: Make it impossible to use the UI to add a reusable block inside the same reusable block

### DIFF
--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1118,6 +1118,29 @@ export function getLastMultiSelectedBlockClientId( state ) {
 }
 
 /**
+ * Checks if possibleAncestorId is an ancestor of possibleDescendentId.
+ *
+ * @param {Object} state                Editor state.
+ * @param {string} possibleAncestorId   Possible ancestor client ID.
+ * @param {string} possibleDescendentId Possible descent client ID.
+ *
+ * @return {boolean} True if possibleAncestorId is an ancestor
+ *                   of possibleDescendentId, and false otherwise.
+ */
+const isAncestorOf = createSelector(
+	( state, possibleAncestorId, possibleDescendentId ) => {
+		let idToCheck = possibleDescendentId;
+		while ( possibleAncestorId !== idToCheck && idToCheck ) {
+			idToCheck = getBlockRootClientId( state, idToCheck );
+		}
+		return possibleAncestorId === idToCheck;
+	},
+	( state ) => [
+		state.editor.present.blocks,
+	],
+);
+
+/**
  * Returns true if a multi-selection exists, and the block corresponding to the
  * specified client ID is the first block of the multi-selection set, or false
  * otherwise.
@@ -1744,6 +1767,10 @@ const canIncludeReusableBlockInInserter = ( state, reusableBlock, rootClientId )
 	}
 
 	if ( ! canInsertBlockTypeUnmemoized( state, referencedBlockName, rootClientId ) ) {
+		return false;
+	}
+
+	if ( isAncestorOf( state, reusableBlock.clientId, rootClientId ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
Fixes client-side problems in https://github.com/WordPress/gutenberg/issues/11206.

It was possible to use the UI to add a reusable block inside itself. This PR addresses this problem.

In order to address this problem, a new selector isAncestorOf is created.


## How has this been tested?
Add a columns block write some paragraphs inside it.
Make the columns block reusable block and save it.
Edit the reusable block add a new paragraph use the slash inserter "/" on the new paragraph and verify it is not possible to insert the same reusable block. (On master it was and the editor crashed).