### PR TITLE
Add image and video transformations in Media & Text block

### DIFF
--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -13,6 +13,7 @@ import {
 	InnerBlocks,
 	getColorClassName,
 } from '@wordpress/editor';
+import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -80,6 +81,63 @@ export const settings = {
 
 	supports: {
 		align: [ 'wide', 'full' ],
+	},
+
+	transforms: {
+		from: [
+			{
+				type: 'block',
+				blocks: [ 'core/image' ],
+				transform: ( { alt, url, id } ) => (
+					createBlock( 'core/media-text', {
+						mediaAlt: alt,
+						mediaId: id,
+						mediaUrl: url,
+						mediaType: 'image',
+					} )
+				),
+			},
+			{
+				type: 'block',
+				blocks: [ 'core/video' ],
+				transform: ( { src, id } ) => (
+					createBlock( 'core/media-text', {
+						mediaId: id,
+						mediaUrl: src,
+						mediaType: 'video',
+					} )
+				),
+			},
+		],
+		to: [
+			{
+				type: 'block',
+				blocks: [ 'core/image' ],
+				isMatch: ( { mediaType, mediaUrl } ) => {
+					return ! mediaUrl || mediaType === 'image';
+				},
+				transform: ( { mediaAlt, mediaId, mediaUrl } ) => {
+					return createBlock( 'core/image', {
+						alt: mediaAlt,
+						id: mediaId,
+						url: mediaUrl,
+					} );
+				},
+			},
+			{
+				type: 'block',
+				blocks: [ 'core/video' ],
+				isMatch: ( { mediaType, mediaUrl } ) => {
+					return ! mediaUrl || mediaType === 'video';
+				},
+				transform: ( { mediaId, mediaUrl } ) => {
+					return createBlock( 'core/video', {
+						id: mediaId,
+						src: mediaUrl,
+					} );
+				},
+			},
+		],
 	},
 
 	edit,


### PR DESCRIPTION
## Description
This pr adds "Media & Text" <-> Video, Image transforms.

## How has this been tested?
Add a video block. Transform it to Media & Text and verify it worked as expected.
Add an image block. Transform it to Media & Text and verify it worked as expected.
Transform both blocks back to video and image.
Add a media text block select an image and transform it to image block.
Add a media text block select a video and transform it to video block.
Transform the image and videos back to media & text.
