### PR TITLE
RichText: Memoize createRecord

### DIFF
--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -177,6 +177,20 @@ export class RichText extends Component {
 	createRecord() {
 		const range = getSelection().getRangeAt( 0 );
 
+		// If the range is shallowly equal to the last, return the last
+		// calculated value. This is useful when creating values on the
+		// `selectionchange` event, which fires more often than it should
+		// without a change in selection.
+		//
+		// Shallowly checking equality for ranges is fine:
+		//
+		// > Thus subsequent calls of this method returns the same range object
+		// > if nothing has removed the context object's range in the meantime.
+		// > In particular, getSelection().getRangeAt( 0 ) ===
+		// > getSelection().getRangeAt( 0 ) evaluates to true if the selection
+		// > is not empty.
+		// >
+		// > https://w3c.github.io/selection-api/#dom-selection-getrangeat
 		if ( range === this.createRecord.lastRange ) {
 			return this.createRecord.lastRecord;
 		}

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -111,7 +111,6 @@ export class RichText extends Component {
 		this.isActive = this.isActive.bind( this );
 
 		this.formatToValue = memize( this.formatToValue.bind( this ), { size: 1 } );
-		this.createRecordFromRange = memize( this.createRecordFromRange.bind( this ), { size: 1 } );
 
 		this.savedContent = value;
 		this.patterns = getPatterns( {
@@ -176,11 +175,13 @@ export class RichText extends Component {
 	}
 
 	createRecord() {
-		return this.createRecordFromRange( getSelection().getRangeAt( 0 ) );
-	}
+		const range = getSelection().getRangeAt( 0 );
 
-	createRecordFromRange( range ) {
-		return create( {
+		if ( range === this.createRecord.lastRange ) {
+			return this.createRecord.lastRecord;
+		}
+
+		const record = create( {
 			element: this.editableRef,
 			range,
 			multilineTag: this.multilineTag,
@@ -191,6 +192,11 @@ export class RichText extends Component {
 			filterString: ( string ) => string.replace( TINYMCE_ZWSP, '' ),
 			prepareEditableTree: this.props.prepareEditableTree,
 		} );
+
+		this.createRecord.lastRecord = record;
+		this.createRecord.lastRange = range;
+
+		return record;
 	}
 
 	applyRecord( record ) {

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -111,6 +111,7 @@ export class RichText extends Component {
 		this.isActive = this.isActive.bind( this );
 
 		this.formatToValue = memize( this.formatToValue.bind( this ), { size: 1 } );
+		this.createRecordFromRange = memize( this.createRecordFromRange.bind( this ), { size: 1 } );
 
 		this.savedContent = value;
 		this.patterns = getPatterns( {
@@ -175,8 +176,10 @@ export class RichText extends Component {
 	}
 
 	createRecord() {
-		const range = getSelection().getRangeAt( 0 );
+		return this.createRecordFromRange( getSelection().getRangeAt( 0 ) );
+	}
 
+	createRecordFromRange( range ) {
 		return create( {
 			element: this.editableRef,
 			range,

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -174,6 +174,15 @@ export class RichText extends Component {
 		return { formats, text, start, end };
 	}
 
+	/**
+	 * Creates a new record from the current editable DOM.
+	 *
+	 * @param {Object} $1       Named arguments.
+	 * @param {Object} $1.cache Wether or not to cache the record based on the
+	 *                          selection.
+	 *
+	 * @return {Object} A new record.
+	 */
 	createRecord( { cache } = {} ) {
 		const range = getSelection().getRangeAt( 0 );
 

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -177,13 +177,16 @@ export class RichText extends Component {
 	/**
 	 * Creates a new record from the current editable DOM.
 	 *
-	 * @param {Object} $1       Named arguments.
-	 * @param {Object} $1.cache Wether or not to cache the record based on the
-	 *                          selection.
+	 * @param {Object} $1          Named arguments.
+	 * @param {Object} $1.useCache Wether or not to use a cached record when the
+	 *                             selection did not change. Recommended to use
+	 *                             e.g. in the `selectionchange` event handler
+	 *                             when nothing other than the selection could
+	 *                             have changed.
 	 *
 	 * @return {Object} A new record.
 	 */
-	createRecord( { cache } = {} ) {
+	createRecord( { useCache } = {} ) {
 		const range = getSelection().getRangeAt( 0 );
 
 		// If the range is shallowly equal to the last, return the last
@@ -200,7 +203,7 @@ export class RichText extends Component {
 		// > is not empty.
 		// >
 		// > https://w3c.github.io/selection-api/#dom-selection-getrangeat
-		if ( cache && range === this.createRecord.lastRange ) {
+		if ( useCache && range === this.createRecord.lastRange ) {
 			return this.createRecord.lastRecord;
 		}
 
@@ -428,7 +431,7 @@ export class RichText extends Component {
 			return;
 		}
 
-		const { start, end, formats } = this.createRecord( { cache: true } );
+		const { start, end, formats } = this.createRecord( { useCache: true } );
 
 		if ( start !== this.state.start || end !== this.state.end ) {
 			const isCaretWithinFormattedText = this.props.isCaretWithinFormattedText;

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -174,7 +174,7 @@ export class RichText extends Component {
 		return { formats, text, start, end };
 	}
 
-	createRecord() {
+	createRecord( { cache } = {} ) {
 		const range = getSelection().getRangeAt( 0 );
 
 		// If the range is shallowly equal to the last, return the last
@@ -191,7 +191,7 @@ export class RichText extends Component {
 		// > is not empty.
 		// >
 		// > https://w3c.github.io/selection-api/#dom-selection-getrangeat
-		if ( range === this.createRecord.lastRange ) {
+		if ( cache && range === this.createRecord.lastRange ) {
 			return this.createRecord.lastRecord;
 		}
 
@@ -419,7 +419,7 @@ export class RichText extends Component {
 			return;
 		}
 
-		const { start, end, formats } = this.createRecord();
+		const { start, end, formats } = this.createRecord( { cache: true } );
 
 		if ( start !== this.state.start || end !== this.state.end ) {
 			const isCaretWithinFormattedText = this.props.isCaretWithinFormattedText;


### PR DESCRIPTION
## Description

It very often occurs that on selection change, the range stays the same and no selection calculation needs to be made. E.g. on entering a character `onSelectionChange` will be called twice, while the selection actually stays the same. We can memoize createRecord, as range object will be strict equal through `getSelection().getRangeAt( 0 )` calls.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->