### PR TITLE
Remove "permalink settings" link from permalink panel.

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-link/index.js
+++ b/packages/edit-post/src/components/sidebar/post-link/index.js
@@ -11,7 +11,6 @@ import { __ } from '@wordpress/i18n';
 import { PanelBody, TextControl, ExternalLink } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose, ifCondition, withState } from '@wordpress/compose';
-import { addQueryArgs } from '@wordpress/url';
 import { cleanForSlug } from '@wordpress/editor';
 
 /**
@@ -101,13 +100,6 @@ function PostLink( {
 					</Fragment> ) :
 					postLink
 				}
-			</ExternalLink>
-			<ExternalLink
-				className="edit-post-post-link__permalink-settings"
-				href={ addQueryArgs( 'options-permalink.php' ) }
-				target="_blank"
-			>
-				{ __( 'Permalink Settings' ) }
 			</ExternalLink>
 		</PanelBody>
 	);

--- a/packages/edit-post/src/components/sidebar/post-link/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-link/style.scss
@@ -9,8 +9,3 @@
 .edit-post-post-link__link {
 	word-wrap: break-word;
 }
-
-.edit-post-post-link__permalink-settings {
-	margin-top: 1em;
-	display: block;
-}


### PR DESCRIPTION
This was a late addition and needs a bit more time and work to introduce properly (like handling capabilities). Let's remove it for now.