### PR TITLE
[RNMobile] Fix aztec editor height not updated on component load

### DIFF
--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -27,7 +27,9 @@ class HeadingEdit extends Component {
 	constructor( props ) {
 		super( props );
 
-		this.aztecHeight = 0;
+		this.state = {
+			aztecHeight: 0,
+		};
 	}
 
 	render() {
@@ -55,7 +57,7 @@ class HeadingEdit extends Component {
 					value={ content }
 					isSelected={ this.props.isSelected }
 					style={ {
-						minHeight: Math.max( minHeight, this.aztecHeight ),
+						minHeight: Math.max( minHeight, this.state.aztecHeight ),
 					} }
 					onChange={ ( event ) => {
 						// Create a React Tree from the new HTML
@@ -78,7 +80,7 @@ class HeadingEdit extends Component {
 							undefined
 					}
 					onContentSizeChange={ ( event ) => {
-						this.aztecHeight = event.aztecHeight;
+						this.setState( { aztecHeight: event.aztecHeight } );
 					} }
 					placeholder={ placeholder || __( 'Write heading…' ) }
 				/>

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -23,7 +23,9 @@ class ParagraphEdit extends Component {
 		super( props );
 		this.splitBlock = this.splitBlock.bind( this );
 
-		this.aztecHeight = 0;
+		this.state = {
+			aztecHeight: 0,
+		};
 	}
 
 	/**
@@ -92,7 +94,7 @@ class ParagraphEdit extends Component {
 					isSelected={ this.props.isSelected }
 					style={ {
 						...style,
-						minHeight: Math.max( minHeight, this.aztecHeight ),
+						minHeight: Math.max( minHeight, this.state.aztecHeight ),
 					} }
 					onChange={ ( event ) => {
 						// Create a React Tree from the new HTML
@@ -105,7 +107,7 @@ class ParagraphEdit extends Component {
 					onSplit={ this.splitBlock }
 					onMerge={ mergeBlocks }
 					onContentSizeChange={ ( event ) => {
-						this.aztecHeight = event.aztecHeight;
+						this.setState( { aztecHeight: event.aztecHeight } );
 					} }
 					placeholder={ placeholder || __( 'Add text or type / to add content' ) }
 				/>


### PR DESCRIPTION
## Description
This fixes a regression on mobile after https://github.com/WordPress/gutenberg/pull/12231 was merged. Some block height might have the wrong value on load as we would not re-render the component when `onContentSizeChange` is called. 

Using the component state instead will fix this.

## How has this been tested?
Tested on mobile, running `yarn android` and noticing the height problem disappeared

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/230230/49005547-436de080-f167-11e8-9c64-e495c9607dea.png)

## Types of changes
- React native components change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
