### PR TITLE
Reusable blocks: Don't show trashed blocks in the editor or frontend

### DIFF
--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -22,6 +22,10 @@ function render_block_core_block( $attributes ) {
 		return '';
 	}
 
+	if ( 'publish' !== $reusable_block->post_status || ! empty( $reusable_block->post_password ) ) {
+		return '';
+	}
+
 	return do_blocks( $reusable_block->post_content );
 }
 


### PR DESCRIPTION
Fixes #12339.

Changes the logic surrounding reusable blocks so that we:

- Do not render a reusable block in the editor if it is trashed.
- Do not render a reusable block on the frontend if it is non-published or password protected.

This matches one's intuition about what _Trashing_ something does.

#### Testing

1. Create a new post
1. Insert a block
1. Convert the block to a reusable block
1. Go to _Manage All Reusable Blocks_
1. Trash the reusable block you created
1. Go back to the post you created. The reusable block should appear as _Deleted or unavailable_
1. Preview the post. The reusable block should not appear