### PR TITLE
Stop propagating to DOM elements the `focusOnMount` prop from `NavigableToolbar` components

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 7.0.2 (Unreleased)
+
+### Bug Fixes
+
+- Stop propagating to DOM elements the `focusOnMount` prop from `NavigableToolbar` components
+
 ## 7.0.1 (2018-11-12)
 
 ### Polish

--- a/packages/editor/src/components/navigable-toolbar/index.js
+++ b/packages/editor/src/components/navigable-toolbar/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { cond, matchesProperty } from 'lodash';
+import { cond, matchesProperty, omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -75,7 +75,9 @@ class NavigableToolbar extends Component {
 				role="toolbar"
 				ref={ this.toolbar }
 				onKeyDown={ this.switchOnKeyDown }
-				{ ...props }
+				{ ...omit( props, [
+					'focusOnMount',
+				] ) }
 			>
 				<KeyboardShortcuts
 					bindGlobal


### PR DESCRIPTION
## Description
This PR removes the `focusOnMount` from the props transferred to `NavigableMenu` when rendering a `NavigableToolbar` component.

Fixes #11769.

## How has this been tested?
Locally by checking in the React devtools that the `focusOnMount` prop is not passed down to the children.

## Screenshots <!-- if applicable -->
Before
<img width="1028" alt="screen shot 2018-11-12 at 17 43 24" src="https://user-images.githubusercontent.com/1233880/48404809-647b0e00-e731-11e8-9461-df331b0450aa.png">

After
<img width="833" alt="screen shot 2018-11-12 at 17 46 43" src="https://user-images.githubusercontent.com/1233880/48404821-68a72b80-e731-11e8-81c7-10b98322bb8e.png">


## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
