### PR TITLE
Fetch all categories to display in Latest Posts dropdown

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -33,7 +33,7 @@ import { withSelect } from '@wordpress/data';
  * Module Constants
  */
 const CATEGORIES_LIST_QUERY = {
-	per_page: 100,
+	per_page: -1,
 };
 const MAX_POSTS_COLUMNS = 6;
 


### PR DESCRIPTION
## Description

Uses `per_page=-1` to trigger the `apiFetch()` middleware and resolve
all categories that can be displayed in the dropdown.

## How has this been tested?

Generate 200 categories using WP-CLI:

```
$ wp term generate category --count=200
```

See that all categories are present in the Latest Posts category
selection:

![image](https://user-images.githubusercontent.com/36432/48240115-70a84980-e386-11e8-965a-713afaf9f6c2.png)

See #10873 