### PR TITLE
Make the Blocks navigation a nested list to better communicate the blocks nesting level

### DIFF
--- a/packages/block-library/src/embed/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/embed/test/__snapshots__/index.js.snap
@@ -7,7 +7,7 @@ exports[`core/embed block edit matches snapshot 1`] = `
   <div
     class="components-placeholder__label"
   >
-    <div
+    <span
       class="editor-block-icon has-colors"
     >
       <svg
@@ -24,7 +24,7 @@ exports[`core/embed block edit matches snapshot 1`] = `
           d="M17 4H3c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm-3 6.5L12.5 12l1.5 1.5V15l-3-3 3-3v1.5zm1 4.5v-1.5l1.5-1.5-1.5-1.5V9l3 3-3 3z"
         />
       </svg>
-    </div>
+    </span>
     Embed URL
   </div>
   <div

--- a/packages/components/src/navigable-container/menu.js
+++ b/packages/components/src/navigable-container/menu.js
@@ -42,13 +42,29 @@ export function NavigableMenu( {
 		}
 	};
 
+	const isAriaOrientationAllowed = [
+		'scrollbar',
+		'select',
+		'separator',
+		'slider',
+		'tablist',
+		'toolbar',
+		'combobox',
+		'listbox',
+		'menu',
+		'menubar',
+		'radiogroup',
+		'tree',
+		'treegrid',
+	].includes( role );
+
 	return (
 		<NavigableContainer
 			ref={ ref }
 			stopNavigationEvents
 			onlyBrowserTabstops={ false }
 			role={ role }
-			aria-orientation={ orientation }
+			aria-orientation={ isAriaOrientationAllowed ? orientation : null }
 			eventToOffset={ eventToOffset }
 			{ ...rest }
 		/>

--- a/packages/components/src/navigable-container/menu.js
+++ b/packages/components/src/navigable-container/menu.js
@@ -42,29 +42,13 @@ export function NavigableMenu( {
 		}
 	};
 
-	const isAriaOrientationAllowed = [
-		'scrollbar',
-		'select',
-		'separator',
-		'slider',
-		'tablist',
-		'toolbar',
-		'combobox',
-		'listbox',
-		'menu',
-		'menubar',
-		'radiogroup',
-		'tree',
-		'treegrid',
-	].includes( role );
-
 	return (
 		<NavigableContainer
 			ref={ ref }
 			stopNavigationEvents
 			onlyBrowserTabstops={ false }
 			role={ role }
-			aria-orientation={ isAriaOrientationAllowed ? orientation : null }
+			aria-orientation={ role === 'presentation' ? null : orientation }
 			eventToOffset={ eventToOffset }
 			{ ...rest }
 		/>

--- a/packages/editor/src/components/block-icon/index.js
+++ b/packages/editor/src/components/block-icon/index.js
@@ -23,7 +23,7 @@ export default function BlockIcon( { icon, showColors = false, className } ) {
 	} : {};
 
 	return (
-		<div
+		<span
 			style={ style }
 			className={ classnames(
 				'editor-block-icon',
@@ -32,6 +32,6 @@ export default function BlockIcon( { icon, showColors = false, className } ) {
 			) }
 		>
 			{ renderedIcon }
-		</div>
+		</span>
 	);
 }

--- a/packages/editor/src/components/block-icon/test/index.js
+++ b/packages/editor/src/components/block-icon/test/index.js
@@ -20,28 +20,28 @@ describe( 'BlockIcon', () => {
 		expect( wrapper.containsMatchingElement( <Icon icon="format-image" /> ) ).toBe( true );
 	} );
 
-	it( 'renders a div without the has-colors classname', () => {
+	it( 'renders a span without the has-colors classname', () => {
 		const wrapper = shallow( <BlockIcon icon="format-image" /> );
 
-		expect( wrapper.find( 'div' ).hasClass( 'has-colors' ) ).toBe( false );
+		expect( wrapper.find( 'span' ).hasClass( 'has-colors' ) ).toBe( false );
 	} );
 
-	it( 'renders a div with the has-colors classname', () => {
+	it( 'renders a span with the has-colors classname', () => {
 		const wrapper = shallow( <BlockIcon icon="format-image" showColors /> );
 
-		expect( wrapper.find( 'div' ).hasClass( 'has-colors' ) ).toBe( true );
+		expect( wrapper.find( 'span' ).hasClass( 'has-colors' ) ).toBe( true );
 	} );
 
 	it( 'skips adding background and foreground styles when colors are not enabled', () => {
 		const wrapper = shallow( <BlockIcon icon={ { background: 'white', foreground: 'black' } } /> );
 
-		expect( wrapper.find( 'div' ).prop( 'style' ) ).toEqual( {} );
+		expect( wrapper.find( 'span' ).prop( 'style' ) ).toEqual( {} );
 	} );
 
 	it( 'adds background and foreground styles when colors are enabled', () => {
 		const wrapper = shallow( <BlockIcon icon={ { background: 'white', foreground: 'black' } } showColors /> );
 
-		expect( wrapper.find( 'div' ).prop( 'style' ) ).toEqual( {
+		expect( wrapper.find( 'span' ).prop( 'style' ) ).toEqual( {
 			backgroundColor: 'white',
 			color: 'black',
 		} );

--- a/packages/editor/src/components/block-navigation/index.js
+++ b/packages/editor/src/components/block-navigation/index.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { withSelect, withDispatch } from '@wordpress/data';
-import { MenuItem, MenuGroup } from '@wordpress/components';
+import { Button, NavigableMenu } from '@wordpress/components';
 import { getBlockType } from '@wordpress/blocks';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
@@ -25,24 +25,31 @@ function BlockNavigationList( {
 	showNestedBlocks,
 } ) {
 	return (
-		<ul className="editor-block-navigation__list" role="presentation">
+		/*
+		 * Disable reason: The `list` ARIA role is redundant but
+		 * Safari+VoiceOver won't announce the list otherwise.
+		 */
+		/* eslint-disable jsx-a11y/no-redundant-roles */
+		<ul className="editor-block-navigation__list" role="list">
 			{ map( blocks, ( block ) => {
 				const blockType = getBlockType( block.name );
+				const isSelected = block.clientId === selectedBlockClientId;
+
 				return (
-					<li key={ block.clientId } role="presentation">
-						<div role="presentation" className="editor-block-navigation__item">
-							<MenuItem
+					<li key={ block.clientId }>
+						<span className="editor-block-navigation__item">
+							<Button
 								className={ classnames( 'editor-block-navigation__item-button', {
 									'is-selected': block.clientId === selectedBlockClientId,
 								} ) }
 								onClick={ () => selectBlock( block.clientId ) }
-								isSelected={ block.clientId === selectedBlockClientId }
-								role="menuitemradio"
+								isSelected={ isSelected }
 							>
 								<BlockIcon icon={ blockType.icon } showColors />
 								{ blockType.title }
-							</MenuItem>
-						</div>
+								{ isSelected && <span className="screen-reader-text">{ __( '(selected block)' ) }</span> }
+							</Button>
+						</span>
 						{ showNestedBlocks && !! block.innerBlocks && !! block.innerBlocks.length && (
 							<BlockNavigationList
 								blocks={ block.innerBlocks }
@@ -55,6 +62,7 @@ function BlockNavigationList( {
 				);
 			} ) }
 		</ul>
+		/* eslint-enable jsx-a11y/no-redundant-roles */
 	);
 }
 
@@ -67,7 +75,11 @@ function BlockNavigation( { rootBlock, rootBlocks, selectedBlockClientId, select
 	);
 
 	return (
-		<MenuGroup label={ __( 'Block Navigation' ) }>
+		<NavigableMenu
+			role="navigation"
+			className="editor-block-navigation__container"
+		>
+			<p className="editor-block-navigation__label">{ __( 'Block Navigation' ) }</p>
 			{ hasHierarchy && (
 				<BlockNavigationList
 					blocks={ [ rootBlock ] }
@@ -90,7 +102,7 @@ function BlockNavigation( { rootBlock, rootBlocks, selectedBlockClientId, select
 					{ __( 'No blocks created yet.' ) }
 				</p>
 			) }
-		</MenuGroup>
+		</NavigableMenu>
 	);
 }
 

--- a/packages/editor/src/components/block-navigation/index.js
+++ b/packages/editor/src/components/block-navigation/index.js
@@ -76,7 +76,7 @@ function BlockNavigation( { rootBlock, rootBlocks, selectedBlockClientId, select
 
 	return (
 		<NavigableMenu
-			role="navigation"
+			role="presentation"
 			className="editor-block-navigation__container"
 		>
 			<p className="editor-block-navigation__label">{ __( 'Block Navigation' ) }</p>

--- a/packages/editor/src/components/block-navigation/index.js
+++ b/packages/editor/src/components/block-navigation/index.js
@@ -37,7 +37,7 @@ function BlockNavigationList( {
 
 				return (
 					<li key={ block.clientId }>
-						<span className="editor-block-navigation__item">
+						<div className="editor-block-navigation__item">
 							<Button
 								className={ classnames( 'editor-block-navigation__item-button', {
 									'is-selected': block.clientId === selectedBlockClientId,
@@ -49,7 +49,7 @@ function BlockNavigationList( {
 								{ blockType.title }
 								{ isSelected && <span className="screen-reader-text">{ __( '(selected block)' ) }</span> }
 							</Button>
-						</span>
+						</div>
 						{ showNestedBlocks && !! block.innerBlocks && !! block.innerBlocks.length && (
 							<BlockNavigationList
 								blocks={ block.innerBlocks }

--- a/packages/editor/src/components/block-navigation/style.scss
+++ b/packages/editor/src/components/block-navigation/style.scss
@@ -26,7 +26,6 @@ $tree-item-height: 36px;
 	}
 
 	.editor-block-navigation__item {
-		display: block;
 		position: relative;
 
 		&::before {

--- a/packages/editor/src/components/block-navigation/style.scss
+++ b/packages/editor/src/components/block-navigation/style.scss
@@ -1,6 +1,15 @@
 $tree-border-width: 2px;
 $tree-item-height: 36px;
 
+.editor-block-navigation__container {
+	padding: $grid-size - $border-width;
+}
+
+.editor-block-navigation__label {
+	margin: 0 0 $grid-size;
+	color: $dark-gray-300;
+}
+
 .editor-block-navigation__list,
 .editor-block-navigation__paragraph {
 	padding: 0;
@@ -17,6 +26,7 @@ $tree-item-height: 36px;
 	}
 
 	.editor-block-navigation__item {
+		display: block;
 		position: relative;
 
 		&::before {
@@ -50,13 +60,24 @@ $tree-item-height: 36px;
 }
 
 .editor-block-navigation__item-button {
-	padding: 6px;
 	display: flex;
 	align-items: center;
+	width: 100%;
+	padding: 6px;
+	text-align: left;
+	color: $dark-gray-600;
 	border-radius: 4px;
 
 	.editor-block-icon {
 		margin-right: 6px;
+	}
+
+	&:hover:not(:disabled):not([aria-disabled="true"]) {
+		@include menu-style__hover;
+	}
+
+	&:focus:not(:disabled):not([aria-disabled="true"]) {
+		@include menu-style__focus;
 	}
 
 	&.is-selected,


### PR DESCRIPTION
## Description

When there are nested blocks, the Blocks navigation displays them with some indentation. However, this information is only visual. This PR seeks to communicate the nesting level also semantically by using an unordered list. Lists convey important information for free: the number of items in the list, their nesting level, the current item number.

Assistive technologies can use the list semantics to properly inform users, so they can actually get the structure of nested blocks. 

I've done my best to avoid visual changes.

Worth noting arrows navigation won't work well with screen readers on Windows because now there isn't an ARIA role to instruct screen readers to stop intercepting keystrokes. I think providing the missing information is more important than arrows navigation. Also, there are proposal to change and extend the functionalities of the Blocks navigation, see #10984, #11408, #11688, and #11711. In all those cases, an ARIA menu wouldn't be the proper UI to use and arrows navigation would need to be removed anyways.

I'm trying to keep the arrows navigation behavior for non-screen reader users for now, but I'd tend to think this component is now more similar to the "Document outline": a simple list with no special interaction other than the native one. Please do let me know if completely removing arrows navigation is desirable.

- makes the Blocks Navigation an unordered (nested) list 
- uses `NavigableMenu` to keep arrows navigation (for now)
- uses a `screen-reader-text` to communicate the selected state of a list item 
- avoids to render an `aria-orientation` attribute, as this is not a menu any longer
- changes the `editor-block-icon` to a `<span>` element: `<div>` elements are invalid HTML within buttons; we'd want this component to be reusable everywhere and also ensure valid HTML and a div doesn't seem appropriate; the `editor-block-icon` is already a flex element with set width and height so this change shouldn't harm anything
- "Block Navigation" is not used as target for `aria-labelledby` any longer, I'm not so worried about it because users get this popover clicking on a button that already announces "Block Navigation"

Fixes #11713 

Screenshots to illustrate how the nesting level gets announced thanks to the native semantics of an `<ul>` element:

![screenshot 2018-11-11 at 12 29 19](https://user-images.githubusercontent.com/1682452/48314564-b1dd6b00-e5cb-11e8-869c-ddf65f4d6465.png)

![screenshot 2018-11-11 at 12 29 27](https://user-images.githubusercontent.com/1682452/48314565-b2760180-e5cb-11e8-986f-46ae34f522e3.png)

![screenshot 2018-11-11 at 12 28 17](https://user-images.githubusercontent.com/1682452/48314566-b2760180-e5cb-11e8-9768-39e9a4d8877d.png)

Note: other screen readers communicate the nesting info in different ways, see the example screenshots on #11713 