### PR TITLE
Bump plugin version to 4.5.1

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -3,7 +3,7 @@
  * Plugin Name: Gutenberg
  * Plugin URI: https://github.com/WordPress/gutenberg
  * Description: Printing since 1440. This is the development plugin for the new block editor in core.
- * Version: 4.5.0
+ * Version: 4.5.1
  * Author: Gutenberg Team
  *
  * @package gutenberg

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "4.5.0",
+	"version": "4.5.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "4.5.0",
+	"version": "4.5.1",
 	"private": true,
 	"description": "A new WordPress editor experience",
 	"repository": "git+https://github.com/WordPress/gutenberg.git",


### PR DESCRIPTION
**Changelog**

 - Raw Handling: fix consecutive lists with one item
 - Avoid showing draft revert message on autosaves
 - Honor the Disable Visual Editor setting in the Gutenberg editor page
 - Docs: Fix dead links in CONTRIBUTING.md
 - Fix undefined index warnings in Latest Comments & Latest Posts
 - Add `react-native` module property to html-entities package.json
 - RichText: List: Sync DOM after editor command
 - Fix RichText infinte rerendering
 - Fix keycodes package missing i18n dependency