### PR TITLE
Date: Optimize the usage of moment-timezone to save some kilobytes

### DIFF
--- a/lib/packages-dependencies.php
+++ b/lib/packages-dependencies.php
@@ -25,7 +25,6 @@ return array(
 	'wp-block-library'                      => array(
 		'editor',
 		'lodash',
-		'moment',
 		'wp-api-fetch',
 		'wp-autop',
 		'wp-blob',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2360,9 +2360,6 @@
 				"classnames": "^2.2.5",
 				"lodash": "^4.17.10",
 				"memize": "^1.0.5",
-				"moment": "^2.22.1",
-				"querystring": "^0.2.0",
-				"querystringify": "^1.0.0",
 				"url": "^0.11.0"
 			}
 		},
@@ -17739,11 +17736,6 @@
 			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
 			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
 			"dev": true
-		},
-		"querystringify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
-			"integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs="
 		},
 		"quick-lru": {
 			"version": "1.1.0",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -38,9 +38,6 @@
 		"classnames": "^2.2.5",
 		"lodash": "^4.17.10",
 		"memize": "^1.0.5",
-		"moment": "^2.22.1",
-		"querystring": "^0.2.0",
-		"querystringify": "^1.0.0",
 		"url": "^0.11.0"
 	},
 	"devDependencies": {

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -2,8 +2,10 @@
  * External dependencies
  */
 import momentLib from 'moment';
-import 'moment-timezone';
+import 'moment-timezone/moment-timezone';
 import 'moment-timezone/moment-timezone-utils';
+
+const WP_ZONE = 'WP';
 
 // Changes made here will likely need to be made in `lib/client-assets.php` as
 // well because it uses the `setSettings()` function to change these settings.
@@ -92,8 +94,8 @@ export function __experimentalGetSettings() {
 function setupWPTimezone() {
 	// Create WP timezone based off dateSettings.
 	momentLib.tz.add( momentLib.tz.pack( {
-		name: 'WP',
-		abbrs: [ 'WP' ],
+		name: WP_ZONE,
+		abbrs: [ WP_ZONE ],
 		untils: [ null ],
 		offsets: [ -settings.timezone.offset * 60 || 0 ],
 	} ) );
@@ -371,8 +373,8 @@ export function dateI18n( dateFormat, dateValue = new Date(), gmt = false ) {
  * @return {boolean} Is in the future.
  */
 export function isInTheFuture( dateValue ) {
-	const now = momentLib.tz( 'WP' );
-	const momentObject = momentLib.tz( dateValue, 'WP' );
+	const now = momentLib.tz( WP_ZONE );
+	const momentObject = momentLib.tz( dateValue, WP_ZONE );
 
 	return momentObject.isAfter( now );
 }
@@ -386,10 +388,10 @@ export function isInTheFuture( dateValue ) {
  */
 export function getDate( dateString ) {
 	if ( ! dateString ) {
-		return momentLib.tz( 'WP' ).toDate();
+		return momentLib.tz( WP_ZONE ).toDate();
 	}
 
-	return momentLib.tz( dateString, 'WP' ).toDate();
+	return momentLib.tz( dateString, WP_ZONE ).toDate();
 }
 
 setupWPTimezone();


### PR DESCRIPTION
## Description
With the latest update of `moment-timezone` library there is a huge increase of the timezones data to be bundled by default. This is the consequence of the bug fix added in https://github.com/moment/moment-timezone/issues/697. It turns out that JSON data is now at **925kB** in `0.5.23` version: https://unpkg.com/moment-timezone@0.5.23/data/packed/latest.json. This is a big change comparing to the version `0.5.16` which we still bundle in Gutenberg: https://unpkg.com/moment-timezone@0.5.16/data/packed/latest.json - **126kB**.

This PR stops including JSON metadata for timezones because we use WordPress specific timezone in here:
https://github.com/WordPress/gutenberg/blob/master/packages/date/src/index.js#L94-L99
It turns out all that data is never consumed in the application and is useless. This opens some nice improvements for the size of the date bundle.

### Before

> ./build/date/index.js     187 KiB      24  [emitted]         date

### After

> ./build/date/index.js    13.2 KiB      24  [emitted]         date

## How has this been tested?
`npm test`

Check whether scheduling posts still works as expected in Gutenberg.

## Types of changes
Refactoring towards lower bundle size.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
