### PR TITLE
Split the comment

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1211,10 +1211,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		),
 	);
 
-	// Set a locale specific default font.
-	/*
-	 * Translators: Use this to specify the CSS font family for the default font
-	 */
+	/* Translators: Use this to specify the CSS font family for the default font */
 	$locale_font_family = esc_html_x( 'Noto Serif', 'CSS Font Family for Editor Font', 'gutenberg' );
 	$styles[]           = array(
 		'css' => "body { font-family: '$locale_font_family' }",

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1211,8 +1211,8 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		),
 	);
 
+	// Set a locale specific default font.
 	/*
-	 * Set a locale specific default font.
 	 * Translators: Use this to specify the CSS font family for the default font
 	 */
 	$locale_font_family = esc_html_x( 'Noto Serif', 'CSS Font Family for Editor Font', 'gutenberg' );


### PR DESCRIPTION

## Description
Separate the comment so translator comment is in it's own block.

## How has this been tested?
This is a change to comments so aside from loading to make sure nothing broke the test will be done as part of parsing.

## Types of changes
Bug fix #12139 corrects the translator comments for i18n

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->