### PR TITLE
Delay private publish

### DIFF
--- a/packages/e2e-tests/specs/editor/various/post-visibility.test.js
+++ b/packages/e2e-tests/specs/editor/various/post-visibility.test.js
@@ -60,7 +60,12 @@ describe( 'Post visibility', () => {
 		const [ privateLabel ] = await page.$x( '//label[text()="Private"]' );
 		await privateLabel.click();
 
-		// Enter a title for this post.
+		// Publish private post
+		await page.click( '.editor-post-publish-panel__toggle' );
+
+		await page.click( '.editor-post-publish-button' );
+
+		// Enter a new title for this post.
 		await page.type( '.editor-post-title__input', ' Changed' );
 
 		await page.click( '.editor-post-publish-button' );

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -165,14 +165,19 @@ export class PostPublishButton extends Component {
 			onClick: this.createOnClick( onClickToggle ),
 		};
 
-		const toggleChildren = isBeingScheduled
-			? __( 'Schedule…' )
-			: __( 'Publish' );
+		let toggleChildren;
+		if ( isBeingScheduled ) {
+			toggleChildren = __( 'Schedule…' );
+		} else if ( 'private' === visibility ) {
+			toggleChildren = __( 'Publish Privately…' );
+		} else {
+			toggleChildren = __( 'Publish…' );
+		}
 		const buttonChildren = (
 			<PublishButtonLabel
 				forceIsSaving={ forceIsSaving }
 				hasNonPostEntityChanges={ hasNonPostEntityChanges }
-			/>
+			/>;
 		);
 
 		const componentProps = isToggle ? toggleProps : buttonProps;

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -165,9 +165,10 @@ export class PostPublishButton extends Component {
 			onClick: this.createOnClick( onClickToggle ),
 		};
 
-		const toggleChildren = isBeingScheduled
-			? __( 'Schedule…' )
-			: __( 'Publish' );
+		const toggleChildren =
+			isBeingScheduled && publishStatus !== 'private'
+				? __( 'Schedule…' )
+				: __( 'Publish' );
 		const buttonChildren = (
 			<PublishButtonLabel
 				forceIsSaving={ forceIsSaving }

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -167,7 +167,7 @@ export class PostPublishButton extends Component {
 
 		const toggleChildren = isBeingScheduled
 			? __( 'Schedule…' )
-			: __( 'Publish…' );
+			: __( 'Publish' );
 		const buttonChildren = (
 			<PublishButtonLabel
 				forceIsSaving={ forceIsSaving }

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -165,19 +165,14 @@ export class PostPublishButton extends Component {
 			onClick: this.createOnClick( onClickToggle ),
 		};
 
-		let toggleChildren;
-		if ( 'private' === visibility ) {
-			toggleChildren = __( 'Publish Privately…' );
-		} else if ( isBeingScheduled ) {
-			toggleChildren = __( 'Schedule…' );
-		} else {
-			toggleChildren = __( 'Publish…' );
-		}
+		const toggleChildren = isBeingScheduled
+			? __( 'Schedule…' )
+			: __( 'Publish…' );
 		const buttonChildren = (
 			<PublishButtonLabel
 				forceIsSaving={ forceIsSaving }
 				hasNonPostEntityChanges={ hasNonPostEntityChanges }
-			/>;
+			/>
 		);
 
 		const componentProps = isToggle ? toggleProps : buttonProps;

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -166,10 +166,10 @@ export class PostPublishButton extends Component {
 		};
 
 		let toggleChildren;
-		if ( isBeingScheduled ) {
-			toggleChildren = __( 'Schedule…' );
-		} else if ( 'private' === visibility ) {
+		if ( 'private' === visibility ) {
 			toggleChildren = __( 'Publish Privately…' );
+		} else if ( isBeingScheduled ) {
+			toggleChildren = __( 'Schedule…' );
 		} else {
 			toggleChildren = __( 'Publish…' );
 		}

--- a/packages/editor/src/components/post-publish-button/label.js
+++ b/packages/editor/src/components/post-publish-button/label.js
@@ -35,7 +35,7 @@ export function PublishButtonLabel( {
 	} else if ( isBeingScheduled && 'private' !== visibility ) {
 		return hasNonPostEntityChanges ? __( 'Schedule…' ) : __( 'Schedule' );
 	} else if ( isPublished ) {
-		return hasNonPostEntityChanges ? __( 'Update…' ) : __( 'Update' ) ;
+		return hasNonPostEntityChanges ? __( 'Update…' ) : __( 'Update' );
 	}
 
 	return __( 'Publish' );

--- a/packages/editor/src/components/post-publish-button/label.js
+++ b/packages/editor/src/components/post-publish-button/label.js
@@ -29,25 +29,13 @@ export function PublishButtonLabel( {
 	}
 
 	if ( ! hasPublishAction ) {
-<<<<<<< HEAD
 		return hasNonPostEntityChanges
 			? __( 'Submit for Review…' )
 			: __( 'Submit for Review' );
-	} else if ( isPublished ) {
-		return hasNonPostEntityChanges ? __( 'Update…' ) : __( 'Update' );
-	} else if ( isBeingScheduled ) {
-		return hasNonPostEntityChanges ? __( 'Schedule…' ) : __( 'Schedule' );
-	}
-
-	if ( 'private' === visibility ) {
-		return __( 'Publish Privately' );
-=======
-		return __( 'Submit for Review' );
 	} else if ( isBeingScheduled && 'private' !== visibility ) {
-		return __( 'Schedule' );
+		return hasNonPostEntityChanges ? __( 'Schedule…' ) : __( 'Schedule' );
 	} else if ( isPublished ) {
-		return __( 'Update' );
->>>>>>> Handle proper labeling for scheduled private posts
+		return hasNonPostEntityChanges ? __( 'Update…' ) : __( 'Update' ) ;
 	}
 
 	return __( 'Publish' );

--- a/packages/editor/src/components/post-publish-button/label.js
+++ b/packages/editor/src/components/post-publish-button/label.js
@@ -18,6 +18,7 @@ export function PublishButtonLabel( {
 	hasPublishAction,
 	isAutosaving,
 	hasNonPostEntityChanges,
+	visibility,
 } ) {
 	if ( isPublishing ) {
 		return __( 'Publishing…' );
@@ -37,6 +38,10 @@ export function PublishButtonLabel( {
 		return hasNonPostEntityChanges ? __( 'Schedule…' ) : __( 'Schedule' );
 	}
 
+	if ( 'private' === visibility ) {
+		return __( 'Publish Privately' );
+	}
+
 	return __( 'Publish' );
 }
 
@@ -50,6 +55,7 @@ export default compose( [
 			getCurrentPost,
 			getCurrentPostType,
 			isAutosavingPost,
+			getEditedPostVisibility,
 		} = select( 'core/editor' );
 		return {
 			isPublished: isCurrentPostPublished(),
@@ -63,6 +69,7 @@ export default compose( [
 			),
 			postType: getCurrentPostType(),
 			isAutosaving: isAutosavingPost(),
+			visibility: getEditedPostVisibility(),
 		};
 	} ),
 ] )( PublishButtonLabel );

--- a/packages/editor/src/components/post-publish-button/label.js
+++ b/packages/editor/src/components/post-publish-button/label.js
@@ -43,8 +43,6 @@ export function PublishButtonLabel( {
 		return __( 'Publish Privately' );
 =======
 		return __( 'Submit for Review' );
-	} else if ( ! isPublished && 'private' === visibility ) {
-		return __( 'Publish Privately' );
 	} else if ( isBeingScheduled && 'private' !== visibility ) {
 		return __( 'Schedule' );
 	} else if ( isPublished ) {

--- a/packages/editor/src/components/post-publish-button/label.js
+++ b/packages/editor/src/components/post-publish-button/label.js
@@ -29,6 +29,7 @@ export function PublishButtonLabel( {
 	}
 
 	if ( ! hasPublishAction ) {
+<<<<<<< HEAD
 		return hasNonPostEntityChanges
 			? __( 'Submit for Review…' )
 			: __( 'Submit for Review' );
@@ -40,6 +41,15 @@ export function PublishButtonLabel( {
 
 	if ( 'private' === visibility ) {
 		return __( 'Publish Privately' );
+=======
+		return __( 'Submit for Review' );
+	} else if ( ! isPublished && 'private' === visibility ) {
+		return __( 'Publish Privately' );
+	} else if ( isBeingScheduled && 'private' !== visibility ) {
+		return __( 'Schedule' );
+	} else if ( isPublished ) {
+		return __( 'Update' );
+>>>>>>> Handle proper labeling for scheduled private posts
 	}
 
 	return __( 'Publish' );

--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -24,6 +24,7 @@ function PostPublishPanelPrepublish( {
 	hasPublishAction,
 	isBeingScheduled,
 	children,
+	visibility,
 } ) {
 	let prePublishTitle, prePublishBodyText;
 
@@ -32,7 +33,7 @@ function PostPublishPanelPrepublish( {
 		prePublishBodyText = __(
 			'When you’re ready, submit your work for review, and an Editor will be able to approve it for you.'
 		);
-	} else if ( isBeingScheduled ) {
+	} else if ( isBeingScheduled && 'private' !== visibility ) {
 		prePublishTitle = __( 'Are you ready to schedule?' );
 		prePublishBodyText = __(
 			'Your work will be published at the specified date and time.'
@@ -90,9 +91,11 @@ function PostPublishPanelPrepublish( {
 }
 
 export default withSelect( ( select ) => {
-	const { getCurrentPost, isEditedPostBeingScheduled } = select(
-		'core/editor'
-	);
+	const {
+		getCurrentPost,
+		isEditedPostBeingScheduled,
+		getEditedPostVisibility,
+	} = select( 'core/editor' );
 	return {
 		hasPublishAction: get(
 			getCurrentPost(),
@@ -100,5 +103,6 @@ export default withSelect( ( select ) => {
 			false
 		),
 		isBeingScheduled: isEditedPostBeingScheduled(),
+		visibility: getEditedPostVisibility(),
 	};
 } )( PostPublishPanelPrepublish );

--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -56,6 +56,7 @@ export class PostSavedState extends Component {
 			isAutosaving,
 			isPending,
 			isLargeViewport,
+			isPrivate,
 		} = this.props;
 		const { forceSavedMessage } = this.state;
 		if ( isSaving ) {
@@ -93,7 +94,7 @@ export class PostSavedState extends Component {
 			return <PostSwitchToDraftButton />;
 		}
 
-		if ( ! isSaveable ) {
+		if ( ! isSaveable || isPrivate ) {
 			return null;
 		}
 
@@ -166,6 +167,7 @@ export default compose( [
 			isSaveable: isEditedPostSaveable(),
 			isAutosaving: isAutosavingPost(),
 			isPending: 'pending' === getEditedPostAttribute( 'status' ),
+			isPrivate: 'private' === getEditedPostAttribute( 'status' ),
 		};
 	} ),
 	withDispatch( ( dispatch ) => ( {

--- a/packages/editor/src/components/post-visibility/index.js
+++ b/packages/editor/src/components/post-visibility/index.js
@@ -151,12 +151,7 @@ export default compose( [
 	withDispatch( ( dispatch ) => {
 		const { editPost } = dispatch( 'core/editor' );
 		return {
-<<<<<<< HEAD
-			onSave: savePost,
 			onUpdateVisibility( status, password = '' ) {
-=======
-			onUpdateVisibility( status, password = null ) {
->>>>>>> Prevent publishing on visibility change to private
 				editPost( { status, password } );
 			},
 		};

--- a/packages/editor/src/components/post-visibility/index.js
+++ b/packages/editor/src/components/post-visibility/index.js
@@ -33,20 +33,10 @@ export class PostVisibility extends Component {
 	}
 
 	setPrivate() {
-		if (
-			// eslint-disable-next-line no-alert
-			! window.confirm(
-				__( 'Would you like to privately publish this post now?' )
-			)
-		) {
-			return;
-		}
-
-		const { onUpdateVisibility, onSave } = this.props;
+		const { onUpdateVisibility } = this.props;
 
 		onUpdateVisibility( 'private' );
 		this.setState( { hasPassword: false } );
-		onSave();
 	}
 
 	setPasswordProtected() {
@@ -159,10 +149,14 @@ export default compose( [
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { savePost, editPost } = dispatch( 'core/editor' );
+		const { editPost } = dispatch( 'core/editor' );
 		return {
+<<<<<<< HEAD
 			onSave: savePost,
 			onUpdateVisibility( status, password = '' ) {
+=======
+			onUpdateVisibility( status, password = null ) {
+>>>>>>> Prevent publishing on visibility change to private
 				editPost( { status, password } );
 			},
 		};

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -746,7 +746,12 @@ export function isEditedPostBeingScheduled( state ) {
  * infer that a post is set to publish "Immediately" we check whether the date
  * and modified date are the same.
  *
- * @param {Object} state Editor state.
+ * Additionally, "private" is a post status that is similar to published, but a
+ * post can be set to private, but not yet saved to the database. In this case,
+ * the date should still be considered floating until the status is offically
+ * saved.
+ *
+ * @param  {Object}  state Editor state.
  *
  * @return {boolean} Whether the edited post has a floating date value.
  */
@@ -754,10 +759,12 @@ export function isEditedPostDateFloating( state ) {
 	const date = getEditedPostAttribute( state, 'date' );
 	const modified = getEditedPostAttribute( state, 'modified' );
 	const status = getEditedPostAttribute( state, 'status' );
+	const savedStatus = getCurrentPostAttribute( state, 'status' );
 	if (
 		status === 'draft' ||
 		status === 'auto-draft' ||
-		status === 'pending'
+		status === 'pending' ||
+		( status === 'private' && status !== savedStatus )
 	) {
 		return date === modified;
 	}

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -746,11 +746,6 @@ export function isEditedPostBeingScheduled( state ) {
  * infer that a post is set to publish "Immediately" we check whether the date
  * and modified date are the same.
  *
- * Additionally, "private" is a post status that is similar to published, but a
- * post can be set to private, but not yet saved to the database. In this case,
- * the date should still be considered floating until the status is offically
- * saved.
- *
  * @param  {Object}  state Editor state.
  *
  * @return {boolean} Whether the edited post has a floating date value.


### PR DESCRIPTION
**Update:** This PR no longer changes the verbiage on the Publish button per feedback. [See updates below](https://github.com/WordPress/gutenberg/pull/12023#issuecomment-494741488) for most recent details.

## Description
This is an approach to setting private visibility that doesn't immediately publish the post. Instead it changes the verbiage on the publish button and disables the save draft button, allowing a user to continue working on the post before going live. 

Fixes #9396 

## Screenshots <!-- if applicable -->
### With the pre-publish panel
![private-publish-prompt](https://user-images.githubusercontent.com/4267290/48665383-37a16080-ea7b-11e8-8392-016d3c45e024.gif)

### With immediate publish
![immediate-private-publish](https://user-images.githubusercontent.com/4267290/48665385-3a9c5100-ea7b-11e8-9e4c-f581e8941b5a.gif)
