### PR TITLE
TinyMCE: fix IE11 lost focus after init

### DIFF
--- a/packages/editor/src/components/rich-text/tinymce.js
+++ b/packages/editor/src/components/rich-text/tinymce.js
@@ -202,6 +202,8 @@ export default class TinyMCE extends Component {
 			settings.plugins.push( 'lists' );
 		}
 
+		const hadFocus = document.activeElement === this.editorNode;
+
 		tinymce.init( {
 			...settings,
 			target: this.editorNode,
@@ -243,6 +245,14 @@ export default class TinyMCE extends Component {
 
 					// Restore the original `setHTML` once initialized.
 					editor.dom.setHTML = setHTML;
+
+					const hasFocus = document.activeElement === this.editorNode;
+
+					// In IE11, focus is lost after initialising TinyMCE, so we
+					// have to set it back.
+					if ( hadFocus && ! hasFocus ) {
+						this.editorNode.focus();
+					}
 				} );
 
 				editor.on( 'keydown', this.onKeyDown, true );

--- a/packages/editor/src/components/rich-text/tinymce.js
+++ b/packages/editor/src/components/rich-text/tinymce.js
@@ -202,8 +202,6 @@ export default class TinyMCE extends Component {
 			settings.plugins.push( 'lists' );
 		}
 
-		const hadFocus = document.activeElement === this.editorNode;
-
 		tinymce.init( {
 			...settings,
 			target: this.editorNode,
@@ -246,11 +244,12 @@ export default class TinyMCE extends Component {
 					// Restore the original `setHTML` once initialized.
 					editor.dom.setHTML = setHTML;
 
-					const hasFocus = document.activeElement === this.editorNode;
-
-					// In IE11, focus is lost after initialising TinyMCE, so we
-					// have to set it back.
-					if ( hadFocus && ! hasFocus ) {
+					// In IE11, focus is lost to parent after initialising
+					// TinyMCE, so we have to set it back.
+					if (
+						document.activeElement !== this.editorNode &&
+						document.activeElement.contains( this.editorNode )
+					) {
 						this.editorNode.focus();
 					}
 				} );


### PR DESCRIPTION
## Description

Fixes #12113.

I'm not sure what is causing the focus loss. An easy fix is to just set it back if focus is gone.

## How has this been tested?
See #12113.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->