### PR TITLE
Remove the gutenberg domain from the dynamic blocks

### DIFF
--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -32,7 +32,7 @@ function render_block_core_archives( $attributes ) {
 		$class .= ' wp-block-archives-dropdown';
 
 		$dropdown_id = esc_attr( uniqid( 'wp-block-archives-' ) );
-		$title       = __( 'Archives', 'gutenberg' );
+		$title       = __( 'Archives', 'default' );
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-archives.php */
 		$dropdown_args = apply_filters(
@@ -50,19 +50,19 @@ function render_block_core_archives( $attributes ) {
 
 		switch ( $dropdown_args['type'] ) {
 			case 'yearly':
-				$label = __( 'Select Year', 'gutenberg' );
+				$label = __( 'Select Year', 'default' );
 				break;
 			case 'monthly':
-				$label = __( 'Select Month', 'gutenberg' );
+				$label = __( 'Select Month', 'default' );
 				break;
 			case 'daily':
-				$label = __( 'Select Day', 'gutenberg' );
+				$label = __( 'Select Day', 'default' );
 				break;
 			case 'weekly':
-				$label = __( 'Select Week', 'gutenberg' );
+				$label = __( 'Select Week', 'default' );
 				break;
 			default:
-				$label = __( 'Select Post', 'gutenberg' );
+				$label = __( 'Select Post', 'default' );
 				break;
 		}
 
@@ -101,7 +101,7 @@ function render_block_core_archives( $attributes ) {
 			$block_content = sprintf(
 				'<div class="%1$s">%2$s</div>',
 				$classnames,
-				__( 'No archives to show.', 'gutenberg' )
+				__( 'No archives to show.', 'default' )
 			);
 		} else {
 

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -27,7 +27,7 @@ function render_block_core_categories( $attributes ) {
 	if ( ! empty( $attributes['displayAsDropdown'] ) ) {
 		$id                       = 'wp-block-categories-' . $block_id;
 		$args['id']               = $id;
-		$args['show_option_none'] = __( 'Select Category', 'gutenberg' );
+		$args['show_option_none'] = __( 'Select Category', 'default' );
 		$wrapper_markup           = '<div class="%1$s">%2$s</div>';
 		$items_markup             = wp_dropdown_categories( $args );
 		$type                     = 'dropdown';

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -29,7 +29,7 @@ if ( ! function_exists( 'gutenberg_draft_or_post_title' ) ) {
 	function gutenberg_draft_or_post_title( $post = 0 ) {
 		$title = get_the_title( $post );
 		if ( empty( $title ) ) {
-			$title = __( '(no title)', 'gutenberg' );
+			$title = __( '(no title)', 'default' );
 		}
 		return esc_html( $title );
 	}
@@ -98,7 +98,7 @@ function gutenberg_render_block_core_latest_comments( $attributes = array() ) {
 
 			$list_items_markup .= sprintf(
 				/* translators: 1: author name (inside <a> or <span> tag, based on if they have a URL), 2: post title related to this comment */
-				__( '%1$s on %2$s', 'gutenberg' ),
+				__( '%1$s on %2$s', 'default' ),
 				$author_markup,
 				$post_title
 			);
@@ -143,7 +143,7 @@ function gutenberg_render_block_core_latest_comments( $attributes = array() ) {
 	) : sprintf(
 		'<div class="%1$s">%2$s</div>',
 		$classnames,
-		__( 'No comments to show.', 'gutenberg' )
+		__( 'No comments to show.', 'default' )
 	);
 
 	return $block_content;

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -30,7 +30,7 @@ function render_block_core_latest_posts( $attributes ) {
 
 		$title = get_the_title( $post_id );
 		if ( ! $title ) {
-			$title = __( '(Untitled)', 'gutenberg' );
+			$title = __( '(Untitled)', 'default' );
 		}
 		$list_items_markup .= sprintf(
 			'<li><a href="%1$s">%2$s</a>',


### PR DESCRIPTION
closes #10788

Removes the "gutenberg" domain from the block library translations as these files are consumed in Core.