### PR TITLE
Fix TinyMCE list plugin registration

### DIFF
--- a/docs/contributors/scripts.md
+++ b/docs/contributors/scripts.md
@@ -50,13 +50,12 @@ The editor also uses some popular third-party packages and scripts. Plugin devel
 | [React](https://reactjs.org) | react  | React is a JavaScript library for building user interfaces |
 | [React Dom](https://reactjs.org/docs/react-dom.html) | react-dom | Serves as the entry point to the DOM and server renderers for React, intended to be paired with React |
 | [Moment](https://momentjs.com/) | moment| Parse, validate, manipulate, and display dates and times in JavaScript |
-| [TinyMCE Lists](https://www.tiny.cloud/docs/plugins/lists/) | tinymce-latest-lists| The `lists` plugin allows you to add numbered and bulleted lists to TinyMCE |
 | [Lodash](https://lodash.com) | lodash| Lodash is a JavaScript library which provides utility functions for common programming tasks |
 
 ## Polyfill Scripts
 
 The editor also provides polyfills for certain features that may not be available in all modern browsers.
-It is recommened to use the main `wp-polyfill` script handle which takes care of loading all the below mentioned polyfills.  
+It is recommened to use the main `wp-polyfill` script handle which takes care of loading all the below mentioned polyfills.
 
 | Script Name | Handle | Description |
 |-------------|--------|-------------|

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -87,6 +87,8 @@ if ( ! function_exists( 'register_tinymce_scripts' ) ) {
 			gutenberg_override_script( 'wp-tinymce-root', includes_url( 'js/tinymce/' ) . "tinymce{$mce_suffix}.js", array(), $tinymce_version );
 			gutenberg_override_script( 'wp-tinymce', includes_url( 'js/tinymce/' ) . "plugins/compat3x/plugin{$suffix}.js", array( 'wp-tinymce-root' ), $tinymce_version );
 		}
+
+		gutenberg_override_script( 'wp-tinymce-lists', includes_url( 'js/tinymce/' ) . "plugins/lists/plugin{$suffix}.js", array( 'wp-tinymce' ), $tinymce_version );
 	}
 }
 
@@ -619,12 +621,6 @@ function gutenberg_register_vendor_scripts() {
 		'moment',
 		'https://unpkg.com/moment@2.22.1/' . $moment_script,
 		array()
-	);
-	$tinymce_version = '4.7.11';
-	gutenberg_register_vendor_script(
-		'tinymce-latest-lists',
-		'https://unpkg.com/tinymce@' . $tinymce_version . '/plugins/lists/plugin' . $suffix . '.js',
-		array( 'wp-tinymce' )
 	);
 	gutenberg_register_vendor_script(
 		'lodash',

--- a/lib/packages-dependencies.php
+++ b/lib/packages-dependencies.php
@@ -134,7 +134,7 @@ return array(
 	'wp-editor'                             => array(
 		'jquery',
 		'lodash',
-		'tinymce-latest-lists',
+		'wp-tinymce-lists',
 		'wp-a11y',
 		'wp-api-fetch',
 		'wp-blob',


### PR DESCRIPTION
## Description

Currently the TinyMCE lists plugin is registered as vendor script and at the wrong TinyMCE version. The core script should be used.

Core script registration: https://github.com/WordPress/wordpress-develop/blob/f02568afb4b36fae4a5d0457e60cb7f75ce05bec/src/wp-includes/script-loader.php#L63.

## How has this been tested?
Ensure the list block still works in WordPress 4.9.8 with the plugin, and WordPress 5.0.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->