### PR TITLE
RichText: clean up: remove paste timeouts

### DIFF
--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -270,24 +270,23 @@ export class RichText extends Component {
 			window.console.log( 'Received item:\n\n', file );
 
 			if ( shouldReplace ) {
-				// Necessary to allow the paste bin to be removed without errors.
-				this.props.setTimeout( () => this.props.onReplace( content ) );
+				this.props.onReplace( content );
 			} else if ( this.onSplit ) {
-				// Necessary to get the right range.
-				// Also done in the TinyMCE paste plugin.
-				this.props.setTimeout( () => this.splitContent( content ) );
+				this.splitContent( content );
 			}
 
 			return;
 		}
 
+		const record = this.getRecord();
+
 		// There is a selection, check if a URL is pasted.
-		if ( ! this.editor.selection.isCollapsed() ) {
+		if ( ! isCollapsed( record ) ) {
 			const pastedText = ( html || plainText ).replace( /<[^>]+>/g, '' ).trim();
 
 			// A URL was pasted, turn the selection into a link
 			if ( isURL( pastedText ) ) {
-				this.onChange( applyFormat( this.getRecord(), {
+				this.onChange( applyFormat( record, {
 					type: 'a',
 					attributes: {
 						href: decodeEntities( pastedText ),
@@ -321,7 +320,7 @@ export class RichText extends Component {
 
 		if ( typeof content === 'string' ) {
 			const recordToInsert = create( { html: content } );
-			this.onChange( insert( this.getRecord(), recordToInsert ) );
+			this.onChange( insert( record, recordToInsert ) );
 		} else if ( this.onSplit ) {
 			if ( ! content.length ) {
 				return;


### PR DESCRIPTION
## Description

This PR removes some unnecessary code. We are no longer using the TinyMCE paste plugin, so there is no need to wait for ranges to be set back or paste bins to be removed. We can also check whether a range is collapsed or not though the rich text value, instead of checking `this.editor.selection.isCollapsed()`.

## How has this been tested?

1. Paste a URL over a word. The word should be linked.
2. Copy an image from one browser (e.g. Safari) with right-click+"copy image" and paste it in Gutenberg in another browser (e.g. Chrome) to paste the image as data. There are other ways to do this, just paste an image cross application. Paste it once in an empty paragraph and once in the middle of text. Either way the image should be pasted correctly.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->