### PR TITLE
Remove the textdomain from block library

### DIFF
--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -32,7 +32,7 @@ function render_block_core_archives( $attributes ) {
 		$class .= ' wp-block-archives-dropdown';
 
 		$dropdown_id = esc_attr( uniqid( 'wp-block-archives-' ) );
-		$title       = __( 'Archives' );
+		$title       = __( 'Archives' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomainDefault
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-archives.php */
 		$dropdown_args = apply_filters(
@@ -50,19 +50,19 @@ function render_block_core_archives( $attributes ) {
 
 		switch ( $dropdown_args['type'] ) {
 			case 'yearly':
-				$label = __( 'Select Year' );
+				$label = __( 'Select Year' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomainDefault
 				break;
 			case 'monthly':
-				$label = __( 'Select Month' );
+				$label = __( 'Select Month' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomainDefault
 				break;
 			case 'daily':
-				$label = __( 'Select Day' );
+				$label = __( 'Select Day' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomainDefault
 				break;
 			case 'weekly':
-				$label = __( 'Select Week' );
+				$label = __( 'Select Week' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomainDefault
 				break;
 			default:
-				$label = __( 'Select Post' );
+				$label = __( 'Select Post' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomainDefault
 				break;
 		}
 
@@ -101,7 +101,7 @@ function render_block_core_archives( $attributes ) {
 			$block_content = sprintf(
 				'<div class="%1$s">%2$s</div>',
 				$classnames,
-				__( 'No archives to show.' )
+				__( 'No archives to show.' ) // phpcs:ignore WordPress.WP.I18n.MissingArgDomainDefault
 			);
 		} else {
 

--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -32,7 +32,7 @@ function render_block_core_archives( $attributes ) {
 		$class .= ' wp-block-archives-dropdown';
 
 		$dropdown_id = esc_attr( uniqid( 'wp-block-archives-' ) );
-		$title       = __( 'Archives', 'default' );
+		$title       = __( 'Archives' );
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-archives.php */
 		$dropdown_args = apply_filters(
@@ -50,19 +50,19 @@ function render_block_core_archives( $attributes ) {
 
 		switch ( $dropdown_args['type'] ) {
 			case 'yearly':
-				$label = __( 'Select Year', 'default' );
+				$label = __( 'Select Year' );
 				break;
 			case 'monthly':
-				$label = __( 'Select Month', 'default' );
+				$label = __( 'Select Month' );
 				break;
 			case 'daily':
-				$label = __( 'Select Day', 'default' );
+				$label = __( 'Select Day' );
 				break;
 			case 'weekly':
-				$label = __( 'Select Week', 'default' );
+				$label = __( 'Select Week' );
 				break;
 			default:
-				$label = __( 'Select Post', 'default' );
+				$label = __( 'Select Post' );
 				break;
 		}
 
@@ -101,7 +101,7 @@ function render_block_core_archives( $attributes ) {
 			$block_content = sprintf(
 				'<div class="%1$s">%2$s</div>',
 				$classnames,
-				__( 'No archives to show.', 'default' )
+				__( 'No archives to show.' )
 			);
 		} else {
 

--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -32,7 +32,7 @@ function render_block_core_archives( $attributes ) {
 		$class .= ' wp-block-archives-dropdown';
 
 		$dropdown_id = esc_attr( uniqid( 'wp-block-archives-' ) );
-		$title       = __( 'Archives' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomainDefault
+		$title       = __( 'Archives' );
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-archives.php */
 		$dropdown_args = apply_filters(
@@ -50,19 +50,19 @@ function render_block_core_archives( $attributes ) {
 
 		switch ( $dropdown_args['type'] ) {
 			case 'yearly':
-				$label = __( 'Select Year' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomainDefault
+				$label = __( 'Select Year' );
 				break;
 			case 'monthly':
-				$label = __( 'Select Month' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomainDefault
+				$label = __( 'Select Month' );
 				break;
 			case 'daily':
-				$label = __( 'Select Day' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomainDefault
+				$label = __( 'Select Day' );
 				break;
 			case 'weekly':
-				$label = __( 'Select Week' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomainDefault
+				$label = __( 'Select Week' );
 				break;
 			default:
-				$label = __( 'Select Post' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomainDefault
+				$label = __( 'Select Post' );
 				break;
 		}
 
@@ -101,7 +101,7 @@ function render_block_core_archives( $attributes ) {
 			$block_content = sprintf(
 				'<div class="%1$s">%2$s</div>',
 				$classnames,
-				__( 'No archives to show.' ) // phpcs:ignore WordPress.WP.I18n.MissingArgDomainDefault
+				__( 'No archives to show.' )
 			);
 		} else {
 

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -27,7 +27,7 @@ function render_block_core_categories( $attributes ) {
 	if ( ! empty( $attributes['displayAsDropdown'] ) ) {
 		$id                       = 'wp-block-categories-' . $block_id;
 		$args['id']               = $id;
-		$args['show_option_none'] = __( 'Select Category' );
+		$args['show_option_none'] = __( 'Select Category' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomainDefault
 		$wrapper_markup           = '<div class="%1$s">%2$s</div>';
 		$items_markup             = wp_dropdown_categories( $args );
 		$type                     = 'dropdown';

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -27,7 +27,7 @@ function render_block_core_categories( $attributes ) {
 	if ( ! empty( $attributes['displayAsDropdown'] ) ) {
 		$id                       = 'wp-block-categories-' . $block_id;
 		$args['id']               = $id;
-		$args['show_option_none'] = __( 'Select Category', 'default' );
+		$args['show_option_none'] = __( 'Select Category' );
 		$wrapper_markup           = '<div class="%1$s">%2$s</div>';
 		$items_markup             = wp_dropdown_categories( $args );
 		$type                     = 'dropdown';

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -27,7 +27,7 @@ function render_block_core_categories( $attributes ) {
 	if ( ! empty( $attributes['displayAsDropdown'] ) ) {
 		$id                       = 'wp-block-categories-' . $block_id;
 		$args['id']               = $id;
-		$args['show_option_none'] = __( 'Select Category' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomainDefault
+		$args['show_option_none'] = __( 'Select Category' );
 		$wrapper_markup           = '<div class="%1$s">%2$s</div>';
 		$items_markup             = wp_dropdown_categories( $args );
 		$type                     = 'dropdown';

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -96,12 +96,14 @@ function gutenberg_render_block_core_latest_comments( $attributes = array() ) {
 			// `esc_html`.
 			$post_title = '<a class="wp-block-latest-comments__comment-link" href="' . esc_url( get_comment_link( $comment ) ) . '">' . gutenberg_draft_or_post_title( $comment->comment_post_ID ) . '</a>';
 
+			// phpcs:disable WordPress.WP.I18n.MissingArgDomainDefault
 			$list_items_markup .= sprintf(
 				/* translators: 1: author name (inside <a> or <span> tag, based on if they have a URL), 2: post title related to this comment */
-				__( '%1$s on %2$s' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomainDefault
+				__( '%1$s on %2$s' ),
 				$author_markup,
 				$post_title
 			);
+			// phpcs:enable WordPress.WP.I18n.MissingArgDomainDefault
 
 			if ( $attributes['displayDate'] ) {
 				$list_items_markup .= sprintf(

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -29,7 +29,7 @@ if ( ! function_exists( 'gutenberg_draft_or_post_title' ) ) {
 	function gutenberg_draft_or_post_title( $post = 0 ) {
 		$title = get_the_title( $post );
 		if ( empty( $title ) ) {
-			$title = __( '(no title)' );
+			$title = __( '(no title)' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomainDefault
 		}
 		return esc_html( $title );
 	}
@@ -98,7 +98,7 @@ function gutenberg_render_block_core_latest_comments( $attributes = array() ) {
 
 			$list_items_markup .= sprintf(
 				/* translators: 1: author name (inside <a> or <span> tag, based on if they have a URL), 2: post title related to this comment */
-				__( '%1$s on %2$s' ),
+				__( '%1$s on %2$s' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomainDefault
 				$author_markup,
 				$post_title
 			);
@@ -143,7 +143,7 @@ function gutenberg_render_block_core_latest_comments( $attributes = array() ) {
 	) : sprintf(
 		'<div class="%1$s">%2$s</div>',
 		$classnames,
-		__( 'No comments to show.' )
+		__( 'No comments to show.' ) // phpcs:ignore WordPress.WP.I18n.MissingArgDomainDefault
 	);
 
 	return $block_content;

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -29,7 +29,7 @@ if ( ! function_exists( 'gutenberg_draft_or_post_title' ) ) {
 	function gutenberg_draft_or_post_title( $post = 0 ) {
 		$title = get_the_title( $post );
 		if ( empty( $title ) ) {
-			$title = __( '(no title)' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomainDefault
+			$title = __( '(no title)' );
 		}
 		return esc_html( $title );
 	}
@@ -96,14 +96,12 @@ function gutenberg_render_block_core_latest_comments( $attributes = array() ) {
 			// `esc_html`.
 			$post_title = '<a class="wp-block-latest-comments__comment-link" href="' . esc_url( get_comment_link( $comment ) ) . '">' . gutenberg_draft_or_post_title( $comment->comment_post_ID ) . '</a>';
 
-			// phpcs:disable WordPress.WP.I18n.MissingArgDomainDefault
 			$list_items_markup .= sprintf(
 				/* translators: 1: author name (inside <a> or <span> tag, based on if they have a URL), 2: post title related to this comment */
 				__( '%1$s on %2$s' ),
 				$author_markup,
 				$post_title
 			);
-			// phpcs:enable WordPress.WP.I18n.MissingArgDomainDefault
 
 			if ( $attributes['displayDate'] ) {
 				$list_items_markup .= sprintf(
@@ -145,7 +143,7 @@ function gutenberg_render_block_core_latest_comments( $attributes = array() ) {
 	) : sprintf(
 		'<div class="%1$s">%2$s</div>',
 		$classnames,
-		__( 'No comments to show.' ) // phpcs:ignore WordPress.WP.I18n.MissingArgDomainDefault
+		__( 'No comments to show.' )
 	);
 
 	return $block_content;

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -29,7 +29,7 @@ if ( ! function_exists( 'gutenberg_draft_or_post_title' ) ) {
 	function gutenberg_draft_or_post_title( $post = 0 ) {
 		$title = get_the_title( $post );
 		if ( empty( $title ) ) {
-			$title = __( '(no title)', 'default' );
+			$title = __( '(no title)' );
 		}
 		return esc_html( $title );
 	}
@@ -98,7 +98,7 @@ function gutenberg_render_block_core_latest_comments( $attributes = array() ) {
 
 			$list_items_markup .= sprintf(
 				/* translators: 1: author name (inside <a> or <span> tag, based on if they have a URL), 2: post title related to this comment */
-				__( '%1$s on %2$s', 'default' ),
+				__( '%1$s on %2$s' ),
 				$author_markup,
 				$post_title
 			);
@@ -143,7 +143,7 @@ function gutenberg_render_block_core_latest_comments( $attributes = array() ) {
 	) : sprintf(
 		'<div class="%1$s">%2$s</div>',
 		$classnames,
-		__( 'No comments to show.', 'default' )
+		__( 'No comments to show.' )
 	);
 
 	return $block_content;

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -33,7 +33,7 @@ function render_block_core_latest_posts( $attributes ) {
 
 		$title = get_the_title( $post_id );
 		if ( ! $title ) {
-			$title = __( '(Untitled)' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomainDefault
+			$title = __( '(Untitled)' );
 		}
 		$list_items_markup .= sprintf(
 			'<li><a href="%1$s">%2$s</a>',

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -33,7 +33,7 @@ function render_block_core_latest_posts( $attributes ) {
 
 		$title = get_the_title( $post_id );
 		if ( ! $title ) {
-			$title = __( '(Untitled)', 'default' );
+			$title = __( '(Untitled)' );
 		}
 		$list_items_markup .= sprintf(
 			'<li><a href="%1$s">%2$s</a>',

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -33,7 +33,7 @@ function render_block_core_latest_posts( $attributes ) {
 
 		$title = get_the_title( $post_id );
 		if ( ! $title ) {
-			$title = __( '(Untitled)' );
+			$title = __( '(Untitled)' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomainDefault
 		}
 		$list_items_markup .= sprintf(
 			'<li><a href="%1$s">%2$s</a>',

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -18,6 +18,10 @@
 		</properties>
 	</rule>
 
+	<rule ref="WordPress.WP.I18n.MissingArgDomainDefault">
+		<exclude-pattern>packages/block-library/src/*</exclude-pattern>
+	</rule>
+
 	<arg value="ps"/>
 	<arg name="extensions" value="php"/>
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/12167