### PR TITLE
Refactor the BlockToolbar compoonent to avoid getSelectedBlock

### DIFF
--- a/docs/data/data-core-editor.md
+++ b/docs/data/data-core-editor.md
@@ -398,6 +398,19 @@ the client ID.
 
 Block name.
 
+### isBlockValid
+
+Returns whether a block is valid or not.
+
+*Parameters*
+
+ * state: Editor state.
+ * clientId: Block client ID.
+
+*Returns*
+
+Is Valid.
+
 ### getBlock
 
 Returns a block given its client ID. This is a parsed copy of the block,

--- a/packages/editor/src/components/block-toolbar/index.js
+++ b/packages/editor/src/components/block-toolbar/index.js
@@ -43,18 +43,19 @@ function BlockToolbar( { blockClientIds, isValid, mode } ) {
 
 export default withSelect( ( select ) => {
 	const {
-		getSelectedBlock,
+		getSelectedBlockClientId,
 		getBlockMode,
 		getMultiSelectedBlockClientIds,
+		isBlockValid,
 	} = select( 'core/editor' );
-	const block = getSelectedBlock();
-	const blockClientIds = block ?
-		[ block.clientId ] :
+	const selectedBlockClientId = getSelectedBlockClientId();
+	const blockClientIds = selectedBlockClientId ?
+		[ selectedBlockClientId ] :
 		getMultiSelectedBlockClientIds();
 
 	return {
 		blockClientIds,
-		isValid: block ? block.isValid : null,
-		mode: block ? getBlockMode( block.clientId ) : null,
+		isValid: selectedBlockClientId ? isBlockValid( selectedBlockClientId ) : null,
+		mode: selectedBlockClientId ? getBlockMode( selectedBlockClientId ) : null,
 	};
 } )( BlockToolbar );

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -602,6 +602,19 @@ export function getBlockName( state, clientId ) {
 }
 
 /**
+ * Returns whether a block is valid or not.
+ *
+ * @param {Object} state    Editor state.
+ * @param {string} clientId Block client ID.
+ *
+ * @return {boolean} Is Valid.
+ */
+export function isBlockValid( state, clientId ) {
+	const block = state.editor.present.blocks.byClientId[ clientId ];
+	return !! block && block.isValid;
+}
+
+/**
  * Returns a block given its client ID. This is a parsed copy of the block,
  * containing its `blockName`, `clientId`, and current `attributes` state. This
  * is not the block's registration settings, which must be retrieved from the


### PR DESCRIPTION
Extracted from #11811

I'm using `getSelectedBlockClientId` and a new `isBlockValid` selector to avoid the less performant `getSelectedBlock` selector in the BlockToolbar.