### PR TITLE
Add 'innerBlocks' support for transforms

### DIFF
--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -311,6 +311,39 @@ transforms: {
 ```
 {% end %}
 
+A block with innerBlocks can also be transformed from and to another block with innerBlocks.
+
+{% codetabs %}
+{% ES5 %}
+```js
+transforms: {
+    to: [
+        {
+            type: 'block',
+            blocks: [ 'some/block-with-innerblocks' ],
+            transform: function( attributes, innerBlocks ) {
+                return createBlock( 'some/other-block-with-innerblocks', attributes, innerBlocks );
+            },
+        },
+    ],
+},
+```
+{% ESNext %}
+```js
+transforms: {
+    to: [
+        {
+            type: 'block',
+            blocks: [ 'some/block-with-innerblocks' ],
+            transform: ( attributes, innerBlocks ) => {
+                return createBlock( 'some/other-block-with-innerblocks', attributes, innerBlocks);
+            },
+        },
+    ],
+},
+```
+{% end %}
+
 An optional `isMatch` function can be specified on a transform object. This provides an opportunity to perform additional checks on whether a transform should be possible. Returning `false` from this function will prevent the transform from being displayed as an option to the user.
 
 {% codetabs %}

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.1.0 (Unreleased)
+
+### New Feature
+
+- Blocks' `transforms` will receive `innerBlocks` as the second argument (or an array of each block's respective `innerBlocks` for a multi-transform).
+
 ## 6.0.5 (2019-01-03)
 
 ## 6.0.4 (2018-12-12)

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -346,9 +346,12 @@ export function switchToBlockType( blocks, name ) {
 
 	let transformationResults;
 	if ( transformation.isMultiBlock ) {
-		transformationResults = transformation.transform( blocksArray.map( ( currentBlock ) => currentBlock.attributes ) );
+		transformationResults = transformation.transform(
+			blocksArray.map( ( currentBlock ) => currentBlock.attributes ),
+			blocksArray.map( ( currentBlock ) => currentBlock.innerBlocks )
+		);
 	} else {
-		transformationResults = transformation.transform( firstBlock.attributes );
+		transformationResults = transformation.transform( firstBlock.attributes, firstBlock.innerBlocks );
 	}
 
 	// Ensure that the transformation function returned an object or an array

--- a/packages/e2e-tests/plugins/inner-blocks-templates/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-templates/index.js
@@ -1,5 +1,6 @@
 ( function() {
 	var registerBlockType = wp.blocks.registerBlockType;
+	var createBlock = wp.blocks.createBlock;
 	var el = wp.element.createElement;
 	var InnerBlocks = wp.editor.InnerBlocks;
 	var __ = wp.i18n.__;
@@ -28,10 +29,10 @@
 
 		edit: function( props ) {
 			return el(
-					InnerBlocks,
-					{
-						template: TEMPLATE,
-					}
+				InnerBlocks,
+				{
+					template: TEMPLATE,
+				}
 			);
 		},
 
@@ -45,11 +46,11 @@
 
 		edit: function( props ) {
 			return el(
-					InnerBlocks,
-					{
-						template: TEMPLATE,
-						templateLock: 'all',
-					}
+				InnerBlocks,
+				{
+					template: TEMPLATE,
+					templateLock: 'all',
+				}
 			);
 		},
 
@@ -63,13 +64,57 @@
 
 		edit: function( props ) {
 			return el(
-					InnerBlocks,
-					{
-						template: TEMPLATE_PARAGRAPH_PLACEHOLDER,
-					}
+				InnerBlocks,
+				{
+					template: TEMPLATE_PARAGRAPH_PLACEHOLDER,
+				}
 			);
 		},
 
 		save,
 	} );
+
+	registerBlockType( 'test/test-inner-blocks-transformer-target', {
+		title: 'Test Inner Blocks transformer target',
+		icon: 'cart',
+		category: 'common',
+
+		transforms: {
+			from: [
+				{
+					type: 'block',
+					blocks: [
+						'test/i-dont-exist',
+						'test/test-inner-blocks-no-locking',
+						'test/test-inner-blocks-locking-all',
+						'test/test-inner-blocks-paragraph-placeholder'
+					],
+					transform: function( attributes, innerBlocks ) {
+						return createBlock( 'test/test-inner-blocks-transformer-target', attributes, innerBlocks );
+					},
+				},
+			],
+			to: [
+				{
+					type: 'block',
+					blocks: [ 'test/i-dont-exist' ],
+					transform: function( attributes, innerBlocks ) {
+						return createBlock( 'test/test-inner-blocks-transformer-target', attributes, innerBlocks );
+					},
+				}
+			]
+		},
+
+		edit: function( props ) {
+			return el(
+				InnerBlocks,
+				{
+					template: TEMPLATE,
+				}
+			);
+		},
+
+		save,
+	} );
+
 } )();


### PR DESCRIPTION
## Description
This PR aims to provide support for 'innerBlocks' in transform rules. The proposed syntax is like this.


```
transforms: {
	from: [
		{
			type: 'block',
			blocks: ['agncy/split'],
			transform: function( attributes, innerBlocks ) {
                           return createBlock( 'wpm/split', attributes, innerBlocks );
                        },
		}
	]
},
```

## How has this been tested?
This PR has been manually tested. E2E tests are possible and the needed plugin code exists, the test itself has not been written. 

## Types of changes
- Added an attribute to the transform function to regard innerBlocks
- Catched a possible error while rendering the block switcher where 'blocks' could be undefined due to a block not being registered

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

closes #13052