### PR TITLE
Avoid using the getSelectedBlock selector in autocompleters

### DIFF
--- a/packages/editor/src/components/autocompleters/block.js
+++ b/packages/editor/src/components/autocompleters/block.js
@@ -40,8 +40,9 @@ function defaultGetInserterItems( rootClientId ) {
  *                   block is selected.
  */
 function defaultGetSelectedBlockName() {
-	const selectedBlock = select( 'core/editor' ).getSelectedBlock();
-	return selectedBlock ? selectedBlock.name : null;
+	const { getSelectedBlockClientId, getBlockName } = select( 'core/editor' );
+	const selectedBlockClientId = getSelectedBlockClientId();
+	return selectedBlockClientId ? getBlockName( selectedBlockClientId ) : null;
 }
 
 /**


### PR DESCRIPTION
Extracted from #11811 this is a small performance optimization PR to avoid using the not so performant getSelectedBlock selector in autocompleters.

**Testing instructions**

 - Just check that the block autocompleter work properly.