### PR TITLE
Autop: Fix RegExp escaping copy/paste error

### DIFF
--- a/packages/autop/CHANGELOG.md
+++ b/packages/autop/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.1 (Unreleased)
+
+### Bug Fix
+
+- `autop` correctly matches whitespace preceding and following block-level elements.
+
 ## 2.0.0 (2018-09-05)
 
 ### Breaking Change

--- a/packages/autop/src/index.js
+++ b/packages/autop/src/index.js
@@ -162,7 +162,7 @@ export function autop( text, br = true ) {
 	const allBlocks = '(?:table|thead|tfoot|caption|col|colgroup|tbody|tr|td|th|div|dl|dd|dt|ul|ol|li|pre|form|map|area|blockquote|address|math|style|p|h[1-6]|hr|fieldset|legend|section|article|aside|hgroup|header|footer|nav|figure|figcaption|details|menu|summary)';
 
 	// Add a double line break above block-level opening tags.
-	text = text.replace( new RegExp( '(<' + allBlocks + '[\s\/>])', 'g' ), '\n\n$1' );
+	text = text.replace( new RegExp( '(<' + allBlocks + '[\\s\/>])', 'g' ), '\n\n$1' );
 
 	// Add a double line break below block-level closing tags.
 	text = text.replace( new RegExp( '(<\/' + allBlocks + '>)', 'g' ), '$1\n\n' );
@@ -226,7 +226,7 @@ export function autop( text, br = true ) {
 	text = text.replace( /<p>([^<]+)<\/(div|address|form)>/g, '<p>$1</p></$2>' );
 
 	// If an opening or closing block element tag is wrapped in a <p>, unwrap it.
-	text = text.replace( new RegExp( '<p>\s*(<\/?' + allBlocks + '[^>]*>)\s*<\/p>', 'g' ), '$1' );
+	text = text.replace( new RegExp( '<p>\\s*(<\/?' + allBlocks + '[^>]*>)\\s*<\/p>', 'g' ), '$1' );
 
 	// In some cases <li> may get wrapped in <p>, fix them.
 	text = text.replace( /<p>(<li.+?)<\/p>/g, '$1' );
@@ -236,10 +236,10 @@ export function autop( text, br = true ) {
 	text = text.replace( /<\/blockquote><\/p>/g, '</p></blockquote>' );
 
 	// If an opening or closing block element tag is preceded by an opening <p> tag, remove it.
-	text = text.replace( new RegExp( '<p>\s*(<\/?' + allBlocks + '[^>]*>)', 'g' ), '$1' );
+	text = text.replace( new RegExp( '<p>\\s*(<\/?' + allBlocks + '[^>]*>)', 'g' ), '$1' );
 
 	// If an opening or closing block element tag is followed by a closing <p> tag, remove it.
-	text = text.replace( new RegExp( '(<\/?' + allBlocks + '[^>]*>)\s*<\/p>', 'g' ), '$1' );
+	text = text.replace( new RegExp( '(<\/?' + allBlocks + '[^>]*>)\\s*<\/p>', 'g' ), '$1' );
 
 	// Optionally insert line breaks.
 	if ( br ) {
@@ -257,7 +257,7 @@ export function autop( text, br = true ) {
 	}
 
 	// If a <br /> tag is after an opening or closing block tag, remove it.
-	text = text.replace( new RegExp( '(<\/?' + allBlocks + '[^>]*>)\s*<br \/>', 'g' ), '$1' );
+	text = text.replace( new RegExp( '(<\/?' + allBlocks + '[^>]*>)\\s*<br \/>', 'g' ), '$1' );
 
 	// If a <br /> tag is before a subset of opening or closing block tags, remove it.
 	text = text.replace( /<br \/>(\s*<\/?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)[^>]*>)/g, '$1' );

--- a/packages/autop/src/test/index.test.js
+++ b/packages/autop/src/test/index.test.js
@@ -495,3 +495,10 @@ test( 'that autop doses not add extra closing p in figure', () => {
 	expect( autop( content1 ).trim() ).toBe( expected1 );
 	expect( autop( content2 ).trim() ).toBe( expected2 );
 } );
+
+test( 'that autop correctly adds a start and end tag when followed by a div', () => {
+	const content = 'Testing autop with a div\n<div class="wp-some-class">content</div>';
+	const expected = '<p>Testing autop with a div</p>\n<div class="wp-some-class">content</div>';
+
+	expect( autop( content ).trim() ).toBe( expected );
+} );

--- a/test/integration/full-content/fixtures/core__freeform.json
+++ b/test/integration/full-content/fixtures/core__freeform.json
@@ -4,9 +4,9 @@
         "name": "core/freeform",
         "isValid": true,
         "attributes": {
-            "content": "<p>Testing freeform block with some\n</p><div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>"
+            "content": "<p>Testing freeform block with some</p>\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>"
         },
         "innerBlocks": [],
-        "originalContent": "<p>Testing freeform block with some\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>"
+        "originalContent": "<p>Testing freeform block with some</p>\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>"
     }
 ]

--- a/test/integration/full-content/fixtures/core__freeform.serialized.html
+++ b/test/integration/full-content/fixtures/core__freeform.serialized.html
@@ -1,4 +1,4 @@
-<p>Testing freeform block with some
-</p><div class="wp-some-class">
+<p>Testing freeform block with some</p>
+<div class="wp-some-class">
 	HTML <span style="color: red;">content</span>
 </div>

--- a/test/integration/full-content/fixtures/core__freeform__undelimited.json
+++ b/test/integration/full-content/fixtures/core__freeform__undelimited.json
@@ -4,9 +4,9 @@
         "name": "core/freeform",
         "isValid": true,
         "attributes": {
-            "content": "<p>Testing freeform block with some\n</p><div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>"
+            "content": "<p>Testing freeform block with some</p>\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>"
         },
         "innerBlocks": [],
-        "originalContent": "<p>Testing freeform block with some\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>"
+        "originalContent": "<p>Testing freeform block with some</p>\n<div class=\"wp-some-class\">\n\tHTML <span style=\"color: red;\">content</span>\n</div>"
     }
 ]

--- a/test/integration/full-content/fixtures/core__freeform__undelimited.serialized.html
+++ b/test/integration/full-content/fixtures/core__freeform__undelimited.serialized.html
@@ -1,4 +1,4 @@
-<p>Testing freeform block with some
-</p><div class="wp-some-class">
+<p>Testing freeform block with some</p>
+<div class="wp-some-class">
 	HTML <span style="color: red;">content</span>
 </div>


### PR DESCRIPTION
[autop](https://github.com/WordPress/gutenberg/tree/master/packages/autop) contains a bunch of regular expressions copied from [core WordPress](https://core.trac.wordpress.org/browser/tags/4.9.8/src/wp-includes/formatting.php#L439). However, in JavaScript when `RegExp` is used the escaped regular expression characters need double-escaping because it's a string.

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp for examples, and also elsewhere in [autop](https://github.com/WordPress/gutenberg/blob/master/packages/autop/src/index.js#L362).

This PR adds the extra backslashes.

Fixes #12610

## How has this been tested?
An extra unit test has been added for #12610 which was caused by the missing backslash.

We really need extra unit tests for each of the changed instances so that it can't happen again. If core has unit tests for `wpautop` then we could think about bringing them over.
