### PR TITLE
Block API: Preserve unknown, respect `null` in server attributes preparation

### DIFF
--- a/lib/class-wp-block-type.php
+++ b/lib/class-wp-block-type.php
@@ -141,18 +141,14 @@ class WP_Block_Type {
 
 			$schema = $this->attributes[ $attribute_name ];
 
-			// Validate value by JSON schema.
+			// Validate value by JSON schema. An invalid value should revert to
+			// its default, if one exists. This occurs by virtue of the missing
+			// attributes loop immediately following. If there is not a default
+			// assigned, the attribute value should remain unset.
 			$is_valid = rest_validate_value_from_schema( $value, $schema );
 			if ( is_wp_error( $is_valid ) ) {
-				// Assigning `null` will trigger defaulting, if applicable.
-				$value = null;
+				unset( $attributes[ $attribute_name ] );
 			}
-
-			if ( is_null( $value ) && isset( $schema['default'] ) ) {
-				$value = $schema['default'];
-			}
-
-			$attributes[ $attribute_name ] = $value;
 		}
 
 		// Populate values of any missing attributes for which the block type

--- a/lib/class-wp-rest-block-renderer-controller.php
+++ b/lib/class-wp-rest-block-renderer-controller.php
@@ -59,6 +59,7 @@ class WP_REST_Block_Renderer_Controller extends WP_REST_Controller {
 								'type'                 => 'object',
 								'additionalProperties' => false,
 								'properties'           => $block_type->get_attributes(),
+								'default'              => array(),
 							),
 							'post_id'    => array(
 								'description' => __( 'ID of the post context.', 'gutenberg' ),

--- a/phpunit/class-block-type-test.php
+++ b/phpunit/class-block-type-test.php
@@ -140,6 +140,7 @@ class Block_Type_Test extends WP_UnitTestCase {
 			'wrongTypeDefaulted' => 5,
 			/* missingDefaulted */
 			'undefined'          => 'include',
+			'intendedNull'       => null,
 		);
 
 		$block_type = new WP_Block_Type(
@@ -160,6 +161,10 @@ class Block_Type_Test extends WP_UnitTestCase {
 						'type'    => 'string',
 						'default' => 'define',
 					),
+					'intendedNull'       => array(
+						'type'    => array( 'string', 'null' ),
+						'default' => 'wrong',
+					),
 				),
 			)
 		);
@@ -169,10 +174,11 @@ class Block_Type_Test extends WP_UnitTestCase {
 		$this->assertEquals(
 			array(
 				'correct'            => 'include',
-				'wrongType'          => null,
+				/* wrongType */
 				'wrongTypeDefaulted' => 'defaulted',
 				'missingDefaulted'   => 'define',
 				'undefined'          => 'include',
+				'intendedNull'       => null,
 			),
 			$prepared_attributes
 		);

--- a/phpunit/class-block-type-test.php
+++ b/phpunit/class-block-type-test.php
@@ -139,7 +139,7 @@ class Block_Type_Test extends WP_UnitTestCase {
 			'wrongType'          => 5,
 			'wrongTypeDefaulted' => 5,
 			/* missingDefaulted */
-			'undefined'          => 'omit',
+			'undefined'          => 'include',
 		);
 
 		$block_type = new WP_Block_Type(
@@ -172,9 +172,20 @@ class Block_Type_Test extends WP_UnitTestCase {
 				'wrongType'          => null,
 				'wrongTypeDefaulted' => 'defaulted',
 				'missingDefaulted'   => 'define',
+				'undefined'          => 'include',
 			),
 			$prepared_attributes
 		);
+	}
+
+	function test_prepare_attributes_none_defined() {
+		$attributes = array( 'exists' => 'keep' );
+
+		$block_type = new WP_Block_Type( 'core/dummy', array() );
+
+		$prepared_attributes = $block_type->prepare_attributes_for_render( $attributes );
+
+		$this->assertEquals( $attributes, $prepared_attributes );
 	}
 
 	function test_has_block_with_mixed_content() {

--- a/phpunit/class-rest-block-renderer-controller-test.php
+++ b/phpunit/class-rest-block-renderer-controller-test.php
@@ -272,7 +272,9 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( self::$block_name );
 		$defaults   = array();
 		foreach ( $block_type->attributes as $key => $attribute ) {
-			$defaults[ $key ] = isset( $attribute['default'] ) ? $attribute['default'] : null;
+			if ( isset( $attribute['default'] ) ) {
+				$defaults[ $key ] = $attribute['default'];
+			}
 		}
 
 		$request = new WP_REST_Request( 'GET', self::$rest_api_route . self::$block_name );


### PR DESCRIPTION
This pull request seeks to revise the behavior of the server-side `BlockType::prepare_attributes_for_render` with regards to validation:

- Skip validation where there is no attribute definition, but keep the attribute value
   - Previously, the attribute would be omitted from the attributes passed to `render_callback`.
   - Notably, this resolves an issue where `render_callback` cannot receive a block's `align` and `customClassName` attribute values, since these are defined as a client-side filter ([related](https://github.com/WordPress/gutenberg/issues/2751#issuecomment-421107960)).
- Validate `null` as a proper value in its own right
   - Previously, a client implementation of a block could track `{"attribute":null}` as an explicitly empty value, and the server would wrongly initiate defaulting behavior.
   - The new behavior will now only populate a default value if the attribute is not defined at all, including when unset in its being invalid per the attribute schema.

This is partly intended to serve for consistency:

- The prior implementation already had a shortcutting condition to return the attributes verbatim if there were no attributes defined. An unknown attribute would be kept, but only if the block type had no `attributes`.
- Omitting the invalid attribute type when no default exists aligns with the client implementation
   - e.g. `wp.blocks.parse( '<!-- wp:latest-posts {"className":2} /-->')[ 0 ].attributes.className === undefined`

One potential downside is a newly introduced inconsistency in that the client still does not respect unknown attributes. This may be simple enough to add support if desired.

**Testing instructions:**

Ensure PHP tests pass:

```
npm run test-php phpunit/class-block-type-test.php 
```

Optionally, you may try registering server-side a `render_callback` for a block which supports alignment or custom class name in the client, ensuring that the value is passed to the `render_callback`.

**Possible future tasks:**

- [ ] `supports` attributes should be defined by the server. This is likely to be blocked by broader conversation of #2751.
- [ ] Respect unknown attributes in the client parse.

cc @mtias @azaozz 