### PR TITLE
Format library: Allow explicit registration when using npm packages

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -544,6 +544,11 @@ function gutenberg_register_scripts_and_styles() {
 		filemtime( gutenberg_dir_path() . 'build/format-library/index.js' ),
 		true
 	);
+	wp_add_inline_script(
+		'wp-format-library',
+		'wp.formatLibrary.registerCoreFormatTypes();',
+		'after'
+	);
 	gutenberg_override_script(
 		'wp-nux',
 		gutenberg_url( 'build/nux/index.js' ),

--- a/packages/format-library/src/index.js
+++ b/packages/format-library/src/index.js
@@ -1,4 +1,11 @@
 /**
+ * WordPress dependencies
+ */
+import {
+	registerFormatType,
+} from '@wordpress/rich-text';
+
+/**
  * Internal dependencies
  */
 import { bold } from './bold';
@@ -8,18 +15,21 @@ import { italic } from './italic';
 import { link } from './link';
 import { strikethrough } from './strikethrough';
 
-/**
- * WordPress dependencies
- */
-import {
-	registerFormatType,
-} from '@wordpress/rich-text';
+export function getCoreFormatTypes() {
+	return [
+		bold,
+		code,
+		image,
+		italic,
+		link,
+		strikethrough,
+	].map(
+		( { name, ...settings } ) => [ name, settings ]
+	);
+}
 
-[
-	bold,
-	code,
-	image,
-	italic,
-	link,
-	strikethrough,
-].forEach( ( { name, ...settings } ) => registerFormatType( name, settings ) );
+export function registerCoreFormatTypes() {
+	getCoreFormatTypes().forEach(
+		( params ) => registerFormatType( ...params )
+	);
+}


### PR DESCRIPTION
## Description

At the moment we register all core format types right away when `@wordpress/format-library` is executed as discussed here https://github.com/WordPress/gutenberg/pull/10209#discussion_r225149941:

>> @gziolo: 'm wondering if we should register core formats right away instead. In effect, don't offer this method at all.

> @aduth: 💯 `registerCoreBlocks` is a necessary hack, and certainly shouldn't serve as an ideal precedent.

Related code:
https://github.com/WordPress/gutenberg/blob/master/packages/format-library/src/index.js#L18-L25

This is not ideal when consuming npm package. This PR was opened to discuss alternative approaches. The idea is to offer more granular integration points for the usage outside of WordPress.

This PR explores the following items:
- `getCoreFormatTypes` returns an array with all core format types in case someone would want to filter out some of the formats. The shape it returns would have to be defined, I opted for the simplicity of refactoring :)
- `registerCoreFormatTypes` method registers all core formats as it happens today.
- in WordPress `registerCoreFormatTypes` is executed right after `wp-format-library` is enqueued which basically mirrors what happens today.

Whatever we decide here, should be also applied to `@wordpress/block-library` for consistency.