### PR TITLE
Fix autocomplete suggestion list positioning

### DIFF
--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -53,8 +53,8 @@ $blocks-button__line-height: $big-font-size + 6px;
 	font-size: $default-font-size;
 	line-height: $default-line-height;
 
-	// the width of input box plus two icon buttons plus a padding
-	$blocks-button__link-input-width: 300px + 2 * $icon-button-size + 8px;
+	// the width of input box plus padding plus two icon buttons.
+	$blocks-button__link-input-width: 300px + 2px + 2 * $icon-button-size;
 	width: $blocks-button__link-input-width;
 
 	.editor-url-input {

--- a/packages/editor/src/components/url-input/index.js
+++ b/packages/editor/src/components/url-input/index.js
@@ -9,7 +9,7 @@ import scrollIntoView from 'dom-scroll-into-view';
  * WordPress dependencies
  */
 import { __, sprintf, _n } from '@wordpress/i18n';
-import { Component, Fragment, createRef } from '@wordpress/element';
+import { Component, createRef } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { UP, DOWN, ENTER, TAB } from '@wordpress/keycodes';
 import { Spinner, withSpokenMessages, Popover } from '@wordpress/components';
@@ -231,28 +231,26 @@ class URLInput extends Component {
 		const { showSuggestions, posts, selectedSuggestion, loading } = this.state;
 		/* eslint-disable jsx-a11y/no-autofocus */
 		return (
-			<Fragment>
-				<div className="editor-url-input">
-					<input
-						autoFocus={ autoFocus }
-						type="text"
-						aria-label={ __( 'URL' ) }
-						required
-						value={ value }
-						onChange={ this.onChange }
-						onInput={ stopEventPropagation }
-						placeholder={ __( 'Paste URL or type to search' ) }
-						onKeyDown={ this.onKeyDown }
-						role="combobox"
-						aria-expanded={ showSuggestions }
-						aria-autocomplete="list"
-						aria-owns={ `editor-url-input-suggestions-${ instanceId }` }
-						aria-activedescendant={ selectedSuggestion !== null ? `editor-url-input-suggestion-${ instanceId }-${ selectedSuggestion }` : undefined }
-						ref={ this.inputRef }
-					/>
+			<div className="editor-url-input">
+				<input
+					autoFocus={ autoFocus }
+					type="text"
+					aria-label={ __( 'URL' ) }
+					required
+					value={ value }
+					onChange={ this.onChange }
+					onInput={ stopEventPropagation }
+					placeholder={ __( 'Paste URL or type to search' ) }
+					onKeyDown={ this.onKeyDown }
+					role="combobox"
+					aria-expanded={ showSuggestions }
+					aria-autocomplete="list"
+					aria-owns={ `editor-url-input-suggestions-${ instanceId }` }
+					aria-activedescendant={ selectedSuggestion !== null ? `editor-url-input-suggestion-${ instanceId }-${ selectedSuggestion }` : undefined }
+					ref={ this.inputRef }
+				/>
 
-					{ ( loading ) && <Spinner /> }
-				</div>
+				{ ( loading ) && <Spinner /> }
 
 				{ showSuggestions && !! posts.length &&
 					<Popover position="bottom" noArrow focusOnMount={ false }>
@@ -281,7 +279,7 @@ class URLInput extends Component {
 						</div>
 					</Popover>
 				}
-			</Fragment>
+			</div>
 		);
 		/* eslint-enable jsx-a11y/no-autofocus */
 	}

--- a/packages/editor/src/components/url-input/style.scss
+++ b/packages/editor/src/components/url-input/style.scss
@@ -39,7 +39,7 @@ $input-size: 300px;
 	transition: all 0.15s ease-in-out;
 	padding: 4px 0;
 	// To match the url-input width: input width + padding + 2 buttons.
-	width: $input-size + 2 + 2 * $icon-button-size;
+	width: $input-size + 2;
 	overflow-y: auto;
 }
 


### PR DESCRIPTION
## Description
Fixes misalignment of the URL Input autocomplete suggestions. 

**Issue**
The autocomplete list renders in a popover, and positions itself relative to its parent. After some refactoring of the components used in the URL inputs (#10495), the list became misaligned due to a different parent being used.

**Fix**
This makes the suggestion list a child of the wrapping div around the input and adjusts the width of the suggestion list narrower to match the input.

## How has this been tested?
Manually tested button block and paragraph inputs

## Screenshots <!-- if applicable -->
**Before**
![Before](https://user-images.githubusercontent.com/1682452/47246892-99c96000-d400-11e8-99ce-54856e0297ed.png)
![screen shot 2018-11-13 at 5 43 51 pm](https://user-images.githubusercontent.com/677833/48404671-b8a2e400-e76b-11e8-959d-d5763fe994c3.png)

**After**
![screen shot 2018-11-13 at 5 37 24 pm](https://user-images.githubusercontent.com/677833/48404559-7083c180-e76b-11e8-8f85-be6180bc5a15.png)
![screen shot 2018-11-13 at 5 37 12 pm](https://user-images.githubusercontent.com/677833/48404563-72e61b80-e76b-11e8-8490-f8093ecd7714.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
