### PR TITLE
Separate Paste Handler

### DIFF
--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -11,7 +11,7 @@ export {
 	getBlockAttributes,
 	parseWithAttributeSchema,
 } from './parser';
-export { default as rawHandler, getPhrasingContentSchema } from './raw-handling';
+export { pasteHandler, rawHandler, getPhrasingContentSchema } from './raw-handling';
 export {
 	default as serialize,
 	getBlockContent,

--- a/packages/editor/src/components/block-drop-zone/index.js
+++ b/packages/editor/src/components/block-drop-zone/index.js
@@ -11,7 +11,7 @@ import {
 	withFilters,
 } from '@wordpress/components';
 import {
-	rawHandler,
+	pasteHandler,
 	getBlockTransforms,
 	findTransform,
 } from '@wordpress/blocks';
@@ -70,7 +70,7 @@ class BlockDropZone extends Component {
 	}
 
 	onHTMLDrop( HTML, position ) {
-		const blocks = rawHandler( { HTML, mode: 'BLOCKS' } );
+		const blocks = pasteHandler( { HTML, mode: 'BLOCKS' } );
 
 		if ( blocks.length ) {
 			this.props.insertBlocks( blocks, this.getInsertIndex( position ) );

--- a/packages/editor/src/components/block-list/block-invalid-warning.js
+++ b/packages/editor/src/components/block-list/block-invalid-warning.js
@@ -94,7 +94,6 @@ const blockToHTML = ( block ) => createBlock( 'core/html', {
 } );
 const blockToBlocks = ( block ) => rawHandler( {
 	HTML: block.originalContent,
-	mode: 'BLOCKS',
 } );
 
 export default withDispatch( ( dispatch, { block } ) => {

--- a/packages/editor/src/components/block-settings-menu/block-html-convert-button.js
+++ b/packages/editor/src/components/block-settings-menu/block-html-convert-button.js
@@ -12,22 +12,17 @@ import BlockConvertButton from './block-convert-button';
 
 export default compose(
 	withSelect( ( select, { clientId } ) => {
-		const { getBlock, canUserUseUnfilteredHTML } = select( 'core/editor' );
-		const block = getBlock( clientId );
+		const block = select( 'core/editor' ).getBlock( clientId );
+
 		return {
 			block,
-			canUserUseUnfilteredHTML: canUserUseUnfilteredHTML(),
 			shouldRender: ( block && block.name === 'core/html' ),
 		};
 	} ),
-	withDispatch( ( dispatch, { block, canUserUseUnfilteredHTML } ) => ( {
+	withDispatch( ( dispatch, { block } ) => ( {
 		onClick: () => dispatch( 'core/editor' ).replaceBlocks(
 			block.clientId,
-			rawHandler( {
-				HTML: getBlockContent( block ),
-				mode: 'BLOCKS',
-				canUserUseUnfilteredHTML,
-			} ),
+			rawHandler( { HTML: getBlockContent( block ) } ),
 		),
 	} ) ),
 )( BlockConvertButton );

--- a/packages/editor/src/components/block-settings-menu/block-unknown-convert-button.js
+++ b/packages/editor/src/components/block-settings-menu/block-unknown-convert-button.js
@@ -12,22 +12,17 @@ import BlockConvertButton from './block-convert-button';
 
 export default compose(
 	withSelect( ( select, { clientId } ) => {
-		const { canUserUseUnfilteredHTML, getBlock } = select( 'core/editor' );
-		const block = getBlock( clientId );
+		const block = select( 'core/editor' ).getBlock( clientId );
+
 		return {
 			block,
-			canUserUseUnfilteredHTML: canUserUseUnfilteredHTML(),
 			shouldRender: ( block && block.name === getFreeformContentHandlerName() ),
 		};
 	} ),
-	withDispatch( ( dispatch, { block, canUserUseUnfilteredHTML } ) => ( {
+	withDispatch( ( dispatch, { block } ) => ( {
 		onClick: () => dispatch( 'core/editor' ).replaceBlocks(
 			block.clientId,
-			rawHandler( {
-				HTML: serialize( block ),
-				mode: 'BLOCKS',
-				canUserUseUnfilteredHTML,
-			} )
+			rawHandler( { HTML: serialize( block ) } )
 		),
 	} ) ),
 )( BlockConvertButton );

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -23,7 +23,7 @@ import {
 import { createBlobURL } from '@wordpress/blob';
 import { BACKSPACE, DELETE, ENTER, rawShortcut } from '@wordpress/keycodes';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { rawHandler, children, getBlockTransforms, findTransform } from '@wordpress/blocks';
+import { pasteHandler, children, getBlockTransforms, findTransform } from '@wordpress/blocks';
 import { withInstanceId, withSafeTimeout, compose } from '@wordpress/compose';
 import { isURL } from '@wordpress/url';
 import {
@@ -306,7 +306,7 @@ export class RichText extends Component {
 		// Note: a pasted file may have the URL as plain text.
 		if ( item && ! html ) {
 			const file = item.getAsFile ? item.getAsFile() : item;
-			const content = rawHandler( {
+			const content = pasteHandler( {
 				HTML: `<img src="${ createBlobURL( file ) }">`,
 				mode: 'BLOCKS',
 				tagName: this.props.tagName,
@@ -358,7 +358,7 @@ export class RichText extends Component {
 			mode = 'AUTO';
 		}
 
-		const content = rawHandler( {
+		const content = pasteHandler( {
 			HTML: html,
 			plainText,
 			mode,

--- a/test/integration/__snapshots__/blocks-raw-handling.spec.js.snap
+++ b/test/integration/__snapshots__/blocks-raw-handling.spec.js.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Blocks raw handling rawHandler should convert HTML post to blocks with minimal content changes 1`] = `
+"<!-- wp:heading -->
+<h2>Howdy</h2>
+<!-- /wp:heading -->
+
+<!-- wp:image -->
+<figure class=\\"wp-block-image\\"><img src=\\"https://w.org\\" alt=\\"\\"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph -->
+<p>This is a paragraph.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Preserve <span style=\\"color:red\\">me</span>!</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {\\"level\\":3} -->
+<h3>More tag</h3>
+<!-- /wp:heading -->
+
+<!-- wp:more -->
+<!--more-->
+<!-- /wp:more -->
+
+<!-- wp:heading {\\"level\\":3} -->
+<h3>Shortcode</h3>
+<!-- /wp:heading -->
+
+<!-- wp:gallery {\\"columns\\":3,\\"linkTo\\":\\"attachment\\"} -->
+<ul class=\\"wp-block-gallery columns-3 is-cropped\\"><li class=\\"blocks-gallery-item\\"><figure><img data-id=\\"1\\" class=\\"wp-image-1\\"/></figure></li></ul>
+<!-- /wp:gallery -->"
+`;

--- a/test/integration/blocks-raw-handling.spec.js
+++ b/test/integration/blocks-raw-handling.spec.js
@@ -9,7 +9,7 @@ import path from 'path';
  */
 import {
 	getBlockContent,
-	rawHandler,
+	pasteHandler,
 	serialize,
 } from '@wordpress/blocks';
 import { registerCoreBlocks } from '@wordpress/block-library';
@@ -22,7 +22,7 @@ describe( 'Blocks raw handling', () => {
 	} );
 
 	it( 'should filter inline content', () => {
-		const filtered = rawHandler( {
+		const filtered = pasteHandler( {
 			HTML: '<h2><em>test</em></h2>',
 			mode: 'INLINE',
 		} );
@@ -32,7 +32,7 @@ describe( 'Blocks raw handling', () => {
 	} );
 
 	it( 'should parse Markdown', () => {
-		const filtered = rawHandler( {
+		const filtered = pasteHandler( {
 			HTML: '* one<br>* two<br>* three',
 			plainText: '* one\n* two\n* three',
 			mode: 'AUTO',
@@ -43,7 +43,7 @@ describe( 'Blocks raw handling', () => {
 	} );
 
 	it( 'should parse inline Markdown', () => {
-		const filtered = rawHandler( {
+		const filtered = pasteHandler( {
 			HTML: 'Some **bold** text.',
 			plainText: 'Some **bold** text.',
 			mode: 'AUTO',
@@ -54,7 +54,7 @@ describe( 'Blocks raw handling', () => {
 	} );
 
 	it( 'should parse HTML in plainText', () => {
-		const filtered = rawHandler( {
+		const filtered = pasteHandler( {
 			HTML: '&lt;p&gt;Some &lt;strong&gt;bold&lt;/strong&gt; text.&lt;/p&gt;',
 			plainText: '<p>Some <strong>bold</strong> text.</p>',
 			mode: 'AUTO',
@@ -65,7 +65,7 @@ describe( 'Blocks raw handling', () => {
 	} );
 
 	it( 'should parse Markdown with HTML', () => {
-		const filtered = rawHandler( {
+		const filtered = pasteHandler( {
 			HTML: '',
 			plainText: '# Some <em>heading</em>\n\nA paragraph.',
 			mode: 'AUTO',
@@ -76,7 +76,7 @@ describe( 'Blocks raw handling', () => {
 	} );
 
 	it( 'should break up forced inline content', () => {
-		const filtered = rawHandler( {
+		const filtered = pasteHandler( {
 			HTML: '<p>test</p><p>test</p>',
 			mode: 'INLINE',
 		} );
@@ -86,7 +86,7 @@ describe( 'Blocks raw handling', () => {
 	} );
 
 	it( 'should normalize decomposed characters', () => {
-		const filtered = rawHandler( {
+		const filtered = pasteHandler( {
 			HTML: 'schön',
 			mode: 'INLINE',
 		} );
@@ -96,7 +96,7 @@ describe( 'Blocks raw handling', () => {
 	} );
 
 	it( 'should treat single list item as inline text', () => {
-		const filtered = rawHandler( {
+		const filtered = pasteHandler( {
 			HTML: '<ul><li>Some <strong>bold</strong> text.</li></ul>',
 			plainText: 'Some <strong>bold</strong> text.\n',
 			mode: 'AUTO',
@@ -107,7 +107,7 @@ describe( 'Blocks raw handling', () => {
 	} );
 
 	it( 'should treat multiple list items as a block', () => {
-		const filtered = rawHandler( {
+		const filtered = pasteHandler( {
 			HTML: '<ul><li>One</li><li>Two</li><li>Three</li></ul>',
 			plainText: 'One\nTwo\nThree\n',
 			mode: 'AUTO',
@@ -143,7 +143,7 @@ describe( 'Blocks raw handling', () => {
 				const HTML = readFile( path.join( __dirname, `fixtures/${ type }-in.html` ) );
 				const plainText = readFile( path.join( __dirname, `fixtures/${ type }-in.txt` ) );
 				const output = readFile( path.join( __dirname, `fixtures/${ type }-out.html` ) );
-				const converted = rawHandler( { HTML, plainText, canUserUseUnfilteredHTML: true } );
+				const converted = pasteHandler( { HTML, plainText, canUserUseUnfilteredHTML: true } );
 				const serialized = typeof converted === 'string' ? converted : serialize( converted );
 
 				expect( serialized ).toBe( output );

--- a/test/integration/blocks-raw-handling.spec.js
+++ b/test/integration/blocks-raw-handling.spec.js
@@ -10,9 +10,14 @@ import path from 'path';
 import {
 	getBlockContent,
 	pasteHandler,
+	rawHandler,
 	serialize,
 } from '@wordpress/blocks';
 import { registerCoreBlocks } from '@wordpress/block-library';
+
+function readFile( filePath ) {
+	return fs.existsSync( filePath ) ? fs.readFileSync( filePath, 'utf8' ).trim() : '';
+}
 
 describe( 'Blocks raw handling', () => {
 	beforeAll( () => {
@@ -117,11 +122,7 @@ describe( 'Blocks raw handling', () => {
 		expect( console ).toHaveLogged();
 	} );
 
-	describe( 'serialize', () => {
-		function readFile( filePath ) {
-			return fs.existsSync( filePath ) ? fs.readFileSync( filePath, 'utf8' ).trim() : '';
-		}
-
+	describe( 'pasteHandler', () => {
 		[
 			'plain',
 			'classic',
@@ -152,6 +153,13 @@ describe( 'Blocks raw handling', () => {
 					expect( console ).toHaveLogged();
 				}
 			} );
+		} );
+	} );
+
+	describe( 'rawHandler', () => {
+		it( 'should convert HTML post to blocks with minimal content changes', () => {
+			const HTML = readFile( path.join( __dirname, 'fixtures/wordpress-convert.html' ) );
+			expect( serialize( rawHandler( { HTML } ) ) ).toMatchSnapshot();
 		} );
 	} );
 } );

--- a/test/integration/fixtures/wordpress-convert.html
+++ b/test/integration/fixtures/wordpress-convert.html
@@ -1,0 +1,8 @@
+<h2>Howdy</h2>
+<img src="https://w.org">
+<p>This is a paragraph.</p>
+<p>Preserve <span style="color:red">me</span>!</p>
+<h3>More tag</h3>
+<p><!--more--></p>
+<h3>Shortcode</h3>
+<p>[gallery ids="1"]</p>


### PR DESCRIPTION
## Description
Fixes #6102.

This PR separates paste handling from raw handling in general. I opted of a separate function instead of an extra argument because raw handling is significantly less complex and doesn't need as many arguments to works with. Raw handling aims to convert HTML without comment delimiters to blocks, trying to retain as much content as possible.

Needs an integration test.

## How has this been tested?
Convert HTML/Classic block to blocks with e.g. a span with attributes in a paragraph.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->