### PR TITLE
fix: Improve empty block text

### DIFF
--- a/docs/design/block-design.md
+++ b/docs/design/block-design.md
@@ -97,7 +97,7 @@ The most basic unit of the editor. The paragraph block is a simple input field.
 
 ### Placeholder:
 
-- Simple placeholder text that says “Add text or type / to add content.” The placeholder disappears when the block is selected.
+- Simple placeholder text that reads “Type text or press / to select a block”. The placeholder disappears when the block is selected.
 
 ### Selected state:
 

--- a/docs/design/block-design.md
+++ b/docs/design/block-design.md
@@ -97,7 +97,7 @@ The most basic unit of the editor. The paragraph block is a simple input field.
 
 ### Placeholder:
 
-- Simple placeholder text that reads “Type text or press / to insert a block”. The placeholder disappears when the block is selected.
+- Simple placeholder text that reads “Start writing or press / to insert a block”. The placeholder disappears when the block is selected.
 
 ### Selected state:
 

--- a/docs/design/block-design.md
+++ b/docs/design/block-design.md
@@ -97,7 +97,7 @@ The most basic unit of the editor. The paragraph block is a simple input field.
 
 ### Placeholder:
 
-- Simple placeholder text that reads “Type text or press / to select a block”. The placeholder disappears when the block is selected.
+- Simple placeholder text that reads “Type text or press / to insert a block”. The placeholder disappears when the block is selected.
 
 ### Selected state:
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1626,7 +1626,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		'disableCustomFontSizes' => get_theme_support( 'disable-custom-font-sizes' ),
 		'disablePostFormats'     => ! current_theme_supports( 'post-formats' ),
 		'titlePlaceholder'       => apply_filters( 'enter_title_here', __( 'Add title', 'gutenberg' ), $post ),
-		'bodyPlaceholder'        => apply_filters( 'write_your_story', __( 'Write your story', 'gutenberg' ), $post ),
+		'bodyPlaceholder'        => apply_filters( 'write_your_story', __( 'Type text or press “/” to select a block', 'gutenberg' ), $post ),
 		'isRTL'                  => is_rtl(),
 		'autosaveInterval'       => 10,
 		'maxUploadFileSize'      => $max_upload_size,

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1626,7 +1626,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		'disableCustomFontSizes' => get_theme_support( 'disable-custom-font-sizes' ),
 		'disablePostFormats'     => ! current_theme_supports( 'post-formats' ),
 		'titlePlaceholder'       => apply_filters( 'enter_title_here', __( 'Add title', 'gutenberg' ), $post ),
-		'bodyPlaceholder'        => apply_filters( 'write_your_story', __( 'Type text or press “/” to insert a block', 'gutenberg' ), $post ),
+		'bodyPlaceholder'        => apply_filters( 'write_your_story', __( 'Start writing or press “/” to insert a block', 'gutenberg' ), $post ),
 		'isRTL'                  => is_rtl(),
 		'autosaveInterval'       => 10,
 		'maxUploadFileSize'      => $max_upload_size,

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1626,7 +1626,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		'disableCustomFontSizes' => get_theme_support( 'disable-custom-font-sizes' ),
 		'disablePostFormats'     => ! current_theme_supports( 'post-formats' ),
 		'titlePlaceholder'       => apply_filters( 'enter_title_here', __( 'Add title', 'gutenberg' ), $post ),
-		'bodyPlaceholder'        => apply_filters( 'write_your_story', __( 'Type text or press “/” to select a block', 'gutenberg' ), $post ),
+		'bodyPlaceholder'        => apply_filters( 'write_your_story', __( 'Type text or press “/” to insert a block', 'gutenberg' ), $post ),
 		'isRTL'                  => is_rtl(),
 		'autosaveInterval'       => 10,
 		'maxUploadFileSize'      => $max_upload_size,

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1626,7 +1626,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		'disableCustomFontSizes' => get_theme_support( 'disable-custom-font-sizes' ),
 		'disablePostFormats'     => ! current_theme_supports( 'post-formats' ),
 		'titlePlaceholder'       => apply_filters( 'enter_title_here', __( 'Add title', 'gutenberg' ), $post ),
-		'bodyPlaceholder'        => apply_filters( 'write_your_story', __( 'Start writing or press “/” to insert a block', 'gutenberg' ), $post ),
+		'bodyPlaceholder'        => apply_filters( 'write_your_story', __( 'Start writing or press / to insert a block', 'gutenberg' ), $post ),
 		'isRTL'                  => is_rtl(),
 		'autosaveInterval'       => 10,
 		'maxUploadFileSize'      => $max_upload_size,

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -246,7 +246,7 @@ class ParagraphBlock extends Component {
 					onReplace={ this.onReplace }
 					onRemove={ () => onReplace( [] ) }
 					aria-label={ __( 'Empty block; type text or use the forward slash key to insert a block' ) }
-					placeholder={ placeholder || __( 'Type text or press “/” to select a block' ) }
+					placeholder={ placeholder || __( 'Type text or press “/” to insert a block' ) }
 				/>
 			</Fragment>
 		);

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -245,7 +245,8 @@ class ParagraphBlock extends Component {
 					onMerge={ mergeBlocks }
 					onReplace={ this.onReplace }
 					onRemove={ () => onReplace( [] ) }
-					placeholder={ placeholder || __( 'Add text or type / to add content' ) }
+					aria-label={ __( 'Type text or use the forward slash key to insert a block' ) }
+					placeholder={ placeholder || __( 'Type text or press “/” to select a block' ) }
 				/>
 			</Fragment>
 		);

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -246,7 +246,7 @@ class ParagraphBlock extends Component {
 					onReplace={ this.onReplace }
 					onRemove={ () => onReplace( [] ) }
 					aria-label={ __( 'Empty block; type text or press the forward slash key to insert a block' ) }
-					placeholder={ placeholder || __( 'Type text or press “/” to insert a block' ) }
+					placeholder={ placeholder || __( 'Start writing or press “/” to insert a block' ) }
 				/>
 			</Fragment>
 		);

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -246,7 +246,7 @@ class ParagraphBlock extends Component {
 					onReplace={ this.onReplace }
 					onRemove={ () => onReplace( [] ) }
 					aria-label={ __( 'Empty block; type text or press the forward slash key to insert a block' ) }
-					placeholder={ placeholder || __( 'Start writing or press “/” to insert a block' ) }
+					placeholder={ placeholder || __( 'Start writing or press / to insert a block' ) }
 				/>
 			</Fragment>
 		);

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -245,7 +245,7 @@ class ParagraphBlock extends Component {
 					onMerge={ mergeBlocks }
 					onReplace={ this.onReplace }
 					onRemove={ () => onReplace( [] ) }
-					aria-label={ __( 'Type text or use the forward slash key to insert a block' ) }
+					aria-label={ __( 'Empty block; type text or use the forward slash key to insert a block' ) }
 					placeholder={ placeholder || __( 'Type text or press “/” to select a block' ) }
 				/>
 			</Fragment>

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -245,7 +245,7 @@ class ParagraphBlock extends Component {
 					onMerge={ mergeBlocks }
 					onReplace={ this.onReplace }
 					onRemove={ () => onReplace( [] ) }
-					aria-label={ __( 'Empty block; type text or use the forward slash key to insert a block' ) }
+					aria-label={ __( 'Empty block; type text or press the forward slash key to insert a block' ) }
 					placeholder={ placeholder || __( 'Type text or press “/” to insert a block' ) }
 				/>
 			</Fragment>

--- a/packages/block-library/src/paragraph/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/paragraph/test/__snapshots__/index.js.snap
@@ -2,38 +2,38 @@
 
 exports[`core/paragraph block edit matches snapshot 1`] = `
 <div>
-
-	<div
-		class="editor-rich-text"
-	>
-		<div>
-			<div>
-				<div
-					class="components-autocomplete"
-				>
-					<p
-						aria-autocomplete="list"
-						aria-expanded="false"
-						aria-label="Empty block; type text or press the forward slash key to insert a block"
-						aria-multiline="true"
-						class="wp-block-paragraph editor-rich-text__tinymce"
-						contenteditable="true"
-						data-is-placeholder-visible="true"
-						role="textbox"
-					>
-						<br
-							data-mce-bogus="1"
-						/>
-					</p>
-					<p
-						class="editor-rich-text__tinymce wp-block-paragraph"
-					>
-						Type text or press “/” to insert a block
-					</p>
-				</div>
-			</div>
-		</div>
-	</div>
-
+   
+  <div
+    class="editor-rich-text"
+  >
+    <div>
+      <div>
+        <div
+          class="components-autocomplete"
+        >
+          <p
+            aria-autocomplete="list"
+            aria-expanded="false"
+            aria-label="Empty block; type text or press the forward slash key to insert a block"
+            aria-multiline="true"
+            class="wp-block-paragraph editor-rich-text__tinymce"
+            contenteditable="true"
+            data-is-placeholder-visible="true"
+            role="textbox"
+          >
+            <br
+              data-mce-bogus="1"
+            />
+          </p>
+          <p
+            class="editor-rich-text__tinymce wp-block-paragraph"
+          >
+            Type text or press “/” to insert a block
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+   
 </div>
 `;

--- a/packages/block-library/src/paragraph/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/paragraph/test/__snapshots__/index.js.snap
@@ -28,7 +28,7 @@ exports[`core/paragraph block edit matches snapshot 1`] = `
           <p
             class="editor-rich-text__tinymce wp-block-paragraph"
           >
-            Type text or press “/” to insert a block
+            Start writing or press “/” to insert a block
           </p>
         </div>
       </div>

--- a/packages/block-library/src/paragraph/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/paragraph/test/__snapshots__/index.js.snap
@@ -2,38 +2,38 @@
 
 exports[`core/paragraph block edit matches snapshot 1`] = `
 <div>
-   
-  <div
-    class="editor-rich-text"
-  >
-    <div>
-      <div>
-        <div
-          class="components-autocomplete"
-        >
-          <p
-            aria-autocomplete="list"
-            aria-expanded="false"
-            aria-label="Empty block; type text or use the forward slash key to insert a block"
-            aria-multiline="true"
-            class="wp-block-paragraph editor-rich-text__tinymce"
-            contenteditable="true"
-            data-is-placeholder-visible="true"
-            role="textbox"
-          >
-            <br
-              data-mce-bogus="1"
-            />
-          </p>
-          <p
-            class="editor-rich-text__tinymce wp-block-paragraph"
-          >
-            Type text or press “/” to select a block
-          </p>
-        </div>
-      </div>
-    </div>
-  </div>
-   
+	 
+	<div
+		class="editor-rich-text"
+	>
+		<div>
+			<div>
+				<div
+					class="components-autocomplete"
+				>
+					<p
+						aria-autocomplete="list"
+						aria-expanded="false"
+						aria-label="Empty block; type text or use the forward slash key to insert a block"
+						aria-multiline="true"
+						class="wp-block-paragraph editor-rich-text__tinymce"
+						contenteditable="true"
+						data-is-placeholder-visible="true"
+						role="textbox"
+					>
+						<br
+							data-mce-bogus="1"
+						/>
+					</p>
+					<p
+						class="editor-rich-text__tinymce wp-block-paragraph"
+					>
+						Type text or press “/” to insert a block
+					</p>
+				</div>
+			</div>
+		</div>
+	</div>
+	 
 </div>
 `;

--- a/packages/block-library/src/paragraph/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/paragraph/test/__snapshots__/index.js.snap
@@ -2,38 +2,38 @@
 
 exports[`core/paragraph block edit matches snapshot 1`] = `
 <div>
-	 
-	<div
-		class="editor-rich-text"
-	>
-		<div>
-			<div>
-				<div
-					class="components-autocomplete"
-				>
-					<p
-						aria-autocomplete="list"
-						aria-expanded="false"
-						aria-label="Empty block; type text or press the forward slash key to insert a block"
-						aria-multiline="true"
-						class="wp-block-paragraph editor-rich-text__tinymce"
-						contenteditable="true"
-						data-is-placeholder-visible="true"
-						role="textbox"
-					>
-						<br
-							data-mce-bogus="1"
-						/>
-					</p>
-					<p
-						class="editor-rich-text__tinymce wp-block-paragraph"
-					>
-						Start writing or press / to insert a block
-					</p>
-				</div>
-			</div>
-		</div>
-	</div>
-	 
+   
+  <div
+    class="editor-rich-text"
+  >
+    <div>
+      <div>
+        <div
+          class="components-autocomplete"
+        >
+          <p
+            aria-autocomplete="list"
+            aria-expanded="false"
+            aria-label="Empty block; type text or press the forward slash key to insert a block"
+            aria-multiline="true"
+            class="wp-block-paragraph editor-rich-text__tinymce"
+            contenteditable="true"
+            data-is-placeholder-visible="true"
+            role="textbox"
+          >
+            <br
+              data-mce-bogus="1"
+            />
+          </p>
+          <p
+            class="editor-rich-text__tinymce wp-block-paragraph"
+          >
+            Start writing or press / to insert a block
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+   
 </div>
 `;

--- a/packages/block-library/src/paragraph/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/paragraph/test/__snapshots__/index.js.snap
@@ -14,7 +14,7 @@ exports[`core/paragraph block edit matches snapshot 1`] = `
           <p
             aria-autocomplete="list"
             aria-expanded="false"
-            aria-label="Add text or type / to add content"
+            aria-label="Type text or use the forward slash key to insert a block"
             aria-multiline="true"
             class="wp-block-paragraph editor-rich-text__tinymce"
             contenteditable="true"
@@ -28,7 +28,7 @@ exports[`core/paragraph block edit matches snapshot 1`] = `
           <p
             class="editor-rich-text__tinymce wp-block-paragraph"
           >
-            Add text or type / to add content
+            Type text or press “/” to select a block
           </p>
         </div>
       </div>

--- a/packages/block-library/src/paragraph/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/paragraph/test/__snapshots__/index.js.snap
@@ -2,38 +2,38 @@
 
 exports[`core/paragraph block edit matches snapshot 1`] = `
 <div>
-   
-  <div
-    class="editor-rich-text"
-  >
-    <div>
-      <div>
-        <div
-          class="components-autocomplete"
-        >
-          <p
-            aria-autocomplete="list"
-            aria-expanded="false"
-            aria-label="Empty block; type text or press the forward slash key to insert a block"
-            aria-multiline="true"
-            class="wp-block-paragraph editor-rich-text__tinymce"
-            contenteditable="true"
-            data-is-placeholder-visible="true"
-            role="textbox"
-          >
-            <br
-              data-mce-bogus="1"
-            />
-          </p>
-          <p
-            class="editor-rich-text__tinymce wp-block-paragraph"
-          >
-            Start writing or press “/” to insert a block
-          </p>
-        </div>
-      </div>
-    </div>
-  </div>
-   
+	 
+	<div
+		class="editor-rich-text"
+	>
+		<div>
+			<div>
+				<div
+					class="components-autocomplete"
+				>
+					<p
+						aria-autocomplete="list"
+						aria-expanded="false"
+						aria-label="Empty block; type text or press the forward slash key to insert a block"
+						aria-multiline="true"
+						class="wp-block-paragraph editor-rich-text__tinymce"
+						contenteditable="true"
+						data-is-placeholder-visible="true"
+						role="textbox"
+					>
+						<br
+							data-mce-bogus="1"
+						/>
+					</p>
+					<p
+						class="editor-rich-text__tinymce wp-block-paragraph"
+					>
+						Start writing or press / to insert a block
+					</p>
+				</div>
+			</div>
+		</div>
+	</div>
+	 
 </div>
 `;

--- a/packages/block-library/src/paragraph/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/paragraph/test/__snapshots__/index.js.snap
@@ -2,7 +2,7 @@
 
 exports[`core/paragraph block edit matches snapshot 1`] = `
 <div>
-	 
+
 	<div
 		class="editor-rich-text"
 	>
@@ -14,7 +14,7 @@ exports[`core/paragraph block edit matches snapshot 1`] = `
 					<p
 						aria-autocomplete="list"
 						aria-expanded="false"
-						aria-label="Empty block; type text or use the forward slash key to insert a block"
+						aria-label="Empty block; type text or press the forward slash key to insert a block"
 						aria-multiline="true"
 						class="wp-block-paragraph editor-rich-text__tinymce"
 						contenteditable="true"
@@ -34,6 +34,6 @@ exports[`core/paragraph block edit matches snapshot 1`] = `
 			</div>
 		</div>
 	</div>
-	 
+
 </div>
 `;

--- a/packages/block-library/src/paragraph/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/paragraph/test/__snapshots__/index.js.snap
@@ -14,7 +14,7 @@ exports[`core/paragraph block edit matches snapshot 1`] = `
           <p
             aria-autocomplete="list"
             aria-expanded="false"
-            aria-label="Type text or use the forward slash key to insert a block"
+            aria-label="Empty block; type text or use the forward slash key to insert a block"
             aria-multiline="true"
             class="wp-block-paragraph editor-rich-text__tinymce"
             contenteditable="true"

--- a/packages/editor/src/components/default-block-appender/index.js
+++ b/packages/editor/src/components/default-block-appender/index.js
@@ -31,7 +31,7 @@ export function DefaultBlockAppender( {
 		return null;
 	}
 
-	const value = decodeEntities( placeholder ) || __( 'Type text or press “/” to insert a block' );
+	const value = decodeEntities( placeholder ) || __( 'Start writing or press “/” to insert a block' );
 
 	// The appender "button" is in-fact a text field so as to support
 	// transitions by WritingFlow occurring by arrow key press. WritingFlow

--- a/packages/editor/src/components/default-block-appender/index.js
+++ b/packages/editor/src/components/default-block-appender/index.js
@@ -31,7 +31,7 @@ export function DefaultBlockAppender( {
 		return null;
 	}
 
-	const value = decodeEntities( placeholder ) || __( 'Start writing or press “/” to insert a block' );
+	const value = decodeEntities( placeholder ) || __( 'Start writing or press / to insert a block' );
 
 	// The appender "button" is in-fact a text field so as to support
 	// transitions by WritingFlow occurring by arrow key press. WritingFlow

--- a/packages/editor/src/components/default-block-appender/index.js
+++ b/packages/editor/src/components/default-block-appender/index.js
@@ -31,7 +31,7 @@ export function DefaultBlockAppender( {
 		return null;
 	}
 
-	const value = decodeEntities( placeholder ) || __( 'Type text or press “/” to select a block' );
+	const value = decodeEntities( placeholder ) || __( 'Type text or press “/” to insert a block' );
 
 	// The appender "button" is in-fact a text field so as to support
 	// transitions by WritingFlow occurring by arrow key press. WritingFlow

--- a/packages/editor/src/components/default-block-appender/index.js
+++ b/packages/editor/src/components/default-block-appender/index.js
@@ -31,7 +31,7 @@ export function DefaultBlockAppender( {
 		return null;
 	}
 
-	const value = decodeEntities( placeholder ) || __( 'Write your story' );
+	const value = decodeEntities( placeholder ) || __( 'Type text or press “/” to select a block' );
 
 	// The appender "button" is in-fact a text field so as to support
 	// transitions by WritingFlow occurring by arrow key press. WritingFlow

--- a/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -2,73 +2,73 @@
 
 exports[`DefaultBlockAppender should append a default block when input focused 1`] = `
 <div
-	className="wp-block editor-default-block-appender"
-	data-root-client-id=""
+  className="wp-block editor-default-block-appender"
+  data-root-client-id=""
 >
-	<WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
-	<input
-		aria-label="Add block"
-		className="editor-default-block-appender__content"
-		onFocus={
-			[MockFunction] {
-				"calls": Array [
-					Array [],
-				],
-				"results": undefined,
-			}
-		}
-		readOnly={true}
-		role="button"
-		type="text"
-		value="Type text or press “/” to insert a block"
-	/>
-	<WithSelect(WithDispatch(InserterWithShortcuts)) />
-	<WithSelect(IfCondition(Inserter))
-		position="top right"
-	/>
+  <WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
+  <input
+    aria-label="Add block"
+    className="editor-default-block-appender__content"
+    onFocus={
+      [MockFunction] {
+        "calls": Array [
+          Array [],
+        ],
+        "results": undefined,
+      }
+    }
+    readOnly={true}
+    role="button"
+    type="text"
+    value="Type text or press “/” to insert a block"
+  />
+  <WithSelect(WithDispatch(InserterWithShortcuts)) />
+  <WithSelect(IfCondition(Inserter))
+    position="top right"
+  />
 </div>
 `;
 
 exports[`DefaultBlockAppender should match snapshot 1`] = `
 <div
-	className="wp-block editor-default-block-appender"
-	data-root-client-id=""
+  className="wp-block editor-default-block-appender"
+  data-root-client-id=""
 >
-	<WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
-	<input
-		aria-label="Add block"
-		className="editor-default-block-appender__content"
-		onFocus={[MockFunction]}
-		readOnly={true}
-		role="button"
-		type="text"
-		value="Type text or press “/” to insert a block"
-	/>
-	<WithSelect(WithDispatch(InserterWithShortcuts)) />
-	<WithSelect(IfCondition(Inserter))
-		position="top right"
-	/>
+  <WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
+  <input
+    aria-label="Add block"
+    className="editor-default-block-appender__content"
+    onFocus={[MockFunction]}
+    readOnly={true}
+    role="button"
+    type="text"
+    value="Type text or press “/” to insert a block"
+  />
+  <WithSelect(WithDispatch(InserterWithShortcuts)) />
+  <WithSelect(IfCondition(Inserter))
+    position="top right"
+  />
 </div>
 `;
 
 exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
 <div
-	className="wp-block editor-default-block-appender"
-	data-root-client-id=""
+  className="wp-block editor-default-block-appender"
+  data-root-client-id=""
 >
-	<WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
-	<input
-		aria-label="Add block"
-		className="editor-default-block-appender__content"
-		onFocus={[MockFunction]}
-		readOnly={true}
-		role="button"
-		type="text"
-		value=""
-	/>
-	<WithSelect(WithDispatch(InserterWithShortcuts)) />
-	<WithSelect(IfCondition(Inserter))
-		position="top right"
-	/>
+  <WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
+  <input
+    aria-label="Add block"
+    className="editor-default-block-appender__content"
+    onFocus={[MockFunction]}
+    readOnly={true}
+    role="button"
+    type="text"
+    value=""
+  />
+  <WithSelect(WithDispatch(InserterWithShortcuts)) />
+  <WithSelect(IfCondition(Inserter))
+    position="top right"
+  />
 </div>
 `;

--- a/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -20,7 +20,7 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
     readOnly={true}
     role="button"
     type="text"
-    value="Type text or press “/” to insert a block"
+    value="Start writing or press “/” to insert a block"
   />
   <WithSelect(WithDispatch(InserterWithShortcuts)) />
   <WithSelect(IfCondition(Inserter))
@@ -42,7 +42,7 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
     readOnly={true}
     role="button"
     type="text"
-    value="Type text or press “/” to insert a block"
+    value="Start writing or press “/” to insert a block"
   />
   <WithSelect(WithDispatch(InserterWithShortcuts)) />
   <WithSelect(IfCondition(Inserter))

--- a/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -2,73 +2,73 @@
 
 exports[`DefaultBlockAppender should append a default block when input focused 1`] = `
 <div
-	className="wp-block editor-default-block-appender"
-	data-root-client-id=""
+  className="wp-block editor-default-block-appender"
+  data-root-client-id=""
 >
-	<WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
-	<input
-		aria-label="Add block"
-		className="editor-default-block-appender__content"
-		onFocus={
-			[MockFunction] {
-				"calls": Array [
-					Array [],
-				],
-				"results": undefined,
-			}
-		}
-		readOnly={true}
-		role="button"
-		type="text"
-		value="Start writing or press / to insert a block"
-	/>
-	<WithSelect(WithDispatch(InserterWithShortcuts)) />
-	<WithSelect(IfCondition(Inserter))
-		position="top right"
-	/>
+  <WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
+  <input
+    aria-label="Add block"
+    className="editor-default-block-appender__content"
+    onFocus={
+      [MockFunction] {
+        "calls": Array [
+          Array [],
+        ],
+        "results": undefined,
+      }
+    }
+    readOnly={true}
+    role="button"
+    type="text"
+    value="Start writing or press / to insert a block"
+  />
+  <WithSelect(WithDispatch(InserterWithShortcuts)) />
+  <WithSelect(IfCondition(Inserter))
+    position="top right"
+  />
 </div>
 `;
 
 exports[`DefaultBlockAppender should match snapshot 1`] = `
 <div
-	className="wp-block editor-default-block-appender"
-	data-root-client-id=""
+  className="wp-block editor-default-block-appender"
+  data-root-client-id=""
 >
-	<WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
-	<input
-		aria-label="Add block"
-		className="editor-default-block-appender__content"
-		onFocus={[MockFunction]}
-		readOnly={true}
-		role="button"
-		type="text"
-		value="Start writing or press / to insert a block"
-	/>
-	<WithSelect(WithDispatch(InserterWithShortcuts)) />
-	<WithSelect(IfCondition(Inserter))
-		position="top right"
-	/>
+  <WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
+  <input
+    aria-label="Add block"
+    className="editor-default-block-appender__content"
+    onFocus={[MockFunction]}
+    readOnly={true}
+    role="button"
+    type="text"
+    value="Start writing or press / to insert a block"
+  />
+  <WithSelect(WithDispatch(InserterWithShortcuts)) />
+  <WithSelect(IfCondition(Inserter))
+    position="top right"
+  />
 </div>
 `;
 
 exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
 <div
-	className="wp-block editor-default-block-appender"
-	data-root-client-id=""
+  className="wp-block editor-default-block-appender"
+  data-root-client-id=""
 >
-	<WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
-	<input
-		aria-label="Add block"
-		className="editor-default-block-appender__content"
-		onFocus={[MockFunction]}
-		readOnly={true}
-		role="button"
-		type="text"
-		value=""
-	/>
-	<WithSelect(WithDispatch(InserterWithShortcuts)) />
-	<WithSelect(IfCondition(Inserter))
-		position="top right"
-	/>
+  <WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
+  <input
+    aria-label="Add block"
+    className="editor-default-block-appender__content"
+    onFocus={[MockFunction]}
+    readOnly={true}
+    role="button"
+    type="text"
+    value=""
+  />
+  <WithSelect(WithDispatch(InserterWithShortcuts)) />
+  <WithSelect(IfCondition(Inserter))
+    position="top right"
+  />
 </div>
 `;

--- a/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -2,73 +2,73 @@
 
 exports[`DefaultBlockAppender should append a default block when input focused 1`] = `
 <div
-  className="wp-block editor-default-block-appender"
-  data-root-client-id=""
+	className="wp-block editor-default-block-appender"
+	data-root-client-id=""
 >
-  <WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
-  <input
-    aria-label="Add block"
-    className="editor-default-block-appender__content"
-    onFocus={
-      [MockFunction] {
-        "calls": Array [
-          Array [],
-        ],
-        "results": undefined,
-      }
-    }
-    readOnly={true}
-    role="button"
-    type="text"
-    value="Start writing or press “/” to insert a block"
-  />
-  <WithSelect(WithDispatch(InserterWithShortcuts)) />
-  <WithSelect(IfCondition(Inserter))
-    position="top right"
-  />
+	<WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
+	<input
+		aria-label="Add block"
+		className="editor-default-block-appender__content"
+		onFocus={
+			[MockFunction] {
+				"calls": Array [
+					Array [],
+				],
+				"results": undefined,
+			}
+		}
+		readOnly={true}
+		role="button"
+		type="text"
+		value="Start writing or press / to insert a block"
+	/>
+	<WithSelect(WithDispatch(InserterWithShortcuts)) />
+	<WithSelect(IfCondition(Inserter))
+		position="top right"
+	/>
 </div>
 `;
 
 exports[`DefaultBlockAppender should match snapshot 1`] = `
 <div
-  className="wp-block editor-default-block-appender"
-  data-root-client-id=""
+	className="wp-block editor-default-block-appender"
+	data-root-client-id=""
 >
-  <WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
-  <input
-    aria-label="Add block"
-    className="editor-default-block-appender__content"
-    onFocus={[MockFunction]}
-    readOnly={true}
-    role="button"
-    type="text"
-    value="Start writing or press “/” to insert a block"
-  />
-  <WithSelect(WithDispatch(InserterWithShortcuts)) />
-  <WithSelect(IfCondition(Inserter))
-    position="top right"
-  />
+	<WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
+	<input
+		aria-label="Add block"
+		className="editor-default-block-appender__content"
+		onFocus={[MockFunction]}
+		readOnly={true}
+		role="button"
+		type="text"
+		value="Start writing or press / to insert a block"
+	/>
+	<WithSelect(WithDispatch(InserterWithShortcuts)) />
+	<WithSelect(IfCondition(Inserter))
+		position="top right"
+	/>
 </div>
 `;
 
 exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
 <div
-  className="wp-block editor-default-block-appender"
-  data-root-client-id=""
+	className="wp-block editor-default-block-appender"
+	data-root-client-id=""
 >
-  <WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
-  <input
-    aria-label="Add block"
-    className="editor-default-block-appender__content"
-    onFocus={[MockFunction]}
-    readOnly={true}
-    role="button"
-    type="text"
-    value=""
-  />
-  <WithSelect(WithDispatch(InserterWithShortcuts)) />
-  <WithSelect(IfCondition(Inserter))
-    position="top right"
-  />
+	<WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
+	<input
+		aria-label="Add block"
+		className="editor-default-block-appender__content"
+		onFocus={[MockFunction]}
+		readOnly={true}
+		role="button"
+		type="text"
+		value=""
+	/>
+	<WithSelect(WithDispatch(InserterWithShortcuts)) />
+	<WithSelect(IfCondition(Inserter))
+		position="top right"
+	/>
 </div>
 `;

--- a/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -20,7 +20,7 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
     readOnly={true}
     role="button"
     type="text"
-    value="Write your story"
+    value="Type text or press “/” to select a block"
   />
   <WithSelect(WithDispatch(InserterWithShortcuts)) />
   <WithSelect(IfCondition(Inserter))
@@ -42,7 +42,7 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
     readOnly={true}
     role="button"
     type="text"
-    value="Write your story"
+    value="Type text or press “/” to select a block"
   />
   <WithSelect(WithDispatch(InserterWithShortcuts)) />
   <WithSelect(IfCondition(Inserter))

--- a/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -2,73 +2,73 @@
 
 exports[`DefaultBlockAppender should append a default block when input focused 1`] = `
 <div
-  className="wp-block editor-default-block-appender"
-  data-root-client-id=""
+	className="wp-block editor-default-block-appender"
+	data-root-client-id=""
 >
-  <WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
-  <input
-    aria-label="Add block"
-    className="editor-default-block-appender__content"
-    onFocus={
-      [MockFunction] {
-        "calls": Array [
-          Array [],
-        ],
-        "results": undefined,
-      }
-    }
-    readOnly={true}
-    role="button"
-    type="text"
-    value="Type text or press “/” to select a block"
-  />
-  <WithSelect(WithDispatch(InserterWithShortcuts)) />
-  <WithSelect(IfCondition(Inserter))
-    position="top right"
-  />
+	<WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
+	<input
+		aria-label="Add block"
+		className="editor-default-block-appender__content"
+		onFocus={
+			[MockFunction] {
+				"calls": Array [
+					Array [],
+				],
+				"results": undefined,
+			}
+		}
+		readOnly={true}
+		role="button"
+		type="text"
+		value="Type text or press “/” to insert a block"
+	/>
+	<WithSelect(WithDispatch(InserterWithShortcuts)) />
+	<WithSelect(IfCondition(Inserter))
+		position="top right"
+	/>
 </div>
 `;
 
 exports[`DefaultBlockAppender should match snapshot 1`] = `
 <div
-  className="wp-block editor-default-block-appender"
-  data-root-client-id=""
+	className="wp-block editor-default-block-appender"
+	data-root-client-id=""
 >
-  <WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
-  <input
-    aria-label="Add block"
-    className="editor-default-block-appender__content"
-    onFocus={[MockFunction]}
-    readOnly={true}
-    role="button"
-    type="text"
-    value="Type text or press “/” to select a block"
-  />
-  <WithSelect(WithDispatch(InserterWithShortcuts)) />
-  <WithSelect(IfCondition(Inserter))
-    position="top right"
-  />
+	<WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
+	<input
+		aria-label="Add block"
+		className="editor-default-block-appender__content"
+		onFocus={[MockFunction]}
+		readOnly={true}
+		role="button"
+		type="text"
+		value="Type text or press “/” to insert a block"
+	/>
+	<WithSelect(WithDispatch(InserterWithShortcuts)) />
+	<WithSelect(IfCondition(Inserter))
+		position="top right"
+	/>
 </div>
 `;
 
 exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
 <div
-  className="wp-block editor-default-block-appender"
-  data-root-client-id=""
+	className="wp-block editor-default-block-appender"
+	data-root-client-id=""
 >
-  <WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
-  <input
-    aria-label="Add block"
-    className="editor-default-block-appender__content"
-    onFocus={[MockFunction]}
-    readOnly={true}
-    role="button"
-    type="text"
-    value=""
-  />
-  <WithSelect(WithDispatch(InserterWithShortcuts)) />
-  <WithSelect(IfCondition(Inserter))
-    position="top right"
-  />
+	<WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
+	<input
+		aria-label="Add block"
+		className="editor-default-block-appender__content"
+		onFocus={[MockFunction]}
+		readOnly={true}
+		role="button"
+		type="text"
+		value=""
+	/>
+	<WithSelect(WithDispatch(InserterWithShortcuts)) />
+	<WithSelect(IfCondition(Inserter))
+		position="top right"
+	/>
 </div>
 `;

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -71,7 +71,7 @@ export class PostTextEditor extends Component {
 		return (
 			<Fragment>
 				<label htmlFor={ `post-content-${ instanceId }` } className="screen-reader-text">
-					{ decodedPlaceholder || __( 'Empty block; type text or press the forward slash key to insert a block' ) }
+					{ decodedPlaceholder || __( 'Type text' ) }
 				</label>
 				<Textarea
 					autoComplete="off"
@@ -80,7 +80,7 @@ export class PostTextEditor extends Component {
 					onBlur={ this.stopEditing }
 					className="editor-post-text-editor"
 					id={ `post-content-${ instanceId }` }
-					placeholder={ decodedPlaceholder || __( 'Type text or press “/” to insert a block' ) }
+					placeholder={ decodedPlaceholder || __( 'Type text' ) }
 				/>
 			</Fragment>
 		);

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -71,7 +71,7 @@ export class PostTextEditor extends Component {
 		return (
 			<Fragment>
 				<label htmlFor={ `post-content-${ instanceId }` } className="screen-reader-text">
-					{ decodedPlaceholder || __( 'Empty block; type text or use the forward slash key to insert a block' ) }
+					{ decodedPlaceholder || __( 'Empty block; type text or press the forward slash key to insert a block' ) }
 				</label>
 				<Textarea
 					autoComplete="off"

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -80,7 +80,7 @@ export class PostTextEditor extends Component {
 					onBlur={ this.stopEditing }
 					className="editor-post-text-editor"
 					id={ `post-content-${ instanceId }` }
-					placeholder={ decodedPlaceholder || __( 'Type text or press “/” to select a block' ) }
+					placeholder={ decodedPlaceholder || __( 'Type text or press “/” to insert a block' ) }
 				/>
 			</Fragment>
 		);

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -7,7 +7,6 @@ import Textarea from 'react-autosize-textarea';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { decodeEntities } from '@wordpress/html-entities';
 import { Component, Fragment } from '@wordpress/element';
 import { parse } from '@wordpress/blocks';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -65,13 +64,12 @@ export class PostTextEditor extends Component {
 
 	render() {
 		const { value } = this.state;
-		const { placeholder, instanceId } = this.props;
-		const decodedPlaceholder = decodeEntities( placeholder );
+		const { instanceId } = this.props;
 
 		return (
 			<Fragment>
 				<label htmlFor={ `post-content-${ instanceId }` } className="screen-reader-text">
-					{ decodedPlaceholder || __( 'Type text' ) }
+					{ __( 'Type text or HTML' ) }
 				</label>
 				<Textarea
 					autoComplete="off"
@@ -80,7 +78,7 @@ export class PostTextEditor extends Component {
 					onBlur={ this.stopEditing }
 					className="editor-post-text-editor"
 					id={ `post-content-${ instanceId }` }
-					placeholder={ decodedPlaceholder || __( 'Type text' ) }
+					placeholder={ __( 'Start writing with text or HTML' ) }
 				/>
 			</Fragment>
 		);
@@ -89,11 +87,9 @@ export class PostTextEditor extends Component {
 
 export default compose( [
 	withSelect( ( select ) => {
-		const { getEditedPostContent, getEditorSettings } = select( 'core/editor' );
-		const { bodyPlaceholder } = getEditorSettings();
+		const { getEditedPostContent } = select( 'core/editor' );
 		return {
 			value: getEditedPostContent(),
-			placeholder: bodyPlaceholder,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -71,7 +71,7 @@ export class PostTextEditor extends Component {
 		return (
 			<Fragment>
 				<label htmlFor={ `post-content-${ instanceId }` } className="screen-reader-text">
-					{ decodedPlaceholder || __( 'Write your story' ) }
+					{ decodedPlaceholder || __( 'Type text or press “/” to select a block' ) }
 				</label>
 				<Textarea
 					autoComplete="off"
@@ -80,7 +80,7 @@ export class PostTextEditor extends Component {
 					onBlur={ this.stopEditing }
 					className="editor-post-text-editor"
 					id={ `post-content-${ instanceId }` }
-					placeholder={ decodedPlaceholder || __( 'Write your story' ) }
+					placeholder={ decodedPlaceholder || __( 'Type text or press “/” to select a block' ) }
 				/>
 			</Fragment>
 		);

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -71,7 +71,7 @@ export class PostTextEditor extends Component {
 		return (
 			<Fragment>
 				<label htmlFor={ `post-content-${ instanceId }` } className="screen-reader-text">
-					{ decodedPlaceholder || __( 'Type text or press “/” to select a block' ) }
+					{ decodedPlaceholder || __( 'Empty block; type text or use the forward slash key to insert a block' ) }
 				</label>
 				<Textarea
 					autoComplete="off"


### PR DESCRIPTION
Fix #9076
Fix #5591

Consolidate the "Write your story" and "Add text or type" placeholders, while also adding context to the placeholder with an `aria-label`.

### Screenshots

<img width="1127" alt="screenshot 2018-11-07 02 57 05" src="https://user-images.githubusercontent.com/90871/48107789-d71f5180-e238-11e8-9a4b-bd3795db7e6a.png">
<img width="1161" alt="screenshot 2018-11-07 02 56 48" src="https://user-images.githubusercontent.com/90871/48107791-d7b7e800-e238-11e8-8a23-ea6776b3c244.png">
