### PR TITLE
Build Tooling: Avoid `.default` on browser global assignments

### DIFF
--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -41,12 +41,10 @@ const entityActions = defaultEntities.reduce( ( result, entity ) => {
 	return result;
 }, {} );
 
-const store = registerStore( REDUCER_KEY, {
+registerStore( REDUCER_KEY, {
 	reducer,
 	controls,
 	actions: { ...actions, ...entityActions },
 	selectors: { ...selectors, ...entitySelectors },
 	resolvers: { ...resolvers, ...entityResolvers },
 } );
-
-export default store;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -167,6 +167,7 @@ const config = {
 			'deprecated',
 			'dom-ready',
 			'redux-routine',
+			'token-list',
 		].map( camelCaseDash ) ),
 		new CopyWebpackPlugin(
 			gutenbergPackages.map( ( packageName ) => ( {


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/11825#issuecomment-439457220

This pull request seeks to correct wrongly-assigned `.default` values on browser-assigned globals. In master you will observe both a `wp.tokenList.default` and a `wp.coreData.default`.

This was discovered with the following console code:

```js
Object.entries( wp ).filter( ( [ key, value ] ) => value.default )
```

**Open question:** These are technically breaking changes, though very much of the "this was obviously always broken" sort. We don't use `core-data`'s default export anywhere, nor _should_ anyone. Should we have any deprecation process here?

**Testing instructions:**

Verify that `wp.tokenList` is the default exported function.

Verify there is no `wp.coreData`.

**Follow-up tasks:**

As noted at https://github.com/WordPress/gutenberg/pull/11825#issuecomment-439458392 and [similarly considered in Slack](https://wordpress.slack.com/archives/C5UNMSU4R/p1542385406412600) ([link requires registration](https://make.wordpress.org/chat/)), we should consider correcting the naming of `tokenList` and `escapeHtml`. 