### PR TITLE
Improve block preview.

### DIFF
--- a/packages/editor/src/components/block-styles/style.scss
+++ b/packages/editor/src/components/block-styles/style.scss
@@ -38,14 +38,17 @@
 	height: 60px;
 	background: $white;
 
-	> * {
+	// Actual preview contents.
+	.editor-block-preview__content {
 		transform: scale(0.7);
 		transform-origin: center center;
-		font-family: $editor-font;
-	}
-
-	.editor-block-preview__content {
 		width: 100%;
+
+		// Unset some of the styles that might be inherited from the editor style.
+		margin: 0;
+		padding: 0;
+		overflow: visible;
+		min-height: auto;
 	}
 }
 


### PR DESCRIPTION
Hopefully fixes #11997.

It polishes the preview code a bit to be leaner and more readable. But mostly it adds a fwe CSS style overrides that it might inherit from the theme.

CC: @m-e-h 

<img width="527" alt="screenshot 2018-11-22 at 11 10 07" src="https://user-images.githubusercontent.com/1204802/48896427-e234cd00-ee47-11e8-9241-aca8a61a8d78.png">

<img width="505" alt="screenshot 2018-11-22 at 11 11 00" src="https://user-images.githubusercontent.com/1204802/48896435-e365fa00-ee47-11e8-85b8-132a860c221a.png">

<img width="827" alt="screenshot 2018-11-22 at 11 11 15" src="https://user-images.githubusercontent.com/1204802/48896436-e4972700-ee47-11e8-816b-4b42d2df35fb.png">

<img width="763" alt="screenshot 2018-11-22 at 11 11 23" src="https://user-images.githubusercontent.com/1204802/48896437-e5c85400-ee47-11e8-9c4c-d06cb53968af.png">
<img width="764" alt="screenshot 2018-11-22 at 11 11 38" src="https://user-images.githubusercontent.com/1204802/48896440-e6f98100-ee47-11e8-8be7-463c0817d1f0.png">
