### PR TITLE
Rich Text: Fix Format Type Assignment During Parsing

### DIFF
--- a/packages/format-library/src/bold/index.js
+++ b/packages/format-library/src/bold/index.js
@@ -11,9 +11,8 @@ const name = 'core/bold';
 export const bold = {
 	name,
 	title: __( 'Bold' ),
-	match: {
-		tagName: 'strong',
-	},
+	tagName: 'strong',
+	className: null,
 	edit( { isActive, value, onChange } ) {
 		const onToggle = () => onChange( toggleFormat( value, { type: name } ) );
 

--- a/packages/format-library/src/code/index.js
+++ b/packages/format-library/src/code/index.js
@@ -10,9 +10,8 @@ const name = 'core/code';
 export const code = {
 	name,
 	title: __( 'Code' ),
-	match: {
-		tagName: 'code',
-	},
+	tagName: 'code',
+	className: null,
 	edit( { value, onChange } ) {
 		const onToggle = () => onChange( toggleFormat( value, { type: name } ) );
 

--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -16,9 +16,8 @@ export const image = {
 	title: __( 'Image' ),
 	keywords: [ __( 'photo' ), __( 'media' ) ],
 	object: true,
-	match: {
-		tagName: 'img',
-	},
+	tagName: 'img',
+	className: null,
 	attributes: {
 		className: 'class',
 		style: 'style',

--- a/packages/format-library/src/italic/index.js
+++ b/packages/format-library/src/italic/index.js
@@ -11,9 +11,8 @@ const name = 'core/italic';
 export const italic = {
 	name,
 	title: __( 'Italic' ),
-	match: {
-		tagName: 'em',
-	},
+	tagName: 'em',
+	className: null,
 	edit( { isActive, value, onChange } ) {
 		const onToggle = () => onChange( toggleFormat( value, { type: name } ) );
 

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -23,9 +23,8 @@ const name = 'core/link';
 export const link = {
 	name,
 	title: __( 'Link' ),
-	match: {
-		tagName: 'a',
-	},
+	tagName: 'a',
+	className: null,
 	attributes: {
 		url: 'href',
 		target: 'target',

--- a/packages/format-library/src/strikethrough/index.js
+++ b/packages/format-library/src/strikethrough/index.js
@@ -11,9 +11,8 @@ const name = 'core/strikethrough';
 export const strikethrough = {
 	name,
 	title: __( 'Strikethrough' ),
-	match: {
-		tagName: 'del',
-	},
+	tagName: 'del',
+	className: null,
 	edit( { isActive, value, onChange } ) {
 		const onToggle = () => onChange( toggleFormat( value, { type: name } ) );
 

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -1,8 +1,7 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
-
-import { find } from 'lodash';
+import { select } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -11,7 +10,6 @@ import { find } from 'lodash';
 import { isEmpty } from './is-empty';
 import { isFormatEqual } from './is-format-equal';
 import { createElement } from './create-element';
-import { getFormatTypes } from './get-format-types';
 import {
 	LINE_SEPARATOR,
 	OBJECT_REPLACEMENT_CHARACTER,
@@ -36,9 +34,23 @@ function simpleFindKey( object, value ) {
 }
 
 function toFormat( { type, attributes } ) {
-	const formatType = find( getFormatTypes(), ( { match } ) =>
-		type === match.tagName
-	);
+	let formatType;
+
+	if ( attributes && attributes.class ) {
+		formatType = select( 'core/rich-text' ).getFormatTypeForClassName( attributes.class );
+
+		if ( formatType ) {
+			attributes.class = ` ${ attributes.class } `.replace( ` ${ formatType.className } `, ' ' ).trim();
+
+			if ( ! attributes.class ) {
+				delete attributes.class;
+			}
+		}
+	}
+
+	if ( ! formatType ) {
+		formatType = select( 'core/rich-text' ).getFormatTypeForBareElement( type );
+	}
 
 	if ( ! formatType ) {
 		return attributes ? { type, attributes } : { type };

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -40,6 +40,7 @@ function toFormat( { type, attributes } ) {
 		formatType = select( 'core/rich-text' ).getFormatTypeForClassName( attributes.class );
 
 		if ( formatType ) {
+			// Preserve any additional classes.
 			attributes.class = ` ${ attributes.class } `.replace( ` ${ formatType.className } `, ' ' ).trim();
 
 			if ( ! attributes.class ) {

--- a/packages/rich-text/src/register-format-type.js
+++ b/packages/rich-text/src/register-format-type.js
@@ -52,6 +52,55 @@ export function registerFormatType( name, settings ) {
 		return;
 	}
 
+	if (
+		typeof settings.tagName !== 'string' ||
+		settings.tagName === ''
+	) {
+		window.console.error(
+			'Format tag names must be a string.'
+		);
+		return;
+	}
+
+	if (
+		( typeof settings.className !== 'string' || settings.className === '' ) &&
+		settings.className !== null
+	) {
+		window.console.error(
+			'Format class names must be a string, or null to handle bare elements.'
+		);
+		return;
+	}
+
+	if ( ! /^[_a-zA-Z]+[a-zA-Z0-9-]*$/.test( settings.className ) ) {
+		window.console.error(
+			'A class name must begin with a letter, followed by any number of hyphens, letters, or numbers.'
+		);
+		return;
+	}
+
+	if ( settings.className === null ) {
+		const formatTypeForBareElement = select( 'core/rich-text' )
+			.getFormatTypeForBareElement( settings.tagName );
+
+		if ( formatTypeForBareElement ) {
+			window.console.error(
+				`Format "${ formatTypeForBareElement.name }" is already registered to handle bare tag name "${ settings.tagName }".`
+			);
+			return;
+		}
+	} else {
+		const formatTypeForClassName = select( 'core/rich-text' )
+			.getFormatTypeForClassName( settings.className );
+
+		if ( formatTypeForClassName ) {
+			window.console.error(
+				`Format "${ formatTypeForClassName.name }" is already registered to handle class name "${ settings.className }".`
+			);
+			return;
+		}
+	}
+
 	if ( ! ( 'title' in settings ) || settings.title === '' ) {
 		window.console.error(
 			'The format "' + settings.name + '" must have a title.'

--- a/packages/rich-text/src/store/selectors.js
+++ b/packages/rich-text/src/store/selectors.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import createSelector from 'rememo';
+import { find } from 'lodash';
 
 /**
  * Returns all the available format types.
@@ -27,4 +28,37 @@ export const getFormatTypes = createSelector(
  */
 export function getFormatType( state, name ) {
 	return state.formatTypes[ name ];
+}
+
+/**
+ * Gets the format type, if any, that can handle a bare element (without a
+ * data-format-type attribute), given the tag name of this element.
+ *
+ * @param {Object} state              Data state.
+ * @param {string} bareElementTagName The tag name of the element to find a
+ *                                    format type for.
+ * @return {?Object} Format type.
+ */
+export function getFormatTypeForBareElement( state, bareElementTagName ) {
+	return find( getFormatTypes( state ), ( { tagName } ) => {
+		return bareElementTagName === tagName;
+	} );
+}
+
+/**
+ * Gets the format type, if any, that can handle an element, given its classes.
+ *
+ * @param {Object} state            Data state.
+ * @param {string} elementClassName The classes of the element to find a format
+ *                                  type for.
+ * @return {?Object} Format type.
+ */
+export function getFormatTypeForClassName( state, elementClassName ) {
+	return find( getFormatTypes( state ), ( { className } ) => {
+		if ( className === null ) {
+			return false;
+		}
+
+		return ` ${ elementClassName } `.indexOf( ` ${ className } ` ) >= 0;
+	} );
 }

--- a/packages/rich-text/src/test/create.js
+++ b/packages/rich-text/src/test/create.js
@@ -9,7 +9,9 @@ import { JSDOM } from 'jsdom';
  */
 import { create } from '../create';
 import { createElement } from '../create-element';
-import { getSparseArrayLength, spec } from './helpers';
+import { registerFormatType } from '../register-format-type';
+import { unregisterFormatType } from '../unregister-format-type';
+import { getSparseArrayLength, spec, specWithRegistration } from './helpers';
 
 const { window } = new JSDOM();
 const { document } = window;
@@ -51,6 +53,28 @@ describe( 'create', () => {
 
 			expect( createdRecord ).toEqual( record );
 			expect( createdFormatsLength ).toEqual( formatsLength );
+		} );
+	} );
+
+	specWithRegistration.forEach( ( {
+		description,
+		formatName,
+		formatType,
+		html,
+		value,
+	} ) => {
+		it( description, () => {
+			if ( formatName ) {
+				registerFormatType( formatName, formatType );
+			}
+
+			const result = create( { html } );
+
+			if ( formatName ) {
+				unregisterFormatType( formatName );
+			}
+
+			expect( result ).toEqual( value );
 		} );
 	} );
 

--- a/packages/rich-text/src/test/create.js
+++ b/packages/rich-text/src/test/create.js
@@ -61,7 +61,7 @@ describe( 'create', () => {
 		formatName,
 		formatType,
 		html,
-		value,
+		value: expectedValue,
 	} ) => {
 		it( description, () => {
 			if ( formatName ) {
@@ -74,7 +74,7 @@ describe( 'create', () => {
 				unregisterFormatType( formatName );
 			}
 
-			expect( result ).toEqual( value );
+			expect( result ).toEqual( expectedValue );
 		} );
 	} );
 

--- a/packages/rich-text/src/test/helpers/index.js
+++ b/packages/rich-text/src/test/helpers/index.js
@@ -709,3 +709,80 @@ export const spec = [
 		},
 	},
 ];
+
+export const specWithRegistration = [
+	{
+		description: 'should create format by matching the class',
+		formatName: 'my-plugin/link',
+		formatType: {
+			title: 'Custom Link',
+			tagName: 'a',
+			className: 'custom-format',
+			edit() {},
+		},
+		html: '<a class="custom-format">a</a>',
+		value: {
+			formats: [ [ {
+				type: 'my-plugin/link',
+				attributes: {},
+				unregisteredAttributes: {},
+			} ] ],
+			text: 'a',
+		},
+	},
+	{
+		description: 'should retain class names',
+		formatName: 'my-plugin/link',
+		formatType: {
+			title: 'Custom Link',
+			tagName: 'a',
+			className: 'custom-format',
+			edit() {},
+		},
+		html: '<a class="custom-format test">a</a>',
+		value: {
+			formats: [ [ {
+				type: 'my-plugin/link',
+				attributes: {},
+				unregisteredAttributes: {
+					class: 'test',
+				},
+			} ] ],
+			text: 'a',
+		},
+	},
+	{
+		description: 'should create base format',
+		formatName: 'core/link',
+		formatType: {
+			title: 'Link',
+			tagName: 'a',
+			className: null,
+			edit() {},
+		},
+		html: '<a class="custom-format">a</a>',
+		value: {
+			formats: [ [ {
+				type: 'core/link',
+				attributes: {},
+				unregisteredAttributes: {
+					class: 'custom-format',
+				},
+			} ] ],
+			text: 'a',
+		},
+	},
+	{
+		description: 'should create fallback format',
+		html: '<a class="custom-format">a</a>',
+		value: {
+			formats: [ [ {
+				type: 'a',
+				attributes: {
+					class: 'custom-format',
+				},
+			} ] ],
+			text: 'a',
+		},
+	},
+];

--- a/packages/rich-text/src/test/register-format-type.js
+++ b/packages/rich-text/src/test/register-format-type.js
@@ -1,0 +1,112 @@
+/**
+ * WordPress dependencies
+ */
+import { select } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+
+import { registerFormatType } from '../register-format-type';
+import { unregisterFormatType } from '../unregister-format-type';
+
+describe( 'registerFormatType', () => {
+	beforeAll( () => {
+		// Initialize the rich-text store.
+		require( '../store' );
+	} );
+
+	afterEach( () => {
+		select( 'core/rich-text' ).getFormatTypes().forEach( ( { name } ) => {
+			unregisterFormatType( name );
+		} );
+	} );
+
+	const validName = 'plugin/test';
+	const validSettings = {
+		tagName: 'test',
+		className: null,
+		title: 'Test',
+		edit() {},
+	};
+
+	it( 'should register format', () => {
+		const settings = registerFormatType( validName, validSettings );
+		expect( settings ).toEqual( { ...validSettings, name: validName } );
+		expect( console ).not.toHaveErrored();
+	} );
+
+	it( 'should error without arguments', () => {
+		registerFormatType();
+		expect( console ).toHaveErroredWith( 'Format names must be strings.' );
+	} );
+
+	it( 'should error on invalid name', () => {
+		registerFormatType( 'test', validSettings );
+		expect( console ).toHaveErroredWith( 'Format names must contain a namespace prefix, include only lowercase alphanumeric characters or dashes, and start with a letter. Example: my-plugin/my-custom-format' );
+	} );
+
+	it( 'should error on already registered name', () => {
+		registerFormatType( validName, validSettings );
+		registerFormatType( validName, validSettings );
+		expect( console ).toHaveErroredWith( 'Format "plugin/test" is already registered.' );
+	} );
+
+	it( 'should error on undefined edit property', () => {
+		registerFormatType( 'plugin/test', {
+			...validSettings,
+			edit: undefined,
+		} );
+		expect( console ).toHaveErroredWith( 'The "edit" property must be specified and must be a valid function.' );
+	} );
+
+	it( 'should error on empty tagName property', () => {
+		registerFormatType( validName, {
+			...validSettings,
+			tagName: '',
+		} );
+		expect( console ).toHaveErroredWith( 'Format tag names must be a string.' );
+	} );
+
+	it( 'should error on invalid empty className property', () => {
+		registerFormatType( validName, {
+			...validSettings,
+			className: '',
+		} );
+		expect( console ).toHaveErroredWith( 'Format class names must be a string, or null to handle bare elements.' );
+	} );
+
+	it( 'should error on invalid className property', () => {
+		registerFormatType( validName, {
+			...validSettings,
+			className: 'invalid class name',
+		} );
+		expect( console ).toHaveErroredWith( 'A class name must begin with a letter, followed by any number of hyphens, letters, or numbers.' );
+	} );
+
+	it( 'should error on already registered tagName', () => {
+		registerFormatType( validName, validSettings );
+		registerFormatType( 'plugin/second', validSettings );
+		expect( console ).toHaveErroredWith( 'Format "plugin/test" is already registered to handle bare tag name "test".' );
+	} );
+
+	it( 'should error on already registered className', () => {
+		registerFormatType( validName, {
+			...validSettings,
+			className: 'test',
+		} );
+		registerFormatType( 'plugin/second', {
+			...validSettings,
+			className: 'test',
+		} );
+		expect( console ).toHaveErroredWith( 'Format "plugin/test" is already registered to handle class name "test".' );
+	} );
+
+	it( 'should error on empty title property', () => {
+		registerFormatType( validName, {
+			...validSettings,
+			title: '',
+		} );
+		expect( console ).toHaveErroredWith( 'The format "plugin/test" must have a title.' );
+	} );
+} );

--- a/packages/rich-text/src/test/to-html-string.js
+++ b/packages/rich-text/src/test/to-html-string.js
@@ -10,6 +10,9 @@ import { JSDOM } from 'jsdom';
 
 import { create } from '../create';
 import { toHTMLString } from '../to-html-string';
+import { registerFormatType } from '../register-format-type';
+import { unregisterFormatType } from '../unregister-format-type';
+import { specWithRegistration } from './helpers';
 
 const { window } = new JSDOM();
 const { document } = window;
@@ -24,6 +27,28 @@ describe( 'toHTMLString', () => {
 	beforeAll( () => {
 		// Initialize the rich-text store.
 		require( '../store' );
+	} );
+
+	specWithRegistration.forEach( ( {
+		description,
+		formatName,
+		formatType,
+		html,
+		value,
+	} ) => {
+		it( description, () => {
+			if ( formatName ) {
+				registerFormatType( formatName, formatType );
+			}
+
+			const result = toHTMLString( { value } );
+
+			if ( formatName ) {
+				unregisterFormatType( formatName );
+			}
+
+			expect( result ).toEqual( html );
+		} );
 	} );
 
 	it( 'should extract recreate HTML 1', () => {

--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -9,21 +9,14 @@ import {
 	ZERO_WIDTH_NO_BREAK_SPACE,
 } from './special-characters';
 
-function fromFormat( { type, attributes, object } ) {
+function fromFormat( { type, attributes, unregisteredAttributes, object } ) {
 	const formatType = getFormatType( type );
 
 	if ( ! formatType ) {
 		return { type, attributes, object };
 	}
 
-	if ( ! attributes ) {
-		return {
-			type: formatType.match.tagName,
-			object: formatType.object,
-		};
-	}
-
-	const elementAttributes = {};
+	const elementAttributes = unregisteredAttributes ? { ...unregisteredAttributes } : {};
 
 	for ( const name in attributes ) {
 		const key = formatType.attributes[ name ];
@@ -35,8 +28,16 @@ function fromFormat( { type, attributes, object } ) {
 		}
 	}
 
+	if ( formatType.className ) {
+		if ( elementAttributes.class ) {
+			elementAttributes.class = `${ formatType.className } ${ elementAttributes.class }`;
+		} else {
+			elementAttributes.class = formatType.className;
+		}
+	}
+
 	return {
-		type: formatType.match.tagName,
+		type: formatType.tagName,
 		object: formatType.object,
 		attributes: elementAttributes,
 	};
@@ -145,15 +146,14 @@ export function toTree( {
 					return;
 				}
 
-				const { type, attributes, object } = format;
 				const parent = getParent( pointer );
-				const newNode = append( parent, fromFormat( { type, attributes, object } ) );
+				const newNode = append( parent, fromFormat( format ) );
 
 				if ( isText( pointer ) && getText( pointer ).length === 0 ) {
 					remove( pointer );
 				}
 
-				pointer = append( object ? parent : newNode, '' );
+				pointer = append( format.object ? parent : newNode, '' );
 			} );
 		}
 

--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -16,7 +16,7 @@ function fromFormat( { type, attributes, unregisteredAttributes, object } ) {
 		return { type, attributes, object };
 	}
 
-	const elementAttributes = unregisteredAttributes ? { ...unregisteredAttributes } : {};
+	const elementAttributes = { ...unregisteredAttributes };
 
 	for ( const name in attributes ) {
 		const key = formatType.attributes[ name ];


### PR DESCRIPTION
## Description

Fixes e.g. #6648, generally that no format type can use the same tag name, so e.g. you cannot have two format types handling `a` or `span` elements.

Currently format types are assigned based on the provided `tagName`. This was a temporary solution, intended to be expanded with classes and other attributes, to find a format type match for a given element.

This is a proposal to instead normally serialise a class name. Only in cases where it is wanted that the format type can handle any element with the tag name, you can pass `null` for the class name.

So say you want to register a custom link format type, you can do so by providing `a` as the `tagName` and a `className`, without clashing with any other format types that want to use the same tag, including the core link format.

Additionally, it enables us to still handle e.g. links if a plugin using the anchor tag gets deactivated.

This is an important change to the Format API that would be good to include before the API even gets shipped, in 4.2, so I'm moving it to the milestone for discussion.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->