### PR TITLE
Annotations: Add end-to-end tests for annotations API

### DIFF
--- a/test/e2e/test-plugins/plugins-api/annotations-sidebar.js
+++ b/test/e2e/test-plugins/plugins-api/annotations-sidebar.js
@@ -15,6 +15,9 @@
 	var registerPlugin = wp.plugins.registerPlugin;
 	var PluginSidebar = wp.editPost.PluginSidebar;
 	var PluginSidebarMoreMenuItem = wp.editPost.PluginSidebarMoreMenuItem;
+	var applyFormat = wp.richText.applyFormat;
+	var registerFormatType = wp.richText.registerFormatType;
+	var domReady = wp.domReady;
 
 	class SidebarContents extends Component {
 		constructor( props ) {
@@ -118,4 +121,38 @@
 		icon: 'text',
 		render: AnnotationsSidebar
 	} );
+
+	window.annotationsCountingRerenders = 0;
+	const props = {};
+
+	const FORMAT_NAME = 'rerender/counter';
+
+	function countRerender( formats, text ) {
+		if ( text.startsWith( 'RerenderCounter' ) ) {
+			window.annotationsCountingRerenders++;
+		}
+
+		return formats;
+	}
+
+	domReady( () => {
+		registerFormatType( FORMAT_NAME, {
+			name: FORMAT_NAME,
+			title: __( 'Rerender counter' ),
+			tagName: 'mark',
+			className: 'annotations-rerender-counter',
+			attributes: {
+				className: 'class',
+			},
+			edit: () => {
+				return null;
+			},
+			__experimentalCreatePrepareEditableTree: () => {
+				return countRerender;
+			},
+			__experimentalGetPropsForEditableTreePreparation: () => {
+				return props;
+			}
+		} );
+	} )
 } )();


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

After introducing `prepareEditableTree` we would rerender all `RichText` instances when typing in one `RichText` instance. Noted here: https://github.com/WordPress/gutenberg/pull/11595#discussion_r231969644. This was partly fixed in https://github.com/WordPress/gutenberg/pull/12161. This PR fixes it completely and adds e2e tests to ensure that this won't happen again in the future.

## How has this been tested?

Using the e2e tests and applying annotations using Yoast SEO.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->