### PR TITLE
Use fancy apostrophe in locked post modal text.

### DIFF
--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -156,11 +156,11 @@ class PostLockedModal extends Component {
 							{ userDisplayName ?
 								sprintf(
 									/* translators: 'post' is generic and may be of any type (post, page, etc.). */
-									__( '%s now has editing control of this post. Don\'t worry, your changes up to this moment have been saved.' ),
+									__( '%s now has editing control of this post. Don’t worry, your changes up to this moment have been saved.' ),
 									userDisplayName
 								) :
 								/* translators: 'post' is generic and may be of any type (post, page, etc.). */
-								__( 'Another user now has editing control of this post. Don\'t worry, your changes up to this moment have been saved.' )
+								__( 'Another user now has editing control of this post. Don’t worry, your changes up to this moment have been saved.' )
 							}
 						</div>
 						<p>


### PR DESCRIPTION
## Description
Other user-facing strings (e.g. NUX tips) use the fancy quotation marks / apostrophe. This PR updates 2 strings in `packages/editor/src/components/post-locked-modal/index.js` to match this convention.