### PR TITLE
Parse blocks to generate the excerpt

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -100,6 +100,7 @@ if ( ! function_exists( 'get_dynamic_blocks_regex' ) ) {
 	 * Retrieve the dynamic blocks regular expression for searching.
 	 *
 	 * @since 3.6.0
+	 * @deprecated 4.4.0 Use gutenberg_parse_blocks()
 	 *
 	 * @return string
 	 */

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -257,6 +257,8 @@ if ( ! function_exists( 'excerpt_remove_blocks' ) ) {
 	 */
 	function excerpt_remove_blocks( $content ) {
 		$allowed_blocks = array(
+			// Classic blocks have their blockName set to null.
+			null,
 			'core/columns',
 			'core/freeform',
 			'core/heading',

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -100,6 +100,7 @@ if ( ! function_exists( 'get_dynamic_blocks_regex' ) ) {
 	 * Retrieve the dynamic blocks regular expression for searching.
 	 *
 	 * @since 3.6.0
+	 * @deprecated 4.4.0 Use gutenberg_parse_blocks()
 	 *
 	 * @return string
 	 */
@@ -197,7 +198,17 @@ if ( ! function_exists( 'strip_dynamic_blocks' ) ) {
 	 * @return string
 	 */
 	function strip_dynamic_blocks( $content ) {
-		return preg_replace( get_dynamic_blocks_regex(), '', $content );
+		$blocks              = gutenberg_parse_blocks( $content );
+		$dynamic_block_names = get_dynamic_block_names();
+		$output              = '';
+
+		foreach ( $blocks as $block ) {
+			if ( ! in_array( $block['blockName'], $dynamic_block_names, true ) ) {
+				$output .= gutenberg_render_block( $block );
+			}
+		}
+
+		return $output;
 	}
 }
 

--- a/phpunit/class-blocks-api-test.php
+++ b/phpunit/class-blocks-api-test.php
@@ -24,15 +24,15 @@ class Blocks_API extends WP_UnitTestCase {
 <!-- /wp:spacer -->';
 
 	public $filtered_content = '
-<!-- wp:paragraph -->
+
 <p>paragraph</p>
-<!-- /wp:paragraph -->
 
 
 
-<!-- wp:spacer -->
+
+
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->';
+';
 
 	/**
 	 * Dummy block rendering function.

--- a/phpunit/class-blocks-api-test.php
+++ b/phpunit/class-blocks-api-test.php
@@ -24,7 +24,12 @@ class Blocks_API extends WP_UnitTestCase {
 <!-- /wp:spacer -->';
 
 	public $filtered_content = '
+
 <p>paragraph</p>
+
+
+
+
 ';
 
 	/**

--- a/phpunit/class-blocks-api-test.php
+++ b/phpunit/class-blocks-api-test.php
@@ -24,14 +24,7 @@ class Blocks_API extends WP_UnitTestCase {
 <!-- /wp:spacer -->';
 
 	public $filtered_content = '
-
 <p>paragraph</p>
-
-
-
-
-
-<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 ';
 
 	/**
@@ -77,17 +70,17 @@ class Blocks_API extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests strip_dynamic_blocks().
+	 * Tests excerpt_remove_blocks().
 	 *
-	 * @covers ::strip_dynamic_blocks
+	 * @covers ::excerpt_remove_blocks
 	 */
-	function test_strip_dynamic_blocks() {
+	function test_excerpt_remove_blocks() {
 		// Simple dynamic block..
 		$content = '<!-- wp:core/block /-->';
-		$this->assertEmpty( strip_dynamic_blocks( $content ) );
+		$this->assertEmpty( excerpt_remove_blocks( $content ) );
 
 		// Dynamic block with options, embedded in other content.
-		$this->assertEquals( $this->filtered_content, strip_dynamic_blocks( $this->content ) );
+		$this->assertEquals( $this->filtered_content, excerpt_remove_blocks( $this->content ) );
 	}
 
 	/**


### PR DESCRIPTION
Now that #11141 has landed, we can use the same logic when generating an excerpt, which allows us to deprecate `get_dynamic_blocks_regex()`.

By using a list of allowed blocks, we can avoid the other issue that `strip_dynamic_blocks()` is intended to address, when a dynamic block can call `get_the_excerpt()`, causing an infinite loop. 

Out of interest, 198c82f is an alternate method, which just tweaks `strip_dynamic_blocks()` to use the parser, but I think this is the better method.