### PR TITLE
Fix issue where default appender has icons overlaying the text

### DIFF
--- a/packages/block-library/src/paragraph/editor.scss
+++ b/packages/block-library/src/paragraph/editor.scss
@@ -1,6 +1,11 @@
 // Specific to the empty paragraph placeholder:
-// when shown on mobile and in nested contexts, the plus to add blocks shows up on the right.
+// when shown on mobile and in nested contexts, on or more icons show up on the right.
 // This padding makes sure it doesn't overlap text.
 .editor-rich-text__tinymce[data-is-placeholder-visible="true"] + .editor-rich-text__tinymce.wp-block-paragraph {
-	padding-right: $icon-button-size;
+	padding-right: $icon-button-size * 3;
+
+	// In nested contexts only one icon shows up.
+	.wp-block .wp-block & {
+		padding-right: $icon-button-size;
+	}
 }

--- a/packages/block-library/src/paragraph/editor.scss
+++ b/packages/block-library/src/paragraph/editor.scss
@@ -1,5 +1,5 @@
 // Specific to the empty paragraph placeholder:
-// when shown on mobile and in nested contexts, on or more icons show up on the right.
+// when shown on mobile and in nested contexts, one or more icons show up on the right.
 // This padding makes sure it doesn't overlap text.
 .editor-rich-text__tinymce[data-is-placeholder-visible="true"] + .editor-rich-text__tinymce.wp-block-paragraph {
 	padding-right: $icon-button-size * 3;


### PR DESCRIPTION
This fixes #11425.

It adds padding to the right of the default block appender to fit 3 icons.

<img width="881" alt="screenshot 2018-12-03 at 11 10 43" src="https://user-images.githubusercontent.com/1204802/49367512-9a862f00-f6ec-11e8-87ca-eae0f19b1289.png">
