### PR TITLE
Block API: Remove undefined className argument from save() methods

### DIFF
--- a/docs/blocks/applying-styles-with-stylesheets.md
+++ b/docs/blocks/applying-styles-with-stylesheets.md
@@ -21,8 +21,8 @@ registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-02', {
 		return el( 'p', { className: props.className }, 'Hello editor.' );
 	},
 
-	save: function( props ) {
-		return el( 'p', { className: props.className }, 'Hello saved content.' );
+	save: function() {
+		return el( 'p', {}, 'Hello saved content.' );
 	}
 } );
 ```
@@ -41,8 +41,8 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-02', {
 		return <p className={ className }>Hello editor.</p>;
 	},
 
-	save( { className } ) {
-		return <p className={ className }>Hello saved content.</p>;
+	save() {
+		return <p>Hello saved content.</p>;
 	}
 } );
 ```

--- a/docs/blocks/block-controls-toolbars-and-inspector.md
+++ b/docs/blocks/block-controls-toolbars-and-inspector.md
@@ -152,12 +152,11 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-04', {
 		);
 	},
 
-	save( { attributes, className } ) {
+	save( { attributes } ) {
 		const { content, alignment } = attributes;
 
 		return (
 			<RichText.Content
-				className={ className }
 				style={ { textAlign: alignment } }
 				value={ content }
 				tagName="p"

--- a/docs/blocks/introducing-attributes-and-editable-fields.md
+++ b/docs/blocks/introducing-attributes-and-editable-fields.md
@@ -96,13 +96,12 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-03', {
 		);
 	},
 
-	save( { attributes, className } ) {
+	save( { attributes } ) {
 		const { content } = attributes;
 
 		return (
 			<RichText.Content
 				tagName="p"
-				className={ className }
 				value={ content }
 			/>
 		);

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -375,7 +375,7 @@ export const settings = {
 		}
 	),
 
-	save( { attributes, className } ) {
+	save( { attributes } ) {
 		const {
 			align,
 			backgroundType,
@@ -396,7 +396,6 @@ export const settings = {
 		}
 
 		const classes = classnames(
-			className,
 			dimRatioToClass( dimRatio ),
 			overlayColorClass,
 			{
@@ -470,11 +469,10 @@ export const settings = {
 			},
 		},
 
-		save( { attributes, className } ) {
+		save( { attributes } ) {
 			const { url, title, hasParallax, dimRatio, align } = attributes;
 			const style = backgroundImageStyles( url );
 			const classes = classnames(
-				className,
 				dimRatioToClass( dimRatio ),
 				{
 					'has-background-dim': dimRatio !== 0,

--- a/packages/block-library/src/subhead/index.js
+++ b/packages/block-library/src/subhead/index.js
@@ -85,13 +85,12 @@ export const settings = {
 		);
 	},
 
-	save( { attributes, className } ) {
+	save( { attributes } ) {
 		const { align, content } = attributes;
 
 		return (
 			<RichText.Content
 				tagName="p"
-				className={ className }
 				style={ { textAlign: align } }
 				value={ content }
 			/>

--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -85,13 +85,12 @@ export const settings = {
 		);
 	},
 
-	save( { attributes, className } ) {
+	save( { attributes } ) {
 		const { textAlign, content } = attributes;
 
 		return (
 			<RichText.Content
 				tagName="pre"
-				className={ className }
 				style={ { textAlign: textAlign } }
 				value={ content }
 			/>


### PR DESCRIPTION
## Description
Unlike the `edit()` method, `save()` doesn't get the `className` property passed to. The [generated](https://github.com/WordPress/gutenberg/blob/v4.2.0/packages/editor/src/hooks/generated-class-name.js#L42) and [custom classes](https://github.com/WordPress/gutenberg/blob/v4.2.0/packages/editor/src/hooks/custom-class-name.js#L157
) are added through filters.

See #7308.

## How has this been tested?
Unit tests and manually by checking that no blocks are invalid.
