### PR TITLE
preserve quote content

### DIFF
--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -102,6 +102,8 @@ export const settings = {
 				type: 'raw',
 				isMatch: ( node ) => (
 					node.nodeName === 'BLOCKQUOTE' &&
+					// The quote block can only handle multiline paragraph
+					// content.
 					Array.from( node.childNodes ).every( ( child ) => child.nodeName === 'P' )
 				),
 				schema: {

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -100,7 +100,10 @@ export const settings = {
 			},
 			{
 				type: 'raw',
-				selector: 'blockquote',
+				isMatch: ( node ) => (
+					node.nodeName === 'BLOCKQUOTE' &&
+					Array.from( node.childNodes ).every( ( child ) => child.nodeName === 'P' )
+				),
 				schema: {
 					blockquote: {
 						children: {

--- a/test/integration/__snapshots__/blocks-raw-handling.spec.js.snap
+++ b/test/integration/__snapshots__/blocks-raw-handling.spec.js.snap
@@ -44,5 +44,13 @@ exports[`Blocks raw handling rawHandler should convert HTML post to blocks with 
 
 <!-- wp:list {\\"ordered\\":true} -->
 <ol><li>Item</li></ol>
-<!-- /wp:list -->"
+<!-- /wp:list -->
+
+<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p>Text.</p></blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:html -->
+<blockquote><h1>Heading</h1><p>Text.</p></blockquote>
+<!-- /wp:html -->"
 `;

--- a/test/integration/fixtures/wordpress-convert.html
+++ b/test/integration/fixtures/wordpress-convert.html
@@ -23,3 +23,16 @@
 	  <li>Item</li>
 	</ol>
 </ol>
+
+<!-- Quote with paragraphs -->
+
+<blockquote>
+	<p>Text.</p>
+</blockquote>
+
+<!-- Quote with more than paragraphs -->
+
+<blockquote>
+	<h1>Heading</h1>
+	<p>Text.</p>
+</blockquote>


### PR DESCRIPTION
closes #10456

## Description
Ensure content we can't handle is preserved in HTML block.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
