### PR TITLE
api-fetch: Throw an Error object when the response is not Ok.

### DIFF
--- a/packages/api-fetch/src/error-response.js
+++ b/packages/api-fetch/src/error-response.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export default class ErrorResponse extends Error {
+	constructor( response, ...args ) {
+		super( response.message || __( 'An unknown error occurred.' ), ...args );
+
+		if ( Error.captureStackTrace ) {
+			Error.captureStackTrace( this, ErrorResponse );
+		}
+
+		this.__response = response;
+
+		for ( const prop in response ) {
+			if ( response.hasOwnProperty( prop ) ) {
+				Object.defineProperty( this, prop, {
+					value: response[ prop ],
+					configurable: true,
+					enumerable: true,
+					writable: true,
+				} );
+			}
+		}
+	}
+
+	toString() {
+		return this.__response.toString();
+	}
+
+	getResponse() {
+		return this.__response;
+	}
+}

--- a/packages/api-fetch/src/error-response.js
+++ b/packages/api-fetch/src/error-response.js
@@ -15,12 +15,24 @@ export default class ErrorResponse extends Error {
 
 		for ( const prop in response ) {
 			if ( response.hasOwnProperty( prop ) ) {
-				Object.defineProperty( this, prop, {
-					value: response[ prop ],
-					configurable: true,
-					enumerable: true,
-					writable: true,
-				} );
+				const descriptor = Object.getOwnPropertyDescriptor( response, prop );
+				const description = {
+					writable: descriptor ? descriptor.writable : true,
+					enumerable: descriptor ? descriptor.enumerable : true,
+					configurable: descriptor ? descriptor.configurable : true,
+				};
+
+				if ( descriptor.get ) {
+					description.get = descriptor.get;
+				} else {
+					description.value = ( descriptor && descriptor.value ) || response[ prop ];
+				}
+
+				if ( descriptor.set ) {
+					description.set = descriptor.set;
+				}
+
+				Object.defineProperty( this, prop, description );
 			}
 		}
 	}

--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import ErrorResponse from './error-response';
 import createNonceMiddleware from './middlewares/nonce';
 import createRootURLMiddleware from './middlewares/root-url';
 import createPreloadingMiddleware from './middlewares/preloading';
@@ -92,7 +93,7 @@ function apiFetch( options ) {
 			.then( parseResponse )
 			.catch( ( response ) => {
 				if ( ! parse ) {
-					throw response;
+					throw new ErrorResponse( response );
 				}
 
 				const invalidJsonError = {
@@ -101,12 +102,12 @@ function apiFetch( options ) {
 				};
 
 				if ( ! response || ! response.json ) {
-					throw invalidJsonError;
+					throw new ErrorResponse( invalidJsonError );
 				}
 
 				return response.json()
 					.catch( () => {
-						throw invalidJsonError;
+						throw new ErrorResponse( invalidJsonError );
 					} )
 					.then( ( error ) => {
 						const unknownError = {
@@ -114,7 +115,7 @@ function apiFetch( options ) {
 							message: __( 'An unknown error occurred.' ),
 						};
 
-						throw error || unknownError;
+						throw new ErrorResponse( error || unknownError );
 					} );
 			} );
 	};


### PR DESCRIPTION
## Description

This implements a new `ErrorResponse` object that `Object.defineProperties`
for all of the properties of the original response object and overrides
the `toString` method to maintain Backwards Compatibility.

Fixes #12375.

## How has this been tested?
Unit Tested.

## Types of changes
Bug Fix. Possible Breaking Change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
