### PR TITLE
Stop using classname-to-style autotransform in react native

### DIFF
--- a/packages/block-library/src/more/edit.native.js
+++ b/packages/block-library/src/more/edit.native.js
@@ -21,11 +21,11 @@ export default function MoreEdit( props ) {
 	const value = customText !== undefined ? customText : defaultText;
 
 	return (
-		<View className={ styles[ 'block-library-more__container' ] }>
-			<View className={ styles[ 'block-library-more__sub-container' ] }>
-				<Text className={ styles[ 'block-library-more__left-marker' ] }>&lt;!--</Text>
+		<View style={ styles[ 'block-library-more__container' ] }>
+			<View style={ styles[ 'block-library-more__sub-container' ] }>
+				<Text style={ styles[ 'block-library-more__left-marker' ] }>&lt;!--</Text>
 				<PlainText
-					className={ styles[ 'block-library-more__plain-text' ] }
+					style={ styles[ 'block-library-more__plain-text' ] }
 					value={ value }
 					multiline={ true }
 					underlineColorAndroid="transparent"
@@ -35,7 +35,7 @@ export default function MoreEdit( props ) {
 					onFocus={ onFocus }
 					onBlur={ onBlur }
 				/>
-				<Text className={ styles[ 'block-library-more__right-marker' ] }>--&gt;</Text>
+				<Text style={ styles[ 'block-library-more__right-marker' ] }>--&gt;</Text>
 			</View>
 		</View> );
 }

--- a/packages/block-library/src/nextpage/edit.native.js
+++ b/packages/block-library/src/nextpage/edit.native.js
@@ -18,7 +18,7 @@ export default function NextPageEdit( { attributes } ) {
 	const { customText = __( 'Page break' ) } = attributes;
 
 	return (
-		<View className={ styles[ 'block-library-nextpage__container' ] }>
+		<View style={ styles[ 'block-library-nextpage__container' ] }>
 			<Hr text={ customText }
 				textStyle={ styles[ 'block-library-nextpage__text' ] }
 				lineStyle={ styles[ 'block-library-nextpage__line' ] } />


### PR DESCRIPTION
## Description
At some point, we added the `react-native-classname-to-style` babel transform to transform `className` jsx attributes into style. This causes problems as it's also transformed in the blocks `save` function. A better approach is to use `style` explicitly instead.

## How has this been tested?
Tested with https://github.com/wordpress-mobile/gutenberg-mobile/pull/310

## Types of changes
- Mobile compatibility changes

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
