### PR TITLE
Change @package to WordPress

### DIFF
--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -2,7 +2,7 @@
 /**
  * Server-side rendering of the `core/archives` block.
  *
- * @package gutenberg
+ * @package WordPress
  */
 
 /**

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -2,7 +2,7 @@
 /**
  * Server-side rendering of the `core/block` block.
  *
- * @package gutenberg
+ * @package WordPress
  */
 
 /**

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -2,7 +2,7 @@
 /**
  * Server-side rendering of the `core/categories` block.
  *
- * @package gutenberg
+ * @package WordPress
  */
 
 /**

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -2,7 +2,7 @@
 /**
  * Server-side rendering of the `core/latest-comments` block.
  *
- * @package gutenberg
+ * @package WordPress
  */
 
 if ( ! function_exists( 'gutenberg_draft_or_post_title' ) ) {

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -2,7 +2,7 @@
 /**
  * Server-side rendering of the `core/latest-posts` block.
  *
- * @package gutenberg
+ * @package WordPress
  */
 
 /**

--- a/packages/block-library/src/shortcode/index.php
+++ b/packages/block-library/src/shortcode/index.php
@@ -2,7 +2,7 @@
 /**
  * Server-side rendering of the `core/shortcode` block.
  *
- * @package gutenberg
+ * @package WordPress
  */
 
 /**


### PR DESCRIPTION
## Description

Renames `@package` gutenberg to WordPress for block-library php files

See #12085 

## How has this been tested?

* Confirmed tests still works

## Types of changes

* Change in comments, no code or functional change


## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
