### PR TITLE
Only initialise TinyMCE once per instance

### DIFF
--- a/packages/editor/src/components/rich-text/tinymce.js
+++ b/packages/editor/src/components/rich-text/tinymce.js
@@ -111,6 +111,7 @@ export default class TinyMCE extends Component {
 		this.bindEditorNode = this.bindEditorNode.bind( this );
 		this.onFocus = this.onFocus.bind( this );
 		this.onKeyDown = this.onKeyDown.bind( this );
+		this.initialize = this.initialize.bind( this );
 	}
 
 	onFocus() {
@@ -167,7 +168,16 @@ export default class TinyMCE extends Component {
 		}
 	}
 
+	/**
+	 * Initializes TinyMCE. Can only be called once per instance.
+	 */
 	initialize() {
+		if ( this.initialize.called ) {
+			return;
+		}
+
+		this.initialize.called = true;
+
 		const { multilineTag } = this.props;
 		const settings = {
 			theme: false,


### PR DESCRIPTION
## Description
Currently we're trying to initialise TinyMCE every time the content editable element receives focus.
## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
