### PR TITLE
Restore the block hover and focus styles in Unified Toolbar mode.

### DIFF
--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -425,7 +425,7 @@ export class BlockListBlock extends Component {
 					const showEmptyBlockSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock && isValid;
 					const showSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock;
 					const shouldAppearSelected = ! isFocusMode && ! showSideInserter && isSelected && ! isTypingWithinBlock;
-					const shouldAppearHovered = ! isFocusMode && isHovered && ! isEmptyDefaultBlock;
+					const shouldAppearHovered = ! isFocusMode && ! hasFixedToolbar && isHovered && ! isEmptyDefaultBlock;
 					// We render block movers and block settings to keep them tabbale even if hidden
 					const shouldRenderMovers = ! isFocusMode && ( isSelected || hoverArea === 'left' ) && ! showEmptyBlockSideInserter && ! isMultiSelecting && ! isPartOfMultiSelection && ! isTypingWithinBlock;
 					const shouldShowBreadcrumb = ! isFocusMode && isHovered && ! isEmptyDefaultBlock;

--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -424,8 +424,8 @@ export class BlockListBlock extends Component {
 					// Empty paragraph blocks should always show up as unselected.
 					const showEmptyBlockSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock && isValid;
 					const showSideInserter = ( isSelected || isHovered ) && isEmptyDefaultBlock;
-					const shouldAppearSelected = ! isFocusMode && ! hasFixedToolbar && ! showSideInserter && isSelected && ! isTypingWithinBlock;
-					const shouldAppearHovered = ! isFocusMode && ! hasFixedToolbar && isHovered && ! isEmptyDefaultBlock;
+					const shouldAppearSelected = ! isFocusMode && ! showSideInserter && isSelected && ! isTypingWithinBlock;
+					const shouldAppearHovered = ! isFocusMode && isHovered && ! isEmptyDefaultBlock;
 					// We render block movers and block settings to keep them tabbale even if hidden
 					const shouldRenderMovers = ! isFocusMode && ( isSelected || hoverArea === 'left' ) && ! showEmptyBlockSideInserter && ! isMultiSelecting && ! isPartOfMultiSelection && ! isTypingWithinBlock;
 					const shouldShowBreadcrumb = ! isFocusMode && isHovered && ! isEmptyDefaultBlock;

--- a/packages/editor/src/components/block-list/breadcrumb.js
+++ b/packages/editor/src/components/block-list/breadcrumb.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { Component, Fragment } from '@wordpress/element';
@@ -53,12 +48,10 @@ export class BlockBreadcrumb extends Component {
 	}
 
 	render() {
-		const { clientId, rootClientId, isLight } = this.props;
+		const { clientId, rootClientId } = this.props;
 
 		return (
-			<div className={ classnames( 'editor-block-list__breadcrumb', {
-				'is-light': isLight,
-			} ) }>
+			<div className={ 'editor-block-list__breadcrumb' }>
 				<Toolbar>
 					{ rootClientId && (
 						<Fragment>
@@ -75,12 +68,11 @@ export class BlockBreadcrumb extends Component {
 
 export default compose( [
 	withSelect( ( select, ownProps ) => {
-		const { getBlockRootClientId, getEditorSettings } = select( 'core/editor' );
+		const { getBlockRootClientId } = select( 'core/editor' );
 		const { clientId } = ownProps;
 
 		return {
 			rootClientId: getBlockRootClientId( clientId ),
-			isLight: getEditorSettings().hasFixedToolbar,
 		};
 	} ),
 ] )( BlockBreadcrumb );

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -908,11 +908,6 @@
 		}
 	}
 
-	&.is-light .components-toolbar {
-		background: rgba($white, 0.5);
-		color: $dark-gray-700;
-	}
-
 	// Position the breadcrumb closer on mobile.
 	[data-align="left"] &,
 	[data-align="right"] & {

--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -56,7 +56,9 @@
 				border-color: $light-opacity-light-500;
 			}
 		}
+	}
 
+	&:not(.is-focus-mode):not(.has-fixed-toolbar) {
 		.editor-post-title__input:hover {
 			border-color: theme(outlines);
 		}

--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -47,7 +47,7 @@
 		}
 	}
 
-	&:not(.is-focus-mode):not(.has-fixed-toolbar) {
+	&:not(.is-focus-mode) {
 		&.is-selected .editor-post-title__input {
 			// use opacity to work in various editor styles
 			border-color: $dark-opacity-light-500;


### PR DESCRIPTION
## Description

The Unified Toolbar mode should not remove outlines. This was discussed and agreed by the accessibility team and it's our recommendation as a team.

For example, I may find Unified Toolbar mode useful for my workflow but, as a user with vision impairments, still want a clear indication of hover and focus on the blocks. Instead, I can't use Unified Toolbar because it removes focus indication.

Quoting from the related issue #10559 
> Regardless of the accessibility issues with focus, I think that these controls should only change the specific items they describe, and not also impact other behaviors - that's confusing, and makes it more difficult to configure the design the way you want.

This PR is an effort to propose a positive action. It partially reverts #9394. An option for a lighter UI when writing is already available with "Spotlight Mode" and as a team we feel that's the proper place for UI modifications that are clearly extraneous to a "Unified Toolbar" option.

Fixes #10559 