### PR TITLE
Fix: Add Block Icon Not Visible

### DIFF
--- a/assets/stylesheets/_z-index.scss
+++ b/assets/stylesheets/_z-index.scss
@@ -20,7 +20,7 @@ $z-layers: (
 	".edit-post-meta-boxes-area .spinner": 5,
 	".editor-block-contextual-toolbar": 21,
 	".components-popover__close": 5,
-	".editor-block-list__insertion-point": 6,
+	".editor-block-list__insertion-point": 22, // Block Toolbar has z-index of 21 which blocks the visibility of this button
 	".editor-inserter-with-shortcuts": 5,
 	".editor-warning": 5,
 	".block-library-gallery-item__inline-menu": 20,

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -671,6 +671,7 @@
 		pointer-events: none;
 
 		&:hover,
+		&:focus,
 		&.is-visible {
 			opacity: 1;
 			pointer-events: auto;


### PR DESCRIPTION
## Description

In #11345 it is noted that the add block button does not appear visually to users when tabbing through blocks. The fix for me seemed to be adding a `:focus` state for the toggle button itself which sets the opacity of the bottom to 1, making it appear. 

It's possible that some class names changed which cause this as I did see a `.is-visible` class reference. There is a parent Div node that does receive the class on focus. Hopefully someone knows the original implementation details and can speak to that. 

## How has this been tested?
I opened edit post screen in Chrome, Safari, Firefox, IE11, and Edge. Then I tabbed backwards through several paragraph blocks. Each time the button appeared for me. 

## Screenshots <!-- if applicable -->

![screen shot 2018-11-01 at 4 33 58 pm](https://user-images.githubusercontent.com/3654512/47878475-bef0a200-ddf4-11e8-89c9-3b1ddf988c9b.png)


## Types of changes
Bug fix 

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
