### PR TITLE
RichText: fix caret position when deleting a selected word

### DIFF
--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -497,11 +497,25 @@ export function isEntirelySelected( element ) {
 
 	const { startContainer, endContainer, startOffset, endOffset } = range;
 
-	return (
+	if (
 		startContainer === element &&
 		endContainer === element &&
 		startOffset === 0 &&
 		endOffset === element.childNodes.length
+	) {
+		return true;
+	}
+
+	const lastChild = element.lastChild;
+	const lastChildContentLength = lastChild.nodeType === TEXT_NODE ?
+		lastChild.data.length :
+		lastChild.childNodes.length;
+
+	return (
+		startContainer === element.firstChild &&
+		endContainer === element.lastChild &&
+		startOffset === 0 &&
+		endOffset === lastChildContentLength
 	);
 }
 

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -600,12 +600,6 @@ export class RichText extends Component {
 	 *                            keyboard.
 	 */
 	onKeyUp( { keyCode } ) {
-		// The input event does not fire when the whole field is selected and
-		// BACKSPACE is pressed.
-		if ( keyCode === BACKSPACE ) {
-			this.onChange( this.createRecord() );
-		}
-
 		// `scrollToRect` is called on `nodechange`, whereas calling it on
 		// `keyup` *when* moving to a new RichText element results in incorrect
 		// scrolling. Though the following allows false positives, it results

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -510,6 +510,13 @@ export class RichText extends Component {
 			const start = getSelectionStart( value );
 			const end = getSelectionEnd( value );
 
+			// Always handle full content deletion ourselves.
+			if ( start === 0 && end !== 0 && end === value.text.length ) {
+				this.onChange( remove( value ) );
+				event.preventDefault();
+				return;
+			}
+
 			if ( this.multilineTag ) {
 				let newValue;
 

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -510,13 +510,6 @@ export class RichText extends Component {
 			const start = getSelectionStart( value );
 			const end = getSelectionEnd( value );
 
-			// Always handle uncollapsed selections ourselves.
-			if ( ! isCollapsed( value ) ) {
-				this.onChange( remove( value ) );
-				event.preventDefault();
-				return;
-			}
-
 			if ( this.multilineTag ) {
 				let newValue;
 

--- a/packages/editor/src/components/rich-text/tinymce.js
+++ b/packages/editor/src/components/rich-text/tinymce.js
@@ -10,6 +10,7 @@ import classnames from 'classnames';
  */
 import { Component, createElement } from '@wordpress/element';
 import { BACKSPACE, DELETE, ENTER, LEFT, RIGHT } from '@wordpress/keycodes';
+import { isEntirelySelected } from '@wordpress/dom';
 
 /**
  * Internal dependencies
@@ -272,9 +273,13 @@ export default class TinyMCE extends Component {
 
 	onKeyDown( event ) {
 		const { keyCode } = event;
+		const isDelete = keyCode === DELETE || keyCode === BACKSPACE;
 
 		// Disables TinyMCE behaviour.
-		if ( keyCode === ENTER ) {
+		if (
+			keyCode === ENTER ||
+			( isDelete && isEntirelySelected( this.editorNode ) )
+		) {
 			event.preventDefault();
 			// For some reason this is needed to also prevent the insertion of
 			// line breaks.

--- a/packages/editor/src/components/rich-text/tinymce.js
+++ b/packages/editor/src/components/rich-text/tinymce.js
@@ -272,11 +272,9 @@ export default class TinyMCE extends Component {
 
 	onKeyDown( event ) {
 		const { keyCode } = event;
-		const { startContainer, startOffset, endContainer, endOffset } = getSelection().getRangeAt( 0 );
-		const isCollapsed = startContainer === endContainer && startOffset === endOffset;
 
 		// Disables TinyMCE behaviour.
-		if ( keyCode === ENTER || ( ! isCollapsed && ( keyCode === DELETE || keyCode === BACKSPACE ) ) ) {
+		if ( keyCode === ENTER ) {
 			event.preventDefault();
 			// For some reason this is needed to also prevent the insertion of
 			// line breaks.

--- a/test/e2e/specs/__snapshots__/writing-flow.test.js.snap
+++ b/test/e2e/specs/__snapshots__/writing-flow.test.js.snap
@@ -32,6 +32,52 @@ exports[`adding blocks should clean TinyMCE content 2`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`adding blocks should create valid paragraph blocks when rapidly pressing Enter 1`] = `
+"<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`adding blocks should insert line break at end 1`] = `
 "<!-- wp:paragraph -->
 <p>a<br><br></p>
@@ -73,5 +119,41 @@ exports[`adding blocks should navigate around inline boundaries 1`] = `
 
 <!-- wp:paragraph -->
 <p>BeforeThird</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`adding blocks should not delete surrounding space when deleting a selected word 1`] = `
+"<!-- wp:paragraph -->
+<p>alpha  gamma</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`adding blocks should not delete surrounding space when deleting a selected word 2`] = `
+"<!-- wp:paragraph -->
+<p>alpha betagamma</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`adding blocks should not delete surrounding space when deleting a word with Alt+Backspace 1`] = `
+"<!-- wp:paragraph -->
+<p>alpha  gamma</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`adding blocks should not delete surrounding space when deleting a word with Alt+Backspace 2`] = `
+"<!-- wp:paragraph -->
+<p>alpha beta gamma</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`adding blocks should not delete surrounding space when deleting a word with Backspace 1`] = `
+"<!-- wp:paragraph -->
+<p>1  3</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`adding blocks should not delete surrounding space when deleting a word with Backspace 2`] = `
+"<!-- wp:paragraph -->
+<p>1 2 3</p>
 <!-- /wp:paragraph -->"
 `;

--- a/test/e2e/specs/__snapshots__/writing-flow.test.js.snap
+++ b/test/e2e/specs/__snapshots__/writing-flow.test.js.snap
@@ -124,13 +124,13 @@ exports[`adding blocks should navigate around inline boundaries 1`] = `
 
 exports[`adding blocks should not delete surrounding space when deleting a selected word 1`] = `
 "<!-- wp:paragraph -->
-<p>alpha  gamma</p>
+<p>alpha  gamma</p>
 <!-- /wp:paragraph -->"
 `;
 
 exports[`adding blocks should not delete surrounding space when deleting a selected word 2`] = `
 "<!-- wp:paragraph -->
-<p>alpha betagamma</p>
+<p>alpha beta gamma</p>
 <!-- /wp:paragraph -->"
 `;
 

--- a/test/e2e/specs/writing-flow.test.js
+++ b/test/e2e/specs/writing-flow.test.js
@@ -224,42 +224,58 @@ describe( 'adding blocks', () => {
 		expect( isInBlock ).toBe( true );
 	} );
 
-	it( 'should not delete trailing spaces when deleting a word with backspace', async () => {
+	it( 'should not delete surrounding space when deleting a word with Backspace', async () => {
 		await clickBlockAppender();
-		await page.keyboard.type( '1 2 3 4' );
+		await page.keyboard.type( '1 2 3' );
+		await pressTimes( 'ArrowLeft', ' 3'.length );
 		await page.keyboard.press( 'Backspace' );
-		await page.keyboard.type( '4' );
-		const blockText = await page.evaluate( () => document.activeElement.textContent );
-		expect( blockText ).toBe( '1 2 3 4' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await page.keyboard.type( '2' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
-	it( 'should not delete trailing spaces when deleting a word with alt + backspace', async () => {
+	it( 'should not delete surrounding space when deleting a word with Alt+Backspace', async () => {
 		await clickBlockAppender();
-		await page.keyboard.type( 'alpha beta gamma delta' );
+		await page.keyboard.type( 'alpha beta gamma' );
+		await pressTimes( 'ArrowLeft', ' gamma'.length );
+
 		if ( process.platform === 'darwin' ) {
 			await pressWithModifier( 'Alt', 'Backspace' );
 		} else {
 			await pressWithModifier( META_KEY, 'Backspace' );
 		}
-		await page.keyboard.type( 'delta' );
-		const blockText = await page.evaluate( () => document.activeElement.textContent );
-		expect( blockText ).toBe( 'alpha beta gamma delta' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await page.keyboard.type( 'beta' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should not delete surrounding space when deleting a selected word', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'alpha beta gamma' );
+		await pressTimes( 'ArrowLeft', ' gamma'.length );
+		await page.keyboard.down( 'Shift' );
+		await pressTimes( 'ArrowLeft', 'beta'.length );
+		await page.keyboard.up( 'Shift' );
+		await page.keyboard.press( 'Backspace' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await page.keyboard.type( 'beta' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
 	it( 'should create valid paragraph blocks when rapidly pressing Enter', async () => {
 		await clickBlockAppender();
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.press( 'Enter' );
-		await page.keyboard.press( 'Enter' );
+		await pressTimes( 'Enter', 10 );
+
 		// Check that none of the paragraph blocks have <br> in them.
-		const postContent = await getEditedPostContent();
-		expect( postContent.indexOf( 'br' ) ).toBe( -1 );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
## Description

Fixes #11964 and adds e2e tests.
Also fixes an issue where CTRL+A wouldn't select all blocks if you first select all text in a rich text field by triple clicking and then pressing CTRL+A.

In #11627 I retained deletion handling for uncollapsed selections (meaning text is selected) because I couldn't figure out the problem fast enough with letting it be handled natively again. It turns out TinyMCE is handling the case where an instance is entirely selected, and the React `onKeyDown` event is only fired after the TinyMCE event, causing TinyMCE to delete the contents first, and then us thinking the field is empty and merging it with the neighbouring block. The solution is to prevent the TinyMCE behaviour in that case, and handle it ourselves.

@notnownikki I also updated the tests you have added, to check if the space is actually there before retyping.

## How has this been tested?
See #11964 and above.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->