### PR TITLE
Remove obsolete props being passed through to DatePicker component

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 5.1.0 (Unreleased)
 
+### Polish
+
+- Remove `<DateTimePicker />` obsolete `locale` prop (and pass-through to child components) and obsolete `is12Hour` prop pass through to `<DateTime />` [#11649](https://github.com/WordPress/gutenberg/pull/11649) 
+
 ### New Feature
 
 - Adjust a11y roles for MenuItem component, so that aria-checked is used properly, related change in Editor/Components/BlockNavigationList ([#11431](https://github.com/WordPress/gutenberg/issues/11431)).

--- a/packages/components/src/date-time/README.md
+++ b/packages/components/src/date-time/README.md
@@ -29,7 +29,6 @@ const MyDateTimePicker = withState( {
 		<DateTimePicker
 			currentDate={ date }
 			onChange={ ( date ) => setState( { date } ) }
-			locale={ settings.l10n.locale }
 			is12Hour={ is12HourTime }
 		/>
 	);
@@ -54,13 +53,6 @@ The function called when a new date or time has been selected. It is passed the 
 - Type: `Function`
 - Required: No
 - Default: `noop`
-
-### locale
-
-The localization for the display of the date and time.
-
-- Type: `string`
-- Required: No
 
 ### is12Hour
 

--- a/packages/components/src/date-time/index.js
+++ b/packages/components/src/date-time/index.js
@@ -34,7 +34,7 @@ export class DateTimePicker extends Component {
 	}
 
 	render() {
-		const { currentDate, is12Hour, locale, onChange } = this.props;
+		const { currentDate, is12Hour, onChange } = this.props;
 
 		return (
 			<div className="components-datetime">
@@ -48,8 +48,6 @@ export class DateTimePicker extends Component {
 						<DatePicker
 							currentDate={ currentDate }
 							onChange={ onChange }
-							locale={ locale }
-							is12Hour={ is12Hour }
 						/>
 					</Fragment>
 				) }

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 6.2.0 (unreleased)
 
+### Polish
+
+- Remove unnecessary `locale` prop usage [#11649](https://github.com/WordPress/gutenberg/pull/11649)
+
 ### New Features
 
 - Adjust a11y roles for menu items, and make sure screen readers can properly use BlockNavigationList ([#11431](https://github.com/WordPress/gutenberg/issues/11431)).

--- a/packages/editor/src/components/post-schedule/index.js
+++ b/packages/editor/src/components/post-schedule/index.js
@@ -22,7 +22,6 @@ export function PostSchedule( { date, onUpdateDate } ) {
 			key="date-time-picker"
 			currentDate={ date }
 			onChange={ onUpdateDate }
-			locale={ settings.l10n.locale }
 			is12Hour={ is12HourTime }
 		/>
 	);


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

The `<DateTimePicker/>` component (and documentation) describes passing through `locale` and `is12Hour` props through to the `<DatePicker />` component.  However, `<DatePicker />` does not implement (nor pass through) either of those props.  Further, `locale` is not used anywhere.

I'm guessing these are carryovers from before the Date picker refactor.

I _think_ `locale` is no longer needed because `react-dates` (which `<DatePicker/>` has as a dependent) uses [`moment.locale()`](https://github.com/airbnb/react-dates#localization) for its localization and `wp.date` initializes moment with the locale via embedded server inline script.  However, while this pull doesn't address this, I think this may be something needing addressed at some point because:

- This is a hidden functionality that is not easily discoverable.  If `moment.locale` fails to be initialized (or moment gets dropped as the date library used by `wp.date`) then the date-picker will not be localized (and it won't be readily apparent).
- `react-dates` has some [user interface strings](https://github.com/airbnb/react-dates/blob/master/src/defaultPhrases.js) that don't appear to be localized at all.  I'm not sure if this is a biggy because I don't know if we have it configured so any of those strings are shown. If however they are or do get used, they should probably be localized.
- `DateTime` does not pass through any props to the underlying `react-dates` component.  It may have been intentional to not expose additional props controlling it to parent components, but in case it wasn't intentional we may want to consider doing so.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

* [x] Verified via browser testing that the existing date-picker used by post-scheduler is not affected
* [x] ran unit tests locally to ensure no tests were broken. 

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

This has minimal impact because the props removed were not being used.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
