### PR TITLE
Fix: Undoing Image Selection from Media Library in Image Block breaks it

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -414,7 +414,7 @@ class ImageEdit extends Component {
 			</BlockControls>
 		);
 
-		if ( isEditing ) {
+		if ( isEditing || ! url ) {
 			const src = isExternal ? url : undefined;
 			return (
 				<Fragment>


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/12279

The image block suffered some changes, and an editing state was added to check when the placeholder should be shown. While before that we showed the placeholder if no URL was set.
If an image is select from the media library, the isEditing local state becomes false. If after an undo is applied the isEditing local state flag continues to be false while the image now has no attributes and the placeholder should be shown again. In master, if we do an undo right after selecting some media from the media library the image block becomes broken, it does not show the placeholder and displays an image without an URL.

This PR changes a condition; we show the placeholder in the image block if isEditing is true or if no image URL exists.

## How has this been tested?
Add an image block.
Select image via the Media Library.
Undo via a button or keyboard shortcut
See the image placeholder is shown again.
Undo again and see the image block is totally removed.

