### PR TITLE
Maintain selection after format props change

### DIFF
--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -778,6 +778,11 @@ export class RichText extends Component {
 
 		if ( shouldReapply ) {
 			const record = this.formatToValue( value );
+
+			// Maintain the previous selection:
+			record.start = this.state.start;
+			record.end = this.state.end;
+
 			this.applyRecord( record );
 		}
 	}


### PR DESCRIPTION
## Description

The format props should only ever affect formatting and never the content itself, so we want to preserve the selection of the user in the same positions it was before.

## How has this been tested?

I found this out when working on https://github.com/WordPress/gutenberg/pull/11861. In an earlier iteration updating the annotations prop the cursor position would be completely lost when typing. This also occurs in https://github.com/Yoast/wordpress-seo/pull/11600 when trying to adjust annotations with updated data.

## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->