### PR TITLE
Add IE check for IE fix

### DIFF
--- a/packages/editor/src/components/rich-text/tinymce.js
+++ b/packages/editor/src/components/rich-text/tinymce.js
@@ -23,6 +23,7 @@ import { diffAriaProps, pickAriaProps } from './aria';
 
 const { getSelection } = window;
 const { TEXT_NODE } = window.Node;
+const { userAgent } = window.navigator;
 
 /**
  * Zero-width space character used by TinyMCE as a caret landing point for
@@ -33,23 +34,6 @@ const { TEXT_NODE } = window.Node;
  * @type {string}
  */
 export const TINYMCE_ZWSP = '\uFEFF';
-
-/**
- * Determines whether we need a fix to provide `input` events for contenteditable.
- *
- * @param {Element} editorNode The root editor node.
- *
- * @return {boolean} A boolean indicating whether the fix is needed.
- */
-function needsInternetExplorerInputFix( editorNode ) {
-	return (
-		// Rely on userAgent in the absence of a reasonable feature test for contenteditable `input` events.
-		/Trident/.test( window.navigator.userAgent ) &&
-		// IE11 dispatches input events for `<input>` and `<textarea>`.
-		! /input/i.test( editorNode.tagName ) &&
-		! /textarea/i.test( editorNode.tagName )
-	);
-}
 
 /**
  * Applies a fix that provides `input` events for contenteditable in Internet Explorer.
@@ -113,6 +97,14 @@ function applyInternetExplorerInputFix( editorNode ) {
 }
 
 const IS_PLACEHOLDER_VISIBLE_ATTR_NAME = 'data-is-placeholder-visible';
+
+/**
+ * Whether or not the user agent is Internet Explorer.
+ *
+ * @type {RegExp}
+ */
+const IS_IE = userAgent.indexOf( 'Trident' ) >= 0;
+
 export default class TinyMCE extends Component {
 	constructor() {
 		super();
@@ -247,6 +239,7 @@ export default class TinyMCE extends Component {
 					// In IE11, focus is lost to parent after initialising
 					// TinyMCE, so we have to set it back.
 					if (
+						IS_IE &&
 						document.activeElement !== this.editorNode &&
 						document.activeElement.contains( this.editorNode )
 					) {
@@ -275,7 +268,7 @@ export default class TinyMCE extends Component {
 			this.removeInternetExplorerInputFix = null;
 		}
 
-		if ( editorNode && needsInternetExplorerInputFix( editorNode ) ) {
+		if ( IS_IE ) {
 			this.removeInternetExplorerInputFix = applyInternetExplorerInputFix( editorNode );
 		}
 	}

--- a/packages/editor/src/components/rich-text/tinymce.js
+++ b/packages/editor/src/components/rich-text/tinymce.js
@@ -101,7 +101,7 @@ const IS_PLACEHOLDER_VISIBLE_ATTR_NAME = 'data-is-placeholder-visible';
 /**
  * Whether or not the user agent is Internet Explorer.
  *
- * @type {RegExp}
+ * @type {boolean}
  */
 const IS_IE = userAgent.indexOf( 'Trident' ) >= 0;
 


### PR DESCRIPTION
## Description

See https://github.com/WordPress/gutenberg/pull/12206#discussion_r235758155.

Merges the user agent check with another. Removes the textarea/input check as a rich text component can never be that.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
