### PR TITLE
Classic Block: set correct focus back after blur

### DIFF
--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -86,9 +86,14 @@ export default class ClassicEdit extends Component {
 		}
 
 		editor.on( 'blur', () => {
+			const bookmark = editor.selection.getBookmark( 2, true );
+
 			setAttributes( {
 				content: editor.getContent(),
 			} );
+
+			editor.once( 'focus', () => editor.selection.moveToBookmark( bookmark ) );
+
 			return false;
 		} );
 

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -78,6 +78,7 @@ export default class ClassicEdit extends Component {
 	onSetup( editor ) {
 		const { attributes: { content }, setAttributes } = this.props;
 		const { ref } = this;
+		let bookmark;
 
 		this.editor = editor;
 
@@ -86,15 +87,23 @@ export default class ClassicEdit extends Component {
 		}
 
 		editor.on( 'blur', () => {
-			const bookmark = editor.selection.getBookmark( 2, true );
+			bookmark = editor.selection.getBookmark( 2, true );
 
 			setAttributes( {
 				content: editor.getContent(),
 			} );
 
-			editor.once( 'focus', () => editor.selection.moveToBookmark( bookmark ) );
+			editor.once( 'focus', () => {
+				if ( bookmark ) {
+					editor.selection.moveToBookmark( bookmark );
+				}
+			} );
 
 			return false;
+		} );
+
+		editor.on( 'mousedown touchstart', () => {
+			bookmark = null;
 		} );
 
 		editor.on( 'keydown', ( event ) => {

--- a/test/e2e/specs/blocks/__snapshots__/classic.test.js.snap
+++ b/test/e2e/specs/blocks/__snapshots__/classic.test.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Classic should be inserted 1`] = `"test"`;
+
+exports[`Classic should insert media 1`] = `"test<img class=\\"alignnone size-full wp-image-130\\" src=\\"http://localhost:8889/wp-content/uploads/2018/11/b9682d07-fa29-4fbb-a9ce-f1019cc82ca1.png\\" alt=\\"\\" width=\\"10\\" height=\\"10\\" />"`;

--- a/test/e2e/specs/blocks/__snapshots__/classic.test.js.snap
+++ b/test/e2e/specs/blocks/__snapshots__/classic.test.js.snap
@@ -1,5 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Classic should be inserted 1`] = `"test"`;
-
-exports[`Classic should insert media 1`] = `"test<img class=\\"alignnone size-full wp-image-130\\" src=\\"http://localhost:8889/wp-content/uploads/2018/11/b9682d07-fa29-4fbb-a9ce-f1019cc82ca1.png\\" alt=\\"\\" width=\\"10\\" height=\\"10\\" />"`;

--- a/test/e2e/specs/blocks/classic.test.js
+++ b/test/e2e/specs/blocks/classic.test.js
@@ -43,7 +43,8 @@ describe( 'Classic', () => {
 		await page.keyboard.type( 'test' );
 
 		// Click the image button.
-		await page.click( 'div[aria-label="Insert Media"]' );
+		await page.waitForSelector( 'div[aria-label="Add Media"]' );
+		await page.click( 'div[aria-label="Add Media"]' );
 
 		// Wait for media modal to appear and upload image.
 		await page.waitForSelector( '.media-modal input[type=file]' );

--- a/test/e2e/specs/blocks/classic.test.js
+++ b/test/e2e/specs/blocks/classic.test.js
@@ -66,6 +66,7 @@ describe( 'Classic', () => {
 		// Move focus away.
 		await pressWithModifier( 'shift', 'Tab' );
 
-		expect( await getEditedPostContent() ).toMatchSnapshot();
+		const regExp = new RegExp( `test<img class="alignnone size-full wp-image-\\d+" src="[^"]+\\/${ filename }\\.png" alt="" width="10" height="10" \\/>` );
+		expect( await getEditedPostContent() ).toMatch( regExp );
 	} );
 } );

--- a/test/e2e/specs/blocks/classic.test.js
+++ b/test/e2e/specs/blocks/classic.test.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import uuid from 'uuid/v4';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getEditedPostContent,
+	newPost,
+	insertBlock,
+	pressWithModifier,
+} from '../../support/utils';
+
+describe( 'Classic', () => {
+	beforeEach( async () => {
+		await newPost();
+	} );
+
+	it( 'should be inserted', async () => {
+		await insertBlock( 'Classic' );
+		// Wait for TinyMCE to initialise.
+		await page.waitForSelector( '.mce-content-body' );
+		// Ensure there is focus.
+		await page.focus( '.mce-content-body' );
+		await page.keyboard.type( 'test' );
+		// Move focus away.
+		await pressWithModifier( 'shift', 'Tab' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should insert media', async () => {
+		await insertBlock( 'Classic' );
+		// Wait for TinyMCE to initialise.
+		await page.waitForSelector( '.mce-content-body' );
+		// Ensure there is focus.
+		await page.focus( '.mce-content-body' );
+		await page.keyboard.type( 'test' );
+
+		// Click the image button.
+		await page.click( 'div[aria-label="Insert Media"]' );
+
+		// Wait for media modal to appear and upload image.
+		await page.waitForSelector( '.media-modal input[type=file]' );
+		const inputElement = await page.$( '.media-modal input[type=file]' );
+		const testImagePath = path.join( __dirname, '..', '..', 'assets', '10x10_e2e_test_image_z9T8jK.png' );
+		const filename = uuid();
+		const tmpFileName = path.join( os.tmpdir(), filename + '.png' );
+		fs.copyFileSync( testImagePath, tmpFileName );
+		await inputElement.uploadFile( tmpFileName );
+
+		// Wait for upload.
+		await page.waitForSelector( `.media-modal li[aria-label="${ filename }"]` );
+
+		// Insert the uploaded image.
+		await page.click( '.media-modal button.media-button-insert' );
+
+		// Wait for image to be inserted.
+		await page.waitForSelector( '.mce-content-body img' );
+
+		// Move focus away.
+		await pressWithModifier( 'shift', 'Tab' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
## Description

Fixes #10509. Alternative attempt to #12393.

When the editor receives focus, after blur, the caret is not restored to the right position.

* This fix will get the selection path on blur (not anything stored in the DOM/HTML).
* Restore the path on the first focus after the blur event. Like this the selection path will always be accurate.

## How has this been tested?
See #10509. Insert an image in the classic block through the toolbar button and ensure it's inserted in the right place.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
