### PR TITLE
Localize DateTimePicker Component

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -262,8 +262,16 @@ function gutenberg_register_scripts_and_styles() {
 					'weekdays'      => array_values( $wp_locale->weekday ),
 					'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
 					'week'          => array(
-						'dow' => (int) get_option( 'start_of_week', 0 )
-					)
+						'dow' => (int) get_option( 'start_of_week', 0 ),
+					),
+					'longDateFormat' => array(
+						'LT' => get_option( 'time_format', __( 'g:i a', 'default' ) ),
+						'LTS' => null,
+						'L' => null,
+						'LL' => get_option( 'date_format', __( 'F j, Y', 'default' ) ),
+						'LLL' => __( 'F j, Y g:i a', 'default' ),
+						'LLLL' => null,
+					),
 				)
 			)
 		),

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -250,6 +250,22 @@ function gutenberg_register_scripts_and_styles() {
 		),
 		'after'
 	);
+	wp_add_inline_script(
+		'moment',
+		sprintf(
+			"moment.locale( '%s', %s );",
+			get_user_locale(),
+			wp_json_encode(
+				array(
+					'months'        => array_values( $wp_locale->month ),
+					'monthsShort'   => array_values( $wp_locale->month_abbrev ),
+					'weekdays'      => array_values( $wp_locale->weekday ),
+					'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
+				)
+			)
+		),
+		'after'
+	);
 	// Loading the old editor and its config to ensure the classic block works as expected.
 	wp_add_inline_script(
 		'editor',

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -261,6 +261,9 @@ function gutenberg_register_scripts_and_styles() {
 					'monthsShort'   => array_values( $wp_locale->month_abbrev ),
 					'weekdays'      => array_values( $wp_locale->weekday ),
 					'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
+					'week'          => array(
+						'dow' => (int) get_option( 'start_of_week', 0 )
+					)
 				)
 			)
 		),

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -257,19 +257,19 @@ function gutenberg_register_scripts_and_styles() {
 			get_user_locale(),
 			wp_json_encode(
 				array(
-					'months'        => array_values( $wp_locale->month ),
-					'monthsShort'   => array_values( $wp_locale->month_abbrev ),
-					'weekdays'      => array_values( $wp_locale->weekday ),
-					'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
-					'week'          => array(
+					'months'         => array_values( $wp_locale->month ),
+					'monthsShort'    => array_values( $wp_locale->month_abbrev ),
+					'weekdays'       => array_values( $wp_locale->weekday ),
+					'weekdaysShort'  => array_values( $wp_locale->weekday_abbrev ),
+					'week'           => array(
 						'dow' => (int) get_option( 'start_of_week', 0 ),
 					),
 					'longDateFormat' => array(
-						'LT' => get_option( 'time_format', __( 'g:i a', 'default' ) ),
-						'LTS' => null,
-						'L' => null,
-						'LL' => get_option( 'date_format', __( 'F j, Y', 'default' ) ),
-						'LLL' => __( 'F j, Y g:i a', 'default' ),
+						'LT'   => get_option( 'time_format', __( 'g:i a', 'default' ) ),
+						'LTS'  => null,
+						'L'    => null,
+						'LL'   => get_option( 'date_format', __( 'F j, Y', 'default' ) ),
+						'LLL'  => __( 'F j, Y g:i a', 'default' ),
 						'LLLL' => null,
 					),
 				)


### PR DESCRIPTION
## Description
wp-date is deprecating its moment method, so we need to localize 

Closes #4533 and #9109

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
Localized month and day (Esperanto
![screen shot 2018-11-16 at 9 58 22 am](https://user-images.githubusercontent.com/128240/48628860-317d8800-e986-11e8-8e3d-ef9dfe7f1c6f.png)
)

Week starts on Wednesday:
![screen shot 2018-11-16 at 9 55 50 am](https://user-images.githubusercontent.com/128240/48628741-f2e7cd80-e985-11e8-94f8-418cd38fb1f9.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
