### PR TITLE
Do not show the block settings menu if selected block is invalid

### DIFF
--- a/packages/editor/src/components/block-toolbar/index.js
+++ b/packages/editor/src/components/block-toolbar/index.js
@@ -34,9 +34,9 @@ function BlockToolbar( { blockClientIds, isValid, mode } ) {
 					<BlockSwitcher clientIds={ blockClientIds } />
 					<BlockControls.Slot />
 					<BlockFormatControls.Slot />
-					<BlockSettingsMenu clientIds={ blockClientIds } />
 				</Fragment>
 			) }
+			{ isValid && ( <BlockSettingsMenu clientIds={ blockClientIds } /> ) }
 		</div>
 	);
 }

--- a/packages/editor/src/components/block-toolbar/index.js
+++ b/packages/editor/src/components/block-toolbar/index.js
@@ -34,9 +34,9 @@ function BlockToolbar( { blockClientIds, isValid, mode } ) {
 					<BlockSwitcher clientIds={ blockClientIds } />
 					<BlockControls.Slot />
 					<BlockFormatControls.Slot />
+					<BlockSettingsMenu clientIds={ blockClientIds } />
 				</Fragment>
 			) }
-			<BlockSettingsMenu clientIds={ blockClientIds } />
 		</div>
 	);
 }


### PR DESCRIPTION
Alternative to https://github.com/WordPress/gutenberg/pull/12052
Fixes https://github.com/WordPress/gutenberg/issues/12002

**Please, consider this PR together with https://github.com/WordPress/gutenberg/pull/12052 We only want to merge one of them.**

The `blockSelection` mechanism doesn't get updated with the `UNDO`/`REDO` actions. I [haven't found](https://github.com/WordPress/gutenberg/issues/12002#issuecomment-440752932) an easy approach to solve the root problem, so I originally proposed we merged https://github.com/WordPress/gutenberg/pull/12052 that hides the plugin slot in the BlockSettingsMenu so the editor doesn't break.

This PR is more holistic in that in hides the whole BlockSettingsMenu instead of only the plugin slot.