### PR TITLE
Upgrade simple-html-tokenizer so it works from the mobile app

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -37,7 +37,7 @@
 		"lodash": "^4.17.10",
 		"rememo": "^3.0.0",
 		"showdown": "^1.8.6",
-		"simple-html-tokenizer": "^0.4.1",
+		"simple-html-tokenizer": "^0.5.1",
 		"tinycolor2": "^1.4.1",
 		"uuid": "^3.3.2"
 	},

--- a/packages/blocks/src/api/validation.js
+++ b/packages/blocks/src/api/validation.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import Tokenizer from 'simple-html-tokenizer/dist/es6/tokenizer';
+import { Tokenizer } from 'simple-html-tokenizer';
 import {
 	identity,
 	xor,


### PR DESCRIPTION
## Description

This PR updates `simple-html-tokenizer` to `^0.5.1`, same as the one used in `gutenberg-mobile` at the moment.

There is currently a version mismatch on `simple-html-tokenizer` between `gutenberg` and `gutenberg-mobile`.

Downgrading to `^0.4.1"` in `gutenberg-mobile` would cause the following error when running tests:
```
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){import EventedTokenizer from './evented-tokenizer';
                                                                                             ^^^^^^

    SyntaxError: Unexpected token import
```

## How has this been tested?
- Running `npm run test` on `gutenberg`
- Running `yarn test` on `gutenberg-mobile` after updating the `gutenberg` submodule to `master` (might require https://github.com/wordpress-mobile/gutenberg-mobile/pull/257 as well)

## Types of changes
Dependency update

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
