### PR TITLE
Components: Add 'disabled' styling to FormToggle

### DIFF
--- a/packages/components/src/form-toggle/index.js
+++ b/packages/components/src/form-toggle/index.js
@@ -9,11 +9,14 @@ import { noop } from 'lodash';
  */
 import { Path, SVG } from '../primitives';
 
-function FormToggle( { className, checked, id, onChange = noop, ...props } ) {
+function FormToggle( { className, checked, disabled, id, onChange = noop, ...props } ) {
 	const wrapperClasses = classnames(
 		'components-form-toggle',
 		className,
-		{ 'is-checked': checked },
+		{
+			'is-checked': checked,
+			'is-disabled': disabled,
+		},
 	);
 
 	return (
@@ -23,6 +26,7 @@ function FormToggle( { className, checked, id, onChange = noop, ...props } ) {
 				id={ id }
 				type="checkbox"
 				checked={ checked }
+				disabled={ disabled }
 				onChange={ onChange }
 				{ ...props }
 			/>

--- a/packages/components/src/form-toggle/style.scss
+++ b/packages/components/src/form-toggle/style.scss
@@ -86,6 +86,14 @@ $toggle-border-width: 2px;
 			border: $toggle-border-width solid theme(toggle);
 		}
 	}
+
+	&.is-disabled {
+		.components-form-toggle__on,
+		.components-form-toggle__off {
+			opacity: 0.25;
+			cursor: default;
+		}
+	}
 }
 
 .components-form-toggle__input[type="checkbox"] {


### PR DESCRIPTION
## Description
Needed for https://github.com/Automattic/wp-calypso/issues/28701
WIP. Will update soon.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
