### PR TITLE
Reusable blocks: Improve UX for non-privileged users

### DIFF
--- a/docs/designers-developers/developers/data/data-core.md
+++ b/docs/designers-developers/developers/data/data-core.md
@@ -153,6 +153,11 @@ Upload Permissions.
 Returns whether the current user can perform the given action on the given
 REST resource.
 
+Calling this may trigger an OPTIONS request to the REST API via the
+`canUser()` resolver.
+
+https://developer.wordpress.org/rest-api/reference/
+
 *Parameters*
 
  * state: Data state.

--- a/docs/designers-developers/developers/data/data-core.md
+++ b/docs/designers-developers/developers/data/data-core.md
@@ -148,6 +148,23 @@ Return Upload Permissions.
 
 Upload Permissions.
 
+### canUser
+
+Returns whether the current user can perform the given action on the given
+REST resource.
+
+*Parameters*
+
+ * state: Data state.
+ * action: Action to check. One of: 'create', 'read', 'update',
+                          'delete'.
+ * resource: REST resource to check, e.g. 'media' or 'posts'.
+ * id: ID of the rest resource to check.
+
+*Returns*
+
+Whether or not the user can perform the action.
+
 ## Actions
 
 ### receiveUserQuery
@@ -214,3 +231,13 @@ Returns an action object used in signalling that Upload permissions have been re
 *Parameters*
 
  * hasUploadPermissions: Does the user have permission to upload files?
+
+### receiveUserPermissions
+
+Returns an action object used in signalling that the current user has
+permission to perform an action on a REST resource.
+
+*Parameters*
+
+ * key: A key that represents the action and REST resource.
+ * isAllowed: Whether or not the user can perform the action.

--- a/docs/designers-developers/developers/data/data-core.md
+++ b/docs/designers-developers/developers/data/data-core.md
@@ -136,7 +136,7 @@ get back from the oEmbed preview API.
 
 Is the preview for the URL an oEmbed link fallback.
 
-### hasUploadPermissions
+### hasUploadPermissions (deprecated)
 
 Returns whether the current user can upload media.
 
@@ -144,6 +144,11 @@ Calling this may trigger an OPTIONS request to the REST API via the
 `canUser()` resolver.
 
 https://developer.wordpress.org/rest-api/reference/
+
+*Deprecated*
+
+Deprecated since 4.9. Callers should use the more generic `canUser()` selector instead of
+            `hasUploadPermissions()`, e.g. `canUser( 'create', 'media' )`.
 
 *Parameters*
 
@@ -170,14 +175,11 @@ https://developer.wordpress.org/rest-api/reference/
  * action: Action to check. One of: 'create', 'read', 'update', 'delete'.
  * resource: REST resource to check, e.g. 'media' or 'posts'.
  * id: Optional ID of the rest resource to check.
- * defaultIsAllowed: What to return when we don't know if the current user can
-                                   perform the given action on the given resource. Defaults to
-                                   `false`.
 
 *Returns*
 
-Whether or not the user can perform the action, or `defaultIsAllowed` if the
-                  OPTIONS request is still being made.
+Whether or not the user can perform the action,
+                            or `undefined` if the OPTIONS request is still being made.
 
 ## Actions
 

--- a/docs/designers-developers/developers/data/data-core.md
+++ b/docs/designers-developers/developers/data/data-core.md
@@ -138,15 +138,21 @@ Is the preview for the URL an oEmbed link fallback.
 
 ### hasUploadPermissions
 
-Return Upload Permissions.
+Returns whether the current user can upload media.
+
+Calling this may trigger an OPTIONS request ot the REST API via the
+`canUser()` resolver.
+
+https://developer.wordpress.org/rest-api/reference/
 
 *Parameters*
 
- * state: State tree.
+ * state: Data state.
 
 *Returns*
 
-Upload Permissions.
+Whether or not the user can upload media. Defaults to `true` if the OPTIONS
+                  request is being made.
 
 ### canUser
 
@@ -161,14 +167,17 @@ https://developer.wordpress.org/rest-api/reference/
 *Parameters*
 
  * state: Data state.
- * action: Action to check. One of: 'create', 'read', 'update',
-                          'delete'.
+ * action: Action to check. One of: 'create', 'read', 'update', 'delete'.
  * resource: REST resource to check, e.g. 'media' or 'posts'.
- * id: ID of the rest resource to check.
+ * id: Optional ID of the rest resource to check.
+ * defaultIsAllowed: What to return when we don't know if the current user can
+                                   perform the given action on the given resource. Defaults to
+                                   `false`.
 
 *Returns*
 
-Whether or not the user can perform the action.
+Whether or not the user can perform the action, or `defaultIsAllowed` if the
+                  OPTIONS request is still being made.
 
 ## Actions
 

--- a/docs/designers-developers/developers/data/data-core.md
+++ b/docs/designers-developers/developers/data/data-core.md
@@ -237,7 +237,7 @@ Returns an action object used in signalling that Upload permissions have been re
 
  * hasUploadPermissions: Does the user have permission to upload files?
 
-### receiveUserPermissions
+### receiveUserPermission
 
 Returns an action object used in signalling that the current user has
 permission to perform an action on a REST resource.

--- a/docs/designers-developers/developers/data/data-core.md
+++ b/docs/designers-developers/developers/data/data-core.md
@@ -140,7 +140,7 @@ Is the preview for the URL an oEmbed link fallback.
 
 Returns whether the current user can upload media.
 
-Calling this may trigger an OPTIONS request ot the REST API via the
+Calling this may trigger an OPTIONS request to the REST API via the
 `canUser()` resolver.
 
 https://developer.wordpress.org/rest-api/reference/

--- a/docs/designers-developers/developers/data/data-core.md
+++ b/docs/designers-developers/developers/data/data-core.md
@@ -147,7 +147,7 @@ https://developer.wordpress.org/rest-api/reference/
 
 *Deprecated*
 
-Deprecated since 4.9. Callers should use the more generic `canUser()` selector instead of
+Deprecated since 5.0. Callers should use the more generic `canUser()` selector instead of
             `hasUploadPermissions()`, e.g. `canUser( 'create', 'media' )`.
 
 *Parameters*

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1086,6 +1086,7 @@ JS;
 		sprintf( '/wp/v2/types/%s?context=edit', $post_type ),
 		sprintf( '/wp/v2/users/me?post_type=%s&context=edit', $post_type ),
 		array( '/wp/v2/media', 'OPTIONS' ),
+		array( '/wp/v2/blocks', 'OPTIONS' ),
 	);
 
 	/**

--- a/lib/packages-dependencies.php
+++ b/lib/packages-dependencies.php
@@ -84,6 +84,7 @@ return array(
 		'lodash',
 		'wp-api-fetch',
 		'wp-data',
+		'wp-deprecated',
 		'wp-url',
 	),
 	'wp-data'                               => array(

--- a/packages/block-library/src/block/edit-panel/index.js
+++ b/packages/block-library/src/block/edit-panel/index.js
@@ -53,7 +53,7 @@ class ReusableBlockEditPanel extends Component {
 	}
 
 	render() {
-		const { isEditing, title, isSaving, onEdit, instanceId } = this.props;
+		const { isEditing, title, isSaving, isEditDisabled, onEdit, instanceId } = this.props;
 
 		return (
 			<Fragment>
@@ -66,6 +66,7 @@ class ReusableBlockEditPanel extends Component {
 							ref={ this.editButton }
 							isLarge
 							className="reusable-block-edit-panel__button"
+							disabled={ isEditDisabled }
 							onClick={ onEdit }
 						>
 							{ __( 'Edit' ) }

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -97,7 +97,7 @@ class ReusableBlockEdit extends Component {
 	}
 
 	render() {
-		const { isSelected, reusableBlock, block, isFetching, isSaving } = this.props;
+		const { isSelected, reusableBlock, block, isFetching, isSaving, canUpdateBlock } = this.props;
 		const { isEditing, title, changedAttributes } = this.state;
 
 		if ( ! reusableBlock && isFetching ) {
@@ -130,6 +130,7 @@ class ReusableBlockEdit extends Component {
 						isEditing={ isEditing }
 						title={ title !== null ? title : reusableBlock.title }
 						isSaving={ isSaving && ! reusableBlock.isTemporary }
+						isEditDisabled={ ! canUpdateBlock }
 						onEdit={ this.startEditing }
 						onChangeTitle={ this.setTitle }
 						onSave={ this.save }
@@ -151,6 +152,8 @@ export default compose( [
 			__experimentalIsSavingReusableBlock: isSavingReusableBlock,
 			getBlock,
 		} = select( 'core/editor' );
+		const { canUser } = select( 'core' );
+
 		const { ref } = ownProps.attributes;
 		const reusableBlock = getReusableBlock( ref );
 
@@ -159,6 +162,7 @@ export default compose( [
 			isFetching: isFetchingReusableBlock( ref ),
 			isSaving: isSavingReusableBlock( ref ),
 			block: reusableBlock ? getBlock( reusableBlock.clientId ) : null,
+			canUpdateBlock: !! reusableBlock && ! reusableBlock.isTemporary && canUser( 'update', 'blocks', ref ),
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -162,7 +162,7 @@ export default compose( [
 			isFetching: isFetchingReusableBlock( ref ),
 			isSaving: isSavingReusableBlock( ref ),
 			block: reusableBlock ? getBlock( reusableBlock.clientId ) : null,
-			canUpdateBlock: !! reusableBlock && ! reusableBlock.isTemporary && canUser( 'update', 'blocks', ref ),
+			canUpdateBlock: !! reusableBlock && ! reusableBlock.isTemporary && !! canUser( 'update', 'blocks', ref ),
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -24,6 +24,7 @@
 		"@babel/runtime": "^7.0.0",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/data": "file:../data",
+		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/url": "file:../url",
 		"equivalent-key-map": "^0.2.2",
 		"lodash": "^4.17.10",

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -137,7 +137,25 @@ export function* saveEntityRecord( kind, name, record ) {
  */
 export function receiveUploadPermissions( hasUploadPermissions ) {
 	return {
-		type: 'RECEIVE_UPLOAD_PERMISSIONS',
-		hasUploadPermissions,
+		type: 'RECEIVE_USER_PERMISSIONS',
+		key: 'create/media',
+		isAllowed: hasUploadPermissions,
+	};
+}
+
+/**
+ * Returns an action object used in signalling that the current user has
+ * permission to perform an action on a REST resource.
+ *
+ * @param {string}  key       A key that represents the action and REST resource.
+ * @param {boolean} isAllowed Whether or not the user can perform the action.
+ *
+ * @return {Object} Action object.
+ */
+export function receiveUserPermissions( key, isAllowed ) {
+	return {
+		type: 'RECEIVE_USER_PERMISSIONS',
+		key,
+		isAllowed,
 	};
 }

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -137,7 +137,7 @@ export function* saveEntityRecord( kind, name, record ) {
  */
 export function receiveUploadPermissions( hasUploadPermissions ) {
 	return {
-		type: 'RECEIVE_USER_PERMISSIONS',
+		type: 'RECEIVE_USER_PERMISSION',
 		key: 'create/media',
 		isAllowed: hasUploadPermissions,
 	};
@@ -152,9 +152,9 @@ export function receiveUploadPermissions( hasUploadPermissions ) {
  *
  * @return {Object} Action object.
  */
-export function receiveUserPermissions( key, isAllowed ) {
+export function receiveUserPermission( key, isAllowed ) {
 	return {
-		type: 'RECEIVE_USER_PERMISSIONS',
+		type: 'RECEIVE_USER_PERMISSION',
 		key,
 		isAllowed,
 	};

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -228,7 +228,7 @@ export function embedPreviews( state = {}, action ) {
  */
 export function userPermissions( state = {}, action ) {
 	switch ( action.type ) {
-		case 'RECEIVE_USER_PERMISSIONS':
+		case 'RECEIVE_USER_PERMISSION':
 			return {
 				...state,
 				[ action.key ]: action.isAllowed,

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -218,17 +218,21 @@ export function embedPreviews( state = {}, action ) {
 }
 
 /**
- * Reducer managing Upload permissions.
+ * State which tracks whether the user can perform an action on a REST
+ * resource.
  *
- * @param  {Object}  state  Current state.
- * @param  {Object}  action Dispatched action.
+ * @param  {Object} state  Current state.
+ * @param  {Object} action Dispatched action.
  *
  * @return {Object} Updated state.
  */
-export function hasUploadPermissions( state = true, action ) {
+export function userPermissions( state = {}, action ) {
 	switch ( action.type ) {
-		case 'RECEIVE_UPLOAD_PERMISSIONS':
-			return action.hasUploadPermissions;
+		case 'RECEIVE_USER_PERMISSIONS':
+			return {
+				...state,
+				[ action.key ]: action.isAllowed,
+			};
 	}
 
 	return state;
@@ -241,5 +245,5 @@ export default combineReducers( {
 	themeSupports,
 	entities,
 	embedPreviews,
-	hasUploadPermissions,
+	userPermissions,
 } );

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -16,7 +16,7 @@ import {
 	receiveEntityRecords,
 	receiveThemeSupports,
 	receiveEmbedPreview,
-	receiveUserPermissions,
+	receiveUserPermission,
 } from './actions';
 import { getKindEntities } from './entities';
 import { apiFetch } from './controls';
@@ -158,5 +158,5 @@ export function* canUser( action, resource, id ) {
 
 	const key = compact( [ action, resource, id ] ).join( '/' );
 	const isAllowed = includes( allowHeader, method );
-	yield receiveUserPermissions( key, isAllowed );
+	yield receiveUserPermission( key, isAllowed );
 }

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -101,6 +101,9 @@ export function* getEmbedPreview( url ) {
 
 /**
  * Requests Upload Permissions from the REST API.
+ *
+ * @deprecated since 4.9. Callers should use the more generic `canUser()` selector instead of
+ *             `hasUploadPermissions()`, e.g. `canUser( 'create', 'media' )`.
  */
 export function* hasUploadPermissions() {
 	yield* canUser( 'create', 'media' );

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -103,7 +103,7 @@ export function* getEmbedPreview( url ) {
 /**
  * Requests Upload Permissions from the REST API.
  *
- * @deprecated since 4.9. Callers should use the more generic `canUser()` selector instead of
+ * @deprecated since 5.0. Callers should use the more generic `canUser()` selector instead of
  *            `hasUploadPermissions()`, e.g. `canUser( 'create', 'media' )`.
  */
 export function* hasUploadPermissions() {

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -125,7 +125,7 @@ export function* canUser( action, resource, id ) {
 
 	const method = methods[ action ];
 	if ( ! method ) {
-		throw new Error( `'${ action }' is not a valid action` );
+		throw new Error( `'${ action }' is not a valid action.` );
 	}
 
 	const path = id ? `/wp/v2/${ resource }/${ id }` : `/wp/v2/${ resource }`;

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -7,6 +7,7 @@ import { find, includes, get, hasIn, compact } from 'lodash';
  * WordPress dependencies
  */
 import { addQueryArgs } from '@wordpress/url';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -103,9 +104,12 @@ export function* getEmbedPreview( url ) {
  * Requests Upload Permissions from the REST API.
  *
  * @deprecated since 4.9. Callers should use the more generic `canUser()` selector instead of
- *             `hasUploadPermissions()`, e.g. `canUser( 'create', 'media' )`.
+ *            `hasUploadPermissions()`, e.g. `canUser( 'create', 'media' )`.
  */
 export function* hasUploadPermissions() {
+	deprecated( "select( 'core' ).hasUploadPermissions()", {
+		alternative: "select( 'core' ).canUser( 'create', 'media' )",
+	} );
 	yield* canUser( 'create', 'media' );
 }
 

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -137,6 +137,7 @@ export function* canUser( action, resource, id ) {
 			// Ideally this would always be an OPTIONS request, but unfortunately there's
 			// a bug in the REST API which causes the Allow header to not be sent on
 			// OPTIONS requests to /posts/:id routes.
+			// https://core.trac.wordpress.org/ticket/45753
 			method: id ? 'GET' : 'OPTIONS',
 			parse: false,
 		} );

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -142,6 +142,8 @@ export function* canUser( action, resource, id ) {
 			parse: false,
 		} );
 	} catch ( error ) {
+		// Do nothing if our OPTIONS request comes back with an API error (4xx or
+		// 5xx). The previously determined isAllowed value will remain in the store.
 		return;
 	}
 

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -185,6 +185,11 @@ export function hasUploadPermissions( state ) {
  * Returns whether the current user can perform the given action on the given
  * REST resource.
  *
+ * Calling this may trigger an OPTIONS request to the REST API via the
+ * `canUser()` resolver.
+ *
+ * https://developer.wordpress.org/rest-api/reference/
+ *
  * @param {Object}  state    Data state.
  * @param {string}  action   Action to check. One of: 'create', 'read', 'update',
  *                           'delete'.

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import createSelector from 'rememo';
-import { map, find, get, filter } from 'lodash';
+import { map, find, get, filter, compact } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -178,5 +178,22 @@ export function isPreviewEmbedFallback( state, url ) {
  * @return {boolean} Upload Permissions.
  */
 export function hasUploadPermissions( state ) {
-	return state.hasUploadPermissions;
+	return canUser( state, 'create', 'media' );
+}
+
+/**
+ * Returns whether the current user can perform the given action on the given
+ * REST resource.
+ *
+ * @param {Object}  state    Data state.
+ * @param {string}  action   Action to check. One of: 'create', 'read', 'update',
+ *                           'delete'.
+ * @param {string}  resource REST resource to check, e.g. 'media' or 'posts'.
+ * @param {?string} id       ID of the rest resource to check.
+ *
+ * @return {boolean} Whether or not the user can perform the action.
+ */
+export function canUser( state, action, resource, id ) {
+	const key = compact( [ action, resource, id ] ).join( '/' );
+	return get( state, [ 'userPermissions', key ], true );
 }

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import createSelector from 'rememo';
-import { map, find, get, filter, compact } from 'lodash';
+import { map, find, get, filter, compact, defaultTo } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -191,7 +191,7 @@ export function hasUploadPermissions( state ) {
 	deprecated( "select( 'core' ).hasUploadPermissions()", {
 		alternative: "select( 'core' ).canUser( 'create', 'media' )",
 	} );
-	return canUser( state, 'create', 'media', undefined, true );
+	return defaultTo( canUser( state, 'create', 'media' ), true );
 }
 
 /**
@@ -207,14 +207,11 @@ export function hasUploadPermissions( state ) {
  * @param {string}   action           Action to check. One of: 'create', 'read', 'update', 'delete'.
  * @param {string}   resource         REST resource to check, e.g. 'media' or 'posts'.
  * @param {string=}  id               Optional ID of the rest resource to check.
- * @param {boolean=} defaultIsAllowed What to return when we don't know if the current user can
- *                                    perform the given action on the given resource. Defaults to
- *                                    `false`.
  *
- * @return {boolean} Whether or not the user can perform the action, or `defaultIsAllowed` if the
- *                   OPTIONS request is still being made.
+ * @return {boolean|undefined} Whether or not the user can perform the action,
+ *                             or `undefined` if the OPTIONS request is still being made.
  */
-export function canUser( state, action, resource, id = undefined, defaultIsAllowed = false ) {
+export function canUser( state, action, resource, id ) {
 	const key = compact( [ action, resource, id ] ).join( '/' );
-	return get( state, [ 'userPermissions', key ], defaultIsAllowed );
+	return get( state, [ 'userPermissions', key ] );
 }

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -174,7 +174,7 @@ export function isPreviewEmbedFallback( state, url ) {
 /**
  * Returns whether the current user can upload media.
  *
- * Calling this may trigger an OPTIONS request ot the REST API via the
+ * Calling this may trigger an OPTIONS request to the REST API via the
  * `canUser()` resolver.
  *
  * https://developer.wordpress.org/rest-api/reference/

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -178,7 +178,7 @@ export function isPreviewEmbedFallback( state, url ) {
  *
  * https://developer.wordpress.org/rest-api/reference/
  *
- * @deprecated since 4.8. Callers should use the more generic `canUser()` selector instead of
+ * @deprecated since 4.9. Callers should use the more generic `canUser()` selector instead of
  *             `hasUploadPermissions()`, e.g. `canUser( 'create', 'media' )`.
  *
  * @param {Object} state Data state.

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -8,6 +8,7 @@ import { map, find, get, filter, compact } from 'lodash';
  * WordPress dependencies
  */
 import { select } from '@wordpress/data';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -187,6 +188,9 @@ export function isPreviewEmbedFallback( state, url ) {
  *                   request is being made.
  */
 export function hasUploadPermissions( state ) {
+	deprecated( "select( 'core' ).hasUploadPermissions()", {
+		alternative: "select( 'core' ).canUser( 'create', 'media' )",
+	} );
 	return canUser( state, 'create', 'media', undefined, true );
 }
 

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -171,14 +171,23 @@ export function isPreviewEmbedFallback( state, url ) {
 }
 
 /**
- * Return Upload Permissions.
+ * Returns whether the current user can upload media.
  *
- * @param  {Object}  state State tree.
+ * Calling this may trigger an OPTIONS request ot the REST API via the
+ * `canUser()` resolver.
  *
- * @return {boolean} Upload Permissions.
+ * https://developer.wordpress.org/rest-api/reference/
+ *
+ * @deprecated since 4.8. Callers should use the more generic `canUser()` selector instead of
+ *             `hasUploadPermissions()`, e.g. `canUser( 'create', 'media' )`.
+ *
+ * @param {Object} state Data state.
+ *
+ * @return {boolean} Whether or not the user can upload media. Defaults to `true` if the OPTIONS
+ *                   request is being made.
  */
 export function hasUploadPermissions( state ) {
-	return canUser( state, 'create', 'media' );
+	return canUser( state, 'create', 'media', undefined, true );
 }
 
 /**
@@ -190,15 +199,18 @@ export function hasUploadPermissions( state ) {
  *
  * https://developer.wordpress.org/rest-api/reference/
  *
- * @param {Object}  state    Data state.
- * @param {string}  action   Action to check. One of: 'create', 'read', 'update',
- *                           'delete'.
- * @param {string}  resource REST resource to check, e.g. 'media' or 'posts'.
- * @param {?string} id       ID of the rest resource to check.
+ * @param {Object}   state            Data state.
+ * @param {string}   action           Action to check. One of: 'create', 'read', 'update', 'delete'.
+ * @param {string}   resource         REST resource to check, e.g. 'media' or 'posts'.
+ * @param {string=}  id               Optional ID of the rest resource to check.
+ * @param {boolean=} defaultIsAllowed What to return when we don't know if the current user can
+ *                                    perform the given action on the given resource. Defaults to
+ *                                    `false`.
  *
- * @return {boolean} Whether or not the user can perform the action.
+ * @return {boolean} Whether or not the user can perform the action, or `defaultIsAllowed` if the
+ *                   OPTIONS request is still being made.
  */
-export function canUser( state, action, resource, id ) {
+export function canUser( state, action, resource, id = undefined, defaultIsAllowed = false ) {
 	const key = compact( [ action, resource, id ] ).join( '/' );
-	return get( state, [ 'userPermissions', key ], true );
+	return get( state, [ 'userPermissions', key ], defaultIsAllowed );
 }

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -179,7 +179,7 @@ export function isPreviewEmbedFallback( state, url ) {
  *
  * https://developer.wordpress.org/rest-api/reference/
  *
- * @deprecated since 4.9. Callers should use the more generic `canUser()` selector instead of
+ * @deprecated since 5.0. Callers should use the more generic `canUser()` selector instead of
  *             `hasUploadPermissions()`, e.g. `canUser( 'create', 'media' )`.
  *
  * @param {Object} state Data state.

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { saveEntityRecord, receiveEntityRecords } from '../actions';
+import { saveEntityRecord, receiveEntityRecords, receiveUserPermissions } from '../actions';
 
 describe( 'saveEntityRecord', () => {
 	it( 'triggers a POST request for a new record', async () => {
@@ -56,5 +56,15 @@ describe( 'saveEntityRecord', () => {
 		// Provide response and trigger action
 		const { value: received } = fulfillment.next( postType );
 		expect( received ).toEqual( receiveEntityRecords( 'root', 'postType', postType, undefined, true ) );
+	} );
+} );
+
+describe( 'receiveUserPermissions', () => {
+	it( 'builds an action object', () => {
+		expect( receiveUserPermissions( 'create/media', true ) ).toEqual( {
+			type: 'RECEIVE_USER_PERMISSIONS',
+			key: 'create/media',
+			isAllowed: true,
+		} );
 	} );
 } );

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { saveEntityRecord, receiveEntityRecords, receiveUserPermissions } from '../actions';
+import { saveEntityRecord, receiveEntityRecords, receiveUserPermission } from '../actions';
 
 describe( 'saveEntityRecord', () => {
 	it( 'triggers a POST request for a new record', async () => {
@@ -59,10 +59,10 @@ describe( 'saveEntityRecord', () => {
 	} );
 } );
 
-describe( 'receiveUserPermissions', () => {
+describe( 'receiveUserPermission', () => {
 	it( 'builds an action object', () => {
-		expect( receiveUserPermissions( 'create/media', true ) ).toEqual( {
-			type: 'RECEIVE_USER_PERMISSIONS',
+		expect( receiveUserPermission( 'create/media', true ) ).toEqual( {
+			type: 'RECEIVE_USER_PERMISSION',
 			key: 'create/media',
 			isAllowed: true,
 		} );

--- a/packages/core-data/src/test/reducer.js
+++ b/packages/core-data/src/test/reducer.js
@@ -7,7 +7,7 @@ import { filter } from 'lodash';
 /**
  * Internal dependencies
  */
-import { terms, entities, embedPreviews, hasUploadPermissions } from '../reducer';
+import { terms, entities, embedPreviews, userPermissions } from '../reducer';
 
 describe( 'terms()', () => {
 	it( 'returns an empty object by default', () => {
@@ -118,21 +118,25 @@ describe( 'embedPreviews()', () => {
 	} );
 } );
 
-describe( 'hasUploadPermissions()', () => {
-	it( 'returns true by default', () => {
-		const state = hasUploadPermissions( undefined, {} );
-
-		expect( state ).toEqual( true );
+describe( 'userPermissions()', () => {
+	it( 'defaults to an empty object', () => {
+		const state = userPermissions( undefined, {} );
+		expect( state ).toEqual( {} );
 	} );
 
-	it( 'returns with updated upload permissions value', () => {
-		const originalState = true;
-
-		const state = hasUploadPermissions( originalState, {
-			type: 'RECEIVE_UPLOAD_PERMISSIONS',
-			hasUploadPermissions: false,
+	it( 'updates state with whether an action is allowed', () => {
+		const original = deepFreeze( {
+			'create/media': false,
 		} );
 
-		expect( state ).toEqual( false );
+		const state = userPermissions( original, {
+			type: 'RECEIVE_USER_PERMISSIONS',
+			key: 'create/media',
+			isAllowed: true,
+		} );
+
+		expect( state ).toEqual( {
+			'create/media': true,
+		} );
 	} );
 } );

--- a/packages/core-data/src/test/reducer.js
+++ b/packages/core-data/src/test/reducer.js
@@ -130,7 +130,7 @@ describe( 'userPermissions()', () => {
 		} );
 
 		const state = userPermissions( original, {
-			type: 'RECEIVE_USER_PERMISSIONS',
+			type: 'RECEIVE_USER_PERMISSION',
 			key: 'create/media',
 			isAllowed: true,
 		} );

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -1,8 +1,9 @@
 /**
  * Internal dependencies
  */
-import { getEntityRecord, getEntityRecords, getEmbedPreview } from '../resolvers';
-import { receiveEntityRecords, receiveEmbedPreview } from '../actions';
+import { getEntityRecord, getEntityRecords, getEmbedPreview, canUser } from '../resolvers';
+import { receiveEntityRecords, receiveEmbedPreview, receiveUserPermissions } from '../actions';
+import { apiFetch } from '../controls';
 
 describe( 'getEntityRecord', () => {
 	const POST_TYPE = { slug: 'post' };
@@ -66,5 +67,95 @@ describe( 'getEmbedPreview', () => {
 		// Provide invalid response and trigger Action
 		const received = ( await fulfillment.throw( { status: 404 } ) ).value;
 		expect( received ).toEqual( receiveEmbedPreview( UNEMBEDDABLE_URL, UNEMBEDDABLE_RESPONSE ) );
+	} );
+} );
+
+describe( 'canUser', () => {
+	it( 'does nothing when there is an API error', () => {
+		const generator = canUser( 'create', 'media' );
+
+		let received = generator.next();
+		expect( received.done ).toBe( false );
+		expect( received.value ).toEqual( apiFetch( {
+			path: '/wp/v2/media',
+			method: 'OPTIONS',
+			parse: false,
+		} ) );
+
+		received = generator.throw( { status: 404 } );
+		expect( received.done ).toBe( true );
+		expect( received.value ).toBeUndefined();
+	} );
+
+	it( 'receives false when the user is not allowed to perform an action', () => {
+		const generator = canUser( 'create', 'media' );
+
+		let received = generator.next();
+		expect( received.done ).toBe( false );
+		expect( received.value ).toEqual( apiFetch( {
+			path: '/wp/v2/media',
+			method: 'OPTIONS',
+			parse: false,
+		} ) );
+
+		received = generator.next( {
+			headers: {
+				Allow: 'GET',
+			},
+		} );
+		expect( received.done ).toBe( false );
+		expect( received.value ).toEqual( receiveUserPermissions( 'create/media', false ) );
+
+		received = generator.next();
+		expect( received.done ).toBe( true );
+		expect( received.value ).toBeUndefined();
+	} );
+
+	it( 'receives true when the user is allowed to perform an action', () => {
+		const generator = canUser( 'create', 'media' );
+
+		let received = generator.next();
+		expect( received.done ).toBe( false );
+		expect( received.value ).toEqual( apiFetch( {
+			path: '/wp/v2/media',
+			method: 'OPTIONS',
+			parse: false,
+		} ) );
+
+		received = generator.next( {
+			headers: {
+				Allow: 'POST, GET, PUT, DELETE',
+			},
+		} );
+		expect( received.done ).toBe( false );
+		expect( received.value ).toEqual( receiveUserPermissions( 'create/media', true ) );
+
+		received = generator.next();
+		expect( received.done ).toBe( true );
+		expect( received.value ).toBeUndefined();
+	} );
+
+	it( 'receives true when the user is allowed to perform an action on a specific resource', () => {
+		const generator = canUser( 'update', 'blocks', 123 );
+
+		let received = generator.next();
+		expect( received.done ).toBe( false );
+		expect( received.value ).toEqual( apiFetch( {
+			path: '/wp/v2/blocks/123',
+			method: 'GET',
+			parse: false,
+		} ) );
+
+		received = generator.next( {
+			headers: {
+				Allow: 'POST, GET, PUT, DELETE',
+			},
+		} );
+		expect( received.done ).toBe( false );
+		expect( received.value ).toEqual( receiveUserPermissions( 'update/blocks/123', true ) );
+
+		received = generator.next();
+		expect( received.done ).toBe( true );
+		expect( received.value ).toBeUndefined();
 	} );
 } );

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { getEntityRecord, getEntityRecords, getEmbedPreview, canUser } from '../resolvers';
-import { receiveEntityRecords, receiveEmbedPreview, receiveUserPermissions } from '../actions';
+import { receiveEntityRecords, receiveEmbedPreview, receiveUserPermission } from '../actions';
 import { apiFetch } from '../controls';
 
 describe( 'getEntityRecord', () => {
@@ -104,7 +104,7 @@ describe( 'canUser', () => {
 			},
 		} );
 		expect( received.done ).toBe( false );
-		expect( received.value ).toEqual( receiveUserPermissions( 'create/media', false ) );
+		expect( received.value ).toEqual( receiveUserPermission( 'create/media', false ) );
 
 		received = generator.next();
 		expect( received.done ).toBe( true );
@@ -128,7 +128,7 @@ describe( 'canUser', () => {
 			},
 		} );
 		expect( received.done ).toBe( false );
-		expect( received.value ).toEqual( receiveUserPermissions( 'create/media', true ) );
+		expect( received.value ).toEqual( receiveUserPermission( 'create/media', true ) );
 
 		received = generator.next();
 		expect( received.done ).toBe( true );
@@ -152,7 +152,7 @@ describe( 'canUser', () => {
 			},
 		} );
 		expect( received.done ).toBe( false );
-		expect( received.value ).toEqual( receiveUserPermissions( 'update/blocks/123', true ) );
+		expect( received.value ).toEqual( receiveUserPermission( 'update/blocks/123', true ) );
 
 		received = generator.next();
 		expect( received.done ).toBe( true );

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -11,6 +11,7 @@ import {
 	getEntityRecords,
 	getEmbedPreview,
 	isPreviewEmbedFallback,
+	canUser,
 } from '../selectors';
 
 describe( 'getEntityRecord', () => {
@@ -115,5 +116,32 @@ describe( 'isPreviewEmbedFallback()', () => {
 			},
 		} );
 		expect( isPreviewEmbedFallback( state, 'http://example.com/' ) ).toEqual( true );
+	} );
+} );
+
+describe( 'canUser', () => {
+	it( 'returns true by default', () => {
+		const state = deepFreeze( {
+			userPermissions: {},
+		} );
+		expect( canUser( state, 'create', 'media' ) ).toBe( true );
+	} );
+
+	it( 'returns whether an action can be performed', () => {
+		const state = deepFreeze( {
+			userPermissions: {
+				'create/media': false,
+			},
+		} );
+		expect( canUser( state, 'create', 'media' ) ).toBe( false );
+	} );
+
+	it( 'returns whether an action can be performed for a given resource', () => {
+		const state = deepFreeze( {
+			userPermissions: {
+				'create/media/123': false,
+			},
+		} );
+		expect( canUser( state, 'create', 'media', 123 ) ).toBe( false );
 	} );
 } );

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -120,18 +120,11 @@ describe( 'isPreviewEmbedFallback()', () => {
 } );
 
 describe( 'canUser', () => {
-	it( 'returns false by default', () => {
+	it( 'returns undefined by default', () => {
 		const state = deepFreeze( {
 			userPermissions: {},
 		} );
-		expect( canUser( state, 'create', 'media' ) ).toBe( false );
-	} );
-
-	it( 'returns true by default if defaultIsAllowed is specified', () => {
-		const state = deepFreeze( {
-			userPermissions: {},
-		} );
-		expect( canUser( state, 'create', 'media', undefined, true ) ).toBe( true );
+		expect( canUser( state, 'create', 'media' ) ).toBe( undefined );
 	} );
 
 	it( 'returns whether an action can be performed', () => {

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -120,11 +120,18 @@ describe( 'isPreviewEmbedFallback()', () => {
 } );
 
 describe( 'canUser', () => {
-	it( 'returns true by default', () => {
+	it( 'returns false by default', () => {
 		const state = deepFreeze( {
 			userPermissions: {},
 		} );
-		expect( canUser( state, 'create', 'media' ) ).toBe( true );
+		expect( canUser( state, 'create', 'media' ) ).toBe( false );
+	} );
+
+	it( 'returns true by default if defaultIsAllowed is specified', () => {
+		const state = deepFreeze( {
+			userPermissions: {},
+		} );
+		expect( canUser( state, 'create', 'media', undefined, true ) ).toBe( true );
 	} );
 
 	it( 'returns whether an action can be performed', () => {

--- a/packages/editor/src/components/block-settings-menu/reusable-block-convert-button.js
+++ b/packages/editor/src/components/block-settings-menu/reusable-block-convert-button.js
@@ -16,6 +16,7 @@ import { compose } from '@wordpress/compose';
 export function ReusableBlockConvertButton( {
 	isVisible,
 	isStaticBlock,
+	canCreateBlocks,
 	onConvertToStatic,
 	onConvertToReusable,
 } ) {
@@ -29,6 +30,7 @@ export function ReusableBlockConvertButton( {
 				<MenuItem
 					className="editor-block-settings-menu__control"
 					icon="controls-repeat"
+					disabled={ ! canCreateBlocks }
 					onClick={ onConvertToReusable }
 				>
 					{ __( 'Add to Reusable Blocks' ) }
@@ -54,6 +56,7 @@ export default compose( [
 			canInsertBlockType,
 			__experimentalGetReusableBlock: getReusableBlock,
 		} = select( 'core/editor' );
+		const { canUser } = select( 'core' );
 
 		const blocks = getBlocksByClientId( clientIds );
 
@@ -80,6 +83,7 @@ export default compose( [
 				! isReusableBlock( blocks[ 0 ] ) ||
 				! getReusableBlock( blocks[ 0 ].attributes.ref )
 			),
+			canCreateBlocks: canUser( 'create', 'blocks' ),
 		};
 	} ),
 	withDispatch( ( dispatch, { clientIds, onToggle = noop } ) => {

--- a/packages/editor/src/components/block-settings-menu/reusable-block-convert-button.js
+++ b/packages/editor/src/components/block-settings-menu/reusable-block-convert-button.js
@@ -65,28 +65,29 @@ export default compose( [
 			!! getReusableBlock( blocks[ 0 ].attributes.ref )
 		);
 
+		// Show 'Convert to Regular Block' when selected block is a reusable block
+		const isVisible = isReusable || (
+			// Hide 'Add to Reusable Blocks' when reusable blocks are disabled
+			canInsertBlockType( 'core/block' ) &&
+
+			every( blocks, ( block ) => (
+				// Guard against the case where a regular block has *just* been converted
+				!! block &&
+
+				// Hide 'Add to Reusable Blocks' on invalid blocks
+				block.isValid &&
+
+				// Hide 'Add to Reusable Blocks' when block doesn't support being made reusable
+				hasBlockSupport( block.name, 'reusable', true )
+			) ) &&
+
+			// Hide 'Add to Reusable Blocks' when current doesn't have permission to do that
+			canUser( 'create', 'blocks' )
+		);
+
 		return {
-			// Show 'Convert to Regular Block' when selected block is a reusable block
-			isVisible: isReusable || (
-				// Hide 'Add to Reusable Blocks' when reusable blocks are disabled
-				canInsertBlockType( 'core/block' ) &&
-
-				every( blocks, ( block ) => (
-					// Guard against the case where a regular block has *just* been converted
-					!! block &&
-
-					// Hide 'Add to Reusable Blocks' on invalid blocks
-					block.isValid &&
-
-					// Hide 'Add to Reusable Blocks' when block doesn't support being made reusable
-					hasBlockSupport( block.name, 'reusable', true )
-				) ) &&
-
-				// Hide 'Add to Reusable Blocks' when current doesn't have permission to do that
-				canUser( 'create', 'blocks' )
-			),
-
 			isReusable,
+			isVisible,
 		};
 	} ),
 	withDispatch( ( dispatch, { clientIds, onToggle = noop } ) => {

--- a/packages/editor/src/components/block-settings-menu/reusable-block-convert-button.js
+++ b/packages/editor/src/components/block-settings-menu/reusable-block-convert-button.js
@@ -82,7 +82,7 @@ export default compose( [
 			) ) &&
 
 			// Hide 'Add to Reusable Blocks' when current doesn't have permission to do that
-			canUser( 'create', 'blocks' )
+			!! canUser( 'create', 'blocks' )
 		);
 
 		return {

--- a/packages/editor/src/components/block-settings-menu/reusable-block-delete-button.js
+++ b/packages/editor/src/components/block-settings-menu/reusable-block-delete-button.js
@@ -12,8 +12,8 @@ import { __ } from '@wordpress/i18n';
 import { isReusableBlock } from '@wordpress/blocks';
 import { withSelect, withDispatch } from '@wordpress/data';
 
-export function ReusableBlockDeleteButton( { reusableBlock, onDelete } ) {
-	if ( ! reusableBlock ) {
+export function ReusableBlockDeleteButton( { id, isDisabled, onDelete } ) {
+	if ( ! id ) {
 		return null;
 	}
 
@@ -21,8 +21,8 @@ export function ReusableBlockDeleteButton( { reusableBlock, onDelete } ) {
 		<MenuItem
 			className="editor-block-settings-menu__control"
 			icon="no"
-			disabled={ reusableBlock.isTemporary }
-			onClick={ () => onDelete( reusableBlock.id ) }
+			disabled={ isDisabled }
+			onClick={ () => onDelete( id ) }
 		>
 			{ __( 'Remove from Reusable Blocks' ) }
 		</MenuItem>
@@ -35,9 +35,16 @@ export default compose( [
 			getBlock,
 			__experimentalGetReusableBlock: getReusableBlock,
 		} = select( 'core/editor' );
+		const { canUser } = select( 'core' );
+
 		const block = getBlock( clientId );
+
+		const id = block && isReusableBlock( block ) ? block.attributes.ref : null;
 		return {
-			reusableBlock: block && isReusableBlock( block ) ? getReusableBlock( block.attributes.ref ) : null,
+			id,
+			isDisabled: !! id && (
+				getReusableBlock( id ).isTemporary || ! canUser( 'delete', 'blocks', id )
+			),
 		};
 	} ),
 	withDispatch( ( dispatch, { onToggle = noop } ) => {

--- a/packages/editor/src/components/block-settings-menu/reusable-block-delete-button.js
+++ b/packages/editor/src/components/block-settings-menu/reusable-block-delete-button.js
@@ -44,7 +44,7 @@ export default compose( [
 			null;
 
 		return {
-			isVisible: !! reusableBlock && canUser( 'delete', 'blocks', reusableBlock.id ),
+			isVisible: !! reusableBlock && !! canUser( 'delete', 'blocks', reusableBlock.id ),
 			isDisabled: reusableBlock && reusableBlock.isTemporary,
 		};
 	} ),

--- a/packages/editor/src/components/block-settings-menu/test/__snapshots__/reusable-block-delete-button.js.snap
+++ b/packages/editor/src/components/block-settings-menu/test/__snapshots__/reusable-block-delete-button.js.snap
@@ -3,6 +3,7 @@
 exports[`ReusableBlockDeleteButton matches the snapshot 1`] = `
 <WithInstanceId(MenuItem)
   className="editor-block-settings-menu__control"
+  disabled={false}
   icon="no"
   onClick={[Function]}
 >

--- a/packages/editor/src/components/block-settings-menu/test/reusable-block-convert-button.js
+++ b/packages/editor/src/components/block-settings-menu/test/reusable-block-convert-button.js
@@ -27,15 +27,13 @@ describe( 'ReusableBlockConvertButton', () => {
 		const wrapper = getShallowRenderOutput(
 			<ReusableBlockConvertButton
 				isVisible
-				isStaticBlock
-				canCreateBlocks
+				isReusable={ false }
 				onConvertToReusable={ onConvert }
 			/>
 		);
 		expect( wrapper.props.children[ 1 ] ).toBeFalsy();
 		const button = wrapper.props.children[ 0 ];
 		expect( button.props.children ).toBe( 'Add to Reusable Blocks' );
-		expect( button.props.disabled ).toBe( false );
 		button.props.onClick();
 		expect( onConvert ).toHaveBeenCalled();
 	} );
@@ -45,7 +43,7 @@ describe( 'ReusableBlockConvertButton', () => {
 		const wrapper = getShallowRenderOutput(
 			<ReusableBlockConvertButton
 				isVisible
-				isStaticBlock={ false }
+				isReusable
 				onConvertToStatic={ onConvert }
 			/>
 		);

--- a/packages/editor/src/components/block-settings-menu/test/reusable-block-convert-button.js
+++ b/packages/editor/src/components/block-settings-menu/test/reusable-block-convert-button.js
@@ -28,12 +28,14 @@ describe( 'ReusableBlockConvertButton', () => {
 			<ReusableBlockConvertButton
 				isVisible
 				isStaticBlock
+				canCreateBlocks
 				onConvertToReusable={ onConvert }
 			/>
 		);
 		expect( wrapper.props.children[ 1 ] ).toBeFalsy();
 		const button = wrapper.props.children[ 0 ];
 		expect( button.props.children ).toBe( 'Add to Reusable Blocks' );
+		expect( button.props.disabled ).toBe( false );
 		button.props.onClick();
 		expect( onConvert ).toHaveBeenCalled();
 	} );

--- a/packages/editor/src/components/block-settings-menu/test/reusable-block-delete-button.js
+++ b/packages/editor/src/components/block-settings-menu/test/reusable-block-delete-button.js
@@ -20,7 +20,8 @@ describe( 'ReusableBlockDeleteButton', () => {
 		const wrapper = getShallowRenderOutput(
 			<ReusableBlockDeleteButton
 				role="menuitem"
-				reusableBlock={ { id: 123 } }
+				id={ 123 }
+				isDisabled={ false }
 				onDelete={ noop }
 			/>
 		);
@@ -32,7 +33,8 @@ describe( 'ReusableBlockDeleteButton', () => {
 		const onDelete = jest.fn();
 		const wrapper = getShallowRenderOutput(
 			<ReusableBlockDeleteButton
-				reusableBlock={ { id: 123 } }
+				id={ 123 }
+				isDisabled={ false }
 				onDelete={ onDelete }
 			/>
 		);

--- a/packages/editor/src/components/block-settings-menu/test/reusable-block-delete-button.js
+++ b/packages/editor/src/components/block-settings-menu/test/reusable-block-delete-button.js
@@ -16,11 +16,19 @@ describe( 'ReusableBlockDeleteButton', () => {
 		return renderer.getRenderOutput();
 	}
 
+	it( 'should not render when isVisible is false', () => {
+		const wrapper = getShallowRenderOutput(
+			<ReusableBlockDeleteButton isVisible={ false } />
+		);
+
+		expect( wrapper ).toBe( null );
+	} );
+
 	it( 'matches the snapshot', () => {
 		const wrapper = getShallowRenderOutput(
 			<ReusableBlockDeleteButton
 				role="menuitem"
-				id={ 123 }
+				isVisible
 				isDisabled={ false }
 				onDelete={ noop }
 			/>
@@ -33,13 +41,13 @@ describe( 'ReusableBlockDeleteButton', () => {
 		const onDelete = jest.fn();
 		const wrapper = getShallowRenderOutput(
 			<ReusableBlockDeleteButton
-				id={ 123 }
+				isVisible
 				isDisabled={ false }
 				onDelete={ onDelete }
 			/>
 		);
 
 		wrapper.props.onClick();
-		expect( onDelete ).toHaveBeenCalledWith( 123 );
+		expect( onDelete ).toHaveBeenCalled();
 	} );
 } );

--- a/packages/editor/src/components/media-placeholder/index.js
+++ b/packages/editor/src/components/media-placeholder/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { every, get, noop, startsWith } from 'lodash';
+import { every, get, noop, startsWith, defaultTo } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -261,7 +261,7 @@ const applyWithSelect = withSelect( ( select ) => {
 	const { canUser } = select( 'core' );
 
 	return {
-		hasUploadPermissions: canUser( 'create', 'media', undefined, true ),
+		hasUploadPermissions: defaultTo( canUser( 'create', 'media' ), true ),
 	};
 } );
 

--- a/packages/editor/src/components/media-placeholder/index.js
+++ b/packages/editor/src/components/media-placeholder/index.js
@@ -258,10 +258,10 @@ export class MediaPlaceholder extends Component {
 }
 
 const applyWithSelect = withSelect( ( select ) => {
-	const { hasUploadPermissions } = select( 'core' );
+	const { canUser } = select( 'core' );
 
 	return {
-		hasUploadPermissions: hasUploadPermissions(),
+		hasUploadPermissions: canUser( 'create', 'media', undefined, true ),
 	};
 } );
 

--- a/packages/editor/src/components/media-upload/check.js
+++ b/packages/editor/src/components/media-upload/check.js
@@ -8,9 +8,9 @@ export function MediaUploadCheck( { hasUploadPermissions, fallback = null, child
 }
 
 export default withSelect( ( select ) => {
-	const { hasUploadPermissions } = select( 'core' );
+	const { canUser } = select( 'core' );
 
 	return {
-		hasUploadPermissions: hasUploadPermissions(),
+		hasUploadPermissions: canUser( 'create', 'media', undefined, true ),
 	};
 } )( MediaUploadCheck );

--- a/packages/editor/src/components/media-upload/check.js
+++ b/packages/editor/src/components/media-upload/check.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { defaultTo } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { withSelect } from '@wordpress/data';
@@ -11,6 +16,6 @@ export default withSelect( ( select ) => {
 	const { canUser } = select( 'core' );
 
 	return {
-		hasUploadPermissions: canUser( 'create', 'media', undefined, true ),
+		hasUploadPermissions: defaultTo( canUser( 'create', 'media' ), true ),
 	};
 } )( MediaUploadCheck );


### PR DESCRIPTION
### What this is

Fixes #12338.

Improves the UX of creating, editing, and deleting a reusable block when logged in as an author or contributor by disabling the _Add to Reusable Blocks_, _Edit_, and _Remove from Reusable Blocks_ buttons when necessary.

This is accomplished under the hood by introducing the `canUser()` selector to `core-data` which allows callers to query whether the REST API supports performing a given action on a given resource, e.g. one can query whether the logged in user can create posts by running `wp.data.select( 'core' ).canUser( 'create', 'posts' )`.

The existing `hasUploadPermissions()` selector is changed to use `canUser( 'create', 'media' )` under the hood.

### How it looks

_Add to Reusable Blocks_ button is visible for admins and editors:

![admin - add](https://user-images.githubusercontent.com/612155/50619911-71a5c380-0f50-11e9-8f30-acf8304b81e6.png)

_Add to Reusable Blocks_ button is hidden for contributors:

![contributor - add](https://user-images.githubusercontent.com/612155/50619915-78343b00-0f50-11e9-84c2-03dbee5f21b9.png)

_Edit_ button is enabled and _Remove from Reusable Blocks_ is visible for admins and editors:

![admin - edit remove](https://user-images.githubusercontent.com/612155/50619935-9601a000-0f50-11e9-8a6f-a679c9da4155.png)

_Edit_ button is disabled and _Remove from Reusable Blocks_ is hidden for authors:

![author - edit remove](https://user-images.githubusercontent.com/612155/50619918-86825700-0f50-11e9-969f-1c139bc113a4.png)

### How to test

1. Try to create a reusable block as a contributor. The _Add to Reusable Blocks_ button should be disabled.
1. Try to updating another user's reusable block as an author. The _Edit_ button should be disabled.
1. Try to deleting another user's reusable block as an author or contributor. The _Remove from Reusable Blocks_ button should be disabled.