### PR TITLE
Update style.scss to fix range slider display

### DIFF
--- a/packages/components/src/range-control/style.scss
+++ b/packages/components/src/range-control/style.scss
@@ -17,7 +17,6 @@
 	}
 
 	.components-range-control__slider {
-		margin-left: 0;
 		flex: 1;
 	}
 }


### PR DESCRIPTION
## Description

This is overriding line 43 which specifies the margin-left via the $grid-size. Having this set to 0 gives the range slider no width and the slider does not display correctly.

## How has this been tested?
Tested on the latest Gutenberg - Version 4.6.1

## Screenshots <!-- if applicable -->
What it currently looks like
<img width="280" alt="screen shot 2018-12-03 at 9 50 00 pm" src="https://user-images.githubusercontent.com/5935028/49369394-6d199f80-f745-11e8-9e30-013161ecd7b6.png">

What it should look like
<img width="281" alt="screen shot 2018-12-03 at 9 49 47 pm" src="https://user-images.githubusercontent.com/5935028/49369408-77d43480-f745-11e8-8812-f461801ec31c.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
