### PR TITLE
Remove _wpGutenbergCodeEditorSettings

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1240,32 +1240,6 @@ function gutenberg_default_post_format_template( $settings, $post ) {
 add_filter( 'block_editor_settings', 'gutenberg_default_post_format_template', 10, 2 );
 
 /**
- * The code editor settings that were last captured by
- * gutenberg_capture_code_editor_settings().
- *
- * @var array|false
- */
-$gutenberg_captured_code_editor_settings = false;
-
-/**
- * When passed to the wp_code_editor_settings filter, this function captures
- * the code editor settings given to it and then prevents
- * wp_enqueue_code_editor() from enqueuing any assets.
- *
- * This is a workaround until e.g. code_editor_settings() is added to Core.
- *
- * @since 2.1.0
- *
- * @param array $settings Code editor settings.
- * @return false
- */
-function gutenberg_capture_code_editor_settings( $settings ) {
-	global $gutenberg_captured_code_editor_settings;
-	$gutenberg_captured_code_editor_settings = $settings;
-	return false;
-}
-
-/**
  * Retrieve a stored autosave that is newer than the post save.
  *
  * Deletes autosaves that are older than the post save.
@@ -1508,19 +1482,6 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		$meta_box_url
 	);
 	wp_localize_script( 'wp-editor', '_wpMetaBoxUrl', $meta_box_url );
-
-	// Populate default code editor settings by short-circuiting wp_enqueue_code_editor.
-	global $gutenberg_captured_code_editor_settings;
-	add_filter( 'wp_code_editor_settings', 'gutenberg_capture_code_editor_settings' );
-	wp_enqueue_code_editor( array( 'type' => 'text/html' ) );
-	remove_filter( 'wp_code_editor_settings', 'gutenberg_capture_code_editor_settings' );
-	wp_add_inline_script(
-		'wp-editor',
-		sprintf(
-			'window._wpGutenbergCodeEditorSettings = %s;',
-			wp_json_encode( $gutenberg_captured_code_editor_settings )
-		)
-	);
 
 	// Initialize the editor.
 	$gutenberg_theme_support = get_theme_support( 'gutenberg' );


### PR DESCRIPTION
Closes #10847.

Removes `_wpGutenbergCodeEditorSettings`. This is dead code since the HTML block no longer uses `wp.codeEditor` as of https://github.com/WordPress/gutenberg/pull/10396.