### PR TITLE
Fix: Unregistering a block type causes blocks that convert to it to break the editor

### DIFF
--- a/packages/editor/src/components/block-switcher/index.js
+++ b/packages/editor/src/components/block-switcher/index.js
@@ -47,7 +47,7 @@ export class BlockSwitcher extends Component {
 		const possibleBlockTransformations = orderBy(
 			filter(
 				getPossibleBlockTransformations( blocks ),
-				( block ) => !! itemsByName[ block.name ]
+				( block ) => block && !! itemsByName[ block.name ]
 			),
 			( block ) => itemsByName[ block.name ].frecency,
 			'desc'


### PR DESCRIPTION
When a block was registered, if we added another block that transformed to it and went to the block switcher the editor may crash.
Fixes: https://github.com/WordPress/gutenberg/issues/12001

## How has this been tested?
I added a list block.
I remove the quote block: ```wp.blocks.unregisterBlockType( 'core/quote' );```.
I went to the switcher of the quote block, I see the application did crash and the transform to paragraph was available.
I started again; I added a list block; I opened the block switcher; I checked quote and paragraph are available as transforms; I opened the console with the switcher opened, I remove the quote block: ```wp.blocks.unregisterBlockType( 'core/quote' );```and I verified the quote block transform disappeared.
