### PR TITLE
Classic Editor plugin url should be translatable

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -42,8 +42,7 @@ function the_gutenberg_project() {
 		} else { // Using Gutenberg in Core.
 			printf(
 				// Translators: link is for Classic Editor plugin.
-				__( 'The Block Editor requires JavaScript. Please try the <a href="%s">Classic Editor plugin</a>.', 'gutenberg' ),
-				'https://wordpress.org/plugins/classic-editor/'
+				__( 'The Block Editor requires JavaScript. Please try the <a href="https://wordpress.org/plugins/classic-editor/">Classic Editor plugin</a>.', 'gutenberg' )
 			);
 		}
 		?>


### PR DESCRIPTION
## Description
I have tried to make Classic Editor plugin URL translatable. Let me know if any changes require.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

Fixes #11983.