### PR TITLE
Override our global aligncenter CSS rules for the cover block

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -95,6 +95,13 @@
 		max-width: $content-width / 2;
 		width: 100%;
 	}
+
+	// Center-aligned cover blocks should not use our global aligncenter block rules
+	&.aligncenter {
+		display: flex;
+		margin-left: inherit;
+		margin-right: inherit;
+	}
 }
 
 .wp-block-cover__video-background {

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -96,11 +96,11 @@
 		width: 100%;
 	}
 
-	// Center-aligned cover blocks should not use our global aligncenter block rules
-	&.aligncenter {
+	// Aligned cover blocks should not use our global alignment rules
+	&.aligncenter,
+	&.alignleft,
+	&.alignright {
 		display: flex;
-		margin-left: inherit;
-		margin-right: inherit;
 	}
 }
 


### PR DESCRIPTION
Previously, center-aligned cover blocks were ignoring our intended `display: flex;` and `margin` rules on the front-end. This ensures they appear as intended.

**Before:** 

![screen shot 2018-11-16 at 11 31 56 am](https://user-images.githubusercontent.com/1202812/48634890-b66f9e00-e994-11e8-9f0e-1eb39d19b9c7.png)

![screen shot 2018-11-16 at 11 45 57 am](https://user-images.githubusercontent.com/1202812/48635095-339b1300-e995-11e8-8ba8-135f1fa9ecf1.png)


**After:**

![screen shot 2018-11-16 at 11 42 32 am](https://user-images.githubusercontent.com/1202812/48634945-cc7d5e80-e994-11e8-9eb5-d2cb4327a0b4.png)

![screen shot 2018-11-16 at 11 44 17 am](https://user-images.githubusercontent.com/1202812/48635063-1b2af880-e995-11e8-894b-fb4d60163888.png)


This was discovered as part of https://github.com/WordPress/twentynineteen/issues/612, but effects all themes. 