### PR TITLE
Honor the Disable Visual Editor setting

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -205,7 +205,7 @@ function gutenberg_pre_init() {
 
 /**
  * Enable Gutenberg based on user_can_richedit setting.
- * Set use_block_editor_for_post based on user setting for disable visual editor.
+ * Set gutenberg_can_edit_post based on user setting for disable visual editor.
  */
 add_filter( 'gutenberg_can_edit_post_type', 'user_can_richedit', 5 );
 add_filter( 'gutenberg_can_edit_post', 'user_can_richedit', 5 );

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -68,6 +68,9 @@ function the_gutenberg_project() {
  */
 function gutenberg_menu() {
 	global $submenu;
+	if ( ! user_can_richedit() ) {
+		return false;
+	}
 
 	add_menu_page(
 		'Gutenberg',
@@ -139,6 +142,10 @@ function is_gutenberg_page() {
 	}
 
 	if ( ! gutenberg_can_edit_post( $post ) ) {
+		return false;
+	}
+
+	if ( ! user_can_richedit() ) {
 		return false;
 	}
 
@@ -274,6 +281,10 @@ add_action( 'admin_init', 'gutenberg_redirect_demo' );
  * @since 1.5.0
  */
 function gutenberg_add_edit_link_filters() {
+	if ( ! user_can_richedit() ) {
+		return;
+	}
+
 	// For hierarchical post types.
 	add_filter( 'page_row_actions', 'gutenberg_add_edit_link', 10, 2 );
 	// For non-hierarchical post types.

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -67,6 +67,9 @@ function the_gutenberg_project() {
  * @since 0.1.0
  */
 function gutenberg_menu() {
+	if ( ! gutenberg_can_edit_post( $post ) ) {
+		return;
+	}
 	global $submenu;
 
 	add_menu_page(
@@ -206,7 +209,6 @@ function gutenberg_pre_init() {
  */
 add_filter( 'gutenberg_can_edit_post_type', 'user_can_richedit', 5 );
 add_filter( 'gutenberg_can_edit_post', 'user_can_richedit', 5 );
-add_filter( 'use_block_editor_for_post', 'user_can_richedit', 5 );
 
 /**
  * Initialize Gutenberg.

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -68,9 +68,6 @@ function the_gutenberg_project() {
  */
 function gutenberg_menu() {
 	global $submenu;
-	if ( ! user_can_richedit() ) {
-		return false;
-	}
 
 	add_menu_page(
 		'Gutenberg',
@@ -145,10 +142,6 @@ function is_gutenberg_page() {
 		return false;
 	}
 
-	if ( ! user_can_richedit() ) {
-		return false;
-	}
-
 	return true;
 }
 
@@ -206,6 +199,14 @@ function gutenberg_pre_init() {
 
 	add_filter( 'replace_editor', 'gutenberg_init', 10, 2 );
 }
+
+/**
+ * Enable Gutenberg based on user_can_richedit setting.
+ * Set use_block_editor_for_post based on user setting for disable visual editor.
+ */
+add_filter( 'gutenberg_can_edit_post_type', 'user_can_richedit', 5 );
+add_filter( 'gutenberg_can_edit_post', 'user_can_richedit', 5 );
+add_filter( 'use_block_editor_for_post', 'user_can_richedit', 5 );
 
 /**
  * Initialize Gutenberg.
@@ -281,10 +282,6 @@ add_action( 'admin_init', 'gutenberg_redirect_demo' );
  * @since 1.5.0
  */
 function gutenberg_add_edit_link_filters() {
-	if ( ! user_can_richedit() ) {
-		return;
-	}
-
 	// For hierarchical post types.
 	add_filter( 'page_row_actions', 'gutenberg_add_edit_link', 10, 2 );
 	// For non-hierarchical post types.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1419,12 +1419,6 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		'after'
 	);
 
-	// Ignore Classic Editor's `rich_editing` user option, aka "Disable visual
-	// editor". Forcing this to be true guarantees that TinyMCE and its plugins
-	// are available in Gutenberg. Fixes
-	// https://github.com/WordPress/gutenberg/issues/5667.
-	add_filter( 'user_can_richedit', '__return_true' );
-
 	wp_enqueue_script( 'wp-edit-post' );
 	wp_enqueue_script( 'wp-format-library' );
 	wp_enqueue_style( 'wp-format-library' );


### PR DESCRIPTION
## Description

Closes #4634.

Show the plain text editor if the user checks the "Disable the visual editor when writing" option
See #4634 

## How has this been tested?

From user settings, check option to Disable the visual editor:

* Edit post from Post list open in plain text editor
* Edit post from link on page view opens in plain text
* Switching back to disable option brings back block editor
* Confirm paragraphs, embeds, and other content works as expected

## Types of changes

* Removes the forcing of user_can_richedit to false
* Disables Gutenberg init by returning if user_can_richedit()
* Removes Gutenberg admin menu item
* Removes Classic Editor link in post view


## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
