### PR TITLE
Placeholder: fix missing margin on block icons that are not dashicons

### DIFF
--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -25,7 +25,8 @@
 	font-weight: 600;
 	margin-bottom: 1em;
 
-	.dashicon {
+	.dashicon,
+	.editor-block-icon {
 		margin-right: 1ch;
 	}
 }


### PR DESCRIPTION
The placeholder component is only adding margin for block icons that are dashicons.

*Before:*
![image](https://user-images.githubusercontent.com/548849/48586266-3999e100-e90e-11e8-9ace-fed5c9a38fb2.png)

*After*
![image](https://user-images.githubusercontent.com/548849/48586243-2a1a9800-e90e-11e8-919d-372452df0728.png)
