### PR TITLE
Improve the block toolbar aria-label

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -22,7 +22,11 @@ import {
 import FullscreenModeClose from '../fullscreen-mode-close';
 
 function HeaderToolbar( { hasFixedToolbar, isLargeViewport, mode } ) {
-	const toolbarAriaLabel = hasFixedToolbar ? __( 'Document and block tools' ) : __( 'Document tools' );
+	const toolbarAriaLabel = hasFixedToolbar ?
+		/* translators: accessibility text for the editor toolbar when Unified Toolbar is on */
+		__( 'Document and block tools' ) :
+		/* translators: accessibility text for the editor toolbar when Unified Toolbar is off */
+		__( 'Document tools' );
 
 	return (
 		<NavigableToolbar

--- a/packages/editor/src/components/block-list/block-contextual-toolbar.js
+++ b/packages/editor/src/components/block-list/block-contextual-toolbar.js
@@ -13,7 +13,7 @@ function BlockContextualToolbar() {
 	return (
 		<NavigableToolbar
 			className="editor-block-contextual-toolbar"
-			aria-label={ __( 'Block Toolbar' ) }
+			aria-label={ __( 'Block tools' ) }
 		>
 			<BlockToolbar />
 		</NavigableToolbar>

--- a/packages/editor/src/components/block-list/block-contextual-toolbar.js
+++ b/packages/editor/src/components/block-list/block-contextual-toolbar.js
@@ -13,6 +13,7 @@ function BlockContextualToolbar() {
 	return (
 		<NavigableToolbar
 			className="editor-block-contextual-toolbar"
+			/* translators: accessibility text for the block toolbar */
 			aria-label={ __( 'Block tools' ) }
 		>
 			<BlockToolbar />


### PR DESCRIPTION
See #11155 and #2387.

The blocks toolbar is currently labelled as "Block toolbar". However, screen readers already announce "toolbar" when they encounter a role="toolbar" so what they actually announce is:

`Block toolbar, toolbar`

![screenshot 101](https://user-images.githubusercontent.com/1682452/47953975-e7a7a180-df84-11e8-91f7-4e2c35742316.png)

For consistency with the new dynamic `aria-label` implemented #11155 I'd propose to change it to "Block tools".

This way, when the Unified Toolbar setting is off:
- the top toolbar is labelled "Document tools"
- the blocks toolbar is labelled "Block tools"

And when the Unified Toolbar setting is on:
- the top toolbar is labelled "Document and block tools"