### PR TITLE
Add more selectors of the blocks api for the mobile app

### DIFF
--- a/packages/blocks/src/api/index.native.js
+++ b/packages/blocks/src/api/index.native.js
@@ -14,6 +14,7 @@ export {
 } from './serializer';
 export {
 	registerBlockType,
+	getFreeformContentHandlerName,
 	setUnregisteredTypeHandlerName,
 	getUnregisteredTypeHandlerName,
 	getBlockType,
@@ -23,5 +24,8 @@ export {
 	setDefaultBlockName,
 	getDefaultBlockName,
 } from './registration';
+export {
+	isUnmodifiedDefaultBlock,
+} from './utils';
 export { getPhrasingContentSchema } from './raw-handling';
 export { default as children } from './children';


### PR DESCRIPTION
## Description
This PR exposes more functions to the react native app.
Required for https://github.com/wordpress-mobile/gutenberg-mobile/pull/276

Exposing:
- `getFreeformContentHandlerName`
- `isUnmodifiedDefaultBlock`

## Types of changes
- React native update
