### PR TITLE
RichText: Fix applying formats on multiline values without wrapper tags

### DIFF
--- a/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
+++ b/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
@@ -301,6 +301,22 @@ exports[`recordToDom should handle selection before br 1`] = `
 </body>
 `;
 
+exports[`recordToDom should ignore formats at line separator 1`] = `
+<body>
+  <p>
+    <em>
+      one
+    </em>
+  </p>
+  <p>
+    <em>
+      two
+    </em>
+    
+  </p>
+</body>
+`;
+
 exports[`recordToDom should ignore line breaks to format HTML 1`] = `
 <body>
   

--- a/packages/rich-text/src/test/create.js
+++ b/packages/rich-text/src/test/create.js
@@ -32,6 +32,10 @@ describe( 'create', () => {
 		createRange,
 		record,
 	} ) => {
+		if ( html === undefined ) {
+			return;
+		}
+
 		it( description, () => {
 			const element = createElement( document, html );
 			const range = createRange( element );

--- a/packages/rich-text/src/test/helpers/index.js
+++ b/packages/rich-text/src/test/helpers/index.js
@@ -531,6 +531,16 @@ export const spec = [
 		},
 	},
 	{
+		description: 'should ignore formats at line separator',
+		multilineTag: 'p',
+		startPath: [],
+		endPath: [],
+		record: {
+			formats: [ [ em ], [ em ], [ em ], [ em ], [ em ], [ em ], [ em ] ],
+			text: 'one\u2028two',
+		},
+	},
+	{
 		description: 'should remove br with settings',
 		settings: {
 			unwrapNode: ( node ) => !! node.getAttribute( 'data-mce-bogus' ),

--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -45,7 +45,7 @@ function fromFormat( { type, attributes, object } ) {
 export function toTree( {
 	value,
 	multilineTag,
-	multilineWrapperTags,
+	multilineWrapperTags = [],
 	createEmpty,
 	append,
 	getLastChild,


### PR DESCRIPTION
## Description
An error occurs if you select two or more lines in e.g. a quote block and make it bold.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->