### PR TITLE
Disable fixed cover attachment on iOS

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -55,6 +55,13 @@
 
 	&.has-parallax {
 		background-attachment: fixed;
+
+		// Mobile Safari does not support fixed background attachment properly.
+		// See also https://stackoverflow.com/questions/24154666/background-size-cover-not-working-on-ios
+		// Chrome on Android does not appear to support the attachment at all: https://issuetracker.google.com/issues/36908439
+		@supports (-webkit-overflow-scrolling: touch) {
+			background-attachment: scroll;
+		}
 	}
 
 	&.has-background-dim::before {


### PR DESCRIPTION
This fixes #4133.

Sadly, Mobile Safari does not support properly the fixed attachment background.

Interestingly, the implementation on Android is also buggy.

This PR leaves Android alone, hoping it'll one day work, but explicitly disables it on Mobile Safari.

iOS:

![screenshot 2018-11-05 at 09 14 41](https://user-images.githubusercontent.com/1204802/47986383-dec9e380-e0dc-11e8-9ae6-7792359df309.png)

Desktop:

![screenshot 2018-11-05 at 09 15 30](https://user-images.githubusercontent.com/1204802/47986386-e25d6a80-e0dc-11e8-928d-543a9c6de910.png)

Android:

![android](https://user-images.githubusercontent.com/1204802/47986388-e4bfc480-e0dc-11e8-9b53-57956b54d40e.png)

Props @craigburgess for fix suggested in https://github.com/WordPress/gutenberg/issues/4133#issuecomment-405927760.