### PR TITLE
Allow custom style in dashicon/svg

### DIFF
--- a/packages/components/src/dashicon/icon-class.native.js
+++ b/packages/components/src/dashicon/icon-class.native.js
@@ -1,4 +1,10 @@
 export const IconClass = ( props ) => {
-	const { icon, className, ariaPressed } = props;
+	const { icon, className, ariaPressed, style } = props;
+
+	// 🙈 style-to-classname-to-style 🙃
+	if ( style !== undefined ) {
+		return style;
+	}
+
 	return [ ariaPressed ? 'dashicon-active' : 'dashicon', 'dashicons-' + icon, className ].filter( Boolean ).join( ' ' );
 };

--- a/packages/components/src/dashicon/index.js
+++ b/packages/components/src/dashicon/index.js
@@ -22,7 +22,8 @@ export default class Dashicon extends Component {
 			this.props.icon !== nextProps.icon ||
 			this.props.size !== nextProps.size ||
 			this.props.className !== nextProps.className ||
-			this.props.ariaPressed !== nextProps.ariaPressed
+			this.props.ariaPressed !== nextProps.ariaPressed ||
+			this.props.style !== nextProps.style
 		);
 	}
 

--- a/packages/components/src/primitives/svg/index.native.js
+++ b/packages/components/src/primitives/svg/index.native.js
@@ -21,13 +21,15 @@ export const SVG = ( props ) => {
 	// Given it carries a string (as it was originally className) but an object is expected for `style`,
 	// we need to check whether `style` exists and is a string, and convert it to an object
 
-	let styleValues = {};
+	let style = {};
 	if ( typeof props.style === 'string' ) {
 		const oneStyle = props.style.split( ' ' ).map( ( element ) => styles[ element ] ).filter( Boolean );
-		styleValues = Object.assign( styleValues, ...oneStyle );
+		style = Object.assign( style, ...oneStyle );
+	} else {
+		style = props.style;
 	}
 
-	const safeProps = { ...props, style: styleValues };
+	const safeProps = { ...props, style };
 
 	return (
 		<Svg


### PR DESCRIPTION
This extends the previous solution in #11827 by allowing a `style` prop to be passed to a `Dashicon`.
The previous solution required `Svg` being aware of other parts of the app and including hardcoded colors in its CSS.

This change lets you override those and specify the style directly. I haven't changed the existing toolbar icons since `IconButton` will pass the extra props to `Button`, not `Dashicon`

To be tested with https://github.com/wordpress-mobile/gutenberg-mobile/pull/286 for the inline toolbar buttons