### PR TITLE
Fix disabled publish/update button still clickable

### DIFF
--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -79,7 +79,7 @@ export class PostPublishButton extends Component {
 		};
 
 		const buttonProps = {
-			'aria-disabled': isButtonDisabled,
+			disabled: isButtonDisabled,
 			className: 'editor-post-publish-button',
 			isBusy: isSaving && isPublished,
 			isLarge: true,
@@ -88,7 +88,7 @@ export class PostPublishButton extends Component {
 		};
 
 		const toggleProps = {
-			'aria-disabled': isToggleDisabled,
+			disabled: isToggleDisabled,
 			'aria-expanded': isOpen,
 			className: 'editor-post-publish-panel__toggle',
 			isBusy: isSaving && isPublished,

--- a/packages/editor/src/components/post-publish-button/test/index.js
+++ b/packages/editor/src/components/post-publish-button/test/index.js
@@ -11,7 +11,7 @@ import { PostPublishButton } from '../';
 jest.mock( '../../../../../components/src/button' );
 
 describe( 'PostPublishButton', () => {
-	describe( 'aria-disabled', () => {
+	describe( 'disabled', () => {
 		it( 'should be true if post is currently saving', () => {
 			const wrapper = shallow(
 				<PostPublishButton
@@ -21,7 +21,7 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			expect( wrapper.prop( 'aria-disabled' ) ).toBe( true );
+			expect( wrapper.prop( 'disabled' ) ).toBe( true );
 		} );
 
 		it( 'should be true if forceIsSaving is true', () => {
@@ -33,7 +33,7 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			expect( wrapper.prop( 'aria-disabled' ) ).toBe( true );
+			expect( wrapper.prop( 'disabled' ) ).toBe( true );
 		} );
 
 		it( 'should be true if post is not publishable and not forceIsDirty', () => {
@@ -45,7 +45,7 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			expect( wrapper.prop( 'aria-disabled' ) ).toBe( true );
+			expect( wrapper.prop( 'disabled' ) ).toBe( true );
 		} );
 
 		it( 'should be true if post is not saveable', () => {
@@ -56,7 +56,7 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			expect( wrapper.prop( 'aria-disabled' ) ).toBe( true );
+			expect( wrapper.prop( 'disabled' ) ).toBe( true );
 		} );
 
 		it( 'should be true if post saving is locked', () => {
@@ -68,7 +68,7 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			expect( wrapper.prop( 'aria-disabled' ) ).toBe( true );
+			expect( wrapper.prop( 'disabled' ) ).toBe( true );
 		} );
 
 		it( 'should be false if post is saveable but not publishable and forceIsDirty is true', () => {
@@ -80,7 +80,7 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			expect( wrapper.prop( 'aria-disabled' ) ).toBe( false );
+			expect( wrapper.prop( 'disabled' ) ).toBe( false );
 		} );
 
 		it( 'should be false if post is publishave and saveable', () => {
@@ -91,7 +91,7 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			expect( wrapper.prop( 'aria-disabled' ) ).toBe( false );
+			expect( wrapper.prop( 'disabled' ) ).toBe( false );
 		} );
 	} );
 

--- a/test/e2e/specs/publish-button.test.js
+++ b/test/e2e/specs/publish-button.test.js
@@ -22,23 +22,23 @@ describe( 'PostPublishButton', () => {
 	} );
 
 	it( 'should be disabled when post is not saveable', async () => {
-		const publishButton = await page.$( '.editor-post-publish-button[aria-disabled="true"]' );
+		const publishButton = await page.$( '.editor-post-publish-button:disabled' );
 		expect( publishButton ).not.toBeNull();
 	} );
 
 	it( 'should be disabled when post is being saved', async () => {
 		await page.type( '.editor-post-title__input', 'E2E Test Post' ); // Make it saveable
-		expect( await page.$( '.editor-post-publish-button[aria-disabled="true"]' ) ).toBeNull();
+		expect( await page.$( '.editor-post-publish-button:disabled' ) ).toBeNull();
 
 		await page.click( '.editor-post-save-draft' );
-		expect( await page.$( '.editor-post-publish-button[aria-disabled="true"]' ) ).not.toBeNull();
+		expect( await page.$( '.editor-post-publish-button:disabled' ) ).not.toBeNull();
 	} );
 
 	it( 'should be disabled when metabox is being saved', async () => {
 		await page.type( '.editor-post-title__input', 'E2E Test Post' ); // Make it saveable
-		expect( await page.$( '.editor-post-publish-button[aria-disabled="true"]' ) ).toBeNull();
+		expect( await page.$( '.editor-post-publish-button:disabled' ) ).toBeNull();
 
 		await page.evaluate( () => window.wp.data.dispatch( 'core/edit-post' ).requestMetaBoxUpdates() );
-		expect( await page.$( '.editor-post-publish-button[aria-disabled="true"]' ) ).not.toBeNull();
+		expect( await page.$( '.editor-post-publish-button:disabled' ) ).not.toBeNull();
 	} );
 } );


### PR DESCRIPTION
## Description
Recently the `disabled` attribute for the publish/update button was replaced by `aria-disabled` to avoid focus loss.
https://github.com/WordPress/gutenberg/commit/fc034921667ee95e4befe1edd89ae69a4bd646bf

The problem with `aria-disabled` is that it won't block the functionality of the button - saving is still possible, using `disabled` will block the functionality as expected. 

In addition `aria-disabled` on a button is agains W3C standards:

> Only use the aria-disabled attribute for elements that are not allowed to have a disabled attribute in HTML5

https://www.w3.org/TR/html-aria/#attr-disabled

## How has this been tested?
Open a post and click "Update" without any changes. The post does not save. 

## Types of changes
Replaced `aria-disabled` with `disabled`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

Fixes #11809.