### PR TITLE
Removed unnecessary className attribute. Fixes #11664

### DIFF
--- a/packages/editor/src/hooks/custom-class-name.js
+++ b/packages/editor/src/hooks/custom-class-name.js
@@ -65,7 +65,7 @@ export const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) =>
 							value={ props.attributes.className || '' }
 							onChange={ ( nextValue ) => {
 								props.setAttributes( {
-									className: nextValue,
+									className: nextValue !== '' ? nextValue : undefined,
 								} );
 							} }
 						/>


### PR DESCRIPTION
## Description
Added a check for empty string to the `onChange` handler of the "Additional CSS Class field".
If the string is empty the `setAttributes` is called with `{ className: undefined }`
This will resolve #11664


## How has this been tested?
Created a new post and added a heading block.
In the Advanced menu, added a class and switched to the Code Editor

Tested on local WP running on Windows with Chrome 70.0.3538.102

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
