### PR TITLE
RichText: Reuse document in createElement

### DIFF
--- a/packages/rich-text/src/create-element.js
+++ b/packages/rich-text/src/create-element.js
@@ -1,13 +1,21 @@
 /**
  * Parse the given HTML into a body element.
  *
+ * Note: The current implementation will return a shared reference, reset on
+ * each call to `createElement`. Therefore, you should not hold a reference to
+ * the value to operate upon asynchronously, as it may have unexpected results.
+ *
  * @param {HTMLDocument} document The HTML document to use to parse.
  * @param {string}       html     The HTML to parse.
  *
  * @return {HTMLBodyElement} Body element with parsed HTML.
  */
 export function createElement( { implementation }, html ) {
-	const { body } = implementation.createHTMLDocument( '' );
-	body.innerHTML = html;
-	return body;
+	if ( ! createElement.body ) {
+		createElement.body = implementation.createHTMLDocument( '' ).body;
+	}
+
+	createElement.body.innerHTML = html;
+
+	return createElement.body;
 }

--- a/packages/rich-text/src/test/to-dom.js
+++ b/packages/rich-text/src/test/to-dom.js
@@ -9,11 +9,16 @@ import { JSDOM } from 'jsdom';
  */
 
 import { toDom, applyValue } from '../to-dom';
-import { createElement } from '../create-element';
 import { spec } from './helpers';
 
 const { window } = new JSDOM();
 const { document } = window;
+
+function createElement( { implementation }, html ) {
+	const { body } = implementation.createHTMLDocument( '' );
+	body.innerHTML = html;
+	return body;
+}
 
 describe( 'recordToDom', () => {
 	beforeAll( () => {


### PR DESCRIPTION
## Description
This one is similar to #12402: we should reuse the same document in `createElement` calls. I wonder if we can use the same function in both places. Note that I had to move the old function to the test as it needs to be able to have two references.

Cc @aduth.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
