### PR TITLE
Fix: Handle of quote paste by correcting schema and isMatch function

### DIFF
--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -103,13 +103,30 @@ export const settings = {
 				isMatch: ( node ) => (
 					node.nodeName === 'BLOCKQUOTE' &&
 					// The quote block can only handle multiline paragraph
-					// content.
-					Array.from( node.childNodes ).every( ( child ) => child.nodeName === 'P' )
+					// content with an optional last cite child.
+					Array.from( node.childNodes ).every(
+						( child, index, children ) => {
+							// Child is paragraph.
+							if ( child.nodeName === 'P' ) {
+								return true;
+							}
+							// Is last child and is a cite.
+							if (
+								index === children.length - 1 &&
+								child.nodeName === 'CITE'
+							) {
+								return true;
+							}
+						}
+					)
 				),
 				schema: {
 					blockquote: {
 						children: {
 							p: {
+								children: getPhrasingContentSchema(),
+							},
+							cite: {
 								children: getPhrasingContentSchema(),
 							},
 						},

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -100,26 +100,30 @@ export const settings = {
 			},
 			{
 				type: 'raw',
-				isMatch: ( node ) => (
-					node.nodeName === 'BLOCKQUOTE' &&
+				isMatch: ( node ) => {
+					return node.nodeName === 'BLOCKQUOTE' &&
 					// The quote block can only handle multiline paragraph
-					// content with an optional last cite child.
+					// content with an optional cite child.
 					Array.from( node.childNodes ).every(
-						( child, index, children ) => {
-							// Child is paragraph.
-							if ( child.nodeName === 'P' ) {
-								return true;
-							}
-							// Is last child and is a cite.
-							if (
-								index === children.length - 1 &&
-								child.nodeName === 'CITE'
-							) {
-								return true;
-							}
-						}
-					)
-				),
+						( () => {
+							let hasCitation = false;
+							return ( child ) => {
+								// Child is a paragraph.
+								if ( child.nodeName === 'P' ) {
+									return true;
+								}
+								// Child is a cite and no other cite child exists before it.
+								if (
+									! hasCitation &&
+									child.nodeName === 'CITE'
+								) {
+									hasCitation = true;
+									return true;
+								}
+							};
+						} )()
+					);
+				},
 				schema: {
 					blockquote: {
 						children: {

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -101,27 +101,28 @@ export const settings = {
 			{
 				type: 'raw',
 				isMatch: ( node ) => {
+					const isParagraphOrSingleCite = ( () => {
+						let hasCitation = false;
+						return ( child ) => {
+							// Child is a paragraph.
+							if ( child.nodeName === 'P' ) {
+								return true;
+							}
+							// Child is a cite and no other cite child exists before it.
+							if (
+								! hasCitation &&
+								child.nodeName === 'CITE'
+							) {
+								hasCitation = true;
+								return true;
+							}
+						};
+					} )();
 					return node.nodeName === 'BLOCKQUOTE' &&
 					// The quote block can only handle multiline paragraph
 					// content with an optional cite child.
 					Array.from( node.childNodes ).every(
-						( () => {
-							let hasCitation = false;
-							return ( child ) => {
-								// Child is a paragraph.
-								if ( child.nodeName === 'P' ) {
-									return true;
-								}
-								// Child is a cite and no other cite child exists before it.
-								if (
-									! hasCitation &&
-									child.nodeName === 'CITE'
-								) {
-									hasCitation = true;
-									return true;
-								}
-							};
-						} )()
+						isParagraphOrSingleCite
 					);
 				},
 				schema: {

--- a/test/integration/blocks-raw-handling.spec.js
+++ b/test/integration/blocks-raw-handling.spec.js
@@ -122,6 +122,45 @@ describe( 'Blocks raw handling', () => {
 		expect( console ).toHaveLogged();
 	} );
 
+	it( 'should correctly handle quotes with one paragraphs and no citation', () => {
+		const filtered = pasteHandler( {
+			HTML: '<blockquote><p>chicken</p></blockquote>',
+			mode: 'AUTO',
+		} ).map( getBlockContent ).join( '' );
+
+		expect( filtered ).toBe( '<blockquote class="wp-block-quote"><p>chicken</p></blockquote>' );
+		expect( console ).toHaveLogged();
+	} );
+	it( 'should correctly handle quotes with multiple paragraphs and no citation', () => {
+		const filtered = pasteHandler( {
+			HTML: '<blockquote><p>chicken</p><p>ribs</p></blockquote>',
+			mode: 'AUTO',
+		} ).map( getBlockContent ).join( '' );
+
+		expect( filtered ).toBe( '<blockquote class="wp-block-quote"><p>chicken</p><p>ribs</p></blockquote>' );
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'should correctly handle quotes with paragraph and citation', () => {
+		const filtered = pasteHandler( {
+			HTML: '<blockquote><p>chicken</p><cite>ribs</cite></blockquote>',
+			mode: 'AUTO',
+		} ).map( getBlockContent ).join( '' );
+
+		expect( filtered ).toBe( '<blockquote class="wp-block-quote"><p>chicken</p><cite>ribs</cite></blockquote>' );
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'should correctly handle quotes with only a citation', () => {
+		const filtered = pasteHandler( {
+			HTML: '<blockquote><cite>ribs</cite></blockquote>',
+			mode: 'AUTO',
+		} ).map( getBlockContent ).join( '' );
+
+		expect( filtered ).toBe( '<blockquote class="wp-block-quote"><p></p><cite>ribs</cite></blockquote>' );
+		expect( console ).toHaveLogged();
+	} );
+
 	describe( 'pasteHandler', () => {
 		[
 			'plain',

--- a/test/integration/blocks-raw-handling.spec.js
+++ b/test/integration/blocks-raw-handling.spec.js
@@ -141,13 +141,33 @@ describe( 'Blocks raw handling', () => {
 		expect( console ).toHaveLogged();
 	} );
 
-	it( 'should correctly handle quotes with paragraph and citation', () => {
+	it( 'should correctly handle quotes with paragraph and citation at the end', () => {
 		const filtered = pasteHandler( {
 			HTML: '<blockquote><p>chicken</p><cite>ribs</cite></blockquote>',
 			mode: 'AUTO',
 		} ).map( getBlockContent ).join( '' );
 
 		expect( filtered ).toBe( '<blockquote class="wp-block-quote"><p>chicken</p><cite>ribs</cite></blockquote>' );
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'should handle a citation before the content', () => {
+		const filtered = pasteHandler( {
+			HTML: '<blockquote><cite>ribs</cite><p>ribs</p></blockquote>',
+			mode: 'AUTO',
+		} ).map( getBlockContent ).join( '' );
+
+		expect( filtered ).toBe( '<blockquote class="wp-block-quote"><p>ribs</p><cite>ribs</cite></blockquote>' );
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'should handle a citation in the middle of the content', () => {
+		const filtered = pasteHandler( {
+			HTML: '<blockquote><p>chicken</p><cite>ribs</cite><p>ribs</p></blockquote>',
+			mode: 'AUTO',
+		} ).map( getBlockContent ).join( '' );
+
+		expect( filtered ).toBe( '<blockquote class="wp-block-quote"><p>chicken</p><p>ribs</p><cite>ribs</cite></blockquote>' );
 		expect( console ).toHaveLogged();
 	} );
 

--- a/test/integration/blocks-raw-handling.spec.js
+++ b/test/integration/blocks-raw-handling.spec.js
@@ -181,6 +181,26 @@ describe( 'Blocks raw handling', () => {
 		expect( console ).toHaveLogged();
 	} );
 
+	it( 'should convert to paragraph quotes with more than one cite', () => {
+		const filtered = pasteHandler( {
+			HTML: '<blockquote><cite>ribs</cite><cite>ribs</cite></blockquote>',
+			mode: 'AUTO',
+		} ).map( getBlockContent ).join( '' );
+
+		expect( filtered ).toBe( '<p>ribsribs</p>' );
+		expect( console ).toHaveLogged();
+	} );
+
+	it( 'should convert to paragraph quotes with more than one cite and at least one paragraph', () => {
+		const filtered = pasteHandler( {
+			HTML: '<blockquote><p>chicken</p><cite>ribs</cite><cite>ribs</cite></blockquote>',
+			mode: 'AUTO',
+		} ).map( getBlockContent ).join( '' );
+
+		expect( filtered ).toBe( '<p>chickenribsribs</p>' );
+		expect( console ).toHaveLogged();
+	} );
+
 	describe( 'pasteHandler', () => {
 		[
 			'plain',


### PR DESCRIPTION
## Description
Copy pasting contents of quotes were not working correctly if the quote contained citations. This PR addresses that by fixing the isMatch function and the schema of the quote raw handling transform.

## How has this been tested?
I pasted this on block editor:
```
<blockquote><p>aaaa</p></blockquote>
<blockquote><p>aaaa</p><p>bbbbb</p></blockquote>
<blockquote><p>aaaa</p><cite>cite</cite></blockquote>
<blockquote><p>aaaa</p><p>bbbbb</p><cite>cite</cite></blockquote>
<blockquote><cite>cite</cite></blockquote>
```
And verfied the result was equal to the "After" screenshot.
## Screenshots <!-- if applicable -->
After:
<img width="744" alt="screenshot 2018-11-23 at 17 03 48" src="https://user-images.githubusercontent.com/11271197/48954644-5e134000-ef42-11e8-854d-47ccdd61fdf9.png">
Before (master):
<img width="679" alt="screenshot 2018-11-23 at 17 04 30" src="https://user-images.githubusercontent.com/11271197/48954649-653a4e00-ef42-11e8-86e3-2ba36d9b3f53.png">
