### PR TITLE
Latest Posts Block: the category filter has no effect at the front end

### DIFF
--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -21,7 +21,7 @@ function render_block_core_latest_posts( $attributes ) {
 	);
 
 	if ( isset( $attributes['categories'] ) ) {
-		$args['categories'] = $attributes['categories'];
+		$args['category'] = $attributes['categories'];
 	}
 
 	$recent_posts = wp_get_recent_posts( $args );


### PR DESCRIPTION
## Description
I fixed a typo in the call to the `wp_get_recent_posts` function.

## How has this been tested?
As the fix is just changing `'categories'` to `'category'`, I tested it simply by changing it directly in my local installation and verifying that the category filter works again as before. (I hope I'm doing all this reasonably well, feel free to scold me otherwise!  :) ).

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
