### PR TITLE
Hide the image upload button on native until it's implemented

### DIFF
--- a/packages/editor/src/components/media-placeholder/index.native.js
+++ b/packages/editor/src/components/media-placeholder/index.native.js
@@ -12,10 +12,9 @@ function MediaPlaceholder( props ) {
                 Image
 			</Text>
 			<Text style={ styles.emptyStateDescription }>
-                Upload a new image or select a file from your library.
+                Select an image from your library.
 			</Text>
 			<View style={ styles.emptyStateButtonsContainer }>
-				<Button title="Upload" onPress={ props.onUploadPress } />
 				<Button title="Media Library" onPress={ props.onMediaLibraryPress } />
 			</View>
 		</View>


### PR DESCRIPTION
Since we can't do image uploads yet, let's just show the 

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/289

![hide-image-upload](https://user-images.githubusercontent.com/8739/49208837-24ff2380-f3b9-11e8-9681-0c4ad86b7910.png)

