### PR TITLE
RichText: mark onSplit as unstable

### DIFF
--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -48,7 +48,7 @@ export default function HeadingEdit( {
 				value={ content }
 				onChange={ ( value ) => setAttributes( { content: value } ) }
 				onMerge={ mergeBlocks }
-				onSplit={
+				unstableOnSplit={
 					insertBlocksAfter ?
 						( before, after, ...blocks ) => {
 							setAttributes( { content: before } );

--- a/packages/block-library/src/list/index.js
+++ b/packages/block-library/src/list/index.js
@@ -233,7 +233,7 @@ export const settings = {
 				className={ className }
 				placeholder={ __( 'Write list…' ) }
 				onMerge={ mergeBlocks }
-				onSplit={
+				unstableOnSplit={
 					insertBlocksAfter ?
 						( before, after, ...blocks ) => {
 							if ( ! blocks.length ) {

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -242,7 +242,7 @@ class ParagraphBlock extends Component {
 							content: nextContent,
 						} );
 					} }
-					onSplit={ this.splitBlock }
+					unstableOnSplit={ this.splitBlock }
 					onMerge={ mergeBlocks }
 					onReplace={ this.onReplace }
 					onRemove={ () => onReplace( [] ) }

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -85,7 +85,6 @@ export class RichText extends Component {
 
 			deprecated( 'wp.editor.RichText onSplit prop', {
 				plugin: 'Gutenberg',
-				version: '4.6',
 				alternative: 'wp.editor.RichText unstableOnSplit prop',
 			} );
 		} else if ( this.props.unstableOnSplit ) {


### PR DESCRIPTION
## Description
`onSplit` is an being revised in #11005, but it's not sure when we can land this change. In the meantime it would be good to mark `onSplit` as unstable. It's a relatively small deprecation. I don't expect many non core blocks to use this prop. Even in core we only use it for 3 blocks.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->