### PR TITLE
Remove Cloudflare warning

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -134,7 +134,7 @@ function gutenberg_check_if_classic_needs_warning_about_blocks() {
 		return;
 	}
 
-	if ( ! has_blocks( $post ) && ! isset( $_REQUEST['cloudflare-error'] ) ) {
+	if ( ! has_blocks( $post ) ) {
 		return;
 	}
 
@@ -142,11 +142,7 @@ function gutenberg_check_if_classic_needs_warning_about_blocks() {
 	wp_enqueue_script( 'wp-a11y' );
 	wp_enqueue_script( 'wp-sanitize' );
 
-	if ( isset( $_REQUEST['cloudflare-error'] ) ) {
-		add_action( 'admin_footer', 'gutenberg_warn_classic_about_cloudflare' );
-	} else {
-		add_action( 'admin_footer', 'gutenberg_warn_classic_about_blocks' );
-	}
+	add_action( 'admin_footer', 'gutenberg_warn_classic_about_blocks' );
 }
 add_action( 'admin_enqueue_scripts', 'gutenberg_check_if_classic_needs_warning_about_blocks' );
 
@@ -269,153 +265,6 @@ function gutenberg_warn_classic_about_blocks() {
 					// Attach event handlers.
 					dialog.warningTabbables.on( 'keydown', dialog.constrainTabbing );
 					dialog.warning.on( 'click', '.blocks-in-post-classic-button', dialog.dismissWarning );
-
-					// Make screen readers announce the warning message after a short delay (necessary for some screen readers).
-					setTimeout( function() {
-						wp.a11y.speak( wp.sanitize.stripTags( dialog.rawMessage.replace( /\s+/g, ' ' ) ), 'assertive' );
-					}, 1000 );
-				};
-
-				dialog.constrainTabbing = function( event ) {
-					var firstTabbable, lastTabbable;
-
-					if ( 9 !== event.which ) {
-						return;
-					}
-
-					firstTabbable = dialog.warningTabbables.first()[0];
-					lastTabbable = dialog.warningTabbables.last()[0];
-
-					if ( lastTabbable === event.target && ! event.shiftKey ) {
-						firstTabbable.focus();
-						event.preventDefault();
-					} else if ( firstTabbable === event.target && event.shiftKey ) {
-						lastTabbable.focus();
-						event.preventDefault();
-					}
-				};
-
-				dialog.dismissWarning = function() {
-					// Hide modal.
-					dialog.warning.remove();
-					$( '#wpwrap' ).removeAttr( 'aria-hidden' );
-					$( 'body' ).removeClass( 'modal-open' );
-				};
-
-				$( document ).ready( dialog.init );
-			} )( jQuery );
-			/* ]]> */
-		</script>
-	<?php
-}
-
-/**
- * Adds a warning to the Classic Editor when CloudFlare is blocking REST API requests.
- *
- * @since 3.4.0
- */
-function gutenberg_warn_classic_about_cloudflare() {
-	?>
-		<style type="text/css">
-			#cloudflare-block-dialog .notification-dialog {
-				position: fixed;
-				top: 50%;
-				left: 50%;
-				width: 500px;
-				box-sizing: border-box;
-				transform: translate(-50%, -50%);
-				margin: 0;
-				padding: 25px;
-				max-height: 90%;
-				background: #fff;
-				box-shadow: 0 3px 6px rgba(0, 0, 0, 0.3);
-				line-height: 1.5;
-				z-index: 1000005;
-				overflow-y: auto;
-			}
-
-			#cloudflare-block-dialog ul {
-				list-style: initial;
-				padding-left: 20px;
-			}
-
-			@media only screen and (max-height: 480px), screen and (max-width: 450px) {
-				#cloudflare-block-dialog .notification-dialog {
-					top: 0;
-					left: 0;
-					width: 100%;
-					height: 100%;
-					transform: none;
-					max-height: 100%;
-				}
-			}
-		</style>
-
-		<div id="cloudflare-block-dialog" class="notification-dialog-wrap">
-			<div class="notification-dialog-background"></div>
-			<div class="notification-dialog">
-				<div class="cloudflare-block-message">
-					<h2><?php _e( 'Cloudflare is blocking REST API requests', 'gutenberg' ); ?></h2>
-					<p><?php _e( 'Your site uses Cloudflare, which provides a Web Application Firewall (WAF) to secure your site against attacks. Unfortunately, some of these WAF rules are incorrectly blocking legitimate access to your site, preventing Gutenberg from functioning correctly.', 'gutenberg' ); ?></p>
-					<p><?php _e( "We're working closely with Cloudflare to fix this issue, but in the mean time, you can work around it in one of two ways:", 'gutenberg' ); ?></p>
-					<ul>
-						<li><?php _e( 'If you have a Cloudflare Pro account, log in to Cloudflare, visit the Firewall settings page, open the "Cloudflare Rule Set" details, open the "Cloudflare WordPress" ruleset, then set the rules "WP0025A" and "WP0025B" to "Disable".', 'gutenberg' ); ?></li>
-						<li>
-						<?php
-							printf(
-								/* translators: %s: link to a comment in the Gutenberg repository */
-								__( 'For free Cloudflare accounts, you can <a href="%s">change the REST API URL</a>, to avoid triggering the WAF rules. Please be aware that this may cause issues with other plugins that use the REST API, and removes any other protection Cloudflare may be offering for the REST API.', 'gutenberg' ),
-								'https://github.com/WordPress/gutenberg/issues/2704#issuecomment-410582252'
-							);
-						?>
-						</li>
-					</ul>
-					<p>
-					<?php
-						printf(
-							/* translators: %s link to an issue in the Gutenberg repository */
-							__( 'If neither of these options are possible for you, please <a href="%s">follow this issue for updates</a>. We hope to have this issue rectified soon!', 'gutenberg' ),
-							'https://github.com/WordPress/gutenberg/issues/2704'
-						);
-					?>
-					</p>
-				</div>
-				<p>
-					<button type="button" class="button button-primary cloudflare-block-classic-button"><?php _e( 'Continue to Classic Editor', 'gutenberg' ); ?></button>
-				</p>
-			</div>
-		</div>
-
-		<script type="text/javascript">
-			/* <![CDATA[ */
-			( function( $ ) {
-				var dialog = {};
-
-				dialog.init = function() {
-					// The modal
-					dialog.warning = $( '#cloudflare-block-dialog' );
-					// Get the links and buttons within the modal.
-					dialog.warningTabbables = dialog.warning.find( 'a, button' );
-
-					// Get the text within the modal.
-					dialog.rawMessage = dialog.warning.find( '.cloudflare-block-message' ).text();
-
-					// Hide all the #wpwrap content from assistive technologies.
-					$( '#wpwrap' ).attr( 'aria-hidden', 'true' );
-
-					// Detach the warning modal from its position and append it to the body.
-					$( document.body )
-						.addClass( 'modal-open' )
-						.append( dialog.warning.detach() );
-
-					// Reveal the modal and set focus on the Gutenberg button.
-					dialog.warning
-						.removeClass( 'hidden' )
-						.find( '.cloudflare-block-classic-button' ).focus();
-
-					// Attach event handlers.
-					dialog.warningTabbables.on( 'keydown', dialog.constrainTabbing );
-					dialog.warning.on( 'click', '.cloudflare-block-classic-button', dialog.dismissWarning );
 
 					// Make screen readers announce the warning message after a short delay (necessary for some screen readers).
 					setTimeout( function() {

--- a/packages/api-fetch/CHANGELOG.md
+++ b/packages/api-fetch/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.2 (Unreleased)
+
+### Double You Tee Eff, Mate?
+
+- Removed checking whether the request was blocked by Cloudflare.
+
 ## 2.2.1 (2018-10-30)
 
 ## 2.2.0 (2018-10-29)

--- a/packages/api-fetch/CHANGELOG.md
+++ b/packages/api-fetch/CHANGELOG.md
@@ -1,9 +1,5 @@
 ## 2.2.2 (Unreleased)
 
-### Double You Tee Eff, Mate?
-
-- Removed checking whether the request was blocked by Cloudflare.
-
 ## 2.2.1 (2018-10-30)
 
 ## 2.2.0 (2018-10-29)

--- a/packages/api-fetch/src/test/index.js
+++ b/packages/api-fetch/src/test/index.js
@@ -32,9 +32,6 @@ describe( 'apiFetch', () => {
 					message: 'Bad Request',
 				} );
 			},
-			clone() {
-				return null;
-			},
 		} ) );
 
 		return apiFetch( { path: '/random' } ).catch( ( body ) => {

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.1.1 (Unreleased)
+
+### Zany Zany Miscellany
+
+- Removed Cloudflare warnings.
+
 ## 6.1.0 (2018-10-30)
 
 ### Deprecations

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -1,9 +1,5 @@
 ## 6.1.1 (Unreleased)
 
-### Zany Zany Miscellany
-
-- Removed Cloudflare warnings.
-
 ## 6.1.0 (2018-10-30)
 
 ### Deprecations

--- a/packages/editor/src/store/effects/posts.js
+++ b/packages/editor/src/store/effects/posts.js
@@ -9,7 +9,6 @@ import { pick, includes } from 'lodash';
  */
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
-import { addQueryArgs } from '@wordpress/url';
 // TODO: Ideally this would be the only dispatch in scope. This requires either
 // refactoring editor actions to yielded controls, or replacing direct dispatch
 // on the editor store with action creators (e.g. `REQUEST_POST_UPDATE_START`).
@@ -266,25 +265,6 @@ export const requestPostUpdateFailure = ( action ) => {
 	dataDispatch( 'core/notices' ).createErrorNotice( noticeMessage, {
 		id: SAVE_POST_NOTICE_ID,
 	} );
-
-	if ( error && 'cloudflare_error' === error.code ) {
-		dataDispatch( 'core/notices' ).createErrorNotice(
-			__( 'Cloudflare is blocking REST API requests.' ),
-			{
-				actions: [
-					{
-						label: __( 'Learn More' ),
-						url: addQueryArgs( 'post.php', {
-							post: post.id,
-							action: 'edit',
-							'classic-editor': '',
-							'cloudflare-error': '',
-						} ),
-					},
-				],
-			},
-		);
-	}
 };
 
 /**


### PR DESCRIPTION
## Description

We haven't seen reports of Cloudflare blocking REST API requests for a while, they've presumably done some tweaking to how their WAF behaves.

This PR removes the Cloudflare warning added in #8640.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
