### PR TITLE
Fix escaping greater than caracters

### DIFF
--- a/packages/escape-html/src/index.js
+++ b/packages/escape-html/src/index.js
@@ -52,6 +52,17 @@ export function escapeLessThan( value ) {
 }
 
 /**
+ * Returns a string with less-than sign replaced.
+ *
+ * @param {string} value Original string.
+ *
+ * @return {string} Escaped string.
+ */
+export function escapeGreaterThan( value ) {
+	return value.replace( />/g, '&gt;' );
+}
+
+/**
  * Returns an escaped attribute value.
  *
  * @link https://w3c.github.io/html/syntax.html#elements-attributes
@@ -80,7 +91,7 @@ export function escapeAttribute( value ) {
  * @return {string} Escaped HTML element value.
  */
 export function escapeHTML( value ) {
-	return escapeLessThan( escapeAmpersand( value ) );
+	return escapeLessThan( escapeGreaterThan( escapeAmpersand( value ) ) );
 }
 
 /**

--- a/packages/escape-html/src/test/index.js
+++ b/packages/escape-html/src/test/index.js
@@ -5,6 +5,7 @@ import {
 	escapeAmpersand,
 	escapeQuotationMark,
 	escapeLessThan,
+	escapeGreaterThan,
 	escapeAttribute,
 	escapeHTML,
 	isValidAttributeName,
@@ -34,6 +35,14 @@ function testEscapeLessThan( implementation ) {
 	} );
 }
 
+function testEscapeGreaterThan( implementation ) {
+	it( 'should escape greater than', () => {
+		const result = implementation( 'Chicken > Ribs' );
+
+		expect( result ).toBe( 'Chicken &gt; Ribs' );
+	} );
+}
+
 describe( 'escapeAmpersand', () => {
 	testEscapeAmpersand( escapeAmpersand );
 } );
@@ -46,6 +55,10 @@ describe( 'escapeLessThan', () => {
 	testEscapeLessThan( escapeLessThan );
 } );
 
+describe( 'escapeGreaterThan', () => {
+	testEscapeGreaterThan( escapeGreaterThan );
+} );
+
 describe( 'escapeAttribute', () => {
 	testEscapeAmpersand( escapeAttribute );
 	testEscapeQuotationMark( escapeAttribute );
@@ -54,6 +67,7 @@ describe( 'escapeAttribute', () => {
 describe( 'escapeHTML', () => {
 	testEscapeAmpersand( escapeHTML );
 	testEscapeLessThan( escapeHTML );
+	testEscapeGreaterThan( escapeHTML );
 } );
 
 describe( 'isValidAttributeName', () => {


### PR DESCRIPTION
closes #11815

In our serializer we escape some characters from HTML to match the classic editor. We were missing the `>` character.

**Testing instructions**

 - type "something something > something"
 - Ensure than the `>` is sanitized properly in the produced HTML