### PR TITLE
Allow links in Plugins group in the More Menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7596,7 +7596,7 @@
 		},
 		"eslint-plugin-react": {
 			"version": "7.7.0",
-			"resolved": "http://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
 			"integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
 			"dev": true,
 			"requires": {
@@ -11733,7 +11733,7 @@
 		},
 		"jest-environment-jsdom": {
 			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
+			"resolved": "http://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
 			"integrity": "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
 			"dev": true,
 			"requires": {
@@ -11896,7 +11896,7 @@
 		},
 		"jest-get-type": {
 			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+			"resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
 			"integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
 			"dev": true
 		},
@@ -12178,7 +12178,7 @@
 		},
 		"jest-message-util": {
 			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
+			"resolved": "http://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
 			"integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
 			"dev": true,
 			"requires": {
@@ -12267,7 +12267,7 @@
 		},
 		"jest-mock": {
 			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.4.3.tgz",
+			"resolved": "http://registry.npmjs.org/jest-mock/-/jest-mock-22.4.3.tgz",
 			"integrity": "sha512-+4R6mH5M1G4NK16CKg9N1DtCaFmuxhcIqF4lQK/Q1CIotqMs/XBemfpDPeVZBFow6iyUNu6EBT9ugdNOTT5o5Q==",
 			"dev": true
 		},
@@ -12821,7 +12821,7 @@
 		},
 		"jest-util": {
 			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
+			"resolved": "http://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
 			"integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
 			"dev": true,
 			"requires": {

--- a/packages/edit-post/src/README.md
+++ b/packages/edit-post/src/README.md
@@ -234,6 +234,8 @@ const MyButtonMoreMenuItem = () => (
 
 #### Props
 
+`PluginMoreMenuItem` supports the following props. Any additional props are passed through to the underlying [MenuItem](../../components/src/menu-item) component.
+
 ##### icon
 
 The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered to the left of the menu item label.

--- a/packages/edit-post/src/README.md
+++ b/packages/edit-post/src/README.md
@@ -236,6 +236,13 @@ const MyButtonMoreMenuItem = () => (
 
 `PluginMoreMenuItem` supports the following props. Any additional props are passed through to the underlying [MenuItem](../../components/src/menu-item) component.
 
+##### href
+
+When `href` is provided then the menu item is represented as an anchor rather than button. It corresponds to the `href` attribute of the anchor.
+
+- Type: `String`
+- Required: No
+
 ##### icon
 
 The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered to the left of the menu item label.
@@ -251,13 +258,6 @@ The callback function to be executed when the user clicks the menu item.
 - Type: `function`
 - Required: No
 - Default: _function which does nothing_
-
-##### url
-
-When `url` is provided then the menu item is represented as an anchor rather than button. It corresponds to the `href` attribute of the anchor.
-
-- Type: `String`
-- Required: No
 
 ### `PluginSidebarMoreMenuItem`
 

--- a/packages/edit-post/src/README.md
+++ b/packages/edit-post/src/README.md
@@ -181,6 +181,81 @@ The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug st
 - Required: No
 - Default: _inherits from the plugin_
 
+### `PluginMoreMenuItem`
+
+Renders a menu item in `Plugins` group in `More Menu` drop down, and can be used to as a button or link depending on the props provided.
+The text within the component appears as the menu item label.
+
+_Example:_
+
+{% codetabs %}
+
+{% ES5 %}
+```js
+var __ = wp.i18n.__;
+var PluginMoreMenuItem = wp.editPost.PluginMoreMenuItem;
+var el = wp.element.createElement;
+
+function onButtonClick() {
+	alert( 'Button clicked.' );
+}
+
+function MyButtonMoreMenuItem() {
+	return el(
+		PluginMoreMenuItem,
+		{
+			icon: 'smiley',
+			onClick: onButtonClick
+		},
+		__( 'My button title' )
+	)
+}
+```
+
+{% ESNext %}
+```jsx
+const { __ } = wp.i18n;
+const { PluginMoreMenuItem } = wp.editPost;
+
+function onButtonClick() {
+	alert( 'Button clicked.' );
+}
+
+const MyButtonMoreMenuItem = () => (
+	<PluginMoreMenuItem
+		icon="smiley"
+		onClick={ onButtonClick }
+	>
+		{ __( 'My button title' ) }
+	</PluginMoreMenuItem>
+);
+```
+{% end %}
+
+#### Props
+
+##### icon
+
+The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered to the left of the menu item label.
+
+- Type: `String` | `Element`
+- Required: No
+- Default: _inherits from the plugin_
+
+##### onClick
+
+The callback function to be executed when the user clicks the menu item.
+
+- Type: `function`
+- Required: No
+- Default: _function which does nothing_
+
+##### url
+
+When `url` is provided then the menu item is represented as an anchor rather than button. It corresponds to the `href` attribute of the anchor.
+
+- Type: `String`
+- Required: No
 
 ### `PluginSidebarMoreMenuItem`
 

--- a/packages/edit-post/src/components/header/plugin-more-menu-item/index.js
+++ b/packages/edit-post/src/components/header/plugin-more-menu-item/index.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { compose } from '@wordpress/compose';
+import { MenuItem } from '@wordpress/components';
+import { withPluginContext } from '@wordpress/plugins';
+
+/**
+ * Internal dependencies
+ */
+import PluginsMoreMenuGroup from '../plugins-more-menu-group';
+
+const PluginMoreMenuItem = ( { children, icon, url, onClick = noop } ) => (
+	<PluginsMoreMenuGroup>
+		{ ( fillProps ) => (
+			<MenuItem
+				href={ url }
+				icon={ icon }
+				onClick={ compose( onClick, fillProps.onClose ) }
+			>
+				{ children }
+			</MenuItem>
+		) }
+	</PluginsMoreMenuGroup>
+);
+
+export default compose(
+	withPluginContext( ( context, ownProps ) => {
+		return {
+			icon: ownProps.icon || context.icon,
+		};
+	} ),
+)( PluginMoreMenuItem );

--- a/packages/edit-post/src/components/header/plugin-more-menu-item/index.js
+++ b/packages/edit-post/src/components/header/plugin-more-menu-item/index.js
@@ -15,12 +15,12 @@ import { withPluginContext } from '@wordpress/plugins';
  */
 import PluginsMoreMenuGroup from '../plugins-more-menu-group';
 
-const PluginMoreMenuItem = ( { children, icon, url, onClick = noop } ) => (
+const PluginMoreMenuItem = ( { children, url, onClick = noop, ...props } ) => (
 	<PluginsMoreMenuGroup>
 		{ ( fillProps ) => (
 			<MenuItem
+				{ ...props }
 				href={ url }
-				icon={ icon }
 				onClick={ compose( onClick, fillProps.onClose ) }
 			>
 				{ children }

--- a/packages/edit-post/src/components/header/plugin-more-menu-item/index.js
+++ b/packages/edit-post/src/components/header/plugin-more-menu-item/index.js
@@ -15,12 +15,11 @@ import { withPluginContext } from '@wordpress/plugins';
  */
 import PluginsMoreMenuGroup from '../plugins-more-menu-group';
 
-const PluginMoreMenuItem = ( { url, onClick = noop, ...props } ) => (
+const PluginMoreMenuItem = ( { onClick = noop, ...props } ) => (
 	<PluginsMoreMenuGroup>
 		{ ( fillProps ) => (
 			<MenuItem
 				{ ...props }
-				href={ url }
 				onClick={ compose( onClick, fillProps.onClose ) }
 			/>
 		) }

--- a/packages/edit-post/src/components/header/plugin-more-menu-item/index.js
+++ b/packages/edit-post/src/components/header/plugin-more-menu-item/index.js
@@ -15,16 +15,14 @@ import { withPluginContext } from '@wordpress/plugins';
  */
 import PluginsMoreMenuGroup from '../plugins-more-menu-group';
 
-const PluginMoreMenuItem = ( { children, url, onClick = noop, ...props } ) => (
+const PluginMoreMenuItem = ( { url, onClick = noop, ...props } ) => (
 	<PluginsMoreMenuGroup>
 		{ ( fillProps ) => (
 			<MenuItem
 				{ ...props }
 				href={ url }
 				onClick={ compose( onClick, fillProps.onClose ) }
-			>
-				{ children }
-			</MenuItem>
+			/>
 		) }
 	</PluginsMoreMenuGroup>
 );

--- a/packages/edit-post/src/components/header/plugin-more-menu-item/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/header/plugin-more-menu-item/test/__snapshots__/index.js.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PluginMoreMenuItem renders menu item as button properly 1`] = `
+<div
+  className="components-menu-group"
+>
+  <div
+    className="components-menu-group__label"
+    id="components-menu-group-label-0"
+  >
+    Plugins
+  </div>
+  <div
+    aria-labelledby="components-menu-group-label-0"
+    aria-orientation="vertical"
+    onKeyDown={[Function]}
+    role="menu"
+  >
+    <button
+      aria-label="My plugin button menu item"
+      className="components-button components-icon-button components-menu-item__button has-icon"
+      onClick={[Function]}
+      role="menuitem"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        className="dashicon dashicons-smiley"
+        focusable="false"
+        height={20}
+        role="img"
+        viewBox="0 0 20 20"
+        width={20}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M7 5.2c1.1 0 2 .89 2 2 0 .37-.11.71-.28 1C8.72 8.2 8 8 7 8s-1.72.2-1.72.2c-.17-.29-.28-.63-.28-1 0-1.11.9-2 2-2zm6 0c1.11 0 2 .89 2 2 0 .37-.11.71-.28 1 0 0-.72-.2-1.72-.2s-1.72.2-1.72.2c-.17-.29-.28-.63-.28-1 0-1.11.89-2 2-2zm-3 13.7c3.72 0 7.03-2.36 8.23-5.88l-1.32-.46C15.9 15.52 13.12 17.5 10 17.5s-5.9-1.98-6.91-4.94l-1.32.46c1.2 3.52 4.51 5.88 8.23 5.88z"
+        />
+      </svg>
+      My plugin button menu item
+    </button>
+  </div>
+</div>
+`;

--- a/packages/edit-post/src/components/header/plugin-more-menu-item/test/index.js
+++ b/packages/edit-post/src/components/header/plugin-more-menu-item/test/index.js
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+import ReactTestRenderer from 'react-test-renderer';
+
+/**
+ * WordPress dependencies
+ */
+import { SlotFillProvider } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import PluginMoreMenuItem from '../';
+import PluginsMoreMenuGroup from '../../plugins-more-menu-group';
+
+describe( 'PluginMoreMenuItem', () => {
+	const fillProps = {
+		onClose: noop,
+	};
+
+	test( 'renders menu item as button properly', () => {
+		const component = ReactTestRenderer.create(
+			<SlotFillProvider>
+				<PluginMoreMenuItem
+					icon="smiley"
+				>
+					My plugin button menu item
+				</PluginMoreMenuItem>
+				<PluginsMoreMenuGroup.Slot fillProps={ fillProps } />
+			</SlotFillProvider>
+		);
+
+		expect( component.toJSON() ).toMatchSnapshot();
+	} );
+
+	test( 'renders menu item as link properly', () => {
+		const url = 'https://make.wordpress.org';
+		const component = ReactTestRenderer.create(
+			<SlotFillProvider>
+				<PluginMoreMenuItem
+					icon="smiley"
+					url={ url }
+				>
+					My plugin link menu item
+				</PluginMoreMenuItem>
+				<PluginsMoreMenuGroup.Slot fillProps={ fillProps } />
+			</SlotFillProvider>
+		);
+
+		expect( component.root.findByType( 'a' ).props.href ).toBe( url );
+	} );
+} );

--- a/packages/edit-post/src/components/header/plugin-more-menu-item/test/index.js
+++ b/packages/edit-post/src/components/header/plugin-more-menu-item/test/index.js
@@ -41,7 +41,7 @@ describe( 'PluginMoreMenuItem', () => {
 			<SlotFillProvider>
 				<PluginMoreMenuItem
 					icon="smiley"
-					url={ url }
+					href={ url }
 				>
 					My plugin link menu item
 				</PluginMoreMenuItem>

--- a/packages/edit-post/src/components/header/plugin-sidebar-more-menu-item/index.js
+++ b/packages/edit-post/src/components/header/plugin-sidebar-more-menu-item/index.js
@@ -3,27 +3,22 @@
  */
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { MenuItem } from '@wordpress/components';
 import { withPluginContext } from '@wordpress/plugins';
 
 /**
  * Internal dependencies
  */
-import PluginsMoreMenuGroup from '../plugins-more-menu-group';
+import PluginMoreMenuItem from '../plugin-more-menu-item';
 
 const PluginSidebarMoreMenuItem = ( { children, icon, isSelected, onClick } ) => (
-	<PluginsMoreMenuGroup>
-		{ ( fillProps ) => (
-			<MenuItem
-				icon={ isSelected ? 'yes' : icon }
-				isSelected={ isSelected }
-				role="menuitemcheckbox"
-				onClick={ compose( onClick, fillProps.onClose ) }
-			>
-				{ children }
-			</MenuItem>
-		) }
-	</PluginsMoreMenuGroup>
+	<PluginMoreMenuItem
+		icon={ isSelected ? 'yes' : icon }
+		isSelected={ isSelected }
+		role="menuitemcheckbox"
+		onClick={ onClick }
+	>
+		{ children }
+	</PluginMoreMenuItem>
 );
 
 export default compose(

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -88,6 +88,7 @@ export function initializeEditor( id, postType, postId, settings, initialEdits )
 }
 
 export { default as PluginBlockSettingsMenuItem } from './components/block-settings-menu/plugin-block-settings-menu-item';
+export { default as PluginMoreMenuItem } from './components/header/plugin-more-menu-item';
 export { default as PluginPostPublishPanel } from './components/sidebar/plugin-post-publish-panel';
 export { default as PluginPostStatusInfo } from './components/sidebar/plugin-post-status-info';
 export { default as PluginPrePublishPanel } from './components/sidebar/plugin-pre-publish-panel';


### PR DESCRIPTION
## Description
Fixes #11570.

 > As a first iteration, we can offer `PluginMoreMenuItem` which takes onClick callback and inserts menu items inside Plugins group. it would allow to handle Modal as well. It might require some code though.

It also includes an option to pass `url` which turns the menu item into a link.

## How has this been tested?

Copy those snippets into JS console and make sure that there are new items added in More Menu. Make sure it produces a valid HTML which follows accessibility guidelines:
- `button` for items with `onClick`
- `link` for items with `url`

```js
( function() {
	const { createElement } = wp.element;
	const { PluginMoreMenuItem } = wp.editPost;
	const { registerPlugin } = wp.plugins;

	registerPlugin( 'my-plugin-more-menu-button', {
		render() {
			return createElement(
				PluginMoreMenuItem,
				{
					icon: 'smiley',
					onClick: function() { alert( 'Smile :)' ); },
				},
				'Smile :)'
			);
		},
	} );
} )();
```

```js
( function() {
	const { get } = lodash;
	const { createElement } = wp.element;
	const { PluginMoreMenuItem } = wp.editPost;
	const { addQueryArgs } = wp.url;
	const { registerPlugin } = wp.plugins;

	registerPlugin( 'classic-editor-add-submenu', {
		render() {
			const url = addQueryArgs( document.location.href, { 'classic-editor': null } );
			const linkText = get( window, [ 'classicEditorPluginL10n', 'linkText' ] ) || 'Switch to Classic Editor';

			return createElement(
				PluginMoreMenuItem,
				{
					icon: 'editor-kitchensink',
					href: url,
				},
				linkText
			);
		},
	} );
} )();
```

## Screenshots <!-- if applicable -->

![screen shot 2018-11-26 at 11 49 31](https://user-images.githubusercontent.com/699132/49013241-54751c80-f17c-11e8-8577-b72cefa45a5d.png)

## TODO

* [x] Docs for `PluginMoreMenuItem` (similar to what we have [here](https://github.com/WordPress/gutenberg/tree/master/packages/edit-post/src#pluginsidebarmoremenuitem))
* [x] New unit tests
* [x] ~~New e2e tests (similar to what we have [here](https://github.com/WordPress/gutenberg/blob/master/test/e2e/specs/plugins-api.test.js#L58-L76))~~ it's indirectly tested by the sidebar menu item which uses this new component behind the scenes

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
