### PR TITLE
Try: Improve permalink editing

### DIFF
--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -333,6 +333,20 @@ _Returns_
 
 -   `?string`: Preview Link.
 
+<a name="getEditedPostSlug" href="#getEditedPostSlug">#</a> **getEditedPostSlug**
+
+Returns the slug for the post being edited, preferring a manually edited
+value if one exists, then a sanitized version of the current post title, and
+finally the post ID.
+
+_Parameters_
+
+-   _state_ `Object`: Editor state.
+
+_Returns_
+
+-   `string`: The current slug to be displayed in the editor
+
 <a name="getEditedPostVisibility" href="#getEditedPostVisibility">#</a> **getEditedPostVisibility**
 
 Returns the current visibility of the post being edited, preferring the

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -139,3 +139,76 @@ function wp_api_nav_menus_taxonomy_args( $args, $taxonomy ) {
 	return $args;
 }
 add_filter( 'register_taxonomy_args', 'wp_api_nav_menus_taxonomy_args', 10, 2 );
+
+/**
+ * Shim for get_sample_permalink() to add support for auto-draft status.
+ *
+ * This function filters the return from get_sample_permalink() and essentially
+ * re-runs the same logic minus the filters, but pretends a status of auto-save
+ * is actually publish in order to return the future permalink format.
+ *
+ * This is a temporary fix until we can patch get_sample_permalink()
+ *
+ * @see https://core.trac.wordpress.org/ticket/46266
+ *
+ * @param array  $permalink Array containing the sample permalink with placeholder for the post name, and the post name.
+ * @param int    $id        ID of the post.
+ * @param string $title     Title of the post.
+ * @param string $name      Slug of the post.
+ * @param object $post      WP_Post object.
+ *
+ * @return array Array containing the sample permalink with placeholder for the post name, and the post name.
+ */
+function gutenberg_auto_draft_get_sample_permalink( $permalink, $id, $title, $name, $post ) {
+	if ( 'auto-draft' !== $post->post_status ) {
+		return $permalink;
+	}
+	$ptype = get_post_type_object( $post->post_type );
+
+	$original_status = $post->post_status;
+	$original_date   = $post->post_date;
+	$original_name   = $post->post_name;
+
+	// Hack: get_permalink() would return ugly permalink for drafts, so we will fake that our post is published.
+	$post->post_status = 'publish';
+	$post->post_name   = sanitize_title( $post->post_name ? $post->post_name : $post->post_title, $post->ID );
+
+	// If the user wants to set a new name -- override the current one.
+	// Note: if empty name is supplied -- use the title instead, see #6072.
+	if ( ! is_null( $name ) ) {
+		$post->post_name = sanitize_title( $name ? $name : $title, $post->ID );
+	}
+
+	$post->post_name = wp_unique_post_slug( $post->post_name, $post->ID, $post->post_status, $post->post_type, $post->post_parent );
+
+	$post->filter = 'sample';
+
+	$permalink = get_permalink( $post, true );
+
+	// Replace custom post_type Token with generic pagename token for ease of use.
+	$permalink = str_replace( "%$post->post_type%", '%pagename%', $permalink );
+
+	// Handle page hierarchy.
+	if ( $ptype->hierarchical ) {
+		$uri = get_page_uri( $post );
+		if ( $uri ) {
+			$uri = untrailingslashit( $uri );
+			$uri = strrev( stristr( strrev( $uri ), '/' ) );
+			$uri = untrailingslashit( $uri );
+		}
+
+		if ( ! empty( $uri ) ) {
+			$uri .= '/';
+		}
+		$permalink = str_replace( '%pagename%', "{$uri}%pagename%", $permalink );
+	}
+
+	$permalink         = array( $permalink, $post->post_name );
+	$post->post_status = $original_status;
+	$post->post_date   = $original_date;
+	$post->post_name   = $original_name;
+	unset( $post->filter );
+
+	return $permalink;
+}
+add_filter( 'get_sample_permalink', 'gutenberg_auto_draft_get_sample_permalink', 10, 5 );

--- a/packages/e2e-tests/specs/editor/various/sidebar-permalink-panel.test.js
+++ b/packages/e2e-tests/specs/editor/various/sidebar-permalink-panel.test.js
@@ -6,7 +6,6 @@ import {
 	createNewPost,
 	deactivatePlugin,
 	findSidebarPanelWithTitle,
-	openDocumentSettingsSidebar,
 	publishPost,
 } from '@wordpress/e2e-test-utils';
 
@@ -23,21 +22,8 @@ describe( 'Sidebar Permalink Panel', () => {
 		await deactivatePlugin( 'gutenberg-test-custom-post-types' );
 	} );
 
-	it( 'should not render permalink sidebar panel while the post is new', async () => {
+	it( 'should allow permalink sidebar panel to be removed', async () => {
 		await createNewPost();
-		await openDocumentSettingsSidebar();
-		expect(
-			await findSidebarPanelWithTitle( 'Permalink' )
-		).toBeUndefined();
-	} );
-
-	it( 'should render permalink sidebar panel after the post is published and allow its removal', async () => {
-		await createNewPost();
-		await page.keyboard.type( 'aaaaa' );
-		await publishPost();
-		// Start editing again.
-		await page.type( '.editor-post-title__input', ' (Updated)' );
-		expect( await findSidebarPanelWithTitle( 'Permalink' ) ).toBeDefined();
 		await page.evaluate( () => {
 			const { removeEditorPanel } = wp.data.dispatch( 'core/edit-post' );
 			removeEditorPanel( 'post-link' );

--- a/packages/edit-post/src/components/sidebar/post-link/index.js
+++ b/packages/edit-post/src/components/sidebar/post-link/index.js
@@ -27,24 +27,18 @@ function PostLink( {
 	editPermalink,
 	forceEmptyField,
 	setState,
-	postTitle,
 	postSlug,
-	postID,
 	postTypeLabel,
 } ) {
 	const { prefix, suffix } = permalinkParts;
 	let prefixElement, postNameElement, suffixElement;
-	const currentSlug =
-		safeDecodeURIComponent( postSlug ) ||
-		cleanForSlug( postTitle ) ||
-		postID;
 	if ( isEditable ) {
 		prefixElement = prefix && (
 			<span className="edit-post-post-link__link-prefix">{ prefix }</span>
 		);
-		postNameElement = currentSlug && (
+		postNameElement = postSlug && (
 			<span className="edit-post-post-link__link-post-name">
-				{ currentSlug }
+				{ postSlug }
 			</span>
 		);
 		suffixElement = suffix && (
@@ -62,7 +56,7 @@ function PostLink( {
 				<div className="editor-post-link">
 					<TextControl
 						label={ __( 'URL Slug' ) }
-						value={ forceEmptyField ? '' : currentSlug }
+						value={ forceEmptyField ? '' : postSlug }
 						onChange={ ( newValue ) => {
 							editPermalink( newValue );
 							// When we delete the field the permalink gets
@@ -127,25 +121,24 @@ function PostLink( {
 export default compose( [
 	withSelect( ( select ) => {
 		const {
-			isEditedPostNew,
 			isPermalinkEditable,
 			getCurrentPost,
 			isCurrentPostPublished,
 			getPermalinkParts,
 			getEditedPostAttribute,
+			getEditedPostSlug,
 		} = select( 'core/editor' );
 		const { isEditorPanelEnabled, isEditorPanelOpened } = select(
 			'core/edit-post'
 		);
 		const { getPostType } = select( 'core' );
 
-		const { link, id } = getCurrentPost();
+		const { link } = getCurrentPost();
 
 		const postTypeName = getEditedPostAttribute( 'type' );
 		const postType = getPostType( postTypeName );
 
 		return {
-			isNew: isEditedPostNew(),
 			postLink: link,
 			isEditable: isPermalinkEditable(),
 			isPublished: isCurrentPostPublished(),
@@ -153,16 +146,14 @@ export default compose( [
 			permalinkParts: getPermalinkParts(),
 			isEnabled: isEditorPanelEnabled( PANEL_NAME ),
 			isViewable: get( postType, [ 'viewable' ], false ),
-			postTitle: getEditedPostAttribute( 'title' ),
-			postSlug: getEditedPostAttribute( 'slug' ),
-			postID: id,
+			postSlug: safeDecodeURIComponent( getEditedPostSlug() ),
 			postTypeLabel: get( postType, [ 'labels', 'view_item' ] ),
 		};
 	} ),
 	ifCondition(
-		( { isEnabled, isNew, postLink, isViewable, permalinkParts } ) => {
+		( { isEnabled, postLink, isViewable, permalinkParts } ) => {
 			return (
-				isEnabled && ! isNew && postLink && isViewable && permalinkParts
+				isEnabled && postLink && isViewable && permalinkParts
 			);
 		}
 	),

--- a/packages/edit-post/src/components/sidebar/post-link/index.js
+++ b/packages/edit-post/src/components/sidebar/post-link/index.js
@@ -150,13 +150,9 @@ export default compose( [
 			postTypeLabel: get( postType, [ 'labels', 'view_item' ] ),
 		};
 	} ),
-	ifCondition(
-		( { isEnabled, postLink, isViewable, permalinkParts } ) => {
-			return (
-				isEnabled && postLink && isViewable && permalinkParts
-			);
-		}
-	),
+	ifCondition( ( { isEnabled, postLink, isViewable, permalinkParts } ) => {
+		return isEnabled && postLink && isViewable && permalinkParts;
+	} ),
 	withDispatch( ( dispatch ) => {
 		const { toggleEditorPanelOpened } = dispatch( 'core/edit-post' );
 		const { editPost } = dispatch( 'core/editor' );

--- a/packages/editor/src/components/post-permalink/index.js
+++ b/packages/editor/src/components/post-permalink/index.js
@@ -19,7 +19,6 @@ import { link as linkIcon } from '@wordpress/icons';
  * Internal dependencies
  */
 import PostPermalinkEditor from './editor.js';
-import { cleanForSlug } from '../../utils/url';
 
 class PostPermalink extends Component {
 	constructor() {
@@ -70,8 +69,6 @@ class PostPermalink extends Component {
 			permalinkParts,
 			postLink,
 			postSlug,
-			postID,
-			postTitle,
 		} = this.props;
 
 		if ( isNew || ! isViewable || ! permalinkParts || ! postLink ) {
@@ -84,11 +81,7 @@ class PostPermalink extends Component {
 			: __( 'Copy the permalink' );
 
 		const { prefix, suffix } = permalinkParts;
-		const slug =
-			safeDecodeURIComponent( postSlug ) ||
-			cleanForSlug( postTitle ) ||
-			postID;
-		const samplePermalink = isEditable ? prefix + slug + suffix : prefix;
+		const samplePermalink = isEditable ? prefix + postSlug + suffix : prefix;
 
 		return (
 			<div className="editor-post-permalink">
@@ -123,7 +116,7 @@ class PostPermalink extends Component {
 
 				{ isEditingPermalink && (
 					<PostPermalinkEditor
-						slug={ slug }
+						slug={ postSlug }
 						onSave={ () =>
 							this.setState( { isEditingPermalink: false } )
 						}
@@ -149,29 +142,28 @@ class PostPermalink extends Component {
 export default compose( [
 	withSelect( ( select ) => {
 		const {
-			isEditedPostNew,
+			isCleanNewPost,
 			isPermalinkEditable,
 			getCurrentPost,
 			getPermalinkParts,
 			getEditedPostAttribute,
 			isCurrentPostPublished,
+			getEditedPostSlug,
 		} = select( 'core/editor' );
 		const { getPostType } = select( 'core' );
 
-		const { id, link } = getCurrentPost();
+		const { link } = getCurrentPost();
 
 		const postTypeName = getEditedPostAttribute( 'type' );
 		const postType = getPostType( postTypeName );
 
 		return {
-			isNew: isEditedPostNew(),
+			isNew: isCleanNewPost(),
 			postLink: link,
 			permalinkParts: getPermalinkParts(),
-			postSlug: getEditedPostAttribute( 'slug' ),
+			postSlug: safeDecodeURIComponent( getEditedPostSlug() ),
 			isEditable: isPermalinkEditable(),
 			isPublished: isCurrentPostPublished(),
-			postTitle: getEditedPostAttribute( 'title' ),
-			postID: id,
 			isViewable: get( postType, [ 'viewable' ], false ),
 		};
 	} ),

--- a/packages/editor/src/components/post-permalink/index.js
+++ b/packages/editor/src/components/post-permalink/index.js
@@ -81,7 +81,9 @@ class PostPermalink extends Component {
 			: __( 'Copy the permalink' );
 
 		const { prefix, suffix } = permalinkParts;
-		const samplePermalink = isEditable ? prefix + postSlug + suffix : prefix;
+		const samplePermalink = isEditable
+			? prefix + postSlug + suffix
+			: prefix;
 
 		return (
 			<div className="editor-post-permalink">

--- a/packages/editor/src/components/post-permalink/index.js
+++ b/packages/editor/src/components/post-permalink/index.js
@@ -144,7 +144,7 @@ class PostPermalink extends Component {
 export default compose( [
 	withSelect( ( select ) => {
 		const {
-			isCleanNewPost,
+			isEditedPostNew,
 			isPermalinkEditable,
 			getCurrentPost,
 			getPermalinkParts,
@@ -160,7 +160,7 @@ export default compose( [
 		const postType = getPostType( postTypeName );
 
 		return {
-			isNew: isCleanNewPost(),
+			isNew: isEditedPostNew(),
 			postLink: link,
 			permalinkParts: getPermalinkParts(),
 			postSlug: safeDecodeURIComponent( getEditedPostSlug() ),

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -30,6 +30,7 @@ import {
 } from './constants';
 import { getPostRawValue } from './reducer';
 import serializeBlocks from './utils/serialize-blocks';
+import { cleanForSlug } from '../utils/url';
 
 /**
  * Shared reference to an empty object for cases where it is important to avoid
@@ -1147,6 +1148,23 @@ export function getPermalink( state ) {
 	}
 
 	return prefix;
+}
+
+/**
+ * Returns the slug for the post being edited, preferring a manually edited
+ * value if one exists, then a sanitized version of the current post title, and
+ * finally the post ID.
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {string} The current slug to be displayed in the editor
+ */
+export function getEditedPostSlug( state ) {
+	return (
+		getEditedPostAttribute( state, 'slug' ) ||
+		cleanForSlug( getEditedPostAttribute( state, 'title' ) ) ||
+		getCurrentPostId( state )
+	);
 }
 
 /**

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -171,6 +171,7 @@ const {
 	isPermalinkEditable,
 	getPermalink,
 	getPermalinkParts,
+	getEditedPostSlug,
 	isPostSavingLocked,
 	isPostAutosavingLocked,
 	canUserUseUnfilteredHTML,
@@ -2901,6 +2902,87 @@ describe( 'selectors', () => {
 			};
 
 			expect( getPermalinkParts( state ) ).toBeNull();
+		} );
+	} );
+
+	describe( 'getEditedPostSlug', () => {
+		it( 'should return the current post’s slug if one exists and has not been edited', () => {
+			const state = {
+				currentPost: {
+					slug: 'custom-slug',
+					title: 'Sample Post',
+				},
+				editor: {
+					present: {
+						edits: {},
+					},
+				},
+			};
+
+			expect( getEditedPostSlug( state ) ).toBe( 'custom-slug' );
+		} );
+
+		it( 'should return the edited post slug if it has been edited', () => {
+			const state = {
+				currentPost: {
+					slug: 'custom-slug',
+					title: 'Sample Post',
+				},
+				editor: {
+					present: {
+						edits: {
+							slug: 'edited-slug',
+						},
+					},
+				},
+			};
+
+			expect( getEditedPostSlug( state ) ).toBe( 'edited-slug' );
+		} );
+
+		it( 'should return the cleaned title as slug if no saved or edited slug exists', () => {
+			const state = {
+				currentPost: {
+					title: 'Sample Post',
+				},
+				editor: {
+					present: {
+						edits: {},
+					},
+				},
+			};
+
+			expect( getEditedPostSlug( state ) ).toBe( 'sample-post' );
+		} );
+
+		it( 'should return cleaned, edited title as slug if it has been edited and no saved or edited slug exists', () => {
+			const state = {
+				currentPost: {
+					title: 'Sample Post',
+				},
+				editor: {
+					present: {
+						edits: {
+							title: 'Edited Title',
+						},
+					},
+				},
+			};
+
+			expect( getEditedPostSlug( state ) ).toBe( 'edited-title' );
+		} );
+
+		it( 'should return the post ID if no slug or post title exists', () => {
+			const state = {
+				postId: 123,
+				editor: {
+					present: {
+						edits: {},
+					},
+				},
+			};
+
+			expect( getEditedPostSlug( state ) ).toBe( 123 );
 		} );
 	} );
 


### PR DESCRIPTION
## Description
Allows immediate editing of permalinks, without requiring a save. 
Fixes: #7129, #12714, #12031

Notes:
- In order edit the permalink before a save, we need to know what the permalink template structure is on page load. To get this, we need to modify `get_sample_permalink()` in core to add the `auto-save` status to the list of statuses that are faked to publish. See: [/wp-admin/includes/post.php#L1310](https://github.com/WordPress/WordPress/blob/47d32decd6668b3ccf100acc8a40aa0a9fc35003/wp-admin/includes/post.php#L1310). In the PR, I just used the `get_sample_permalink` filter at the end of the function and passed the parameters back through it, pretending it was published. I will need to open a separate core ticket to address this for whenever it's merged. 

## How has this been tested?
Extensive testing across various post statuses and different orders of editing the slug and/or title and the different methods of saving, publishing and transitioning the post status. 