### PR TITLE
Fix undefined variable warning in gutenberg.php

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -67,10 +67,6 @@ function the_gutenberg_project() {
  * @since 0.1.0
  */
 function gutenberg_menu() {
-	global $post;
-	if ( ! gutenberg_can_edit_post( $post ) ) {
-		return;
-	}
 	global $submenu;
 
 	add_menu_page(

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -67,6 +67,7 @@ function the_gutenberg_project() {
  * @since 0.1.0
  */
 function gutenberg_menu() {
+	global $post;
 	if ( ! gutenberg_can_edit_post( $post ) ) {
 		return;
 	}


### PR DESCRIPTION
Introduced an undefined global `$post` variable in 095d18fe5f1b55ab243cdba947740542e5b0fe47. 

Quick fix for that. 

closes #12061