### PR TITLE
Fall back to paragraph for pasted URLs that can't embed

### DIFF
--- a/packages/block-library/src/embed/core-embeds.js
+++ b/packages/block-library/src/embed/core-embeds.js
@@ -26,6 +26,15 @@ import { createBlock } from '@wordpress/blocks';
 
 export const common = [
 	{
+		name: 'core-embed/paste-handler',
+		settings: {
+			title: 'Internal embed paste handler',
+			icon: embedContentIcon,
+			description: 'Used to process pasted URLs into an actual embed block.',
+			isPasteHandler: true,
+		},
+	},
+	{
 		name: 'core-embed/twitter',
 		settings: {
 			title: 'Twitter',

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { isFromWordPress, createUpgradedEmbedBlock, getClassNames, createPasteFallbackBlock } from './util';
+import { DEFAULT_EMBED_BLOCK } from './constants';
 import EmbedControls from './embed-controls';
 import EmbedLoading from './embed-loading';
 import EmbedPlaceholder from './embed-placeholder';
@@ -70,10 +71,10 @@ export function getEmbedEditComponent( title, icon, responsive = true, pasting =
 				return;
 			}
 
-			// This URL can be embedded, so pass it over to the core embed block to continue.
+			// This URL can be embedded, so pass it over to the default embed block to continue.
 			if ( url && ! fetching && ! cannotEmbed ) {
 				this.props.onReplace(
-					createBlock( 'core/embed', { url } )
+					createBlock( DEFAULT_EMBED_BLOCK, { url } )
 				);
 			}
 		}

--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -25,7 +25,7 @@ export const settings = getEmbedBlockSettings( {
 				type: 'raw',
 				isMatch: ( node ) => node.nodeName === 'P' && /^\s*(https?:\/\/\S+)\s*$/i.test( node.textContent ),
 				transform: ( node ) => {
-					return createBlock( 'core/embed', {
+					return createBlock( 'core-embed/paste-handler', {
 						url: node.textContent.trim(),
 					} );
 				},

--- a/packages/block-library/src/embed/settings.js
+++ b/packages/block-library/src/embed/settings.js
@@ -37,10 +37,10 @@ const embedAttributes = {
 	},
 };
 
-export function getEmbedBlockSettings( { title, description, icon, category = 'embed', transforms, keywords = [], supports = {}, responsive = true } ) {
+export function getEmbedBlockSettings( { title, description, icon, category = 'embed', transforms, keywords = [], supports = {}, responsive = true, isPasteHandler = false } ) {
 	// translators: %s: Name of service (e.g. VideoPress, YouTube)
 	const blockDescription = description || sprintf( __( 'Add a block that displays content pulled from other sites, like Twitter, Instagram or YouTube.' ), title );
-	const edit = getEmbedEditComponent( title, icon, responsive );
+	const edit = getEmbedEditComponent( title, icon, responsive, isPasteHandler );
 	return {
 		title,
 		description: blockDescription,
@@ -51,6 +51,7 @@ export function getEmbedBlockSettings( { title, description, icon, category = 'e
 
 		supports: {
 			align: true,
+			inserter: ! isPasteHandler,
 			...supports,
 		},
 

--- a/packages/block-library/src/embed/util.js
+++ b/packages/block-library/src/embed/util.js
@@ -163,3 +163,7 @@ export function getClassNames( html, existingClassNames = '', allowResponsive = 
 
 	return existingClassNames;
 }
+
+export function createPasteFallbackBlock( url ) {
+	return createBlock( 'core/paragraph', { content: url } );
+}

--- a/test/e2e/specs/embedding.test.js
+++ b/test/e2e/specs/embedding.test.js
@@ -168,8 +168,8 @@ describe( 'Embedding content', () => {
 	} );
 
 	it( 'should handle non-embeddable pasted URLs', async () => {
-		// URL that cannot be embedded.
 		await clickBlockAppender();
+		// URL that cannot be embedded.
 		await page.keyboard.type( 'https://twitter.com/wooyaygutenberg123454312' );
 		await pressWithModifier( META_KEY, 'a' ); // Select the URL we just typed.
 		await pressWithModifier( META_KEY, 'x' ); // Cut it.
@@ -185,8 +185,8 @@ describe( 'Embedding content', () => {
 	} );
 
 	it( 'should handle embeddable pasted URLs', async () => {
-		// URL that can be embedded.
 		await clickBlockAppender();
+		// URL that can be embedded.
 		await page.keyboard.type( 'https://www.youtube.com/watch?v=lXMskKTw3Bc' );
 		await pressWithModifier( META_KEY, 'a' ); // Select the URL we just typed.
 		await pressWithModifier( META_KEY, 'x' ); // Cut it.
@@ -196,8 +196,8 @@ describe( 'Embedding content', () => {
 	} );
 
 	it( 'should put unknown but embeddable pasted URLs into the generic embed block', async () => {
-		// URL that can be embedded.
 		await clickBlockAppender();
+		// URL that can be embedded, but we don't have a specific block for.
 		await page.keyboard.type( 'https://giphy.com/gifs/reaction-jdOm0IddQuJP2' );
 		await pressWithModifier( META_KEY, 'a' ); // Select the URL we just typed.
 		await pressWithModifier( META_KEY, 'x' ); // Cut it.


### PR DESCRIPTION
## Description

Fixes: https://github.com/WordPress/gutenberg/issues/4799

If you paste a URL that cannot be embedded, we should fall back to a paragraph block with the URL as its content.

This adds code for handling pastes, and registers a paste handler embed block with the code activated. If the URL can be embedded, it's passed to the default embed block, which operates on it normally. If it can't be embedded, it is replaced with a paragraph. E2E tests have been added to cover this behaviour.

## How has this been tested?

New e2e tests added.

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
