### PR TITLE
Exclude reusable blocks from the global block count

### DIFF
--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -15,7 +15,6 @@ import {
 	map,
 	orderBy,
 	reduce,
-	size,
 	some,
 } from 'lodash';
 import createSelector from 'rememo';
@@ -728,16 +727,17 @@ export const getClientIdsWithDescendants = createSelector(
  */
 export const getGlobalBlockCount = createSelector(
 	( state, blockName ) => {
+		const clientIds = getClientIdsWithDescendants( state );
 		if ( ! blockName ) {
-			return size( state.editor.present.blocks.byClientId );
+			return clientIds.length;
 		}
-		return reduce(
-			state.editor.present.blocks.byClientId,
-			( count, block ) => block.name === blockName ? count + 1 : count,
-			0
-		);
+		return reduce( clientIds, ( count, clientId ) => {
+			const block = state.editor.present.blocks.byClientId[ clientId ];
+			return block.name === blockName ? count + 1 : count;
+		}, 0 );
 	},
 	( state ) => [
+		state.editor.present.blocks.order,
 		state.editor.present.blocks.byClientId,
 	]
 );

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -2511,54 +2511,44 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'getGlobalBlockCount', () => {
-		it( 'should return the global number of top-level blocks in the post', () => {
-			const state = {
-				editor: {
-					present: {
-						blocks: {
-							byClientId: {
-								23: { clientId: 23, name: 'core/heading', attributes: {} },
-								123: { clientId: 123, name: 'core/paragraph', attributes: {} },
-							},
+		const state = {
+			editor: {
+				present: {
+					blocks: {
+						byClientId: {
+							123: { clientId: 123, name: 'core/heading', attributes: {} },
+							456: { clientId: 456, name: 'core/paragraph', attributes: {} },
+							789: { clientId: 789, name: 'core/paragraph', attributes: {} },
+						},
+						order: {
+							'': [ 123, 456 ],
 						},
 					},
 				},
-			};
+			},
+		};
 
+		it( 'should return the global number of blocks in the post', () => {
 			expect( getGlobalBlockCount( state ) ).toBe( 2 );
 		} );
 
-		it( 'should return the global umber of blocks of a given type', () => {
-			const state = {
-				editor: {
-					present: {
-						blocks: {
-							byClientId: {
-								123: { clientId: 123, name: 'core/columns', attributes: {} },
-								456: { clientId: 456, name: 'core/paragraph', attributes: {} },
-								789: { clientId: 789, name: 'core/paragraph', attributes: {} },
-								124: { clientId: 123, name: 'core/heading', attributes: {} },
-							},
-						},
-					},
-				},
-			};
-
-			expect( getGlobalBlockCount( state, 'core/heading' ) ).toBe( 1 );
+		it( 'should return the global number of blocks in the post of a given type', () => {
+			expect( getGlobalBlockCount( state, 'core/paragraph' ) ).toBe( 1 );
 		} );
 
 		it( 'should return 0 if no blocks exist', () => {
-			const state = {
+			const emptyState = {
 				editor: {
 					present: {
 						blocks: {
 							byClientId: {},
+							order: {},
 						},
 					},
 				},
 			};
-			expect( getGlobalBlockCount( state ) ).toBe( 0 );
-			expect( getGlobalBlockCount( state, 'core/heading' ) ).toBe( 0 );
+			expect( getGlobalBlockCount( emptyState ) ).toBe( 0 );
+			expect( getGlobalBlockCount( emptyState, 'core/heading' ) ).toBe( 0 );
 		} );
 	} );
 


### PR DESCRIPTION
Fixes #11744.

Modifies `getGlobalBlockCount()` to exclude reusable blocks from its count. This fixes the block count including reusable blocks that have been parsed and stored into `blocks.byClientId` but not inserted into the post or page.

#### How to test

1. Create a new post
2. Insert a block
3. Convert it to a reusable block
5. Click _Content Structure_
6. It should report that there is 1 block