### PR TITLE
RichText: fix inserting line separator without previous formats

### DIFF
--- a/packages/rich-text/src/insert-line-separator.js
+++ b/packages/rich-text/src/insert-line-separator.js
@@ -24,10 +24,11 @@ export function insertLineSeparator(
 ) {
 	const beforeText = getTextContent( value ).slice( 0, startIndex );
 	const previousLineSeparatorIndex = beforeText.lastIndexOf( LINE_SEPARATOR );
+	const previousLineSeparatorFormats = value.formats[ previousLineSeparatorIndex ];
 	let formats = [ , ];
 
-	if ( previousLineSeparatorIndex !== -1 ) {
-		formats = [ value.formats[ previousLineSeparatorIndex ] ];
+	if ( previousLineSeparatorFormats ) {
+		formats = [ previousLineSeparatorFormats ];
 	}
 
 	const valueToInsert = {

--- a/packages/rich-text/src/test/insert-line-separator.js
+++ b/packages/rich-text/src/test/insert-line-separator.js
@@ -54,7 +54,7 @@ describe( 'insertLineSeparator', () => {
 		expect( getSparseArrayLength( result.formats ) ).toBe( 0 );
 	} );
 
-	it( 'should insert line separator in nested item', () => {
+	it( 'should insert line separator with previous line separator formats', () => {
 		const value = {
 			formats: [ , , , [ ol ], , ],
 			text: `1${ LINE_SEPARATOR }2${ LINE_SEPARATOR }a`,
@@ -72,5 +72,25 @@ describe( 'insertLineSeparator', () => {
 		expect( result ).not.toBe( value );
 		expect( result ).toEqual( expected );
 		expect( getSparseArrayLength( result.formats ) ).toBe( 2 );
+	} );
+
+	it( 'should insert line separator without formats if previous line separator did not have any', () => {
+		const value = {
+			formats: [ , , , , , ],
+			text: `1${ LINE_SEPARATOR }2${ LINE_SEPARATOR }a`,
+			start: 5,
+			end: 5,
+		};
+		const expected = {
+			formats: [ , , , , , , ],
+			text: `1${ LINE_SEPARATOR }2${ LINE_SEPARATOR }a${ LINE_SEPARATOR }`,
+			start: 6,
+			end: 6,
+		};
+		const result = insertLineSeparator( deepFreeze( value ) );
+
+		expect( result ).not.toBe( value );
+		expect( result ).toEqual( expected );
+		expect( getSparseArrayLength( result.formats ) ).toBe( 0 );
 	} );
 } );


### PR DESCRIPTION
## Description

Fixes #11508. The cause of the error is an `undefined` insertion if the previous line separator did not have any formats assigned. The fix is to ensure that the previous line has formats, if not, the format at the line separator index should remain empty.

## How has this been tested?
See #11508. I also added a unit test.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
