### PR TITLE
Try: JS Console warning for when in Quirks Mode

### DIFF
--- a/docs/designers-developers/developers/backwards-compatibility/meta-box.md
+++ b/docs/designers-developers/developers/backwards-compatibility/meta-box.md
@@ -82,3 +82,5 @@ Most PHP meta boxes should continue to work in Gutenberg, but some meta boxes th
 - Plugins relying on selectors that target the post title, post content fields, and other metaboxes (of the old editor).
 - Plugins relying on TinyMCE's API because there's no longer a single TinyMCE instance to talk to in Gutenberg.
 - Plugins making updates to their DOM on "submit" or on "save".
+
+Please also note that if your plugin triggers a PHP warning or notice to be output on the page, this will cause the HTML document type (`<!DOCTYPE html>`) to be output incorrectly. This will cause the browser to render using "Quirks Mode", which is a compatibility layer that gets enabled when the browser doesn't know what type of document it is parsing. The block editor is not meant to work in this mode, but it can _appear_ to be working just fine. If you encounter issues such as *meta boxes overlaying the editor* or other layout issues, please check the raw page source of your document to see that the document type definition is the first thing output on the page. There will also be a warning in the JavaScript console, noting the issue.

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -567,25 +567,3 @@ function gutenberg_add_responsive_body_class( $classes ) {
 }
 
 add_filter( 'body_class', 'gutenberg_add_responsive_body_class' );
-
-/**
- * Prints JavaScript to detect whether the browser is in standards mode or not.
- *
- * @since 4.6
- */
-function gutenberg_detect_quirks_mode() {
-	?>
-	<script type="text/javascript">
-		document.addEventListener( 'DOMContentLoaded', function() {
-			try {
-				var documentMode = document.compatMode==='CSS1Compat'?'Standards':'Quirks';
-				if (documentMode != 'Standards' ) {
-					console.log( '[Warning] Your browser is using Quirks Mode. \nThis can cause rendering issues such as blocks overlaying meta boxes in the editor. Quirks Mode can be triggered by PHP errors or HTML code appearing before the opening <!DOCTYPE html>. Try checking the raw page source or your site\'s PHP error log and resolving errors there, removing any HTML before the doctype, or disabling plugins.' );
-				}
-			} catch( e ) { }
-		} );
-	</script>
-	<?php
-}
-add_action( 'admin_print_scripts-post.php', 'gutenberg_detect_quirks_mode' );
-add_action( 'admin_print_scripts-post-new.php', 'gutenberg_detect_quirks_mode' );

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -567,3 +567,25 @@ function gutenberg_add_responsive_body_class( $classes ) {
 }
 
 add_filter( 'body_class', 'gutenberg_add_responsive_body_class' );
+
+/**
+ * Prints JavaScript to detect whether the browser is in standards mode or not.
+ *
+ * @since 4.6
+ */
+function gutenberg_detect_quirks_mode() {
+	?>
+	<script type="text/javascript">
+		document.addEventListener( 'DOMContentLoaded', function() {
+			try {
+				var documentMode = document.compatMode==='CSS1Compat'?'Standards':'Quirks';
+				if (documentMode != 'Standards' ) {
+					console.log( '[Warning] Your browser is using Quirks Mode. \nThis can cause rendering issues such as blocks overlaying meta boxes in the editor. Quirks Mode can be triggered by PHP errors or HTML code appearing before the opening <!DOCTYPE html>. Try checking the raw page source or your site\'s PHP error log and resolving errors there, removing any HTML before the doctype, or disabling plugins.' );
+				}
+			} catch( e ) { }
+		} );
+	</script>
+	<?php
+}
+add_action( 'admin_print_scripts-post.php', 'gutenberg_detect_quirks_mode' );
+add_action( 'admin_print_scripts-post-new.php', 'gutenberg_detect_quirks_mode' );

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -72,7 +72,7 @@ export function initializeEditor( id, postType, postId, settings, initialEdits )
 	const documentMode = document.compatMode === 'CSS1Compat' ? 'Standards' : 'Quirks';
 	if ( documentMode !== 'Standards' ) {
 		// eslint-disable-next-line no-console
-		console.warn( '[Warning] Your browser is using Quirks Mode. \nThis can cause rendering issues such as blocks overlaying meta boxes in the editor. Quirks Mode can be triggered by PHP errors or HTML code appearing before the opening <!DOCTYPE html>. Try checking the raw page source or your site\'s PHP error log and resolving errors there, removing any HTML before the doctype, or disabling plugins.' );
+		console.warn( "Your browser is using Quirks Mode. \nThis can cause rendering issues such as blocks overlaying meta boxes in the editor. Quirks Mode can be triggered by PHP errors or HTML code appearing before the opening <!DOCTYPE html>. Try checking the raw page source or your site's PHP error log and resolving errors there, removing any HTML before the doctype, or disabling plugins." );
 	}
 
 	dispatch( 'core/nux' ).triggerGuide( [

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -69,13 +69,11 @@ export function initializeEditor( id, postType, postId, settings, initialEdits )
 	registerCoreBlocks();
 
 	// Show a console log warning if the browser is not in Standards rendering mode.
-	try {
-		const documentMode = document.compatMode === 'CSS1Compat' ? 'Standards' : 'Quirks';
-		if ( documentMode !== 'Standards' ) {
-			// eslint-disable-next-line no-console
-			console.warn( '[Warning] Your browser is using Quirks Mode. \nThis can cause rendering issues such as blocks overlaying meta boxes in the editor. Quirks Mode can be triggered by PHP errors or HTML code appearing before the opening <!DOCTYPE html>. Try checking the raw page source or your site\'s PHP error log and resolving errors there, removing any HTML before the doctype, or disabling plugins.' );
-		}
-	} catch ( e ) { }
+	const documentMode = document.compatMode === 'CSS1Compat' ? 'Standards' : 'Quirks';
+	if ( documentMode !== 'Standards' ) {
+		// eslint-disable-next-line no-console
+		console.warn( '[Warning] Your browser is using Quirks Mode. \nThis can cause rendering issues such as blocks overlaying meta boxes in the editor. Quirks Mode can be triggered by PHP errors or HTML code appearing before the opening <!DOCTYPE html>. Try checking the raw page source or your site\'s PHP error log and resolving errors there, removing any HTML before the doctype, or disabling plugins.' );
+	}
 
 	dispatch( 'core/nux' ).triggerGuide( [
 		'core/editor.inserter',

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -68,6 +68,15 @@ export function initializeEditor( id, postType, postId, settings, initialEdits )
 
 	registerCoreBlocks();
 
+	// Show a console log warning if the browser is not in Standards rendering mode.
+	try {
+		const documentMode = document.compatMode === 'CSS1Compat' ? 'Standards' : 'Quirks';
+		if ( documentMode !== 'Standards' ) {
+			// eslint-disable-next-line no-console
+			console.warn( '[Warning] Your browser is using Quirks Mode. \nThis can cause rendering issues such as blocks overlaying meta boxes in the editor. Quirks Mode can be triggered by PHP errors or HTML code appearing before the opening <!DOCTYPE html>. Try checking the raw page source or your site\'s PHP error log and resolving errors there, removing any HTML before the doctype, or disabling plugins.' );
+		}
+	} catch ( e ) { }
+
 	dispatch( 'core/nux' ).triggerGuide( [
 		'core/editor.inserter',
 		'core/editor.settings',


### PR DESCRIPTION
This PR detects whether the browser is in Quirks Mode. Quirks Mode is a rendering method used when the doctype definition is missing or incorrectly placed in the HTML source, causing the browser to have difficulty detecting the type of document it is to render.

This is usually caused by a PHP error, or even just a style tag that is output incorrectly on the page. See discussion in https://github.com/WordPress/gutenberg/pull/12455 and https://github.com/WordPress/gutenberg/issues/11378.

The usual result is Gutenberg rendering incorrectly, notably with metaboxes overlapping content.

The purpose of this PR is to help developers debug the issue and fix it at the root. As such, it adds a console warning, props @nickcernis for the text:

```
[Warning] Your browser is using Quirks Mode. This can cause rendering issues such as blocks overlaying meta boxes in the editor. Quirks Mode can be triggered by PHP errors or HTML code appearing before the opening <!DOCTYPE html>. Try checking the raw page source or your site's PHP error log and resolving errors there, removing any HTML before the doctype, or disabling plugins.
```

It also augments the documentation to add a note about this.

![screenshot 2018-12-04 at 09 25 46](https://user-images.githubusercontent.com/1204802/49428932-91a66380-f7a7-11e8-890c-2f560657310e.png)
