### PR TITLE
Fix cover block placeholder background color

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -84,7 +84,13 @@
 	}
 
 	&.components-placeholder {
-		height: inherit;
+		// use opacity to work in various editor styles
+		background: $dark-opacity-light-200;
+		min-height: 200px;
+
+		.is-dark-theme & {
+			background: $light-opacity-light-200;
+		}
 	}
 
 	// Apply max-width to floated items that have no intrinsic width


### PR DESCRIPTION
Prevent the `components` package styles from overriding the cover block background color.

Fixes #12179.
Related: [Trac-45279](https://core.trac.wordpress.org/ticket/45279).

For details on how to reproduce the issue, see #12179.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- ~[ ] My code follows the accessibility standards.~ <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- ~[ ] My code has proper inline documentation.~ <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
