### PR TITLE
Fix issue with disabled togglecontrol double border

### DIFF
--- a/packages/components/src/form-toggle/style.scss
+++ b/packages/components/src/form-toggle/style.scss
@@ -63,7 +63,7 @@ $toggle-border-width: 2px;
 		}
 	}
 
-	// checked state
+	// Checked state.
 	&.is-checked .components-form-toggle__track {
 		background-color: theme(toggle);
 		border: $toggle-border-width solid theme(toggle);
@@ -86,9 +86,15 @@ $toggle-border-width: 2px;
 			border: $toggle-border-width solid theme(toggle);
 		}
 	}
+
+	// Disabled state:
+	.components-disabled & {
+		opacity: 0.3;
+	}
 }
 
-.components-form-toggle__input[type="checkbox"] {
+// This needs specificity to override inherited checkbox styles.
+.components-form-toggle input.components-form-toggle__input[type="checkbox"] {
 	position: absolute;
 	top: 0;
 	left: 0;
@@ -98,6 +104,17 @@ $toggle-border-width: 2px;
 	margin: 0;
 	padding: 0;
 	z-index: z-index(".components-form-toggle__input");
+
+	// This overrides a border style that is inherited from parent checkbox styles.
+	border: none;
+	&:checked {
+		background: none;
+	}
+
+	// Don't show custom checkbox checkmark.
+	&::before {
+		content: "";
+	}
 }
 
 // Ensure on indicator works in normal and Windows high contrast mode both.

--- a/packages/components/src/toggle-control/style.scss
+++ b/packages/components/src/toggle-control/style.scss
@@ -10,4 +10,9 @@
 		display: block;
 		margin-bottom: 4px;
 	}
+
+	// This overrides a border style that is inherited from parent checkbox styles.
+	.components-form-toggle__input {
+		border: none;
+	}
 }

--- a/packages/components/src/toggle-control/style.scss
+++ b/packages/components/src/toggle-control/style.scss
@@ -10,9 +10,4 @@
 		display: block;
 		margin-bottom: 4px;
 	}
-
-	// This overrides a border style that is inherited from parent checkbox styles.
-	.components-form-toggle__input {
-		border: none;
-	}
 }


### PR DESCRIPTION
Fixes #12049.

This PR fixes an issue where a togglecontrol, wrapped in a Disabled component, would show a double border. The issue was that it inherited a border from the parent checkbox style (because the toggle is technically a reskinned checkbox).

Before:

<img width="240" alt="screenshot 2018-11-20 at 10 04 48" src="https://user-images.githubusercontent.com/1204802/48762837-3145fb00-ecac-11e8-8d0d-8a25692b0d8f.png">

After:

<img width="261" alt="screenshot 2018-11-20 at 10 04 34" src="https://user-images.githubusercontent.com/1204802/48762840-330fbe80-ecac-11e8-9c23-55edcad48677.png">
