### PR TITLE
Add: action to set category icon; Fix: Managing block categories documentation

### DIFF
--- a/docs/designers-developers/developers/data/data-core-blocks.md
+++ b/docs/designers-developers/developers/data/data-core-blocks.md
@@ -225,3 +225,12 @@ Returns an action object used to set block categories.
 *Parameters*
 
  * categories: Block categories.
+
+### setCategoryIcon
+
+Returns an action object used to the icon of a category.
+
+*Parameters*
+
+ * slug: Block category slug.
+ * icon: Block category icon.

--- a/docs/designers-developers/developers/data/data-core-blocks.md
+++ b/docs/designers-developers/developers/data/data-core-blocks.md
@@ -226,11 +226,11 @@ Returns an action object used to set block categories.
 
  * categories: Block categories.
 
-### setCategoryIcon
+### updateCategory
 
-Returns an action object used to the icon of a category.
+Returns an action object used to update a category.
 
 *Parameters*
 
  * slug: Block category slug.
- * icon: Block category icon.
+ * category: Object containing the category properties that should be updated.

--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -329,7 +329,7 @@ function my_plugin_block_categories( $categories, $post ) {
 			array(
 				'slug' => 'my-category',
 				'title' => __( 'My category', 'my-plugin' ),
-				'icon'  => '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="none" d="M0 0h24v24H0V0z" /><path d="M19 13H5v-2h14v2z" /></svg>',
+				'icon'  => 'wordpress',
 			),
 		)
 	);
@@ -337,4 +337,17 @@ function my_plugin_block_categories( $categories, $post ) {
 add_filter( 'block_categories', 'my_plugin_block_categories', 10, 2 );
 ```
 
-You can also display an icon with your block category by setting an `icon` attribute. The value can be the slug of a [WordPress Dashicon](https://developer.wordpress.org/resource/dashicons/), or a custom `svg` element.
+You can also display an icon with your block category by setting an `icon` attribute. The value can be the slug of a [WordPress Dashicon](https://developer.wordpress.org/resource/dashicons/).
+It is possible to set an SVG as the icon of the category if a custom icon is needed.
+To do so, the icon should be rendered and set on the frontend, so it can make use of WordPress SVG, allowing mobile compatibility and making the icon more accessible.
+To use an SVG icon add a category as shown in the previous example, and add javascript code to the editor calling wp.blocks.setCategoryIcon e.g:
+```js
+(function() {
+	var el = wp.element.createElement;
+	var SVG = wp.components.SVG;
+	var circle = el( 'circle', { cx: 10, cy: 10, r: 10, fill: 'red', stroke:	'blue', strokeWidth: '10' } );
+	var svgIcon = el( SVG, { width: 20, height: 20, viewBox: '0 0 20 20'},	circle);
+	wp.blocks.setCategoryIcon( 'my-category', svgIcon );
+} )();
+``` 
+

--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -337,17 +337,18 @@ function my_plugin_block_categories( $categories, $post ) {
 add_filter( 'block_categories', 'my_plugin_block_categories', 10, 2 );
 ```
 
-You can also display an icon with your block category by setting an `icon` attribute. The value can be the slug of a [WordPress Dashicon](https://developer.wordpress.org/resource/dashicons/).
-It is possible to set an SVG as the icon of the category if a custom icon is needed.
-To do so, the icon should be rendered and set on the frontend, so it can make use of WordPress SVG, allowing mobile compatibility and making the icon more accessible.
-To use an SVG icon add a category as shown in the previous example, and add javascript code to the editor calling wp.blocks.setCategoryIcon e.g:
+You can also display an icon with your block category by setting an `icon` attribute.The value can be the slug of a [WordPress Dashicon](https://developer.wordpress.org/resource/dashicons/).
+
+It is possible to set an SVG as the icon of the category if a custom icon is needed.To do so, the icon should be rendered and set on the frontend, so it can make use of WordPress SVG, allowing mobile compatibility and making the icon more accessible.
+
+To set an SVG icon for the category shown in the previous example, add the following example JavaScript code to the editor calling `wp.blocks.updateCategory` e.g:
 ```js
-(function() {
+( function() {
 	var el = wp.element.createElement;
 	var SVG = wp.components.SVG;
-	var circle = el( 'circle', { cx: 10, cy: 10, r: 10, fill: 'red', stroke:	'blue', strokeWidth: '10' } );
-	var svgIcon = el( SVG, { width: 20, height: 20, viewBox: '0 0 20 20'},	circle);
-	wp.blocks.setCategoryIcon( 'my-category', svgIcon );
+	var circle = el( 'circle', { cx: 10, cy: 10, r: 10, fill: 'red', stroke: 'blue', strokeWidth: '10' } );
+	var svgIcon = el( SVG, { width: 20, height: 20, viewBox: '0 0 20 20'}, circle);
+	wp.blocks.updateCategory( 'my-category', { icon: svgIcon } );
 } )();
 ``` 
 

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -72,7 +72,7 @@ function build_dropdown_script_block_core_categories( $dropdown_id ) {
 	?>
 	<script type='text/javascript'>
 	/* <![CDATA[ */
-	(function() {
+	( function() {
 		var dropdown = document.getElementById( '<?php echo esc_js( $dropdown_id ); ?>' );
 		function onCatChange() {
 			if ( dropdown.options[ dropdown.selectedIndex ].value > 0 ) {

--- a/packages/blocks/src/api/categories.js
+++ b/packages/blocks/src/api/categories.js
@@ -20,3 +20,13 @@ export function getCategories() {
 export function setCategories( categories ) {
 	dispatch( 'core/blocks' ).setCategories( categories );
 }
+
+/**
+ * Sets the category icon.
+ *
+ * @param {string}       slug Block category slug.
+ * @param {string|Array} icon Block category icon.
+ */
+export function setCategoryIcon( slug, icon ) {
+	dispatch( 'core/blocks' ).setCategoryIcon( slug, icon );
+}

--- a/packages/blocks/src/api/categories.js
+++ b/packages/blocks/src/api/categories.js
@@ -22,11 +22,11 @@ export function setCategories( categories ) {
 }
 
 /**
- * Sets the category icon.
+ * Updates a category.
  *
- * @param {string}       slug Block category slug.
- * @param {string|Array} icon Block category icon.
+ * @param {string} slug          Block category slug.
+ * @param {Object} category Object containing the category properties that should be updated.
  */
-export function setCategoryIcon( slug, icon ) {
-	dispatch( 'core/blocks' ).setCategoryIcon( slug, icon );
+export function updateCategory( slug, category ) {
+	dispatch( 'core/blocks' ).updateCategory( slug, category );
 }

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -24,7 +24,7 @@ export { isValidBlockContent } from './validation';
 export {
 	getCategories,
 	setCategories,
-	setCategoryIcon,
+	updateCategory,
 } from './categories';
 export {
 	registerBlockType,

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -24,6 +24,7 @@ export { isValidBlockContent } from './validation';
 export {
 	getCategories,
 	setCategories,
+	setCategoryIcon,
 } from './categories';
 export {
 	registerBlockType,

--- a/packages/blocks/src/store/actions.js
+++ b/packages/blocks/src/store/actions.js
@@ -120,3 +120,19 @@ export function setCategories( categories ) {
 		categories,
 	};
 }
+
+/**
+ * Returns an action object used to the icon of a category.
+ *
+ * @param {string}       slug Block category slug.
+ * @param {string|Array} icon Block category icon.
+ *
+ * @return {Object} Action object.
+ */
+export function setCategoryIcon( slug, icon ) {
+	return {
+		type: 'SET_CATEGORY_ICON',
+		slug,
+		icon,
+	};
+}

--- a/packages/blocks/src/store/actions.js
+++ b/packages/blocks/src/store/actions.js
@@ -122,17 +122,17 @@ export function setCategories( categories ) {
 }
 
 /**
- * Returns an action object used to the icon of a category.
+ * Returns an action object used to update a category.
  *
- * @param {string}       slug Block category slug.
- * @param {string|Array} icon Block category icon.
+ * @param {string} slug     Block category slug.
+ * @param {Object} category Object containing the category properties that should be updated.
  *
  * @return {Object} Action object.
  */
-export function setCategoryIcon( slug, icon ) {
+export function updateCategory( slug, category ) {
 	return {
-		type: 'SET_CATEGORY_ICON',
+		type: 'UPDATE_CATEGORY',
 		slug,
-		icon,
+		category,
 	};
 }

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -1,7 +1,16 @@
 /**
  * External dependencies
  */
-import { keyBy, omit, mapValues, get, uniqBy, filter, map } from 'lodash';
+import {
+	filter,
+	find,
+	get,
+	keyBy,
+	map,
+	mapValues,
+	omit,
+	uniqBy,
+} from 'lodash';
 
 /**
  * WordPress dependencies
@@ -124,10 +133,24 @@ export const unregisteredFallbackBlockName = createBlockNameSetterReducer( 'SET_
  * @return {Object} Updated state.
  */
 export function categories( state = DEFAULT_CATEGORIES, action ) {
-	if ( action.type === 'SET_CATEGORIES' ) {
-		return action.categories || [];
+	switch ( action.type ) {
+		case 'SET_CATEGORIES':
+			return action.categories || [];
+		case 'SET_CATEGORY_ICON': {
+			const categoryToChange = find( state, [ 'slug', action.slug ] );
+			if ( categoryToChange ) {
+				return map( state, ( category ) => {
+					if ( category.slug === action.slug ) {
+						return {
+							...category,
+							icon: action.icon,
+						};
+					}
+					return category;
+				} );
+			}
+		}
 	}
-
 	return state;
 }
 

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -5,6 +5,7 @@ import {
 	filter,
 	find,
 	get,
+	isEmpty,
 	keyBy,
 	map,
 	mapValues,
@@ -136,14 +137,17 @@ export function categories( state = DEFAULT_CATEGORIES, action ) {
 	switch ( action.type ) {
 		case 'SET_CATEGORIES':
 			return action.categories || [];
-		case 'SET_CATEGORY_ICON': {
+		case 'UPDATE_CATEGORY': {
+			if ( ! action.category || isEmpty( action.category ) ) {
+				return state;
+			}
 			const categoryToChange = find( state, [ 'slug', action.slug ] );
 			if ( categoryToChange ) {
 				return map( state, ( category ) => {
 					if ( category.slug === action.slug ) {
 						return {
 							...category,
-							icon: action.icon,
+							...action.category,
 						};
 					}
 					return category;

--- a/packages/blocks/src/store/test/reducer.js
+++ b/packages/blocks/src/store/test/reducer.js
@@ -226,4 +226,43 @@ describe( 'categories', () => {
 			{ slug: 'wings', title: 'Wings' },
 		] );
 	} );
+
+	it( 'should add the category icon', () => {
+		const original = deepFreeze( [ {
+			slug: 'chicken',
+			title: 'Chicken',
+		} ] );
+
+		const state = categories( original, {
+			type: 'SET_CATEGORY_ICON',
+			slug: 'chicken',
+			icon: 'new-icon',
+		} );
+
+		expect( state ).toEqual( [ {
+			slug: 'wings',
+			title: 'Wings',
+			icon: 'new-icon',
+		} ] );
+	} );
+
+	it( 'should update the category icon', () => {
+		const original = deepFreeze( [ {
+			slug: 'chicken',
+			title: 'Chicken',
+			icon: 'old-icon',
+		} ] );
+
+		const state = categories( original, {
+			type: 'SET_CATEGORY_ICON',
+			slug: 'chicken',
+			icon: 'new-icon',
+		} );
+
+		expect( state ).toEqual( [ {
+			slug: 'wings',
+			title: 'Wings',
+			icon: 'new-icon',
+		} ] );
+	} );
 } );

--- a/packages/blocks/src/store/test/reducer.js
+++ b/packages/blocks/src/store/test/reducer.js
@@ -234,14 +234,16 @@ describe( 'categories', () => {
 		} ] );
 
 		const state = categories( original, {
-			type: 'SET_CATEGORY_ICON',
+			type: 'UPDATE_CATEGORY',
 			slug: 'chicken',
-			icon: 'new-icon',
+			category: {
+				icon: 'new-icon',
+			},
 		} );
 
 		expect( state ).toEqual( [ {
-			slug: 'wings',
-			title: 'Wings',
+			slug: 'chicken',
+			title: 'Chicken',
 			icon: 'new-icon',
 		} ] );
 	} );
@@ -251,18 +253,60 @@ describe( 'categories', () => {
 			slug: 'chicken',
 			title: 'Chicken',
 			icon: 'old-icon',
+		}, {
+			slug: 'wings',
+			title: 'Wings',
+			icon: 'old-icon',
 		} ] );
 
 		const state = categories( original, {
-			type: 'SET_CATEGORY_ICON',
+			type: 'UPDATE_CATEGORY',
 			slug: 'chicken',
-			icon: 'new-icon',
+			category: {
+				icon: 'new-icon',
+			},
 		} );
 
 		expect( state ).toEqual( [ {
+			slug: 'chicken',
+			title: 'Chicken',
+			icon: 'new-icon',
+		}, {
 			slug: 'wings',
 			title: 'Wings',
-			icon: 'new-icon',
+			icon: 'old-icon',
+		} ] );
+	} );
+
+	it( 'should update multiple category properties', () => {
+		const original = deepFreeze( [ {
+			slug: 'chicken',
+			title: 'Chicken',
+			icon: 'old-icon',
+		}, {
+			slug: 'wings',
+			title: 'Wings',
+			icon: 'old-icon',
+		} ] );
+
+		const state = categories( original, {
+			type: 'UPDATE_CATEGORY',
+			slug: 'wings',
+			category: {
+				title: 'New Wings',
+				chicken: 'ribs',
+			},
+		} );
+
+		expect( state ).toEqual( [ {
+			slug: 'chicken',
+			title: 'Chicken',
+			icon: 'old-icon',
+		}, {
+			slug: 'wings',
+			title: 'New Wings',
+			chicken: 'ribs',
+			icon: 'old-icon',
 		} ] );
 	} );
 } );


### PR DESCRIPTION
Closes: https://github.com/WordPress/gutenberg/issues/11594

The documentation of "Managing block categories" was wrong as on the server we can not set SVG icons. The server would not be able to use our SVG component.
This PR fixes the documentation and adds a new action that allows updating the icon on the front end in a simple way.


## How has this been tested?
```
Add the following code to functions.php:
function my_plugin_block_categories( $categories, $post ) {
	if ( $post->post_type !== 'post' ) {
		return $categories;
	}
	return array_merge(
		$categories,
		array(
			array(
				'slug' => 'my-category',
				'title' => __( 'My category', 'my-plugin' ),
			),
		)
	);
}
add_filter( 'block_categories', 'my_plugin_block_categories', 10, 2 );
```
Execute the following code block on the browser console:
```
(function() {
	var el = wp.element.createElement;
	var SVG = wp.components.SVG;
	var circle = el( 'circle', { cx: 10, cy: 10, r: 10, fill: 'red', stroke:	'blue', strokeWidth: '10' } );
	var svgIcon = el( SVG, { width: 20, height: 20, viewBox: '0 0 20 20'},	circle);
	wp.blocks.updateCategory( 'my-category', { icon: svgIcon } );
} )();
( function() {
	const { registerBlockType } = wp.blocks;
	const { createElement: el } = wp.element;
	const { InnerBlocks } = wp.editor;

	registerBlockType( 'block/simple-block', {
		title: 'Test Simple Block',
		icon: 'carrot',
		category: 'my-category',

		edit() {
			return el( 'div', { style: { outline: '1px solid gray', padding: 5 } },
				el( 'p', {}, 'ok' )
			);
		},

		save() {
			return el( 'div', { style: { outline: '1px solid gray', padding: 5 } },
				el( 'p', {}, 'ok' )
			);
		},
	} );
} )();
```
Verify a circle is the icon of "My category"