### PR TITLE
Maybe update block selection on UNDO/REDO actions

### DIFF
--- a/packages/editor/src/store/effects.js
+++ b/packages/editor/src/store/effects.js
@@ -20,6 +20,7 @@ import { _n, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import {
+	clearSelectedBlock,
 	setupEditorState,
 	replaceBlocks,
 	selectBlock,
@@ -33,6 +34,7 @@ import {
 	getBlocks,
 	getBlockCount,
 	getPreviousBlockClientId,
+	getSelectedBlock,
 	getSelectedBlockClientId,
 	getSelectedBlockCount,
 	getTemplate,
@@ -121,6 +123,15 @@ export function selectPreviousBlock( action, store ) {
 	if ( blockClientIdToSelect !== selectedBlockClientId ) {
 		return selectBlock( blockClientIdToSelect, -1 );
 	}
+}
+
+export function maybeUpdateBlockSelection( action, store ) {
+	if ( !! getSelectedBlock( store.getState() ) ) {
+		// do nothing if block exists
+		return;
+	}
+	// otherwise, clear block selection
+	clearSelectedBlock();
 }
 
 /**
@@ -270,4 +281,6 @@ export default {
 		/* translators: %s: number of selected blocks */
 		speak( sprintf( _n( '%s block selected.', '%s blocks selected.', blockCount ), blockCount ), 'assertive' );
 	},
+	UNDO: maybeUpdateBlockSelection,
+	REDO: maybeUpdateBlockSelection,
 };


### PR DESCRIPTION
Addresses https://github.com/WordPress/gutenberg/issues/12002

On `UNDO`/`REDO` actions, check whether the block still exists. If it doesn't, clear selection.
