### PR TITLE
Fix: remove formats from document outline headings

### DIFF
--- a/packages/editor/src/components/document-outline/index.js
+++ b/packages/editor/src/components/document-outline/index.js
@@ -9,12 +9,15 @@ import { countBy, flatMap, get } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
+import {
+	create,
+	getTextContent,
+} from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
  */
 import DocumentOutlineItem from './item';
-import RichText from './../rich-text';
 
 /**
  * Module constants
@@ -120,10 +123,9 @@ export const DocumentOutline = ( { blocks = [], title, onSelect, isTitleSupporte
 						>
 							{ item.isEmpty ?
 								emptyHeadingContent :
-								<RichText.Content
-									tagName="span"
-									value={ item.attributes.content }
-								/>
+								getTextContent(
+									create( { html: item.attributes.content } )
+								)
 							}
 							{ isIncorrectLevel && incorrectLevelContent }
 							{ item.level === 1 && hasMultipleH1 && multipleH1Headings }

--- a/packages/editor/src/components/document-outline/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/document-outline/test/__snapshots__/index.js.snap
@@ -12,11 +12,7 @@ exports[`DocumentOutline header blocks present should match snapshot 1`] = `
       onClick={[Function]}
       path={Array []}
     >
-      <Component
-        format="string"
-        tagName="span"
-        value="Heading parent"
-      />
+      Heading parent
     </TableOfContentsItem>
     <TableOfContentsItem
       isValid={true}
@@ -25,11 +21,7 @@ exports[`DocumentOutline header blocks present should match snapshot 1`] = `
       onClick={[Function]}
       path={Array []}
     >
-      <Component
-        format="string"
-        tagName="span"
-        value="Heading child"
-      />
+      Heading child
     </TableOfContentsItem>
   </ul>
 </div>
@@ -47,11 +39,7 @@ exports[`DocumentOutline header blocks present should render warnings for multip
       onClick={[Function]}
       path={Array []}
     >
-      <Component
-        format="string"
-        tagName="span"
-        value="Heading 1"
-      />
+      Heading 1
       <br
         key="incorrect-break-multiple-h1"
       />
@@ -68,11 +56,7 @@ exports[`DocumentOutline header blocks present should render warnings for multip
       onClick={[Function]}
       path={Array []}
     >
-      <Component
-        format="string"
-        tagName="span"
-        value="Heading 1"
-      />
+      Heading 1
       <br
         key="incorrect-break-multiple-h1"
       />


### PR DESCRIPTION
## Description
After https://github.com/WordPress/gutenberg/pull/8204 was merged, we started using the heading content as the outline item.
So if the heading contained custom formats, they were shown in the document outline. Showing the formats in the outline may break the formats as discovered by @mcsf.

This PR makes sure we show the plain text in the hading without any formats.

Props to @mcsf for finding the issue and proposing a solution.

## How has this been tested?
In the code editor I pasted:
```
<!-- wp:heading -->
<h2>aaaa</h2>
<!-- /wp:heading -->

<!-- wp:heading {"level":3} -->
<h3><span style="line-height: 100px; color: red">bbbb</span></h3>
<!-- /wp:heading -->

<!-- wp:heading -->
<h2>cccccc</h2>
<!-- /wp:heading -->
```
I checked that the document inspector shown matches the "After" image.

## Screenshots <!-- if applicable -->
Before:

<img width="384" alt="screenshot 2018-11-20 at 19 43 23" src="https://user-images.githubusercontent.com/11271197/48798909-ac83cd00-ecfd-11e8-836c-f3f42c9538d7.png">

After:
<img width="381" alt="screenshot 2018-11-20 at 19 44 01" src="https://user-images.githubusercontent.com/11271197/48798916-b1e11780-ecfd-11e8-8e8c-a7f7170f1b5f.png">
