### PR TITLE
Add wp-polyfill as dependency to react

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -973,7 +973,8 @@ function gutenberg_register_vendor_scripts() {
 
 	gutenberg_register_vendor_script(
 		'react',
-		'https://unpkg.com/react@16.6.3/umd/react' . $react_suffix . '.js'
+		'https://unpkg.com/react@16.6.3/umd/react' . $react_suffix . '.js',
+		array( 'wp-polyfill' )
 	);
 	gutenberg_register_vendor_script(
 		'react-dom',


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
When investigating [an IE11 issue in Yoast SEO](https://github.com/Yoast/wordpress-seo/issues/11597), we ran into the issue that IE11 [needs wp-polyfill to be registered before React and React DOM](https://github.com/facebook/react/issues/8379#issuecomment-418542006). It looks like this never leads to problems in Gutenberg itself because wp-polyfill has always already been loaded as a dependency of other dependencies. However, when plugins rely on Gutenberg's React, like we do, it does lead to issues in IE11.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
IE11 test by @afercia in progress

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bugfix



## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
