### PR TITLE
Avoid showing draft revert message on autosaves

### DIFF
--- a/packages/editor/src/store/effects/posts.js
+++ b/packages/editor/src/store/effects/posts.js
@@ -170,10 +170,10 @@ export const requestPostUpdate = async ( action, store ) => {
  * @param {Object} store   Redux Store.
  */
 export const requestPostUpdateSuccess = ( action ) => {
-	const { previousPost, post, isAutosave, postType } = action;
+	const { previousPost, post, postType } = action;
 
 	// Autosaves are neither shown a notice nor redirected.
-	if ( isAutosave ) {
+	if ( get( action.options, [ 'isAutosave' ] ) ) {
 		return;
 	}
 

--- a/packages/editor/src/store/test/effects.js
+++ b/packages/editor/src/store/test/effects.js
@@ -320,7 +320,7 @@ describe( 'effects', () => {
 			const previousPost = getPublishedPost();
 			const post = { ...getPublishedPost(), id: defaultPost.id + 1 };
 
-			handler( { post, previousPost, isAutosave: true } );
+			handler( { post, previousPost, options: { isAutosave: true } } );
 
 			expect( dataDispatch( 'core/notices' ).createSuccessNotice ).not.toHaveBeenCalled();
 		} );


### PR DESCRIPTION
Fix #12147

**Testing instructions**

 - Publish a post
 - Edit the post
 - Wait for autosave
 - The "reverted to draft" message should not show up