### PR TITLE
[RNMobile] Expose `onFocus` and wire it for correct block-toolbar management

### DIFF
--- a/packages/block-library/src/code/edit.native.js
+++ b/packages/block-library/src/code/edit.native.js
@@ -21,7 +21,7 @@ import styles from './theme.scss';
 // Note: styling is applied directly to the (nested) PlainText component. Web-side components
 // apply it to the container 'div' but we don't have a proper proposal for cascading styling yet.
 export default function CodeEdit( props ) {
-	const { attributes, setAttributes, style } = props;
+	const { attributes, setAttributes, style, onFocus } = props;
 
 	return (
 		<View>
@@ -34,6 +34,7 @@ export default function CodeEdit( props ) {
 				placeholder={ __( 'Write code…' ) }
 				aria-label={ __( 'Code' ) }
 				isSelected={ props.isSelected }
+				onFocus={ onFocus }
 			/>
 		</View>
 	);

--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -56,6 +56,7 @@ class HeadingEdit extends Component {
 					tagName={ tagName }
 					value={ content }
 					isSelected={ this.props.isSelected }
+					onFocus={ this.props.onFocus }
 					style={ {
 						minHeight: Math.max( minHeight, this.state.aztecHeight ),
 					} }

--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -56,7 +56,7 @@ class HeadingEdit extends Component {
 					tagName={ tagName }
 					value={ content }
 					isSelected={ this.props.isSelected }
-					onFocus={ this.props.onFocus }
+					onFocus={ this.props.onFocus } // always assign onFocus as a props
 					style={ {
 						minHeight: Math.max( minHeight, this.state.aztecHeight ),
 					} }

--- a/packages/block-library/src/more/edit.native.js
+++ b/packages/block-library/src/more/edit.native.js
@@ -15,7 +15,7 @@ import { PlainText } from '@wordpress/editor';
 import styles from './editor.scss';
 
 export default function MoreEdit( props ) {
-	const { attributes, setAttributes } = props;
+	const { attributes, setAttributes, onFocus } = props;
 	const { customText } = attributes;
 	const defaultText = __( 'Read more' );
 	const value = customText !== undefined ? customText : defaultText;
@@ -32,6 +32,7 @@ export default function MoreEdit( props ) {
 					onChange={ ( newValue ) => setAttributes( { customText: newValue } ) }
 					placeholder={ defaultText }
 					isSelected={ props.isSelected }
+					onFocus={ onFocus }
 				/>
 				<Text className={ styles[ 'block-library-more__right-marker' ] }>--&gt;</Text>
 			</View>

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -92,7 +92,7 @@ class ParagraphEdit extends Component {
 					tagName="p"
 					value={ content }
 					isSelected={ this.props.isSelected }
-					onFocus={ this.props.onFocus }
+					onFocus={ this.props.onFocus } // always assign onFocus as a props
 					style={ {
 						...style,
 						minHeight: Math.max( minHeight, this.state.aztecHeight ),

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -92,6 +92,7 @@ class ParagraphEdit extends Component {
 					tagName="p"
 					value={ content }
 					isSelected={ this.props.isSelected }
+					onFocus={ this.props.onFocus }
 					style={ {
 						...style,
 						minHeight: Math.max( minHeight, this.state.aztecHeight ),

--- a/packages/editor/src/components/plain-text/index.native.js
+++ b/packages/editor/src/components/plain-text/index.native.js
@@ -31,7 +31,7 @@ export default class PlainText extends Component {
 				ref={ ( x ) => this._input = x }
 				className={ [ styles[ 'editor-plain-text' ], this.props.className ] }
 				onChangeText={ ( text ) => this.props.onChange( text ) }
-				onFocus={ this.props.onFocus }
+				onFocus={ this.props.onFocus } // always assign onFocus as a props
 				{ ...this.props }
 			/>
 		);

--- a/packages/editor/src/components/plain-text/index.native.js
+++ b/packages/editor/src/components/plain-text/index.native.js
@@ -31,6 +31,7 @@ export default class PlainText extends Component {
 				ref={ ( x ) => this._input = x }
 				className={ [ styles[ 'editor-plain-text' ], this.props.className ] }
 				onChangeText={ ( text ) => this.props.onChange( text ) }
+				onFocus={ this.props.onFocus }
 				{ ...this.props }
 			/>
 		);

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -356,6 +356,7 @@ export class RichText extends Component {
 					}
 					text={ { text: html, eventCount: this.lastEventCount } }
 					onChange={ this.onChange }
+					onFocus={ this.props.onFocus }
 					onEnter={ this.onEnter }
 					onBackspace={ this.onBackspace }
 					onContentSizeChange={ this.onContentSizeChange }


### PR DESCRIPTION
This PR fixes an issue where tapping on a `PlainText`, or `AztecWrapper`, powered blocks (`code`, `more`, and `para` blocks for now) does not propagate the `onFocus` event to the ReactNative side.


To test this PR check the following gb-mobile PR here: https://github.com/wordpress-mobile/gutenberg-mobile/pull/277