### PR TITLE
Remove aria-expanded from RichText

### DIFF
--- a/packages/block-library/src/button/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/button/test/__snapshots__/index.js.snap
@@ -16,7 +16,6 @@ exports[`core/button block edit matches snapshot 1`] = `
           >
             <div
               aria-autocomplete="list"
-              aria-expanded="false"
               aria-label="Add text…"
               aria-multiline="true"
               class="wp-block-button__link editor-rich-text__tinymce"

--- a/packages/block-library/src/heading/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/heading/test/__snapshots__/index.js.snap
@@ -11,7 +11,6 @@ exports[`core/heading block edit matches snapshot 1`] = `
       >
         <h2
           aria-autocomplete="list"
-          aria-expanded="false"
           aria-label="Write heading…"
           aria-multiline="true"
           class="editor-rich-text__tinymce"

--- a/packages/block-library/src/list/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/list/test/__snapshots__/index.js.snap
@@ -11,7 +11,6 @@ exports[`core/list block edit matches snapshot 1`] = `
       >
         <ul
           aria-autocomplete="list"
-          aria-expanded="false"
           aria-label="Write list…"
           aria-multiline="true"
           class="editor-rich-text__tinymce"

--- a/packages/block-library/src/paragraph/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/paragraph/test/__snapshots__/index.js.snap
@@ -13,7 +13,6 @@ exports[`core/paragraph block edit matches snapshot 1`] = `
         >
           <p
             aria-autocomplete="list"
-            aria-expanded="false"
             aria-label="Empty block; start writing or type forward slash to choose a block"
             aria-multiline="true"
             class="wp-block-paragraph editor-rich-text__tinymce"

--- a/packages/block-library/src/preformatted/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/preformatted/test/__snapshots__/index.js.snap
@@ -11,7 +11,6 @@ exports[`core/preformatted block edit matches snapshot 1`] = `
       >
         <pre
           aria-autocomplete="list"
-          aria-expanded="false"
           aria-label="Write preformatted text…"
           aria-multiline="true"
           class="editor-rich-text__tinymce"

--- a/packages/block-library/src/pullquote/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/pullquote/test/__snapshots__/index.js.snap
@@ -15,7 +15,6 @@ exports[`core/pullquote block edit matches snapshot 1`] = `
           >
             <div
               aria-autocomplete="list"
-              aria-expanded="false"
               aria-label="Write quote…"
               aria-multiline="true"
               class="editor-rich-text__tinymce"

--- a/packages/block-library/src/quote/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/quote/test/__snapshots__/index.js.snap
@@ -14,7 +14,6 @@ exports[`core/quote block edit matches snapshot 1`] = `
         >
           <div
             aria-autocomplete="list"
-            aria-expanded="false"
             aria-label="Write quote…"
             aria-multiline="true"
             class="editor-rich-text__tinymce"

--- a/packages/block-library/src/text-columns/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/text-columns/test/__snapshots__/index.js.snap
@@ -17,7 +17,6 @@ exports[`core/text-columns block edit matches snapshot 1`] = `
           >
             <p
               aria-autocomplete="list"
-              aria-expanded="false"
               aria-label="New Column"
               aria-multiline="true"
               class="editor-rich-text__tinymce"
@@ -52,7 +51,6 @@ exports[`core/text-columns block edit matches snapshot 1`] = `
           >
             <p
               aria-autocomplete="list"
-              aria-expanded="false"
               aria-label="New Column"
               aria-multiline="true"
               class="editor-rich-text__tinymce"

--- a/packages/block-library/src/verse/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/verse/test/__snapshots__/index.js.snap
@@ -11,7 +11,6 @@ exports[`core/verse block edit matches snapshot 1`] = `
       >
         <pre
           aria-autocomplete="list"
-          aria-expanded="false"
           aria-label="Write…"
           aria-multiline="true"
           class="editor-rich-text__tinymce"

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -858,7 +858,7 @@ export class RichText extends Component {
 					record={ record }
 					onChange={ this.onChange }
 				>
-					{ ( { isExpanded, listBoxId, activeId } ) => (
+					{ ( { listBoxId, activeId } ) => (
 						<Fragment>
 							<TinyMCE
 								tagName={ Tagname }
@@ -869,7 +869,6 @@ export class RichText extends Component {
 								isPlaceholderVisible={ isPlaceholderVisible }
 								aria-label={ placeholder }
 								aria-autocomplete="list"
-								aria-expanded={ isExpanded }
 								aria-owns={ listBoxId }
 								aria-activedescendant={ activeId }
 								{ ...ariaProps }


### PR DESCRIPTION
## Description
This PR seeks to fix invalid HTML and invalid ARIA properties in the RichText component by removing the `aria-expanded` attribute. For more details, please see the related issue.

Fixes #12523 