### PR TITLE
Fix IE11 toolbar.

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -167,16 +167,16 @@ function gutenberg_register_scripts_and_styles() {
 
 	register_tinymce_scripts();
 
-	wp_script_add_data(
+	wp_add_inline_script(
 		'wp-polyfill',
-		'data',
 		gutenberg_get_script_polyfill(
 			array(
 				'\'fetch\' in window' => 'wp-polyfill-fetch',
 				'document.contains'   => 'wp-polyfill-node-contains',
 				'window.FormData && window.FormData.prototype.keys' => 'wp-polyfill-formdata',
 				'Element.prototype.matches && Element.prototype.closest' => 'wp-polyfill-element-closest',
-			)
+			),
+			'after'
 		)
 	);
 


### PR DESCRIPTION
This PR is a better replacement for #12096.

In IE11, in the toolbar markup, you can briefly see the appearance of a new HTML element called <jscomp_symbol_react.fragment16>. This is obviously not a real element, but it is rendered by IE11 as a real element, which means it breaks the flexing of the actual children of the toolbar.

This PR, props to @youknowriad, adds a change to the assets so the element doesn't appear in the first place.

Before:

<img width="681" alt="screenshot 2018-11-20 at 11 37 57" src="https://user-images.githubusercontent.com/1204802/48768176-c3ec9700-ecb8-11e8-8b02-7ab7f065bd77.png">

After:

<img width="746" alt="screenshot 2018-11-20 at 11 37 34" src="https://user-images.githubusercontent.com/1204802/48768177-c5b65a80-ecb8-11e8-89a5-f4b32aab563f.png">

closes #11918