### PR TITLE
Add hasInserterItems selector and improve getInserterItems selector performance

### DIFF
--- a/docs/data/data-core-editor.md
+++ b/docs/data/data-core-editor.md
@@ -1155,6 +1155,19 @@ Items are returned ordered descendingly by their 'utility' and 'frecency'.
 
 Items that appear in inserter.
 
+### hasInserterItems
+
+Determines whether there are items to show in the inserter.
+
+*Parameters*
+
+ * state: Editor state.
+ * rootClientId: Optional root client ID of block list.
+
+*Returns*
+
+Items that appear in inserter.
+
 ### __experimentalGetReusableBlock
 
 Returns the reusable block with the given ID.

--- a/packages/editor/src/components/inserter/index.js
+++ b/packages/editor/src/components/inserter/index.js
@@ -103,7 +103,7 @@ export default compose( [
 		const {
 			getEditedPostAttribute,
 			getBlockInsertionPoint,
-			getInserterItems,
+			hasInserterItems,
 		} = select( 'core/editor' );
 
 		if ( rootClientId === undefined && index === undefined ) {
@@ -117,7 +117,7 @@ export default compose( [
 
 		return {
 			title: getEditedPostAttribute( 'title' ),
-			hasItems: getInserterItems( rootClientId ).length > 0,
+			hasItems: hasInserterItems( rootClientId ),
 			rootClientId,
 			index,
 		};


### PR DESCRIPTION
The `getInserterItems` is called often (even if the inserter in not open) and its memoization is not performant.

In this PR, I'm adding a new `hasInserterItems` selector which is more performant as it doesn't have to create inserter items and can return quickly after one insertable item is found.

I also refactored a little bit the selectors to avoid using a memoized version of `canInsertBlockType` as I think it's just not efficient to call memoized selectors inside other memoized selectors.

I don't have the numbers as it's very hard to measure but I'd love your thoughts. I'm also considering dropping the memoization of these two selectors entirely because the cache is invalidated too often IMO.