### PR TITLE
Use block icons in media placeholders

### DIFF
--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -121,7 +121,7 @@ class AudioEdit extends Component {
 		if ( editing ) {
 			return (
 				<MediaPlaceholder
-					icon=<BlockIcon icon={ icon } />
+					icon={ <BlockIcon icon={ icon } /> }
 					className={ className }
 					onSelect={ onSelectAudio }
 					onSelectURL={ this.onSelectURL }

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -1,25 +1,31 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { getBlobByURL, isBlobURL } from '@wordpress/blob';
 import {
 	Disabled,
 	IconButton,
 	PanelBody,
 	SelectControl,
-	Toolbar,
 	ToggleControl,
+	Toolbar,
 	withNotices,
 } from '@wordpress/components';
-import { Component, Fragment } from '@wordpress/element';
 import {
 	BlockControls,
+	BlockIcon,
 	InspectorControls,
 	MediaPlaceholder,
 	RichText,
 	mediaUpload,
 } from '@wordpress/editor';
-import { getBlobByURL, isBlobURL } from '@wordpress/blob';
+import { Component, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import icon from './icon';
 
 /**
  * Internal dependencies
@@ -115,7 +121,7 @@ class AudioEdit extends Component {
 		if ( editing ) {
 			return (
 				<MediaPlaceholder
-					icon="media-audio"
+					icon=<BlockIcon icon={ icon } />
 					className={ className }
 					onSelect={ onSelectAudio }
 					onSelectURL={ this.onSelectURL }

--- a/packages/block-library/src/audio/icon.js
+++ b/packages/block-library/src/audio/icon.js
@@ -1,0 +1,6 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+export default <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Path d="m12 3l0.01 10.55c-0.59-0.34-1.27-0.55-2-0.55-2.22 0-4.01 1.79-4.01 4s1.79 4 4.01 4 3.99-1.79 3.99-4v-10h4v-4h-6zm-1.99 16c-1.1 0-2-0.9-2-2s0.9-2 2-2 2 0.9 2 2-0.9 2-2 2z" /></SVG>;

--- a/packages/block-library/src/audio/index.js
+++ b/packages/block-library/src/audio/index.js
@@ -1,16 +1,16 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { createBlobURL } from '@wordpress/blob';
+import { createBlock } from '@wordpress/blocks';
 import { RichText } from '@wordpress/editor';
-import { SVG, Path } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import edit from './edit';
-import { createBlock } from '@wordpress/blocks';
-import { createBlobURL } from '@wordpress/blob';
+import icon from './icon';
 
 export const name = 'core/audio';
 
@@ -19,7 +19,7 @@ export const settings = {
 
 	description: __( 'Embed a simple audio player.' ),
 
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Path d="m12 3l0.01 10.55c-0.59-0.34-1.27-0.55-2-0.55-2.22 0-4.01 1.79-4.01 4s1.79 4 4.01 4 3.99-1.79 3.99-4v-10h4v-4h-6zm-1.99 16c-1.1 0-2-0.9-2-2s0.9-2 2-2 2 0.9 2 2-0.9 2-2 2z" /></SVG>,
+	icon,
 
 	category: 'common',
 

--- a/packages/block-library/src/audio/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/audio/test/__snapshots__/index.js.snap
@@ -7,20 +7,27 @@ exports[`core/audio block edit matches snapshot 1`] = `
   <div
     class="components-placeholder__label"
   >
-    <svg
-      aria-hidden="true"
-      class="dashicon dashicons-media-audio"
-      focusable="false"
-      height="20"
-      role="img"
-      viewBox="0 0 20 20"
-      width="20"
-      xmlns="http://www.w3.org/2000/svg"
+    <span
+      class="editor-block-icon"
     >
-      <path
-        d="M12 2l4 4v12H4V2h8zm0 4h3l-3-3v3zm1 7.26V8.09c0-.11-.04-.21-.12-.29-.07-.08-.16-.11-.27-.1 0 0-3.97.71-4.25.78C8.07 8.54 8 8.8 8 9v3.37c-.2-.09-.42-.07-.6-.07-.38 0-.7.13-.96.39-.26.27-.4.58-.4.96 0 .37.14.69.4.95.26.27.58.4.96.4.34 0 .7-.04.96-.26.26-.23.64-.65.64-1.12V10.3l3-.6V12c-.67-.2-1.17.04-1.44.31-.26.26-.39.58-.39.95 0 .38.13.69.39.96.27.26.71.39 1.08.39.38 0 .7-.13.96-.39.26-.27.4-.58.4-.96z"
-      />
-    </svg>
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        height="24"
+        role="img"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M0,0h24v24H0V0z"
+          fill="none"
+        />
+        <path
+          d="m12 3l0.01 10.55c-0.59-0.34-1.27-0.55-2-0.55-2.22 0-4.01 1.79-4.01 4s1.79 4 4.01 4 3.99-1.79 3.99-4v-10h4v-4h-6zm-1.99 16c-1.1 0-2-0.9-2-2s0.9-2 2-2 2 0.9 2 2-0.9 2-2 2z"
+        />
+      </svg>
+    </span>
     Audio
   </div>
   <div

--- a/packages/block-library/src/cover/icon.js
+++ b/packages/block-library/src/cover/icon.js
@@ -1,0 +1,6 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+export default <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M4 4h7V2H4c-1.1 0-2 .9-2 2v7h2V4zm6 9l-4 5h12l-3-4-2.03 2.71L10 13zm7-4.5c0-.83-.67-1.5-1.5-1.5S14 7.67 14 8.5s.67 1.5 1.5 1.5S17 9.33 17 8.5zM20 2h-7v2h7v7h2V4c0-1.1-.9-2-2-2zm0 18h-7v2h7c1.1 0 2-.9 2-2v-7h-2v7zM4 13H2v7c0 1.1.9 2 2 2h7v-2H4v-7z" /><Path d="M0 0h24v24H0z" fill="none" /></SVG>;

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import { createBlock } from '@wordpress/blocks';
 import {
 	FocalPointPicker,
 	IconButton,
@@ -14,25 +15,28 @@ import {
 	ToggleControl,
 	Toolbar,
 	withNotices,
-	SVG,
-	Path,
 } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
-import { createBlock } from '@wordpress/blocks';
 import { compose } from '@wordpress/compose';
 import {
+	AlignmentToolbar,
 	BlockControls,
+	BlockIcon,
 	InspectorControls,
 	MediaPlaceholder,
 	MediaUpload,
 	MediaUploadCheck,
-	AlignmentToolbar,
 	PanelColorSettings,
 	RichText,
-	withColors,
 	getColorClassName,
+	withColors,
 } from '@wordpress/editor';
+import { Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import icon from './icon';
 
 const blockAttributes = {
 	title: {
@@ -84,7 +88,7 @@ export const settings = {
 
 	description: __( 'Add an image or video with a text overlay — great for headers.' ),
 
-	icon: <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M4 4h7V2H4c-1.1 0-2 .9-2 2v7h2V4zm6 9l-4 5h12l-3-4-2.03 2.71L10 13zm7-4.5c0-.83-.67-1.5-1.5-1.5S14 7.67 14 8.5s.67 1.5 1.5 1.5S17 9.33 17 8.5zM20 2h-7v2h7v7h2V4c0-1.1-.9-2-2-2zm0 18h-7v2h7c1.1 0 2-.9 2-2v-7h-2v7zM4 13H2v7c0 1.1.9 2 2 2h7v-2H4v-7z" /><Path d="M0 0h24v24H0z" fill="none" /></SVG>,
+	icon,
 
 	category: 'common',
 
@@ -308,7 +312,7 @@ export const settings = {
 
 			if ( ! url ) {
 				const hasTitle = ! RichText.isEmpty( title );
-				const icon = hasTitle ? undefined : 'format-image';
+				const placeholderIcon = hasTitle ? undefined : <BlockIcon icon={ icon } />;
 				const label = hasTitle ? (
 					<RichText
 						tagName="h2"
@@ -322,7 +326,7 @@ export const settings = {
 					<Fragment>
 						{ controls }
 						<MediaPlaceholder
-							icon={ icon }
+							icon={ placeholderIcon }
 							className={ className }
 							labels={ {
 								title: label,

--- a/packages/block-library/src/cover/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/cover/test/__snapshots__/index.js.snap
@@ -7,20 +7,27 @@ exports[`core/cover block edit matches snapshot 1`] = `
   <div
     class="components-placeholder__label"
   >
-    <svg
-      aria-hidden="true"
-      class="dashicon dashicons-format-image"
-      focusable="false"
-      height="20"
-      role="img"
-      viewBox="0 0 20 20"
-      width="20"
-      xmlns="http://www.w3.org/2000/svg"
+    <span
+      class="editor-block-icon"
     >
-      <path
-        d="M2.25 1h15.5c.69 0 1.25.56 1.25 1.25v15.5c0 .69-.56 1.25-1.25 1.25H2.25C1.56 19 1 18.44 1 17.75V2.25C1 1.56 1.56 1 2.25 1zM17 17V3H3v14h14zM10 6c0-1.1-.9-2-2-2s-2 .9-2 2 .9 2 2 2 2-.9 2-2zm3 5s0-6 3-6v10c0 .55-.45 1-1 1H5c-.55 0-1-.45-1-1V8c2 0 3 4 3 4s1-3 3-3 3 2 3 2z"
-      />
-    </svg>
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        height="24"
+        role="img"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4 4h7V2H4c-1.1 0-2 .9-2 2v7h2V4zm6 9l-4 5h12l-3-4-2.03 2.71L10 13zm7-4.5c0-.83-.67-1.5-1.5-1.5S14 7.67 14 8.5s.67 1.5 1.5 1.5S17 9.33 17 8.5zM20 2h-7v2h7v7h2V4c0-1.1-.9-2-2-2zm0 18h-7v2h7c1.1 0 2-.9 2-2v-7h-2v7zM4 13H2v7c0 1.1.9 2 2 2h7v-2H4v-7z"
+        />
+        <path
+          d="M0 0h24v24H0z"
+          fill="none"
+        />
+      </svg>
+    </span>
     Cover
   </div>
   <div

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -6,29 +6,35 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { getBlobByURL, revokeBlobURL, isBlobURL } from '@wordpress/blob';
+import {
+	getBlobByURL,
+	isBlobURL,
+	revokeBlobURL,
+} from '@wordpress/blob';
 import {
 	ClipboardButton,
 	IconButton,
 	Toolbar,
 	withNotices,
 } from '@wordpress/components';
+import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
-import { Component, Fragment } from '@wordpress/element';
 import {
-	MediaUpload,
-	MediaPlaceholder,
-	MediaUploadCheck,
 	BlockControls,
+	BlockIcon,
+	MediaUpload,
+	MediaUploadCheck,
+	MediaPlaceholder,
 	RichText,
 	mediaUpload,
 } from '@wordpress/editor';
-import { compose } from '@wordpress/compose';
+import { Component, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import icon from './icon';
 import FileBlockInspector from './inspector';
 
 class FileEdit extends Component {
@@ -136,7 +142,7 @@ class FileEdit extends Component {
 		if ( ! href || hasError ) {
 			return (
 				<MediaPlaceholder
-					icon="media-default"
+					icon=<BlockIcon icon={ icon } />
 					labels={ {
 						title: __( 'File' ),
 						instructions: __( 'Drag a file, upload a new one or select a file from your library.' ),

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -142,7 +142,7 @@ class FileEdit extends Component {
 		if ( ! href || hasError ) {
 			return (
 				<MediaPlaceholder
-					icon=<BlockIcon icon={ icon } />
+					icon={ <BlockIcon icon={ icon } /> }
 					labels={ {
 						title: __( 'File' ),
 						instructions: __( 'Drag a file, upload a new one or select a file from your library.' ),

--- a/packages/block-library/src/file/icon.js
+++ b/packages/block-library/src/file/icon.js
@@ -1,0 +1,6 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+export default <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><Path d="M9 6l2 2h9v10H4V6h5m1-2H4L2 6v12l2 2h16l2-2V8l-2-2h-8l-2-2z" /></SVG>;

--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -11,12 +11,12 @@ import { createBlobURL } from '@wordpress/blob';
 import { createBlock } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
 import { RichText } from '@wordpress/editor';
-import { SVG, Path } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import edit from './edit';
+import icon from './icon';
 
 export const name = 'core/file';
 
@@ -25,7 +25,7 @@ export const settings = {
 
 	description: __( 'Add a link to a downloadable file.' ),
 
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><Path d="M9 6l2 2h9v10H4V6h5m1-2H4L2 6v12l2 2h16l2-2V8l-2-2h-8l-2-2z" /></SVG>,
+	icon,
 
 	category: 'common',
 

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -7,12 +7,10 @@ import { filter, pick, map, get } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component, Fragment } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
 import {
-	IconButton,
 	DropZone,
 	FormFileUpload,
+	IconButton,
 	PanelBody,
 	RangeControl,
 	SelectControl,
@@ -22,16 +20,20 @@ import {
 } from '@wordpress/components';
 import {
 	BlockControls,
-	MediaUpload,
+	BlockIcon,
 	MediaPlaceholder,
+	MediaUpload,
 	InspectorControls,
 	mediaUpload,
 } from '@wordpress/editor';
+import { Component, Fragment } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import GalleryImage from './gallery-image';
+import icon from './icon';
 
 const MAX_COLUMNS = 8;
 const linkOptions = [
@@ -220,7 +222,7 @@ class GalleryEdit extends Component {
 				<Fragment>
 					{ controls }
 					<MediaPlaceholder
-						icon="format-gallery"
+						icon=<BlockIcon icon={ icon } />
 						className={ className }
 						labels={ {
 							title: __( 'Gallery' ),

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -222,7 +222,7 @@ class GalleryEdit extends Component {
 				<Fragment>
 					{ controls }
 					<MediaPlaceholder
-						icon=<BlockIcon icon={ icon } />
+						icon={ <BlockIcon icon={ icon } /> }
 						className={ className }
 						labels={ {
 							title: __( 'Gallery' ),

--- a/packages/block-library/src/gallery/icon.js
+++ b/packages/block-library/src/gallery/icon.js
@@ -1,0 +1,6 @@
+/**
+ * WordPress dependencies
+ */
+import { G, Path, SVG } from '@wordpress/components';
+
+export default <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M20 4v12H8V4h12m0-2H8L6 4v12l2 2h12l2-2V4l-2-2z" /><Path d="M12 12l1 2 3-3 3 4H9z" /><Path d="M2 6v14l2 2h14v-2H4V6H2z" /></G></SVG>;

--- a/packages/block-library/src/gallery/index.js
+++ b/packages/block-library/src/gallery/index.js
@@ -10,12 +10,12 @@ import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 import { RichText, mediaUpload } from '@wordpress/editor';
 import { createBlobURL } from '@wordpress/blob';
-import { G, Path, SVG } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { default as edit, defaultColumnsNumber, pickRelevantMediaFiles } from './edit';
+import icon from './icon';
 
 const blockAttributes = {
 	images: {
@@ -84,7 +84,7 @@ const parseShortcodeIds = ( ids ) => {
 export const settings = {
 	title: __( 'Gallery' ),
 	description: __( 'Display multiple images in a rich gallery.' ),
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M20 4v12H8V4h12m0-2H8L6 4v12l2 2h12l2-2V4l-2-2z" /><Path d="M12 12l1 2 3-3 3 4H9z" /><Path d="M2 6v14l2 2h14v-2H4V6H2z" /></G></SVG>,
+	icon,
 	category: 'common',
 	keywords: [ __( 'images' ), __( 'photos' ) ],
 	attributes: blockAttributes,

--- a/packages/block-library/src/gallery/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/gallery/test/__snapshots__/index.js.snap
@@ -7,20 +7,35 @@ exports[`core/gallery block edit matches snapshot 1`] = `
   <div
     class="components-placeholder__label"
   >
-    <svg
-      aria-hidden="true"
-      class="dashicon dashicons-format-gallery"
-      focusable="false"
-      height="20"
-      role="img"
-      viewBox="0 0 20 20"
-      width="20"
-      xmlns="http://www.w3.org/2000/svg"
+    <span
+      class="editor-block-icon"
     >
-      <path
-        d="M16 4h1.96c.57 0 1.04.47 1.04 1.04v12.92c0 .57-.47 1.04-1.04 1.04H5.04C4.47 19 4 18.53 4 17.96V16H2.04C1.47 16 1 15.53 1 14.96V2.04C1 1.47 1.47 1 2.04 1h12.92c.57 0 1.04.47 1.04 1.04V4zM3 14h11V3H3v11zm5-8.5C8 4.67 7.33 4 6.5 4S5 4.67 5 5.5 5.67 7 6.5 7 8 6.33 8 5.5zm2 4.5s1-5 3-5v8H4V7c2 0 2 3 2 3s.33-2 2-2 2 2 2 2zm7 7V6h-1v8.96c0 .57-.47 1.04-1.04 1.04H6v1h11z"
-      />
-    </svg>
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        height="24"
+        role="img"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M0 0h24v24H0V0z"
+          fill="none"
+        />
+        <g>
+          <path
+            d="M20 4v12H8V4h12m0-2H8L6 4v12l2 2h12l2-2V4l-2-2z"
+          />
+          <path
+            d="M12 12l1 2 3-3 3 4H9z"
+          />
+          <path
+            d="M2 6v14l2 2h14v-2H4V6H2z"
+          />
+        </g>
+      </svg>
+    </span>
     Gallery
   </div>
   <div

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -425,7 +425,7 @@ class ImageEdit extends Component {
 				<Fragment>
 					{ controls }
 					<MediaPlaceholder
-						icon=<BlockIcon icon={ icon } />
+						icon={ <BlockIcon icon={ icon } /> }
 						className={ className }
 						onSelect={ this.onSelectImage }
 						onSelectURL={ this.onSelectURL }

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -3,21 +3,18 @@
  */
 import classnames from 'classnames';
 import {
+	compact,
 	get,
 	isEmpty,
 	map,
 	last,
 	pick,
-	compact,
 } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { getPath } from '@wordpress/url';
-import { __, sprintf } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
-import { getBlobByURL, revokeBlobURL, isBlobURL } from '@wordpress/blob';
+import { getBlobByURL, isBlobURL, revokeBlobURL } from '@wordpress/blob';
 import {
 	Button,
 	ButtonGroup,
@@ -26,30 +23,35 @@ import {
 	ResizableBox,
 	SelectControl,
 	Spinner,
-	TextControl,
 	TextareaControl,
+	TextControl,
+	ToggleControl,
 	Toolbar,
 	withNotices,
-	ToggleControl,
 } from '@wordpress/components';
+import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import {
-	RichText,
+	BlockAlignmentToolbar,
 	BlockControls,
+	BlockIcon,
 	InspectorControls,
 	MediaPlaceholder,
 	MediaUpload,
 	MediaUploadCheck,
-	BlockAlignmentToolbar,
+	RichText,
 	mediaUpload,
 } from '@wordpress/editor';
+import { Component, Fragment } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { getPath } from '@wordpress/url';
 import { withViewportMatch } from '@wordpress/viewport';
-import { compose } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import { createUpgradedEmbedBlock } from '../embed/util';
+import icon from './icon';
 import ImageSize from './image-size';
 
 /**
@@ -423,7 +425,7 @@ class ImageEdit extends Component {
 				<Fragment>
 					{ controls }
 					<MediaPlaceholder
-						icon="format-image"
+						icon=<BlockIcon icon={ icon } />
 						className={ className }
 						onSelect={ this.onSelectImage }
 						onSelectURL={ this.onSelectURL }

--- a/packages/block-library/src/image/icon.js
+++ b/packages/block-library/src/image/icon.js
@@ -1,0 +1,6 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+export default <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Path d="m19 5v14h-14v-14h14m0-2h-14c-1.1 0-2 0.9-2 2v14c0 1.1 0.9 2 2 2h14c1.1 0 2-0.9 2-2v-14c0-1.1-0.9-2-2-2z" /><Path d="m14.14 11.86l-3 3.87-2.14-2.59-3 3.86h12l-3.86-5.14z" /></SVG>;

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -6,24 +6,21 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Fragment } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { createBlobURL } from '@wordpress/blob';
 import {
 	createBlock,
 	getBlockAttributes,
 	getPhrasingContentSchema,
 } from '@wordpress/blocks';
 import { RichText } from '@wordpress/editor';
-import { createBlobURL } from '@wordpress/blob';
-import {
-	Path,
-	SVG,
-} from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import edit from './edit';
+import icon from './icon';
 
 export const name = 'core/image';
 
@@ -131,7 +128,7 @@ export const settings = {
 
 	description: __( 'Insert an image to make a visual statement.' ),
 
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Path d="m19 5v14h-14v-14h14m0-2h-14c-1.1 0-2 0.9-2 2v14c0 1.1 0.9 2 2 2h14c1.1 0 2-0.9 2-2v-14c0-1.1-0.9-2-2-2z" /><Path d="m14.14 11.86l-3 3.87-2.14-2.59-3 3.86h12l-3.86-5.14z" /></SVG>,
+	icon,
 
 	category: 'common',
 

--- a/packages/block-library/src/media-text/icon.js
+++ b/packages/block-library/src/media-text/icon.js
@@ -1,0 +1,6 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+export default <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M13 17h8v-2h-8v2zM3 19h8V5H3v14zM13 9h8V7h-8v2zm0 4h8v-2h-8v2z" /></SVG>;

--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -1,24 +1,24 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import classnames from 'classnames';
+import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { Path, SVG } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { createBlock } from '@wordpress/blocks';
 import {
 	InnerBlocks,
 	getColorClassName,
 } from '@wordpress/editor';
-import { createBlock } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import edit from './edit';
+import icon from './icon';
 
 const DEFAULT_MEDIA_WIDTH = 50;
 
@@ -73,7 +73,7 @@ export const settings = {
 
 	description: __( 'Set media and words side-by-side for a richer layout.' ),
 
-	icon: <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M13 17h8v-2h-8v2zM3 19h8V5H3v14zM13 9h8V7h-8v2zm0 4h8v-2h-8v2z" /></SVG>,
+	icon,
 
 	category: 'layout',
 

--- a/packages/block-library/src/media-text/media-container-icon.js
+++ b/packages/block-library/src/media-text/media-container-icon.js
@@ -1,0 +1,6 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+export default <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M18 2l2 4h-2l-2-4h-3l2 4h-2l-2-4h-1a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V2zm2 12H10V4.4L11.8 8H20z" /><Path d="M14 20H4V10h3V8H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-3h-2z" /><Path d="M5 19h8l-1.59-2H9.24l-.84 1.1L7 16.3 5 19z" /></SVG>;

--- a/packages/block-library/src/media-text/media-container.js
+++ b/packages/block-library/src/media-text/media-container.js
@@ -1,14 +1,20 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
 import { IconButton, ResizableBox, Toolbar } from '@wordpress/components';
 import {
 	BlockControls,
+	BlockIcon,
 	MediaPlaceholder,
 	MediaUpload,
 } from '@wordpress/editor';
+import { Component, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import icon from './icon';
 
 /**
  * Constants
@@ -67,7 +73,7 @@ class MediaContainer extends Component {
 		const { onSelectMedia, className } = this.props;
 		return (
 			<MediaPlaceholder
-				icon="format-image"
+				icon=<BlockIcon icon={ icon } />
 				labels={ {
 					title: __( 'Media area' ),
 				} }

--- a/packages/block-library/src/media-text/media-container.js
+++ b/packages/block-library/src/media-text/media-container.js
@@ -73,7 +73,7 @@ class MediaContainer extends Component {
 		const { onSelectMedia, className } = this.props;
 		return (
 			<MediaPlaceholder
-				icon=<BlockIcon icon={ icon } />
+				icon={ <BlockIcon icon={ icon } /> }
 				labels={ {
 					title: __( 'Media area' ),
 				} }

--- a/packages/block-library/src/media-text/media-container.js
+++ b/packages/block-library/src/media-text/media-container.js
@@ -14,7 +14,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import icon from './icon';
+import icon from './media-container-icon';
 
 /**
  * Constants

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { getBlobByURL, isBlobURL } from '@wordpress/blob';
 import {
 	BaseControl,
 	Button,
@@ -9,13 +9,13 @@ import {
 	IconButton,
 	PanelBody,
 	SelectControl,
-	Toolbar,
 	ToggleControl,
+	Toolbar,
 	withNotices,
 } from '@wordpress/components';
-import { Component, Fragment, createRef } from '@wordpress/element';
 import {
 	BlockControls,
+	BlockIcon,
 	InspectorControls,
 	MediaPlaceholder,
 	MediaUpload,
@@ -23,12 +23,14 @@ import {
 	RichText,
 	mediaUpload,
 } from '@wordpress/editor';
-import { getBlobByURL, isBlobURL } from '@wordpress/blob';
+import { Component, Fragment, createRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { createUpgradedEmbedBlock } from '../embed/util';
+import icon from './icon';
 
 const ALLOWED_MEDIA_TYPES = [ 'video' ];
 const VIDEO_POSTER_ALLOWED_MEDIA_TYPES = [ 'image' ];
@@ -150,7 +152,7 @@ class VideoEdit extends Component {
 		if ( editing ) {
 			return (
 				<MediaPlaceholder
-					icon="media-video"
+					icon=<BlockIcon icon={ icon } />
 					className={ className }
 					onSelect={ onSelectVideo }
 					onSelectURL={ this.onSelectURL }

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -152,7 +152,7 @@ class VideoEdit extends Component {
 		if ( editing ) {
 			return (
 				<MediaPlaceholder
-					icon=<BlockIcon icon={ icon } />
+					icon={ <BlockIcon icon={ icon } /> }
 					className={ className }
 					onSelect={ onSelectVideo }
 					onSelectURL={ this.onSelectURL }

--- a/packages/block-library/src/video/icon.js
+++ b/packages/block-library/src/video/icon.js
@@ -1,0 +1,6 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+export default <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><Path d="M4 6l2 4h14v8H4V6m18-2h-4l2 4h-3l-2-4h-2l2 4h-3l-2-4H8l2 4H7L5 4H4L2 6v12l2 2h16l2-2V4z" /></SVG>;

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -1,16 +1,16 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { RichText } from '@wordpress/editor';
-import { createBlock } from '@wordpress/blocks';
 import { createBlobURL } from '@wordpress/blob';
-import { SVG, Path } from '@wordpress/components';
+import { createBlock } from '@wordpress/blocks';
+import { RichText } from '@wordpress/editor';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import edit from './edit';
+import icon from './icon';
 
 export const name = 'core/video';
 
@@ -19,7 +19,7 @@ export const settings = {
 
 	description: __( 'Embed a video from your media library or upload a new one.' ),
 
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><Path d="M4 6l2 4h14v8H4V6m18-2h-4l2 4h-3l-2-4h-2l2 4h-3l-2-4H8l2 4H7L5 4H4L2 6v12l2 2h16l2-2V4z" /></SVG>,
+	icon,
 
 	keywords: [ __( 'movie' ) ],
 

--- a/packages/block-library/src/video/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/video/test/__snapshots__/index.js.snap
@@ -7,20 +7,27 @@ exports[`core/video block edit matches snapshot 1`] = `
   <div
     class="components-placeholder__label"
   >
-    <svg
-      aria-hidden="true"
-      class="dashicon dashicons-media-video"
-      focusable="false"
-      height="20"
-      role="img"
-      viewBox="0 0 20 20"
-      width="20"
-      xmlns="http://www.w3.org/2000/svg"
+    <span
+      class="editor-block-icon"
     >
-      <path
-        d="M12 2l4 4v12H4V2h8zm0 4h3l-3-3v3zm-1 8v-3c0-.27-.1-.51-.29-.71-.2-.19-.44-.29-.71-.29H7c-.27 0-.51.1-.71.29-.19.2-.29.44-.29.71v3c0 .27.1.51.29.71.2.19.44.29.71.29h3c.27 0 .51-.1.71-.29.19-.2.29-.44.29-.71zm3 1v-5l-2 2v1z"
-      />
-    </svg>
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        height="24"
+        role="img"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M0 0h24v24H0V0z"
+          fill="none"
+        />
+        <path
+          d="M4 6l2 4h14v8H4V6m18-2h-4l2 4h-3l-2-4h-2l2 4h-3l-2-4H8l2 4H7L5 4H4L2 6v12l2 2h16l2-2V4z"
+        />
+      </svg>
+    </span>
     Video
   </div>
   <div

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -21,6 +21,7 @@
 
 .components-placeholder__label {
 	display: flex;
+	align-items: center;
 	justify-content: center;
 	font-weight: 600;
 	margin-bottom: 1em;


### PR DESCRIPTION
## Description
Fixes #9642.

This PR changes the media placeholders of the media blocks to use the corresponding icon of each block, instead of using Dashicons. Since the icons are now being used by both the `index.js` and (if it exists) `edit.js` of each of these blocks, I have moved these icons into `icon.js` files for each block, so the icons are not defined twice and can be imported by multiple other modules.

List of blocks this PR affects:
- Audio
- Cover
- File
- Gallery
- Image
- Media & Text
- Video

I also took the opportunity to reorganize the imports in the files I modified: they are now organized alphabetically, and imports that were previously incorrectly listed under "Internal dependencies" are now listed under "WordPress dependencies".

## Screenshot
![image](https://user-images.githubusercontent.com/19592990/48384717-35bd5300-e6b1-11e8-8044-b65c347f3a82.png)

## Related issues and PRs
- Replaces #9646