### PR TITLE
Fix undefined index warnings in Latest Comments & Latest Posts

### DIFF
--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -119,7 +119,7 @@ function gutenberg_render_block_core_latest_comments( $attributes = array() ) {
 	}
 
 	$class = 'wp-block-latest-comments';
-	if ( $attributes['align'] ) {
+	if ( isset( $attributes['align'] ) ) {
 		$class .= " align{$attributes['align']}";
 	}
 	if ( $attributes['displayAvatar'] ) {

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -13,15 +13,18 @@
  * @return string Returns the post content with latest posts added.
  */
 function render_block_core_latest_posts( $attributes ) {
-	$recent_posts = wp_get_recent_posts(
-		array(
-			'numberposts' => $attributes['postsToShow'],
-			'post_status' => 'publish',
-			'order'       => $attributes['order'],
-			'orderby'     => $attributes['orderBy'],
-			'category'    => $attributes['categories'],
-		)
+	$args = array(
+		'numberposts' => $attributes['postsToShow'],
+		'post_status' => 'publish',
+		'order'       => $attributes['order'],
+		'orderby'     => $attributes['orderBy'],
 	);
+
+	if ( isset( $attributes['categories'] ) ) {
+		$args['categories'] = $attributes['categories'];
+	}
+
+	$recent_posts = wp_get_recent_posts( $args );
 
 	$list_items_markup = '';
 


### PR DESCRIPTION
Fixes #12119.

In #12003, `prepare_attributes_for_render` was changed so that the `$attributes` array that is passed to `render_callback` contains the same keys as what is passed to the block on the front-end. That is, it omits keys that are not set.

This caused some 'Undefined index' notices in the Latest Comments and Latest Posts blocks. We need to be using `isset()` when using attributes that do not have a default value defined.

#### Testing

1. Ensure that PHP is set to report notices, e.g. using `error_reporting( E_ALL );`
1. Create a post
1. Insert a Latest Comments block
1. Insert a Latest Posts block
1. Preview the post
1. There should be no PHP notice messages