### PR TITLE
Avoid getBlock selector in the DefaultBlockAppender and EditorKeyboardShortcuts components

### DIFF
--- a/packages/editor/src/components/default-block-appender/index.js
+++ b/packages/editor/src/components/default-block-appender/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
 import TextareaAutosize from 'react-autosize-textarea';
 
 /**
@@ -67,12 +66,11 @@ export function DefaultBlockAppender( {
 }
 export default compose(
 	withSelect( ( select, ownProps ) => {
-		const { getBlockCount, getBlock, getEditorSettings, getTemplateLock } = select( 'core/editor' );
+		const { getBlockCount, getBlockName, isBlockValid, getEditorSettings, getTemplateLock } = select( 'core/editor' );
 
 		const isEmpty = ! getBlockCount( ownProps.rootClientId );
-		const lastBlock = getBlock( ownProps.lastBlockClientId );
-		const isLastBlockDefault = get( lastBlock, [ 'name' ] ) === getDefaultBlockName();
-		const isLastBlockValid = get( lastBlock, [ 'isValid' ] );
+		const isLastBlockDefault = getBlockName( ownProps.lastBlockClientId ) === getDefaultBlockName();
+		const isLastBlockValid = isBlockValid( ownProps.lastBlockClientId );
 		const { bodyPlaceholder } = getEditorSettings();
 
 		return {

--- a/packages/editor/src/components/editor-global-keyboard-shortcuts/index.js
+++ b/packages/editor/src/components/editor-global-keyboard-shortcuts/index.js
@@ -155,10 +155,10 @@ export default compose( [
 			isEditedPostDirty,
 			getBlockRootClientId,
 			getTemplateLock,
-			getSelectedBlock,
+			getSelectedBlockClientId,
 		} = select( 'core/editor' );
-		const block = getSelectedBlock();
-		const selectedBlockClientIds = block ? [ block.clientId ] : getMultiSelectedBlockClientIds();
+		const selectedBlockClientId = getSelectedBlockClientId();
+		const selectedBlockClientIds = selectedBlockClientId ? [ selectedBlockClientId ] : getMultiSelectedBlockClientIds();
 
 		return {
 			rootBlocksClientIds: getBlockOrder(),


### PR DESCRIPTION
Another small quick win extracted from #11811