### PR TITLE
Block API: Consider encoding-normalized text as equivalent

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -470,6 +470,7 @@ function gutenberg_register_scripts_and_styles() {
 			'wp-dom',
 			'wp-element',
 			'wp-hooks',
+			'wp-html-entities',
 			'wp-i18n',
 			'wp-is-shallow-equal',
 			'wp-polyfill',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2365,6 +2365,7 @@
 				"@wordpress/dom": "file:packages/dom",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",
+				"@wordpress/html-entities": "file:packages/html-entities",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/shortcode": "file:packages/shortcode",

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.3.2 (Unreleased)
+
+### Bug Fix
+
+- The block validator is more lenient toward equivalent encoding forms.
+
 ## 5.3.1 (2018-11-12)
 
 ## 5.3.0 (2018-11-09)

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -29,6 +29,7 @@
 		"@wordpress/dom": "file:../dom",
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",
+		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/shortcode": "file:../shortcode",

--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -46,8 +46,8 @@ describe( 'validation', () => {
 			expect( new IdentityEntityParser() instanceof IdentityEntityParser ).toBe( true );
 		} );
 
-		it( 'returns parse as undefined', () => {
-			expect( new IdentityEntityParser().parse( 'quot' ) ).toBe( undefined );
+		it( 'returns parse as decoded value', () => {
+			expect( new IdentityEntityParser().parse( 'quot' ) ).toBe( '"' );
 		} );
 	} );
 
@@ -124,15 +124,6 @@ describe( 'validation', () => {
 			const isEqual = isEquivalentTextTokens(
 				{ chars: '  a \t  b \n c' },
 				{ chars: 'a \n b \t c  ' },
-			);
-
-			expect( isEqual ).toBe( true );
-		} );
-
-		it( 'should return true on normalized text encoding', () => {
-			const isEqual = isEquivalentTextTokens(
-				{ chars: '&#x1f641;' },
-				{ chars: '🙁' },
 			);
 
 			expect( isEqual ).toBe( true );
@@ -399,8 +390,8 @@ describe( 'validation', () => {
 
 		it( 'should return true for effectively equivalent html', () => {
 			const isEquivalent = isEquivalentHTML(
-				'<div>&quot; Hello<span   class="b a" id="foo"> World! &#128517;</  span>  "</div>',
-				'<div  >" Hello\n<span id="foo" class="a  b">World! 😅</span>"</div>'
+				'<div>&quot; Hello<span   class="b a" id="foo" data-foo="here &mdash; there"> World! &#128517;</  span>  "</div>',
+				'<div  >" Hello\n<span id="foo" class="a  b" data-foo="here — there">World! 😅</span>"</div>'
 			);
 
 			expect( isEquivalent ).toBe( true );

--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -2,10 +2,11 @@
  * Internal dependencies
  */
 import {
+	IdentityEntityParser,
 	getTextPiecesSplitOnWhitespace,
 	getTextWithCollapsedWhitespace,
 	getMeaningfulAttributePairs,
-	isEqualTextTokensWithCollapsedWhitespace,
+	isEquivalentTextTokens,
 	getNormalizedStyleValue,
 	getStyleProperties,
 	isEqualAttributesOfName,
@@ -37,6 +38,16 @@ describe( 'validation', () => {
 	afterEach( () => {
 		getBlockTypes().forEach( ( block ) => {
 			unregisterBlockType( block.name );
+		} );
+	} );
+
+	describe( 'IdentityEntityParser', () => {
+		it( 'can be constructed', () => {
+			expect( new IdentityEntityParser() instanceof IdentityEntityParser ).toBe( true );
+		} );
+
+		it( 'returns parse as undefined', () => {
+			expect( new IdentityEntityParser().parse( 'quot' ) ).toBe( undefined );
 		} );
 	} );
 
@@ -98,9 +109,9 @@ describe( 'validation', () => {
 		} );
 	} );
 
-	describe( 'isEqualTextTokensWithCollapsedWhitespace()', () => {
+	describe( 'isEquivalentTextTokens()', () => {
 		it( 'should return false if not equal with collapsed whitespace', () => {
-			const isEqual = isEqualTextTokensWithCollapsedWhitespace(
+			const isEqual = isEquivalentTextTokens(
 				{ chars: '  a \t  b \n c' },
 				{ chars: 'a \n c \t b  ' },
 			);
@@ -110,9 +121,18 @@ describe( 'validation', () => {
 		} );
 
 		it( 'should return true if equal with collapsed whitespace', () => {
-			const isEqual = isEqualTextTokensWithCollapsedWhitespace(
+			const isEqual = isEquivalentTextTokens(
 				{ chars: '  a \t  b \n c' },
 				{ chars: 'a \n b \t c  ' },
+			);
+
+			expect( isEqual ).toBe( true );
+		} );
+
+		it( 'should return true on normalized text encoding', () => {
+			const isEqual = isEquivalentTextTokens(
+				{ chars: '&#x1f641;' },
+				{ chars: '🙁' },
 			);
 
 			expect( isEqual ).toBe( true );
@@ -379,8 +399,8 @@ describe( 'validation', () => {
 
 		it( 'should return true for effectively equivalent html', () => {
 			const isEquivalent = isEquivalentHTML(
-				'<div>&quot; Hello<span   class="b a" id="foo"> World!</  span>  "</div>',
-				'<div  >" Hello\n<span id="foo" class="a  b">World!</span>"</div>'
+				'<div>&quot; Hello<span   class="b a" id="foo"> World! &#128517;</  span>  "</div>',
+				'<div  >" Hello\n<span id="foo" class="a  b">World! 😅</span>"</div>'
 			);
 
 			expect( isEquivalent ).toBe( true );

--- a/packages/blocks/src/api/validation.js
+++ b/packages/blocks/src/api/validation.js
@@ -152,7 +152,6 @@ const MEANINGFUL_ATTRIBUTES = [
 const TEXT_NORMALIZATIONS = [
 	identity,
 	getTextWithCollapsedWhitespace,
-	decodeEntities,
 ];
 
 /**
@@ -168,10 +167,12 @@ export class IdentityEntityParser {
 	 *
 	 * In this implementation, undefined is always returned.
 	 *
+	 * @param {string} entity Entity fragment discovered in HTML.
+	 *
 	 * @return {?string} Entity substitute value.
 	 */
-	parse() {
-		return undefined;
+	parse( entity ) {
+		return decodeEntities( '&' + entity + ';' );
 	}
 }
 

--- a/packages/blocks/src/api/validation.js
+++ b/packages/blocks/src/api/validation.js
@@ -1,13 +1,21 @@
 /**
  * External dependencies
  */
-import { tokenize } from 'simple-html-tokenizer';
-import { xor, fromPairs, isEqual, includes, stubTrue } from 'lodash';
+import Tokenizer from 'simple-html-tokenizer/dist/es6/tokenizer';
+import {
+	identity,
+	xor,
+	fromPairs,
+	isEqual,
+	includes,
+	stubTrue,
+} from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import deprecated from '@wordpress/deprecated';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -135,6 +143,39 @@ const MEANINGFUL_ATTRIBUTES = [
 ];
 
 /**
+ * Array of functions which receive a text string on which to apply normalizing
+ * behavior for consideration in text token equivalence, carefully ordered from
+ * least-to-most expensive operations.
+ *
+ * @type {Array}
+ */
+const TEXT_NORMALIZATIONS = [
+	identity,
+	getTextWithCollapsedWhitespace,
+	decodeEntities,
+];
+
+/**
+ * Subsitute EntityParser class for `simple-html-tokenizer` which bypasses
+ * entity substitution in favor of validator's internal normalization.
+ *
+ * @see https://github.com/tildeio/simple-html-tokenizer/tree/master/src/entity-parser.ts
+ */
+export class IdentityEntityParser {
+	/**
+	 * Returns a substitute string for an entity string sequence between `&`
+	 * and `;`, or undefined if no substitution should occur.
+	 *
+	 * In this implementation, undefined is always returned.
+	 *
+	 * @return {?string} Entity substitute value.
+	 */
+	parse() {
+		return undefined;
+	}
+}
+
+/**
  * Object of logger functions.
  */
 const log = ( () => {
@@ -186,6 +227,10 @@ export function getTextPiecesSplitOnWhitespace( text ) {
  * @return {string} Trimmed text with consecutive whitespace collapsed.
  */
 export function getTextWithCollapsedWhitespace( text ) {
+	// This is an overly simplified whitespace comparison. The specification is
+	// more prescriptive of whitespace behavior in inline and block contexts.
+	//
+	// See: https://medium.com/@patrickbrosset/when-does-white-space-matter-in-html-b90e8a7cdd33
 	return getTextPiecesSplitOnWhitespace( text ).join( ' ' );
 }
 
@@ -220,18 +265,28 @@ export function getMeaningfulAttributePairs( token ) {
  *
  * @return {boolean} Whether two text tokens are equivalent.
  */
-export function isEqualTextTokensWithCollapsedWhitespace( actual, expected ) {
-	// This is an overly simplified whitespace comparison. The specification is
-	// more prescriptive of whitespace behavior in inline and block contexts.
-	//
-	// See: https://medium.com/@patrickbrosset/when-does-white-space-matter-in-html-b90e8a7cdd33
-	const isEquivalentText = isEqual( ...[ actual.chars, expected.chars ].map( getTextWithCollapsedWhitespace ) );
+export function isEquivalentTextTokens( actual, expected ) {
+	// This function is intentionally written as syntactically "ugly" as a hot
+	// path optimization. Text is progressively normalized in order from least-
+	// to-most operationally expensive, until the earliest point at which text
+	// can be confidently inferred as being equal.
+	let actualChars = actual.chars;
+	let expectedChars = expected.chars;
 
-	if ( ! isEquivalentText ) {
-		log.warning( 'Expected text `%s`, saw `%s`.', expected.chars, actual.chars );
+	for ( let i = 0; i < TEXT_NORMALIZATIONS.length; i++ ) {
+		const normalize = TEXT_NORMALIZATIONS[ i ];
+
+		actualChars = normalize( actualChars );
+		expectedChars = normalize( expectedChars );
+
+		if ( actualChars === expectedChars ) {
+			return true;
+		}
 	}
 
-	return isEquivalentText;
+	log.warning( 'Expected text `%s`, saw `%s`.', expected.chars, actual.chars );
+
+	return false;
 }
 
 /**
@@ -359,8 +414,8 @@ export const isEqualTokensOfType = {
 			...[ actual, expected ].map( getMeaningfulAttributePairs )
 		);
 	},
-	Chars: isEqualTextTokensWithCollapsedWhitespace,
-	Comment: isEqualTextTokensWithCollapsedWhitespace,
+	Chars: isEquivalentTextTokens,
+	Comment: isEquivalentTextTokens,
 };
 
 /**
@@ -396,7 +451,7 @@ export function getNextNonWhitespaceToken( tokens ) {
  */
 function getHTMLTokens( html ) {
 	try {
-		return tokenize( html );
+		return new Tokenizer( new IdentityEntityParser() ).tokenize( html );
 	} catch ( e ) {
 		log.warning( 'Malformed HTML detected: %s', html );
 	}

--- a/test/unit/jest.config.json
+++ b/test/unit/jest.config.json
@@ -14,5 +14,8 @@
 		"/test/e2e",
 		"<rootDir>/.*/build/",
 		"<rootDir>/.*/build-module/"
+	],
+	"transformIgnorePatterns": [
+		"node_modules/(?!(simple-html-tokenizer)/)"
 	]
 }


### PR DESCRIPTION
Fixes #9906

This pull request seeks to improve the block validation step to allow more leniency for effectively equivalent text encoded in varying forms.

The changes here were authored in such a way where there may be a slight performance benefit over master, both in a reduction of bundle size (an approximate 18% reduction gzipped on the `blocks` module) and in optimizing for an early return of equality if normalization (whitespace or encoding) is not necessary to determine equivalence of text sequences.

**Implementation notes:**

In the process of implementing further text normalization here, it was discovered that the underlying `simple-html-tokenizer` performs [its own entities substitution](https://github.com/tildeio/simple-html-tokenizer/blob/master/src/entity-parser.ts) when encountering text tokens in an HTML string. For the purposes of validation, this was considered to be redundant and was thus swapped with a stub entity parser in the included changes. Note that this is the change which enables the significant drop in bundle size. Note also as an aside that there's desire to consolidate to a single parser between the blocks parse and validator parse, so the use of `simple-html-tokenizer` may or may not persist far into the future.

**Testing instructions:**

Verify that block invalidation is not triggered by encoding variations.

For example, inserting the following HTML as the contents of a post (in Text Mode, Classic Editor Text tab, or directly in the database) should not be presented as an invalid block when next viewing the Visual Mode of the editor:

```html
<!-- wp:paragraph -->
<p>This works. &#128517;</p>
<!-- /wp:paragraph -->
```

cc @MarkRH