### PR TITLE
Update: Don't focus paragraph on media & text block.

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -187,6 +187,7 @@ class MediaTextEdit extends Component {
 					<InnerBlocks
 						allowedBlocks={ ALLOWED_BLOCKS }
 						template={ TEMPLATE }
+						templateInsertUpdatesSelection={ false }
 					/>
 				</div>
 			</Fragment>


### PR DESCRIPTION
## Description
This PR makes sure that when we insert a "Media & Text" block, the media & text block gets selected instead of its child paragraph getting the selection right away.

Addresses an accessibility problem raised by @afercia:
> This makes all the UI that is before the second RichText hardly discoverable for screen reader users and hardly operable for sighted keyboard users. Ideally, I'd tend to think this is one case where setting initial focus on the block outer wrapper would be the best option, also considering that in an already existing block the order of media and text could be reversed.

This PR makes use of a series of changes that were meanwhile merged that make this possible.

## How has this been tested?
I added "Media & Text" block and I checked the outer block gets selected, the focus does not go the child paragraph.

## Screenshots <!-- if applicable -->
Before:
![nov-15-2018 12-08-48](https://user-images.githubusercontent.com/11271197/48552241-dd17d100-e8cf-11e8-8496-4bac785ecff9.gif)

After:
![nov-15-2018 12-06-25](https://user-images.githubusercontent.com/11271197/48552250-e5700c00-e8cf-11e8-97a2-52a5124a0c48.gif)

