### PR TITLE
Always show icon in block toolbar

### DIFF
--- a/packages/editor/src/components/block-switcher/index.js
+++ b/packages/editor/src/components/block-switcher/index.js
@@ -58,7 +58,20 @@ export class BlockSwitcher extends Component {
 		const hasStyles = blocks.length === 1 && get( blockType, [ 'styles' ], [] ).length !== 0;
 
 		if ( ! hasStyles && ! possibleBlockTransformations.length ) {
-			return null;
+			if ( blocks.length > 1 ) {
+				return null;
+			}
+			return (
+				<Toolbar>
+					<IconButton
+						disabled
+						className="editor-block-switcher__no-switcher-icon"
+						label={ __( 'Block icon' ) }
+					>
+						<BlockIcon icon={ blockType.icon } showColors />
+					</IconButton>
+				</Toolbar>
+			);
 		}
 
 		return (

--- a/packages/editor/src/components/block-switcher/style.scss
+++ b/packages/editor/src/components/block-switcher/style.scss
@@ -3,15 +3,27 @@
 	height: $icon-button-size;
 }
 
-// Style this the same as the block buttons in the library.
-// Needs specificiity to override the icon button.
-.components-icon-button.editor-block-switcher__toggle {
-	width: auto;
+.components-icon-button.editor-block-switcher__toggle,
+.components-icon-button.editor-block-switcher__no-switcher-icon {
 	margin: 0;
 	display: block;
 	height: $icon-button-size;
 	padding: 3px;
+}
 
+
+.components-icon-button.editor-block-switcher__no-switcher-icon {
+	width: $icon-button-size + 6px + 6px;
+	.editor-block-icon {
+		margin-right: auto;
+		margin-left: auto;
+	}
+}
+
+// Style this the same as the block buttons in the library.
+// Needs specificiity to override the icon button.
+.components-icon-button.editor-block-switcher__toggle {
+	width: auto;
 	// Unset icon button styles.
 	&:active,
 	&:not(:disabled):not([aria-disabled="true"]):hover,


### PR DESCRIPTION
Closes: https://github.com/WordPress/gutenberg/issues/11552

This PR applies a change to the block switcher now when a single block is selected it renders the block icon disabled and without the arrow or hover effect as discussed in https://github.com/WordPress/gutenberg/issues/11552.


## How has this been tested?
Verify that the icon of the columns block or "Media & Text" correctly appears.

## Screenshots <!-- if applicable -->
<img width="913" alt="screenshot 2018-11-07 at 18 23 52" src="https://user-images.githubusercontent.com/11271197/48152340-856bdb00-e2bb-11e8-8aef-0cde01688561.png">
<img width="571" alt="screenshot 2018-11-07 at 18 24 14" src="https://user-images.githubusercontent.com/11271197/48152345-87ce3500-e2bb-11e8-8741-d5ad6d65058a.png">

