### PR TITLE
Avoid calling missing get_current_screen function

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -101,6 +101,14 @@ function is_gutenberg_page() {
 		return false;
 	}
 
+	/*
+	 * There have been reports of specialized loading scenarios where `get_current_screen`
+	 * does not exist. In these cases, it is safe to say we are not loading Gutenberg.
+	 */
+	if ( ! function_exists( 'get_current_screen' ) ) {
+		return false;
+	}
+
 	if ( get_current_screen()->base !== 'post' ) {
 		return false;
 	}


### PR DESCRIPTION
## Description
The `get_current_screen` function is [documented](https://codex.wordpress.org/Function_Reference/get_current_screen#Usage_Restrictions) to not always be defined even when `is_admin` returns `true`. We've encountered a case like this with Gutenberg on WordPress.com where `is_gutenberg_page` incorrectly assumes `get_current_screen` exists.

Let's update `is_gutenberg_page` to check if `get_current_screen` exists.

## How has this been tested?
* Added a filter for `ms_site_check` that triggers `wp_enqueue_scripts` before exiting and encountered the *Call to undefined function get_current_screen()* fatal.
* Added this check and no longer experienced a fatal.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
