### PR TITLE
Tests: add e2e test for invalid blocks

### DIFF
--- a/test/e2e/specs/invalid-block.test.js
+++ b/test/e2e/specs/invalid-block.test.js
@@ -1,0 +1,43 @@
+/**
+ * Internal dependencies
+ */
+import {
+	newPost,
+	clickBlockAppender,
+} from '../support/utils';
+
+describe( 'invalid blocks', () => {
+	beforeEach( async () => {
+		await newPost();
+	} );
+
+	it( 'Should show an invalid block message with clickable options', async () => {
+		// Create an empty paragraph with the focus in the block
+		await clickBlockAppender();
+		await page.keyboard.type( 'hello' );
+
+		// Click the 'more options'
+		await page.mouse.move( 200, 300, { steps: 10 } );
+		await page.click( 'button[aria-label="More options"]' );
+
+		// Change to HTML mode and close the options
+		const changeModeButton = await page.waitForXPath( '//button[text()="Edit as HTML"]' );
+		await changeModeButton.click();
+
+		// Focus on the textarea and enter an invalid paragraph
+		await page.click( '.editor-block-list__layout .editor-block-list__block .editor-block-list__block-html-textarea' );
+		await page.keyboard.type( '<p>invalid paragraph' );
+
+		// Takes the focus away from the block so the invalid warning is triggered
+		await page.click( '.editor-post-save-draft' );
+		expect( console ).toHaveErrored();
+		expect( console ).toHaveWarned();
+
+		// Click on the 'resolve' button
+		await page.click( '.editor-warning__actions button' );
+
+		// Check we get the resolve modal with the appropriate contents
+		const htmlBlockContent = await page.$eval( '.editor-block-compare__html', ( node ) => node.textContent );
+		expect( htmlBlockContent ).toEqual( '<p>hello</p><p>invalid paragraph' );
+	} );
+} );


### PR DESCRIPTION
Adds an e2e test for invalid blocks.

Tests that the invalid block warning appears and that buttons are clickable. This should cover the issue fixed in #11768

## How has this been tested?
The automated tests in this PR show the test works.

To show the test detects the problem in #11768 you will need to do a bit of juggling:
1. Run test against c206d07403dda1d419e82b1b24e9fbeb9f3c01f9 (the last commit before the fix in #11768)
2. Verify that the test fails
<img width="500" alt="1__john_imac____sites_personal_wp_plugins_gutenberg__zsh_" src="https://user-images.githubusercontent.com/1277682/48419959-2857a580-e751-11e8-8940-2459525b8256.png">
