### PR TITLE
Fix modals in Edge.

### DIFF
--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -66,12 +66,19 @@
 	justify-content: space-between;
 	background: $white;
 	align-items: center;
-	box-sizing: border-box;
 	height: $header-height;
 	position: sticky;
 	top: 0;
 	z-index: z-index(".components-modal__header");
 	margin: 0 -#{ $grid-size-large } $grid-size-large;
+
+	// Rules inside this query are only run by Microsoft Edge.
+	// Edge has bugs around position: sticky;, so it needs a separate top rule.
+	// See also https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/17555420/.
+	@supports (-ms-ime-align:auto) {
+		position: fixed;
+		width: 100%;
+	}
 
 	.components-modal__header-heading {
 		font-size: 1em;
@@ -107,4 +114,10 @@
 	box-sizing: border-box;
 	height: 100%;
 	padding: 0 $grid-size-large $grid-size-large;
+
+	// Rules inside this query are only run by Microsoft Edge.
+	// This is a companion top padding to the fixed rule in line 77.
+	@supports (-ms-ime-align:auto) {
+		padding-top: $header-height;
+	}
 }


### PR DESCRIPTION
This PR fixes #11585.

Edge has a buggy implementation of `position: sticky;`, which includes issues with flickering, z-index, and parent container paddings. See more at https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/17555420/.

This is mainly an issue in deeply nested elements, it seems.

This PR includes an edge only hack that overrides the sticky and uses `position: fixed;` instead.

JIFs, Edge:

![edge modals](https://user-images.githubusercontent.com/1204802/48934642-32be3000-ef05-11e8-899e-64f53630ac23.gif)

IE 11:

![ie modals](https://user-images.githubusercontent.com/1204802/48934655-3b166b00-ef05-11e8-9783-762e21a0689d.gif)

Chrome, Mac:

![chrome mac](https://user-images.githubusercontent.com/1204802/48934676-4ec1d180-ef05-11e8-94d4-2050f6070c02.gif)

Safari, Mac:

![safari mac](https://user-images.githubusercontent.com/1204802/48934682-56817600-ef05-11e8-92a6-cc017f3e5c83.gif)

Firefox, Mac:

![firefox mac](https://user-images.githubusercontent.com/1204802/48934689-5f724780-ef05-11e8-8e37-95717b1506c3.gif)


