### PR TITLE
Block switch: ensure hover is reset when style changed

### DIFF
--- a/packages/editor/src/components/block-styles/index.js
+++ b/packages/editor/src/components/block-styles/index.js
@@ -79,6 +79,7 @@ function BlockStyles( {
 	function updateClassName( style ) {
 		const updatedClassName = replaceActiveStyle( className, activeStyle, style );
 		onChangeClassName( updatedClassName );
+		onHoverClassName( null );
 		onSwitch();
 	}
 


### PR DESCRIPTION
The block style picker is used by a block's toolbar to allow the style to be changed. As you hover over a style it sends a `onHoverClassName` event to `BlockSwitcher` indicating which style is being hovered over, which is then used to show a preview.

<img width="633" alt="edit_post_ _wordpress_latest_ _wordpress" src="https://user-images.githubusercontent.com/1277682/48905772-58422f80-ee5a-11e8-8700-4477e42e5ec1.png">

When you click on a style the `BlockSwitcher` is hidden but retains its last state, including the hover style.

If you show the `BlockSwitcher` again it will appear with a hover style and preview already selected

This PR sends a `onHoverClassName` event when a style is picked, ensuring the `BlockSwitcher` component is reset.

Fixes #12225

## How has this been tested?
1. Create a button block and enter some details
2. Click the block style icon in the block toolbar (not the sidebar)
3. Pick a style
4. Click the block style icon again and verify that the preview is not shown
5. Verify that the block style picker in the sidebar functions as expected - nothing should change here as it doesnt show a preview

## Types of changes
Non-breaking change to `<BlockStyles/>`

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
