### PR TITLE
Use correct translation function for assistive text

### DIFF
--- a/packages/editor/src/store/effects.js
+++ b/packages/editor/src/store/effects.js
@@ -14,7 +14,7 @@ import {
 	doBlocksMatchTemplate,
 	synchronizeBlocksWithTemplate,
 } from '@wordpress/blocks';
-import { __, sprintf } from '@wordpress/i18n';
+import { _n, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -267,6 +267,6 @@ export default {
 	MULTI_SELECT: ( action, { getState } ) => {
 		const blockCount = getSelectedBlockCount( getState() );
 
-		speak( sprintf( __( '%s blocks selected.' ), blockCount ), 'assertive' );
+		speak( sprintf( _n( '%s block selected.', '%s blocks selected.', blockCount ), blockCount ), 'assertive' );
 	},
 };

--- a/packages/editor/src/store/effects.js
+++ b/packages/editor/src/store/effects.js
@@ -267,6 +267,7 @@ export default {
 	MULTI_SELECT: ( action, { getState } ) => {
 		const blockCount = getSelectedBlockCount( getState() );
 
+		/* translators: %s: number of selected blocks */
 		speak( sprintf( _n( '%s block selected.', '%s blocks selected.', blockCount ), blockCount ), 'assertive' );
 	},
 };


### PR DESCRIPTION
## Description
The "%s blocks selected." message needs to use the `_n()` translation function for proper internationalization. Otherwise the wording is not correct for cases where there's only 1 block selected, for example.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
