### PR TITLE
Fix 'undefined' in link popover when no href is provided

### DIFF
--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -172,7 +172,7 @@ class InlineLinkUI extends Component {
 	}
 
 	setLinkTarget( opensInNewWindow ) {
-		const { activeAttributes: { url }, value, onChange } = this.props;
+		const { activeAttributes: { url = '' }, value, onChange } = this.props;
 
 		this.setState( { opensInNewWindow } );
 

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -84,12 +84,27 @@ const LinkEditor = ( { value, onChangeInputValue, onKeyDown, submitLink, autocom
 	/* eslint-enable jsx-a11y/no-noninteractive-element-interactions */
 );
 
-const LinkViewer = ( { url, editLink } ) => {
+const LinkViewerUrl = ( { url } ) => {
 	const prependedURL = prependHTTP( url );
 	const linkClassName = classnames( 'editor-format-toolbar__link-container-value', {
 		'has-invalid-link': ! isValidHref( prependedURL ),
 	} );
 
+	if ( ! url ) {
+		return <span className={ linkClassName }></span>;
+	}
+
+	return (
+		<ExternalLink
+			className={ linkClassName }
+			href={ url }
+		>
+			{ filterURLForDisplay( safeDecodeURI( url ) ) }
+		</ExternalLink>
+	);
+};
+
+const LinkViewer = ( { url, editLink } ) => {
 	return (
 		// Disable reason: KeyPress must be suppressed so the block doesn't hide the toolbar
 		/* eslint-disable jsx-a11y/no-static-element-interactions */
@@ -97,12 +112,7 @@ const LinkViewer = ( { url, editLink } ) => {
 			className="editor-format-toolbar__link-container-content"
 			onKeyPress={ stopKeyPropagation }
 		>
-			<ExternalLink
-				className={ linkClassName }
-				href={ url }
-			>
-				{ filterURLForDisplay( safeDecodeURI( url ) ) }
-			</ExternalLink>
+			<LinkViewerUrl url={ url } />
 			<IconButton icon="edit" label={ __( 'Edit' ) } onClick={ editLink } />
 		</div>
 		/* eslint-enable jsx-a11y/no-static-element-interactions */
@@ -122,7 +132,10 @@ class InlineLinkUI extends Component {
 		this.resetState = this.resetState.bind( this );
 		this.autocompleteRef = createRef();
 
-		this.state = {};
+		this.state = {
+			opensInNewWindow: false,
+			inputValue: '',
+		};
 	}
 
 	static getDerivedStateFromProps( props, state ) {


### PR DESCRIPTION
If you edit a link that has no `href` value it will show `undefined`, and throw an error if you then select `open in new tab`.

<img width="265" alt="screenshot 2018-11-07 at 12 05 51" src="https://user-images.githubusercontent.com/841956/48128162-e678bc00-e285-11e8-9357-8e48655da0b2.png">

This PR handles the `undefined` display better, as well as catching the subsequent problems caused by it.

![edit_post_ _wordpress_latest_ _wordpress](https://user-images.githubusercontent.com/1277682/48254359-c1a95380-e401-11e8-882a-32ed01d701de.jpg)

There may be a better UX for this situation, but I've focussed on keeping existing behaviour rather than make too many modifications. It seems a very edge case situation.

Fixes #11574

## How has this been tested?
1. Create a post and add a blank paragraph
2. Switch to code editor
3. In the paragraph, add a link without an href: `<a>some link</a>`
4. Switch back to visual editor
5. Verify clicking the link shows an empty link editor popover, and that clicking the link ellipsis and enabling `open in new tab` doesn't throw an error
6. Verify that the link popover works in general situations where an `href` is present

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
