### PR TITLE
Fixes #11474

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -31,6 +31,7 @@
 			border-color: #999;
 			box-shadow: inset 0 -1px 0 #999;
 			color: #23282d;
+			text-decoration: none;
 		}
 
 		&:focus:enabled {
@@ -40,6 +41,8 @@
 			box-shadow:
 				inset 0 -1px 0 #999,
 				0 0 0 2px $blue-medium-200;
+			text-decoration: none;
+
 		}
 
 		&:active:enabled {


### PR DESCRIPTION
## Description
Fixes #11474 by adding text-decoration: none; to the button style's :focus and :hover states.

## How has this been tested?
Tested using a blank _s theme with the style.css enqueued in the editor with `a:hover, a:focus { text-decoration: underline; }` added.

## Types of changes
Bug fix: removes underline style that could be inherited by a theme's style.css 

## Checklist:
- [ x ] My code is tested.
- [ x ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ x ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ x ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
