### PR TITLE
RichText: Correct HTML formatting whitespace

### DIFF
--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -93,7 +93,7 @@ function toFormat( { type, attributes } ) {
 function trim( value ) {
 	value = replace( value, /^ +/, '' );
 	value = replace( value, / +$/, '' );
-	value = replace( value, / +/, ' ' );
+	value = replace( value, / {2,}/, ' ' );
 
 	return value;
 }

--- a/packages/rich-text/src/replace.js
+++ b/packages/rich-text/src/replace.js
@@ -43,8 +43,20 @@ export function replace( { formats, text, start, end }, pattern, replacement ) {
 
 		formats = formats.slice( 0, offset ).concat( newFormats, formats.slice( offset + match.length ) );
 
-		if ( start ) {
-			start = end = offset + newText.length;
+		if ( start !== undefined && start >= offset ) {
+			if ( start <= offset + match.length ) {
+				start = offset + newText.length;
+			} else {
+				start = start - match.length + newText.length;
+			}
+		}
+
+		if ( end !== undefined && end >= offset ) {
+			if ( end <= offset + match.length ) {
+				end = offset + newText.length;
+			} else {
+				end = end - match.length + newText.length;
+			}
 		}
 
 		return newText;


### PR DESCRIPTION
## Description

Fixes #11588. When creating a rich text value from text nodes, this branch reduces any sequence af new lines, tabs and spaces to one space. Afterwards, on a per line basis, it also trims leading and trailing whitespace, and reduces any sequence of spaces to one. This is needed because any sequence af new lines, tabs and spaces is used to format HTML, not as content. The browser will only displag it as one space, if it is used in between words.

Previously we were just removing any line breaks, which would normall still be displayed by the browser as a space.

## How has this been tested?

Edit a paragraph as HTML. Remove a space and insert a line break (use ENTER). Edit visually. You should see a space where you inserted the line break. Edit as HTML. The line break should be replaced by a space.

Previously the line break would have been removed.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->