### PR TITLE
Add undo redo

### DIFF
--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -24,6 +24,12 @@ import './editor.scss';
 const minHeight = 50;
 
 class HeadingEdit extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.aztecHeight = 0;
+	}
+
 	render() {
 		const {
 			attributes,
@@ -49,7 +55,7 @@ class HeadingEdit extends Component {
 					value={ content }
 					isSelected={ this.props.isSelected }
 					style={ {
-						minHeight: Math.max( minHeight, typeof attributes.aztecHeight === 'undefined' ? 0 : attributes.aztecHeight ),
+						minHeight: Math.max( minHeight, this.aztecHeight ),
 					} }
 					onChange={ ( event ) => {
 						// Create a React Tree from the new HTML
@@ -72,7 +78,7 @@ class HeadingEdit extends Component {
 							undefined
 					}
 					onContentSizeChange={ ( event ) => {
-						setAttributes( { aztecHeight: event.aztecHeight } );
+						this.aztecHeight = event.aztecHeight;
 					} }
 					placeholder={ placeholder || __( 'Write heading…' ) }
 				/>

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -23,7 +23,7 @@ class ParagraphEdit extends Component {
 		super( props );
 		this.splitBlock = this.splitBlock.bind( this );
 
-		this.aztecHeight = ( props.attributes || {} ).aztecHeight || null;
+		this.aztecHeight = 0;
 	}
 
 	/**
@@ -92,7 +92,7 @@ class ParagraphEdit extends Component {
 					isSelected={ this.props.isSelected }
 					style={ {
 						...style,
-						minHeight: Math.max( minHeight, typeof attributes.aztecHeight === 'undefined' ? 0 : attributes.aztecHeight ),
+						minHeight: Math.max( minHeight, this.aztecHeight ),
 					} }
 					onChange={ ( event ) => {
 						// Create a React Tree from the new HTML
@@ -101,20 +101,12 @@ class ParagraphEdit extends Component {
 							...this.props.attributes,
 							content: newParaBlock.attributes.content,
 						} );
-					}
-					}
+					} }
 					onSplit={ this.splitBlock }
 					onMerge={ mergeBlocks }
 					onContentSizeChange={ ( event ) => {
-						if ( this.aztecHeight !== event.aztecHeight ) {
-							setAttributes( {
-								...this.props.attributes,
-								aztecHeight: event.aztecHeight,
-							} );
-							this.aztecHeight = event.aztecHeight;
-						}
-					}
-					}
+						this.aztecHeight = event.aztecHeight;
+					} }
 					placeholder={ placeholder || __( 'Add text or type / to add content' ) }
 				/>
 			</View>

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -19,9 +19,11 @@ import styles from './style.scss';
 const name = 'core/paragraph';
 
 class ParagraphEdit extends Component {
-	constructor() {
-		super( ...arguments );
+	constructor( props ) {
+		super( props );
 		this.splitBlock = this.splitBlock.bind( this );
+
+		this.aztecHeight = ( props.attributes || {} ).aztecHeight || null;
 	}
 
 	/**
@@ -104,10 +106,13 @@ class ParagraphEdit extends Component {
 					onSplit={ this.splitBlock }
 					onMerge={ mergeBlocks }
 					onContentSizeChange={ ( event ) => {
-						setAttributes( {
-							...this.props.attributes,
-							aztecHeight: event.aztecHeight,
-						} );
+						if ( this.aztecHeight !== event.aztecHeight ) {
+							setAttributes( {
+								...this.props.attributes,
+								aztecHeight: event.aztecHeight,
+							} );
+							this.aztecHeight = event.aztecHeight;
+						}
 					}
 					}
 					placeholder={ placeholder || __( 'Add text or type / to add content' ) }

--- a/packages/components/src/button/index.native.js
+++ b/packages/components/src/button/index.native.js
@@ -51,7 +51,21 @@ const styles = StyleSheet.create( {
 } );
 
 export default function Button( props ) {
-	const { children, onClick, 'aria-label': ariaLabel, 'aria-pressed': ariaPressed, 'data-subscript': subscript } = props;
+	const {
+		children,
+		onClick,
+		disabled,
+		'aria-disabled': ariaDisabled,
+		'aria-label': ariaLabel,
+		'aria-pressed': ariaPressed,
+		'data-subscript': subscript,
+	} = props;
+
+	const isDisabled = ariaDisabled || disabled;
+	const buttonViewStyle = {
+		opacity: isDisabled ? 0.2 : 1,
+		...( ariaPressed ? styles.buttonActive : styles.buttonInactive )
+	};
 
 	return (
 		<TouchableOpacity
@@ -60,8 +74,9 @@ export default function Button( props ) {
 			accessibilityLabel={ ariaLabel }
 			onPress={ onClick }
 			style={ styles.container }
+			disabled={ isDisabled }
 		>
-			<View style={ ariaPressed ? styles.buttonActive : styles.buttonInactive }>
+			<View style={ buttonViewStyle }>
 				<View style={ { flexDirection: 'row' } }>
 					{ children }
 					{ subscript && ( <Text style={ ariaPressed ? styles.subscriptActive : styles.subscriptInactive }>{ subscript }</Text> ) }

--- a/packages/components/src/button/index.native.js
+++ b/packages/components/src/button/index.native.js
@@ -64,7 +64,7 @@ export default function Button( props ) {
 	const isDisabled = ariaDisabled || disabled;
 	const buttonViewStyle = {
 		opacity: isDisabled ? 0.2 : 1,
-		...( ariaPressed ? styles.buttonActive : styles.buttonInactive )
+		...( ariaPressed ? styles.buttonActive : styles.buttonInactive ),
 	};
 
 	return (

--- a/packages/editor/src/components/index.native.js
+++ b/packages/editor/src/components/index.native.js
@@ -6,3 +6,5 @@ export { default as MediaPlaceholder } from './media-placeholder';
 export { default as BlockFormatControls } from './block-format-controls';
 export { default as BlockControls } from './block-controls';
 export { default as BlockEdit } from './block-edit';
+export { default as EditorHistoryRedo } from './editor-history/redo';
+export { default as EditorHistoryUndo } from './editor-history/undo';


### PR DESCRIPTION
## Description
This PR exposes the Undo and Redo components from the editor to the react native app.

## How has this been tested?
Tested with https://github.com/wordpress-mobile/gutenberg-mobile/pull/269

## Types of changes
- Expose mobile components to the outside world
- Make the opacity lower when button are disabled on mobile

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
