### PR TITLE
Set document title for preview interstitial

### DIFF
--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -80,6 +80,7 @@ function writeInterstitialMessage( targetDocument ) {
 	`;
 
 	targetDocument.write( markup );
+	targetDocument.title = __( 'Generating preview…' );
 	targetDocument.close();
 }
 


### PR DESCRIPTION
## Description

Fixes #12462 by explicitly setting the document title for the preview interstitial.

## How has this been tested?
Tested manually by previewing a post.

## Screenshots

<img width="754" alt="screenshot 2018-11-30 at 13 46 37" src="https://user-images.githubusercontent.com/841956/49290132-691c2200-f4a6-11e8-8246-0d32e91cb990.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
