### PR TITLE
API Fetch: Avoid unnecessary options shallow clone on unhandled method

### DIFF
--- a/packages/api-fetch/src/middlewares/http-v1.js
+++ b/packages/api-fetch/src/middlewares/http-v1.js
@@ -1,17 +1,50 @@
+/**
+ * Set of HTTP methods which are eligible to be overridden.
+ *
+ * @type {Set}
+ */
+const OVERRIDE_METHODS = new Set( [
+	'PATCH',
+	'PUT',
+	'DELETE',
+] );
+
+/**
+ * Default request method.
+ *
+ * "A request has an associated method (a method). Unless stated otherwise it
+ * is `GET`."
+ *
+ * @see  https://fetch.spec.whatwg.org/#requests
+ *
+ * @type {string}
+ */
+const DEFAULT_METHOD = 'GET';
+
+/**
+ * API Fetch middleware which overrides the request method for HTTP v1
+ * compatibility leveraging the REST API X-HTTP-Method-Override header.
+ *
+ * @param {Object}   options Fetch options.
+ * @param {Function} next    [description]
+ *
+ * @return {*} The evaluated result of the remaining middleware chain.
+ */
 function httpV1Middleware( options, next ) {
-	const newOptions = { ...options };
-	if ( newOptions.method ) {
-		if ( [ 'PATCH', 'PUT', 'DELETE' ].indexOf( newOptions.method.toUpperCase() ) >= 0 ) {
-			if ( ! newOptions.headers ) {
-				newOptions.headers = {};
-			}
-			newOptions.headers[ 'X-HTTP-Method-Override' ] = newOptions.method;
-			newOptions.headers[ 'Content-Type' ] = 'application/json';
-			newOptions.method = 'POST';
-		}
+	const { method = DEFAULT_METHOD } = options;
+	if ( OVERRIDE_METHODS.has( method.toUpperCase() ) ) {
+		options = {
+			...options,
+			headers: {
+				...options.headers,
+				'X-HTTP-Method-Override': method,
+				'Content-Type': 'application/json',
+			},
+			method: 'POST',
+		};
 	}
 
-	return next( newOptions, next );
+	return next( options, next );
 }
 
 export default httpV1Middleware;

--- a/packages/api-fetch/src/middlewares/test/http-v1.js
+++ b/packages/api-fetch/src/middlewares/test/http-v1.js
@@ -20,7 +20,7 @@ describe( 'HTTP v1 Middleware', () => {
 
 		const requestOptions = { method: 'GET', path: '/wp/v2/posts' };
 		const callback = ( options ) => {
-			expect( options ).toEqual( requestOptions );
+			expect( options ).toBe( requestOptions );
 		};
 
 		httpV1Middleware( requestOptions, callback );
@@ -31,7 +31,7 @@ describe( 'HTTP v1 Middleware', () => {
 
 		const requestOptions = { path: '/wp/v2/posts' };
 		const callback = ( options ) => {
-			expect( options ).toEqual( requestOptions );
+			expect( options ).toBe( requestOptions );
 		};
 
 		httpV1Middleware( requestOptions, callback );

--- a/packages/api-fetch/src/middlewares/test/http-v1.js
+++ b/packages/api-fetch/src/middlewares/test/http-v1.js
@@ -25,4 +25,15 @@ describe( 'HTTP v1 Middleware', () => {
 
 		httpV1Middleware( requestOptions, callback );
 	} );
+
+	it( "shouldn't touch the options for an undefined method", () => {
+		expect.hasAssertions();
+
+		const requestOptions = { path: '/wp/v2/posts' };
+		const callback = ( options ) => {
+			expect( options ).toEqual( requestOptions );
+		};
+
+		httpV1Middleware( requestOptions, callback );
+	} );
 } );


### PR DESCRIPTION
See https://github.com/WordPress/gutenberg/pull/7018#discussion_r229857697

This pull request seeks to refactor the `@wordpress/api-fetch` HTTP v1 middleware to avoid an unnecessary shallow clone of options unless intended to be enhanced by the middleware.

**Testing instructions:**

Ensure unit test pass:

```
npm run test-unit
```