### PR TITLE
Fix the Privacy Policy help notice

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -316,9 +316,7 @@ function gutenberg_show_privacy_policy_help_text() {
 	if ( is_gutenberg_page() ) {
 		remove_action( 'edit_form_after_title', array( 'WP_Privacy_Policy_Content', 'notice' ) );
 
-		global $post;
-
-		WP_Privacy_Policy_Content::notice( $post );
+		WP_Privacy_Policy_Content::notice( get_post() );
 	}
 }
 add_action( 'admin_notices', 'gutenberg_show_privacy_policy_help_text' );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -311,6 +311,8 @@ function gutenberg_warn_classic_about_blocks() {
  * WordPress Core uses this hook to display this notice, it never displays.
  * Outputting the notice on the `admin_notices` hook allows Gutenberg to
  * consume the notice and display it with the Notices API.
+ *
+ * @since 4.5.0
  */
 function gutenberg_show_privacy_policy_help_text() {
 	if ( is_gutenberg_page() ) {

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -315,7 +315,7 @@ function gutenberg_warn_classic_about_blocks() {
  * @since 4.5.0
  */
 function gutenberg_show_privacy_policy_help_text() {
-	if ( is_gutenberg_page() ) {
+	if ( is_gutenberg_page() && has_action( 'edit_form_after_title', array( 'WP_Privacy_Policy_Content', 'notice' ) ) ) {
 		remove_action( 'edit_form_after_title', array( 'WP_Privacy_Policy_Content', 'notice' ) );
 
 		WP_Privacy_Policy_Content::notice( get_post() );

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -116,7 +116,6 @@ function gutenberg_wpautop( $content ) {
 remove_filter( 'the_content', 'wpautop' );
 add_filter( 'the_content', 'gutenberg_wpautop', 6 );
 
-
 /**
  * Check if we need to load the block warning in the Classic Editor.
  *
@@ -304,3 +303,22 @@ function gutenberg_warn_classic_about_blocks() {
 		</script>
 	<?php
 }
+
+/**
+ * Display the privacy policy help notice.
+ *
+ * In Gutenberg, the `edit_form_after_title` hook is not supported. Because
+ * WordPress Core uses this hook to display this notice, it never displays.
+ * Outputting the notice on the `admin_notices` hook allows Gutenberg to
+ * consume the notice and display it with the Notices API.
+ */
+function gutenberg_show_privacy_policy_help_text() {
+	if ( is_gutenberg_page() ) {
+		remove_action( 'edit_form_after_title', array( 'WP_Privacy_Policy_Content', 'notice' ) );
+
+		global $post;
+
+		WP_Privacy_Policy_Content::notice( $post );
+	}
+}
+add_action( 'admin_notices', 'gutenberg_show_privacy_policy_help_text' );


### PR DESCRIPTION
Related issue: #10448.
Depends on #11604.

The new editor does not support the `edit_form_after_title` action hook. Because WordPress Core uses this hook to output the notice, it is not printed to the screen.

After #11604 is merged, legacy style admin notices (`<div class="notice">...notice content...</div>`) will be consumed by the Notices API and displayed. This change ensures that when #11604 is merged the privacy policy notice will appear again when editing the privacy policy page.

This PR moves the notice to the `admin_notices` action hook to ensure it is printed to the page and is consumable.

To test, ensure the `Need help putting together your new Privacy Policy page?` notice is output in the page source only when editing the privacy policy page. To further test, pull this change into the `update/legacy-notices` branch locally, and verify the notice correctly appears when editing the privacy policy page.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] ~My code follows the accessibility standards.~ (NA) <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
