### PR TITLE
Add ability to specify a different default editor font per locale

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -763,11 +763,16 @@ function gutenberg_register_scripts_and_styles() {
 
 	/*
 	 * Translators: If there are characters in your language that are not supported
-	 * by Noto Serif, translate this to 'off'. Do not translate into your own language.
+	 * by a Noto font, translate this to 'off'. Do not translate into your own language.
 	 */
-	if ( 'off' !== _x( 'on', 'Noto Serif font: on or off', 'gutenberg' ) ) {
-		$query_args = array(
-			'family' => urlencode( 'Noto Serif:400,400i,700,700i' ),
+	if ( 'off' !== _x( 'on', 'Noto Font: on or off', 'gutenberg' ) ) {
+		/*
+		 * Translators: Use this to specify the proper Noto font family that is
+		 * supported by your language. This must correspond to a Google Font.
+		 */
+		$font_family = _x( 'Noto Serif:400,400i,700,700i', 'Google Noto Font', 'gutenberg' );
+		$query_args  = array(
+			'family' => urlencode( $font_family ),
 		);
 
 		$fonts_url = esc_url_raw( add_query_arg( $query_args, 'https://fonts.googleapis.com/css' ) );
@@ -1559,6 +1564,16 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 			),
 		),
 	);
+
+	/*
+	 * Set a locale specific default font.
+	 * Translators: Use this to specify the CSS font family for the default font
+	 */
+	$locale_font_family = esc_html_x( 'Noto Serif', 'CSS Font Family for Editor Font', 'gutenberg' );
+	$styles[]           = array(
+		'css' => "body { font-family: '$locale_font_family' }",
+	);
+
 	if ( $editor_styles && current_theme_supports( 'editor-styles' ) ) {
 		foreach ( $editor_styles as $style ) {
 			if ( filter_var( $style, FILTER_VALIDATE_URL ) ) {

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -758,24 +758,19 @@ function gutenberg_register_scripts_and_styles() {
 	// Editor Styles.
 	// This empty stylesheet is defined to ensure backwards compatibility.
 	gutenberg_override_style( 'wp-blocks', false );
-
 	$fonts_url = '';
 
 	/*
-	 * Translators: If there are characters in your language that are not supported
-	 * by a Noto font, translate this to 'off'. Do not translate into your own language.
+	 * Translators: Use this to specify the proper Google Font name and variants
+	 * to load that is supported by your language. Do not translate.
+	 * Set to 'off' to disable loading.
 	 */
-	if ( 'off' !== _x( 'on', 'Noto Font: on or off', 'gutenberg' ) ) {
-		/*
-		 * Translators: Use this to specify the proper Noto font family that is
-		 * supported by your language. This must correspond to a Google Font.
-		 */
-		$font_family = _x( 'Noto Serif:400,400i,700,700i', 'Google Noto Font', 'gutenberg' );
-		$query_args  = array(
+	$font_family = _x( 'Noto Serif:400,400i,700,700i', 'Google Font Name and Variants', 'gutenberg' );
+	if ( 'off' !== $font_family ) {
+		$query_args = array(
 			'family' => urlencode( $font_family ),
 		);
-
-		$fonts_url = esc_url_raw( add_query_arg( $query_args, 'https://fonts.googleapis.com/css' ) );
+		$fonts_url  = esc_url_raw( add_query_arg( $query_args, 'https://fonts.googleapis.com/css' ) );
 	}
 
 	gutenberg_override_style(


### PR DESCRIPTION
## Description

Allow translators to specifying a different default font based on the language/locale. The translator can specify a different Google font to load, and what the CSS font-family should be for different locales. 

Fixes #9891 

## Types of changes

Adds two new translation fields to allow language translation to specify a default font. 

The first field is `Google Font Name and Variants` which can be set to `off` to disable loading an external Google font. The default value is: `Noto Serif:400,400i,700,700i'

The second field is `CSS Font Family for Editor Font` which is the css font-family name specified in the Google font loaded. The default value is: `Noto Serif`

This includes the variants because certain fonts may not support italics, for example Noto Sans JP.

The second field could also be used to specify a default system font.

## How to Test

Confirm the Editor default text is using the Noto Serif font.

1. Generate a gutenberg.pot file using makepot.php from core [See i18n](https://codex.wordpress.org/I18n_for_WordPress_Developers)

2. Copy gutenberg.pot to gutenberg-es_MX.po 

3. Edit gutenberg-es_MX.po and change the fields, here's the example I used 
```
#: lib/client-assets.php:768
msgctxt "Google Font Name and Variants"
msgid "Noto Serif:400,400i,700,700i"
msgstr "Pacifico:400,700"

#: lib/client-assets.php:1567
msgctxt "CSS Font Family for Editor Font"
msgid "Noto Serif"
msgstr "Pacifico"
```
4. Generate the mo file using `msgfmt -o gutenberg-es_MX.mo gutenberg-es_MX.po`
If you use Homebrew on OSX, you may need to run `brew link gettext --force` to add the msgfmt binary.

5. Go to Settings > General and change your site Language to Espanol de Mexico
This may require first adding `define( 'WPLANG', 'es_MX' );` to your wp-config.php.

6. Finally confirm the default editor font is changed to Pacifico, which is a distinct script font. 

You can obviously test using a different locale and font to match what works best for your language. 

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
