### PR TITLE
Blocks: Upgrade hpq from 1.2.0 to 1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2111,12 +2111,6 @@
 				"simple-html-tokenizer": "^0.4.1",
 				"tinycolor2": "^1.4.1",
 				"uuid": "^3.1.0"
-			},
-			"dependencies": {
-				"hpq": {
-					"version": "1.3.0",
-					"bundled": true
-				}
 			}
 		},
 		"@wordpress/browserslist-config": {
@@ -9855,6 +9849,11 @@
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
 			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
 			"dev": true
+		},
+		"hpq": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/hpq/-/hpq-1.3.0.tgz",
+			"integrity": "sha512-fvYTvdCFOWQupGxqkahrkA+ERBuMdzkxwtUdKrxR6rmMd4Pfl+iZ1QiQYoaZ0B/v0y59MOMnz3XFUWbT50/NWA=="
 		},
 		"hsl-regex": {
 			"version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2104,13 +2104,19 @@
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/shortcode": "file:packages/shortcode",
-				"hpq": "^1.2.0",
+				"hpq": "^1.3.0",
 				"lodash": "^4.17.10",
 				"rememo": "^3.0.0",
 				"showdown": "^1.8.6",
 				"simple-html-tokenizer": "^0.4.1",
 				"tinycolor2": "^1.4.1",
 				"uuid": "^3.1.0"
+			},
+			"dependencies": {
+				"hpq": {
+					"version": "1.3.0",
+					"bundled": true
+				}
 			}
 		},
 		"@wordpress/browserslist-config": {
@@ -9849,11 +9855,6 @@
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
 			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
 			"dev": true
-		},
-		"hpq": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/hpq/-/hpq-1.2.0.tgz",
-			"integrity": "sha1-nGGLI5YqLXPW6Cugh0l4vLNov6I="
 		},
 		"hsl-regex": {
 			"version": "1.0.0",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -32,7 +32,7 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/shortcode": "file:../shortcode",
-		"hpq": "^1.2.0",
+		"hpq": "^1.3.0",
 		"lodash": "^4.17.10",
 		"rememo": "^3.0.0",
 		"showdown": "^1.8.6",


### PR DESCRIPTION
This pull request seeks to upgrade the `hpq` dependency from 1.2.0 to 1.3.0. The 1.3.0 release is performance-oriented, improving parse by approximately a factor of **4x** ([Try Benchmark](https://jsbin.com/moqevar/1/edit?html,js,console,output)). This was discovered in a performance profile of Gutenberg to be a top candidate for boot-time delays, moreso for larger posts, as each individual block will have previously been rendered into a separate created document. 

[View Changelog](https://github.com/aduth/hpq/blob/master/CHANGELOG.md)
[Notable relevant `hpq` commit](https://github.com/aduth/hpq/commit/183d314f944cdfed330e1d92648ec39ff286a662)
[Try Benchmark](https://jsbin.com/moqevar/1/edit?html,js,console,output)

**Testing instructions:**

This is a dependency minor release update, and is not anticipated to have any incompatible changes.