### PR TITLE
Don't show "Change Permalinks" button for static front page

### DIFF
--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -1284,6 +1284,18 @@ Returns true if the post is being published, or false otherwise.
 
 Whether post is being published.
 
+### isFrontPage
+
+Returns whether the current page is set as the front page or not.
+
+*Parameters*
+
+ * state: Editor state.
+
+*Returns*
+
+Whether or not the page is set as the front page.
+
 ### isPermalinkEditable
 
 Returns whether the permalink is editable or not.

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -219,6 +219,7 @@ function gutenberg_add_permalink_template_to_posts( $response, $post, $request )
 
 	$response->data['permalink_template'] = $sample_permalink[0];
 	$response->data['generated_slug']     = $sample_permalink[1];
+	$response->data['is_front_page']      = 'page' === get_option( 'show_on_front' ) && $post->ID === (int) get_option( 'page_on_front' );
 
 	return $response;
 }

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -219,7 +219,7 @@ function gutenberg_add_permalink_template_to_posts( $response, $post, $request )
 
 	$response->data['permalink_template'] = $sample_permalink[0];
 	$response->data['generated_slug']     = $sample_permalink[1];
-	$response->data['is_front_page']      = 'page' === get_option( 'show_on_front' ) && $post->ID === (int) get_option( 'page_on_front' );
+	$response->data['is_front_page']      = 'page' === get_option( 'show_on_front' ) && (int) get_option( 'page_on_front' ) === $post->ID;
 
 	return $response;
 }

--- a/packages/editor/src/components/post-permalink/index.js
+++ b/packages/editor/src/components/post-permalink/index.js
@@ -57,7 +57,7 @@ class PostPermalink extends Component {
 	}
 
 	render() {
-		const { isNew, postLink, permalinkParts, postSlug, postTitle, postID, isEditable, isPublished } = this.props;
+		const { isNew, postLink, permalinkParts, postSlug, postTitle, postID, isEditable, isPublished, isFrontPage } = this.props;
 
 		if ( isNew || ! postLink ) {
 			return null;
@@ -112,7 +112,7 @@ class PostPermalink extends Component {
 					</Button>
 				}
 
-				{ ! isEditable &&
+				{ ! isEditable && ! isFrontPage &&
 					<Button
 						className="editor-post-permalink__change"
 						isLarge
@@ -137,6 +137,7 @@ export default compose( [
 			getPermalinkParts,
 			getEditedPostAttribute,
 			isCurrentPostPublished,
+			isFrontPage,
 		} = select( 'core/editor' );
 
 		const { id, link } = getCurrentPost();
@@ -147,6 +148,7 @@ export default compose( [
 			permalinkParts: getPermalinkParts(),
 			postSlug: getEditedPostAttribute( 'slug' ),
 			isEditable: isPermalinkEditable(),
+			isFrontPage: isFrontPage(),
 			isPublished: isCurrentPostPublished(),
 			postTitle: getEditedPostAttribute( 'title' ),
 			postID: id,

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -2143,6 +2143,17 @@ export function isPublishingPost( state ) {
 }
 
 /**
+ * Returns whether the current page is set as the front page or not.
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {boolean} Whether or not the page is set as the front page.
+ */
+export function isFrontPage( state ) {
+	return Boolean( getEditedPostAttribute( state, 'is_front_page' ) );
+}
+
+/**
  * Returns whether the permalink is editable or not.
  *
  * @param {Object} state Editor state.


### PR DESCRIPTION
## Description

Hides the "Change Permalinks" button when editing the page that is set to be the static front page. You can't edit the slug for something that's being accessed via `https://example.com` only.

Fixes #12498.

## How has this been tested?
Tested this manually by changing the static front page settings and editing the page in Gutenberg.

## Screenshots

<img width="462" alt="screenshot 2018-12-01 at 14 43 54" src="https://user-images.githubusercontent.com/841956/49328878-c59b4200-f577-11e8-8f51-01cf3463ce55.png">
<img width="638" alt="screenshot 2018-12-01 at 14 43 40" src="https://user-images.githubusercontent.com/841956/49328879-c633d880-f577-11e8-8376-3fc8fa6b3b51.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
