### PR TITLE
Polish appender in mobile and nested contexts.

### DIFF
--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -103,12 +103,6 @@
 			// WritingFlow click redirector.
 			outline: 1px solid transparent;
 		}
-
-		@include break-small() {
-			.editor-default-block-appender__content {
-				padding: 0 $block-padding;
-			}
-		}
 	}
 
 	// Ensure that the height of the first appender, and the one between blocks, is the same as text.

--- a/packages/editor/src/components/default-block-appender/style.scss
+++ b/packages/editor/src/components/default-block-appender/style.scss
@@ -8,8 +8,6 @@
 		background: none;
 		box-shadow: none;
 		display: block;
-		margin-left: $border-width;
-		margin-right: $border-width;
 		cursor: text;
 		width: 100%;
 		outline: $border-width solid transparent;
@@ -17,7 +15,9 @@
 		resize: none;
 
 		// Emulate the dimensions of a paragraph block.
-		padding: 0 #{ $block-padding };
+		// On mobile and in nested contexts, the plus to add blocks shows up on the right.
+		// The rightmost padding makes sure it doesn't overlap text.
+		padding: 0 #{ $block-padding + $icon-button-size } 0 $block-padding;
 
 		// Use opacity to work in various editor styles.
 		color: $dark-opacity-300;

--- a/packages/editor/src/components/rich-text/style.scss
+++ b/packages/editor/src/components/rich-text/style.scss
@@ -97,6 +97,15 @@
 		& > p {
 			margin-top: 0;
 		}
+
+		// Ensure that if placeholder wraps (mobile/nested contexts) the clickable area is full-height.
+		height: 100%;
+
+		// On mobile and in nested contexts, the plus to add blocks shows up on the right.
+		// This padding makes sure it doesn't overlap text.
+		& + .editor-rich-text__tinymce {
+			padding-right: $icon-button-size;
+		}
 	}
 
 	// Placeholder text.


### PR DESCRIPTION
On mobile, and in nested contexts, the empty block / appender shows a plus to add a block on the right side. But recent editor style font changes and changes to the placeholder text have revealed that with certain font lengths, this plus button might overlap the text.

This PR fixes that, so there's always some right-padding that matches the width of the icon, so it never overlaps text.

Additionally, the hit are is increased so it's the same height as the placeholder text, in case the placeholder text wraps

Before:

<img width="370" alt="screenshot 2018-11-12 at 12 20 46" src="https://user-images.githubusercontent.com/1204802/48345903-a8124100-e679-11e8-9290-717b1aeeb5a4.png">

After:

<img width="691" alt="screenshot 2018-11-12 at 12 32 58" src="https://user-images.githubusercontent.com/1204802/48345911-aba5c800-e679-11e8-9afd-5bce39547b2e.png">

The following shows the hit area change only, and the red background is only there to debug. Also note how I changed the placeholder text on the left to not wrap, to verify no negative consequances to the height change. 

<img width="812" alt="screenshot 2018-11-12 at 12 25 18" src="https://user-images.githubusercontent.com/1204802/48345915-b1031280-e679-11e8-9f2e-843897ff9c77.png">

