### PR TITLE
Stops preview placeholder URLs to break out of their container box (#11880)

### DIFF
--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -20,6 +20,11 @@
 	margin-bottom: 1em;
 }
 
+// Stops preview placeholder URLs to break out of their container box.
+.components-placeholder__error {
+	width: 100%;
+}
+
 .wp-embed-responsive {
 	.wp-block-embed {
 		// Add responsiveness to common aspect ratios.


### PR DESCRIPTION
## Description
I added a width of 100% to the container box which fixed the issue that URLs kept overflowing their container box on several screen sizes. 
Reference: #11880 

## Types of changes
Made the change in /packages/block-library/src/embed/style.scss.
```
.components-placeholder__error {
	width: 100%;
}
```