### PR TITLE
Disable clipboard button in file block during upload

### DIFF
--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -216,6 +216,7 @@ class FileEdit extends Component {
 							className={ `${ className }__copy-url-button` }
 							onCopy={ this.confirmCopyURL }
 							onFinishCopy={ this.resetCopyConfirmation }
+							disabled={ isBlobURL( href ) }
 						>
 							{ showCopyConfirmation ? __( 'Copied!' ) : __( 'Copy URL' ) }
 						</ClipboardButton>


### PR DESCRIPTION
## Description
Fixes #12493 by disabling the clipboard button in the file block while the upload is in progress. This prevents users clicking on the button and copying a blob URL during upload.

## How has this been tested?
Manual testing by following the steps outlined in the issue.

## Types of changes
Bug fix by disabling the button during the upload.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
