### PR TITLE
Remove moment from the public API of the date module

### DIFF
--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -11,6 +11,7 @@ Gutenberg's deprecation policy is intended to support backwards-compatibility fo
 - `wp.data` `registry.registerSelectors` has been deprecated. Use `registry.registerStore` instead.
 - `wp.data` `registry.registerActions` has been deprecated. Use `registry.registerStore` instead.
 - `wp.data` `registry.registerResolvers` has been deprecated. Use `registry.registerStore` instead.
+- `moment` has been removed from the public API for the date module.
 
 ## 4.3.0
 

--- a/packages/date/CHANGELOG.md
+++ b/packages/date/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.1 (Unreleased)
+## 2.2.0 (Unreleased)
 
 ### Deprecations
 

--- a/packages/date/CHANGELOG.md
+++ b/packages/date/CHANGELOG.md
@@ -1,8 +1,14 @@
+## 2.1.1 (Unreleased)
+
+### Deprecations
+
+- Remove `moment` from the public API for the date module.
+
 ## 2.1.0 (2018-10-29)
 
 ### Breaking Change
 
-- Marked getSettings as experimental 
+- Marked getSettings as experimental
 
 ## 2.0.3 (2018-09-26)
 

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -392,9 +392,16 @@ export function dateI18n( dateFormat, dateValue = new Date(), gmt = false ) {
 	return format( dateFormat, dateMoment );
 }
 
-export function isInTheFuture( dateString, minutesOffset = 0 ) {
-	const now = momentLib.tz( 'WP' ).add( minutesOffset, 'minute' );
-	const momentObject = momentLib.tz( dateString, 'WP' );
+/**
+ * Check whether a date is considered in the future according to the WordPress settings.
+ *
+ * @param {(Date|string)} dateValue  Date object or string.
+ *
+ * @return {boolean} Is in the future.
+ */
+export function isInTheFuture( dateValue ) {
+	const now = momentLib.tz( 'WP' );
+	const momentObject = momentLib.tz( dateValue, 'WP' );
 
 	return momentObject.isAfter( now );
 }

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -119,6 +119,12 @@ function setupWPTimezone() {
 // the attached timezone, instead of setting a default timezone on
 // the global moment object.
 export const moment = ( ...args ) => {
+	deprecated( 'wp.date.moment', {
+		version: '4.4',
+		alternative: 'the moment script as a dependency',
+		plugin: 'Gutenberg',
+	} );
+
 	return momentLib.tz( ...args, 'WP' );
 };
 
@@ -384,6 +390,13 @@ export function dateI18n( dateFormat, dateValue = new Date(), gmt = false ) {
 	dateMoment.locale( settings.l10n.locale );
 	// Format and return.
 	return format( dateFormat, dateMoment );
+}
+
+export function isInTheFuture( dateString, minutesOffset = 0 ) {
+	const now = momentLib.tz( 'WP' ).add( minutesOffset, 'minute' );
+	const momentObject = momentLib.tz( dateString, 'WP' );
+
+	return momentObject.isAfter( now );
 }
 
 setupWPTimezone();

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -54,6 +54,7 @@ export const INSERTER_UTILITY_NONE = 0;
 const MILLISECONDS_PER_HOUR = 3600 * 1000;
 const MILLISECONDS_PER_DAY = 24 * 3600 * 1000;
 const MILLISECONDS_PER_WEEK = 7 * 24 * 3600 * 1000;
+const ONE_MINUTE_IN_MS = 60 * 1000;
 
 /**
  * Shared reference to an empty array for cases where it is important to avoid
@@ -323,7 +324,7 @@ export function isCurrentPostPublished( state ) {
 	const post = getCurrentPost( state );
 
 	return [ 'publish', 'private' ].indexOf( post.status ) !== -1 ||
-		( post.status === 'future' && ! isInTheFuture( post.date, 1 ) );
+		( post.status === 'future' && ! isInTheFuture( new Date( Number( new Date( post.date ) ) + ONE_MINUTE_IN_MS ) ) );
 }
 
 /**
@@ -481,7 +482,11 @@ export function hasAutosave( state ) {
  * @return {boolean} Whether the post has been published.
  */
 export function isEditedPostBeingScheduled( state ) {
-	return isInTheFuture( getEditedPostAttribute( state, 'date' ), 1 );
+	const date = getEditedPostAttribute( state, 'date' );
+	// Offset the date by one minute (network latency)
+	const checkedDate = new Date( Number( new Date( date ) ) + ONE_MINUTE_IN_MS );
+
+	return isInTheFuture( checkedDate );
 }
 
 /**

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -32,7 +32,7 @@ import {
 	getFreeformContentHandlerName,
 	isUnmodifiedDefaultBlock,
 } from '@wordpress/blocks';
-import { moment } from '@wordpress/date';
+import { isInTheFuture } from '@wordpress/date';
 import { removep } from '@wordpress/autop';
 import { select } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
@@ -323,7 +323,7 @@ export function isCurrentPostPublished( state ) {
 	const post = getCurrentPost( state );
 
 	return [ 'publish', 'private' ].indexOf( post.status ) !== -1 ||
-		( post.status === 'future' && moment( post.date ).isBefore( moment() ) );
+		( post.status === 'future' && ! isInTheFuture( post.date, 1 ) );
 }
 
 /**
@@ -481,11 +481,7 @@ export function hasAutosave( state ) {
  * @return {boolean} Whether the post has been published.
  */
 export function isEditedPostBeingScheduled( state ) {
-	const date = moment( getEditedPostAttribute( state, 'date' ) );
-	// Adding 1 minute as an error threshold between the server and the client dates.
-	const now = moment().add( 1, 'minute' );
-
-	return date.isAfter( now );
+	return isInTheFuture( getEditedPostAttribute( state, 'date' ), 1 );
 }
 
 /**

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -1512,7 +1512,7 @@ describe( 'selectors', () => {
 
 	describe( 'isEditedPostBeingScheduled', () => {
 		it( 'should return true for posts with a future date', () => {
-			const time = Date.now() + ( 1000 * 3600 * 24 * 7 ); // sdays in the future
+			const time = Date.now() + ( 1000 * 3600 * 24 * 7 ); // 7 days in the future
 			const date = new Date( time );
 			const state = {
 				editor: {

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -15,7 +15,6 @@ import {
 	setDefaultBlockName,
 	setFreeformContentHandlerName,
 } from '@wordpress/blocks';
-import { moment } from '@wordpress/date';
 import { RawHTML } from '@wordpress/element';
 
 /**
@@ -1513,10 +1512,12 @@ describe( 'selectors', () => {
 
 	describe( 'isEditedPostBeingScheduled', () => {
 		it( 'should return true for posts with a future date', () => {
+			const time = Date.now() + ( 1000 * 3600 * 24 * 7 ); // sdays in the future
+			const date = new Date( time );
 			const state = {
 				editor: {
 					present: {
-						edits: { date: moment().add( 7, 'days' ).format( '' ) },
+						edits: { date: date.toUTCString() },
 					},
 				},
 			};


### PR DESCRIPTION
I'm doing so by adding a new function in the data module `isInTheFuture` to check whether a given WP date is considered in the future or not.


**Testing instructions**

- Make sure scheduling still works as expected (especially if the WP timezone is different from the browser's timezone).