### PR TITLE
Fix typo in @wordpress/components/panel README

### DIFF
--- a/packages/components/src/panel/README.md
+++ b/packages/components/src/panel/README.md
@@ -81,7 +81,7 @@ The is a generic container for panel content. Default styles add a top margin an
 
 ##### className
 
-The class that will be added with `components-panel__row`.  to the classes of the wrapper div. If no `className` is passed only `components-panel__body` is used.
+The class that will be added with `components-panel__row`.  to the classes of the wrapper div. If no `className` is passed only `components-panel__row` is used.
 
 - Type: `String`
 - Required: No


### PR DESCRIPTION
Pretty self explanatory. Cheers :beers: