### PR TITLE
i18n: use consistent color values (RGB/HEX/HSL)

### DIFF
--- a/packages/components/src/color-picker/inputs.js
+++ b/packages/components/src/color-picker/inputs.js
@@ -103,12 +103,12 @@ export class Inputs extends Component {
 		} else if ( this.state.view === 'rgb' ) {
 			this.setState( { view: 'hsl' } );
 
-			speak( __( 'Hue/saturation/lightness mode active' ) );
+			speak( __( 'HSL mode active' ) );
 		} else if ( this.state.view === 'hsl' ) {
 			if ( this.props.hsl.a === 1 ) {
 				this.setState( { view: 'hex' } );
 
-				speak( __( 'Hex color mode active' ) );
+				speak( __( 'HEX color mode active' ) );
 			} else {
 				this.setState( { view: 'rgb' } );
 
@@ -162,7 +162,7 @@ export class Inputs extends Component {
 			return (
 				<div className="components-color-picker__inputs-fields">
 					<Input
-						label={ __( 'Color value in hexadecimal' ) }
+						label={ __( 'Color value in HEX' ) }
 						valueKey="hex"
 						value={ this.props.hex }
 						onChange={ this.handleChange }

--- a/packages/components/src/color-picker/inputs.js
+++ b/packages/components/src/color-picker/inputs.js
@@ -108,7 +108,7 @@ export class Inputs extends Component {
 			if ( this.props.hsl.a === 1 ) {
 				this.setState( { view: 'hex' } );
 
-				speak( __( 'HEX color mode active' ) );
+				speak( __( 'Hex color mode active' ) );
 			} else {
 				this.setState( { view: 'rgb' } );
 
@@ -162,7 +162,7 @@ export class Inputs extends Component {
 			return (
 				<div className="components-color-picker__inputs-fields">
 					<Input
-						label={ __( 'Color value in HEX' ) }
+						label={ __( 'Color value in Hex' ) }
 						valueKey="hex"
 						value={ this.props.hex }
 						onChange={ this.handleChange }


### PR DESCRIPTION
## Description

The color-picker uses full color formats in some case and the abbreviations is others. This PR replaces all the i18n strings to use consistent color values ( **RGB** / **HEX** / **HSL** ).

## How has this been tested?

Using the https://translate.wordpress.org/ platform

## Screenshots

![i18n-colors-1](https://user-images.githubusercontent.com/576623/48861441-38fcc100-edcc-11e8-9e6f-719a3defa936.png)

![i18n-colors-2](https://user-images.githubusercontent.com/576623/48861436-3601d080-edcc-11e8-83c3-2d221712d880.png)

## Types of changes

String changes inside `__()` functions.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
