### PR TITLE
Remove deprecated componentWillReceiveProps from TinyMCE component

### DIFF
--- a/packages/editor/src/components/rich-text/tinymce.js
+++ b/packages/editor/src/components/rich-text/tinymce.js
@@ -130,15 +130,7 @@ export default class TinyMCE extends Component {
 		this.initialize();
 	}
 
-	shouldComponentUpdate() {
-		// We must prevent rerenders because TinyMCE will modify the DOM, thus
-		// breaking React's ability to reconcile changes.
-		//
-		// See: https://github.com/facebook/react/issues/6802
-		return false;
-	}
-
-	componentWillReceiveProps( nextProps ) {
+	shouldComponentUpdate( nextProps ) {
 		this.configureIsPlaceholderVisible( nextProps.isPlaceholderVisible );
 
 		if ( ! isEqual( this.props.style, nextProps.style ) ) {
@@ -155,6 +147,12 @@ export default class TinyMCE extends Component {
 			this.editorNode.removeAttribute( key ) );
 		updatedKeys.forEach( ( key ) =>
 			this.editorNode.setAttribute( key, nextProps[ key ] ) );
+
+		// We must prevent rerenders because TinyMCE will modify the DOM, thus
+		// breaking React's ability to reconcile changes.
+		//
+		// See: https://github.com/facebook/react/issues/6802
+		return false;
 	}
 
 	componentWillUnmount() {


### PR DESCRIPTION
## Description

See #11360. Removes `componentWillReceiveProps` by doing all updates during `shouldComponentUpdate`. Normally this should only return `boolean` without side effects, but since we're doing our own reconciliation within this component, I think it's fine to use `shouldComponentUpdate` to figure out what should be updated.

@aduth @youknowriad Do you think this is fine?

## How has this been tested?
Make sure placeholders display correctly, aria props, className and styles update.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->