### PR TITLE
Focus on RichText when selection changes

### DIFF
--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -288,6 +288,18 @@ export class RichText extends Component {
 		return true;
 	}
 
+	componentDidMount() {
+		if ( this.props.isSelected ) {
+			this._editor.focus();
+		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( this.props.isSelected && ! prevProps.isSelected ) {
+			this._editor.focus();
+		}
+	}
+
 	isFormatActive( format ) {
 		return this.state.formats[ format ] && this.state.formats[ format ].isActive;
 	}


### PR DESCRIPTION
This solves an issue on iOS where RichText doesn’t get the focus when inserting or splitting into a new block.

To test see https://github.com/wordpress-mobile/gutenberg-mobile/pull/298