### PR TITLE
Add min-width to audio block.

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.3 (Unreleased)
+
+### Bug Fixes
+
+- Add a minimum width for the audio block to fixed floated audio blocks.
+
 ## 2.2.2 (2018-11-12)
 
 ### Polish

--- a/packages/block-library/src/audio/editor.scss
+++ b/packages/block-library/src/audio/editor.scss
@@ -1,7 +1,3 @@
 .wp-block-audio {
 	margin: 0;
 }
-
-.wp-block-audio audio {
-	width: 100%;
-}

--- a/packages/block-library/src/audio/editor.scss
+++ b/packages/block-library/src/audio/editor.scss
@@ -4,7 +4,4 @@
 
 .wp-block-audio audio {
 	width: 100%;
-
-	// The audio block has no intrinsic width and needs an explicit min-width to not collapse.
-	min-width: $break-mobile / 2;
 }

--- a/packages/block-library/src/audio/editor.scss
+++ b/packages/block-library/src/audio/editor.scss
@@ -4,4 +4,7 @@
 
 .wp-block-audio audio {
 	width: 100%;
+
+	// The audio block has no intrinsic width and needs an explicit min-width to not collapse.
+	min-width: $break-mobile / 2;
 }

--- a/packages/block-library/src/audio/style.scss
+++ b/packages/block-library/src/audio/style.scss
@@ -4,3 +4,8 @@
 	text-align: center;
 	font-size: $default-font-size;
 }
+
+.wp-block-audio audio {
+	// The audio block has no intrinsic width and needs an explicit min-width to not collapse.
+	min-width: $break-mobile / 2;
+}

--- a/packages/block-library/src/audio/style.scss
+++ b/packages/block-library/src/audio/style.scss
@@ -1,11 +1,17 @@
-.wp-block-audio figcaption {
-	margin-top: 0.5em;
-	color: $dark-gray-300;
-	text-align: center;
-	font-size: $default-font-size;
-}
+.wp-block-audio {
+	// Supply caption styles to audio blocks, even if the theme hasn't opted in.
+	// Reason being: the new markup, <figcaptions>, are not likely to be styled in the majority of existing themes,
+	// so we supply the styles so as to not appear broken or unstyled in those themes.
+	figcaption {
+		@include caption-style();
+	}
 
-.wp-block-audio audio {
-	// The audio block has no intrinsic width and needs an explicit min-width to not collapse.
-	min-width: $break-mobile / 2;
+	// Show full-width when not aligned.
+	audio {
+		width: 100%;
+
+		// The browser natively applies a 300px width to the audio block.
+		// We restore this as a min-width instead, for alignments.
+		min-width: 300px;
+	}
 }


### PR DESCRIPTION
Fixes #11740.

The audio block has no intrinsic width, and collapses if we don't set an explicit min-width on it. This PR does that.

<img width="769" alt="screenshot 2018-11-12 at 09 16 49" src="https://user-images.githubusercontent.com/1204802/48335502-34166f80-e65e-11e8-9028-5c97cb1e108e.png">

What should the min-width be? In this case I've set it to 240px, which is a nice round number, and seems to be the tiniest width at which the actual controls appear usable in. 

It would be a nice enhancement in the future to let the user set the width of the audio block themselves, perhaps in an inspector interface like that for the image block. 

Have set no milestone since I'm imagining this will go in as a 4.3RC fix.