### PR TITLE
RichText: convert HTML formatting whitespace to spaces

### DIFF
--- a/packages/editor/src/components/rich-text/style.scss
+++ b/packages/editor/src/components/rich-text/style.scss
@@ -8,6 +8,16 @@
 	margin: 0;
 	position: relative;
 	line-height: $editor-line-height;
+	// In HTML, leading and trailing spaces are not visible, and multiple spaces
+	// elsewhere are visually reduced to one space. This rule prevents spaces
+	// from collapsing so all space is visible in the editor and can be removed.
+	// It also prevents some browsers from inserting non-breaking spaces at the
+	// end of a line to prevent the space from visually disappearing. Sometimes
+	// these non breaking spaces can linger in the editor causing unwanted non
+	// breaking spaces in between words. If also prevent Firefox from inserting
+	// a trailing `br` node to visualise any trailing space, causing the element
+	// to be saved.
+	white-space: pre-wrap;
 
 	> p:empty {
 		min-height: $editor-font-size * $editor-line-height;

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -300,7 +300,7 @@ function createFromElement( {
 	const filterStringComplete = ( string ) => {
 		// Reduce any whitespace used for HTML formatting to one space
 		// character, because it will also be displayed as such by the browser.
-		string = string.replace( /[\n\r\t ]+/g, ' ' );
+		string = string.replace( /[\n\r\t]+/g, ' ' );
 
 		if ( filterString ) {
 			string = filterString( string );

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -297,11 +297,10 @@ function createFromElement( {
 
 	const length = element.childNodes.length;
 
-	// Remove any line breaks in text nodes. They are not content, but used to
-	// format the HTML. Line breaks in HTML are stored as BR elements.
-	// See https://www.w3.org/TR/html5/syntax.html#newlines.
 	const filterStringComplete = ( string ) => {
-		string = string.replace( /[\r\n]/g, '' );
+		// Reduce any whitespace used for HTML formatting to one space
+		// character, because it will also be displayed as such by the browser.
+		string = string.replace( /[\n\r\t ]+/g, ' ' );
 
 		if ( filterString ) {
 			string = filterString( string );

--- a/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
+++ b/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
@@ -317,13 +317,6 @@ exports[`recordToDom should ignore formats at line separator 1`] = `
 </body>
 `;
 
-exports[`recordToDom should ignore line breaks to format HTML 1`] = `
-<body>
-  
-  <br />
-</body>
-`;
-
 exports[`recordToDom should preserve emoji 1`] = `
 <body>
   🍒
@@ -336,6 +329,18 @@ exports[`recordToDom should preserve emoji in formatting 1`] = `
     🍒
   </em>
   
+</body>
+`;
+
+exports[`recordToDom should preserve non breaking space 1`] = `
+<body>
+  test  test
+</body>
+`;
+
+exports[`recordToDom should reduce multiple consecutive spaces to one 1`] = `
+<body>
+  test test
 </body>
 `;
 
@@ -356,6 +361,12 @@ exports[`recordToDom should remove with settings 1`] = `
 <body>
   
   <br />
+</body>
+`;
+
+exports[`recordToDom should replace characters to format HTML with space 1`] = `
+<body>
+   
 </body>
 `;
 

--- a/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
+++ b/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
@@ -338,12 +338,6 @@ exports[`recordToDom should preserve non breaking space 1`] = `
 </body>
 `;
 
-exports[`recordToDom should reduce multiple consecutive spaces to one 1`] = `
-<body>
-  test test
-</body>
-`;
-
 exports[`recordToDom should remove br with settings 1`] = `
 <body>
   

--- a/packages/rich-text/src/test/helpers/index.js
+++ b/packages/rich-text/src/test/helpers/index.js
@@ -47,24 +47,6 @@ export const spec = [
 		},
 	},
 	{
-		description: 'should reduce multiple consecutive spaces to one',
-		html: 'test  test',
-		createRange: ( element ) => ( {
-			startOffset: 5,
-			startContainer: element.firstChild,
-			endOffset: 5,
-			endContainer: element.firstChild,
-		} ),
-		startPath: [ 0, 5 ],
-		endPath: [ 0, 5 ],
-		record: {
-			start: 5,
-			end: 5,
-			formats: [ , , , , , , , , , ],
-			text: 'test test',
-		},
-	},
-	{
 		description: 'should preserve non breaking space',
 		html: 'test\u00a0 test',
 		createRange: ( element ) => ( {

--- a/packages/rich-text/src/test/helpers/index.js
+++ b/packages/rich-text/src/test/helpers/index.js
@@ -29,8 +29,8 @@ export const spec = [
 		},
 	},
 	{
-		description: 'should ignore line breaks to format HTML',
-		html: '\n\n\r\n',
+		description: 'should replace characters to format HTML with space',
+		html: '\n\n\r\n\t',
 		createRange: ( element ) => ( {
 			startOffset: 0,
 			startContainer: element,
@@ -38,12 +38,48 @@ export const spec = [
 			endContainer: element,
 		} ),
 		startPath: [ 0, 0 ],
-		endPath: [ 0, 0 ],
+		endPath: [ 0, 1 ],
 		record: {
 			start: 0,
-			end: 0,
-			formats: [],
-			text: '',
+			end: 1,
+			formats: [ , ],
+			text: ' ',
+		},
+	},
+	{
+		description: 'should reduce multiple consecutive spaces to one',
+		html: 'test  test',
+		createRange: ( element ) => ( {
+			startOffset: 5,
+			startContainer: element.firstChild,
+			endOffset: 5,
+			endContainer: element.firstChild,
+		} ),
+		startPath: [ 0, 5 ],
+		endPath: [ 0, 5 ],
+		record: {
+			start: 5,
+			end: 5,
+			formats: [ , , , , , , , , , ],
+			text: 'test test',
+		},
+	},
+	{
+		description: 'should preserve non breaking space',
+		html: 'test\u00a0 test',
+		createRange: ( element ) => ( {
+			startOffset: 5,
+			startContainer: element.firstChild,
+			endOffset: 5,
+			endContainer: element.firstChild,
+		} ),
+		startPath: [ 0, 5 ],
+		endPath: [ 0, 5 ],
+		record: {
+			start: 5,
+			end: 5,
+			formats: [ , , , , , , , , , , ],
+			text: 'test\u00a0 test',
 		},
 	},
 	{

--- a/test/e2e/specs/__snapshots__/links.test.js.snap
+++ b/test/e2e/specs/__snapshots__/links.test.js.snap
@@ -20,7 +20,7 @@ exports[`Links can be created instantly when a URL is selected 1`] = `
 
 exports[`Links can be created without any text selected 1`] = `
 "<!-- wp:paragraph -->
-<p>This is Gutenberg: <a href=\\"https://wordpress.org/gutenberg\\">https://wordpress.org/gutenberg</a></p>
+<p>This is Gutenberg: <a href=\\"https://wordpress.org/gutenberg\\">https://wordpress.org/gutenberg</a></p>
 <!-- /wp:paragraph -->"
 `;
 

--- a/test/e2e/specs/__snapshots__/rich-text.test.js.snap
+++ b/test/e2e/specs/__snapshots__/rich-text.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`RichText should apply formatting when selection is collapsed 1`] = `
 "<!-- wp:paragraph -->
-<p>Some <strong>bold</strong>.</p>
+<p>Some <strong>bold</strong>.</p>
 <!-- /wp:paragraph -->"
 `;
 

--- a/test/e2e/specs/__snapshots__/undo.test.js.snap
+++ b/test/e2e/specs/__snapshots__/undo.test.js.snap
@@ -28,12 +28,12 @@ exports[`undo should undo typing after a pause 2`] = `
 
 exports[`undo should undo typing after non input change 1`] = `
 "<!-- wp:paragraph -->
-<p>before keyboard <strong>after keyboard</strong></p>
+<p>before keyboard <strong>after keyboard</strong></p>
 <!-- /wp:paragraph -->"
 `;
 
 exports[`undo should undo typing after non input change 2`] = `
 "<!-- wp:paragraph -->
-<p>before keyboard </p>
+<p>before keyboard </p>
 <!-- /wp:paragraph -->"
 `;

--- a/test/e2e/specs/__snapshots__/writing-flow.test.js.snap
+++ b/test/e2e/specs/__snapshots__/writing-flow.test.js.snap
@@ -124,7 +124,7 @@ exports[`adding blocks should navigate around inline boundaries 1`] = `
 
 exports[`adding blocks should not delete surrounding space when deleting a selected word 1`] = `
 "<!-- wp:paragraph -->
-<p>alpha  gamma</p>
+<p>alpha  gamma</p>
 <!-- /wp:paragraph -->"
 `;
 
@@ -136,7 +136,7 @@ exports[`adding blocks should not delete surrounding space when deleting a selec
 
 exports[`adding blocks should not delete surrounding space when deleting a word with Alt+Backspace 1`] = `
 "<!-- wp:paragraph -->
-<p>alpha  gamma</p>
+<p>alpha  gamma</p>
 <!-- /wp:paragraph -->"
 `;
 
@@ -148,7 +148,7 @@ exports[`adding blocks should not delete surrounding space when deleting a word 
 
 exports[`adding blocks should not delete surrounding space when deleting a word with Backspace 1`] = `
 "<!-- wp:paragraph -->
-<p>1  3</p>
+<p>1  3</p>
 <!-- /wp:paragraph -->"
 `;
 

--- a/test/e2e/specs/adding-inline-tokens.test.js
+++ b/test/e2e/specs/adding-inline-tokens.test.js
@@ -44,7 +44,7 @@ describe( 'adding inline tokens', () => {
 		await page.click( '.media-modal button.media-button-select' );
 
 		// Check the content.
-		const regex = new RegExp( `<!-- wp:paragraph -->\\s*<p>a\\u00A0<img class="wp-image-\\d+" style="width:\\s*10px;?" src="[^"]+\\/${ filename }\\.png" alt=""\\/?><\\/p>\\s*<!-- \\/wp:paragraph -->` );
+		const regex = new RegExp( `<!-- wp:paragraph -->\\s*<p>a <img class="wp-image-\\d+" style="width:\\s*10px;?" src="[^"]+\\/${ filename }\\.png" alt=""\\/?><\\/p>\\s*<!-- \\/wp:paragraph -->` );
 		expect( await getEditedPostContent() ).toMatch( regex );
 	} );
 } );


### PR DESCRIPTION
## Description

Fixes #11588, #5872 and #7474.

When creating a rich text value from text nodes, this branch reduces any sequence of new lines and tabs to one space. This is needed because any sequence of new lines and tabs is used to format HTML, not as content. The browser will only display it as one space, if it is used in between words.

Previously we were just removing any line breaks, which would normally still be displayed by the browser as a space.

It also visualises and leading and trailing spaces, and and consecutive spaces elsewhere. This prevents buggy behaviour in different browsers when there is only one spaces, and prevent e.g. Chrome from inserting non breaking spaces and Firefox a trailing line break to visualise a trailing space when typing.

## How has this been tested?

Edit a paragraph as HTML. Remove a space and insert a line break (use ENTER). Edit visually. You should see a space where you inserted the line break. Edit the content. Edit as HTML. The line break should be replaced by a space.

Previously the line break would have been removed.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->