### PR TITLE
Avoid unnecessary re-renders when navigating between blocks

### DIFF
--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -665,9 +665,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps ) => {
 		onSelect( clientId = ownProps.clientId, initialPosition ) {
 			selectBlock( clientId, initialPosition );
 		},
-		onMultiSelect( ...args ) {
-			multiSelect( ...args );
-		},
+		onMultiSelect: multiSelect,
 		onInsertBlocks( blocks, index ) {
 			const { rootClientId } = ownProps;
 			insertBlocks( blocks, index, rootClientId );

--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -70,6 +70,7 @@ export class BlockListBlock extends Component {
 		this.onDragStart = this.onDragStart.bind( this );
 		this.onDragEnd = this.onDragEnd.bind( this );
 		this.selectOnOpen = this.selectOnOpen.bind( this );
+		this.onShiftSelection = this.onShiftSelection.bind( this );
 		this.hadTouchStart = false;
 
 		this.state = {
@@ -280,7 +281,7 @@ export class BlockListBlock extends Component {
 
 		if ( event.shiftKey ) {
 			if ( ! this.props.isSelected ) {
-				this.props.onShiftSelection( this.props.clientId );
+				this.onShiftSelection();
 				event.preventDefault();
 			}
 		} else {
@@ -349,6 +350,20 @@ export class BlockListBlock extends Component {
 	selectOnOpen( open ) {
 		if ( open && ! this.props.isSelected ) {
 			this.props.onSelect();
+		}
+	}
+
+	onShiftSelection() {
+		if ( ! this.props.isSelectionEnabled ) {
+			return;
+		}
+
+		const { getBlockSelectionStart, onMultiSelect, onSelect } = this.props;
+
+		if ( getBlockSelectionStart() ) {
+			onMultiSelect( getBlockSelectionStart(), this.props.clientId );
+		} else {
+			onSelect( this.props.clientId );
 		}
 	}
 
@@ -589,6 +604,7 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId, isLargeV
 		getEditorSettings,
 		hasSelectedInnerBlock,
 		getTemplateLock,
+		getBlockSelectionStart,
 	} = select( 'core/editor' );
 	const isSelected = isBlockSelected( clientId );
 	const { hasFixedToolbar, focusMode } = getEditorSettings();
@@ -622,6 +638,9 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId, isLargeV
 		block,
 		isSelected,
 		isParentOfSelectedBlock,
+		// We only care about this value when the shift key is pressed.
+		// We call it dynamically in the event handler to avoid unnecessary re-renders.
+		getBlockSelectionStart,
 	};
 } );
 
@@ -629,6 +648,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps ) => {
 	const {
 		updateBlockAttributes,
 		selectBlock,
+		multiSelect,
 		insertBlocks,
 		insertDefaultBlock,
 		removeBlock,
@@ -644,6 +664,9 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps ) => {
 		},
 		onSelect( clientId = ownProps.clientId, initialPosition ) {
 			selectBlock( clientId, initialPosition );
+		},
+		onMultiSelect( ...args ) {
+			multiSelect( ...args );
 		},
 		onInsertBlocks( blocks, index ) {
 			const { rootClientId } = ownProps;

--- a/packages/editor/src/components/block-list/index.js
+++ b/packages/editor/src/components/block-list/index.js
@@ -29,7 +29,6 @@ class BlockList extends Component {
 
 		this.onSelectionStart = this.onSelectionStart.bind( this );
 		this.onSelectionEnd = this.onSelectionEnd.bind( this );
-		this.onShiftSelection = this.onShiftSelection.bind( this );
 		this.setBlockRef = this.setBlockRef.bind( this );
 		this.setLastClientY = this.setLastClientY.bind( this );
 		this.onPointerMove = throttle( this.onPointerMove.bind( this ), 100 );
@@ -170,20 +169,6 @@ class BlockList extends Component {
 		}
 	}
 
-	onShiftSelection( clientId ) {
-		if ( ! this.props.isSelectionEnabled ) {
-			return;
-		}
-
-		const { selectionStartClientId, onMultiSelect, onSelect } = this.props;
-
-		if ( selectionStartClientId ) {
-			onMultiSelect( selectionStartClientId, clientId );
-		} else {
-			onSelect( clientId );
-		}
-	}
-
 	render() {
 		const {
 			blockClientIds,
@@ -200,7 +185,6 @@ class BlockList extends Component {
 						clientId={ clientId }
 						blockRef={ this.setBlockRef }
 						onSelectionStart={ this.onSelectionStart }
-						onShiftSelection={ this.onShiftSelection }
 						rootClientId={ rootClientId }
 						isFirst={ blockIndex === 0 }
 						isLast={ blockIndex === blockClientIds.length - 1 }
@@ -221,7 +205,6 @@ export default compose( [
 			isMultiSelecting,
 			getMultiSelectedBlocksStartClientId,
 			getMultiSelectedBlocksEndClientId,
-			getBlockSelectionStart,
 		} = select( 'core/editor' );
 		const { rootClientId } = ownProps;
 
@@ -229,7 +212,6 @@ export default compose( [
 			blockClientIds: getBlockOrder( rootClientId ),
 			selectionStart: getMultiSelectedBlocksStartClientId(),
 			selectionEnd: getMultiSelectedBlocksEndClientId(),
-			selectionStartClientId: isSelectionEnabled() && getBlockSelectionStart(),
 			isSelectionEnabled: isSelectionEnabled(),
 			isMultiSelecting: isMultiSelecting(),
 		};
@@ -239,14 +221,12 @@ export default compose( [
 			startMultiSelect,
 			stopMultiSelect,
 			multiSelect,
-			selectBlock,
 		} = dispatch( 'core/editor' );
 
 		return {
 			onStartMultiSelect: startMultiSelect,
 			onStopMultiSelect: stopMultiSelect,
 			onMultiSelect: multiSelect,
-			onSelect: selectBlock,
 		};
 	} ),
 ] )( BlockList );


### PR DESCRIPTION
## Description
Another try to fix #11397 :)

As pointed out by @aduth `isSelectionEnabled` is almost always `true` so this check shouldn't work. It might be a bug which was apparently fixed in the meantime or me being wrong when testing. Anyways, this PR takes a bit different approach.

First of all, I moved `onShiftSelection` one level down as it doesn't depend on `BlockList` at all. This should make easier reasoning about its behavior next to the code which actually uses it.

_Note to myself_: ~check if we can make it work as it would be a static method.~ - dismissed.

The fix is documented inline. To avoid all re-renders we don't compute the value inside `withSelect` as it changes for all `BlockListBlock` instances. Instead we pass down selector and call it dynamically only when it's necessary. It is very rare use case, as it only happens when user holds down `shift` key and activates multi selection.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots

### Before

![block list before](https://user-images.githubusercontent.com/699132/47908792-4f2ef580-de8e-11e8-837e-23e990349352.gif)

### After

![block list after](https://user-images.githubusercontent.com/699132/47908805-5524d680-de8e-11e8-9994-f349356dd31e.gif)

## Types of changes

Refactoring, no changes to the logic.
## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
