### PR TITLE
Edit Post: Select blocks only once multiple verified

### DIFF
--- a/packages/edit-post/src/hooks/validate-multiple-use/index.js
+++ b/packages/edit-post/src/hooks/validate-multiple-use/index.js
@@ -33,7 +33,6 @@ const enhance = compose(
 	 * @return {Component} Enhanced component with merged state data props.
 	 */
 	withSelect( ( select, block ) => {
-		const blocks = select( 'core/editor' ).getBlocks();
 		const multiple = hasBlockSupport( block.name, 'multiple', true );
 
 		// For block types with `multiple` support, there is no "original
@@ -44,6 +43,7 @@ const enhance = compose(
 
 		// Otherwise, only pass `originalBlockClientId` if it refers to a different
 		// block from the current one.
+		const blocks = select( 'core/editor' ).getBlocks();
 		const firstOfSameType = find( blocks, ( { name } ) => block.name === name );
 		const isInvalid = firstOfSameType && firstOfSameType.clientId !== block.clientId;
 		return {


### PR DESCRIPTION
Related: #5031

This pull request seeks to optimize the multiple-use validation to avoid calling the `getBlocks` selector until after verifying that a non-multiple-supporting block is present in the post. This should help alleviate some performance bottleneck for a currently-underperforming selector (`getBlocks`), particularly when the the condition will not apply for the vast majority of blocks.

This is effectively a refactoring to reorganize code to only assign a variable value at a point where it is certain to be relevant for use by the remainder of the function. As an aside, it would be very interesting to try to develop a lint rule to verify that a variable is used before the next `return` statement.

**Testing instructions:**

Repeat testing instructions from #5031

Add a `console.count` at the point the `getBlocks` function is called, and verify that it is not called while authoring paragraph content (unlike before).