### PR TITLE
Stops preview placeholder URLs to break out of their container box (#11880)

### DIFF
--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -20,6 +20,11 @@
 	margin-bottom: 1em;
 }
 
+// Stops preview placeholder URLs to break out of their container box.
+.components-placeholder__error {
+	width: 100%;
+}
+
 .wp-embed-responsive {
 	.wp-block-embed {
 		// Add responsiveness to common aspect ratios.


### PR DESCRIPTION
## Description
I added a width of 100% to the container box which fixed the issue that URLs kept overflowing their container box on several screen sizes.
Reference: #11880 

For some reason `word-wrap: break-word;` didn't work for me.

## How has this been tested?
I added an embed element and resized the window a couple times to make sure it works.

## Types of changes
Made the change in /packages/block-library/src/embed/style.scss.

```
.components-placeholder__error {
	width: 100%;
}
```

## Checklist:
- [ ✓ ] My code is tested.
- [  ✓] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ✓ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ✓ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->