### PR TITLE
RichText: Don't update live DOM on composition

### DIFF
--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -383,10 +383,12 @@ export class RichText extends Component {
 
 	/**
 	 * Handle input on the next selection change event.
+	 *
+	 * @param {Event} event Input event.
 	 */
-	onInput( { isComposing } ) {
+	onInput( event ) {
 		// Don't trigger a change yet if characters are being composed.
-		if ( isComposing ) {
+		if ( event.nativeEvent.isComposing ) {
 			return;
 		}
 

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -384,7 +384,12 @@ export class RichText extends Component {
 	/**
 	 * Handle input on the next selection change event.
 	 */
-	onInput() {
+	onInput( { isComposing } ) {
+		// Don't trigger a change yet if characters are being composed.
+		if ( isComposing ) {
+			return;
+		}
+
 		const record = this.createRecord();
 		const transformed = this.patterns.reduce( ( accumlator, transform ) => transform( accumlator ), record );
 

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -384,10 +384,13 @@ export class RichText extends Component {
 	/**
 	 * Handle input on the next selection change event.
 	 *
-	 * @param {Event} event Input event.
+	 * @param {SyntheticEvent} event Synthetic input event.
 	 */
 	onInput( event ) {
-		// Don't trigger a change yet if characters are being composed.
+		// For Input Method Editor (IME), used in Chinese, Japanese, and Korean
+		// (CJK), do not trigger a change if characters are being composed.
+		// Browsers setting `isComposing` to `true` will emit a final `input`
+		// event when the characters are composed.
 		if ( event.nativeEvent.isComposing ) {
 			return;
 		}

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -92,6 +92,7 @@ export class RichText extends Component {
 		this.onCreateUndoLevel = this.onCreateUndoLevel.bind( this );
 		this.setFocusedElement = this.setFocusedElement.bind( this );
 		this.onInput = this.onInput.bind( this );
+		this.onCompositionEnd = this.onCompositionEnd.bind( this );
 		this.onSelectionChange = this.onSelectionChange.bind( this );
 		this.getRecord = this.getRecord.bind( this );
 		this.createRecord = this.createRecord.bind( this );
@@ -389,8 +390,8 @@ export class RichText extends Component {
 	onInput( event ) {
 		// For Input Method Editor (IME), used in Chinese, Japanese, and Korean
 		// (CJK), do not trigger a change if characters are being composed.
-		// Browsers setting `isComposing` to `true` will emit a final `input`
-		// event when the characters are composed.
+		// Browsers setting `isComposing` to `true` will usually emit a final
+		// `input` event when the characters are composed.
 		if ( event.nativeEvent.isComposing ) {
 			return;
 		}
@@ -399,6 +400,12 @@ export class RichText extends Component {
 		const transformed = this.patterns.reduce( ( accumlator, transform ) => transform( accumlator ), record );
 
 		this.onChange( transformed );
+	}
+
+	onCompositionEnd() {
+		// Ensure the value is up-to-date for browsers that don't emit a final
+		// input event after composition.
+		this.onChange( this.createRecord() );
 	}
 
 	/**
@@ -925,6 +932,7 @@ export class RichText extends Component {
 								key={ key }
 								onPaste={ this.onPaste }
 								onInput={ this.onInput }
+								onCompositionEnd={ this.onCompositionEnd }
 								onKeyDown={ this.onKeyDown }
 								onKeyUp={ this.onKeyUp }
 								onFocus={ this.onFocus }

--- a/packages/editor/src/components/rich-text/tinymce.js
+++ b/packages/editor/src/components/rich-text/tinymce.js
@@ -325,6 +325,7 @@ export default class TinyMCE extends Component {
 			onInput,
 			onKeyDown,
 			onKeyUp,
+			onCompositionEnd,
 		} = this.props;
 
 		/*
@@ -354,6 +355,7 @@ export default class TinyMCE extends Component {
 			onFocus: this.onFocus,
 			onKeyDown,
 			onKeyUp,
+			onCompositionEnd,
 		} );
 	}
 }


### PR DESCRIPTION
## Description
See #11813 and #11795. This is just an attempt at fixing the issue.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->