### PR TITLE
Nonce Middleware: Wrap the nonce middleware function into it's own function.

### DIFF
--- a/packages/api-fetch/src/middlewares/nonce.js
+++ b/packages/api-fetch/src/middlewares/nonce.js
@@ -3,8 +3,9 @@
  */
 import { addAction } from '@wordpress/hooks';
 
-const createNonceMiddleware = ( nonce ) => ( options, next ) => {
+const createNonceMiddleware = ( nonce ) => {
 	let usedNonce = nonce;
+
 	/**
 	 * This is not ideal but it's fine for now.
 	 *
@@ -17,31 +18,33 @@ const createNonceMiddleware = ( nonce ) => ( options, next ) => {
 		}
 	} );
 
-	let headers = options.headers || {};
-	// If an 'X-WP-Nonce' header (or any case-insensitive variation
-	// thereof) was specified, no need to add a nonce header.
-	let addNonceHeader = true;
-	for ( const headerName in headers ) {
-		if ( headers.hasOwnProperty( headerName ) ) {
-			if ( headerName.toLowerCase() === 'x-wp-nonce' ) {
-				addNonceHeader = false;
-				break;
+	return function( options, next ) {
+		let headers = options.headers || {};
+		// If an 'X-WP-Nonce' header (or any case-insensitive variation
+		// thereof) was specified, no need to add a nonce header.
+		let addNonceHeader = true;
+		for ( const headerName in headers ) {
+			if ( headers.hasOwnProperty( headerName ) ) {
+				if ( headerName.toLowerCase() === 'x-wp-nonce' ) {
+					addNonceHeader = false;
+					break;
+				}
 			}
 		}
-	}
 
-	if ( addNonceHeader ) {
-	// Do not mutate the original headers object, if any.
-		headers = {
-			...headers,
-			'X-WP-Nonce': usedNonce,
-		};
-	}
+		if ( addNonceHeader ) {
+			// Do not mutate the original headers object, if any.
+			headers = {
+				...headers,
+				'X-WP-Nonce': usedNonce,
+			};
+		}
 
-	return next( {
-		...options,
-		headers,
-	} );
+		return next( {
+			...options,
+			headers,
+		} );
+	};
 };
 
 export default createNonceMiddleware;


### PR DESCRIPTION
## Description
The nonce middleware function is re-generated on every API call, which is causing the initial nonce to always be used and the `addAction()` to be queued up multiple times.

Splitting this up and returning a function here solves both of the problems, and should fix #9260 

## How has this been tested?

To test, Set the nonce_life to 60s and have heartbeat run every 20s.
Use the editor for >2minutes (Switching images around works), you shouldn't encounter update failed messages, and the console should be clear.
```
add_filter( 'nonce_life', function() { return 60; } );

add_filter( 'heartbeat_settings', function( $settings ) { $settings['interval'] = 20; return $settings; } );
```