### PR TITLE
Hooks: Dispatch all heartbeat events as hooks actions

### DIFF
--- a/lib/packages-dependencies.php
+++ b/lib/packages-dependencies.php
@@ -131,7 +131,6 @@ return array(
 		'wp-viewport',
 	),
 	'wp-editor'                             => array(
-		'jquery',
 		'lodash',
 		'wp-tinymce-lists',
 		'wp-a11y',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2562,7 +2562,6 @@
 				"classnames": "^2.2.5",
 				"dom-scroll-into-view": "^1.2.1",
 				"inherits": "^2.0.3",
-				"jquery": "^3.3.1",
 				"lodash": "^4.17.10",
 				"memize": "^1.0.5",
 				"react-autosize-textarea": "^3.0.2",
@@ -12773,11 +12772,6 @@
 			"requires": {
 				"merge-stream": "^1.0.1"
 			}
-		},
-		"jquery": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-			"integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
 		},
 		"js-base64": {
 			"version": "2.4.6",

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 9.0.7 (Unreleased)
+
+### Internal
+
+- Removed `jQuery` dependency
+
 ## 9.0.6 (2018-12-18)
 
 ### Bug Fixes

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -47,7 +47,6 @@
 		"classnames": "^2.2.5",
 		"dom-scroll-into-view": "^1.2.1",
 		"inherits": "^2.0.3",
-		"jquery": "^3.3.1",
 		"lodash": "^4.17.10",
 		"memize": "^1.0.5",
 		"react-autosize-textarea": "^3.0.2",

--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -104,18 +104,15 @@ class PostLockedModal extends Component {
 			return;
 		}
 
-		const data = {
-			action: 'wp-remove-post-lock',
-			_wpnonce: postLockUtils.unlockNonce,
-			post_ID: postId,
-			active_post_lock: activePostLock,
-		};
+		const data = new window.FormData();
+		data.append( 'action', 'wp-remove-post-lock' );
+		data.append( '_wpnonce', postLockUtils.unlockNonce );
+		data.append( 'post_ID', postId );
+		data.append( 'active_post_lock', activePostLock );
 
-		jQuery.post( {
-			async: false,
-			url: postLockUtils.ajaxUrl,
-			data,
-		} );
+		const xhr = new window.XMLHttpRequest();
+		xhr.open( 'POST', postLockUtils.ajaxUrl, false );
+		xhr.send( data );
 	}
 
 	render() {

--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -62,10 +62,9 @@ class PostLockedModal extends Component {
 	 * When the user does not send a heartbeat in a heartbeat-tick
 	 * the user is no longer editing and another user can start editing.
 	 *
-	 * @param {Object} event Event.
-	 * @param {Object} data  Data to send in the heartbeat request.
+	 * @param {Object} data Data to send in the heartbeat request.
 	 */
-	sendPostLock( event, data ) {
+	sendPostLock( data ) {
 		const { isLocked, activePostLock, postId } = this.props;
 		if ( isLocked ) {
 			return;
@@ -80,10 +79,9 @@ class PostLockedModal extends Component {
 	/**
 	 * Refresh post locks: update the lock string or show the dialog if somebody has taken over editing.
 	 *
-	 * @param {Object} event Event.
-	 * @param {Object} data  Data received in the heartbeat request
+	 * @param {Object} data Data received in the heartbeat request
 	 */
-	receivePostLock( event, data ) {
+	receivePostLock( data ) {
 		if ( ! data[ 'wp-refresh-post-lock' ] ) {
 			return;
 		}

--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -240,8 +240,8 @@ export default compose(
 			updatePostLock,
 		};
 	} ),
+	withInstanceId,
 	withGlobalEvents( {
 		beforeunload: 'releasePostLock',
-	} ),
-	withInstanceId,
+	} )
 )( PostLockedModal );

--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -30,19 +30,19 @@ class PostLockedModal extends Component {
 	}
 
 	componentDidMount() {
-		const hookNamePrefix = this.getHookNamePrefix();
+		const hookName = this.getHookName();
 
 		// Details on these events on the Heartbeat API docs
 		// https://developer.wordpress.org/plugins/javascript/heartbeat-api/
-		addAction( 'heartbeat.send', hookNamePrefix + '-send', this.sendPostLock );
-		addAction( 'heartbeat.tick', hookNamePrefix + '-tick', this.receivePostLock );
+		addAction( 'heartbeat.send', hookName, this.sendPostLock );
+		addAction( 'heartbeat.tick', hookName, this.receivePostLock );
 	}
 
 	componentWillUnmount() {
-		const hookNamePrefix = this.getHookNamePrefix();
+		const hookName = this.getHookName();
 
-		removeAction( 'heartbeat.send', hookNamePrefix + '-send' );
-		removeAction( 'heartbeat.tick', hookNamePrefix + '-tick' );
+		removeAction( 'heartbeat.send', hookName );
+		removeAction( 'heartbeat.tick', hookName );
 	}
 
 	/**
@@ -51,9 +51,9 @@ class PostLockedModal extends Component {
 	 *
 	 * @return {string} Hook name prefix.
 	 */
-	getHookNamePrefix() {
+	getHookName() {
 		const { instanceId } = this.props;
-		return 'core/editor/post-locked-modal-' + instanceId + '-heartbeat';
+		return 'core/editor/post-locked-modal-' + instanceId;
 	}
 
 	/**


### PR DESCRIPTION
Related: #4217

This pull request seeks to enhance our handling of heartbeat-to-hooks upgrade to consistently fire all heartbeat events as actions. In addition to promoting consistency, it enables us to refactor the PostLockedModal to avoid having the `editor` module depend on jQuery.

**Testing instructions:**

Verify there are no regressions in the behavior of post locking by repeating testing instructions from #4217.

Verify there are no regressions in other existing usage of upgrade heartbeat events, i.e. the [`api-fetch` nonce middleware](https://github.com/WordPress/gutenberg/blob/3eb44f43b2fe3cedaea4e752c457e02e8f49e270/packages/api-fetch/src/middlewares/nonce.js#L15).