### PR TITLE
Enhance styling of nextpage block using the Hr element

### DIFF
--- a/packages/block-library/src/nextpage/edit.native.js
+++ b/packages/block-library/src/nextpage/edit.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { View, Text } from 'react-native';
+import { View } from 'react-native';
 import Hr from 'react-native-hr';
 
 /**
@@ -19,9 +19,9 @@ export default function NextPageEdit( { attributes } ) {
 
 	return (
 		<View className={ styles[ 'block-library-nextpage__container' ] }>
-			<Hr text={ customText } 
-			textStyle={styles['block-library-nextpage__text']} 
-			lineStyle={styles['block-library-nextpage__line']}/>
+			<Hr text={ customText }
+				textStyle={ styles[ 'block-library-nextpage__text' ] }
+				lineStyle={ styles[ 'block-library-nextpage__line' ] } />
 		</View>
 	);
 }

--- a/packages/block-library/src/nextpage/edit.native.js
+++ b/packages/block-library/src/nextpage/edit.native.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { View, Text } from 'react-native';
+import Hr from 'react-native-hr';
 
 /**
  * WordPress dependencies
@@ -18,7 +19,9 @@ export default function NextPageEdit( { attributes } ) {
 
 	return (
 		<View className={ styles[ 'block-library-nextpage__container' ] }>
-			<Text>{ customText }</Text>
+			<Hr text={ customText } 
+			textStyle={styles['block-library-nextpage__text']} 
+			lineStyle={styles['block-library-nextpage__line']}/>
 		</View>
 	);
 }

--- a/packages/block-library/src/nextpage/editor.native.scss
+++ b/packages/block-library/src/nextpage/editor.native.scss
@@ -6,7 +6,7 @@
 }
 
 .block-library-nextpage__line {
-	background-color: darkgray;
+	background-color: #555d66;
 	height: 2;
 }
 

--- a/packages/block-library/src/nextpage/editor.native.scss
+++ b/packages/block-library/src/nextpage/editor.native.scss
@@ -4,3 +4,12 @@
 	align-items: center;
 	padding: 4px 4px 4px 4px;
 }
+
+.block-library-nextpage__line {
+	background-color: darkgray;
+	height: 2;
+}
+
+.block-library-nextpage__text {
+	text-decoration-style: solid;
+}


### PR DESCRIPTION
## Description

In this PR nextpage block is updated with Hr element for styling purposes. [Parent PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/205) introduces the new react-native-hr library so it must be merged quickly after this otherwise mobile-gutenberg code will not compile.

## How has this been tested?
Steps for how to test can be found in the parent PR [here](https://github.com/wordpress-mobile/gutenberg-mobile/pull/205).
Additionally:
- Run gutenberg web in local and see that http://localhost:8888/wp-admin/ is up and running, also nextpage block is working fine
- Mobile tests are run in the GB repo and passed OK

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->