### PR TITLE
Fix exception when editing non-public CPTs

### DIFF
--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -1292,11 +1292,12 @@ Returns the permalink for the post.
 
 *Returns*
 
-The permalink.
+The permalink, or null if the post is not viewable.
 
 ### getPermalinkParts
 
-Returns the permalink for a post, split into it's three parts: the prefix, the postName, and the suffix.
+Returns the permalink for a post, split into it's three parts: the prefix,
+the postName, and the suffix.
 
 *Parameters*
 
@@ -1304,7 +1305,8 @@ Returns the permalink for a post, split into it's three parts: the prefix, the p
 
 *Returns*
 
-The prefix, postName, and suffix for the permalink.
+An object containing the prefix, postName, and suffix for
+                 the permalink, or null if the post is not viewable.
 
 ### inSomeHistory
 

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -206,6 +206,11 @@ function gutenberg_add_permalink_template_to_posts( $response, $post, $request )
 		return $response;
 	}
 
+	$post_type_obj = get_post_type_object( $post->post_type );
+	if ( ! is_post_type_viewable( $post_type_obj ) || ! $post_type_obj->public ) {
+		return $response;
+	}
+
 	if ( ! function_exists( 'get_sample_permalink' ) ) {
 		require_once ABSPATH . '/wp-admin/includes/post.php';
 	}

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -2119,10 +2119,15 @@ export function isPermalinkEditable( state ) {
  *
  * @param {Object} state Editor state.
  *
- * @return {string} The permalink.
+ * @return {?string} The permalink, or null if the post is not viewable.
  */
 export function getPermalink( state ) {
-	const { prefix, postName, suffix } = getPermalinkParts( state );
+	const permalinkParts = getPermalinkParts( state );
+	if ( ! permalinkParts ) {
+		return null;
+	}
+
+	const { prefix, postName, suffix } = permalinkParts;
 
 	if ( isPermalinkEditable( state ) ) {
 		return prefix + postName + suffix;
@@ -2132,14 +2137,20 @@ export function getPermalink( state ) {
 }
 
 /**
- * Returns the permalink for a post, split into it's three parts: the prefix, the postName, and the suffix.
+ * Returns the permalink for a post, split into it's three parts: the prefix,
+ * the postName, and the suffix.
  *
  * @param {Object} state Editor state.
  *
- * @return {Object} The prefix, postName, and suffix for the permalink.
+ * @return {Object} An object containing the prefix, postName, and suffix for
+ *                  the permalink, or null if the post is not viewable.
  */
 export function getPermalinkParts( state ) {
 	const permalinkTemplate = getEditedPostAttribute( state, 'permalink_template' );
+	if ( ! permalinkTemplate ) {
+		return null;
+	}
+
 	const postName = getEditedPostAttribute( state, 'slug' ) || getEditedPostAttribute( state, 'generated_slug' );
 
 	const [ prefix, suffix ] = permalinkTemplate.split( PERMALINK_POSTNAME_REGEX );

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -5042,6 +5042,17 @@ describe( 'selectors', () => {
 
 			expect( getPermalink( state ) ).toBe( 'http://foo.test/bar/baz/' );
 		} );
+
+		it( 'should return null if the post has no permalink template', () => {
+			const state = {
+				currentPost: {},
+				editor: {
+					present: {},
+				},
+			};
+
+			expect( getPermalink( state ) ).toBeNull();
+		} );
 	} );
 
 	describe( 'getPermalinkParts', () => {
@@ -5086,6 +5097,17 @@ describe( 'selectors', () => {
 			};
 
 			expect( getPermalinkParts( state ) ).toEqual( parts );
+		} );
+
+		it( 'should return null if the post has no permalink template', () => {
+			const state = {
+				currentPost: {},
+				editor: {
+					present: {},
+				},
+			};
+
+			expect( getPermalinkParts( state ) ).toBeNull();
 		} );
 	} );
 


### PR DESCRIPTION
Fixes #12129.

- Changes the posts API endpoint to only set `permalink_template` and `generated_slug` when the post is public and queryable. This matches the behaviour in Core.
- Changes the `getPermalink()` and `getPermalinkParts()` selectors to return null when there is no `permalink_template`. This fixes an exception on non-public CPTs caused by attempting to parse an undefined `permalink_template`.

#### Testing

1. Edit a non-public post using the block editor (e.g. a reusable block by going to _Manage All Reusable Blocks_ and then clicking _Edit_)
2. Publish a post and change its permalink using the sidebar
3. Publish a post and change its permalink using the permalink editor in the post title