### PR TITLE
refreshes library on open

### DIFF
--- a/packages/edit-post/src/hooks/components/media-upload/index.js
+++ b/packages/edit-post/src/hooks/components/media-upload/index.js
@@ -163,6 +163,8 @@ class MediaUpload extends Component {
 	}
 
 	onOpen() {
+		this.updateCollection();
+
 		if ( ! this.props.value ) {
 			return;
 		}
@@ -181,6 +183,19 @@ class MediaUpload extends Component {
 
 		if ( onClose ) {
 			onClose();
+		}
+	}
+
+	updateCollection() {
+		const frameContent = this.frame.content.get();
+		if ( frameContent ) {
+			const collection = frameContent.collection;
+			// clean all attachments we have in memory.
+			collection.toArray().forEach( ( model ) => model.trigger( 'destroy', model ) );
+			// reset has more flag, if library had small amount of items all items may have been loaded before.
+			collection.mirroring._hasMore = true;
+			// request items
+			collection.more();
 		}
 	}
 


### PR DESCRIPTION
Creating this PR as I am having issues passing tests even while rebasing in: https://github.com/WordPress/gutenberg/pull/10843

Starting fresh.

We need to refresh the collection when a user uploads media outside of the Media Library workflow (i.e. file drops, file uploads, others?)

This adds a refresh of the collection after finishing uploading media via REST API fixing #4612

Insert 1st Image Block
Drag image to 1st block
Insert 2nd Image Block
Click Add from Media Library button on 2nd block (The first image you dragged will most likely show)
Close Popup window
Drag new image to 2nd block
Insert 3rd Image block
Click Add from Media Library button on new block (Image that was last dragged should now appear!)
based on jorgefilipecosta 's closed PR : #6390
