### PR TITLE
Compat: Upgrade admin notices to use Notices module at runtime

### DIFF
--- a/docs/data/data-core-notices.md
+++ b/docs/data/data-core-notices.md
@@ -20,7 +20,8 @@ Yields action objects used in signalling that a notice is to be created.
 
 *Parameters*
 
- * status: Notice status.
+ * statusOrNotice: Notice status, or a
+                                                      notice object.
                                                       Defaults to `info`.
  * content: Notice message.
  * options: Notice options.

--- a/docs/data/data-core-notices.md
+++ b/docs/data/data-core-notices.md
@@ -23,7 +23,9 @@ Yields action objects used in signalling that a notice is to be created.
  * statusOrNotice: Notice status, or a
                                                       notice object.
                                                       Defaults to `info`.
- * content: Notice message.
+ * contentOrOptions: Notice message, or
+                                                      options if the first
+                                                      argument is WPNotice.
  * options: Notice options.
  * options.context: Context under which to
                                                       group notice.
@@ -33,6 +35,11 @@ Yields action objects used in signalling that a notice is to be created.
  * options.isDismissible: Whether the notice can
                                                       be dismissed by user.
                                                       Defaults to `true`.
+ * options.speak: Whether the notice
+                                                      content should be
+                                                      announced to screen
+                                                      readers. Defaults to
+                                                      `true`.
  * options.actions: User actions to be
                                                       presented with notice.
 

--- a/docs/data/data-core-notices.md
+++ b/docs/data/data-core-notices.md
@@ -20,12 +20,9 @@ Yields action objects used in signalling that a notice is to be created.
 
 *Parameters*
 
- * statusOrNotice: Notice status, or a
-                                                      notice object.
+ * status: Notice status.
                                                       Defaults to `info`.
- * contentOrOptions: Notice message, or
-                                                      options if the first
-                                                      argument is WPNotice.
+ * content: Notice message.
  * options: Notice options.
  * options.context: Context under which to
                                                       group notice.

--- a/docs/reference/coding-guidelines.md
+++ b/docs/reference/coding-guidelines.md
@@ -93,9 +93,13 @@ Exposed APIs that are still being tested, discussed and are subject to change sh
 Example:
 
 ```js
-export {
-	internalApi as __experimentalExposedApi
-} from './internalApi.js';
+export { __experimentalDoAction } from './api';
+```
+
+If an API must be exposed but is clearly not intended to be supported into the future, you may also use `__unstable` as a prefix to differentiate it from an experimental API. Unstable APIs should serve an immediate and temporary purpose. They should _never_ be used by plugin developers as they can be removed at any point without notice, and thus should be omitted from public-facing documentation. The inline code documentation should clearly caution their use.
+
+```js
+export { __unstableDoAction } from './api';
 ```
 
 ### Variable Naming

--- a/lib/packages-dependencies.php
+++ b/lib/packages-dependencies.php
@@ -126,6 +126,7 @@ return array(
 		'wp-embed',
 		'wp-i18n',
 		'wp-keycodes',
+		'wp-notices',
 		'wp-nux',
 		'wp-plugins',
 		'wp-url',

--- a/packages/components/src/notice/index.js
+++ b/packages/components/src/notice/index.js
@@ -8,6 +8,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { RawHTML } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -21,10 +22,15 @@ function Notice( {
 	onRemove = noop,
 	isDismissible = true,
 	actions = [],
+	__unstableHTML,
 } ) {
 	const classes = classnames( className, 'components-notice', 'is-' + status, {
 		'is-dismissible': isDismissible,
 	} );
+
+	if ( __unstableHTML ) {
+		children = <RawHTML>{ children }</RawHTML>;
+	}
 
 	return (
 		<div className={ classes }>

--- a/packages/components/src/notice/list.js
+++ b/packages/components/src/notice/list.js
@@ -4,6 +4,11 @@
 import { noop, omit } from 'lodash';
 
 /**
+ * WordPress dependencies
+ */
+import { RawHTML } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import Notice from './';
@@ -25,8 +30,16 @@ function NoticeList( { notices, onRemove = noop, className = 'components-notice-
 		<div className={ className }>
 			{ children }
 			{ [ ...notices ].reverse().map( ( notice ) => (
-				<Notice { ...omit( notice, 'content' ) } key={ notice.id } onRemove={ removeNotice( notice.id ) }>
-					{ notice.content }
+				<Notice
+					{ ...omit( notice, [ 'content', '__unstableHTML' ] ) }
+					key={ notice.id }
+					onRemove={ removeNotice( notice.id ) }
+				>
+					{
+						notice.__unstableHTML ?
+							<RawHTML>{ notice.__unstableHTML }</RawHTML> :
+							notice.content
+					}
 				</Notice>
 			) ) }
 		</div>

--- a/packages/components/src/notice/list.js
+++ b/packages/components/src/notice/list.js
@@ -4,11 +4,6 @@
 import { noop, omit } from 'lodash';
 
 /**
- * WordPress dependencies
- */
-import { RawHTML } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
 import Notice from './';
@@ -31,15 +26,11 @@ function NoticeList( { notices, onRemove = noop, className = 'components-notice-
 			{ children }
 			{ [ ...notices ].reverse().map( ( notice ) => (
 				<Notice
-					{ ...omit( notice, [ 'content', '__unstableHTML' ] ) }
+					{ ...omit( notice, [ 'content' ] ) }
 					key={ notice.id }
 					onRemove={ removeNotice( notice.id ) }
 				>
-					{
-						notice.__unstableHTML ?
-							<RawHTML>{ notice.__unstableHTML }</RawHTML> :
-							notice.content
-					}
+					{ notice.content }
 				</Notice>
 			) ) }
 		</div>

--- a/packages/edit-post/CHANGELOG.md
+++ b/packages/edit-post/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.0 (Unreleased)
+
+### New Feature
+
+- The new `AdminNotices` component will transparently upgrade any `.notice` elements on the page to the equivalent `@wordpress/notices` module notice state.
+
 ## 3.0.2 (2018-11-15)
 
 ## 3.0.1 (2018-11-12)

--- a/packages/edit-post/src/components/admin-notices/index.js
+++ b/packages/edit-post/src/components/admin-notices/index.js
@@ -34,21 +34,19 @@ function getAdminNotices() {
 }
 
 /**
- * Given an admin notice Element, returns the upgraded content string. Prefers
- * text found within its first child paragraph node, but falls back to the text
- * content of the entire notice element.
+ * Given an admin notice Element, returns the element from which content should
+ * be sourced.
  *
  * @param {Element} element Admin notice element.
  *
- * @return {string} Upgraded notice content.
+ * @return {Element} Upgraded notice HTML.
  */
-function getNoticeContentFromElement( element ) {
-	let node = element;
-	if ( node.firstElementChild && node.firstElementChild.nodeName === 'P' ) {
-		node = node.firstElementChild;
+function getNoticeContentSourceFromElement( element ) {
+	if ( element.firstElementChild && element.firstElementChild.nodeName === 'P' ) {
+		return element.firstElementChild;
 	}
 
-	return node.textContent.trim();
+	return element;
 }
 
 /**
@@ -77,10 +75,12 @@ function getNoticeStatusFromClassList( element ) {
  */
 function getNoticeFromElement( element ) {
 	const status = getNoticeStatusFromClassList( element );
-	const content = getNoticeContentFromElement( element );
+	const contentSource = getNoticeContentSourceFromElement( element );
+	const __unstableHTML = contentSource.innerHTML.trim();
+	const content = contentSource.textContent.trim();
 	const isDismissible = element.classList.contains( 'is-dismissible' );
 
-	return { status, content, isDismissible };
+	return { status, content, __unstableHTML, isDismissible };
 }
 
 export class AdminNotices extends Component {

--- a/packages/edit-post/src/components/admin-notices/index.js
+++ b/packages/edit-post/src/components/admin-notices/index.js
@@ -1,0 +1,112 @@
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { withDispatch } from '@wordpress/data';
+
+/**
+ * Set of class name suffixes to associate as the status of an admin notice.
+ *
+ * @type {Set}
+ */
+const NOTICE_STATUSES = new Set( [
+	'success',
+	'warning',
+	'error',
+	'info',
+] );
+
+/**
+ * Pattern matching a class list item matching the pattern of an admin notice
+ * status class.
+ *
+ * @type {RegExp}
+ */
+const REGEXP_NOTICE_STATUS = /^notice-(\w+)$/;
+
+/**
+ * Returns an array of admin notice Elements.
+ *
+ * @return {Element[]} Admin notice elements.
+ */
+function getAdminNotices() {
+	return [ ...document.querySelectorAll( '.notice' ) ];
+}
+
+/**
+ * Given an admin notice Element, returns the upgraded content string. Prefers
+ * text found within its first child paragraph node, but falls back to the text
+ * content of the entire notice element.
+ *
+ * @param {Element} element Admin notice element.
+ *
+ * @return {string} Upgraded notice content.
+ */
+function getNoticeContentFromElement( element ) {
+	let node = element;
+	if ( node.firstElementChild && node.firstElementChild.nodeName === 'P' ) {
+		node = node.firstElementChild;
+	}
+
+	return node.textContent.trim();
+}
+
+/**
+ * Given an admin notice Element, returns the upgraded status type, or
+ * undefined if one cannot be determined (i.e. one is not assigned).
+ *
+ * @param {Element} element Admin notice element.
+ *
+ * @return {?string} Upgraded status type.
+ */
+function getNoticeStatusFromClassList( element ) {
+	for ( const className of element.classList ) {
+		const match = className.match( REGEXP_NOTICE_STATUS );
+		if ( match && NOTICE_STATUSES.has( match[ 1 ] ) ) {
+			return match[ 1 ];
+		}
+	}
+}
+
+/**
+ * Given an admin notice Element, returns a notices module object.
+ *
+ * @param {Element} element Admin notice element.
+ *
+ * @return {WPNotice} Notice object.
+ */
+function getNoticeFromElement( element ) {
+	const status = getNoticeStatusFromClassList( element );
+	const content = getNoticeContentFromElement( element );
+	const isDismissible = element.classList.contains( 'is-dismissible' );
+
+	return { status, content, isDismissible };
+}
+
+export class AdminNotices extends Component {
+	componentDidMount() {
+		this.convertNotices();
+	}
+
+	convertNotices() {
+		const { createNotice } = this.props;
+		getAdminNotices().forEach( ( element ) => {
+			// Convert and create.
+			const notice = getNoticeFromElement( element );
+			createNotice( notice );
+
+			// Remove (now-redundant) admin notice element.
+			element.parentNode.removeChild( element );
+		} );
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default withDispatch( ( dispatch ) => {
+	const { createNotice } = dispatch( 'core/notices' );
+
+	return { createNotice };
+} )( AdminNotices );

--- a/packages/edit-post/src/components/admin-notices/index.js
+++ b/packages/edit-post/src/components/admin-notices/index.js
@@ -25,7 +25,9 @@ const NOTICE_CLASS_STATUSES = {
  * @return {Element[]} Admin notice elements.
  */
 function getAdminNotices() {
-	return [ ...document.querySelectorAll( '.notice' ) ];
+	// The order is reversed to match expectations of rendered order, since a
+	// NoticesList is itself rendered in reverse order (newest to oldest).
+	return [ ...document.querySelectorAll( '.notice' ) ].reverse();
 }
 
 /**

--- a/packages/edit-post/src/components/admin-notices/index.js
+++ b/packages/edit-post/src/components/admin-notices/index.js
@@ -29,19 +29,17 @@ function getAdminNotices() {
 }
 
 /**
- * Given an admin notice Element, returns the element from which content should
- * be sourced.
+ * Given an admin notice Element, returns the relevant notice content HTML.
  *
  * @param {Element} element Admin notice element.
  *
  * @return {Element} Upgraded notice HTML.
  */
-function getNoticeContentSourceFromElement( element ) {
-	if ( element.firstElementChild && element.firstElementChild.nodeName === 'P' ) {
-		return element.firstElementChild;
-	}
-
-	return element;
+function getNoticeHTMLFromElement( element ) {
+	return [ ...element.childNodes ].filter( ( child ) => (
+		child.nodeType !== window.Node.ELEMENT_NODE ||
+		! child.classList.contains( 'notice-dismiss' )
+	) ).map( ( child ) => child.outerHTML ).join( '' );
 }
 
 /**
@@ -69,9 +67,8 @@ function getNoticeStatusFromClassList( element ) {
  */
 function getNoticeFromElement( element ) {
 	const status = getNoticeStatusFromClassList( element );
-	const contentSource = getNoticeContentSourceFromElement( element );
-	const __unstableHTML = contentSource.innerHTML.trim();
-	const content = contentSource.textContent.trim();
+	const content = '';
+	const __unstableHTML = getNoticeHTMLFromElement( element );
 	const isDismissible = element.classList.contains( 'is-dismissible' );
 
 	return { status, content, __unstableHTML, isDismissible };
@@ -87,7 +84,7 @@ export class AdminNotices extends Component {
 		getAdminNotices().forEach( ( element ) => {
 			// Convert and create.
 			const notice = getNoticeFromElement( element );
-			createNotice( notice );
+			createNotice( notice, { speak: false } );
 
 			// Remove (now-redundant) admin notice element.
 			element.parentNode.removeChild( element );

--- a/packages/edit-post/src/components/admin-notices/index.js
+++ b/packages/edit-post/src/components/admin-notices/index.js
@@ -5,24 +5,19 @@ import { Component } from '@wordpress/element';
 import { withDispatch } from '@wordpress/data';
 
 /**
- * Set of class name suffixes to associate as the status of an admin notice.
+ * Mapping of server-supported notice class names to an equivalent notices
+ * module status.
  *
- * @type {Set}
+ * @type {Map}
  */
-const NOTICE_STATUSES = new Set( [
-	'success',
-	'warning',
-	'error',
-	'info',
-] );
-
-/**
- * Pattern matching a class list item matching the pattern of an admin notice
- * status class.
- *
- * @type {RegExp}
- */
-const REGEXP_NOTICE_STATUS = /^notice-(\w+)$/;
+const NOTICE_CLASS_STATUSES = {
+	'notice-success': 'success',
+	updated: 'success',
+	'notice-warning': 'warning',
+	'notice-error': 'error',
+	error: 'error',
+	'notice-info': 'info',
+};
 
 /**
  * Returns an array of admin notice Elements.
@@ -59,9 +54,8 @@ function getNoticeContentSourceFromElement( element ) {
  */
 function getNoticeStatusFromClassList( element ) {
 	for ( const className of element.classList ) {
-		const match = className.match( REGEXP_NOTICE_STATUS );
-		if ( match && NOTICE_STATUSES.has( match[ 1 ] ) ) {
-			return match[ 1 ];
+		if ( NOTICE_CLASS_STATUSES.hasOwnProperty( className ) ) {
+			return NOTICE_CLASS_STATUSES[ className ];
 		}
 	}
 }

--- a/packages/edit-post/src/components/admin-notices/index.js
+++ b/packages/edit-post/src/components/admin-notices/index.js
@@ -36,10 +36,20 @@ function getAdminNotices() {
  * @return {Element} Upgraded notice HTML.
  */
 function getNoticeHTMLFromElement( element ) {
-	return [ ...element.childNodes ].filter( ( child ) => (
-		child.nodeType !== window.Node.ELEMENT_NODE ||
-		! child.classList.contains( 'notice-dismiss' )
-	) ).map( ( child ) => child.outerHTML ).join( '' );
+	const fragments = [];
+
+	for ( const child of element.childNodes ) {
+		if ( child.nodeType !== window.Node.ELEMENT_NODE ) {
+			const value = child.nodeValue.trim();
+			if ( value ) {
+				fragments.push( child.nodeValue );
+			}
+		} else if ( ! child.classList.contains( 'notice-dismiss' ) ) {
+			fragments.push( child.outerHTML );
+		}
+	}
+
+	return fragments.join( '' );
 }
 
 /**

--- a/packages/edit-post/src/components/admin-notices/index.js
+++ b/packages/edit-post/src/components/admin-notices/index.js
@@ -27,7 +27,7 @@ const NOTICE_CLASS_STATUSES = {
 function getAdminNotices() {
 	// The order is reversed to match expectations of rendered order, since a
 	// NoticesList is itself rendered in reverse order (newest to oldest).
-	return [ ...document.querySelectorAll( '.notice' ) ].reverse();
+	return [ ...document.querySelectorAll( '#wpbody-content > .notice' ) ].reverse();
 }
 
 /**

--- a/packages/edit-post/src/components/admin-notices/index.js
+++ b/packages/edit-post/src/components/admin-notices/index.js
@@ -37,7 +37,7 @@ function getAdminNotices() {
  *
  * @return {Element} Upgraded notice HTML.
  */
-function getNoticeHTMLFromElement( element ) {
+function getNoticeHTML( element ) {
 	const fragments = [];
 
 	for ( const child of element.childNodes ) {
@@ -62,28 +62,12 @@ function getNoticeHTMLFromElement( element ) {
  *
  * @return {?string} Upgraded status type.
  */
-function getNoticeStatusFromClassList( element ) {
+function getNoticeStatus( element ) {
 	for ( const className of element.classList ) {
 		if ( NOTICE_CLASS_STATUSES.hasOwnProperty( className ) ) {
 			return NOTICE_CLASS_STATUSES[ className ];
 		}
 	}
-}
-
-/**
- * Given an admin notice Element, returns a notices module object.
- *
- * @param {Element} element Admin notice element.
- *
- * @return {WPNotice} Notice object.
- */
-function getNoticeFromElement( element ) {
-	const status = getNoticeStatusFromClassList( element );
-	const content = '';
-	const __unstableHTML = getNoticeHTMLFromElement( element );
-	const isDismissible = element.classList.contains( 'is-dismissible' );
-
-	return { status, content, __unstableHTML, isDismissible };
 }
 
 export class AdminNotices extends Component {
@@ -95,8 +79,14 @@ export class AdminNotices extends Component {
 		const { createNotice } = this.props;
 		getAdminNotices().forEach( ( element ) => {
 			// Convert and create.
-			const notice = getNoticeFromElement( element );
-			createNotice( notice, { speak: false } );
+			const status = getNoticeStatus( element );
+			const content = getNoticeHTML( element );
+			const isDismissible = element.classList.contains( 'is-dismissible' );
+			createNotice( status, content, {
+				speak: false,
+				__unstableHTML: true,
+				isDismissible,
+			} );
 
 			// Remove (now-redundant) admin notice element.
 			element.parentNode.removeChild( element );

--- a/packages/edit-post/src/components/admin-notices/test/index.js
+++ b/packages/edit-post/src/components/admin-notices/test/index.js
@@ -14,10 +14,9 @@ describe( 'AdminNotices', () => {
 		// outputs of (a) non-element first child of the element (whitespace
 		// text node) and (b) untrimmed content.
 		document.body.innerHTML = `
-				<p>
-					My <strong>notice</strong> text
-				</p>
 			<div class="notice updated is-dismissible">
+				<p>My <strong>notice</strong> text</p>
+				<p>My second line of text</p>
 				<button type="button" class="notice-dismiss">
 					<span class="screen-reader-text">Dismiss this notice.</span>
 				</button>
@@ -32,10 +31,10 @@ describe( 'AdminNotices', () => {
 
 		expect( createNotice ).toHaveBeenCalledWith( {
 			status: 'success',
+			content: '',
+			__unstableHTML: '<p>My <strong>notice</strong> text</p><p>My second line of text</p>',
 			isDismissible: true,
-			content: 'My notice text',
-			__unstableHTML: 'My <strong>notice</strong> text',
-		} );
+		}, { speak: false } );
 		expect( document.body.childElementCount ).toBe( 0 );
 	} );
 } );

--- a/packages/edit-post/src/components/admin-notices/test/index.js
+++ b/packages/edit-post/src/components/admin-notices/test/index.js
@@ -21,6 +21,7 @@ describe( 'AdminNotices', () => {
 					<span class="screen-reader-text">Dismiss this notice.</span>
 				</button>
 			</div>
+			<div class="notice notice-warning">Warning</div>
 		`;
 	} );
 
@@ -29,12 +30,25 @@ describe( 'AdminNotices', () => {
 
 		renderer.create( <AdminNotices createNotice={ createNotice } /> );
 
-		expect( createNotice ).toHaveBeenCalledWith( {
-			status: 'success',
-			content: '',
-			__unstableHTML: '<p>My <strong>notice</strong> text</p><p>My second line of text</p>',
-			isDismissible: true,
-		}, { speak: false } );
+		expect( createNotice ).toHaveBeenCalledTimes( 2 );
+		expect( createNotice.mock.calls[ 0 ] ).toEqual( [
+			{
+				status: 'success',
+				content: '',
+				__unstableHTML: '<p>My <strong>notice</strong> text</p><p>My second line of text</p>',
+				isDismissible: true,
+			},
+			{ speak: false },
+		] );
+		expect( createNotice.mock.calls[ 1 ] ).toEqual( [
+			{
+				status: 'warning',
+				content: '',
+				__unstableHTML: 'Warning',
+				isDismissible: false,
+			},
+			{ speak: false },
+		] );
 		expect( document.body.childElementCount ).toBe( 0 );
 	} );
 } );

--- a/packages/edit-post/src/components/admin-notices/test/index.js
+++ b/packages/edit-post/src/components/admin-notices/test/index.js
@@ -16,7 +16,7 @@ describe( 'AdminNotices', () => {
 		document.body.innerHTML = `
 			<div class="notice notice-success is-dismissible">
 				<p>
-					My notice text
+					My <strong>notice</strong> text
 				</p>
 				<button type="button" class="notice-dismiss">
 					<span class="screen-reader-text">Dismiss this notice.</span>
@@ -34,6 +34,7 @@ describe( 'AdminNotices', () => {
 			status: 'success',
 			isDismissible: true,
 			content: 'My notice text',
+			__unstableHTML: 'My <strong>notice</strong> text',
 		} );
 		expect( document.body.childElementCount ).toBe( 0 );
 	} );

--- a/packages/edit-post/src/components/admin-notices/test/index.js
+++ b/packages/edit-post/src/components/admin-notices/test/index.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import renderer from 'react-test-renderer';
+
+/**
+ * Internal dependencies
+ */
+import { AdminNotices } from '../';
+
+describe( 'AdminNotices', () => {
+	beforeEach( () => {
+		// The superfluous whitespace is intentional in verifying expected
+		// outputs of (a) non-element first child of the element (whitespace
+		// text node) and (b) untrimmed content.
+		document.body.innerHTML = `
+			<div class="notice notice-success is-dismissible">
+				<p>
+					My notice text
+				</p>
+				<button type="button" class="notice-dismiss">
+					<span class="screen-reader-text">Dismiss this notice.</span>
+				</button>
+			</div>
+		`;
+	} );
+
+	it( 'should upgrade notices', () => {
+		const createNotice = jest.fn();
+
+		renderer.create( <AdminNotices createNotice={ createNotice } /> );
+
+		expect( createNotice ).toHaveBeenCalledWith( {
+			status: 'success',
+			isDismissible: true,
+			content: 'My notice text',
+		} );
+		expect( document.body.childElementCount ).toBe( 0 );
+	} );
+} );

--- a/packages/edit-post/src/components/admin-notices/test/index.js
+++ b/packages/edit-post/src/components/admin-notices/test/index.js
@@ -14,10 +14,10 @@ describe( 'AdminNotices', () => {
 		// outputs of (a) non-element first child of the element (whitespace
 		// text node) and (b) untrimmed content.
 		document.body.innerHTML = `
-			<div class="notice notice-success is-dismissible">
 				<p>
 					My <strong>notice</strong> text
 				</p>
+			<div class="notice updated is-dismissible">
 				<button type="button" class="notice-dismiss">
 					<span class="screen-reader-text">Dismiss this notice.</span>
 				</button>

--- a/packages/edit-post/src/components/admin-notices/test/index.js
+++ b/packages/edit-post/src/components/admin-notices/test/index.js
@@ -33,19 +33,19 @@ describe( 'AdminNotices', () => {
 		expect( createNotice ).toHaveBeenCalledTimes( 2 );
 		expect( createNotice.mock.calls[ 0 ] ).toEqual( [
 			{
-				status: 'success',
+				status: 'warning',
 				content: '',
-				__unstableHTML: '<p>My <strong>notice</strong> text</p><p>My second line of text</p>',
-				isDismissible: true,
+				__unstableHTML: 'Warning',
+				isDismissible: false,
 			},
 			{ speak: false },
 		] );
 		expect( createNotice.mock.calls[ 1 ] ).toEqual( [
 			{
-				status: 'warning',
+				status: 'success',
 				content: '',
-				__unstableHTML: 'Warning',
-				isDismissible: false,
+				__unstableHTML: '<p>My <strong>notice</strong> text</p><p>My second line of text</p>',
+				isDismissible: true,
 			},
 			{ speak: false },
 		] );

--- a/packages/edit-post/src/components/admin-notices/test/index.js
+++ b/packages/edit-post/src/components/admin-notices/test/index.js
@@ -14,14 +14,19 @@ describe( 'AdminNotices', () => {
 		// outputs of (a) non-element first child of the element (whitespace
 		// text node) and (b) untrimmed content.
 		document.body.innerHTML = `
-			<div class="notice updated is-dismissible">
-				<p>My <strong>notice</strong> text</p>
-				<p>My second line of text</p>
-				<button type="button" class="notice-dismiss">
-					<span class="screen-reader-text">Dismiss this notice.</span>
-				</button>
+			<div id="wpbody-content">
+				<div class="notice updated is-dismissible">
+					<p>My <strong>notice</strong> text</p>
+					<p>My second line of text</p>
+					<button type="button" class="notice-dismiss">
+						<span class="screen-reader-text">Dismiss this notice.</span>
+					</button>
+				</div>
+				<div class="notice notice-warning">Warning</div>
+				<aside class="elsewhere">
+					<div class="notice">Ignore me</div>
+				</aside>
 			</div>
-			<div class="notice notice-warning">Warning</div>
 		`;
 	} );
 
@@ -49,6 +54,8 @@ describe( 'AdminNotices', () => {
 				isDismissible: true,
 			},
 		] );
-		expect( document.body.childElementCount ).toBe( 0 );
+
+		// Verify all but `<aside>` are removed.
+		expect( document.getElementById( 'wpbody-content' ).childElementCount ).toBe( 1 );
 	} );
 } );

--- a/packages/edit-post/src/components/admin-notices/test/index.js
+++ b/packages/edit-post/src/components/admin-notices/test/index.js
@@ -32,22 +32,22 @@ describe( 'AdminNotices', () => {
 
 		expect( createNotice ).toHaveBeenCalledTimes( 2 );
 		expect( createNotice.mock.calls[ 0 ] ).toEqual( [
+			'warning',
+			'Warning',
 			{
-				status: 'warning',
-				content: '',
-				__unstableHTML: 'Warning',
+				speak: false,
+				__unstableHTML: true,
 				isDismissible: false,
 			},
-			{ speak: false },
 		] );
 		expect( createNotice.mock.calls[ 1 ] ).toEqual( [
+			'success',
+			'<p>My <strong>notice</strong> text</p><p>My second line of text</p>',
 			{
-				status: 'success',
-				content: '',
-				__unstableHTML: '<p>My <strong>notice</strong> text</p><p>My second line of text</p>',
+				speak: false,
+				__unstableHTML: true,
 				isDismissible: true,
 			},
-			{ speak: false },
 		] );
 		expect( document.body.childElementCount ).toBe( 0 );
 	} );

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -37,6 +37,7 @@ import Sidebar from '../sidebar';
 import PluginPostPublishPanel from '../sidebar/plugin-post-publish-panel';
 import PluginPrePublishPanel from '../sidebar/plugin-pre-publish-panel';
 import FullscreenMode from '../fullscreen-mode';
+import AdminNotices from '../admin-notices';
 
 function Layout( {
 	mode,
@@ -69,6 +70,7 @@ function Layout( {
 			<BrowserURL />
 			<UnsavedChangesWarning />
 			<AutosaveMonitor />
+			<AdminNotices />
 			<Header />
 			<div
 				className="edit-post-layout__content"

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -5,6 +5,7 @@ import '@wordpress/core-data';
 import '@wordpress/editor';
 import '@wordpress/nux';
 import '@wordpress/viewport';
+import '@wordpress/notices';
 import { registerCoreBlocks } from '@wordpress/block-library';
 import { render, unmountComponentAtNode } from '@wordpress/element';
 import { dispatch } from '@wordpress/data';

--- a/packages/notices/CHANGELOG.md
+++ b/packages/notices/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - The `createNotice` can now optionally accept a WPNotice object as the sole argument.
 
+### Bug Fixes
+
+- While `createNotice` only explicitly supported content of type `string`, it was not previously enforced. This has been corrected.
+
 ## 1.0.5 (2018-11-15)
 
 ## 1.0.4 (2018-11-09)

--- a/packages/notices/CHANGELOG.md
+++ b/packages/notices/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### New Feature
 
 - The `createNotice` can now optionally accept a WPNotice object as the sole argument.
+- New option `speak` enables control as to whether the notice content is announced to screen readers (defaults to `true`)
 
 ### Bug Fixes
 

--- a/packages/notices/CHANGELOG.md
+++ b/packages/notices/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.0 (Unreleased)
+
+### New Feature
+
+- The `createNotice` can now optionally accept a WPNotice object as the sole argument.
+
 ## 1.0.5 (2018-11-15)
 
 ## 1.0.4 (2018-11-09)

--- a/packages/notices/src/store/actions.js
+++ b/packages/notices/src/store/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { uniqueId } from 'lodash';
+import { isPlainObject, uniqueId } from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,7 +11,8 @@ import { DEFAULT_CONTEXT } from './constants';
 /**
  * Yields action objects used in signalling that a notice is to be created.
  *
- * @param {?string}                status                Notice status.
+ * @param {?string|WPNotice}       statusOrNotice        Notice status, or a
+ *                                                       notice object.
  *                                                       Defaults to `info`.
  * @param {string}                 content               Notice message.
  * @param {?Object}                options               Notice options.
@@ -26,7 +27,18 @@ import { DEFAULT_CONTEXT } from './constants';
  * @param {?Array<WPNoticeAction>} options.actions       User actions to be
  *                                                       presented with notice.
  */
-export function* createNotice( status = 'info', content, options = {} ) {
+export function* createNotice( statusOrNotice = 'info', content, options = {} ) {
+	let status;
+
+	if ( isPlainObject( statusOrNotice ) ) {
+		// Support overloaded form `createNotice( notice: WPNotice )`.
+		options = statusOrNotice;
+		( { status = 'info', content } = options );
+	} else {
+		// Else consider the first argument the status type string.
+		status = statusOrNotice;
+	}
+
 	const {
 		isDismissible = true,
 		context = DEFAULT_CONTEXT,

--- a/packages/notices/src/store/actions.js
+++ b/packages/notices/src/store/actions.js
@@ -46,6 +46,11 @@ export function* createNotice( statusOrNotice = DEFAULT_STATUS, content, options
 		actions = [],
 	} = options;
 
+	// The supported value shape of content is currently limited to plain text
+	// strings. To avoid setting expectation that e.g. a WPElement could be
+	// supported, cast to a string.
+	content = String( content );
+
 	yield { type: 'SPEAK', message: content };
 
 	yield {

--- a/packages/notices/src/store/actions.js
+++ b/packages/notices/src/store/actions.js
@@ -28,12 +28,12 @@ import { DEFAULT_CONTEXT, DEFAULT_STATUS } from './constants';
  *                                                       presented with notice.
  */
 export function* createNotice( statusOrNotice = DEFAULT_STATUS, content, options = {} ) {
-	let status;
+	let status, __unstableHTML;
 
 	if ( isPlainObject( statusOrNotice ) ) {
 		// Support overloaded form `createNotice( notice: WPNotice )`.
 		options = statusOrNotice;
-		( { status = DEFAULT_STATUS, content } = options );
+		( { status = DEFAULT_STATUS, content, __unstableHTML } = options );
 	} else {
 		// Else consider the first argument the status type string.
 		status = statusOrNotice;
@@ -55,6 +55,7 @@ export function* createNotice( statusOrNotice = DEFAULT_STATUS, content, options
 			id,
 			status,
 			content,
+			__unstableHTML,
 			isDismissible,
 			actions,
 		},

--- a/packages/notices/src/store/actions.js
+++ b/packages/notices/src/store/actions.js
@@ -6,7 +6,7 @@ import { isPlainObject, uniqueId } from 'lodash';
 /**
  * Internal dependencies
  */
-import { DEFAULT_CONTEXT } from './constants';
+import { DEFAULT_CONTEXT, DEFAULT_STATUS } from './constants';
 
 /**
  * Yields action objects used in signalling that a notice is to be created.
@@ -27,13 +27,13 @@ import { DEFAULT_CONTEXT } from './constants';
  * @param {?Array<WPNoticeAction>} options.actions       User actions to be
  *                                                       presented with notice.
  */
-export function* createNotice( statusOrNotice = 'info', content, options = {} ) {
+export function* createNotice( statusOrNotice = DEFAULT_STATUS, content, options = {} ) {
 	let status;
 
 	if ( isPlainObject( statusOrNotice ) ) {
 		// Support overloaded form `createNotice( notice: WPNotice )`.
 		options = statusOrNotice;
-		( { status = 'info', content } = options );
+		( { status = DEFAULT_STATUS, content } = options );
 	} else {
 		// Else consider the first argument the status type string.
 		status = statusOrNotice;

--- a/packages/notices/src/store/actions.js
+++ b/packages/notices/src/store/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isPlainObject, uniqueId } from 'lodash';
+import { uniqueId } from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,12 +11,9 @@ import { DEFAULT_CONTEXT, DEFAULT_STATUS } from './constants';
 /**
  * Yields action objects used in signalling that a notice is to be created.
  *
- * @param {?string|WPNotice}       statusOrNotice        Notice status, or a
- *                                                       notice object.
+ * @param {?string}                status                Notice status.
  *                                                       Defaults to `info`.
- * @param {string|?Object}         contentOrOptions      Notice message, or
- *                                                       options if the first
- *                                                       argument is WPNotice.
+ * @param {string}                 content               Notice message.
  * @param {?Object}                options               Notice options.
  * @param {?string}                options.context       Context under which to
  *                                                       group notice.
@@ -34,25 +31,14 @@ import { DEFAULT_CONTEXT, DEFAULT_STATUS } from './constants';
  * @param {?Array<WPNoticeAction>} options.actions       User actions to be
  *                                                       presented with notice.
  */
-export function* createNotice( statusOrNotice = DEFAULT_STATUS, contentOrOptions, options = {} ) {
-	let status, content, __unstableHTML;
-
-	if ( isPlainObject( statusOrNotice ) ) {
-		// Support overloaded form `createNotice( notice: WPNotice, options: ?Object )`.
-		options = { ...contentOrOptions, ...statusOrNotice };
-		( { status = DEFAULT_STATUS, content, __unstableHTML } = statusOrNotice );
-	} else {
-		// Else consider the first argument the status type string.
-		status = statusOrNotice;
-		content = contentOrOptions;
-	}
-
+export function* createNotice( status = DEFAULT_STATUS, content, options = {} ) {
 	const {
 		speak = true,
 		isDismissible = true,
 		context = DEFAULT_CONTEXT,
 		id = uniqueId( context ),
 		actions = [],
+		__unstableHTML,
 	} = options;
 
 	// The supported value shape of content is currently limited to plain text

--- a/packages/notices/src/store/constants.js
+++ b/packages/notices/src/store/constants.js
@@ -6,3 +6,10 @@
  * @type {string}
  */
 export const DEFAULT_CONTEXT = 'global';
+
+/**
+ * Default notice status.
+ *
+ * @type {string}
+ */
+export const DEFAULT_STATUS = 'info';

--- a/packages/notices/src/store/selectors.js
+++ b/packages/notices/src/store/selectors.js
@@ -26,7 +26,7 @@ const DEFAULT_NOTICES = [];
  *                                      user. Defaults to `true`.
  * @property {WPNoticeAction[]} actions User actions to present with notice.
  *
- * @typedef {Notice}
+ * @typedef {WPNotice}
  */
 
 /**
@@ -48,7 +48,7 @@ const DEFAULT_NOTICES = [];
  * @param {Object}  state   Notices state.
  * @param {?string} context Optional grouping context.
  *
- * @return {Notice[]} Array of notices.
+ * @return {WPNotice[]} Array of notices.
  */
 export function getNotices( state, context = DEFAULT_CONTEXT ) {
 	return state[ context ] || DEFAULT_NOTICES;

--- a/packages/notices/src/store/selectors.js
+++ b/packages/notices/src/store/selectors.js
@@ -22,6 +22,11 @@ const DEFAULT_NOTICES = [];
  *                                      `info`, `error`, or `warning`. Defaults
  *                                      to `info`.
  * @property {string}  content          Notice message.
+ * @property {string}  __unstableHTML   Notice message as raw HTML. Intended to
+ *                                      serve primarily for compatibility of
+ *                                      server-rendered notices, and SHOULD NOT
+ *                                      be used for notices. It is subject to
+ *                                      removal without notice.
  * @property {boolean} isDismissible    Whether the notice can be dismissed by
  *                                      user. Defaults to `true`.
  * @property {WPNoticeAction[]} actions User actions to present with notice.

--- a/packages/notices/src/store/test/actions.js
+++ b/packages/notices/src/store/test/actions.js
@@ -113,6 +113,28 @@ describe( 'actions', () => {
 				},
 			} );
 		} );
+
+		it( 'yields action when speak disabled', () => {
+			const result = createNotice( {
+				id,
+				content: '',
+				__unstableHTML: 'my <strong>message</strong>',
+				isDismissible: false,
+			}, { speak: false } );
+
+			expect( result.next().value ).toEqual( {
+				type: 'CREATE_NOTICE',
+				context: DEFAULT_CONTEXT,
+				notice: {
+					id,
+					status: DEFAULT_STATUS,
+					content: '',
+					__unstableHTML: 'my <strong>message</strong>',
+					isDismissible: false,
+					actions: [],
+				},
+			} );
+		} );
 	} );
 
 	describe( 'createSuccessNotice', () => {

--- a/packages/notices/src/store/test/actions.js
+++ b/packages/notices/src/store/test/actions.js
@@ -9,7 +9,7 @@ import {
 	createWarningNotice,
 	removeNotice,
 } from '../actions';
-import { DEFAULT_CONTEXT } from '../constants';
+import { DEFAULT_CONTEXT, DEFAULT_STATUS } from '../constants';
 
 describe( 'actions', () => {
 	describe( 'createNotice', () => {
@@ -83,7 +83,7 @@ describe( 'actions', () => {
 				context: DEFAULT_CONTEXT,
 				notice: {
 					id,
-					status: 'info',
+					status: DEFAULT_STATUS,
 					content,
 					isDismissible: false,
 					actions: [],
@@ -131,7 +131,7 @@ describe( 'actions', () => {
 				type: 'CREATE_NOTICE',
 				context: DEFAULT_CONTEXT,
 				notice: {
-					status: 'info',
+					status: DEFAULT_STATUS,
 					content,
 					isDismissible: true,
 					id: expect.any( String ),

--- a/packages/notices/src/store/test/actions.js
+++ b/packages/notices/src/store/test/actions.js
@@ -70,6 +70,7 @@ describe( 'actions', () => {
 			const result = createNotice( {
 				id,
 				content,
+				__unstableHTML: 'my <strong>message</strong>',
 				isDismissible: false,
 			} );
 
@@ -85,6 +86,7 @@ describe( 'actions', () => {
 					id,
 					status: DEFAULT_STATUS,
 					content,
+					__unstableHTML: 'my <strong>message</strong>',
 					isDismissible: false,
 					actions: [],
 				},

--- a/packages/notices/src/store/test/actions.js
+++ b/packages/notices/src/store/test/actions.js
@@ -38,6 +38,27 @@ describe( 'actions', () => {
 			} );
 		} );
 
+		it( 'normalizes content to string', () => {
+			const result = createNotice( status, <strong>Hello</strong> );
+
+			expect( result.next().value ).toMatchObject( {
+				type: 'SPEAK',
+				message: expect.any( String ),
+			} );
+
+			expect( result.next().value ).toMatchObject( {
+				type: 'CREATE_NOTICE',
+				context: DEFAULT_CONTEXT,
+				notice: {
+					status,
+					content: expect.any( String ),
+					isDismissible: true,
+					id: expect.any( String ),
+					actions: [],
+				},
+			} );
+		} );
+
 		it( 'yields actions when options passed', () => {
 			const context = 'foo';
 			const options = {

--- a/packages/notices/src/store/test/actions.js
+++ b/packages/notices/src/store/test/actions.js
@@ -13,10 +13,11 @@ import { DEFAULT_CONTEXT } from '../constants';
 
 describe( 'actions', () => {
 	describe( 'createNotice', () => {
+		const id = 'my-id';
 		const status = 'status';
 		const content = 'my message';
 
-		it( 'should yields actions when options is empty', () => {
+		it( 'yields actions when options is empty', () => {
 			const result = createNotice( status, content );
 
 			expect( result.next().value ).toMatchObject( {
@@ -37,8 +38,7 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		it( 'should yields actions when options passed', () => {
-			const id = 'my-id';
+		it( 'yields actions when options passed', () => {
 			const context = 'foo';
 			const options = {
 				id,
@@ -59,6 +59,31 @@ describe( 'actions', () => {
 				notice: {
 					id,
 					status,
+					content,
+					isDismissible: false,
+					actions: [],
+				},
+			} );
+		} );
+
+		it( 'yields actions when notice object passed', () => {
+			const result = createNotice( {
+				id,
+				content,
+				isDismissible: false,
+			} );
+
+			expect( result.next().value ).toMatchObject( {
+				type: 'SPEAK',
+				message: content,
+			} );
+
+			expect( result.next().value ).toEqual( {
+				type: 'CREATE_NOTICE',
+				context: DEFAULT_CONTEXT,
+				notice: {
+					id,
+					status: 'info',
 					content,
 					isDismissible: false,
 					actions: [],

--- a/packages/notices/src/store/test/actions.js
+++ b/packages/notices/src/store/test/actions.js
@@ -87,40 +87,17 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		it( 'yields actions when notice object passed', () => {
-			const result = createNotice( {
-				id,
-				content,
-				__unstableHTML: 'my <strong>message</strong>',
-				isDismissible: false,
-			} );
-
-			expect( result.next().value ).toMatchObject( {
-				type: 'SPEAK',
-				message: content,
-			} );
-
-			expect( result.next().value ).toEqual( {
-				type: 'CREATE_NOTICE',
-				context: DEFAULT_CONTEXT,
-				notice: {
-					id,
-					status: DEFAULT_STATUS,
-					content,
-					__unstableHTML: 'my <strong>message</strong>',
-					isDismissible: false,
-					actions: [],
-				},
-			} );
-		} );
-
 		it( 'yields action when speak disabled', () => {
-			const result = createNotice( {
-				id,
-				content: '',
-				__unstableHTML: 'my <strong>message</strong>',
-				isDismissible: false,
-			}, { speak: false } );
+			const result = createNotice(
+				undefined,
+				'my <strong>message</strong>',
+				{
+					id,
+					__unstableHTML: true,
+					isDismissible: false,
+					speak: false,
+				}
+			);
 
 			expect( result.next().value ).toEqual( {
 				type: 'CREATE_NOTICE',
@@ -128,8 +105,8 @@ describe( 'actions', () => {
 				notice: {
 					id,
 					status: DEFAULT_STATUS,
-					content: '',
-					__unstableHTML: 'my <strong>message</strong>',
+					content: 'my <strong>message</strong>',
+					__unstableHTML: true,
 					isDismissible: false,
 					actions: [],
 				},


### PR DESCRIPTION
Related: #5975, #6388
Supersedes #5590 
Closes #10448 

This pull request seeks to try to seamlessly upgrade notices output via an `admin_notices` or `all_admin_notices` action server-side.

**Implementation notes:**

The flow here is:

- Discover admin notices by `.notice` class
- Convert to `@wordpress/notices` notice object
   - This occurs in `edit-post`, though in the future I think either this compatibility should (a) become unnecessary or (b) be moved somewhere more generic
- Dispatch to create notice through `@wordpress/notices`
- Removes the admin notice from the DOM

**Testing instructions:**

Here's a plugin if you need one:

[demo-notice.zip](https://github.com/WordPress/gutenberg/files/2559361/demo-notice.zip)

This will add a dismissible success notice to any admin screen.

Verify that upon visiting Gutenberg, a notice echo'd during `admin_notices` or `all_admin_notices` is displayed.

**Pending tasks:**

- [x] Notice content is supported only as a plaintext string. Advanced markup is not supported. In not supporting non-plaintext, we can't truly close #10448, which includes an inline link. The notices module supports linkable "actions", but not interspersed with the plaintext. This ties in a bit with #9846, with the most direct solutions being one of either (a) allow elements as notice content or (b) pass notice content to a [`RawHTML` component](https://github.com/WordPress/gutenberg/blob/master/packages/element/src/raw-html.js), neither of which is ideal in my mind.