### PR TITLE
Fix: Show generic upload errors coming from the server in the image block

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -100,6 +100,7 @@ class ImageEdit extends Component {
 		this.onSetCustomHref = this.onSetCustomHref.bind( this );
 		this.onSetLinkDestination = this.onSetLinkDestination.bind( this );
 		this.toggleIsEditing = this.toggleIsEditing.bind( this );
+		this.onUploadError = this.onUploadError.bind( this );
 
 		this.state = {
 			captionFocused: false,
@@ -139,6 +140,14 @@ class ImageEdit extends Component {
 				captionFocused: false,
 			} );
 		}
+	}
+
+	onUploadError( message ) {
+		const { noticeOperations } = this.props;
+		noticeOperations.createErrorNotice( message );
+		this.setState( {
+			isEditing: true,
+		} );
 	}
 
 	onSelectImage( media ) {
@@ -274,7 +283,6 @@ class ImageEdit extends Component {
 			isSelected,
 			className,
 			maxWidth,
-			noticeOperations,
 			noticeUI,
 			toggleSelection,
 			isRTL,
@@ -339,7 +347,7 @@ class ImageEdit extends Component {
 						onSelect={ this.onSelectImage }
 						onSelectURL={ this.onSelectURL }
 						notices={ noticeUI }
-						onError={ noticeOperations.createErrorNotice }
+						onError={ this.onUploadError }
 						accept="image/*"
 						allowedTypes={ ALLOWED_MEDIA_TYPES }
 						value={ { id, src } }


### PR DESCRIPTION
The image block was not showing generic upload errors. This issue is a regression introduced when the edition state was added. When an error happens we should go back to the edition state otherwise the error is not shown.

This PR makes sure when an upload error happens the image block goes back to the edition state, and the error is shown to the user.

This problem was not affecting the other blocks I tested (audio, video, gallery, cover).

## How has this been tested?
I created a post and added an image block.
I added a PHP error (appended a random string) in the index.php of WordPress to make the return error 500 on all uploads.
I uploaded an image, and I checked we correctly display an error for the user.

## Screenshots <!-- if applicable -->
Before:
<img width="722" alt="screenshot 2018-11-02 at 19 22 14" src="https://user-images.githubusercontent.com/11271197/47936525-dfdcf400-ded5-11e8-99db-b52a4dfea3e0.png">

After:
<img width="730" alt="screenshot 2018-11-02 at 19 21 05" src="https://user-images.githubusercontent.com/11271197/47936536-e8352f00-ded5-11e8-8f08-d598213b5303.png">

