### PR TITLE
Remove .md only commit check in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,6 @@ cache:
     - $HOME/.npm
 
 before_install:
-  - |
-    git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)' || {
-      echo "Only docs were updated, stopping build process."
-      exit
-    }
   - nvm install && nvm use
   - npm install npm -g
 


### PR DESCRIPTION
#10843 caused some failing tests to make it into `master` for the same reason the phpcs issue came through last week (See #11829). Seems certain rebases are throwing off the `.md` only file check and terminating the job early. I can’t figure out why certain rebases on PRs are causing issues but not others.

This was from [the last run of #10843](https://travis-ci.org/WordPress/gutenberg/jobs/453014037#L484):
```
fatal: Invalid symmetric difference expression 4dcf338ba603f47bf6027a764ab0b0d389e81700...21c94151d26e53234703df2f5b47b050ec801ad4
```

This PR strips out the .md check portion for now until we can get it sorted.
https://github.com/WordPress/gutenberg/blob/master/.travis.yml#L22-L26

Docs only change builds taking longer is an acceptable problem if it means we don’t keep getting test failures in master