### PR TITLE
Build Tooling: Move wp-polyfill-ecmascript override to scripts registration

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -865,6 +865,24 @@ function gutenberg_register_scripts_and_styles() {
 			$live_reload_url
 		);
 	}
+
+	// Temporary backward compatibility for `wp-polyfill-ecmascript`, which has
+	// since been absorbed into `wp-polyfill`.
+	//
+	// [TODO][REMOVEME] To be removed in Gutenberg v4.5.
+	gutenberg_override_script(
+		'wp-polyfill-ecmascript',
+		null,
+		array(
+			'wp-polyfill',
+			'wp-deprecated',
+		)
+	);
+	wp_script_add_data(
+		'wp-polyfill-ecmascript',
+		'data',
+		'wp.deprecated( "wp-polyfill-ecmascript script handle", { plugin: "Gutenberg", version: "4.5" } );'
+	);
 }
 add_action( 'wp_enqueue_scripts', 'gutenberg_register_scripts_and_styles', 5 );
 add_action( 'admin_enqueue_scripts', 'gutenberg_register_scripts_and_styles', 5 );
@@ -979,20 +997,6 @@ function gutenberg_register_vendor_scripts() {
 	gutenberg_register_vendor_script(
 		'wp-polyfill',
 		'https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.0.0/polyfill' . $suffix . '.js'
-	);
-	// Ensure backwards compatibility after renaming to wp-polyfill.
-	gutenberg_override_script(
-		'wp-polyfill-ecmascript',
-		null,
-		array(
-			'wp-polyfill',
-			'wp-deprecated',
-		)
-	);
-	wp_script_add_data(
-		'wp-polyfill-ecmascript',
-		'data',
-		'wp.deprecated( "wp-polyfill-ecmascript script handle", { plugin: "Gutenberg", version: "4.5" } );'
 	);
 }
 


### PR DESCRIPTION
Related: #11216

This pull request seeks to resolve an issue where the plugin packaging procedure fails. The vendor file download process calls `gutenberg_register_vendor_scripts` with a very small subset of stubbed PHP functions, which does not include `gutenberg_override_script`. The function call should not occur here anyways, as it is not strictly relevant to the registration of vendor scripts. Thus, with these changes it has been moved into `gutenberg_register_scripts_and_styles`.

**Testing instructions:**

Repeat testing instructions from #11216 

Verify the plugin packaging completes without errors:

```
npm run package-plugin
```