### PR TITLE
Fix regression with unclickable block warnings

### DIFF
--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -201,11 +201,13 @@
 
 	// Warnings
 	&.has-warning .editor-block-list__block-edit {
+		// When a block has a warning, you shouldn't be able to manipulate the contents.
 		> * {
 			pointer-events: none;
 			user-select: none;
 		}
 
+		// Allow the warning action buttons to be manipulable.
 		.editor-warning {
 			pointer-events: all;
 		}

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -201,9 +201,13 @@
 
 	// Warnings
 	&.has-warning .editor-block-list__block-edit {
-		> :not(.editor-warning) {
+		> * {
 			pointer-events: none;
 			user-select: none;
+		}
+
+		.editor-warning {
+			pointer-events: all;
 		}
 	}
 

--- a/packages/editor/src/components/warning/style.scss
+++ b/packages/editor/src/components/warning/style.scss
@@ -34,7 +34,6 @@
 
 	.editor-warning__action {
 		margin: 0 6px 0 0;
-		margin-left: 0;
 	}
 }
 


### PR DESCRIPTION
Fixes #11764.

This PR makes the "Resolve" and "Convert to HTML" buttons clickable again.

![screenshot 2018-11-12 at 17 20 01](https://user-images.githubusercontent.com/1204802/48360341-4c5aae80-e69f-11e8-9437-d0ce94170fe2.png)
