### PR TITLE
Update media url only if it exists

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -22,8 +22,8 @@ export default function ImageEdit( props ) {
 	const onMediaLibraryPress = () => {
 		// Call onMediaLibraryPress from the Native<->RN bridge. It should trigger an image picker from
 		// the WordPress media library and call the provided callback to set the image URL.
-		RNReactNativeGutenbergBridge.onMediaLibraryPress( (mediaUrl) => {
-			if (mediaUrl) {
+		RNReactNativeGutenbergBridge.onMediaLibraryPress( ( mediaUrl ) => {
+			if ( mediaUrl)  {
 				setAttributes( { url: mediaUrl } );
 			}
 		} );

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -22,7 +22,11 @@ export default function ImageEdit( props ) {
 	const onMediaLibraryPress = () => {
 		// Call onMediaLibraryPress from the Native<->RN bridge. It should trigger an image picker from
 		// the WordPress media library and call the provided callback to set the image URL.
-		RNReactNativeGutenbergBridge.onMediaLibraryPress( ( mediaUrl ) => setAttributes( { url: mediaUrl } ) );
+		RNReactNativeGutenbergBridge.onMediaLibraryPress( (mediaUrl) => {
+			if (mediaUrl) {
+				setAttributes( { url: mediaUrl } );
+			}
+		} );
 	};
 
 	if ( ! url ) {

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -23,7 +23,7 @@ export default function ImageEdit( props ) {
 		// Call onMediaLibraryPress from the Native<->RN bridge. It should trigger an image picker from
 		// the WordPress media library and call the provided callback to set the image URL.
 		RNReactNativeGutenbergBridge.onMediaLibraryPress( ( mediaUrl ) => {
-			if ( mediaUrl)  {
+			if ( mediaUrl ) {
 				setAttributes( { url: mediaUrl } );
 			}
 		} );


### PR DESCRIPTION
## Description
This update is for handling situations where user just presses Cancel on the media picker.
We don't want the image block to update in that case.

## How has this been tested?
Test steps can be found on [parent PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/10430)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
