### PR TITLE
 Fix the isBeingScheduled Selector. 

### DIFF
--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -395,17 +395,31 @@ export function dateI18n( dateFormat, dateValue = new Date(), gmt = false ) {
 /**
  * Check whether a date is considered in the future according to the WordPress settings.
  *
- * @param {(Date|string)} dateValue  Date object or string. (The timezone is ignored in date objects)
+ * @param {string} dateValue Date String or Date object in the Defined WP Timezone.
  *
  * @return {boolean} Is in the future.
  */
 export function isInTheFuture( dateValue ) {
-	const TIMEZONELESS_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
-	const timezoneLessDate = momentLib( dateValue ).format( TIMEZONELESS_FORMAT );
 	const now = momentLib.tz( 'WP' );
-	const momentObject = momentLib.tz( timezoneLessDate, 'WP' );
+	const momentObject = momentLib.tz( dateValue, 'WP' );
 
 	return momentObject.isAfter( now );
+}
+
+/**
+ * Given a string containing a date object formatted using the WP timezone
+ * Returns the corresponding JavaScript Date Object
+ *
+ * @param {string?} dateString Date formatted in the WP timezone.
+ *
+ * @return {Date} Date
+ */
+export function getDate( dateString ) {
+	if ( ! dateString ) {
+		return momentLib.tz( 'WP' ).toDate();
+	}
+
+	return momentLib.tz( dateString, 'WP' ).toDate();
 }
 
 setupWPTimezone();

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -395,13 +395,15 @@ export function dateI18n( dateFormat, dateValue = new Date(), gmt = false ) {
 /**
  * Check whether a date is considered in the future according to the WordPress settings.
  *
- * @param {(Date|string)} dateValue  Date object or string.
+ * @param {(Date|string)} dateValue  Date object or string. (The timezone is ignored in date objects)
  *
  * @return {boolean} Is in the future.
  */
 export function isInTheFuture( dateValue ) {
+	const TIMEZONELESS_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
+	const timezoneLessDate = momentLib( dateValue ).format( TIMEZONELESS_FORMAT );
 	const now = momentLib.tz( 'WP' );
-	const momentObject = momentLib.tz( dateValue, 'WP' );
+	const momentObject = momentLib.tz( timezoneLessDate, 'WP' );
 
 	return momentObject.isAfter( now );
 }

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -407,8 +407,7 @@ export function isInTheFuture( dateValue ) {
 }
 
 /**
- * Given a string containing a date object formatted using the WP timezone
- * Returns the corresponding JavaScript Date Object
+ * Create and return a JavaScript Date Object from a date string in the WP timezone.
  *
  * @param {string?} dateString Date formatted in the WP timezone.
  *

--- a/packages/date/src/test/index.js
+++ b/packages/date/src/test/index.js
@@ -1,0 +1,37 @@
+/**
+ * Internal dependencies
+ */
+import { isInTheFuture, getDate, setSettings, __experimentalGetSettings } from '../';
+
+describe( 'isInTheFuture', () => {
+	it( 'should return true if the date is in the future', () => {
+		const date = new Date( Number( getDate() ) + ( 1000 * 60 ) ); // 1 minute in the future
+
+		expect( isInTheFuture( date ) ).toBe( true );
+	} );
+
+	it( 'should return true if the date is in the past', () => {
+		const date = new Date( Number( getDate() ) - ( 1000 * 60 ) ); // 1 minute in the past
+
+		expect( isInTheFuture( date ) ).toBe( false );
+	} );
+
+	it( 'should ignore the timezone', () => {
+		const settings = __experimentalGetSettings();
+
+		// Set a timezone in the future
+		setSettings( {
+			...settings,
+			timezone: { offset: '4', string: '' },
+		} );
+
+		let date = new Date( Number( getDate() ) - ( 1000 * 60 ) ); // 1 minute in the past
+		expect( isInTheFuture( date ) ).toBe( false );
+
+		date = new Date( Number( getDate() ) + ( 1000 * 60 ) ); // 1 minute in the future
+		expect( isInTheFuture( date ) ).toBe( true );
+
+		// Restore default settings
+		setSettings( settings );
+	} );
+} );

--- a/packages/date/src/test/index.js
+++ b/packages/date/src/test/index.js
@@ -5,13 +5,15 @@ import { isInTheFuture, getDate, setSettings, __experimentalGetSettings } from '
 
 describe( 'isInTheFuture', () => {
 	it( 'should return true if the date is in the future', () => {
-		const date = new Date( Number( getDate() ) + ( 1000 * 60 ) ); // 1 minute in the future
+		// Create a Date object 1 minute in the future.
+		const date = new Date( Number( getDate() ) + ( 1000 * 60 ) );
 
 		expect( isInTheFuture( date ) ).toBe( true );
 	} );
 
 	it( 'should return true if the date is in the past', () => {
-		const date = new Date( Number( getDate() ) - ( 1000 * 60 ) ); // 1 minute in the past
+		// Create a Date object 1 minute in the past.
+		const date = new Date( Number( getDate() ) - ( 1000 * 60 ) );
 
 		expect( isInTheFuture( date ) ).toBe( false );
 	} );
@@ -24,11 +26,12 @@ describe( 'isInTheFuture', () => {
 			...settings,
 			timezone: { offset: '4', string: '' },
 		} );
-
-		let date = new Date( Number( getDate() ) - ( 1000 * 60 ) ); // 1 minute in the past
+		// Create a Date object 1 minute in the past.
+		let date = new Date( Number( getDate() ) - ( 1000 * 60 ) );
 		expect( isInTheFuture( date ) ).toBe( false );
 
-		date = new Date( Number( getDate() ) + ( 1000 * 60 ) ); // 1 minute in the future
+		// Create a Date object 1 minute in the future.
+		date = new Date( Number( getDate() ) + ( 1000 * 60 ) );
 		expect( isInTheFuture( date ) ).toBe( true );
 
 		// Restore default settings

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -32,7 +32,7 @@ import {
 	getFreeformContentHandlerName,
 	isUnmodifiedDefaultBlock,
 } from '@wordpress/blocks';
-import { isInTheFuture } from '@wordpress/date';
+import { isInTheFuture, getDate } from '@wordpress/date';
 import { removep } from '@wordpress/autop';
 import { select } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
@@ -333,7 +333,7 @@ export function isCurrentPostPublished( state ) {
 	const post = getCurrentPost( state );
 
 	return [ 'publish', 'private' ].indexOf( post.status ) !== -1 ||
-		( post.status === 'future' && ! isInTheFuture( new Date( Number( new Date( post.date ) ) + ONE_MINUTE_IN_MS ) ) );
+		( post.status === 'future' && ! isInTheFuture( new Date( Number( getDate( post.date ) ) - ONE_MINUTE_IN_MS ) ) );
 }
 
 /**
@@ -493,7 +493,7 @@ export function hasAutosave( state ) {
 export function isEditedPostBeingScheduled( state ) {
 	const date = getEditedPostAttribute( state, 'date' );
 	// Offset the date by one minute (network latency)
-	const checkedDate = new Date( Number( new Date( date ) ) + ONE_MINUTE_IN_MS );
+	const checkedDate = new Date( Number( getDate( date ) ) - ONE_MINUTE_IN_MS );
 
 	return isInTheFuture( checkedDate );
 }


### PR DESCRIPTION
closes #11554 

Dealing with timezones in JavaScript while the timezone is defined in the server is hard in WordPress. Hopefully, I added some tests to the date module to avoid breakage.

This fixes two issues:

 - Doing `new Date( wpDateString )` is wrong because it will read the date as if it was in the browser's timezone which is wrong. I added a `getDate` function to the date module to apply the WP timezone instead.

 - A small bug introduced in #11418 (where instead of removing a minute offset, we were adding a minute)