### PR TITLE
Make it possible to undo prefix transforms

### DIFF
--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -124,18 +124,18 @@ Block styles can be used to provide alternative styles to block. It works by add
 // Register block styles.
 styles: [
 	// Mark style as default.
-	{ 
-		name: 'default', 
-		label: __( 'Rounded' ), 
-		isDefault: true 
+	{
+		name: 'default',
+		label: __( 'Rounded' ),
+		isDefault: true
 	},
-	{ 
-		name: 'outline', 
-		label: __( 'Outline' ) 
+	{
+		name: 'outline',
+		label: __( 'Outline' )
 	},
-	{ 
-		name: 'squared', 
-		label: __( 'Squared' ) 
+	{
+		name: 'squared',
+		label: __( 'Squared' )
 	},
 ],
 ```
@@ -409,6 +409,43 @@ transforms: {
 			},
 		},
 	]
+}
+```
+{% end %}
+
+A prefix transform is a transform that will be applied if the user prefixes some text in e.g. the paragraph block with a given pattern and a trailing space.
+
+{% codetabs %}
+{% ES5 %}
+```js
+transforms: {
+    from: [
+        {
+            type: 'prefix',
+            prefix: '?',
+            transform: function( content ) {
+                return createBlock( 'my-plugin/question', {
+                    content,
+                } );
+            },
+        },
+    ]
+}
+```
+{% ESNext %}
+```js
+transforms: {
+    from: [
+        {
+            type: 'prefix',
+            prefix: '?',
+            transform( content ) {
+                return createBlock( 'my-plugin/question', {
+                    content,
+                } );
+            },
+        },
+    ]
 }
 ```
 {% end %}

--- a/packages/block-library/src/code/index.js
+++ b/packages/block-library/src/code/index.js
@@ -39,8 +39,7 @@ export const settings = {
 	transforms: {
 		from: [
 			{
-				type: 'pattern',
-				trigger: 'enter',
+				type: 'enter',
 				regExp: /^```$/,
 				transform: () => createBlock( 'core/code' ),
 			},

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -107,18 +107,16 @@ export const settings = {
 					} );
 				},
 			},
-			{
-				type: 'pattern',
-				regExp: /^(#{2,6})\s/,
-				transform: ( { content, match } ) => {
-					const level = match[ 1 ].length;
-
+			...[ 2, 3, 4, 5, 6 ].map( ( level ) => ( {
+				type: 'prefix',
+				prefix: Array( level + 1 ).join( '#' ),
+				transform( content ) {
 					return createBlock( 'core/heading', {
 						level,
 						content,
 					} );
 				},
-			},
+			} ) ),
 		],
 		to: [
 			{

--- a/packages/block-library/src/list/index.js
+++ b/packages/block-library/src/list/index.js
@@ -110,25 +110,25 @@ export const settings = {
 					} );
 				},
 			},
-			{
-				type: 'pattern',
-				regExp: /^[*-]\s/,
-				transform: ( { content } ) => {
+			...[ '*', '-' ].map( ( prefix ) => ( {
+				type: 'prefix',
+				prefix,
+				transform( content ) {
 					return createBlock( 'core/list', {
 						values: `<li>${ content }</li>`,
 					} );
 				},
-			},
-			{
-				type: 'pattern',
-				regExp: /^1[.)]\s/,
-				transform: ( { content } ) => {
+			} ) ),
+			...[ '1.', '1)' ].map( ( prefix ) => ( {
+				type: 'prefix',
+				prefix,
+				transform( content ) {
 					return createBlock( 'core/list', {
 						ordered: true,
 						values: `<li>${ content }</li>`,
 					} );
 				},
-			},
+			} ) ),
 		],
 		to: [
 			{

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -90,9 +90,9 @@ export const settings = {
 				} ),
 			},
 			{
-				type: 'pattern',
-				regExp: /^>\s/,
-				transform: ( { content } ) => {
+				type: 'prefix',
+				prefix: '>',
+				transform: ( content ) => {
 					return createBlock( 'core/quote', {
 						value: `<p>${ content }</p>`,
 					} );

--- a/packages/block-library/src/separator/index.js
+++ b/packages/block-library/src/separator/index.js
@@ -27,8 +27,7 @@ export const settings = {
 	transforms: {
 		from: [
 			{
-				type: 'pattern',
-				trigger: 'enter',
+				type: 'enter',
 				regExp: /^-{3,}$/,
 				transform: () => createBlock( 'core/separator' ),
 			},

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -111,12 +111,11 @@ export class RichText extends Component {
 		this.savedContent = value;
 		this.patterns = getPatterns( {
 			onReplace,
-			multilineTag: this.multilineTag,
+			onCreateUndoLevel: this.onCreateUndoLevel,
 			valueToFormat: this.valueToFormat,
 		} );
-		this.enterPatterns = getBlockTransforms( 'from' ).filter( ( { type, trigger } ) =>
-			type === 'pattern' && trigger === 'enter'
-		);
+		this.enterPatterns = getBlockTransforms( 'from' )
+			.filter( ( { type } ) => type === 'enter' );
 
 		this.state = {};
 

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -113,6 +113,7 @@ export class RichText extends Component {
 			onReplace,
 			onCreateUndoLevel: this.onCreateUndoLevel,
 			valueToFormat: this.valueToFormat,
+			onChange: this.onChange,
 		} );
 		this.enterPatterns = getBlockTransforms( 'from' )
 			.filter( ( { type } ) => type === 'enter' );

--- a/packages/editor/src/components/rich-text/patterns.js
+++ b/packages/editor/src/components/rich-text/patterns.js
@@ -1,18 +1,18 @@
 /**
- * External dependencies
- */
-import { filter } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { getBlockTransforms, findTransform } from '@wordpress/blocks';
-import { remove, applyFormat, getTextContent } from '@wordpress/rich-text';
+import {
+	remove,
+	applyFormat,
+	getTextContent,
+	getSelectionStart,
+	slice,
+} from '@wordpress/rich-text';
 
-export function getPatterns( { onReplace, multiline, valueToFormat } ) {
-	const patterns = filter( getBlockTransforms( 'from' ), ( { type, trigger } ) => {
-		return type === 'pattern' && trigger === undefined;
-	} );
+export function getPatterns( { onReplace, valueToFormat, onCreateUndoLevel } ) {
+	const prefixTransforms = getBlockTransforms( 'from' )
+		.filter( ( { type } ) => type === 'prefix' );
 
 	return [
 		( record ) => {
@@ -20,31 +20,32 @@ export function getPatterns( { onReplace, multiline, valueToFormat } ) {
 				return record;
 			}
 
+			const start = getSelectionStart( record );
 			const text = getTextContent( record );
-			const transformation = findTransform( patterns, ( item ) => {
-				return item.regExp.test( text );
+			const characterBefore = text.slice( start - 1, start );
+
+			if ( ! /\s/.test( characterBefore ) ) {
+				return record;
+			}
+
+			const trimmedTextBefore = text.slice( 0, start ).trim();
+			const transformation = findTransform( prefixTransforms, ( { prefix } ) => {
+				return trimmedTextBefore === prefix;
 			} );
 
 			if ( ! transformation ) {
 				return record;
 			}
 
-			const result = text.match( transformation.regExp );
+			const content = valueToFormat( slice( record, start, text.length ) );
+			const block = transformation.transform( content );
 
-			const block = transformation.transform( {
-				content: valueToFormat( remove( record, 0, result[ 0 ].length ) ),
-				match: result,
-			} );
-
+			onCreateUndoLevel();
 			onReplace( [ block ] );
 
 			return record;
 		},
 		( record ) => {
-			if ( multiline ) {
-				return record;
-			}
-
 			const text = getTextContent( record );
 
 			// Quick check the text for the necessary character.

--- a/test/e2e/specs/__snapshots__/rich-text.test.js.snap
+++ b/test/e2e/specs/__snapshots__/rich-text.test.js.snap
@@ -23,3 +23,15 @@ exports[`RichText should handle change in tag name gracefully 1`] = `
 <h3></h3>
 <!-- /wp:heading -->"
 `;
+
+exports[`RichText should transform backtick to code 1`] = `
+"<!-- wp:paragraph -->
+<p>A <code>backtick</code></p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`RichText should transform backtick to code 2`] = `
+"<!-- wp:paragraph -->
+<p>A \`backtick\`</p>
+<!-- /wp:paragraph -->"
+`;

--- a/test/e2e/specs/blocks/__snapshots__/code.test.js.snap
+++ b/test/e2e/specs/blocks/__snapshots__/code.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Code can be created by three backticks and enter 1`] = `
+"<!-- wp:code -->
+<pre class=\\"wp-block-code\\"><code>&lt;?php</code></pre>
+<!-- /wp:code -->"
+`;

--- a/test/e2e/specs/blocks/__snapshots__/heading.test.js.snap
+++ b/test/e2e/specs/blocks/__snapshots__/heading.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Separator can be created by prefixing existing content with number signs and a space 1`] = `
+"<!-- wp:heading {\\"level\\":4} -->
+<h4>4</h4>
+<!-- /wp:heading -->"
+`;
+
+exports[`Separator can be created by prefixing number sign and a space 1`] = `
+"<!-- wp:heading {\\"level\\":3} -->
+<h3>3</h3>
+<!-- /wp:heading -->"
+`;

--- a/test/e2e/specs/blocks/__snapshots__/list.test.js.snap
+++ b/test/e2e/specs/blocks/__snapshots__/list.test.js.snap
@@ -75,9 +75,9 @@ exports[`List can be created by using an asterisk at the start of a paragraph bl
 `;
 
 exports[`List can undo asterisk transform 1`] = `
-"<!-- wp:list {\\"ordered\\":true} -->
-<ol><li>November</li></ol>
-<!-- /wp:list -->"
+"<!-- wp:paragraph -->
+<p>1.</p>
+<!-- /wp:paragraph -->"
 `;
 
 exports[`List should create paragraph on split at end and merge back with content 1`] = `

--- a/test/e2e/specs/blocks/__snapshots__/list.test.js.snap
+++ b/test/e2e/specs/blocks/__snapshots__/list.test.js.snap
@@ -74,6 +74,12 @@ exports[`List can be created by using an asterisk at the start of a paragraph bl
 <!-- /wp:list -->"
 `;
 
+exports[`List can undo asterisk transform 1`] = `
+"<!-- wp:list {\\"ordered\\":true} -->
+<ol><li>November</li></ol>
+<!-- /wp:list -->"
+`;
+
 exports[`List should create paragraph on split at end and merge back with content 1`] = `
 "<!-- wp:list -->
 <ul><li>one</li></ul>

--- a/test/e2e/specs/blocks/__snapshots__/separator.test.js.snap
+++ b/test/e2e/specs/blocks/__snapshots__/separator.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Separator can be created by three dashes and enter 1`] = `
+"<!-- wp:separator -->
+<hr class=\\"wp-block-separator\\"/>
+<!-- /wp:separator -->"
+`;

--- a/test/e2e/specs/blocks/code.test.js
+++ b/test/e2e/specs/blocks/code.test.js
@@ -1,0 +1,23 @@
+/**
+ * Internal dependencies
+ */
+import {
+	clickBlockAppender,
+	getEditedPostContent,
+	newPost,
+} from '../../support/utils';
+
+describe( 'Code', () => {
+	beforeEach( async () => {
+		await newPost();
+	} );
+
+	it( 'can be created by three backticks and enter', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '```' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '<?php' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+} );

--- a/test/e2e/specs/blocks/heading.test.js
+++ b/test/e2e/specs/blocks/heading.test.js
@@ -1,0 +1,30 @@
+/**
+ * Internal dependencies
+ */
+import {
+	clickBlockAppender,
+	getEditedPostContent,
+	newPost,
+} from '../../support/utils';
+
+describe( 'Separator', () => {
+	beforeEach( async () => {
+		await newPost();
+	} );
+
+	it( 'can be created by prefixing number sign and a space', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '### 3' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'can be created by prefixing existing content with number signs and a space', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '4' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.type( '#### ' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+} );

--- a/test/e2e/specs/blocks/list.test.js
+++ b/test/e2e/specs/blocks/list.test.js
@@ -51,7 +51,6 @@ describe( 'List', () => {
 		await clickBlockAppender();
 		await page.keyboard.type( '1. ' );
 		await pressWithModifier( META_KEY, 'z' );
-		await page.keyboard.type( 'November' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );

--- a/test/e2e/specs/blocks/list.test.js
+++ b/test/e2e/specs/blocks/list.test.js
@@ -9,6 +9,7 @@ import {
 	convertBlock,
 	pressWithModifier,
 	insertBlock,
+	META_KEY,
 } from '../../support/utils';
 
 describe( 'List', () => {
@@ -42,6 +43,15 @@ describe( 'List', () => {
 		// Create a block with some text that will trigger a list creation.
 		await clickBlockAppender();
 		await page.keyboard.type( '1) A list item' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'can undo asterisk transform', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '1. ' );
+		await pressWithModifier( META_KEY, 'z' );
+		await page.keyboard.type( 'November' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );

--- a/test/e2e/specs/blocks/list.test.js
+++ b/test/e2e/specs/blocks/list.test.js
@@ -9,7 +9,6 @@ import {
 	convertBlock,
 	pressWithModifier,
 	insertBlock,
-	META_KEY,
 } from '../../support/utils';
 
 describe( 'List', () => {
@@ -50,7 +49,7 @@ describe( 'List', () => {
 	it( 'can undo asterisk transform', async () => {
 		await clickBlockAppender();
 		await page.keyboard.type( '1. ' );
-		await pressWithModifier( META_KEY, 'z' );
+		await pressWithModifier( 'primary', 'z' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );

--- a/test/e2e/specs/blocks/separator.test.js
+++ b/test/e2e/specs/blocks/separator.test.js
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import {
+	clickBlockAppender,
+	getEditedPostContent,
+	newPost,
+} from '../../support/utils';
+
+describe( 'Separator', () => {
+	beforeEach( async () => {
+		await newPost();
+	} );
+
+	it( 'can be created by three dashes and enter', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '---' );
+		await page.keyboard.press( 'Enter' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+} );

--- a/test/e2e/specs/rich-text.test.js
+++ b/test/e2e/specs/rich-text.test.js
@@ -63,7 +63,7 @@ describe( 'RichText', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 
-		await pressWithModifier( META_KEY, 'z' );
+		await pressWithModifier( 'primary', 'z' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );

--- a/test/e2e/specs/rich-text.test.js
+++ b/test/e2e/specs/rich-text.test.js
@@ -56,4 +56,15 @@ describe( 'RichText', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should transform backtick to code', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'A `backtick`' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await pressWithModifier( META_KEY, 'z' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );


### PR DESCRIPTION
## Description

Fixes #11358.

This PR adjusts the prefix transforms so that they only execute when they match text right at the caret, so that they are undoable, and makes the check faster checking if the previous character is a space and not using any regular expressions otherwise on the whole text. Also adds e2e tests for all prefix and enter transforms, and adds some documentation.

## How has this been tested?
Extra e2e tests have been added, but ensure e.g. list shortcuts like `1. ` still work and it's possible to undo them and have it so that the prefix can be at the start without it being transformed.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
