### PR TITLE
Fix 'jump' for nested items in list

### DIFF
--- a/packages/block-library/src/list/editor.scss
+++ b/packages/block-library/src/list/editor.scss
@@ -5,6 +5,5 @@
 	margin-left: 1.3em;
 	li {
 		margin-bottom: 0;
-		line-height: 2;
 	}
 }

--- a/packages/block-library/src/list/editor.scss
+++ b/packages/block-library/src/list/editor.scss
@@ -3,4 +3,8 @@
 .block-library-list .editor-rich-text__tinymce ol {
 	padding-left: 1.3em;
 	margin-left: 1.3em;
+	li {
+		margin-bottom: 0;
+		line-height: 2;
+	}
 }


### PR DESCRIPTION
## Description
Fix 'jumping' of nested items in list: #12526 
Change margin-bottom and line-height in block-list file.

## How has this been tested?
I have ran 'npm run test' and have seen that all tests passed or skipped.

## Screenshots
![block-list](https://user-images.githubusercontent.com/13454526/49453566-aef92300-f7e3-11e8-86ba-1b3635fd72cc.gif)

## Types of changes
Minor bug fix: #12526

## Checklist:
- [x] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
