### PR TITLE
Replaced "MenuGroup" with "NavigableMenu" in Warning Component. (Fixed:#12503)

### DIFF
--- a/packages/components/src/menu-group/index.js
+++ b/packages/components/src/menu-group/index.js
@@ -35,7 +35,7 @@ export function MenuGroup( {
 			{ label &&
 				<div className="components-menu-group__label" id={ labelId }>{ label }</div>
 			}
-			<NavigableMenu orientation="vertical" aria-labelledby={ labelId }>
+			<NavigableMenu orientation="vertical" aria-labelledby={ label ? labelId : null }>
 				{ children }
 			</NavigableMenu>
 		</div>

--- a/packages/editor/src/components/warning/index.js
+++ b/packages/editor/src/components/warning/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Children } from '@wordpress/element';
-import { Dropdown, IconButton, NavigableMenu, MenuItem } from '@wordpress/components';
+import { Dropdown, IconButton, MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 function Warning( { className, actions, children, secondaryActions } ) {
@@ -40,13 +40,13 @@ function Warning( { className, actions, children, secondaryActions } ) {
 						/>
 					) }
 					renderContent={ () => (
-						<NavigableMenu orientation="vertical" className="editor-warning-menu__content">
+						<MenuGroup>
 							{ secondaryActions.map( ( item, pos ) =>
 								<MenuItem onClick={ item.onClick } key={ pos }>
 									{ item.title }
 								</MenuItem>
 							) }
-						</NavigableMenu>
+						</MenuGroup>
 					) }
 				/>
 			) }

--- a/packages/editor/src/components/warning/index.js
+++ b/packages/editor/src/components/warning/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Children } from '@wordpress/element';
-import { Dropdown, IconButton, MenuGroup, MenuItem } from '@wordpress/components';
+import { Dropdown, IconButton, NavigableMenu, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 function Warning( { className, actions, children, secondaryActions } ) {
@@ -40,13 +40,13 @@ function Warning( { className, actions, children, secondaryActions } ) {
 						/>
 					) }
 					renderContent={ () => (
-						<MenuGroup label={ __( 'More options' ) }>
+						<NavigableMenu orientation="vertical" className="editor-warning-menu__content">
 							{ secondaryActions.map( ( item, pos ) =>
 								<MenuItem onClick={ item.onClick } key={ pos }>
 									{ item.title }
 								</MenuItem>
 							) }
-						</MenuGroup>
+						</NavigableMenu>
 					) }
 				/>
 			) }

--- a/packages/editor/src/components/warning/style.scss
+++ b/packages/editor/src/components/warning/style.scss
@@ -58,7 +58,3 @@
 		transform: rotate(90deg);
 	}
 }
-
-.editor-warning-menu__content {
-	padding: $grid-size - $border-width;
-}

--- a/packages/editor/src/components/warning/style.scss
+++ b/packages/editor/src/components/warning/style.scss
@@ -58,3 +58,7 @@
 		transform: rotate(90deg);
 	}
 }
+
+.editor-warning-menu__content {
+	padding: $grid-size - $border-width;
+}


### PR DESCRIPTION
## Description
Replaced "MenuGroup" with "NavigableMenu" in Warning Component. which get rid of menu group title "More options" and fixes #12503

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots
![editor_warning_popover](https://user-images.githubusercontent.com/10613171/49340509-c1018700-f666-11e8-91a3-14b60d445839.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue)  -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
