### PR TITLE
Keep the cursor position in the Classic Block

### DIFF
--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -102,6 +102,13 @@ export default class ClassicEdit extends Component {
 			return false;
 		} );
 
+		editor.on( 'init', () => {
+			// Store the initial "raw" content.
+			setAttributes( {
+				contentRaw: editor.getContent( { format: 'raw' } ),
+			} );
+		} );
+
 		editor.on( 'beforeSetContent focus', () => {
 			if ( editor.wpClassicBlockBookmark ) {
 				editor.selection.moveToBookmark( editor.wpClassicBlockBookmark );


### PR DESCRIPTION
Fixes #10509.

- On blur store the cursor position and the "raw" content of the Classic Block.
- Use the "raw" content when refreshing the editor content on `componentDidUpdate()`. It contains the cursor position "bookmark".
- Restore the cursor position on focus and before inserting content.
