### PR TITLE
Provide workaround for IE11 broken toolbars.

### DIFF
--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -874,6 +874,14 @@
 		position: absolute;
 		left: 0;
 	}
+
+	// Weird IE11/React issue where an element called "<jscomp_symbol_react.fragment16>" is briefly visible.
+	// The following rule styles that temporary element to not cause any visual glitches.
+	// @todo: retire this as soon as we can. See also: https://github.com/facebook/react/issues/13414
+	> :not(div) {
+		display: flex;
+		min-width: 100%;
+	}
 }
 
 


### PR DESCRIPTION
This is an exotic one.

In IE11, in the toolbar markup, you can briefly see the appearance of a new HTML element called `<jscomp_symbol_react.fragment16>`. This is obviously not a real element, but it is rendered by IE11 as a real element, which means it breaks the flexing of the actual children of the toolbar.

This PR _styles_ that temporary element, to at least not be broken.

This is an ugly workaround to an upstream React issue reported here: https://github.com/facebook/react/issues/13414

It might be worth looking into the workaround suggested [here](https://github.com/facebook/react/issues/13414#issuecomment-413707461) instead.

Before:

<img width="681" alt="screenshot 2018-11-20 at 11 37 57" src="https://user-images.githubusercontent.com/1204802/48768176-c3ec9700-ecb8-11e8-8b02-7ab7f065bd77.png">

After:

<img width="746" alt="screenshot 2018-11-20 at 11 37 34" src="https://user-images.githubusercontent.com/1204802/48768177-c5b65a80-ecb8-11e8-89a5-f4b32aab563f.png">

