### PR TITLE
Restore native backspace behaviour

### DIFF
--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -494,8 +494,6 @@ export class RichText extends Component {
 	 * @link https://en.wikipedia.org/wiki/Caret_navigation
 	 *
 	 * @param {KeyboardEvent} event Keydown event.
-	 *
-	 * @return {?boolean} True if the event was handled.
 	 */
 	onDeleteKeyDown( event ) {
 		const { onMerge, onRemove } = this.props;
@@ -536,8 +534,6 @@ export class RichText extends Component {
 		}
 
 		event.preventDefault();
-
-		return true;
 	}
 
 	/**
@@ -549,15 +545,18 @@ export class RichText extends Component {
 		const { keyCode } = event;
 
 		if ( keyCode === DELETE || keyCode === BACKSPACE ) {
-			if ( this.onDeleteKeyDown( event ) ) {
+			const value = this.createRecord();
+			const start = getSelectionStart( value );
+			const end = getSelectionEnd( value );
+
+			// Always handle uncollapsed selections ourselves.
+			if ( ! isCollapsed( value ) ) {
+				this.onChange( remove( value ) );
+				event.preventDefault();
 				return;
 			}
 
 			if ( this.multilineTag ) {
-				const value = this.createRecord();
-				const start = getSelectionStart( value );
-				const end = getSelectionEnd( value );
-
 				let newValue;
 
 				if ( keyCode === BACKSPACE ) {
@@ -584,6 +583,8 @@ export class RichText extends Component {
 					event.preventDefault();
 				}
 			}
+
+			this.onDeleteKeyDown( event );
 		} else if ( keyCode === ENTER ) {
 			event.preventDefault();
 

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -535,6 +535,8 @@ export class RichText extends Component {
 			onRemove( ! isReverse );
 		}
 
+		event.preventDefault();
+
 		return true;
 	}
 

--- a/packages/editor/src/components/rich-text/tinymce.js
+++ b/packages/editor/src/components/rich-text/tinymce.js
@@ -252,9 +252,11 @@ export default class TinyMCE extends Component {
 
 	onKeyDown( event ) {
 		const { keyCode } = event;
+		const { startContainer, startOffset, endContainer, endOffset } = getSelection().getRangeAt( 0 );
+		const isCollapsed = startContainer === endContainer && startOffset === endOffset;
 
 		// Disables TinyMCE behaviour.
-		if ( keyCode === ENTER ) {
+		if ( keyCode === ENTER || ( ! isCollapsed && ( keyCode === DELETE || keyCode === BACKSPACE ) ) ) {
 			event.preventDefault();
 			// For some reason this is needed to also prevent the insertion of
 			// line breaks.

--- a/packages/editor/src/components/rich-text/tinymce.js
+++ b/packages/editor/src/components/rich-text/tinymce.js
@@ -254,7 +254,7 @@ export default class TinyMCE extends Component {
 		const { keyCode } = event;
 
 		// Disables TinyMCE behaviour.
-		if ( keyCode === ENTER || keyCode === BACKSPACE || keyCode === DELETE ) {
+		if ( keyCode === ENTER ) {
 			event.preventDefault();
 			// For some reason this is needed to also prevent the insertion of
 			// line breaks.

--- a/test/e2e/specs/writing-flow.test.js
+++ b/test/e2e/specs/writing-flow.test.js
@@ -223,4 +223,13 @@ describe( 'adding blocks', () => {
 		) );
 		expect( isInBlock ).toBe( true );
 	} );
+
+	it( 'should not delete trailing spaces when deleting a word', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '1 2 3 4' );
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.type( '4' );
+		const blockText = await page.evaluate( () => document.activeElement.textContent );
+		expect( blockText ).toBe( '1 2 3 4' );
+	} );
 } );

--- a/test/e2e/specs/writing-flow.test.js
+++ b/test/e2e/specs/writing-flow.test.js
@@ -224,12 +224,21 @@ describe( 'adding blocks', () => {
 		expect( isInBlock ).toBe( true );
 	} );
 
-	it( 'should not delete trailing spaces when deleting a word', async () => {
+	it( 'should not delete trailing spaces when deleting a word with backspace', async () => {
 		await clickBlockAppender();
 		await page.keyboard.type( '1 2 3 4' );
 		await page.keyboard.press( 'Backspace' );
 		await page.keyboard.type( '4' );
 		const blockText = await page.evaluate( () => document.activeElement.textContent );
 		expect( blockText ).toBe( '1 2 3 4' );
+	} );
+
+	it( 'should not delete trailing spaces when deleting a word with alt + backspace', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'alpha beta gamma delta' );
+		await pressWithModifier( META_KEY, 'Backspace' );
+		await page.keyboard.type( 'delta' );
+		const blockText = await page.evaluate( () => document.activeElement.textContent );
+		expect( blockText ).toBe( 'alpha beta gamma delta' );
 	} );
 } );


### PR DESCRIPTION
## Description

Restores a part of #11287. It should not restore any bugginess! :)

We need to make sure none of the issues that #10799 fixed are reintroduced.

Still needs e2e test and investigate failing e2e tests.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->