### PR TITLE
Fix empty heading anchor id leaving an empty id attribute on heading html tags

### DIFF
--- a/packages/editor/src/hooks/anchor.js
+++ b/packages/editor/src/hooks/anchor.js
@@ -97,7 +97,7 @@ export const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) =>
  * @return {Object} Filtered props applied to save element.
  */
 export function addSaveProps( extraProps, blockType, attributes ) {
-	if ( hasBlockSupport( blockType, 'anchor' ) ) {
+	if ( hasBlockSupport( blockType, 'anchor' ) && attributes.anchor !== '' ) {
 		extraProps.id = attributes.anchor;
 	}
 

--- a/packages/editor/src/hooks/test/anchor.js
+++ b/packages/editor/src/hooks/test/anchor.js
@@ -62,5 +62,17 @@ describe( 'anchor', () => {
 
 			expect( extraProps.id ).toBe( 'foo' );
 		} );
+
+		it( 'should have no id property if anchor attribute id is an empty string', () => {
+			const attributes = { anchor: '' };
+			const extraProps = getSaveContentExtraProps( {}, {
+				...blockSettings,
+				supports: {
+					anchor: true,
+				},
+			}, attributes );
+
+			expect( extraProps ).not.toHaveProperty( 'id' );
+		} );
 	} );
 } );


### PR DESCRIPTION
## Description
Resolves: #11663

This PR resolves the bug where an empty anchor id on a heading block would result in a stray empty id attribute on the heading html tag. This solution updates the editor anchor hook to check that the anchor id attribute is not an empty string before saving it as additional props. Also adds a test to cover this behaviour.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
* Added additional unit test for the anchor `addSaveProps` method to check that an empty string passed in to `extraProps` does not result in an id being created.
* Manually tested in Chrome 70.0.3538.77 and Safari Version 12.0 (13606.2.11) on macOS High Sierra 10.13.6.

Steps to reproduce the behaviour (from issue #11663):

* Insert a heading block and type some text
* In the Advanced panel, set an HTML Anchor attribute
* Empty the HTML Anchor field
* Switch to Code Editor.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
