### PR TITLE
Fix image URL after documentation reorganisation.

### DIFF
--- a/docs/designers-developers/developers/tutorials/block-tutorial/block-controls-toolbars-and-inspector.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/block-controls-toolbars-and-inspector.md
@@ -171,7 +171,7 @@ Note that `BlockControls` is only visible when the block is currently selected a
 
 ## Inspector
 
-<img src="https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/blocks/inspector.png" with="281" height="527" alt="inspector">
+<img src="https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/block-tutorial/inspector.png" with="281" height="527" alt="inspector">
 
 The inspector is used to display less-often-used settings or settings that require more screen space. The inspector should be used for **block-level settings only**.
 


### PR DESCRIPTION
As reported in https://meta.trac.wordpress.org/ticket/3958:
> I open the https://wordpress.org/gutenberg/handbook/blocks/block-controls-toolbars-and-inspector/ and I see the Inspector section where I did not find the image.

Looks like it was missed in #11817 for #11251.