### PR TITLE
Do not display post link when the Post Type is not viewable

### DIFF
--- a/packages/editor/src/components/post-publish-panel/postpublish.js
+++ b/packages/editor/src/components/post-publish-panel/postpublish.js
@@ -58,10 +58,25 @@ class PostPublishPanelPostpublish extends Component {
 		const { children, isScheduled, post, postType } = this.props;
 		const postLabel = get( postType, [ 'labels', 'singular_name' ] );
 		const viewPostLabel = get( postType, [ 'labels', 'view_item' ] );
+		const isViewable = get( postType, [ 'viewable' ], false );
 
-		const postPublishNonLinkHeader = isScheduled ?
+		let postPublishNonLinkHeader = isScheduled ?
 			<Fragment>{ __( 'is now scheduled. It will go live on' ) } <PostScheduleLabel />.</Fragment> :
 			__( 'is now live.' );
+
+		if ( ! isViewable ) {
+			postPublishNonLinkHeader = isScheduled ?
+				<Fragment>{ __( 'is now scheduled. It will be published on' ) } <PostScheduleLabel />.</Fragment> :
+				__( 'is now published.' );
+
+			return (
+				<div className="post-publish-panel__postpublish">
+					<PanelBody className="post-publish-panel__postpublish-header">
+						{ post.title || __( '(no title)' ) } { postPublishNonLinkHeader }
+					</PanelBody>
+				</div>
+			);
+		}
 
 		return (
 			<div className="post-publish-panel__postpublish">


### PR DESCRIPTION
The wp_block is a good example: when you create a new reusable block from the editor, the success notice and the publish panel should not display links to the saved reusable block as these links lead to nowhere on the front-end. This can concern any post type setting their public property to false.

## Description
I've added checks on the viewable property of the Post Type to make sure links leading to nowhere are not displayed within the editor notices or Publish panel when this property is set to false.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
1. I've tested my changes creating new reusable blocks from the Add New button of the reusable blocks management screen to check a not viewable post type has not front-end links displayed.
2. I've tested my changes with regular (& viewable) post type to check these changes had no impact on the viewable post type.

<!-- Include details of your testing environment, tests ran to see how -->
Gutenberg master / WordPress 5.0-beta3-20181106.024238

## Screenshots

![bugnotviewable](https://user-images.githubusercontent.com/1834524/48042282-36ba2600-e181-11e8-9b08-c48fce533ad3.png)

Without the changes, red arrows are showing the parts that the editor should not display for a not viewable post type.

![fixednoticepublishpanel](https://user-images.githubusercontent.com/1834524/48042324-74b74a00-e181-11e8-9657-5ee5c8c5050c.png)

With the changes, green arrows are showing how parts have been edited for the not viewable post types.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->


closes #8151