### PR TITLE
PostPublishPanel: return focus to element that opened the panel

### DIFF
--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -1,11 +1,8 @@
 Gutenberg's deprecation policy is intended to support backwards-compatibility for releases, when possible. The current deprecations are listed below and are grouped by _the version at which they will be removed completely_. If your plugin depends on these behaviors, you must update to the recommended alternative before the noted version.
 
-## 4.6
-
-- `wp.editor.PostPublishPanelToggle` has been deprecated in favor of `wp.editor.PostPublishButton`.
-
 ## 4.5.0
 - `Dropdown.refresh()` has been deprecated as the contained `Popover` is now automatically refreshed.
+- `wp.editor.PostPublishPanelToggle` has been deprecated in favor of `wp.editor.PostPublishButton`.
 
 ## 4.4.0
 

--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -1,5 +1,9 @@
 Gutenberg's deprecation policy is intended to support backwards-compatibility for releases, when possible. The current deprecations are listed below and are grouped by _the version at which they will be removed completely_. If your plugin depends on these behaviors, you must update to the recommended alternative before the noted version.
 
+## 5.1
+
+- `wp.editor.PostPublishPanelToggle` has been deprecated in favor of `wp.editor.PostPublishButton`.
+
 ## 4.5.0
 - `Dropdown.refresh()` has been deprecated as the contained `Popover` is now automatically refreshed.
 

--- a/docs/reference/deprecated.md
+++ b/docs/reference/deprecated.md
@@ -1,6 +1,6 @@
 Gutenberg's deprecation policy is intended to support backwards-compatibility for releases, when possible. The current deprecations are listed below and are grouped by _the version at which they will be removed completely_. If your plugin depends on these behaviors, you must update to the recommended alternative before the noted version.
 
-## 5.1
+## 4.6
 
 - `wp.editor.PostPublishPanelToggle` has been deprecated in favor of `wp.editor.PostPublishButton`.
 

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -41,10 +41,16 @@ function Header( {
 			<HeaderToolbar />
 			<div className="edit-post-header__settings">
 				{ ! isPublishSidebarOpened && (
+					// This button isn't completely hidden by the publish sidebar.
+					// We can't hide the whole toolbar when the publish sidebar is open because
+					// we want to prevent mounting/unmounting the PostPublishButtonOrToggle DOM node.
+					// We track that DOM node to return focus to the PostPublishButtonOrToggle
+					// when the publish sidebar has been closed.
 					<PostSavedState
-					forceIsDirty={ hasActiveMetaboxes }
-					forceIsSaving={ isSaving }
-				/> ) }
+						forceIsDirty={ hasActiveMetaboxes }
+						forceIsSaving={ isSaving }
+					/>
+				) }
 				<PostPreviewButton />
 				<PostPublishButtonOrToggle
 					forceIsDirty={ hasActiveMetaboxes }

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -40,7 +40,8 @@ function Header( {
 		>
 			<HeaderToolbar />
 			<div className="edit-post-header__settings">
-				{ ! isPublishSidebarOpened && ( <PostSavedState
+				{ ! isPublishSidebarOpened && (
+					<PostSavedState
 					forceIsDirty={ hasActiveMetaboxes }
 					forceIsSaving={ isSaving }
 				/> ) }

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -39,34 +39,32 @@ function Header( {
 			tabIndex="-1"
 		>
 			<HeaderToolbar />
-			{ ! isPublishSidebarOpened && (
-				<div className="edit-post-header__settings">
-					<PostSavedState
-						forceIsDirty={ hasActiveMetaboxes }
-						forceIsSaving={ isSaving }
+			<div className="edit-post-header__settings">
+				{ ! isPublishSidebarOpened && ( <PostSavedState
+					forceIsDirty={ hasActiveMetaboxes }
+					forceIsSaving={ isSaving }
+				/> ) }
+				<PostPreviewButton />
+				<PostPublishButtonOrToggle
+					forceIsDirty={ hasActiveMetaboxes }
+					forceIsSaving={ isSaving }
+				/>
+				<div>
+					<IconButton
+						icon="admin-generic"
+						label={ __( 'Settings' ) }
+						onClick={ toggleGeneralSidebar }
+						isToggled={ isEditorSidebarOpened }
+						aria-expanded={ isEditorSidebarOpened }
+						shortcut={ shortcuts.toggleSidebar }
 					/>
-					<PostPreviewButton />
-					<PostPublishButtonOrToggle
-						forceIsDirty={ hasActiveMetaboxes }
-						forceIsSaving={ isSaving }
-					/>
-					<div>
-						<IconButton
-							icon="admin-generic"
-							label={ __( 'Settings' ) }
-							onClick={ toggleGeneralSidebar }
-							isToggled={ isEditorSidebarOpened }
-							aria-expanded={ isEditorSidebarOpened }
-							shortcut={ shortcuts.toggleSidebar }
-						/>
-						<DotTip tipId="core/editor.settings">
-							{ __( 'You’ll find more settings for your page and blocks in the sidebar. Click “Settings” to open it.' ) }
-						</DotTip>
-					</div>
-					<PinnedPlugins.Slot />
-					<MoreMenu />
+					<DotTip tipId="core/editor.settings">
+						{ __( 'You’ll find more settings for your page and blocks in the sidebar. Click “Settings” to open it.' ) }
+					</DotTip>
 				</div>
-			) }
+				<PinnedPlugins.Slot />
+				<MoreMenu />
+			</div>
 		</div>
 	);
 }

--- a/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
+++ b/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
@@ -40,8 +40,8 @@ export function PostPublishButtonOrToggle( {
 	 * 	 Originally, we considered showing a button for pending posts that couldn't be published
 	 * 	 (for example, for an author with the contributor role). Some languages can have
 	 * 	 long translations for "Submit for review", so given the lack of UI real estate available
-	 * 	 we decided to take into account the viewport in that case. See
-	 *   https://github.com/WordPress/gutenberg/issues/10475
+	 * 	 we decided to take into account the viewport in that case.
+	 *  	 See: https://github.com/WordPress/gutenberg/issues/10475
 	 *
 	 * 2) Then, in small viewports, we'll show a TOGGLE.
 	 *

--- a/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
+++ b/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
@@ -28,14 +28,17 @@ export function PostPublishButtonOrToggle( {
 		<PostPublishButton
 			forceIsDirty={ forceIsDirty }
 			forceIsSaving={ forceIsSaving }
+			isOpen={ isPublishSidebarOpened }
+			isToggle={ false }
+			onToggle={ togglePublishSidebar }
 		/>
 	);
 	const toggle = (
 		<PostPublishPanelToggle
+			forceIsDirty={ forceIsDirty }
+			forceIsSaving={ forceIsSaving }
 			isOpen={ isPublishSidebarOpened }
 			onToggle={ togglePublishSidebar }
-			forceIsSaving={ forceIsSaving }
-			forceIsDirty={ forceIsDirty }
 		/>
 	);
 

--- a/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
+++ b/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
@@ -38,9 +38,9 @@ export function PostPublishButtonOrToggle( {
 	 * - is scheduled to be published
 	 * - is pending and can't be published (but only for viewports >= medium).
 	 * 	 Originally, we considered showing a button for pending posts that couldn't be published
-	 * 	 (for ex, for a contributor role). Some languages can have really long translations
-	 * 	 for "Submit for review", so given the lack of UI real state available
-	 * 	 we decided to take into account the viewport in that particular case.
+	 * 	 (for example, for an author with the contributor role). Some languages can have
+	 * 	 long translations for "Submit for review", so given the lack of UI real estate available
+	 * 	 we decided to take into account the viewport in that case.
 	 *
 	 * 2) Then, in small viewports, we'll show a TOGGLE.
 	 *

--- a/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
+++ b/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
@@ -27,25 +27,27 @@ export function PostPublishButtonOrToggle( {
 	const IS_TOGGLE = 'toggle';
 	const IS_BUTTON = 'button';
 	let component;
+
 	/**
-	 * We want to show a BUTTON when the post status is at the _final stage_
+	 * Conditions to show a BUTTON (publish directly) or a TOGGLE (open publish sidebar):
+	 *
+	 * 1) We want to show a BUTTON when the post status is at the _final stage_
 	 * for a particular role (see https://codex.wordpress.org/Post_Status):
 	 *
 	 * - is published
 	 * - is scheduled to be published
-	 * - is pending and can't be published (but only for viewports >= medium)
+	 * - is pending and can't be published (but only for viewports >= medium).
+	 * 	 Originally, we considered showing a button for pending posts that couldn't be published
+	 * 	 (for ex, for a contributor role). Some languages can have really long translations
+	 * 	 for "Submit for review", so given the lack of UI real state available
+	 * 	 we decided to take into account the viewport in that particular case.
 	 *
-	 * Originally we considered showing a button for pending posts
-	 * that couldn't be published (for ex, for a contributor role).
-	 * Some languages can have really long translations for "Submit for review",
-	 * so given the lack of UI real state we decided to take into account the viewport
-	 * in that particular case.
-	 */
-	/**
-	 * Then, we take other things into account:
+	 * 2) Then, in small viewports, we'll show a TOGGLE.
 	 *
-	 * - Show TOGGLE if it is small viewport.
-	 * - Otherwise, use publish sidebar status to decide - TOGGLE if enabled, BUTTON if not.
+	 * 3) Finally, we'll use the publish sidebar status to decide:
+	 *
+	 * - if it is enabled, we show a TOGGLE
+	 * - if it is disabled, we show a BUTTON
 	 */
 	if (
 		isPublished ||

--- a/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
+++ b/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
@@ -40,7 +40,8 @@ export function PostPublishButtonOrToggle( {
 	 * 	 Originally, we considered showing a button for pending posts that couldn't be published
 	 * 	 (for example, for an author with the contributor role). Some languages can have
 	 * 	 long translations for "Submit for review", so given the lack of UI real estate available
-	 * 	 we decided to take into account the viewport in that case.
+	 * 	 we decided to take into account the viewport in that case. See
+	 *   https://github.com/WordPress/gutenberg/issues/10475
 	 *
 	 * 2) Then, in small viewports, we'll show a TOGGLE.
 	 *

--- a/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
+++ b/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
@@ -8,7 +8,7 @@ import { get } from 'lodash';
  */
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { PostPublishPanelToggle, PostPublishButton } from '@wordpress/editor';
+import { PostPublishButton } from '@wordpress/editor';
 import { withViewportMatch } from '@wordpress/viewport';
 
 export function PostPublishButtonOrToggle( {
@@ -24,24 +24,9 @@ export function PostPublishButtonOrToggle( {
 	isScheduled,
 	togglePublishSidebar,
 } ) {
-	const button = (
-		<PostPublishButton
-			forceIsDirty={ forceIsDirty }
-			forceIsSaving={ forceIsSaving }
-			isOpen={ isPublishSidebarOpened }
-			isToggle={ false }
-			onToggle={ togglePublishSidebar }
-		/>
-	);
-	const toggle = (
-		<PostPublishPanelToggle
-			forceIsDirty={ forceIsDirty }
-			forceIsSaving={ forceIsSaving }
-			isOpen={ isPublishSidebarOpened }
-			onToggle={ togglePublishSidebar }
-		/>
-	);
-
+	const IS_TOGGLE = 'toggle';
+	const IS_BUTTON = 'button';
+	let component;
 	/**
 	 * We want to show a BUTTON when the post status is at the _final stage_
 	 * for a particular role (see https://codex.wordpress.org/Post_Status):
@@ -56,25 +41,35 @@ export function PostPublishButtonOrToggle( {
 	 * so given the lack of UI real state we decided to take into account the viewport
 	 * in that particular case.
 	 */
-	if (
-		isPublished ||
-		( isScheduled && isBeingScheduled ) ||
-		( isPending && ! hasPublishAction && ! isLessThanMediumViewport )
-	) {
-		return button;
-	}
-
 	/**
 	 * Then, we take other things into account:
 	 *
 	 * - Show TOGGLE if it is small viewport.
 	 * - Otherwise, use publish sidebar status to decide - TOGGLE if enabled, BUTTON if not.
 	 */
-	if ( isLessThanMediumViewport ) {
-		return toggle;
+	if (
+		isPublished ||
+		( isScheduled && isBeingScheduled ) ||
+		( isPending && ! hasPublishAction && ! isLessThanMediumViewport )
+	) {
+		component = IS_BUTTON;
+	} else if ( isLessThanMediumViewport ) {
+		component = IS_TOGGLE;
+	} else if ( isPublishSidebarEnabled ) {
+		component = IS_TOGGLE;
+	} else {
+		component = IS_BUTTON;
 	}
 
-	return isPublishSidebarEnabled ? toggle : button;
+	return (
+		<PostPublishButton
+			forceIsDirty={ forceIsDirty }
+			forceIsSaving={ forceIsSaving }
+			isOpen={ isPublishSidebarOpened }
+			isToggle={ component === IS_TOGGLE }
+			onToggle={ togglePublishSidebar }
+		/>
+	);
 }
 
 export default compose(

--- a/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
+++ b/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
@@ -6,9 +6,9 @@ import { get } from 'lodash';
 /**
  * WordPress dependencies.
  */
-import { PostPublishPanelToggle, PostPublishButton } from '@wordpress/editor';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
+import { PostPublishPanelToggle, PostPublishButton } from '@wordpress/editor';
 import { withViewportMatch } from '@wordpress/viewport';
 
 export function PostPublishButtonOrToggle( {

--- a/packages/edit-post/src/components/header/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/header/test/__snapshots__/index.js.snap
@@ -1,13 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PostPublishButtonOrToggle should render a button when post is not (1), (2), (3), the viewport is >= medium, and the publish sidebar is disabled 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
+exports[`PostPublishButtonOrToggle should render a button when post is not (1), (2), (3), the viewport is >= medium, and the publish sidebar is disabled 1`] = `
+<WithSelect(WithDispatch(PostPublishButton))
+  isToggle={false}
+/>
+`;
 
-exports[`PostPublishButtonOrToggle should render a button when the post is pending and cannot be published but the viewport is >= medium (3) 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
+exports[`PostPublishButtonOrToggle should render a button when the post is pending and cannot be published but the viewport is >= medium (3) 1`] = `
+<WithSelect(WithDispatch(PostPublishButton))
+  isToggle={false}
+/>
+`;
 
-exports[`PostPublishButtonOrToggle should render a button when the post is published (1) 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
+exports[`PostPublishButtonOrToggle should render a button when the post is published (1) 1`] = `
+<WithSelect(WithDispatch(PostPublishButton))
+  isToggle={false}
+/>
+`;
 
-exports[`PostPublishButtonOrToggle should render a button when the post is scheduled (2) 1`] = `<WithSelect(WithDispatch(PostPublishButton)) />`;
+exports[`PostPublishButtonOrToggle should render a button when the post is scheduled (2) 1`] = `
+<WithSelect(WithDispatch(PostPublishButton))
+  isToggle={false}
+/>
+`;
 
-exports[`PostPublishButtonOrToggle should render a toggle when post is not (1), (2), (3), the viewport is >= medium, and the publish sidebar is enabled 1`] = `<WithSelect(PostPublishPanelToggle) />`;
+exports[`PostPublishButtonOrToggle should render a toggle when post is not (1), (2), (3), the viewport is >= medium, and the publish sidebar is enabled 1`] = `
+<WithSelect(WithDispatch(PostPublishButton))
+  isToggle={true}
+/>
+`;
 
-exports[`PostPublishButtonOrToggle should render a toggle when post is not published or scheduled and the viewport is < medium 1`] = `<WithSelect(PostPublishPanelToggle) />`;
+exports[`PostPublishButtonOrToggle should render a toggle when post is not published or scheduled and the viewport is < medium 1`] = `
+<WithSelect(WithDispatch(PostPublishButton))
+  isToggle={true}
+/>
+`;

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 6.2.1 (Unreleased)
 
+### Deprecations
+
+- `wp.editor.PostPublishPanelToggle` has been deprecated in favor of `wp.editor.PostPublishButton`.
+
 ### Polish
 
 - Reactive block styles.

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -10,6 +10,7 @@ import { Button } from '@wordpress/components';
 import { Component, createRef } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -94,13 +95,17 @@ export class PostPublishButton extends Component {
 			onClick: onToggle,
 		};
 
+		const toggleChildren = isBeingScheduled ? __( 'Schedule…' ) : __( 'Publish…' );
+		const buttonChildren = <PublishButtonLabel forceIsSaving={ forceIsSaving } />;
+
 		const componentProps = isToggle ? toggleProps : buttonProps;
+		const componentChildren = isToggle ? toggleChildren : buttonChildren;
 		return (
 			<Button
 				ref={ this.buttonNode }
 				{ ...componentProps }
 			>
-				<PublishButtonLabel forceIsSaving={ forceIsSaving } />
+				{ componentChildren }
 			</Button>
 		);
 	}

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -11,6 +11,7 @@ import { Component, createRef } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
+import { DotTip } from '@wordpress/nux';
 
 /**
  * Internal dependencies
@@ -106,6 +107,9 @@ export class PostPublishButton extends Component {
 				{ ...componentProps }
 			>
 				{ componentChildren }
+				<DotTip tipId="core/editor.publish">
+					{ __( 'Finished writing? That’s great, let’s get this published right now. Just click “Publish” and you’re good to go.' ) }
+				</DotTip>
 			</Button>
 		);
 	}

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -28,25 +28,35 @@ export class PostPublishButton extends Component {
 
 	render() {
 		const {
-			isSaving,
-			onStatusChange,
-			onSave,
-			isBeingScheduled,
-			visibility,
-			isPublishable,
-			isSaveable,
-			isPostSavingLocked,
-			isPublished,
-			hasPublishAction,
-			onSubmit = noop,
 			forceIsDirty,
 			forceIsSaving,
+			hasPublishAction,
+			isBeingScheduled,
+			isOpen,
+			isPostSavingLocked,
+			isPublishable,
+			isPublished,
+			isSaveable,
+			isSaving,
+			isToggle,
+			onSave,
+			onStatusChange,
+			onSubmit = noop,
+			onToggle,
+			visibility,
 		} = this.props;
 		const isButtonDisabled =
 			isSaving ||
 			forceIsSaving ||
 			! isSaveable ||
 			isPostSavingLocked ||
+			( ! isPublishable && ! forceIsDirty );
+
+		const isToggleDisabled =
+			isPublished ||
+			isSaving ||
+			forceIsSaving ||
+			! isSaveable ||
 			( ! isPublishable && ! forceIsDirty );
 
 		let publishStatus;
@@ -74,10 +84,21 @@ export class PostPublishButton extends Component {
 			isPrimary: true,
 			onClick,
 		};
+
+		const toggleProps = {
+			'aria-expanded': isOpen,
+			className: 'editor-post-publish-panel__toggle',
+			disabled: isToggleDisabled,
+			isBusy: isSaving && isPublished,
+			isPrimary: true,
+			onClick: onToggle,
+		};
+
+		const componentProps = isToggle ? toggleProps : buttonProps;
 		return (
 			<Button
 				ref={ this.buttonNode }
-				{ ...buttonProps }
+				{ ...componentProps }
 			>
 				<PublishButtonLabel forceIsSaving={ forceIsSaving } />
 			</Button>

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -66,15 +66,18 @@ export class PostPublishButton extends Component {
 			onSave();
 		};
 
+		const buttonProps = {
+			className: 'editor-post-publish-button',
+			disabled: isButtonDisabled,
+			isBusy: isSaving && isPublished,
+			isLarge: true,
+			isPrimary: true,
+			onClick,
+		};
 		return (
 			<Button
 				ref={ this.buttonNode }
-				className="editor-post-publish-button"
-				isPrimary
-				isLarge
-				onClick={ onClick }
-				disabled={ isButtonDisabled }
-				isBusy={ isSaving && isPublished }
+				{ ...buttonProps }
 			>
 				<PublishButtonLabel forceIsSaving={ forceIsSaving } />
 			</Button>

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -78,8 +78,8 @@ export class PostPublishButton extends Component {
 		};
 
 		const buttonProps = {
+			'aria-disabled': isButtonDisabled,
 			className: 'editor-post-publish-button',
-			disabled: isButtonDisabled,
 			isBusy: isSaving && isPublished,
 			isLarge: true,
 			isPrimary: true,
@@ -87,9 +87,9 @@ export class PostPublishButton extends Component {
 		};
 
 		const toggleProps = {
+			'aria-disabled': isToggleDisabled,
 			'aria-expanded': isOpen,
 			className: 'editor-post-publish-panel__toggle',
-			disabled: isToggleDisabled,
 			isBusy: isSaving && isPublished,
 			isPrimary: true,
 			onClick: onToggle,

--- a/packages/editor/src/components/post-publish-button/test/index.js
+++ b/packages/editor/src/components/post-publish-button/test/index.js
@@ -11,8 +11,8 @@ import { PostPublishButton } from '../';
 jest.mock( '../../../../../components/src/button' );
 
 describe( 'PostPublishButton', () => {
-	describe( 'disabled', () => {
-		it( 'should be disabled if post is currently saving', () => {
+	describe( 'aria-disabled', () => {
+		it( 'should be true if post is currently saving', () => {
 			const wrapper = shallow(
 				<PostPublishButton
 					isPublishable
@@ -21,10 +21,10 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			expect( wrapper.prop( 'disabled' ) ).toBe( true );
+			expect( wrapper.prop( 'aria-disabled' ) ).toBe( true );
 		} );
 
-		it( 'should be disabled if forceIsSaving is true', () => {
+		it( 'should be true if forceIsSaving is true', () => {
 			const wrapper = shallow(
 				<PostPublishButton
 					isPublishable
@@ -33,10 +33,10 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			expect( wrapper.prop( 'disabled' ) ).toBe( true );
+			expect( wrapper.prop( 'aria-disabled' ) ).toBe( true );
 		} );
 
-		it( 'should be disabled if post is not publishable and not forceIsDirty', () => {
+		it( 'should be true if post is not publishable and not forceIsDirty', () => {
 			const wrapper = shallow(
 				<PostPublishButton
 					isSaveable
@@ -45,10 +45,10 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			expect( wrapper.prop( 'disabled' ) ).toBe( true );
+			expect( wrapper.prop( 'aria-disabled' ) ).toBe( true );
 		} );
 
-		it( 'should be disabled if post is not saveable', () => {
+		it( 'should be true if post is not saveable', () => {
 			const wrapper = shallow(
 				<PostPublishButton
 					isPublishable
@@ -56,10 +56,10 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			expect( wrapper.prop( 'disabled' ) ).toBe( true );
+			expect( wrapper.prop( 'aria-disabled' ) ).toBe( true );
 		} );
 
-		it( 'should be disabled if post saving is locked', () => {
+		it( 'should be true if post saving is locked', () => {
 			const wrapper = shallow(
 				<PostPublishButton
 					isPublishable
@@ -68,10 +68,10 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			expect( wrapper.prop( 'disabled' ) ).toBe( true );
+			expect( wrapper.prop( 'aria-disabled' ) ).toBe( true );
 		} );
 
-		it( 'should be enabled if post is saveable but not publishable and forceIsDirty is true', () => {
+		it( 'should be false if post is saveable but not publishable and forceIsDirty is true', () => {
 			const wrapper = shallow(
 				<PostPublishButton
 					isSaveable
@@ -80,10 +80,10 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			expect( wrapper.prop( 'disabled' ) ).toBe( false );
+			expect( wrapper.prop( 'aria-disabled' ) ).toBe( false );
 		} );
 
-		it( 'should be enabled if post is publishave and saveable', () => {
+		it( 'should be false if post is publishave and saveable', () => {
 			const wrapper = shallow(
 				<PostPublishButton
 					isPublishable
@@ -91,7 +91,7 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			expect( wrapper.prop( 'disabled' ) ).toBe( false );
+			expect( wrapper.prop( 'aria-disabled' ) ).toBe( false );
 		} );
 	} );
 

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -12,6 +12,7 @@ import {
 	IconButton,
 	Spinner,
 	CheckboxControl,
+	withFocusReturn,
 	withConstrainedTabbing,
 } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -142,5 +143,6 @@ export default compose( [
 			},
 		};
 	} ),
+	withFocusReturn,
 	withConstrainedTabbing,
 ] )( PostPublishPanel );

--- a/packages/editor/src/components/post-publish-panel/test/toggle.js
+++ b/packages/editor/src/components/post-publish-panel/test/toggle.js
@@ -20,6 +20,9 @@ describe( 'PostPublishPanelToggle', () => {
 			);
 
 			expect( wrapper.prop( 'disabled' ) ).toBe( true );
+			expect( console ).toHaveWarnedWith(
+				'PostPublishPanelToggle is deprecated and will be removed from Gutenberg in 5.1. Please use PostPublishButton instead.'
+			);
 		} );
 
 		it( 'should be disabled if post is currently force saving', () => {

--- a/packages/editor/src/components/post-publish-panel/test/toggle.js
+++ b/packages/editor/src/components/post-publish-panel/test/toggle.js
@@ -21,7 +21,7 @@ describe( 'PostPublishPanelToggle', () => {
 
 			expect( wrapper.prop( 'disabled' ) ).toBe( true );
 			expect( console ).toHaveWarnedWith(
-				'PostPublishPanelToggle is deprecated and will be removed from Gutenberg in 4.6. Please use PostPublishButton instead.'
+				'PostPublishPanelToggle is deprecated and will be removed from Gutenberg in 4.5. Please use PostPublishButton instead.'
 			);
 		} );
 

--- a/packages/editor/src/components/post-publish-panel/test/toggle.js
+++ b/packages/editor/src/components/post-publish-panel/test/toggle.js
@@ -66,7 +66,7 @@ describe( 'PostPublishPanelToggle', () => {
 				/>
 			);
 
-			expect( wrapper.prop( 'disabled' ) ).toBe( true );
+			expect( wrapper.prop( 'disabled' ) ).toBe( false );
 		} );
 
 		it( 'should be enabled if post is saveable but not publishable and forceIsDirty is true', () => {

--- a/packages/editor/src/components/post-publish-panel/test/toggle.js
+++ b/packages/editor/src/components/post-publish-panel/test/toggle.js
@@ -66,7 +66,7 @@ describe( 'PostPublishPanelToggle', () => {
 				/>
 			);
 
-			expect( wrapper.prop( 'disabled' ) ).toBe( false );
+			expect( wrapper.prop( 'disabled' ) ).toBe( true );
 		} );
 
 		it( 'should be enabled if post is saveable but not publishable and forceIsDirty is true', () => {

--- a/packages/editor/src/components/post-publish-panel/test/toggle.js
+++ b/packages/editor/src/components/post-publish-panel/test/toggle.js
@@ -21,7 +21,7 @@ describe( 'PostPublishPanelToggle', () => {
 
 			expect( wrapper.prop( 'disabled' ) ).toBe( true );
 			expect( console ).toHaveWarnedWith(
-				'PostPublishPanelToggle is deprecated and will be removed from Gutenberg in 5.1. Please use PostPublishButton instead.'
+				'PostPublishPanelToggle is deprecated and will be removed from Gutenberg in 4.6. Please use PostPublishButton instead.'
 			);
 		} );
 

--- a/packages/editor/src/components/post-publish-panel/toggle.js
+++ b/packages/editor/src/components/post-publish-panel/toggle.js
@@ -27,7 +27,7 @@ export function PostPublishPanelToggle( {
 		( ! isPublishable && ! forceIsDirty );
 
 	deprecated( 'PostPublishPanelToggle', {
-		version: '5.1',
+		version: '4.6',
 		alternative: 'PostPublishButton',
 		plugin: 'Gutenberg',
 	} );

--- a/packages/editor/src/components/post-publish-panel/toggle.js
+++ b/packages/editor/src/components/post-publish-panel/toggle.js
@@ -27,7 +27,7 @@ export function PostPublishPanelToggle( {
 		( ! isPublishable && ! forceIsDirty );
 
 	deprecated( 'PostPublishPanelToggle', {
-		version: '4.6',
+		version: '4.5',
 		alternative: 'PostPublishButton',
 		plugin: 'Gutenberg',
 	} );

--- a/packages/editor/src/components/post-publish-panel/toggle.js
+++ b/packages/editor/src/components/post-publish-panel/toggle.js
@@ -3,6 +3,7 @@
  */
 import { Button } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
+import deprecated from '@wordpress/deprecated';
 import { __ } from '@wordpress/i18n';
 import { withSelect } from '@wordpress/data';
 import { DotTip } from '@wordpress/nux';
@@ -24,6 +25,12 @@ export function PostPublishPanelToggle( {
 		forceIsSaving ||
 		! isSaveable ||
 		( ! isPublishable && ! forceIsDirty );
+
+	deprecated( 'PostPublishPanelToggle', {
+		version: '5.1',
+		alternative: 'PostPublishButton',
+		plugin: 'Gutenberg',
+	} );
 
 	return (
 		<Button

--- a/test/e2e/specs/preview.test.js
+++ b/test/e2e/specs/preview.test.js
@@ -94,12 +94,12 @@ describe( 'Preview', () => {
 		previewTitle = await previewPage.$eval( '.entry-title', ( node ) => node.textContent );
 		expect( previewTitle ).toBe( 'Hello World!' );
 
-		// Preview for published post (no unsaved changes) directs to canonical
-		// URL for post.
+		// Preview for published post (no unsaved changes) directs to canonical URL for post.
 		await editorPage.bringToFront();
 		await publishPost();
+		// Wait until the publish panel is closed
 		await Promise.all( [
-			editorPage.waitForFunction( () => ! document.querySelector( '.editor-post-preview' ) ),
+			editorPage.waitForFunction( () => ! document.querySelector( '.editor-post-publish-panel' ) ),
 			editorPage.click( '.editor-post-publish-panel__header button' ),
 		] );
 		expectedPreviewURL = await editorPage.$eval( '.components-notice.is-success a', ( node ) => node.href );

--- a/test/e2e/specs/publish-button.test.js
+++ b/test/e2e/specs/publish-button.test.js
@@ -22,22 +22,23 @@ describe( 'PostPublishButton', () => {
 	} );
 
 	it( 'should be disabled when post is not saveable', async () => {
-		const publishButton = await page.$( '.editor-post-publish-button:disabled' );
-
+		const publishButton = await page.$( '.editor-post-publish-button[aria-disabled="true"]' );
 		expect( publishButton ).not.toBeNull();
 	} );
 
 	it( 'should be disabled when post is being saved', async () => {
 		await page.type( '.editor-post-title__input', 'E2E Test Post' ); // Make it saveable
-		expect( await page.$( '.editor-post-publish-button:disabled' ) ).toBeNull();
+		expect( await page.$( '.editor-post-publish-button[aria-disabled="true"]' ) ).toBeNull();
+
 		await page.click( '.editor-post-save-draft' );
-		expect( await page.$( '.editor-post-publish-button:disabled' ) ).not.toBeNull();
+		expect( await page.$( '.editor-post-publish-button[aria-disabled="true"]' ) ).not.toBeNull();
 	} );
 
 	it( 'should be disabled when metabox is being saved', async () => {
 		await page.type( '.editor-post-title__input', 'E2E Test Post' ); // Make it saveable
-		expect( await page.$( '.editor-post-publish-button:disabled' ) ).toBeNull();
+		expect( await page.$( '.editor-post-publish-button[aria-disabled="true"]' ) ).toBeNull();
+
 		await page.evaluate( () => window.wp.data.dispatch( 'core/edit-post' ).requestMetaBoxUpdates() );
-		expect( await page.$( '.editor-post-publish-button:disabled' ) ).not.toBeNull();
+		expect( await page.$( '.editor-post-publish-button[aria-disabled="true"]' ) ).not.toBeNull();
 	} );
 } );


### PR DESCRIPTION
Addresses the last bit of https://github.com/WordPress/gutenberg/issues/4187#issuecomment-427480786
~Depends on https://github.com/WordPress/gutenberg/pull/11584~
Closes #4187

## Description

This PR manages where focus goes after the PostPublishPanel is closed. At the moment, it's lost and just goes to the body element.

![peek 2018-11-09 13-33](https://user-images.githubusercontent.com/583546/48262800-22e21e80-e424-11e8-9365-349d707ae8a3.gif)

**Changes this PR introduces:**

- Uses the `withReturnFocus` HOC to return focus to the element that had it before opening the publish sidebar.
- Changes the Header settings not to be unmounted when the publish sidebar is opened. This requires us to hide the "Saving draft" button, because it is not completely hidden by the publish sidebar.
- Uses a single component as the Publish button, instead of the two we had. This helps in that the DOM node that opens the publish sidebar isn't changed by a new component. It does so by teaching the `PostPublishButton` how to behave like a button (publish directly) or a toggle (opens the publish sidebar instead).

## Questions

- [x] Should we deprecate `PostPublishToggle` in favor of the `PostPublishButton` component in this PR *We'll go with deprecating it and removing it in 5.1.*