### PR TITLE
Fix editor break on Unified toolbar

### DIFF
--- a/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-group.js
+++ b/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-group.js
@@ -13,6 +13,9 @@ import { withSelect } from '@wordpress/data';
 const { Fill: PluginBlockSettingsMenuGroup, Slot } = createSlotFill( 'PluginBlockSettingsMenuGroup' );
 
 const PluginBlockSettingsMenuGroupSlot = ( { fillProps, selectedBlocks } ) => {
+	if ( !! selectedBlocks ) {
+		return null;
+	}
 	selectedBlocks = map( selectedBlocks, ( block ) => block.name );
 	return (
 		<Slot fillProps={ { ...fillProps, selectedBlocks } } >


### PR DESCRIPTION
How to reproduce:

* Open a post
* Change to Unified toolbar mode
* Go to the block settings menu
* Select the "Duplicate block" option
* Hit Ctrl+Z (Alternative: click Undo button and then open the block settings menu).

The editor crashes.

![peek 2018-11-16 20-19](https://user-images.githubusercontent.com/583546/48642644-c2338280-e9dd-11e8-8074-4566d13d4a4c.gif)
