### PR TITLE
Edit Post: Avoid rendering AdminNotices compatibility component

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -37,7 +37,6 @@ import Sidebar from '../sidebar';
 import PluginPostPublishPanel from '../sidebar/plugin-post-publish-panel';
 import PluginPrePublishPanel from '../sidebar/plugin-pre-publish-panel';
 import FullscreenMode from '../fullscreen-mode';
-import AdminNotices from '../admin-notices';
 
 function Layout( {
 	mode,
@@ -71,7 +70,6 @@ function Layout( {
 			<BrowserURL />
 			<UnsavedChangesWarning />
 			<AutosaveMonitor />
-			<AdminNotices />
 			<Header />
 			<div
 				className="edit-post-layout__content"


### PR DESCRIPTION
Alternative to: #12440
Related: #11604
Closes #12243

This pull request seeks to cease the admin notices compatibility upgrade. Unlike #12440, it keeps all of the code changes from #11604, but since all of the compatibility behavior had been implemented in an isolated component, it simply stops rendering the component, thereby avoiding its behavior.

Over #12440, it has some advantages:

- Limited potential for breakage, since there is very little impacted code (simply removes the element from Layout's rendering)
- Avoids the requirement of a major version bump on affected packages
- Allows for / anticipates some future compatibility of admin notices (though not prescribing any specific implementation or UI treatment for how this would occur)

The downsides are limited to:

- This is essentially dead code which lingers in the distributed packages as long as it remains unused
- If we ultimately decide against any future compatibility, we either live with the dead code or a major version bump / breaking change inevitably must occur

**Testing instructions:**

Verify the inverse of the testing instructions outlined in #11604.