### PR TITLE
Avoid changing default wpautop priority

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -100,23 +100,6 @@ function gutenberg_add_rest_nonce_to_heartbeat_response_headers( $response ) {
 add_filter( 'wp_refresh_nonces', 'gutenberg_add_rest_nonce_to_heartbeat_response_headers' );
 
 /**
- * As a substitute for the default content `wpautop` filter, applies autop
- * behavior only for posts where content does not contain blocks.
- *
- * @param  string $content Post content.
- * @return string          Paragraph-converted text if non-block content.
- */
-function gutenberg_wpautop( $content ) {
-	if ( has_blocks( $content ) ) {
-		return $content;
-	}
-
-	return wpautop( $content );
-}
-remove_filter( 'the_content', 'wpautop' );
-add_filter( 'the_content', 'gutenberg_wpautop', 6 );
-
-/**
  * Check if we need to load the block warning in the Classic Editor.
  *
  * @since 3.4.0


### PR DESCRIPTION
## Description
This is a change to avoid problems due to changing the default wpautop priority.

Fixes #11691.

## How has this been tested?

* Created a post in the classic editor and verified auto-embeds render correctly for the following raw content (mentioned in #11691):
```
Some text above
https://www.youtube.com/watch?v=3V9QHBgrPNY

https://www.youtube.com/watch?v=f5KyMNDJE6o
```

* Tested that block content opened in the classic editor retains its paragraphs.
* Tested that non-block content is autop'd.
* Unit tests.

## Types of changes
Take a similar approach to core by removing the `wpautop` filter when block content is detected and subsequently restore it for later applications of the `the_content` filter.

The core changeset used for reference:
https://core.trac.wordpress.org/changeset/43879

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
