### PR TITLE
Better position sticky toolbar on floats

### DIFF
--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -318,6 +318,14 @@
 		right: 0;
 	}
 
+	// Position the sticky toolbar correctly beyond the mobile breakpoint.
+	@include break-small() {
+		&[data-align="right"] .editor-block-contextual-toolbar,
+		&[data-align="left"] .editor-block-contextual-toolbar {
+			top: $block-padding;
+		}
+	}
+
 	// Left
 	&[data-align="left"] {
 		// This is in the editor only; the image should be floated on the frontend.


### PR DESCRIPTION
The toolbar for floats, beyond the mobile breakpoint, was a little offset. This PR fixes it.

Before:

<img width="495" alt="screenshot 2018-11-13 at 12 21 18" src="https://user-images.githubusercontent.com/1204802/48410419-d3ab2f00-e73e-11e8-8269-e634b93afe8f.png">

After:

<img width="481" alt="screenshot 2018-11-13 at 12 21 05" src="https://user-images.githubusercontent.com/1204802/48410425-d73eb600-e73e-11e8-8f03-a1d40c6a978c.png">
