### PR TITLE
fix(synchronizeBlocksWithTemplate): Fix, merge template attributes on update

### DIFF
--- a/packages/blocks/src/api/templates.js
+++ b/packages/blocks/src/api/templates.js
@@ -57,11 +57,6 @@ export function synchronizeBlocksWithTemplate( blocks = [], template ) {
 	return map( template, ( [ name, attributes, innerBlocksTemplate ], index ) => {
 		const block = blocks[ index ];
 
-		if ( block && block.name === name ) {
-			const innerBlocks = synchronizeBlocksWithTemplate( block.innerBlocks, innerBlocksTemplate );
-			return { ...block, innerBlocks };
-		}
-
 		// To support old templates that were using the "children" format
 		// for the attributes using "html" strings now, we normalize the template attributes
 		// before creating the blocks.
@@ -96,6 +91,11 @@ export function synchronizeBlocksWithTemplate( blocks = [], template ) {
 			get( blockType, [ 'attributes' ], {} ),
 			attributes
 		);
+
+		if ( block && block.name === name ) {
+			const innerBlocks = synchronizeBlocksWithTemplate( block.innerBlocks, innerBlocksTemplate );
+			return { ...block, attributes: normalizedAttributes, innerBlocks };
+		}
 
 		return createBlock(
 			name,


### PR DESCRIPTION
## Description

As per #11873 - we were having the same issue whilst making a custom Section block (cc #4900). This fix will resolve that problem.

The issue we had was that block attributes weren't updating despite the template changing, if the block that was updating was already in the correct position. (Primarily in the case of columns for us - but true of any template)

This PR moves the block return below the NormalizeAttribute function so we can access the normalized attributes. It then returns the updated attributes as part of the block, ensuring that if the template attributes change, they are correctly reflected.

## How has this been tested?

Tested against the columns to ensure that they continue to work without any additional template changes.

Built the plugin and run in our development and staging environments to allow us to use custom templates that require this functionality.

## Types of changes
Bug fix - attributes previously not updated as part of block synchronise.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
