### PR TITLE
Disabled conditions for publish buttons

### DIFF
--- a/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
+++ b/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
@@ -35,6 +35,7 @@ export function PostPublishButtonOrToggle( {
 			isOpen={ isPublishSidebarOpened }
 			onToggle={ togglePublishSidebar }
 			forceIsSaving={ forceIsSaving }
+			forceIsDirty={ forceIsDirty }
 		/>
 	);
 

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -42,9 +42,12 @@ export class PostPublishButton extends Component {
 			forceIsDirty,
 			forceIsSaving,
 		} = this.props;
-		const isButtonEnabled = ( ! isSaving && ! forceIsSaving ) &&
-			( forceIsDirty || isPublishable ) &&
-			( isSaveable && ! isPostSavingLocked );
+		const isButtonDisabled =
+			isSaving ||
+			forceIsSaving ||
+			! isSaveable ||
+			isPostSavingLocked ||
+			( ! isPublishable && ! forceIsDirty );
 
 		let publishStatus;
 		if ( ! hasPublishAction ) {
@@ -70,7 +73,7 @@ export class PostPublishButton extends Component {
 				isPrimary
 				isLarge
 				onClick={ onClick }
-				disabled={ ! isButtonEnabled }
+				disabled={ isButtonDisabled }
 				isBusy={ isSaving && isPublished }
 			>
 				<PublishButtonLabel forceIsSaving={ forceIsSaving } />

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -35,12 +35,14 @@ export class PostPublishButton extends Component {
 			visibility,
 			isPublishable,
 			isSaveable,
+			isPostSavingLocked,
 			hasPublishAction,
 			onSubmit = noop,
 			forceIsDirty,
 			forceIsSaving,
 		} = this.props;
-		const isButtonEnabled = ( forceIsDirty || isPublishable ) && isSaveable;
+		const isButtonEnabled = ( forceIsDirty || isPublishable ) &&
+			( isSaveable && ! isPostSavingLocked );
 
 		let publishStatus;
 		if ( ! hasPublishAction ) {
@@ -91,7 +93,8 @@ export default compose( [
 			isSaving: forceIsSaving || isSavingPost(),
 			isBeingScheduled: isEditedPostBeingScheduled(),
 			visibility: getEditedPostVisibility(),
-			isSaveable: isEditedPostSaveable() && ! isPostSavingLocked(),
+			isSaveable: isEditedPostSaveable(),
+			isPostSavingLocked: isPostSavingLocked(),
 			isPublishable: isEditedPostPublishable(),
 			hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
 			postType: getCurrentPostType(),

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -37,9 +37,10 @@ export class PostPublishButton extends Component {
 			isSaveable,
 			hasPublishAction,
 			onSubmit = noop,
+			forceIsDirty,
 			forceIsSaving,
 		} = this.props;
-		const isButtonEnabled = isPublishable && isSaveable;
+		const isButtonEnabled = ( forceIsDirty || isPublishable ) && isSaveable;
 
 		let publishStatus;
 		if ( ! hasPublishAction ) {
@@ -75,7 +76,7 @@ export class PostPublishButton extends Component {
 }
 
 export default compose( [
-	withSelect( ( select, { forceIsSaving, forceIsDirty } ) => {
+	withSelect( ( select, { forceIsSaving } ) => {
 		const {
 			isSavingPost,
 			isEditedPostBeingScheduled,
@@ -91,7 +92,7 @@ export default compose( [
 			isBeingScheduled: isEditedPostBeingScheduled(),
 			visibility: getEditedPostVisibility(),
 			isSaveable: isEditedPostSaveable() && ! isPostSavingLocked(),
-			isPublishable: forceIsDirty || isEditedPostPublishable(),
+			isPublishable: isEditedPostPublishable(),
 			hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
 			postType: getCurrentPostType(),
 		};

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -41,7 +41,8 @@ export class PostPublishButton extends Component {
 			forceIsDirty,
 			forceIsSaving,
 		} = this.props;
-		const isButtonEnabled = ( forceIsDirty || isPublishable ) &&
+		const isButtonEnabled = ( ! isSaving && ! forceIsSaving ) &&
+			( forceIsDirty || isPublishable ) &&
 			( isSaveable && ! isPostSavingLocked );
 
 		let publishStatus;
@@ -78,7 +79,7 @@ export class PostPublishButton extends Component {
 }
 
 export default compose( [
-	withSelect( ( select, { forceIsSaving } ) => {
+	withSelect( ( select ) => {
 		const {
 			isSavingPost,
 			isEditedPostBeingScheduled,
@@ -90,7 +91,7 @@ export default compose( [
 			getCurrentPostType,
 		} = select( 'core/editor' );
 		return {
-			isSaving: forceIsSaving || isSavingPost(),
+			isSaving: isSavingPost(),
 			isBeingScheduled: isEditedPostBeingScheduled(),
 			visibility: getEditedPostVisibility(),
 			isSaveable: isEditedPostSaveable(),

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -36,6 +36,7 @@ export class PostPublishButton extends Component {
 			isPublishable,
 			isSaveable,
 			isPostSavingLocked,
+			isPublished,
 			hasPublishAction,
 			onSubmit = noop,
 			forceIsDirty,
@@ -70,7 +71,7 @@ export class PostPublishButton extends Component {
 				isLarge
 				onClick={ onClick }
 				disabled={ ! isButtonEnabled }
-				isBusy={ isSaving }
+				isBusy={ isSaving && isPublished }
 			>
 				<PublishButtonLabel forceIsSaving={ forceIsSaving } />
 			</Button>
@@ -84,6 +85,7 @@ export default compose( [
 			isSavingPost,
 			isEditedPostBeingScheduled,
 			getEditedPostVisibility,
+			isCurrentPostPublished,
 			isEditedPostSaveable,
 			isEditedPostPublishable,
 			isPostSavingLocked,
@@ -97,6 +99,7 @@ export default compose( [
 			isSaveable: isEditedPostSaveable(),
 			isPostSavingLocked: isPostSavingLocked(),
 			isPublishable: isEditedPostPublishable(),
+			isPublished: isCurrentPostPublished(),
 			hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
 			postType: getCurrentPostType(),
 		};

--- a/packages/editor/src/components/post-publish-button/test/index.js
+++ b/packages/editor/src/components/post-publish-button/test/index.js
@@ -179,7 +179,10 @@ describe( 'PostPublishButton', () => {
 
 	it( 'should have save modifier class', () => {
 		const wrapper = shallow(
-			<PostPublishButton hasPublishAction={ true } isSaving />
+			<PostPublishButton
+				isSaving
+				isPublished
+			/>
 		);
 
 		expect( wrapper.find( 'Button' ).prop( 'isBusy' ) ).toBe( true );

--- a/packages/editor/src/components/post-publish-button/test/index.js
+++ b/packages/editor/src/components/post-publish-button/test/index.js
@@ -24,6 +24,18 @@ describe( 'PostPublishButton', () => {
 			expect( wrapper.prop( 'disabled' ) ).toBe( true );
 		} );
 
+		it( 'should be disabled if forceIsSaving is true', () => {
+			const wrapper = shallow(
+				<PostPublishButton
+					isPublishable
+					isSaveable
+					forceIsSaving
+				/>
+			);
+
+			expect( wrapper.prop( 'disabled' ) ).toBe( true );
+		} );
+
 		it( 'should be disabled if post is not publishable', () => {
 			const wrapper = shallow(
 				<PostPublishButton

--- a/packages/editor/src/components/post-publish-button/test/index.js
+++ b/packages/editor/src/components/post-publish-button/test/index.js
@@ -36,11 +36,12 @@ describe( 'PostPublishButton', () => {
 			expect( wrapper.prop( 'disabled' ) ).toBe( true );
 		} );
 
-		it( 'should be disabled if post is not publishable', () => {
+		it( 'should be disabled if post is not publishable and not forceIsDirty', () => {
 			const wrapper = shallow(
 				<PostPublishButton
-					isPublishable={ false }
 					isSaveable
+					isPublishable={ false }
+					forceIsDirty={ false }
 				/>
 			);
 
@@ -56,6 +57,18 @@ describe( 'PostPublishButton', () => {
 			);
 
 			expect( wrapper.prop( 'disabled' ) ).toBe( true );
+		} );
+
+		it( 'should be enabled if post is saveable but not publishable and forceIsDirty is true', () => {
+			const wrapper = shallow(
+				<PostPublishButton
+					isSaveable
+					isPublishable={ false }
+					forceIsDirty
+				/>
+			);
+
+			expect( wrapper.prop( 'disabled' ) ).toBe( false );
 		} );
 
 		it( 'should be enabled otherwise', () => {

--- a/packages/editor/src/components/post-publish-button/test/index.js
+++ b/packages/editor/src/components/post-publish-button/test/index.js
@@ -71,7 +71,7 @@ describe( 'PostPublishButton', () => {
 			expect( wrapper.prop( 'disabled' ) ).toBe( false );
 		} );
 
-		it( 'should be enabled otherwise', () => {
+		it( 'should be enabled if post is publishave and saveable', () => {
 			const wrapper = shallow(
 				<PostPublishButton
 					isPublishable

--- a/packages/editor/src/components/post-publish-button/test/index.js
+++ b/packages/editor/src/components/post-publish-button/test/index.js
@@ -26,7 +26,10 @@ describe( 'PostPublishButton', () => {
 
 		it( 'should be disabled if post is not publishable', () => {
 			const wrapper = shallow(
-				<PostPublishButton hasPublishAction={ true } isPublishable={ false } />
+				<PostPublishButton
+					isPublishable={ false }
+					isSaveable
+				/>
 			);
 
 			expect( wrapper.prop( 'disabled' ) ).toBe( true );

--- a/packages/editor/src/components/post-publish-button/test/index.js
+++ b/packages/editor/src/components/post-publish-button/test/index.js
@@ -48,7 +48,10 @@ describe( 'PostPublishButton', () => {
 
 		it( 'should be enabled otherwise', () => {
 			const wrapper = shallow(
-				<PostPublishButton hasPublishAction={ true } isPublishable isSaveable />
+				<PostPublishButton
+					isPublishable
+					isSaveable
+				/>
 			);
 
 			expect( wrapper.prop( 'disabled' ) ).toBe( false );

--- a/packages/editor/src/components/post-publish-button/test/index.js
+++ b/packages/editor/src/components/post-publish-button/test/index.js
@@ -37,7 +37,10 @@ describe( 'PostPublishButton', () => {
 
 		it( 'should be disabled if post is not saveable', () => {
 			const wrapper = shallow(
-				<PostPublishButton hasPublishAction={ true } isSaveable={ false } />
+				<PostPublishButton
+					isPublishable
+					isSaveable={ false }
+				/>
 			);
 
 			expect( wrapper.prop( 'disabled' ) ).toBe( true );

--- a/packages/editor/src/components/post-publish-button/test/index.js
+++ b/packages/editor/src/components/post-publish-button/test/index.js
@@ -59,6 +59,18 @@ describe( 'PostPublishButton', () => {
 			expect( wrapper.prop( 'disabled' ) ).toBe( true );
 		} );
 
+		it( 'should be disabled if post saving is locked', () => {
+			const wrapper = shallow(
+				<PostPublishButton
+					isPublishable
+					isSaveable
+					isPostSavingLocked
+				/>
+			);
+
+			expect( wrapper.prop( 'disabled' ) ).toBe( true );
+		} );
+
 		it( 'should be enabled if post is saveable but not publishable and forceIsDirty is true', () => {
 			const wrapper = shallow(
 				<PostPublishButton

--- a/packages/editor/src/components/post-publish-button/test/index.js
+++ b/packages/editor/src/components/post-publish-button/test/index.js
@@ -14,7 +14,11 @@ describe( 'PostPublishButton', () => {
 	describe( 'disabled', () => {
 		it( 'should be disabled if post is currently saving', () => {
 			const wrapper = shallow(
-				<PostPublishButton hasPublishAction={ true } isSaving />
+				<PostPublishButton
+					isPublishable
+					isSaveable
+					isSaving
+				/>
 			);
 
 			expect( wrapper.prop( 'disabled' ) ).toBe( true );

--- a/packages/editor/src/components/post-publish-panel/test/toggle.js
+++ b/packages/editor/src/components/post-publish-panel/test/toggle.js
@@ -12,7 +12,11 @@ describe( 'PostPublishPanelToggle', () => {
 	describe( 'disabled', () => {
 		it( 'should be disabled if post is currently saving', () => {
 			const wrapper = shallow(
-				<PostPublishPanelToggle isSaving />
+				<PostPublishPanelToggle
+					isPublishable
+					isSaveable
+					isSaving
+				/>
 			);
 
 			expect( wrapper.prop( 'disabled' ) ).toBe( true );

--- a/packages/editor/src/components/post-publish-panel/test/toggle.js
+++ b/packages/editor/src/components/post-publish-panel/test/toggle.js
@@ -24,7 +24,11 @@ describe( 'PostPublishPanelToggle', () => {
 
 		it( 'should be disabled if post is currently force saving', () => {
 			const wrapper = shallow(
-				<PostPublishPanelToggle forceIsSaving />
+				<PostPublishPanelToggle
+					isPublishable
+					isSaveable
+					forceIsSaving
+				/>
 			);
 
 			expect( wrapper.prop( 'disabled' ) ).toBe( true );

--- a/packages/editor/src/components/post-publish-panel/test/toggle.js
+++ b/packages/editor/src/components/post-publish-panel/test/toggle.js
@@ -34,9 +34,13 @@ describe( 'PostPublishPanelToggle', () => {
 			expect( wrapper.prop( 'disabled' ) ).toBe( true );
 		} );
 
-		it( 'should be disabled if post is not publishable', () => {
+		it( 'should be disabled if post is not publishable and not forceIsDirty', () => {
 			const wrapper = shallow(
-				<PostPublishPanelToggle isPublishable={ false } />
+				<PostPublishPanelToggle
+					isSaveable
+					isPublishable={ false }
+					forceIsDirty={ false }
+				/>
 			);
 
 			expect( wrapper.prop( 'disabled' ) ).toBe( true );
@@ -56,6 +60,18 @@ describe( 'PostPublishPanelToggle', () => {
 			);
 
 			expect( wrapper.prop( 'disabled' ) ).toBe( true );
+		} );
+
+		it( 'should be enabled if post is saveable but not publishable and forceIsDirty is true', () => {
+			const wrapper = shallow(
+				<PostPublishPanelToggle
+					isSaveable
+					isPublishable={ false }
+					forceIsDirty={ true }
+				/>
+			);
+
+			expect( wrapper.prop( 'disabled' ) ).toBe( false );
 		} );
 
 		it( 'should be enabled otherwise', () => {

--- a/packages/editor/src/components/post-publish-panel/test/toggle.js
+++ b/packages/editor/src/components/post-publish-panel/test/toggle.js
@@ -57,12 +57,16 @@ describe( 'PostPublishPanelToggle', () => {
 			expect( wrapper.prop( 'disabled' ) ).toBe( true );
 		} );
 
-		it( 'should be disabled if post is not published', () => {
+		it( 'should be disabled if post is published', () => {
 			const wrapper = shallow(
-				<PostPublishPanelToggle isPublished={ false } />
+				<PostPublishPanelToggle
+					isSaveable
+					isPublishable
+					isPublished
+				/>
 			);
 
-			expect( wrapper.prop( 'disabled' ) ).toBe( true );
+			expect( wrapper.prop( 'disabled' ) ).toBe( false );
 		} );
 
 		it( 'should be enabled if post is saveable but not publishable and forceIsDirty is true', () => {

--- a/packages/editor/src/components/post-publish-panel/test/toggle.js
+++ b/packages/editor/src/components/post-publish-panel/test/toggle.js
@@ -81,9 +81,12 @@ describe( 'PostPublishPanelToggle', () => {
 			expect( wrapper.prop( 'disabled' ) ).toBe( false );
 		} );
 
-		it( 'should be enabled otherwise', () => {
+		it( 'should be enabled if post is publishave and saveable', () => {
 			const wrapper = shallow(
-				<PostPublishPanelToggle isPublishable isSaveable />
+				<PostPublishPanelToggle
+					isPublishable
+					isSaveable
+				/>
 			);
 
 			expect( wrapper.prop( 'disabled' ) ).toBe( false );

--- a/packages/editor/src/components/post-publish-panel/test/toggle.js
+++ b/packages/editor/src/components/post-publish-panel/test/toggle.js
@@ -66,7 +66,7 @@ describe( 'PostPublishPanelToggle', () => {
 				/>
 			);
 
-			expect( wrapper.prop( 'disabled' ) ).toBe( false );
+			expect( wrapper.prop( 'disabled' ) ).toBe( true );
 		} );
 
 		it( 'should be enabled if post is saveable but not publishable and forceIsDirty is true', () => {

--- a/packages/editor/src/components/post-publish-panel/test/toggle.js
+++ b/packages/editor/src/components/post-publish-panel/test/toggle.js
@@ -48,7 +48,10 @@ describe( 'PostPublishPanelToggle', () => {
 
 		it( 'should be disabled if post is not saveable', () => {
 			const wrapper = shallow(
-				<PostPublishPanelToggle isSaveable={ false } />
+				<PostPublishPanelToggle
+					isSaveable={ false }
+					isPublishable
+				/>
 			);
 
 			expect( wrapper.prop( 'disabled' ) ).toBe( true );

--- a/packages/editor/src/components/post-publish-panel/toggle.js
+++ b/packages/editor/src/components/post-publish-panel/toggle.js
@@ -18,11 +18,10 @@ export function PostPublishPanelToggle( {
 	forceIsSaving,
 	forceIsDirty,
 } ) {
-	const isButtonEnabled = (
-		( ! isSaving && ! forceIsSaving ) &&
-		( isPublishable || forceIsDirty ) &&
-		isSaveable
-	) || isPublished;
+	const isButtonDisabled = isPublished ||
+		! isSaveable ||
+		isSaving || forceIsSaving ||
+		( ! isPublishable && ! forceIsDirty );
 
 	return (
 		<Button
@@ -30,7 +29,7 @@ export function PostPublishPanelToggle( {
 			isPrimary
 			onClick={ onToggle }
 			aria-expanded={ isOpen }
-			disabled={ ! isButtonEnabled }
+			disabled={ isButtonDisabled }
 			isBusy={ isSaving && isPublished }
 		>
 			{ isBeingScheduled ? __( 'Schedule…' ) : __( 'Publish…' ) }

--- a/packages/editor/src/components/post-publish-panel/toggle.js
+++ b/packages/editor/src/components/post-publish-panel/toggle.js
@@ -18,9 +18,11 @@ export function PostPublishPanelToggle( {
 	forceIsSaving,
 	forceIsDirty,
 } ) {
-	const isButtonDisabled = isPublished ||
+	const isButtonDisabled =
+		isPublished ||
+		isSaving ||
+		forceIsSaving ||
 		! isSaveable ||
-		isSaving || forceIsSaving ||
 		( ! isPublishable && ! forceIsDirty );
 
 	return (

--- a/packages/editor/src/components/post-publish-panel/toggle.js
+++ b/packages/editor/src/components/post-publish-panel/toggle.js
@@ -16,9 +16,12 @@ export function PostPublishPanelToggle( {
 	onToggle,
 	isOpen,
 	forceIsSaving,
+	forceIsDirty,
 } ) {
 	const isButtonEnabled = (
-		! isSaving && ! forceIsSaving && isPublishable && isSaveable
+		( ! isSaving && ! forceIsSaving ) &&
+		( isPublishable || forceIsDirty ) &&
+		isSaveable
 	) || isPublished;
 
 	return (

--- a/test/e2e/specs/publish-button.test.js
+++ b/test/e2e/specs/publish-button.test.js
@@ -1,0 +1,43 @@
+import {
+	arePrePublishChecksEnabled,
+	disablePrePublishChecks,
+	enablePrePublishChecks,
+	newPost,
+} from '../support/utils';
+
+describe( 'PostPublishButton', () => {
+	let werePrePublishChecksEnabled;
+	beforeEach( async () => {
+		await newPost( );
+		werePrePublishChecksEnabled = await arePrePublishChecksEnabled();
+		if ( werePrePublishChecksEnabled ) {
+			await disablePrePublishChecks();
+		}
+	} );
+
+	afterEach( async () => {
+		if ( werePrePublishChecksEnabled ) {
+			await enablePrePublishChecks();
+		}
+	} );
+
+	it( 'should be disabled when post is not saveable', async () => {
+		const publishButton = await page.$( '.editor-post-publish-button:disabled' );
+
+		expect( publishButton ).not.toBeNull();
+	} );
+
+	it( 'should be disabled when post is being saved', async () => {
+		await page.type( '.editor-post-title__input', 'E2E Test Post' ); // Make it saveable
+		expect( await page.$( '.editor-post-publish-button:disabled' ) ).toBeNull();
+		await page.click( '.editor-post-save-draft' );
+		expect( await page.$( '.editor-post-publish-button:disabled' ) ).not.toBeNull();
+	} );
+
+	it( 'should be disabled when metabox is being saved', async () => {
+		await page.type( '.editor-post-title__input', 'E2E Test Post' ); // Make it saveable
+		expect( await page.$( '.editor-post-publish-button:disabled' ) ).toBeNull();
+		await page.evaluate( () => window.wp.data.dispatch( 'core/edit-post' ).requestMetaBoxUpdates() );
+		expect( await page.$( '.editor-post-publish-button:disabled' ) ).not.toBeNull();
+	} );
+} );


### PR DESCRIPTION
We have two components that can be used to publish a post: `PostPublishToggle` or `PostPublishPanelButton`. The first will open the `PostPublishPanel` sidebar, the second is used in the `PostPublishPanel` sidebar, and substitutes the toggle when pre-publish checks are disabled or when the post is published.

The conditions under which they are disabled are different at the moment, tests pass due to wrong assumptions and/or conditions aren't met. In bold what this PR fixes:

| | Button | Toggle |
| --- | --- | --- 
isSavingPost=true | **disabled** | disabled |
forceIsSaving=true | **disabled** | disabled |
isEditedPostSaveable=false | disabled | disabled |
isEditedPostPublishable=false && forceIsDirty=false | disabled | disabled |
isCurrentPostPublished=true | - | **disabled** |
isPostSavingLocked=true | disabled | - |
isEditedPostSaveable=true && isEditedPostPublishable=false && forceIsDirty=true | enabled | **enabled** |
isEditedPostSaveable=true && isEditedPostPublishable=true && forceIsDirty=false | enabled | enabled |


# Testing

**Button and Toggle are disabled while a draft is being saved**

* Create a new post.
* Click "Save draft" button.
* Check that publish toggle is disabled.
* Repeat for the publish button (disable pre-publish checks in "More options > Options" modal first).

They should look like this:

![screenshot from 2018-11-08 10-42-45](https://user-images.githubusercontent.com/583546/48190505-35d0f200-e343-11e8-8953-e4feecb22528.png)

Note that when a post is being published, the button should show a busy status instead:

![screenshot from 2018-11-08 10-45-16](https://user-images.githubusercontent.com/583546/48190950-446bd900-e344-11e8-82d0-54d0948eb62a.png)

**Button and Toggle are disabled when forceIsSaving is true**

* Create a new post.
* Open the console and execute `wp.data.dispatch( 'core/edit-post' ).requestMetaBoxUpdates();`
* Check that the publish toggle is disabled for a quick moment.
* Repeat for the publish button (disable pre-publish checks in "More options > Options" modal first).

They should look like this:

![screenshot from 2018-11-08 10-42-45](https://user-images.githubusercontent.com/583546/48190505-35d0f200-e343-11e8-8953-e4feecb22528.png)

**Toggle is disabled if post is published**

No manual testing for this, we have a unit test that covers it. In Gutenberg case, the toggle is never shown if the post is published (we show the button instead). TLDR: at this point in the release cycle I don't want to introduce API changes.

**Toggle is enabled if post is saveable (has contents) and forceIsDirty**

No manual test for this either. Same reasons than above. Note that `forceIsDirty` has been added here as a new condition just for completeness. It doesn't modifies API.
