### PR TITLE
Allow the user to Convert unembeddable URLs to links and try embedding again

### DIFF
--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -55,10 +55,11 @@ export function getEmbedEditComponent( title, icon, responsive = true ) {
 		componentDidUpdate( prevProps ) {
 			const hasPreview = undefined !== this.props.preview;
 			const hadPreview = undefined !== prevProps.preview;
-			const switchedPreview = this.props.preview && this.props.attributes.url !== prevProps.attributes.url;
+			const previewChanged = prevProps.preview && this.props.preview && this.props.preview.html !== prevProps.preview.html;
+			const switchedPreview = previewChanged || ( hasPreview && ! hadPreview );
 			const switchedURL = this.props.attributes.url !== prevProps.attributes.url;
 
-			if ( ( hasPreview && ! hadPreview ) || switchedPreview || switchedURL ) {
+			if ( switchedPreview || switchedURL ) {
 				if ( this.props.cannotEmbed ) {
 					// Can't embed this URL, and we've just received or switched the preview.
 					return;
@@ -140,7 +141,7 @@ export function getEmbedEditComponent( title, icon, responsive = true ) {
 		render() {
 			const { url, editingURL } = this.state;
 			const { caption, type, allowResponsive } = this.props.attributes;
-			const { fetching, setAttributes, isSelected, className, preview, cannotEmbed, themeSupportsResponsive } = this.props;
+			const { fetching, setAttributes, isSelected, className, preview, cannotEmbed, themeSupportsResponsive, tryAgain } = this.props;
 
 			if ( fetching ) {
 				return (
@@ -162,6 +163,7 @@ export function getEmbedEditComponent( title, icon, responsive = true ) {
 						cannotEmbed={ cannotEmbed }
 						onChange={ ( event ) => this.setState( { url: event.target.value } ) }
 						fallback={ () => fallback( url, this.props.onReplace ) }
+						tryAgain={ tryAgain }
 					/>
 				);
 			}

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { isFromWordPress, createUpgradedEmbedBlock, getClassNames } from './util';
+import { isFromWordPress, createUpgradedEmbedBlock, getClassNames, fallback } from './util';
 import EmbedControls from './embed-controls';
 import EmbedLoading from './embed-loading';
 import EmbedPlaceholder from './embed-placeholder';
@@ -161,6 +161,7 @@ export function getEmbedEditComponent( title, icon, responsive = true ) {
 						value={ url }
 						cannotEmbed={ cannotEmbed }
 						onChange={ ( event ) => this.setState( { url: event.target.value } ) }
+						fallback={ () => fallback( url, this.props.onReplace ) }
 					/>
 				);
 			}

--- a/packages/block-library/src/embed/embed-placeholder.js
+++ b/packages/block-library/src/embed/embed-placeholder.js
@@ -6,7 +6,7 @@ import { Button, Placeholder } from '@wordpress/components';
 import { BlockIcon } from '@wordpress/editor';
 
 const EmbedPlaceholder = ( props ) => {
-	const { icon, label, value, onSubmit, onChange, cannotEmbed, fallback } = props;
+	const { icon, label, value, onSubmit, onChange, cannotEmbed, fallback, tryAgain } = props;
 	return (
 		<Placeholder icon={ <BlockIcon icon={ icon } showColors /> } label={ label } className="wp-block-embed">
 			<form onSubmit={ onSubmit }>
@@ -25,7 +25,7 @@ const EmbedPlaceholder = ( props ) => {
 				{ cannotEmbed &&
 					<p className="components-placeholder__error">
 						{ __( 'Sorry, we could not embed that content.' ) }<br />
-						<Button isLarge onClick={ fallback }>{ _x( 'Convert to link', 'button label' ) }</Button>
+						<Button isLarge onClick={ tryAgain }>{ _x( 'Try again', 'button label' ) }</Button> <Button isLarge onClick={ fallback }>{ _x( 'Convert to link', 'button label' ) }</Button>
 					</p>
 				}
 			</form>

--- a/packages/block-library/src/embed/embed-placeholder.js
+++ b/packages/block-library/src/embed/embed-placeholder.js
@@ -22,8 +22,12 @@ const EmbedPlaceholder = ( props ) => {
 					type="submit">
 					{ _x( 'Embed', 'button label' ) }
 				</Button>
-				{ cannotEmbed && <p className="components-placeholder__error">{ __( 'Sorry, we could not embed that content.' ) }</p> }
-				{ cannotEmbed && <p><Button isLarge onClick={ fallback }>{ _x( 'Convert to link', 'button label' ) }</Button></p> }
+				{ cannotEmbed &&
+					<p className="components-placeholder__error">
+						{ __( 'Sorry, we could not embed that content.' ) }<br />
+						<Button isLarge onClick={ fallback }>{ _x( 'Convert to link', 'button label' ) }</Button>
+					</p>
+				}
 			</form>
 		</Placeholder>
 	);

--- a/packages/block-library/src/embed/embed-placeholder.js
+++ b/packages/block-library/src/embed/embed-placeholder.js
@@ -6,7 +6,7 @@ import { Button, Placeholder } from '@wordpress/components';
 import { BlockIcon } from '@wordpress/editor';
 
 const EmbedPlaceholder = ( props ) => {
-	const { icon, label, value, onSubmit, onChange, cannotEmbed } = props;
+	const { icon, label, value, onSubmit, onChange, cannotEmbed, fallback } = props;
 	return (
 		<Placeholder icon={ <BlockIcon icon={ icon } showColors /> } label={ label } className="wp-block-embed">
 			<form onSubmit={ onSubmit }>
@@ -23,6 +23,7 @@ const EmbedPlaceholder = ( props ) => {
 					{ _x( 'Embed', 'button label' ) }
 				</Button>
 				{ cannotEmbed && <p className="components-placeholder__error">{ __( 'Sorry, we could not embed that content.' ) }</p> }
+				{ cannotEmbed && <p><Button isLarge onClick={ fallback }>{ _x( 'Convert to link', 'button label' ) }</Button></p> }
 			</form>
 		</Placeholder>
 	);

--- a/packages/block-library/src/embed/settings.js
+++ b/packages/block-library/src/embed/settings.js
@@ -14,7 +14,7 @@ import classnames from 'classnames/dedupe';
 import { __, sprintf } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { RichText } from '@wordpress/editor';
-import { withSelect } from '@wordpress/data';
+import { withSelect, withDispatch } from '@wordpress/data';
 
 const embedAttributes = {
 	url: {
@@ -78,6 +78,16 @@ export function getEmbedBlockSettings( { title, description, icon, category = 'e
 					fetching,
 					themeSupportsResponsive: themeSupports[ 'responsive-embeds' ],
 					cannotEmbed,
+				};
+			} ),
+			withDispatch( ( dispatch, ownProps ) => {
+				const { url } = ownProps.attributes;
+				const coreData = dispatch( 'core/data' );
+				const tryAgain = () => {
+					coreData.invalidateResolution( 'core', 'getEmbedPreview', [ url ] );
+				};
+				return {
+					tryAgain,
 				};
 			} )
 		)( edit ),

--- a/packages/block-library/src/embed/util.js
+++ b/packages/block-library/src/embed/util.js
@@ -163,3 +163,17 @@ export function getClassNames( html, existingClassNames = '', allowResponsive = 
 
 	return existingClassNames;
 }
+
+/**
+ * Fallback behaviour for unembeddable URLs.
+ * Creates a paragraph block containing a link to the URL, and calls `onReplace`.
+ *
+ * @param {string}   url       The URL that could not be embedded.
+ * @param {function} onReplace Function to call with the created fallback block.
+ */
+export function fallback( url, onReplace ) {
+	const link = <a href={ url }>{ url }</a>;
+	onReplace(
+		createBlock( 'core/paragraph', { content: renderToString( link ) } )
+	);
+}

--- a/test/e2e/specs/__snapshots__/embedding.test.js.snap
+++ b/test/e2e/specs/__snapshots__/embedding.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Embedding content should allow the user to convert unembeddable URLs to a paragraph with a link in it 1`] = `
+"<!-- wp:paragraph -->
+<p><a href=\\"https://twitter.com/wooyaygutenberg123454312\\">https://twitter.com/wooyaygutenberg123454312</a></p>
+<!-- /wp:paragraph -->"
+`;

--- a/test/e2e/specs/embedding.test.js
+++ b/test/e2e/specs/embedding.test.js
@@ -8,6 +8,7 @@ import {
 	setUpResponseMocking,
 	JSONResponse,
 	getEditedPostContent,
+	clickButton,
 } from '../support/utils';
 
 const MOCK_EMBED_WORDPRESS_SUCCESS_RESPONSE = {
@@ -168,8 +169,27 @@ describe( 'Embedding content', () => {
 		await page.keyboard.type( 'https://twitter.com/wooyaygutenberg123454312' );
 		await page.keyboard.press( 'Enter' );
 
-		await page.waitForSelector( '.components-placeholder.wp-block-embed > .components-placeholder__fieldset > form > p > button' );
-		await page.click( '.components-placeholder.wp-block-embed > .components-placeholder__fieldset > form > p > button' );
+		await clickButton( 'Convert to link' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should allow the user to try embedding a failed URL again', async () => {
+		// URL that can't be embedded.
+		await clickBlockAppender();
+		await page.keyboard.type( '/embed' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'https://twitter.com/wooyaygutenberg123454312' );
+		await page.keyboard.press( 'Enter' );
+		// Set up a different mock to make sure that try again actually does make the request again.
+		await setUpResponseMocking(
+			[
+				{
+					match: isEmbedding( 'https://twitter.com/wooyaygutenberg123454312' ),
+					onRequestMatch: JSONResponse( MOCK_EMBED_RICH_SUCCESS_RESPONSE ),
+				},
+			]
+		);
+		await clickButton( 'Try again' );
+		await page.waitForSelector( 'figure.wp-block-embed-twitter' );
 	} );
 } );

--- a/test/e2e/support/utils/click-button.js
+++ b/test/e2e/support/utils/click-button.js
@@ -1,0 +1,9 @@
+/**
+ * Clicks a button based on the text on the button.
+ *
+ * @param {string} buttonText The text that appears on the button to click.
+ */
+export async function clickButton( buttonText ) {
+	const button = await page.waitForXPath( `//button[contains(text(), '${ buttonText }')]` );
+	await button.click();
+}

--- a/test/e2e/support/utils/index.js
+++ b/test/e2e/support/utils/index.js
@@ -1,6 +1,7 @@
 export { arePrePublishChecksEnabled } from './are-pre-publish-checks-enabled';
 export { clearLocalStorage } from './clear-local-storage';
 export { clickBlockAppender } from './click-block-appender';
+export { clickButton } from './click-button';
 export { clickOnCloseModalButton } from './click-on-close-modal-button';
 export { clickOnMoreMenuItem } from './click-on-more-menu-item';
 export { convertBlock } from './convert-block';

--- a/test/e2e/support/utils/set-up-response-mocking.js
+++ b/test/e2e/support/utils/set-up-response-mocking.js
@@ -1,4 +1,14 @@
 /**
+ * Track if we have already initialized the request interception.
+ */
+let interceptionInitialized = false;
+
+/**
+ * Array of mock responses.
+ */
+let requestMocks = [];
+
+/**
  * Sets up mock checks and responses. Accepts a list of mock settings with the following properties:
  *   - match: function to check if a request should be mocked.
  *   - onRequestMatch: async function to respond to the request.
@@ -21,15 +31,23 @@
  * @param {Array} mocks Array of mock settings.
  */
 export async function setUpResponseMocking( mocks ) {
-	await page.setRequestInterception( true );
-	page.on( 'request', async ( request ) => {
-		for ( let i = 0; i < mocks.length; i++ ) {
-			const mock = mocks[ i ];
-			if ( mock.match( request ) ) {
-				await mock.onRequestMatch( request );
-				return;
+	if ( ! interceptionInitialized ) {
+		// We only want to set up the request interception once, or else we get a crash
+		// when we try to process the same request twice.
+		interceptionInitialized = true;
+		await page.setRequestInterception( true );
+		page.on( 'request', async ( request ) => {
+			for ( let i = 0; i < requestMocks.length; i++ ) {
+				const mock = requestMocks[ i ];
+				if ( mock.match( request ) ) {
+					await mock.onRequestMatch( request );
+					return;
+				}
 			}
-		}
-		request.continue();
-	} );
+			request.continue();
+		} );
+	}
+	// Overwrite with the passed in mocks, so we can change the mocks mid-test to test
+	// recovery from scenarios where a request had failed, but is working again.
+	requestMocks = [ ...mocks ];
 }


### PR DESCRIPTION
## Description

On the UI that tells the user that the URL could not be embedded, this adds a button to convert the URL to a paragraph block with a link, and a button to attempt the embedding again.

## How has this been tested?

Try to embed a URL that can't be embedded, press the new "Convert to link" button. Press the "Try again" button and you should see the embed proxy request again.

## Screenshots <!-- if applicable -->

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
