### PR TITLE
Data: Respect changing props from withDispatch's mapDispatchToProps

### DIFF
--- a/packages/data/src/components/with-dispatch/index.js
+++ b/packages/data/src/components/with-dispatch/index.js
@@ -1,12 +1,6 @@
 /**
- * External dependencies
- */
-import { mapValues } from 'lodash';
-
-/**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
 import { pure, compose, createHigherOrderComponent } from '@wordpress/compose';
 
 /**
@@ -30,46 +24,10 @@ const withDispatch = ( mapDispatchToProps ) => createHigherOrderComponent(
 	compose( [
 		pure,
 		( WrappedComponent ) => {
-			class ComponentWithDispatch extends Component {
-				constructor( props ) {
-					super( ...arguments );
+			function ComponentWithDispatch( { registry, ownProps } ) {
+				const mergeProps = mapDispatchToProps( registry.dispatch, ownProps );
 
-					this.proxyProps = {};
-					this.setProxyProps( props );
-				}
-
-				componentDidUpdate() {
-					this.setProxyProps( this.props );
-				}
-
-				proxyDispatch( propName, ...args ) {
-					// Original dispatcher is a pre-bound (dispatching) action creator.
-					mapDispatchToProps( this.props.registry.dispatch, this.props.ownProps )[ propName ]( ...args );
-				}
-
-				setProxyProps( props ) {
-					// Assign as instance property so that in subsequent render
-					// reconciliation, the prop values are referentially equal.
-					// Importantly, note that while `mapDispatchToProps` is
-					// called, it is done only to determine the keys for which
-					// proxy functions should be created. The actual registry
-					// dispatch does not occur until the function is called.
-					const propsToDispatchers = mapDispatchToProps( this.props.registry.dispatch, props.ownProps );
-					this.proxyProps = mapValues( propsToDispatchers, ( dispatcher, propName ) => {
-						// Prebind with prop name so we have reference to the original
-						// dispatcher to invoke. Track between re-renders to avoid
-						// creating new function references every render.
-						if ( this.proxyProps.hasOwnProperty( propName ) ) {
-							return this.proxyProps[ propName ];
-						}
-
-						return this.proxyDispatch.bind( this, propName );
-					} );
-				}
-
-				render() {
-					return <WrappedComponent { ...this.props.ownProps } { ...this.proxyProps } />;
-				}
+				return <WrappedComponent { ...ownProps } { ...mergeProps } />;
 			}
 
 			return ( ownProps ) => (


### PR DESCRIPTION
Related (alternative to): #11866

This pull request seeks to update `withDispatch` to resolve an issue where if a different set of keys is returned from `mapDispatchToProps`, they are not immediately made available to the underlying component.

**Implementation notes:**

This approach abandons the prior implementation of "proxy props", which were introduced as a means to limit React's reconciliation process, since it's assumed that `mapDispatchToProps` will always define new function references in its return object. While the previous proxying avoided this behavior, it did so at the expense of needing to iterate keys of the return value of `mapDispatchToProps`, and of needing to call `mapDispatchToProps` once more at the time of the actual dispatch to account for any outer-scope variable definitions referenced by the dispatch callback. In fairness, the latter of these is a more minor point, since component dispatches very infrequently relative to rendering updates.

In all, there is likely little practical impact here so far as performance is concerned, but it does fix the previously-broken implication that `mapDispatchToProps` may return a different result in response to received `ownProps`. The approach in #11866 improves performance, but makes clear there is no support for changing the return shape of `mapDispatchToProps`.

**Testing instructions:**

Ensure tests pass:

```
npm run test
```