### PR TITLE
Editor Store: Have refreshPost() effect bypass caching

### DIFF
--- a/packages/editor/src/store/effects/posts.js
+++ b/packages/editor/src/store/effects/posts.js
@@ -312,8 +312,8 @@ export const refreshPost = async ( action, store ) => {
 	const postTypeSlug = getCurrentPostType( getState() );
 	const postType = await resolveSelector( 'core', 'getPostType', postTypeSlug );
 	const newPost = await apiFetch( {
-		// Use timestamp to bypass caching
-		path: `/wp/v2/${ postType.rest_base }/${ post.id }?context=edit&timestamp=${ Date.now() }`,
+		// Timestamp arg allows caller to bypass browser caching, which is expected for this specific function.
+		path: `/wp/v2/${ postType.rest_base }/${ post.id }?context=edit&_timestamp=${ Date.now() }`,
 	} );
 	dispatch( resetPost( newPost ) );
 };

--- a/packages/editor/src/store/effects/posts.js
+++ b/packages/editor/src/store/effects/posts.js
@@ -312,7 +312,8 @@ export const refreshPost = async ( action, store ) => {
 	const postTypeSlug = getCurrentPostType( getState() );
 	const postType = await resolveSelector( 'core', 'getPostType', postTypeSlug );
 	const newPost = await apiFetch( {
-		path: `/wp/v2/${ postType.rest_base }/${ post.id }?context=edit`,
+		// Use timestamp to bypass caching
+		path: `/wp/v2/${ postType.rest_base }/${ post.id }?context=edit&timestamp=${ Date.now() }`,
 	} );
 	dispatch( resetPost( newPost ) );
 };


### PR DESCRIPTION
## Description
Make `refreshPost()` effect bypass caching (by adding a `timestamp` query arg)

## How has this been tested?
See  #12055 for instructions to reproduce the issue (on `master`).
Verify that on this branch, entering `wp.data.dispatch( 'core/editor' ).refreshPost()` into your browser console _does_ fire a network request.
Verify that any other network requests for routes that are preloaded still use cached data, i.e. don't fire network requests -- for a list, see https://github.com/WordPress/gutenberg/blob/b198e5c4791b2282332def0de89841cd64d75f8e/lib/client-assets.php#L1038-L1047 

## Types of changes
Bug fix -- fixes #12055. Alternative approach to #12058, prompted by @youknowriad's [suggestion](https://github.com/WordPress/gutenberg/pull/12058#discussion_r234601808).

## Checklist
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

/cc @tyxla 