### PR TITLE
Cache createBlock call in isUnmodifiedDefaultBlock

### DIFF
--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -67,5 +67,34 @@ describe( 'block helpers', () => {
 
 			expect( isUnmodifiedDefaultBlock( block ) ).toBe( false );
 		} );
+
+		it( 'should invalidate cache if the default block name changed', () => {
+			registerBlockType( 'core/test-block1', {
+				attributes: {
+					includesDefault1: {
+						type: 'boolean',
+						default: true,
+					},
+				},
+				save: noop,
+				category: 'common',
+				title: 'test block',
+			} );
+			registerBlockType( 'core/test-block2', {
+				attributes: {
+					includesDefault2: {
+						type: 'boolean',
+						default: true,
+					},
+				},
+				save: noop,
+				category: 'common',
+				title: 'test block',
+			} );
+			setDefaultBlockName( 'core/test-block1' );
+			isUnmodifiedDefaultBlock( createBlock( 'core/test-block1' ) );
+			setDefaultBlockName( 'core/test-block2' );
+			expect( isUnmodifiedDefaultBlock( createBlock( 'core/test-block2' ) ) ).toBe( true );
+		} );
 	} );
 } );

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -38,7 +38,15 @@ export function isUnmodifiedDefaultBlock( block ) {
 		return false;
 	}
 
-	// Cache a newly created default block.
+	// Invalidate default block cache if default block name changed.
+	if (
+		isUnmodifiedDefaultBlock.block &&
+		isUnmodifiedDefaultBlock.block.name !== defaultBlockName
+	) {
+		delete isUnmodifiedDefaultBlock.block;
+	}
+
+	// Cache a created default block.
 	if ( ! isUnmodifiedDefaultBlock.block ) {
 		isUnmodifiedDefaultBlock.block = createBlock( defaultBlockName );
 	}

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -38,16 +38,12 @@ export function isUnmodifiedDefaultBlock( block ) {
 		return false;
 	}
 
-	// Invalidate default block cache if default block name changed.
+	// Cache a created default block if no cache exists or the default block
+	// name changed.
 	if (
-		isUnmodifiedDefaultBlock.block &&
+		! isUnmodifiedDefaultBlock.block ||
 		isUnmodifiedDefaultBlock.block.name !== defaultBlockName
 	) {
-		delete isUnmodifiedDefaultBlock.block;
-	}
-
-	// Cache a created default block.
-	if ( ! isUnmodifiedDefaultBlock.block ) {
 		isUnmodifiedDefaultBlock.block = createBlock( defaultBlockName );
 	}
 

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -38,7 +38,12 @@ export function isUnmodifiedDefaultBlock( block ) {
 		return false;
 	}
 
-	const newDefaultBlock = createBlock( defaultBlockName );
+	// Cache a newly created default block.
+	if ( ! isUnmodifiedDefaultBlock.block ) {
+		isUnmodifiedDefaultBlock.block = createBlock( defaultBlockName );
+	}
+
+	const newDefaultBlock = isUnmodifiedDefaultBlock.block;
 	const blockType = getBlockType( defaultBlockName );
 
 	return every( blockType.attributes, ( value, key ) =>


### PR DESCRIPTION
## Description

`createBlock` in `isUnmodifiedDefaultBlock`  is run for _every_ paragraph block in the post on _every_ key press. This PR caches the value so it is only run once per page load.

<img width="904" alt="screen shot 2018-12-02 at 14 18 18" src="https://user-images.githubusercontent.com/4710635/49340219-280a4600-f63d-11e8-9cee-41c537acb72d.png">


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
