### PR TITLE
Add in all dependencies for a given block

### DIFF
--- a/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
@@ -15,7 +15,7 @@ function gutenberg_boilerplate_block() {
 	wp_register_script(
 		'gutenberg-boilerplate-es5-step01',
 		plugins_url( 'step-01/block.js', __FILE__ ),
-		array( 'wp-blocks', 'wp-element' )
+		array( 'wp-blocks', 'wp-element', 'wp-components', 'wp-editor' )
 	);
 
 	register_block_type( 'gutenberg-boilerplate-es5/hello-world-step-01', array(


### PR DESCRIPTION
Previously Gutenberg Plugin added these dependencies, related to:
https://core.trac.wordpress.org/ticket/45219
and
https://github.com/WordPress/gutenberg/issues/11069

## Description
Documentation needs to be updated to include other dependencies.

## How has this been tested?
With WP 5.0 beta

## Types of changes
Documentation
