### PR TITLE
Fix getSelectedBlockClientId selector

### DIFF
--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -852,8 +852,8 @@ export function hasSelectedBlock( state ) {
  * @return {?string} Selected block client ID.
  */
 export function getSelectedBlockClientId( state ) {
-	const { start, end } = state.blockSelection;
-	return start === end && start ? start : null;
+	const selectedBlock = getSelectedBlock( state );
+	return get( selectedBlock, [ 'clientId' ], null );
 }
 
 /**
@@ -864,7 +864,11 @@ export function getSelectedBlockClientId( state ) {
  * @return {?Object} Selected block.
  */
 export function getSelectedBlock( state ) {
-	const clientId = getSelectedBlockClientId( state );
+	const { start, end } = state.blockSelection;
+	let clientId = null;
+	if ( start === end && start ) {
+		clientId = start;
+	}
 	return clientId ? getBlock( state, clientId ) : null;
 }
 

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -853,7 +853,10 @@ export function hasSelectedBlock( state ) {
  */
 export function getSelectedBlockClientId( state ) {
 	const { start, end } = state.blockSelection;
-	return start === end && start ? start : null;
+	// We need to check the block exists because the current state.blockSelection reducer
+	// doesn't take into account the UNDO / REDO actions to update selection.
+	// To be removed when that's fixed.
+	return start && start === end && !! state.editor.present.blocks.byClientId[ start ] ? start : null;
 }
 
 /**

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -852,8 +852,8 @@ export function hasSelectedBlock( state ) {
  * @return {?string} Selected block client ID.
  */
 export function getSelectedBlockClientId( state ) {
-	const selectedBlock = getSelectedBlock( state );
-	return get( selectedBlock, [ 'clientId' ], null );
+	const { start, end } = state.blockSelection;
+	return start === end && start ? start : null;
 }
 
 /**
@@ -864,11 +864,7 @@ export function getSelectedBlockClientId( state ) {
  * @return {?Object} Selected block.
  */
 export function getSelectedBlock( state ) {
-	const { start, end } = state.blockSelection;
-	let clientId = null;
-	if ( start === end && start ) {
-		clientId = start;
-	}
+	const clientId = getSelectedBlockClientId( state );
 	return clientId ? getBlock( state, clientId ) : null;
 }
 

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -2555,6 +2555,24 @@ describe( 'selectors', () => {
 	describe( 'getSelectedBlockClientId', () => {
 		it( 'should return null if no block is selected', () => {
 			const state = {
+				currentPost: {},
+				editor: {
+					present: {
+						blocks: {
+							byClientId: {
+								23: { clientId: 23, name: 'core/heading', attributes: {} },
+								123: { clientId: 123, name: 'core/paragraph', attributes: {} },
+							},
+							order: {
+								'': [ 23, 123 ],
+								23: [],
+								123: [],
+							},
+						},
+						edits: {},
+					},
+				},
+				initialEdits: {},
 				blockSelection: { start: null, end: null },
 			};
 
@@ -2563,6 +2581,24 @@ describe( 'selectors', () => {
 
 		it( 'should return null if there is multi selection', () => {
 			const state = {
+				currentPost: {},
+				editor: {
+					present: {
+						blocks: {
+							byClientId: {
+								23: { clientId: 23, name: 'core/heading', attributes: {} },
+								123: { clientId: 123, name: 'core/paragraph', attributes: {} },
+							},
+							order: {
+								'': [ 23, 123 ],
+								23: [],
+								123: [],
+							},
+						},
+						edits: {},
+					},
+				},
+				initialEdits: {},
 				blockSelection: { start: 23, end: 123 },
 			};
 
@@ -2571,6 +2607,24 @@ describe( 'selectors', () => {
 
 		it( 'should return the selected block ClientId', () => {
 			const state = {
+				currentPost: {},
+				editor: {
+					present: {
+						blocks: {
+							byClientId: {
+								23: { clientId: 23, name: 'core/heading', attributes: {} },
+								123: { clientId: 123, name: 'core/paragraph', attributes: {} },
+							},
+							order: {
+								'': [ 23, 123 ],
+								23: [],
+								123: [],
+							},
+						},
+						edits: {},
+					},
+				},
+				initialEdits: {},
 				blockSelection: { start: 23, end: 23 },
 			};
 

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -2571,6 +2571,7 @@ describe( 'selectors', () => {
 
 		it( 'should return the selected block ClientId', () => {
 			const state = {
+				editor: { present: { blocks: { byClientId: { 23: { name: 'fake block' } } } } },
 				blockSelection: { start: 23, end: 23 },
 			};
 

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -2555,24 +2555,6 @@ describe( 'selectors', () => {
 	describe( 'getSelectedBlockClientId', () => {
 		it( 'should return null if no block is selected', () => {
 			const state = {
-				currentPost: {},
-				editor: {
-					present: {
-						blocks: {
-							byClientId: {
-								23: { clientId: 23, name: 'core/heading', attributes: {} },
-								123: { clientId: 123, name: 'core/paragraph', attributes: {} },
-							},
-							order: {
-								'': [ 23, 123 ],
-								23: [],
-								123: [],
-							},
-						},
-						edits: {},
-					},
-				},
-				initialEdits: {},
 				blockSelection: { start: null, end: null },
 			};
 
@@ -2581,24 +2563,6 @@ describe( 'selectors', () => {
 
 		it( 'should return null if there is multi selection', () => {
 			const state = {
-				currentPost: {},
-				editor: {
-					present: {
-						blocks: {
-							byClientId: {
-								23: { clientId: 23, name: 'core/heading', attributes: {} },
-								123: { clientId: 123, name: 'core/paragraph', attributes: {} },
-							},
-							order: {
-								'': [ 23, 123 ],
-								23: [],
-								123: [],
-							},
-						},
-						edits: {},
-					},
-				},
-				initialEdits: {},
 				blockSelection: { start: 23, end: 123 },
 			};
 
@@ -2607,24 +2571,6 @@ describe( 'selectors', () => {
 
 		it( 'should return the selected block ClientId', () => {
 			const state = {
-				currentPost: {},
-				editor: {
-					present: {
-						blocks: {
-							byClientId: {
-								23: { clientId: 23, name: 'core/heading', attributes: {} },
-								123: { clientId: 123, name: 'core/paragraph', attributes: {} },
-							},
-							order: {
-								'': [ 23, 123 ],
-								23: [],
-								123: [],
-							},
-						},
-						edits: {},
-					},
-				},
-				initialEdits: {},
 				blockSelection: { start: 23, end: 23 },
 			};
 


### PR DESCRIPTION
Addresses https://github.com/WordPress/gutenberg/issues/12002
Superseedes https://github.com/WordPress/gutenberg/pull/12209 and https://github.com/WordPress/gutenberg/pull/12052 that tried to fix this only for the `BlockSettingsMenu` component.

At the moment, we don't have a way to clear or update block selection for `UNDO` / `REDO` actions. This is problematic for every client that uses `getSelectedBlockClientId` because they may end up with a block that no longer exist in the editor.

By inverting the dependencies between `getSelectedBlockClientId`  and `getSelectedBlock` we make sure we always return a valid clientId in `getSelectedBlockClientId`.

We still have to fix the `UNDO`/`REDO` problem, but this patch gives us time to think while the external API works as expected.
