### PR TITLE
Bump the plugin version to 4.6

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -3,7 +3,7 @@
  * Plugin Name: Gutenberg
  * Plugin URI: https://github.com/WordPress/gutenberg
  * Description: Printing since 1440. This is the development plugin for the new block editor in core.
- * Version: 4.5.1
+ * Version: 4.6.0
  * Author: Gutenberg Team
  *
  * @package gutenberg

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "4.5.1",
+	"version": "4.6.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "4.5.1",
+	"version": "4.6.0",
 	"private": true,
 	"description": "A new WordPress editor experience",
 	"repository": "git+https://github.com/WordPress/gutenberg.git",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/block-library",
-	"version": "2.2.7",
+	"version": "2.2.8",
 	"description": "Block library for the WordPress editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/components",
-	"version": "7.0.2",
+	"version": "7.0.3",
 	"description": "UI components for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/edit-post",
-	"version": "3.1.2",
+	"version": "3.1.3",
 	"description": "Edit Post module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/editor",
-	"version": "9.0.2",
+	"version": "9.0.3",
 	"description": "Building blocks for WordPress editors.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/format-library/package.json
+++ b/packages/format-library/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/format-library",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"description": "Format library for the WordPress editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/list-reusable-blocks/package.json
+++ b/packages/list-reusable-blocks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/list-reusable-blocks",
-	"version": "1.1.15",
+	"version": "1.1.16",
 	"description": "Adding Export/Import support to the reusable blocks listing.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/nux/package.json
+++ b/packages/nux/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/nux",
-	"version": "3.0.3",
+	"version": "3.0.4",
 	"description": "NUX (New User eXperience) module for WordPress.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## Changelog

- Fix issue with drag-and-drop in columns.
- Fix TinyMCE list plugin registration.
- Fix IE11 flexbox alignment when min-width is set.
- Fix IE11 focus loss after TinyMCE init. Add IE check.
- Fix getSelectedBlockClientId selector.
- Fix issue where unregistering a block type would cause blocks that convert to it to break.
- Fix Classic block not showing galleries on a grid.
- Fix visual issues with Button block text wrap.
- Fix modals in Edge.
- Fix Categories block filter effect on the front-end.
- Fix an issue where the block toolbar would cause an image to jump downwards when the wide or full - alignments were activated.
- Apply IE11 input fix only when mounting TinyMCE.
- Improve block preview styling.
- Make the Image Link URL field readonly.
- Disable HTML edit from Media & Text block.
- Avoid loading theme editor styles if not existing (RTL languages).
- Improve scoping of nested paragraph right-padding CSS rule.
- Add e2e tests for the format API.
- Merge similar text strings for i18n.
- Move editor specific styles from style.scss to editor.scss in Cover block.
- Simplify sidebar tabs aria-labels.
- Remove onSplit from RichText docs.
- Remove textdomain from the block library.
- Avoid rendering AdminNotices compatibility component.
- Avoid changing default wpautop priority.
- Change @package names to WordPress.
- Update published packages changelogs.