### PR TITLE
Preformatted block: theme.scss wrong selector

### DIFF
--- a/packages/block-library/src/preformatted/theme.scss
+++ b/packages/block-library/src/preformatted/theme.scss
@@ -1,7 +1,5 @@
 .wp-block-preformatted {
-	pre {
-		font-family: $editor-html-font;
-		font-size: $text-editor-font-size;
-		color: $dark-gray-800;
-	}
+	font-family: $editor-html-font;
+	font-size: $text-editor-font-size;
+	color: $dark-gray-800;
 }


### PR DESCRIPTION
## Description
While in the editor the Preformatted block is rendered in a container element with a CSS class `wp-block-preformatted` which wraps a `<pre>` element, in the front-end the `<pre>` element itself has the class `wp-block-preformatted`. 

## How has this been tested?
Create Preformatted block and check on frontend if the styles are applied to `<pre class="wp-block-preformatted">`.

## Types of changes
Removed the nested pre element selector from theme.scss.
Fixes #12520.

## Checklist:
- [x ] My code is tested.
- [ x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
