### PR TITLE
Fix “align center” button in Latest Posts block to add data-align="center" in the editor

### DIFF
--- a/packages/block-library/src/latest-posts/index.js
+++ b/packages/block-library/src/latest-posts/index.js
@@ -28,7 +28,7 @@ export const settings = {
 
 	getEditWrapperProps( attributes ) {
 		const { align } = attributes;
-		if ( 'left' === align || 'right' === align || 'wide' === align || 'full' === align ) {
+		if ( [ 'left', 'center', 'right', 'wide', 'full' ].includes( align ) ) {
 			return { 'data-align': align };
 		}
 	},


### PR DESCRIPTION
Resolves #12306, where clicking the center button on the Latest Posts block previously had no effect on the block markup in the admin area.

## Description
Adjusts editor wrapper props of the Latest Posts block to include center support.

Mirrors method used by other blocks (such as Latest Comments).

Does not attempt to refactor for efficiency or consistency, as this is covered separately by https://github.com/WordPress/gutenberg/issues/7908.

## How has this been tested?
Manual test made by:

1. Adding a Latest Posts block.
2. Clicking the “align center button”.
3. Confirming `data-align="center"` appears on the block in the editor.

## Types of changes
- Bug fix (one-line change)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
