### PR TITLE
Merge similar strings

### DIFF
--- a/packages/editor/src/components/url-input/index.js
+++ b/packages/editor/src/components/url-input/index.js
@@ -198,7 +198,7 @@ class URLInput extends Component {
 				if ( this.state.selectedSuggestion !== null ) {
 					this.selectLink( post );
 					// Announce a link has been selected when tabbing away from the input field.
-					this.props.speak( __( 'Link selected' ) );
+					this.props.speak( __( 'Link selected.' ) );
 				}
 				break;
 			}

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -217,7 +217,7 @@ class InlineLinkUI extends Component {
 		} else if ( isActive ) {
 			speak( __( 'Link edited.' ), 'assertive' );
 		} else {
-			speak( __( 'Link inserted' ), 'assertive' );
+			speak( __( 'Link inserted.' ), 'assertive' );
 		}
 	}
 


### PR DESCRIPTION
In #10838, speak messages were changed to match Classic Editor. However, they do not match since messages in Classic Editor end with full stop ([see](https://core.trac.wordpress.org/browser/branches/5.0/src/wp-includes/script-loader.php?rev=43958#L1241)). Third message, that is introduced here, uses full stop (`Link edited.`).

We should match behaviour in Classic Editor, or change both messages in Classic Editor and message that is new here.

