### PR TITLE
Dismiss notice overlap fix

### DIFF
--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -1,27 +1,33 @@
-.components-notice {
-	background-color: $blue-medium-100;
-	border-left: 4px solid $blue-medium-500;
-	margin: 5px 15px 2px;
-	padding: 8px 12px;
+.edit-post-layout {
 
-	&.is-dismissible {
-		padding-right: 36px;
-		position: relative;
-	}
+	.components-notice-list {
 
-	&.is-success {
-		border-left-color: $alert-green;
-		background-color: lighten($alert-green, 45%);
-	}
+		.components-notice {
+			background-color: $blue-medium-100;
+			border-left: 4px solid $blue-medium-500;
+			margin: 5px 15px 2px;
+			padding: 8px 12px;
 
-	&.is-warning {
-		border-left-color: $alert-yellow;
-		background-color: lighten($alert-yellow, 35%);
-	}
+			&.is-dismissible {
+				padding-right: 36px;
+				position: relative;
+			}
 
-	&.is-error {
-		border-left-color: $alert-red;
-		background-color: lighten($alert-red, 35%);
+			&.is-success {
+				border-left-color: $alert-green;
+				background-color: lighten($alert-green, 45%);
+			}
+
+			&.is-warning {
+				border-left-color: $alert-yellow;
+				background-color: lighten($alert-yellow, 35%);
+			}
+
+			&.is-error {
+				border-left-color: $alert-red;
+				background-color: lighten($alert-red, 35%);
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Better targets the dismissable notices to add more padding to the right side to avoid overlaping of the text.

Fixes #11156 