### PR TITLE
Fix: Make media library refresh on open - try 2

### DIFF
--- a/packages/edit-post/src/hooks/components/media-upload/index.js
+++ b/packages/edit-post/src/hooks/components/media-upload/index.js
@@ -163,6 +163,8 @@ class MediaUpload extends Component {
 	}
 
 	onOpen() {
+		this.updateCollection();
+
 		if ( ! this.props.value ) {
 			return;
 		}
@@ -181,6 +183,22 @@ class MediaUpload extends Component {
 
 		if ( onClose ) {
 			onClose();
+		}
+	}
+
+	updateCollection() {
+		const frameContent = this.frame.content.get();
+		if ( frameContent && frameContent.collection ) {
+			const collection = frameContent.collection;
+
+			// clean all attachments we have in memory.
+			collection.toArray().forEach( ( model ) => model.trigger( 'destroy', model ) );
+
+			// reset has more flag, if library had small amount of items all items may have been loaded before.
+			collection.mirroring._hasMore = true;
+
+			// request items
+			collection.more();
 		}
 	}
 


### PR DESCRIPTION
## Description
Fixes: #4612
This PR is a try two of PR https://github.com/WordPress/gutenberg/pull/10843 which was merged but then reverted because of making end 2 end tests fail. The only change is the addition of ```&& frameContent.collection``` to the if condition.
If we have the media library completely empty frameContent.collection may be empty and it was triggering an error in the inline images test.



## How has this been tested?
This PR makes sure a refresh happens each time we open the media library.

Insert 1st Image Block
Drag image to 1st block
Insert 2nd Image Block
Click Add from Media Library button on 2nd block (The first image you dragged will most likely show)
Close Popup window
Drag new image to 2nd block
Insert 3rd Image block
Click Add from Media Library button on new block (Image that was last dragged should now appear!)