### PR TITLE
i18n: Replace Jed with Tannin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2631,6 +2631,7 @@
 				"@babel/runtime": "^7.0.0",
 				"gettext-parser": "^1.3.1",
 				"lodash": "^4.17.10",
+				"memize": "^1.0.5",
 				"sprintf-js": "^1.1.1",
 				"tannin": "^1.0.1"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2076,6 +2076,38 @@
 			"integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
 			"dev": true
 		},
+		"@tannin/compile": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.0.1.tgz",
+			"integrity": "sha512-ymd9icvnkQin8UG4eRU3+xBc7gqTn/Kv5+EMY3ALWVwIl6j/7McWbCkxB8MgU40UaHJk8kLCk06wiKszXLdXWQ==",
+			"requires": {
+				"@tannin/evaluate": "^1.0.0",
+				"@tannin/postfix": "^1.0.0"
+			}
+		},
+		"@tannin/evaluate": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.0.0.tgz",
+			"integrity": "sha512-gO7YbJsD8sj5/nqUbFZv71Meu2++D9n4DZov/cWwp3YJbBwKShPlWwwlXr/0vz4vuxm/gys+3NiGbZkmhlXf0Q=="
+		},
+		"@tannin/plural-forms": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.0.1.tgz",
+			"integrity": "sha512-SXutT+XLbMOECvmWDBSqIOHhS5hzWG9875HCFGKYgp8ghGPrJ4HZ325Xc0hsRThdjgrWMEQixlbpWl4SXOQTig==",
+			"requires": {
+				"@tannin/compile": "^1.0.0"
+			}
+		},
+		"@tannin/postfix": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.0.0.tgz",
+			"integrity": "sha512-59/mWwU7sXHfoU2kI3RcWRki2Jjbz5nEVJNBN4MUyIhPjXTebAcZqgsQACvlk+sjKVOTMEMHcrFrKQbaxz/1Dw=="
+		},
+		"@tannin/sprintf": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@tannin/sprintf/-/sprintf-1.0.0.tgz",
+			"integrity": "sha512-oXtaNxBa/ZyYSNu4pg3CLXb1gnehR1sDMiZCw4C6i18BXUeqflFxO4A1l4AGU5ZtAg6MjQLdYfSy2SaCuJ1xEw=="
+		},
 		"@types/node": {
 			"version": "10.12.2",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.2.tgz",
@@ -2602,10 +2634,10 @@
 			"version": "file:packages/i18n",
 			"requires": {
 				"@babel/runtime": "^7.0.0",
+				"@tannin/sprintf": "^1.0.0",
 				"gettext-parser": "^1.3.1",
-				"jed": "^1.1.1",
 				"lodash": "^4.17.10",
-				"memize": "^1.0.5"
+				"tannin": "^1.0.1"
 			}
 		},
 		"@wordpress/is-shallow-equal": {
@@ -11153,11 +11185,6 @@
 				"has-to-string-tag-x": "^1.2.0",
 				"is-object": "^1.0.1"
 			}
-		},
-		"jed": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/jed/-/jed-1.1.1.tgz",
-			"integrity": "sha1-elSbvZ/+FYWwzQoZHiAwVb7ldLQ="
 		},
 		"jest": {
 			"version": "23.4.2",
@@ -20344,6 +20371,14 @@
 					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 					"dev": true
 				}
+			}
+		},
+		"tannin": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tannin/-/tannin-1.0.1.tgz",
+			"integrity": "sha512-dDtnwHQ63bS/Gz0ZLY+E+JCdRoTZkmoKDoC64y3hzAD2X2qrp8jSuWNUjtiYHA48mtj4Ens9xl4knAOm1t+rfQ==",
+			"requires": {
+				"@tannin/plural-forms": "^1.0.0"
 			}
 		},
 		"tapable": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2103,11 +2103,6 @@
 			"resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.0.0.tgz",
 			"integrity": "sha512-59/mWwU7sXHfoU2kI3RcWRki2Jjbz5nEVJNBN4MUyIhPjXTebAcZqgsQACvlk+sjKVOTMEMHcrFrKQbaxz/1Dw=="
 		},
-		"@tannin/sprintf": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@tannin/sprintf/-/sprintf-1.0.0.tgz",
-			"integrity": "sha512-oXtaNxBa/ZyYSNu4pg3CLXb1gnehR1sDMiZCw4C6i18BXUeqflFxO4A1l4AGU5ZtAg6MjQLdYfSy2SaCuJ1xEw=="
-		},
 		"@types/node": {
 			"version": "10.12.2",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.2.tgz",
@@ -2634,9 +2629,9 @@
 			"version": "file:packages/i18n",
 			"requires": {
 				"@babel/runtime": "^7.0.0",
-				"@tannin/sprintf": "^1.0.0",
 				"gettext-parser": "^1.3.1",
 				"lodash": "^4.17.10",
+				"sprintf-js": "^1.1.1",
 				"tannin": "^1.0.1"
 			}
 		},
@@ -19570,8 +19565,7 @@
 		"sprintf-js": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
-			"integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw=",
-			"dev": true
+			"integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
 		},
 		"sshpk": {
 			"version": "1.14.2",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -26,6 +26,7 @@
 		"@babel/runtime": "^7.0.0",
 		"gettext-parser": "^1.3.1",
 		"lodash": "^4.17.10",
+		"memize": "^1.0.5",
 		"sprintf-js": "^1.1.1",
 		"tannin": "^1.0.1"
 	},

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -24,10 +24,10 @@
 	},
 	"dependencies": {
 		"@babel/runtime": "^7.0.0",
+		"@tannin/sprintf": "^1.0.0",
 		"gettext-parser": "^1.3.1",
-		"jed": "^1.1.1",
 		"lodash": "^4.17.10",
-		"memize": "^1.0.5"
+		"tannin": "^1.0.1"
 	},
 	"devDependencies": {
 		"benchmark": "^2.1.4"

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -24,9 +24,9 @@
 	},
 	"dependencies": {
 		"@babel/runtime": "^7.0.0",
-		"@tannin/sprintf": "^1.0.0",
 		"gettext-parser": "^1.3.1",
 		"lodash": "^4.17.10",
+		"sprintf-js": "^1.1.1",
 		"tannin": "^1.0.1"
 	},
 	"devDependencies": {

--- a/packages/i18n/src/index.js
+++ b/packages/i18n/src/index.js
@@ -3,7 +3,7 @@
  */
 import Tannin from 'tannin';
 
-export { default as sprintf } from '@tannin/sprintf';
+export { sprintf } from 'sprintf-js';
 
 /**
  * Default locale data to use for Tannin domain when not otherwise provided.

--- a/packages/i18n/src/index.js
+++ b/packages/i18n/src/index.js
@@ -33,12 +33,19 @@ const i18n = new Tannin( {} );
  * @param {?Object} data   Locale data configuration.
  * @param {?string} domain Domain for which configuration applies.
  */
-export function setLocaleData( data = DEFAULT_LOCALE_DATA, domain = 'default' ) {
-	i18n.data[ domain ] = Object.assign(
-		{},
-		i18n.data[ domain ],
-		data
-	);
+export function setLocaleData( data, domain = 'default' ) {
+	i18n.data[ domain ] = {
+		...DEFAULT_LOCALE_DATA,
+		...i18n.data[ domain ],
+		...data,
+	};
+
+	// Populate default domain configuration (supported locale date which omits
+	// a plural forms expression).
+	i18n.data[ domain ][ '' ] = {
+		...DEFAULT_LOCALE_DATA[ '' ],
+		...i18n.data[ domain ][ '' ],
+	};
 }
 
 /**

--- a/packages/i18n/src/index.js
+++ b/packages/i18n/src/index.js
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import Tannin from 'tannin';
-
-export { sprintf } from 'sprintf-js';
+import memoize from 'memize';
+import sprintfjs from 'sprintf-js';
 
 /**
  * Default locale data to use for Tannin domain when not otherwise provided.
@@ -16,6 +16,15 @@ const DEFAULT_LOCALE_DATA = {
 		plural_forms: 'plural=(n!=1)',
 	},
 };
+
+/**
+ * Log to console, once per message; or more precisely, per referentially equal
+ * argument set. Because Jed throws errors, we log these to the console instead
+ * to avoid crashing the application.
+ *
+ * @param {...*} args Arguments to pass to `console.error`
+ */
+const logErrorOnce = memoize( console.error ); // eslint-disable-line no-console
 
 /**
  * The underlying instance of Tannin to which exported functions interface.
@@ -134,4 +143,25 @@ export function _n( single, plural, number, domain ) {
  */
 export function _nx( single, plural, number, context, domain ) {
 	return dcnpgettext( domain, context, single, plural, number );
+}
+
+/**
+ * Returns a formatted string. If an error occurs in applying the format, the
+ * original format string is returned.
+ *
+ * @param {string}   format  The format of the string to generate.
+ * @param {string[]} ...args Arguments to apply to the format.
+ *
+ * @see http://www.diveintojavascript.com/projects/javascript-sprintf
+ *
+ * @return {string} The formatted string.
+ */
+export function sprintf( format, ...args ) {
+	try {
+		return sprintfjs.sprintf( format, ...args );
+	} catch ( error ) {
+		logErrorOnce( 'sprintf error: \n\n' + error.toString() );
+
+		return format;
+	}
 }

--- a/packages/i18n/src/index.js
+++ b/packages/i18n/src/index.js
@@ -13,7 +13,7 @@ export { default as sprintf } from '@tannin/sprintf';
  */
 const DEFAULT_LOCALE_DATA = {
 	'': {
-		'Plural-Forms': 'plural=(n!=1)',
+		plural_forms: 'plural=(n!=1)',
 	},
 };
 

--- a/packages/i18n/src/test/index.js
+++ b/packages/i18n/src/test/index.js
@@ -70,10 +70,24 @@ describe( 'i18n', () => {
 		} );
 	} );
 
-	describe( 'setAdditionalLocale', () => {
+	describe( 'setLocaleData', () => {
 		beforeAll( () => {
 			setLocaleData( additionalLocaleData, 'test_domain' );
 		} );
+
+		it( 'supports omitted plural forms expression', () => {
+			setLocaleData( {
+				'': {
+					domain: 'test_domain2',
+					lang: 'fr',
+				},
+
+				'%d banana': [ '%d banane', '%d bananes' ],
+			}, 'test_domain2' );
+
+			expect( _n( '%d banana', '%d bananes', 2, 'test_domain2' ) ).toBe( '%d bananes' );
+		} );
+
 		describe( '__', () => {
 			it( 'existing translation still available', () => {
 				expect( __( 'hello', 'test_domain' ) ).toBe( 'bonjour' );

--- a/packages/i18n/src/test/index.js
+++ b/packages/i18n/src/test/index.js
@@ -3,6 +3,10 @@
  */
 import { sprintf, __, _x, _n, _nx, setLocaleData } from '../';
 
+// Mock memoization as identity function. Inline since Jest errors on out-of-
+// scope references in a mock callback.
+jest.mock( 'memize', () => ( fn ) => fn );
+
 const localeData = {
 	'': {
 		// Domain name

--- a/packages/i18n/src/test/index.js
+++ b/packages/i18n/src/test/index.js
@@ -3,10 +3,6 @@
  */
 import { sprintf, __, _x, _n, _nx, setLocaleData } from '../';
 
-// Mock memoization as identity function. Inline since Jest errors on out-of-
-// scope references in a mock callback.
-jest.mock( 'memize', () => ( fn ) => fn );
-
 const localeData = {
 	'': {
 		// Domain name
@@ -34,28 +30,6 @@ const additionalLocaleData = {
 setLocaleData( localeData, 'test_domain' );
 
 describe( 'i18n', () => {
-	describe( 'error absorb', () => {
-		it( '__', () => {
-			__( 'Hello', 'domain-without-data' );
-			expect( console ).toHaveErrored();
-		} );
-
-		it( '_x', () => {
-			_x( 'feed', 'verb', 'domain-without-data' );
-			expect( console ).toHaveErrored();
-		} );
-
-		it( '_n', () => {
-			_n( '%d banana', '%d bananas', 3, 'domain-without-data' );
-			expect( console ).toHaveErrored();
-		} );
-
-		it( '_nx', () => {
-			_nx( '%d apple', '%d apples', 3, 'fruit', 'domain-without-data' );
-			expect( console ).toHaveErrored();
-		} );
-	} );
-
 	describe( '__', () => {
 		it( 'use the translation', () => {
 			expect( __( 'hello', 'test_domain' ) ).toBe( 'bonjour' );
@@ -89,13 +63,6 @@ describe( 'i18n', () => {
 	} );
 
 	describe( 'sprintf()', () => {
-		it( 'absorbs errors', () => {
-			const result = sprintf( 'Hello %(placeholder-not-provided)s' );
-
-			expect( console ).toHaveErrored();
-			expect( result ).toBe( 'Hello %(placeholder-not-provided)s' );
-		} );
-
 		it( 'replaces placeholders', () => {
 			const result = sprintf( __( 'hello %s', 'test_domain' ), 'Riad' );
 

--- a/packages/i18n/src/test/index.js
+++ b/packages/i18n/src/test/index.js
@@ -63,6 +63,13 @@ describe( 'i18n', () => {
 	} );
 
 	describe( 'sprintf()', () => {
+		it( 'absorbs errors', () => {
+			const result = sprintf( 'Hello %(placeholder-not-provided)s' );
+
+			expect( console ).toHaveErrored();
+			expect( result ).toBe( 'Hello %(placeholder-not-provided)s' );
+		} );
+
 		it( 'replaces placeholders', () => {
 			const result = sprintf( __( 'hello %s', 'test_domain' ), 'Riad' );
 

--- a/packages/i18n/src/test/index.js
+++ b/packages/i18n/src/test/index.js
@@ -18,13 +18,13 @@ const localeData = {
 
 	'hello %s': [ 'bonjour %s' ],
 
-	'%d banana': [ 'une banane', '%d bananes' ],
+	'%d banana': [ '%d banane', '%d bananes' ],
 
-	'fruit\u0004%d apple': [ 'une pomme', '%d pommes' ],
+	'fruit\u0004%d apple': [ '%d pomme', '%d pommes' ],
 };
 const additionalLocaleData = {
 	cheeseburger: [ 'hamburger au fromage' ],
-	'%d cat': [ 'un chat', '%d chats' ],
+	'%d cat': [ '%d chat', '%d chats' ],
 };
 
 setLocaleData( localeData, 'test_domain' );
@@ -48,7 +48,7 @@ describe( 'i18n', () => {
 		} );
 
 		it( 'use the singular form', () => {
-			expect( _n( '%d banana', '%d bananas', 1, 'test_domain' ) ).toBe( 'une banane' );
+			expect( _n( '%d banana', '%d bananas', 1, 'test_domain' ) ).toBe( '%d banane' );
 		} );
 	} );
 
@@ -58,7 +58,7 @@ describe( 'i18n', () => {
 		} );
 
 		it( 'use the singular form', () => {
-			expect( _nx( '%d apple', '%d apples', 1, 'fruit', 'test_domain' ) ).toBe( 'une pomme' );
+			expect( _nx( '%d apple', '%d apples', 1, 'fruit', 'test_domain' ) ).toBe( '%d pomme' );
 		} );
 	} );
 
@@ -90,7 +90,7 @@ describe( 'i18n', () => {
 			} );
 
 			it( 'new singular form was added', () => {
-				expect( _n( '%d cat', '%d cats', 1, 'test_domain' ) ).toBe( 'un chat' );
+				expect( _n( '%d cat', '%d cats', 1, 'test_domain' ) ).toBe( '%d chat' );
 			} );
 
 			it( 'new plural form was added', () => {


### PR DESCRIPTION
Related: https://github.com/WordPress/packages/pull/101

This pull request seeks to propose an internal refactoring of the `@wordpress/i18n` module to replace Jed with the largely-compatible [Tannin library](https://github.com/aduth/tannin). This has no impact on the public interface of the module, and instead serves as an overall performance, memory use, and bundle size improvement ([see benchmarks](https://github.com/aduth/tannin#benchmarks)).

**Context:** Summarized at https://github.com/WordPress/packages/pull/101, Jed's implementation has a critical performance flaw in that it parses and compiles the locale plural forms expression every time a translation function is called with pluralization or when locale data is not explicitly provided (e.g. default English). While memoization remedies the issue, it's more a bandaid solution in that (a) the underlying operation is still expensive† and (b) it incurs an additional cost of memory storage of redundant cached data. Tannin addresses these issues by computing the parsed evaluator of plural forms at most a single time, and by having more efficient expression parsing and evaluation to begin with.

† Even with caching, the current Gutenberg master incurs a plural forms parse nearly 300 times during the initial load.

**Testing Instructions:**

There should be no impact on the application. There are numerous layers of unit testing to validate variations of translations, but verify that the correct strings are shown in general usage, notably:

- Non-English locales
- Pluralization

Ensure unit tests pass:

```
npm run test-unit
```