### PR TITLE
Metaboxes overlap content: Try compat hack for when the browser is in quirks mode

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -567,3 +567,27 @@ function gutenberg_add_responsive_body_class( $classes ) {
 }
 
 add_filter( 'body_class', 'gutenberg_add_responsive_body_class' );
+
+
+/**
+ * Prints JavaScript to detect whether the browser is in standards mode or not.
+ *
+ * @since 4.5
+ */
+function gutenberg_detect_quirks_mode() {
+	?>
+	<script type="text/javascript">
+		document.addEventListener( 'DOMContentLoaded', function() {
+			try {
+				var documentMode = document.compatMode==='CSS1Compat'?'Standards':'Quirks';
+				if (documentMode != 'Standards' ) {
+					console.log( 'You are in ' + documentMode + ' mode.' );
+					document.body.className += ' ' + 'is-quirks-mode';
+				}
+			} catch( e ) { }
+		} );
+	</script>
+	<?php
+}
+add_action( 'admin_print_scripts-post.php', 'gutenberg_detect_quirks_mode' );
+add_action( 'admin_print_scripts-post-new.php', 'gutenberg_detect_quirks_mode' );

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -103,6 +103,13 @@
 		@supports (position: sticky) {
 			flex-basis: 100%;
 		}
+
+		// This is an ugly hack that applies a table display to the main editing canvas when the browser is
+		// detected to be in quirks mode. Without this hack in quirks mode, the flexbox rules we use to size
+		// the various elements do not work, causing overlap.
+		.is-quirks-mode & {
+			display: table;
+		}
 	}
 
 	.edit-post-layout__metaboxes {


### PR DESCRIPTION
**Note: Do not merge this.** This PR is mostly a proof of concept, but it is quite a hack, and one that I feel we shouldn't need or apply. But hopefully opening this PR can start a discussion on what, if anything, we should do instead.

## Preface

Browsers can run in _standards_ mode, or in _quirks_ mode. Usually when a proper `doctype` declaration is present _right at the top of the page_, the browser will render everything in standards mode. Standards mode means that the browser renders modern CSS as it's supposed to be rendered.

However lots of things can trigger what's referred to as "quirks" mode. The usual method is when the `doctype` declaration (`<!DOCTYPE html>`) is missing, or isn't the very first thing in the document. This makes the browser render in a compatibility mode, which is to say the browser doesn't know if it's looking at HTML2, XHTML, HTML4, HTML5, or even just a text document. This compatibility mode tries its best, but often fails to render modern CSS the way it should be. When Gutenberg is loaded in quirks mod, the editor still works, however there are some intricacies of the flexbox CSS we are using for the layout, that break.

## What happens to put Gutenberg in quirks mode?

It seems that in the majority of cases, what triggers quirks mode for Gutenberg, is a PHP warning, or PHP error. These are output as little notices at the top of the page, before the `doctype`. Because of that, quirks mode is initiated because without the `doctype` information, the browser doesn't know how to render the page.

## What then?

It seems obvious that the real fix here is for the developer to address any PHP errors or notices that might have been thrown, this could be by a theme, a plugin, or a metabox. 

But because the notice might be invisible to the user (it is output at the top of the page but hidden by the editor bar or something else), a user or even a developer might not see this error, and therefore not know whether a plugin, theme, or even Gutenberg is to blame for the buggy behavior. This is especially true because Gutenberg almost fully works, even when in quirksmode.

## What does this PR do?

This PR adds a horrendous hack (seriously, we should probably find a different approach, but see this as a proof of concept) that detects whether Gutenberg is being loaded in quirks mode, and then applies an `is-quirks-mode` CSS class to the `body` element. This CSS class is then used to apply a CSS hack that prevents metaboxes from overlapping content in the main editing canvas.

So it's a hack to enable a hack that makes metaboxes not overlap, and makes Gutenberg work _reasonably_ well, despite being in quirks mode.

## What would be a better solution?

Ideally we can figure a way to ensure Gutenberg is always loaded in standards mode. But given the fact that themes and plugins can modify the markup that loads on the Gutenberg editor page, it is just not feasible to ensure this. To put it differently: **Gutenberg can't fix your PHP errors**.

A different solution could be to still detect the quirks mode, but show a notice that says "Gutenberg has detected an error in a plugin, and might not work as intended"... or something to that effect.

Please share your thoughts. 