### PR TITLE
Removed Link from ## User Handbook Section

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -12,7 +12,6 @@ Learn how to build blocks and extend the editor, best practices for designing bl
 
 Discover the new features Gutenberg offers, learn how your site will be affected by the new editor and how to keep using the old interface, and tips for creating beautiful posts and pages.
 
-[Visit the User Handbook](../docs/users/readme.md)
 
 ## Contributor Handbook
 


### PR DESCRIPTION
Removed "Visit the User Handbook" link from ##User Handbook Section.

## Description
We have removed "Visit the User Handbook" link from User Handbook section. Reff. #12585.