### PR TITLE
Filter to allow plugins override block attributes

### DIFF
--- a/lib/class-wp-block-type.php
+++ b/lib/class-wp-block-type.php
@@ -154,8 +154,8 @@ class WP_Block_Type {
 		* 
 		* @since 3.5.0
 		* 
-		* @param array $prepared_attributes Block attributes.
-		* @param WP_Block_Type $this Block object which attributes are filtered.
+		* @param array			$prepared_attributes	Block attributes.
+		* @param WP_Block_Type	$block_type				Block object which attributes are filtered.
 		*/
 		$prepared_attributes = apply_filters( 'block_attributes', $prepared_attributes, $this );
 

--- a/lib/class-wp-block-type.php
+++ b/lib/class-wp-block-type.php
@@ -157,7 +157,7 @@ class WP_Block_Type {
 		* @param array			$prepared_attributes	Block attributes.
 		* @param WP_Block_Type	$block_type				Block object which attributes are filtered.
 		*/
-		$prepared_attributes = apply_filters( 'block_attributes', $prepared_attributes, $this );
+		$prepared_attributes = apply_filters( 'block_prepared_attributes', $prepared_attributes, $this );
 
 		return $prepared_attributes;
 	}

--- a/lib/class-wp-block-type.php
+++ b/lib/class-wp-block-type.php
@@ -149,6 +149,16 @@ class WP_Block_Type {
 			$prepared_attributes[ $attribute_name ] = $value;
 		}
 
+		/**
+		* Filter to allow plugins to override block attributes
+		* 
+		* @since 3.5.0
+		* 
+		* @param array $prepared_attributes block attributes 
+		*/
+
+		$prepared_attributes = apply_filters( 'block_attributes', $prepared_attributes );
+
 		return $prepared_attributes;
 	}
 

--- a/lib/class-wp-block-type.php
+++ b/lib/class-wp-block-type.php
@@ -154,8 +154,8 @@ class WP_Block_Type {
 		* 
 		* @since 3.5.0
 		* 
-		* @param array			$prepared_attributes	Block attributes.
-		* @param WP_Block_Type	$block_type				Block object which attributes are filtered.
+		* @param array         $prepared_attributes Block attributes.
+		* @param WP_Block_Type $block_type          Block object which attributes are filtered.
 		*/
 		$prepared_attributes = apply_filters( 'block_prepared_attributes', $prepared_attributes, $this );
 

--- a/lib/class-wp-block-type.php
+++ b/lib/class-wp-block-type.php
@@ -150,14 +150,14 @@ class WP_Block_Type {
 		}
 
 		/**
-		* Filter to allow plugins to override block attributes
+		* Filter to allow plugins to override Block attributes.
 		* 
 		* @since 3.5.0
 		* 
-		* @param array $prepared_attributes block attributes 
+		* @param array $prepared_attributes Block attributes.
+		* @param WP_Block_Type $this Block object which attributes are filtered.
 		*/
-
-		$prepared_attributes = apply_filters( 'block_attributes', $prepared_attributes );
+		$prepared_attributes = apply_filters( 'block_attributes', $prepared_attributes, $this );
 
 		return $prepared_attributes;
 	}

--- a/lib/class-wp-block-type.php
+++ b/lib/class-wp-block-type.php
@@ -151,9 +151,9 @@ class WP_Block_Type {
 
 		/**
 		* Filter to allow plugins to override Block attributes.
-		* 
-		* @since 3.5.0
-		* 
+		*
+		* @since 4.5.0
+		*
 		* @param array         $prepared_attributes Block attributes.
 		* @param WP_Block_Type $block_type          Block object which attributes are filtered.
 		*/


### PR DESCRIPTION
## Description

Closes #8912, #11195 (related but more specific proposals).

Add a filter so plugins and themes can override block attributes.

## Why is this needed?
Dynamic blocks, rendered server side keep their values in block attributes. Some of those attributes might be texts printed in the front-end to be read by people. This kind of strings should be available for translation. 
We are preparing in WPML code to make it translatable, but we need to hook somewhere somewhere in Gutenberg to filter values. This place seems to be most appropriate for this. 

## How has this been tested?
This has been tested in WPML with following code example (to translate dynamic strings created with ACF Blocks beta).

```
add_filter( 'block_prepared_attributes', 'block_attributes_filter', 1, 10 );
function block_attributes_filter( $attributes, $block_type ) {
    if ( $block_type->name === 'my-plugin/my-block' &&  isset( $attributes['data'] ) ) {
            $original_post_id = apply_filters( 'wpml_object_id', get_the_ID(), get_post_type(), true, apply_filters( 'wpml_default_language', null) );
            foreach ( $attributes['data'] as $name => $value ) {
                $string_name = WPML_Gutenberg_Strings_In_Block::get_string_id($attributes['name'], $value);
                $translated = apply_filters( 'wpml_translate_string',
                    $value,
                    $string_name,
                    array('kind' => 'Gutenberg', 'name' => $original_post_id) );
                $attributes['data'][$name] = $translated;
            }
        }

        return $attributes;
}
```

## Types of changes
Add a new filter

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
