### PR TITLE
Rename functions, removing gutenberg_ prefix

### DIFF
--- a/lib/load.php
+++ b/lib/load.php
@@ -62,10 +62,10 @@ if ( ! function_exists( 'render_block_core_block' ) ) {
 if ( ! function_exists( 'render_block_core_categories' ) ) {
 	require dirname( __FILE__ ) . '/../packages/block-library/src/categories/index.php';
 }
-// Currently merged in core as `gutenberg_render_block_core_latest_comments`,
+// Currently merged in core as `wp_render_block_core_latest_comments`,
 // expected to change soon.
 if ( ! function_exists( 'render_block_core_latest_comments' )
-	&& ! function_exists( 'gutenberg_render_block_core_latest_comments' ) ) {
+	&& ! function_exists( 'wp_render_block_core_latest_comments' ) ) {
 	require dirname( __FILE__ ) . '/../packages/block-library/src/latest-comments/index.php';
 }
 if ( ! function_exists( 'render_block_core_latest_posts' ) ) {

--- a/lib/load.php
+++ b/lib/load.php
@@ -62,10 +62,7 @@ if ( ! function_exists( 'render_block_core_block' ) ) {
 if ( ! function_exists( 'render_block_core_categories' ) ) {
 	require dirname( __FILE__ ) . '/../packages/block-library/src/categories/index.php';
 }
-// Currently merged in core as `wp_render_block_core_latest_comments`,
-// expected to change soon.
-if ( ! function_exists( 'render_block_core_latest_comments' )
-	&& ! function_exists( 'wp_render_block_core_latest_comments' ) ) {
+if ( ! function_exists( 'render_block_core_latest_comments' ) ) {
 	require dirname( __FILE__ ) . '/../packages/block-library/src/latest-comments/index.php';
 }
 if ( ! function_exists( 'render_block_core_latest_posts' ) ) {

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -5,7 +5,7 @@
  * @package WordPress
  */
 
-if ( ! function_exists( 'gutenberg_draft_or_post_title' ) ) {
+if ( ! function_exists( 'wp_latest_comments_draft_or_post_title' ) ) {
 	/**
 	 * Get the post title.
 	 *
@@ -26,7 +26,7 @@ if ( ! function_exists( 'gutenberg_draft_or_post_title' ) ) {
 	 * @param int|WP_Post $post Optional. Post ID or WP_Post object. Default is global $post.
 	 * @return string The post title if set; "(no title)" if no title is set.
 	 */
-	function gutenberg_draft_or_post_title( $post = 0 ) {
+	function wp_latest_comments_draft_or_post_title( $post = 0 ) {
 		$title = get_the_title( $post );
 		if ( empty( $title ) ) {
 			$title = __( '(no title)' );
@@ -42,7 +42,7 @@ if ( ! function_exists( 'gutenberg_draft_or_post_title' ) ) {
  *
  * @return string Returns the post content with latest comments added.
  */
-function gutenberg_render_block_core_latest_comments( $attributes = array() ) {
+function wp_render_block_core_latest_comments( $attributes = array() ) {
 	// This filter is documented in wp-includes/widgets/class-wp-widget-recent-comments.php.
 	$comments = get_comments(
 		apply_filters(
@@ -94,7 +94,7 @@ function gutenberg_render_block_core_latest_comments( $attributes = array() ) {
 
 			// `_draft_or_post_title` calls `esc_html()` so we don't need to wrap that call in
 			// `esc_html`.
-			$post_title = '<a class="wp-block-latest-comments__comment-link" href="' . esc_url( get_comment_link( $comment ) ) . '">' . gutenberg_draft_or_post_title( $comment->comment_post_ID ) . '</a>';
+			$post_title = '<a class="wp-block-latest-comments__comment-link" href="' . esc_url( get_comment_link( $comment ) ) . '">' . wp_latest_comments_draft_or_post_title( $comment->comment_post_ID ) . '</a>';
 
 			$list_items_markup .= sprintf(
 				/* translators: 1: author name (inside <a> or <span> tag, based on if they have a URL), 2: post title related to this comment */
@@ -179,6 +179,6 @@ register_block_type(
 				'enum' => array( 'center', 'left', 'right', 'wide', 'full', '' ),
 			),
 		),
-		'render_callback' => 'gutenberg_render_block_core_latest_comments',
+		'render_callback' => 'wp_render_block_core_latest_comments',
 	)
 );

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -5,34 +5,32 @@
  * @package WordPress
  */
 
-if ( ! function_exists( 'wp_latest_comments_draft_or_post_title' ) ) {
-	/**
-	 * Get the post title.
-	 *
-	 * The post title is fetched and if it is blank then a default string is
-	 * returned.
-	 *
-	 * Copied from `wp-admin/includes/template.php`, but we can't include that
-	 * file because:
-	 *
-	 * 1. It causes bugs with test fixture generation and strange Docker 255 error
-	 *    codes.
-	 * 2. It's in the admin; ideally we *shouldn't* be including files from the
-	 *    admin for a block's output. It's a very small/simple function as well,
-	 *    so duplicating it isn't too terrible.
-	 *
-	 * @since 3.3.0
-	 *
-	 * @param int|WP_Post $post Optional. Post ID or WP_Post object. Default is global $post.
-	 * @return string The post title if set; "(no title)" if no title is set.
-	 */
-	function wp_latest_comments_draft_or_post_title( $post = 0 ) {
-		$title = get_the_title( $post );
-		if ( empty( $title ) ) {
-			$title = __( '(no title)' );
-		}
-		return esc_html( $title );
+/**
+ * Get the post title.
+ *
+ * The post title is fetched and if it is blank then a default string is
+ * returned.
+ *
+ * Copied from `wp-admin/includes/template.php`, but we can't include that
+ * file because:
+ *
+ * 1. It causes bugs with test fixture generation and strange Docker 255 error
+ *    codes.
+ * 2. It's in the admin; ideally we *shouldn't* be including files from the
+ *    admin for a block's output. It's a very small/simple function as well,
+ *    so duplicating it isn't too terrible.
+ *
+ * @since 3.3.0
+ *
+ * @param int|WP_Post $post Optional. Post ID or WP_Post object. Default is global $post.
+ * @return string The post title if set; "(no title)" if no title is set.
+ */
+function wp_latest_comments_draft_or_post_title( $post = 0 ) {
+	$title = get_the_title( $post );
+	if ( empty( $title ) ) {
+		$title = __( '(no title)' );
 	}
+	return esc_html( $title );
 }
 
 /**

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -42,7 +42,7 @@ if ( ! function_exists( 'wp_latest_comments_draft_or_post_title' ) ) {
  *
  * @return string Returns the post content with latest comments added.
  */
-function wp_render_block_core_latest_comments( $attributes = array() ) {
+function render_block_core_latest_comments( $attributes = array() ) {
 	// This filter is documented in wp-includes/widgets/class-wp-widget-recent-comments.php.
 	$comments = get_comments(
 		apply_filters(
@@ -179,6 +179,6 @@ register_block_type(
 				'enum' => array( 'center', 'left', 'right', 'wide', 'full', '' ),
 			),
 		),
-		'render_callback' => 'wp_render_block_core_latest_comments',
+		'render_callback' => 'render_block_core_latest_comments',
 	)
 );


### PR DESCRIPTION
## Description

Renames two functions in latest-comments block PHP code.
Removes `gutenberg_` prefix

See #12085 

## How has this been tested?

* Confirmed latest comments block loads
* Confirmed no other function name conflicts

## Types of changes

* Renames two internal functions to latest comments block
* Updates reference to the function in lib/load.php

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
