### PR TITLE
Add a way to programmatically remove editor panels from UI

### DIFF
--- a/docs/data/data-core-edit-post.md
+++ b/docs/data/data-core-edit-post.md
@@ -89,6 +89,20 @@ Returns true if the publish sidebar is opened.
 
 Whether the publish sidebar is open.
 
+### isEditorPanelRemoved
+
+Returns true if the given panel is removed, or false otherwise. Panels are
+not removed by default.
+
+*Parameters*
+
+ * state: Global application state.
+ * panelName: A string that identifies the panel.
+
+*Returns*
+
+Whether or not the panel is removed.
+
 ### isEditorPanelEnabled
 
 Returns true if the given panel is enabled, or false otherwise. Panels are
@@ -300,6 +314,14 @@ Returns an action object used to open or close a panel in the editor.
 *Parameters*
 
  * panelName: A string that identifies the panel to open or close.
+
+### removeEditorPanel
+
+Returns an action object used to remove a panel from the editor.
+
+*Parameters*
+
+ * panelName: A string that identifies the panel to remove.
 
 ### toggleFeature
 

--- a/docs/data/data-core-edit-post.md
+++ b/docs/data/data-core-edit-post.md
@@ -91,8 +91,8 @@ Whether the publish sidebar is open.
 
 ### isEditorPanelRemoved
 
-Returns true if the given panel is removed, or false otherwise. Panels are
-not removed by default.
+Returns true if the given panel was programmatically removed, or false otherwise.
+All panels are not removed by default.
 
 *Parameters*
 

--- a/packages/edit-post/src/components/options-modal/options/enable-panel.js
+++ b/packages/edit-post/src/components/options-modal/options/enable-panel.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { compose } from '@wordpress/compose';
+import { compose, ifCondition } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
@@ -10,9 +10,14 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import BaseOption from './base';
 
 export default compose(
-	withSelect( ( select, { panelName } ) => ( {
-		isChecked: select( 'core/edit-post' ).isEditorPanelEnabled( panelName ),
-	} ) ),
+	withSelect( ( select, { panelName } ) => {
+		const { isEditorPanelEnabled, isEditorPanelRemoved } = select( 'core/edit-post' );
+		return {
+			isRemoved: isEditorPanelRemoved( panelName ),
+			isChecked: isEditorPanelEnabled( panelName ),
+		};
+	} ),
+	ifCondition( ( { isRemoved } ) => ! isRemoved ),
 	withDispatch( ( dispatch, { panelName } ) => ( {
 		onChange: () => dispatch( 'core/edit-post' ).toggleEditorPanelEnabled( panelName ),
 	} ) )

--- a/packages/edit-post/src/components/options-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/options-modal/test/__snapshots__/index.js.snap
@@ -28,22 +28,22 @@ exports[`OptionsModal should match snapshot when the modal is active 1`] = `
     <WithSelect(PostTaxonomies)
       taxonomyWrapper={[Function]}
     />
-    <WithSelect(WithDispatch(BaseOption))
+    <WithSelect(IfCondition(WithDispatch(BaseOption)))
       label="Featured Image"
       panelName="featured-image"
     />
     <PostExcerptCheck>
-      <WithSelect(WithDispatch(BaseOption))
+      <WithSelect(IfCondition(WithDispatch(BaseOption)))
         label="Excerpt"
         panelName="post-excerpt"
       />
     </PostExcerptCheck>
-    <WithSelect(WithDispatch(BaseOption))
+    <WithSelect(IfCondition(WithDispatch(BaseOption)))
       label="Discussion"
       panelName="discussion-panel"
     />
     <WithSelect(PageAttributesCheck)>
-      <WithSelect(WithDispatch(BaseOption))
+      <WithSelect(IfCondition(WithDispatch(BaseOption)))
         label="Page Attributes"
         panelName="page-attributes"
       />

--- a/packages/edit-post/src/components/options-modal/test/__snapshots__/meta-boxes-section.js.snap
+++ b/packages/edit-post/src/components/options-modal/test/__snapshots__/meta-boxes-section.js.snap
@@ -17,12 +17,12 @@ exports[`MetaBoxesSection renders a Custom Fields option and meta box options 1`
   <WithSelect(EnableCustomFieldsOption)
     label="Custom Fields"
   />
-  <WithSelect(WithDispatch(BaseOption))
+  <WithSelect(IfCondition(WithDispatch(BaseOption)))
     key="test1"
     label="Meta Box 1"
     panelName="meta-box-test1"
   />
-  <WithSelect(WithDispatch(BaseOption))
+  <WithSelect(IfCondition(WithDispatch(BaseOption)))
     key="test2"
     label="Meta Box 2"
     panelName="meta-box-test2"
@@ -34,12 +34,12 @@ exports[`MetaBoxesSection renders meta box options 1`] = `
 <Section
   title="Advanced Panels"
 >
-  <WithSelect(WithDispatch(BaseOption))
+  <WithSelect(IfCondition(WithDispatch(BaseOption)))
     key="test1"
     label="Meta Box 1"
     panelName="meta-box-test1"
   />
-  <WithSelect(WithDispatch(BaseOption))
+  <WithSelect(IfCondition(WithDispatch(BaseOption)))
     key="test2"
     label="Meta Box 2"
     panelName="meta-box-test2"

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -112,6 +112,20 @@ export function toggleEditorPanelOpened( panelName ) {
 }
 
 /**
+ * Returns an action object used to remove a panel from the editor.
+ *
+ * @param {string} panelName A string that identifies the panel to remove.
+ *
+ * @return {Object} Action object.
+ */
+export function removeEditorPanel( panelName ) {
+	return {
+		type: 'REMOVE_PANEL',
+		panelName,
+	};
+}
+
+/**
  * Returns an action object used to toggle a feature flag.
  *
  * @param {string} feature Feature name.

--- a/packages/edit-post/src/store/reducer.js
+++ b/packages/edit-post/src/store/reducer.js
@@ -73,6 +73,17 @@ export const preferences = combineReducers( {
 					},
 				};
 			}
+
+			case 'REMOVE_PANEL': {
+				const { panelName } = action;
+				return {
+					...state,
+					[ panelName ]: {
+						...state[ panelName ],
+						removed: true,
+					},
+				};
+			}
 		}
 
 		return state;

--- a/packages/edit-post/src/store/reducer.js
+++ b/packages/edit-post/src/store/reducer.js
@@ -134,15 +134,6 @@ export function activeGeneralSidebar( state = DEFAULT_ACTIVE_GENERAL_SIDEBAR, ac
 	return state;
 }
 
-export function panel( state = 'document', action ) {
-	switch ( action.type ) {
-		case 'SET_ACTIVE_PANEL':
-			return action.panel;
-	}
-
-	return state;
-}
-
 /**
  * Reducer for storing the name of the open modal, or null if no modal is open.
  *
@@ -220,7 +211,6 @@ const metaBoxes = combineReducers( {
 export default combineReducers( {
 	preferences,
 	activeGeneralSidebar,
-	panel,
 	activeModal,
 	publishSidebarActive,
 	metaBoxes,

--- a/packages/edit-post/src/store/reducer.js
+++ b/packages/edit-post/src/store/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { get, includes } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -117,6 +117,28 @@ export const preferences = combineReducers( {
 } );
 
 /**
+ * Reducer storing the list of all programmatically removed panels.
+ *
+ * @param {Array}  state  Current state.
+ * @param {Object} action Action object.
+ *
+ * @return {Array} Updated state.
+ */
+export function removedPanels( state = [], action ) {
+	switch ( action.type ) {
+		case 'REMOVE_PANEL':
+			if ( ! includes( state, action.panelName ) ) {
+				return [
+					...state,
+					action.panelName,
+				];
+			}
+	}
+
+	return state;
+}
+
+/**
  * Reducer returning the next active general sidebar state. The active general
  * sidebar is a unique name to identify either an editor or plugin sidebar.
  *
@@ -209,9 +231,10 @@ const metaBoxes = combineReducers( {
 } );
 
 export default combineReducers( {
-	preferences,
 	activeGeneralSidebar,
 	activeModal,
-	publishSidebarActive,
 	metaBoxes,
+	preferences,
+	publishSidebarActive,
+	removedPanels,
 } );

--- a/packages/edit-post/src/store/reducer.js
+++ b/packages/edit-post/src/store/reducer.js
@@ -73,17 +73,6 @@ export const preferences = combineReducers( {
 					},
 				};
 			}
-
-			case 'REMOVE_PANEL': {
-				const { panelName } = action;
-				return {
-					...state,
-					[ panelName ]: {
-						...state[ panelName ],
-						removed: true,
-					},
-				};
-			}
 		}
 
 		return state;

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -100,8 +100,8 @@ export function isPublishSidebarOpened( state ) {
 }
 
 /**
- * Returns true if the given panel is removed, or false otherwise. Panels are
- * not removed by default.
+ * Returns true if the given panel was programmatically removed, or false otherwise.
+ * All panels are not removed by default.
  *
  * @param {Object} state     Global application state.
  * @param {string} panelName A string that identifies the panel.
@@ -109,8 +109,7 @@ export function isPublishSidebarOpened( state ) {
  * @return {boolean} Whether or not the panel is removed.
  */
 export function isEditorPanelRemoved( state, panelName ) {
-	const panels = getPreference( state, 'panels' );
-	return get( panels, [ panelName, 'removed' ], false );
+	return includes( state.removedPanels, panelName );
 }
 
 /**

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -100,6 +100,20 @@ export function isPublishSidebarOpened( state ) {
 }
 
 /**
+ * Returns true if the given panel is removed, or false otherwise. Panels are
+ * not removed by default.
+ *
+ * @param {Object} state     Global application state.
+ * @param {string} panelName A string that identifies the panel.
+ *
+ * @return {boolean} Whether or not the panel is removed.
+ */
+export function isEditorPanelRemoved( state, panelName ) {
+	const panels = getPreference( state, 'panels' );
+	return get( panels, [ panelName, 'removed' ], false );
+}
+
+/**
  * Returns true if the given panel is enabled, or false otherwise. Panels are
  * enabled by default.
  *
@@ -110,7 +124,9 @@ export function isPublishSidebarOpened( state ) {
  */
 export function isEditorPanelEnabled( state, panelName ) {
 	const panels = getPreference( state, 'panels' );
-	return get( panels, [ panelName, 'enabled' ], true );
+
+	return ! isEditorPanelRemoved( state, panelName ) &&
+		get( panels, [ panelName, 'enabled' ], true );
 }
 
 /**

--- a/packages/edit-post/src/store/test/actions.js
+++ b/packages/edit-post/src/store/test/actions.js
@@ -4,6 +4,7 @@
 import {
 	toggleEditorPanelEnabled,
 	toggleEditorPanelOpened,
+	removeEditorPanel,
 	openGeneralSidebar,
 	closeGeneralSidebar,
 	openPublishSidebar,
@@ -55,6 +56,15 @@ describe( 'actions', () => {
 		it( 'should return an TOGGLE_PUBLISH_SIDEBAR action', () => {
 			expect( togglePublishSidebar() ).toEqual( {
 				type: 'TOGGLE_PUBLISH_SIDEBAR',
+			} );
+		} );
+	} );
+
+	describe( 'removeEditorPanel', () => {
+		it( 'should return a REMOVE_PANEL action', () => {
+			expect( removeEditorPanel( 'post-status' ) ).toEqual( {
+				type: 'REMOVE_PANEL',
+				panelName: 'post-status',
 			} );
 		} );
 	} );

--- a/packages/edit-post/src/store/test/reducer.js
+++ b/packages/edit-post/src/store/test/reducer.js
@@ -169,6 +169,21 @@ describe( 'state', () => {
 			} );
 		} );
 
+		it( 'should remove panels', () => {
+			const original = deepFreeze( {
+				panels: {
+					'post-status': {},
+				},
+			} );
+			const state = preferences( original, {
+				type: 'REMOVE_PANEL',
+				panelName: 'post-status',
+			} );
+			expect( state.panels ).toEqual( {
+				'post-status': { removed: true },
+			} );
+		} );
+
 		it( 'should return switched mode', () => {
 			const state = preferences( deepFreeze( { editorMode: 'visual' } ), {
 				type: 'SWITCH_MODE',

--- a/packages/edit-post/src/store/test/reducer.js
+++ b/packages/edit-post/src/store/test/reducer.js
@@ -13,6 +13,7 @@ import {
 	activeModal,
 	isSavingMetaBoxes,
 	metaBoxLocations,
+	removedPanels,
 } from '../reducer';
 
 describe( 'state', () => {
@@ -169,21 +170,6 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should remove panels', () => {
-			const original = deepFreeze( {
-				panels: {
-					'post-status': {},
-				},
-			} );
-			const state = preferences( original, {
-				type: 'REMOVE_PANEL',
-				panelName: 'post-status',
-			} );
-			expect( state.panels ).toEqual( {
-				'post-status': { removed: true },
-			} );
-		} );
-
 		it( 'should return switched mode', () => {
 			const state = preferences( deepFreeze( { editorMode: 'visual' } ), {
 				type: 'SWITCH_MODE',
@@ -326,6 +312,26 @@ describe( 'state', () => {
 			expect( state ).toEqual( {
 				normal: [ 'postcustom' ],
 			} );
+		} );
+	} );
+
+	describe( 'removedPanels', () => {
+		it( 'should remove panel', () => {
+			const original = deepFreeze( [] );
+			const state = removedPanels( original, {
+				type: 'REMOVE_PANEL',
+				panelName: 'post-status',
+			} );
+			expect( state ).toEqual( [ 'post-status' ] );
+		} );
+
+		it( 'should not remove already removed panel', () => {
+			const original = deepFreeze( [ 'post-status' ] );
+			const state = removedPanels( original, {
+				type: 'REMOVE_PANEL',
+				panelName: 'post-status',
+			} );
+			expect( state ).toBe( original );
 		} );
 	} );
 } );

--- a/packages/edit-post/src/store/test/selectors.js
+++ b/packages/edit-post/src/store/test/selectors.js
@@ -204,9 +204,7 @@ describe( 'selectors', () => {
 	describe( 'isEditorPanelRemoved', () => {
 		it( 'should return false by default', () => {
 			const state = deepFreeze( {
-				preferences: {
-					panels: {},
-				},
+				removedPanels: [],
 			} );
 
 			expect( isEditorPanelRemoved( state, 'post-status' ) ).toBe( false );
@@ -214,11 +212,9 @@ describe( 'selectors', () => {
 
 		it( 'should return true when panel was removed', () => {
 			const state = deepFreeze( {
-				preferences: {
-					panels: {
-						'post-status': { removed: true },
-					},
-				},
+				removedPanels: [
+					'post-status',
+				],
 			} );
 
 			expect( isEditorPanelRemoved( state, 'post-status' ) ).toBe( true );
@@ -266,10 +262,10 @@ describe( 'selectors', () => {
 					panels: {
 						'post-status': {
 							enabled: true,
-							removed: true,
 						},
 					},
 				},
+				removedPanels: [ 'post-status' ],
 			} );
 
 			expect( isEditorPanelEnabled( state, 'post-status' ) ).toBe( false );

--- a/packages/edit-post/src/store/test/selectors.js
+++ b/packages/edit-post/src/store/test/selectors.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
  * Internal dependencies
  */
 import {
@@ -16,6 +21,7 @@ import {
 	getActiveMetaBoxLocations,
 	isMetaBoxLocationActive,
 	isEditorPanelEnabled,
+	isEditorPanelRemoved,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -195,6 +201,30 @@ describe( 'selectors', () => {
 		} );
 	} );
 
+	describe( 'isEditorPanelRemoved', () => {
+		it( 'should return false by default', () => {
+			const state = deepFreeze( {
+				preferences: {
+					panels: {},
+				},
+			} );
+
+			expect( isEditorPanelRemoved( state, 'post-status' ) ).toBe( false );
+		} );
+
+		it( 'should return true when panel was removed', () => {
+			const state = deepFreeze( {
+				preferences: {
+					panels: {
+						'post-status': { removed: true },
+					},
+				},
+			} );
+
+			expect( isEditorPanelRemoved( state, 'post-status' ) ).toBe( true );
+		} );
+	} );
+
 	describe( 'isEditorPanelEnabled', () => {
 		it( 'should return true by default', () => {
 			const state = {
@@ -226,6 +256,21 @@ describe( 'selectors', () => {
 					},
 				},
 			};
+
+			expect( isEditorPanelEnabled( state, 'post-status' ) ).toBe( false );
+		} );
+
+		it( 'should return false when a panel is enabled but removed', () => {
+			const state = deepFreeze( {
+				preferences: {
+					panels: {
+						'post-status': {
+							enabled: true,
+							removed: true,
+						},
+					},
+				},
+			} );
 
 			expect( isEditorPanelEnabled( state, 'post-status' ) ).toBe( false );
 		} );

--- a/test/e2e/specs/new-post-default-content.test.js
+++ b/test/e2e/specs/new-post-default-content.test.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { newPost, getEditedPostContent, openDocumentSettingsSidebar } from '../support/utils';
+import { findSidebarPanelWithTitle, newPost, getEditedPostContent, openDocumentSettingsSidebar } from '../support/utils';
 import { activatePlugin, deactivatePlugin } from '../support/plugins';
 
 describe( 'new editor filtered state', () => {
@@ -27,7 +27,7 @@ describe( 'new editor filtered state', () => {
 
 		// open the sidebar, we want to see the excerpt.
 		await openDocumentSettingsSidebar();
-		const [ excerptButton ] = await page.$x( '//div[@class="edit-post-sidebar"]//button[@class="components-button components-panel__body-toggle"][contains(text(),"Excerpt")]' );
+		const excerptButton = await findSidebarPanelWithTitle( 'Excerpt' );
 		if ( excerptButton ) {
 			await excerptButton.click( 'button' );
 		}

--- a/test/e2e/specs/sidebar.test.js
+++ b/test/e2e/specs/sidebar.test.js
@@ -2,8 +2,10 @@
  * Internal dependencies
  */
 import {
+	findSidebarPanelWithTitle,
 	newPost,
 	observeFocusLoss,
+	openDocumentSettingsSidebar,
 	pressWithModifier,
 	setViewport,
 } from '../support/utils';
@@ -12,12 +14,12 @@ const SIDEBAR_SELECTOR = '.edit-post-sidebar';
 const ACTIVE_SIDEBAR_TAB_SELECTOR = '.edit-post-sidebar__panel-tab.is-active';
 const ACTIVE_SIDEBAR_BUTTON_TEXT = 'Document';
 
-describe( 'Publishing', () => {
+describe( 'Sidebar', () => {
 	beforeAll( () => {
 		observeFocusLoss();
 	} );
 
-	it( 'Should have sidebar visible at the start with document sidebar active on desktop', async () => {
+	it( 'should have sidebar visible at the start with document sidebar active on desktop', async () => {
 		await setViewport( 'large' );
 		await newPost();
 		const { nodesCount, content, height, width } = await page.$$eval( ACTIVE_SIDEBAR_TAB_SELECTOR, ( nodes ) => {
@@ -41,14 +43,14 @@ describe( 'Publishing', () => {
 		expect( height ).toBeGreaterThan( 10 );
 	} );
 
-	it( 'Should have the sidebar closed by default on mobile', async () => {
+	it( 'should have the sidebar closed by default on mobile', async () => {
 		await setViewport( 'small' );
 		await newPost();
 		const sidebar = await page.$( SIDEBAR_SELECTOR );
 		expect( sidebar ).toBeNull();
 	} );
 
-	it( 'Should close the sidebar when resizing from desktop to mobile', async () => {
+	it( 'should close the sidebar when resizing from desktop to mobile', async () => {
 		await setViewport( 'large' );
 		await newPost();
 
@@ -62,7 +64,7 @@ describe( 'Publishing', () => {
 		expect( sidebarsMobile ).toHaveLength( 0 );
 	} );
 
-	it( 'Should reopen sidebar the sidebar when resizing from mobile to desktop if the sidebar was closed automatically', async () => {
+	it( 'should reopen sidebar the sidebar when resizing from mobile to desktop if the sidebar was closed automatically', async () => {
 		await setViewport( 'large' );
 		await newPost();
 		await setViewport( 'small' );
@@ -76,7 +78,7 @@ describe( 'Publishing', () => {
 		expect( sidebarsDesktop ).toHaveLength( 1 );
 	} );
 
-	it( 'Should preserve tab order while changing active tab', async () => {
+	it( 'should preserve tab order while changing active tab', async () => {
 		await newPost();
 
 		// Region navigate to Sidebar.
@@ -101,5 +103,33 @@ describe( 'Publishing', () => {
 			document.activeElement.classList.contains( 'is-active' )
 		) );
 		expect( isActiveBlockTab ).toBe( true );
+	} );
+
+	it( 'should be possible to programmatically remove Document Settings panels', async () => {
+		await newPost();
+
+		await openDocumentSettingsSidebar();
+
+		expect( await findSidebarPanelWithTitle( 'Categories' ) ).toBeDefined();
+		expect( await findSidebarPanelWithTitle( 'Tags' ) ).toBeDefined();
+		expect( await findSidebarPanelWithTitle( 'Featured Image' ) ).toBeDefined();
+		expect( await findSidebarPanelWithTitle( 'Excerpt' ) ).toBeDefined();
+		expect( await findSidebarPanelWithTitle( 'Discussion' ) ).toBeDefined();
+
+		await page.evaluate( () => {
+			const { removeEditorPanel } = wp.data.dispatch( 'core/edit-post' );
+
+			removeEditorPanel( 'taxonomy-panel-category' );
+			removeEditorPanel( 'taxonomy-panel-post_tag' );
+			removeEditorPanel( 'featured-image' );
+			removeEditorPanel( 'post-excerpt' );
+			removeEditorPanel( 'discussion-panel' );
+		} );
+
+		expect( await findSidebarPanelWithTitle( 'Categories' ) ).toBeUndefined();
+		expect( await findSidebarPanelWithTitle( 'Tags' ) ).toBeUndefined();
+		expect( await findSidebarPanelWithTitle( 'Featured Image' ) ).toBeUndefined();
+		expect( await findSidebarPanelWithTitle( 'Excerpt' ) ).toBeUndefined();
+		expect( await findSidebarPanelWithTitle( 'Discussion' ) ).toBeUndefined();
 	} );
 } );

--- a/test/e2e/support/utils/find-sidebar-panel-with-title.js
+++ b/test/e2e/support/utils/find-sidebar-panel-with-title.js
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import { first } from 'lodash';
+
+/**
+ * Finds a sidebar panel with the provided title.
+ *
+ * @param {string} panelTitle The name of sidebar panel.
+ *
+ * @return {?ElementHandle} Object that represents an in-page DOM element.
+ */
+export async function findSidebarPanelWithTitle( panelTitle ) {
+	return first( await page.$x( `//div[@class="edit-post-sidebar"]//button[@class="components-button components-panel__body-toggle"][contains(text(),"${ panelTitle }")]` ) );
+}

--- a/test/e2e/support/utils/index.js
+++ b/test/e2e/support/utils/index.js
@@ -8,6 +8,7 @@ export { disablePrePublishChecks } from './disable-pre-publish-checks';
 export { enablePageDialogAccept } from './enable-page-dialog-accept';
 export { enablePrePublishChecks } from './enable-pre-publish-checks';
 export { ensureSidebarOpened } from './ensure-sidebar-opened';
+export { findSidebarPanelWithTitle } from './find-sidebar-panel-with-title';
 export { getAllBlocks } from './get-all-blocks';
 export { getEditedPostContent } from './get-edited-post-content';
 export { getUrl } from './get-url';


### PR DESCRIPTION
## Description
Closes #6225.
Related to #6533.

This PR addressed the following requests:

> Is there anything equivalent for Gutenberg, i.e. to remove a panel from the settings on the right side?

From @ecobux:
> is there any solution how to remove the panel of the post tags?

## How has this been tested?

Execute the following code in the JS console to remove one of the panels and ensure it is not present in the sidebar and Options modal (you can access it from More Menu):

```js
wp.data.dispatch( 'core/edit-post').removeEditorPanel( 'taxonomy-panel-category' ) ;
wp.data.dispatch( 'core/edit-post').removeEditorPanel( 'taxonomy-panel-post_tag' );
wp.data.dispatch( 'core/edit-post').removeEditorPanel( 'featured-image' );
wp.data.dispatch( 'core/edit-post').removeEditorPanel( 'post-excerpt' );
wp.data.dispatch( 'core/edit-post').removeEditorPanel( 'discussion-panel' );
```

Note that you can't remove `Post & Visibility` panel. The following (despite being valid) won't be reflected in the UI:

```js
wp.data.dispatch( 'core/edit-post').removeEditorPanel( 'post-status' );
```

## Screenshots <!-- if applicable -->

With all available panels completely removed:
![screen shot 2018-11-13 at 10 20 40](https://user-images.githubusercontent.com/699132/48403252-cdf91d80-e72d-11e8-82f6-b54d15eae23b.png)


With a few panels completely removed:
![screen shot 2018-11-13 at 09 41 43](https://user-images.githubusercontent.com/699132/48402493-0dbf0580-e72c-11e8-9448-91946bc5a6e6.png)

## Known issues

@noisysocks I would appreciate your help here:

![screen shot 2018-11-13 at 09 59 42](https://user-images.githubusercontent.com/699132/48402494-0dbf0580-e72c-11e8-9cc0-c70093c620f5.png)

When you remove all panels, the section title is still there. Is there an easy way to hide it, too? I know I could use CSS but I would prefer to do it properly :)

Another thing I'm not happy about is that this setting persists. I think this could cause some issues when someone uninstalls a plugin which would use this feature as marked panels would remain removed. Should we move this outside of the persisted state?

## Types of changes
New feature (non-breaking change which adds functionality for backwars compatibility).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
