### PR TITLE
CORE/COLUMNS fix margins on med screens, and odd numbers of cols

### DIFF
--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -18,7 +18,9 @@
 
 	// Beyond mobile, allow 2 columns.
 	@include break-small() {
-		flex-basis: 50%;
+
+		// Size should be half the available width, minus the margins added below
+		flex-basis: calc(50% - #{$grid-size-large * 2});
 		flex-grow: 0;
 	}
 
@@ -31,18 +33,31 @@
 
 	// Add space between columns. Themes can customize this if they wish to work differently.
 	// Only apply this beyond the mobile breakpoint, as there's only a single column on mobile.
+
+	// 2 columns at this breakpoint, and items beyond the second will wrap.
 	@include break-small() {
-		&:nth-child(odd) {
-			margin-right: $grid-size-large * 2;
-		}
 		&:nth-child(even) {
 			margin-left: $grid-size-large * 2;
 		}
+		&:nth-child(odd) {
+			margin-right: $grid-size-large * 2;
+		}
+	}
 
+	// N columns at this breakpoint.
+	// Reset odd, even margins from small breakpoint.
+	// Add margin to both sides on all inside columns.
+	// Add inner margin only on first and last items.
+	@include break-medium() {
+		&:nth-child(even) {
+			margin-left: initial;
+		}
+		&:nth-child(odd) {
+			margin-right: initial;
+		}
 		&:not(:first-child) {
 			margin-left: $grid-size-large * 2;
 		}
-
 		&:not(:last-child) {
 			margin-right: $grid-size-large * 2;
 		}

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -44,20 +44,20 @@
 		}
 	}
 
-	// N columns at this breakpoint.
-	// Reset odd, even margins from small breakpoint.
-	// Add margin to both sides on all inside columns.
-	// Add inner margin only on first and last items.
+	// All columns fit in one row at this breakpoint.
 	@include break-medium() {
+		// Reset odd, even margins from small breakpoint.
 		&:nth-child(even) {
 			margin-left: initial;
 		}
 		&:nth-child(odd) {
 			margin-right: initial;
 		}
+		// Add left margin to all but first item
 		&:not(:first-child) {
 			margin-left: $grid-size-large * 2;
 		}
+		// add right margin to all but last item
 		&:not(:last-child) {
 			margin-right: $grid-size-large * 2;
 		}


### PR DESCRIPTION
## Background
There should be 3 breakpoints:

**Mobile: less than 600px**
all columns full width and stacked. No margins.

**Small: 600px - 782px**
columns wrap in rows of 2. Margins on the inside.

**Medium: bigger than 782px**
all columns fit in one row. Margins on the inside.

## PROBLEMS!

**PROBLEM 1**
Columns don't wrap properly at Small breakpoint

![image](https://user-images.githubusercontent.com/1050936/49835575-3f47e280-fd65-11e8-975e-41e590392cbc.png)

**SOLUTION**
- move `not` selectors to Medium breakpoint
- adjust flex-basis to account for margins using calc()


**PROBLEM 2**
At the Medium breakpoint, when there is an odd number of columns, and extra margin is added to the last item.

![image](https://user-images.githubusercontent.com/1050936/49835697-a82f5a80-fd65-11e8-9ee2-504f1a12b68b.png)

**SOLUTION**
- reset `odd` and `even` selectors to `initial` at the Medium breakpoint

## How has this been tested?
tested in local wordpress docker env, codepen.

ORIG:
https://codepen.io/drdogbot7/pen/NEOQPQ

FIX:
https://codepen.io/drdogbot7/pen/GwYVNz

## Types of changes
Only css affecting core/columns.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
