### PR TITLE
Editor: Apply IE11 input fix only when mounting TinyMCE

### DIFF
--- a/packages/editor/src/components/rich-text/tinymce.js
+++ b/packages/editor/src/components/rich-text/tinymce.js
@@ -259,17 +259,14 @@ export default class TinyMCE extends Component {
 			this.props.setRef( editorNode );
 		}
 
-		/**
-		 * A ref function can be used for cleanup because React calls it with
-		 * `null` when unmounting.
-		 */
-		if ( this.removeInternetExplorerInputFix ) {
-			this.removeInternetExplorerInputFix();
-			this.removeInternetExplorerInputFix = null;
-		}
-
 		if ( IS_IE ) {
-			this.removeInternetExplorerInputFix = applyInternetExplorerInputFix( editorNode );
+			if ( editorNode ) {
+				// Mounting:
+				this.removeInternetExplorerInputFix = applyInternetExplorerInputFix( editorNode );
+			} else {
+				// Unmounting:
+				this.removeInternetExplorerInputFix();
+			}
 		}
 	}
 


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/12234#discussion_r236365127

This pull request seeks to resolve an error which will occur when unmounting an instance of the RichText component in IE11. As of #12234, the `ref` callback handler was not accounting for the `null` value being passed during unmounting of the component, thus resulting in errors when subsequent logic would attempt to reference properties as if it were an DOM node.

>React will call the `ref` callback with the DOM element when the component mounts, and **call it with `null` when it unmounts.**

https://reactjs.org/docs/refs-and-the-dom.html#callback-refs

**Testing instructions:**

In Internet Explorer 11 and your preferred browser, ensure that no errors are logged when removing a paragraph block:

1. Navigate to Posts > Add New
2. Click the writing prompt
3. Press Backspace