### PR TITLE
Fix SVG styles for mobile

### DIFF
--- a/packages/components/src/primitives/svg/index.native.js
+++ b/packages/components/src/primitives/svg/index.native.js
@@ -17,13 +17,9 @@ export {
 } from 'react-native-svg';
 
 export const SVG = ( props ) => {
-	// We're using the react-native-classname-to-style plugin, so when a `className` prop is passed it gets converted to `style` here.
-	// Given it carries a string (as it was originally className) but an object is expected for `style`,
-	// we need to check whether `style` exists and is a string, and convert it to an object
-
 	let styleValues = {};
-	if ( typeof props.style === 'string' ) {
-		const oneStyle = props.style.split( ' ' ).map( ( element ) => styles[ element ] ).filter( Boolean );
+	if ( typeof props.className === 'string' ) {
+		const oneStyle = props.className.split( ' ' ).map( ( element ) => styles[ element ] ).filter( Boolean );
 		styleValues = Object.assign( styleValues, ...oneStyle );
 	}
 

--- a/packages/components/src/primitives/svg/index.native.js
+++ b/packages/components/src/primitives/svg/index.native.js
@@ -17,12 +17,8 @@ export {
 } from 'react-native-svg';
 
 export const SVG = ( props ) => {
-	let styleValues = {};
-	if ( typeof props.className === 'string' ) {
-		const oneStyle = props.className.split( ' ' ).map( ( element ) => styles[ element ] ).filter( Boolean );
-		styleValues = Object.assign( styleValues, ...oneStyle );
-	}
-
+	const stylesFromClasses = ( props.className || '' ).split( ' ' ).map( ( element ) => styles[ element ] ).filter( Boolean );
+	const styleValues = Object.assign( {}, props.style, ...stylesFromClasses );
 	const safeProps = { ...props, style: styleValues };
 
 	return (


### PR DESCRIPTION
## Description
This PR fixes the custom styling we have on mobile for SVGs.
https://github.com/WordPress/gutenberg/pull/12552 introduced a regression as we removed the `className` => `style` transform but did not update this part.

## How has this been tested?
Tested with https://github.com/wordpress-mobile/gutenberg-mobile/issues/320

## Screenshots <!-- if applicable -->

## Types of changes
- Mobile compatibility changes

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
