### PR TITLE
Create an empty InlineLinkUI for mobile

### DIFF
--- a/packages/format-library/src/link/inline.native.js
+++ b/packages/format-library/src/link/inline.native.js
@@ -1,0 +1,7 @@
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+class InlineLinkUI extends Component {
+}


### PR DESCRIPTION
We'll create a different custom UI in a following PR, but for now this is necessary to import `format-library` in gutenberg-mobile.

There is not much to test yet, but you should be able to `import '@wordpress/format-library';` from somewhere in `gutenberg-mobile` without getting an error.
