### PR TITLE
Fix typo and clarify wording of camelCaseString docblock

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,10 +17,10 @@ const LibraryExportDefaultPlugin = require( '@wordpress/library-export-default-w
 const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
 
 /**
- * Given a string, returns a new string with dash separators converedd to
- * camel-case equivalent. This is not as aggressive as `_.camelCase` in
- * converting to uppercase, where Lodash will convert letters following
- * numbers.
+ * Given a string, returns a new string with dash separators converted to
+ * camelCase equivalent. This is not as aggressive as `_.camelCase` in
+ * converting to uppercase, where Lodash will also capitalize letters
+ * following numbers.
  *
  * @param {string} string Input dash-delimited string.
  *


### PR DESCRIPTION
## Description
Corrects spelling of "converted" and clarifies wording of the explanation
for why _.camelCase is not a viable alternative.

## Checklist:
- [x] My code is proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
