### PR TITLE
Components: Restore click-to-close behavior of Dropdown toggle

### DIFF
--- a/packages/components/src/dropdown/index.js
+++ b/packages/components/src/dropdown/index.js
@@ -11,12 +11,15 @@ import Popover from '../popover';
 class Dropdown extends Component {
 	constructor() {
 		super( ...arguments );
+
 		this.toggle = this.toggle.bind( this );
 		this.close = this.close.bind( this );
-		this.bindContainer = this.bindContainer.bind( this );
 		this.closeIfClickOutside = this.closeIfClickOutside.bind( this );
 		this.refresh = this.refresh.bind( this );
+
+		this.containerRef = createRef();
 		this.popoverRef = createRef();
+
 		this.state = {
 			isOpen: false,
 		};
@@ -36,10 +39,6 @@ class Dropdown extends Component {
 		if ( prevState.isOpen !== isOpen && onToggle ) {
 			onToggle( isOpen );
 		}
-	}
-
-	bindContainer( ref ) {
-		this.container = ref;
 	}
 
 	/**
@@ -68,6 +67,7 @@ class Dropdown extends Component {
 	 * @param {MouseEvent} event Click event triggering `onClickOutside`.
 	 */
 	closeIfClickOutside( event ) {
+		if ( ! this.containerRef.current.contains( event.target ) ) {
 			this.close();
 		}
 	}
@@ -91,7 +91,7 @@ class Dropdown extends Component {
 		const args = { isOpen, onToggle: this.toggle, onClose: this.close };
 
 		return (
-			<div className={ className } ref={ this.bindContainer }>
+			<div className={ className } ref={ this.containerRef }>
 				{ renderToggle( args ) }
 				{ isOpen && (
 					<Popover

--- a/packages/components/src/dropdown/index.js
+++ b/packages/components/src/dropdown/index.js
@@ -13,8 +13,8 @@ class Dropdown extends Component {
 		super( ...arguments );
 		this.toggle = this.toggle.bind( this );
 		this.close = this.close.bind( this );
-		this.clickOutside = this.clickOutside.bind( this );
 		this.bindContainer = this.bindContainer.bind( this );
+		this.closeIfClickOutside = this.closeIfClickOutside.bind( this );
 		this.refresh = this.refresh.bind( this );
 		this.popoverRef = createRef();
 		this.state = {
@@ -59,8 +59,15 @@ class Dropdown extends Component {
 		} ) );
 	}
 
-	clickOutside( event ) {
-		if ( ! this.container.contains( event.target ) ) {
+	/**
+	 * Closes the dropdown if a click occurs outside the dropdown wrapper. This
+	 * is intentionally distinct from `onClose` in that a click outside the
+	 * popover may occur in the toggling of the dropdown via its toggle button.
+	 * The correct behavior is to keep the dropdown closed.
+	 *
+	 * @param {MouseEvent} event Click event triggering `onClickOutside`.
+	 */
+	closeIfClickOutside( event ) {
 			this.close();
 		}
 	}
@@ -92,7 +99,7 @@ class Dropdown extends Component {
 						ref={ this.popoverRef }
 						position={ position }
 						onClose={ this.close }
-						onClickOutside={ this.clickOutside }
+						onClickOutside={ this.closeIfClickOutside }
 						expandOnMobile={ expandOnMobile }
 						headerTitle={ headerTitle }
 					>

--- a/packages/components/src/dropdown/index.js
+++ b/packages/components/src/dropdown/index.js
@@ -11,13 +11,12 @@ import Popover from '../popover';
 class Dropdown extends Component {
 	constructor() {
 		super( ...arguments );
-
 		this.toggle = this.toggle.bind( this );
 		this.close = this.close.bind( this );
+		this.clickOutside = this.clickOutside.bind( this );
+		this.bindContainer = this.bindContainer.bind( this );
 		this.refresh = this.refresh.bind( this );
-
 		this.popoverRef = createRef();
-
 		this.state = {
 			isOpen: false,
 		};
@@ -39,6 +38,10 @@ class Dropdown extends Component {
 		}
 	}
 
+	bindContainer( ref ) {
+		this.container = ref;
+	}
+
 	/**
 	 * When contents change height due to user interaction,
 	 * `refresh` can be called to re-render Popover with correct
@@ -54,6 +57,12 @@ class Dropdown extends Component {
 		this.setState( ( state ) => ( {
 			isOpen: ! state.isOpen,
 		} ) );
+	}
+
+	clickOutside( event ) {
+		if ( ! this.container.contains( event.target ) ) {
+			this.close();
+		}
 	}
 
 	close() {
@@ -75,7 +84,7 @@ class Dropdown extends Component {
 		const args = { isOpen, onToggle: this.toggle, onClose: this.close };
 
 		return (
-			<div className={ className }>
+			<div className={ className } ref={ this.bindContainer }>
 				{ renderToggle( args ) }
 				{ isOpen && (
 					<Popover
@@ -83,6 +92,7 @@ class Dropdown extends Component {
 						ref={ this.popoverRef }
 						position={ position }
 						onClose={ this.close }
+						onClickOutside={ this.clickOutside }
 						expandOnMobile={ expandOnMobile }
 						headerTitle={ headerTitle }
 					>

--- a/test/e2e/specs/demo.test.js
+++ b/test/e2e/specs/demo.test.js
@@ -40,6 +40,6 @@ describe( 'new editor state', () => {
 	} );
 
 	it( 'should be immediately saveable', async () => {
-		await page.$( 'button.editor-post-save-draft' );
+		expect( await page.$( 'button.editor-post-save-draft' ) ).toBeTruthy();
 	} );
 } );

--- a/test/e2e/specs/popovers.test.js
+++ b/test/e2e/specs/popovers.test.js
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import { newPost } from '../support/utils';
+
+describe( 'popovers', () => {
+	beforeEach( async () => {
+		await newPost();
+	} );
+
+	describe( 'dropdown', () => {
+		it( 'toggles via click', async () => {
+			const isMoreMenuOpen = async () => !! await page.$( '.edit-post-more-menu__content' );
+
+			expect( await isMoreMenuOpen() ).toBe( false );
+
+			// Toggle opened.
+			await page.click( '.edit-post-more-menu > button' );
+			expect( await isMoreMenuOpen() ).toBe( true );
+
+			// Toggle closed.
+			await page.click( '.edit-post-more-menu > button' );
+			expect( await isMoreMenuOpen() ).toBe( false );
+		} );
+	} );
+} );


### PR DESCRIPTION
Partially addresses #11579
Regression introduced in #11253 
Effectively reverts 58725c42980f81dbcf18d921be7ca43507c968e0

This pull request seeks to resolve a regression where clicking a Dropdown toggle button while the Dropdown's Popover is already opened results in the Popover remaining opened.

**Testing instructions:**

Verify that clicking a Dropdown toggle button while the Popover is visible results in the popover being hidden.

1. Navigate to Posts > Add New
2. Click the More Menu button in the top-right
3. Click the More Menu button in the top-right, again
4. Note that the Popover is now closed.

Ensure end-to-end tests pass:

```
npm run test-e2e test/e2e/specs/popovers.test.js
```