### PR TITLE
Include :visited links in button color

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -34,7 +34,8 @@ $blocks-button__line-height: $big-font-size + 6px;
 
 	&:hover,
 	&:focus,
-	&:active {
+	&:active,
+	&:visited {
 		color: inherit;
 	}
 }
@@ -47,7 +48,7 @@ $blocks-button__line-height: $big-font-size + 6px;
 	color: $dark-gray-700;
 
 	.wp-block-button__link {
-		background: transparent;
+		background-color: transparent;
 		border: 2px solid currentcolor;
 	}
 }


### PR DESCRIPTION
## Description
I noticed the underscores theme's `:visited` link color was overriding our button color.

I also made the outline button's transparent background specific to the background-color so it wouldn't overwrite other background properties. For example a `background-image: linear-gradient()` on hover.

## How has this been tested?
visual tests with default themes and _s.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
