### PR TITLE
Add missing tests for Format API code

### DIFF
--- a/packages/rich-text/src/insert-object.js
+++ b/packages/rich-text/src/insert-object.js
@@ -12,7 +12,7 @@ const OBJECT_REPLACEMENT_CHARACTER = '\ufffc';
  * removed. Indices are retrieved from the selection if none are provided.
  *
  * @param {Object} value          Value to modify.
- * @param {string} formatToInsert Format to insert as object.
+ * @param {Object} formatToInsert Format to insert as object.
  * @param {number} startIndex     Start index.
  * @param {number} endIndex       End index.
  *

--- a/packages/rich-text/src/store/test/actions.js
+++ b/packages/rich-text/src/store/test/actions.js
@@ -1,0 +1,30 @@
+/**
+ * Internal dependencies
+ */
+import { addFormatTypes, removeFormatTypes } from '../actions';
+
+describe( 'actions', () => {
+	describe( 'addFormatTypes', () => {
+		it( 'should cast format types as an array', () => {
+			const formatTypes = { name: 'core/test-format' };
+			const expected = {
+				type: 'ADD_FORMAT_TYPES',
+				formatTypes: [ formatTypes ],
+			};
+
+			expect( addFormatTypes( formatTypes ) ).toEqual( expected );
+		} );
+	} );
+
+	describe( 'removeFormatTypes', () => {
+		it( 'should cast format types as an array', () => {
+			const names = 'core/test-format';
+			const expected = {
+				type: 'REMOVE_FORMAT_TYPES',
+				names: [ names ],
+			};
+
+			expect( removeFormatTypes( names ) ).toEqual( expected );
+		} );
+	} );
+} );

--- a/packages/rich-text/src/store/test/selectors.js
+++ b/packages/rich-text/src/store/test/selectors.js
@@ -1,0 +1,33 @@
+/**
+ * Internal dependencies
+ */
+import { getFormatTypes, getFormatType } from '../selectors';
+
+describe( 'selectors', () => {
+	const defaultState = {
+		formatTypes: {
+			'core/test-format': { name: 'core/test-format' },
+			'core/test-format-2': { name: 'core/test-format-2' },
+		},
+	};
+
+	describe( 'getFormatTypes', () => {
+		it( 'should get format types', () => {
+			const expected = [
+				{ name: 'core/test-format' },
+				{ name: 'core/test-format-2' },
+			];
+
+			expect( getFormatTypes( defaultState ) ).toEqual( expected );
+		} );
+	} );
+
+	describe( 'getFormatType', () => {
+		it( 'should get a format type', () => {
+			const expected = { name: 'core/test-format' };
+			const result = getFormatType( defaultState, 'core/test-format' );
+
+			expect( result ).toEqual( expected );
+		} );
+	} );
+} );

--- a/packages/rich-text/src/store/test/selectors.js
+++ b/packages/rich-text/src/store/test/selectors.js
@@ -1,15 +1,20 @@
 /**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
  * Internal dependencies
  */
 import { getFormatTypes, getFormatType } from '../selectors';
 
 describe( 'selectors', () => {
-	const defaultState = {
+	const defaultState = deepFreeze( {
 		formatTypes: {
 			'core/test-format': { name: 'core/test-format' },
 			'core/test-format-2': { name: 'core/test-format-2' },
 		},
-	};
+	} );
 
 	describe( 'getFormatTypes', () => {
 		it( 'should get format types', () => {

--- a/packages/rich-text/src/test/get-format-type.js
+++ b/packages/rich-text/src/test/get-format-type.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getFormatType } from '../get-format-type';
+import { unregisterFormatType } from '../unregister-format-type';
+import { registerFormatType } from '../register-format-type';
+import { getFormatTypes } from '../get-format-types';
+
+describe( 'getFormatType', () => {
+	// Initialize format store.
+	require( '../store' );
+
+	afterEach( () => {
+		getFormatTypes().forEach( ( format ) => {
+			unregisterFormatType( format.name );
+		} );
+	} );
+
+	it( 'should return all format type elements', () => {
+		const formatType = {
+			edit: noop,
+			title: 'format title',
+			keywords: [ 'one', 'two', 'three' ],
+			formatTestSetting: 'settingTestValue',
+		};
+
+		registerFormatType( 'core/test-format-with-settings', formatType );
+
+		expect( getFormatType( 'core/test-format-with-settings' ) ).toEqual( {
+			name: 'core/test-format-with-settings',
+			...formatType,
+		} );
+	} );
+} );

--- a/packages/rich-text/src/test/get-format-type.js
+++ b/packages/rich-text/src/test/get-format-type.js
@@ -12,8 +12,10 @@ import { registerFormatType } from '../register-format-type';
 import { getFormatTypes } from '../get-format-types';
 
 describe( 'getFormatType', () => {
-	// Initialize format store.
-	require( '../store' );
+	beforeAll( () => {
+		// Initialize the rich-text store.
+		require( '../store' );
+	} );
 
 	afterEach( () => {
 		getFormatTypes().forEach( ( format ) => {
@@ -27,6 +29,8 @@ describe( 'getFormatType', () => {
 			title: 'format title',
 			keywords: [ 'one', 'two', 'three' ],
 			formatTestSetting: 'settingTestValue',
+			tagName: 'test',
+			className: null,
 		};
 
 		registerFormatType( 'core/test-format-with-settings', formatType );

--- a/packages/rich-text/src/test/get-format-types.js
+++ b/packages/rich-text/src/test/get-format-types.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getFormatTypes } from '../get-format-types';
+import { unregisterFormatType } from '../unregister-format-type';
+import { registerFormatType } from '../register-format-type';
+
+describe( 'getFormatTypes', () => {
+	// Initialize format store.
+	require( '../store' );
+
+	afterEach( () => {
+		getFormatTypes().forEach( ( format ) => {
+			unregisterFormatType( format.name );
+		} );
+	} );
+
+	it( 'should return an empty array at first', () => {
+		expect( getFormatTypes() ).toEqual( [] );
+	} );
+
+	it( 'should return all registered formats', () => {
+		const formatType1 = { edit: noop, title: 'format title' };
+		const formatType2 = {
+			edit: noop,
+			title: 'format title 2',
+			keywords: [ 'one', 'two', 'three' ],
+			formatTestSetting: 'settingTestValue',
+		};
+		registerFormatType( 'core/test-format', formatType1 );
+		registerFormatType( 'core/test-format-with-settings', formatType2 );
+		expect( getFormatTypes() ).toEqual( [
+			{
+				name: 'core/test-format',
+				...formatType1,
+			},
+			{
+				name: 'core/test-format-with-settings',
+				...formatType2,
+			},
+		] );
+	} );
+} );

--- a/packages/rich-text/src/test/get-format-types.js
+++ b/packages/rich-text/src/test/get-format-types.js
@@ -11,8 +11,10 @@ import { unregisterFormatType } from '../unregister-format-type';
 import { registerFormatType } from '../register-format-type';
 
 describe( 'getFormatTypes', () => {
-	// Initialize format store.
-	require( '../store' );
+	beforeAll( () => {
+		// Initialize the rich-text store.
+		require( '../store' );
+	} );
 
 	afterEach( () => {
 		getFormatTypes().forEach( ( format ) => {
@@ -25,23 +27,30 @@ describe( 'getFormatTypes', () => {
 	} );
 
 	it( 'should return all registered formats', () => {
-		const formatType1 = { edit: noop, title: 'format title' };
-		const formatType2 = {
+		const testFormat = {
+			edit: noop,
+			title: 'format title',
+			tagName: 'test',
+			className: null,
+		};
+		const testFormatWithSettings = {
 			edit: noop,
 			title: 'format title 2',
 			keywords: [ 'one', 'two', 'three' ],
+			tagName: 'test 2',
+			className: null,
 			formatTestSetting: 'settingTestValue',
 		};
-		registerFormatType( 'core/test-format', formatType1 );
-		registerFormatType( 'core/test-format-with-settings', formatType2 );
+		registerFormatType( 'core/test-format', testFormat );
+		registerFormatType( 'core/test-format-with-settings', testFormatWithSettings );
 		expect( getFormatTypes() ).toEqual( [
 			{
 				name: 'core/test-format',
-				...formatType1,
+				...testFormat,
 			},
 			{
 				name: 'core/test-format-with-settings',
-				...formatType2,
+				...testFormatWithSettings,
 			},
 		] );
 	} );

--- a/packages/rich-text/src/test/insert-object.js
+++ b/packages/rich-text/src/test/insert-object.js
@@ -6,15 +6,13 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-
 import { insertObject } from '../insert-object';
 import { getSparseArrayLength } from './helpers';
+import { OBJECT_REPLACEMENT_CHARACTER } from '../special-characters';
 
 describe( 'insert', () => {
 	const obj = { type: 'obj' };
 	const em = { type: 'em' };
-
-	const OBJECT_REPLACEMENT_CHARACTER = '\ufffc';
 
 	it( 'should delete and insert', () => {
 		const record = {
@@ -25,7 +23,7 @@ describe( 'insert', () => {
 		};
 		const expected = {
 			formats: [ , , [ { ...obj, object: true } ], [ em ], , , , , , , ],
-			text: 'on' + OBJECT_REPLACEMENT_CHARACTER + 'o three',
+			text: `on${ OBJECT_REPLACEMENT_CHARACTER }o three`,
 			start: 3,
 			end: 3,
 		};

--- a/packages/rich-text/src/test/insert-object.js
+++ b/packages/rich-text/src/test/insert-object.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+
+import { insertObject } from '../insert-object';
+import { getSparseArrayLength } from './helpers';
+
+describe( 'insert', () => {
+	const obj = { type: 'obj' };
+	const em = { type: 'em' };
+
+	const OBJECT_REPLACEMENT_CHARACTER = '\ufffc';
+
+	it( 'should delete and insert', () => {
+		const record = {
+			formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
+			text: 'one two three',
+			start: 6,
+			end: 6,
+		};
+		const expected = {
+			formats: [ , , [ { ...obj, object: true } ], [ em ], , , , , , , ],
+			text: 'on' + OBJECT_REPLACEMENT_CHARACTER + 'o three',
+			start: 3,
+			end: 3,
+		};
+		const result = insertObject( deepFreeze( record ), obj, 2, 6 );
+
+		expect( result ).toEqual( expected );
+		expect( result ).not.toBe( record );
+		expect( getSparseArrayLength( result.formats ) ).toBe( 2 );
+	} );
+} );

--- a/packages/rich-text/src/test/register-format-type.js
+++ b/packages/rich-text/src/test/register-format-type.js
@@ -1,0 +1,123 @@
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+/**
+ *  Internal dependencies
+ */
+import { registerFormatType } from '../register-format-type';
+import { unregisterFormatType } from '../unregister-format-type';
+import { getFormatType } from '../get-format-type';
+import { getFormatTypes } from '../get-format-types';
+
+describe( 'registerFormatType', () => {
+	const defaultFormatSettings = { edit: noop, title: 'format title' };
+
+	// Initialize format store.
+	require( '../store' );
+
+	afterEach( () => {
+		getFormatTypes().forEach( ( format ) => {
+			unregisterFormatType( format.name );
+		} );
+	} );
+
+	it( 'should reject numbers', () => {
+		const format = registerFormatType( 42 );
+		expect( console ).toHaveErroredWith( 'Format names must be strings.' );
+		expect( format ).toBeUndefined();
+	} );
+
+	it( 'should reject format types without a namespace', () => {
+		const format = registerFormatType( 'doing-it-wrong' );
+		expect( console ).toHaveErroredWith( 'Format names must contain a namespace prefix, include only lowercase alphanumeric characters or dashes, and start with a letter. Example: my-plugin/my-custom-format' );
+		expect( format ).toBeUndefined();
+	} );
+
+	it( 'should reject format types with too many namespaces', () => {
+		const format = registerFormatType( 'doing/it/wrong' );
+		expect( console ).toHaveErroredWith( 'Format names must contain a namespace prefix, include only lowercase alphanumeric characters or dashes, and start with a letter. Example: my-plugin/my-custom-format' );
+		expect( format ).toBeUndefined();
+	} );
+
+	it( 'should reject format types with invalid characters', () => {
+		const format = registerFormatType( 'still/_doing_it_wrong' );
+		expect( console ).toHaveErroredWith( 'Format names must contain a namespace prefix, include only lowercase alphanumeric characters or dashes, and start with a letter. Example: my-plugin/my-custom-format' );
+		expect( format ).toBeUndefined();
+	} );
+
+	it( 'should reject format types with uppercase characters', () => {
+		const format = registerFormatType( 'Core/Bold' );
+		expect( console ).toHaveErroredWith( 'Format names must contain a namespace prefix, include only lowercase alphanumeric characters or dashes, and start with a letter. Example: my-plugin/my-custom-format' );
+		expect( format ).toBeUndefined();
+	} );
+
+	it( 'should reject format types not starting with a letter', () => {
+		const format = registerFormatType( 'my-plugin/4-fancy-format' );
+		expect( console ).toHaveErroredWith( 'Format names must contain a namespace prefix, include only lowercase alphanumeric characters or dashes, and start with a letter. Example: my-plugin/my-custom-format' );
+		expect( format ).toBeUndefined();
+	} );
+
+	it( 'should accept valid format names', () => {
+		const format = registerFormatType( 'my-plugin/fancy-format-4', defaultFormatSettings );
+		expect( console ).not.toHaveErrored();
+		expect( format ).toEqual( {
+			name: 'my-plugin/fancy-format-4',
+			edit: noop,
+			title: 'format title',
+		} );
+	} );
+
+	it( 'should prohibit registering the same format twice', () => {
+		registerFormatType( 'core/test-format', defaultFormatSettings );
+		const format = registerFormatType( 'core/test-format', defaultFormatSettings );
+		expect( console ).toHaveErroredWith( 'Format "core/test-format" is already registered.' );
+		expect( format ).toBeUndefined();
+	} );
+
+	it( 'should reject formats without an edit function', () => {
+		const format = registerFormatType( 'my-plugin/fancy-format-5' );
+		expect( console ).toHaveErroredWith( 'The "edit" property must be specified and must be a valid function.' );
+		expect( format ).toBeUndefined();
+	} );
+
+	it( 'should reject formats with an invalid edit function', () => {
+		const formatType = { edit: 'not-a-function', title: 'format title' },
+			format = registerFormatType( 'my-plugin/fancy-format-6', formatType );
+		expect( console ).toHaveErroredWith( 'The "edit" property must be specified and must be a valid function.' );
+		expect( format ).toBeUndefined();
+	} );
+
+	it( 'should reject formats without title', () => {
+		const formatType = { edit: noop },
+			format = registerFormatType( 'my-plugin/fancy-format-7', formatType );
+		expect( console ).toHaveErroredWith( 'The format "my-plugin/fancy-format-7" must have a title.' );
+		expect( format ).toBeUndefined();
+	} );
+
+	it( 'should reject formats with empty titles', () => {
+		const formatType = { edit: noop, title: '' },
+			format = registerFormatType( 'my-plugin/fancy-format-8', formatType );
+		expect( console ).toHaveErroredWith( 'The format "my-plugin/fancy-format-8" must have a title.' );
+		expect( format ).toBeUndefined();
+	} );
+
+	it( 'should reject titles which are not strings', () => {
+		const formatType = { edit: noop, title: 1337 },
+			format = registerFormatType( 'my-plugin/fancy-format-9', formatType );
+		expect( console ).toHaveErroredWith( 'Format titles must be strings.' );
+		expect( format ).toBeUndefined();
+	} );
+
+	it( 'should store a copy of the format type', () => {
+		const formatType = { edit: noop, title: 'format title' };
+		registerFormatType( 'core/test-format-with-settings', formatType );
+		formatType.mutated = true;
+		expect( getFormatType( 'core/test-format-with-settings' ) ).toEqual( {
+			name: 'core/test-format-with-settings',
+			edit: noop,
+			title: 'format title',
+		} );
+	} );
+} );

--- a/packages/rich-text/src/test/toggle-format.js
+++ b/packages/rich-text/src/test/toggle-format.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+
+import { toggleFormat } from '../toggle-format';
+import { getSparseArrayLength } from './helpers';
+
+describe( 'toggleFormat', () => {
+	const strong = { type: 'strong' };
+	const em = { type: 'em' };
+
+	it( 'should remove format if it exists at start of selection', () => {
+		const record = {
+			formats: [ , , , [ strong ], [ em, strong ], [ em ], [ em ], , , , , , , ],
+			text: 'one two three',
+			start: 3,
+			end: 6,
+		};
+		const expected = {
+			formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
+			text: 'one two three',
+			start: 3,
+			end: 6,
+		};
+		const result = toggleFormat( deepFreeze( record ), strong );
+
+		expect( result ).toEqual( expected );
+		expect( result ).not.toBe( record );
+		expect( getSparseArrayLength( result.formats ) ).toBe( 3 );
+	} );
+
+	it( 'should apply format if it doesn\'t exist at start of selection', () => {
+		const record = {
+			formats: [ , , , , [ em, strong ], [ em ], [ em ], , , , , , , ],
+			text: 'one two three',
+			start: 3,
+			end: 6,
+		};
+		const expected = {
+			formats: [ , , , [ strong ], [ em, strong ], [ em, strong ], [ em ], , , , , , , ],
+			text: 'one two three',
+			start: 3,
+			end: 6,
+		};
+		const result = toggleFormat( deepFreeze( record ), strong );
+
+		expect( result ).toEqual( expected );
+		expect( result ).not.toBe( record );
+		expect( getSparseArrayLength( result.formats ) ).toBe( 4 );
+	} );
+} );

--- a/packages/rich-text/src/test/unregister-format-type.js
+++ b/packages/rich-text/src/test/unregister-format-type.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { unregisterFormatType } from '../unregister-format-type';
+import { registerFormatType } from '../register-format-type';
+import { getFormatTypes } from '../get-format-types';
+
+describe( 'unregisterFormatType', () => {
+	const defaultFormatSettings = { edit: noop, title: 'format title' };
+
+	// Initialize format store.
+	require( '../store' );
+
+	afterEach( () => {
+		getFormatTypes().forEach( ( format ) => {
+			unregisterFormatType( format.name );
+		} );
+	} );
+
+	it( 'should fail if the format is not registered', () => {
+		const oldFormat = unregisterFormatType( 'core/test-format' );
+		expect( console ).toHaveErroredWith( 'Format core/test-format is not registered.' );
+		expect( oldFormat ).toBeUndefined();
+	} );
+
+	it( 'should unregister existing formats', () => {
+		registerFormatType( 'core/test-format', defaultFormatSettings );
+		expect( getFormatTypes() ).toEqual( [
+			{
+				name: 'core/test-format',
+				...defaultFormatSettings,
+			},
+		] );
+		const oldFormat = unregisterFormatType( 'core/test-format' );
+		expect( console ).not.toHaveErrored();
+		expect( oldFormat ).toEqual( {
+			name: 'core/test-format',
+			...defaultFormatSettings,
+		} );
+		expect( getFormatTypes() ).toEqual( [] );
+	} );
+} );

--- a/packages/rich-text/src/test/unregister-format-type.js
+++ b/packages/rich-text/src/test/unregister-format-type.js
@@ -9,12 +9,20 @@ import { noop } from 'lodash';
 import { unregisterFormatType } from '../unregister-format-type';
 import { registerFormatType } from '../register-format-type';
 import { getFormatTypes } from '../get-format-types';
+import { getFormatType } from '../get-format-type';
 
 describe( 'unregisterFormatType', () => {
-	const defaultFormatSettings = { edit: noop, title: 'format title' };
+	const defaultFormatSettings = {
+		edit: noop,
+		title: 'format title',
+		tagName: 'test',
+		className: null,
+	};
 
-	// Initialize format store.
-	require( '../store' );
+	beforeAll( () => {
+		// Initialize the rich-text store.
+		require( '../store' );
+	} );
 
 	afterEach( () => {
 		getFormatTypes().forEach( ( format ) => {
@@ -30,12 +38,10 @@ describe( 'unregisterFormatType', () => {
 
 	it( 'should unregister existing formats', () => {
 		registerFormatType( 'core/test-format', defaultFormatSettings );
-		expect( getFormatTypes() ).toEqual( [
-			{
-				name: 'core/test-format',
-				...defaultFormatSettings,
-			},
-		] );
+		expect( getFormatType( 'core/test-format' ) ).toEqual( {
+			name: 'core/test-format',
+			...defaultFormatSettings,
+		} );
 		const oldFormat = unregisterFormatType( 'core/test-format' );
 		expect( console ).not.toHaveErrored();
 		expect( oldFormat ).toEqual( {


### PR DESCRIPTION
## Description
Closes #11110.

Addressed https://github.com/WordPress/gutenberg/issues/11110 by adding various tests. I used tests from other parts of the code as a reference. I am new to Jest and Gutenberg development though.

## Types of changes
Adds tests to several functions in the Format API, which should hopefully not break anything? 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
