### PR TITLE
Fix RichText rerendering when it shouldn't

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2283,6 +2283,7 @@
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/rich-text": "file:packages/rich-text",
 				"lodash": "^4.17.10",
+				"memize": "^1.0.5",
 				"rememo": "^3.0.0",
 				"uuid": "^3.3.2"
 			}

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -26,6 +26,7 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/rich-text": "file:../rich-text",
 		"lodash": "^4.17.10",
+		"memize": "^1.0.5",
 		"rememo": "^3.0.0",
 		"uuid": "^3.3.2"
 	},

--- a/packages/annotations/src/format/annotation.js
+++ b/packages/annotations/src/format/annotation.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import memize from 'memize';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -115,6 +120,40 @@ function updateAnnotationsWithPositions( annotations, positions, { removeAnnotat
 	} );
 }
 
+/**
+ * Create prepareEditableTree memoized based on the annotation props.
+ *
+ * @param {Object} The props with annotations in them.
+ *
+ * @return {Function} The prepareEditableTree.
+ */
+const createPrepareEditableTree = memize( ( props ) => {
+	const { annotations } = props;
+
+	return ( formats, text ) => {
+		if ( annotations.length === 0 ) {
+			return formats;
+		}
+
+		let record = { formats, text };
+		record = applyAnnotations( record, annotations );
+		return record.formats;
+	};
+} );
+
+/**
+ * Returns the annotations as a props object. Memoized to prevent re-renders.
+ *
+ * @param {Array} The annotations to put in the object.
+ *
+ * @return {Object} The annotations props object.
+ */
+const getAnnotationObject = memize( ( annotations ) => {
+	return {
+		annotations,
+	};
+} );
+
 export const annotation = {
 	name: FORMAT_NAME,
 	title: __( 'Annotation' ),
@@ -128,21 +167,9 @@ export const annotation = {
 		return null;
 	},
 	__experimentalGetPropsForEditableTreePreparation( select, { richTextIdentifier, blockClientId } ) {
-		return {
-			annotations: select( STORE_KEY ).__experimentalGetAnnotationsForRichText( blockClientId, richTextIdentifier ),
-		};
+		return getAnnotationObject( select( STORE_KEY ).__experimentalGetAnnotationsForRichText( blockClientId, richTextIdentifier ) );
 	},
-	__experimentalCreatePrepareEditableTree( { annotations } ) {
-		return ( formats, text ) => {
-			if ( annotations.length === 0 ) {
-				return formats;
-			}
-
-			let record = { formats, text };
-			record = applyAnnotations( record, annotations );
-			return record.formats;
-		};
-	},
+	__experimentalCreatePrepareEditableTree: createPrepareEditableTree,
 	__experimentalGetPropsForEditableTreeChangeHandler( dispatch ) {
 		return {
 			removeAnnotation: dispatch( STORE_KEY ).__experimentalRemoveAnnotation,

--- a/packages/annotations/src/store/selectors.js
+++ b/packages/annotations/src/store/selectors.js
@@ -4,7 +4,16 @@
 import createSelector from 'rememo';
 import { get, flatMap } from 'lodash';
 
-const emptyArray = [];
+/**
+ * Shared reference to an empty array for cases where it is important to avoid
+ * returning a new array reference on every invocation, as in a connected or
+ * other pure component which performs `shouldComponentUpdate` check on props.
+ * This should be used as a last resort, since the normalized data should be
+ * maintained by the reducer result in state.
+ *
+ * @type {Array}
+ */
+const EMPTY_ARRAY = [];
 
 /**
  * Returns the annotations for a specific client ID.
@@ -21,12 +30,12 @@ export const __experimentalGetAnnotationsForBlock = createSelector(
 		} );
 	},
 	( state, blockClientId ) => [
-		get( state, blockClientId, emptyArray ),
+		get( state, blockClientId, EMPTY_ARRAY ),
 	]
 );
 
 export const __experimentalGetAllAnnotationsForBlock = function( state, blockClientId ) {
-	return get( state, blockClientId, [] );
+	return get( state, blockClientId, EMPTY_ARRAY );
 };
 
 /**
@@ -56,7 +65,7 @@ export const __experimentalGetAnnotationsForRichText = createSelector(
 		} );
 	},
 	( state, blockClientId ) => [
-		get( state, blockClientId, emptyArray ),
+		get( state, blockClientId, EMPTY_ARRAY ),
 	]
 );
 

--- a/packages/annotations/src/store/selectors.js
+++ b/packages/annotations/src/store/selectors.js
@@ -4,6 +4,8 @@
 import createSelector from 'rememo';
 import { get, flatMap } from 'lodash';
 
+const emptyArray = [];
+
 /**
  * Returns the annotations for a specific client ID.
  *
@@ -19,7 +21,7 @@ export const __experimentalGetAnnotationsForBlock = createSelector(
 		} );
 	},
 	( state, blockClientId ) => [
-		get( state, blockClientId, [] ),
+		get( state, blockClientId, emptyArray ),
 	]
 );
 
@@ -54,7 +56,7 @@ export const __experimentalGetAnnotationsForRichText = createSelector(
 		} );
 	},
 	( state, blockClientId ) => [
-		get( state, blockClientId, [] ),
+		get( state, blockClientId, emptyArray ),
 	]
 );
 

--- a/packages/rich-text/src/register-format-type.js
+++ b/packages/rich-text/src/register-format-type.js
@@ -12,6 +12,17 @@ import { addFilter } from '@wordpress/hooks';
 import { compose } from '@wordpress/compose';
 
 /**
+ * Shared reference to an empty array for cases where it is important to avoid
+ * returning a new array reference on every invocation, as in a connected or
+ * other pure component which performs `shouldComponentUpdate` check on props.
+ * This should be used as a last resort, since the normalized data should be
+ * maintained by the reducer result in state.
+ *
+ * @type {Array}
+ */
+const EMPTY_ARRAY = [];
+
+/**
  * Registers a new format provided a unique name and an object defining its
  * behavior.
  *
@@ -120,8 +131,7 @@ export function registerFormatType( name, settings ) {
 
 	dispatch( 'core/rich-text' ).addFormatTypes( settings );
 
-	const emptyArray = [];
-	const getFunctionStackMemoized = memize( ( previousStack = emptyArray, newFunction ) => {
+	const getFunctionStackMemoized = memize( ( previousStack = EMPTY_ARRAY, newFunction ) => {
 		return [
 			...previousStack,
 			newFunction,


### PR DESCRIPTION
closes #12150

## Description

The prepareEditableTree and onChangeEditableValue function stacks would have a new reference on every render. This prevents that by memoized the stack based on the previous stack and the newly added function.

## How has this been tested?

Tested using Yoast SEO. I am working on e2e tests to test that RichText's doesn't rerender too often.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->