### PR TITLE
Notices: Remove "files" block in package.json

### DIFF
--- a/packages/notices/package.json
+++ b/packages/notices/package.json
@@ -16,10 +16,6 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
-	"files": [
-		"build",
-		"build-module"
-	],
 	"main": "build/index.js",
 	"react-native": "src/index",
 	"dependencies": {


### PR DESCRIPTION
## Description
Removes the `files` block in `package.json`.

This hides the `src/` files when installing the package via NPM which makes it more annoying to figure out how the package works. This block also isn't included for any other packages.

See https://wordpress.slack.com/archives/C02QB2JS7/p1543347395368100

## How has this been tested?
I'm not really sure how to test this.

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
