### PR TITLE
Exclude HTML editing from Columns and Column blocks.

### DIFF
--- a/packages/block-library/src/columns/column.js
+++ b/packages/block-library/src/columns/column.js
@@ -21,6 +21,7 @@ export const settings = {
 	supports: {
 		inserter: false,
 		reusable: false,
+		html: false,
 	},
 
 	edit() {

--- a/packages/block-library/src/columns/index.js
+++ b/packages/block-library/src/columns/index.js
@@ -85,6 +85,7 @@ export const settings = {
 
 	supports: {
 		align: [ 'wide', 'full' ],
+		html: false,
 	},
 
 	deprecated: [


### PR DESCRIPTION
Fixes #11438

Editing these wrapper blocks in HTML directly is fragile and prone to breaking the users' content. HTML editing should be left to leaf-blocks.