### PR TITLE
Hide custom fields option when the meta box is disabled

### DIFF
--- a/packages/edit-post/src/components/options-modal/meta-boxes-section.js
+++ b/packages/edit-post/src/components/options-modal/meta-boxes-section.js
@@ -15,7 +15,7 @@ import { withSelect } from '@wordpress/data';
 import Section from './section';
 import { EnableCustomFieldsOption, EnablePanelOption } from './options';
 
-function MetaBoxesSection( { areCustomFieldsRegistered, metaBoxes, ...sectionProps } ) {
+export function MetaBoxesSection( { areCustomFieldsRegistered, metaBoxes, ...sectionProps } ) {
 	if ( ! areCustomFieldsRegistered && metaBoxes.length === 0 ) {
 		return null;
 	}

--- a/packages/edit-post/src/components/options-modal/meta-boxes-section.js
+++ b/packages/edit-post/src/components/options-modal/meta-boxes-section.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { map } from 'lodash';
+import { filter, map } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -16,23 +16,19 @@ import Section from './section';
 import { EnableCustomFieldsOption, EnablePanelOption } from './options';
 
 export function MetaBoxesSection( { areCustomFieldsRegistered, metaBoxes, ...sectionProps } ) {
-	if ( ! areCustomFieldsRegistered && metaBoxes.length === 0 ) {
+	// The 'Custom Fields' meta box is a special case that we handle separately.
+	const thirdPartyMetaBoxes = filter( metaBoxes, ( { id } ) => id !== 'postcustom' );
+
+	if ( ! areCustomFieldsRegistered && thirdPartyMetaBoxes.length === 0 ) {
 		return null;
 	}
 
 	return (
 		<Section { ...sectionProps }>
-			{ areCustomFieldsRegistered && (
-				<EnableCustomFieldsOption label={ __( 'Custom Fields' ) } />
-			) }
-			{ map(
-				metaBoxes,
-				( { id, title } ) =>
-					// The 'Custom Fields' meta box is a special case handled above.
-					id !== 'postcustom' && (
-						<EnablePanelOption key={ id } label={ title } panelName={ `meta-box-${ id }` } />
-					)
-			) }
+			{ areCustomFieldsRegistered && <EnableCustomFieldsOption label={ __( 'Custom Fields' ) } /> }
+			{ map( thirdPartyMetaBoxes, ( { id, title } ) => (
+				<EnablePanelOption key={ id } label={ title } panelName={ `meta-box-${ id }` } />
+			) ) }
 		</Section>
 	);
 }

--- a/packages/edit-post/src/components/options-modal/meta-boxes-section.js
+++ b/packages/edit-post/src/components/options-modal/meta-boxes-section.js
@@ -15,14 +15,14 @@ import { withSelect } from '@wordpress/data';
 import Section from './section';
 import { EnableCustomFieldsOption, EnablePanelOption } from './options';
 
-function MetaBoxesSection( { hasCustomFieldsSupport, metaBoxes, ...sectionProps } ) {
-	if ( ! hasCustomFieldsSupport && metaBoxes.length === 0 ) {
+function MetaBoxesSection( { areCustomFieldsRegistered, metaBoxes, ...sectionProps } ) {
+	if ( ! areCustomFieldsRegistered && metaBoxes.length === 0 ) {
 		return null;
 	}
 
 	return (
 		<Section { ...sectionProps }>
-			{ hasCustomFieldsSupport && (
+			{ areCustomFieldsRegistered && (
 				<EnableCustomFieldsOption label={ __( 'Custom Fields' ) } />
 			) }
 			{ map(
@@ -38,13 +38,11 @@ function MetaBoxesSection( { hasCustomFieldsSupport, metaBoxes, ...sectionProps 
 }
 
 export default withSelect( ( select ) => {
-	const { getEditedPostAttribute } = select( 'core/editor' );
-	const { getPostType } = select( 'core' );
+	const { getEditorSettings } = select( 'core/editor' );
 	const { getAllMetaBoxes } = select( 'core/edit-post' );
 
-	const postType = getPostType( getEditedPostAttribute( 'type' ) );
 	return {
-		hasCustomFieldsSupport: postType.supports[ 'custom-fields' ],
+		areCustomFieldsRegistered: getEditorSettings().enableCustomFields !== undefined,
 		metaBoxes: getAllMetaBoxes(),
 	};
 } )( MetaBoxesSection );

--- a/packages/edit-post/src/components/options-modal/options/enable-custom-fields.js
+++ b/packages/edit-post/src/components/options-modal/options/enable-custom-fields.js
@@ -9,7 +9,7 @@ import { withSelect } from '@wordpress/data';
  */
 import BaseOption from './base';
 
-class EnableCustomFieldsOption extends Component {
+export class EnableCustomFieldsOption extends Component {
 	constructor( { isChecked } ) {
 		super( ...arguments );
 

--- a/packages/edit-post/src/components/options-modal/options/enable-custom-fields.js
+++ b/packages/edit-post/src/components/options-modal/options/enable-custom-fields.js
@@ -43,5 +43,5 @@ class EnableCustomFieldsOption extends Component {
 }
 
 export default withSelect( ( select ) => ( {
-	isChecked: select( 'core/editor' ).getEditorSettings().enableCustomFields,
+	isChecked: !! select( 'core/editor' ).getEditorSettings().enableCustomFields,
 } ) )( EnableCustomFieldsOption );

--- a/packages/edit-post/src/components/options-modal/options/test/__snapshots__/enable-custom-fields.js.snap
+++ b/packages/edit-post/src/components/options-modal/options/test/__snapshots__/enable-custom-fields.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EnableCustomFieldsOption renders properly when checked 1`] = `
+<BaseOption
+  isChecked={true}
+  label="Custom Fields"
+  onChange={[Function]}
+/>
+`;
+
+exports[`EnableCustomFieldsOption renders properly when unchecked 1`] = `
+<BaseOption
+  isChecked={false}
+  label="Custom Fields"
+  onChange={[Function]}
+/>
+`;

--- a/packages/edit-post/src/components/options-modal/options/test/enable-custom-fields.js
+++ b/packages/edit-post/src/components/options-modal/options/test/enable-custom-fields.js
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { EnableCustomFieldsOption } from '../enable-custom-fields';
+
+describe( 'EnableCustomFieldsOption', () => {
+	it( 'renders properly when checked', () => {
+		const wrapper = shallow( <EnableCustomFieldsOption label="Custom Fields" isChecked /> );
+		expect( wrapper ).toMatchSnapshot();
+	} );
+
+	it( 'can be unchecked', () => {
+		const submit = jest.fn();
+		const getElementById = jest.spyOn( document, 'getElementById' ).mockImplementation( () => ( {
+			submit,
+		} ) );
+
+		const wrapper = shallow( <EnableCustomFieldsOption label="Custom Fields" isChecked /> );
+
+		expect( wrapper.prop( 'isChecked' ) ).toBe( true );
+
+		wrapper.prop( 'onChange' )();
+		wrapper.update();
+
+		expect( wrapper.prop( 'isChecked' ) ).toBe( false );
+		expect( getElementById ).toHaveBeenCalledWith( 'toggle-custom-fields-form' );
+		expect( submit ).toHaveBeenCalled();
+
+		getElementById.mockRestore();
+	} );
+
+	it( 'renders properly when unchecked', () => {
+		const wrapper = shallow(
+			<EnableCustomFieldsOption label="Custom Fields" isChecked={ false } />
+		);
+		expect( wrapper ).toMatchSnapshot();
+	} );
+
+	it( 'can be checked', () => {
+		const submit = jest.fn();
+		const getElementById = jest.spyOn( document, 'getElementById' ).mockImplementation( () => ( {
+			submit,
+		} ) );
+
+		const wrapper = shallow(
+			<EnableCustomFieldsOption label="Custom Fields" isChecked={ false } />
+		);
+
+		expect( wrapper.prop( 'isChecked' ) ).toBe( false );
+
+		wrapper.prop( 'onChange' )();
+		wrapper.update();
+
+		expect( wrapper.prop( 'isChecked' ) ).toBe( true );
+		expect( getElementById ).toHaveBeenCalledWith( 'toggle-custom-fields-form' );
+		expect( submit ).toHaveBeenCalled();
+
+		getElementById.mockRestore();
+	} );
+} );

--- a/packages/edit-post/src/components/options-modal/test/__snapshots__/meta-boxes-section.js.snap
+++ b/packages/edit-post/src/components/options-modal/test/__snapshots__/meta-boxes-section.js.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MetaBoxesSection renders a Custom Fields option 1`] = `
+<Section
+  title="Advanced Panels"
+>
+  <WithSelect(EnableCustomFieldsOption)
+    label="Custom Fields"
+  />
+</Section>
+`;
+
+exports[`MetaBoxesSection renders a Custom Fields option and meta box options 1`] = `
+<Section
+  title="Advanced Panels"
+>
+  <WithSelect(EnableCustomFieldsOption)
+    label="Custom Fields"
+  />
+  <WithSelect(WithDispatch(BaseOption))
+    key="test1"
+    label="Meta Box 1"
+    panelName="meta-box-test1"
+  />
+  <WithSelect(WithDispatch(BaseOption))
+    key="test2"
+    label="Meta Box 2"
+    panelName="meta-box-test2"
+  />
+</Section>
+`;
+
+exports[`MetaBoxesSection renders meta box options 1`] = `
+<Section
+  title="Advanced Panels"
+>
+  <WithSelect(WithDispatch(BaseOption))
+    key="test1"
+    label="Meta Box 1"
+    panelName="meta-box-test1"
+  />
+  <WithSelect(WithDispatch(BaseOption))
+    key="test2"
+    label="Meta Box 2"
+    panelName="meta-box-test2"
+  />
+</Section>
+`;

--- a/packages/edit-post/src/components/options-modal/test/meta-boxes-section.js
+++ b/packages/edit-post/src/components/options-modal/test/meta-boxes-section.js
@@ -11,14 +11,21 @@ import { MetaBoxesSection } from '../meta-boxes-section';
 describe( 'MetaBoxesSection', () => {
 	it( 'does not render if there are no options', () => {
 		const wrapper = shallow(
-			<MetaBoxesSection areCustomFieldsRegistered={ false } metaBoxes={ [] } />
+			<MetaBoxesSection
+				areCustomFieldsRegistered={ false }
+				metaBoxes={ [ { id: 'postcustom', title: 'This should not render' } ] }
+			/>
 		);
 		expect( wrapper.isEmptyRender() ).toBe( true );
 	} );
 
 	it( 'renders a Custom Fields option', () => {
 		const wrapper = shallow(
-			<MetaBoxesSection title="Advanced Panels" areCustomFieldsRegistered metaBoxes={ [] } />
+			<MetaBoxesSection
+				title="Advanced Panels"
+				areCustomFieldsRegistered
+				metaBoxes={ [ { id: 'postcustom', title: 'This should not render' } ] }
+			/>
 		);
 		expect( wrapper ).toMatchSnapshot();
 	} );
@@ -29,6 +36,7 @@ describe( 'MetaBoxesSection', () => {
 				title="Advanced Panels"
 				areCustomFieldsRegistered={ false }
 				metaBoxes={ [
+					{ id: 'postcustom', title: 'This should not render' },
 					{ id: 'test1', title: 'Meta Box 1' },
 					{ id: 'test2', title: 'Meta Box 2' },
 				] }

--- a/packages/edit-post/src/components/options-modal/test/meta-boxes-section.js
+++ b/packages/edit-post/src/components/options-modal/test/meta-boxes-section.js
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { MetaBoxesSection } from '../meta-boxes-section';
+
+describe( 'MetaBoxesSection', () => {
+	it( 'does not render if there are no options', () => {
+		const wrapper = shallow(
+			<MetaBoxesSection areCustomFieldsRegistered={ false } metaBoxes={ [] } />
+		);
+		expect( wrapper.isEmptyRender() ).toBe( true );
+	} );
+
+	it( 'renders a Custom Fields option', () => {
+		const wrapper = shallow(
+			<MetaBoxesSection title="Advanced Panels" areCustomFieldsRegistered metaBoxes={ [] } />
+		);
+		expect( wrapper ).toMatchSnapshot();
+	} );
+
+	it( 'renders meta box options', () => {
+		const wrapper = shallow(
+			<MetaBoxesSection
+				title="Advanced Panels"
+				areCustomFieldsRegistered={ false }
+				metaBoxes={ [
+					{ id: 'test1', title: 'Meta Box 1' },
+					{ id: 'test2', title: 'Meta Box 2' },
+				] }
+			/>
+		);
+		expect( wrapper ).toMatchSnapshot();
+	} );
+
+	it( 'renders a Custom Fields option and meta box options', () => {
+		const wrapper = shallow(
+			<MetaBoxesSection
+				title="Advanced Panels"
+				areCustomFieldsRegistered
+				metaBoxes={ [
+					{ id: 'postcustom', title: 'This should not render' },
+					{ id: 'test1', title: 'Meta Box 1' },
+					{ id: 'test2', title: 'Meta Box 2' },
+				] }
+			/>
+		);
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
## Description
Don't render the Custom Fields option when the `enableCustomFields` editor setting is `undefined`. This means that, in 5.0, plugins can properly disable custom fields.

Combined with https://core.trac.wordpress.org/ticket/45282, this fixes #11386.

I did not copy over the PHP changes from the above Trac ticket into the Gutenberg plugin because meta boxes work a little differently (better!) in 5.0 versus the Gutenberg plugin. I'm happy to have #11386 only fixed in 5.0, considering that Gutenberg will require a minimum WordPress version of 5.0 soon meaning we can remove most of `lib/client-assets.php`.

I've also added some unit tests for the two components involved.

**To test:**

1. Create a new post
1. Click _Show more tools & options_
1. Select _Options_
1. Check that _Custom Fields_ is not checked
1. Toggle it
1. Click _Show more tools & options_
1. Select _Options_
1. Check that _Custom Fields_ is checked
1. Manually delete the `'enableCustomFields' => ...` line from `lib/client-assets:1647`
1. Create a new post
1. Click _Show more tools & options_
1. Select _Options_
1. Check that _Custom Fields_ does not appear