### PR TITLE
Reusable blocks: Use view context, always include title.raw and content.raw

### DIFF
--- a/lib/class-wp-rest-blocks-controller.php
+++ b/lib/class-wp-rest-blocks-controller.php
@@ -33,4 +33,55 @@ class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 
 		return parent::check_read_permission( $post );
 	}
+
+	/**
+	 * Filters a response based on the context defined in the schema.
+	 *
+	 * @since 4.4.0
+	 *
+	 * @param array  $data    Response data to fiter.
+	 * @param string $context Context defined in the schema.
+	 * @return array Filtered response.
+	 */
+	public function filter_response_by_context( $data, $context ) {
+		$data = parent::filter_response_by_context( $data, $context );
+
+		/**
+		 * Remove `content.rendered` from the response. It doesn't make sense for a
+		 * reusable block to have rendered content on its own, since rendering a
+		 * block requires it to be inside a post or a page.
+		 */
+		unset( $data['content']['rendered'] );
+
+		return $data;
+	}
+
+	/**
+	 * Retrieves the block's schema, conforming to JSON Schema.
+	 *
+	 * @since 4.4.0
+	 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema() {
+		$schema = parent::get_item_schema();
+
+		/*
+		 * Allow all contexts to access `title.raw` and `content.raw`. Clients always
+		 * need the raw markup of a reusable block to do anything useful, e.g. parse
+		 * it or display it in an editor.
+		 */
+		$schema['properties']['title']['properties']['raw']['context']   = array( 'view', 'edit' );
+		$schema['properties']['content']['properties']['raw']['context'] = array( 'view', 'edit' );
+
+		/*
+		 * Remove `content.rendered` from the schema. It doesn’t make sense for a
+		 * reusable block to have rendered content on its own, since rendering a
+		 * block requires it to be inside a post or a page.
+		 */
+		unset( $schema['properties']['content']['properties']['rendered'] );
+
+		return $schema;
+	}
+
 }

--- a/lib/class-wp-rest-blocks-controller.php
+++ b/lib/class-wp-rest-blocks-controller.php
@@ -46,7 +46,7 @@ class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 	public function filter_response_by_context( $data, $context ) {
 		$data = parent::filter_response_by_context( $data, $context );
 
-		/**
+		/*
 		 * Remove `content.rendered` from the response. It doesn't make sense for a
 		 * reusable block to have rendered content on its own, since rendering a
 		 * block requires it to be inside a post or a page.

--- a/lib/class-wp-rest-blocks-controller.php
+++ b/lib/class-wp-rest-blocks-controller.php
@@ -47,10 +47,11 @@ class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 		$data = parent::filter_response_by_context( $data, $context );
 
 		/*
-		 * Remove `content.rendered` from the response. It doesn't make sense for a
-		 * reusable block to have rendered content on its own, since rendering a
-		 * block requires it to be inside a post or a page.
+		 * Remove `title.rendered` and `content.rendered` from the response. It
+		 * doesn't make sense for a reusable block to have rendered content on its
+		 * own, since rendering a block requires it to be inside a post or a page.
 		 */
+		unset( $data['title']['rendered'] );
 		unset( $data['content']['rendered'] );
 
 		return $data;
@@ -75,10 +76,11 @@ class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 		$schema['properties']['content']['properties']['raw']['context'] = array( 'view', 'edit' );
 
 		/*
-		 * Remove `content.rendered` from the schema. It doesn’t make sense for a
-		 * reusable block to have rendered content on its own, since rendering a
-		 * block requires it to be inside a post or a page.
+		 * Remove `title.rendered` and `content.rendered` from the schema. It doesn’t
+		 * make sense for a reusable block to have rendered content on its own, since
+		 * rendering a block requires it to be inside a post or a page.
 		 */
+		unset( $schema['properties']['title']['properties']['rendered'] );
 		unset( $schema['properties']['content']['properties']['rendered'] );
 
 		return $schema;

--- a/packages/block-library/src/block/index.js
+++ b/packages/block-library/src/block/index.js
@@ -15,7 +15,7 @@ export const settings = {
 
 	category: 'reusable',
 
-	description: __( 'Create content, and save it to reuse across your site. Update the block, and the changes apply everywhere it’s used.' ),
+	description: __( 'Create content, and save it for you and other contributors to reuse across your site. Update the block, and the changes apply everywhere it’s used.' ),
 
 	attributes: {
 		ref: {

--- a/packages/editor/src/store/effects/reusable-blocks.js
+++ b/packages/editor/src/store/effects/reusable-blocks.js
@@ -64,9 +64,9 @@ export const fetchReusableBlocks = async ( action, store ) => {
 
 	let result;
 	if ( id ) {
-		result = apiFetch( { path: `/wp/v2/${ postType.rest_base }/${ id }?context=edit` } );
+		result = apiFetch( { path: `/wp/v2/${ postType.rest_base }/${ id }` } );
 	} else {
-		result = apiFetch( { path: `/wp/v2/${ postType.rest_base }?per_page=-1&context=edit` } );
+		result = apiFetch( { path: `/wp/v2/${ postType.rest_base }?per_page=-1` } );
 	}
 
 	try {

--- a/packages/editor/src/store/effects/reusable-blocks.js
+++ b/packages/editor/src/store/effects/reusable-blocks.js
@@ -24,7 +24,6 @@ import { dispatch as dataDispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { resolveSelector } from './utils';
 import {
 	__experimentalReceiveReusableBlocks as receiveReusableBlocksAction,
 	removeBlocks,
@@ -57,7 +56,7 @@ export const fetchReusableBlocks = async ( action, store ) => {
 
 	// TODO: these are potentially undefined, this fix is in place
 	// until there is a filter to not use reusable blocks if undefined
-	const postType = await resolveSelector( 'core', 'getPostType', 'wp_block' );
+	const postType = await apiFetch( { path: '/wp/v2/types/wp_block' } );
 	if ( ! postType ) {
 		return;
 	}
@@ -109,7 +108,7 @@ export const fetchReusableBlocks = async ( action, store ) => {
 export const saveReusableBlocks = async ( action, store ) => {
 	// TODO: these are potentially undefined, this fix is in place
 	// until there is a filter to not use reusable blocks if undefined
-	const postType = await resolveSelector( 'core', 'getPostType', 'wp_block' );
+	const postType = await apiFetch( { path: '/wp/v2/types/wp_block' } );
 	if ( ! postType ) {
 		return;
 	}
@@ -153,7 +152,7 @@ export const saveReusableBlocks = async ( action, store ) => {
 export const deleteReusableBlocks = async ( action, store ) => {
 	// TODO: these are potentially undefined, this fix is in place
 	// until there is a filter to not use reusable blocks if undefined
-	const postType = await resolveSelector( 'core', 'getPostType', 'wp_block' );
+	const postType = await apiFetch( { path: '/wp/v2/types/wp_block' } );
 	if ( ! postType ) {
 		return;
 	}

--- a/packages/editor/src/store/effects/test/reusable-blocks.js
+++ b/packages/editor/src/store/effects/test/reusable-blocks.js
@@ -83,7 +83,7 @@ describe( 'reusable blocks effects', () => {
 			} );
 
 			apiFetch.mockImplementation( ( options ) => {
-				if ( options.path === '/wp/v2/types/wp_block?context=edit' ) {
+				if ( options.path === '/wp/v2/types/wp_block' ) {
 					return postTypePromise;
 				}
 
@@ -130,7 +130,7 @@ describe( 'reusable blocks effects', () => {
 			} );
 
 			apiFetch.mockImplementation( ( options ) => {
-				if ( options.path === '/wp/v2/types/wp_block?context=edit' ) {
+				if ( options.path === '/wp/v2/types/wp_block' ) {
 					return postTypePromise;
 				}
 
@@ -172,7 +172,7 @@ describe( 'reusable blocks effects', () => {
 			} );
 
 			apiFetch.mockImplementation( ( options ) => {
-				if ( options.path === '/wp/v2/types/wp_block?context=edit' ) {
+				if ( options.path === '/wp/v2/types/wp_block' ) {
 					return postTypePromise;
 				}
 
@@ -202,7 +202,7 @@ describe( 'reusable blocks effects', () => {
 			} );
 
 			apiFetch.mockImplementation( ( options ) => {
-				if ( options.path === '/wp/v2/types/wp_block?context=edit' ) {
+				if ( options.path === '/wp/v2/types/wp_block' ) {
 					return postTypePromise;
 				}
 
@@ -236,7 +236,7 @@ describe( 'reusable blocks effects', () => {
 			} );
 
 			apiFetch.mockImplementation( ( options ) => {
-				if ( options.path === '/wp/v2/types/wp_block?context=edit' ) {
+				if ( options.path === '/wp/v2/types/wp_block' ) {
 					return postTypePromise;
 				}
 
@@ -284,7 +284,7 @@ describe( 'reusable blocks effects', () => {
 			} );
 
 			apiFetch.mockImplementation( ( options ) => {
-				if ( options.path === '/wp/v2/types/wp_block?context=edit' ) {
+				if ( options.path === '/wp/v2/types/wp_block' ) {
 					return postTypePromise;
 				}
 
@@ -330,7 +330,7 @@ describe( 'reusable blocks effects', () => {
 			} );
 
 			apiFetch.mockImplementation( ( options ) => {
-				if ( options.path === '/wp/v2/types/wp_block?context=edit' ) {
+				if ( options.path === '/wp/v2/types/wp_block' ) {
 					return postTypePromise;
 				}
 

--- a/phpunit/class-rest-blocks-controller-test.php
+++ b/phpunit/class-rest-blocks-controller-test.php
@@ -189,8 +189,7 @@ class REST_Blocks_Controller_Test extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			array(
-				'raw'      => 'My cool block',
-				'rendered' => 'My cool block',
+				'raw' => 'My cool block',
 			),
 			$data['title']
 		);

--- a/phpunit/class-rest-blocks-controller-test.php
+++ b/phpunit/class-rest-blocks-controller-test.php
@@ -41,11 +41,21 @@ class REST_Blocks_Controller_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Delete our fake data after each test runs.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		if ( isset( self::$user_id ) ) {
+			self::delete_user( self::$user_id );
+		}
+	}
+
+	/**
 	 * Delete our fake data after our tests run.
 	 */
 	public static function wpTearDownAfterClass() {
 		wp_delete_post( self::$post_id );
-		self::delete_user( self::$user_id );
 	}
 
 	/**

--- a/test/e2e/specs/reusable-blocks.test.js
+++ b/test/e2e/specs/reusable-blocks.test.js
@@ -189,8 +189,13 @@ describe( 'Reusable Blocks', () => {
 
 		// Delete the block and accept the confirmation dialog
 		await page.click( 'button[aria-label="More options"]' );
-		const convertButton = await page.waitForXPath( '//button[text()="Remove from Reusable Blocks"]' );
-		await Promise.all( [ waitForAndAcceptDialog(), convertButton.click() ] );
+		const deleteButton = await page.waitForXPath( '//button[text()="Remove from Reusable Blocks"]' );
+		await Promise.all( [ waitForAndAcceptDialog(), deleteButton.click() ] );
+
+		// Wait for deletion to finish
+		await page.waitForXPath(
+			'//*[contains(@class, "components-notice") and contains(@class, "is-success")]/*[text()="Block deleted."]'
+		);
 
 		// Check that we have an empty post again
 		expect( await getEditedPostContent() ).toBe( '' );


### PR DESCRIPTION
Supersedes https://github.com/WordPress/gutenberg/pull/11891. Fixes #11343.

Existing reusable blocks on a post would not render if the user was an author or a contributor. This happened because requests to fetch a single block or post are blocked when `?context=edit` is passed and the current user is not an editor.

The fix is to stop passing `?context=edit` to block requests, but this causes another problem which is that Gutenberg needs access to both `title.raw` and `content.raw` in the API response.

We therefore both stop passing `?context=edit` to block requests *and* modify the blocks API so that `title.raw` and `content.raw` are always provided.

#### How to test

1. Create two users, `user1` (any role) and `user2` (author role)
1. Log in as `user1` and create a reusable block
1. Log in as `user2` and create a post using `user1`'s block
1. The block should render correctly.
1. Save the post and refresh the edit screen.
1. The block should again render correctly.
