### PR TITLE
Add `react-native` module property to html-entities package.json

### DIFF
--- a/packages/html-entities/package.json
+++ b/packages/html-entities/package.json
@@ -19,6 +19,7 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
+	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.0.0"
 	},


### PR DESCRIPTION
## Description
This PR adds a property to the `@wordpress/html-entities`'s `package.json` file, making its sources accessible from a react-native project.

## How has this been tested?
From https://github.com/wordpress-mobile/gutenberg-mobile/pull/259
Run
```
yarn install
yarn android
```
The app should load without errors
Without this patch, the following error will occur:
```
Loading dependency graph, done.
error: bundling failed: Error: While trying to resolve module `@wordpress/html-entities` from file `/Users/.../gutenberg-mobile/gutenberg/packages/blocks/src/api/validation.js`, the package `/Users/.../gutenberg-mobile/gutenberg/packages/html-entities/package.json` was successfully found. However, this package itself specifies a `main` module field that could not be resolved (`/Users/.../gutenberg-mobile/gutenberg/packages/html-entities/build/index.js`. 
```

## Types of changes
Build system changes, mobile related

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
