### PR TITLE
api-fetch: Add Accept json header to l10n requests

### DIFF
--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -36,6 +36,10 @@ function apiFetch( options ) {
 			headers[ 'Content-Type' ] = 'application/json';
 		}
 
+		if ( ! headers.Accept ) {
+			headers.Accept = 'application/json';
+		}
+
 		const responsePromise = window.fetch(
 			url || path,
 			{

--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -37,7 +37,7 @@ function apiFetch( options ) {
 		}
 
 		if ( ! headers.Accept ) {
-			headers.Accept = 'application/json';
+			headers.Accept = 'application/json, */*;q=0.1';
 		}
 
 		const responsePromise = window.fetch(

--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -31,14 +31,11 @@ function checkCloudflareError( error ) {
 function apiFetch( options ) {
 	const raw = ( nextOptions ) => {
 		const { url, path, body, data, parse = true, ...remainingOptions } = nextOptions;
-		const headers = remainingOptions.headers || {};
-		if ( ! headers[ 'Content-Type' ] && data ) {
-			headers[ 'Content-Type' ] = 'application/json';
-		}
-
-		if ( ! headers.Accept ) {
-			headers.Accept = 'application/json, */*;q=0.1';
-		}
+		const headers = {
+			Accept: 'application/json, */*;q=0.1',
+			'Content-Type': 'application/json',
+			...remainingOptions.headers,
+		};
 
 		const responsePromise = window.fetch(
 			url || path,

--- a/packages/api-fetch/src/test/index.js
+++ b/packages/api-fetch/src/test/index.js
@@ -107,4 +107,38 @@ describe( 'apiFetch', () => {
 			} );
 		} );
 	} );
+
+	it( 'should apply an Accept: application/json header', () => {
+		window.fetch.mockReturnValue( Promise.resolve( {
+			status: 200,
+			json() {
+				return Promise.resolve( { message: 'ok' } );
+			},
+		} ) );
+
+		const headers = {};
+
+		return apiFetch( { path: '/random', headers } ).then( () => {
+			expect( headers ).toHaveProperty( 'Accept' );
+			expect( headers.Accept ).toBe( 'application/json' );
+		} );
+	} );
+
+	it( 'should not override an existing accept header', () => {
+		window.fetch.mockReturnValue( Promise.resolve( {
+			status: 200,
+			json() {
+				return Promise.resolve( { message: 'ok' } );
+			},
+		} ) );
+
+		const headers = {
+			Accept: '*/*',
+		};
+
+		return apiFetch( { path: '/random', headers } ).then( () => {
+			expect( headers ).toHaveProperty( 'Accept' );
+			expect( headers.Accept ).toBe( '*/*' );
+		} );
+	} );
 } );

--- a/packages/api-fetch/src/test/index.js
+++ b/packages/api-fetch/src/test/index.js
@@ -120,7 +120,7 @@ describe( 'apiFetch', () => {
 
 		return apiFetch( { path: '/random', headers } ).then( () => {
 			expect( headers ).toHaveProperty( 'Accept' );
-			expect( headers.Accept ).toBe( 'application/json' );
+			expect( headers.Accept ).toBe( 'application/json, */*;q=0.1' );
 		} );
 	} );
 

--- a/packages/api-fetch/src/test/index.js
+++ b/packages/api-fetch/src/test/index.js
@@ -107,38 +107,4 @@ describe( 'apiFetch', () => {
 			} );
 		} );
 	} );
-
-	it( 'should apply an Accept: application/json header', () => {
-		window.fetch.mockReturnValue( Promise.resolve( {
-			status: 200,
-			json() {
-				return Promise.resolve( { message: 'ok' } );
-			},
-		} ) );
-
-		const headers = {};
-
-		return apiFetch( { path: '/random', headers } ).then( () => {
-			expect( headers ).toHaveProperty( 'Accept' );
-			expect( headers.Accept ).toBe( 'application/json, */*;q=0.1' );
-		} );
-	} );
-
-	it( 'should not override an existing accept header', () => {
-		window.fetch.mockReturnValue( Promise.resolve( {
-			status: 200,
-			json() {
-				return Promise.resolve( { message: 'ok' } );
-			},
-		} ) );
-
-		const headers = {
-			Accept: '*/*',
-		};
-
-		return apiFetch( { path: '/random', headers } ).then( () => {
-			expect( headers ).toHaveProperty( 'Accept' );
-			expect( headers.Accept ).toBe( '*/*' );
-		} );
-	} );
 } );


### PR DESCRIPTION
## Description
Fixes #11327. The server side localization switching requires an 'Accept' or
'Content-Type' header set to 'application/json` to detect that it is a JSON
request.

## How has this been tested?
Manually verify that `Accept: application/json` is in the `apiFetch` requests and the UI is properly localized.
With a unit test verifying that the `headers` option is mutated as expected.

## Screenshots <!-- if applicable -->
![fix localization](https://user-images.githubusercontent.com/3460448/47821146-15e37200-dd36-11e8-8ad1-87ac673de913.png)

## Types of changes
Bug Fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

I'm not sure if this can be properly unit tested. I considered trying to check that the `headers` passed into options is properly mutated, but my local install is currently failing when trying to run tests.