### PR TITLE
Avoid rerending the current block if the previous block change

### DIFF
--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -113,10 +113,6 @@ wp.hooks.addFilter(
 );
 ```
 
-#### `blocks.isUnmodifiedDefaultBlock.attributes`
-
-Used internally by the default block (paragraph) to exclude the attributes from the check if the block was modified.
-
 #### `blocks.switchToBlockType.transformedBlock`
 
 Used to filters an individual transform result from block transformation. All of the original blocks are passed, since transformations are many-to-many, not one-to-one.

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-import { every, has, keys, isEqual, isFunction, isString } from 'lodash';
+import { every, has, isFunction, isString } from 'lodash';
 import { default as tinycolor, mostReadable } from 'tinycolor2';
 
 /**
  * WordPress dependencies
  */
-import { applyFilters } from '@wordpress/hooks';
 import { Component, isValidElement } from '@wordpress/element';
 
 /**
@@ -40,14 +39,10 @@ export function isUnmodifiedDefaultBlock( block ) {
 	}
 
 	const newDefaultBlock = createBlock( defaultBlockName );
+	const blockType = getBlockType( defaultBlockName );
 
-	const attributeKeys = applyFilters( 'blocks.isUnmodifiedDefaultBlock.attributes', [
-		...keys( newDefaultBlock.attributes ),
-		...keys( block.attributes ),
-	] );
-
-	return every( attributeKeys, ( key ) =>
-		isEqual( newDefaultBlock.attributes[ key ], block.attributes[ key ] )
+	return every( blockType.attributes, ( value, key ) =>
+		newDefaultBlock.attributes[ key ] === block.attributes[ key ]
 	);
 }
 

--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -437,7 +437,6 @@ export class BlockListBlock extends Component {
 					// Insertion point can only be made visible if the block is at the
 					// the extent of a multi-selection, or not in a multi-selection.
 					const shouldShowInsertionPoint = ( isPartOfMultiSelection && isFirstMultiSelected ) || ! isPartOfMultiSelection;
-					const canShowInBetweenInserter = ! isEmptyDefaultBlock;
 
 					// The wp-block className is important for editor styles.
 					// Generate the wrapper class names handling the different states of the block.
@@ -522,7 +521,6 @@ export class BlockListBlock extends Component {
 								<BlockInsertionPoint
 									clientId={ clientId }
 									rootClientId={ rootClientId }
-									canShowInserter={ canShowInBetweenInserter }
 								/>
 							) }
 							<BlockDropZone
@@ -684,8 +682,8 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId, isLargeV
 		isSelected,
 		isParentOfSelectedBlock,
 
-		// We only care about this value when the shift key is pressed.
-		// We call it dynamically in the event handler to avoid unnecessary re-renders.
+		// We only care about these selectors when events are triggered.
+		// We call them dynamically in the event handlers to avoid unnecessary re-renders.
 		getBlockSelectionStart,
 		getPreviousBlockClientId,
 		getNextBlockClientId,

--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -228,8 +228,9 @@ export class BlockListBlock extends Component {
 	}
 
 	mergeBlocks( forward = false ) {
-		const { clientId, previousBlockClientId, nextBlockClientId, onMerge } = this.props;
-
+		const { clientId, getPreviousBlockClientId, getNextBlockClientId, onMerge } = this.props;
+		const previousBlockClientId = getPreviousBlockClientId( clientId );
+		const nextBlockClientId = getNextBlockClientId( clientId );
 		// Do nothing when it's the first block.
 		if (
 			( ! forward && ! previousBlockClientId ) ||
@@ -404,7 +405,6 @@ export class BlockListBlock extends Component {
 						isMultiSelecting,
 						isEmptyDefaultBlock,
 						isMovable,
-						isPreviousBlockADefaultEmptyBlock,
 						isParentOfSelectedBlock,
 						isDraggable,
 						className,
@@ -437,7 +437,7 @@ export class BlockListBlock extends Component {
 					// Insertion point can only be made visible if the block is at the
 					// the extent of a multi-selection, or not in a multi-selection.
 					const shouldShowInsertionPoint = ( isPartOfMultiSelection && isFirstMultiSelected ) || ! isPartOfMultiSelection;
-					const canShowInBetweenInserter = ! isEmptyDefaultBlock && ! isPreviousBlockADefaultEmptyBlock;
+					const canShowInBetweenInserter = ! isEmptyDefaultBlock;
 
 					// The wp-block className is important for editor styles.
 					// Generate the wrapper class names handling the different states of the block.
@@ -634,8 +634,6 @@ export class BlockListBlock extends Component {
 const applyWithSelect = withSelect( ( select, { clientId, rootClientId, isLargeViewport } ) => {
 	const {
 		isBlockSelected,
-		getPreviousBlockClientId,
-		getNextBlockClientId,
 		getBlockName,
 		isBlockValid,
 		getBlockAttributes,
@@ -653,17 +651,17 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId, isLargeV
 		hasSelectedInnerBlock,
 		getTemplateLock,
 		getBlockSelectionStart,
+		getPreviousBlockClientId,
+		getNextBlockClientId,
 	} = select( 'core/editor' );
 	const isSelected = isBlockSelected( clientId );
 	const { hasFixedToolbar, focusMode } = getEditorSettings();
-	const previousBlockClientId = getPreviousBlockClientId( clientId );
 	const templateLock = getTemplateLock( rootClientId );
 	const isParentOfSelectedBlock = hasSelectedInnerBlock( clientId, true );
 	const name = getBlockName( clientId );
 	const attributes = getBlockAttributes( clientId );
 
 	return {
-		nextBlockClientId: getNextBlockClientId( clientId ),
 		isPartOfMultiSelection: isBlockMultiSelected( clientId ) || isAncestorMultiSelected( clientId ),
 		isFirstMultiSelected: isFirstMultiSelectedBlock( clientId ),
 		isMultiSelecting: isMultiSelecting(),
@@ -676,10 +674,6 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId, isLargeV
 		isSelectionEnabled: isSelectionEnabled(),
 		initialPosition: getSelectedBlocksInitialCaretPosition(),
 		isEmptyDefaultBlock: name && isUnmodifiedDefaultBlock( { name, attributes } ),
-		isPreviousBlockADefaultEmptyBlock: previousBlockClientId && isUnmodifiedDefaultBlock( {
-			name: getBlockName( previousBlockClientId ),
-			attributes: getBlockAttributes( previousBlockClientId ),
-		} ),
 		isValid: isBlockValid( clientId ),
 		isMovable: 'all' !== templateLock,
 		isLocked: !! templateLock,
@@ -687,12 +681,14 @@ const applyWithSelect = withSelect( ( select, { clientId, rootClientId, isLargeV
 		hasFixedToolbar: hasFixedToolbar && isLargeViewport,
 		name,
 		attributes,
-		previousBlockClientId,
 		isSelected,
 		isParentOfSelectedBlock,
+
 		// We only care about this value when the shift key is pressed.
 		// We call it dynamically in the event handler to avoid unnecessary re-renders.
 		getBlockSelectionStart,
+		getPreviousBlockClientId,
+		getNextBlockClientId,
 	};
 } );
 

--- a/packages/editor/src/components/block-list/insertion-point.js
+++ b/packages/editor/src/components/block-list/insertion-point.js
@@ -6,7 +6,6 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import { Component } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 
@@ -85,18 +84,15 @@ export default withSelect( ( select, { clientId, rootClientId } ) => {
 	const {
 		getBlockIndex,
 		getBlockInsertionPoint,
-		getBlock,
 		isBlockInsertionPointVisible,
 	} = select( 'core/editor' );
 	const blockIndex = getBlockIndex( clientId, rootClientId );
 	const insertIndex = blockIndex;
 	const insertionPoint = getBlockInsertionPoint();
-	const block = getBlock( clientId );
 	const showInsertionPoint = (
 		isBlockInsertionPointVisible() &&
 		insertionPoint.index === insertIndex &&
-		insertionPoint.rootClientId === rootClientId &&
-		! isUnmodifiedDefaultBlock( block )
+		insertionPoint.rootClientId === rootClientId
 	);
 
 	return { showInsertionPoint, insertIndex };

--- a/packages/editor/src/components/block-list/insertion-point.js
+++ b/packages/editor/src/components/block-list/insertion-point.js
@@ -47,7 +47,6 @@ class BlockInsertionPoint extends Component {
 		const { isInserterFocused } = this.state;
 		const {
 			showInsertionPoint,
-			canShowInserter,
 			rootClientId,
 			insertIndex,
 		} = this.props;
@@ -57,29 +56,27 @@ class BlockInsertionPoint extends Component {
 				{ showInsertionPoint && (
 					<div className="editor-block-list__insertion-point-indicator" />
 				) }
-				{ canShowInserter && (
-					<div
-						onFocus={ this.onFocusInserter }
-						onBlur={ this.onBlurInserter }
-						// While ideally it would be enough to capture the
-						// bubbling focus event from the Inserter, due to the
-						// characteristics of click focusing of `button`s in
-						// Firefox and Safari, it is not reliable.
-						//
-						// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
-						tabIndex={ -1 }
-						className={
-							classnames( 'editor-block-list__insertion-point-inserter', {
-								'is-visible': isInserterFocused,
-							} )
-						}
-					>
-						<Inserter
-							rootClientId={ rootClientId }
-							index={ insertIndex }
-						/>
-					</div>
-				) }
+				<div
+					onFocus={ this.onFocusInserter }
+					onBlur={ this.onBlurInserter }
+					// While ideally it would be enough to capture the
+					// bubbling focus event from the Inserter, due to the
+					// characteristics of click focusing of `button`s in
+					// Firefox and Safari, it is not reliable.
+					//
+					// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
+					tabIndex={ -1 }
+					className={
+						classnames( 'editor-block-list__insertion-point-inserter', {
+							'is-visible': isInserterFocused,
+						} )
+					}
+				>
+					<Inserter
+						rootClientId={ rootClientId }
+						index={ insertIndex }
+					/>
+				</div>
 			</div>
 		);
 	}


### PR DESCRIPTION
This PR builds on top of #11899 And it's another refactoring to the `BlockListBlock` component to avoid useless selectors.

In my testing. Key press events are `22%` faster in long posts.