### PR TITLE
Fix regression with Sibling Inserter.

### DIFF
--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -686,7 +686,7 @@
 // Don't show the sibling inserter before the selected block.
 .edit-post-layout:not(.has-fixed-toolbar) {
 	// The child selector is necessary for this to work properly in nested contexts.
-	.is-selected > .editor-block-list__insertion-point-inserter {
+	.is-selected > .editor-block-list__insertion-point > .editor-block-list__insertion-point-inserter {
 		opacity: 0;
 		pointer-events: none;
 

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -686,7 +686,8 @@
 // Don't show the sibling inserter before the selected block.
 .edit-post-layout:not(.has-fixed-toolbar) {
 	// The child selector is necessary for this to work properly in nested contexts.
-	.is-selected > .editor-block-list__insertion-point > .editor-block-list__insertion-point-inserter {
+	.is-selected > .editor-block-list__insertion-point > .editor-block-list__insertion-point-inserter,
+	.is-focused > .editor-block-list__insertion-point > .editor-block-list__insertion-point-inserter {
 		opacity: 0;
 		pointer-events: none;
 


### PR DESCRIPTION
The sibling inserter is the plus you see when you hover between two blocks.

When you have no blocks selected, or use the unified toolbar mode. you can access the sibling inserter between any two blocks.

When you have a block selected, and have the block-affixed toolbars, only the sibling inserter below the selected block should be availabl
e. Though it should still be keyboard accessible.

This PR fixes that.

Before:

![before](https://user-images.githubusercontent.com/1204802/48617325-74dff280-e996-11e8-9021-5c0158754e7c.gif)

After:

![after](https://user-images.githubusercontent.com/1204802/48617329-77424c80-e996-11e8-99ae-ba4def92df6a.gif)


