### PR TITLE
Optimize the insertion point component

### DIFF
--- a/packages/editor/src/components/block-list/insertion-point.js
+++ b/packages/editor/src/components/block-list/insertion-point.js
@@ -6,7 +6,6 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import { Component } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 
@@ -88,18 +87,15 @@ export default withSelect( ( select, { clientId, rootClientId } ) => {
 	const {
 		getBlockIndex,
 		getBlockInsertionPoint,
-		getBlock,
 		isBlockInsertionPointVisible,
 	} = select( 'core/editor' );
 	const blockIndex = getBlockIndex( clientId, rootClientId );
 	const insertIndex = blockIndex;
 	const insertionPoint = getBlockInsertionPoint();
-	const block = getBlock( clientId );
 	const showInsertionPoint = (
 		isBlockInsertionPointVisible() &&
 		insertionPoint.index === insertIndex &&
-		insertionPoint.rootClientId === rootClientId &&
-		! isUnmodifiedDefaultBlock( block )
+		insertionPoint.rootClientId === rootClientId
 	);
 
 	return { showInsertionPoint, insertIndex };


### PR DESCRIPTION
This PR avoids calling the `getBlock` selector in the `InsertionPoint` component. I'm not really certain why this call was necessary. It doesn't seem to harm the experience in my testing.

This is a 6% performance improvement when typing.