### PR TITLE
Enable previewing changes to the post featured image

### DIFF
--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -12,6 +12,7 @@ import { __, _x } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { DotTip } from '@wordpress/nux';
 import { ifCondition, compose } from '@wordpress/compose';
+import { addQueryArgs } from '@wordpress/url';
 
 function writeInterstitialMessage( targetDocument ) {
 	let markup = renderToString(
@@ -203,11 +204,18 @@ export default compose( [
 		const {
 			getPostType,
 		} = select( 'core' );
+
+		let previewLink = getAutosaveAttribute( 'preview_link' );
+		const featuredImageId = getEditedPostAttribute( 'featured_media' );
+		if ( previewLink && featuredImageId ) {
+			previewLink = addQueryArgs( previewLink, { _thumbnail_id: featuredImageId } );
+		}
+
 		const postType = getPostType( getEditedPostAttribute( 'type' ) );
 		return {
 			postId: getCurrentPostId(),
 			currentPostLink: getCurrentPostAttribute( 'link' ),
-			previewLink: getAutosaveAttribute( 'preview_link' ),
+			previewLink,
 			isSaveable: isEditedPostSaveable(),
 			isAutosaveable: isEditedPostAutosaveable(),
 			isViewable: get( postType, [ 'viewable' ], false ),


### PR DESCRIPTION
Fixes partially https://github.com/WordPress/gutenberg/issues/9151

Match the Classic Editor's behaviour by appending _thumbnail_id to the
post preview URL so that changes to the featured image are visible.

## Description
Pass the featured image id to the preview screen.  Currently only works with published posts (possibly resolved by https://github.com/WordPress/gutenberg/pull/11409)

## How has this been tested?
* Publish a post.
* change the featured image.
* without saving the post, click preview - the preview will show the newly selected featured image.

## Screenshots <!-- if applicable -->

## Types of changes
* Add the featured image id as a query var when opening the preview pane


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
