### PR TITLE
Fixes #11949: Error: The block "xxx" can have a maximum of 3 keywords.

### DIFF
--- a/docs/block-api.md
+++ b/docs/block-api.md
@@ -106,7 +106,7 @@ icon: {
 
 * **Type:** `Array`
 
-Sometimes a block could have aliases that help users discover it while searching. For example, an `image` block could also want to be discovered by `photo`. You can do so by providing an array of terms (which can be translated). It is only allowed to add as much as three terms per block.
+Sometimes a block could have aliases that help users discover it while searching. For example, an `image` block could also want to be discovered by `photo`. You can do so by providing an array of terms (which can be translated).
 
 ```js
 // Make it easier to discover a block with keyword aliases.
@@ -124,18 +124,18 @@ Block styles can be used to provide alternative styles to block. It works by add
 // Register block styles.
 styles: [
 	// Mark style as default.
-	{ 
-		name: 'default', 
-		label: __( 'Rounded' ), 
-		isDefault: true 
+	{
+		name: 'default',
+		label: __( 'Rounded' ),
+		isDefault: true
 	},
-	{ 
-		name: 'outline', 
-		label: __( 'Outline' ) 
+	{
+		name: 'outline',
+		label: __( 'Outline' )
 	},
-	{ 
-		name: 'squared', 
-		label: __( 'Squared' ) 
+	{
+		name: 'squared',
+		label: __( 'Squared' )
 	},
 ],
 ```

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -1,4 +1,4 @@
-/* eslint no-console: [ 'error', { allow: [ 'error' ] } ] */
+/* eslint no-console: [ 'error', { allow: [ 'error', 'warn' ] } ] */
 
 /**
  * External dependencies
@@ -141,7 +141,7 @@ export function registerBlockType( name, settings ) {
 	}
 
 	if ( 'keywords' in settings && settings.keywords.length > 3 ) {
-		console.error(
+		console.warn(
 			'The block "' + name + '" can have a maximum of 3 keywords.'
 		);
 		settings.keywords = settings.keywords.slice( 0, 3 );

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -103,12 +103,6 @@ export function registerBlockType( name, settings ) {
 		);
 		return;
 	}
-	if ( 'keywords' in settings && settings.keywords.length > 3 ) {
-		console.error(
-			'The block "' + name + '" can have a maximum of 3 keywords.'
-		);
-		return;
-	}
 	if ( ! ( 'category' in settings ) ) {
 		console.error(
 			'The block "' + name + '" must have a category.'
@@ -144,6 +138,13 @@ export function registerBlockType( name, settings ) {
 			'The icon should be a string, an element, a function, or an object following the specifications documented in https://wordpress.org/gutenberg/handbook/block-api/#icon-optional'
 		);
 		return;
+	}
+
+	if ( 'keywords' in settings && settings.keywords.length > 3 ) {
+		console.error(
+			'The block "' + name + '" can have a maximum of 3 keywords.'
+		);
+		settings.keywords = settings.keywords.slice( 0, 3 );
 	}
 
 	dispatch( 'core/blocks' ).addBlockTypes( settings );

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -1,4 +1,4 @@
-/* eslint no-console: [ 'error', { allow: [ 'error', 'warn' ] } ] */
+/* eslint no-console: [ 'error', { allow: [ 'error' ] } ] */
 
 /**
  * External dependencies
@@ -138,13 +138,6 @@ export function registerBlockType( name, settings ) {
 			'The icon should be a string, an element, a function, or an object following the specifications documented in https://wordpress.org/gutenberg/handbook/block-api/#icon-optional'
 		);
 		return;
-	}
-
-	if ( 'keywords' in settings && settings.keywords.length > 3 ) {
-		console.warn(
-			'The block "' + name + '" can have a maximum of 3 keywords.'
-		);
-		settings.keywords = settings.keywords.slice( 0, 3 );
 	}
 
 	dispatch( 'core/blocks' ).addBlockTypes( settings );

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -119,13 +119,6 @@ describe( 'blocks', () => {
 			expect( block ).toBeUndefined();
 		} );
 
-		it( 'should reject blocks with more than 3 keywords', () => {
-			const blockType = { save: noop, keywords: [ 'apple', 'orange', 'lemon', 'pineapple' ], category: 'common', title: 'block title' },
-				block = registerBlockType( 'my-plugin/fancy-block-7', blockType );
-			expect( console ).toHaveErroredWith( 'The block "my-plugin/fancy-block-7" can have a maximum of 3 keywords.' );
-			expect( block ).toBeUndefined();
-		} );
-
 		it( 'should reject blocks without category', () => {
 			const blockType = { settingName: 'settingValue', save: noop, title: 'block title' },
 				block = registerBlockType( 'my-plugin/fancy-block-8', blockType );


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/11949
Instead of failing to register a block if more than 3 keywords are given, only return the first 3 by slicing the keywords array.

## How has this been tested?
`npm run lint`

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
