### PR TITLE
Fix: Remove invalid isValidBlock export

### DIFF
--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -20,7 +20,7 @@ export {
 	getSaveElement,
 	getSaveContent,
 } from './serializer';
-export { isValidBlockContent, isValidBlock } from './validation';
+export { isValidBlockContent } from './validation';
 export {
 	getCategories,
 	setCategories,


### PR DESCRIPTION
## Description
We missed the removal of this export when the function was removed.

## How has this been tested?
Run "npm run dev" and verify there are no build warnings.