### PR TITLE
feat: Add multi-block selection announcement

### DIFF
--- a/packages/editor/src/store/effects.js
+++ b/packages/editor/src/store/effects.js
@@ -6,6 +6,7 @@ import { compact, last } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { speak } from '@wordpress/a11y';
 import {
 	parse,
 	getBlockType,
@@ -13,6 +14,7 @@ import {
 	doBlocksMatchTemplate,
 	synchronizeBlocksWithTemplate,
 } from '@wordpress/blocks';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -32,6 +34,7 @@ import {
 	getBlockCount,
 	getPreviousBlockClientId,
 	getSelectedBlock,
+	getSelectedBlockCount,
 	getTemplate,
 	getTemplateLock,
 	isValidTemplate,
@@ -258,4 +261,12 @@ export default {
 	REPLACE_BLOCKS: [
 		ensureDefaultBlock,
 	],
+	ADD_TERM_TO_EDITED_POST: ( action ) => {
+		addTermToEditedPost( action );
+	},
+	MULTI_SELECT: ( action, { getState } ) => {
+		const blockCount = getSelectedBlockCount( getState() );
+
+		speak( sprintf( __( '%s blocks selected.' ), blockCount ), 'assertive' );
+	},
 };

--- a/packages/editor/src/store/effects.js
+++ b/packages/editor/src/store/effects.js
@@ -261,9 +261,6 @@ export default {
 	REPLACE_BLOCKS: [
 		ensureDefaultBlock,
 	],
-	ADD_TERM_TO_EDITED_POST: ( action ) => {
-		addTermToEditedPost( action );
-	},
 	MULTI_SELECT: ( action, { getState } ) => {
 		const blockCount = getSelectedBlockCount( getState() );
 

--- a/test/e2e/specs/multi-block-selection.test.js
+++ b/test/e2e/specs/multi-block-selection.test.js
@@ -117,4 +117,25 @@ describe( 'Multi-block selection', () => {
 		// Verify selection
 		await expectMultiSelected( blocks, true );
 	} );
+
+	it( 'should speak() number of blocks selected with multi-block selection', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'First Paragraph' );
+		await insertBlock( 'Paragraph' );
+		await page.keyboard.type( 'Second Paragraph' );
+		await insertBlock( 'Paragraph' );
+		await page.keyboard.type( 'Third Paragraph' );
+
+		// Multiselect via keyboard.
+		await pressWithModifier( META_KEY, 'a' );
+		await pressWithModifier( META_KEY, 'a' );
+
+		// TODO: It would be great to do this test by spying on `wp.a11y.speak`,
+		// but it's very difficult to do that because `wp.a11y` has
+		// DOM-dependant side-effect setup code and doesn't seem straightforward
+		// to mock. Instead, we check for the DOM node that `wp.a11y.speak()`
+		// inserts text into.
+		const speakTextContent = await page.$eval( '#a11y-speak-assertive', ( element ) => element.textContent );
+		expect( speakTextContent.trim() ).toEqual( '3 blocks selected.' );
+	} );
 } );


### PR DESCRIPTION
Fixes #3696 by speaking the number of blocks selected when multi selection occurs.

There is still a lot of text that's read out after the number of blocks are selected but this is at least _something_:

<img width="446" alt="screenshot 2018-11-02 at 16 23 07" src="https://user-images.githubusercontent.com/90871/47927575-97b0d800-debb-11e8-9946-97ed8bed990b.png">

I tried to E2E test this but the `a11y` library does a bunch of stuff with DOM so I couldn't see a way to use `jest.spyOn` there. I'll see if I can do it from inside the `page.evaluate` context with Puppeteer, but I'm unsure that'll work.

At any rate: confirmed to work with Firefox NVDA.