### PR TITLE
Make the image Link URL field readonly

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -441,7 +441,7 @@ class ImageEdit extends Component {
 		} );
 
 		const isResizable = [ 'wide', 'full' ].indexOf( align ) === -1 && isLargeViewport;
-		const isLinkURLInputDisabled = linkDestination !== LINK_DESTINATION_CUSTOM;
+		const isLinkURLInputReadOnly = linkDestination !== LINK_DESTINATION_CUSTOM;
 
 		const getInspectorControls = ( imageWidth, imageHeight ) => (
 			<InspectorControls>
@@ -529,8 +529,8 @@ class ImageEdit extends Component {
 								label={ __( 'Link URL' ) }
 								value={ href || '' }
 								onChange={ this.onSetCustomHref }
-								placeholder={ ! isLinkURLInputDisabled ? 'https://' : undefined }
-								disabled={ isLinkURLInputDisabled }
+								placeholder={ ! isLinkURLInputReadOnly ? 'https://' : undefined }
+								readOnly={ isLinkURLInputReadOnly }
 							/>
 							<ToggleControl
 								label={ __( 'Open in New Tab' ) }


### PR DESCRIPTION
## Description

Changes the image link URL field from `disabled` to `readonly`. As a user, when an image is linked to its media file or its attachment page, I'd still expect to be able to copy the URL for external usage.

Fixes #12189