### PR TITLE
Fix save lock control (length check on object)

### DIFF
--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -2056,7 +2056,7 @@ export function isPostLocked( state ) {
  * @return {boolean} Is locked.
  */
 export function isPostSavingLocked( state ) {
-	return state.postSavingLock.length > 0;
+	return Object.keys( state.postSavingLock ).length > 0;
 }
 
 /**

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -964,7 +964,7 @@ describe( 'selectors', () => {
 	describe( 'isPostSavingLocked', () => {
 		it( 'should return true if the post has postSavingLocks', () => {
 			const state = {
-				postSavingLock: [ { 1: true } ],
+				postSavingLock: { example: true },
 				currentPost: {},
 				saving: {},
 			};
@@ -974,7 +974,7 @@ describe( 'selectors', () => {
 
 		it( 'should return false if the post has no postSavingLocks', () => {
 			const state = {
-				postSavingLock: [],
+				postSavingLock: {},
 				currentPost: {},
 				saving: {},
 			};


### PR DESCRIPTION
## Description
Tried to use https://github.com/WordPress/gutenberg/pull/10649 and found a little glitch using .length on an object, which broke the whole feature.

## How has this been tested?
Using `wp.data.dispatch( 'core/editor' ).lockPostSaving( 'mylock' );`
to lock the publish/update button

And `wp.data.dispatch( 'core/editor' ).unlockPostSaving( 'mylock' );`
to unlock it.


## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
