### PR TITLE
Block List: Always show trailing inserter

### DIFF
--- a/packages/editor/src/components/block-list-appender/index.js
+++ b/packages/editor/src/components/block-list-appender/index.js
@@ -28,7 +28,7 @@ function BlockListAppender( {
 		return null;
 	}
 
-	if ( canInsertDefaultBlock ) {
+	if ( ! blockClientIds.length && canInsertDefaultBlock ) {
 		return (
 			<IgnoreNestedEvents childHandledEvents={ [ 'onFocus', 'onClick', 'onKeyDown' ] }>
 				<DefaultBlockAppender


### PR DESCRIPTION
Partially addresses: #10519 closes #11329

This pull request seeks to update the block list to always display a trailing inserter menu.

*Status:* In its current form, it is very much a stub branch to prompt discussion around the interactions. Notably:

- If the dashed border of the trailing inserter is undesirable, would its removal be detrimental to its purpose having been introduced in #10136 ? How do we ensure consistency here to avoid having two appearances for what is essentially the same interaction?
- What should be initially shown to the user when they start drafting a New Post. If the purpose of #10519 is consistency in the behaviors surrounding the appending of a new block, should that also mean it's the only option available for a new post?
- Should the clickable area below the block list remain? Its purpose was to mimic the feeling of any other text editable region (word processors, textareas like the one in which you're soon to comment), but it may feel out of place with the more block-oriented nature of the always-visible trailing inserter.

![image](https://user-images.githubusercontent.com/1779930/47815904-fe04f180-dd27-11e8-90bf-3080c7272fe0.png)
