### PR TITLE
Add check for css file before trying to read

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1224,9 +1224,14 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 					'css' => file_get_contents( $style ),
 				);
 			} else {
-				$file     = get_theme_file_path( $style );
+				$file = get_theme_file_path( $style );
+				if ( file_exists( get_theme_file_path( $style ) ) ) {
+					$css = file_get_contents( get_theme_file_path( $style ) );
+				} else {
+					$css = '';
+				}
 				$styles[] = array(
-					'css'     => file_get_contents( get_theme_file_path( $style ) ),
+					'css'     => $css,
 					'baseURL' => get_theme_file_uri( $style ),
 				);
 			}

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1225,15 +1225,12 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 				);
 			} else {
 				$file = get_theme_file_path( $style );
-				if ( file_exists( get_theme_file_path( $style ) ) ) {
-					$css = file_get_contents( get_theme_file_path( $style ) );
-				} else {
-					$css = '';
+				if ( file_exists( $file ) ) {
+					$styles[] = array(
+						'css'     => file_get_contents( $file ),
+						'baseURL' => get_theme_file_uri( $style ),
+					);
 				}
-				$styles[] = array(
-					'css'     => $css,
-					'baseURL' => get_theme_file_uri( $style ),
-				);
 			}
 		}
 	}


### PR DESCRIPTION
Matches existing core trac ticket: https://core.trac.wordpress.org/ticket/45288

Fixes #12196

## Description

Adds a check to see if the css file exists before trying to read it.

## How has this been tested?

* Confirm everything still works
* Confirm no error if style file does not exist


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
