### PR TITLE
Fix: Cover Block: Move some editor specific styles from style.scss to editor.scss

### DIFF
--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -23,4 +23,21 @@
 	&.has-right-content .editor-rich-text__inline-toolbar {
 		justify-content: flex-end;
 	}
+
+	&.components-placeholder {
+		// use opacity to work in various editor styles
+		background: $dark-opacity-light-200;
+		min-height: 200px;
+
+		.is-dark-theme & {
+			background: $light-opacity-light-200;
+		}
+	}
+
+	// Apply max-width to floated items that have no intrinsic width
+	[data-align="left"] &,
+	[data-align="right"] & {
+		max-width: $content-width / 2;
+		width: 100%;
+	}
 }

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -83,19 +83,7 @@
 		}
 	}
 
-	&.components-placeholder {
-		// use opacity to work in various editor styles
-		background: $dark-opacity-light-200;
-		min-height: 200px;
-
-		.is-dark-theme & {
-			background: $light-opacity-light-200;
-		}
-	}
-
 	// Apply max-width to floated items that have no intrinsic width
-	[data-align="left"] &,
-	[data-align="right"] &,
 	&.alignleft,
 	&.alignright {
 		max-width: $content-width / 2;


### PR DESCRIPTION
During the reviews of https://github.com/WordPress/gutenberg/pull/12187 we found out that the cover block contains some editor specific styles on the front end.
This is a problem because we would be transferring bytes on the frontend of websites that are not used at all.
This PR just moves this styles to editor.scss so they are loaded only in the editor.


## How has this been tested?
I checked that there was no noticeable change on the cover block (and its placeholder).

