### PR TITLE
Gallery: Upload images one at a time

### DIFF
--- a/packages/editor/src/utils/media-upload/media-upload.js
+++ b/packages/editor/src/utils/media-upload/media-upload.js
@@ -115,7 +115,9 @@ export async function mediaUpload( {
 		onError( error );
 	};
 
-	for ( const mediaFile of files ) {
+	// Using a normal for loop here since the loop contains an 'await'.
+	for ( let idx = 0; idx < files.length; ++idx ) {
+		const mediaFile = files[ idx ];
 		// verify if user is allowed to upload this mime type
 		if ( allowedMimeTypesForUser && ! isAllowedMimeTypeForUser( mediaFile.type ) ) {
 			triggerError( {
@@ -123,7 +125,7 @@ export async function mediaUpload( {
 				message: __( 'Sorry, this file type is not permitted for security reasons.' ),
 				file: mediaFile,
 			} );
-			return;
+			continue;
 		}
 
 		// Check if the block supports this mime type
@@ -133,7 +135,7 @@ export async function mediaUpload( {
 				message: __( 'Sorry, this file type is not supported here.' ),
 				file: mediaFile,
 			} );
-			return;
+			continue;
 		}
 
 		// verify if file is greater than the maximum file upload size allowed for the site.
@@ -143,7 +145,7 @@ export async function mediaUpload( {
 				message: __( 'This file exceeds the maximum upload size for this site.' ),
 				file: mediaFile,
 			} );
-			return;
+			continue;
 		}
 
 		// Don't allow empty files to be uploaded.
@@ -153,17 +155,14 @@ export async function mediaUpload( {
 				message: __( 'This file is empty.' ),
 				file: mediaFile,
 			} );
-			return;
+			continue;
 		}
 
 		// Set temporary URL to create placeholder media file, this is replaced
 		// with final file from media gallery when upload is `done` below
 		filesSet.push( { url: createBlobURL( mediaFile ) } );
 		onFileChange( filesSet );
-	}
 
-	for ( let idx = 0; idx < files.length; ++idx ) {
-		const mediaFile = files[ idx ];
 		try {
 			const savedMedia = await createMediaFromFile( mediaFile, additionalData );
 			const mediaObject = {

--- a/packages/editor/src/utils/media-upload/media-upload.js
+++ b/packages/editor/src/utils/media-upload/media-upload.js
@@ -115,9 +115,9 @@ export async function mediaUpload( {
 		onError( error );
 	};
 
-	// Using a normal for loop here since the loop contains an 'await'.
-	for ( let idx = 0; idx < files.length; ++idx ) {
-		const mediaFile = files[ idx ];
+	const validFiles = [];
+
+	for ( const mediaFile of files ) {
 		// verify if user is allowed to upload this mime type
 		if ( allowedMimeTypesForUser && ! isAllowedMimeTypeForUser( mediaFile.type ) ) {
 			triggerError( {
@@ -158,11 +158,16 @@ export async function mediaUpload( {
 			continue;
 		}
 
+		validFiles.push( mediaFile );
+
 		// Set temporary URL to create placeholder media file, this is replaced
 		// with final file from media gallery when upload is `done` below
 		filesSet.push( { url: createBlobURL( mediaFile ) } );
 		onFileChange( filesSet );
+	}
 
+	for ( let idx = 0; idx < validFiles.length; ++idx ) {
+		const mediaFile = validFiles[ idx ];
 		try {
 			const savedMedia = await createMediaFromFile( mediaFile, additionalData );
 			const mediaObject = {

--- a/packages/editor/src/utils/media-upload/test/media-upload.js
+++ b/packages/editor/src/utils/media-upload/test/media-upload.js
@@ -1,7 +1,19 @@
 /**
+ * WordPress dependencies
+ */
+import { createBlobURL } from '@wordpress/blob';
+
+/**
  * Internal dependencies
  */
 import { mediaUpload, getMimeTypesArray } from '../media-upload';
+
+// Image uploading fails in a test environment because
+// window.URL.createObjectURL is missing. We can check success by seeing if
+// mediaUpload() attempts to create a blob URL for the image.
+jest.mock( '@wordpress/blob', () => ( {
+	createBlobURL: jest.fn(),
+} ) );
 
 const invalidMediaObj = {
 	url: 'https://cldup.com/uuUqE_dXzy.jpg',
@@ -18,12 +30,10 @@ const validMediaObj = {
 
 describe( 'mediaUpload', () => {
 	const onFileChangeSpy = jest.fn();
-	const createObjectURL = jest.fn();
-	window.URL.createObjectURL = createObjectURL;
 
 	beforeEach( () => {
 		onFileChangeSpy.mockReset();
-		createObjectURL.mockReset();
+		createBlobURL.mockReset();
 	} );
 
 	it( 'should do nothing on no files', () => {
@@ -51,26 +61,18 @@ describe( 'mediaUpload', () => {
 			type: 'image/jpeg',
 			name: 'myImage.jpeg',
 		};
-		expect( () => {
-			mediaUpload( {
-				filesList: [ testFile ],
-				onFileChange: onFileChangeSpy,
-				allowedTypes: [ 'image/gif' ],
-				onError,
-			} );
-		} ).not.toThrow();
-		expect( createObjectURL ).not.toHaveBeenCalled();
+		mediaUpload( {
+			filesList: [ testFile ],
+			onFileChange: onFileChangeSpy,
+			allowedTypes: [ 'image/gif' ],
+			onError,
+		} );
+		expect( createBlobURL ).not.toHaveBeenCalled();
 		expect( onError ).toHaveBeenCalled();
 		expect( onError.mock.calls[ 0 ][ 0 ].code ).toBe( 'MIME_TYPE_NOT_SUPPORTED' );
-
-		createObjectURL.mockReset();
 	} );
 
 	it( 'should work as expected if allowedTypes contains a complete mime type string and the validation has success', () => {
-		// When the upload has success we get errors because we don't have available on the test environment
-		// all the functions required by mediaUpload.
-		// We know that when a validation success the function tries to create a temporary url for the file
-		// so we use that function to test the validation success.
 		const onError = jest.fn();
 		const testFile = {
 			url: 'https://cldup.com/uuUqE_dXzy.mp3',
@@ -78,15 +80,13 @@ describe( 'mediaUpload', () => {
 			name: 'myImage.jpeg',
 		};
 
-		expect( () => {
-			mediaUpload( {
-				filesList: [ testFile ],
-				onFileChange: onFileChangeSpy,
-				allowedTypes: [ 'image/jpeg' ],
-				onError,
-			} );
-		} ).toThrow();
-		expect( createObjectURL ).not.toHaveBeenCalled();
+		mediaUpload( {
+			filesList: [ testFile ],
+			onFileChange: onFileChangeSpy,
+			allowedTypes: [ 'image/jpeg' ],
+			onError,
+		} );
+		expect( createBlobURL ).toHaveBeenCalled();
 		expect( onError ).not.toHaveBeenCalled();
 	} );
 
@@ -97,26 +97,18 @@ describe( 'mediaUpload', () => {
 			type: 'audio/mp3',
 			name: 'mymusic.mp3',
 		};
-		expect( () => {
-			mediaUpload( {
-				filesList: [ testFile ],
-				onFileChange: onFileChangeSpy,
-				allowedTypes: [ 'video', 'image' ],
-				onError,
-			} );
-		} ).not.toThrow();
-		expect( createObjectURL ).not.toHaveBeenCalled();
+		mediaUpload( {
+			filesList: [ testFile ],
+			onFileChange: onFileChangeSpy,
+			allowedTypes: [ 'video', 'image' ],
+			onError,
+		} );
+		expect( createBlobURL ).not.toHaveBeenCalled();
 		expect( onError ).toHaveBeenCalled();
 		expect( onError.mock.calls[ 0 ][ 0 ].code ).toBe( 'MIME_TYPE_NOT_SUPPORTED' );
-
-		createObjectURL.mockReset();
 	} );
 
 	it( 'should work as expected if allowedTypes contains multiple types and the validation has success', () => {
-		// When the upload has success we get errors because we don't have available on the test environment
-		// all the functions required by mediaUpload.
-		// We know that when a validation success the function tries to create a temporary url for the file
-		// so we use that function to test the validation success.
 		const onError = jest.fn();
 		const testFile = {
 			url: 'https://cldup.com/uuUqE_dXzy.mp3',
@@ -124,15 +116,13 @@ describe( 'mediaUpload', () => {
 			name: 'mymusic.mp3',
 		};
 
-		expect( () => {
-			mediaUpload( {
-				filesList: [ testFile ],
-				onFileChange: onFileChangeSpy,
-				allowedTypes: [ 'image', 'audio' ],
-				onError,
-			} );
-		} ).toThrow();
-		expect( createObjectURL ).not.toHaveBeenCalled();
+		mediaUpload( {
+			filesList: [ testFile ],
+			onFileChange: onFileChangeSpy,
+			allowedTypes: [ 'image', 'audio' ],
+			onError,
+		} );
+		expect( createBlobURL ).toHaveBeenCalled();
 		expect( onError ).not.toHaveBeenCalled();
 	} );
 

--- a/packages/editor/src/utils/media-upload/test/media-upload.js
+++ b/packages/editor/src/utils/media-upload/test/media-upload.js
@@ -126,6 +126,33 @@ describe( 'mediaUpload', () => {
 		expect( onError ).not.toHaveBeenCalled();
 	} );
 
+	it( 'should only fail the file that caused the validation to fail and still allow others to succeed when uploading multiple files', () => {
+		const onError = jest.fn();
+		const invalidTestFile = {
+			url: 'https://cldup.com/uuUqE_dXzy.mp3',
+			type: 'image/jpeg',
+			name: 'myimage.jpg',
+		};
+		const validTestFile = {
+			url: 'https://cldup.com/uuUqE_dXzy.mp3',
+			type: 'audio/mp3',
+			name: 'mymusic.mp3',
+		};
+
+		mediaUpload( {
+			filesList: [ invalidTestFile, validTestFile ],
+			onFileChange: onFileChangeSpy,
+			allowedTypes: [ 'audio' ],
+			onError,
+		} );
+
+		expect( onError.mock.calls ).toHaveLength( 1 );
+		expect( onError.mock.calls[ 0 ][ 0 ].file ).toBe( invalidTestFile );
+
+		expect( createBlobURL.mock.calls ).toHaveLength( 1 );
+		expect( createBlobURL ).toHaveBeenCalledWith( validTestFile );
+	} );
+
 	it( 'should call error handler with the correct error object if file size is greater than the maximum', () => {
 		const onError = jest.fn();
 


### PR DESCRIPTION
Fixes #8935.

### The problem 🤔 

![](https://user-images.githubusercontent.com/1138304/44046867-affa7870-9f24-11e8-8389-bf41a4fa6667.png)

_Note: I've tested this all using VVV, but other development and production environments would be similar._

When 5-10 large (10 MB) images are uploaded at once using the Gallery block, it's highly likely that a few `The response was not a valid JSON response.` errors appear on the screen.

This is because the server has responded to some of the upload requests with a `502 Bad Gateway` error. The body of these responses is a nginx HTML error page, which explains the 'Invalid JSON' message.

Tailing the nginx error log (`/vagrant/www/wordpress-default/log/error.log`) reveals that the error occurs because its connection to php-fpm was reset:

```
2018/11/07 06:35:31 [error] 5676#5676: *133 recv() failed (104: Connection reset by peer) while reading response header from upstream, client: 192.168.50.1, server: local.wordpress.test, request: "POST /wp-json/wp/v2/media?_locale=user HTTP/1.1", upstream: "fastcgi://unix:/var/run/php7.2-fpm.sock:", host: "local.wordpress.test", referrer: "http://local.wordpress.test/wp-admin/post-new.php"
```

Tailing the system log (`/var/syslog`) reveals that this is because the operating system ran out of memory and so decided to kill php-fpm:

```
Nov  7 05:54:49 vvv kernel: [62514.273979] Killed process 7868 (php-fpm7.2) total-vm:1613272kB, anon-rss:763208kB, file-rss:8212kB
```

You can see from the system log that the php-fpm workers were altogether consuming about 1.7 GB of memory—easily enough to cause an OOM in this virtual machine that's configured with 2 GB of RAM:

```
Nov  7 05:54:49 vvv kernel: [62514.273061] [ pid ]   uid  tgid total_vm      rss nr_ptes swapents oom_score_adj name
Nov  7 05:54:49 vvv kernel: [62514.273162] [ 7825]     0  7825   112500     2370     155        0             0 php-fpm7.2
Nov  7 05:54:49 vvv kernel: [62514.273164] [ 7868]    33  7868   403318   192855     692        0             0 php-fpm7.2
Nov  7 05:54:49 vvv kernel: [62514.273167] [ 7871]    33  7871   294628    90474     491        0             0 php-fpm7.2
Nov  7 05:54:49 vvv kernel: [62514.273169] [ 7884]    33  7884   399494    64932     667        0             0 php-fpm7.2
Nov  7 05:54:49 vvv kernel: [62514.273171] [ 7928]    33  7928   402001    90221     704        0             0 php-fpm7.2
Nov  7 05:54:49 vvv kernel: [62514.273173] [ 7930]    33  7930   244805    16504     343        0             0 php-fpm7.2
```

This is because WordPress generates thumbnails for each image that is uploaded. Generating thumbnails for a large image is very memory intensive. In our case, we're generating thumbnails for several large images at once.

I'm not entirely clear on why the PHP runtime itself doesn't throw an OOM exception from exceeding the `memory_limit` set in `php.ini`. My guess is that it's because image resizing happens in a seperate module running under the php-fpm process.

### Proposed fix 😮 

Both the Upload New Media page and the Media Library both handle uploading multiple images by uploading one image at a time. That is, we wait until the first `POST` request to `async-upload.php` finishes before starting on the second.

Borrowing this approach for Gutenberg is a nice fix for the above issue because:

- It reduces load on the server as thumbnails are generated for only one image at a time.
- It works across all of the different WordPress server environments we're likely to encounter.
- It makes the Gallery block in Gutenberg consistent with the rest of WordPress.

It's also really simple to implement thanks to `async` and `await`.

### How to test 📋 

1. Ensure that your PHP max upload size setting is high enough
1. Create a new post
1. Insert a Gallery block
1. Click _Upload_
1. Select ~10 large (10 MB) images
1. All images should eventually upload without error.
1. Check that uploading in other blocks has not regressed e.g. Image, File, Audio, Video

### Future work 📆 

There are some unrelated issues that should be fixed separately:

- There is no indication that an image in the Gallery block is uploading.
- There is a flash of white when an image in the Gallery block has uploaded because we swap out the `blob:` URL for a non-cached `http://` URL.