### PR TITLE
Refactor the block inspector component to avoid getSelectedBlock

### DIFF
--- a/packages/editor/src/components/block-inspector/index.js
+++ b/packages/editor/src/components/block-inspector/index.js
@@ -21,19 +21,18 @@ import InspectorControls from '../inspector-controls';
 import InspectorAdvancedControls from '../inspector-advanced-controls';
 import BlockStyles from '../block-styles';
 
-const BlockInspector = ( { selectedBlock, blockType, count, hasBlockStyles } ) => {
+const BlockInspector = ( { selectedBlockClientId, selectedBlockName, blockType, count, hasBlockStyles } ) => {
 	if ( count > 1 ) {
 		return <span className="editor-block-inspector__multi-blocks">{ __( 'Coming Soon' ) }</span>;
 	}
 
-	const isSelectedBlockUnregistered =
-		!! selectedBlock && selectedBlock.name === getUnregisteredTypeHandlerName();
+	const isSelectedBlockUnregistered = selectedBlockName === getUnregisteredTypeHandlerName();
 
 	/*
 	 * If the selected block is of an unregistered type, avoid showing it as an actual selection
 	 * because we want the user to focus on the unregistered block warning, not block settings.
 	 */
-	if ( ! selectedBlock || isSelectedBlockUnregistered ) {
+	if ( ! blockType || ! selectedBlockClientId || isSelectedBlockUnregistered ) {
 		return <span className="editor-block-inspector__no-blocks">{ __( 'No block selected.' ) }</span>;
 	}
 
@@ -53,7 +52,7 @@ const BlockInspector = ( { selectedBlock, blockType, count, hasBlockStyles } ) =
 						initialOpen={ false }
 					>
 						<BlockStyles
-							clientId={ selectedBlock.clientId }
+							clientId={ selectedBlockClientId }
 						/>
 					</PanelBody>
 				</div>
@@ -79,15 +78,17 @@ const BlockInspector = ( { selectedBlock, blockType, count, hasBlockStyles } ) =
 
 export default withSelect(
 	( select ) => {
-		const { getSelectedBlock, getSelectedBlockCount } = select( 'core/editor' );
+		const { getSelectedBlockClientId, getSelectedBlockCount, getBlockName } = select( 'core/editor' );
 		const { getBlockStyles } = select( 'core/blocks' );
-		const selectedBlock = getSelectedBlock();
-		const blockType = selectedBlock && getBlockType( selectedBlock.name );
-		const blockStyles = selectedBlock && getBlockStyles( selectedBlock.name );
+		const selectedBlockClientId = getSelectedBlockClientId();
+		const selectedBlockName = selectedBlockClientId && getBlockName( selectedBlockClientId );
+		const blockType = selectedBlockClientId && getBlockType( selectedBlockName );
+		const blockStyles = selectedBlockClientId && getBlockStyles( selectedBlockName );
 		return {
 			count: getSelectedBlockCount(),
 			hasBlockStyles: blockStyles && blockStyles.length > 0,
-			selectedBlock,
+			selectedBlockName,
+			selectedBlockClientId,
 			blockType,
 		};
 	}


### PR DESCRIPTION
Extracted from #11811

This PR refactors the block inspector component to use `getSelectedBlockClientId` and `getBlockName` instead of `getSelectedBlock` which is not very performant.