### PR TITLE
Fix escape key failing to close inline link popover

### DIFF
--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -14,7 +14,7 @@ import {
 	ToggleControl,
 	withSpokenMessages,
 } from '@wordpress/components';
-import { ESCAPE, LEFT, RIGHT, UP, DOWN, BACKSPACE, ENTER } from '@wordpress/keycodes';
+import { LEFT, RIGHT, UP, DOWN, BACKSPACE, ENTER } from '@wordpress/keycodes';
 import { prependHTTP, safeDecodeURI, filterURLForDisplay } from '@wordpress/url';
 import {
 	create,
@@ -143,11 +143,6 @@ class InlineLinkUI extends Component {
 	}
 
 	onKeyDown( event ) {
-		if ( event.keyCode === ESCAPE ) {
-			event.stopPropagation();
-			this.resetState();
-		}
-
 		if ( [ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].indexOf( event.keyCode ) > -1 ) {
 			// Stop the key event from propagating up to ObserveTyping.startTypingInTextField.
 			event.stopPropagation();
@@ -234,6 +229,7 @@ class InlineLinkUI extends Component {
 			>
 				<URLPopover
 					onClickOutside={ this.onClickOutside }
+					onClose={ this.resetState }
 					focusOnMount={ showInput ? 'firstElement' : false }
 					renderSettings={ () => (
 						<ToggleControl

--- a/test/e2e/specs/links.test.js
+++ b/test/e2e/specs/links.test.js
@@ -387,6 +387,21 @@ describe( 'Links', () => {
 		// Expect the the escape key to dismiss the popover normally.
 		await page.keyboard.press( 'Escape' );
 		expect( await page.$( '.editor-url-popover' ) ).toBeNull();
+
+		// Press Cmd+K to insert a link
+		await pressWithModifier( META_KEY, 'K' );
+
+		// Wait for the URL field to auto-focus
+		await waitForAutoFocus();
+		expect( await page.$( '.editor-url-popover' ) ).not.toBeNull();
+
+		// Tab to the settings icon button.
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+
+		// Expect the the escape key to dismiss the popover normally.
+		await page.keyboard.press( 'Escape' );
+		expect( await page.$( '.editor-url-popover' ) ).toBeNull();
 	} );
 
 	it( 'can be modified using the keyboard once a link has been set', async () => {


### PR DESCRIPTION
## Description
Ensure the escape key can be used to close the Inline Link UI regardless of where focus is within the popover.

**The bug**
InlineLinkUI previously rolled it's own handler for closing the popover when the escape key was pressed:
https://github.com/WordPress/gutenberg/blob/c206d07403dda1d419e82b1b24e9fbeb9f3c01f9/packages/format-library/src/link/inline.js#L145-L149

Unfortunately this is only bound to a subset of the popover's UI. If the focus was on the settings part of the popover, the escape key would not trigger closure of the popover.

**Fix**
Bind an onClose handler for the popover (which handles the escape key implicitly) instead of handling it in an ad-hoc fashion.

## How has this been tested?
1. Add a paragraph and add some text
2. Highlight a word and hit command+k (or ctrl+k on linux/windows) to turn it into a link
3. Tab to the link settings icon (three dots)
4. Press escape
5. Observe that the popover closes

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
