### PR TITLE
Remove duplicate toolbarcontainer class name

### DIFF
--- a/packages/components/src/toolbar/index.js
+++ b/packages/components/src/toolbar/index.js
@@ -67,7 +67,7 @@ function Toolbar( { controls = [], children, className, isCollapsed, icon, label
 	}
 
 	return (
-		<ToolbarContainer className={ className }>
+		<ToolbarContainer className={ classnames( 'components-toolbar', className ) }>
 			{ flatMap( controlSets, ( controlSet, indexOfSet ) => (
 				controlSet.map( ( control, indexOfControl ) => (
 					<ToolbarButton

--- a/packages/components/src/toolbar/index.js
+++ b/packages/components/src/toolbar/index.js
@@ -67,7 +67,7 @@ function Toolbar( { controls = [], children, className, isCollapsed, icon, label
 	}
 
 	return (
-		<ToolbarContainer className={ classnames( 'components-toolbar', className ) }>
+		<ToolbarContainer className={ className }>
 			{ flatMap( controlSets, ( controlSet, indexOfSet ) => (
 				controlSet.map( ( control, indexOfControl ) => (
 					<ToolbarButton

--- a/packages/components/src/toolbar/toolbar-container.js
+++ b/packages/components/src/toolbar/toolbar-container.js
@@ -1,10 +1,5 @@
-/**
- * External dependencies
- */
-import classnames from 'classnames';
-
 const ToolbarContainer = ( props ) => (
-	<div className={ classnames( 'components-toolbar', props.className ) }>
+	<div className={ props.className }>
 		{ props.children }
 	</div>
 );


### PR DESCRIPTION
The class `components-toolbar` appears twice in the DOM, added by `<Toolbar />` and `<ToolbarContainer />`.

<img width="455" alt="devtools_-_latest_local_wp-admin_post_php_post_3294_action_edit" src="https://user-images.githubusercontent.com/1277682/49085226-712b5600-f249-11e8-9f73-d70d60d19e57.png">

This PR removes the class from `<Toolbar />` so it's not passed down to `<ToolbarContainer />` and so won't appear twice.

## How has this been tested?
1. Use browser inspector and verify that a block toolbar does not have duplicate `components-toolbar` on the block toolbar

## Types of changes
Minor class removal
