### PR TITLE
RichText: only replace range and nodes if different

### DIFF
--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -247,6 +247,16 @@ export function applyValue( future, current ) {
 	}
 }
 
+/**
+ * Returns true if two ranges are equal, or false otherwise. Ranges are
+ * considered equal if their start and end occur in the same container and
+ * offset.
+ *
+ * @param {Range} a First range object to test.
+ * @param {Range} b First range object to test.
+ *
+ * @return {boolean} Whether the two ranges are equal.
+ */
 function isRangeEqual( a, b ) {
 	return (
 		a.startContainer === b.startContainer &&

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -292,11 +292,15 @@ export function applySelection( selection, current ) {
 		range.setEnd( endContainer, endOffset );
 	}
 
-	// If ranges the live range is the same, there's no need to remove and add.
-	if ( isRangeEqual( range, windowSelection.getRangeAt( 0 ) ) ) {
-		return;
+	if ( windowSelection.rangeCount > 0 ) {
+		// If the to be added range and the live range are the same, there's no
+		// need to remove the live range and add the equivalent range.
+		if ( isRangeEqual( range, windowSelection.getRangeAt( 0 ) ) ) {
+			return;
+		}
+
+		windowSelection.removeAllRanges();
 	}
 
-	windowSelection.removeAllRanges();
 	windowSelection.addRange( range );
 }

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -251,6 +251,15 @@ export function applyValue( future, current ) {
 	}
 }
 
+function isRangeEqual( a, b ) {
+	return (
+		a.startContainer === b.startContainer &&
+		a.startOffset === b.startOffset &&
+		a.endContainer === b.endContainer &&
+		a.endOffset === b.endOffset
+	);
+}
+
 export function applySelection( selection, current ) {
 	const { node: startContainer, offset: startOffset } = getNodeByPath( current, selection.startPath );
 	const { node: endContainer, offset: endOffset } = getNodeByPath( current, selection.endPath );
@@ -281,6 +290,11 @@ export function applySelection( selection, current ) {
 	} else {
 		range.setStart( startContainer, startOffset );
 		range.setEnd( endContainer, endOffset );
+	}
+
+	// If ranges the live range is the same, there's no need to remove and add.
+	if ( isRangeEqual( range, windowSelection.getRangeAt( 0 ) ) ) {
+		return;
 	}
 
 	windowSelection.removeAllRanges();

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -226,21 +226,17 @@ export function apply( {
 
 export function applyValue( future, current ) {
 	let i = 0;
+	let futureChild;
 
-	while ( future.firstChild ) {
+	while ( ( futureChild = future.firstChild ) ) {
 		const currentChild = current.childNodes[ i ];
-		const futureNodeType = future.firstChild.nodeType;
 
 		if ( ! currentChild ) {
-			current.appendChild( future.firstChild );
-		} else if (
-			futureNodeType !== currentChild.nodeType ||
-			futureNodeType !== TEXT_NODE ||
-			future.firstChild.nodeValue !== currentChild.nodeValue
-		) {
-			current.replaceChild( future.firstChild, currentChild );
+			current.appendChild( futureChild );
+		} else if ( ! currentChild.isEqualNode( futureChild ) ) {
+			current.replaceChild( futureChild, currentChild );
 		} else {
-			future.removeChild( future.firstChild );
+			future.removeChild( futureChild );
 		}
 
 		i++;

--- a/test/e2e/specs/__snapshots__/rich-text.test.js.snap
+++ b/test/e2e/specs/__snapshots__/rich-text.test.js.snap
@@ -24,6 +24,12 @@ exports[`RichText should handle change in tag name gracefully 1`] = `
 <!-- /wp:heading -->"
 `;
 
+exports[`RichText should only mutate text data on input 1`] = `
+"<!-- wp:paragraph -->
+<p>1<strong>2</strong>34</p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`RichText should transform backtick to code 1`] = `
 "<!-- wp:paragraph -->
 <p>A <code>backtick</code></p>

--- a/test/e2e/specs/rich-text.test.js
+++ b/test/e2e/specs/rich-text.test.js
@@ -87,11 +87,7 @@ describe( 'RichText', () => {
 			};
 
 			const mutationObserver = new MutationObserver( ( records ) => {
-				if ( called ) {
-					throw new Error( 'Typing should only mutate once.' );
-				}
-
-				if ( records.length > 1 ) {
+				if ( called || records.length > 1 ) {
 					throw new Error( 'Typing should only mutate once.' );
 				}
 


### PR DESCRIPTION
## Description

When the selection that needs to be set is the same as the live selection, we shouldn't remove all ranges and add it again. When nodes that need to be set are equal, we also shouldn't replace them.

Decreases work done on a key press by about 10%.

Eliminates 2 extra selection change events some browsers emit even though they are emitted after a series of changes (so the selection stays the same during those emissions).

Eliminates extra layout and style recalculation.

<img width="750" alt="screen shot 2018-12-03 at 14 36 00" src="https://user-images.githubusercontent.com/4710635/49376815-ce6f4d80-f708-11e8-949c-da7a2d3e274b.png">

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->