### PR TITLE
Add default block style if missing

### DIFF
--- a/packages/editor/src/components/block-styles/index.js
+++ b/packages/editor/src/components/block-styles/index.js
@@ -11,6 +11,8 @@ import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import TokenList from '@wordpress/token-list';
 import { ENTER, SPACE } from '@wordpress/keycodes';
+import { __ } from '@wordpress/i18n';
+import { getBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -68,11 +70,23 @@ function BlockStyles( {
 	onChangeClassName,
 	name,
 	attributes,
+	type,
 	onSwitch = noop,
 	onHoverClassName = noop,
 } ) {
 	if ( ! styles || styles.length === 0 ) {
 		return null;
+	}
+
+	if ( ! type.styles && ! find( styles, 'isDefault' ) ) {
+		styles = [
+			{
+				name: 'default',
+				label: __( 'Default' ),
+				isDefault: true,
+			},
+			...styles,
+		];
 	}
 
 	const activeStyle = getActiveStyle( styles, className );
@@ -131,12 +145,14 @@ export default compose( [
 		const { getBlock } = select( 'core/editor' );
 		const { getBlockStyles } = select( 'core/blocks' );
 		const block = getBlock( clientId );
+		const blockType = getBlockType( block.name );
 
 		return {
 			name: block.name,
 			attributes: block.attributes,
 			className: block.attributes.className || '',
 			styles: getBlockStyles( block.name ),
+			type: blockType,
 		};
 	} ),
 	withDispatch( ( dispatch, { clientId } ) => {

--- a/packages/editor/src/components/block-styles/index.js
+++ b/packages/editor/src/components/block-styles/index.js
@@ -11,7 +11,7 @@ import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import TokenList from '@wordpress/token-list';
 import { ENTER, SPACE } from '@wordpress/keycodes';
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 import { getBlockType } from '@wordpress/blocks';
 
 /**
@@ -82,7 +82,7 @@ function BlockStyles( {
 		styles = [
 			{
 				name: 'default',
-				label: __( 'Default' ),
+				label: _x( 'Default', 'block style' ),
 				isDefault: true,
 			},
 			...styles,


### PR DESCRIPTION
## Description

This attempts to fix #11613 by adding a default block style if block styles were added to a block which doesn't have any by default.

## How has this been tested?
Only manual testing so far. I could need some assistance if E2E tests or similar are needed.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
