### PR TITLE
Fix: Problems on Media & Text block resizing; Load wp-block-library styles before wp-edit-blocks

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -461,6 +461,7 @@ function gutenberg_register_scripts_and_styles() {
 		array(
 			'wp-components',
 			'wp-editor',
+			'wp-block-library',
 			// Always include visual styles so the editor never appears broken.
 			'wp-block-library-theme',
 		),


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/12600

The bug happened because on WordPress core the block styles in editor.scss appear before styles in styles.scss.
In the plugin, this does not happen and I think some styles were created with the expectation that editor tweaks can be made an editor.scss and they overwrite the styles set in styles.scss that appear on the front end.

Until now, we know that this bug is causing the noticeable impact on media & text block but it may be impacting the styles of other blocks as well.


In the plugin, things worked correctly, but I'm applying the change here too so when the fix is added to core the plugin is consistent.

### Testing Instructions

**To Reproduce**

1. Add a Media & Text block
2. Add an image
3. Attempt to resize
4. We should not see the following error

![100](https://user-images.githubusercontent.com/1202812/49471047-d945e300-f7d9-11e8-8551-7d3d34f914b3.gif)
