### PR TITLE
CSS coding standards for font-weight

### DIFF
--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -105,7 +105,7 @@
 
 			&.am-pm button {
 				font-size: 11px;
-				font-weight: bold;
+				font-weight: 600;
 			}
 
 			select {

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -65,7 +65,7 @@
 
 	.components-modal__header-heading {
 		font-size: 1em;
-		font-weight: normal;
+		font-weight: 400;
 	}
 
 	h1 {

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/style.scss
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/style.scss
@@ -1,7 +1,7 @@
 .edit-post-keyboard-shortcut-help {
 	&__title {
 		font-size: 1rem;
-		font-weight: bold;
+		font-weight: 600;
 	}
 
 	&__section {
@@ -11,7 +11,7 @@
 
 	&__section-title {
 		font-size: 0.9rem;
-		font-weight: bold;
+		font-weight: 600;
 	}
 
 	&__shortcut {
@@ -27,7 +27,7 @@
 
 	&__shortcut-term {
 		order: 1;
-		font-weight: bold;
+		font-weight: 600;
 		margin: 0 0 0 1rem;
 	}
 

--- a/packages/edit-post/src/components/options-modal/style.scss
+++ b/packages/edit-post/src/components/options-modal/style.scss
@@ -1,7 +1,7 @@
 .edit-post-options-modal {
 	&__title {
 		font-size: 1rem;
-		font-weight: bold;
+		font-weight: 600;
 	}
 
 	&__section {
@@ -10,7 +10,7 @@
 
 	&__section-title {
 		font-size: 0.9rem;
-		font-weight: bold;
+		font-weight: 600;
 	}
 
 	&__option {

--- a/packages/editor/src/components/block-compare/style.scss
+++ b/packages/editor/src/components/block-compare/style.scss
@@ -73,6 +73,6 @@
 
 	.editor-block-compare__heading {
 		font-size: 1em;
-		font-weight: normal;
+		font-weight: 400;
 	}
 }

--- a/packages/editor/src/components/media-placeholder/styles.native.scss
+++ b/packages/editor/src/components/media-placeholder/styles.native.scss
@@ -9,7 +9,7 @@
 
 .emptyStateTitle {
 	text-align: center;
-	font-weight: bold;
+	font-weight: 600;
 	padding-bottom: 12;
 }
 


### PR DESCRIPTION
## Description

I've updated font-weight for numeric values (normal -> 400 and bold -> 600)

Closes: #11687 

## How has this been tested?
This has been tested with "npm test" and manually on Chrome and Firefox

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
