### PR TITLE
Update/editor styles wrap

### DIFF
--- a/packages/editor/src/editor-styles/transforms/test/__snapshots__/wrap.js.snap
+++ b/packages/editor/src/editor-styles/transforms/test/__snapshots__/wrap.js.snap
@@ -17,6 +17,7 @@ opacity: 0;
 
 exports[`CSS selector wrap should ignore selectors 1`] = `
 ".my-namespace h1,
+.my-namespace:not(EDITOR_STYLES),
 body {
 color: red;
 }"

--- a/packages/editor/src/editor-styles/transforms/test/wrap.js
+++ b/packages/editor/src/editor-styles/transforms/test/wrap.js
@@ -23,7 +23,7 @@ describe( 'CSS selector wrap', () => {
 
 	it( 'should ignore selectors', () => {
 		const callback = wrap( '.my-namespace', 'body' );
-		const input = `h1, body { color: red; }`;
+		const input = `h1, :root, body { color: red; }`;
 		const output = traverse( input, callback );
 
 		expect( output ).toMatchSnapshot();

--- a/packages/editor/src/editor-styles/transforms/wrap.js
+++ b/packages/editor/src/editor-styles/transforms/wrap.js
@@ -6,7 +6,7 @@ import { includes } from 'lodash';
 /**
  * @const string IS_ROOT_TAG Regex to check if the selector is a root tag selector.
  */
-const IS_ROOT_TAG = /^(body|html).*$/;
+const IS_ROOT_TAG = /^(body|html|:root).*$/;
 
 const wrap = ( namespace, ignore = [] ) => ( node ) => {
 	const updateSelector = ( selector ) => {
@@ -18,6 +18,12 @@ const wrap = ( namespace, ignore = [] ) => ( node ) => {
 		{if ( ! selector.match( IS_ROOT_TAG ) ) {
 			return namespace + ' ' + selector;
 		}}
+
+		// If explicity :root selector namespace with pseudo to respect original specificity intended on namespace.
+		if ( ':root' === selector.trim() ) {
+			// We use an invalid negation to inherit the negation's :pseudo specificity weight applied on namespace.
+			return selector.replace( ':root', `${ namespace }:not(EDITOR_STYLES)` );
+		}
 
 		// HTML and Body elements cannot be contained within our container so lets extract their styles.
 		return selector.replace( /^(body|html)/, namespace );


### PR DESCRIPTION
## Description
Refer to #11955 - as this would resolve the issue by adding support for the editor-styles wrap for stylesheets using `:root` selector.

## How has this been tested?
Have only done initial testing with the specificity to ensure that's correct and updated the tests with new snapshots currently.

## Types of changes
Bug fix: Stylesheets making use for `:root` selector are now able to be handled.

## Checklist:
- [ x ] My code is tested.
- [ x ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ x ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ x ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
