### PR TITLE
chore Fix: missing imports on some end 2 end test utils

### DIFF
--- a/test/e2e/support/utils/get-url.js
+++ b/test/e2e/support/utils/get-url.js
@@ -2,6 +2,7 @@
  * Node dependencies
  */
 import { join } from 'path';
+import { URL } from 'url';
 
 import { WP_BASE_URL } from './config';
 

--- a/test/e2e/support/utils/is-wp-path.js
+++ b/test/e2e/support/utils/is-wp-path.js
@@ -1,4 +1,9 @@
 /**
+ * Node dependencies
+ */
+import { URL } from 'url';
+
+/**
  * Internal dependencies
  */
 import { getUrl } from './get-url';


### PR DESCRIPTION
## Description
This PR just adds missing imports to our end 2 end test utils.

## How has this been tested?
Verify the end 2 end tests pass locally.
Without this changes, this command ```npm run test-e2e test/e2e/specs/adding-inline-tokens.test.js``` always failed.

