### PR TITLE
Make cssnano remove all comments

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -179,9 +179,9 @@ const config = {
 							require( 'cssnano' )( {
 								preset: [ 'default', {
 									discardComments: {
-							                    removeAll: true,
-							                },
-								}]
+										removeAll: true,
+									},
+								} ],
 							} ),
 						] )
 							.process( content, { from: 'src/app.css', to: 'dest/app.css' } )

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -177,7 +177,11 @@ const config = {
 					if ( config.mode === 'production' ) {
 						return postcss( [
 							require( 'cssnano' )( {
-								preset: 'default',
+								preset: [ 'default', {
+									discardComments: {
+							                    removeAll: true,
+							                },
+								}]
 							} ),
 						] )
 							.process( content, { from: 'src/app.css', to: 'dest/app.css' } )


### PR DESCRIPTION
As referenced by @jasmussen [here](https://github.com/WordPress/gutenberg/pull/11752#issuecomment-437832125), this should fix the fact that `/*` style comments are not removed by cssnano.


