### PR TITLE
Quote block: Wrap cite with footer

### DIFF
--- a/packages/block-library/src/quote/editor.scss
+++ b/packages/block-library/src/quote/editor.scss
@@ -1,7 +1,7 @@
 .wp-block-quote {
 	margin: 0;
 
-	&__citation {
+	footer {
 		font-size: $default-font-size;
 	}
 }

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -31,7 +31,7 @@ const blockAttributes = {
 	[ ATTRIBUTE_CITATION ]: {
 		type: 'string',
 		source: 'html',
-		selector: 'cite',
+		selector: 'footer cite',
 		default: '',
 	},
 	align: {
@@ -264,6 +264,8 @@ export const settings = {
 								// translators: placeholder text used for the citation
 								__( 'Write citation…' )
 							}
+							tagName="footer"
+							// Class left for compatibility with theme editor styles targeting older version of block that did not use footer element.
 							className="wp-block-quote__citation"
 						/>
 					) }
@@ -278,7 +280,9 @@ export const settings = {
 		return (
 			<blockquote style={ { textAlign: align ? align : null } }>
 				<RichText.Content multiline value={ value } />
-				{ ! RichText.isEmpty( citation ) && <RichText.Content tagName="cite" value={ citation } /> }
+				{ ! RichText.isEmpty( citation ) && (
+					<footer><RichText.Content tagName="cite" value={ citation } /></footer>
+				) }
 			</blockquote>
 		);
 	},
@@ -302,6 +306,33 @@ export const settings = {
 		{
 			attributes: {
 				...blockAttributes,
+				citation: {
+					type: 'string',
+					source: 'html',
+					selector: 'cite',
+					default: '',
+				},
+			},
+			save( { attributes } ) {
+				const { align, value, citation } = attributes;
+
+				return (
+					<blockquote style={ { textAlign: align ? align : null } }>
+						<RichText.Content multiline value={ value } />
+						{ ! RichText.isEmpty( citation ) && <RichText.Content tagName="cite" value={ citation } /> }
+					</blockquote>
+				);
+			},
+		},
+		{
+			attributes: {
+				...blockAttributes,
+				citation: {
+					type: 'string',
+					source: 'html',
+					selector: 'cite',
+					default: '',
+				},
 				style: {
 					type: 'number',
 					default: 1,

--- a/packages/block-library/src/quote/style.scss
+++ b/packages/block-library/src/quote/style.scss
@@ -10,7 +10,10 @@
 			line-height: 1.6;
 		}
 
-		cite,
+		// The p + cite selector is for compatibility with older versions of the block that did not use
+		// footer. It has to be this specific in order to not target cite elements within the quoted
+		// paragraphs (or other quoted content if the block is updated to use nesting).
+		p + cite,
 		footer {
 			font-size: 18px;
 			text-align: right;

--- a/packages/block-library/src/quote/theme.scss
+++ b/packages/block-library/src/quote/theme.scss
@@ -1,14 +1,14 @@
 .wp-block-quote {
 	margin: 20px 0;
 
-	cite,
-	footer,
-	&__citation {
+	footer {
 		color: $dark-gray-300;
 		font-size: $default-font-size;
 		margin-top: 1em;
 		position: relative;
-		font-style: normal;
+		cite {
+			font-style: normal;
+		}
 	}
 }
 

--- a/packages/e2e-tests/specs/blocks/__snapshots__/quote.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/quote.test.js.snap
@@ -12,7 +12,7 @@ exports[`Quote can be converted to headings 1`] = `
 <!-- /wp:heading -->
 
 <!-- wp:quote -->
-<blockquote class=\\"wp-block-quote\\"><p>two</p><cite>cite</cite></blockquote>
+<blockquote class=\\"wp-block-quote\\"><p>two</p><footer><cite>cite</cite></footer></blockquote>
 <!-- /wp:quote -->"
 `;
 
@@ -26,7 +26,7 @@ exports[`Quote can be converted to headings 2`] = `
 <!-- /wp:heading -->
 
 <!-- wp:quote -->
-<blockquote class=\\"wp-block-quote\\"><p></p><cite>cite</cite></blockquote>
+<blockquote class=\\"wp-block-quote\\"><p></p><footer><cite>cite</cite></footer></blockquote>
 <!-- /wp:quote -->"
 `;
 

--- a/post-content.php
+++ b/post-content.php
@@ -84,7 +84,7 @@
 <!-- wp:quote {"style":1} -->
 <blockquote class="wp-block-quote">
 	<p><?php _e( 'The editor will endeavor to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.', 'gutenberg' ); ?></p>
-	<cite><?php _e( 'Matt Mullenweg, 2017', 'gutenberg' ); ?></cite>
+	<footer><cite><?php _e( 'Matt Mullenweg, 2017', 'gutenberg' ); ?></cite></footer>
 </blockquote>
 <!-- /wp:quote -->
 

--- a/test/integration/blocks-raw-handling.spec.js
+++ b/test/integration/blocks-raw-handling.spec.js
@@ -147,7 +147,7 @@ describe( 'Blocks raw handling', () => {
 			mode: 'AUTO',
 		} ).map( getBlockContent ).join( '' );
 
-		expect( filtered ).toBe( '<blockquote class="wp-block-quote"><p>chicken</p><cite>ribs</cite></blockquote>' );
+		expect( filtered ).toBe( '<blockquote class="wp-block-quote"><p>chicken</p><footer><cite>ribs</cite></footer></blockquote>' );
 		expect( console ).toHaveLogged();
 	} );
 
@@ -157,7 +157,7 @@ describe( 'Blocks raw handling', () => {
 			mode: 'AUTO',
 		} ).map( getBlockContent ).join( '' );
 
-		expect( filtered ).toBe( '<blockquote class="wp-block-quote"><p>ribs</p><cite>ribs</cite></blockquote>' );
+		expect( filtered ).toBe( '<blockquote class="wp-block-quote"><p>ribs</p><footer><cite>ribs</cite></footer></blockquote>' );
 		expect( console ).toHaveLogged();
 	} );
 
@@ -167,7 +167,7 @@ describe( 'Blocks raw handling', () => {
 			mode: 'AUTO',
 		} ).map( getBlockContent ).join( '' );
 
-		expect( filtered ).toBe( '<blockquote class="wp-block-quote"><p>chicken</p><p>ribs</p><cite>ribs</cite></blockquote>' );
+		expect( filtered ).toBe( '<blockquote class="wp-block-quote"><p>chicken</p><p>ribs</p><footer><cite>ribs</cite></footer></blockquote>' );
 		expect( console ).toHaveLogged();
 	} );
 
@@ -177,7 +177,7 @@ describe( 'Blocks raw handling', () => {
 			mode: 'AUTO',
 		} ).map( getBlockContent ).join( '' );
 
-		expect( filtered ).toBe( '<blockquote class="wp-block-quote"><p></p><cite>ribs</cite></blockquote>' );
+		expect( filtered ).toBe( '<blockquote class="wp-block-quote"><p></p><footer><cite>ribs</cite></footer></blockquote>' );
 		expect( console ).toHaveLogged();
 	} );
 

--- a/test/integration/full-content/fixtures/core__quote__style-1.html
+++ b/test/integration/full-content/fixtures/core__quote__style-1.html
@@ -1,3 +1,3 @@
 <!-- wp:core/quote -->
-<blockquote class="wp-block-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>
+<blockquote class="wp-block-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer><cite>Matt Mullenweg, 2017</cite></footer></blockquote>
 <!-- /wp:core/quote -->

--- a/test/integration/full-content/fixtures/core__quote__style-1.json
+++ b/test/integration/full-content/fixtures/core__quote__style-1.json
@@ -8,6 +8,6 @@
             "citation": "Matt Mullenweg, 2017"
         },
         "innerBlocks": [],
-        "originalContent": "<blockquote class=\"wp-block-quote\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>"
+        "originalContent": "<blockquote class=\"wp-block-quote\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer><cite>Matt Mullenweg, 2017</cite></footer></blockquote>"
     }
 ]

--- a/test/integration/full-content/fixtures/core__quote__style-1.parsed.json
+++ b/test/integration/full-content/fixtures/core__quote__style-1.parsed.json
@@ -3,9 +3,9 @@
         "blockName": "core/quote",
         "attrs": {},
         "innerBlocks": [],
-        "innerHTML": "\n<blockquote class=\"wp-block-quote\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>\n",
+        "innerHTML": "\n<blockquote class=\"wp-block-quote\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer><cite>Matt Mullenweg, 2017</cite></footer></blockquote>\n",
         "innerContent": [
-            "\n<blockquote class=\"wp-block-quote\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>\n"
+            "\n<blockquote class=\"wp-block-quote\"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer><cite>Matt Mullenweg, 2017</cite></footer></blockquote>\n"
         ]
     },
     {

--- a/test/integration/full-content/fixtures/core__quote__style-1.serialized.html
+++ b/test/integration/full-content/fixtures/core__quote__style-1.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:quote -->
-<blockquote class="wp-block-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><cite>Matt Mullenweg, 2017</cite></blockquote>
+<blockquote class="wp-block-quote"><p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p><footer><cite>Matt Mullenweg, 2017</cite></footer></blockquote>
 <!-- /wp:quote -->

--- a/test/integration/full-content/fixtures/core__quote__style-2.html
+++ b/test/integration/full-content/fixtures/core__quote__style-2.html
@@ -1,3 +1,3 @@
 <!-- wp:core/quote {"className":"is-style-large"} -->
-<blockquote class="wp-block-quote is-style-large"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>
+<blockquote class="wp-block-quote is-style-large"><p>There is no greater agony than bearing an untold story inside you.</p><footer><cite>Maya Angelou</cite></footer></blockquote>
 <!-- /wp:core/quote -->

--- a/test/integration/full-content/fixtures/core__quote__style-2.json
+++ b/test/integration/full-content/fixtures/core__quote__style-2.json
@@ -9,6 +9,6 @@
             "className": "is-style-large"
         },
         "innerBlocks": [],
-        "originalContent": "<blockquote class=\"wp-block-quote is-style-large\"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>"
+        "originalContent": "<blockquote class=\"wp-block-quote is-style-large\"><p>There is no greater agony than bearing an untold story inside you.</p><footer><cite>Maya Angelou</cite></footer></blockquote>"
     }
 ]

--- a/test/integration/full-content/fixtures/core__quote__style-2.parsed.json
+++ b/test/integration/full-content/fixtures/core__quote__style-2.parsed.json
@@ -5,9 +5,9 @@
             "className": "is-style-large"
         },
         "innerBlocks": [],
-        "innerHTML": "\n<blockquote class=\"wp-block-quote is-style-large\"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>\n",
+        "innerHTML": "\n<blockquote class=\"wp-block-quote is-style-large\"><p>There is no greater agony than bearing an untold story inside you.</p><footer><cite>Maya Angelou</cite></footer></blockquote>\n",
         "innerContent": [
-            "\n<blockquote class=\"wp-block-quote is-style-large\"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>\n"
+            "\n<blockquote class=\"wp-block-quote is-style-large\"><p>There is no greater agony than bearing an untold story inside you.</p><footer><cite>Maya Angelou</cite></footer></blockquote>\n"
         ]
     },
     {

--- a/test/integration/full-content/fixtures/core__quote__style-2.serialized.html
+++ b/test/integration/full-content/fixtures/core__quote__style-2.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:quote {"className":"is-style-large"} -->
-<blockquote class="wp-block-quote is-style-large"><p>There is no greater agony than bearing an untold story inside you.</p><cite>Maya Angelou</cite></blockquote>
+<blockquote class="wp-block-quote is-style-large"><p>There is no greater agony than bearing an untold story inside you.</p><footer><cite>Maya Angelou</cite></footer></blockquote>
 <!-- /wp:quote -->


### PR DESCRIPTION
## Description
Replaces #10465.

This PR changes the Quote block to use a `<footer>` to wrap the `<cite>` used for its citation. This fixes the issues described in #11652 and allows styling to be applied to the citation of the Quote block without affecting `<cite>`s in the `<p>` elements. This is useful, as `<cite>` elements can be used for things like book or game titles referenced in text, and not just as quote citations.

## How has this been tested?
I have tested to make sure that old Quote blocks are automatically converted properly and existing Quote blocks still look the way they should on the front-end both before and after their markup is updated.

## Types of changes
- Quote attribute `citation` `selector` property value changed from `'cite'` to `'footer cite'`.
- The RichText for the citation in the editor markup now uses a `<footer>` element.
- The front-end markup now wraps the citation `<cite>` in a `<footer>`. (The `<cite>` element is not used in the editor markup due to issues with RichText and inline elements.)
- Updated `deprecated` array to ensure that existing Quote blocks are preserved.
- Updated tests to match new Quote block markup.

## Additional info
- https://www.w3.org/TR/html52/grouping-content.html#the-blockquote-element (Specifically example 15.)
- https://www.w3.org/TR/html52/textlevel-semantics.html#the-cite-element