### PR TITLE
Editor: Fix regression introduced in CopyHandler

### DIFF
--- a/packages/editor/src/components/copy-handler/index.js
+++ b/packages/editor/src/components/copy-handler/index.js
@@ -8,31 +8,14 @@ import { withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
 class CopyHandler extends Component {
-	constructor() {
-		super( ...arguments );
-
-		this.onCopy = this.onCopy.bind( this );
-		this.onCut = this.onCut.bind( this );
-	}
-
 	componentDidMount() {
-		document.addEventListener( 'copy', this.onCopy );
-		document.addEventListener( 'cut', this.onCut );
+		document.addEventListener( 'copy', this.props.onCopy );
+		document.addEventListener( 'cut', this.props.onCut );
 	}
 
 	componentWillUnmount() {
-		document.removeEventListener( 'copy', this.onCopy );
-		document.removeEventListener( 'cut', this.onCut );
-	}
-
-	onCopy( event ) {
-		this.props.onCopy( event.clipboardData );
-		event.preventDefault();
-	}
-
-	onCut( event ) {
-		this.props.onCut( event.clipboardData );
-		event.preventDefault();
+		document.removeEventListener( 'copy', this.props.onCopy );
+		document.removeEventListener( 'cut', this.props.onCut );
 	}
 
 	render() {
@@ -54,7 +37,7 @@ export default compose( [
 		const selectedBlockClientIds = selectedBlockClientId ? [ selectedBlockClientId ] : getMultiSelectedBlockClientIds();
 
 		return {
-			onCopy( dataTransfer ) {
+			onCopy( event ) {
 				if ( selectedBlockClientIds.length === 0 ) {
 					return;
 				}
@@ -66,11 +49,13 @@ export default compose( [
 
 				const serialized = serialize( getBlocksByClientId( selectedBlockClientIds ) );
 
-				dataTransfer.setData( 'text/plain', serialized );
-				dataTransfer.setData( 'text/html', serialized );
+				event.clipboardData.setData( 'text/plain', serialized );
+				event.clipboardData.setData( 'text/html', serialized );
+
+				event.preventDefault();
 			},
-			onCut( dataTransfer ) {
-				this.onCopy( dataTransfer );
+			onCut( event ) {
+				this.onCopy( event );
 
 				if ( hasMultiSelection() ) {
 					removeBlocks( selectedBlockClientIds );

--- a/packages/editor/src/components/copy-handler/index.js
+++ b/packages/editor/src/components/copy-handler/index.js
@@ -8,14 +8,21 @@ import { withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
 class CopyHandler extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.onCopy = ( event ) => this.props.onCopy( event );
+		this.onCut = ( event ) => this.props.onCut( event );
+	}
+
 	componentDidMount() {
-		document.addEventListener( 'copy', this.props.onCopy );
-		document.addEventListener( 'cut', this.props.onCut );
+		document.addEventListener( 'copy', this.onCopy );
+		document.addEventListener( 'cut', this.onCut );
 	}
 
 	componentWillUnmount() {
-		document.removeEventListener( 'copy', this.props.onCopy );
-		document.removeEventListener( 'cut', this.props.onCut );
+		document.removeEventListener( 'copy', this.onCopy );
+		document.removeEventListener( 'cut', this.onCut );
 	}
 
 	render() {
@@ -33,31 +40,38 @@ export default compose( [
 		} = select( 'core/editor' );
 		const { removeBlocks } = dispatch( 'core/editor' );
 
-		const selectedBlockClientId = getSelectedBlockClientId();
-		const selectedBlockClientIds = selectedBlockClientId ? [ selectedBlockClientId ] : getMultiSelectedBlockClientIds();
+		const onCopy = ( event ) => {
+			const selectedBlockClientIds = getSelectedBlockClientId() ?
+				[ getSelectedBlockClientId() ] :
+				getMultiSelectedBlockClientIds();
+
+			if ( selectedBlockClientIds.length === 0 ) {
+				return;
+			}
+
+			// Let native copy behaviour take over in input fields.
+			if ( ! hasMultiSelection() && documentHasSelection() ) {
+				return;
+			}
+
+			const serialized = serialize( getBlocksByClientId( selectedBlockClientIds ) );
+
+			event.clipboardData.setData( 'text/plain', serialized );
+			event.clipboardData.setData( 'text/html', serialized );
+
+			event.preventDefault();
+		};
 
 		return {
-			onCopy( event ) {
-				if ( selectedBlockClientIds.length === 0 ) {
-					return;
-				}
-
-				// Let native copy behaviour take over in input fields.
-				if ( ! hasMultiSelection() && documentHasSelection() ) {
-					return;
-				}
-
-				const serialized = serialize( getBlocksByClientId( selectedBlockClientIds ) );
-
-				event.clipboardData.setData( 'text/plain', serialized );
-				event.clipboardData.setData( 'text/html', serialized );
-
-				event.preventDefault();
-			},
+			onCopy,
 			onCut( event ) {
-				this.onCopy( event );
+				onCopy( event );
 
 				if ( hasMultiSelection() ) {
+					const selectedBlockClientIds = getSelectedBlockClientId() ?
+						[ getSelectedBlockClientId() ] :
+						getMultiSelectedBlockClientIds();
+
 					removeBlocks( selectedBlockClientIds );
 				}
 			},


### PR DESCRIPTION
## Description

Fixes #12506.

Regression introduced in #11851.

Reported by @afercia:

> - go in any post
> - select some text in a block editable area, either with mouse or keyboard doesn't matter, and try to paste it in another block or in an external editor
> - nothing happens (if you have previous content in your clipboard, that will be pasted)
> - try to cut text: nothing happens
> - try also in the post title: same as above
> - try also with an embed, for example a vimeo embed: paste `https://vimeo.com/22439234` then edit it e.g. remove a few numbers, copy, paste it: the previous full URL get pasted
> - try to cut the vimeo URL: nothing happens
> - try even to select some text in the editor UI, outside of any block, for example the paragraph block description:
> 
> <img width="301" alt="screenshot 2018-12-01 at 17 49 27" src="https://user-images.githubusercontent.com/1682452/49331740-6868b600-f5a2-11e8-9aa7-5460fb62ee7b.png">
> 
> - copy and paste it: same as above
> - switch to Code Editor mode: everything works normally
> 
> Basically any basic Copy / Cut operation in the Visual Editor is currently broken.

Initially, I tried to fix it by returning the information whether copy handler override was triggered but it is not possible to return a value from the dispatch handler exposed by `withDispatch`. It seems like a design decision?

I ended up with moving `event` handling to the handlers created in `withDispatch` which removes some lines of code. I know that @aduth wanted to avoid that in #11851 as discussed in https://github.com/WordPress/gutenberg/pull/11851#discussion_r236743156. An alternative would be to move event handling to the callback. I'm happy to iterate if you think it'd be cleaner. 

## How has this been tested?
- go to any post
- select some text in a block editable area, either with mouse or keyboard doesn't matter, and try to paste it in another block or in an external editor
- try to cut text
- try also in the post title
- try also with an embed, for example a vimeo embed: paste `https://vimeo.com/22439234` then edit it e.g. remove a few numbers, copy, paste it: the previous full URL get pasted
- try to cut the vimeo URL
- try even to select some text in the editor UI, outside of any block, for example the paragraph block description:

<img width="301" alt="screenshot 2018-12-01 at 17 49 27" src="https://user-images.githubusercontent.com/1682452/49331740-6868b600-f5a2-11e8-9aa7-5460fb62ee7b.png">

- copy and paste it
- switch to Code Editor mode

All of that should basically work.