### PR TITLE
Paragraph: clear dropcap height so hover area shown correctly

### DIFF
--- a/packages/block-library/src/paragraph/style.scss
+++ b/packages/block-library/src/paragraph/style.scss
@@ -28,6 +28,13 @@ p {
 		text-transform: uppercase;
 		font-style: normal;
 	}
+
+	&.has-drop-cap::after {
+		content: "";
+		display: table;
+		clear: both;
+		padding-top: $block-padding;
+	}
 }
 
 p.has-background {

--- a/packages/block-library/src/paragraph/style.scss
+++ b/packages/block-library/src/paragraph/style.scss
@@ -29,7 +29,7 @@ p {
 		font-style: normal;
 	}
 
-	&.has-drop-cap::after {
+	&.has-drop-cap:not(:focus)::after {
 		content: "";
 		display: table;
 		clear: both;


### PR DESCRIPTION
A short paragraph with a dropcap shows a hover area that is too small:

<img width="359" alt="edit_post_ _wordpress_latest_ _wordpress" src="https://user-images.githubusercontent.com/1277682/48842377-fca97080-ed8b-11e8-93f1-d3555f9883a8.png">

This is because the dropcap letter is floated and the height isn’t taken into account, causing the block’s hover area to be incorrect. A paragraph that spans multiple lines won't exhibit this problem as the height is provided by the rest of the text.

This PR clears the dropcap so the height is applied.

Fixes problem in #12172
Fixes #12177

## How has this been tested?
1. Create a post with a single paragraph block
2. Enable dropcaps from block options
3. Hover over the block and note the hover area is shown around the dropcap and content

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
