### PR TITLE
Do not show the block settings menu plugin slot if block doesn't exist

### DIFF
--- a/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-group.js
+++ b/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-group.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, map } from 'lodash';
+import { filter, isEmpty, map } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -12,10 +12,14 @@ import { withSelect } from '@wordpress/data';
 
 const { Fill: PluginBlockSettingsMenuGroup, Slot } = createSlotFill( 'PluginBlockSettingsMenuGroup' );
 
-const PluginBlockSettingsMenuGroupSlot = ( { fillProps, selectedBlocks } ) => {
-	selectedBlocks = map( selectedBlocks, ( block ) => block.name );
+export const PluginBlockSettingsMenuGroupSlot = ( { fillProps, selectedBlocks } ) => {
+	const blockNames = map( filter( selectedBlocks, ( block ) => ( block !== null ) && block.name ), ( block ) => block.name );
+	if ( blockNames.length === 0 ) {
+		return null;
+	}
+
 	return (
-		<Slot fillProps={ { ...fillProps, selectedBlocks } } >
+		<Slot fillProps={ { ...fillProps, selectedBlocks: blockNames } } >
 			{ ( fills ) => ! isEmpty( fills ) && (
 				<Fragment>
 					<div className="editor-block-settings-menu__separator" />

--- a/packages/edit-post/src/components/block-settings-menu/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/block-settings-menu/test/__snapshots__/index.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PluginBlockSettingsMenuGroupSlot should render normally if block selected has name property 1`] = `
+<PluginBlockSettingsMenuGroupSlot
+  fillProps={
+    Object {
+      "selectedBlocks": Array [
+        "paragraph",
+      ],
+    }
+  }
+>
+  [Function]
+</PluginBlockSettingsMenuGroupSlot>
+`;

--- a/packages/edit-post/src/components/block-settings-menu/test/index.js
+++ b/packages/edit-post/src/components/block-settings-menu/test/index.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies.
+ */
+import ShallowRenderer from 'react-test-renderer/shallow';
+
+/**
+ * Internal dependencies.
+ */
+import { PluginBlockSettingsMenuGroupSlot } from '../plugin-block-settings-menu-group';
+
+describe( 'PluginBlockSettingsMenuGroupSlot', () => {
+	test( 'should render normally if block selected has name property', () => {
+		const renderer = new ShallowRenderer();
+		renderer.render(
+			<PluginBlockSettingsMenuGroupSlot selectedBlocks={ [ { name: 'paragraph' } ] } />
+		);
+
+		expect( renderer.getRenderOutput() ).toMatchSnapshot();
+	} );
+
+	test( 'should be hidden if no block is selected', () => {
+		const renderer = new ShallowRenderer();
+		renderer.render(
+			<PluginBlockSettingsMenuGroupSlot selectedBlocks={ [ null ] } />
+		);
+
+		expect( renderer.getRenderOutput() ).toBeNull();
+	} );
+
+	test( 'should be hidden if block selected has no name declared', () => {
+		const renderer = new ShallowRenderer();
+		renderer.render(
+			<PluginBlockSettingsMenuGroupSlot selectedBlocks={ [ {} ] } />
+		);
+
+		expect( renderer.getRenderOutput() ).toBeNull();
+	} );
+} );


### PR DESCRIPTION
Do not show the block settings menu plugin slot if the selected block doesn't exist.

**Please, consider this PR together with https://github.com/WordPress/gutenberg/pull/12214 We only want to merge one of them**

## How to test

* Clone https://github.com/nosolosw/blocksettingsmenu-plugin/
* Add the plugin to your docker, by adding `- <path-to-cloned-blocksettingsmenurepo>:/var/www/html/wp-content/plugins/gutenberg-block-settings-plugin` to your wordpress volume section in your docker-compose.yml.
* Start up your docker setup, activate the Block Settings Menu plugin.
* Open a post in Unified Toolbar mode.
* Select a block and click the block settings menu.
* Make sure there is a new item called `My new plugin`.

![screenshot from 2018-11-19 11-59-12](https://user-images.githubusercontent.com/583546/48702946-950bed80-ebf2-11e8-9d5c-518a5019c030.png)

* Click Duplicate block.
* Then click Undo button.
* Open the block settings menu and make sure the `My new plugin` is not shown.

![screenshot from 2018-11-19 12-00-05](https://user-images.githubusercontent.com/583546/48702992-b967ca00-ebf2-11e8-970a-8c8a645c3245.png)

