### PR TITLE
Fix broken link to design/dev docs

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -6,7 +6,7 @@ The Gutenberg project provides three sources of documentation:
 
 Learn how to build blocks and extend the editor, best practices for designing block interfaces, and how to create themes that make the most of the new features Gutenberg provides.
 
-[Visit the Designer & Developer Handbook](../docs/designers-developers/readme.md)
+[Visit the Designer & Developer Handbook](../docs/designers-developers/)
 
 ## User Handbook
 


### PR DESCRIPTION
The `Visit the Designer & Developer Handbook` link at https://wordpress.org/gutenberg/handbook/ is broken. I think this will fix it.