### PR TITLE
Editor Store: Make refreshPost() effect bypass cache by using a new apiFetch option

### DIFF
--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -46,7 +46,10 @@ function registerMiddleware( middleware ) {
 
 function apiFetch( options ) {
 	const raw = ( nextOptions ) => {
-		const { url, path, data, parse = true, ...remainingOptions } = nextOptions;
+		// TODO: We should set eslint's `no-unused-vars` rule's `ignoreRestSiblings` option to true
+		// (https://eslint.org/docs/rules/no-unused-vars#ignorerestsiblings) and remove the next line.
+		// eslint-disable-next-line no-unused-vars
+		const { url, path, data, parse = true, usePreloaded = true, ...remainingOptions } = nextOptions;
 		let { body, headers } = nextOptions;
 
 		// Merge explicitly-provided headers with default values.

--- a/packages/api-fetch/src/middlewares/preloading.js
+++ b/packages/api-fetch/src/middlewares/preloading.js
@@ -27,8 +27,8 @@ const createPreloadingMiddleware = ( preloadedData ) => ( options, next ) => {
 			.join( '&' );
 	}
 
-	const { parse = true } = options;
-	if ( typeof options.path === 'string' ) {
+	const { parse = true, usePreloaded = true } = options;
+	if ( usePreloaded && typeof options.path === 'string' ) {
 		const method = options.method || 'GET';
 		const path = getStablePath( options.path );
 

--- a/packages/editor/src/store/effects/posts.js
+++ b/packages/editor/src/store/effects/posts.js
@@ -313,6 +313,7 @@ export const refreshPost = async ( action, store ) => {
 	const postType = await resolveSelector( 'core', 'getPostType', postTypeSlug );
 	const newPost = await apiFetch( {
 		path: `/wp/v2/${ postType.rest_base }/${ post.id }?context=edit`,
+		usePreloaded: false,
 	} );
 	dispatch( resetPost( newPost ) );
 };


### PR DESCRIPTION
## Description
- apiFetch: Add `usePreloaded` option to allow bypassing the cache
- Editor Store: Make `refreshPost()` effect bypass cache (by setting `usePreloaded` to `true`)

## How has this been tested?
See  #12055 for instructions to reproduce the issue (on `master`).
Verify that on this branch, entering `wp.data.dispatch( 'core/editor' ).refreshPost()` into your browser console _does_ fire a network request.
Verify that any other network requests for routes that are preloaded still use cached data, i.e. don't fire network requests -- for a list, see https://github.com/WordPress/gutenberg/blob/b198e5c4791b2282332def0de89841cd64d75f8e/lib/client-assets.php#L1038-L1047 

## Types of changes
Bug fix -- fixes #12055

## Checklist
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

/cc @tyxla @youknowriad 