### PR TITLE
Fix incorrect parens in docs

### DIFF
--- a/packages/components/src/text-control/README.md
+++ b/packages/components/src/text-control/README.md
@@ -13,13 +13,13 @@ import { withState } from '@wordpress/compose';
 
 const MyTextControl = withState( {
 	className: '',
-} )( ( { className, setState } ) => ( 
+} )( ( { className, setState } ) => {
 	<TextControl
 		label="Additional CSS Class"
 		value={ className }
 		onChange={ ( className ) => setState( { className } ) }
 	/>
-) );
+} );
 ```
 
 ## Props


### PR DESCRIPTION
Should be brackets, not parens.
