### PR TITLE
Format toolbar: prevent mousedown triggering selection

### DIFF
--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -46,7 +46,7 @@ import {
 	charAt,
 } from '@wordpress/rich-text';
 import { decodeEntities } from '@wordpress/html-entities';
-import { withFilters } from '@wordpress/components';
+import { withFilters, IsolatedEventContainer } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -887,9 +887,9 @@ export class RichText extends Component {
 					</BlockFormatControls>
 				) }
 				{ isSelected && inlineToolbar && (
-					<div className="editor-rich-text__inline-toolbar">
+					<IsolatedEventContainer className="editor-rich-text__inline-toolbar">
 						<FormatToolbar controls={ formattingControls } />
-					</div>
+					</IsolatedEventContainer>
 				) }
 				<Autocomplete
 					onReplace={ this.props.onReplace }


### PR DESCRIPTION
If the format toolbar is positioned over another component that has `mousedown` handlers it is possible to trigger these handlers by pressing the mouse in the toolbar and moving. This can then cause the toolbar to disappear.

Here you can see that click-dragging in the toolbar selects the underlying blocks, removing the toolbar.

![flicker](https://user-images.githubusercontent.com/1277682/47550707-f7294980-d8f7-11e8-88d5-d07684a831a7.gif)

This PR stops the `mousedown` event propagating outside of the toolbar, and follows a similar pattern to the `<Modal />` and `<Popover />` components in #11753

Fixes #11087

## How has this been tested?
The problem is demonstrated in #11087 where a cover image block is created in such a way that clicking in the format toolbar and moving the mouse triggers a selection of the underlying blocks.

To test, follow the steps in #11087 and confirm that toolbar remains in place when the mouse button is down over a toolbar button and you then move the mouse.

## Types of changes
This should be a non-breaking bug fix. I've only applied the wrapper to the inline toolbar, as I don't think it's necessary elsewhere. It shouldn't affect anything else inside the toolbar.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
