### PR TITLE
Fetch all attachments when opening a gallery in the Media Library

### DIFF
--- a/packages/edit-post/src/hooks/components/media-upload/index.js
+++ b/packages/edit-post/src/hooks/components/media-upload/index.js
@@ -67,7 +67,7 @@ const getAttachmentsCollection = ( ids ) => {
 		order: 'ASC',
 		orderby: 'post__in',
 		post__in: ids,
-		per_page: 100,
+		posts_per_page: -1,
 		query: true,
 		type: 'image',
 	} );


### PR DESCRIPTION
## Description

Switches `wp.media.query` to use `posts_per_page=-1` and fetch all attachments when opening a gallery in the Media Library.

See https://github.com/WordPress/gutenberg/issues/10873#issuecomment-437234144

## How has this been tested?

1. Create a Gallery Block and click Edit:

![image](https://user-images.githubusercontent.com/36432/48241341-4dcc6400-e38b-11e8-9111-122dc79348bd.png)

2. Inspect the Network Tab and verify that `posts_per_page=-1` was used in the request and that the request was successful:

![image](https://user-images.githubusercontent.com/36432/48241398-9c79fe00-e38b-11e8-9769-34454cdc7a77.png)