### PR TITLE
Update "Unified Toolbar" name mode to "Top Toolbar" for clarity.

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -23,9 +23,9 @@ import FullscreenModeClose from '../fullscreen-mode-close';
 
 function HeaderToolbar( { hasFixedToolbar, isLargeViewport, mode } ) {
 	const toolbarAriaLabel = hasFixedToolbar ?
-		/* translators: accessibility text for the editor toolbar when Unified Toolbar is on */
+		/* translators: accessibility text for the editor toolbar when Top Toolbar is on */
 		__( 'Document and block tools' ) :
-		/* translators: accessibility text for the editor toolbar when Unified Toolbar is off */
+		/* translators: accessibility text for the editor toolbar when Top Toolbar is off */
 		__( 'Document tools' );
 
 	return (

--- a/packages/edit-post/src/components/header/writing-menu/index.js
+++ b/packages/edit-post/src/components/header/writing-menu/index.js
@@ -17,7 +17,7 @@ function WritingMenu( { onClose } ) {
 		>
 			<FeatureToggle
 				feature="fixedToolbar"
-				label={ __( 'Unified Toolbar' ) }
+				label={ __( 'Top Toolbar' ) }
 				info={ __( 'Access all block and document tools in a single place' ) }
 				onToggle={ onClose } />
 			<FeatureToggle


### PR DESCRIPTION
Small copy change to improve clarity of this mode:

![image](https://user-images.githubusercontent.com/548849/48727669-a6182700-ec11-11e8-81b4-030bc5eb3dcd.png)
