### PR TITLE
Add: Permalink panel toggle mechanism.

### DIFF
--- a/packages/edit-post/src/components/options-modal/index.js
+++ b/packages/edit-post/src/components/options-modal/index.js
@@ -42,6 +42,7 @@ export function OptionsModal( { isModalActive, closeModal } ) {
 				<EnableTipsOption label={ __( 'Enable Tips' ) } />
 			</Section>
 			<Section title={ __( 'Document Panels' ) }>
+				<EnablePanelOption label={ __( 'Permalink' ) } panelName="post-link" />
 				<PostTaxonomies
 					taxonomyWrapper={ ( content, taxonomy ) => (
 						<EnablePanelOption

--- a/packages/edit-post/src/components/options-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/options-modal/test/__snapshots__/index.js.snap
@@ -25,6 +25,10 @@ exports[`OptionsModal should match snapshot when the modal is active 1`] = `
   <Section
     title="Document Panels"
   >
+    <WithSelect(IfCondition(WithDispatch(BaseOption)))
+      label="Permalink"
+      panelName="post-link"
+    />
     <WithSelect(PostTaxonomies)
       taxonomyWrapper={[Function]}
     />

--- a/packages/edit-post/src/components/sidebar/post-link/index.js
+++ b/packages/edit-post/src/components/sidebar/post-link/index.js
@@ -116,6 +116,7 @@ export default compose( [
 			getEditedPostAttribute,
 		} = select( 'core/editor' );
 		const {
+			isEditorPanelEnabled,
 			isEditorPanelOpened,
 		} = select( 'core/edit-post' );
 		const {
@@ -132,14 +133,15 @@ export default compose( [
 			isPublished: isCurrentPostPublished(),
 			isOpened: isEditorPanelOpened( PANEL_NAME ),
 			permalinkParts: getPermalinkParts(),
+			isEnabled: isEditorPanelEnabled( PANEL_NAME ),
 			isViewable: get( postType, [ 'viewable' ], false ),
 			postTitle: getEditedPostAttribute( 'title' ),
 			postSlug: getEditedPostAttribute( 'slug' ),
 			postID: id,
 		};
 	} ),
-	ifCondition( ( { isNew, postLink, isViewable } ) => {
-		return ! isNew && postLink && isViewable;
+	ifCondition( ( { isEnabled, isNew, postLink, isViewable } ) => {
+		return isEnabled && ! isNew && postLink && isViewable;
 	} ),
 	withDispatch( ( dispatch ) => {
 		const { toggleEditorPanelOpened } = dispatch( 'core/edit-post' );

--- a/test/e2e/specs/sidebar-permalink-panel.test.js
+++ b/test/e2e/specs/sidebar-permalink-panel.test.js
@@ -1,0 +1,35 @@
+/**
+ * Internal dependencies
+ */
+import {
+	findSidebarPanelWithTitle,
+	newPost,
+	openDocumentSettingsSidebar,
+	publishPost,
+} from '../support/utils';
+
+// This tests are not together with the remaining sidebar tests,
+// because we need to publish/save a post, to correctly test the permalink panel.
+// The sidebar test suit enforces that focus is never lost, but during save operations
+// the focus is lost and a new element is focused once the save is completed.
+describe( 'Sidebar Permalink Panel', () => {
+	it( 'should not render permalink sidebar panel while the post is new', async () => {
+		await newPost();
+		await openDocumentSettingsSidebar();
+		expect( await findSidebarPanelWithTitle( 'Permalink' ) ).toBeUndefined();
+	} );
+
+	it( 'should render permalink sidebar panel after the post is published and allow its removal', async () => {
+		await newPost();
+		await page.keyboard.type( 'aaaaa' );
+		await publishPost();
+		// Start editing again.
+		await page.type( '.editor-post-title__input', ' (Updated)' );
+		expect( await findSidebarPanelWithTitle( 'Permalink' ) ).toBeDefined();
+		await page.evaluate( () => {
+			const { removeEditorPanel } = wp.data.dispatch( 'core/edit-post' );
+			removeEditorPanel( 'post-link' );
+		} );
+		expect( await findSidebarPanelWithTitle( 'Permalink' ) ).toBeUndefined();
+	} );
+} );


### PR DESCRIPTION
## Description
This PR implements the toggle mechanism that was missing for the permalink panel.

The Permalink panel toggle option only appears if the permalink can, in fact, be shown so the user does not have the bad experience of being able to enable a panel that does not appear anyway.

The new component PostLinkCheck may have been used on PostLink, I did not reuse it because most of the props we query from the state to make the check are needed anyway, so we would just be querying them 2 times, besides that the ifCondition would in PostLink would still be needed to check if the panel is enabled. So we would almost not reduce any line of code and we would make the component more complex.

## How has this been tested?
Create a new post, verify the permalink panel is not appearing and in the options panel, the permalink panel is not referred.
Publish the post verify the Permalink panel appears.
Go to the options panel verify the permalink panel now appears there, disable it, and verify it was disabled with success.
Enable again the Permalink panel, paste ```wp.data.dispatch( 'core/edit-post').removeEditorPanel( 'post-link' );```in the console verify the Permalink panel disapers and verify the option to toggle it is now not available.


