### PR TITLE
Convert to blocks: put unhandled HTML in HTML block, correct invalid lists

### DIFF
--- a/packages/blocks/src/api/raw-handling/index.js
+++ b/packages/blocks/src/api/raw-handling/index.js
@@ -270,6 +270,8 @@ export function rawHandler( { HTML = '' } ) {
 		// from raw HTML. These filters move around some content or add
 		// additional tags, they do not remove any content.
 		const filters = [
+			// Needed to adjust invalid lists.
+			listReducer,
 			// Needed to create more and nextpage blocks.
 			specialCommentConverter,
 			// Needed to create media blocks.

--- a/packages/blocks/src/api/raw-handling/index.js
+++ b/packages/blocks/src/api/raw-handling/index.js
@@ -84,13 +84,14 @@ function htmlToBlocks( { html, rawTransforms } ) {
 		const rawTransform = findTransform( rawTransforms, ( { isMatch } ) => isMatch( node ) );
 
 		if ( ! rawTransform ) {
-			console.warn(
-				'A block registered a raw transformation schema for `' + node.nodeName + '` but did not match it. ' +
-				'Make sure there is a `selector` or `isMatch` property that can match the schema.\n' +
-				'Sanitized HTML: `' + node.outerHTML + '`'
+			return createBlock(
+				// Should not be hardcoded.
+				'core/html',
+				getBlockAttributes(
+					'core/html',
+					node.outerHTML
+				)
 			);
-
-			return;
 		}
 
 		const { transform, blockName } = rawTransform;

--- a/test/integration/__snapshots__/blocks-raw-handling.spec.js.snap
+++ b/test/integration/__snapshots__/blocks-raw-handling.spec.js.snap
@@ -31,5 +31,18 @@ exports[`Blocks raw handling rawHandler should convert HTML post to blocks with 
 
 <!-- wp:gallery {\\"ids\\":[1],\\"columns\\":3,\\"linkTo\\":\\"attachment\\"} -->
 <ul class=\\"wp-block-gallery columns-3 is-cropped\\"><li class=\\"blocks-gallery-item\\"><figure><img data-id=\\"1\\" class=\\"wp-image-1\\"/></figure></li></ul>
-<!-- /wp:gallery -->"
+<!-- /wp:gallery -->
+
+<!-- wp:html -->
+<dl>
+	<dt>Term</dt>
+	<dd>
+		Description.
+	</dd>
+</dl>
+<!-- /wp:html -->
+
+<!-- wp:list {\\"ordered\\":true} -->
+<ol><li>Item</li></ol>
+<!-- /wp:list -->"
 `;

--- a/test/integration/fixtures/wordpress-convert.html
+++ b/test/integration/fixtures/wordpress-convert.html
@@ -6,3 +6,20 @@
 <p><!--more--></p>
 <h3>Shortcode</h3>
 <p>[gallery ids="1"]</p>
+
+<!-- HTML tags without block equivalent -->
+
+<dl>
+	<dt>Term</dt>
+	<dd>
+		Description.
+	</dd>
+</dl>
+
+<!-- Invalid list  -->
+
+<ol>
+	<ol>
+	  <li>Item</li>
+	</ol>
+</ol>


### PR DESCRIPTION
## Description
Fixes #12029.

> After a quick look at the diffs and pasted content, it seems to me that the problem is (an) unhandled `<dl>` element(s).
>
> Previously we would unwrap the element, then the block normaliser would merge the lines into a paragraph. Not ideal, but the content wasn't lost.
>
> Now we preserve the tag, but there is no handler for `dl`.

Also restores correcting invalid list HTML.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->