### PR TITLE
RNMobile: Register default block

### DIFF
--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -3,6 +3,7 @@
  */
 import {
 	registerBlockType,
+	setDefaultBlockName,
 } from '@wordpress/blocks';
 
 /**
@@ -27,3 +28,5 @@ export const registerCoreBlocks = () => {
 		registerBlockType( name, settings );
 	} );
 };
+
+setDefaultBlockName( paragraph.name );

--- a/packages/blocks/src/api/index.native.js
+++ b/packages/blocks/src/api/index.native.js
@@ -20,6 +20,8 @@ export {
 	getBlockTypes,
 	hasBlockSupport,
 	isReusableBlock,
+	setDefaultBlockName,
+	getDefaultBlockName,
 } from './registration';
 export { getPhrasingContentSchema } from './raw-handling';
 export { default as children } from './children';


### PR DESCRIPTION
Now that the Gutenberg Mobile uses the web store, we can take advantages of it.

This PR registers the `paragraph` block as the default block to be used when the user removes all blocks from the document, to ensure that there is always at least one block to type on.

![default_block_demo](https://user-images.githubusercontent.com/9772967/48631680-d6578f80-e99d-11e8-8134-5e46e4df3c49.gif)

- It works when removing blocks, not yet for starting a new empty post.
- With the focus issue solved it will feel more "natural", with the cursor already in the paragraph block.

To test:
Follow the instructions in the `gutenberg-mobile` side:
https://github.com/wordpress-mobile/gutenberg-mobile/pull/249