### PR TITLE
Avoid using getSelectedBlock and getBlock as much as we can

### DIFF
--- a/docs/data/data-core-editor.md
+++ b/docs/data/data-core-editor.md
@@ -398,6 +398,20 @@ the client ID.
 
 Block name.
 
+### getBlockAttributes
+
+Returns a block's attributes given its client ID, or null if no block exists with
+the client ID.
+
+*Parameters*
+
+ * state: Editor state.
+ * clientId: Block client ID.
+
+*Returns*
+
+Block attributes.
+
 ### isBlockValid
 
 Returns whether a block is valid or not.

--- a/docs/data/data-core-editor.md
+++ b/docs/data/data-core-editor.md
@@ -398,6 +398,19 @@ the client ID.
 
 Block name.
 
+### isBlockValid
+
+Returns whether a block is valid or not.
+
+*Parameters*
+
+ * state: Editor state.
+ * clientId: Block client ID.
+
+*Returns*
+
+Is Valid.
+
 ### getBlock
 
 Returns a block given its client ID. This is a parsed copy of the block,

--- a/packages/editor/src/components/autocompleters/block.js
+++ b/packages/editor/src/components/autocompleters/block.js
@@ -40,8 +40,8 @@ function defaultGetInserterItems( rootClientId ) {
  *                   block is selected.
  */
 function defaultGetSelectedBlockName() {
-	const selectedBlock = select( 'core/editor' ).getSelectedBlock();
-	return selectedBlock ? selectedBlock.name : null;
+	const selectedBlockClientId = select( 'core/editor' ).getSelectedBlockClientId();
+	return selectedBlockClientId ? select( 'core/editor' ).getBlockName( selectedBlockClientId ) : null;
 }
 
 /**

--- a/packages/editor/src/components/block-inspector/index.js
+++ b/packages/editor/src/components/block-inspector/index.js
@@ -21,19 +21,18 @@ import InspectorControls from '../inspector-controls';
 import InspectorAdvancedControls from '../inspector-advanced-controls';
 import BlockStyles from '../block-styles';
 
-const BlockInspector = ( { selectedBlock, blockType, count, hasBlockStyles } ) => {
+const BlockInspector = ( { selectedBlockName, selectedBlockClientId, blockType, count, hasBlockStyles } ) => {
 	if ( count > 1 ) {
 		return <span className="editor-block-inspector__multi-blocks">{ __( 'Coming Soon' ) }</span>;
 	}
 
-	const isSelectedBlockUnregistered =
-		!! selectedBlock && selectedBlock.name === getUnregisteredTypeHandlerName();
+	const isSelectedBlockUnregistered = selectedBlockName === getUnregisteredTypeHandlerName();
 
 	/*
 	 * If the selected block is of an unregistered type, avoid showing it as an actual selection
 	 * because we want the user to focus on the unregistered block warning, not block settings.
 	 */
-	if ( ! selectedBlock || isSelectedBlockUnregistered ) {
+	if ( ! selectedBlockClientId || isSelectedBlockUnregistered ) {
 		return <span className="editor-block-inspector__no-blocks">{ __( 'No block selected.' ) }</span>;
 	}
 
@@ -52,9 +51,7 @@ const BlockInspector = ( { selectedBlock, blockType, count, hasBlockStyles } ) =
 						title={ __( 'Styles' ) }
 						initialOpen={ false }
 					>
-						<BlockStyles
-							clientId={ selectedBlock.clientId }
-						/>
+						<BlockStyles clientId={ selectedBlockClientId } />
 					</PanelBody>
 				</div>
 			) }
@@ -79,15 +76,17 @@ const BlockInspector = ( { selectedBlock, blockType, count, hasBlockStyles } ) =
 
 export default withSelect(
 	( select ) => {
-		const { getSelectedBlock, getSelectedBlockCount } = select( 'core/editor' );
+		const { getSelectedBlockClientId, getBlockName, getSelectedBlockCount } = select( 'core/editor' );
 		const { getBlockStyles } = select( 'core/blocks' );
-		const selectedBlock = getSelectedBlock();
-		const blockType = selectedBlock && getBlockType( selectedBlock.name );
-		const blockStyles = selectedBlock && getBlockStyles( selectedBlock.name );
+		const selectedBlockClientId = getSelectedBlockClientId();
+		const selectedBlockName = selectedBlockClientId && getBlockName( selectedBlockClientId );
+		const blockType = selectedBlockName && getBlockType( selectedBlockName );
+		const blockStyles = selectedBlockName && getBlockStyles( selectedBlockName );
 		return {
 			count: getSelectedBlockCount(),
 			hasBlockStyles: blockStyles && blockStyles.length > 0,
-			selectedBlock,
+			selectedBlockClientId,
+			selectedBlockName,
 			blockType,
 		};
 	}

--- a/packages/editor/src/components/block-inspector/index.js
+++ b/packages/editor/src/components/block-inspector/index.js
@@ -26,13 +26,13 @@ const BlockInspector = ( { selectedBlockName, selectedBlockClientId, blockType, 
 		return <span className="editor-block-inspector__multi-blocks">{ __( 'Coming Soon' ) }</span>;
 	}
 
-	const isSelectedBlockUnregistered = selectedBlockName === getUnregisteredTypeHandlerName();
+	const isSelectedBlockUnregistered = !! selectedBlockClientId && selectedBlockName === getUnregisteredTypeHandlerName();
 
 	/*
 	 * If the selected block is of an unregistered type, avoid showing it as an actual selection
 	 * because we want the user to focus on the unregistered block warning, not block settings.
 	 */
-	if ( ! selectedBlockClientId || isSelectedBlockUnregistered ) {
+	if ( ! blockType || ! selectedBlockClientId || isSelectedBlockUnregistered ) {
 		return <span className="editor-block-inspector__no-blocks">{ __( 'No block selected.' ) }</span>;
 	}
 
@@ -82,6 +82,7 @@ export default withSelect(
 		const selectedBlockName = selectedBlockClientId && getBlockName( selectedBlockClientId );
 		const blockType = selectedBlockName && getBlockType( selectedBlockName );
 		const blockStyles = selectedBlockName && getBlockStyles( selectedBlockName );
+
 		return {
 			count: getSelectedBlockCount(),
 			hasBlockStyles: blockStyles && blockStyles.length > 0,

--- a/packages/editor/src/components/block-list/block-invalid-warning.js
+++ b/packages/editor/src/components/block-list/block-invalid-warning.js
@@ -9,7 +9,8 @@ import {
 	createBlock,
 	rawHandler,
 } from '@wordpress/blocks';
-import { withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+import { withDispatch, withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -96,18 +97,23 @@ const blockToBlocks = ( block ) => rawHandler( {
 	HTML: block.originalContent,
 } );
 
-export default withDispatch( ( dispatch, { block } ) => {
-	const { replaceBlock } = dispatch( 'core/editor' );
+export default compose( [
+	withSelect( ( select, { clientId } ) => ( {
+		block: select( 'core/editor' ).getBlock( clientId ),
+	} ) ),
+	withDispatch( ( dispatch, { block } ) => {
+		const { replaceBlock } = dispatch( 'core/editor' );
 
-	return {
-		convertToClassic() {
-			replaceBlock( block.clientId, blockToClassic( block ) );
-		},
-		convertToHTML() {
-			replaceBlock( block.clientId, blockToHTML( block ) );
-		},
-		convertToBlocks() {
-			replaceBlock( block.clientId, blockToBlocks( block ) );
-		},
-	};
-} )( BlockInvalidWarning );
+		return {
+			convertToClassic() {
+				replaceBlock( block.clientId, blockToClassic( block ) );
+			},
+			convertToHTML() {
+				replaceBlock( block.clientId, blockToHTML( block ) );
+			},
+			convertToBlocks() {
+				replaceBlock( block.clientId, blockToBlocks( block ) );
+			},
+		};
+	} ),
+] )( BlockInvalidWarning );

--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -166,9 +166,9 @@ export class BlockListBlock extends Component {
 	}
 
 	setAttributes( attributes ) {
-		const { block, onChange } = this.props;
-		const type = getBlockType( block.name );
-		onChange( block.clientId, attributes );
+		const { clientId, blockName, onChange } = this.props;
+		const type = getBlockType( blockName );
+		onChange( clientId, attributes );
 
 		const metaAttributes = reduce( attributes, ( result, value, key ) => {
 			if ( get( type, [ 'attributes', key, 'source' ] ) === 'meta' ) {
@@ -231,7 +231,7 @@ export class BlockListBlock extends Component {
 	}
 
 	mergeBlocks( forward = false ) {
-		const { block, previousBlockClientId, nextBlockClientId, onMerge } = this.props;
+		const { clientId, previousBlockClientId, nextBlockClientId, onMerge } = this.props;
 
 		// Do nothing when it's the first block.
 		if (
@@ -242,9 +242,9 @@ export class BlockListBlock extends Component {
 		}
 
 		if ( forward ) {
-			onMerge( block.clientId, nextBlockClientId );
+			onMerge( clientId, nextBlockClientId );
 		} else {
-			onMerge( previousBlockClientId, block.clientId );
+			onMerge( previousBlockClientId, clientId );
 		}
 	}
 
@@ -390,7 +390,6 @@ export class BlockListBlock extends Component {
 			<HoverArea container={ this.wrapperNode }>
 				{ ( { hoverArea } ) => {
 					const {
-						block,
 						order,
 						mode,
 						isFocusMode,
@@ -412,16 +411,18 @@ export class BlockListBlock extends Component {
 						isParentOfSelectedBlock,
 						isDraggable,
 						className,
+						blockName,
+						isValid,
+						blockAttributes,
 					} = this.props;
 					const isHovered = this.state.isHovered && ! isMultiSelecting;
-					const { name: blockName, isValid } = block;
 					const blockType = getBlockType( blockName );
 					// translators: %s: Type of block (i.e. Text, Image etc)
 					const blockLabel = sprintf( __( 'Block: %s' ), blockType.title );
 					// The block as rendered in the editor is composed of general block UI
 					// (mover, toolbar, wrapper) and the display of the block content.
 
-					const isUnregisteredBlock = block.name === getUnregisteredTypeHandlerName();
+					const isUnregisteredBlock = blockName === getUnregisteredTypeHandlerName();
 
 					// If the block is selected and we're typing the block should not appear.
 					// Empty paragraph blocks should always show up as unselected.
@@ -462,7 +463,7 @@ export class BlockListBlock extends Component {
 					if ( blockType.getEditWrapperProps ) {
 						wrapperProps = {
 							...wrapperProps,
-							...blockType.getEditWrapperProps( block.attributes ),
+							...blockType.getEditWrapperProps( blockAttributes ),
 						};
 					}
 					const blockElementId = `block-${ clientId }`;
@@ -475,7 +476,7 @@ export class BlockListBlock extends Component {
 						<BlockEdit
 							name={ blockName }
 							isSelected={ isSelected }
-							attributes={ block.attributes }
+							attributes={ blockAttributes }
 							setAttributes={ this.setAttributes }
 							insertBlocksAfter={ isLocked ? undefined : this.insertBlocksAfter }
 							onReplace={ isLocked ? undefined : onReplace }
@@ -507,7 +508,7 @@ export class BlockListBlock extends Component {
 							onMouseOverHandled={ this.hideHoverEffects }
 							onMouseLeave={ this.hideHoverEffects }
 							className={ wrapperClassName }
-							data-type={ block.name }
+							data-type={ blockName }
 							onTouchStart={ this.onTouchStart }
 							onFocus={ this.onFocus }
 							onClick={ this.onClick }
@@ -592,10 +593,10 @@ export class BlockListBlock extends Component {
 										{ ! isValid && [
 											<BlockInvalidWarning
 												key="invalid-warning"
-												block={ block }
+												clientId={ clientId }
 											/>,
 											<div key="invalid-preview">
-												{ getSaveElement( blockType, block.attributes ) }
+												{ getSaveElement( blockType, blockAttributes ) }
 											</div>,
 										] }
 									</BlockCrashBoundary>
@@ -638,7 +639,9 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId, isLargeV
 		isBlockSelected,
 		getPreviousBlockClientId,
 		getNextBlockClientId,
-		getBlock,
+		getBlockName,
+		isBlockValid,
+		getBlockAttributes,
 		isAncestorMultiSelected,
 		isBlockMultiSelected,
 		isFirstMultiSelectedBlock,
@@ -657,11 +660,11 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId, isLargeV
 	} = select( 'core/editor' );
 	const isSelected = isBlockSelected( clientId );
 	const { hasFixedToolbar, focusMode } = getEditorSettings();
-	const block = getBlock( clientId );
 	const previousBlockClientId = getPreviousBlockClientId( clientId );
-	const previousBlock = getBlock( previousBlockClientId );
 	const templateLock = getTemplateLock( rootClientId );
 	const isParentOfSelectedBlock = hasSelectedInnerBlock( clientId, true );
+	const blockName = getBlockName( clientId );
+	const blockAttributes = getBlockAttributes( clientId );
 
 	return {
 		nextBlockClientId: getNextBlockClientId( clientId ),
@@ -677,14 +680,19 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId, isLargeV
 		mode: getBlockMode( clientId ),
 		isSelectionEnabled: isSelectionEnabled(),
 		initialPosition: getSelectedBlocksInitialCaretPosition(),
-		isEmptyDefaultBlock: block && isUnmodifiedDefaultBlock( block ),
-		isPreviousBlockADefaultEmptyBlock: previousBlock && isUnmodifiedDefaultBlock( previousBlock ),
+		isEmptyDefaultBlock: blockName && isUnmodifiedDefaultBlock( { name: blockName, attributes: blockAttributes } ),
+		isPreviousBlockADefaultEmptyBlock: previousBlockClientId && isUnmodifiedDefaultBlock( {
+			name: getBlockName( previousBlockClientId ),
+			attributes: getBlockAttributes( previousBlockClientId ),
+		} ),
+		isValid: isBlockValid( clientId ),
 		isMovable: 'all' !== templateLock,
 		isLocked: !! templateLock,
 		isFocusMode: focusMode && isLargeViewport,
 		hasFixedToolbar: hasFixedToolbar && isLargeViewport,
+		blockName,
+		blockAttributes,
 		previousBlockClientId,
-		block,
 		isSelected,
 		isParentOfSelectedBlock,
 		// We only care about this value when the shift key is pressed.

--- a/packages/editor/src/components/block-toolbar/index.js
+++ b/packages/editor/src/components/block-toolbar/index.js
@@ -43,18 +43,19 @@ function BlockToolbar( { blockClientIds, isValid, mode } ) {
 
 export default withSelect( ( select ) => {
 	const {
-		getSelectedBlock,
+		getSelectedBlockClientId,
 		getBlockMode,
+		isBlockValid,
 		getMultiSelectedBlockClientIds,
 	} = select( 'core/editor' );
-	const block = getSelectedBlock();
-	const blockClientIds = block ?
-		[ block.clientId ] :
+	const selectedBlockClientId = getSelectedBlockClientId();
+	const blockClientIds = selectedBlockClientId ?
+		[ selectedBlockClientId ] :
 		getMultiSelectedBlockClientIds();
 
 	return {
 		blockClientIds,
-		isValid: block ? block.isValid : null,
-		mode: block ? getBlockMode( block.clientId ) : null,
+		isValid: selectedBlockClientId ? isBlockValid( selectedBlockClientId ) : null,
+		mode: selectedBlockClientId ? getBlockMode( selectedBlockClientId ) : null,
 	};
 } )( BlockToolbar );

--- a/packages/editor/src/components/copy-handler/index.js
+++ b/packages/editor/src/components/copy-handler/index.js
@@ -26,18 +26,18 @@ class CopyHandler extends Component {
 	}
 
 	onCopy( event ) {
-		const { multiSelectedBlocks, selectedBlock } = this.props;
+		const { selectedBlockClientIds, getBlocks } = this.props;
 
-		if ( ! multiSelectedBlocks.length && ! selectedBlock ) {
+		if ( ! selectedBlockClientIds || selectedBlockClientIds.length === 0 ) {
 			return;
 		}
 
 		// Let native copy behaviour take over in input fields.
-		if ( selectedBlock && documentHasSelection() ) {
+		if ( selectedBlockClientIds.length === 1 && documentHasSelection() ) {
 			return;
 		}
 
-		const serialized = serialize( selectedBlock || multiSelectedBlocks );
+		const serialized = serialize( getBlocks( selectedBlockClientIds ) );
 
 		event.clipboardData.setData( 'text/plain', serialized );
 		event.clipboardData.setData( 'text/html', serialized );
@@ -63,14 +63,20 @@ class CopyHandler extends Component {
 export default compose( [
 	withSelect( ( select ) => {
 		const {
-			getMultiSelectedBlocks,
 			getMultiSelectedBlockClientIds,
-			getSelectedBlock,
+			getSelectedBlockClientId,
+			getBlocks,
 		} = select( 'core/editor' );
+
+		const selectedBlockClientId = getSelectedBlockClientId();
+		const selectedBlockClientIds = selectedBlockClientId ? [ selectedBlockClientId ] : getMultiSelectedBlockClientIds();
+
 		return {
-			multiSelectedBlocks: getMultiSelectedBlocks(),
-			multiSelectedBlockClientIds: getMultiSelectedBlockClientIds(),
-			selectedBlock: getSelectedBlock(),
+			selectedBlockClientIds,
+
+			// We only care about this value when the copy is performed
+			// We call it dynamically in the event handler to avoid unnecessary re-renders.
+			getBlocks,
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {

--- a/packages/editor/src/components/default-block-appender/index.js
+++ b/packages/editor/src/components/default-block-appender/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
 import TextareaAutosize from 'react-autosize-textarea';
 
 /**
@@ -67,12 +66,17 @@ export function DefaultBlockAppender( {
 }
 export default compose(
 	withSelect( ( select, ownProps ) => {
-		const { getBlockCount, getBlock, getEditorSettings, getTemplateLock } = select( 'core/editor' );
+		const {
+			getBlockCount,
+			getEditorSettings,
+			getTemplateLock,
+			getBlockName,
+			isBlockValid,
+		} = select( 'core/editor' );
 
 		const isEmpty = ! getBlockCount( ownProps.rootClientId );
-		const lastBlock = getBlock( ownProps.lastBlockClientId );
-		const isLastBlockDefault = get( lastBlock, [ 'name' ] ) === getDefaultBlockName();
-		const isLastBlockValid = get( lastBlock, [ 'isValid' ] );
+		const isLastBlockDefault = getBlockName( ownProps.lastBlockClientId ) === getDefaultBlockName();
+		const isLastBlockValid = isBlockValid( ownProps.lastBlockClientId );
 		const { bodyPlaceholder } = getEditorSettings();
 
 		return {

--- a/packages/editor/src/components/editor-global-keyboard-shortcuts/index.js
+++ b/packages/editor/src/components/editor-global-keyboard-shortcuts/index.js
@@ -155,10 +155,10 @@ export default compose( [
 			isEditedPostDirty,
 			getBlockRootClientId,
 			getTemplateLock,
-			getSelectedBlock,
+			getSelectedBlockClientId,
 		} = select( 'core/editor' );
-		const block = getSelectedBlock();
-		const selectedBlockClientIds = block ? [ block.clientId ] : getMultiSelectedBlockClientIds();
+		const selectedBlockClientId = getSelectedBlockClientId();
+		const selectedBlockClientIds = selectedBlockClientId ? [ selectedBlockClientId ] : getMultiSelectedBlockClientIds();
 
 		return {
 			rootBlocksClientIds: getBlockOrder(),

--- a/packages/editor/src/hooks/align.js
+++ b/packages/editor/src/hooks/align.js
@@ -111,8 +111,8 @@ export const withToolbarControls = createHigherOrderComponent( ( BlockEdit ) => 
  */
 export const withDataAlign = createHigherOrderComponent( ( BlockListBlock ) => {
 	return ( props ) => {
-		const { align } = props.block.attributes;
-		const validAlignments = getBlockValidAlignments( props.block.name );
+		const { align } = props.blockAttributes;
+		const validAlignments = getBlockValidAlignments( props.blockName );
 
 		let wrapperProps = props.wrapperProps;
 		if ( includes( validAlignments, align ) ) {

--- a/packages/editor/src/store/effects.js
+++ b/packages/editor/src/store/effects.js
@@ -33,7 +33,7 @@ import {
 	getBlocks,
 	getBlockCount,
 	getPreviousBlockClientId,
-	getSelectedBlock,
+	getSelectedBlockClientId,
 	getSelectedBlockCount,
 	getTemplate,
 	getTemplateLock,
@@ -104,7 +104,7 @@ export function selectPreviousBlock( action, store ) {
 
 	const firstRemovedBlockClientId = action.clientIds[ 0 ];
 	const state = store.getState();
-	const currentSelectedBlock = getSelectedBlock( state );
+	const currentSelectedBlock = getSelectedBlockClientId( state );
 
 	// recreate the state before the block was removed.
 	const previousState = { ...state, editor: { present: last( state.editor.past ) } };

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -602,6 +602,19 @@ export function getBlockName( state, clientId ) {
 }
 
 /**
+ * Returns whether a block is valid or not.
+ *
+ * @param {Object} state    Editor state.
+ * @param {string} clientId Block client ID.
+ *
+ * @return {boolean} Is Valid.
+ */
+export function isBlockValid( state, clientId ) {
+	const block = state.editor.present.blocks.byClientId[ clientId ];
+	return block && block.isValid;
+}
+
+/**
  * Returns a block given its client ID. This is a parsed copy of the block,
  * containing its `blockName`, `clientId`, and current `attributes` state. This
  * is not the block's registration settings, which must be retrieved from the
@@ -1503,14 +1516,14 @@ export function getSuggestedPostFormat( state ) {
 	// If there is only one block in the content of the post grab its name
 	// so we can derive a suitable post format from it.
 	if ( blocks.length === 1 ) {
-		name = getBlock( state, blocks[ 0 ] ).name;
+		name = getBlockName( state, blocks[ 0 ] );
 	}
 
 	// If there are two blocks in the content and the last one is a text blocks
 	// grab the name of the first one to also suggest a post format from it.
 	if ( blocks.length === 2 ) {
-		if ( getBlock( state, blocks[ 1 ] ).name === 'core/paragraph' ) {
-			name = getBlock( state, blocks[ 0 ] ).name;
+		if ( getBlockName( state, blocks[ 1 ] ) === 'core/paragraph' ) {
+			name = getBlockName( state, blocks[ 0 ] );
 		}
 	}
 
@@ -1789,17 +1802,17 @@ export const getInserterItems = createSelector(
 				return false;
 			}
 
-			const referencedBlock = getBlock( state, reusableBlock.clientId );
-			if ( ! referencedBlock ) {
+			const referencedBlockName = getBlockName( state, reusableBlock.clientId );
+			if ( ! referencedBlockName ) {
 				return false;
 			}
 
-			const referencedBlockType = getBlockType( referencedBlock.name );
+			const referencedBlockType = getBlockType( referencedBlockName );
 			if ( ! referencedBlockType ) {
 				return false;
 			}
 
-			if ( ! canInsertBlockType( state, referencedBlockType.name, rootClientId ) ) {
+			if ( ! canInsertBlockType( state, referencedBlockName, rootClientId ) ) {
 				return false;
 			}
 
@@ -1809,8 +1822,8 @@ export const getInserterItems = createSelector(
 		const buildReusableBlockInserterItem = ( reusableBlock ) => {
 			const id = `core/block/${ reusableBlock.id }`;
 
-			const referencedBlock = getBlock( state, reusableBlock.clientId );
-			const referencedBlockType = getBlockType( referencedBlock.name );
+			const referencedBlockName = getBlockName( state, reusableBlock.clientId );
+			const referencedBlockType = getBlockType( referencedBlockName );
 
 			const { time, count = 0 } = getInsertUsage( state, id ) || {};
 			const utility = calculateUtility( 'reusable', count, false );


### PR DESCRIPTION
While investigating #11782 I discovered that the `getBlock` selector is not very performant even memoized. This PR tries to tweak our components to avoid relying too much on the block objects and use the block Ids and discrete properties instead.

I honestly don't know if it did improve the slowness feeling or not. It's very hard to measure properly.