### PR TITLE
Change aria-checked to only be used on matching ARIA roles for MenuItem.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.0.3 (unreleased)
+## 5.1.0 (unreleased)
 
 ### New Features
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.0.3 (unreleased)
+
+### New Features
+
+- Adjust a11y roles for MenuItem component, so that aria-checked is used properly, related change in Editor/Components/BlockNavigationList ([#11431](https://github.com/WordPress/gutenberg/issues/11431)).
+
 ## 5.0.2 (2018-11-03)
 
 ### Polish

--- a/packages/components/src/menu-item/README.md
+++ b/packages/components/src/menu-item/README.md
@@ -25,7 +25,7 @@ const MyMenuItem = withState( {
 
 MenuItem supports the following props. Any additional props are passed through to the underlying [Button](../button) or [IconButton](../icon-button) component.
 
-### `children` 
+### `children`
 
 - Type: `WPElement`
 - Required: No
@@ -65,3 +65,11 @@ Refer to documentation for [IconButton's `icon` prop](../icon-button/README.md#i
 - Required: No
 
 Refer to documentation for [Shortcut's `shortcut` prop](../shortcut/README.md#shortcut).
+
+### `role`
+
+- Type: `string`
+- Require: No
+- Default: `'menuitem'`
+
+[Aria Spec](https://www.w3.org/TR/wai-aria-1.1/#aria-checked). If you need to have selectable menu items use menuitemradio for single select, and menuitemcheckbox for multiselect.

--- a/packages/components/src/menu-item/index.js
+++ b/packages/components/src/menu-item/index.js
@@ -74,21 +74,16 @@ export function MenuItem( {
 		props.icon = icon;
 	}
 
-	const atts = {
-		'aria-label': label,
-		role,
-		className,
-		...props,
-	};
-
-	// Make sure aria-checked matches spec https://www.w3.org/TR/wai-aria-1.1/#aria-checked
-	if ( role === 'menuitemcheckbox' || role === 'menuitemradio' ) {
-		atts[ 'aria-checked' ] = isSelected;
-	}
-
 	return createElement(
 		tagName,
-		atts,
+		{
+			'aria-label': label,
+			// Make sure aria-checked matches spec https://www.w3.org/TR/wai-aria-1.1/#aria-checked
+			'aria-checked': ( role === 'menuitemcheckbox' || role === 'menuitemradio' ) ? isSelected : undefined,
+			role,
+			className,
+			...props,
+		},
 		children,
 		<Shortcut className="components-menu-item__shortcut" shortcut={ shortcut } />
 	);

--- a/packages/components/src/menu-item/index.js
+++ b/packages/components/src/menu-item/index.js
@@ -74,15 +74,21 @@ export function MenuItem( {
 		props.icon = icon;
 	}
 
+	const atts = {
+		'aria-label': label,
+		role,
+		className,
+		...props,
+	};
+
+	// Make sure aria-checked matches spec https://www.w3.org/TR/wai-aria-1.1/#aria-checked
+	if ( role === 'menuitemcheckbox' || role === 'menuitemradio' ) {
+		atts[ 'aria-checked' ] = isSelected;
+	}
+
 	return createElement(
 		tagName,
-		{
-			'aria-label': label,
-			'aria-checked': isSelected,
-			role,
-			className,
-			...props,
-		},
+		atts,
 		children,
 		<Shortcut className="components-menu-item__shortcut" shortcut={ shortcut } />
 	);

--- a/packages/components/src/menu-item/test/index.js
+++ b/packages/components/src/menu-item/test/index.js
@@ -72,4 +72,26 @@ describe( 'MenuItem', () => {
 
 		expect( wrapper.prop( 'aria-label' ) ).toBeUndefined();
 	} );
+
+	it( 'should avoid using aria-checked if only menuitem is set as aria-role', () => {
+		const wrapper = shallow(
+			<MenuItem role="menuitem"><div /></MenuItem>
+		);
+
+		expect( wrapper.prop( 'aria-checked' ) ).toBeUndefined();
+	} );
+
+	it( 'should use aria-checked if menuitemradio or menuitemcheckbox is set as aria-role', () => {
+		let wrapper = shallow(
+			<MenuItem role="menuitemradio" isSelected={ true }><div /></MenuItem>
+		);
+
+		expect( wrapper.prop( 'aria-checked' ) ).toBeTrue();
+
+		wrapper = shallow(
+			<MenuItem role="menuitemcheckbox" isSelected={ true }><div /></MenuItem>
+		);
+
+		expect( wrapper.prop( 'aria-checked' ) ).toBeTrue();
+	} );
 } );

--- a/packages/components/src/menu-item/test/index.js
+++ b/packages/components/src/menu-item/test/index.js
@@ -75,7 +75,7 @@ describe( 'MenuItem', () => {
 
 	it( 'should avoid using aria-checked if only menuitem is set as aria-role', () => {
 		const wrapper = shallow(
-			<MenuItem role="menuitem"><div /></MenuItem>
+			<MenuItem role="menuitem" isSelected={ true }><div /></MenuItem>
 		);
 
 		expect( wrapper.prop( 'aria-checked' ) ).toBeUndefined();

--- a/packages/components/src/menu-item/test/index.js
+++ b/packages/components/src/menu-item/test/index.js
@@ -86,12 +86,12 @@ describe( 'MenuItem', () => {
 			<MenuItem role="menuitemradio" isSelected={ true }><div /></MenuItem>
 		);
 
-		expect( wrapper.prop( 'aria-checked' ) ).toBeTrue();
+		expect( wrapper.prop( 'aria-checked' ) ).toBe( true );
 
 		wrapper = shallow(
 			<MenuItem role="menuitemcheckbox" isSelected={ true }><div /></MenuItem>
 		);
 
-		expect( wrapper.prop( 'aria-checked' ) ).toBeTrue();
+		expect( wrapper.prop( 'aria-checked' ) ).toBe( true );
 	} );
 } );

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 6.1.2 (unreleased)
+## 6.2.0 (unreleased)
 
 ### New Features
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.1.2 (unreleased)
+
+### New Features
+
+- Adjust a11y roles for menu items, and make sure screen readers can properly use BlockNavigationList ([#11431](https://github.com/WordPress/gutenberg/issues/11431)).
+
 ## 6.1.1 (2018-11-03)
 
 ### Polish

--- a/packages/editor/src/components/block-navigation/index.js
+++ b/packages/editor/src/components/block-navigation/index.js
@@ -37,6 +37,7 @@ function BlockNavigationList( {
 								} ) }
 								onClick={ () => selectBlock( block.clientId ) }
 								isSelected={ block.clientId === selectedBlockClientId }
+								role="menuitemradio"
 							>
 								<BlockIcon icon={ blockType.icon } showColors />
 								{ blockType.title }


### PR DESCRIPTION
Fixes #11431.

## Description
Changes aria-checked to only be used on matching ARIA roles for MenuItem. Fixes an a11y issue where Screen readers can not properly understand the BlockNavigationList for which block is currently active.

## How has this been tested?
Via Jest and manually: [see here](https://github.com/WordPress/gutenberg/pull/11459/files#diff-572573d78bc2aa76b61e03bb977054fd)

## Types of changes
Updates the MenuItem component from the general components library to only use aria-checked when the aria-role is either menuitemcheckbox, or menuitemradio. This also changes BlockNavigationList to use the menuitemradio role, so screen readers can properly understand which block is currently active.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
