### PR TITLE
Restore the help modal in the classic block

### DIFF
--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -79,13 +79,6 @@ export default class ClassicEdit extends Component {
 
 		this.editor = editor;
 
-		// Disable TinyMCE's keyboard shortcut help.
-		editor.on( 'BeforeExecCommand', ( event ) => {
-			if ( event.command === 'WP_Help' ) {
-				event.preventDefault();
-			}
-		} );
-
 		if ( content ) {
 			editor.on( 'loadContent', () => editor.setContent( content ) );
 		}


### PR DESCRIPTION
It has some duplicates with the main help modal, but many things are specific for the classic block. Also, its content can be "tweaked" specifically for the classic block in the `wordpress` MCE plugin (in core).

 #9748