### PR TITLE
Fix block edit toolbar appearing twice

### DIFF
--- a/packages/components/src/slot-fill/context.js
+++ b/packages/components/src/slot-fill/context.js
@@ -58,8 +58,9 @@ class SlotFillProvider extends Component {
 	}
 
 	unregisterSlot( name ) {
-		delete this.slots[ name ];
 		this.forceUpdateFills( name );
+		this.forceUpdateSlot( name );
+		delete this.slots[ name ];
 	}
 
 	unregisterFill( name, instance ) {

--- a/packages/components/src/slot-fill/test/slot.js
+++ b/packages/components/src/slot-fill/test/slot.js
@@ -215,13 +215,28 @@ describe( 'Slot', () => {
 		it( 'should return the named slot', () => {
 			const provider = shallow( <Provider></Provider> );
 			const instance = provider.instance();
-			const slot = { name: 'slot', forceUpdate: noop };
+			const forceUpdate = jest.fn();
+			const slot = { name: 'slot', forceUpdate };
 
 			instance.registerSlot( 'test', slot );
 			expect( instance.getSlot( 'test' ) ).toBe( slot );
+			expect( forceUpdate ).toHaveBeenCalledTimes( 1 );
 		} );
 
-		it( 'should not allow duplicate slots', () => {
+		it( 'should remove the named slot', () => {
+			const provider = shallow( <Provider></Provider> );
+			const instance = provider.instance();
+			const forceUpdate = jest.fn();
+			const slot = { name: 'slot', forceUpdate };
+
+			instance.registerSlot( 'test', slot );
+			instance.unregisterSlot( 'test' );
+
+			expect( instance.getSlot( 'test' ) ).toBe( undefined );
+			expect( forceUpdate ).toHaveBeenCalledTimes( 2 );
+		} );
+
+		it( 'should not allow multiple slots of same name', () => {
 			const provider = shallow( <Provider></Provider> );
 			const instance = provider.instance();
 			const slot1 = { name: 'slot1', forceUpdate: noop };
@@ -231,6 +246,34 @@ describe( 'Slot', () => {
 			instance.registerSlot( 'test', slot2 );
 
 			expect( instance.getSlot( 'test' ) ).toBe( slot1 );
+		} );
+
+		it( 'should allow multiple fills of same name', () => {
+			const provider = shallow( <Provider></Provider> );
+			const instance = provider.instance();
+			const fill1 = { name: 'fill1', forceUpdate: noop };
+			const fill2 = { name: 'fill2', forceUpdate: noop };
+
+			instance.registerFill( 'test', fill1 );
+			instance.registerFill( 'test', fill2 );
+
+			expect( instance.getFills( 'test' ) ).toEqual( [ fill1, fill2 ] );
+		} );
+
+		it( 'should force update of slot and fill when slot is removed', () => {
+			const provider = shallow( <Provider></Provider> );
+			const instance = provider.instance();
+			const forceUpdateFill = jest.fn();
+			const forceUpdateSlot = jest.fn();
+			const slot = { name: 'slot', forceUpdate: forceUpdateSlot };
+			const fill = { name: 'fill', forceUpdate: forceUpdateFill };
+
+			instance.registerSlot( 'test', slot );
+			instance.registerFill( 'test', fill );
+			instance.unregisterSlot( 'test' );
+
+			expect( forceUpdateFill ).toHaveBeenCalledTimes( 1 ); // Slot is unregistered
+			expect( forceUpdateSlot ).toHaveBeenCalledTimes( 3 ); // Slot is registered, fill is registered, slot is unregistered
 		} );
 	} );
 } );

--- a/packages/components/src/slot-fill/test/slot.js
+++ b/packages/components/src/slot-fill/test/slot.js
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import { isEmpty } from 'lodash';
+import { isEmpty, noop } from 'lodash';
 import ReactTestRenderer from 'react-test-renderer';
+import { shallow } from 'enzyme';
 
 /**
  * Internal dependencies
@@ -208,5 +209,28 @@ describe( 'Slot', () => {
 		);
 
 		expect( testRenderer.toJSON() ).toMatchSnapshot();
+	} );
+
+	describe( 'Manage Slots', () => {
+		it( 'should return the named slot', () => {
+			const provider = shallow( <Provider></Provider> );
+			const instance = provider.instance();
+			const slot = { name: 'slot', forceUpdate: noop };
+
+			instance.registerSlot( 'test', slot );
+			expect( instance.getSlot( 'test' ) ).toBe( slot );
+		} );
+
+		it( 'should not allow duplicate slots', () => {
+			const provider = shallow( <Provider></Provider> );
+			const instance = provider.instance();
+			const slot1 = { name: 'slot1', forceUpdate: noop };
+			const slot2 = { name: 'slot2', forceUpdate: noop };
+
+			instance.registerSlot( 'test', slot1 );
+			instance.registerSlot( 'test', slot2 );
+
+			expect( instance.getSlot( 'test' ) ).toBe( slot1 );
+		} );
 	} );
 } );

--- a/packages/editor/src/components/block-actions/index.js
+++ b/packages/editor/src/components/block-actions/index.js
@@ -70,6 +70,7 @@ export default compose( [
 			multiSelect,
 			removeBlocks,
 			insertDefaultBlock,
+			clearSelectedBlock,
 		} = dispatch( 'core/editor' );
 
 		return {
@@ -79,6 +80,9 @@ export default compose( [
 				}
 
 				const clonedBlocks = blocks.map( ( block ) => cloneBlock( block ) );
+
+				clearSelectedBlock();
+
 				insertBlocks(
 					clonedBlocks,
 					lastSelectedIndex + 1,


### PR DESCRIPTION
If you duplicate a block with the keyboard shortcut `shift+cmd+d` it duplicates the block toolbar:

<img width="502" alt="edit_post_ _wordpress_latest_ _wordpress" src="https://user-images.githubusercontent.com/1277682/49081336-733be780-f23e-11e8-90c6-2e61951cd83b.png">

This PR stops this happening, but doesn’t fix the underlying problem. I'm putting it here as an open question (I'm not really sure what is supposed to happen), along with some fixes.

As far as I can tell the problem is caused by the Slot/Fill system, where it’s possible for two same-named slots to be added, with the second overwriting the first. When either slot is removed it then removes both. This is only made apparent when using the keyboard shortcut as it changes the order in which slots are created and removed.

To make it easier to understand I'll use the duplicate block toolbar as an example. Note in this context, `BlockActions` is the slot used to show the block edit toolbar. I've added some debug to Gutenberg so it outputs the slot/fill actions to make it clearer what is happening.

I may have misunderstood some/all parts of this!

### Duplicating a block using the block menu

1. Block is selected and `BlockActions` slot appears
<img width="285" alt="edit_post_ _wordpress_latest_ _wordpress" src="https://user-images.githubusercontent.com/1277682/49374412-24d49000-f6f9-11e8-8ec2-d63049b3a123.png">

`SLOT: register`
`FILL: register`

2. Duplicate is chosen from block menu
3.  Block menu disappears, and slot is removed

`SLOT: unregister`
`FILL: unregister`

4. Block is duplicated
5. New block is auto-selected and a new `BlockActions` slot is created for it:

`SLOT: register`
`FILL: register`

6. Duplicated block appears with edit toolbar, as expected:
<img width="240" alt="edit_post_ _wordpress_latest_ _wordpress" src="https://user-images.githubusercontent.com/1277682/49374531-87c62700-f6f9-11e8-9467-37bf3d42352b.png">

### Duplicating a block using the keyboard shortcut `shift+cmd+d`
1. Block is selected and `BlockActions` slot appears

`SLOT: register`
`FILL: register`

2. Shortcut is triggered
3. Block is duplicated, existing `BlockActions` slot still exists
4. New block is auto-selected and another `BlockControls` slot is created, overwriting the existing `BlockControls` slot. The old one is still visible as it's not been updated yet (I am stepping through the code here to show each part)

`SLOT: register`
`FILL: register`

<img width="269" alt="edit_post_ _wordpress_latest_ _wordpress" src="https://user-images.githubusercontent.com/1277682/49374626-d247a380-f6f9-11e8-9883-6dcb75913ca2.png">
5. The new slot is updated and we see the original slot with its fill, and the new slot with the original fill and the new block fill:
<img width="366" alt="edit_post_ _wordpress_latest_ _wordpress" src="https://user-images.githubusercontent.com/1277682/49374636-de336580-f6f9-11e8-9c9c-f123a21fbb06.png">
6. The original block is no longer selected so it tries to remove itself. However, it actually removes the new `BlockControls` slot

`SLOT: unregister`
`FILL: unregister`

We are left in this state:
<img width="372" alt="edit_post_ _wordpress_latest_ _wordpress" src="https://user-images.githubusercontent.com/1277682/49374681-015e1500-f6fa-11e8-91ea-8afd75a6ef90.png">
7. At some point something happens (a heartbeat maybe?) that triggers an update, and the slot returns to normal:
<img width="259" alt="edit_post_ _wordpress_latest_ _wordpress" src="https://user-images.githubusercontent.com/1277682/49374705-0f139a80-f6fa-11e8-948f-5a4635e6aa58.png">

## What is happening?

The above example is trying to show that when using the menu, the slot is created, removed, and then created again, and everything works as expected. When using the keyboard shortcut, the slot is created for the first block, created for the second block, and then the first removed. Because of the way the slot/fill system works the second slot [overwrites the first](https://github.com/WordPress/gutenberg/blob/master/packages/components/src/slot-fill/context.js#L44), and when the first is removed, it's actually [removing the second](https://github.com/WordPress/gutenberg/blob/master/packages/components/src/slot-fill/context.js#L61).

## The fix

Back to this PR!

I'm not really sure how the slot/fill system is supposed to behave when two slots of the same name are added. This is the real problem, which I haven't attempted to fix. I note in https://github.com/WordPress/gutenberg/blob/master/packages/components/src/slot-fill/slot.js#L37 that an instance is being passed, even though it's not used, and I wonder if this indicates it could work like the fills (where multiple same named fills can exist)?

I have included two fixes here. Both of them fix the problem in different ways, and I wanted to get some feedback about the preferred route (which may be neither):
- `BlockActions` has been modified to clear the block selection when the duplicate action is triggered. This forces it to behave the same regardless of if from the menu or keyboard. This only fixes the block edit toolbar and shouldnt affect anything else
- `SlotFillProvider` has been modified to `forceUpdateSlot` before deleting a slot. This ensures the slot is cleared first, and stops the duplicate. This fixes the display, but not what happens underneath. I don't know if it could affect other things.

There's also a bunch of unit tests, of which one tests the duplicate slot problem and will always fail. I've included it here to make it easier to test, but it would need to be fixed properly or removed.

Fixes #12355