### PR TITLE
Post/page title: add word-break keep-all

### DIFF
--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -18,6 +18,7 @@
 		color: $dark-gray-900;
 		transition: border 0.1s ease-out;
 		padding: #{ $block-padding + 5px } $block-padding;
+		word-break: keep-all;
 
 		// Stack borders on mobile.
 		border: $border-width solid transparent;


### PR DESCRIPTION
The aim of this PR is to fix #11786. Specifically, to improve how words are broken onto multiple lines.

I suspect this PR improves that, and it's based on advice in https://github.com/WordPress/gutenberg/issues/11786#issuecomment-438653910.

![screenshot 2018-11-15 at 12 17 25](https://user-images.githubusercontent.com/1204802/48549605-88c12100-e8d0-11e8-8478-0c4b93889680.png)
