### PR TITLE
Token List: Add missing stringifier and iterator

### DIFF
--- a/packages/token-list/CHANGELOG.md
+++ b/packages/token-list/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.0 (Unreleased)
+
+### Enhancements
+
+- Implements missing stringification behavior (i.e. `toString`), as prescribed in the standard to be the `value` property (the interface's `stringifier`)
+
 ## 1.0.0 (2018-09-05)
 
 - Initial release

--- a/packages/token-list/CHANGELOG.md
+++ b/packages/token-list/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Enhancements
 
 - Implements missing stringification behavior (i.e. `toString`), as prescribed in the standard to be the `value` property (the interface's `stringifier`)
+- Implements missing iterator behavior
 
 ## 1.0.0 (2018-09-05)
 

--- a/packages/token-list/src/index.js
+++ b/packages/token-list/src/index.js
@@ -60,6 +60,18 @@ export default class TokenList {
 	}
 
 	/**
+	 * Returns the stringified form of the TokenList.
+	 *
+	 * @link https://dom.spec.whatwg.org/#DOMTokenList-stringification-behavior
+	 * @link https://www.ecma-international.org/ecma-262/9.0/index.html#sec-tostring
+	 *
+	 * @return {string} Token set as string.
+	 */
+	toString() {
+		return this.value;
+	}
+
+	/**
 	 * Returns the token with index `index`.
 	 *
 	 * @link https://dom.spec.whatwg.org/#dom-domtokenlist-item

--- a/packages/token-list/src/index.js
+++ b/packages/token-list/src/index.js
@@ -72,6 +72,17 @@ export default class TokenList {
 	}
 
 	/**
+	 * Returns an iterator for the TokenList, iterating items of the set.
+	 *
+	 * @link https://dom.spec.whatwg.org/#domtokenlist
+	 *
+	 * @return {Generator} TokenList iterator.
+	 */
+	* [ Symbol.iterator ]() {
+		return yield* this._valueAsArray;
+	}
+
+	/**
 	 * Returns the token with index `index`.
 	 *
 	 * @link https://dom.spec.whatwg.org/#dom-domtokenlist-item

--- a/packages/token-list/src/test/index.js
+++ b/packages/token-list/src/test/index.js
@@ -28,11 +28,23 @@ describe( 'token-list', () => {
 	} );
 
 	describe( 'value', () => {
+		it( 'gets the stringified value', () => {
+			const list = new TokenList( 'abc   ' );
+
+			expect( list.value ).toBe( 'abc' );
+		} );
+
 		it( 'sets to stringified value', () => {
 			const list = new TokenList();
 			list.value = undefined;
 
 			expect( list.value ).toBe( 'undefined' );
+		} );
+
+		it( 'is the stringifier of the instance', () => {
+			const list = new TokenList( 'abc   ' );
+
+			expect( String( list ) ).toBe( 'abc' );
 		} );
 	} );
 

--- a/packages/token-list/src/test/index.js
+++ b/packages/token-list/src/test/index.js
@@ -25,6 +25,34 @@ describe( 'token-list', () => {
 			expect( list.value ).toBe( 'abc' );
 			expect( list ).toHaveLength( 1 );
 		} );
+
+		describe( 'array method inheritence', () => {
+			it( 'entries', () => {
+				const list = new TokenList( 'abc   ' );
+
+				expect( [ ...list.entries() ] ).toEqual( [ [ 0, 'abc' ] ] );
+			} );
+
+			it( 'forEach', () => {
+				expect.assertions( 1 );
+
+				const list = new TokenList( 'abc   ' );
+
+				list.forEach( ( item ) => expect( item ).toBe( 'abc' ) );
+			} );
+
+			it( 'values', () => {
+				const list = new TokenList( 'abc   ' );
+
+				expect( [ ...list.values() ] ).toEqual( [ 'abc' ] );
+			} );
+
+			it( 'keys', () => {
+				const list = new TokenList( 'abc   ' );
+
+				expect( [ ...list.keys() ] ).toEqual( [ 0 ] );
+			} );
+		} );
 	} );
 
 	describe( 'value', () => {

--- a/packages/token-list/src/test/index.js
+++ b/packages/token-list/src/test/index.js
@@ -48,6 +48,26 @@ describe( 'token-list', () => {
 		} );
 	} );
 
+	describe( 'Symbol.iterator', () => {
+		it( 'returns a generator', () => {
+			const list = new TokenList();
+
+			expect( list[ Symbol.iterator ]().next ).toEqual( expect.any( Function ) );
+		} );
+
+		it( 'yields entries', () => {
+			expect.assertions( 2 );
+
+			const classes = [ 'abc', 'def' ];
+			const list = new TokenList( classes.join( ' ' ) );
+
+			let i = 0;
+			for ( const item of list ) {
+				expect( item ).toBe( classes[ i++ ] );
+			}
+		} );
+	} );
+
 	describe( 'item', () => {
 		it( 'should return undefined if item at index does not exist', () => {
 			const list = new TokenList();


### PR DESCRIPTION
This pull request seeks to implement missing stringifier and iterator behaviors for the `@wordpress/token-list` module.

While it's not very well described, these two features are clearly contained in the [specification of the `DOMTokenList` interface](https://dom.spec.whatwg.org/#interface-domtokenlist):

![image](https://user-images.githubusercontent.com/1779930/48445201-f996fa80-e763-11e8-9124-cc1b2d830679.png)

You can further verify this behavior in the browser by running the following command in the console after using the Right Click > Inspect Element option:

```
String( $0.classList )
```

**Testing instructions:**

Ensure unit tests pass:

```
npm run test-unit
```

This specific functionality is not currently used in the application, but was considered in a yet-to-be-proposed resolution for #11352.