### PR TITLE
Use apostrophe instead of single-quote character.

### DIFF
--- a/packages/block-library/src/missing/index.js
+++ b/packages/block-library/src/missing/index.js
@@ -17,7 +17,7 @@ function MissingBlockWarning( { attributes, convertToHTML } ) {
 	let messageHTML;
 	if ( hasContent && hasHTMLBlock ) {
 		messageHTML = sprintf(
-			__( 'Your site doesn\'t include support for the "%s" block. You can leave this block intact, convert its content to a Custom HTML block, or remove it entirely.' ),
+			__( 'Your site doesn’t include support for the "%s" block. You can leave this block intact, convert its content to a Custom HTML block, or remove it entirely.' ),
 			originalName
 		);
 		actions.push(
@@ -27,7 +27,7 @@ function MissingBlockWarning( { attributes, convertToHTML } ) {
 		);
 	} else {
 		messageHTML = sprintf(
-			__( 'Your site doesn\'t include support for the "%s" block. You can leave this block intact or remove it entirely.' ),
+			__( 'Your site doesn’t include support for the "%s" block. You can leave this block intact or remove it entirely.' ),
 			originalName
 		);
 	}
@@ -59,7 +59,7 @@ export const settings = {
 	name,
 	category: 'common',
 	title: __( 'Unrecognized Block' ),
-	description: __( 'Your site doesn\'t include support for this block.' ),
+	description: __( 'Your site doesn’t include support for this block.' ),
 
 	supports: {
 		className: false,


### PR DESCRIPTION
In strings in Gutenberg, apostrophe is used instead of single-quote character. [There are](https://translate.wordpress.org/projects/wp-plugins/gutenberg/stable/sr/default?filters%5Bterm%5D=%27&filters%5Buser_login%5D=&filters%5Bstatus%5D=current_or_waiting_or_fuzzy_or_untranslated&filter=Filter&sort%5Bby%5D=priority&sort%5Bhow%5D=desc) few exceptions, but I already proposed changing them in 9cce198 for #10886.

This PR changes other three strings introduced in #8274.