### PR TITLE
Fix url validation errors

### DIFF
--- a/packages/format-library/CHANGELOG.md
+++ b/packages/format-library/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.3 (Unreleased)
+
+### Bug fixes
+- Link URL validation now works correctly when a URL includes a fragment. Previously any URL containing a fragment failed validation.
+- Link URL validation catches an incorrect number of forward slashes following a url using the http protocol.
+
 ## 1.2.2 (2018-11-15)
 
 ## 1.2.1 (2018-11-12)

--- a/packages/format-library/src/link/test/utils.js
+++ b/packages/format-library/src/link/test/utils.js
@@ -38,6 +38,7 @@ describe( 'isValidHref', () => {
 			expect( isValidHref( 'mailto: test@somewhere.com' ) ).toBe( false );
 			expect( isValidHref( 'ht#tp://this/is/invalid' ) ).toBe( false );
 			expect( isValidHref( 'ht#tp://th&is/is/invalid' ) ).toBe( false );
+			expect( isValidHref( 'http:/test.com' ) ).toBe( false );
 			expect( isValidHref( 'http://?test.com' ) ).toBe( false );
 			expect( isValidHref( 'http://#test.com' ) ).toBe( false );
 			expect( isValidHref( 'http://test.com?double?params' ) ).toBe( false );

--- a/packages/format-library/src/link/test/utils.js
+++ b/packages/format-library/src/link/test/utils.js
@@ -26,6 +26,8 @@ describe( 'isValidHref', () => {
 			expect( isValidHref( 'https://test.com' ) ).toBe( true );
 			expect( isValidHref( 'http://test-with-hyphen.com' ) ).toBe( true );
 			expect( isValidHref( 'http://test.com/' ) ).toBe( true );
+			expect( isValidHref( 'http://test.com#fragment' ) ).toBe( true );
+			expect( isValidHref( 'http://test.com/path#fragment' ) ).toBe( true );
 			expect( isValidHref( 'http://test.com/with/path/separators' ) ).toBe( true );
 			expect( isValidHref( 'http://test.com/with?query=string&params' ) ).toBe( true );
 		} );

--- a/packages/format-library/src/link/utils.js
+++ b/packages/format-library/src/link/utils.js
@@ -60,7 +60,7 @@ export function isValidHref( href ) {
 		}
 
 		const fragment = getFragment( trimmedHref );
-		if ( fragment && ! isValidFragment( trimmedHref ) ) {
+		if ( fragment && ! isValidFragment( fragment ) ) {
 			return false;
 		}
 	}

--- a/packages/format-library/src/link/utils.js
+++ b/packages/format-library/src/link/utils.js
@@ -37,10 +37,16 @@ export function isValidHref( href ) {
 		return false;
 	}
 
-	// Does the href start with something that looks like a url protocol?
+	// Does the href start with something that looks like a URL protocol?
 	if ( /^\S+:/.test( trimmedHref ) ) {
 		const protocol = getProtocol( trimmedHref );
 		if ( ! isValidProtocol( protocol ) ) {
+			return false;
+		}
+
+		// Add some extra checks for http(s) URIs, since these are the most common use-case.
+		// This ensures URIs with an http protocol have exactly two forward slashes following the protocol.
+		if ( startsWith( protocol, 'http' ) && ! /^https?:\/\/[^\/\s]/i.test( trimmedHref ) ) {
 			return false;
 		}
 

--- a/packages/url/CHANGELOG.md
+++ b/packages/url/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.3.1 (Unreleased)
+
+### Bug fixes
+- The `isValidProtocol` function now correctly considers the protocol of the URL as only incoporating characters up to and including the colon (':').
+- `getFragment` is now greedier and matches fragments from the first occurence of the '#' symbol instead of the last.
+
 ## 2.3.0 (2018-11-12)
 
 ### New Features

--- a/packages/url/src/index.js
+++ b/packages/url/src/index.js
@@ -37,13 +37,13 @@ export function getProtocol( url ) {
  *
  * @param {string} protocol The url protocol.
  *
- * @return {boolean} True if the argument is a valid protocol (e.g. http://, tel:).
+ * @return {boolean} True if the argument is a valid protocol (e.g. http:, tel:).
  */
 export function isValidProtocol( protocol ) {
 	if ( ! protocol ) {
 		return false;
 	}
-	return /^[a-z\-.\+]+[0-9]*:(?:\/\/)?\/?$/i.test( protocol );
+	return /^[a-z\-.\+]+[0-9]*:$/i.test( protocol );
 }
 
 /**

--- a/packages/url/src/index.js
+++ b/packages/url/src/index.js
@@ -138,7 +138,7 @@ export function isValidQueryString( queryString ) {
  * @return {?string} The fragment part of the URL.
  */
 export function getFragment( url ) {
-	const matches = /^\S+(#[^\s\?]*)/.exec( url );
+	const matches = /^\S+?(#[^\s\?]*)/.exec( url );
 	if ( matches ) {
 		return matches[ 1 ];
 	}

--- a/packages/url/src/test/index.test.js
+++ b/packages/url/src/test/index.test.js
@@ -78,9 +78,7 @@ describe( 'isValidProtocol', () => {
 		expect( isValidProtocol( 'tel:' ) ).toBe( true );
 		expect( isValidProtocol( 'http:' ) ).toBe( true );
 		expect( isValidProtocol( 'https:' ) ).toBe( true );
-		expect( isValidProtocol( 'http://' ) ).toBe( true );
-		expect( isValidProtocol( 'https://' ) ).toBe( true );
-		expect( isValidProtocol( 'file:///' ) ).toBe( true );
+		expect( isValidProtocol( 'file:' ) ).toBe( true );
 		expect( isValidProtocol( 'test.protocol:' ) ).toBe( true );
 		expect( isValidProtocol( 'test-protocol:' ) ).toBe( true );
 		expect( isValidProtocol( 'test+protocol:' ) ).toBe( true );


### PR DESCRIPTION
## Description
When adding href validation in #11286 I made a few errors, which this PR addresses

1. Fragments in URLs were not being checked correctly, any existence of a fragment would make a URL fail the validation 🤦‍♂️ . This was happening due to the wrong value being passed to `isValidFragment` (the entire href was being passed instead of just the fragment).
2. Because of the issue above, tests were also returning a false positive when validating incorrect fragments with two hashes like '#test#test'. This was happening because `getFragment` only captured from the last occurrence of a hash, now it captures from the first.
3. Validation of HTTP urls didn't catch issues like the incorrect number of forward slashes following the protocol. I've added a special case for HTTP urls.
4. `isValidProtocol` considered a protocol with trailing forward slashes as valid. I realised this didn't match what `getProtocol` considered a protocol (characters up to and including the colon, e.g. 'http:'), so I've made it stricter.

## How has this been tested?
- Added test cases to unit tests
- Manual testing
1. Try adding one of the following URLs as a link:
- https:/test.com
- https:///test.com
- https:test.com
- https://test.com#test#test
2. Expect the validation to fail (the link should be displayed in red text).
3. Try adding the following URL as a link:
- https://test.com#test
4. Expect the validation to succeed (the link should be displayed normally).
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
