### PR TITLE
Editor Store: Fix refreshPost() effect

### DIFF
--- a/packages/editor/src/store/effects/posts.js
+++ b/packages/editor/src/store/effects/posts.js
@@ -9,6 +9,7 @@ import { pick, includes } from 'lodash';
  */
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 // TODO: Ideally this would be the only dispatch in scope. This requires either
 // refactoring editor actions to yielded controls, or replacing direct dispatch
 // on the editor store with action creators (e.g. `REQUEST_POST_UPDATE_START`).
@@ -313,8 +314,10 @@ export const refreshPost = async ( action, store ) => {
 	const postTypeSlug = getCurrentPostType( getState() );
 	const postType = await resolveSelector( 'core', 'getPostType', postTypeSlug );
 	const newPost = await apiFetch( {
-		path: `/wp/v2/${ postType.rest_base }/${ post.id }`,
-		data: { context: 'edit' },
+		path: addQueryArgs(
+			`/wp/v2/${ postType.rest_base }/${ post.id }`,
+			{ context: 'edit' }
+		),
 	} );
 	dispatch( resetPost( newPost ) );
 };

--- a/packages/editor/src/store/effects/posts.js
+++ b/packages/editor/src/store/effects/posts.js
@@ -9,7 +9,6 @@ import { pick, includes } from 'lodash';
  */
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
-import { addQueryArgs } from '@wordpress/url';
 // TODO: Ideally this would be the only dispatch in scope. This requires either
 // refactoring editor actions to yielded controls, or replacing direct dispatch
 // on the editor store with action creators (e.g. `REQUEST_POST_UPDATE_START`).
@@ -314,10 +313,7 @@ export const refreshPost = async ( action, store ) => {
 	const postTypeSlug = getCurrentPostType( getState() );
 	const postType = await resolveSelector( 'core', 'getPostType', postTypeSlug );
 	const newPost = await apiFetch( {
-		path: addQueryArgs(
-			`/wp/v2/${ postType.rest_base }/${ post.id }`,
-			{ context: 'edit' }
-		),
+		path: `/wp/v2/${ postType.rest_base }/${ post.id }?context=edit`,
 	} );
 	dispatch( resetPost( newPost ) );
 };


### PR DESCRIPTION
## Description
Found while working on https://github.com/Automattic/wp-calypso/pull/28549. `refreshPost()` uses `data` for `context: 'edit'`, even though it is a `GET` request (`method` isn't specified, thus falling back to `GET`). This causes `window.fetch()` to fail.

The fix is to use a query arg instead.

## How has this been tested?

### To reproduce the bug on `master`:

- Edit a post
- In the browser console, enter `wp.data.dispatch( 'core/editor' ).refreshPost()`
- This triggers the following error:

```
Uncaught (in promise)
{code: "invalid_json", message: "The response is not a valid JSON response."}
```

### To reproduce the fix

Repeat the same steps. Verify that no error is triggered.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
