### PR TITLE
Sidebar permalink panel a11y improvements

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-link/index.js
+++ b/packages/edit-post/src/components/sidebar/post-link/index.js
@@ -8,7 +8,7 @@ import { get } from 'lodash';
  */
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { PanelBody, TextControl } from '@wordpress/components';
+import { PanelBody, TextControl, ExternalLink } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose, ifCondition, withState } from '@wordpress/compose';
 import { addQueryArgs } from '@wordpress/url';
@@ -77,7 +77,7 @@ function PostLink( {
 			<p className="edit-post-post-link__preview-label">
 				{ __( 'Preview' ) }
 			</p>
-			<a
+			<ExternalLink
 				className="edit-post-post-link__link"
 				href={ postLink }
 				target="_blank"
@@ -88,14 +88,14 @@ function PostLink( {
 					</Fragment> ) :
 					postLink
 				}
-			</a>
-			<a
+			</ExternalLink>
+			<ExternalLink
 				className="edit-post-post-link__permalink-settings"
 				href={ addQueryArgs( 'options-permalink.php' ) }
 				target="_blank"
 			>
 				{ __( 'Permalink Settings' ) }
-			</a>
+			</ExternalLink>
 		</PanelBody>
 	);
 }

--- a/packages/edit-post/src/components/sidebar/post-link/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-link/style.scss
@@ -1,9 +1,5 @@
-.edit-post-post-link__link {
-	font-weight: 600;
-}
-
 .edit-post-post-link__link-post-name {
-	font-weight: 800;
+	font-weight: 600;
 }
 
 .edit-post-post-link__preview-label {
@@ -16,6 +12,5 @@
 
 .edit-post-post-link__permalink-settings {
 	margin-top: 1em;
-	font-weight: 500;
 	display: block;
 }


### PR DESCRIPTION
Splitting this out from #11874

<img width="303" alt="screenshot 2018-11-18 at 14 45 44" src="https://user-images.githubusercontent.com/1682452/48673352-b14f5200-eb40-11e8-8611-cc19ecb50aa5.png">

In the new permalink sidebar panel, the "Preview" and "Permalink Settings" links use `target="_blank"` but users are not informed the link is going to open in a new browser's tab. Gutenberg has a component for this: `ExternalLink`, which adds the standard visually hidden text `(opens in a new tab)` and also adds an icon.

This PR uses `ExternalLink` for these two links.

Also, the value core currently used for the `bold` font weight is `600`. See https://github.com/WordPress/gutenberg/issues/11687, https://github.com/WordPress/gutenberg/issues/5848, and, more importantly, https://core.trac.wordpress.org/changeset/37740. Core doesn't use `800` or `500`. The second commit in this PR changes the links font weight to a normal weight and keeps the `post-name` part of the link bold.

Screenshot after:

<img width="308" alt="screenshot 2018-11-18 at 14 45 22" src="https://user-images.githubusercontent.com/1682452/48673432-b234b380-eb41-11e8-9536-f119262797b4.png">


