### PR TITLE
Improve scoping of nested paragraph right-padding rule

### DIFF
--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -18,6 +18,7 @@
 @import "./list/editor.scss";
 @import "./more/editor.scss";
 @import "./nextpage/editor.scss";
+@import "./paragraph/editor.scss";
 @import "./preformatted/editor.scss";
 @import "./pullquote/editor.scss";
 @import "./quote/editor.scss";

--- a/packages/block-library/src/paragraph/editor.scss
+++ b/packages/block-library/src/paragraph/editor.scss
@@ -1,0 +1,6 @@
+// Specific to the empty paragraph placeholder:
+// when shown on mobile and in nested contexts, the plus to add blocks shows up on the right.
+// This padding makes sure it doesn't overlap text.
+.editor-rich-text__tinymce[data-is-placeholder-visible="true"] + .editor-rich-text__tinymce.wp-block-paragraph {
+	padding-right: $icon-button-size;
+}

--- a/packages/block-library/src/paragraph/style.scss
+++ b/packages/block-library/src/paragraph/style.scss
@@ -37,10 +37,3 @@ p.has-background {
 p.has-text-color a {
 	color: inherit;
 }
-
-// Specific to the empty paragraph placeholder:
-// when shown on mobile and in nested contexts, the plus to add blocks shows up on the right.
-// This padding makes sure it doesn't overlap text.
-.editor-rich-text__tinymce[data-is-placeholder-visible="true"] + .editor-rich-text__tinymce.wp-block-paragraph {
-	padding-right: $icon-button-size;
-}

--- a/packages/block-library/src/paragraph/style.scss
+++ b/packages/block-library/src/paragraph/style.scss
@@ -37,3 +37,10 @@ p.has-background {
 p.has-text-color a {
 	color: inherit;
 }
+
+// Specific to the empty paragraph placeholder:
+// when shown on mobile and in nested contexts, the plus to add blocks shows up on the right.
+// This padding makes sure it doesn't overlap text.
+.editor-rich-text__tinymce[data-is-placeholder-visible="true"] + .editor-rich-text__tinymce.wp-block-paragraph {
+	padding-right: $icon-button-size;
+}

--- a/packages/editor/src/components/rich-text/style.scss
+++ b/packages/editor/src/components/rich-text/style.scss
@@ -103,7 +103,7 @@
 
 		// On mobile and in nested contexts, the plus to add blocks shows up on the right.
 		// This padding makes sure it doesn't overlap text.
-		& + .editor-rich-text__tinymce {
+		& + .editor-rich-text__tinymce.wp-block-paragraph {
 			padding-right: $icon-button-size;
 		}
 	}

--- a/packages/editor/src/components/rich-text/style.scss
+++ b/packages/editor/src/components/rich-text/style.scss
@@ -100,12 +100,6 @@
 
 		// Ensure that if placeholder wraps (mobile/nested contexts) the clickable area is full-height.
 		height: 100%;
-
-		// On mobile and in nested contexts, the plus to add blocks shows up on the right.
-		// This padding makes sure it doesn't overlap text.
-		& + .editor-rich-text__tinymce.wp-block-paragraph {
-			padding-right: $icon-button-size;
-		}
 	}
 
 	// Placeholder text.


### PR DESCRIPTION
This addresses feedback in https://github.com/WordPress/gutenberg/pull/11757#issuecomment-440269586.

The initial issue was that in the default appender, and in empty paragraphs, the plus to add blocks overlaps the placeholder text. The right-padding fixed that. But it bled into other blocks with placeholders, such as the Button block.

This PR scopes the rich text rule to only apply to empty paragraphs. The appender was already scoped.

Before:

![before](https://user-images.githubusercontent.com/1204802/48777005-b1328c00-ecd1-11e8-95a7-cee1fdb36130.png)

After:

![after](https://user-images.githubusercontent.com/1204802/48777008-b2fc4f80-ecd1-11e8-96d7-346ae65f10bb.png)

The button isn't as wide on the right side, in the after. 