### PR TITLE
Update image loading state to use a spinner and a faded static image.

### DIFF
--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -17,8 +17,8 @@ ul.wp-block-gallery li {
 		outline: 4px solid theme(primary);
 	}
 
-	&.is-transient img {
-		@include edit-post__loading-fade-animation;
+	.is-transient img {
+		opacity: 0.3;
 	}
 
 	.editor-rich-text {
@@ -119,7 +119,8 @@ ul.wp-block-gallery li {
 	position: absolute;
 	top: 50%;
 	left: 50%;
-	transform: translate(-50%, -50%);
+	margin-top: -9px;
+	margin-left: -9px;
 }
 
 // Last item always needs margins reset.

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress Dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import { IconButton, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { BACKSPACE, DELETE } from '@wordpress/keycodes';
@@ -99,10 +99,24 @@ class GalleryImage extends Component {
 				break;
 		}
 
-		// Disable reason: Image itself is not meant to be
-		// interactive, but should direct image selection and unfocus caption fields
-		// eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
-		const img = url ? <img src={ url } alt={ alt } data-id={ id } onClick={ this.onImageClick } tabIndex="0" onKeyDown={ this.onImageClick } aria-label={ ariaLabel } /> : <Spinner />;
+		const img = (
+			// Disable reason: Image itself is not meant to be interactive, but should
+			// direct image selection and unfocus caption fields.
+			/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+			<Fragment>
+				<img
+					src={ url }
+					alt={ alt }
+					data-id={ id }
+					onClick={ this.onImageClick }
+					tabIndex="0"
+					onKeyDown={ this.onImageClick }
+					aria-label={ ariaLabel }
+				/>
+				{ isBlobURL( url ) && <Spinner /> }
+			</Fragment>
+			/* eslint-enable jsx-a11y/no-noninteractive-element-interactions */
+		);
 
 		const className = classnames( {
 			'is-selected': isSelected,

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -25,6 +25,7 @@ import {
 	PanelBody,
 	ResizableBox,
 	SelectControl,
+	Spinner,
 	TextControl,
 	TextareaControl,
 	Toolbar,
@@ -517,6 +518,7 @@ class ImageEdit extends Component {
 										{ getInspectorControls( imageWidth, imageHeight ) }
 										<div style={ { width, height } }>
 											{ img }
+											{ isBlobURL( url ) && <Spinner /> }
 										</div>
 									</Fragment>
 								);
@@ -591,6 +593,7 @@ class ImageEdit extends Component {
 										} }
 									>
 										{ img }
+										{ isBlobURL( url ) && <Spinner /> }
 									</ResizableBox>
 								</Fragment>
 							);

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -507,10 +507,17 @@ class ImageEdit extends Component {
 							} else {
 								defaultedAlt = __( 'This image has an empty alt attribute' );
 							}
-							// Disable reason: Image itself is not meant to be
-							// interactive, but should direct focus to block
-							// eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
-							const img = <img src={ url } alt={ defaultedAlt } onClick={ this.onImageClick } />;
+
+							const img = (
+								// Disable reason: Image itself is not meant to be interactive, but
+								// should direct focus to block.
+								/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+								<Fragment>
+									<img src={ url } alt={ defaultedAlt } onClick={ this.onImageClick } />
+									{ isBlobURL( url ) && <Spinner /> }
+								</Fragment>
+								/* eslint-enable jsx-a11y/no-noninteractive-element-interactions */
+							);
 
 							if ( ! isResizable || ! imageWidthWithinContainer ) {
 								return (
@@ -518,7 +525,6 @@ class ImageEdit extends Component {
 										{ getInspectorControls( imageWidth, imageHeight ) }
 										<div style={ { width, height } }>
 											{ img }
-											{ isBlobURL( url ) && <Spinner /> }
 										</div>
 									</Fragment>
 								);
@@ -593,7 +599,6 @@ class ImageEdit extends Component {
 										} }
 									>
 										{ img }
-										{ isBlobURL( url ) && <Spinner /> }
 									</ResizableBox>
 								</Fragment>
 							);

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -2,11 +2,20 @@
 	position: relative;
 
 	&.is-transient img {
-		@include edit-post__loading-fade-animation;
+		opacity: 0.3;
 	}
 
 	figcaption img {
 		display: inline;
+	}
+
+	// Shown while image is being uploaded
+	.components-spinner {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		margin-top: -9px;
+		margin-left: -9px;
 	}
 }
 


### PR DESCRIPTION
The current implementation of "this image is being uploaded" uses a heavy pulsating effect that has not proven to be very clear but it has been distracting.

This simply removes that effect and shows a spinner at the center — consistent with how Embeds are working — while leaving the image faded out until upload completes.

<img width="629" alt="screenshot 2018-11-14 at 15 38 09" src="https://user-images.githubusercontent.com/548849/48506604-96bb6700-e828-11e8-823c-b9d710983334.png">

Related #8810.