### PR TITLE
Autocompleters: Consider block category

### DIFF
--- a/packages/editor/src/components/autocompleters/block.js
+++ b/packages/editor/src/components/autocompleters/block.js
@@ -68,8 +68,8 @@ export function createBlockCompleter( {
 			);
 		},
 		getOptionKeywords( inserterItem ) {
-			const { title, keywords = [] } = inserterItem;
-			return [ ...keywords, title ];
+			const { title, keywords = [], category } = inserterItem;
+			return [ category, ...keywords, title ];
 		},
 		getOptionLabel( inserterItem ) {
 			const { icon, title } = inserterItem;

--- a/packages/editor/src/components/autocompleters/test/block.js
+++ b/packages/editor/src/components/autocompleters/test/block.js
@@ -40,30 +40,33 @@ describe( 'block', () => {
 		expect( completer.options() ).toEqual( [ option1, option3 ] );
 	} );
 
-	it( 'should derive option keywords from block keywords and block title', () => {
+	it( 'should derive option keywords from block category, block keywords and block title', () => {
 		const inserterItemWithTitleAndKeywords = {
 			name: 'core/foo',
 			title: 'foo',
 			keywords: [ 'foo-keyword-1', 'foo-keyword-2' ],
+			category: 'formatting',
 		};
 		const inserterItemWithTitleAndEmptyKeywords = {
 			name: 'core/bar',
 			title: 'bar',
 			// Intentionally empty keyword list
 			keywords: [],
+			category: 'common',
 		};
 		const inserterItemWithTitleAndUndefinedKeywords = {
 			name: 'core/baz',
 			title: 'baz',
+			category: 'widgets',
 			// Intentionally omitted keyword list
 		};
 
 		expect( blockCompleter.getOptionKeywords( inserterItemWithTitleAndKeywords ) )
-			.toEqual( [ 'foo-keyword-1', 'foo-keyword-2', 'foo' ] );
+			.toEqual( [ 'formatting', 'foo-keyword-1', 'foo-keyword-2', 'foo' ] );
 		expect( blockCompleter.getOptionKeywords( inserterItemWithTitleAndEmptyKeywords ) )
-			.toEqual( [ 'bar' ] );
+			.toEqual( [ 'common', 'bar' ] );
 		expect( blockCompleter.getOptionKeywords( inserterItemWithTitleAndUndefinedKeywords ) )
-			.toEqual( [ 'baz' ] );
+			.toEqual( [ 'widgets', 'baz' ] );
 	} );
 
 	it( 'should render a block option label', () => {


### PR DESCRIPTION
## Description
In https://github.com/WordPress/gutenberg/pull/9999 we updated the inserter to respect the block categories when searching. This PR applies the update to the block autocompleters, which allows us to use the slash inserter with a block category, revealing all the blocks from that category.

## How has this been tested?
* Start a new post.
* In a new paragraph block type `/CATEGORY` where `CATEGORY` is one of the block categories (`common`, `formatting`, 'layout`, `widgets`, etc.)
* Verify that all the blocks under that category appear in the list.

## Screenshots <!-- if applicable -->
![](https://cldup.com/ATs6q2AFlD.png)

## Types of changes
* Now considering category when searching for blocks in slash inserter / block autocompleters.
* Added tests to verify we consider the category in autocompleters.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
