### PR TITLE
NUX: aria-label  - Rename Gutenberg to Editor

### DIFF
--- a/packages/nux/src/components/dot-tip/index.js
+++ b/packages/nux/src/components/dot-tip/index.js
@@ -38,7 +38,7 @@ export function DotTip( {
 			focusOnMount="container"
 			getAnchorRect={ getAnchorRect }
 			role="dialog"
-			aria-label={ __( 'Gutenberg tips' ) }
+			aria-label={ __( 'Editor tips' ) }
 			onClick={ onClick }
 		>
 			<p>{ children }</p>

--- a/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
@@ -2,7 +2,7 @@
 
 exports[`DotTip should render correctly 1`] = `
 <Popover
-  aria-label="Gutenberg tips"
+  aria-label="Editor tips"
   className="nux-dot-tip"
   focusOnMount="container"
   getAnchorRect={[Function]}


### PR DESCRIPTION
## Description
Renames the NUX aria-label from `Gutenberg tips` to `Editor tips`.
Fixes #12436
