### PR TITLE
Update displayed permalink when slug is cleared

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-link/index.js
+++ b/packages/edit-post/src/components/sidebar/post-link/index.js
@@ -12,6 +12,7 @@ import { PanelBody, TextControl } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose, ifCondition, withState } from '@wordpress/compose';
 import { addQueryArgs } from '@wordpress/url';
+import { cleanForSlug } from '@wordpress/editor';
 
 /**
  * Module Constants
@@ -27,15 +28,18 @@ function PostLink( {
 	editPermalink,
 	forceEmptyField,
 	setState,
+	postTitle,
+	postSlug,
 } ) {
-	const { prefix, postName, suffix } = permalinkParts;
+	const { prefix, suffix } = permalinkParts;
 	let prefixElement, postNameElement, suffixElement;
+	const currentSlug = postSlug || cleanForSlug( postTitle );
 	if ( isEditable ) {
 		prefixElement = prefix && (
 			<span className="edit-post-post-link__link-prefix">{ prefix }</span>
 		);
-		postNameElement = postName && (
-			<span className="edit-post-post-link__link-post-name">{ postName }</span>
+		postNameElement = currentSlug && (
+			<span className="edit-post-post-link__link-post-name">{ currentSlug }</span>
 		);
 		suffixElement = suffix && (
 			<span className="edit-post-post-link__link-suffix">{ suffix }</span>
@@ -51,7 +55,7 @@ function PostLink( {
 			{ isEditable && (
 				<TextControl
 					label={ __( 'URL' ) }
-					value={ forceEmptyField ? '' : postName }
+					value={ forceEmptyField ? '' : currentSlug }
 					onChange={ ( newValue ) => {
 						editPermalink( newValue );
 						// When we delete the field the permalink gets
@@ -66,6 +70,14 @@ function PostLink( {
 							}
 							return;
 						}
+						if ( forceEmptyField ) {
+							setState( {
+								forceEmptyField: false,
+							} );
+						}
+					} }
+					onBlur={ ( event ) => {
+						editPermalink( cleanForSlug( event.target.value ) );
 						if ( forceEmptyField ) {
 							setState( {
 								forceEmptyField: false,
@@ -128,6 +140,8 @@ export default compose( [
 			isOpened: isEditorPanelOpened( PANEL_NAME ),
 			permalinkParts: getPermalinkParts(),
 			isViewable: get( postType, [ 'viewable' ], false ),
+			postTitle: getEditedPostAttribute( 'title' ),
+			postSlug: getEditedPostAttribute( 'slug' ),
 		};
 	} ),
 	ifCondition( ( { isNew, postLink, isViewable } ) => {

--- a/packages/edit-post/src/components/sidebar/post-link/index.js
+++ b/packages/edit-post/src/components/sidebar/post-link/index.js
@@ -30,10 +30,11 @@ function PostLink( {
 	setState,
 	postTitle,
 	postSlug,
+	postID,
 } ) {
 	const { prefix, suffix } = permalinkParts;
 	let prefixElement, postNameElement, suffixElement;
-	const currentSlug = postSlug || cleanForSlug( postTitle );
+	const currentSlug = postSlug || cleanForSlug( postTitle ) || postID;
 	if ( isEditable ) {
 		prefixElement = prefix && (
 			<span className="edit-post-post-link__link-prefix">{ prefix }</span>
@@ -129,7 +130,7 @@ export default compose( [
 			getPostType,
 		} = select( 'core' );
 
-		const { link } = getCurrentPost();
+		const { link, id } = getCurrentPost();
 		const postTypeName = getEditedPostAttribute( 'type' );
 		const postType = getPostType( postTypeName );
 		return {
@@ -142,6 +143,7 @@ export default compose( [
 			isViewable: get( postType, [ 'viewable' ], false ),
 			postTitle: getEditedPostAttribute( 'title' ),
 			postSlug: getEditedPostAttribute( 'slug' ),
+			postID: id,
 		};
 	} ),
 	ifCondition( ( { isNew, postLink, isViewable } ) => {

--- a/packages/editor/src/components/post-permalink/editor.js
+++ b/packages/editor/src/components/post-permalink/editor.js
@@ -7,19 +7,24 @@ import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 
+/**
+ * Internal dependencies
+ */
+import { cleanForSlug } from '../../utils/url';
+
 class PostPermalinkEditor extends Component {
-	constructor( { permalinkParts } ) {
+	constructor( { permalinkParts, postSlug } ) {
 		super( ...arguments );
 
 		this.state = {
-			editedPostName: permalinkParts.postName,
+			editedPostName: postSlug || permalinkParts.postName,
 		};
 
 		this.onSavePermalink = this.onSavePermalink.bind( this );
 	}
 
 	onSavePermalink( event ) {
-		const postName = this.state.editedPostName.replace( /\s+/g, '-' );
+		const postName = cleanForSlug( this.state.editedPostName );
 
 		event.preventDefault();
 

--- a/packages/editor/src/components/post-permalink/editor.js
+++ b/packages/editor/src/components/post-permalink/editor.js
@@ -13,11 +13,11 @@ import { compose } from '@wordpress/compose';
 import { cleanForSlug } from '../../utils/url';
 
 class PostPermalinkEditor extends Component {
-	constructor( { permalinkParts, postSlug } ) {
+	constructor( { permalinkParts, slug } ) {
 		super( ...arguments );
 
 		this.state = {
-			editedPostName: postSlug || permalinkParts.postName,
+			editedPostName: slug || permalinkParts.postName,
 		};
 
 		this.onSavePermalink = this.onSavePermalink.bind( this );

--- a/packages/editor/src/components/post-permalink/index.js
+++ b/packages/editor/src/components/post-permalink/index.js
@@ -17,7 +17,7 @@ import { safeDecodeURI } from '@wordpress/url';
  * Internal Dependencies
  */
 import PostPermalinkEditor from './editor.js';
-import { getWPAdminURL } from '../../utils/url';
+import { getWPAdminURL, cleanForSlug } from '../../utils/url';
 
 class PostPermalink extends Component {
 	constructor() {
@@ -57,13 +57,18 @@ class PostPermalink extends Component {
 	}
 
 	render() {
-		const { isNew, postLink, isEditable, samplePermalink, isPublished } = this.props;
-		const { isCopied, isEditingPermalink } = this.state;
-		const ariaLabel = isCopied ? __( 'Permalink copied' ) : __( 'Copy the permalink' );
+		const { isNew, postLink, permalinkParts, postSlug, postTitle, isEditable, isPublished } = this.props;
 
 		if ( isNew || ! postLink ) {
 			return null;
 		}
+
+		const { isCopied, isEditingPermalink } = this.state;
+		const ariaLabel = isCopied ? __( 'Permalink copied' ) : __( 'Copy the permalink' );
+
+		const { prefix, suffix } = permalinkParts;
+		const slug = postSlug || cleanForSlug( postTitle );
+		const samplePermalink = ( isEditable ) ? prefix + slug + suffix : prefix;
 
 		return (
 			<div className="editor-post-permalink">
@@ -92,6 +97,7 @@ class PostPermalink extends Component {
 
 				{ isEditingPermalink &&
 					<PostPermalinkEditor
+						postSlug={ slug }
 						onSave={ () => this.setState( { isEditingPermalink: false } ) }
 					/>
 				}
@@ -128,7 +134,8 @@ export default compose( [
 			isEditedPostNew,
 			isPermalinkEditable,
 			getCurrentPost,
-			getPermalink,
+			getPermalinkParts,
+			getEditedPostAttribute,
 			isCurrentPostPublished,
 		} = select( 'core/editor' );
 
@@ -137,8 +144,9 @@ export default compose( [
 		return {
 			isNew: isEditedPostNew(),
 			postLink: link,
+			permalinkParts: getPermalinkParts(),
+			postSlug: getEditedPostAttribute( 'slug' ),
 			isEditable: isPermalinkEditable(),
-			samplePermalink: getPermalink(),
 			isPublished: isCurrentPostPublished(),
 		};
 	} ),

--- a/packages/editor/src/components/post-permalink/index.js
+++ b/packages/editor/src/components/post-permalink/index.js
@@ -97,7 +97,7 @@ class PostPermalink extends Component {
 
 				{ isEditingPermalink &&
 					<PostPermalinkEditor
-						postSlug={ slug }
+						slug={ slug }
 						onSave={ () => this.setState( { isEditingPermalink: false } ) }
 					/>
 				}

--- a/packages/editor/src/components/post-permalink/index.js
+++ b/packages/editor/src/components/post-permalink/index.js
@@ -148,6 +148,7 @@ export default compose( [
 			postSlug: getEditedPostAttribute( 'slug' ),
 			isEditable: isPermalinkEditable(),
 			isPublished: isCurrentPostPublished(),
+			postTitle: getEditedPostAttribute( 'title' ),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/editor/src/components/post-permalink/index.js
+++ b/packages/editor/src/components/post-permalink/index.js
@@ -57,7 +57,7 @@ class PostPermalink extends Component {
 	}
 
 	render() {
-		const { isNew, postLink, permalinkParts, postSlug, postTitle, isEditable, isPublished } = this.props;
+		const { isNew, postLink, permalinkParts, postSlug, postTitle, postID, isEditable, isPublished } = this.props;
 
 		if ( isNew || ! postLink ) {
 			return null;
@@ -67,7 +67,7 @@ class PostPermalink extends Component {
 		const ariaLabel = isCopied ? __( 'Permalink copied' ) : __( 'Copy the permalink' );
 
 		const { prefix, suffix } = permalinkParts;
-		const slug = postSlug || cleanForSlug( postTitle );
+		const slug = postSlug || cleanForSlug( postTitle ) || postID;
 		const samplePermalink = ( isEditable ) ? prefix + slug + suffix : prefix;
 
 		return (
@@ -139,7 +139,7 @@ export default compose( [
 			isCurrentPostPublished,
 		} = select( 'core/editor' );
 
-		const { link } = getCurrentPost();
+		const { id, link } = getCurrentPost();
 
 		return {
 			isNew: isEditedPostNew(),
@@ -149,6 +149,7 @@ export default compose( [
 			isEditable: isPermalinkEditable(),
 			isPublished: isCurrentPostPublished(),
 			postTitle: getEditedPostAttribute( 'title' ),
+			postID: id,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -140,7 +140,7 @@ class PostTitle extends Component {
 								/* eslint-enable jsx-a11y/no-autofocus */
 							/>
 						</KeyboardShortcuts>
-						{ isSelected && isPostTypeViewable && <PostPermalink /> }
+						{ isSelected && isPostTypeViewable && <PostPermalink postTitle={ title } /> }
 					</div>
 				</div>
 			</PostTypeSupportCheck>

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -140,7 +140,7 @@ class PostTitle extends Component {
 								/* eslint-enable jsx-a11y/no-autofocus */
 							/>
 						</KeyboardShortcuts>
-						{ isSelected && isPostTypeViewable && <PostPermalink postTitle={ title } /> }
+						{ isSelected && isPostTypeViewable && <PostPermalink /> }
 					</div>
 				</div>
 			</PostTypeSupportCheck>

--- a/packages/editor/src/utils/index.js
+++ b/packages/editor/src/utils/index.js
@@ -4,3 +4,4 @@
 import mediaUpload from './media-upload';
 
 export { mediaUpload };
+export { cleanForSlug } from './url.js';

--- a/packages/editor/src/utils/test/url.js
+++ b/packages/editor/src/utils/test/url.js
@@ -1,0 +1,10 @@
+/**
+ * Internal dependencies
+ */
+import { cleanForSlug } from '../url';
+
+describe( 'cleanForSlug()', () => {
+	it( 'Should return string prepared for use as url slug', () => {
+		expect( cleanForSlug( ' /Déjà_vu. ' ) ).toBe( 'deja-vu' );
+	} );
+} );

--- a/packages/editor/src/utils/url.js
+++ b/packages/editor/src/utils/url.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { deburr, toLower } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { addQueryArgs } from '@wordpress/url';
@@ -15,4 +20,24 @@ import { addQueryArgs } from '@wordpress/url';
  */
 export function getWPAdminURL( page, query ) {
 	return addQueryArgs( page, query );
+}
+
+/**
+ * Performs some basic cleanup of a string for use as a post slug
+ *
+ * This replicates some of what santize_title() does in WordPress core, but
+ * is only designed to approximate what the slug will be.
+ *
+ * Converts whitespace, periods, forward slashes and underscores to hyphens.
+ * Converts Latin-1 Supplement and Latin Extended-A letters to basic Latin
+ * letters. Removes combining diacritical marks. Converts remaining string
+ * to lowercase. It does not touch octets, HTML entities, or other encoded
+ * characters.
+ *
+ * @param {string} string Title or slug to be processed
+ *
+ * @return {string} Processed string
+ */
+export function cleanForSlug( string ) {
+	return toLower( deburr( string.replace( /[\s\./_]+/g, '-' ) ) );
 }

--- a/packages/editor/src/utils/url.js
+++ b/packages/editor/src/utils/url.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { deburr, toLower } from 'lodash';
+import { deburr, toLower, trim } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -39,5 +39,5 @@ export function getWPAdminURL( page, query ) {
  * @return {string} Processed string
  */
 export function cleanForSlug( string ) {
-	return toLower( deburr( string.replace( /[\s\./_]+/g, '-' ) ) );
+	return toLower( deburr( trim( string.replace( /[\s\./_]+/g, '-' ), '-' ) ) );
 }


### PR DESCRIPTION
## Description
Closes #7002.

This does a simple fix of the issue in #7002 where a permalink slug appears to stay the same after it is cleared, when it should be generated based off of what is in the title. 

With this fix, if the post has not been published yet and the slug has not been manually customized, then the slug continually updates to reflect what is in the post title. Once it's published or the slug is manually edited, it will be frozen to that value. If cleared, it will go back to auto-rendering based off the post title. This is technically the same save functionality as before, it's just displaying a closer representation to the actual value that will be saved. 

I also improved on the existing slug cleaning a bit, without going all the way to a full recreation of `sanitize_title()` in JS. (I also didn't want to call the utility function `sanitizeTitle` for that reason. If someone has a better name suggestion, please let me know.)

## How has this been tested?
1. Create a new post
2. Give it a title
3. Click save draft
4. Edit the slug
5. Change the title 
6. Notice remains the custom slug from step 4
7. Clear the slug and save 
8. Notice it auto-generates the slug from the new post title

## Screenshots <!-- if applicable -->
![permalink-edit](https://user-images.githubusercontent.com/4267290/48380144-a447e400-e6a4-11e8-950d-d7adb075eb6a.gif)

## Additional Notes
Even with this change, we still have some work to do to achieve feature parity between the old and new editor when it comes to editing the permalink. As it stands, it can't be edited until a manual save has occurred, which is confusing. Ideally it would become editable on blur from the title, as it was before. However, in order to do that, we need it to be able treat it like a preview link for autosaves and drafts, since the actual permalink URL won't be available yet. 

I think the ideal fix here is to abstract out the preview link functionality from the preview button component and allow it to be reused here, but that might need to just be a future enhancement post 5.0. This will work in the short-term to improve the permalink editor. 

Fixes #7002