### PR TITLE
[RNMobile] Wire onBlur on mobile blocks and components

### DIFF
--- a/packages/block-library/src/code/edit.native.js
+++ b/packages/block-library/src/code/edit.native.js
@@ -21,7 +21,7 @@ import styles from './theme.scss';
 // Note: styling is applied directly to the (nested) PlainText component. Web-side components
 // apply it to the container 'div' but we don't have a proper proposal for cascading styling yet.
 export default function CodeEdit( props ) {
-	const { attributes, setAttributes, style, onFocus } = props;
+	const { attributes, setAttributes, style, onFocus, onBlur } = props;
 
 	return (
 		<View>
@@ -35,6 +35,7 @@ export default function CodeEdit( props ) {
 				aria-label={ __( 'Code' ) }
 				isSelected={ props.isSelected }
 				onFocus={ onFocus }
+				onBlur={ onBlur }
 			/>
 		</View>
 	);

--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -57,6 +57,7 @@ class HeadingEdit extends Component {
 					value={ content }
 					isSelected={ this.props.isSelected }
 					onFocus={ this.props.onFocus } // always assign onFocus as a props
+					onBlur={ this.props.onBlur } // always assign onBlur as a props
 					style={ {
 						minHeight: Math.max( minHeight, this.state.aztecHeight ),
 					} }

--- a/packages/block-library/src/more/edit.native.js
+++ b/packages/block-library/src/more/edit.native.js
@@ -15,7 +15,7 @@ import { PlainText } from '@wordpress/editor';
 import styles from './editor.scss';
 
 export default function MoreEdit( props ) {
-	const { attributes, setAttributes, onFocus } = props;
+	const { attributes, setAttributes, onFocus, onBlur } = props;
 	const { customText } = attributes;
 	const defaultText = __( 'Read more' );
 	const value = customText !== undefined ? customText : defaultText;
@@ -33,6 +33,7 @@ export default function MoreEdit( props ) {
 					placeholder={ defaultText }
 					isSelected={ props.isSelected }
 					onFocus={ onFocus }
+					onBlur={ onBlur }
 				/>
 				<Text className={ styles[ 'block-library-more__right-marker' ] }>--&gt;</Text>
 			</View>

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -93,6 +93,7 @@ class ParagraphEdit extends Component {
 					value={ content }
 					isSelected={ this.props.isSelected }
 					onFocus={ this.props.onFocus } // always assign onFocus as a props
+					onBlur={ this.props.onBlur } // always assign onBlur as a props
 					style={ {
 						...style,
 						minHeight: Math.max( minHeight, this.state.aztecHeight ),

--- a/packages/editor/src/components/plain-text/index.native.js
+++ b/packages/editor/src/components/plain-text/index.native.js
@@ -32,6 +32,7 @@ export default class PlainText extends Component {
 				className={ [ styles[ 'editor-plain-text' ], this.props.className ] }
 				onChangeText={ ( text ) => this.props.onChange( text ) }
 				onFocus={ this.props.onFocus } // always assign onFocus as a props
+				onBlur={ this.props.onBlur } // always assign onBlur as a props
 				{ ...this.props }
 			/>
 		);

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -357,6 +357,7 @@ export class RichText extends Component {
 					text={ { text: html, eventCount: this.lastEventCount } }
 					onChange={ this.onChange }
 					onFocus={ this.props.onFocus }
+					onBlur={ this.props.onBlur }
 					onEnter={ this.onEnter }
 					onBackspace={ this.onBackspace }
 					onContentSizeChange={ this.onContentSizeChange }


### PR DESCRIPTION
This PR adds the `onBlur` method to mobile blocks and components, so that when their native side counterpart (AztecWrapper or TextInput) call `onBlur` due to focus lost, the ReactNative side can  signal that, and unselect the block => Toolbar is going to be dismissed accordingly, and other things like that.


To test this PR follow the steps in the GB-mobile companion PR here: https://github.com/wordpress-mobile/gutenberg-mobile/pull/283
