### PR TITLE
Prevent RESET_BLOCKS from affecting reusable blocks

### DIFF
--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -116,14 +116,11 @@ function getFlattenedBlocks( blocks ) {
  * @return {Array} List of descendant client IDs.
  */
 function getNestedBlockClientIds( blocksOrder, rootClientId = '' ) {
-	const attachedClientIds = [];
-	if ( blocksOrder[ rootClientId ] ) {
-		blocksOrder[ rootClientId ].forEach( ( clientId ) => {
-			attachedClientIds.push( clientId );
-			attachedClientIds.push( ...getNestedBlockClientIds( blocksOrder, clientId ) );
-		} );
-	}
-	return attachedClientIds;
+	return reduce( blocksOrder[ rootClientId ], ( result, clientId ) => [
+		...result,
+		clientId,
+		...getNestedBlockClientIds( blocksOrder, clientId ),
+	], [] );
 }
 
 /**

--- a/packages/editor/src/store/test/reducer.js
+++ b/packages/editor/src/store/test/reducer.js
@@ -1074,6 +1074,58 @@ describe( 'state', () => {
 		} );
 
 		describe( 'blocks', () => {
+			it( 'should not reset any blocks that are not in the post', () => {
+				const actions = [
+					{
+						type: 'RESET_BLOCKS',
+						blocks: [
+							{
+								clientId: 'block1',
+								innerBlocks: [
+									{ clientId: 'block11', innerBlocks: [] },
+									{ clientId: 'block12', innerBlocks: [] },
+								],
+							},
+						],
+					},
+					{
+						type: 'RECEIVE_BLOCKS',
+						blocks: [
+							{
+								clientId: 'block2',
+								innerBlocks: [
+									{ clientId: 'block21', innerBlocks: [] },
+									{ clientId: 'block22', innerBlocks: [] },
+								],
+							},
+						],
+					},
+				];
+				const original = deepFreeze( actions.reduce( editor, undefined ) );
+
+				const state = editor( original, {
+					type: 'RESET_BLOCKS',
+					blocks: [
+						{
+							clientId: 'block3',
+							innerBlocks: [
+								{ clientId: 'block31', innerBlocks: [] },
+								{ clientId: 'block32', innerBlocks: [] },
+							],
+						},
+					],
+				} );
+
+				expect( state.present.blocks.byClientId ).toEqual( {
+					block2: { clientId: 'block2' },
+					block21: { clientId: 'block21' },
+					block22: { clientId: 'block22' },
+					block3: { clientId: 'block3' },
+					block31: { clientId: 'block31' },
+					block32: { clientId: 'block32' },
+				} );
+			} );
+
 			describe( 'byClientId', () => {
 				it( 'should return with attribute block updates', () => {
 					const original = deepFreeze( editor( undefined, {

--- a/packages/editor/src/store/test/reducer.js
+++ b/packages/editor/src/store/test/reducer.js
@@ -1074,55 +1074,30 @@ describe( 'state', () => {
 		} );
 
 		describe( 'blocks', () => {
-			it( 'should not reset any blocks that are not in the post', () => {
-				const actions = [
-					{
-						type: 'RESET_BLOCKS',
-						blocks: [
-							{
-								clientId: 'block1',
-								innerBlocks: [
-									{ clientId: 'block11', innerBlocks: [] },
-									{ clientId: 'block12', innerBlocks: [] },
-								],
-							},
-						],
-					},
-					{
-						type: 'RECEIVE_BLOCKS',
-						blocks: [
-							{
-								clientId: 'block2',
-								innerBlocks: [
-									{ clientId: 'block21', innerBlocks: [] },
-									{ clientId: 'block22', innerBlocks: [] },
-								],
-							},
-						],
-					},
-				];
-				const original = deepFreeze( actions.reduce( editor, undefined ) );
-
+			it( 'should not reset blocks referenced by a reusable block', () => {
+				const original = deepFreeze( editor( undefined, {
+					type: 'RESET_BLOCKS',
+					blocks: [
+						{ clientId: 'block1', innerBlocks: [] },
+						{ clientId: 'block2', innerBlocks: [] },
+					],
+				} ) );
 				const state = editor( original, {
 					type: 'RESET_BLOCKS',
 					blocks: [
-						{
-							clientId: 'block3',
-							innerBlocks: [
-								{ clientId: 'block31', innerBlocks: [] },
-								{ clientId: 'block32', innerBlocks: [] },
-							],
-						},
+						{ clientId: 'block3', innerBlocks: [] },
 					],
+					reusableBlockClientIds: [ 'block2' ],
 				} );
 
 				expect( state.present.blocks.byClientId ).toEqual( {
 					block2: { clientId: 'block2' },
-					block21: { clientId: 'block21' },
-					block22: { clientId: 'block22' },
 					block3: { clientId: 'block3' },
-					block31: { clientId: 'block31' },
-					block32: { clientId: 'block32' },
+				} );
+				expect( state.present.blocks.order ).toEqual( {
+					'': [ 'block3' ],
+					block2: [],
+					block3: [],
 				} );
 			} );
 

--- a/packages/editor/src/store/test/reducer.js
+++ b/packages/editor/src/store/test/reducer.js
@@ -1074,30 +1074,55 @@ describe( 'state', () => {
 		} );
 
 		describe( 'blocks', () => {
-			it( 'should not reset blocks referenced by a reusable block', () => {
-				const original = deepFreeze( editor( undefined, {
-					type: 'RESET_BLOCKS',
-					blocks: [
-						{ clientId: 'block1', innerBlocks: [] },
-						{ clientId: 'block2', innerBlocks: [] },
-					],
-				} ) );
+			it( 'should not reset any blocks that are not in the post', () => {
+				const actions = [
+					{
+						type: 'RESET_BLOCKS',
+						blocks: [
+							{
+								clientId: 'block1',
+								innerBlocks: [
+									{ clientId: 'block11', innerBlocks: [] },
+									{ clientId: 'block12', innerBlocks: [] },
+								],
+							},
+						],
+					},
+					{
+						type: 'RECEIVE_BLOCKS',
+						blocks: [
+							{
+								clientId: 'block2',
+								innerBlocks: [
+									{ clientId: 'block21', innerBlocks: [] },
+									{ clientId: 'block22', innerBlocks: [] },
+								],
+							},
+						],
+					},
+				];
+				const original = deepFreeze( actions.reduce( editor, undefined ) );
+
 				const state = editor( original, {
 					type: 'RESET_BLOCKS',
 					blocks: [
-						{ clientId: 'block3', innerBlocks: [] },
+						{
+							clientId: 'block3',
+							innerBlocks: [
+								{ clientId: 'block31', innerBlocks: [] },
+								{ clientId: 'block32', innerBlocks: [] },
+							],
+						},
 					],
-					reusableBlockClientIds: [ 'block2' ],
 				} );
 
 				expect( state.present.blocks.byClientId ).toEqual( {
 					block2: { clientId: 'block2' },
+					block21: { clientId: 'block21' },
+					block22: { clientId: 'block22' },
 					block3: { clientId: 'block3' },
-				} );
-				expect( state.present.blocks.order ).toEqual( {
-					'': [ 'block3' ],
-					block2: [],
-					block3: [],
+					block31: { clientId: 'block31' },
+					block32: { clientId: 'block32' },
 				} );
 			} );
 


### PR DESCRIPTION
Fixes #5754.

Changes the editor reducer so that RESET_BLOCKS will only remove blocks that are actually in the post, i.e. blocks that are a descendent of the `''` `blocks.order` key.

This fixes a bug where editing a post in Text Mode would break any reusable blocks in the post.

#### How to test

1. Create a new post
2. Create or insert a reusable block
3. Switch to Text Mode
4. Make an edit, e.g. add a line of text
5. Return to Visual Mode
6. The reusable block should be unaffected