### PR TITLE
Optimize isViewportMatch

### DIFF
--- a/packages/viewport/src/store/selectors.js
+++ b/packages/viewport/src/store/selectors.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { takeRight } from 'lodash';
-
-/**
  * Returns true if the viewport matches the given query, or false otherwise.
  *
  * @param {Object} state Viewport state object.
@@ -20,9 +15,10 @@ import { takeRight } from 'lodash';
  * @return {boolean} Whether viewport matches query.
  */
 export function isViewportMatch( state, query ) {
-	// Pad to _at least_ two elements to take from the right, effectively
-	// defaulting the left-most value.
-	const key = takeRight( [ '>=', ...query.split( ' ' ) ], 2 ).join( ' ' );
+	// Default to `>=` if no operator is present.
+	if ( query.indexOf( ' ' ) === -1 ) {
+		query = '>= ' + query;
+	}
 
-	return !! state[ key ];
+	return !! state[ query ];
 }


### PR DESCRIPTION
## Description

`isViewportMatch` gets called countless times on every key press. While it's a relatively small calculation, it quickly adds up taking more time. This PR optimizes the calculation by using `String.prototype.indexOf` and a conditional string concatenation instead of Lodash's `takeRight`, `Array.prototype.split` and `Array.prototype.join`.

In my testing on a big post, this reduces the work done on a key press by 1-2%.

I saw several of these in a single key press event:

<img width="275" alt="screen shot 2018-12-03 at 13 38 58" src="https://user-images.githubusercontent.com/4710635/49374180-d3c89a00-f700-11e8-89bf-61bbf4285f07.png">


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->