### PR TITLE
Updated FontSizePicker on v-4.1.1

### DIFF
--- a/packages/components/src/font-size-picker/README.md
+++ b/packages/components/src/font-size-picker/README.md
@@ -7,21 +7,16 @@ The component renders a series of buttons that allow the user to select predefin
 
 
 ```jsx
-import { FontSizePicker } from '@wordpress/components';
+import { FontSizePicker } from '@wordpress/editor';
 import { withState } from '@wordpress/compose';
 
 const MyFontSizePicker = withState( {
 	fontSize: 16,
 } )( ( { fontSize, setState } ) => { 
-	const fontSizes = [
-		{ shortName: 'S', size: 12 },
-		{ shortName: 'M', size: 16 }
-	];
 	const fallbackFontSize = 16;
 	
 	return ( 
 		<FontSizePicker 
-			fontSizes={ fontSizes } 
 			value={ fontSize }
 			fallbackFontSize={ fallbackFontSize }
 			onChange={ fontSize => setState( { fontSize } ) } 


### PR DESCRIPTION
On version 4.1.1 we can't get the FontSizePicker from wp/components. We need to import from editor.