### PR TITLE
Try: Only enforce embed min-width after mobile breakpoint

### DIFF
--- a/packages/block-library/src/embed/editor.scss
+++ b/packages/block-library/src/embed/editor.scss
@@ -7,7 +7,9 @@
 
 	// Apply a min-width, or the embed can collapse when floated.
 	// Instagram widgets have a min-width of 326px, so go a bit beyond that.
-	min-width: 360px;
+	@include break-small() {
+		min-width: 360px;
+	}
 
 	&.is-loading {
 		display: flex;


### PR DESCRIPTION
Maybe fixes #10310.

If an instagram embed is smaller than 326px, it gets cropped. That's why we have a 360px min-width, which is a width that is friendly to most phones.

However an editor style can be mobile-unfriendly, with wide left and right paddings. If you insert an embed in such a post, it's born with that 360px min-width and will zoom the browser.

This PR makes a decision: It is better that the embed looks broken, than the editor breaks. As such, we allow embeds to be cropped on the mobile breakpoint. At least than a user can set that embed to be fullwide to give it extra space on mobile.

Cropped embed:

![screenshot 2018-11-16 at 10 17 23](https://user-images.githubusercontent.com/1204802/48612406-38f26080-e989-11e8-9bed-ae8fc8db07c2.png)

Embed is then set to fullwide:

![screenshot 2018-11-16 at 10 19 47](https://user-images.githubusercontent.com/1204802/48612413-3d1e7e00-e989-11e8-874f-cf32fbe55158.png)
