### PR TITLE
Add toolbar to image block

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -8,38 +8,12 @@ import RNReactNativeGutenbergBridge from 'react-native-gutenberg-bridge';
  * Internal dependencies
  */
 import { MediaPlaceholder, RichText, BlockFormatControls } from '@wordpress/editor';
-import { Toolbar } from '@wordpress/components';
+import { Toolbar, IconButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-
-const TOOLBAR_BUTTON_TAG_EDIT = 'edit';
-
-const TOOLBAR_BUTTONS = [
-	{
-		icon: 'edit',
-		title: __( 'Edit image' ),
-		tag: TOOLBAR_BUTTON_TAG_EDIT,
-	},
-];
 
 export default function ImageEdit( props ) {
 	const { attributes, isSelected, setAttributes } = props;
 	const { url, caption } = attributes;
-
-	const toggleToolbarButton = ( tag ) => {
-		return () => {
-			switch ( tag ) {
-				case TOOLBAR_BUTTON_TAG_EDIT:
-					onMediaLibraryPress();
-					break;
-			}
-		};
-	};
-
-	const toolbarControls = TOOLBAR_BUTTONS.map( ( control ) => ( {
-		...control,
-		onClick: toggleToolbarButton( control.tag ),
-		isActive: true,
-	} ) );
 
 	const onUploadPress = () => {
 		// This method should present an image picker from
@@ -64,10 +38,21 @@ export default function ImageEdit( props ) {
 		);
 	}
 
+	const toolbarEditButton = (
+		<Toolbar>
+			<IconButton
+				className="components-toolbar__control"
+				label={ __( 'Edit image' ) }
+				icon="edit"
+				onClick={ onMediaLibraryPress }
+			/>
+		</Toolbar>
+	);
+
 	return (
 		<View style={ { flex: 1 } }>
 			<BlockFormatControls>
-				<Toolbar controls={ toolbarControls } />
+				{ toolbarEditButton }
 			</BlockFormatControls>
 			<Image
 				style={ { width: '100%', height: 200 } }

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -7,11 +7,39 @@ import RNReactNativeGutenbergBridge from 'react-native-gutenberg-bridge';
 /**
  * Internal dependencies
  */
-import { MediaPlaceholder, RichText } from '@wordpress/editor';
+import { MediaPlaceholder, RichText, BlockFormatControls } from '@wordpress/editor';
+import { Toolbar } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const TOOLBAR_BUTTON_TAG_EDIT = 'edit';
+
+const TOOLBAR_BUTTONS = [
+	{
+		icon: 'edit',
+		title: __( 'Edit image' ),
+		tag: TOOLBAR_BUTTON_TAG_EDIT,
+	},
+];
 
 export default function ImageEdit( props ) {
 	const { attributes, isSelected, setAttributes } = props;
 	const { url, caption } = attributes;
+
+	const toggleToolbarButton = ( tag ) => {
+		return () => {
+			switch ( tag ) {
+				case TOOLBAR_BUTTON_TAG_EDIT:
+					onMediaLibraryPress();
+					break;
+			}
+		};
+	};
+
+	const toolbarControls = TOOLBAR_BUTTONS.map( ( control ) => ( {
+		...control,
+		onClick: toggleToolbarButton( control.tag ),
+		isActive: true,
+	} ) );
 
 	const onUploadPress = () => {
 		// This method should present an image picker from
@@ -20,8 +48,6 @@ export default function ImageEdit( props ) {
 	};
 
 	const onMediaLibraryPress = () => {
-		// Call onMediaLibraryPress from the Native<->RN bridge. It should trigger an image picker from
-		// the WordPress media library and call the provided callback to set the image URL.
 		RNReactNativeGutenbergBridge.onMediaLibraryPress( ( mediaUrl ) => {
 			if ( mediaUrl ) {
 				setAttributes( { url: mediaUrl } );
@@ -40,6 +66,9 @@ export default function ImageEdit( props ) {
 
 	return (
 		<View style={ { flex: 1 } }>
+			<BlockFormatControls>
+				<Toolbar controls={ toolbarControls } />
+			</BlockFormatControls>
 			<Image
 				style={ { width: '100%', height: 200 } }
 				resizeMethod="scale"

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -7,7 +7,7 @@ import RNReactNativeGutenbergBridge from 'react-native-gutenberg-bridge';
 /**
  * Internal dependencies
  */
-import { MediaPlaceholder, RichText, BlockFormatControls } from '@wordpress/editor';
+import { MediaPlaceholder, RichText, BlockControls } from '@wordpress/editor';
 import { Toolbar, IconButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -51,9 +51,9 @@ export default function ImageEdit( props ) {
 
 	return (
 		<View style={ { flex: 1 } }>
-			<BlockFormatControls>
+			<BlockControls>
 				{ toolbarEditButton }
-			</BlockFormatControls>
+			</BlockControls>
 			<Image
 				style={ { width: '100%', height: 200 } }
 				resizeMethod="scale"

--- a/packages/components/src/index.native.js
+++ b/packages/components/src/index.native.js
@@ -3,6 +3,7 @@ export * from './primitives';
 export { default as Dashicon } from './dashicon';
 export { default as Toolbar } from './toolbar';
 export { default as withSpokenMessages } from './higher-order/with-spoken-messages';
+export { default as IconButton } from './icon-button';
 export { createSlotFill, Slot, Fill, Provider as SlotFillProvider } from './slot-fill';
 
 // Higher-Order Components


### PR DESCRIPTION
## Description

This PR includes changes for adding toolbar to image block and also adding edit button in it.

## How has this been tested?

- Refer to [parent PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/10430) to find out how to setup the testing environment.

Test 1:
- Open a blog post
- Add image block, tap Media Library, select an image
- Add another image block but don't set an image for it
- Tap on the image block with an image set, verify that toolbar is visible
- Tap on the image block with no image is set, verify that toolbar isn't visible

Test 2:
- Open a blog post
- Add image block, tap Media Library, select an image
- See that toolbar appears with an edit button in it(pencil icon)
- Tap edit button in the toolbar
- Verify that image picker is opened, select an image
- Verify that image is changed in the image block

Test 3:
- Open a blog post
- Add image block, tap Media Library, select an image
- See that toolbar appears with an edit button in it(pencil icon)
- Tap edit button in the toolbar
- Verify that image picker is opened, tap "Cancel"
- Verify that image is NOT changed in the image block

## Screenshots <!-- if applicable -->
<img width="379" alt="screen shot 2018-11-09 at 13 49 07" src="https://user-images.githubusercontent.com/5032900/48258543-5e7de800-e426-11e8-87cd-ea39130bb2e4.png">

## Types of changes
<!-- New feature (non-breaking change which adds functionality) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
