### PR TITLE
Editor: Stop re-rendering all blocks when navigating with arrow keys

### DIFF
--- a/packages/editor/src/components/block-list/index.js
+++ b/packages/editor/src/components/block-list/index.js
@@ -229,7 +229,7 @@ export default compose( [
 			blockClientIds: getBlockOrder( rootClientId ),
 			selectionStart: getMultiSelectedBlocksStartClientId(),
 			selectionEnd: getMultiSelectedBlocksEndClientId(),
-			selectionStartClientId: getBlockSelectionStart(),
+			selectionStartClientId: isSelectionEnabled() && getBlockSelectionStart(),
 			isSelectionEnabled: isSelectionEnabled(),
 			isMultiSelecting: isMultiSelecting(),
 		};


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
I tested it using React Dev Tools by enabling `Highlight Updates` option in settings (see screencasts for details).

Use arrow keys (up/down) to navigate between blocks and observe whether blocks re-render less often than before. In general, only previous and current block should change.

## Solution

`selectionStartClientId` is only used when selection is enabled (`isSelectionEnabled`). This PR ensure that the needed value is set only in the correct context.

## Screenshots

### Before

![block list before](https://user-images.githubusercontent.com/699132/47908792-4f2ef580-de8e-11e8-837e-23e990349352.gif)

### After

![block list after](https://user-images.githubusercontent.com/699132/47908805-5524d680-de8e-11e8-9994-f349356dd31e.gif)

## Types of changes

Refactoring, no changes to the logic.