### PR TITLE
Add registry param to withDispatch component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7622,7 +7622,7 @@
 		},
 		"eslint-plugin-react": {
 			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
+			"resolved": "http://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
 			"integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
 			"dev": true,
 			"requires": {

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### New Feature
 
-- `withDispatch`'s `mapDispatchToProps` function takes the `select` function as the 3rd param ([#11851](https://github.com/WordPress/gutenberg/pull/11851)).
+- `withDispatch`'s `mapDispatchToProps` function takes the `registry` object as the 3rd param ([#11851](https://github.com/WordPress/gutenberg/pull/11851)).
 
 ## 4.0.1 (2018-11-20)
 

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.1.0 (Unreleased)
+
+### New Feature
+
+- `withDispatch`'s `mapDispatchToProps` function takes the `select` function as the 3rd param ([#11851](https://github.com/WordPress/gutenberg/pull/11851)).
+
 ## 4.0.1 (2018-11-20)
 
 ## 4.0.0 (2018-11-15)

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### New Feature
 
 - `withDispatch`'s `mapDispatchToProps` function takes the `registry` object as the 3rd param ([#11851](https://github.com/WordPress/gutenberg/pull/11851)).
+- `withSelect`'s `mapSelectToProps` function takes the `registry` object as the 3rd param ([#11851](https://github.com/WordPress/gutenberg/pull/11851)).
 
 ## 4.0.1 (2018-11-20)
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -286,7 +286,7 @@ const SaleButton = withDispatch( ( dispatch, ownProps ) => {
 //  <SaleButton discountPercent="20">Start Sale!</SaleButton>
 ```
 
-In the majority of cases it will be sufficient to use only two first params passed to `mapDispatchToProps` as illustrated in the previous example. However, there might be some very advanced use cases where using `select` function might be used as a tool to optimize the performance of your component. It is useful when you need to fetch some dynamic data from the store at the time when event is fired, but at the same time you never use it to render your component. In such scenario you can avoid using the `withSelect` higher order component to compute such prop, which might lead to unnecessary re-renders of you component caused by its frequent value change.
+In the majority of cases, it will be sufficient to use only two first params passed to `mapDispatchToProps` as illustrated in the previous example. However, there might be some very advanced use cases where using `select` function might be used as a tool to optimize the performance of your component. It is useful when you need to fetch some dynamic data from the store at the time when the event is fired, but at the same time, you never use it to render your component. In such scenario, you can avoid using the `withSelect` higher order component to compute such prop, which might lead to unnecessary re-renders of you component caused by its frequent value change.
 
 ```jsx
 function Button( { onClick, children } ) {

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -286,7 +286,7 @@ const SaleButton = withDispatch( ( dispatch, ownProps ) => {
 //  <SaleButton discountPercent="20">Start Sale!</SaleButton>
 ```
 
-In the majority of cases, it will be sufficient to use only two first params passed to `mapDispatchToProps` as illustrated in the previous example. However, there might be some very advanced use cases where using `select` function might be used as a tool to optimize the performance of your component. It is useful when you need to fetch some dynamic data from the store at the time when the event is fired, but at the same time, you never use it to render your component. In such scenario, you can avoid using the `withSelect` higher order component to compute such prop, which might lead to unnecessary re-renders of you component caused by its frequent value change.
+In the majority of cases, it will be sufficient to use only two first params passed to `mapDispatchToProps` as illustrated in the previous example. However, there might be some very advanced use cases where using `select` function might be used as a tool to optimize the performance of your component. It is useful when you need to fetch some dynamic data from the store at the time when the event is fired, but at the same time, you never use it to render your component. In such scenario, you can avoid using the `withSelect` higher order component to compute such prop, which might lead to unnecessary re-renders of you component caused by its frequent value change. Keep in mind, that `mapDispatchToProps` must return an object with functions only. 
 
 ```jsx
 function Button( { onClick, children } ) {

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -261,7 +261,7 @@ In the above example, when `HammerPriceDisplay` is rendered into an application,
 
 #### `withDispatch( mapDispatchToProps: Function ): Function`
 
-Use `withDispatch` to inject dispatching action props into your component. Passed a function which returns an object mapping prop names to action dispatchers, a higher-order component function is returned. The higher-order component can be used to enhance a component. For example, you can define callback behaviors as props for responding to user interactions. The mapping function is passed the [`dispatch` function](#dispatch), the props passed to the original component and the [`select` function](#select).
+Use `withDispatch` to inject dispatching action props into your component. Passed a function which returns an object mapping prop names to action dispatchers, a higher-order component function is returned. The higher-order component can be used to enhance a component. For example, you can define callback behaviors as props for responding to user interactions. The mapping function is passed the [`dispatch` function](#dispatch), the props passed to the original component and the `registry` object.
 
 ```jsx
 function Button( { onClick, children } ) {
@@ -286,7 +286,7 @@ const SaleButton = withDispatch( ( dispatch, ownProps ) => {
 //  <SaleButton discountPercent="20">Start Sale!</SaleButton>
 ```
 
-In the majority of cases, it will be sufficient to use only two first params passed to `mapDispatchToProps` as illustrated in the previous example. However, there might be some very advanced use cases where using `select` function might be used as a tool to optimize the performance of your component. It is useful when you need to fetch some dynamic data from the store at the time when the event is fired, but at the same time, you never use it to render your component. In such scenario, you can avoid using the `withSelect` higher order component to compute such prop, which might lead to unnecessary re-renders of you component caused by its frequent value change. Keep in mind, that `mapDispatchToProps` must return an object with functions only. 
+In the majority of cases, it will be sufficient to use only two first params passed to `mapDispatchToProps` as illustrated in the previous example. However, there might be some very advanced use cases where using the `registry` object might be used as a tool to optimize the performance of your component. Using `select` function from the registry might be useful when you need to fetch some dynamic data from the store at the time when the event is fired, but at the same time, you never use it to render your component. In such scenario, you can avoid using the `withSelect` higher order component to compute such prop, which might lead to unnecessary re-renders of you component caused by its frequent value change. Keep in mind, that `mapDispatchToProps` must return an object with functions only. 
 
 ```jsx
 function Button( { onClick, children } ) {
@@ -295,7 +295,7 @@ function Button( { onClick, children } ) {
 
 const { withDispatch } = wp.data;
 
-const SaleButton = withDispatch( ( dispatch, ownProps, select ) => {
+const SaleButton = withDispatch( ( dispatch, ownProps, { select } ) => {
 	// Stock number changes frequently.
 	const { getStockNumber } = select( 'my-shop' );
 	const { startSale } = dispatch( 'my-shop' );

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -261,7 +261,7 @@ In the above example, when `HammerPriceDisplay` is rendered into an application,
 
 #### `withDispatch( mapDispatchToProps: Function ): Function`
 
-Use `withDispatch` to inject dispatching action props into your component. Passed a function which returns an object mapping prop names to action dispatchers, a higher-order component function is returned. The higher-order component can be used to enhance a component. For example, you can define callback behaviors as props for responding to user interactions. The mapping function is passed the [`dispatch` function](#dispatch) and the props passed to the original component.
+Use `withDispatch` to inject dispatching action props into your component. Passed a function which returns an object mapping prop names to action dispatchers, a higher-order component function is returned. The higher-order component can be used to enhance a component. For example, you can define callback behaviors as props for responding to user interactions. The mapping function is passed the [`dispatch` function](#dispatch), the props passed to the original component and the [`select` function](#select).
 
 ```jsx
 function Button( { onClick, children } ) {
@@ -272,10 +272,37 @@ const { withDispatch } = wp.data;
 
 const SaleButton = withDispatch( ( dispatch, ownProps ) => {
 	const { startSale } = dispatch( 'my-shop' );
-	const { discountPercent = 20 } = ownProps;
+	const { discountPercent } = ownProps;
 
 	return {
 		onClick() {
+			startSale( discountPercent );
+		},
+	};
+} )( Button );
+
+// Rendered in the application:
+//
+//  <SaleButton discountPercent="20">Start Sale!</SaleButton>
+```
+
+In the majority of cases it will be sufficient to use only two first params passed to `mapDispatchToProps` as illustrated in the previous example. However, there might be some very advanced use cases where using `select` function might be used as a tool to optimize the performance of your component. It is useful when you need to fetch some dynamic data from the store at the time when event is fired, but at the same time you never use it to render your component. In such scenario you can avoid using the `withSelect` higher order component to compute such prop, which might lead to unnecessary re-renders of you component caused by its frequent value change.
+
+```jsx
+function Button( { onClick, children } ) {
+	return <button type="button" onClick={ onClick }>{ children }</button>;
+}
+
+const { withDispatch } = wp.data;
+
+const SaleButton = withDispatch( ( dispatch, ownProps, select ) => {
+	// Stock number changes frequently.
+	const { getStockNumber } = select( 'my-shop' );
+	const { startSale } = dispatch( 'my-shop' );
+	
+	return {
+		onClick() {
+			const dicountPercent = getStockNumber() > 50 ? 10 : 20;
 			startSale( discountPercent );
 		},
 	};

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -229,7 +229,7 @@ A higher-order component is a function which accepts a [component](https://githu
 
 #### `withSelect( mapSelectToProps: Function ): Function`
 
-Use `withSelect` to inject state-derived props into a component. Passed a function which returns an object mapping prop names to the subscribed data source, a higher-order component function is returned. The higher-order component can be used to enhance a presentational component, updating it automatically when state changes. The mapping function is passed the [`select` function](#select) and the props passed to the original component.
+Use `withSelect` to inject state-derived props into a component. Passed a function which returns an object mapping prop names to the subscribed data source, a higher-order component function is returned. The higher-order component can be used to enhance a presentational component, updating it automatically when state changes. The mapping function is passed the [`select` function](#select), the props passed to the original component and the `registry` object.
 
 _Example:_
 

--- a/packages/data/src/components/with-dispatch/index.js
+++ b/packages/data/src/components/with-dispatch/index.js
@@ -51,6 +51,10 @@ const withDispatch = ( mapDispatchToProps ) => createHigherOrderComponent(
 				// dispatch does not occur until the function is called.
 				const propsToDispatchers = mapDispatchToProps( this.props.registry.dispatch, props.ownProps, this.props.registry.select );
 				this.proxyProps = mapValues( propsToDispatchers, ( dispatcher, propName ) => {
+					if ( typeof dispatcher !== 'function' ) {
+						throw new TypeError( `${ propName } returned from mapDispatchToProps in withDispatch HOC must be a function` );
+					}
+
 					// Prebind with prop name so we have reference to the original
 					// dispatcher to invoke. Track between re-renders to avoid
 					// creating new function references every render.

--- a/packages/data/src/components/with-dispatch/index.js
+++ b/packages/data/src/components/with-dispatch/index.js
@@ -52,9 +52,9 @@ const withDispatch = ( mapDispatchToProps ) => createHigherOrderComponent(
 				const propsToDispatchers = mapDispatchToProps( this.props.registry.dispatch, props.ownProps, this.props.registry.select );
 				this.proxyProps = mapValues( propsToDispatchers, ( dispatcher, propName ) => {
 					if ( typeof dispatcher !== 'function' ) {
-						throw new TypeError( `${ propName } returned from mapDispatchToProps in withDispatch HOC must be a function` );
+						// eslint-disable-next-line no-console
+						console.warn( `Property ${ propName } returned from mapDispatchToProps in withDispatch must be a function.` );
 					}
-
 					// Prebind with prop name so we have reference to the original
 					// dispatcher to invoke. Track between re-renders to avoid
 					// creating new function references every render.

--- a/packages/data/src/components/with-dispatch/index.js
+++ b/packages/data/src/components/with-dispatch/index.js
@@ -39,7 +39,7 @@ const withDispatch = ( mapDispatchToProps ) => createHigherOrderComponent(
 
 			proxyDispatch( propName, ...args ) {
 				// Original dispatcher is a pre-bound (dispatching) action creator.
-				mapDispatchToProps( this.props.registry.dispatch, this.props.ownProps, this.props.registry.select )[ propName ]( ...args );
+				mapDispatchToProps( this.props.registry.dispatch, this.props.ownProps, this.props.registry )[ propName ]( ...args );
 			}
 
 			setProxyProps( props ) {
@@ -49,7 +49,7 @@ const withDispatch = ( mapDispatchToProps ) => createHigherOrderComponent(
 				// called, it is done only to determine the keys for which
 				// proxy functions should be created. The actual registry
 				// dispatch does not occur until the function is called.
-				const propsToDispatchers = mapDispatchToProps( this.props.registry.dispatch, props.ownProps, this.props.registry.select );
+				const propsToDispatchers = mapDispatchToProps( this.props.registry.dispatch, props.ownProps, this.props.registry );
 				this.proxyProps = mapValues( propsToDispatchers, ( dispatcher, propName ) => {
 					if ( typeof dispatcher !== 'function' ) {
 						// eslint-disable-next-line no-console

--- a/packages/data/src/components/with-dispatch/index.js
+++ b/packages/data/src/components/with-dispatch/index.js
@@ -39,7 +39,7 @@ const withDispatch = ( mapDispatchToProps ) => createHigherOrderComponent(
 
 			proxyDispatch( propName, ...args ) {
 				// Original dispatcher is a pre-bound (dispatching) action creator.
-				mapDispatchToProps( this.props.registry.dispatch, this.props.ownProps )[ propName ]( ...args );
+				mapDispatchToProps( this.props.registry.dispatch, this.props.ownProps, this.props.registry.select )[ propName ]( ...args );
 			}
 
 			setProxyProps( props ) {
@@ -49,7 +49,7 @@ const withDispatch = ( mapDispatchToProps ) => createHigherOrderComponent(
 				// called, it is done only to determine the keys for which
 				// proxy functions should be created. The actual registry
 				// dispatch does not occur until the function is called.
-				const propsToDispatchers = mapDispatchToProps( this.props.registry.dispatch, props.ownProps );
+				const propsToDispatchers = mapDispatchToProps( this.props.registry.dispatch, props.ownProps, this.props.registry.select );
 				this.proxyProps = mapValues( propsToDispatchers, ( dispatcher, propName ) => {
 					// Prebind with prop name so we have reference to the original
 					// dispatcher to invoke. Track between re-renders to avoid

--- a/packages/data/src/components/with-dispatch/test/index.js
+++ b/packages/data/src/components/with-dispatch/test/index.js
@@ -136,7 +136,7 @@ describe( 'withDispatch', () => {
 			},
 		} );
 
-		const Component = withDispatch( ( _dispatch, ownProps, _select ) => {
+		const Component = withDispatch( ( _dispatch, ownProps, { select: _select } ) => {
 			const outerCount = _select( 'counter' ).getCount();
 			return {
 				update: () => {

--- a/packages/data/src/components/with-dispatch/test/index.js
+++ b/packages/data/src/components/with-dispatch/test/index.js
@@ -165,4 +165,22 @@ describe( 'withDispatch', () => {
 		counterUpdateHandler();
 		expect( store.getState() ).toBe( 3 );
 	} );
+
+	it( 'throws an error when mapDispatchToProps returns non-function property', () => {
+		const expectedError = 'count returned from mapDispatchToProps in withDispatch HOC must be a function';
+		const Component = withDispatch( () => {
+			return {
+				count: 3,
+			};
+		} )( ( props ) => <span>{ props.count }</span> );
+
+		expect( () => {
+			TestRenderer.create(
+				<RegistryProvider value={ registry }>
+					<Component />
+				</RegistryProvider>
+			);
+		} ).toThrowError( expectedError );
+		expect( console ).toHaveErrored();
+	} );
 } );

--- a/packages/data/src/components/with-dispatch/test/index.js
+++ b/packages/data/src/components/with-dispatch/test/index.js
@@ -119,4 +119,50 @@ describe( 'withDispatch', () => {
 		expect( firstRegistryAction ).toHaveBeenCalledTimes( 2 );
 		expect( secondRegistryAction ).toHaveBeenCalledTimes( 2 );
 	} );
+
+	it( 'always calls select with the latest state in the handler passed to the component', () => {
+		const store = registry.registerStore( 'counter', {
+			reducer: ( state = 0, action ) => {
+				if ( action.type === 'update' ) {
+					return action.count;
+				}
+				return state;
+			},
+			actions: {
+				update: ( count ) => ( { type: 'update', count } ),
+			},
+			selectors: {
+				getCount: ( state ) => state,
+			},
+		} );
+
+		const Component = withDispatch( ( _dispatch, ownProps, _select ) => {
+			const outerCount = _select( 'counter' ).getCount();
+			return {
+				update: () => {
+					const innerCount = _select( 'counter' ).getCount();
+					expect( innerCount ).toBe( outerCount );
+					const actionReturnedFromDispatch = _dispatch( 'counter' ).update( innerCount + 1 );
+					expect( actionReturnedFromDispatch ).toBe( undefined );
+				},
+			};
+		} )( ( props ) => <button onClick={ props.update } /> );
+
+		const testRenderer = TestRenderer.create(
+			<RegistryProvider value={ registry }>
+				<Component />
+			</RegistryProvider>
+		);
+
+		const counterUpdateHandler = testRenderer.root.findByType( 'button' ).props.onClick;
+
+		counterUpdateHandler();
+		expect( store.getState() ).toBe( 1 );
+
+		counterUpdateHandler();
+		expect( store.getState() ).toBe( 2 );
+
+		counterUpdateHandler();
+		expect( store.getState() ).toBe( 3 );
+	} );
 } );

--- a/packages/data/src/components/with-dispatch/test/index.js
+++ b/packages/data/src/components/with-dispatch/test/index.js
@@ -166,21 +166,20 @@ describe( 'withDispatch', () => {
 		expect( store.getState() ).toBe( 3 );
 	} );
 
-	it( 'throws an error when mapDispatchToProps returns non-function property', () => {
-		const expectedError = 'count returned from mapDispatchToProps in withDispatch HOC must be a function';
+	it( 'warns when mapDispatchToProps returns non-function property', () => {
 		const Component = withDispatch( () => {
 			return {
 				count: 3,
 			};
-		} )( ( props ) => <span>{ props.count }</span> );
+		} )( () => null );
 
-		expect( () => {
-			TestRenderer.create(
-				<RegistryProvider value={ registry }>
-					<Component />
-				</RegistryProvider>
-			);
-		} ).toThrowError( expectedError );
-		expect( console ).toHaveErrored();
+		TestRenderer.create(
+			<RegistryProvider value={ registry }>
+				<Component />
+			</RegistryProvider>
+		);
+		expect( console ).toHaveWarnedWith(
+			'Property count returned from mapDispatchToProps in withDispatch must be a function.'
+		);
 	} );
 } );

--- a/packages/data/src/components/with-select/index.js
+++ b/packages/data/src/components/with-select/index.js
@@ -39,7 +39,7 @@ const withSelect = ( mapSelectToProps ) => createHigherOrderComponent( ( Wrapped
 	 */
 	function getNextMergeProps( props ) {
 		return (
-			mapSelectToProps( props.registry.select, props.ownProps ) ||
+			mapSelectToProps( props.registry.select, props.ownProps, props.registry ) ||
 			DEFAULT_MERGE_PROPS
 		);
 	}

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -86,7 +86,7 @@ export default compose(
 		isPublishSidebarOpened: select( 'core/edit-post' ).isPublishSidebarOpened(),
 		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
 	} ) ),
-	withDispatch( ( dispatch, ownProps, select ) => {
+	withDispatch( ( dispatch, ownProps, { select } ) => {
 		const { getBlockSelectionStart } = select( 'core/editor' );
 		const { openGeneralSidebar, closeGeneralSidebar } = dispatch( 'core/edit-post' );
 

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -82,18 +82,17 @@ function Header( {
 export default compose(
 	withSelect( ( select ) => ( {
 		hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
-		hasBlockSelection: !! select( 'core/editor' ).getBlockSelectionStart(),
 		isEditorSidebarOpened: select( 'core/edit-post' ).isEditorSidebarOpened(),
 		isPublishSidebarOpened: select( 'core/edit-post' ).isPublishSidebarOpened(),
 		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
 	} ) ),
-	withDispatch( ( dispatch, { hasBlockSelection } ) => {
+	withDispatch( ( dispatch, ownProps, select ) => {
+		const { getBlockSelectionStart } = select( 'core/editor' );
 		const { openGeneralSidebar, closeGeneralSidebar } = dispatch( 'core/edit-post' );
-		const sidebarToOpen = hasBlockSelection ? 'edit-post/block' : 'edit-post/document';
+
 		return {
-			openGeneralSidebar: () => openGeneralSidebar( sidebarToOpen ),
+			openGeneralSidebar: () => openGeneralSidebar( getBlockSelectionStart() ? 'edit-post/block' : 'edit-post/document' ),
 			closeGeneralSidebar: closeGeneralSidebar,
-			hasBlockSelection: undefined,
 		};
 	} ),
 )( Header );

--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -669,7 +669,7 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId, isLargeV
 	};
 } );
 
-const applyWithDispatch = withDispatch( ( dispatch, ownProps, select ) => {
+const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 	const { getBlockSelectionStart } = select( 'core/editor' );
 	const {
 		updateBlockAttributes,

--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -71,7 +71,6 @@ export class BlockListBlock extends Component {
 		this.onDragStart = this.onDragStart.bind( this );
 		this.onDragEnd = this.onDragEnd.bind( this );
 		this.selectOnOpen = this.selectOnOpen.bind( this );
-		this.onShiftSelection = this.onShiftSelection.bind( this );
 		this.hadTouchStart = false;
 
 		this.state = {
@@ -290,7 +289,7 @@ export class BlockListBlock extends Component {
 
 		if ( event.shiftKey ) {
 			if ( ! this.props.isSelected ) {
-				this.onShiftSelection();
+				this.props.onShiftSelection();
 				event.preventDefault();
 			}
 		} else {
@@ -359,20 +358,6 @@ export class BlockListBlock extends Component {
 	selectOnOpen( open ) {
 		if ( open && ! this.props.isSelected ) {
 			this.props.onSelect();
-		}
-	}
-
-	onShiftSelection() {
-		if ( ! this.props.isSelectionEnabled ) {
-			return;
-		}
-
-		const { getBlockSelectionStart, onMultiSelect, onSelect } = this.props;
-
-		if ( getBlockSelectionStart() ) {
-			onMultiSelect( getBlockSelectionStart(), this.props.clientId );
-		} else {
-			onSelect( this.props.clientId );
 		}
 	}
 
@@ -649,7 +634,6 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId, isLargeV
 		getEditorSettings,
 		hasSelectedInnerBlock,
 		getTemplateLock,
-		getBlockSelectionStart,
 	} = select( 'core/editor' );
 	const isSelected = isBlockSelected( clientId );
 	const { hasFixedToolbar, focusMode } = getEditorSettings();
@@ -682,13 +666,11 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId, isLargeV
 		block,
 		isSelected,
 		isParentOfSelectedBlock,
-		// We only care about this value when the shift key is pressed.
-		// We call it dynamically in the event handler to avoid unnecessary re-renders.
-		getBlockSelectionStart,
 	};
 } );
 
-const applyWithDispatch = withDispatch( ( dispatch, ownProps ) => {
+const applyWithDispatch = withDispatch( ( dispatch, ownProps, select ) => {
+	const { getBlockSelectionStart } = select( 'core/editor' );
 	const {
 		updateBlockAttributes,
 		selectBlock,
@@ -709,7 +691,6 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps ) => {
 		onSelect( clientId = ownProps.clientId, initialPosition ) {
 			selectBlock( clientId, initialPosition );
 		},
-		onMultiSelect: multiSelect,
 		onInsertBlocks( blocks, index ) {
 			const { rootClientId } = ownProps;
 			insertBlocks( blocks, index, rootClientId );
@@ -729,6 +710,17 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps ) => {
 		},
 		onMetaChange( meta ) {
 			editPost( { meta } );
+		},
+		onShiftSelection() {
+			if ( ! ownProps.isSelectionEnabled ) {
+				return;
+			}
+
+			if ( getBlockSelectionStart() ) {
+				multiSelect( getBlockSelectionStart(), ownProps.clientId );
+			} else {
+				selectBlock( ownProps.clientId );
+			}
 		},
 		toggleSelection( selectionEnabled ) {
 			toggleSelection( selectionEnabled );

--- a/packages/editor/src/components/copy-handler/index.js
+++ b/packages/editor/src/components/copy-handler/index.js
@@ -11,33 +11,23 @@ class CopyHandler extends Component {
 	constructor() {
 		super( ...arguments );
 
-		this.onCopy = this.onCopy.bind( this );
 		this.onCut = this.onCut.bind( this );
 	}
 
 	componentDidMount() {
-		document.addEventListener( 'copy', this.onCopy );
+		document.addEventListener( 'copy', this.props.onCopy );
 		document.addEventListener( 'cut', this.onCut );
 	}
 
 	componentWillUnmount() {
-		document.removeEventListener( 'copy', this.onCopy );
+		document.removeEventListener( 'copy', this.props.onCopy );
 		document.removeEventListener( 'cut', this.onCut );
-	}
-
-	onCopy( event ) {
-		const serialized = serialize( this.props.getSelectedBlocks() );
-
-		event.clipboardData.setData( 'text/plain', serialized );
-		event.clipboardData.setData( 'text/html', serialized );
-
-		event.preventDefault();
 	}
 
 	onCut( event ) {
 		const { hasMultiSelection, selectedBlockClientIds } = this.props;
 
-		this.onCopy( event );
+		this.props.onCopy( event );
 
 		if ( hasMultiSelection ) {
 			this.props.onRemove( selectedBlockClientIds );
@@ -70,7 +60,7 @@ export default compose( [
 		const { removeBlocks } = dispatch( 'core/editor' );
 
 		return {
-			getSelectedBlocks: function() {
+			onCopy( event ) {
 				const { hasMultiSelection, selectedBlockClientIds } = ownProps;
 
 				if ( selectedBlockClientIds.length === 0 ) {
@@ -82,7 +72,12 @@ export default compose( [
 					return;
 				}
 
-				return serialize( getBlocksByClientId( selectedBlockClientIds ) );
+				const serialized = serialize( getBlocksByClientId( selectedBlockClientIds ) );
+
+				event.clipboardData.setData( 'text/plain', serialized );
+				event.clipboardData.setData( 'text/html', serialized );
+
+				event.preventDefault();
 			},
 			onRemove: removeBlocks,
 		};

--- a/packages/editor/src/components/copy-handler/index.js
+++ b/packages/editor/src/components/copy-handler/index.js
@@ -65,7 +65,7 @@ export default compose( [
 			selectedBlockClientIds,
 		};
 	} ),
-	withDispatch( ( dispatch, ownProps, select ) => {
+	withDispatch( ( dispatch, ownProps, { select } ) => {
 		const { getBlocksByClientId } = select( 'core/editor' );
 		const { removeBlocks } = dispatch( 'core/editor' );
 


### PR DESCRIPTION
## Description
In the majority of cases, it will be sufficient to use only two first params passed to `mapDispatchToProps`. However, there might be some very advanced use cases where using `select` function might be used as a tool to optimize the performance of your component. It is useful when you need to fetch some dynamic data from the store at the time when the event is fired, but at the same time, you never use it to render your component. In such scenario, you can avoid using the `withSelect` higher order component to compute such prop, which might lead to unnecessary re-renders of you component caused by its frequent value change.

## TODO
* [x] Update docs
* [x] Update code occurences which pass selectors as prop

## How has this been tested?
Unit tests: `npm run test`

1. Open an existing post (can be the demo).
1. Select all blocks (cmd+a twice) and copy them using `cmd+c`.
1. Paste them in the new empty post with `cmd+v`.
1. Select all blocks again and cut them using `cmd+x`.
1. Paste them in the new empty post with `cmd+v`.

## Types of changes
Refactoring.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
