### PR TITLE
Add `wp-image-####` CSS class to images in the Media and Text block

### DIFF
--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -159,7 +159,6 @@ export const settings = {
 		const mediaTypeRenders = {
 			image: () => <img src={ mediaUrl } alt={ mediaAlt } className={ ( mediaId && mediaType === 'image' ) ? `wp-image-${ mediaId }` : null } />,
 			video: () => <video controls src={ mediaUrl } />,
-
 		};
 		const backgroundClass = getColorClassName( 'background-color', backgroundColor );
 		const className = classnames( {

--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -24,6 +24,50 @@ const DEFAULT_MEDIA_WIDTH = 50;
 
 export const name = 'core/media-text';
 
+const blockAttributes = {
+	align: {
+		type: 'string',
+		default: 'wide',
+	},
+	backgroundColor: {
+		type: 'string',
+	},
+	customBackgroundColor: {
+		type: 'string',
+	},
+	mediaAlt: {
+		type: 'string',
+		source: 'attribute',
+		selector: 'figure img',
+		attribute: 'alt',
+		default: '',
+	},
+	mediaPosition: {
+		type: 'string',
+		default: 'left',
+	},
+	mediaId: {
+		type: 'number',
+	},
+	mediaUrl: {
+		type: 'string',
+		source: 'attribute',
+		selector: 'figure video,figure img',
+		attribute: 'src',
+	},
+	mediaType: {
+		type: 'string',
+	},
+	mediaWidth: {
+		type: 'number',
+		default: 50,
+	},
+	isStackedOnMobile: {
+		type: 'boolean',
+		default: false,
+	},
+};
+
 export const settings = {
 	title: __( 'Media & Text' ),
 
@@ -35,49 +79,7 @@ export const settings = {
 
 	keywords: [ __( 'image' ), __( 'video' ) ],
 
-	attributes: {
-		align: {
-			type: 'string',
-			default: 'wide',
-		},
-		backgroundColor: {
-			type: 'string',
-		},
-		customBackgroundColor: {
-			type: 'string',
-		},
-		mediaAlt: {
-			type: 'string',
-			source: 'attribute',
-			selector: 'figure img',
-			attribute: 'alt',
-			default: '',
-		},
-		mediaPosition: {
-			type: 'string',
-			default: 'left',
-		},
-		mediaId: {
-			type: 'number',
-		},
-		mediaUrl: {
-			type: 'string',
-			source: 'attribute',
-			selector: 'figure video,figure img',
-			attribute: 'src',
-		},
-		mediaType: {
-			type: 'string',
-		},
-		mediaWidth: {
-			type: 'number',
-			default: 50,
-		},
-		isStackedOnMobile: {
-			type: 'boolean',
-			default: false,
-		},
-	},
+	attributes: blockAttributes,
 
 	supports: {
 		align: [ 'wide', 'full' ],
@@ -152,12 +154,13 @@ export const settings = {
 			mediaType,
 			mediaUrl,
 			mediaWidth,
+			mediaId,
 		} = attributes;
 		const mediaTypeRenders = {
-			image: () => <img src={ mediaUrl } alt={ mediaAlt } />,
+			image: () => <img src={ mediaUrl } alt={ mediaAlt } className={ ( mediaId && mediaType === 'image' ) ? `wp-image-${ mediaId }` : null } />,
 			video: () => <video controls src={ mediaUrl } />,
-		};
 
+		};
 		const backgroundClass = getColorClassName( 'background-color', backgroundColor );
 		const className = classnames( {
 			'has-media-on-the-right': 'right' === mediaPosition,
@@ -184,4 +187,51 @@ export const settings = {
 			</div>
 		);
 	},
+
+	deprecated: [
+		{
+			attributes: blockAttributes,
+			save( { attributes } ) {
+				const {
+					backgroundColor,
+					customBackgroundColor,
+					isStackedOnMobile,
+					mediaAlt,
+					mediaPosition,
+					mediaType,
+					mediaUrl,
+					mediaWidth,
+				} = attributes;
+				const mediaTypeRenders = {
+					image: () => <img src={ mediaUrl } alt={ mediaAlt } />,
+					video: () => <video controls src={ mediaUrl } />,
+				};
+				const backgroundClass = getColorClassName( 'background-color', backgroundColor );
+				const className = classnames( {
+					'has-media-on-the-right': 'right' === mediaPosition,
+					[ backgroundClass ]: backgroundClass,
+					'is-stacked-on-mobile': isStackedOnMobile,
+				} );
+
+				let gridTemplateColumns;
+				if ( mediaWidth !== DEFAULT_MEDIA_WIDTH ) {
+					gridTemplateColumns = 'right' === mediaPosition ? `auto ${ mediaWidth }%` : `${ mediaWidth }% auto`;
+				}
+				const style = {
+					backgroundColor: backgroundClass ? undefined : customBackgroundColor,
+					gridTemplateColumns,
+				};
+				return (
+					<div className={ className } style={ style }>
+						<figure className="wp-block-media-text__media" >
+							{ ( mediaTypeRenders[ mediaType ] || noop )() }
+						</figure>
+						<div className="wp-block-media-text__content">
+							<InnerBlocks.Content />
+						</div>
+					</div>
+				);
+			},
+		},
+	],
 };

--- a/test/integration/full-content/fixtures/core__media-text.html
+++ b/test/integration/full-content/fixtures/core__media-text.html
@@ -1,7 +1,7 @@
 <!-- wp:media-text {"mediaId":17985,"mediaType":"image"} -->
 <div class="wp-block-media-text alignwide">
 	<figure class="wp-block-media-text__media">
-		<img src="http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg" alt=""/>
+		<img src="http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg" alt="" class="wp-image-17985"/>
 	</figure>
 	<div class="wp-block-media-text__content">
 		<!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->

--- a/test/integration/full-content/fixtures/core__media-text.json
+++ b/test/integration/full-content/fixtures/core__media-text.json
@@ -28,6 +28,6 @@
                 "originalContent": "<p class=\"has-large-font-size\">My Content</p>"
             }
         ],
-        "originalContent": "<div class=\"wp-block-media-text alignwide\">\n\t<figure class=\"wp-block-media-text__media\">\n\t\t<img src=\"http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg\" alt=\"\"/>\n\t</figure>\n\t<div class=\"wp-block-media-text__content\">\n\t\t\n\t</div>\n</div>"
+        "originalContent": "<div class=\"wp-block-media-text alignwide\">\n\t<figure class=\"wp-block-media-text__media\">\n\t\t<img src=\"http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg\" alt=\"\" class=\"wp-image-17985\"/>\n\t</figure>\n\t<div class=\"wp-block-media-text__content\">\n\t\t\n\t</div>\n</div>"
     }
 ]

--- a/test/integration/full-content/fixtures/core__media-text.parsed.json
+++ b/test/integration/full-content/fixtures/core__media-text.parsed.json
@@ -19,9 +19,9 @@
                 ]
             }
         ],
-        "innerHTML": "\n<div class=\"wp-block-media-text alignwide\">\n\t<figure class=\"wp-block-media-text__media\">\n\t\t<img src=\"http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg\" alt=\"\"/>\n\t</figure>\n\t<div class=\"wp-block-media-text__content\">\n\t\t\n\t</div>\n</div>\n",
+        "innerHTML": "\n<div class=\"wp-block-media-text alignwide\">\n\t<figure class=\"wp-block-media-text__media\">\n\t\t<img src=\"http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg\" alt=\"\" class=\"wp-image-17985\"/>\n\t</figure>\n\t<div class=\"wp-block-media-text__content\">\n\t\t\n\t</div>\n</div>\n",
         "innerContent": [
-            "\n<div class=\"wp-block-media-text alignwide\">\n\t<figure class=\"wp-block-media-text__media\">\n\t\t<img src=\"http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg\" alt=\"\"/>\n\t</figure>\n\t<div class=\"wp-block-media-text__content\">\n\t\t",
+            "\n<div class=\"wp-block-media-text alignwide\">\n\t<figure class=\"wp-block-media-text__media\">\n\t\t<img src=\"http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg\" alt=\"\" class=\"wp-image-17985\"/>\n\t</figure>\n\t<div class=\"wp-block-media-text__content\">\n\t\t",
             null,
             "\n\t</div>\n</div>\n"
         ]

--- a/test/integration/full-content/fixtures/core__media-text.serialized.html
+++ b/test/integration/full-content/fixtures/core__media-text.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:media-text {"mediaId":17985,"mediaType":"image"} -->
-<div class="wp-block-media-text alignwide"><figure class="wp-block-media-text__media"><img src="http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg" alt=""/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->
+<div class="wp-block-media-text alignwide"><figure class="wp-block-media-text__media"><img src="http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg" alt="" class="wp-image-17985"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->
 <p class="has-large-font-size">My Content</p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:media-text -->

--- a/test/integration/full-content/fixtures/core__media-text__image-alt-no-align.html
+++ b/test/integration/full-content/fixtures/core__media-text__image-alt-no-align.html
@@ -1,7 +1,7 @@
 <!-- wp:media-text {"align":"none","mediaId":17985,"mediaType":"image"} -->
 <div class="wp-block-media-text">
 	<figure class="wp-block-media-text__media">
-		<img src="http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg" alt="my alt"/>
+		<img src="http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg" alt="my alt" class="wp-image-17985" />
 	</figure>
 	<div class="wp-block-media-text__content">
 		<!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->

--- a/test/integration/full-content/fixtures/core__media-text__image-alt-no-align.json
+++ b/test/integration/full-content/fixtures/core__media-text__image-alt-no-align.json
@@ -28,6 +28,6 @@
                 "originalContent": "<p class=\"has-large-font-size\">Content</p>"
             }
         ],
-        "originalContent": "<div class=\"wp-block-media-text\">\n\t<figure class=\"wp-block-media-text__media\">\n\t\t<img src=\"http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg\" alt=\"my alt\"/>\n\t</figure>\n\t<div class=\"wp-block-media-text__content\">\n\t\t\n\t</div>\n</div>"
+        "originalContent": "<div class=\"wp-block-media-text\">\n\t<figure class=\"wp-block-media-text__media\">\n\t\t<img src=\"http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg\" alt=\"my alt\" class=\"wp-image-17985\" />\n\t</figure>\n\t<div class=\"wp-block-media-text__content\">\n\t\t\n\t</div>\n</div>"
     }
 ]

--- a/test/integration/full-content/fixtures/core__media-text__image-alt-no-align.parsed.json
+++ b/test/integration/full-content/fixtures/core__media-text__image-alt-no-align.parsed.json
@@ -20,9 +20,9 @@
                 ]
             }
         ],
-        "innerHTML": "\n<div class=\"wp-block-media-text\">\n\t<figure class=\"wp-block-media-text__media\">\n\t\t<img src=\"http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg\" alt=\"my alt\"/>\n\t</figure>\n\t<div class=\"wp-block-media-text__content\">\n\t\t\n\t</div>\n</div>\n",
+        "innerHTML": "\n<div class=\"wp-block-media-text\">\n\t<figure class=\"wp-block-media-text__media\">\n\t\t<img src=\"http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg\" alt=\"my alt\" class=\"wp-image-17985\" />\n\t</figure>\n\t<div class=\"wp-block-media-text__content\">\n\t\t\n\t</div>\n</div>\n",
         "innerContent": [
-            "\n<div class=\"wp-block-media-text\">\n\t<figure class=\"wp-block-media-text__media\">\n\t\t<img src=\"http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg\" alt=\"my alt\"/>\n\t</figure>\n\t<div class=\"wp-block-media-text__content\">\n\t\t",
+            "\n<div class=\"wp-block-media-text\">\n\t<figure class=\"wp-block-media-text__media\">\n\t\t<img src=\"http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg\" alt=\"my alt\" class=\"wp-image-17985\" />\n\t</figure>\n\t<div class=\"wp-block-media-text__content\">\n\t\t",
             null,
             "\n\t</div>\n</div>\n"
         ]

--- a/test/integration/full-content/fixtures/core__media-text__image-alt-no-align.serialized.html
+++ b/test/integration/full-content/fixtures/core__media-text__image-alt-no-align.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:media-text {"align":"none","mediaId":17985,"mediaType":"image"} -->
-<div class="wp-block-media-text"><figure class="wp-block-media-text__media"><img src="http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg" alt="my alt"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->
+<div class="wp-block-media-text"><figure class="wp-block-media-text__media"><img src="http://localhost/wp-content/uploads/2018/09/1600px-Mount_Everest_as_seen_from_Drukair2_PLW_edit.jpg" alt="my alt" class="wp-image-17985"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->
 <p class="has-large-font-size">Content</p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:media-text -->


### PR DESCRIPTION
This is used to add `srcset` and `sizes` attributes on the front-end. As we use the "large" image size now, having these attributes becomes (almost) mandatory :)
