### PR TITLE
Font Size Picker: Use a menuitemradio role and better labels.

### DIFF
--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -17,7 +17,6 @@ import Button from '../button';
 import Dropdown from '../dropdown';
 import RangeControl from '../range-control';
 import { NavigableMenu } from '../navigable-container';
-import MenuItem from '../menu-item';
 
 function FontSizePicker( {
 	fallbackFontSize,
@@ -66,7 +65,7 @@ function FontSizePicker( {
 								const isSelected = ( value === size || ( ! value && slug === 'normal' ) );
 
 								return (
-									<MenuItem
+									<Button
 										key={ slug }
 										onClick={ () => onChange( slug === 'normal' ? undefined : size ) }
 										className={ 'is-font-' + slug }
@@ -77,7 +76,7 @@ function FontSizePicker( {
 										<span className="components-font-size-picker__dropdown-text-size" style={ { fontSize: size } }>
 											{ name }
 										</span>
-									</MenuItem>
+									</Button>
 								);
 							} ) }
 						</NavigableMenu>

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -6,8 +6,7 @@ import { map } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
-import { withInstanceId } from '@wordpress/compose';
+import { __, _x, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -18,6 +17,7 @@ import Button from '../button';
 import Dropdown from '../dropdown';
 import RangeControl from '../range-control';
 import { NavigableMenu } from '../navigable-container';
+import MenuItem from '../menu-item';
 
 function FontSizePicker( {
 	fallbackFontSize,
@@ -37,6 +37,7 @@ function FontSizePicker( {
 	};
 
 	const currentFont = fontSizes.find( ( font ) => font.size === value );
+	const currentFontSizeName = ( currentFont && currentFont.name ) || ( ! value && _x( 'Normal', 'font size name' ) ) || _x( 'Custom', 'font size name' );
 
 	return (
 		<BaseControl label={ __( 'Font Size' ) }>
@@ -51,26 +52,34 @@ function FontSizePicker( {
 							isLarge
 							onClick={ onToggle }
 							aria-expanded={ isOpen }
-							aria-label={ __( 'Custom font size' ) }
+							aria-label={ sprintf(
+								/* translators: %s: font size name */
+								__( 'Font size: %s' ), currentFontSizeName
+							) }
 						>
-							{ ( currentFont && currentFont.name ) || ( ! value && _x( 'Normal', 'font size name' ) ) || _x( 'Custom', 'font size name' ) }
+							{ currentFontSizeName }
 						</Button>
 					) }
 					renderContent={ () => (
 						<NavigableMenu>
-							{ map( fontSizes, ( { name, size, slug } ) => (
-								<Button
-									key={ slug }
-									onClick={ () => onChange( slug === 'normal' ? undefined : size ) }
-									className={ 'is-font-' + slug }
-									role="menuitem"
-								>
-									{ ( value === size || ( ! value && slug === 'normal' ) ) &&	<Dashicon icon="saved" /> }
-									<span className="components-font-size-picker__dropdown-text-size" style={ { fontSize: size } }>
-										{ name }
-									</span>
-								</Button>
-							) ) }
+							{ map( fontSizes, ( { name, size, slug } ) => {
+								const isSelected = ( value === size || ( ! value && slug === 'normal' ) );
+
+								return (
+									<MenuItem
+										key={ slug }
+										onClick={ () => onChange( slug === 'normal' ? undefined : size ) }
+										className={ 'is-font-' + slug }
+										role="menuitemradio"
+										aria-checked={ isSelected }
+									>
+										{ isSelected && <Dashicon icon="saved" /> }
+										<span className="components-font-size-picker__dropdown-text-size" style={ { fontSize: size } }>
+											{ name }
+										</span>
+									</MenuItem>
+								);
+							} ) }
 						</NavigableMenu>
 					) }
 				/>
@@ -90,7 +99,6 @@ function FontSizePicker( {
 					onClick={ () => onChange( undefined ) }
 					isSmall
 					isDefault
-					aria-label={ __( 'Reset font size' ) }
 				>
 					{ __( 'Reset' ) }
 				</Button>
@@ -112,4 +120,4 @@ function FontSizePicker( {
 	);
 }
 
-export default withInstanceId( FontSizePicker );
+export default FontSizePicker;

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -68,7 +68,7 @@ function FontSizePicker( {
 									<Button
 										key={ slug }
 										onClick={ () => onChange( slug === 'normal' ? undefined : size ) }
-										className={ 'is-font-' + slug }
+										className={ `is-font-${ slug }` }
 										role="menuitemradio"
 										aria-checked={ isSelected }
 									>


### PR DESCRIPTION
## Description

This PR seeks to introduce a few small improvements for the font size picker:

- adds the currently selected font size name to the toggle button `aria-label`
- uses an ARIA role `menuitemradio` on the menu items
- adds an `aria-checked` attribute to communicate which the selected item is
- removes the `aria-label` from the Reset button: the text "Reset" is enough
- removes `withInstanceId`: seems to me it wasn't used at all

Screenshots:

When focusing the toggle button, the currently selected font size is included in the button aria-label:

![screenshot 2018-11-27 at 19 34 36](https://user-images.githubusercontent.com/1682452/49105049-ea45a000-f27f-11e8-9579-a9ed00f39444.png)

When navigating through the menu items, the selected state of the selected item is announced:

![screenshot 2018-11-27 at 19 35 55](https://user-images.githubusercontent.com/1682452/49105055-ef0a5400-f27f-11e8-9e52-027604f96c86.png)


Fixes #12371 