### PR TITLE
API Fetch: Fix non-JSON apiFetch body request

### DIFF
--- a/packages/api-fetch/README.md
+++ b/packages/api-fetch/README.md
@@ -22,6 +22,28 @@ apiFetch( { path: '/wp-json/wp/v2/posts' } ).then( posts => {
 } );
 ```
 
+### Options
+
+`apiFetch` supports and passes through all [options of the `fetch` global](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch).
+
+Additionally, the following options are available:
+
+#### `path` (`string`)
+
+Shorthand to be used in place of `url`, appended to the REST API root URL for the current site.
+
+#### `url` (`string`)
+
+Absolute URL to the endpoint from which to fetch.
+
+#### `parse` (`boolean`, default `true`)
+
+Unlike `fetch`, the `Promise` return value of `apiFetch` will resolve to the parsed JSON result. Disable this behavior by passing `parse` as `false`.
+
+#### `data` (`object`)
+
+Shorthand to be used in place of `body`, accepts an object value to be stringified to JSON.
+
 ### Middlewares
 
 the `api-fetch` package supports middlewares. Middlewares are functions you can use to wrap the `apiFetch` calls to perform any pre/post process to the API requests.

--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -21,6 +21,10 @@ import userLocaleMiddleware from './middlewares/user-locale';
  * @type {Object}
  */
 const DEFAULT_HEADERS = {
+	// The backend uses the Accept header as a condition for considering an
+	// incoming request as a REST request.
+	//
+	// See: https://core.trac.wordpress.org/ticket/44534
 	Accept: 'application/json, */*;q=0.1',
 };
 

--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -14,6 +14,26 @@ import namespaceEndpointMiddleware from './middlewares/namespace-endpoint';
 import httpV1Middleware from './middlewares/http-v1';
 import userLocaleMiddleware from './middlewares/user-locale';
 
+/**
+ * Default set of header values which should be sent with every request unless
+ * explicitly provided through apiFetch options.
+ *
+ * @type {Object}
+ */
+const DEFAULT_HEADERS = {
+	Accept: 'application/json, */*;q=0.1',
+};
+
+/**
+ * Default set of fetch option values which should be sent with every request
+ * unless explicitly provided through apiFetch options.
+ *
+ * @type {Object}
+ */
+const DEFAULT_OPTIONS = {
+	credentials: 'include',
+};
+
 const middlewares = [];
 
 function registerMiddleware( middleware ) {
@@ -22,19 +42,24 @@ function registerMiddleware( middleware ) {
 
 function apiFetch( options ) {
 	const raw = ( nextOptions ) => {
-		const { url, path, body, data, parse = true, ...remainingOptions } = nextOptions;
-		const headers = {
-			Accept: 'application/json, */*;q=0.1',
-			'Content-Type': 'application/json',
-			...remainingOptions.headers,
-		};
+		const { url, path, data, parse = true, ...remainingOptions } = nextOptions;
+		let { body, headers } = nextOptions;
+
+		// Merge explicitly-provided headers with default values.
+		headers = { ...DEFAULT_HEADERS, ...headers };
+
+		// The `data` property is a shorthand for sending a JSON body.
+		if ( data ) {
+			body = JSON.stringify( data );
+			headers[ 'Content-Type' ] = 'application/json';
+		}
 
 		const responsePromise = window.fetch(
 			url || path,
 			{
+				...DEFAULT_OPTIONS,
 				...remainingOptions,
-				credentials: 'include',
-				body: body || JSON.stringify( data ),
+				body,
 				headers,
 			}
 		);


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/11336/files#r230458631

This pull request seeks to resolve an issue where using `apiFetch` with a non-JSON `body` option would incorrectly include a `Content-Type: 'application/json'` header.

This faithfully restores the treatment of `body` prior to #11336, with the following exceptions:

- If `data` is passed, it will always assign the `Content-Type: 'application/json'` header, regardless if the developer provides their own header option. This is expected because `data` is a shorthand to be used for JSON data (evidenced by `JSON.stringify` in generating the body).
- The `credentials` option can be overridden, unlike before

**Testing instructions:**

Verify that you can drop an image on the Image block placeholder to upload new image.

Ensure unit tests pass:

```
npm run test-unit packages/api-fetch
```

cc @TimothyBJacobs 