### PR TITLE
Capitalise 'page break' block title

### DIFF
--- a/packages/block-library/src/nextpage/index.js
+++ b/packages/block-library/src/nextpage/index.js
@@ -10,7 +10,7 @@ import edit from './edit';
 export const name = 'core/nextpage';
 
 export const settings = {
-	title: __( 'Page break' ),
+	title: __( 'Page Break' ),
 
 	description: __( 'Separate your content into a multi-page experience.' ),
 


### PR DESCRIPTION
The page break block was using sentence case for its title—it should use title case like all the other blocks instead.

Now it does!

<img width="297" alt="screenshot 2018-11-02 00 10 09" src="https://user-images.githubusercontent.com/376315/47886712-af447e00-de33-11e8-9780-d83f7a318401.png">

Fixes #11381.