### PR TITLE
Only refresh the popover if the anchor position changes

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.0.1 (Unreleased)
+
+### Bug Fixes
+
+- Avoid constantly recomputing the popover position.
+
 ## 6.0.0 (2018-11-12)
 
 ### Breaking Change

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -53,7 +53,7 @@ class Popover extends Component {
 			contentHeight: null,
 			contentWidth: null,
 			isMobile: false,
-			popoverSize: {},
+			popoverSize: null,
 		};
 
 		// Property used keep track of the previous anchor rect
@@ -144,7 +144,7 @@ class Popover extends Component {
 			width: contentRect.width,
 			height: contentRect.height,
 		};
-		const didPopoverSizeChange = (
+		const didPopoverSizeChange = ! this.state.popoverSize || (
 			popoverSize.width !== this.state.popoverSize.width ||
 			popoverSize.height !== this.state.popoverSize.height
 		);

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -56,7 +56,7 @@ class Popover extends Component {
 			popoverSize: null,
 		};
 
-		// Property used keep track of the previous anchor rect
+		// Property used keep track of the previous anchor rectangle
 		// used to compute the popover position and size.
 		this.anchorRect = {};
 	}

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -56,7 +56,7 @@ class Popover extends Component {
 			popoverSize: null,
 		};
 
-		// Property used keep track of the previous anchor rectangle
+		// Property used keep track of the previous anchor rect
 		// used to compute the popover position and size.
 		this.anchorRect = {};
 	}


### PR DESCRIPTION
On small screens where the inserter can't show up fully, this PR #11257 introduced a small regression where the popover was recomputing its height constantly causing this weird behavior.

![popoverdance](https://user-images.githubusercontent.com/272444/48337103-4f837980-e662-11e8-82d3-47b93e34e937.gif)

In This PR, I'm updating it to only recompute if the anchor position changes, we can't recompute if the popover size change because the recomputing itself can cause the popover size to change causing an infinite loop.