### PR TITLE
Editor: Resolve macOS Firefox / Safari sibling inserter behavior

### DIFF
--- a/packages/editor/src/components/block-list/insertion-point.js
+++ b/packages/editor/src/components/block-list/insertion-point.js
@@ -61,6 +61,13 @@ class BlockInsertionPoint extends Component {
 					<div
 						onFocus={ this.onFocusInserter }
 						onBlur={ this.onBlurInserter }
+						// While ideally it would be enough to capture the
+						// bubbling focus event from the Inserter, due to the
+						// characteristics of click focusing of `button`s in
+						// Firefox and Safari, it is not reliable.
+						//
+						// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
+						tabIndex={ -1 }
 						className={
 							classnames( 'editor-block-list__insertion-point-inserter', {
 								'is-visible': isInserterFocused,


### PR DESCRIPTION
This pull request seeks to resolve an issue where attempting to use the sibling inserter in Firefox or Safari will result in unintended block selection ([see example](https://user-images.githubusercontent.com/1779930/48279006-448bd780-e41d-11e8-8016-33daf1178cdd.gif)).

The reason for this can be attributed to browser-and-OS-specific handling of `click` and `focus` events, specifically affecting Firefox and Safari on macOS.

See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus

The changes here reason this issue by allowing the `div` wrapper to be focusable (not tabbable), thus receiving the `focus` event on itself.

**Testing instructions:**

Verify that the sibling inserter behaves as expected in your preferred browser, and in Firefox and Safari for macOS.