### PR TITLE
Fix: Upload permissions error on end 2 end inline tokens test

### DIFF
--- a/bin/install-wordpress.sh
+++ b/bin/install-wordpress.sh
@@ -77,5 +77,9 @@ fi
 echo -e $(status_message "Activating Gutenberg...")
 docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CLI plugin activate gutenberg >/dev/null
 
+# Make sure the uploads folder exist and we have permissions to add files there.
+docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CONTAINER mkdir -p /var/www/html/wp-content/uploads
+docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CONTAINER chmod -v 767 /var/www/html/wp-content/uploads
+
 # Install a dummy favicon to avoid 404 errors.
 docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CONTAINER touch /var/www/html/favicon.ico

--- a/test/e2e/specs/adding-inline-tokens.test.js
+++ b/test/e2e/specs/adding-inline-tokens.test.js
@@ -21,7 +21,7 @@ describe( 'adding inline tokens', () => {
 		await newPost();
 	} );
 
-	it.skip( 'should insert inline image', async () => {
+	it( 'should insert inline image', async () => {
 		// Create a paragraph.
 		await clickBlockAppender();
 		await page.keyboard.type( 'a ' );


### PR DESCRIPTION
The `adding-inline-tokens.test.js` test was failing on travis, instead of an image upload being successfull we got an error reporting that no permissions exist.

This PR uses 2 commands on the docker container to do the following actions:
Create an uploads folder inside wp-content.
Change the folder  permissions to 766.
766 was choose because according to the hierarchy we should follow when trying to fix permission problems available in https://codex.wordpress.org/Changing_File_Permissions is the most adequate value. The value bellow it (765) does not work.


## How has this been tested?

I checked the end to end tests execute with success on our CI environment more specifically the test/e2e/specs/adding-inline-tokens.test.js test case.