### PR TITLE
Make a simple version of DefaultBlockAppender for mobile

### DIFF
--- a/packages/editor/src/components/default-block-appender/index.native.js
+++ b/packages/editor/src/components/default-block-appender/index.native.js
@@ -36,11 +36,6 @@ export function DefaultBlockAppender( {
 						multiline
 						numberOfLines={ 0 }
 						value={ value }
-						onKeyPress={ onAppend }
-						selection={ { start: 0, end: 0 } }
-						/* eslint-disable jsx-a11y/no-autofocus */
-						autoFocus
-						/* eslint-enable jsx-a11y/no-autofocus */
 					/>
 				</View>
 			</View>

--- a/packages/editor/src/components/default-block-appender/index.native.js
+++ b/packages/editor/src/components/default-block-appender/index.native.js
@@ -23,7 +23,7 @@ export function DefaultBlockAppender( {
 		return null;
 	}
 
-	const value = decodeEntities( placeholder ) || __( 'Start writing or press \u2295 to choose a block' );
+	const value = decodeEntities( placeholder ) || __( 'Start writing or press \u2295 to add content' );
 
 	return (
 		<TouchableWithoutFeedback
@@ -36,12 +36,18 @@ export function DefaultBlockAppender( {
 						multiline
 						numberOfLines={ 0 }
 						value={ value }
+						onKeyPress={ onAppend }
+						selection={ { start: 0, end: 0 } }
+						/* eslint-disable jsx-a11y/no-autofocus */
+						autoFocus
+						/* eslint-enable jsx-a11y/no-autofocus */
 					/>
 				</View>
 			</View>
 		</TouchableWithoutFeedback>
 	);
 }
+
 export default compose(
 	withSelect( ( select, ownProps ) => {
 		const { getBlockCount, getEditorSettings, getTemplateLock } = select( 'core/editor' );

--- a/packages/editor/src/components/default-block-appender/index.native.js
+++ b/packages/editor/src/components/default-block-appender/index.native.js
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import { TextInput, TouchableWithoutFeedback, View } from 'react-native';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { compose } from '@wordpress/compose';
+import { decodeEntities } from '@wordpress/html-entities';
+import { withSelect, withDispatch } from '@wordpress/data';
+
+export function DefaultBlockAppender( {
+	isLocked,
+	isVisible,
+	onAppend,
+	placeholder,
+} ) {
+	if ( isLocked || ! isVisible ) {
+		return null;
+	}
+
+	const value = decodeEntities( placeholder ) || __( 'Start writing or press \u2295 to choose a block' );
+
+	return (
+		<TouchableWithoutFeedback
+			onPress={ onAppend }
+		>
+			<View style={ { flex: 1 } } pointerEvents="box-only">
+				<TextInput
+					textAlignVertical="top"
+					multiline
+					numberOfLines={ 0 }
+					value={ value }
+				/>
+			</View>
+		</TouchableWithoutFeedback>
+	);
+}
+export default compose(
+	withSelect( ( select, ownProps ) => {
+		const { getBlockCount, getEditorSettings, getTemplateLock } = select( 'core/editor' );
+
+		const isEmpty = ! getBlockCount( ownProps.rootClientId );
+		const { bodyPlaceholder } = getEditorSettings();
+
+		return {
+			isVisible: isEmpty,
+			isLocked: !! getTemplateLock( ownProps.rootClientId ),
+			placeholder: bodyPlaceholder,
+		};
+	} ),
+	withDispatch( ( dispatch, ownProps ) => {
+		const {
+			insertDefaultBlock,
+			startTyping,
+		} = dispatch( 'core/editor' );
+
+		return {
+			onAppend() {
+				const { rootClientId } = ownProps;
+
+				insertDefaultBlock( undefined, rootClientId );
+				startTyping();
+			},
+		};
+	} ),
+)( DefaultBlockAppender );

--- a/packages/editor/src/components/default-block-appender/index.native.js
+++ b/packages/editor/src/components/default-block-appender/index.native.js
@@ -32,6 +32,7 @@ export function DefaultBlockAppender( {
 			<View style={ styles.blockHolder } pointerEvents="box-only">
 				<View style={ styles.blockContainer }>
 					<TextInput
+						style={ styles.textView }
 						textAlignVertical="top"
 						multiline
 						numberOfLines={ 0 }

--- a/packages/editor/src/components/default-block-appender/index.native.js
+++ b/packages/editor/src/components/default-block-appender/index.native.js
@@ -11,6 +11,8 @@ import { compose } from '@wordpress/compose';
 import { decodeEntities } from '@wordpress/html-entities';
 import { withSelect, withDispatch } from '@wordpress/data';
 
+import styles from './style.scss';
+
 export function DefaultBlockAppender( {
 	isLocked,
 	isVisible,
@@ -27,13 +29,15 @@ export function DefaultBlockAppender( {
 		<TouchableWithoutFeedback
 			onPress={ onAppend }
 		>
-			<View style={ { flex: 1 } } pointerEvents="box-only">
-				<TextInput
-					textAlignVertical="top"
-					multiline
-					numberOfLines={ 0 }
-					value={ value }
-				/>
+			<View style={ styles.blockHolder } pointerEvents="box-only">
+				<View style={ styles.blockContainer }>
+					<TextInput
+						textAlignVertical="top"
+						multiline
+						numberOfLines={ 0 }
+						value={ value }
+					/>
+				</View>
 			</View>
 		</TouchableWithoutFeedback>
 	);

--- a/packages/editor/src/components/default-block-appender/style.native.scss
+++ b/packages/editor/src/components/default-block-appender/style.native.scss
@@ -7,3 +7,8 @@
 	background-color: $white;
 	padding: 8px;
 }
+
+.textView {
+	color: #87a6bc;
+	font-size: 16px;
+}

--- a/packages/editor/src/components/default-block-appender/style.native.scss
+++ b/packages/editor/src/components/default-block-appender/style.native.scss
@@ -1,0 +1,9 @@
+
+.blockHolder {
+	flex: 1 1 auto;
+}
+
+.blockContainer {
+	background-color: $white;
+	padding: 8px;
+}

--- a/packages/editor/src/components/index.native.js
+++ b/packages/editor/src/components/index.native.js
@@ -6,5 +6,6 @@ export { default as MediaPlaceholder } from './media-placeholder';
 export { default as BlockFormatControls } from './block-format-controls';
 export { default as BlockControls } from './block-controls';
 export { default as BlockEdit } from './block-edit';
+export { default as DefaultBlockAppender } from './default-block-appender';
 export { default as EditorHistoryRedo } from './editor-history/redo';
 export { default as EditorHistoryUndo } from './editor-history/undo';


### PR DESCRIPTION
## Description
This PR creates a mobile version of DefaultBlockAppender so we can have it in the react native app

## How has this been tested?
Tested with https://github.com/wordpress-mobile/gutenberg-mobile/pull/299

## Screenshot

![image](https://user-images.githubusercontent.com/230230/49304310-43097880-f4cc-11e8-816b-ebd68d8c8f75.png)


## Types of changes
- Mobile app compatibility improvements
