### PR TITLE
Add message if JavaScript is disabled

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -33,7 +33,7 @@ function the_gutenberg_project() {
 		<?php
 			// Using Gutenberg as Plugin
 			if ( is_plugin_active( 'gutenberg/gutenberg.php' ) ) {
-				$current_url = esc_url( $_SERVER['REQUEST_URI'] . "&classic-editor" );
+				$current_url = esc_url( add_query_arg( 'classic-editor', true, $_SERVER['REQUEST_URI'] ) );
 				printf(
 					__( 'The Block Editor requires JavaScript. You can use the <a href="%s">Classic Editor</a>.', 'gutenberg' ),
 					$current_url

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -32,7 +32,7 @@ function the_gutenberg_project() {
 		<noscript>
 			<div class="error" style='margin-top:32px'><p>
 			<?php
-			echo __( 'The block editor requires Javascript to be enabled.', 'gutenberg' );
+			_e( 'The block editor requires Javascript to be enabled.', 'gutenberg' );
 			?>
 			</p></div>
 		</noscript>
@@ -130,7 +130,7 @@ function is_gutenberg_page() {
  */
 function gutenberg_wordpress_version_notice() {
 	echo '<div class="error"><p>';
-	echo __( 'Gutenberg requires WordPress 4.9.8 or later to function properly. Please upgrade WordPress before activating Gutenberg.', 'gutenberg' );
+	_e( 'Gutenberg requires WordPress 4.9.8 or later to function properly. Please upgrade WordPress before activating Gutenberg.', 'gutenberg' );
 	echo '</p></div>';
 
 	deactivate_plugins( array( 'gutenberg/gutenberg.php' ) );
@@ -143,7 +143,7 @@ function gutenberg_wordpress_version_notice() {
  */
 function gutenberg_build_files_notice() {
 	echo '<div class="error"><p>';
-	echo __( 'Gutenberg development mode requires files to be built. Run <code>npm install</code> to install dependencies, <code>npm run build</code> to build the files or <code>npm run dev</code> to build the files and watch for changes. Read the <a href="https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTING.md">contributing</a> file for more information.', 'gutenberg' );
+	_e( 'Gutenberg development mode requires files to be built. Run <code>npm install</code> to install dependencies, <code>npm run build</code> to build the files or <code>npm run dev</code> to build the files and watch for changes. Read the <a href="https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTING.md">contributing</a> file for more information.', 'gutenberg' );
 	echo '</p></div>';
 }
 

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -32,7 +32,10 @@ function the_gutenberg_project() {
 		<noscript>
 			<div class="error" style='margin-top:32px'><p>
 			<?php
-			_e( 'The Block Editor requires JavaScript. Go to your browser\'s settings and enable JavaScript before using it.', 'gutenberg' );
+				printf(
+					__( 'The Block Editor requires JavaScript, please try the <a href="%s">Classic Editor plugin</a>.', 'gutenberg' ),
+					'https://wordpress.org/plugins/classic-editor/'
+				) ;
 			?>
 			</p></div>
 		</noscript>

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -28,17 +28,17 @@ gutenberg_pre_init();
 function the_gutenberg_project() {
 	global $post_type_object;
 	?>
+	<noscript>
+		<div class="error" style='position:absolute;top:32px;z-index:40'><p>
+		<?php
+			printf(
+				__( 'The Block Editor requires JavaScript, please try the <a href="%s">Classic Editor plugin</a>.', 'gutenberg' ),
+				'https://wordpress.org/plugins/classic-editor/'
+			) ;
+		?>
+		</p></div>
+	</noscript>
 	<div class="block-editor gutenberg">
-		<noscript>
-			<div class="error" style='margin-top:32px'><p>
-			<?php
-				printf(
-					__( 'The Block Editor requires JavaScript, please try the <a href="%s">Classic Editor plugin</a>.', 'gutenberg' ),
-					'https://wordpress.org/plugins/classic-editor/'
-				) ;
-			?>
-			</p></div>
-		</noscript>
 		<h1 class="screen-reader-text"><?php echo esc_html( $post_type_object->labels->edit_item ); ?></h1>
 		<div id="editor" class="block-editor__container gutenberg__editor"></div>
 		<div id="metaboxes" style="display: none;">

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -32,7 +32,7 @@ function the_gutenberg_project() {
 		<noscript>
 			<div class="error" style='margin-top:32px'><p>
 			<?php
-			_e( 'The block editor requires Javascript to be enabled.', 'gutenberg' );
+			_e( 'The Block Editor requires JavaScript. Go to your browser\'s settings and enable JavaScript before using it.', 'gutenberg' );
 			?>
 			</p></div>
 		</noscript>

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -30,9 +30,11 @@ function the_gutenberg_project() {
 	?>
 	<div class="block-editor gutenberg">
 		<noscript>
-			<div class="error" style='margin-top:32px'><p><?php
+			<div class="error" style='margin-top:32px'><p>
+			<?php
 			echo __( 'The block editor requires Javascript to be enabled.', 'gutenberg' );
-			?></p></div>
+			?>
+			</p></div>
 		</noscript>
 		<h1 class="screen-reader-text"><?php echo esc_html( $post_type_object->labels->edit_item ); ?></h1>
 		<div id="editor" class="block-editor__container gutenberg__editor"></div>

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -29,6 +29,11 @@ function the_gutenberg_project() {
 	global $post_type_object;
 	?>
 	<div class="block-editor gutenberg">
+		<noscript>
+			<div class="error" style='margin-top:32px'><p><?php
+			echo __( 'The block editor requires Javascript to be enabled.', 'gutenberg' );
+			?></p></div>
+		</noscript>
 		<h1 class="screen-reader-text"><?php echo esc_html( $post_type_object->labels->edit_item ); ?></h1>
 		<div id="editor" class="block-editor__container gutenberg__editor"></div>
 		<div id="metaboxes" style="display: none;">

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -29,12 +29,21 @@ function the_gutenberg_project() {
 	global $post_type_object;
 	?>
 	<noscript>
-		<div class="error" style='position:absolute;top:32px;z-index:40'><p>
+		<div class="error" style="position:absolute;top:32px;z-index:40"><p>
 		<?php
-			printf(
-				__( 'The Block Editor requires JavaScript, please try the <a href="%s">Classic Editor plugin</a>.', 'gutenberg' ),
-				'https://wordpress.org/plugins/classic-editor/'
-			) ;
+			// Using Gutenberg as Plugin
+			if ( is_plugin_active( 'gutenberg/gutenberg.php' ) ) {
+				$current_url = esc_url( $_SERVER['REQUEST_URI'] . "&classic-editor" );
+				printf(
+					__( 'The Block Editor requires JavaScript. You can use the <a href="%s">Classic Editor</a>.', 'gutenberg' ),
+					$current_url
+				) ;
+			} else { // Using Gutenberg in Core
+				printf(
+					__( 'The Block Editor requires JavaScript. Please try the <a href="%s">Classic Editor plugin</a>.', 'gutenberg' ),
+					'https://wordpress.org/plugins/classic-editor/'
+				) ;
+			}
 		?>
 		</p></div>
 	</noscript>

--- a/packages/edit-post/src/components/fullscreen-mode/style.scss
+++ b/packages/edit-post/src/components/fullscreen-mode/style.scss
@@ -1,4 +1,4 @@
-body.is-fullscreen-mode {
+body.is-fullscreen-mode:not(.no-js) {
 	// Reset the html.wp-topbar padding
 	// Because this uses negative margins, we have to compensate for the height.
 	margin-top: -$admin-bar-height-big;

--- a/packages/edit-post/src/components/fullscreen-mode/style.scss
+++ b/packages/edit-post/src/components/fullscreen-mode/style.scss
@@ -1,4 +1,4 @@
-body.is-fullscreen-mode:not(.no-js) {
+body.js.is-fullscreen-mode {
 	// Reset the html.wp-topbar padding
 	// Because this uses negative margins, we have to compensate for the height.
 	margin-top: -$admin-bar-height-big;


### PR DESCRIPTION
## Description

Adds a noscript and message if Javascript is disabled.

This also required adding a :not(.no-js) to the fullscreen body class
which hides/shows the rest of the wp-admin chrome.



## How has this been tested?

* Disable Javascript using console settings 
1. Prior to change confirm the page is blank.
2. After change you should see the message

<img width="711" alt="screen shot 2018-11-08 at 11 23 34 am" src="https://user-images.githubusercontent.com/45363/48222398-60be4480-e349-11e8-9c7c-ac342315b53d.png">


## Types of changes

See #2719 

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
