### PR TITLE
Fix multiselection for float elements

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 7.0.1  (Unreleased)
+
+### Bug Fixes
+
+- Fix multi-selection triggering too often when using floated blocks.
+
 ## 7.0.0 (2018-11-12)
 
 ### Breaking Change

--- a/packages/editor/src/components/block-list/index.js
+++ b/packages/editor/src/components/block-list/index.js
@@ -81,6 +81,9 @@ class BlockList extends Component {
 		}
 
 		const blockContentBoundaries = getBlockDOMNode( this.selectionAtStart ).getBoundingClientRect();
+
+		// prevent multi-selection from triggering when the selected block is a float
+		// and the cursor is still between the top and the bottom of the block.
 		if ( clientY >= blockContentBoundaries.top && clientY <= blockContentBoundaries.bottom ) {
 			return;
 		}

--- a/packages/editor/src/components/block-list/index.js
+++ b/packages/editor/src/components/block-list/index.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import {
-	findLast,
+	filter,
+	last,
 	map,
 	invert,
 	mapValues,
@@ -22,6 +23,7 @@ import { compose } from '@wordpress/compose';
  */
 import BlockListBlock from './block';
 import BlockListAppender from '../block-list-appender';
+import { getBlockDOMNode } from '../../utils/dom';
 
 class BlockList extends Component {
 	constructor( props ) {
@@ -78,9 +80,14 @@ class BlockList extends Component {
 			this.props.onStartMultiSelect();
 		}
 
-		const boundaries = this.nodes[ this.selectionAtStart ].getBoundingClientRect();
-		const y = clientY - boundaries.top;
-		const key = findLast( this.coordMapKeys, ( coordY ) => coordY < y );
+		const blockContentBoundaries = getBlockDOMNode( this.selectionAtStart ).getBoundingClientRect();
+		if ( clientY >= blockContentBoundaries.top && clientY <= blockContentBoundaries.bottom ) {
+			return;
+		}
+
+		const y = clientY - blockContentBoundaries.top;
+		const hoveredBlocks = filter( this.coordMapKeys, ( coordY ) => coordY < y );
+		const key = last( hoveredBlocks );
 
 		this.onSelectionChange( this.coordMap[ key ] );
 	}

--- a/packages/editor/src/components/block-list/index.js
+++ b/packages/editor/src/components/block-list/index.js
@@ -2,8 +2,7 @@
  * External dependencies
  */
 import {
-	filter,
-	last,
+	findLast,
 	map,
 	invert,
 	mapValues,
@@ -89,8 +88,7 @@ class BlockList extends Component {
 		}
 
 		const y = clientY - blockContentBoundaries.top;
-		const hoveredBlocks = filter( this.coordMapKeys, ( coordY ) => coordY < y );
-		const key = last( hoveredBlocks );
+		const key = findLast( this.coordMapKeys, ( coordY ) => coordY < y );
 
 		this.onSelectionChange( this.coordMap[ key ] );
 	}


### PR DESCRIPTION
When we have float elements on the page, multi-selection triggers too often. The idea of this PR is to prevent multi-selection from triggering when the selected block is a float and the cursor is still between the top and the bottom of the block.

Fixes #11698.
