### PR TITLE
Editor: Fix visibility of sibling inserter on tab focus

### DIFF
--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -672,7 +672,7 @@
 // Don't show the sibling inserter before the selected block.
 .edit-post-layout:not(.has-fixed-toolbar) {
 	// The child selector is necessary for this to work properly in nested contexts.
-	.is-selected > .editor-block-list__insertion-point .editor-inserter__toggle {
+	.is-selected > .editor-block-list__insertion-point-inserter {
 		opacity: 0;
 		pointer-events: none;
 


### PR DESCRIPTION
Likely regressed in #11018

This pull request seeks to resolve an issue (regression) where tab-focusing the sibling inserter would not cause it to become visible. It would still be operable by space-activation. With these changes, the button itself is now once-again visible.

Before|After
---|---
![Before](https://user-images.githubusercontent.com/1779930/48279881-ea404600-e41f-11e8-97d5-9967a455af53.png)|![After](https://user-images.githubusercontent.com/1779930/48279861-dc8ac080-e41f-11e8-9d14-b3c9e03465f8.png)

**Implementation notes:**

The issue is that in adapting the sibling inserter to use the Inserter in #11018, the `.is-visible` modifier applying opacity was not correctly adapted to `.editor-block-list__insertion-point-inserter`.

It's unclear whether we need two separate classes each applying opacity.

**Testing instructions:**

Verify that, via tab navigation, the sibling inserter button is made visible once focused.