### PR TITLE
Performance: BlockListAppender: 1.7x increase on key press

### DIFF
--- a/packages/editor/src/components/default-block-appender/index.js
+++ b/packages/editor/src/components/default-block-appender/index.js
@@ -7,7 +7,7 @@ import TextareaAutosize from 'react-autosize-textarea';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { compose } from '@wordpress/compose';
+import { compose, withState } from '@wordpress/compose';
 import { getDefaultBlockName } from '@wordpress/blocks';
 import { decodeEntities } from '@wordpress/html-entities';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -26,6 +26,8 @@ export function DefaultBlockAppender( {
 	showPrompt,
 	placeholder,
 	rootClientId,
+	hovered,
+	setState,
 } ) {
 	if ( isLocked || ! isVisible ) {
 		return null;
@@ -49,7 +51,12 @@ export function DefaultBlockAppender( {
 	// The wp-block className is important for editor styles.
 
 	return (
-		<div data-root-client-id={ rootClientId || '' } className="wp-block editor-default-block-appender">
+		<div
+			data-root-client-id={ rootClientId || '' }
+			className="wp-block editor-default-block-appender"
+			onMouseEnter={ () => setState( { hovered: true } ) }
+			onMouseLeave={ () => setState( { hovered: false } ) }
+		>
 			<BlockDropZone rootClientId={ rootClientId } />
 			<TextareaAutosize
 				role="button"
@@ -59,12 +66,13 @@ export function DefaultBlockAppender( {
 				onFocus={ onAppend }
 				value={ showPrompt ? value : '' }
 			/>
-			<InserterWithShortcuts rootClientId={ rootClientId } />
+			{ hovered && <InserterWithShortcuts rootClientId={ rootClientId } /> }
 			<Inserter position="top right" />
 		</div>
 	);
 }
 export default compose(
+	withState( { hovered: false } ),
 	withSelect( ( select, ownProps ) => {
 		const { getBlockCount, getBlockName, isBlockValid, getEditorSettings, getTemplateLock } = select( 'core/editor' );
 

--- a/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -4,6 +4,8 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
 <div
   className="wp-block editor-default-block-appender"
   data-root-client-id=""
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
   <WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
   <TextareaAutosize
@@ -22,7 +24,6 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
     rows={1}
     value="Start writing or type / to choose a block"
   />
-  <WithSelect(WithDispatch(InserterWithShortcuts)) />
   <WithSelect(IfCondition(Inserter))
     position="top right"
   />
@@ -33,6 +34,8 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
 <div
   className="wp-block editor-default-block-appender"
   data-root-client-id=""
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
   <WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
   <TextareaAutosize
@@ -44,7 +47,6 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
     rows={1}
     value="Start writing or type / to choose a block"
   />
-  <WithSelect(WithDispatch(InserterWithShortcuts)) />
   <WithSelect(IfCondition(Inserter))
     position="top right"
   />
@@ -55,6 +57,8 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
 <div
   className="wp-block editor-default-block-appender"
   data-root-client-id=""
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
   <WithDispatch(WithSelect(WithFilters(BlockDropZone))) />
   <TextareaAutosize
@@ -66,7 +70,6 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
     rows={1}
     value=""
   />
-  <WithSelect(WithDispatch(InserterWithShortcuts)) />
   <WithSelect(IfCondition(Inserter))
     position="top right"
   />


### PR DESCRIPTION
## Description

See #11782. This only has any effect if the main block list OR one of the columns block lists ends in a block other than a paragraph, e.g. a list.

Currently we are adding the "inserter shortcuts", which uses the expensive `getInserterItems` selector. This can get called multiple times on ever key press. 

I changed it so that the shortcuts in the appender are only displayed on hover. They will also be displayed as soon as the appender receives focus. This is the same behaviour as an empty paragraph.

In my testing, this increases performance 1.7x with [this post](https://github.com/WordPress/gutenberg/issues/10418#issuecomment-436431030)! No CPU slowdown and React production. (Previously I accidentally compared a profile with CPU slowdown with one without, which made me think the increase was higher.)

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->