### PR TITLE
Parser: Fix default PHP parser to cast inner blocks as arrays

### DIFF
--- a/packages/block-serialization-default-parser/parser.php
+++ b/packages/block-serialization-default-parser/parser.php
@@ -457,7 +457,7 @@ class WP_Block_Parser {
 	 */
 	function add_inner_block( WP_Block_Parser_Block $block, $token_start, $token_length, $last_offset = null ) {
 		$parent = $this->stack[ count( $this->stack ) - 1 ];
-		$parent->block->innerBlocks[] = $block;
+		$parent->block->innerBlocks[] = (array) $block;
 		$html = substr( $this->document, $parent->prev_offset, $token_start - $parent->prev_offset );
 
 		if ( ! empty( $html ) ) {


### PR DESCRIPTION
Since the introduction of the default parsers we have had a bug in the
PHP version whereby inner blocks were being popped onto the output
stack as PHP classes instead of as simple associated arrays. Blocks
that weren't inner blocks were being properly type-casted as arrays.

This patch adds the cast in where it's needed in order to fix this
inconsistent behavior.

So far this hasn't caused any troubles or exposed itself but while
working on other PRs like #11434 it became evident in test code.

## Testing

Hopefully you will see by inspection how limited this change is.
Nothing internally should be relying on the `WP_Block_Parser_Block`
classes so this change should simply be removing that leak.

Load up Gutenberg, try some things - I estimate that a smoke-test
should uncover problems.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->