### PR TITLE
RichText: List: Sync DOM after editor command

### DIFF
--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -861,6 +861,7 @@ export class RichText extends Component {
 						editor={ this.editor }
 						onTagNameChange={ onTagNameChange }
 						tagName={ Tagname }
+						onSyncDOM={ () => this.onChange( this.createRecord() ) }
 					/>
 				) }
 				{ isSelected && ! inlineToolbar && (

--- a/packages/editor/src/components/rich-text/list-edit.js
+++ b/packages/editor/src/components/rich-text/list-edit.js
@@ -35,27 +35,39 @@ function isActiveListType( editor, tagName, rootTagName ) {
 	return list.nodeName.toLowerCase() === tagName;
 }
 
-export const ListEdit = ( { editor, onTagNameChange, tagName } ) => (
+export const ListEdit = ( { editor, onTagNameChange, tagName, onSyncDOM } ) => (
 	<Fragment>
 		<RichTextShortcut
 			type="primary"
 			character="["
-			onUse={ () => editor.execCommand( 'Outdent' ) }
+			onUse={ () => {
+				editor.execCommand( 'Outdent' );
+				onSyncDOM();
+			} }
 		/>
 		<RichTextShortcut
 			type="primary"
 			character="]"
-			onUse={ () => editor.execCommand( 'Indent' ) }
+			onUse={ () => {
+				editor.execCommand( 'Indent' );
+				onSyncDOM();
+			} }
 		/>
 		<RichTextShortcut
 			type="primary"
 			character="m"
-			onUse={ () => editor.execCommand( 'Indent' ) }
+			onUse={ () => {
+				editor.execCommand( 'Indent' );
+				onSyncDOM();
+			} }
 		/>
 		<RichTextShortcut
 			type="primaryShift"
 			character="m"
-			onUse={ () => editor.execCommand( 'Outdent' ) }
+			onUse={ () => {
+				editor.execCommand( 'Outdent' );
+				onSyncDOM();
+			} }
 		/>
 		<BlockFormatControls>
 			<Toolbar
@@ -69,6 +81,7 @@ export const ListEdit = ( { editor, onTagNameChange, tagName } ) => (
 								onTagNameChange( 'ul' );
 							} else {
 								editor.execCommand( 'InsertUnorderedList' );
+								onSyncDOM();
 							}
 						},
 					},
@@ -81,18 +94,25 @@ export const ListEdit = ( { editor, onTagNameChange, tagName } ) => (
 								onTagNameChange( 'ol' );
 							} else {
 								editor.execCommand( 'InsertOrderedList' );
+								onSyncDOM();
 							}
 						},
 					},
 					{
 						icon: 'editor-outdent',
 						title: __( 'Outdent list item' ),
-						onClick: () => editor.execCommand( 'Outdent' ),
+						onClick() {
+							editor.execCommand( 'Outdent' );
+							onSyncDOM();
+						},
 					},
 					{
 						icon: 'editor-indent',
 						title: __( 'Indent list item' ),
-						onClick: () => editor.execCommand( 'Indent' ),
+						onClick() {
+							editor.execCommand( 'Indent' );
+							onSyncDOM();
+						},
 					},
 				] }
 			/>

--- a/test/e2e/specs/blocks/__snapshots__/list.test.js.snap
+++ b/test/e2e/specs/blocks/__snapshots__/list.test.js.snap
@@ -80,6 +80,12 @@ exports[`List can undo asterisk transform 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`List should be immeadiately saved on indentation 1`] = `
+"<!-- wp:list -->
+<ul><li>one<ul><li></li></ul></li></ul>
+<!-- /wp:list -->"
+`;
+
 exports[`List should create paragraph on split at end and merge back with content 1`] = `
 "<!-- wp:list -->
 <ul><li>one</li></ul>

--- a/test/e2e/specs/blocks/list.test.js
+++ b/test/e2e/specs/blocks/list.test.js
@@ -194,4 +194,13 @@ describe( 'List', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should be immeadiately saved on indentation', async () => {
+		await insertBlock( 'List' );
+		await page.keyboard.type( 'one' );
+		await page.keyboard.press( 'Enter' );
+		await pressWithModifier( 'primary', 'm' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );


### PR DESCRIPTION
## Description

Fixes #12027. Since we're using editor commands for lists that manipulate the DOM directly, the internal state is not update immediately. On input, the internal state _will_ sync, so this is only a problem when you indent/change list type, and don't make any further changes. The solution is to create a RichText value from DOM right after the command and update the state.

## How has this been tested?
See #12027.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->