### PR TITLE
Fix keycodes package missing i18n dependency

### DIFF
--- a/lib/packages-dependencies.php
+++ b/lib/packages-dependencies.php
@@ -184,6 +184,7 @@ return array(
 	'wp-is-shallow-equal'                   => array(),
 	'wp-keycodes'                           => array(
 		'lodash',
+		'wp-i18n',
 	),
 	'wp-list-reusable-blocks'               => array(
 		'lodash',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2659,6 +2659,7 @@
 			"version": "file:packages/keycodes",
 			"requires": {
 				"@babel/runtime": "^7.0.0",
+				"@wordpress/i18n": "file:packages/i18n",
 				"lodash": "^4.17.10"
 			}
 		},
@@ -11402,7 +11403,7 @@
 				},
 				"yargs": {
 					"version": "11.1.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+					"resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
 					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 					"dev": true,
 					"requires": {
@@ -12713,7 +12714,7 @@
 				},
 				"yargs": {
 					"version": "11.1.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+					"resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
 					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 					"dev": true,
 					"requires": {

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -21,6 +21,7 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.0.0",
+		"@wordpress/i18n": "file:../i18n",
 		"lodash": "^4.17.10"
 	},
 	"publishConfig": {


### PR DESCRIPTION
## Description
Fixes #11502.

> The keycodes plugin is missing the `@wordpress/i18n` dependency.

