### PR TITLE
Get wordcount type from translation

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -123,4 +123,4 @@ This list is manually curated to include valuable contributions by volunteers th
 | @jakeparis | @jakeparis |
 | @designsimply | @designsimply |
 | @aldavigdis | @aldavigdis |
-
+| @miya0001 | @miyauchi |

--- a/packages/editor/src/components/word-count/index.js
+++ b/packages/editor/src/components/word-count/index.js
@@ -6,8 +6,15 @@ import { _x } from '@wordpress/i18n';
 import { count as wordCount } from '@wordpress/wordcount';
 
 function WordCount( { content } ) {
+	/*
+	 * translators: If your word count is based on single characters (e.g. East Asian characters),
+	 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
+	 * Do not translate into your own language.
+	 */
+	const wordCountType = _x( 'words', 'Word count type. Do not translate!' );
+
 	return (
-		<span className="word-count">{ wordCount( content, _x( 'words', 'Word count type. Do not translate!' ) ) }</span>
+		<span className="word-count">{ wordCount( content, wordCountType ) }</span>
 	);
 }
 

--- a/packages/editor/src/components/word-count/index.js
+++ b/packages/editor/src/components/word-count/index.js
@@ -2,11 +2,12 @@
  * WordPress dependencies
  */
 import { withSelect } from '@wordpress/data';
+import { _x } from '@wordpress/i18n';
 import { count as wordCount } from '@wordpress/wordcount';
 
 function WordCount( { content } ) {
 	return (
-		<span className="word-count">{ wordCount( content, 'words' ) }</span>
+		<span className="word-count">{ wordCount( content, _x( 'words', 'Word count type. Do not translate!' ) ) }</span>
 	);
 }
 


### PR DESCRIPTION
## Description

The value of wordcount type should be translatable, but it is fixed value as `words`.

## How has this been tested?

I changed the value from `words` to `characters_including_spaces`, then I see it works as expected.

But it can't get the `characters_including_spaces` with `_x( 'words', 'Word count type. Do not translate!' )` as my patch.
(I tried with `ja`.)

I am sorry I can't found the solution to get translated value from `.po` for here.
This text should be added into `tinymce.addI18n()` on WordPress core?

## Screenshots

![](https://www.evernote.com/l/ABVi5HR2DsJGOL3kTFL7u_UIzHmZnPB2_LMB/image.png)

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
