### PR TITLE
Editor: Cache block meta-sourcing for getBlock selector

### DIFF
--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -40,6 +40,7 @@ import { addQueryArgs } from '@wordpress/url';
  */
 import { PREFERENCES_DEFAULTS } from './defaults';
 import { EDIT_MERGE_PROPERTIES } from './constants';
+import createWeakCache from '../utils/create-weak-cache';
 
 /***
  * Module constants
@@ -65,6 +66,21 @@ const ONE_MINUTE_IN_MS = 60 * 1000;
  * @type {Array}
  */
 const EMPTY_ARRAY = [];
+
+/**
+ * Given a block type object, returns true if an attribute value is sourced
+ * from a meta property, or false otherwise.
+ *
+ * The value is cached weakly by strict object reference to the provided block
+ * type argument.
+ *
+ * @param {WPBlockType} blockType Block type against which to test.
+ *
+ * @return {boolean} Whether block type has an meta-sourced attribute.
+ */
+const hasMetaSourcedAttribute = createWeakCache( ( blockType ) => {
+	return some( blockType.attributes, { source: 'meta' } );
+} );
 
 /**
  * Returns true if any past editor history snapshots exist, or false otherwise.
@@ -649,7 +665,7 @@ export const getBlockAttributes = createSelector(
 		// TODO: Create generic external sourcing pattern, not explicitly
 		// targeting meta attributes.
 		const type = getBlockType( block.name );
-		if ( type ) {
+		if ( type && hasMetaSourcedAttribute( type ) ) {
 			attributes = reduce( type.attributes, ( result, value, key ) => {
 				if ( value.source === 'meta' ) {
 					if ( result === attributes ) {

--- a/packages/editor/src/utils/create-weak-cache.js
+++ b/packages/editor/src/utils/create-weak-cache.js
@@ -1,0 +1,25 @@
+/**
+ * Returns a function which caches a computed value on a given object key. Due
+ * to its caching being achieved by WeakCache, the function must only accept a
+ * valid WeakMap key as its argument (objects, arrays). The function is only
+ * passed the key; any other arguments are discarded.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap
+ *
+ * @param {Function} getCacheValue Function to compute the cache value.
+ *
+ * @return {Function} Function whose computed value is weakly cached.
+ */
+function createWeakCache( getCacheValue ) {
+	const cache = new WeakMap();
+
+	return ( key ) => {
+		if ( ! cache.has( key ) ) {
+			cache.set( key, getCacheValue( key ) );
+		}
+
+		return cache.get( key );
+	};
+}
+
+export default createWeakCache;

--- a/packages/editor/src/utils/test/create-weak-cache.js
+++ b/packages/editor/src/utils/test/create-weak-cache.js
@@ -1,0 +1,41 @@
+/**
+ * Internal dependencies
+ */
+import createWeakCache from '../create-weak-cache';
+
+describe( 'createWeakCache', () => {
+	const getNumKeys = jest.fn().mockImplementation( ( object ) => Object.keys( object ).length );
+	const getNumKeysCached = createWeakCache( getNumKeys );
+
+	beforeEach( () => {
+		getNumKeys.mockClear();
+	} );
+
+	it( 'should return the value from the function argument', () => {
+		const object = { a: 1 };
+
+		expect( getNumKeysCached( object ) ).toBe( 1 );
+	} );
+
+	it( 'should return the value from cache', () => {
+		const object = { a: 1 };
+
+		expect( getNumKeysCached( object ) ).toBe( 1 );
+		expect( getNumKeysCached( object ) ).toBe( 1 );
+		expect( getNumKeys ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should return the value from the function argument on new reference', () => {
+		expect( getNumKeysCached( { a: 1 } ) ).toBe( 1 );
+		expect( getNumKeysCached( { a: 1 } ) ).toBe( 1 );
+		expect( getNumKeys ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'should throw on invalid key argument', () => {
+		expect( () => getNumKeysCached( undefined ) ).toThrow();
+	} );
+
+	it( 'should discard additional arguments', () => {
+		expect( createWeakCache( ( a, b ) => b || 'ok' )( {}, 10 ) ).toBe( 'ok' );
+	} );
+} );


### PR DESCRIPTION
This pull request seeks to optimize the implementation of `getBlock`, avoiding repeated iterations of a block's attributes to determine whether a meta-sourced attribute exists. Prior to these changes, every call to `getBlock` would iterate each of a block's attributes to determine whether it needed to provide a value from post meta. As there are very few blocks to which this behavior applies, it's largely wasted effort, particularly considering that, since the block type won't change, we especially need not consider block types after it can be determined for the first time that no meta-sourced attributes exist.

**Implementation notes:**

There are many different ways we could go about solving this general issue of attributes derivation for meta attributes. Previously I'd considered some larger refactorings of block attributes sourcing (#5077). This is something which isn't included here, and should still be considered separately (#4989). The changes here are a more direct remedy to the logic of the current implementation.

Even within such a direct solution, I'm open to suggestions for improvement. I'd considered a few options with code placement of the utilities, and optionally selectors within the `blocks` module to detect whether attributes matching certain predicates exist. It's worth noting that the foundational block has no consideration of meta sources; this is a concept introduced by the editor. Thus, the closest I had got to making this a block concern was by introducing a `getAttributeNamesBySource` selector, which was both needlessly specific and not as impactful (easily-cached) as what's considered here.

The advantage of using a WeakMap cache is that it doesn't require manual invalidation, and respects the assumed immutability of a block type once registered. The downside as implemented is that it's another layer of caching, and introduces a few new utility functions which don't fall neatly into existing patterns (`hasMetaSourcedAttribute` is not quite a selector, `createWeakCache` could stand alone as its own module).

**Testing instructions:**

There should be no impact on general use of the editor, namely those behaviors which touch `getBlockAttributes` (keypress in paragraph). Confirm also no regressions on the behavior of blocks whose attributes are sourced from meta.†

_† No meta-sourced core blocks exist. You may consider [this example Stars block](https://gist.github.com/pento/19b35d621709042fc899e394a9387a54), with revisions to bring it up to date (add `source: 'meta'` to block type definition)_