### PR TITLE
Use wp_json_encode and json_decode

### DIFF
--- a/bin/get-server-blocks.php
+++ b/bin/get-server-blocks.php
@@ -36,4 +36,4 @@ foreach ( glob( dirname( dirname( __FILE__ ) ) . '/packages/block-library/src/*/
 
 do_action( 'init' );
 
-echo json_encode( gutenberg_prepare_blocks_for_js() );
+echo wp_json_encode( gutenberg_prepare_blocks_for_js() );

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -223,7 +223,7 @@ if ( ! function_exists( 'do_blocks' ) ) {
 			// Attempt to parse attributes JSON, if available.
 			$attributes = array();
 			if ( ! empty( $block_attributes_json ) ) {
-				$decoded_attributes = json_decode( $block_attributes_json, true );
+				$decoded_attributes = wp_json_decode( $block_attributes_json, true );
 				if ( ! is_null( $decoded_attributes ) ) {
 					$attributes = $decoded_attributes;
 				}

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -650,7 +650,7 @@ function gutenberg_register_scripts_and_styles() {
 	);
 	if ( isset( $tinymce_settings['style_formats'] ) && is_string( $tinymce_settings['style_formats'] ) ) {
 		// Decode the options as we used to recommende json_encoding the TinyMCE settings.
-		$tinymce_settings['style_formats'] = json_decode( $tinymce_settings['style_formats'] );
+		$tinymce_settings['style_formats'] = wp_json_decode( $tinymce_settings['style_formats'] );
 	}
 	wp_localize_script(
 		'wp-block-library',
@@ -1329,7 +1329,7 @@ function gutenberg_load_locale_data() {
 	$locale_data = gutenberg_get_jed_locale_data( 'gutenberg' );
 	wp_add_inline_script(
 		'wp-i18n',
-		'wp.i18n.setLocaleData( ' . json_encode( $locale_data ) . ' );'
+		'wp.i18n.setLocaleData( ' . wp_json_encode( $locale_data ) . ' );'
 	);
 }
 
@@ -1492,7 +1492,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	// Preload server-registered block schemas.
 	wp_add_inline_script(
 		'wp-blocks',
-		'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . json_encode( gutenberg_prepare_blocks_for_js() ) . ');'
+		'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( gutenberg_prepare_blocks_for_js() ) . ');'
 	);
 
 	// Get admin url for handling meta boxes.

--- a/lib/parser.php
+++ b/lib/parser.php
@@ -20,7 +20,7 @@ if (!function_exists("Gutenberg_PEG_ord_unicode")) {
         if (strlen($character) === 1) {
             return ord($character);
         }
-        $json = json_encode($character);
+        $json = wp_json_encode($character);
         $utf16_1 = hexdec(substr($json, 3, 4));
         if (substr($json, 7, 2) === "\u") {
             $utf16_2 = hexdec(substr($json, 9, 4));
@@ -212,7 +212,7 @@ class Gutenberg_PEG_Parser {
               . $expectedDescs[count($expected) - 1]
           : $expectedDescs[0];
 
-        $foundDesc = $found ? json_encode($found) : "end of input";
+        $foundDesc = $found ? wp_json_encode($found) : "end of input";
 
         $message = "Expected " . $expectedDesc . " but " . $foundDesc . " found.";
       }
@@ -289,7 +289,7 @@ class Gutenberg_PEG_Parser {
         );
         }
     private function peg_f7($type) { return "core/$type"; }
-    private function peg_f8($attrs) { return json_decode( $attrs, true ); }
+    private function peg_f8($attrs) { return wp_json_decode( $attrs, true ); }
 
     private function peg_parseBlock_List() {
 

--- a/packages/block-serialization-default-parser/parser.php
+++ b/packages/block-serialization-default-parser/parser.php
@@ -391,8 +391,8 @@ class WP_Block_Parser {
 		 * are associative arrays. If we use `array()` we get a JSON `[]`
 		 */
 		$attrs = $has_attrs
-			? json_decode( $matches[ 'attrs' ][ 0 ], /* as-associative */ true )
-			: json_decode( '{}', /* don't ask why, just verify in PHP */ false );
+			? wp_json_decode( $matches[ 'attrs' ][ 0 ], /* as-associative */ true )
+			: wp_json_decode( '{}', /* don't ask why, just verify in PHP */ false );
 
 		/*
 		 * This state isn't allowed

--- a/packages/block-serialization-default-parser/test/test-parser.php
+++ b/packages/block-serialization-default-parser/test/test-parser.php
@@ -4,4 +4,4 @@ require_once __DIR__ . '/../parser.php';
 
 $parser = new WP_Block_Parser();
 
-echo json_encode( $parser->parse( file_get_contents( 'php://stdin' ) ) );
+echo wp_json_encode( $parser->parse( file_get_contents( 'php://stdin' ) ) );

--- a/packages/block-serialization-spec-parser/grammar.pegjs
+++ b/packages/block-serialization-spec-parser/grammar.pegjs
@@ -311,7 +311,7 @@ Block_Attributes
   "JSON-encoded attributes embedded in a block's opening comment"
   = attrs:$("{" (!("}" __ """/"? "-->") .)* "}")
   {
-    /** <?php return json_decode( $attrs, true ); ?> **/
+    /** <?php return wp_json_decode( $attrs, true ); ?> **/
     return maybeJSON( attrs );
   }
 

--- a/packages/block-serialization-spec-parser/parser.js
+++ b/packages/block-serialization-spec-parser/parser.js
@@ -252,7 +252,7 @@
         peg$c29 = peg$literalExpectation("}", false),
         peg$c30 = "",
         peg$c31 = function(attrs) {
-            /** <?php return json_decode( $attrs, true ); ?> **/
+            /** <?php return wp_json_decode( $attrs, true ); ?> **/
             return maybeJSON( attrs );
           },
         peg$c32 = /^[ \t\r\n]/,

--- a/packages/block-serialization-spec-parser/test/test-parser.php
+++ b/packages/block-serialization-spec-parser/test/test-parser.php
@@ -4,4 +4,4 @@ require_once __DIR__ . '/../../../lib/parser.php';
 
 $parser = new Gutenberg_PEG_Parser();
 
-echo json_encode( $parser->parse( file_get_contents( 'php://stdin' ) ) );
+echo wp_json_encode( $parser->parse( file_get_contents( 'php://stdin' ) ) );

--- a/phpunit/class-block-type-test.php
+++ b/phpunit/class-block-type-test.php
@@ -86,7 +86,7 @@ class Block_Type_Test extends WP_UnitTestCase {
 			)
 		);
 		$output     = $block_type->render( $attributes );
-		$this->assertEquals( $attributes, json_decode( $output, true ) );
+		$this->assertEquals( $attributes, wp_json_decode( $output, true ) );
 	}
 
 	function test_render_with_content() {
@@ -106,7 +106,7 @@ class Block_Type_Test extends WP_UnitTestCase {
 			)
 		);
 		$output     = $block_type->render( $attributes, $content );
-		$this->assertEquals( $expected, json_decode( $output, true ) );
+		$this->assertEquals( $expected, wp_json_decode( $output, true ) );
 	}
 
 	function test_render_for_static_block() {
@@ -247,12 +247,12 @@ class Block_Type_Test extends WP_UnitTestCase {
 	}
 
 	function render_dummy_block( $attributes ) {
-		return json_encode( $attributes );
+		return wp_json_encode( $attributes );
 	}
 
 	function render_dummy_block_with_content( $attributes, $content ) {
 		$attributes['_content'] = $content;
 
-		return json_encode( $attributes );
+		return wp_json_encode( $attributes );
 	}
 }

--- a/phpunit/class-parsing-test.php
+++ b/phpunit/class-parsing-test.php
@@ -63,7 +63,7 @@ class Parsing_Test extends WP_UnitTestCase {
 		}
 
 		$html            = self::strip_r( file_get_contents( $html_path ) );
-		$expected_parsed = json_decode( self::strip_r( file_get_contents( $parsed_json_path ) ), true );
+		$expected_parsed = wp_json_decode( self::strip_r( file_get_contents( $parsed_json_path ) ), true );
 
 		$parser = new Gutenberg_PEG_Parser;
 		$result = $parser->parse( _gutenberg_utf8_split( $html ) );
@@ -91,10 +91,10 @@ class Parsing_Test extends WP_UnitTestCase {
 		}
 
 		$html            = self::strip_r( file_get_contents( $html_path ) );
-		$expected_parsed = json_decode( self::strip_r( file_get_contents( $parsed_json_path ) ), true );
+		$expected_parsed = wp_json_decode( self::strip_r( file_get_contents( $parsed_json_path ) ), true );
 
 		$parser = new WP_Block_Parser();
-		$result = json_decode( json_encode( $parser->parse( $html ) ), true );
+		$result = wp_json_decode( wp_json_encode( $parser->parse( $html ) ), true );
 
 		$this->assertEquals(
 			$expected_parsed,

--- a/phpunit/class-rest-block-renderer-controller-test.php
+++ b/phpunit/class-rest-block-renderer-controller-test.php
@@ -282,7 +282,7 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
 
-		$this->assertEquals( $defaults, json_decode( $data['rendered'], true ) );
+		$this->assertEquals( $defaults, wp_json_decode( $data['rendered'], true ) );
 		$this->assertEquals(
 			json_decode( $block_type->render( $defaults ) ),
 			json_decode( $data['rendered'] )
@@ -315,7 +315,7 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
 
-		$this->assertEquals( $expected_attributes, json_decode( $data['rendered'], true ) );
+		$this->assertEquals( $expected_attributes, wp_json_decode( $data['rendered'], true ) );
 		$this->assertEquals(
 			json_decode( $block_type->render( $attributes ), true ),
 			json_decode( $data['rendered'], true )


### PR DESCRIPTION
## Description
Change all references to json_encode and json_decode and replace with wp_json_encode and json_decode. This is to follow WordPress coding standards. 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
