### PR TITLE
Updated Readme to fix the path example by removing wp-json from it.

### DIFF
--- a/packages/api-fetch/README.md
+++ b/packages/api-fetch/README.md
@@ -17,7 +17,7 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 ```js
 import apiFetch from '@wordpress/api-fetch';
 
-apiFetch( { path: '/wp-json/wp/v2/posts' } ).then( posts => {
+apiFetch( { path: '/wp/v2/posts' } ).then( posts => {
 	console.log( posts );
 } );
 ```


### PR DESCRIPTION
While testing the apiFetch component we realised that the path didn't need to include wp-json because that has already been added.

## Description
Updated the path parameter to mirror working code.

## How has this been tested?
The apiFetch was tested with the example from the readme and produced an error. I realised that wp-json was in the URL twice. Therefore I removed it in the documentation. 

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
