### PR TITLE
fix: Media on the right option in MediaText block

### DIFF
--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -7,7 +7,7 @@
 	align-items: center;
 	grid-template-areas: "media-text-media media-text-content";
 	grid-template-columns: 50% auto;
-	.has-media-on-the-right {
+	&.has-media-on-the-right {
 		grid-template-areas: "media-text-content media-text-media";
 		grid-template-columns: auto 50%;
 	}


### PR DESCRIPTION
What happens is:

When we select 'Show media on right' option, the editor shows it correctly.
![screen shot 2018-11-06 at 12 09 23](https://user-images.githubusercontent.com/15556410/48063445-fb3d4d00-e1bc-11e8-9dd3-dced72878984.png)

But on the front end, media is shown on the left.
![screen shot 2018-11-06 at 12 09 41](https://user-images.githubusercontent.com/15556410/48063466-0b552c80-e1bd-11e8-9ec2-8c21bad017b1.png)

This PR fixes the css rule.
