### PR TITLE
Remove checks for store existance in withSelect HOCs for media components

### DIFF
--- a/packages/editor/src/components/media-placeholder/index.js
+++ b/packages/editor/src/components/media-placeholder/index.js
@@ -52,7 +52,7 @@ const InsertFromURLPopover = ( { src, onChange, onSubmit, onClose } ) => (
 	</URLPopover>
 );
 
-class MediaPlaceholder extends Component {
+export class MediaPlaceholder extends Component {
 	constructor() {
 		super( ...arguments );
 		this.state = {
@@ -258,13 +258,10 @@ class MediaPlaceholder extends Component {
 }
 
 const applyWithSelect = withSelect( ( select ) => {
-	let hasUploadPermissions = false;
-	if ( undefined !== select( 'core' ) ) {
-		hasUploadPermissions = select( 'core' ).hasUploadPermissions();
-	}
+	const { hasUploadPermissions } = select( 'core' );
 
 	return {
-		hasUploadPermissions: hasUploadPermissions,
+		hasUploadPermissions: hasUploadPermissions(),
 	};
 } );
 

--- a/packages/editor/src/components/media-placeholder/test/index.js
+++ b/packages/editor/src/components/media-placeholder/test/index.js
@@ -6,12 +6,14 @@ import { mount } from 'enzyme';
 /**
  * Internal dependencies
  */
-import MediaPlaceholder from '../';
+import { MediaPlaceholder } from '../';
+
+jest.mock( '../../media-upload/check', () => () => null );
 
 describe( 'MediaPlaceholder', () => {
 	it( 'renders successfully when allowedTypes property is not specified', () => {
 		expect( () => mount(
-			<MediaPlaceholder />
+			<MediaPlaceholder hasUploadPermissions={ false } />
 		) ).not.toThrow();
 	} );
 } );

--- a/packages/editor/src/components/media-upload/check.js
+++ b/packages/editor/src/components/media-upload/check.js
@@ -8,12 +8,9 @@ export function MediaUploadCheck( { hasUploadPermissions, fallback = null, child
 }
 
 export default withSelect( ( select ) => {
-	let hasUploadPermissions = false;
-	if ( undefined !== select( 'core' ) ) {
-		hasUploadPermissions = select( 'core' ).hasUploadPermissions();
-	}
+	const { hasUploadPermissions } = select( 'core' );
 
 	return {
-		hasUploadPermissions: hasUploadPermissions,
+		hasUploadPermissions: hasUploadPermissions(),
 	};
 } )( MediaUploadCheck );


### PR DESCRIPTION
## Description

This is follow-up for work done by @imath in #4155. It addresses comments left by @youknowriad:
- https://github.com/WordPress/gutenberg/pull/4155#discussion_r233751201
- https://github.com/WordPress/gutenberg/pull/4155#discussion_r233751376

## How has this been tested?
`npm test`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
