### PR TITLE
Update the block styles registration to avoid timing issues

### DIFF
--- a/docs/data/data-core-blocks.md
+++ b/docs/data/data-core-blocks.md
@@ -23,6 +23,19 @@ Returns a block type by name.
 
 Block Type.
 
+### getBlockStyles
+
+Returns block styles by block name.
+
+*Parameters*
+
+ * state: Data state.
+ * name: Block type name.
+
+*Returns*
+
+Block Styles.
+
 ### getCategories
 
 Returns all the available categories.
@@ -160,6 +173,24 @@ Returns an action object used to remove a registered block type.
 *Parameters*
 
  * names: Block name.
+
+### addBlockStyles
+
+Returns an action object used in signalling that new block styles have been added.
+
+*Parameters*
+
+ * blockName: Block name.
+ * styles: Block styles.
+
+### removeBlockStyles
+
+Returns an action object used in signalling that block styles have been removed.
+
+*Parameters*
+
+ * blockName: Block name.
+ * styleNames: Block style names.
 
 ### setDefaultBlockName
 

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### New feature
 
 - `getBlockAttributes`, `getBlockTransforms`, `getSaveContent`, `getSaveElement` and `isValidBlockContent` methods can now take also block's name as the first param ([#11490](https://github.com/WordPress/gutenberg/pull/11490)). Passing a block's type object continues to work as before.
+- `registerBlockStyles` and `unregisterBlockStyles` can be triggered at any moment (before or after block registration).
 
 ## 5.2.0 (2018-11-09)
 
@@ -16,7 +17,7 @@
 
 ## 5.1.0 (2018-10-30)
 
-### New feature
+### New features
 
 - `isValidBlockContent` function has been added ([#10891](https://github.com/WordPress/gutenberg/pull/10891)).
 

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -3,12 +3,12 @@
 /**
  * External dependencies
  */
-import { get, isFunction, some, reject } from 'lodash';
+import { get, isFunction, some } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { applyFilters, addFilter } from '@wordpress/hooks';
+import { applyFilters } from '@wordpress/hooks';
 import { select, dispatch } from '@wordpress/data';
 
 /**
@@ -329,19 +329,7 @@ export const hasChildBlocksWithInserterSupport = ( blockName ) => {
  * @param {Object} styleVariation Object containing `name` which is the class name applied to the block and `label` which identifies the variation to the user.
  */
 export const registerBlockStyle = ( blockName, styleVariation ) => {
-	addFilter( 'blocks.registerBlockType', `${ blockName }/${ styleVariation.name }`, ( settings, name ) => {
-		if ( blockName !== name ) {
-			return settings;
-		}
-
-		return {
-			...settings,
-			styles: [
-				...get( settings, [ 'styles' ], [] ),
-				styleVariation,
-			],
-		};
-	} );
+	dispatch( 'core/blocks' ).addBlockStyles( blockName, styleVariation );
 };
 
 /**
@@ -351,14 +339,5 @@ export const registerBlockStyle = ( blockName, styleVariation ) => {
  * @param {string} styleVariationName Name of class applied to the block.
  */
 export const unregisterBlockStyle = ( blockName, styleVariationName ) => {
-	addFilter( 'blocks.registerBlockType', `${ blockName }/${ styleVariationName }/unregister`, ( settings, name ) => {
-		if ( blockName !== name ) {
-			return settings;
-		}
-
-		return {
-			...settings,
-			styles: reject( get( settings, [ 'styles' ], [] ), { name: styleVariationName } ),
-		};
-	} );
+	dispatch( 'core/blocks' ).removeBlockStyles( blockName, styleVariationName );
 };

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -28,8 +28,6 @@ import {
 	hasBlockSupport,
 	isReusableBlock,
 	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase
-	registerBlockStyle,
-	unregisterBlockStyle,
 } from '../registration';
 
 describe( 'blocks', () => {
@@ -582,90 +580,6 @@ describe( 'blocks', () => {
 		it( 'should return false for other blocks', () => {
 			const block = { name: 'core/paragraph' };
 			expect( isReusableBlock( block ) ).toBe( false );
-		} );
-	} );
-
-	describe( 'registerBlockStyle', () => {
-		afterEach( () => {
-			removeFilter( 'blocks.registerBlockType', 'my-plugin/block-without-styles/big' );
-			removeFilter( 'blocks.registerBlockType', 'my-plugin/block-without-styles/small' );
-		} );
-
-		it( 'should add styles', () => {
-			registerBlockStyle( 'my-plugin/block-without-styles', { name: 'big', label: 'Big style' } );
-			const settings = registerBlockType( 'my-plugin/block-without-styles', defaultBlockSettings );
-
-			expect( settings.styles ).toEqual( [
-				{ name: 'big', label: 'Big style' },
-			] );
-		} );
-
-		it( 'should accumulate styles', () => {
-			registerBlockStyle( 'my-plugin/block-without-styles', { name: 'small', label: 'Small style' } );
-			registerBlockStyle( 'my-plugin/block-without-styles', { name: 'big', label: 'Big style' } );
-			const settings = registerBlockType( 'my-plugin/block-without-styles', {
-				...defaultBlockSettings,
-				styles: [ { name: 'normal', label: 'Normal style' } ],
-			} );
-
-			expect( settings.styles ).toEqual( [
-				{ name: 'normal', label: 'Normal style' },
-				{ name: 'small', label: 'Small style' },
-				{ name: 'big', label: 'Big style' },
-			] );
-		} );
-	} );
-
-	describe( 'unregisterBlockStyle', () => {
-		afterEach( () => {
-			removeFilter( 'blocks.registerBlockType', 'my-plugin/block-with-styles/big/unregister' );
-			removeFilter( 'blocks.registerBlockType', 'my-plugin/block-with-styles/small/unregister' );
-			removeFilter( 'blocks.registerBlockType', 'my-plugin/block-with-styles/big' );
-			removeFilter( 'blocks.registerBlockType', 'my-plugin/block-with-styles/small' );
-		} );
-
-		it( 'should remove styles', () => {
-			unregisterBlockStyle( 'my-plugin/block-with-styles', 'big' );
-			const settings = registerBlockType( 'my-plugin/block-with-styles', {
-				...defaultBlockSettings,
-				styles: [ { name: 'big', label: 'Big style' } ],
-			} );
-
-			expect( settings.styles ).toEqual( [] );
-		} );
-
-		it( 'should keep other styles', () => {
-			unregisterBlockStyle( 'my-plugin/block-with-styles', 'small' );
-			const settings = registerBlockType( 'my-plugin/block-with-styles', {
-				...defaultBlockSettings,
-				styles: [
-					{ name: 'normal', label: 'Normal style' },
-					{ name: 'small', label: 'Small style' },
-					{ name: 'big', label: 'Big style' },
-				],
-			} );
-
-			expect( settings.styles ).toEqual( [
-				{ name: 'normal', label: 'Normal style' },
-				{ name: 'big', label: 'Big style' },
-			] );
-		} );
-
-		it( 'should remove a prior registerBlockStyle', () => {
-			registerBlockStyle( 'my-plugin/block-with-styles', { name: 'big', label: 'Big style' } );
-			registerBlockStyle( 'my-plugin/block-with-styles', { name: 'small', label: 'Small style' } );
-			unregisterBlockStyle( 'my-plugin/block-with-styles', 'big' );
-			const settings = registerBlockType( 'my-plugin/block-with-styles', {
-				...defaultBlockSettings,
-				styles: [
-					{ name: 'normal', label: 'Normal style' },
-				],
-			} );
-
-			expect( settings.styles ).toEqual( [
-				{ name: 'normal', label: 'Normal style' },
-				{ name: 'small', label: 'Small style' },
-			] );
 		} );
 	} );
 } );

--- a/packages/blocks/src/store/actions.js
+++ b/packages/blocks/src/store/actions.js
@@ -32,6 +32,38 @@ export function removeBlockTypes( names ) {
 }
 
 /**
+ * Returns an action object used in signalling that new block styles have been added.
+ *
+ * @param {string}       blockName  Block name.
+ * @param {Array|Object} styles     Block styles.
+ *
+ * @return {Object} Action object.
+ */
+export function addBlockStyles( blockName, styles ) {
+	return {
+		type: 'ADD_BLOCK_STYLES',
+		styles: castArray( styles ),
+		blockName,
+	};
+}
+
+/**
+ * Returns an action object used in signalling that block styles have been removed.
+ *
+ * @param {string}       blockName  Block name.
+ * @param {Array|string} styleNames Block style names.
+ *
+ * @return {Object} Action object.
+ */
+export function removeBlockStyles( blockName, styleNames ) {
+	return {
+		type: 'REMOVE_BLOCK_STYLES',
+		styleNames: castArray( styleNames ),
+		blockName,
+	};
+}
+
+/**
  * Returns an action object used to set the default block name.
  *
  * @param {string} name Block name.

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { keyBy, omit } from 'lodash';
+import { keyBy, omit, mapValues, get, uniqBy, filter } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -44,6 +44,47 @@ export function blockTypes( state = {}, action ) {
 }
 
 /**
+ * Reducer managing the block style variations.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function blockStyles( state = {}, action ) {
+	switch ( action.type ) {
+		case 'ADD_BLOCK_TYPES':
+			return {
+				...state,
+				...mapValues( keyBy( action.blockTypes, 'name' ), ( blockType ) => {
+					return uniqBy( [
+						...get( blockType, [ 'styles' ], [] ),
+						...get( state, [ blockType.name ], [] ),
+					], ( style ) => style.name );
+				} ),
+			};
+		case 'ADD_BLOCK_STYLES':
+			return {
+				...state,
+				[ action.blockName ]: uniqBy( [
+					...get( state, [ action.blockName ], [] ),
+					...( action.styles ),
+				], ( style ) => style.name ),
+			};
+		case 'REMOVE_BLOCK_STYLES':
+			return {
+				...state,
+				[ action.blockName ]: filter(
+					get( state, [ action.blockName ], [] ),
+					( style ) => action.styleNames.indexOf( style.name ) === -1,
+				),
+			};
+	}
+
+	return state;
+}
+
+/**
  * Higher-order Reducer creating a reducer keeping track of given block name.
  *
  * @param {string} setActionType  Action type.
@@ -68,7 +109,6 @@ export function createBlockNameSetterReducer( setActionType ) {
 }
 
 export const defaultBlockName = createBlockNameSetterReducer( 'SET_DEFAULT_BLOCK_NAME' );
-
 export const freeformFallbackBlockName = createBlockNameSetterReducer( 'SET_FREEFORM_FALLBACK_BLOCK_NAME' );
 export const unregisteredFallbackBlockName = createBlockNameSetterReducer( 'SET_UNREGISTERED_FALLBACK_BLOCK_NAME' );
 
@@ -90,6 +130,7 @@ export function categories( state = DEFAULT_CATEGORIES, action ) {
 
 export default combineReducers( {
 	blockTypes,
+	blockStyles,
 	defaultBlockName,
 	freeformFallbackBlockName,
 	unregisteredFallbackBlockName,

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { keyBy, omit, mapValues, get, uniqBy, filter } from 'lodash';
+import { keyBy, omit, mapValues, get, uniqBy, filter, map } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -34,7 +34,10 @@ export function blockTypes( state = {}, action ) {
 		case 'ADD_BLOCK_TYPES':
 			return {
 				...state,
-				...keyBy( action.blockTypes, 'name' ),
+				...keyBy(
+					map( action.blockTypes, ( blockType ) => omit( blockType, 'styles ' ) ),
+					'name'
+				),
 			};
 		case 'REMOVE_BLOCK_TYPES':
 			return omit( state, action.names );

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -31,6 +31,18 @@ export function getBlockType( state, name ) {
 }
 
 /**
+ * Returns block styles by block name.
+ *
+ * @param {Object} state Data state.
+ * @param {string} name  Block type name.
+ *
+ * @return {Array?} Block Styles.
+ */
+export function getBlockStyles( state, name ) {
+	return state.blockStyles[ name ];
+}
+
+/**
  * Returns all the available categories.
  *
  * @param {Object} state Data state.

--- a/packages/blocks/src/store/test/reducer.js
+++ b/packages/blocks/src/store/test/reducer.js
@@ -7,6 +7,7 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import {
+	blockStyles,
 	blockTypes,
 	categories,
 	defaultBlockName,
@@ -20,7 +21,7 @@ describe( 'blockTypes', () => {
 		expect( blockTypes( undefined, {} ) ).toEqual( {} );
 	} );
 
-	it( 'should add add a new block type', () => {
+	it( 'should add a new block type', () => {
 		const original = deepFreeze( {
 			'core/paragraph': { name: 'core/paragraph' },
 		} );
@@ -49,6 +50,87 @@ describe( 'blockTypes', () => {
 
 		expect( state ).toEqual( {
 			'core/paragraph': { name: 'core/paragraph' },
+		} );
+	} );
+} );
+
+describe( 'blockStyles', () => {
+	it( 'should return an empty object as default state', () => {
+		expect( blockStyles( undefined, {} ) ).toEqual( {} );
+	} );
+
+	it( 'should add a new block styles', () => {
+		const original = deepFreeze( {} );
+
+		let state = blockStyles( original, {
+			type: 'ADD_BLOCK_STYLES',
+			blockName: 'core/image',
+			styles: [ { name: 'fancy' } ],
+		} );
+
+		expect( state ).toEqual( {
+			'core/image': [
+				{ name: 'fancy' },
+			],
+		} );
+
+		state = blockStyles( state, {
+			type: 'ADD_BLOCK_STYLES',
+			blockName: 'core/image',
+			styles: [ { name: 'lightbox' } ],
+		} );
+
+		expect( state ).toEqual( {
+			'core/image': [
+				{ name: 'fancy' },
+				{ name: 'lightbox' },
+			],
+		} );
+	} );
+
+	it( 'should add block styles when adding a block', () => {
+		const original = deepFreeze( {
+			'core/image': [
+				{ name: 'fancy' },
+			],
+		} );
+
+		const state = blockStyles( original, {
+			type: 'ADD_BLOCK_TYPES',
+			blockTypes: [ {
+				name: 'core/image',
+				styles: [
+					{ name: 'original' },
+				],
+			} ],
+		} );
+
+		expect( state ).toEqual( {
+			'core/image': [
+				{ name: 'original' },
+				{ name: 'fancy' },
+			],
+		} );
+	} );
+
+	it( 'should remove block styles', () => {
+		const original = deepFreeze( {
+			'core/image': [
+				{ name: 'fancy' },
+				{ name: 'lightbox' },
+			],
+		} );
+
+		const state = blockStyles( original, {
+			type: 'REMOVE_BLOCK_STYLES',
+			blockName: 'core/image',
+			styleNames: [ 'fancy' ],
+		} );
+
+		expect( state ).toEqual( {
+			'core/image': [
+				{ name: 'lightbox' },
+			],
 		} );
 	} );
 } );

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.2.1 (Unreleased)
+
+### Polish
+
+- Reactive block styles.
+
 ## 6.2.0 (2018-11-09)
 
 ### New Features

--- a/packages/editor/src/components/block-inspector/index.js
+++ b/packages/editor/src/components/block-inspector/index.js
@@ -21,7 +21,7 @@ import InspectorControls from '../inspector-controls';
 import InspectorAdvancedControls from '../inspector-advanced-controls';
 import BlockStyles from '../block-styles';
 
-const BlockInspector = ( { selectedBlock, blockType, count } ) => {
+const BlockInspector = ( { selectedBlock, blockType, count, hasBlockStyles } ) => {
 	if ( count > 1 ) {
 		return <span className="editor-block-inspector__multi-blocks">{ __( 'Coming Soon' ) }</span>;
 	}
@@ -46,7 +46,7 @@ const BlockInspector = ( { selectedBlock, blockType, count } ) => {
 					<div className="editor-block-inspector__card-description">{ blockType.description }</div>
 				</div>
 			</div>
-			{ !! blockType.styles && (
+			{ hasBlockStyles && (
 				<div>
 					<PanelBody
 						title={ __( 'Styles' ) }
@@ -80,12 +80,15 @@ const BlockInspector = ( { selectedBlock, blockType, count } ) => {
 export default withSelect(
 	( select ) => {
 		const { getSelectedBlock, getSelectedBlockCount } = select( 'core/editor' );
+		const { getBlockStyles } = select( 'core/blocks' );
 		const selectedBlock = getSelectedBlock();
 		const blockType = selectedBlock && getBlockType( selectedBlock.name );
+		const blockStyles = selectedBlock && getBlockStyles( selectedBlock.name );
 		return {
+			count: getSelectedBlockCount(),
+			hasBlockStyles: blockStyles && blockStyles.length > 0,
 			selectedBlock,
 			blockType,
-			count: getSelectedBlockCount(),
 		};
 	}
 )( BlockInspector );

--- a/packages/editor/src/components/block-styles/index.js
+++ b/packages/editor/src/components/block-styles/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, get, noop } from 'lodash';
+import { find, noop } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -9,7 +9,6 @@ import classnames from 'classnames';
  */
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { getBlockType } from '@wordpress/blocks';
 import TokenList from '@wordpress/token-list';
 import { ENTER, SPACE } from '@wordpress/keycodes';
 
@@ -72,7 +71,7 @@ function BlockStyles( {
 	onSwitch = noop,
 	onHoverClassName = noop,
 } ) {
-	if ( ! styles ) {
+	if ( ! styles || styles.length === 0 ) {
 		return null;
 	}
 
@@ -129,13 +128,15 @@ function BlockStyles( {
 
 export default compose( [
 	withSelect( ( select, { clientId } ) => {
-		const block = select( 'core/editor' ).getBlock( clientId );
+		const { getBlock } = select( 'core/editor' );
+		const { getBlockStyles } = select( 'core/blocks' );
+		const block = getBlock( clientId );
 
 		return {
 			name: block.name,
 			attributes: block.attributes,
 			className: block.attributes.className || '',
-			styles: get( getBlockType( block.name ), [ 'styles' ] ),
+			styles: getBlockStyles( block.name ),
 		};
 	} ),
 	withDispatch( ( dispatch, { clientId } ) => {

--- a/packages/editor/src/components/block-switcher/index.js
+++ b/packages/editor/src/components/block-switcher/index.js
@@ -169,7 +169,8 @@ export default compose(
 		const { getBlockStyles } = select( 'core/blocks' );
 		const rootClientId = getBlockRootClientId( first( castArray( clientIds ) ) );
 		const blocks = getBlocksByClientId( clientIds );
-		const styles = blocks && blocks.length === 1 && getBlockStyles( blocks[ 0 ].name );
+		const firstBlock = blocks && blocks.length === 1 ? blocks[ 0 ] : null;
+		const styles = firstBlock && getBlockStyles( firstBlock.name );
 		return {
 			blocks,
 			inserterItems: getInserterItems( rootClientId ),

--- a/packages/editor/src/components/block-switcher/index.js
+++ b/packages/editor/src/components/block-switcher/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { castArray, filter, first, get, mapKeys, orderBy } from 'lodash';
+import { castArray, filter, first, mapKeys, orderBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -36,7 +36,7 @@ export class BlockSwitcher extends Component {
 	}
 
 	render() {
-		const { blocks, onTransform, inserterItems } = this.props;
+		const { blocks, onTransform, inserterItems, hasBlockStyles } = this.props;
 		const { hoveredClassName } = this.state;
 
 		if ( ! blocks || ! blocks.length ) {
@@ -55,9 +55,8 @@ export class BlockSwitcher extends Component {
 
 		const sourceBlockName = blocks[ 0 ].name;
 		const blockType = getBlockType( sourceBlockName );
-		const hasStyles = blocks.length === 1 && get( blockType, [ 'styles' ], [] ).length !== 0;
 
-		if ( ! hasStyles && ! possibleBlockTransformations.length ) {
+		if ( ! hasBlockStyles && ! possibleBlockTransformations.length ) {
 			if ( blocks.length > 1 ) {
 				return null;
 			}
@@ -119,7 +118,7 @@ export class BlockSwitcher extends Component {
 				} }
 				renderContent={ ( { onClose } ) => (
 					<Fragment>
-						{ hasStyles &&
+						{ hasBlockStyles &&
 							<PanelBody
 								title={ __( 'Block Styles' ) }
 								initialOpen
@@ -167,10 +166,14 @@ export class BlockSwitcher extends Component {
 export default compose(
 	withSelect( ( select, { clientIds } ) => {
 		const { getBlocksByClientId, getBlockRootClientId, getInserterItems } = select( 'core/editor' );
+		const { getBlockStyles } = select( 'core/blocks' );
 		const rootClientId = getBlockRootClientId( first( castArray( clientIds ) ) );
+		const blocks = getBlocksByClientId( clientIds );
+		const styles = blocks && blocks.length === 1 && getBlockStyles( blocks[ 0 ].name );
 		return {
-			blocks: getBlocksByClientId( clientIds ),
+			blocks,
 			inserterItems: getInserterItems( rootClientId ),
+			hasBlockStyles: styles && styles.length > 0,
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => ( {


### PR DESCRIPTION
closes #11392 

At the moment, registering blockStyle variations is very fragile because you have to register it before the block registers itself and at the same time the block registers itself before the dom is ready which makes it very hard to do properly.

In this PR, I'm updating the block styles registration:

 - Moving away from filters
 - Using a separate reducer to keep track of block styles
 - Instead of relying on `getBlockType` to fetch the styles, rely on a selector (reactive)

This way we can register/unregister block styles at any moment.

---
I'd also argue that we should stop using `getBlockType` and `getBlockTypes` entirely and try to refactor our code to use the selectors instead. So any change that would happen to the block settings after the initial registration would be taken into consideration in the UI.

**Testing instructions**

 - Open the console and register a style variation: `wp.blocks.registerBlockStyle( 'core/image', { name: 'fancy' } )`
 - Insert an image, you should see the block style variation in the block switcher menu.