### PR TITLE
Remove wp-polyfill-ecmascript BC workaround

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -500,24 +500,6 @@ function gutenberg_register_scripts_and_styles() {
 			$live_reload_url
 		);
 	}
-
-	// Temporary backward compatibility for `wp-polyfill-ecmascript`, which has
-	// since been absorbed into `wp-polyfill`.
-	//
-	// [TODO][REMOVEME] To be removed in Gutenberg v4.5.
-	gutenberg_override_script(
-		'wp-polyfill-ecmascript',
-		null,
-		array(
-			'wp-polyfill',
-			'wp-deprecated',
-		)
-	);
-	wp_script_add_data(
-		'wp-polyfill-ecmascript',
-		'data',
-		'wp.deprecated( "wp-polyfill-ecmascript script handle", { plugin: "Gutenberg", version: "4.5" } );'
-	);
 }
 add_action( 'wp_enqueue_scripts', 'gutenberg_register_scripts_and_styles', 5 );
 add_action( 'admin_enqueue_scripts', 'gutenberg_register_scripts_and_styles', 5 );


### PR DESCRIPTION
## Description
Introduced in #11696, this code was marked with a note that it should be removed in Gutenberg 4.5.

This ship has now already sailed as we're currently at Gutenberg 4.6.1.

Can we remove this now? 🙂 