### PR TITLE
Use sentence case in toolbar tooltips

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -201,7 +201,7 @@ class GalleryEdit extends Component {
 							render={ ( { open } ) => (
 								<IconButton
 									className="components-toolbar__control"
-									label={ __( 'Edit Gallery' ) }
+									label={ __( 'Edit gallery' ) }
 									icon="edit"
 									onClick={ open }
 								/>

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -398,7 +398,7 @@ export default class TableEdit extends Component {
 					<Toolbar>
 						<DropdownMenu
 							icon="editor-table"
-							label={ __( 'Edit Table' ) }
+							label={ __( 'Edit table' ) }
 							controls={ this.getTableControls() }
 						/>
 					</Toolbar>


### PR DESCRIPTION
As discussed in #11708 with @gziolo, this PR changes instances where Title Case is used in toolbar tooltips to use Sentence case.

I've tested all blocks, and found that Title Case is used only in one more instance: for _List View_/_Grid View_ in Latest Posts block. 

<img width="257" alt="screen shot 2018-11-22 at 22 33 41" src="https://user-images.githubusercontent.com/2678421/48922854-d548c580-eea9-11e8-882d-d0878bf81da0.png">

This seems inconsistent with other blocks, should this be converted to styles, should we change strings to _Convert to list view_/_Convert to grid view_, or should we just change case?