### PR TITLE
Fix WYSIWYG metaboxes saving

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2531,7 +2531,8 @@
 				"@wordpress/viewport": "file:packages/viewport",
 				"classnames": "^2.2.5",
 				"lodash": "^4.17.10",
-				"refx": "^3.0.0"
+				"refx": "^3.0.0",
+				"tinymce": "^4.7.2"
 			}
 		},
 		"@wordpress/editor": {

--- a/packages/edit-post/CHANGELOG.md
+++ b/packages/edit-post/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.3 (Unreleased)
+
+### Bug Fixes
+
+- Fix saving WYSIWYG Meta Boxes
+
 ## 3.1.2 (2018-11-22)
 
 ## 3.1.1 (2018-11-21)

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -40,7 +40,8 @@
 		"@wordpress/viewport": "file:../viewport",
 		"classnames": "^2.2.5",
 		"lodash": "^4.17.10",
-		"refx": "^3.0.0"
+		"refx": "^3.0.0",
+		"tinymce": "^4.7.2"
 	},
 	"devDependencies": {
 		"deep-freeze": "^0.0.1",

--- a/packages/edit-post/src/store/effects.js
+++ b/packages/edit-post/src/store/effects.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { reduce } from 'lodash';
+import tinymce from 'tinymce';
 
 /**
  * WordPress dependencies
@@ -72,6 +73,9 @@ const effects = {
 		} );
 	},
 	REQUEST_META_BOX_UPDATES( action, store ) {
+		// Saves the wp_editor fields
+		tinymce.triggerSave();
+
 		const state = store.getState();
 
 		// Additional data needed for backwards compatibility.


### PR DESCRIPTION
closes #7176

This is the exact same fix I've applied before in #8762 but in my testing this time it works properly and fixes the issue consistently. I tested using @danielbachhuber's snippet here https://github.com/WordPress/gutenberg/issues/7176#issuecomment-412134455