### PR TITLE
Added list-format-toolbar class to identify the list toolbar

### DIFF
--- a/packages/editor/src/components/rich-text/list-edit.js
+++ b/packages/editor/src/components/rich-text/list-edit.js
@@ -70,52 +70,54 @@ export const ListEdit = ( { editor, onTagNameChange, tagName, onSyncDOM } ) => (
 			} }
 		/>
 		<BlockFormatControls>
-			<Toolbar
-				controls={ [
-					{
-						icon: 'editor-ul',
-						title: __( 'Convert to unordered list' ),
-						isActive: isActiveListType( editor, 'ul', tagName ),
-						onClick() {
-							if ( isListRootSelected( editor ) ) {
-								onTagNameChange( 'ul' );
-							} else {
-								editor.execCommand( 'InsertUnorderedList' );
+			<div className="list-format-toolbar">
+				<Toolbar
+					controls={ [
+						{
+							icon: 'editor-ul',
+							title: __( 'Convert to unordered list' ),
+							isActive: isActiveListType( editor, 'ul', tagName ),
+							onClick() {
+								if ( isListRootSelected( editor ) ) {
+									onTagNameChange( 'ul' );
+								} else {
+									editor.execCommand( 'InsertUnorderedList' );
+									onSyncDOM();
+								}
+							},
+						},
+						{
+							icon: 'editor-ol',
+							title: __( 'Convert to ordered list' ),
+							isActive: isActiveListType( editor, 'ol', tagName ),
+							onClick() {
+								if ( isListRootSelected( editor ) ) {
+									onTagNameChange( 'ol' );
+								} else {
+									editor.execCommand( 'InsertOrderedList' );
+									onSyncDOM();
+								}
+							},
+						},
+						{
+							icon: 'editor-outdent',
+							title: __( 'Outdent list item' ),
+							onClick() {
+								editor.execCommand( 'Outdent' );
 								onSyncDOM();
-							}
+							},
 						},
-					},
-					{
-						icon: 'editor-ol',
-						title: __( 'Convert to ordered list' ),
-						isActive: isActiveListType( editor, 'ol', tagName ),
-						onClick() {
-							if ( isListRootSelected( editor ) ) {
-								onTagNameChange( 'ol' );
-							} else {
-								editor.execCommand( 'InsertOrderedList' );
+						{
+							icon: 'editor-indent',
+							title: __( 'Indent list item' ),
+							onClick() {
+								editor.execCommand( 'Indent' );
 								onSyncDOM();
-							}
+							},
 						},
-					},
-					{
-						icon: 'editor-outdent',
-						title: __( 'Outdent list item' ),
-						onClick() {
-							editor.execCommand( 'Outdent' );
-							onSyncDOM();
-						},
-					},
-					{
-						icon: 'editor-indent',
-						title: __( 'Indent list item' ),
-						onClick() {
-							editor.execCommand( 'Indent' );
-							onSyncDOM();
-						},
-					},
-				] }
-			/>
+					] }
+				/>
+			</div>
 		</BlockFormatControls>
 	</Fragment>
 );

--- a/packages/editor/src/components/rich-text/list-edit.js
+++ b/packages/editor/src/components/rich-text/list-edit.js
@@ -70,54 +70,53 @@ export const ListEdit = ( { editor, onTagNameChange, tagName, onSyncDOM } ) => (
 			} }
 		/>
 		<BlockFormatControls>
-			<div className="list-format-toolbar">
-				<Toolbar
-					controls={ [
-						{
-							icon: 'editor-ul',
-							title: __( 'Convert to unordered list' ),
-							isActive: isActiveListType( editor, 'ul', tagName ),
-							onClick() {
-								if ( isListRootSelected( editor ) ) {
-									onTagNameChange( 'ul' );
-								} else {
-									editor.execCommand( 'InsertUnorderedList' );
-									onSyncDOM();
-								}
-							},
-						},
-						{
-							icon: 'editor-ol',
-							title: __( 'Convert to ordered list' ),
-							isActive: isActiveListType( editor, 'ol', tagName ),
-							onClick() {
-								if ( isListRootSelected( editor ) ) {
-									onTagNameChange( 'ol' );
-								} else {
-									editor.execCommand( 'InsertOrderedList' );
-									onSyncDOM();
-								}
-							},
-						},
-						{
-							icon: 'editor-outdent',
-							title: __( 'Outdent list item' ),
-							onClick() {
-								editor.execCommand( 'Outdent' );
+			<Toolbar
+				className="editor-rich-text__list-format-toolbar"
+				controls={ [
+					{
+						icon: 'editor-ul',
+						title: __( 'Convert to unordered list' ),
+						isActive: isActiveListType( editor, 'ul', tagName ),
+						onClick() {
+							if ( isListRootSelected( editor ) ) {
+								onTagNameChange( 'ul' );
+							} else {
+								editor.execCommand( 'InsertUnorderedList' );
 								onSyncDOM();
-							},
+							}
 						},
-						{
-							icon: 'editor-indent',
-							title: __( 'Indent list item' ),
-							onClick() {
-								editor.execCommand( 'Indent' );
+					},
+					{
+						icon: 'editor-ol',
+						title: __( 'Convert to ordered list' ),
+						isActive: isActiveListType( editor, 'ol', tagName ),
+						onClick() {
+							if ( isListRootSelected( editor ) ) {
+								onTagNameChange( 'ol' );
+							} else {
+								editor.execCommand( 'InsertOrderedList' );
 								onSyncDOM();
-							},
+							}
 						},
-					] }
-				/>
-			</div>
+					},
+					{
+						icon: 'editor-outdent',
+						title: __( 'Outdent list item' ),
+						onClick() {
+							editor.execCommand( 'Outdent' );
+							onSyncDOM();
+						},
+					},
+					{
+						icon: 'editor-indent',
+						title: __( 'Indent list item' ),
+						onClick() {
+							editor.execCommand( 'Indent' );
+							onSyncDOM();
+						},
+					},
+				] }
+			/>
 		</BlockFormatControls>
 	</Fragment>
 );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Added a class to identify the list formatting toolbar visible when editing lists in RichText.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Wrapped the list formatting toolbar inside a div with a class in order to identify the toolbar, similar to how the normal editor formatting toolbar can be identified with its class.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

Note: This is my first tiny contribution :)