### PR TITLE
[RNMobile] Make sure the native side is refreshed after blocks Merging

### DIFF
--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -220,12 +220,6 @@ export class RichText extends Component {
 		const empty = this.isEmpty();
 
 		if ( onMerge ) {
-			// The onMerge event can cause a content update event for this block.  Such event should
-			// definitely be processed by our native components, since they have no knowledge of
-			// how the split works.  Setting lastEventCount to undefined forces the native component to
-			// always update when provided with new content.
-			this.lastEventCount = undefined;
-
 			onMerge( ! isReverse );
 		}
 
@@ -273,12 +267,21 @@ export class RichText extends Component {
 			this.lastContent = undefined;
 			return true;
 		}
-		// The check below allows us to avoid updating the content right after an `onChange` call
-		// first time the component is drawn with empty content `lastContent` is undefined
+		// The check below allows us to avoid updating the content right after an `onChange` call.
+		// The first time the component is drawn `lastContent` and `lastEventCount ` are both undefined
+		if ( this.lastEventCount && 
+			nextProps.value &&
+			this.lastContent &&
+			nextProps.value === this.lastContent) {
+			return false;
+		}
+
+		// If the component is changed React side (merging/splitting/custom text actions) we need to make sure 
+		// the native is updated as well
 		if ( nextProps.value &&
 			this.lastContent &&
-			this.lastEventCount ) {
-			return false;
+			nextProps.value !== this.lastContent) {
+			this.lastEventCount = undefined; // force a refresh on the native side
 		}
 
 		return true;

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -269,18 +269,18 @@ export class RichText extends Component {
 		}
 		// The check below allows us to avoid updating the content right after an `onChange` call.
 		// The first time the component is drawn `lastContent` and `lastEventCount ` are both undefined
-		if ( this.lastEventCount && 
+		if ( this.lastEventCount &&
 			nextProps.value &&
 			this.lastContent &&
-			nextProps.value === this.lastContent) {
+			nextProps.value === this.lastContent ) {
 			return false;
 		}
 
-		// If the component is changed React side (merging/splitting/custom text actions) we need to make sure 
+		// If the component is changed React side (merging/splitting/custom text actions) we need to make sure
 		// the native is updated as well
 		if ( nextProps.value &&
 			this.lastContent &&
-			nextProps.value !== this.lastContent) {
+			nextProps.value !== this.lastContent ) {
 			this.lastEventCount = undefined; // force a refresh on the native side
 		}
 


### PR DESCRIPTION
This PR fixes a problem where the native UI is not correctly refreshed when 2 blocks are merged together, resulting in one block with "old" content on the screen (Despite the datasources are updated).

To test this PR use this GB mobile PR here: <soon to arrive>.