### PR TITLE
Mobile: Fix post visibility popover not appearing

### DIFF
--- a/assets/stylesheets/_z-index.scss
+++ b/assets/stylesheets/_z-index.scss
@@ -85,6 +85,7 @@ $z-layers: (
 
 	// Shows above edit post sidebar; Specificity needs to be higher than 3 classes.
 	".block-editor__container .components-popover.components-color-palette__picker.is-bottom": 100001,
+	".edit-post-post-visibility__dialog.components-popover.is-bottom": 100001,
 
 	".components-autocomplete__results": 1000000,
 

--- a/packages/editor/src/components/post-visibility/style.scss
+++ b/packages/editor/src/components/post-visibility/style.scss
@@ -33,3 +33,7 @@
 		margin-left: 28px;
 	}
 }
+
+.edit-post-post-visibility__dialog.components-popover.is-bottom {
+	z-index: z-index(".edit-post-post-visibility__dialog.components-popover.is-bottom");
+}

--- a/test/e2e/specs/post-visibility.test.js
+++ b/test/e2e/specs/post-visibility.test.js
@@ -1,0 +1,31 @@
+/**
+ * Internal dependencies
+ */
+import {
+	setViewport,
+	newPost,
+	openDocumentSettingsSidebar,
+} from '../support/utils';
+
+describe( 'Post visibility', () => {
+	[ 'large', 'small' ].forEach( ( viewport ) => {
+		it( `can be changed when the viewport is ${ viewport }`, async () => {
+			await setViewport( viewport );
+
+			await newPost();
+
+			await openDocumentSettingsSidebar();
+
+			await page.click( '.edit-post-post-visibility__toggle' );
+
+			const [ privateLabel ] = await page.$x( '//label[text()="Private"]' );
+			await privateLabel.click();
+
+			const currentStatus = await page.evaluate( () => {
+				return wp.data.select( 'core/editor' ).getEditedPostAttribute( 'status' );
+			} );
+
+			expect( currentStatus ).toBe( 'private' );
+		} );
+	} );
+} );

--- a/test/e2e/support/utils/open-document-settings-sidebar.js
+++ b/test/e2e/support/utils/open-document-settings-sidebar.js
@@ -7,6 +7,6 @@ export async function openDocumentSettingsSidebar() {
 	);
 
 	if ( openButton ) {
-		await page.click( openButton );
+		await openButton.click();
 	}
 }


### PR DESCRIPTION
Fixes #11951.

Bottom popovers have a z-index of 99990 so that they appear below the WordPress admin bar which has a z-index of 99999. On mobile viewports, this causes the _Post Visibility_ popover to appear below the editor sidebar which has a z-index of 100000.

I've fixed this by bumping up the z-index of the _Post Visibility_ popover.

This is essentially the same fix as https://github.com/WordPress/gutenberg/pull/10481 except it's for post visibility instead of the colour picker.

I've added an E2E test to catch future regressions.

#### How to test

1. Create a new post on mobile
2. Open the document settings
3. Change the post visibility