### PR TITLE
Fix disabled undo button timeout

### DIFF
--- a/packages/editor/src/utils/with-history/index.js
+++ b/packages/editor/src/utils/with-history/index.js
@@ -113,6 +113,11 @@ const withHistory = ( options = {} ) => ( reducer ) => {
 		}
 
 		let nextPast = past;
+		// The `lastAction` property is used to compare actions in the
+		// `shouldOverwriteState` option. If an action should be ignored, do not
+		// submit that action as the last action, otherwise the ability to
+		// compare subsequent actions will break.
+		let lastActionToSubmit = previousAction;
 
 		if (
 			shouldCreateUndoLevel ||
@@ -120,6 +125,7 @@ const withHistory = ( options = {} ) => ( reducer ) => {
 			! shouldOverwriteState( action, previousAction )
 		) {
 			nextPast = [ ...past, present ];
+			lastActionToSubmit = action;
 		}
 
 		return {
@@ -127,7 +133,7 @@ const withHistory = ( options = {} ) => ( reducer ) => {
 			present: nextPresent,
 			future: [],
 			shouldCreateUndoLevel: false,
-			lastAction: action,
+			lastAction: lastActionToSubmit,
 		};
 	};
 };

--- a/packages/editor/src/utils/with-history/test/index.js
+++ b/packages/editor/src/utils/with-history/test/index.js
@@ -185,14 +185,13 @@ describe( 'withHistory', () => {
 		};
 
 		const reducer = withHistory( {
-			shouldOverwriteState: ( action, previousAction ) =>
-				previousAction && action.type === previousAction.type,
+			shouldOverwriteState: ( action, previousAction ) => (
+				previousAction && action.type === previousAction.type
+			),
 			ignoreTypes: [ 'IGNORE' ],
 		} )( complexCounter );
 
-		let state;
-		state = reducer( undefined, {} );
-		state = reducer( state, { type: 'INCREMENT' } );
+		let state = reducer( reducer( undefined, {} ), { type: 'INCREMENT' } );
 
 		expect( state ).toEqual( {
 			past: [ { count: 0 } ],

--- a/packages/editor/src/utils/with-history/test/index.js
+++ b/packages/editor/src/utils/with-history/test/index.js
@@ -167,6 +167,62 @@ describe( 'withHistory', () => {
 		} );
 	} );
 
+	it( 'should overwrite present state with option.shouldOverwriteState right after ignored action', () => {
+		const complexCounter = ( state = { count: 0 }, action ) => {
+			if ( action.type === 'INCREMENT' ) {
+				return {
+					...state,
+					count: state.count + 1,
+				};
+			} else if ( action.type === 'IGNORE' ) {
+				return {
+					...state,
+					ignore: action.content,
+				};
+			}
+
+			return state;
+		};
+
+		const reducer = withHistory( {
+			shouldOverwriteState: ( action, previousAction ) =>
+				previousAction && action.type === previousAction.type,
+			ignoreTypes: [ 'IGNORE' ],
+		} )( complexCounter );
+
+		let state;
+		state = reducer( undefined, {} );
+		state = reducer( state, { type: 'INCREMENT' } );
+
+		expect( state ).toEqual( {
+			past: [ { count: 0 } ],
+			present: { count: 1 },
+			future: [],
+			lastAction: { type: 'INCREMENT' },
+			shouldCreateUndoLevel: false,
+		} );
+
+		state = reducer( state, { type: 'IGNORE', content: 'ignore' } );
+
+		expect( state ).toEqual( {
+			past: [ { count: 0 } ],
+			present: { count: 1, ignore: 'ignore' },
+			future: [],
+			lastAction: { type: 'INCREMENT' },
+			shouldCreateUndoLevel: false,
+		} );
+
+		state = reducer( state, { type: 'INCREMENT' } );
+
+		expect( state ).toEqual( {
+			past: [ { count: 0 } ],
+			present: { count: 2, ignore: 'ignore' },
+			future: [],
+			lastAction: { type: 'INCREMENT' },
+			shouldCreateUndoLevel: false,
+		} );
+	} );
+
 	it( 'should create undo level with option.shouldOverwriteState and CREATE_UNDO_LEVEL', () => {
 		const reducer = withHistory( {
 			shouldOverwriteState: ( { type } ) => type === 'INCREMENT',

--- a/test/e2e/specs/undo.test.js
+++ b/test/e2e/specs/undo.test.js
@@ -32,9 +32,8 @@ describe( 'undo', () => {
 		await pressWithModifier( META_KEY, 'z' ); // Undo 1st paragraph text.
 		await pressWithModifier( META_KEY, 'z' ); // Undo 1st block.
 
-		// After undoing every action, there should be no more undo history.
-		await page.waitForSelector( '.editor-history__undo[aria-disabled="true"]' );
-
 		expect( await getEditedPostContent() ).toBe( '' );
+		// After undoing every action, there should be no more undo history.
+		expect( await page.$( '.editor-history__undo[aria-disabled="true"]' ) ).not.toBeNull();
 	} );
 } );


### PR DESCRIPTION
## Description

This PR gets rid of the timeouts we've been seeing in the undo e2e tests. The cause is the `RECEIVE_BLOCKS` action sometimes dispatching between two `UPDATE_BLOCK_ATTRIBUTES` actions. The `RECEIVE_BLOCKS` is not fully ignored: it does not create a new history record, but it _does_ set the `lastAction` attribute. This causes `shouldOverwriteState` to return false where it shouldn't, because it compares the current and previous action.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->