### PR TITLE
Remove "User Handbook" section

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -8,12 +8,6 @@ Learn how to build blocks and extend the editor, best practices for designing bl
 
 [Visit the Designer & Developer Handbook](../docs/designers-developers/readme.md)
 
-## User Handbook
-
-Discover the new features Gutenberg offers, learn how your site will be affected by the new editor and how to keep using the old interface, and tips for creating beautiful posts and pages.
-
-[Visit the User Handbook](../docs/users/readme.md)
-
 ## Contributor Handbook
 
 Help make Gutenberg better by contributing ideas, code, testing, and more.


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Currently the "User Handbook" section in the Gutenberg Handbook 404's

https://wordpress.org/gutenberg/handbook/

> https://wordpress.org/gutenberg/handbook/users/
> _"Oops! That page can’t be found."_
> _"It looks like nothing was found at this location. Maybe try one of the links below or a search?"_

Let's remove the link until work in #11252 has started adding some pages to HelpHub at https://wordpress.org/support/

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
