### PR TITLE
fix scss syntax error.

### DIFF
--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -128,6 +128,6 @@
 }
 
 .has-larger-font-size, // not used now, kept because of backward compatibility.
-.has-huge-font-size, {
+.has-huge-font-size {
 	font-size: 42px;
 }


### PR DESCRIPTION
## Description
fix  scss syntax error.

## Types of changes
 Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
