### PR TITLE
Use the image sizes names filter

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1326,6 +1326,35 @@ function gutenberg_load_locale_data() {
 }
 
 /**
+ * Retrieve The available image sizes for a post
+ *
+ * @return array
+ */
+function gutenberg_get_available_image_sizes() {
+	$sizes      = get_intermediate_image_sizes();
+	$sizes[]    = 'full';
+	$size_names = apply_filters(
+		'image_size_names_choose',
+		array(
+			'thumbnail' => __( 'Thumbnail', 'gutenberg' ),
+			'medium'    => __( 'Medium', 'gutenberg' ),
+			'large'     => __( 'Large', 'gutenberg' ),
+			'full'      => __( 'Full Size', 'gutenberg' ),
+		)
+	);
+
+	$all_sizes = array();
+	foreach ( $sizes as $size_slug ) {
+		$all_sizes[] = array(
+			'slug' => $size_slug,
+			'name' => isset( $size_names[ $size_slug ] ) ? $size_names[ $size_slug ] : $size_slug,
+		);
+	}
+
+	return $all_sizes;
+}
+
+/**
  * Scripts & Styles.
  *
  * Enqueues the needed scripts and styles when visiting the top-level page of
@@ -1602,6 +1631,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		'maxUploadFileSize'      => $max_upload_size,
 		'allowedMimeTypes'       => get_allowed_mime_types(),
 		'styles'                 => $styles,
+		'availableImageSizes'    => gutenberg_get_available_image_sizes(),
 
 		// Ideally, we'd remove this and rely on a REST API endpoint.
 		'postLock'               => $lock_details,

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -8,6 +8,7 @@ import {
 	map,
 	pick,
 	startCase,
+	keyBy,
 } from 'lodash';
 
 /**
@@ -245,7 +246,7 @@ class ImageEdit extends Component {
 		};
 	}
 
-	getAvailableSizes() {
+	getImageSizes() {
 		return get( this.props.image, [ 'media_details', 'sizes' ], {} );
 	}
 
@@ -266,9 +267,22 @@ class ImageEdit extends Component {
 
 	render() {
 		const { isEditing } = this.state;
-		const { attributes, setAttributes, isLargeViewport, isSelected, className, maxWidth, noticeOperations, noticeUI, toggleSelection, isRTL } = this.props;
+		const {
+			attributes,
+			setAttributes,
+			isLargeViewport,
+			isSelected,
+			className,
+			maxWidth,
+			noticeOperations,
+			noticeUI,
+			toggleSelection,
+			isRTL,
+			availableImageSizes,
+		} = this.props;
 		const { url, alt, caption, align, id, href, linkDestination, width, height, linkTarget } = attributes;
 		const isExternal = isExternalImage( id, url );
+		const availableImageSizesBySlug = keyBy( availableImageSizes, 'slug' );
 
 		let toolbarEditButton;
 		if ( url ) {
@@ -340,7 +354,7 @@ class ImageEdit extends Component {
 			'is-focused': isSelected,
 		} );
 
-		const availableSizes = this.getAvailableSizes();
+		const imageSizes = this.getImageSizes();
 		const isResizable = [ 'wide', 'full' ].indexOf( align ) === -1 && isLargeViewport;
 		const isLinkURLInputDisabled = linkDestination !== LINK_DESTINATION_CUSTOM;
 
@@ -353,13 +367,13 @@ class ImageEdit extends Component {
 						onChange={ this.updateAlt }
 						help={ __( 'Alternative text describes your image to people who can’t see it. Add a short description with its key details.' ) }
 					/>
-					{ ! isEmpty( availableSizes ) && (
+					{ ! isEmpty( imageSizes ) && (
 						<SelectControl
 							label={ __( 'Image Size' ) }
 							value={ url }
-							options={ map( availableSizes, ( size, name ) => ( {
+							options={ map( imageSizes, ( size, slug ) => ( {
 								value: size.source_url,
-								label: startCase( name ),
+								label: availableImageSizesBySlug[ slug ] ? availableImageSizesBySlug[ slug ].name : startCase( slug ),
 							} ) ) }
 							onChange={ this.updateImageURL }
 						/>
@@ -574,12 +588,13 @@ export default compose( [
 		const { getMedia } = select( 'core' );
 		const { getEditorSettings } = select( 'core/editor' );
 		const { id } = props.attributes;
-		const { maxWidth, isRTL } = getEditorSettings();
+		const { maxWidth, isRTL, availableImageSizes } = getEditorSettings();
 
 		return {
 			image: id ? getMedia( id ) : null,
 			maxWidth,
 			isRTL,
+			availableImageSizes,
 		};
 	} ),
 	withViewportMatch( { isLargeViewport: 'medium' } ),

--- a/packages/editor/src/store/defaults.js
+++ b/packages/editor/src/store/defaults.js
@@ -11,13 +11,14 @@ export const PREFERENCES_DEFAULTS = {
 /**
  * The default editor settings
  *
- *  alignWide         boolean        Enable/Disable Wide/Full Alignments
- *  colors            Array          Palette colors
- *  fontSizes         Array          Available font sizes
- *  maxWidth          number         Max width to constraint resizing
- *  blockTypes        boolean|Array  Allowed block types
- *  hasFixedToolbar   boolean        Whether or not the editor toolbar is fixed
- *  focusMode         boolean        Whether the focus mode is enabled or not
+ *  alignWide            boolean        Enable/Disable Wide/Full Alignments
+ *  colors               Array          Palette colors
+ *  fontSizes            Array          Available font sizes
+ *  availableImageSizes  Array          Available image sizes
+ *  maxWidth             number         Max width to constraint resizing
+ *  blockTypes           boolean|Array  Allowed block types
+ *  hasFixedToolbar      boolean        Whether or not the editor toolbar is fixed
+ *  focusMode            boolean        Whether the focus mode is enabled or not
  */
 export const EDITOR_SETTINGS_DEFAULTS = {
 	alignWide: false,
@@ -104,6 +105,13 @@ export const EDITOR_SETTINGS_DEFAULTS = {
 			size: 48,
 			slug: 'huge',
 		},
+	],
+
+	availableImageSizes: [
+		{ id: 'thumbnail', label: __( 'Thumbnail' ) },
+		{ id: 'medium', label: __( 'Medium' ) },
+		{ id: 'large', label: __( 'Large' ) },
+		{ id: 'full', label: __( 'Full Size' ) },
 	],
 
 	// This is current max width of the block inner area

--- a/packages/editor/src/store/defaults.js
+++ b/packages/editor/src/store/defaults.js
@@ -108,10 +108,10 @@ export const EDITOR_SETTINGS_DEFAULTS = {
 	],
 
 	availableImageSizes: [
-		{ id: 'thumbnail', label: __( 'Thumbnail' ) },
-		{ id: 'medium', label: __( 'Medium' ) },
-		{ id: 'large', label: __( 'Large' ) },
-		{ id: 'full', label: __( 'Full Size' ) },
+		{ slug: 'thumbnail', label: __( 'Thumbnail' ) },
+		{ slug: 'medium', label: __( 'Medium' ) },
+		{ slug: 'large', label: __( 'Large' ) },
+		{ slug: 'full', label: __( 'Full Size' ) },
 	],
 
 	// This is current max width of the block inner area


### PR DESCRIPTION
closes #8219

Add a new editor config: "availableImageSizes" to be able to display the image sizes labels properly in the image block's inspector.

(Needs to be backported to Core once merged cc @pento)

**Testing instructions**

 - Repeat instructions in #8219 and verify the size names are displayed properly.