### PR TITLE
Fix Unregister block code

### DIFF
--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -237,7 +237,9 @@ Adding blocks is easy enough, removing them is as easy. Plugin or theme authors 
 
 ```js
 // my-plugin.js
-wp.domReady( function() {
+window._wpLoadGutenbergEditor.then( function() {
+  wp.blocks.unregisterBlockType( "core/verse" );
+});
 	wp.blocks.unregisterBlockType( 'core/verse' );
 } );
 ```

--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -254,7 +254,7 @@ function my_plugin_blacklist_blocks() {
 	wp_enqueue_script(
 		'my-plugin-blacklist-blocks',
 		plugins_url( 'my-plugin.js', __FILE__ ),
-		array( 'wp-blocks', 'wp-dom-ready' )
+		array( 'wp-blocks', 'wp-edit-post )
 	);
 }
 add_action( 'enqueue_block_editor_assets', 'my_plugin_blacklist_blocks' );

--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -252,7 +252,7 @@ function my_plugin_blacklist_blocks() {
 	wp_enqueue_script(
 		'my-plugin-blacklist-blocks',
 		plugins_url( 'my-plugin.js', __FILE__ ),
-		array( 'wp-edit-post' )
+		array( 'wp-blocks', 'wp-dom-ready' )
 	);
 }
 add_action( 'enqueue_block_editor_assets', 'my_plugin_blacklist_blocks' );

--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -237,8 +237,9 @@ Adding blocks is easy enough, removing them is as easy. Plugin or theme authors 
 
 ```js
 // my-plugin.js
-
-wp.blocks.unregisterBlockType( 'core/verse' );
+_wpLoadBlockEditor.then( function() {
+	wp.blocks.unregisterBlockType( 'core/verse' );
+});
 ```
 
 and load this script in the Editor
@@ -251,7 +252,7 @@ function my_plugin_blacklist_blocks() {
 	wp_enqueue_script(
 		'my-plugin-blacklist-blocks',
 		plugins_url( 'my-plugin.js', __FILE__ ),
-		array( 'wp-blocks' )
+		array( 'wp-edit-post' )
 	);
 }
 add_action( 'enqueue_block_editor_assets', 'my_plugin_blacklist_blocks' );

--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -237,7 +237,7 @@ Adding blocks is easy enough, removing them is as easy. Plugin or theme authors 
 
 ```js
 // my-plugin.js
-_wpLoadBlockEditor.then( function() {
+wp.domReady( function() {
 	wp.blocks.unregisterBlockType( 'core/verse' );
 });
 ```

--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -239,7 +239,7 @@ Adding blocks is easy enough, removing them is as easy. Plugin or theme authors 
 // my-plugin.js
 wp.domReady( function() {
 	wp.blocks.unregisterBlockType( 'core/verse' );
-});
+} );
 ```
 
 and load this script in the Editor


### PR DESCRIPTION
Eyh folks, not sure it's the best way to to this. I quickly talked about it with Riad. 

The dependency is not the right one, 'wp-edit-post' seems more appropriate
In the JS file, if we respect the current doc, there is an error because blocks are still initializing so unregister a non yet registered block will cause an undefined error. 

Maybe there is a more sexy way than use _wpLoadBlockEditor

Fixes #11723.