### PR TITLE
Test for rapid enter presses

### DIFF
--- a/test/e2e/specs/writing-flow.test.js
+++ b/test/e2e/specs/writing-flow.test.js
@@ -236,7 +236,11 @@ describe( 'adding blocks', () => {
 	it( 'should not delete trailing spaces when deleting a word with alt + backspace', async () => {
 		await clickBlockAppender();
 		await page.keyboard.type( 'alpha beta gamma delta' );
-		await pressWithModifier( META_KEY, 'Backspace' );
+		if ( process.platform === 'darwin' ) {
+			await pressWithModifier( 'Alt', 'Backspace' );
+		} else {
+			await pressWithModifier( META_KEY, 'Backspace' );
+		}
 		await page.keyboard.type( 'delta' );
 		const blockText = await page.evaluate( () => document.activeElement.textContent );
 		expect( blockText ).toBe( 'alpha beta gamma delta' );

--- a/test/e2e/specs/writing-flow.test.js
+++ b/test/e2e/specs/writing-flow.test.js
@@ -241,4 +241,21 @@ describe( 'adding blocks', () => {
 		const blockText = await page.evaluate( () => document.activeElement.textContent );
 		expect( blockText ).toBe( 'alpha beta gamma delta' );
 	} );
+
+	it( 'should create valid paragraph blocks when holding down Enter', async () => {
+		await clickBlockAppender();
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
+		// Check that none of the paragraph blocks have <br> in them.
+		const postContent = await getEditedPostContent();
+		expect( postContent.indexOf( 'br' ) ).toBe( -1 );
+	} );
 } );

--- a/test/e2e/specs/writing-flow.test.js
+++ b/test/e2e/specs/writing-flow.test.js
@@ -246,7 +246,7 @@ describe( 'adding blocks', () => {
 		expect( blockText ).toBe( 'alpha beta gamma delta' );
 	} );
 
-	it( 'should create valid paragraph blocks when holding down Enter', async () => {
+	it( 'should create valid paragraph blocks when rapidly pressing Enter', async () => {
 		await clickBlockAppender();
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.press( 'Enter' );


### PR DESCRIPTION
## Description

e2e test that covers rapid enter presses, as fixed by https://github.com/WordPress/gutenberg/issues/6021

Also has a fix for the word deletion test on Macs.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
