### PR TITLE
add :root selector to IS_ROOT_TAG for editor-styles

### DIFF
--- a/packages/editor/src/editor-styles/transforms/wrap.js
+++ b/packages/editor/src/editor-styles/transforms/wrap.js
@@ -6,7 +6,7 @@ import { includes } from 'lodash';
 /**
  * @const string IS_ROOT_TAG Regex to check if the selector is a root tag selector.
  */
-const IS_ROOT_TAG = /^(body|html).*$/;
+const IS_ROOT_TAG = /^(body|html|:root).*$/;
 
 const wrap = ( namespace, ignore = [] ) => ( node ) => {
 	const updateSelector = ( selector ) => {
@@ -20,7 +20,7 @@ const wrap = ( namespace, ignore = [] ) => ( node ) => {
 		}}
 
 		// HTML and Body elements cannot be contained within our container so lets extract their styles.
-		return selector.replace( /^(body|html)/, namespace );
+		return selector.replace( /^(body|html|:root)/, namespace );
 	};
 
 	if ( node.type === 'rule' ) {


### PR DESCRIPTION
## Description
The `:root` selector should be treated the same as the `html` selector. https://developer.mozilla.org/en-US/docs/Web/CSS/:root

In addition to covering direct `:root` styles, CSS Custom Properties applied to `:root` will now be available for editor-styles.

## How has this been tested?
visual tests confirmed that styles on `:root` are now applied to the Wrapping Class.

## Screenshots <!-- if applicable -->

## Types of changes
this
```
:root {
	--color-1: green;
}

.wp-block-button__link {
	background-color: var(--color-1);
}
```
becomes this
```
.editor-styles-wrapper {
	--color-1: green;
}

.editor-styles-wrapper .wp-block-button__link {
	background-color: var(--color-1);
}
```

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
