### PR TITLE
Add context argument to registry.select()

### DIFF
--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 4.1.0 (Unreleased)
+
+### New Features
+
+- `registerGenericStore` `getSelectors()` now takes an optional `context` object.
+- `withSelect` now provides a `context` of `{ component: this }` to `getSelectors()`.
+
 ## 4.0.1 (2018-11-20)
 
 ## 4.0.0 (2018-11-15)

--- a/packages/data/src/components/with-select/index.js
+++ b/packages/data/src/components/with-select/index.js
@@ -30,20 +30,6 @@ const withSelect = ( mapSelectToProps ) => createHigherOrderComponent( ( Wrapped
 	 */
 	const DEFAULT_MERGE_PROPS = {};
 
-	/**
-	 * Given a props object, returns the next merge props by mapSelectToProps.
-	 *
-	 * @param {Object} props Props to pass as argument to mapSelectToProps.
-	 *
-	 * @return {Object} Props to merge into rendered wrapped element.
-	 */
-	function getNextMergeProps( props ) {
-		return (
-			mapSelectToProps( props.registry.select, props.ownProps ) ||
-			DEFAULT_MERGE_PROPS
-		);
-	}
-
 	class ComponentWithSelect extends Component {
 		constructor( props ) {
 			super( props );
@@ -52,7 +38,24 @@ const withSelect = ( mapSelectToProps ) => createHigherOrderComponent( ( Wrapped
 
 			this.subscribe( props.registry );
 
-			this.mergeProps = getNextMergeProps( props );
+			this.mergeProps = this.getNextMergeProps( props );
+		}
+
+		/**
+		 * Given a props object, returns the next merge props by mapSelectToProps.
+		 *
+		 * @param {Object} props Props to pass as argument to mapSelectToProps.
+		 *
+		 * @return {Object} Props to merge into rendered wrapped element.
+		 */
+		getNextMergeProps( props ) {
+			const context = { component: this };
+			const select = ( reducerKey ) => props.registry.select( reducerKey, context );
+
+			return (
+				mapSelectToProps( select, props.ownProps ) ||
+				DEFAULT_MERGE_PROPS
+			);
 		}
 
 		componentDidMount() {
@@ -94,7 +97,7 @@ const withSelect = ( mapSelectToProps ) => createHigherOrderComponent( ( Wrapped
 			}
 
 			if ( hasPropsChanged ) {
-				const nextMergeProps = getNextMergeProps( nextProps );
+				const nextMergeProps = this.getNextMergeProps( nextProps );
 				if ( ! isShallowEqual( this.mergeProps, nextMergeProps ) ) {
 					// If merge props change as a result of the incoming props,
 					// they should be reflected as such in the upcoming render.
@@ -119,7 +122,7 @@ const withSelect = ( mapSelectToProps ) => createHigherOrderComponent( ( Wrapped
 				return;
 			}
 
-			const nextMergeProps = getNextMergeProps( this.props );
+			const nextMergeProps = this.getNextMergeProps( this.props );
 			if ( isShallowEqual( this.mergeProps, nextMergeProps ) ) {
 				return;
 			}

--- a/packages/data/src/components/with-select/test/index.js
+++ b/packages/data/src/components/with-select/test/index.js
@@ -64,6 +64,39 @@ describe( 'withSelect', () => {
 		} );
 	} );
 
+	it( 'passes through the component context to the registry store', () => {
+		const getSelectors = jest.fn();
+
+		const genericStore = {
+			getSelectors,
+			getActions: () => {},
+			subscribe: () => {},
+		};
+
+		registry.registerGenericStore( 'store1', genericStore );
+
+		function mapSelectToProps( select ) {
+			select( 'store1' );
+		}
+
+		const OriginalComponent = () => <div></div>;
+
+		const ComponentWithSelect = withSelect( mapSelectToProps )( OriginalComponent );
+
+		const testRenderer = TestRenderer.create(
+			<RegistryProvider value={ registry }>
+				<ComponentWithSelect />
+			</RegistryProvider>
+		);
+		const testInstance = testRenderer.root;
+
+		expect( getSelectors ).toHaveBeenCalledTimes( 1 );
+
+		const selectorContext = getSelectors.mock.calls[ 0 ][ 0 ];
+		const componentInstance = testInstance.children[ 0 ].instance;
+		expect( selectorContext.component ).toBe( componentInstance );
+	} );
+
 	it( 'should rerun selection on state changes', () => {
 		registry.registerStore( 'counter', {
 			reducer: ( state = 0, action ) => {

--- a/packages/data/src/components/with-select/test/index.js
+++ b/packages/data/src/components/with-select/test/index.js
@@ -67,13 +67,13 @@ describe( 'withSelect', () => {
 	it( 'passes through the component context to the registry store', () => {
 		const getSelectors = jest.fn();
 
-		const genericStore = {
+		const customStore = {
 			getSelectors,
 			getActions: () => {},
 			subscribe: () => {},
 		};
 
-		registry.registerGenericStore( 'store1', genericStore );
+		registry.registerGenericStore( 'store1', customStore );
 
 		function mapSelectToProps( select ) {
 			select( 'store1' );

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -69,12 +69,14 @@ export function createRegistry( storeConfigs = {} ) {
 	 *
 	 * @param {string} reducerKey Part of the state shape to register the
 	 *                            selectors for.
+	 * @param {Object} [context]  Optional context object for data select operation.
+	 *                            (e.g. { component: <Component Instance> } )
 	 *
 	 * @return {*} The selector's returned value.
 	 */
-	function select( reducerKey ) {
+	function select( reducerKey, context ) {
 		const store = stores[ reducerKey ];
-		return store && store.getSelectors();
+		return store && store.getSelectors( context );
 	}
 
 	/**

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -444,12 +444,12 @@ describe( 'createRegistry', () => {
 
 		it( 'passes through optional context to getSelectors', () => {
 			const getSelectors = jest.fn();
-			const genericStore = {
+			const customStore = {
 				getSelectors,
 				getActions: () => {},
 				subscribe: () => {},
 			};
-			registry.registerGenericStore( 'store1', genericStore );
+			registry.registerGenericStore( 'store1', customStore );
 
 			const component = { displayName: 'MyComponent' };
 			registry.select( 'store1', { component } );

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -441,6 +441,22 @@ describe( 'createRegistry', () => {
 			expect( registry.select( 'reducer1' ).selector2() ).toEqual( 'result2' );
 			expect( selector2 ).toBeCalledWith( store.getState() );
 		} );
+
+		it( 'passes through optional context to getSelectors', () => {
+			const getSelectors = jest.fn();
+			const genericStore = {
+				getSelectors,
+				getActions: () => {},
+				subscribe: () => {},
+			};
+			registry.registerGenericStore( 'store1', genericStore );
+
+			const component = { displayName: 'MyComponent' };
+			registry.select( 'store1', { component } );
+
+			expect( getSelectors ).toHaveBeenCalledTimes( 1 );
+			expect( getSelectors ).toHaveBeenCalledWith( { component } );
+		} );
 	} );
 
 	describe( 'subscribe', () => {


### PR DESCRIPTION
## Description
This adds an optional context argument to `registry.select()` and then adds support for `withSelect` to pass the component as a context for a select operation.

## Why is this needed?
This makes it possible to map select calls to specific components, which means a data system can have knowledge of which components depend on which data. This gives better options for shared data handling that can be tied to the lifecycle of a given component.

## How has this been tested?
All existing tests still pass, and additional tests have been added to ensure the operation of this new, optional feature.

## Types of changes
Adds an optional argument to `register.select( reducerKey, context)`.
Adds code to `withSelect` to supply a context of `{ component }`.

Both changes are fully backwards-compatible.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
