### PR TITLE
Reusable blocks: Use view context, always include title.raw and content.raw

### DIFF
--- a/lib/class-wp-rest-blocks-controller.php
+++ b/lib/class-wp-rest-blocks-controller.php
@@ -33,4 +33,21 @@ class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 
 		return parent::check_read_permission( $post );
 	}
+
+	/**
+	 * Retrieves the block's schema, conforming to JSON Schema.
+	 *
+	 * @since 4.4.0
+	 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema() {
+		$schema = parent::get_item_schema();
+
+		// Allow all contexts to access the raw title and content of a block.
+		unset( $schema['properties']['title']['properties']['raw']['context'] );
+		unset( $schema['properties']['content']['properties']['raw']['context'] );
+
+		return $schema;
+	}
 }

--- a/packages/editor/src/store/effects/reusable-blocks.js
+++ b/packages/editor/src/store/effects/reusable-blocks.js
@@ -64,9 +64,9 @@ export const fetchReusableBlocks = async ( action, store ) => {
 
 	let result;
 	if ( id ) {
-		result = apiFetch( { path: `/wp/v2/${ postType.rest_base }/${ id }?context=edit` } );
+		result = apiFetch( { path: `/wp/v2/${ postType.rest_base }/${ id }` } );
 	} else {
-		result = apiFetch( { path: `/wp/v2/${ postType.rest_base }?per_page=-1&context=edit` } );
+		result = apiFetch( { path: `/wp/v2/${ postType.rest_base }?per_page=-1` } );
 	}
 
 	try {

--- a/phpunit/class-rest-blocks-controller-test.php
+++ b/phpunit/class-rest-blocks-controller-test.php
@@ -35,7 +35,7 @@ class REST_Blocks_Controller_Test extends WP_UnitTestCase {
 				'post_type'    => 'wp_block',
 				'post_status'  => 'publish',
 				'post_title'   => 'My cool block',
-				'post_content' => '<!-- wp:core/paragraph --><p>Hello!</p><!-- /wp:core/paragraph -->',
+				'post_content' => '<!-- wp:paragraph --><p>Hello!</p><!-- /wp:paragraph -->',
 			)
 		);
 
@@ -101,7 +101,7 @@ class REST_Blocks_Controller_Test extends WP_UnitTestCase {
 				$request->set_body_params(
 					array(
 						'title'   => 'Test',
-						'content' => '<!-- wp:core/paragraph --><p>Test</p><!-- /wp:core/paragraph -->',
+						'content' => '<!-- wp:paragraph --><p>Test</p><!-- /wp:paragraph -->',
 					)
 				);
 
@@ -124,7 +124,7 @@ class REST_Blocks_Controller_Test extends WP_UnitTestCase {
 						'post_type'    => 'wp_block',
 						'post_status'  => 'publish',
 						'post_title'   => 'My cool block',
-						'post_content' => '<!-- wp:core/paragraph --><p>Hello!</p><!-- /wp:core/paragraph -->',
+						'post_content' => '<!-- wp:paragraph --><p>Hello!</p><!-- /wp:paragraph -->',
 						'post_author'  => $user_id,
 					)
 				);
@@ -133,7 +133,7 @@ class REST_Blocks_Controller_Test extends WP_UnitTestCase {
 				$request->set_body_params(
 					array(
 						'title'   => 'Test',
-						'content' => '<!-- wp:core/paragraph --><p>Test</p><!-- /wp:core/paragraph -->',
+						'content' => '<!-- wp:paragraph --><p>Test</p><!-- /wp:paragraph -->',
 					)
 				);
 
@@ -154,7 +154,7 @@ class REST_Blocks_Controller_Test extends WP_UnitTestCase {
 				$request->set_body_params(
 					array(
 						'title'   => 'Test',
-						'content' => '<!-- wp:core/paragraph --><p>Test</p><!-- /wp:core/paragraph -->',
+						'content' => '<!-- wp:paragraph --><p>Test</p><!-- /wp:paragraph -->',
 					)
 				);
 
@@ -175,5 +175,36 @@ class REST_Blocks_Controller_Test extends WP_UnitTestCase {
 		if ( isset( $user_id ) ) {
 			self::delete_user( $user_id );
 		}
+	}
+
+	/**
+	 * Check that the raw title and content of a block can be accessed by a
+	 * low-privileged role when no `context` param is provided.
+	 */
+	public function test_includes_raw_title_and_content() {
+		$user_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		wp_set_current_user( $user_id );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/blocks/' . self::$post_id );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals(
+			array(
+				'raw'      => 'My cool block',
+				'rendered' => 'My cool block',
+			),
+			$data['title']
+		);
+		$this->assertEquals(
+			array(
+				'raw'       => '<!-- wp:paragraph --><p>Hello!</p><!-- /wp:paragraph -->',
+				'rendered'  => '<p>Hello!</p>',
+				'protected' => false,
+			),
+			$data['content']
+		);
+
+		self::delete_user( $user_id );
 	}
 }


### PR DESCRIPTION
Fixes #11343.

Existing reusable blocks on a post would not render if the user was an author or a contributor. This happened because requests to fetch a single block or post are blocked when ?context=edit is passed and the current user is not an editor.

The fix is to stop passing `?context=edit` to block requests, but this causes another problem which is that Gutenberg needs access to both `title.raw` and `content.raw` in the API response.

We therefore both stop passing `?context=edit` to block requests *and* modify the blocks API so that `title.raw` and `content.raw` are always provided.

#### How to test

1. Create two users, `user1` (any role) and `user2` (author role)
1. Log in as `user1` and create a reusable block
1. Log in as `user2` and create a post using `user1`'s block
1. The block should render correctly.
1. Save the post and refresh the edit screen.
1. The block should again render correctly.
