### PR TITLE
Edit Post: Target specific core notice for upgrade

### DIFF
--- a/packages/edit-post/src/components/admin-notices/index.js
+++ b/packages/edit-post/src/components/admin-notices/index.js
@@ -79,14 +79,16 @@ export class AdminNotices extends Component {
 		const { createNotice } = this.props;
 		getAdminNotices().forEach( ( element ) => {
 			// Convert and create.
-			const status = getNoticeStatus( element );
-			const content = getNoticeHTML( element );
-			const isDismissible = element.classList.contains( 'is-dismissible' );
-			createNotice( status, content, {
-				speak: false,
-				__unstableHTML: true,
-				isDismissible,
-			} );
+			if ( element.classList.contains( 'wp-pp-notice' ) ) {
+				const status = getNoticeStatus( element );
+				const content = getNoticeHTML( element );
+				const isDismissible = element.classList.contains( 'is-dismissible' );
+				createNotice( status, content, {
+					speak: false,
+					__unstableHTML: true,
+					isDismissible,
+				} );
+			}
 
 			// Remove (now-redundant) admin notice element.
 			element.parentNode.removeChild( element );

--- a/packages/edit-post/src/components/admin-notices/test/index.js
+++ b/packages/edit-post/src/components/admin-notices/test/index.js
@@ -15,6 +15,9 @@ describe( 'AdminNotices', () => {
 		// text node) and (b) untrimmed content.
 		document.body.innerHTML = `
 			<div id="wpbody-content">
+				<div class="notice notice-warning inline wp-pp-notice">
+					<p>Need help putting together your new Privacy Policy page?</p>
+				</div>
 				<div class="notice updated is-dismissible">
 					<p>My <strong>notice</strong> text</p>
 					<p>My second line of text</p>
@@ -30,28 +33,19 @@ describe( 'AdminNotices', () => {
 		`;
 	} );
 
-	it( 'should upgrade notices', () => {
+	it( 'should upgrade privacy policy notice', () => {
 		const createNotice = jest.fn();
 
 		renderer.create( <AdminNotices createNotice={ createNotice } /> );
 
-		expect( createNotice ).toHaveBeenCalledTimes( 2 );
+		expect( createNotice ).toHaveBeenCalledTimes( 1 );
 		expect( createNotice.mock.calls[ 0 ] ).toEqual( [
 			'warning',
-			'Warning',
+			'<p>Need help putting together your new Privacy Policy page?</p>',
 			{
 				speak: false,
 				__unstableHTML: true,
 				isDismissible: false,
-			},
-		] );
-		expect( createNotice.mock.calls[ 1 ] ).toEqual( [
-			'success',
-			'<p>My <strong>notice</strong> text</p><p>My second line of text</p>',
-			{
-				speak: false,
-				__unstableHTML: true,
-				isDismissible: true,
 			},
 		] );
 


### PR DESCRIPTION
closes #12243

This pull request seeks to limit the notices which are upgraded to be displayed in the editor to be limited to only the core notices which had previously existed to target the editor (namely, the Privacy Policy notice).

This is a measure to avoid issues with non-dismissible notices being shown in the editor, until a more durable solution can be reached to show admin notices in the editor.

**Testing instructions:**

Verify that the privacy policy and only the privacy policy core admin notice is shown in the editor.