### PR TITLE
RichText: remove onSplit from docs

### DIFF
--- a/packages/editor/src/components/rich-text/README.md
+++ b/packages/editor/src/components/rich-text/README.md
@@ -25,10 +25,6 @@ Render a rich [`contenteditable` input](https://developer.mozilla.org/en-US/docs
 
 *Optional.* By default, a line break will be inserted on <kbd>Enter</kbd>. If the editable field can contain multiple paragraphs, this property can be set to create new paragraphs on <kbd>Enter</kbd>.
 
-### `onSplit( before: Array|String, after: Array|String, ...blocks: Object ): Function`
-
-*Optional.* Called when the content can be split with `before` and `after`. There might be blocks present, which should be inserted in between.
-
 ### `onReplace( blocks: Array ): Function`
 
 *Optional.* Called when the `RichText` instance is empty and it can be replaced with the given blocks.


### PR DESCRIPTION
## Description

`onSplit` was marked unstable in #11926, but the docs were not removed.


## Types of changes
Docs update.

