### PR TITLE
Update/shortcuts docs

### DIFF
--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -219,8 +219,8 @@ This is the canonical list of keyboard shortcuts:
 		</tr>
 		<tr>
 			<td>Remove a link.</td>
-			<td><kbd>Shift</kbd>+<kbd>Alt</kbd>+<kbd>S</kbd></td>
-			<td><kbd>⌃</kbd><kbd>⌥</kbd><kbd>S</kbd></td>
+			<td><kbd>Shift</kbd>+<kbd>Alt</kbd>+<kbd>K</kbd></td>
+			<td><kbd>⌃</kbd><kbd>⌥</kbd><kbd>K</kbd></td>
 		</tr>
 		<tr>
 			<td>Add a strikethrough to the selected text.</td>

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -219,8 +219,8 @@ This is the canonical list of keyboard shortcuts:
 		</tr>
 		<tr>
 			<td>Remove a link.</td>
-			<td><kbd>Shift</kbd>+<kbd>Alt</kbd>+<kbd>K</kbd></td>
-			<td><kbd>⌃</kbd><kbd>⌥</kbd><kbd>K</kbd></td>
+			<td><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd></td>
+			<td><kbd>⇧</kbd><kbd>⌘</kbd><kbd>K</kbd></td>
 		</tr>
 		<tr>
 			<td>Add a strikethrough to the selected text.</td>

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/config.js
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/config.js
@@ -142,7 +142,7 @@ const textFormattingShortcuts = {
 			description: __( 'Convert the selected text into a link.' ),
 		},
 		{
-			keyCombination: access( 's' ),
+			keyCombination: primaryShift( 'k' ),
 			description: __( 'Remove a link.' ),
 		},
 		{

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
@@ -260,11 +260,11 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
           Object {
             "description": "Remove a link.",
             "keyCombination": Array [
+              "Ctrl",
+              "+",
               "Shift",
               "+",
-              "Alt",
-              "+",
-              "S",
+              "K",
             ],
           },
           Object {


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/10915

Updates keyboard shortcut in docs and modal for `Remove a link`.
