### PR TITLE
Only check MediaPlaceholder allowedTypes array length if prop exists

### DIFF
--- a/packages/editor/src/components/media-placeholder/index.js
+++ b/packages/editor/src/components/media-placeholder/index.js
@@ -142,7 +142,7 @@ class MediaPlaceholder extends Component {
 		let instructions = labels.instructions || '';
 		let title = labels.title || '';
 		if ( ! instructions || ! title ) {
-			const isOneType = 1 === allowedTypes.length;
+			const isOneType = 1 === allowedTypes && allowedTypes.length;
 			const isAudio = isOneType && 'audio' === allowedTypes[ 0 ];
 			const isImage = isOneType && 'image' === allowedTypes[ 0 ];
 			const isVideo = isOneType && 'video' === allowedTypes[ 0 ];

--- a/packages/editor/src/components/media-placeholder/index.js
+++ b/packages/editor/src/components/media-placeholder/index.js
@@ -142,7 +142,7 @@ class MediaPlaceholder extends Component {
 		let instructions = labels.instructions || '';
 		let title = labels.title || '';
 		if ( ! instructions || ! title ) {
-			const isOneType = allowedTypes.length;
+			const isOneType = 1 === allowedTypes.length;
 			const isAudio = isOneType && 'audio' === allowedTypes[ 0 ];
 			const isImage = isOneType && 'image' === allowedTypes[ 0 ];
 			const isVideo = isOneType && 'video' === allowedTypes[ 0 ];

--- a/packages/editor/src/components/media-placeholder/index.js
+++ b/packages/editor/src/components/media-placeholder/index.js
@@ -131,7 +131,7 @@ class MediaPlaceholder extends Component {
 			onHTMLDrop = noop,
 			multiple = false,
 			notices,
-			allowedTypes,
+			allowedTypes = [],
 		} = this.props;
 
 		const {
@@ -142,7 +142,7 @@ class MediaPlaceholder extends Component {
 		let instructions = labels.instructions || '';
 		let title = labels.title || '';
 		if ( ! instructions || ! title ) {
-			const isOneType = 1 === allowedTypes && allowedTypes.length;
+			const isOneType = allowedTypes.length;
 			const isAudio = isOneType && 'audio' === allowedTypes[ 0 ];
 			const isImage = isOneType && 'image' === allowedTypes[ 0 ];
 			const isVideo = isOneType && 'video' === allowedTypes[ 0 ];

--- a/packages/editor/src/components/media-placeholder/test/index.js
+++ b/packages/editor/src/components/media-placeholder/test/index.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { mount } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import MediaPlaceholder from '../';
+
+describe( 'MediaPlaceholder', () => {
+	it( 'renders successfully when allowedTypes property is not specified', () => {
+		expect( () => mount(
+			<MediaPlaceholder />
+		) ).not.toThrow();
+	} );
+} );


### PR DESCRIPTION
## Description
Adds an existence check to `allowedTypes` before attempting to access `allowedTypes.length` to fix #11692.

## How has this been tested?
- tested this patch against three custom blocks which utilize `MediaPlaceholder` without `allowedTypes` and confirmed that in all cases the patch allows these custom blocks to load as they did several weeks ago.
- introduced a basic unit test to catch the bug described in the issue

## Types of changes
Bug fix: Add an undefined/null check to an array before accessing `.length`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] N/A ~~My code follows the accessibility standards.~~ <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
