### PR TITLE
FormToggle: component styles for external use

### DIFF
--- a/packages/components/src/form-toggle/style.scss
+++ b/packages/components/src/form-toggle/style.scss
@@ -11,6 +11,7 @@ $toggle-border-width: 2px;
 	.components-form-toggle__off {
 		position: absolute;
 		top: $toggle-border-width * 3;
+		box-sizing: border-box;
 	}
 
 	.components-form-toggle__off {
@@ -27,6 +28,7 @@ $toggle-border-width: 2px;
 	.components-form-toggle__track {
 		content: "";
 		display: inline-block;
+		box-sizing: border-box;
 		vertical-align: top;
 		background-color: $white;
 		border: $toggle-border-width solid $dark-gray-300;
@@ -39,6 +41,7 @@ $toggle-border-width: 2px;
 	.components-form-toggle__thumb {
 		display: block;
 		position: absolute;
+		box-sizing: border-box;
 		top: $toggle-border-width * 2;
 		left: $toggle-border-width * 2;
 		width: $toggle-height - ($toggle-border-width * 4);

--- a/packages/components/src/form-toggle/style.scss
+++ b/packages/components/src/form-toggle/style.scss
@@ -4,6 +4,7 @@ $toggle-border-width: 2px;
 
 .components-form-toggle {
 	position: relative;
+	display: inline-block;
 
 	// On/Off icon indicators.
 	.components-form-toggle__on,


### PR DESCRIPTION
## Description
Identified styles causing rendering issues with the FormToggle component outside of the block editor.

## How has this been tested?
1. Created a new plugin utilizing React and the `@wordpress/components` package.
2. Imported and rendered a FormToggle component as well as a ToggleControl component.
3. Verified component looks as issue #8871 has described (and shown with images).
4. Verified component looks correct within the block editor.
5. Applied CSS fixes to component.
6. Verified component looks correct and unchanged within the block editor.
7. Verified component looks correct in the test plugin (outside of the block editor).

## Screenshots

*Broken:*

![formtoggle-broken](https://user-images.githubusercontent.com/375788/49158433-20226d00-f2f0-11e8-9d48-e6a23b075af8.png)

*Fixed:*

![formtoggle-fixed](https://user-images.githubusercontent.com/375788/49158439-287aa800-f2f0-11e8-834a-d1b496dd3e34.png)


## Types of changes
Fixes #8871

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
