### PR TITLE
RichText: Reuse DOM document across calls to createEmpty

### DIFF
--- a/packages/rich-text/CHANGELOG.md
+++ b/packages/rich-text/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.3 (Unreleased)
+
+### Internal
+
+- Internal performance optimizations to avoid excessive expensive creation of DOM documents.
+
 ## 3.0.2 (2018-11-21)
 
 ## 3.0.1 (2018-11-20)

--- a/packages/rich-text/src/create-element.js
+++ b/packages/rich-text/src/create-element.js
@@ -1,13 +1,21 @@
 /**
  * Parse the given HTML into a body element.
  *
+ * Note: The current implementation will return a shared reference, reset on
+ * each call to `createElement`. Therefore, you should not hold a reference to
+ * the value to operate upon asynchronously, as it may have unexpected results.
+ *
  * @param {HTMLDocument} document The HTML document to use to parse.
  * @param {string}       html     The HTML to parse.
  *
  * @return {HTMLBodyElement} Body element with parsed HTML.
  */
 export function createElement( { implementation }, html ) {
-	const { body } = implementation.createHTMLDocument( '' );
-	body.innerHTML = html;
-	return body;
+	if ( ! createElement.body ) {
+		createElement.body = implementation.createHTMLDocument( '' ).body;
+	}
+
+	createElement.body.innerHTML = html;
+
+	return createElement.body;
 }

--- a/packages/rich-text/src/create-element.js
+++ b/packages/rich-text/src/create-element.js
@@ -11,6 +11,10 @@
  * @return {HTMLBodyElement} Body element with parsed HTML.
  */
 export function createElement( { implementation }, html ) {
+	// Because `createHTMLDocument` is an expensive operation, and with this
+	// function being internal to `rich-text` (full control in avoiding a risk
+	// of asynchronous operations on the shared reference), a single document
+	// is reused and reset for each call to the function.
 	if ( ! createElement.body ) {
 		createElement.body = implementation.createHTMLDocument( '' ).body;
 	}

--- a/packages/rich-text/src/test/to-dom.js
+++ b/packages/rich-text/src/test/to-dom.js
@@ -9,16 +9,11 @@ import { JSDOM } from 'jsdom';
  */
 
 import { toDom, applyValue } from '../to-dom';
+import { createElement } from '../create-element';
 import { spec } from './helpers';
 
 const { window } = new JSDOM();
 const { document } = window;
-
-function createElement( { implementation }, html ) {
-	const { body } = implementation.createHTMLDocument( '' );
-	body.innerHTML = html;
-	return body;
-}
 
 describe( 'recordToDom', () => {
 	beforeAll( () => {
@@ -71,8 +66,8 @@ describe( 'applyValue', () => {
 
 	cases.forEach( ( { current, future, description, movedCount } ) => {
 		it( description, () => {
-			const body = createElement( document, current );
-			const futureBody = createElement( document, future );
+			const body = createElement( document, current ).cloneNode( true );
+			const futureBody = createElement( document, future ).cloneNode( true );
 			const childNodes = Array.from( futureBody.childNodes );
 			applyValue( futureBody, body );
 			const count = childNodes.reduce( ( acc, { parentNode } ) => {

--- a/packages/rich-text/src/test/to-dom.js
+++ b/packages/rich-text/src/test/to-dom.js
@@ -9,11 +9,16 @@ import { JSDOM } from 'jsdom';
  */
 
 import { toDom, applyValue } from '../to-dom';
-import { createElement } from '../create-element';
 import { spec } from './helpers';
 
 const { window } = new JSDOM();
 const { document } = window;
+
+function createElement( { implementation }, html ) {
+	const { body } = implementation.createHTMLDocument( '' );
+	body.innerHTML = html;
+	return body;
+}
 
 describe( 'recordToDom', () => {
 	beforeAll( () => {

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -3,6 +3,7 @@
  */
 
 import { toTree } from './to-tree';
+import { createElement } from './create-element';
 
 /**
  * Browser dependencies
@@ -68,19 +69,7 @@ function getNodeByPath( node, path ) {
  *
  * @return {WPRichTextTree} RichText tree.
  */
-function createEmpty() {
-	// Because `createHTMLDocument` is an expensive operation, and with this
-	// function being internal to `rich-text` (full control in avoiding a risk
-	// of asynchronous operations on the shared reference), a single document
-	// is reused and reset for each call to the function.
-	if ( createEmpty.body ) {
-		createEmpty.body.innerHTML = '';
-	} else {
-		createEmpty.body = document.implementation.createHTMLDocument( '' ).body;
-	}
-
-	return createEmpty.body;
-}
+const createEmpty = () => createElement( document, '' );
 
 function append( element, child ) {
 	if ( typeof child === 'string' ) {

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -58,9 +58,28 @@ function getNodeByPath( node, path ) {
 	};
 }
 
+/**
+ * Returns a new instance of a DOM tree upon which RichText operations can be
+ * applied.
+ *
+ * Note: The current implementation will return a shared reference, reset on
+ * each call to `createEmpty`. Therefore, you should not hold a reference to
+ * the value to operate upon asynchronously, as it may have unexpected results.
+ *
+ * @return {WPRichTextTree} RichText tree.
+ */
 function createEmpty() {
-	const { body } = document.implementation.createHTMLDocument( '' );
-	return body;
+	// Because `createHTMLDocument` is an expensive operation, and with this
+	// function being internal to `rich-text` (full control in avoiding a risk
+	// of asynchronous operations on the shared reference), a single document
+	// is reused and reset for each call to the function.
+	if ( createEmpty.body ) {
+		createEmpty.body.innerHTML = '';
+	} else {
+		createEmpty.body = document.implementation.createHTMLDocument( '' ).body;
+	}
+
+	return createEmpty.body;
 }
 
 function append( element, child ) {


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/7890#discussion_r236879765

This pull request seeks to optimize the behavior of RichText's internal `createEmpty` implementation for DOM tree operations. It reuses a single reference to a DOM document rather than creating a new instance for each invocation.

**Implementation notes:**

Using a shared reference could potentially have unintended side effects if the reference is held for later use. Given that this function is internal to the module, I think it's an acceptable compromise. I made an attempt to be as clear as possible about this potential gotcha through inline code comments.

As an aside, I noted that this function is called _6 times_ for every key press in a paragraph. This is something which should be evaluated for future optimization, but is not strictly relevant to the changes proposed here.

Possibly related: #11602

**Testing instructions:**

Ensure unit tests pass:

```
npm run test-unit packages/rich-text
```

Verify there are no regressions in the general behavior of text input in RichText (e.g. paragraph).