### PR TITLE
Allow a block to disable being converted into a reusable block; Fix: Column block

### DIFF
--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -504,6 +504,13 @@ inserter: false,
 multiple: false,
 ```
 
+- `reusable` (default `true`): A block may want to disable the ability of being converted into a reusable block.
+By default all blocks can be converted to a reusable block. If supports reusable is set to false, the option to convert the block into a reusable block will not appear.
+
+```js
+// Don't allow the block to be converted into a reusable block.
+reusable: false,
+```
 ## Edit and Save
 
 The `edit` and `save` functions define the editor interface with which a user would interact, and the markup to be serialized back when a post is saved. They are the heart of how a block operates, so they are [covered separately](../docs/block-api/block-edit-save.md).

--- a/packages/block-library/src/classic/index.js
+++ b/packages/block-library/src/classic/index.js
@@ -31,6 +31,9 @@ export const settings = {
 	supports: {
 		className: false,
 		customClassName: false,
+		// Hide 'Add to Reusable Blocks' on Classic blocks. Showing it causes a
+		// confusing UX, because of its similarity to the 'Convert to Blocks' button.
+		reusable: false,
 	},
 
 	edit,

--- a/packages/block-library/src/columns/column.js
+++ b/packages/block-library/src/columns/column.js
@@ -20,6 +20,7 @@ export const settings = {
 
 	supports: {
 		inserter: false,
+		reusable: false,
 	},
 
 	edit() {

--- a/packages/block-library/src/missing/index.js
+++ b/packages/block-library/src/missing/index.js
@@ -66,6 +66,7 @@ export const settings = {
 		customClassName: false,
 		inserter: false,
 		html: false,
+		reusable: false,
 	},
 
 	attributes: {


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/10679

This PR adds a flag that allows a block to opt-out being converted into a reusable block as discussed in https://github.com/WordPress/gutenberg/issues/10679.

This new logic is used to disable the conversion of column block into a reusable block and to simplify existing logic that disables classic and missing block conversion to reusable blocks.

These simplifications add a behavior change.
Before it was not possible to convert classic or missing block into a reusable block, but if another block was selected with it (even an empty paragraph) it was possible to convert that blocks into reusable blocks, now that's not the case.
If a block that is part of the selection cannot be converted into a reusable block, the option to convert the selected blocks into a reusable block will not be shown.
I think that is the desired behavior.



## How has this been tested?
Verify it is not possible to convert to reusable blocks, the "Column" block, the classic block or an invalid block.
Verify it is still possible to convert to reusable blocks the "Columns" block.
Test complex scenarios e.g. multiple selections of Columns and a paragraph, and verify the conversion is possible.

