### PR TITLE
Update npm dependencies to fix found vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2285,12 +2285,6 @@
 				"lodash": "^4.17.10",
 				"rememo": "^3.0.0",
 				"uuid": "^3.3.2"
-			},
-			"dependencies": {
-				"uuid": {
-					"version": "3.3.2",
-					"bundled": true
-				}
 			}
 		},
 		"@wordpress/api-fetch": {
@@ -2647,7 +2641,7 @@
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.0.0",
-				"jest-matcher-utils": "^22.4.3",
+				"jest-matcher-utils": "^23.6.0",
 				"lodash": "^4.17.10"
 			}
 		},
@@ -2656,7 +2650,7 @@
 			"dev": true,
 			"requires": {
 				"@wordpress/jest-console": "file:packages/jest-console",
-				"babel-jest": "^23.4.2",
+				"babel-jest": "^23.6.0",
 				"enzyme": "^3.7.0",
 				"enzyme-adapter-react-16": "^1.6.0",
 				"jest-enzyme": "^6.0.2"
@@ -2751,7 +2745,7 @@
 				"chalk": "^2.4.1",
 				"cross-spawn": "^5.1.0",
 				"eslint": "^4.19.1",
-				"jest": "^23.4.2",
+				"jest": "^23.6.0",
 				"npm-package-json-lint": "^3.3.1",
 				"read-pkg-up": "^1.0.1",
 				"resolve-bin": "^0.4.0"
@@ -3009,12 +3003,12 @@
 			"dev": true
 		},
 		"append-transform": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
-			"integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
 			"dev": true,
 			"requires": {
-				"default-require-extensions": "^2.0.0"
+				"default-require-extensions": "^1.0.0"
 			}
 		},
 		"aproba": {
@@ -3680,9 +3674,9 @@
 			}
 		},
 		"babel-jest": {
-			"version": "23.4.2",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.4.2.tgz",
-			"integrity": "sha512-wg1LJ2tzsafXqPFVgAsYsMCVD5U7kwJZAvbZIxVm27iOewsQw1BR7VZifDlMTEWVo3wasoPPyMdKXWCsfFPr3Q==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.6.0.tgz",
+			"integrity": "sha512-lqKGG6LYXYu+DQh/slrQ8nxXQkEkhugdXsU6St7GmhVS7Ilc/22ArwqXNJrf0QaOBjZB0360qZMwXqDYQHXaew==",
 			"dev": true,
 			"requires": {
 				"babel-plugin-istanbul": "^4.1.6",
@@ -5702,12 +5696,6 @@
 				}
 			}
 		},
-		"compare-versions": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.3.0.tgz",
-			"integrity": "sha512-MAAAIOdi2s4Gl6rZ76PNcUa9IOYB+5ICdT41o5uMRf09aEu/F9RK+qhe8RjXNPwcTjGV7KU7h2P/fljThFVqyQ==",
-			"dev": true
-		},
 		"component-emitter": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
@@ -6859,20 +6847,12 @@
 			"integrity": "sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ=="
 		},
 		"default-require-extensions": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
-			"integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
 			"dev": true,
 			"requires": {
-				"strip-bom": "^3.0.0"
-			},
-			"dependencies": {
-				"strip-bom": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-					"dev": true
-				}
+				"strip-bom": "^2.0.0"
 			}
 		},
 		"defaults": {
@@ -7942,15 +7922,15 @@
 			}
 		},
 		"expect": {
-			"version": "23.4.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-23.4.0.tgz",
-			"integrity": "sha1-baTsyZwUcSU+cogziYOtHrrbYMM=",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-23.6.0.tgz",
+			"integrity": "sha512-dgSoOHgmtn/aDGRVFWclQyPDKl2CQRq0hmIEoUAuQs/2rn2NcvCWcSCovm6BLeuB/7EZuLGu2QfnR+qRt5OM4w==",
 			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.0",
-				"jest-diff": "^23.2.0",
+				"jest-diff": "^23.6.0",
 				"jest-get-type": "^22.1.0",
-				"jest-matcher-utils": "^23.2.0",
+				"jest-matcher-utils": "^23.6.0",
 				"jest-message-util": "^23.4.0",
 				"jest-regex-util": "^23.3.0"
 			},
@@ -8000,14 +7980,14 @@
 					}
 				},
 				"jest-matcher-utils": {
-					"version": "23.2.0",
-					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.2.0.tgz",
-					"integrity": "sha1-TUmB8jIT6Tnjzt8j3DTHR7WuGRM=",
+					"version": "23.6.0",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.6.0.tgz",
+					"integrity": "sha512-rosyCHQfBcol4NsckTn01cdelzWLU9Cq7aaigDf8VwwpIRvWE/9zLgX2bON+FkEW69/0UuYslUe22SOdEf2nog==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
 						"jest-get-type": "^22.1.0",
-						"pretty-format": "^23.2.0"
+						"pretty-format": "^23.6.0"
 					}
 				},
 				"jest-message-util": {
@@ -8054,9 +8034,9 @@
 					}
 				},
 				"pretty-format": {
-					"version": "23.2.0",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
-					"integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
+					"version": "23.6.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
+					"integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0",
@@ -11059,23 +11039,45 @@
 			"dev": true
 		},
 		"istanbul-api": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.1.tgz",
-			"integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.7.tgz",
+			"integrity": "sha512-4/ApBnMVeEPG3EkSzcw25wDe4N66wxwn+KKn6b47vyek8Xb3NBAcg4xfuQbS7BqcZuTX4wxfD5lVagdggR3gyA==",
 			"dev": true,
 			"requires": {
 				"async": "^2.1.4",
-				"compare-versions": "^3.1.0",
 				"fileset": "^2.0.2",
-				"istanbul-lib-coverage": "^1.2.0",
-				"istanbul-lib-hook": "^1.2.0",
-				"istanbul-lib-instrument": "^1.10.1",
-				"istanbul-lib-report": "^1.1.4",
-				"istanbul-lib-source-maps": "^1.2.4",
-				"istanbul-reports": "^1.3.0",
+				"istanbul-lib-coverage": "^1.2.1",
+				"istanbul-lib-hook": "^1.2.2",
+				"istanbul-lib-instrument": "^1.10.2",
+				"istanbul-lib-report": "^1.1.5",
+				"istanbul-lib-source-maps": "^1.2.6",
+				"istanbul-reports": "^1.5.1",
 				"js-yaml": "^3.7.0",
 				"mkdirp": "^0.5.1",
 				"once": "^1.4.0"
+			},
+			"dependencies": {
+				"istanbul-lib-coverage": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz",
+					"integrity": "sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ==",
+					"dev": true
+				},
+				"istanbul-lib-instrument": {
+					"version": "1.10.2",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.2.tgz",
+					"integrity": "sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==",
+					"dev": true,
+					"requires": {
+						"babel-generator": "^6.18.0",
+						"babel-template": "^6.16.0",
+						"babel-traverse": "^6.18.0",
+						"babel-types": "^6.18.0",
+						"babylon": "^6.18.0",
+						"istanbul-lib-coverage": "^1.2.1",
+						"semver": "^5.3.0"
+					}
+				}
 			}
 		},
 		"istanbul-lib-coverage": {
@@ -11085,12 +11087,12 @@
 			"dev": true
 		},
 		"istanbul-lib-hook": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.1.tgz",
-			"integrity": "sha512-eLAMkPG9FU0v5L02lIkcj/2/Zlz9OuluaXikdr5iStk8FDbSwAixTK9TkYxbF0eNnzAJTwM2fkV2A1tpsIp4Jg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.2.tgz",
+			"integrity": "sha512-/Jmq7Y1VeHnZEQ3TL10VHyb564mn6VrQXHchON9Jf/AEcmQ3ZIiyD1BVzNOKTZf/G3gE+kiGK6SmpF9y3qGPLw==",
 			"dev": true,
 			"requires": {
-				"append-transform": "^1.0.0"
+				"append-transform": "^0.4.0"
 			}
 		},
 		"istanbul-lib-instrument": {
@@ -11109,12 +11111,12 @@
 			}
 		},
 		"istanbul-lib-report": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz",
-			"integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.5.tgz",
+			"integrity": "sha512-UsYfRMoi6QO/doUshYNqcKJqVmFe9w51GZz8BS3WB0lYxAllQYklka2wP9+dGZeHYaWIdcXUx8JGdbqaoXRXzw==",
 			"dev": true,
 			"requires": {
-				"istanbul-lib-coverage": "^1.2.0",
+				"istanbul-lib-coverage": "^1.2.1",
 				"mkdirp": "^0.5.1",
 				"path-parse": "^1.0.5",
 				"supports-color": "^3.1.2"
@@ -11124,6 +11126,12 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
 					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
+				},
+				"istanbul-lib-coverage": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz",
+					"integrity": "sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ==",
 					"dev": true
 				},
 				"supports-color": {
@@ -11138,22 +11146,30 @@
 			}
 		},
 		"istanbul-lib-source-maps": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz",
-			"integrity": "sha512-8O2T/3VhrQHn0XcJbP1/GN7kXMiRAlPi+fj3uEHrjBD8Oz7Py0prSC25C09NuAZS6bgW1NNKAvCSHZXB0irSGA==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.6.tgz",
+			"integrity": "sha512-TtbsY5GIHgbMsMiRw35YBHGpZ1DVFEO19vxxeiDMYaeOFOCzfnYVxvl6pOUIZR4dtPhAGpSMup8OyF8ubsaqEg==",
 			"dev": true,
 			"requires": {
 				"debug": "^3.1.0",
-				"istanbul-lib-coverage": "^1.2.0",
+				"istanbul-lib-coverage": "^1.2.1",
 				"mkdirp": "^0.5.1",
 				"rimraf": "^2.6.1",
 				"source-map": "^0.5.3"
+			},
+			"dependencies": {
+				"istanbul-lib-coverage": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz",
+					"integrity": "sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ==",
+					"dev": true
+				}
 			}
 		},
 		"istanbul-reports": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.3.0.tgz",
-			"integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.5.1.tgz",
+			"integrity": "sha512-+cfoZ0UXzWjhAdzosCPP3AN8vvef8XDkWtTfgaN+7L3YTpNYITnCaEkceo5SEYy644VkHka/P1FvkWvrG/rrJw==",
 			"dev": true,
 			"requires": {
 				"handlebars": "^4.0.3"
@@ -11181,13 +11197,13 @@
 			}
 		},
 		"jest": {
-			"version": "23.4.2",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-23.4.2.tgz",
-			"integrity": "sha512-w10HGpVFWT1oN8B2coxeiMEsZoggkDaw3i26xHGLU+rsR+LYkBk8qpZCgi+1cD1S6ttPjZDL8E8M99lmNhgTeA==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-23.6.0.tgz",
+			"integrity": "sha512-lWzcd+HSiqeuxyhG+EnZds6iO3Y3ZEnMrfZq/OTGvF/C+Z4fPMCdhWTGSAiO2Oym9rbEXfwddHhh6jqrTF3+Lw==",
 			"dev": true,
 			"requires": {
 				"import-local": "^1.0.0",
-				"jest-cli": "^23.4.2"
+				"jest-cli": "^23.6.0"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -11235,9 +11251,9 @@
 					}
 				},
 				"jest-cli": {
-					"version": "23.4.2",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.4.2.tgz",
-					"integrity": "sha512-vaDzy0wRWrgSfz4ZImCqD2gtZqCSoEWp60y3USvGDxA2b4K0rGj2voru6a5scJFjDx5GCiNWKpz2E8IdWDVjdw==",
+					"version": "23.6.0",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.6.0.tgz",
+					"integrity": "sha512-hgeD1zRUp1E1zsiyOXjEn4LzRLWdJBV//ukAHGlx6s5mfCNJTbhbHjgxnDUXA8fsKWN/HqFFF6X5XcCwC/IvYQ==",
 					"dev": true,
 					"requires": {
 						"ansi-escapes": "^3.0.0",
@@ -11252,18 +11268,18 @@
 						"istanbul-lib-instrument": "^1.10.1",
 						"istanbul-lib-source-maps": "^1.2.4",
 						"jest-changed-files": "^23.4.2",
-						"jest-config": "^23.4.2",
+						"jest-config": "^23.6.0",
 						"jest-environment-jsdom": "^23.4.0",
 						"jest-get-type": "^22.1.0",
-						"jest-haste-map": "^23.4.1",
+						"jest-haste-map": "^23.6.0",
 						"jest-message-util": "^23.4.0",
 						"jest-regex-util": "^23.3.0",
-						"jest-resolve-dependencies": "^23.4.2",
-						"jest-runner": "^23.4.2",
-						"jest-runtime": "^23.4.2",
-						"jest-snapshot": "^23.4.2",
+						"jest-resolve-dependencies": "^23.6.0",
+						"jest-runner": "^23.6.0",
+						"jest-runtime": "^23.6.0",
+						"jest-snapshot": "^23.6.0",
 						"jest-util": "^23.4.0",
-						"jest-validate": "^23.4.0",
+						"jest-validate": "^23.6.0",
 						"jest-watcher": "^23.4.0",
 						"jest-worker": "^23.2.0",
 						"micromatch": "^2.3.11",
@@ -11324,6 +11340,18 @@
 						"source-map": "^0.6.0"
 					}
 				},
+				"jest-validate": {
+					"version": "23.6.0",
+					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.6.0.tgz",
+					"integrity": "sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"jest-get-type": "^22.1.0",
+						"leven": "^2.1.0",
+						"pretty-format": "^23.6.0"
+					}
+				},
 				"kind-of": {
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -11362,7 +11390,7 @@
 				},
 				"yargs": {
 					"version": "11.1.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+					"resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
 					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 					"dev": true,
 					"requires": {
@@ -11401,24 +11429,25 @@
 			}
 		},
 		"jest-config": {
-			"version": "23.4.2",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.4.2.tgz",
-			"integrity": "sha512-CDJGO4H+7P+T6khaSHEjTxqVaIlmQMEFAyJFOVrAQeM+Xn12iZ+YY8Pluk1RDxi8Jqj9DoE09PHQzASCGePGtg==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.6.0.tgz",
+			"integrity": "sha512-i8V7z9BeDXab1+VNo78WM0AtWpBRXJLnkT+lyT+Slx/cbP5sZJ0+NDuLcmBE5hXAoK0aUp7vI+MOxR+R4d8SRQ==",
 			"dev": true,
 			"requires": {
 				"babel-core": "^6.0.0",
-				"babel-jest": "^23.4.2",
+				"babel-jest": "^23.6.0",
 				"chalk": "^2.0.1",
 				"glob": "^7.1.1",
 				"jest-environment-jsdom": "^23.4.0",
 				"jest-environment-node": "^23.4.0",
 				"jest-get-type": "^22.1.0",
-				"jest-jasmine2": "^23.4.2",
+				"jest-jasmine2": "^23.6.0",
 				"jest-regex-util": "^23.3.0",
-				"jest-resolve": "^23.4.1",
+				"jest-resolve": "^23.6.0",
 				"jest-util": "^23.4.0",
-				"jest-validate": "^23.4.0",
-				"pretty-format": "^23.2.0"
+				"jest-validate": "^23.6.0",
+				"micromatch": "^2.3.11",
+				"pretty-format": "^23.6.0"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -11461,6 +11490,16 @@
 						"private": "^0.1.8",
 						"slash": "^1.0.0",
 						"source-map": "^0.5.7"
+					}
+				},
+				"babel-jest": {
+					"version": "23.6.0",
+					"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.6.0.tgz",
+					"integrity": "sha512-lqKGG6LYXYu+DQh/slrQ8nxXQkEkhugdXsU6St7GmhVS7Ilc/22ArwqXNJrf0QaOBjZB0360qZMwXqDYQHXaew==",
+					"dev": true,
+					"requires": {
+						"babel-plugin-istanbul": "^4.1.6",
+						"babel-preset-jest": "^23.2.0"
 					}
 				},
 				"braces": {
@@ -11555,6 +11594,18 @@
 						}
 					}
 				},
+				"jest-validate": {
+					"version": "23.6.0",
+					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.6.0.tgz",
+					"integrity": "sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"jest-get-type": "^22.1.0",
+						"leven": "^2.1.0",
+						"pretty-format": "^23.6.0"
+					}
+				},
 				"kind-of": {
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -11586,9 +11637,9 @@
 					}
 				},
 				"pretty-format": {
-					"version": "23.2.0",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
-					"integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
+					"version": "23.6.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
+					"integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0",
@@ -11662,21 +11713,21 @@
 			}
 		},
 		"jest-diff": {
-			"version": "23.2.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.2.0.tgz",
-			"integrity": "sha1-nyz0tR4Sx5FVAgCrwWtHEwrxBio=",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.6.0.tgz",
+			"integrity": "sha512-Gz9l5Ov+X3aL5L37IT+8hoCUsof1CVYBb2QEkOupK64XyRR3h+uRpYIm97K7sY8diFxowR8pIGEdyfMKTixo3g==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
 				"diff": "^3.2.0",
 				"jest-get-type": "^22.1.0",
-				"pretty-format": "^23.2.0"
+				"pretty-format": "^23.6.0"
 			},
 			"dependencies": {
 				"pretty-format": {
-					"version": "23.2.0",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
-					"integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
+					"version": "23.6.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
+					"integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0",
@@ -11695,19 +11746,19 @@
 			}
 		},
 		"jest-each": {
-			"version": "23.4.0",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-23.4.0.tgz",
-			"integrity": "sha1-L6nt2J2qGk7cn/m/YGKja3E0UUM=",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-23.6.0.tgz",
+			"integrity": "sha512-x7V6M/WGJo6/kLoissORuvLIeAoyo2YqLOoCDkohgJ4XOXSqOtyvr8FbInlAWS77ojBsZrafbozWoKVRdtxFCg==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
-				"pretty-format": "^23.2.0"
+				"pretty-format": "^23.6.0"
 			},
 			"dependencies": {
 				"pretty-format": {
-					"version": "23.2.0",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
-					"integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
+					"version": "23.6.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
+					"integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0",
@@ -11895,13 +11946,14 @@
 			"dev": true
 		},
 		"jest-haste-map": {
-			"version": "23.4.1",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.4.1.tgz",
-			"integrity": "sha512-PGQxOEGAfRbTyJkmZeOKkVSs+KVeWgG625p89KUuq+sIIchY5P8iPIIc+Hw2tJJPBzahU3qopw1kF/qyhDdNBw==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.6.0.tgz",
+			"integrity": "sha512-uyNhMyl6dr6HaXGHp8VF7cK6KpC6G9z9LiMNsst+rJIZ8l7wY0tk8qwjPmEghczojZ2/ZhtEdIabZ0OQRJSGGg==",
 			"dev": true,
 			"requires": {
 				"fb-watchman": "^2.0.0",
 				"graceful-fs": "^4.1.11",
+				"invariant": "^2.2.4",
 				"jest-docblock": "^23.2.0",
 				"jest-serializer": "^23.0.1",
 				"jest-worker": "^23.2.0",
@@ -11986,23 +12038,23 @@
 			}
 		},
 		"jest-jasmine2": {
-			"version": "23.4.2",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.4.2.tgz",
-			"integrity": "sha512-MUoqn41XHMQe5u8QvRTH2HahpBNzImnnjS3pV/T7LvrCM6f2zfGdi1Pm+bRbFMLJROqR8VlK8HmsenL2WjrUIQ==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.6.0.tgz",
+			"integrity": "sha512-pe2Ytgs1nyCs8IvsEJRiRTPC0eVYd8L/dXJGU08GFuBwZ4sYH/lmFDdOL3ZmvJR8QKqV9MFuwlsAi/EWkFUbsQ==",
 			"dev": true,
 			"requires": {
 				"babel-traverse": "^6.0.0",
 				"chalk": "^2.0.1",
 				"co": "^4.6.0",
-				"expect": "^23.4.0",
+				"expect": "^23.6.0",
 				"is-generator-fn": "^1.0.0",
-				"jest-diff": "^23.2.0",
-				"jest-each": "^23.4.0",
-				"jest-matcher-utils": "^23.2.0",
+				"jest-diff": "^23.6.0",
+				"jest-each": "^23.6.0",
+				"jest-matcher-utils": "^23.6.0",
 				"jest-message-util": "^23.4.0",
-				"jest-snapshot": "^23.4.2",
+				"jest-snapshot": "^23.6.0",
 				"jest-util": "^23.4.0",
-				"pretty-format": "^23.2.0"
+				"pretty-format": "^23.6.0"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -12050,14 +12102,14 @@
 					}
 				},
 				"jest-matcher-utils": {
-					"version": "23.2.0",
-					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.2.0.tgz",
-					"integrity": "sha1-TUmB8jIT6Tnjzt8j3DTHR7WuGRM=",
+					"version": "23.6.0",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.6.0.tgz",
+					"integrity": "sha512-rosyCHQfBcol4NsckTn01cdelzWLU9Cq7aaigDf8VwwpIRvWE/9zLgX2bON+FkEW69/0UuYslUe22SOdEf2nog==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
 						"jest-get-type": "^22.1.0",
-						"pretty-format": "^23.2.0"
+						"pretty-format": "^23.6.0"
 					}
 				},
 				"jest-message-util": {
@@ -12120,9 +12172,9 @@
 					}
 				},
 				"pretty-format": {
-					"version": "23.2.0",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
-					"integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
+					"version": "23.6.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
+					"integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0",
@@ -12138,18 +12190,18 @@
 			}
 		},
 		"jest-leak-detector": {
-			"version": "23.2.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.2.0.tgz",
-			"integrity": "sha1-wonZYdxjjxQ1fU75bgQx7MGqN30=",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.6.0.tgz",
+			"integrity": "sha512-f/8zA04rsl1Nzj10HIyEsXvYlMpMPcy0QkQilVZDFOaPbv2ur71X5u2+C4ZQJGyV/xvVXtCCZ3wQ99IgQxftCg==",
 			"dev": true,
 			"requires": {
-				"pretty-format": "^23.2.0"
+				"pretty-format": "^23.6.0"
 			},
 			"dependencies": {
 				"pretty-format": {
-					"version": "23.2.0",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
-					"integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
+					"version": "23.6.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
+					"integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0",
@@ -12159,14 +12211,14 @@
 			}
 		},
 		"jest-matcher-utils": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
-			"integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.6.0.tgz",
+			"integrity": "sha512-rosyCHQfBcol4NsckTn01cdelzWLU9Cq7aaigDf8VwwpIRvWE/9zLgX2bON+FkEW69/0UuYslUe22SOdEf2nog==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
-				"jest-get-type": "^22.4.3",
-				"pretty-format": "^22.4.3"
+				"jest-get-type": "^22.1.0",
+				"pretty-format": "^23.6.0"
 			}
 		},
 		"jest-message-util": {
@@ -12281,9 +12333,9 @@
 			"dev": true
 		},
 		"jest-resolve": {
-			"version": "23.4.1",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.4.1.tgz",
-			"integrity": "sha512-VNk4YRNR5gsHhNS0Lp46/DzTT11e+ecbUC61ikE593cKbtdrhrMO+zXkOJaE8YDD5sHxH9W6OfssNn4FkZBzZQ==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.6.0.tgz",
+			"integrity": "sha512-XyoRxNtO7YGpQDmtQCmZjum1MljDqUCob7XlZ6jy9gsMugHdN2hY4+Acz9Qvjz2mSsOnPSH7skBmDYCHXVZqkA==",
 			"dev": true,
 			"requires": {
 				"browser-resolve": "^1.11.3",
@@ -12292,30 +12344,30 @@
 			}
 		},
 		"jest-resolve-dependencies": {
-			"version": "23.4.2",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.4.2.tgz",
-			"integrity": "sha512-JUrU1/1mQAf0eKwKT4+RRnaqcw0UcRzRE38vyO+YnqoXUVidf646iuaKE+NG7E6Gb0+EVPOJ6TgqkaTPdQz78A==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.6.0.tgz",
+			"integrity": "sha512-EkQWkFWjGKwRtRyIwRwI6rtPAEyPWlUC2MpzHissYnzJeHcyCn1Hc8j7Nn1xUVrS5C6W5+ZL37XTem4D4pLZdA==",
 			"dev": true,
 			"requires": {
 				"jest-regex-util": "^23.3.0",
-				"jest-snapshot": "^23.4.2"
+				"jest-snapshot": "^23.6.0"
 			}
 		},
 		"jest-runner": {
-			"version": "23.4.2",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.4.2.tgz",
-			"integrity": "sha512-o+aEdDE7/Gyp8fLYEEf5B8aOUguz76AYcAMl5pueucey2Q50O8uUIXJ7zvt8O6OEJDztR3Kb+osMoh8MVIqgTw==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.6.0.tgz",
+			"integrity": "sha512-kw0+uj710dzSJKU6ygri851CObtCD9cN8aNkg8jWJf4ewFyEa6kwmiH/r/M1Ec5IL/6VFa0wnAk6w+gzUtjJzA==",
 			"dev": true,
 			"requires": {
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.1.11",
-				"jest-config": "^23.4.2",
+				"jest-config": "^23.6.0",
 				"jest-docblock": "^23.2.0",
-				"jest-haste-map": "^23.4.1",
-				"jest-jasmine2": "^23.4.2",
-				"jest-leak-detector": "^23.2.0",
+				"jest-haste-map": "^23.6.0",
+				"jest-jasmine2": "^23.6.0",
+				"jest-leak-detector": "^23.6.0",
 				"jest-message-util": "^23.4.0",
-				"jest-runtime": "^23.4.2",
+				"jest-runtime": "^23.6.0",
 				"jest-util": "^23.4.0",
 				"jest-worker": "^23.2.0",
 				"source-map-support": "^0.5.6",
@@ -12432,9 +12484,9 @@
 					"dev": true
 				},
 				"source-map-support": {
-					"version": "0.5.6",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
-					"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
+					"version": "0.5.9",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+					"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
 					"dev": true,
 					"requires": {
 						"buffer-from": "^1.0.0",
@@ -12444,9 +12496,9 @@
 			}
 		},
 		"jest-runtime": {
-			"version": "23.4.2",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.4.2.tgz",
-			"integrity": "sha512-qaUDOi7tcdDe3MH5g5ycEslTpx0voPZvzIYbKjvWxCzCL2JEemLM+7IEe0BeLi2v5wvb/uh3dkb2wQI67uPtCw==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.6.0.tgz",
+			"integrity": "sha512-ycnLTNPT2Gv+TRhnAYAQ0B3SryEXhhRj1kA6hBPSeZaNQkJ7GbZsxOLUkwg6YmvWGdX3BB3PYKFLDQCAE1zNOw==",
 			"dev": true,
 			"requires": {
 				"babel-core": "^6.0.0",
@@ -12456,14 +12508,14 @@
 				"exit": "^0.1.2",
 				"fast-json-stable-stringify": "^2.0.0",
 				"graceful-fs": "^4.1.11",
-				"jest-config": "^23.4.2",
-				"jest-haste-map": "^23.4.1",
+				"jest-config": "^23.6.0",
+				"jest-haste-map": "^23.6.0",
 				"jest-message-util": "^23.4.0",
 				"jest-regex-util": "^23.3.0",
-				"jest-resolve": "^23.4.1",
-				"jest-snapshot": "^23.4.2",
+				"jest-resolve": "^23.6.0",
+				"jest-snapshot": "^23.6.0",
 				"jest-util": "^23.4.0",
-				"jest-validate": "^23.4.0",
+				"jest-validate": "^23.6.0",
 				"micromatch": "^2.3.11",
 				"realpath-native": "^1.0.0",
 				"slash": "^1.0.0",
@@ -12589,6 +12641,18 @@
 						}
 					}
 				},
+				"jest-validate": {
+					"version": "23.6.0",
+					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.6.0.tgz",
+					"integrity": "sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"jest-get-type": "^22.1.0",
+						"leven": "^2.1.0",
+						"pretty-format": "^23.6.0"
+					}
+				},
 				"kind-of": {
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -12619,6 +12683,16 @@
 						"regex-cache": "^0.4.2"
 					}
 				},
+				"pretty-format": {
+					"version": "23.6.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
+					"integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0",
+						"ansi-styles": "^3.2.0"
+					}
+				},
 				"strip-bom": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -12627,7 +12701,7 @@
 				},
 				"yargs": {
 					"version": "11.1.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+					"resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
 					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 					"dev": true,
 					"requires": {
@@ -12663,20 +12737,20 @@
 			"dev": true
 		},
 		"jest-snapshot": {
-			"version": "23.4.2",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.4.2.tgz",
-			"integrity": "sha512-rCBxIURDlVEW1gJgJSpo8l2F2gFwp9U7Yb3CmcABUpmQ8NASpb6LJkEvtcQifAYSi22OL44TSuanq1G6x1GJwg==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.6.0.tgz",
+			"integrity": "sha512-tM7/Bprftun6Cvj2Awh/ikS7zV3pVwjRYU2qNYS51VZHgaAMBs5l4o/69AiDHhQrj5+LA2Lq4VIvK7zYk/bswg==",
 			"dev": true,
 			"requires": {
 				"babel-types": "^6.0.0",
 				"chalk": "^2.0.1",
-				"jest-diff": "^23.2.0",
-				"jest-matcher-utils": "^23.2.0",
+				"jest-diff": "^23.6.0",
+				"jest-matcher-utils": "^23.6.0",
 				"jest-message-util": "^23.4.0",
-				"jest-resolve": "^23.4.1",
+				"jest-resolve": "^23.6.0",
 				"mkdirp": "^0.5.1",
 				"natural-compare": "^1.4.0",
-				"pretty-format": "^23.2.0",
+				"pretty-format": "^23.6.0",
 				"semver": "^5.5.0"
 			},
 			"dependencies": {
@@ -12725,14 +12799,14 @@
 					}
 				},
 				"jest-matcher-utils": {
-					"version": "23.2.0",
-					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.2.0.tgz",
-					"integrity": "sha1-TUmB8jIT6Tnjzt8j3DTHR7WuGRM=",
+					"version": "23.6.0",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.6.0.tgz",
+					"integrity": "sha512-rosyCHQfBcol4NsckTn01cdelzWLU9Cq7aaigDf8VwwpIRvWE/9zLgX2bON+FkEW69/0UuYslUe22SOdEf2nog==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.0.1",
 						"jest-get-type": "^22.1.0",
-						"pretty-format": "^23.2.0"
+						"pretty-format": "^23.6.0"
 					}
 				},
 				"jest-message-util": {
@@ -12779,9 +12853,9 @@
 					}
 				},
 				"pretty-format": {
-					"version": "23.2.0",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
-					"integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
+					"version": "23.6.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
+					"integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0",
@@ -13234,9 +13308,9 @@
 			"dev": true
 		},
 		"kleur": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/kleur/-/kleur-2.0.1.tgz",
-			"integrity": "sha512-Zq/jyANIJ2uX8UZjWlqLwbyhcxSXJtT/Y89lClyeZd3l++3ztL1I5SSCYrbcbwSunTjC88N3WuMk0kRDQD6gzA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-2.0.2.tgz",
+			"integrity": "sha512-77XF9iTllATmG9lSlIv0qdQ2BQ/h9t0bJllHlbvsQ0zUWfU7Yi0S8L5JXzPZgkefIiajLmBJJ4BsMJmqcf7oxQ==",
 			"dev": true
 		},
 		"known-css-properties": {
@@ -14522,9 +14596,9 @@
 			}
 		},
 		"merge": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+			"integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
 			"dev": true
 		},
 		"merge-descriptors": {
@@ -14977,13 +15051,13 @@
 			}
 		},
 		"node-notifier": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
-			"integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.3.0.tgz",
+			"integrity": "sha512-AhENzCSGZnZJgBARsUjnQ7DnZbzyP+HxlVXuD0xqAnvL8q+OqtSX7lGg9e8nHzwXkMMXNdVeqq4E2M3EUAqX6Q==",
 			"dev": true,
 			"requires": {
 				"growly": "^1.3.0",
-				"semver": "^5.4.1",
+				"semver": "^5.5.0",
 				"shellwords": "^0.1.1",
 				"which": "^1.3.0"
 			}
@@ -17400,9 +17474,9 @@
 			"dev": true
 		},
 		"pretty-format": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
-			"integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+			"version": "23.6.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
+			"integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
 			"dev": true,
 			"requires": {
 				"ansi-regex": "^3.0.0",
@@ -18156,9 +18230,9 @@
 			}
 		},
 		"realpath-native": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.1.tgz",
-			"integrity": "sha512-W14EcXuqUvKP8dkWkD7B95iMy77lpMnlFXbbk409bQtNCbeu0kvRE5reo+yIZ3JXxg6frbGsz2DLQ39lrCB40g==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.2.tgz",
+			"integrity": "sha512-+S3zTvVt9yTntFrBpm7TQmQ3tzpCrnA1a/y+3cUHAc9ZR6aIjG0WNLR+Rj79QpJktY+VeW/TQtFlQ1bzsehI8g==",
 			"dev": true,
 			"requires": {
 				"util.promisify": "^1.0.0"

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -26,7 +26,7 @@
 	"module": "build-module/index.js",
 	"dependencies": {
 		"@babel/runtime": "^7.0.0",
-		"jest-matcher-utils": "^22.4.3",
+		"jest-matcher-utils": "^23.6.0",
 		"lodash": "^4.17.10"
 	},
 	"peerDependencies": {

--- a/packages/jest-preset-default/package.json
+++ b/packages/jest-preset-default/package.json
@@ -27,7 +27,7 @@
 	"main": "index.js",
 	"dependencies": {
 		"@wordpress/jest-console": "file:../jest-console",
-		"babel-jest": "^23.4.2",
+		"babel-jest": "^23.6.0",
 		"enzyme": "^3.7.0",
 		"enzyme-adapter-react-16": "^1.6.0",
 		"jest-enzyme": "^6.0.2"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -38,7 +38,7 @@
 		"chalk": "^2.4.1",
 		"cross-spawn": "^5.1.0",
 		"eslint": "^4.19.1",
-		"jest": "^23.4.2",
+		"jest": "^23.6.0",
 		"npm-package-json-lint": "^3.3.1",
 		"read-pkg-up": "^1.0.1",
 		"resolve-bin": "^0.4.0"


### PR DESCRIPTION
This changes the output of `npm install` by fixing 9 vulnerabilities.

I executed `npm audit fix` and discovered that it fixes 8 vulnerabilities by upgrading `jest` to the latest version. I updated all `jest` packages to match the latest version which fixed all 9 issues.

## Before

> added 2 packages from 2 contributors, removed 9 packages, updated 39 packages and audited 106046 packages in 45.48s
> found 9 low severity vulnerabilities
>   run `npm audit fix` to fix them, or `npm audit` for details

## After

> audited 106258 packages in 37.767s
> found 0 vulnerabilities