### PR TITLE
Editor: Merge meta attributes in getEditedPostAttribute

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 9.0.3 (Unreleased)
+
+### Bug Fixes
+
+- `getEditedPostAttribute` now correctly returns the merged result of edits as a partial change when given `'meta'` as the `attributeName`.
+
 ## 9.0.2 (2018-11-22)
 
 ## 9.0.1 (2018-11-21)

--- a/packages/editor/src/store/constants.js
+++ b/packages/editor/src/store/constants.js
@@ -1,0 +1,9 @@
+/**
+ * Set of post properties for which edits should assume a merging behavior,
+ * assuming an object value.
+ *
+ * @type {Set}
+ */
+export const EDIT_MERGE_PROPERTIES = new Set( [
+	'meta',
+] );

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -35,16 +35,7 @@ import {
 	INITIAL_EDITS_DEFAULTS,
 } from './defaults';
 import { insertAt, moveTo } from './array';
-
-/**
- * Set of post properties for which edits should assume a merging behavior,
- * assuming an object value.
- *
- * @type {Set}
- */
-const EDIT_MERGE_PROPERTIES = new Set( [
-	'meta',
-] );
+import { EDIT_MERGE_PROPERTIES } from './constants';
 
 /**
  * Returns a post attribute value, flattening nested rendered content using its

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -310,8 +310,8 @@ export function getEditedPostAttribute( state, attributeName ) {
 		// consider caching in a way which would not impact non-merged property
 		// derivation. Alternatively, introduce a new selector for meta lookup.
 		return {
-			...edits[ attributeName ],
 			...getCurrentPostAttribute( state, attributeName ),
+			...edits[ attributeName ],
 		};
 	}
 

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -36,9 +36,10 @@ import { removep } from '@wordpress/autop';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
- * Dependencies
+ * Internal dependencies
  */
 import { PREFERENCES_DEFAULTS } from './defaults';
+import { EDIT_MERGE_PROPERTIES } from './constants';
 
 /***
  * Module constants
@@ -297,8 +298,36 @@ export function getEditedPostAttribute( state, attributeName ) {
 			return getEditedPostContent( state );
 	}
 
+	// Fall back to saved post value if not edited.
 	if ( ! edits.hasOwnProperty( attributeName ) ) {
 		return getCurrentPostAttribute( state, attributeName );
+	}
+
+	// Merge properties are objects which contain only the patch edit in state,
+	// and thus must be merged with the current post attribute.
+	if ( EDIT_MERGE_PROPERTIES.has( attributeName ) ) {
+		// To avoid creating a new reference on each return, and with guarantee
+		// that a merge property is of type object, use WeakMap to cache the
+		// result for so long as the edit value is referenced (effectively as
+		// long as the merge property has the same edit value). Over `rememo`,
+		// this has the benefit of (a) optimizing as the less common case and
+		// (b) being a more performant cache lookup.
+		let { mergeCache } = getEditedPostAttribute;
+		if ( ! mergeCache ) {
+			mergeCache = getEditedPostAttribute.mergeCache = new WeakMap;
+		}
+
+		if ( ! mergeCache.has( edits[ attributeName ] ) ) {
+			mergeCache.set(
+				edits[ attributeName ],
+				{
+					...edits[ attributeName ],
+					...getCurrentPostAttribute( state, attributeName ),
+				}
+			);
+		}
+
+		return mergeCache.get( edits[ attributeName ] );
 	}
 
 	return edits[ attributeName ];

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -306,28 +306,13 @@ export function getEditedPostAttribute( state, attributeName ) {
 	// Merge properties are objects which contain only the patch edit in state,
 	// and thus must be merged with the current post attribute.
 	if ( EDIT_MERGE_PROPERTIES.has( attributeName ) ) {
-		// To avoid creating a new reference on each return, and with guarantee
-		// that a merge property is of type object, use WeakMap to cache the
-		// result for so long as the edit value is referenced (effectively as
-		// long as the merge property has the same edit value). Over `rememo`,
-		// this has the benefit of (a) optimizing as the less common case and
-		// (b) being a more performant cache lookup.
-		let { mergeCache } = getEditedPostAttribute;
-		if ( ! mergeCache ) {
-			mergeCache = getEditedPostAttribute.mergeCache = new WeakMap;
-		}
-
-		if ( ! mergeCache.has( edits[ attributeName ] ) ) {
-			mergeCache.set(
-				edits[ attributeName ],
-				{
-					...edits[ attributeName ],
-					...getCurrentPostAttribute( state, attributeName ),
-				}
-			);
-		}
-
-		return mergeCache.get( edits[ attributeName ] );
+		// [TODO]: Since this will return a new reference on each invocation,
+		// consider caching in a way which would not impact non-merged property
+		// derivation. Alternatively, introduce a new selector for meta lookup.
+		return {
+			...edits[ attributeName ],
+			...getCurrentPostAttribute( state, attributeName ),
+		};
 	}
 
 	return edits[ attributeName ];

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -608,6 +608,7 @@ describe( 'selectors', () => {
 				currentPost: {
 					meta: {
 						a: 1,
+						b: 1,
 					},
 				},
 				editor: {

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -184,7 +184,6 @@ describe( 'selectors', () => {
 		unregisterBlockType( 'core/test-freeform' );
 
 		setFreeformContentHandlerName( undefined );
-		getEditedPostAttribute.mergeCache = new WeakMap;
 	} );
 
 	describe( 'hasEditorUndo', () => {
@@ -626,117 +625,6 @@ describe( 'selectors', () => {
 			expect( getEditedPostAttribute( state, 'meta' ) ).toEqual( {
 				a: 1,
 				b: 2,
-			} );
-		} );
-
-		it( 'should return same mergeable value reference if unchanged edit', () => {
-			const state = {
-				currentPost: {
-					meta: {
-						a: 1,
-					},
-				},
-				editor: {
-					present: {
-						edits: {
-							meta: {
-								b: 2,
-							},
-						},
-					},
-				},
-				initialEdits: {},
-			};
-
-			const before = getEditedPostAttribute( state, 'meta' );
-			const after = getEditedPostAttribute( state, 'meta' );
-
-			expect( before ).toBe( after );
-		} );
-
-		it( 'should return accurate merged value if changed edit', () => {
-			const currentPost = {
-				meta: {
-					a: 1,
-				},
-			};
-			const initialEdits = {};
-			const beforeState = {
-				currentPost,
-				initialEdits,
-				editor: {
-					present: {
-						edits: {
-							meta: {
-								b: 2,
-							},
-						},
-					},
-				},
-			};
-
-			const afterState = {
-				currentPost,
-				initialEdits,
-				editor: {
-					present: {
-						edits: {
-							meta: {
-								b: 3,
-							},
-						},
-					},
-				},
-			};
-
-			const before = getEditedPostAttribute( beforeState, 'meta' );
-			const after = getEditedPostAttribute( afterState, 'meta' );
-
-			expect( before ).not.toBe( after );
-			expect( after ).toEqual( {
-				a: 1,
-				b: 3,
-			} );
-		} );
-
-		it( 'should return accurate merged value if changed current post', () => {
-			const initialEdits = {};
-			const editor = {
-				present: {
-					edits: {
-						meta: {
-							b: 2,
-						},
-					},
-				},
-			};
-			const beforeState = {
-				currentPost: {
-					meta: {
-						a: 1,
-					},
-				},
-				initialEdits,
-				editor,
-			};
-
-			const afterState = {
-				currentPost: {
-					meta: {
-						a: 2,
-					},
-				},
-				initialEdits,
-				editor,
-			};
-
-			const before = getEditedPostAttribute( beforeState, 'meta' );
-			const after = getEditedPostAttribute( afterState, 'meta' );
-
-			expect( before ).not.toBe( after );
-			expect( after ).toEqual( {
-				a: 2,
-				b: 3,
 			} );
 		} );
 	} );

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, without } from 'lodash';
+import { filter, invoke, without } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -174,6 +174,7 @@ describe( 'selectors', () => {
 		setFreeformContentHandlerName( 'core/test-freeform' );
 
 		cachedSelectors.forEach( ( { clear } ) => clear() );
+		invoke( getEditedPostAttribute.mergeCache, [ 'clear' ] );
 	} );
 
 	afterEach( () => {
@@ -601,6 +602,103 @@ describe( 'selectors', () => {
 			};
 
 			expect( getEditedPostAttribute( state, 'valueOf' ) ).toBeUndefined();
+		} );
+
+		it( 'should merge mergeable properties with current post value', () => {
+			const state = {
+				currentPost: {
+					meta: {
+						a: 1,
+					},
+				},
+				editor: {
+					present: {
+						edits: {
+							meta: {
+								b: 2,
+							},
+						},
+					},
+				},
+				initialEdits: {},
+			};
+
+			expect( getEditedPostAttribute( state, 'meta' ) ).toEqual( {
+				a: 1,
+				b: 2,
+			} );
+		} );
+
+		it( 'should return same mergeable value reference if unchanged', () => {
+			const state = {
+				currentPost: {
+					meta: {
+						a: 1,
+					},
+				},
+				editor: {
+					present: {
+						edits: {
+							meta: {
+								b: 2,
+							},
+						},
+					},
+				},
+				initialEdits: {},
+			};
+
+			const before = getEditedPostAttribute( state, 'meta' );
+			const after = getEditedPostAttribute( state, 'meta' );
+
+			expect( before ).toBe( after );
+		} );
+
+		it( 'should return accurate merged value if changed', () => {
+			const beforeState = {
+				currentPost: {
+					meta: {
+						a: 1,
+					},
+				},
+				editor: {
+					present: {
+						edits: {
+							meta: {
+								b: 2,
+							},
+						},
+					},
+				},
+				initialEdits: {},
+			};
+
+			const afterState = {
+				currentPost: {
+					meta: {
+						a: 1,
+					},
+				},
+				editor: {
+					present: {
+						edits: {
+							meta: {
+								b: 3,
+							},
+						},
+					},
+				},
+				initialEdits: {},
+			};
+
+			const before = getEditedPostAttribute( beforeState, 'meta' );
+			const after = getEditedPostAttribute( afterState, 'meta' );
+
+			expect( before ).not.toBe( after );
+			expect( after ).toEqual( {
+				a: 1,
+				b: 3,
+			} );
 		} );
 	} );
 

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -629,7 +629,7 @@ describe( 'selectors', () => {
 			} );
 		} );
 
-		it( 'should return same mergeable value reference if unchanged', () => {
+		it( 'should return same mergeable value reference if unchanged edit', () => {
 			const state = {
 				currentPost: {
 					meta: {
@@ -654,13 +654,16 @@ describe( 'selectors', () => {
 			expect( before ).toBe( after );
 		} );
 
-		it( 'should return accurate merged value if changed', () => {
-			const beforeState = {
-				currentPost: {
-					meta: {
-						a: 1,
-					},
+		it( 'should return accurate merged value if changed edit', () => {
+			const currentPost = {
+				meta: {
+					a: 1,
 				},
+			};
+			const initialEdits = {};
+			const beforeState = {
+				currentPost,
+				initialEdits,
 				editor: {
 					present: {
 						edits: {
@@ -670,15 +673,11 @@ describe( 'selectors', () => {
 						},
 					},
 				},
-				initialEdits: {},
 			};
 
 			const afterState = {
-				currentPost: {
-					meta: {
-						a: 1,
-					},
-				},
+				currentPost,
+				initialEdits,
 				editor: {
 					present: {
 						edits: {
@@ -688,7 +687,6 @@ describe( 'selectors', () => {
 						},
 					},
 				},
-				initialEdits: {},
 			};
 
 			const before = getEditedPostAttribute( beforeState, 'meta' );
@@ -697,6 +695,47 @@ describe( 'selectors', () => {
 			expect( before ).not.toBe( after );
 			expect( after ).toEqual( {
 				a: 1,
+				b: 3,
+			} );
+		} );
+
+		it( 'should return accurate merged value if changed current post', () => {
+			const initialEdits = {};
+			const editor = {
+				present: {
+					edits: {
+						meta: {
+							b: 2,
+						},
+					},
+				},
+			};
+			const beforeState = {
+				currentPost: {
+					meta: {
+						a: 1,
+					},
+				},
+				initialEdits,
+				editor,
+			};
+
+			const afterState = {
+				currentPost: {
+					meta: {
+						a: 2,
+					},
+				},
+				initialEdits,
+				editor,
+			};
+
+			const before = getEditedPostAttribute( beforeState, 'meta' );
+			const after = getEditedPostAttribute( afterState, 'meta' );
+
+			expect( before ).not.toBe( after );
+			expect( after ).toEqual( {
+				a: 2,
 				b: 3,
 			} );
 		} );

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, invoke, without } from 'lodash';
+import { filter, without } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -174,7 +174,6 @@ describe( 'selectors', () => {
 		setFreeformContentHandlerName( 'core/test-freeform' );
 
 		cachedSelectors.forEach( ( { clear } ) => clear() );
-		invoke( getEditedPostAttribute.mergeCache, [ 'clear' ] );
 	} );
 
 	afterEach( () => {
@@ -185,6 +184,7 @@ describe( 'selectors', () => {
 		unregisterBlockType( 'core/test-freeform' );
 
 		setFreeformContentHandlerName( undefined );
+		getEditedPostAttribute.mergeCache = new WeakMap;
 	} );
 
 	describe( 'hasEditorUndo', () => {


### PR DESCRIPTION
Fixes #12289
Regression of #10827

This pull request seeks to resolve an issue where `getEditedPostAttribute( 'meta' )` would return only the edited value, not including other unedited values from the current saved post.

While in #10827 we'd introduced the "merge" concept to the `edits` reducer, we'd not considered to account for it being a partial fragment in the return value of `getEditedPostAttribute`. The changes here apply that behavior.

**Implementation notes:**

I made the implementation perhaps more complicated than necessary in a pursuit of avoiding returning a new reference object from each call to `getEditedPostAttribute`. Elsewhere we use `createSelector` for similar effect, but in this instance I thought it may be too heavy-handed given that this is a rarer use-case (not present in core code) and given the fitness of `WeakMap` as a cache given the edited object value as key (since the value is guaranteed to be an object, and guaranteed to never change reference unless its value actually changes).

**Testing instructions:**

Repeat Steps to Reproduce from #12289

Ensure unit tests pass:

```
npm test
```

cc @florianbrinkmann