### PR TITLE
Remove permalink-based features from nonpublic CPTs

### DIFF
--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -40,8 +40,8 @@ export class PostPublishPanel extends Component {
 	}
 
 	onSubmit() {
-		const { onClose, hasPublishAction } = this.props;
-		if ( ! hasPublishAction ) {
+		const { onClose, hasPublishAction, isPostTypeViewable } = this.props;
+		if ( ! hasPublishAction || ! isPostTypeViewable ) {
 			onClose();
 		}
 	}
@@ -61,7 +61,7 @@ export class PostPublishPanel extends Component {
 			PrePublishExtension,
 			...additionalProps
 		} = this.props;
-		const propsForPanel = omit( additionalProps, [ 'hasPublishAction', 'isDirty' ] );
+		const propsForPanel = omit( additionalProps, [ 'hasPublishAction', 'isDirty', 'isPostTypeViewable' ] );
 		const isPublishedOrScheduled = isPublished || ( isScheduled && isBeingScheduled );
 		const isPrePublish = ! isPublishedOrScheduled && ! isSaving;
 		const isPostPublish = isPublishedOrScheduled && ! isSaving;
@@ -112,8 +112,10 @@ export class PostPublishPanel extends Component {
 
 export default compose( [
 	withSelect( ( select ) => {
+		const { getPostType } = select( 'core' );
 		const {
 			getCurrentPost,
+			getEditedPostAttribute,
 			isCurrentPostPublished,
 			isCurrentPostScheduled,
 			isEditedPostBeingScheduled,
@@ -121,8 +123,11 @@ export default compose( [
 			isSavingPost,
 		} = select( 'core/editor' );
 		const { isPublishSidebarEnabled } = select( 'core/editor' );
+		const postType = getPostType( getEditedPostAttribute( 'type' ) );
+
 		return {
 			hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
+			isPostTypeViewable: get( postType, [ 'viewable' ], false ),
 			isBeingScheduled: isEditedPostBeingScheduled(),
 			isDirty: isEditedPostDirty(),
 			isPublished: isCurrentPostPublished(),

--- a/packages/editor/src/store/effects/posts.js
+++ b/packages/editor/src/store/effects/posts.js
@@ -183,7 +183,7 @@ export const requestPostUpdateSuccess = ( action ) => {
 	const willPublish = includes( publishStatus, post.status );
 
 	let noticeMessage;
-	let shouldShowLink = true;
+	let shouldShowLink = postType.viewable;
 
 	if ( ! isPublished && ! willPublish ) {
 		// If saving a non-published post, don't show notice.

--- a/packages/editor/src/store/effects/posts.js
+++ b/packages/editor/src/store/effects/posts.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { BEGIN, COMMIT, REVERT } from 'redux-optimist';
-import { pick, includes } from 'lodash';
+import { get, pick, includes } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -183,7 +183,7 @@ export const requestPostUpdateSuccess = ( action ) => {
 	const willPublish = includes( publishStatus, post.status );
 
 	let noticeMessage;
-	let shouldShowLink = postType.viewable;
+	let shouldShowLink = get( postType, [ 'viewable' ], false );
 
 	if ( ! isPublished && ! willPublish ) {
 		// If saving a non-published post, don't show notice.

--- a/packages/editor/src/store/test/effects.js
+++ b/packages/editor/src/store/test/effects.js
@@ -245,6 +245,7 @@ describe( 'effects', () => {
 				item_reverted_to_draft: 'Post reverted to draft.',
 				item_updated: 'Post updated.',
 			},
+			viewable: true,
 		} );
 
 		it( 'should dispatch notices when publishing or scheduling a post', () => {
@@ -261,6 +262,22 @@ describe( 'effects', () => {
 					actions: [
 						{ label: 'View post', url: undefined },
 					],
+				}
+			);
+		} );
+
+		it( 'should dispatch notices when publishing or scheduling an unviewable post', () => {
+			const previousPost = getDraftPost();
+			const post = getPublishedPost();
+			const postType = { ...getPostType(), viewable: false };
+
+			handler( { post, previousPost, postType } );
+
+			expect( dataDispatch( 'core/notices' ).createSuccessNotice ).toHaveBeenCalledWith(
+				'Post published.',
+				{
+					id: SAVE_POST_NOTICE_ID,
+					actions: [],
 				}
 			);
 		} );


### PR DESCRIPTION
## Description

Fixes #12008.
Using the released version of the plugin, I came across the error described in #12008 when enabling the new editor for a non-public CPT with an admin UI. I think that issue has been resolved in this repo (and can probably be closed) since the last release, but I found a few other small things to update for non-public CPTs. This PR makes the following changes:

1. Remove the "View Post" link from the publish post notice in the editor. Now it just says "Post published".
2. Skip the "What's next?" sidebar step for non-public CPT because it only pertains to permalinks, which aren't applicable to nonpublic CPTs. If other content is added to this sidebar in the future, the permalink section can be omitted instead of skipping the sidebar step. With this change, when the user confirms publish, the sidebar goes back to the default view instead of to "What's next?"


## How has this been tested?
A failing unit test was resolved, and a new unit test added. Tested in the browser using both a non-public CPT and the built-in `post` type (where everything should be unchanged).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
