### PR TITLE
Refactor selectors used in copy-handler

### DIFF
--- a/packages/editor/src/components/copy-handler/index.js
+++ b/packages/editor/src/components/copy-handler/index.js
@@ -26,14 +26,14 @@ class CopyHandler extends Component {
 	}
 
 	onCopy( event ) {
-		const { selectedBlockClientIds, getBlocks } = this.props;
+		const { hasMultiSelection, selectedBlockClientIds, getBlocks } = this.props;
 
-		if ( ! selectedBlockClientIds || selectedBlockClientIds.length === 0 ) {
+		if ( selectedBlockClientIds.length === 0 ) {
 			return;
 		}
 
 		// Let native copy behaviour take over in input fields.
-		if ( selectedBlockClientIds.length === 1 && documentHasSelection() ) {
+		if ( ! hasMultiSelection && documentHasSelection() ) {
 			return;
 		}
 
@@ -46,11 +46,11 @@ class CopyHandler extends Component {
 	}
 
 	onCut( event ) {
-		const { selectedBlockClientIds } = this.props;
+		const { hasMultiSelection, selectedBlockClientIds } = this.props;
 
 		this.onCopy( event );
 
-		if ( selectedBlockClientIds && selectedBlockClientIds.length ) {
+		if ( hasMultiSelection ) {
 			this.props.onRemove( selectedBlockClientIds );
 		}
 	}
@@ -66,12 +66,14 @@ export default compose( [
 			getMultiSelectedBlockClientIds,
 			getSelectedBlockClientId,
 			getBlocks,
+			hasMultiSelection,
 		} = select( 'core/editor' );
 
 		const selectedBlockClientId = getSelectedBlockClientId();
 		const selectedBlockClientIds = selectedBlockClientId ? [ selectedBlockClientId ] : getMultiSelectedBlockClientIds();
 
 		return {
+			hasMultiSelection: hasMultiSelection(),
 			selectedBlockClientIds,
 
 			// We only care about this value when the copy is performed

--- a/packages/editor/src/components/copy-handler/index.js
+++ b/packages/editor/src/components/copy-handler/index.js
@@ -26,18 +26,18 @@ class CopyHandler extends Component {
 	}
 
 	onCopy( event ) {
-		const { multiSelectedBlocks, selectedBlock } = this.props;
+		const { selectedBlockClientIds, getBlocks } = this.props;
 
-		if ( ! multiSelectedBlocks.length && ! selectedBlock ) {
+		if ( ! selectedBlockClientIds || selectedBlockClientIds.length === 0 ) {
 			return;
 		}
 
 		// Let native copy behaviour take over in input fields.
-		if ( selectedBlock && documentHasSelection() ) {
+		if ( selectedBlockClientIds.length === 1 && documentHasSelection() ) {
 			return;
 		}
 
-		const serialized = serialize( selectedBlock || multiSelectedBlocks );
+		const serialized = serialize( getBlocks( selectedBlockClientIds ) );
 
 		event.clipboardData.setData( 'text/plain', serialized );
 		event.clipboardData.setData( 'text/html', serialized );
@@ -46,12 +46,12 @@ class CopyHandler extends Component {
 	}
 
 	onCut( event ) {
-		const { multiSelectedBlockClientIds } = this.props;
+		const { selectedBlockClientIds } = this.props;
 
 		this.onCopy( event );
 
-		if ( multiSelectedBlockClientIds.length ) {
-			this.props.onRemove( multiSelectedBlockClientIds );
+		if ( selectedBlockClientIds && selectedBlockClientIds.length ) {
+			this.props.onRemove( selectedBlockClientIds );
 		}
 	}
 
@@ -63,14 +63,20 @@ class CopyHandler extends Component {
 export default compose( [
 	withSelect( ( select ) => {
 		const {
-			getMultiSelectedBlocks,
 			getMultiSelectedBlockClientIds,
-			getSelectedBlock,
+			getSelectedBlockClientId,
+			getBlocks,
 		} = select( 'core/editor' );
+
+		const selectedBlockClientId = getSelectedBlockClientId();
+		const selectedBlockClientIds = selectedBlockClientId ? [ selectedBlockClientId ] : getMultiSelectedBlockClientIds();
+
 		return {
-			multiSelectedBlocks: getMultiSelectedBlocks(),
-			multiSelectedBlockClientIds: getMultiSelectedBlockClientIds(),
-			selectedBlock: getSelectedBlock(),
+			selectedBlockClientIds,
+
+			// We only care about this value when the copy is performed
+			// We call it dynamically in the event handler to avoid unnecessary re-renders.
+			getBlocks,
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {

--- a/packages/editor/src/components/copy-handler/index.js
+++ b/packages/editor/src/components/copy-handler/index.js
@@ -26,7 +26,7 @@ class CopyHandler extends Component {
 	}
 
 	onCopy( event ) {
-		const { hasMultiSelection, selectedBlockClientIds, getBlocks } = this.props;
+		const { hasMultiSelection, selectedBlockClientIds, getBlocksByClientId } = this.props;
 
 		if ( selectedBlockClientIds.length === 0 ) {
 			return;
@@ -37,7 +37,7 @@ class CopyHandler extends Component {
 			return;
 		}
 
-		const serialized = serialize( getBlocks( selectedBlockClientIds ) );
+		const serialized = serialize( getBlocksByClientId( selectedBlockClientIds ) );
 
 		event.clipboardData.setData( 'text/plain', serialized );
 		event.clipboardData.setData( 'text/html', serialized );
@@ -65,7 +65,7 @@ export default compose( [
 		const {
 			getMultiSelectedBlockClientIds,
 			getSelectedBlockClientId,
-			getBlocks,
+			getBlocksByClientId,
 			hasMultiSelection,
 		} = select( 'core/editor' );
 
@@ -78,7 +78,7 @@ export default compose( [
 
 			// We only care about this value when the copy is performed
 			// We call it dynamically in the event handler to avoid unnecessary re-renders.
-			getBlocks,
+			getBlocksByClientId,
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {


### PR DESCRIPTION
Extracted form #11811

In this PR, I avoid using the not-so performant selectors `getSelectedBlock` and `getMultiSelectedBlocks` in the `withSelect` HoC and I replace them with `getSelectedBlockClientId` and a `getBlocks` selectors only used in the block handler.