### PR TITLE
Notices: Make non-dismissible notices push content down

### DIFF
--- a/assets/stylesheets/_z-index.scss
+++ b/assets/stylesheets/_z-index.scss
@@ -68,9 +68,9 @@ $z-layers: (
 	// but bellow #adminmenuback { z-index: 100 }
 	".edit-post-sidebar {greater than small}": 90,
 
-	// Show notices below expanded wp-admin submenus:
-	// #adminmenuwrap { z-index: 9990 }
-	".components-notice-list": 9989,
+	// Show notices below expanded editor bar
+	// .edit-post-header { z-index: 30 }
+	".components-notice-list": 29,
 
 	// Show modal under the wp-admin menus and the popover
 	".components-modal__screen-overlay": 100000,

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 7.0.3 (Unreleased)
+
+### Polish
+
+- The `Notice` component will now always include the `.components-notice-list` class.
+
 ## 7.0.2 (2018-11-22)
 
 ## 7.0.1 (2018-11-21)

--- a/packages/components/src/notice/list.js
+++ b/packages/components/src/notice/list.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { noop, omit } from 'lodash';
 
 /**
@@ -18,8 +19,10 @@ import Notice from './';
 * @param  {Object}   $0.children  Array of children to be rendered inside the notice list.
 * @return {Object}                The rendered notices list.
 */
-function NoticeList( { notices, onRemove = noop, className = 'components-notice-list', children } ) {
+function NoticeList( { notices, onRemove = noop, className, children } ) {
 	const removeNotice = ( id ) => () => onRemove( id );
+
+	className = classnames( 'components-notice-list', className );
 
 	return (
 		<div className={ className }>

--- a/packages/components/src/notice/test/list.js
+++ b/packages/components/src/notice/test/list.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import ShallowRenderer from 'react-test-renderer/shallow';
+
+/**
+ * WordPress dependencies
+ */
+import TokenList from '@wordpress/token-list';
+
+/**
+ * Internal dependencies
+ */
+import NoticeList from '../list';
+
+describe( 'NoticeList', () => {
+	it( 'should merge className', () => {
+		const renderer = new ShallowRenderer();
+
+		renderer.render( <NoticeList notices={ [] } className="is-ok" /> );
+
+		const classes = new TokenList( renderer.getRenderOutput().props.className );
+		expect( classes.contains( 'is-ok' ) ).toBe( true );
+		expect( classes.contains( 'components-notice-list' ) ).toBe( true );
+	} );
+} );

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -73,7 +73,6 @@ function Layout( {
 			<AutosaveMonitor />
 			<AdminNotices />
 			<Header />
-			<EditorNotices dismissible={ false } />
 			<div
 				className="edit-post-layout__content"
 				role="region"
@@ -81,6 +80,7 @@ function Layout( {
 				aria-label={ __( 'Editor content' ) }
 				tabIndex="-1"
 			>
+				<EditorNotices dismissible={ false } className="components-notice-list is-pinned" />
 				<EditorNotices dismissible={ true } />
 				<PreserveScrollInReorder />
 				<EditorModeKeyboardShortcuts />

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -73,6 +73,7 @@ function Layout( {
 			<AutosaveMonitor />
 			<AdminNotices />
 			<Header />
+			<EditorNotices dismissible={ false } />
 			<div
 				className="edit-post-layout__content"
 				role="region"
@@ -80,7 +81,7 @@ function Layout( {
 				aria-label={ __( 'Editor content' ) }
 				tabIndex="-1"
 			>
-				<EditorNotices />
+				<EditorNotices dismissible={ true } />
 				<PreserveScrollInReorder />
 				<EditorModeKeyboardShortcuts />
 				<KeyboardShortcutHelpModal />

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -80,7 +80,7 @@ function Layout( {
 				aria-label={ __( 'Editor content' ) }
 				tabIndex="-1"
 			>
-				<EditorNotices dismissible={ false } className="components-notice-list is-pinned" />
+				<EditorNotices dismissible={ false } className="is-pinned" />
 				<EditorNotices dismissible={ true } />
 				<PreserveScrollInReorder />
 				<EditorModeKeyboardShortcuts />

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -59,9 +59,6 @@
 	}
 }
 
-@include editor-left(".edit-post-layout__content .components-notice-list");
-@include editor-right(".edit-post-layout__content .components-notice-list");
-
 .edit-post-layout__metaboxes:not(:empty) {
 	border-top: $border-width solid $light-gray-500;
 	margin-top: 10px;

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -6,7 +6,7 @@
 .edit-post-layout {
 	position: relative;
 
-	.components-notice-list {
+	.edit-post-layout__content .components-notice-list {
 		position: sticky;
 		top: $header-height;
 		right: 0;
@@ -16,15 +16,15 @@
 			position: fixed;
 			top: inherit;
 		}
+	}
 
-		.components-notice {
-			margin: 0 0 5px;
-			padding: 6px 12px;
-			min-height: $panel-header-height;
+	.components-notice {
+		margin: 0 0 5px;
+		padding: 6px 12px;
+		min-height: $panel-header-height;
 
-			.components-notice__dismiss {
-				margin: 10px 5px;
-			}
+		.components-notice__dismiss {
+			margin: 10px 5px;
 		}
 	}
 
@@ -53,8 +53,8 @@
 	}
 }
 
-@include editor-left(".components-notice-list");
-@include editor-right(".components-notice-list");
+@include editor-left(".edit-post-layout__content .components-notice-list");
+@include editor-right(".edit-post-layout__content .components-notice-list");
 
 .edit-post-layout__metaboxes:not(:empty) {
 	border-top: $border-width solid $light-gray-500;

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -6,15 +6,21 @@
 .edit-post-layout {
 	position: relative;
 
-	.edit-post-layout__content .components-notice-list {
+	.components-notice-list {
 		position: sticky;
 		top: $header-height;
 		right: 0;
 		color: $dark-gray-900;
 
 		@include break-small {
-			position: fixed;
-			top: inherit;
+			top: 0;
+		}
+
+		// Non-dismissible notices.
+		&.is-pinned.is-pinned {
+			position: relative;
+			left: 0;
+			top: 0;
 		}
 	}
 
@@ -28,7 +34,7 @@
 		}
 	}
 
-	// on mobile, toolbars behave differently
+	// On mobile, toolbars behave differently.
 	@include break-small {
 		padding-top: $header-height;
 	}
@@ -38,7 +44,7 @@
 			padding-top: $block-controls-height;
 		}
 
-		// on mobile, toolbars behave differently
+		// On mobile, toolbars behave differently.
 		@include break-small {
 			padding-top: $header-height + $block-toolbar-height;
 

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -85,10 +85,14 @@
 		padding-bottom: 0;
 	}
 
-	// On mobile the main content area has to scroll otherwise you can invoke
-	// the overscroll bounce on the non-scrolling container, causing
-	// (ノಠ益ಠ)ノ彡┻━┻
-	overflow-y: auto;
+	// On mobile the main content (html or body) area has to scroll.
+	// If, like we do on the desktop, scroll an element (.edit-post-layout__content) you can invoke
+	// the overscroll bounce on the non-scrolling container, causing for a frustrating scrolling experience.
+	// The following rule enables this scrolling beyond the mobile breakpoint, because on the desktop
+	// breakpoints scrolling an isolated element helps avoid scroll bleed.
+	@include break-small() {
+		overflow-y: auto;
+	}
 	-webkit-overflow-scrolling: touch;
 
 	// This rule ensures that if you've scrolled to the end of a container,

--- a/packages/editor/src/components/editor-notices/index.js
+++ b/packages/editor/src/components/editor-notices/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { filter } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { NoticeList } from '@wordpress/components';
@@ -10,10 +15,16 @@ import { compose } from '@wordpress/compose';
  */
 import TemplateValidationNotice from '../template-validation-notice';
 
-function EditorNotices( props ) {
+export function EditorNotices( { dismissible, notices, ...props } ) {
+	if ( dismissible !== undefined ) {
+		notices = filter( notices, { isDismissible: dismissible } );
+	}
+
 	return (
-		<NoticeList { ...props }>
-			<TemplateValidationNotice />
+		<NoticeList notices={ notices } { ...props }>
+			{ dismissible !== false && (
+				<TemplateValidationNotice />
+			) }
 		</NoticeList>
 	);
 }

--- a/packages/editor/src/components/editor-notices/test/index.js
+++ b/packages/editor/src/components/editor-notices/test/index.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { EditorNotices } from '../';
+
+describe( 'EditorNotices', () => {
+	const notices = [
+		{ content: 'Eat your vegetables!', isDismissible: true },
+		{ content: 'Brush your teeth!', isDismissible: true },
+		{ content: 'Existence is fleeting!', isDismissible: false },
+	];
+
+	it( 'renders all notices', () => {
+		const wrapper = shallow( <EditorNotices notices={ notices } /> );
+		expect( wrapper.prop( 'notices' ) ).toHaveLength( 3 );
+		expect( wrapper.children() ).toHaveLength( 1 );
+	} );
+
+	it( 'renders only dismissible notices', () => {
+		const wrapper = shallow( <EditorNotices notices={ notices } dismissible={ true } /> );
+		expect( wrapper.prop( 'notices' ) ).toHaveLength( 2 );
+		expect( wrapper.children() ).toHaveLength( 1 );
+	} );
+
+	it( 'renders only non-dismissible notices', () => {
+		const wrapper = shallow( <EditorNotices notices={ notices } dismissible={ false } /> );
+		expect( wrapper.prop( 'notices' ) ).toHaveLength( 1 );
+		expect( wrapper.children() ).toHaveLength( 0 );
+	} );
+} );


### PR DESCRIPTION
Attempts to fix #12243.

Prevents non-dismissible notices from obscuring the post content by separating them from dismissible notices and placing them outside of `edit-post-layout__content`.

#### Testing

1. Create a new post
2. Create some non-dismissible notices by running this in your console: `[ ...Array( 3 ) ].forEach( () => wp.data.dispatch( 'core/notices' ).createInfoNotice( 'Not dismissible', { isDismissible: false } ) )`
3. See that they are push the editor's content down
4. For good measure, create some dismissible notices by running this in your console: `[ ...Array( 3 ) ].forEach( () => wp.data.dispatch( 'core/notices' ).createInfoNotice( 'Dismissible' ) )`