### PR TITLE
Gallery Block: Add Media Library button to the upload new image area

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## 2.0.0 (Unreleased)
 
+### New Features
+
+- Added the `addToGallery` property to the `MediaUpload` interface. The property allows users to open the media modal in the `gallery-library`instead of `gallery-edit` state.
+- Added the `addToGallery` property to the `MediaPlaceholder` component. The component passes the property to the `MediaUpload` component used inside the placeholder.
+- Added the `isAppender` property to the `MediaPlaceholder` component. The property changes the look of the placeholder to be adequate to scenarios where new files are added to an already existing set of files, e.g., adding files to a gallery.
+- Added the `dropZoneUIOnly` property to the `MediaPlaceholder` component. The property makes the `MediaPlaceholder` only render a dropzone without any other additional UI.
+
 ### Breaking Changes
 
 - `CopyHandler` will now only catch cut/copy events coming from its `props.children`, instead of from anywhere in the `document`.

--- a/packages/block-editor/src/components/media-placeholder/style.scss
+++ b/packages/block-editor/src/components/media-placeholder/style.scss
@@ -45,3 +45,23 @@
 .components-form-file-upload .block-editor-media-placeholder__button {
 	margin-right: $grid-size-small;
 }
+
+.block-editor-media-placeholder.is-appender {
+	min-height: 100px;
+	background-color: unset;
+	outline: $border-width dashed $dark-gray-150;
+
+	&:hover {
+		outline: $border-width dashed $dark-gray-500;
+	}
+
+	.block-editor-media-placeholder__upload-button {
+		margin-right: $grid-size-small;
+		&.components-button:hover,
+		&.components-button:focus {
+			box-shadow: none;
+			border: $border-width solid $dark-gray-500;
+		}
+	}
+
+}

--- a/packages/block-editor/src/components/media-placeholder/style.scss
+++ b/packages/block-editor/src/components/media-placeholder/style.scss
@@ -53,6 +53,7 @@
 
 	&:hover {
 		outline: $border-width dashed $dark-gray-500;
+		cursor: pointer;
 	}
 
 	.block-editor-media-placeholder__upload-button {

--- a/packages/block-editor/src/components/media-placeholder/style.scss
+++ b/packages/block-editor/src/components/media-placeholder/style.scss
@@ -48,7 +48,6 @@
 
 .block-editor-media-placeholder.is-appender {
 	min-height: 100px;
-	background-color: unset;
 	outline: $border-width dashed $dark-gray-150;
 
 	&:hover {

--- a/packages/block-editor/src/components/media-placeholder/style.scss
+++ b/packages/block-editor/src/components/media-placeholder/style.scss
@@ -55,6 +55,13 @@
 		cursor: pointer;
 	}
 
+	.is-dark-theme & {
+
+		&:hover {
+			outline: $border-width dashed $white;
+		}
+	}
+
 	.block-editor-media-placeholder__upload-button {
 		margin-right: $grid-size-small;
 		&.components-button:hover,

--- a/packages/block-editor/src/components/media-upload/README.md
+++ b/packages/block-editor/src/components/media-upload/README.md
@@ -101,6 +101,25 @@ CSS class added to the media modal frame.
 - Type: `String`
 - Required: No
 
+
+### addToGallery
+
+If true, the gallery media modal opens directly in the media library where the user can add additional images.
+If false the gallery media modal opens in the edit mode where the user can edit existing images, by reordering them, remove them, or change their attributes.
+Only applies if `gallery === true`.
+
+- Type: `Boolean`
+- Required: No
+- Default: `false`
+
+### gallery
+
+If true, the component will initiate all the states required to represent a gallery. By default, the media modal opens in the gallery edit frame, but that can be changed using the `addToGallery`flag.
+
+- Type: `Boolean`
+- Required: No
+- Default: `false`
+
 ## render
 
 A callback invoked to render the Button opening the media library.

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -8,8 +8,6 @@ import { filter, pick, map, get } from 'lodash';
  * WordPress dependencies
  */
 import {
-	DropZone,
-	FormFileUpload,
 	IconButton,
 	PanelBody,
 	RangeControl,
@@ -25,7 +23,6 @@ import {
 	MediaUpload,
 	InspectorControls,
 } from '@wordpress/block-editor';
-import { mediaUpload } from '@wordpress/editor';
 import { Component, Fragment } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -64,8 +61,6 @@ class GalleryEdit extends Component {
 		this.toggleImageCrop = this.toggleImageCrop.bind( this );
 		this.onRemoveImage = this.onRemoveImage.bind( this );
 		this.setImageAttributes = this.setImageAttributes.bind( this );
-		this.addFiles = this.addFiles.bind( this );
-		this.uploadFromFiles = this.uploadFromFiles.bind( this );
 		this.setAttributes = this.setAttributes.bind( this );
 
 		this.state = {
@@ -152,27 +147,6 @@ class GalleryEdit extends Component {
 		} );
 	}
 
-	uploadFromFiles( event ) {
-		this.addFiles( event.target.files );
-	}
-
-	addFiles( files ) {
-		const currentImages = this.props.attributes.images || [];
-		const { noticeOperations } = this.props;
-		const { setAttributes } = this;
-		mediaUpload( {
-			allowedTypes: ALLOWED_MEDIA_TYPES,
-			filesList: files,
-			onFileChange: ( images ) => {
-				const imagesNormalized = images.map( ( image ) => pickRelevantMediaFiles( image ) );
-				setAttributes( {
-					images: currentImages.concat( imagesNormalized ),
-				} );
-			},
-			onError: noticeOperations.createErrorNotice,
-		} );
-	}
-
 	componentDidUpdate( prevProps ) {
 		// Deselect images when deselecting the block
 		if ( ! this.props.isSelected && prevProps.isSelected ) {
@@ -187,15 +161,11 @@ class GalleryEdit extends Component {
 		const { attributes, isSelected, className, noticeOperations, noticeUI } = this.props;
 		const { images, columns = defaultColumnsNumber( attributes ), align, imageCrop, linkTo } = attributes;
 
-		const dropZone = (
-			<DropZone
-				onFilesDrop={ this.addFiles }
-			/>
-		);
+		const hasImages = !! images.length;
 
 		const controls = (
 			<BlockControls>
-				{ !! images.length && (
+				{ hasImages && (
 					<Toolbar>
 						<MediaUpload
 							onSelect={ this.onSelectImages }
@@ -217,24 +187,32 @@ class GalleryEdit extends Component {
 			</BlockControls>
 		);
 
-		if ( images.length === 0 ) {
+		const mediaPlaceholder = (
+			<MediaPlaceholder
+				addToGallery={ hasImages }
+				isAppender={ hasImages }
+				className={ className }
+				dropZoneUIOnly={ hasImages && ! isSelected }
+				icon={ ! hasImages && <BlockIcon icon={ icon } /> }
+				labels={ {
+					title: ! hasImages && __( 'Gallery' ),
+					instructions: ! hasImages && __( 'Drag images, upload new ones or select files from your library.' ),
+				} }
+				onSelect={ this.onSelectImages }
+				accept="image/*"
+				allowedTypes={ ALLOWED_MEDIA_TYPES }
+				multiple
+				value={ hasImages ? images : undefined }
+				onError={ noticeOperations.createErrorNotice }
+				notices={ hasImages ? undefined : noticeUI }
+			/>
+		);
+
+		if ( ! hasImages ) {
 			return (
 				<Fragment>
 					{ controls }
-					<MediaPlaceholder
-						icon={ <BlockIcon icon={ icon } /> }
-						className={ className }
-						labels={ {
-							title: __( 'Gallery' ),
-							instructions: __( 'Drag images, upload new ones or select files from your library.' ),
-						} }
-						onSelect={ this.onSelectImages }
-						accept="image/*"
-						allowedTypes={ ALLOWED_MEDIA_TYPES }
-						multiple
-						notices={ noticeUI }
-						onError={ noticeOperations.createErrorNotice }
-					/>
+					{ mediaPlaceholder }
 				</Fragment>
 			);
 		}
@@ -277,7 +255,6 @@ class GalleryEdit extends Component {
 						}
 					) }
 				>
-					{ dropZone }
 					{ images.map( ( img, index ) => {
 						/* translators: %1$d is the order number of the image, %2$d is the total number of images. */
 						const ariaLabel = sprintf( __( 'image %1$d of %2$d in gallery' ), ( index + 1 ), images.length );
@@ -298,21 +275,8 @@ class GalleryEdit extends Component {
 							</li>
 						);
 					} ) }
-					{ isSelected &&
-						<li className="blocks-gallery-item has-add-item-button">
-							<FormFileUpload
-								multiple
-								isLarge
-								className="block-library-gallery-add-item-button"
-								onChange={ this.uploadFromFiles }
-								accept="image/*"
-								icon="insert"
-							>
-								{ __( 'Upload an image' ) }
-							</FormFileUpload>
-						</li>
-					}
 				</ul>
+				{ mediaPlaceholder }
 			</Fragment>
 		);
 	}

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -53,31 +53,6 @@ ul.wp-block-gallery li {
 		}
 	}
 
-	.components-form-file-upload,
-	.components-button.block-library-gallery-add-item-button {
-		width: 100%;
-		height: 100%;
-	}
-
-	.components-button.block-library-gallery-add-item-button {
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
-		box-shadow: none;
-		border: none;
-		border-radius: 0;
-		min-height: 100px;
-
-		& .dashicon {
-			margin-top: 10px;
-		}
-
-		&:hover,
-		&:focus {
-			border: $border-width solid $dark-gray-500;
-		}
-	}
-
 	.block-editor-rich-text figcaption {
 		a {
 			color: $white;
@@ -117,15 +92,4 @@ ul.wp-block-gallery li {
 	left: 50%;
 	margin-top: -9px;
 	margin-left: -9px;
-}
-
-// Last item always needs margins reset.
-// When block is selected, only reset the right margin of the 2nd to last item.
-.wp-block-gallery {
-	.is-selected & .blocks-gallery-image:nth-last-child(2),
-	.is-selected & .blocks-gallery-item:nth-last-child(2),
-	.is-typing & .blocks-gallery-image:nth-last-child(2),
-	.is-typing & .blocks-gallery-item:nth-last-child(2) {
-		margin-right: 0;
-	}
 }

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -126,14 +126,6 @@
 		margin-right: 0;
 	}
 
-	// Make the "Add new Gallery item" button full-width (so it always appears
-	// below other items).
-	.blocks-gallery-item {
-		&.has-add-item-button {
-			width: 100%;
-		}
-	}
-
 	// Apply max-width to floated items that have no intrinsic width.
 	&.alignleft,
 	&.alignright {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 7.2.1 (Unreleased)
 
+### New Features
+
+- Added a new `render` property to `FormFileUpload` component. Allowing users of the component to custom the UI for their needs.
+
 ### Bug fixes
 
 - Fix `instanceId` prop passed through to `Button` component via `MenuItems` producing React console error. Fixed by removing the unnecessary use of `withInstanceId` on the `MenuItems` component [#14599](https://github.com/WordPress/gutenberg/pull/14599)

--- a/packages/components/src/form-file-upload/index.js
+++ b/packages/components/src/form-file-upload/index.js
@@ -24,10 +24,10 @@ class FormFileUpload extends Component {
 	}
 
 	render() {
-		const { children, multiple = false, accept, onChange, icon = 'upload', ...props } = this.props;
+		const { children, multiple = false, accept, onChange, icon = 'upload', render, ...props } = this.props;
 
-		return (
-			<div className="components-form-file-upload">
+		const ui = render ?
+			render( { openFileDialog: this.openFileDialog } ) : (
 				<IconButton
 					icon={ icon }
 					onClick={ this.openFileDialog }
@@ -35,6 +35,10 @@ class FormFileUpload extends Component {
 				>
 					{ children }
 				</IconButton>
+			);
+		return (
+			<div className="components-form-file-upload">
+				{ ui }
 				<input
 					type="file"
 					ref={ this.bindInput }

--- a/packages/edit-post/CHANGELOG.md
+++ b/packages/edit-post/CHANGELOG.md
@@ -1,4 +1,11 @@
-## 3.2.0 (Next)
+## V.V.V (Unreleased)
+
+### New Features
+
+- Implement the `addToGallery` option in the `MediaUpload` hook. The option allows users to open the media modal in the `gallery-library`instead of `gallery-edit` state.
+
+
+## 3.2.0 (2019-03-06)
 
 ### Polish
 

--- a/packages/edit-post/src/hooks/components/media-upload/index.js
+++ b/packages/edit-post/src/hooks/components/media-upload/index.js
@@ -78,10 +78,10 @@ const getAttachmentsCollection = ( ids ) => {
 class MediaUpload extends Component {
 	constructor( {
 		allowedTypes,
-		multiple = false,
 		gallery = false,
-		title = __( 'Select or Upload Media' ),
 		modalClass,
+		multiple = false,
+		title = __( 'Select or Upload Media' ),
 	} ) {
 		super( ...arguments );
 		this.openModal = this.openModal.bind( this );
@@ -124,6 +124,7 @@ class MediaUpload extends Component {
 
 	buildAndSetGalleryFrame() {
 		const {
+			addToGallery = false,
 			allowedTypes,
 			multiple = false,
 			value = null,
@@ -140,7 +141,12 @@ class MediaUpload extends Component {
 		if ( this.frame ) {
 			this.frame.remove();
 		}
-		const currentState = value ? 'gallery-edit' : 'gallery';
+		let currentState;
+		if ( addToGallery ) {
+			currentState = 'gallery-library';
+		} else {
+			currentState = value ? 'gallery-edit' : 'gallery';
+		}
 		if ( ! this.GalleryDetailsMediaFrame ) {
 			this.GalleryDetailsMediaFrame = getGalleryDetailsMediaFrame();
 		}


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/8309
Supersedes: https://github.com/WordPress/gutenberg/pull/9682

This PR adds a media library button in the upload new image are of the gallery block.
Trying to follow the design 2 proposed in https://github.com/WordPress/gutenberg/pull/9682#issuecomment-425435709 by @kjellr and approved by @karmatosed.

A new functionality that allows the gallery to open in library/add frame instead of the edit frame was added to MediaUpload, so when the user pressed the media library button in the add zone the user goes directly to the add to library section when using the edit gallery button on the toolbar the user goes to the edit gallery section.

## Description
I added a gallery;
I added some images;
I selected the gallery;
I checked that a new media library button exists in the add to gallery zone.
If I click on it I go directly to a frame that allows the addition of images from the library to the gallery.

## How has this been tested?

## Screenshot
<img width="997" alt="screenshot 2018-11-27 at 15 35 14" src="https://user-images.githubusercontent.com/11271197/49093136-64176280-f25b-11e8-82de-ff44cee4ab47.png">
