### PR TITLE
Improve the top bar tools interaction and consistency

### DIFF
--- a/packages/editor/src/components/block-navigation/dropdown.js
+++ b/packages/editor/src/components/block-navigation/dropdown.js
@@ -5,6 +5,7 @@ import { Fragment } from '@wordpress/element';
 import { IconButton, Dropdown, SVG, Path, KeyboardShortcuts } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { rawShortcut, displayShortcut } from '@wordpress/keycodes';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -17,7 +18,7 @@ const MenuIcon = (
 	</SVG>
 );
 
-function BlockNavigationDropdown() {
+function BlockNavigationDropdown( { hasBlocks } ) {
 	return	(
 		<Dropdown
 			renderToggle={ ( { isOpen, onToggle } ) => (
@@ -31,10 +32,11 @@ function BlockNavigationDropdown() {
 					<IconButton
 						icon={ MenuIcon }
 						aria-expanded={ isOpen }
-						onClick={ onToggle }
+						onClick={ hasBlocks ? onToggle : undefined }
 						label={ __( 'Block Navigation' ) }
 						className="editor-block-navigation"
 						shortcut={ displayShortcut.access( 'o' ) }
+						aria-disabled={ ! hasBlocks }
 					/>
 				</Fragment>
 			) }
@@ -45,4 +47,8 @@ function BlockNavigationDropdown() {
 	);
 }
 
-export default BlockNavigationDropdown;
+export default withSelect( ( select ) => {
+	return {
+		hasBlocks: !! select( 'core/editor' ).getBlockCount(),
+	};
+} )( BlockNavigationDropdown );

--- a/packages/editor/src/components/block-navigation/index.js
+++ b/packages/editor/src/components/block-navigation/index.js
@@ -74,6 +74,10 @@ function BlockNavigation( { rootBlock, rootBlocks, selectedBlockClientId, select
 		)
 	);
 
+	if ( ! rootBlocks || rootBlocks.length === 0 ) {
+		return null;
+	}
+
 	return (
 		<NavigableMenu
 			role="presentation"
@@ -94,13 +98,6 @@ function BlockNavigation( { rootBlock, rootBlocks, selectedBlockClientId, select
 					selectedBlockClientId={ selectedBlockClientId }
 					selectBlock={ selectBlock }
 				/>
-			) }
-			{ ( ! rootBlocks || rootBlocks.length === 0 ) && (
-				// If there are no blocks in this document, don't render a list of blocks.
-				// Instead: inform the user no blocks exist yet.
-				<p className="editor-block-navigation__paragraph">
-					{ __( 'No blocks created yet.' ) }
-				</p>
 			) }
 		</NavigableMenu>
 	);

--- a/packages/editor/src/components/block-navigation/index.js
+++ b/packages/editor/src/components/block-navigation/index.js
@@ -67,16 +67,16 @@ function BlockNavigationList( {
 }
 
 function BlockNavigation( { rootBlock, rootBlocks, selectedBlockClientId, selectBlock } ) {
+	if ( ! rootBlocks || rootBlocks.length === 0 ) {
+		return null;
+	}
+
 	const hasHierarchy = (
 		rootBlock && (
 			rootBlock.clientId !== selectedBlockClientId ||
 			( rootBlock.innerBlocks && rootBlock.innerBlocks.length !== 0 )
 		)
 	);
-
-	if ( ! rootBlocks || rootBlocks.length === 0 ) {
-		return null;
-	}
 
 	return (
 		<NavigableMenu

--- a/packages/editor/src/components/table-of-contents/index.js
+++ b/packages/editor/src/components/table-of-contents/index.js
@@ -18,12 +18,12 @@ function TableOfContents( { hasBlocks } ) {
 			contentClassName="table-of-contents__popover"
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<IconButton
-					onClick={ onToggle }
+					onClick={ hasBlocks ? onToggle : undefined }
 					icon="info-outline"
 					aria-expanded={ isOpen }
 					label={ __( 'Content structure' ) }
 					labelPosition="bottom"
-					disabled={ ! hasBlocks }
+					aria-disabled={ ! hasBlocks }
 				/>
 			) }
 			renderContent={ () => <TableOfContentsPanel /> }

--- a/test/e2e/specs/block-hierarchy-navigation.test.js
+++ b/test/e2e/specs/block-hierarchy-navigation.test.js
@@ -102,15 +102,4 @@ describe( 'Navigating the block hierarchy', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
-
-	it( 'should report "No blocks created yet." when post is empty', async () => {
-		await openBlockNavigator();
-
-		const blockNavigationText = await page.$eval(
-			'.editor-block-navigation__paragraph',
-			( navigationParagraph ) => navigationParagraph.textContent
-		);
-
-		expect( blockNavigationText ).toEqual( 'No blocks created yet.' );
-	} );
 } );


### PR DESCRIPTION
Fixes #12040

This PR seeks to improve semantics, interaction, and consistency of the Undo, Redo, "Content structure", and "Block navigation" tools in the top bar, trying to have a more consistent user experience.

Currently, some of these controls are initially disabled and not focusable, other ones are not really disabled and focusable, also the tooltip is visible or not visible depending on the disabled state. See below for more details.

This PR:
- simplifies and makes `BlockNavigationDropdown` and the table-of-contents `Dropdown` work similarly
- when there is no content, their buttons use now `aria-disabled` so they're still focusable and discoverable, also their tooltip is visible
- removes the text 'No blocks created yet.' and returns early if there are no blocks yet 
- removes an unnecessary test 

Quoting from the related issue:

Currently, there are at least 3 different _initial_ behaviors that are potentially confusing for users:

Undo and Redo buttons:
  - they're not really disabled, they use an `aria-disabled="true"` attribute
  - they're still focusable
  - their tooltip is visible

As discussed in previous issues / PRs, they're not disabled to avoid a focus loss when using a keyboard and there are no more undo / redo steps.

Content structure button:
  - it uses a `disabled` attribute, so it's really disabled
  - it's not focusable
  - the tooltip is not visible

As it's not focusable and its tooltip is not visible, the discoverability of this tool is a bit reduced.

Block Navigation button:
  - it's always enabled
  - it's always focusable 
  - the tooltip is visible
  - its popover is always rendered even when it's empty because there are no blocks inserted yet, which is a noticeable different behavior compared to the Content structure tool

From an accessibility perspective, using `aria-disabled="true"` and "noop'ing" an UI control is equivalent to disabling it with a `disable` attribute, as long as it is perceived as disabled by all users, i.e. also visually. The relevant difference is that a control with `aria-disabled="true"` is still focusable. Removing focusability from disabled elements can offer users both advantages and disadvantages. A must read recommendation can be found in the ARIA authoring practices:

5.7 Focusability of disabled controls
https://www.w3.org/TR/wai-aria-practices-1.1/#kbd_disabled_controls

Although those recommendations apply to ARIA widgets, the Gutenberg top bar can be considered a "toolbar", where the ability to discover the functionalities within the toolbar is a primary concern. I'd recommend to adopt a consistent convention for the focusability of these controls and always use `aria-disabled="true"` / "noop". The Block navigation menu should not open its panel when there are no blocks.

Lastly, please do let me know if more consistency in title-case / sentence-case for the tooltips text is desirable. Right now, they're not so consistent:

<img width="836" alt="screenshot 2018-11-19 at 17 34 55" src="https://user-images.githubusercontent.com/1682452/48722055-7245fd00-ec23-11e8-9aac-d868d4f06561.png">
