### PR TITLE
Fix issues with image initial size

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -536,6 +536,9 @@ class ImageEdit extends Component {
 							const minWidth = imageWidth < imageHeight ? MIN_SIZE : MIN_SIZE * ratio;
 							const minHeight = imageHeight < imageWidth ? MIN_SIZE : MIN_SIZE / ratio;
 
+							// This is horrendous. Consider it a proof of concept.
+							const maxWidth = document.querySelector( '.editor-block-list__block-edit' ).offsetWidth;
+
 							let showRightHandle = false;
 							let showLeftHandle = false;
 
@@ -576,9 +579,9 @@ class ImageEdit extends Component {
 											} : undefined
 										}
 										minWidth={ minWidth }
-										maxWidth="100%"
+										maxWidth={ maxWidth }
 										minHeight={ minHeight }
-										maxHeight="100%"
+										maxHeight={ maxWidth / ratio }
 										lockAspectRatio
 										enable={ {
 											top: false,

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -302,6 +302,7 @@ class ImageEdit extends Component {
 			isLargeViewport,
 			isSelected,
 			className,
+			maxWidth,
 			noticeUI,
 			toggleSelection,
 			isRTL,
@@ -536,8 +537,12 @@ class ImageEdit extends Component {
 							const minWidth = imageWidth < imageHeight ? MIN_SIZE : MIN_SIZE * ratio;
 							const minHeight = imageHeight < imageWidth ? MIN_SIZE : MIN_SIZE / ratio;
 
-							// This is horrendous. Consider it a proof of concept.
-							const maxWidth = document.querySelector( '.editor-block-list__block-edit' ).offsetWidth;
+							// With the current implementation of ResizableBox, an image needs an explicit pixel value for the max-width.
+							// In absence of being able to set the content-width, this max-width is currently dictated by the vanilla editor style.
+							// The following variable adds a buffer to this vanilla style, so 3rd party themes have some wiggleroom.
+							// This does, in most cases, allow you to scale the image beyond the width of the main column, though not infinitely.
+							// @todo It would be good to revisit this once a content-width variable becomes available.
+							const maxWidthBuffer = maxWidth * 2.5;
 
 							let showRightHandle = false;
 							let showLeftHandle = false;
@@ -579,9 +584,9 @@ class ImageEdit extends Component {
 											} : undefined
 										}
 										minWidth={ minWidth }
-										maxWidth={ maxWidth }
+										maxWidth={ maxWidthBuffer }
 										minHeight={ minHeight }
-										maxHeight={ maxWidth / ratio }
+										maxHeight={ maxWidthBuffer / ratio }
 										lockAspectRatio
 										enable={ {
 											top: false,
@@ -629,10 +634,11 @@ export default compose( [
 		const { getMedia } = select( 'core' );
 		const { getEditorSettings } = select( 'core/editor' );
 		const { id } = props.attributes;
-		const { isRTL, imageSizes } = getEditorSettings();
+		const { maxWidth, isRTL, imageSizes } = getEditorSettings();
 
 		return {
 			image: id ? getMedia( id ) : null,
+			maxWidth,
 			isRTL,
 			imageSizes,
 		};

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -302,7 +302,6 @@ class ImageEdit extends Component {
 			isLargeViewport,
 			isSelected,
 			className,
-			maxWidth,
 			noticeUI,
 			toggleSelection,
 			isRTL,
@@ -577,9 +576,9 @@ class ImageEdit extends Component {
 											} : undefined
 										}
 										minWidth={ minWidth }
-										maxWidth={ maxWidth }
+										maxWidth="100%"
 										minHeight={ minHeight }
-										maxHeight={ maxWidth / ratio }
+										maxHeight="100%"
 										lockAspectRatio
 										enable={ {
 											top: false,
@@ -627,11 +626,10 @@ export default compose( [
 		const { getMedia } = select( 'core' );
 		const { getEditorSettings } = select( 'core/editor' );
 		const { id } = props.attributes;
-		const { maxWidth, isRTL, imageSizes } = getEditorSettings();
+		const { isRTL, imageSizes } = getEditorSettings();
 
 		return {
 			image: id ? getMedia( id ) : null,
-			maxWidth,
 			isRTL,
 			imageSizes,
 		};


### PR DESCRIPTION
This PR aims to fix an issue where if an editor style provides a wider main column width than the default, images are still constrained by the default editor width (580px).

For example, the editor main column width in TwentyNineteen is wider than that of the vanilla editor style. So any image you insert there is constrained, but only in the editor.

This PR simply removes our max-width variable and defaults it to 100%. I can't tell if there are any downsides or risks to this, please give me your thoughts on it.

Before:

<img width="931" alt="before" src="https://user-images.githubusercontent.com/1204802/48475783-d6b92480-e7fd-11e8-80b3-08260da4ace2.png">

After:

<img width="946" alt="after" src="https://user-images.githubusercontent.com/1204802/48475791-d91b7e80-e7fd-11e8-9bdb-feb8c5501d1f.png">

closes #9302
