### PR TITLE
Fix: Translator comments are not included for quote and pullquote placeholders

### DIFF
--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -84,15 +84,19 @@ class PullQuoteEdit extends Component {
 									value: nextValue,
 								} )
 							}
-							/* translators: placeholder text used for the quote */
-							placeholder={ __( 'Write quote…' ) }
+							placeholder={
+								// translators: placeholder text used for the quote
+								__( 'Write quote…' )
+							}
 							wrapperClassName="block-library-pullquote__content"
 						/>
 						{ ( ! RichText.isEmpty( citation ) || isSelected ) && (
 							<RichText
 								value={ citation }
-								/* translators: placeholder text used for the citation */
-								placeholder={ __( 'Write citation…' ) }
+								placeholder={
+									// translators: placeholder text used for the citation
+									__( 'Write citation…' )
+								}
 								onChange={
 									( nextCitation ) => setAttributes( {
 										citation: nextCitation,

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -215,8 +215,10 @@ export const settings = {
 								onReplace( [] );
 							}
 						} }
-						/* translators: placeholder text used for the quote */
-						placeholder={ __( 'Write quote…' ) }
+						placeholder={
+							// translators: placeholder text used for the quote
+							__( 'Write quote…' )
+						}
 					/>
 					{ ( ! RichText.isEmpty( citation ) || isSelected ) && (
 						<RichText
@@ -226,8 +228,10 @@ export const settings = {
 									citation: nextCitation,
 								} )
 							}
-							/* translators: placeholder text used for the citation */
-							placeholder={ __( 'Write citation…' ) }
+							placeholder={
+								// translators: placeholder text used for the citation
+								__( 'Write citation…' )
+							}
 							className="wp-block-quote__citation"
 						/>
 					) }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/11494

The translator comments for quote and pullquote placeholders were not included in the "/languages/gutenberg-translations.php" file.
This PR just applies very simple changes to the source without any functional meaning to make sure the translator comments appear.


## How has this been tested?
Generate the /languages/gutenberg-translations.php file e.g: by executing ./bin/build-plugin-zip.sh.
Verify the file contains the translator comments "placeholder text used for the citation" and "placeholder text used for the quote" (a search for the strings is enough to check, in master it does not contain the translator comments).
