### PR TITLE
Testing: add e2e test for the HTML block

### DIFF
--- a/test/e2e/specs/blocks/__snapshots__/html.test.js.snap
+++ b/test/e2e/specs/blocks/__snapshots__/html.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HTML can be created by typing "/html" 1`] = `
+exports[`HTML block can be created by typing "/html" 1`] = `
 "<!-- wp:html -->
 <p>Pythagorean theorem: 
 <var>a</var><sup>2</sup> + <var>b</var><sup>2</sup> = <var>c</var><sup>2</sup> </p>

--- a/test/e2e/specs/blocks/__snapshots__/html.test.js.snap
+++ b/test/e2e/specs/blocks/__snapshots__/html.test.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HTML can be created by typing "/html" 1`] = `
+"<!-- wp:html -->
+<p>Pythagorean theorem: 
+<var>a</var><sup>2</sup> + <var>b</var><sup>2</sup> = <var>c</var><sup>2</sup> </p>
+<!-- /wp:html -->"
+`;

--- a/test/e2e/specs/blocks/html.test.js
+++ b/test/e2e/specs/blocks/html.test.js
@@ -7,7 +7,7 @@ import {
 	newPost,
 } from '../../support/utils';
 
-describe( 'HTML', () => {
+describe( 'HTML block', () => {
 	beforeEach( async () => {
 		await newPost();
 	} );

--- a/test/e2e/specs/blocks/html.test.js
+++ b/test/e2e/specs/blocks/html.test.js
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import {
+	clickBlockAppender,
+	getEditedPostContent,
+	newPost,
+} from '../../support/utils';
+
+describe( 'HTML', () => {
+	beforeEach( async () => {
+		await newPost();
+	} );
+
+	it( 'can be created by typing "/html"', async () => {
+		// Create a Custom HTML block with the slash shortcut.
+		await clickBlockAppender();
+		await page.keyboard.type( '/html' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '<p>Pythagorean theorem: ' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '<var>a</var><sup>2</sup> + <var>b</var><sup>2</sup> = <var>c</var><sup>2</sup> </p>' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
## Description
This PR adds a basic test for the Custom HTML block.

## How has this been tested?
`npm run test-e2e`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. 
- [x] My code follows the accessibility standards. 
- [x] My code has proper inline documentation. 