### PR TITLE
Docs: Make contributors history links clickable

### DIFF
--- a/docs/contributors/history.md
+++ b/docs/contributors/history.md
@@ -1,19 +1,19 @@
 # History
 
 ## Survey
-There was a survey done: https://make.wordpress.org/core/2017/04/07/editor-experience-survey-results/
+There was a survey done: [https://make.wordpress.org/core/2017/04/07/editor-experience-survey-results/](https://make.wordpress.org/core/2017/04/07/editor-experience-survey-results/)
 
 ## Inspiration
 This includes a list of historical articles and influences on Gutenberg.
 
-- LivingDocs: https://beta.livingdocs.io/articles
-- Parrot: https://intenseminimalism.com/2017/parrot-an-integrated-site-builder-and-editor-concept-for-wordpress/
+- LivingDocs: [https://beta.livingdocs.io/articles](https://beta.livingdocs.io/articles)
+- Parrot: [https://intenseminimalism.com/2017/parrot-an-integrated-site-builder-and-editor-concept-for-wordpress/](https://intenseminimalism.com/2017/parrot-an-integrated-site-builder-and-editor-concept-for-wordpress/)
 - Apple Keynote
 - Slack
 - Google Sites v2
 
 ## Blog posts by the team
 
-- Gutenberg tag on make/core: updates and much more: https://make.wordpress.org/core/tag/gutenberg/
-- Suggested revised timeline: https://make.wordpress.org/core/2017/08/11/revised-suggested-roadmap-for-gutenberg-and-customization/
-- Discovering Gutenberg: https://make.wordpress.org/core/2017/08/08/discovering-gutenberg-and-next-steps/
+- Gutenberg tag on make/core: updates and much more: [https://make.wordpress.org/core/tag/gutenberg/](https://make.wordpress.org/core/tag/gutenberg/)
+- Suggested revised timeline: [https://make.wordpress.org/core/2017/08/11/revised-suggested-roadmap-for-gutenberg-and-customization/](https://make.wordpress.org/core/2017/08/11/revised-suggested-roadmap-for-gutenberg-and-customization/)
+- Discovering Gutenberg: [https://make.wordpress.org/core/2017/08/08/discovering-gutenberg-and-next-steps/](https://make.wordpress.org/core/2017/08/08/discovering-gutenberg-and-next-steps/)


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Makes existing HTML links clickable

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Links are not clickable at https://wordpress.org/gutenberg/handbook/contributors/history/

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Docs

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
