### PR TITLE
Remove a duplicate line in _breakpoints.scss

### DIFF
--- a/assets/stylesheets/_breakpoints.scss
+++ b/assets/stylesheets/_breakpoints.scss
@@ -7,7 +7,6 @@ $break-huge: 1440px;
 $break-wide: 1280px;
 $break-xlarge: 1080px;
 $break-large: 960px;	// admin sidebar auto folds
-$break-large: 960px;	// admin sidebar auto folds
 $break-medium: 782px;	// adminbar goes big
 $break-small: 600px;
 $break-mobile: 480px;


### PR DESCRIPTION
## Description
Remove an unneeded duplicate line in _breakpoints.scss that had no influence on styles

## How has this been tested?
Due to the triviality of an unneeded line in scss, no tests were performed.

## Types of changes
add simplicity

## Checklist:
- [] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
