### PR TITLE
Update/i18n pullquote and quote translator comments

### DIFF
--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -84,14 +84,14 @@ class PullQuoteEdit extends Component {
 									value: nextValue,
 								} )
 							}
-							/* translators: the text of the quotation */
+							/* translators: placeholder text used for the quote */
 							placeholder={ __( 'Write quote…' ) }
 							wrapperClassName="block-library-pullquote__content"
 						/>
 						{ ( ! RichText.isEmpty( citation ) || isSelected ) && (
 							<RichText
 								value={ citation }
-								/* translators: the individual or entity quoted */
+								/* translators: placeholder text used for the citation */
 								placeholder={ __( 'Write citation…' ) }
 								onChange={
 									( nextCitation ) => setAttributes( {

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -215,7 +215,7 @@ export const settings = {
 								onReplace( [] );
 							}
 						} }
-						/* translators: the text of the quotation */
+						/* translators: placeholder text used for the quote */
 						placeholder={ __( 'Write quote…' ) }
 					/>
 					{ ( ! RichText.isEmpty( citation ) || isSelected ) && (
@@ -226,7 +226,7 @@ export const settings = {
 									citation: nextCitation,
 								} )
 							}
-							/* translators: the individual or entity quoted */
+							/* translators: placeholder text used for the citation */
 							placeholder={ __( 'Write citation…' ) }
 							className="wp-block-quote__citation"
 						/>


### PR DESCRIPTION
## Description
Fixes: #11467

## How has this been tested?
Ran through building the translation strings.
Opened #11494 as a result, noticing these comments aren't even being parsed and included in the final build.

## Types of changes
Accessibility - Updated translator comments for pullquote and quote.

## Checklist:
- [ x ] My code is tested.
- [ x ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ x ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ x ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
