### PR TITLE
Fix the text/code editor width

### DIFF
--- a/packages/edit-post/src/components/text-editor/style.scss
+++ b/packages/edit-post/src/components/text-editor/style.scss
@@ -19,6 +19,7 @@
 }
 
 .edit-post-text-editor {
+	width: 100%;
 	margin-left: $grid-size-large;
 	margin-right: $grid-size-large;
 


### PR DESCRIPTION
The text/code editor had a max-width, but no _width_, which made it sort of just choose its own width. Now it matches the $content-width.

Before:

<img width="699" alt="screenshot 2018-11-12 at 09 35 39" src="https://user-images.githubusercontent.com/1204802/48336249-2bbf3400-e660-11e8-919f-170dfbeb183c.png">

After:

<img width="723" alt="screenshot 2018-11-12 at 09 35 28" src="https://user-images.githubusercontent.com/1204802/48336254-2e218e00-e660-11e8-8a30-4d67990c63ad.png">
