### PR TITLE
Expose @wordpress/editor to Gutenberg mobile

### DIFF
--- a/packages/blocks/src/api/index.native.js
+++ b/packages/blocks/src/api/index.native.js
@@ -19,6 +19,7 @@ export {
 	getBlockType,
 	getBlockTypes,
 	hasBlockSupport,
+	isReusableBlock,
 } from './registration';
 export { getPhrasingContentSchema } from './raw-handling';
 export { default as children } from './children';

--- a/packages/components/src/index.native.js
+++ b/packages/components/src/index.native.js
@@ -3,3 +3,6 @@ export * from './primitives';
 export { default as Dashicon } from './dashicon';
 export { default as Toolbar } from './toolbar';
 export { default as withSpokenMessages } from './higher-order/with-spoken-messages';
+
+// Higher-Order Components
+export { default as withFilters } from './higher-order/with-filters';

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -18,6 +18,7 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
+	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.0.0",
 		"moment": "^2.22.1",

--- a/packages/editor/src/components/block-edit/edit.native.js
+++ b/packages/editor/src/components/block-edit/edit.native.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { omit } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { withFilters } from '@wordpress/components';
+import { getBlockType } from '@wordpress/blocks';
+
+export const Edit = ( props ) => {
+	const { attributes = {}, name } = props;
+	const blockType = getBlockType( name );
+
+	if ( ! blockType ) {
+		return null;
+	}
+
+	const style = props.style || attributes.style;
+	const Component = blockType.edit;
+
+	return (
+		<Component
+			{ ...omit( props, [ 'className' ] ) }
+			style={ style }
+		/>
+	);
+};
+
+export default withFilters( 'editor.BlockEdit' )( Edit );

--- a/packages/editor/src/components/block-edit/edit.native.js
+++ b/packages/editor/src/components/block-edit/edit.native.js
@@ -1,31 +1,22 @@
 /**
- * External dependencies
- */
-import { omit } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { withFilters } from '@wordpress/components';
 import { getBlockType } from '@wordpress/blocks';
 
 export const Edit = ( props ) => {
-	const { attributes = {}, name } = props;
+	const { name } = props;
 	const blockType = getBlockType( name );
 
 	if ( ! blockType ) {
 		return null;
 	}
 
-	const style = props.style || attributes.style;
 	const Component = blockType.edit;
 
 	return (
-		<Component
-			{ ...omit( props, [ 'className' ] ) }
-			style={ style }
-		/>
+		<Component { ...props } />
 	);
 };
 
-export default Edit;
+export default withFilters( 'editor.BlockEdit' )( Edit );

--- a/packages/editor/src/components/block-edit/edit.native.js
+++ b/packages/editor/src/components/block-edit/edit.native.js
@@ -28,4 +28,4 @@ export const Edit = ( props ) => {
 	);
 };
 
-export default withFilters( 'editor.BlockEdit' )( Edit );
+export default Edit;

--- a/packages/editor/src/components/index.native.js
+++ b/packages/editor/src/components/index.native.js
@@ -3,3 +3,4 @@ export * from './font-sizes';
 export { default as PlainText } from './plain-text';
 export { default as RichText } from './rich-text';
 export { default as MediaPlaceholder } from './media-placeholder';
+export { default as BlockEdit } from './block-edit';

--- a/packages/editor/src/index.native.js
+++ b/packages/editor/src/index.native.js
@@ -1,0 +1,14 @@
+/**
+ * WordPress dependencies
+ */
+import '@wordpress/blocks';
+import '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import './store';
+import './hooks';
+
+export * from './components';
+export * from './utils';


### PR DESCRIPTION
## Description
This PR exposes `@wordpress/editor` to the `gutenberg-mobile` project, so we can reuse its store and some existing components in the mobile app.

It can be tested manually on mobile with this experiment PR https://github.com/wordpress-mobile/gutenberg-mobile/pull/215 which is not going to be merged.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
