### PR TITLE
Editor: Support className in save for custom className difference

### DIFF
--- a/packages/block-editor/src/hooks/test/custom-class-name.js
+++ b/packages/block-editor/src/hooks/test/custom-class-name.js
@@ -10,7 +10,13 @@ import { getHTMLRootElementClasses } from '../custom-class-name';
 
 describe( 'custom className', () => {
 	const blockSettings = {
-		save: () => <div className="default" />,
+		save: ( { attributes } ) => {
+			if ( attributes.className === 'is-varied-on-classname' ) {
+				return <div className="varied" />;
+			}
+
+			return <div className="default" />;
+		},
 		category: 'common',
 		title: 'block title',
 	};
@@ -155,6 +161,16 @@ describe( 'custom className', () => {
 			);
 
 			expect( attributes.className ).toBe( 'custom1 custom3' );
+		} );
+
+		it( 'should allow save to consider the className attribute', () => {
+			const attributes = addParsedDifference(
+				{ className: 'is-varied-on-classname' },
+				blockSettings,
+				'<div class="varied is-varied-on-classname foo"></div>'
+			);
+
+			expect( attributes.className ).toBe( 'is-varied-on-classname foo' );
 		} );
 
 		it( 'should not remove the custom classes for dynamic blocks', () => {

--- a/packages/blocks/src/api/validation.js
+++ b/packages/blocks/src/api/validation.js
@@ -642,8 +642,8 @@ export function isValidBlockContent( blockTypeOrName, attributes, expectedBlockC
 			'Block validation failed for `%s` (%o).\n\nExpected:\n\n%s\n\nActual:\n\n%s',
 			blockType.name,
 			blockType,
-			actualBlockContent,
-			expectedBlockContent
+			expectedBlockContent,
+			actualBlockContent
 		);
 	}
 

--- a/packages/blocks/src/api/validation.js
+++ b/packages/blocks/src/api/validation.js
@@ -620,30 +620,30 @@ export function isEquivalentHTML( actual, expected ) {
  *
  * Logs to console in development environments when invalid.
  *
- * @param {string|Object} blockTypeOrName Block type.
- * @param {Object}        attributes      Parsed block attributes.
- * @param {string}        innerHTML       Original block content.
+ * @param {string|Object} blockTypeOrName      Block type.
+ * @param {Object}        attributes           Parsed block attributes.
+ * @param {string}        expectedBlockContent Original block content.
  *
  * @return {boolean} Whether block is valid.
  */
-export function isValidBlockContent( blockTypeOrName, attributes, innerHTML ) {
+export function isValidBlockContent( blockTypeOrName, attributes, expectedBlockContent ) {
 	const blockType = normalizeBlockType( blockTypeOrName );
-	let saveContent;
+	let actualBlockContent;
 	try {
-		saveContent = getSaveContent( blockType, attributes );
+		actualBlockContent = getSaveContent( blockType, attributes );
 	} catch ( error ) {
 		log.error( 'Block validation failed because an error occurred while generating block content:\n\n%s', error.toString() );
 		return false;
 	}
 
-	const isValid = isEquivalentHTML( innerHTML, saveContent );
+	const isValid = isEquivalentHTML( expectedBlockContent, actualBlockContent );
 	if ( ! isValid ) {
 		log.error(
 			'Block validation failed for `%s` (%o).\n\nExpected:\n\n%s\n\nActual:\n\n%s',
 			blockType.name,
 			blockType,
-			saveContent,
-			innerHTML
+			actualBlockContent,
+			expectedBlockContent
 		);
 	}
 


### PR DESCRIPTION
Fixes #11352 

This pull request seeks to resolve an issue where if a block's `save` implementation considers the `className` attribute in determining its own output result, the behavior of the custom class name "parsed difference" logic may mistakenly consider additional classes to be custom classes, resulting in issues such as the one described in #11352.

**Implementation notes:**

While all tests pass and therefore this can be considered an effective fix, I'm not too fond of the current implementation of suspending the filter while the default save content is generated. I'll want to see if there's a more elegant way to go about this (suggestions welcome).

**Testing instructions:**

Repeat steps to reproduce from #11352, ensuring there are no duplicate color classes.

Ensure unit tests pass:

```
npm run test-unit packages/editor/src/hooks/test/custom-class-name.js
```