### PR TITLE
Simplify sidebar tabs aria-labels.

### DIFF
--- a/packages/edit-post/src/components/sidebar/settings-header/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-header/index.js
@@ -18,16 +18,16 @@ const SettingsHeader = ( { count, openDocumentSettings, openBlockSettings, sideb
 		sprintf( _n( '%d Block', '%d Blocks', blockCount ), blockCount );
 
 	const [ documentAriaLabel, documentActiveClass ] = sidebarName === 'edit-post/document' ?
-		// translators: ARIA label for the Document Settings sidebar tab, selected.
-		[ __( 'Document settings (selected)' ), 'is-active' ] :
-		// translators: ARIA label for the Document Settings sidebar tab, not selected.
-		[ __( 'Document settings' ), '' ];
+		// translators: ARIA label for the Document sidebar tab, selected.
+		[ __( 'Document (selected)' ), 'is-active' ] :
+		// translators: ARIA label for the Document sidebar tab, not selected.
+		[ __( 'Document' ), '' ];
 
 	const [ blockAriaLabel, blockActiveClass ] = sidebarName === 'edit-post/block' ?
-		// translators: ARIA label for the Block Settings sidebar tab, selected.
-		[ __( 'Block settings (selected)' ), 'is-active' ] :
-		// translators: ARIA label for the Block Settings sidebar tab, not selected.
-		[ __( 'Block settings' ), '' ];
+		// translators: ARIA label for the Block sidebar tab, selected.
+		[ __( 'Block (selected)' ), 'is-active' ] :
+		// translators: ARIA label for the Block sidebar tab, not selected.
+		[ __( 'Block' ), '' ];
 
 	return (
 		<SidebarHeader

--- a/test/e2e/specs/preferences.test.js
+++ b/test/e2e/specs/preferences.test.js
@@ -33,7 +33,7 @@ describe( 'preferences', () => {
 		expect( await getActiveSidebarTabText() ).toBe( 'Document' );
 
 		// Change to "Block" tab.
-		await page.click( '.edit-post-sidebar__panel-tab[aria-label="Block settings"]' );
+		await page.click( '.edit-post-sidebar__panel-tab[aria-label="Block"]' );
 		expect( await getActiveSidebarTabText() ).toBe( 'Block' );
 
 		// Regression test: Reload resets to document tab.


### PR DESCRIPTION
## Description
This PR seeks to improve the sidebar tabs `aria-label` attributes for better translations in other languages, so their accessibility is preserved also in languages other than English. For more details, please refer to the related issue #11617.

Fixes #11617 
