### PR TITLE
Fix: Classic Block: Gallery shortcode does not display images in a grid

### DIFF
--- a/packages/block-library/src/classic/editor.scss
+++ b/packages/block-library/src/classic/editor.scss
@@ -116,6 +116,65 @@
 		cursor: default;
 		border: 2px dashed rgb(186, 186, 186);
 	}
+
+	/**
+	* The following gallery styles were replicated
+	* from the styles applied in the tinymce skin,
+	* /wp-includes/js/tinymce/skins/wordpress/wp-content.css.
+	*/
+	.wpview-type-gallery::after {
+		content: "";
+		display: table;
+		clear: both;
+	}
+
+	.gallery img[data-mce-selected]:focus {
+		outline: none;
+	}
+
+	.gallery a {
+		cursor: default;
+	}
+
+	.gallery {
+		margin: auto -6px;
+		padding: 6px 0;
+		line-height: 1;
+		overflow-x: hidden;
+	}
+
+	.gallery .gallery-item {
+		float: left;
+		margin: 0;
+		text-align: center;
+		padding: 6px;
+		-webkit-box-sizing: border-box;
+		-moz-box-sizing: border-box;
+		box-sizing: border-box;
+	}
+
+	.gallery .gallery-caption,
+	.gallery .gallery-icon {
+		margin: 0;
+	}
+
+	.gallery .gallery-caption {
+		font-size: 13px;
+		margin: 4px 0;
+	}
+
+	@for $i from 1 through 9 {
+		.gallery-columns-#{ $i } .gallery-item {
+			width: #{ (100 / $i) + "%" };
+		}
+	}
+
+	.gallery img {
+		max-width: 100%;
+		height: auto;
+		border: none;
+		padding: 0;
+	}
 }
 
 .editor-block-list__layout .editor-block-list__block[data-type="core/freeform"] {


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/11940
This PR adds the necessary styles for the gallery shortcode correctly display as columns.
Styles replicate what was done in /wp-includes/js/tinymce/skins/wordpress/wp-content.css.

## How has this been tested?
Add a gallery shortcode inside the classic block and verify columns are correctly displayed.

