### PR TITLE
Fix: Disable HTML edit from Media & Text block

### DIFF
--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -83,6 +83,7 @@ export const settings = {
 
 	supports: {
 		align: [ 'wide', 'full' ],
+		html: false,
 	},
 
 	transforms: {


### PR DESCRIPTION
## Description
Blocks that rely on InnerBlocks have some problems if the user uses the HTML edit function of the block the editor may crash.
To solve that on the columns block HTML edit was disabled, this PR applies the same solution to the Media & Text block.

Fixes:https://github.com/WordPress/gutenberg/issues/11884

## How has this been tested?
I added a media text block, I added content in it, I went to the block "More Options" menu and I verified "Edit as HTML option is not available.
