### PR TITLE
Add filter for preview interstitial markup

### DIFF
--- a/docs/designers-developers/developers/filters/editor-filters.md
+++ b/docs/designers-developers/developers/filters/editor-filters.md
@@ -16,3 +16,17 @@ var withImageSize = function( size, mediaId, postId ) {
 wp.hooks.addFilter( 'editor.PostFeaturedImage.imageSize', 'my-plugin/with-image-size', withImageSize );
 ```
 
+### `editor.interstitialMessage`
+
+Filters the interstitial message shown when generating previews.
+
+_Example:_
+
+```js
+var customPreviewMessage = function() {
+    return '<b>Post preview is being generated!</b>';
+};
+
+wp.hooks.addFilter( 'editor.interstitialMessage', 'my-plugin/custom-preview-message', customPreviewMessage );
+```
+

--- a/docs/designers-developers/developers/filters/editor-filters.md
+++ b/docs/designers-developers/developers/filters/editor-filters.md
@@ -16,7 +16,7 @@ var withImageSize = function( size, mediaId, postId ) {
 wp.hooks.addFilter( 'editor.PostFeaturedImage.imageSize', 'my-plugin/with-image-size', withImageSize );
 ```
 
-### `editor.interstitialMessage`
+### `editor.PostPreview.interstitialMarkup`
 
 Filters the interstitial message shown when generating previews.
 
@@ -27,6 +27,6 @@ var customPreviewMessage = function() {
     return '<b>Post preview is being generated!</b>';
 };
 
-wp.hooks.addFilter( 'editor.interstitialMessage', 'my-plugin/custom-preview-message', customPreviewMessage );
+wp.hooks.addFilter( 'editor.PostPreview.interstitialMarkup', 'my-plugin/custom-preview-message', customPreviewMessage );
 ```
 

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -12,6 +12,7 @@ import { __, _x } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { DotTip } from '@wordpress/nux';
 import { ifCondition, compose } from '@wordpress/compose';
+import { applyFilters } from '@wordpress/hooks';
 
 function writeInterstitialMessage( targetDocument ) {
 	let markup = renderToString(
@@ -78,6 +79,13 @@ function writeInterstitialMessage( targetDocument ) {
 			}
 		</style>
 	`;
+
+	/**
+	 * Filters the interstitial message shown when generating previews.
+	 *
+	 * @param {String} markup The preview interstitial markup.
+	 */
+	markup = applyFilters( 'editor.interstitialMessage', markup );
 
 	targetDocument.write( markup );
 	targetDocument.close();

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -85,7 +85,7 @@ function writeInterstitialMessage( targetDocument ) {
 	 *
 	 * @param {String} markup The preview interstitial markup.
 	 */
-	markup = applyFilters( 'editor.interstitialMessage', markup );
+	markup = applyFilters( 'editor.PostPreview.interstitialMarkup', markup );
 
 	targetDocument.write( markup );
 	targetDocument.close();


### PR DESCRIPTION
## Description

This uses `applyFilters` to make the preview interstitial markup filterable.

Fixes #12238.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
