### PR TITLE
[RNMobile] add isSelected prop to PlainText-backed blocks

### DIFF
--- a/packages/block-library/src/code/edit.native.js
+++ b/packages/block-library/src/code/edit.native.js
@@ -21,8 +21,7 @@ import styles from './theme.scss';
 // Note: styling is applied directly to the (nested) PlainText component. Web-side components
 // apply it to the container 'div' but we don't have a proper proposal for cascading styling yet.
 export default function CodeEdit( props ) {
-	const { attributes, setAttributes } = props;
-	const { style } = attributes;
+	const { attributes, setAttributes, style } = props;
 
 	return (
 		<View>

--- a/packages/block-library/src/code/edit.native.js
+++ b/packages/block-library/src/code/edit.native.js
@@ -20,7 +20,10 @@ import styles from './theme.scss';
 
 // Note: styling is applied directly to the (nested) PlainText component. Web-side components
 // apply it to the container 'div' but we don't have a proper proposal for cascading styling yet.
-export default function CodeEdit( { attributes, setAttributes, style } ) {
+export default function CodeEdit( props ) {
+	const { attributes, setAttributes } = props;
+	const { style } = attributes;
+
 	return (
 		<View>
 			<PlainText
@@ -31,6 +34,7 @@ export default function CodeEdit( { attributes, setAttributes, style } ) {
 				onChange={ ( content ) => setAttributes( { content } ) }
 				placeholder={ __( 'Write code…' ) }
 				aria-label={ __( 'Code' ) }
+				isSelected={ props.isSelected }
 			/>
 		</View>
 	);

--- a/packages/block-library/src/more/edit.native.js
+++ b/packages/block-library/src/more/edit.native.js
@@ -14,7 +14,8 @@ import { __ } from '@wordpress/i18n';
 import { PlainText } from '@wordpress/editor';
 import styles from './editor.scss';
 
-export default function MoreEdit( { attributes, setAttributes } ) {
+export default function MoreEdit( props ) {
+	const { attributes, setAttributes } = props;
 	const { customText } = attributes;
 	const defaultText = __( 'Read more' );
 	const value = customText !== undefined ? customText : defaultText;
@@ -30,6 +31,7 @@ export default function MoreEdit( { attributes, setAttributes } ) {
 					underlineColorAndroid="transparent"
 					onChange={ ( newValue ) => setAttributes( { customText: newValue } ) }
 					placeholder={ defaultText }
+					isSelected={ props.isSelected }
 				/>
 				<Text className={ styles[ 'block-library-more__right-marker' ] }>--&gt;</Text>
 			</View>

--- a/packages/editor/src/components/plain-text/index.native.js
+++ b/packages/editor/src/components/plain-text/index.native.js
@@ -8,18 +8,26 @@ import { TextInput } from 'react-native';
  */
 import styles from './style.scss';
 
-function PlainText( { onChange, className, ...props } ) {
-	if (props.isSelected === true) {
-		setTimeout(() => this._input.focus(), 250);
+export default class PlainText extends React.Component {
+	componentDidMount() {
+		// if isSelected is true, we should request the focus on this TextInput
+		if ( (this._input.isFocused() === false) && (this._input.props.isSelected === true) ) {
+			this.focus();
+		}
 	}
-	return (
+
+	focus () {
+	  this._input && this._input.focus()
+	}
+
+	render () {
+	  return (
 		<TextInput
 			ref={(x) => this._input = x}
-			className={ [ styles[ 'editor-plain-text' ], className ] }
-			onChangeText={ ( text ) => onChange( text ) }
-			{ ...props }
+			className={ [ styles[ 'editor-plain-text' ], this.props.className ] }
+			onChangeText={ ( text ) => this.props.onChange( text ) }
+			{...this.props}
 		/>
-	);
+	  )
+	}
 }
-
-export default PlainText;

--- a/packages/editor/src/components/plain-text/index.native.js
+++ b/packages/editor/src/components/plain-text/index.native.js
@@ -4,30 +4,35 @@
 import { TextInput } from 'react-native';
 
 /**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import styles from './style.scss';
 
-export default class PlainText extends React.Component {
+export default class PlainText extends Component {
 	componentDidMount() {
 		// if isSelected is true, we should request the focus on this TextInput
-		if ( (this._input.isFocused() === false) && (this._input.props.isSelected === true) ) {
+		if ( ( this._input.isFocused() === false ) && ( this._input.props.isSelected === true ) ) {
 			this.focus();
 		}
 	}
 
-	focus () {
-	  this._input && this._input.focus()
+	focus() {
+		this._input.focus();
 	}
 
-	render () {
-	  return (
-		<TextInput
-			ref={(x) => this._input = x}
-			className={ [ styles[ 'editor-plain-text' ], this.props.className ] }
-			onChangeText={ ( text ) => this.props.onChange( text ) }
-			{...this.props}
-		/>
-	  )
+	render() {
+		return (
+			<TextInput
+				ref={ ( x ) => this._input = x }
+				className={ [ styles[ 'editor-plain-text' ], this.props.className ] }
+				onChangeText={ ( text ) => this.props.onChange( text ) }
+				{ ...this.props }
+			/>
+		);
 	}
 }

--- a/packages/editor/src/components/plain-text/index.native.js
+++ b/packages/editor/src/components/plain-text/index.native.js
@@ -9,8 +9,12 @@ import { TextInput } from 'react-native';
 import styles from './style.scss';
 
 function PlainText( { onChange, className, ...props } ) {
+	if (props.isSelected === true) {
+		setTimeout(() => this._input.focus(), 250);
+	}
 	return (
 		<TextInput
+			ref={(x) => this._input = x}
 			className={ [ styles[ 'editor-plain-text' ], className ] }
 			onChangeText={ ( text ) => onChange( text ) }
 			{ ...props }


### PR DESCRIPTION
## Description
This is a follow up PR to #11857, bringing the same functionality to PlainText-backed blocks:
- Promotes `PlainText` implementation to be a React Native component (so we can make use of the lifecycle events more clearly)
- adds `isSelected` prop to `Code` and `More` blocks

By doing this, we can make it easier to handle the focus at the low level when `isSelected` is true.

## How has this been tested?
To be tested as per indicated in https://github.com/wordpress-mobile/gutenberg-mobile/pull/250

1. make sure to select a block (tap on a block and see the up/down arrows appear, etc)
2. now tap on the `+` inserter icon
3. choose one of Code or More blocks (the only ones that currently are backed by `PlainText `implementation)
4. observe the new block is inserted, the block is shown as selected (it has the up/down arrows and such) and the cursor starts blinking there (that is, it got the focus).

## Screenshots <!-- if applicable -->
Before, the focus would not be gotten when a new "PlainText"-backed block was inserted:
![cursor_after_insert_okno](https://user-images.githubusercontent.com/6597771/48631935-6e557900-e99e-11e8-8fe3-336308eb2be2.gif)

Now, the cursor appears blinking after insertion:
![cursor_after_insert_ok](https://user-images.githubusercontent.com/6597771/48631977-83320c80-e99e-11e8-982d-ae6040680836.gif)


## Types of changes
Bug fix (non-breaking change which fixes an issue)

