### PR TITLE
[RNmobile] Fix problems with undo/redo on Android

### DIFF
--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -268,6 +268,10 @@ export class RichText extends Component {
 			this.lastContent = undefined;
 			return true;
 		}
+
+		// TODO: Please re-introduce the check to avoid updating the content right after an `onChange` call.
+		// It was removed in https://github.com/WordPress/gutenberg/pull/12417 to fix undo/redo problem.
+
 		// If the component is changed React side (undo/redo/merging/splitting/custom text actions)
 		// we need to make sure the native is updated as well
 		if ( nextProps.value &&

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -268,18 +268,8 @@ export class RichText extends Component {
 			this.lastContent = undefined;
 			return true;
 		}
-		/*
-		// The check below allows us to avoid updating the content right after an `onChange` call.
-		// The first time the component is drawn `lastContent` and `lastEventCount ` are both undefined
-		if ( this.lastEventCount &&
-			nextProps.value &&
-			this.lastContent &&
-			nextProps.value === this.lastContent ) {
-			return false;
-		}
-*/
-		// If the component is changed React side (merging/splitting/custom text actions) we need to make sure
-		// the native is updated as well
+		// If the component is changed React side (undo/redo/merging/splitting/custom text actions) 
+		// we need to make sure the native is updated as well
 		if ( nextProps.value &&
 			this.lastContent &&
 			nextProps.value !== this.lastContent ) {

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -268,7 +268,7 @@ export class RichText extends Component {
 			this.lastContent = undefined;
 			return true;
 		}
-		// If the component is changed React side (undo/redo/merging/splitting/custom text actions) 
+		// If the component is changed React side (undo/redo/merging/splitting/custom text actions)
 		// we need to make sure the native is updated as well
 		if ( nextProps.value &&
 			this.lastContent &&

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -268,6 +268,7 @@ export class RichText extends Component {
 			this.lastContent = undefined;
 			return true;
 		}
+		/*
 		// The check below allows us to avoid updating the content right after an `onChange` call.
 		// The first time the component is drawn `lastContent` and `lastEventCount ` are both undefined
 		if ( this.lastEventCount &&
@@ -276,7 +277,7 @@ export class RichText extends Component {
 			nextProps.value === this.lastContent ) {
 			return false;
 		}
-
+*/
 		// If the component is changed React side (merging/splitting/custom text actions) we need to make sure
 		// the native is updated as well
 		if ( nextProps.value &&


### PR DESCRIPTION
This PR fixes a problem where the undo/redo feature was not working on Android if small changes were made to the content.

Actually undo/redo feature was not working fine even if there were lot of changes to the content, but in this case the problem was less noticeable, since the undo/redo feature replaced the content with the wrong text.

The problem was that RichText props were not correctly updated on typing. Then on `undo` the RichText component already had the same "old" value stored in it, and the Native side was not refreshed at all (The `setText` method of the AztecWrapper was not invoked).


To test this PR follow the steps in the gb-mobile PR here:https://github.com/wordpress-mobile/gutenberg-mobile/pull/297