### PR TITLE
Parser: Allow empty attributes in default parsers

### DIFF
--- a/packages/block-serialization-default-parser/parser.php
+++ b/packages/block-serialization-default-parser/parser.php
@@ -364,7 +364,7 @@ class WP_Block_Parser {
 		 * match back in PHP to see which one it was.
 		 */
 		$has_match = preg_match(
-			'/<!--\s+(?<closer>\/)?wp:(?<namespace>[a-z][a-z0-9_-]*\/)?(?<name>[a-z][a-z0-9_-]*)\s+(?<attrs>{(?:[^}]+|}+(?=})|(?!}\s+-->).)+?}\s+)?(?<void>\/)?-->/s',
+			'/<!--\s+(?<closer>\/)?wp:(?<namespace>[a-z][a-z0-9_-]*\/)?(?<name>[a-z][a-z0-9_-]*)\s+(?<attrs>{(?:[^}]+|}+(?=})|(?!}\s+-->).)*?}\s+)?(?<void>\/)?-->/s',
 			$this->document,
 			$matches,
 			PREG_OFFSET_CAPTURE,

--- a/packages/block-serialization-default-parser/src/index.js
+++ b/packages/block-serialization-default-parser/src/index.js
@@ -2,7 +2,7 @@ let document;
 let offset;
 let output;
 let stack;
-const tokenizer = /<!--\s+(\/)?wp:([a-z][a-z0-9_-]*\/)?([a-z][a-z0-9_-]*)\s+({(?:[^}]+|}+(?=})|(?!}\s+-->)[^])+?}\s+)?(\/)?-->/g;
+const tokenizer = /<!--\s+(\/)?wp:([a-z][a-z0-9_-]*\/)?([a-z][a-z0-9_-]*)\s+({(?:[^}]+|}+(?=})|(?!}\s+-->)[^])*?}\s+)?(\/)?-->/g;
 
 function Block( blockName, attrs, innerBlocks, innerHTML, innerContent ) {
 	return {


### PR DESCRIPTION
Since the introduction of the default parser in #8083 we have had a
subtle bug in the parsing which failed when empty attributes were
specified in a block's comment delimiter - `{}`

The absense of attributes was fine but _empty_ attributes were a
failure. This is due to using `+?` in the RegExp tokenizer instead of
using `*?` (which allows for no inner content in the JSON string).

This patch updates the quantifier to restore functionality and fix the
bug. This didn't appear in practice because we don't intentionally set
`{}` as the attributes - the serializer drops it altogther, and our
tests didn't catch it for similar reasons.

## Testing

Open up a post with the code editor.
Enter `<!-- wp:test {} /-->` and see if it breaks.
If it breaks, once you hit `Save Draft` it will replace it with `<p><!-- wp:test {} /--></p>`

If it's working, you won't see it change on `Save Draft`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->