### PR TITLE
Enhancing Quote block styling for different alignments

### DIFF
--- a/packages/block-library/src/quote/editor.scss
+++ b/packages/block-library/src/quote/editor.scss
@@ -1,5 +1,5 @@
 .wp-block-quote {
-	margin: 0;
+	margin: 0 inherit;
 
 	&__citation {
 		font-size: $default-font-size;

--- a/packages/block-library/src/quote/editor.scss
+++ b/packages/block-library/src/quote/editor.scss
@@ -3,5 +3,45 @@
 
 	&__citation {
 		font-size: $default-font-size;
-	}
-}
+	} // &__citation
+
+	&.is-left {
+		border-left: 4px solid $black;
+		padding-left: 1em;
+	} // &.is-left
+
+	&.is-right {
+		border-right: 4px solid $black;
+		padding-right: 1em;
+		text-align: right;
+	} // &.is-right
+
+	&.is-center {
+		margin: 3em inherit;
+		padding-left: 2em;
+		padding-right: 2em;
+		text-align: center;
+
+		&::before {
+			background-color: $black;
+			content: "";
+			display: block;
+			height: 4px;
+			margin-left: calc(50% - 10%);
+			margin-bottom: 2em;
+			width: 20%;
+		} // &::before
+
+		&::after {
+			background-color: $black;
+			content: "";
+			display: block;
+			height: 4px;
+			margin-left: calc(50% - 10%);
+			margin-top: 2em;
+			width: 20%;
+		} // &::after
+
+	} // .is-center
+
+} // .wp-block-quote

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { omit } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -200,7 +201,7 @@ export const settings = {
 						} }
 					/>
 				</BlockControls>
-				<blockquote className={ className } style={ { textAlign: align } }>
+				<blockquote className={ align }>
 					<RichText
 						multiline
 						value={ value }

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -191,6 +191,12 @@ export const settings = {
 
 	edit( { attributes, setAttributes, isSelected, mergeBlocks, onReplace, className } ) {
 		const { align, value, citation } = attributes;
+
+		const classes = classnames(
+			className,
+			align,
+		);
+
 		return (
 			<Fragment>
 				<BlockControls>

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -207,7 +207,7 @@ export const settings = {
 						} }
 					/>
 				</BlockControls>
-				<blockquote className={ align }>
+				<blockquote className={ classes }>
 					<RichText
 						multiline
 						value={ value }

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -248,11 +248,16 @@ export const settings = {
 		);
 	},
 
-	save( { attributes } ) {
+	save( { attributes, className } ) {
 		const { align, value, citation } = attributes;
 
+		const classes = classnames(
+			className,
+			align,
+		);
+
 		return (
-			<blockquote style={ { textAlign: align ? align : null } }>
+			<blockquote className={ classes }>
 				<RichText.Content multiline value={ value } />
 				{ ! RichText.isEmpty( citation ) && <RichText.Content tagName="cite" value={ citation } /> }
 			</blockquote>

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -196,7 +196,7 @@ export const settings = {
 					<AlignmentToolbar
 						value={ align }
 						onChange={ ( nextAlign ) => {
-							setAttributes( { align: nextAlign } );
+							setAttributes( { align: 'is-' + nextAlign } );
 						} }
 					/>
 				</BlockControls>

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -33,6 +33,7 @@ const blockAttributes = {
 	},
 	align: {
 		type: 'string',
+		default: 'is-left',
 	},
 };
 

--- a/packages/block-library/src/quote/style.scss
+++ b/packages/block-library/src/quote/style.scss
@@ -3,7 +3,7 @@
 	&.is-large {
 
 		p {
-			font-size: 24px;
+			font-size: 1.33em;
 			font-style: italic;
 			line-height: 1.6;
 		}

--- a/packages/block-library/src/quote/style.scss
+++ b/packages/block-library/src/quote/style.scss
@@ -10,7 +10,9 @@
 
 		cite,
 		footer {
-			font-size: 18px;
-		}
-	}
-}
+			font-size: 1em;
+		} // cite, footer
+
+	} // &.is-style-large, &.is-large
+
+} // .wp-block-quote

--- a/packages/block-library/src/quote/style.scss
+++ b/packages/block-library/src/quote/style.scss
@@ -1,8 +1,6 @@
 .wp-block-quote {
 	&.is-style-large,
 	&.is-large {
-		margin: 0 0 16px;
-		padding: 0 1em;
 
 		p {
 			font-size: 24px;

--- a/packages/block-library/src/quote/style.scss
+++ b/packages/block-library/src/quote/style.scss
@@ -11,7 +11,6 @@
 		cite,
 		footer {
 			font-size: 18px;
-			text-align: right;
 		}
 	}
 }

--- a/packages/block-library/src/quote/style.scss
+++ b/packages/block-library/src/quote/style.scss
@@ -1,4 +1,5 @@
 .wp-block-quote {
+
 	&.is-style-large,
 	&.is-large {
 
@@ -6,7 +7,7 @@
 			font-size: 1.33em;
 			font-style: italic;
 			line-height: 1.6;
-		}
+		} // p
 
 		cite,
 		footer {

--- a/packages/block-library/src/quote/theme.scss
+++ b/packages/block-library/src/quote/theme.scss
@@ -1,5 +1,5 @@
 .wp-block-quote {
-	margin: 20px 0;
+	margin: 1em inherit;
 
 	cite,
 	footer,

--- a/packages/block-library/src/quote/theme.scss
+++ b/packages/block-library/src/quote/theme.scss
@@ -9,10 +9,45 @@
 		margin-top: 1em;
 		position: relative;
 		font-style: normal;
-	}
-}
+	} // cite, footer, &__citation
 
-.wp-block-quote:not(.is-large):not(.is-style-large) {
-	border-left: 4px solid $black;
-	padding-left: 1em;
-}
+	&.is-left {
+		border-left: 4px solid $black;
+		padding-left: 1em;
+	} // &.is-left
+
+	&.is-right {
+		border-right: 4px solid $black;
+		padding-right: 1em;
+		text-align: right;
+	} // &.is-right
+
+	&.is-center {
+		margin: 3em inherit;
+		padding-left: 2em;
+		padding-right: 2em;
+		text-align: center;
+
+		&::before {
+			background-color: $black;
+			content: "";
+			display: block;
+			height: 4px;
+			margin-left: calc(50% - 10%);
+			margin-bottom: 2em;
+			width: 20%;
+		} // &::before
+
+		&::after {
+			background-color: $black;
+			content: "";
+			display: block;
+			height: 4px;
+			margin-left: calc(50% - 10%);
+			margin-top: 2em;
+			width: 20%;
+		} // &::after
+
+	} // .is-center
+
+} // .wp-block-quote


### PR DESCRIPTION
Fixes #11609 _and_ addresses #10970 

## Description
These changes affect the Quote block. 
* Added: className assignment based on alignment chosen in BlockControls (`.is-left` (default), `.is-center`, or `is-right`) for editor and frontend output.
* Enhanced: styling for `blockquote` based on `is-left`, `is-center`, or `is-right`m while also accounting for the existing Style option of either: "Regular" or "Large" quotes.

## How has this been tested?
Changes were tested in local environment with Gutenberg post with all variations of Quote block added. Changes were tested against the TwentySixteen theme _and_ TwentyNineteen theme (currently being developed).

Note: in TwentyNineteen there are already some sane and simple stylistic overrides for Gutenberg Quotes. This PR's changes has a negative stylistic impact on the current styles in TwentyNineteen. However, I would be happy to open and submit a PR to address this minor updates to align with this set of changes.

Tested in Chrome: 70.0.3538.77 on macOS 10.14

## Screenshots 

![twentysixteen-gutenberg-quotes-block](https://user-images.githubusercontent.com/405912/48229226-87927000-e375-11e8-97f0-0914cfaf3824.png)

![twentynineteen-gutenberg-quote-block](https://user-images.githubusercontent.com/405912/48229240-90834180-e375-11e8-8231-d210cf92c783.png)

![Gutenberg editor new Quote block styles](https://user-images.githubusercontent.com/405912/48229255-9ed15d80-e375-11e8-97cf-58284d69c5d1.png)


## Types of changes
Previously the Quote block had the ability to use the BlockControls to align: left, center or right. However, the alignment was being set on the `<blockquote>` element with `style="text-align: right;"`. I removed this assignment and replaced with className assignment.

| Before                        | After             |
|-------------------------------|-------------------|
| default/none                  | class="is-left"   |
| `style="text-align: right;"`   | class="is-right"  |
| `style="text-align: center;"` | class="is-center" |

## Checklist:
- [ x ] My code is tested.
- [ x ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ x ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ x ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

(via @10up)
