### PR TITLE
 Docs: Update section on transforming from shortcodes

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -120,3 +120,4 @@ This list is manually curated to include valuable contributions by volunteers th
 | @getsource | @mikeschroder |
 | @greatislander | @greatislander |
 | @sharazghouri | @sharaz |
+| @jakeparis | |

--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -233,8 +233,8 @@ transforms: {
                 // An attribute can be source from the shortcode attributes
                 align: {
                     type: 'string',
-                    shortcode: function( named ) {
-                        var align = named.align ? named.align : 'alignnone';
+                    shortcode: function( attributes ) {
+                        var align = attributes.named.align ? attributes.named.align : 'alignnone';
                         return align.replace( 'align', '' );
                     },
                 },


### PR DESCRIPTION
## Description
Replacement for #11693 which I could rebase after docs structure changes.

Props to @jakeparis for catching the issue. This PR also adds @jakeparis to the list of contributors.

> input into shortcode is missing destructuring syntax.

I opted for ES5 syntax to ensure it works also in older browsers like IE11.