### PR TITLE
Fix small visual regression with button variation preview.

### DIFF
--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -31,6 +31,11 @@ $blocks-button__line-height: $big-font-size + 6px;
 		opacity: 0.8;
 	}
 
+	// Polish the empty placeholder text for the button in variation previews.
+	.editor-rich-text__tinymce[data-is-placeholder-visible="true"] {
+		height: auto;
+	}
+
 	// Don't let the placeholder text wrap in the variation preview.
 	.editor-block-preview__content & {
 		max-width: 100%;


### PR DESCRIPTION
In https://github.com/WordPress/gutenberg/pull/11757/files#diff-9bc45fdf28d434e26e152546f25fd08eR101, a change was introduced to how custom placeholder text works.

Custom placeholder text is basically a duplicate version of the text, which holds the visual placeholder. The height change as linked above was added to make sure the two elements are in sync, height-wise. Which is important for when the placeholder text wraps.

The Button styles this placeholder directly, which means it changes things sligtly in this regard. The long term solution would be to refactor this slightly, so that we don't style this placeholder, but instead style a parent element in the editor. But in the mean time, this PR fixes the current markup and CSS.

Before:

<img width="492" alt="screenshot 2018-11-19 at 10 48 04" src="https://user-images.githubusercontent.com/1204802/48699245-49087b00-ebe9-11e8-85a2-bda3e38af02a.png">

After:

<img width="491" alt="screenshot 2018-11-19 at 10 47 06" src="https://user-images.githubusercontent.com/1204802/48699247-4b6ad500-ebe9-11e8-8af2-3b6bb096ff2c.png">
