### PR TITLE
Update: Font Size Picker component documentation

### DIFF
--- a/packages/components/src/font-size-picker/README.md
+++ b/packages/components/src/font-size-picker/README.md
@@ -9,54 +9,73 @@ The component renders a series of buttons that allow the user to select predefin
 ```jsx
 import { FontSizePicker } from '@wordpress/components';
 import { withState } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
 
+...
 const MyFontSizePicker = withState( {
 	fontSize: 16,
-} )( ( { fontSize, setState } ) => { 
+} )( ( { fontSize, setState } ) => {
 	const fontSizes = [
-		{ shortName: 'S', size: 12 },
-		{ shortName: 'M', size: 16 }
+		{
+			name: __( 'Small' ),
+			slug: 'small',
+			size: 12,
+		},
+		{
+			name: __( 'Big' ),
+			slug: 'big',
+			size: 26,
+		},
 	];
 	const fallbackFontSize = 16;
-	
-	return ( 
-		<FontSizePicker 
-			fontSizes={ fontSizes } 
+
+	return (
+		<FontSizePicker
+			fontSizes={ fontSizes }
 			value={ fontSize }
 			fallbackFontSize={ fallbackFontSize }
-			onChange={ fontSize => setState( { fontSize } ) } 
+			onChange={ ( newFontSize ) => {
+				setState( { fontSize: newFontSize } );
+			} }
 		/>
-	); 
+	);
 } );
+
+...
+
+<MyFontSizePicker />
 ```
 
 ## Props
 
 The component accepts the following props:
 
+### disableCustomFontSizes
+
+If `true`, it will not be possible to choose a custom fontSize. The user will be forced to pick one of the pre-defined sizes passed in fontSizes.
+
+- Type: `Boolean`
+- Required: no
+- Default: `false`
+
+### fallbackFontSize
+
+If no value exists, this prop defines the starting position for the font size picker slider. Only relevant if `withSlider` is `true`.
+
+- Type: `Number`
+- Required: No
+
 ### fontSizes
 
-An array of font size objects. The object should contain properties size, name, shortName.
-The property "size" contains a number with the font size value. The "shortName" property includes a small label used in the buttons. Property "name" is used as the label when shortName is not provided.
+An array of font size objects. The object should contain properties size, name, and slug.
+The property `size` contains a number with the font size value, in `px`.
+The `name` property includes a label for that font size e.g.: `Small`.
+The `slug` property is a string with a unique identifier for the font size. Used for the class generation process.
 
 - Type: `Array`
 - Required: No
 
-### fallbackFontSize
-
-In no value exists this prop contains the font size picker slider starting position.
-
-- Type: `Number`
-- Required: No
-
-### value
-
-The current font size value. If a button value matches the font size value that button is pressed. RangeControl is rendered with this value.
-
-- Type: `Number`
-- Required: No
-
-## onChange
+### onChange
 
 A function that receives the new font size value.
 If onChange is called without any parameter, it should reset the value, attending to what reset means in that context, e.g., set the font size to undefined or set the font size a starting value.
@@ -64,3 +83,17 @@ If onChange is called without any parameter, it should reset the value, attendin
 - Type: `function`
 - Required: Yes
 
+### value
+
+The current font size value.
+
+- Type: `Number`
+- Required: No
+
+### withSlider
+
+If `true`, the UI will contain a slider, instead of a numeric text input field. If `false`, no slider will be present.
+
+- Type: `Boolean`
+- Required: no
+- Default: `false`

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -25,7 +25,7 @@ function FontSizePicker( {
 	disableCustomFontSizes = false,
 	onChange,
 	value,
-	withSlider,
+	withSlider = false,
 } ) {
 	const onChangeValue = ( event ) => {
 		const newValue = event.target.value;


### PR DESCRIPTION
## Description
This pr updates the documentation of @wordpress/components/FontSizePicker.

The component was updated with additional props added and the structure of existing props changed but the updates to the docs were missing.

## How has this been tested?
Just documentation updates. I checked the sample code works and does not contain linting error, by pasting it in an existing block.
