### PR TITLE
Fix dependencies for @wordpress/components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2395,6 +2395,7 @@
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/keycodes": "file:packages/keycodes",
+				"@wordpress/rich-text": "file:packages/rich-text",
 				"@wordpress/url": "file:packages/url",
 				"classnames": "^2.2.5",
 				"clipboard": "^2.0.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -31,6 +31,7 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/keycodes": "file:../keycodes",
+		"@wordpress/rich-text": "file:../rich-text",
 		"@wordpress/url": "file:../url",
 		"classnames": "^2.2.5",
 		"clipboard": "^2.0.1",


### PR DESCRIPTION
## Description

Fixes #11017 and maybe woocommerce/wc-admin#616

## How has this been tested?

Test project at https://github.com/georgeh/issue-11017

Confirmed that webpack cannot build `@wordpress/components` without `@wordpress/rich-text`.

Due to the way the packages are referenced, it may not be possible to test until this change is published. Gutenberg packages use relative paths, which makes it so that they cannot be installed via git branches.
