### PR TITLE
Fix small gap in style variation button

### DIFF
--- a/packages/editor/src/components/block-styles/style.scss
+++ b/packages/editor/src/components/block-styles/style.scss
@@ -29,7 +29,7 @@
 
 .editor-block-styles__item-preview {
 	outline: $border-width solid transparent; // Shown in Windows High Contrast mode.
-	box-shadow: inset 0 0 0 1px rgba($dark-gray-900, 0.2);
+	border: 1px solid rgba($dark-gray-900, 0.2);
 	overflow: hidden;
 	padding: 0;
 	text-align: initial;


### PR DESCRIPTION
This PR fixes #12066.

I believe the issue is caused by the border on the button being an inset shadow, which stacks below the background colors of the content inside the preview. By making it a border, this becomes a non issue.

Before:

<img width="574" alt="screenshot 2018-11-20 at 09 54 45" src="https://user-images.githubusercontent.com/1204802/48762281-fb544700-ecaa-11e8-967c-8806cb8e0b77.png">

After:

<img width="585" alt="screenshot 2018-11-20 at 09 54 32" src="https://user-images.githubusercontent.com/1204802/48762287-fe4f3780-ecaa-11e8-9bf8-ce09a32e68b7.png">
