### PR TITLE
Editor: Use store to always have up to date list of format types

### DIFF
--- a/packages/editor/src/components/rich-text/format-edit.js
+++ b/packages/editor/src/components/rich-text/format-edit.js
@@ -2,8 +2,9 @@
  * WordPress dependencies
  */
 import { normalizeIconObject } from '@wordpress/blocks';
+import { withSelect } from '@wordpress/data';
 import { Component, Fragment } from '@wordpress/element';
-import { getActiveFormat, getFormatTypes } from '@wordpress/rich-text';
+import { getActiveFormat } from '@wordpress/rich-text';
 import { Fill, KeyboardShortcuts, ToolbarButton } from '@wordpress/components';
 import { rawShortcut, displayShortcut } from '@wordpress/keycodes';
 
@@ -81,10 +82,10 @@ class Shortcut extends Component {
 	}
 }
 
-const FormatEdit = ( { onChange, value } ) => {
+const FormatEdit = ( { formatTypes, onChange, value } ) => {
 	return (
 		<Fragment>
-			{ getFormatTypes().map( ( { name, edit: Edit, keywords } ) => {
+			{ formatTypes.map( ( { name, edit: Edit, keywords } ) => {
 				if ( ! Edit ) {
 					return null;
 				}
@@ -115,4 +116,12 @@ const FormatEdit = ( { onChange, value } ) => {
 	);
 };
 
-export default FormatEdit;
+export default withSelect(
+	( select ) => {
+		const { getFormatTypes } = select( 'core/rich-text' );
+
+		return {
+			formatTypes: getFormatTypes(),
+		};
+	}
+)( FormatEdit );

--- a/packages/editor/src/index.js
+++ b/packages/editor/src/index.js
@@ -5,6 +5,7 @@ import '@wordpress/blocks';
 import '@wordpress/core-data';
 import '@wordpress/notices';
 import '@wordpress/nux';
+import '@wordpress/rich-text';
 import '@wordpress/viewport';
 
 /**

--- a/packages/rich-text/src/index.js
+++ b/packages/rich-text/src/index.js
@@ -5,8 +5,6 @@ export { charAt } from './char-at';
 export { concat } from './concat';
 export { create } from './create';
 export { getActiveFormat } from './get-active-format';
-export { getFormatType } from './get-format-type';
-export { getFormatTypes } from './get-format-types';
 export { getSelectionEnd } from './get-selection-end';
 export { getSelectionStart } from './get-selection-start';
 export { getTextContent } from './get-text-content';


### PR DESCRIPTION
## Description
This PR refactors `RichText` component to use `withSelect` to get the list of format types. This ensures that every change to the list of format types is immediately reflected in the UI. Without this change, the user needed to perform an action which explicitly re-render toolbar controls (select other RichText or change the state of controls, etc).

Given that `getFormatTypes` and `getFormatType` methods are no longer referenced outside of `@wordpress/rich-text` package I made them private (they were never documented as public). This should also help to ensure that they are consumed through the data layer abstractions.

## How has this been tested?
`npm test`

1. Add a block with `RichText` (paragraph or quote, list, etc ..)
2. Start typing.
3. Open JS console.
4. Execute:
```js
wp.richText.unregisterFormatType( 'core/bold' );
```
5. Make sure that Bold format control is immediately removed.

## Types of changes
Refactoring.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
