### PR TITLE
[RNMobile] Fix crash editing More blocks

### DIFF
--- a/packages/block-library/src/more/edit.native.js
+++ b/packages/block-library/src/more/edit.native.js
@@ -7,6 +7,7 @@ import { View, Text } from 'react-native';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -14,28 +15,49 @@ import { __ } from '@wordpress/i18n';
 import { PlainText } from '@wordpress/editor';
 import styles from './editor.scss';
 
-export default function MoreEdit( props ) {
-	const { attributes, setAttributes, onFocus, onBlur } = props;
-	const { customText } = attributes;
-	const defaultText = __( 'Read more' );
-	const value = customText !== undefined ? customText : defaultText;
+export default class MoreEdit extends Component {
+	constructor() {
+		super( ...arguments );
+		this.onChangeInput = this.onChangeInput.bind( this );
+		
+		this.state = {
+			defaultText: __( 'Read more' ),
+		};
+	}
 
-	return (
-		<View style={ styles[ 'block-library-more__container' ] }>
-			<View style={ styles[ 'block-library-more__sub-container' ] }>
-				<Text style={ styles[ 'block-library-more__left-marker' ] }>&lt;!--</Text>
-				<PlainText
-					style={ styles[ 'block-library-more__plain-text' ] }
-					value={ value }
-					multiline={ true }
-					underlineColorAndroid="transparent"
-					onChange={ ( newValue ) => setAttributes( { customText: newValue } ) }
-					placeholder={ defaultText }
-					isSelected={ props.isSelected }
-					onFocus={ onFocus }
-					onBlur={ onBlur }
-				/>
-				<Text style={ styles[ 'block-library-more__right-marker' ] }>--&gt;</Text>
-			</View>
-		</View> );
+	onChangeInput( newValue ) {
+		// Set defaultText to an empty string, allowing the user to clear/replace the input field's text
+		this.setState( {
+			defaultText: '',
+		} );
+		const value = newValue.length === 0 ? undefined : newValue;
+		console.log(value);
+		this.props.setAttributes( { customText: value } );
+	}
+
+	render() {
+		const { attributes, setAttributes, onFocus, onBlur } = this.props;
+		const { customText } = attributes;
+		const defaultText = __( 'Read more' );
+		const value = customText !== undefined ? customText : defaultText;
+
+		return (
+			<View style={ styles[ 'block-library-more__container' ] }>
+				<View style={ styles[ 'block-library-more__sub-container' ] }>
+					<Text style={ styles[ 'block-library-more__left-marker' ] }>&lt;!--</Text>
+					<PlainText
+						style={ styles[ 'block-library-more__plain-text' ] }
+						value={ value }
+						multiline={ true }
+						underlineColorAndroid="transparent"
+						onChange={ this.onChangeInput }
+						placeholder={ defaultText }
+						isSelected={ this.props.isSelected }
+						onFocus={ onFocus }
+						onBlur={ onBlur }
+					/>
+					<Text style={ styles[ 'block-library-more__right-marker' ] }>--&gt;</Text>
+				</View>
+			</View> );
+	}
 }

--- a/packages/block-library/src/more/edit.native.js
+++ b/packages/block-library/src/more/edit.native.js
@@ -57,6 +57,7 @@ export default class MoreEdit extends Component {
 					/>
 					<Text style={ styles[ 'block-library-more__right-marker' ] }>--&gt;</Text>
 				</View>
-			</View> );
+			</View>
+		);
 	}
 }

--- a/packages/block-library/src/more/edit.native.js
+++ b/packages/block-library/src/more/edit.native.js
@@ -19,7 +19,7 @@ export default class MoreEdit extends Component {
 	constructor() {
 		super( ...arguments );
 		this.onChangeInput = this.onChangeInput.bind( this );
-		
+
 		this.state = {
 			defaultText: __( 'Read more' ),
 		};
@@ -31,12 +31,11 @@ export default class MoreEdit extends Component {
 			defaultText: '',
 		} );
 		const value = newValue.length === 0 ? undefined : newValue;
-		console.log(value);
 		this.props.setAttributes( { customText: value } );
 	}
 
 	render() {
-		const { attributes, setAttributes, onFocus, onBlur } = this.props;
+		const { attributes, onFocus, onBlur } = this.props;
 		const { customText } = attributes;
 		const defaultText = __( 'Read more' );
 		const value = customText !== undefined ? customText : defaultText;

--- a/packages/editor/src/components/plain-text/index.native.js
+++ b/packages/editor/src/components/plain-text/index.native.js
@@ -28,12 +28,12 @@ export default class PlainText extends Component {
 	render() {
 		return (
 			<TextInput
+				{ ...this.props }
 				ref={ ( x ) => this._input = x }
 				className={ [ styles[ 'editor-plain-text' ], this.props.className ] }
-				onChangeText={ ( text ) => this.props.onChange( text ) }
+				onChange={ (event) => { this.props.onChange( event.nativeEvent.text ) } }
 				onFocus={ this.props.onFocus } // always assign onFocus as a props
 				onBlur={ this.props.onBlur } // always assign onBlur as a props
-				{ ...this.props }
 			/>
 		);
 	}

--- a/packages/editor/src/components/plain-text/index.native.js
+++ b/packages/editor/src/components/plain-text/index.native.js
@@ -31,7 +31,9 @@ export default class PlainText extends Component {
 				{ ...this.props }
 				ref={ ( x ) => this._input = x }
 				className={ [ styles[ 'editor-plain-text' ], this.props.className ] }
-				onChange={ (event) => { this.props.onChange( event.nativeEvent.text ) } }
+				onChange={ ( event ) => {
+					this.props.onChange( event.nativeEvent.text );
+				} }
 				onFocus={ this.props.onFocus } // always assign onFocus as a props
 				onBlur={ this.props.onBlur } // always assign onBlur as a props
 			/>


### PR DESCRIPTION
This PR fixes an issue on the More block, that makes the app unstable/crashing when editing the content of the block. 

Originally reported here:  https://github.com/wordpress-mobile/gutenberg-mobile/issues/316

The core problem was that both `onChange` and `onChangeText` were wired in `PlainText` component to the same `onChange` prop of the block, resulting in a loop of text update calls. 
`PlainText` had `{ ...this.props }` and then `onChangeText={ ( text ) => this.props.onChange( text ) }`.  The first part connected the `onChange` directly, and then we had explicitly set the it again `onTextChanged`. We need to be super careful when using  `{ ...this.props }`


I also refactored the More block in preparation of the `Enter.key` handling.

Testing step in the gb-mobile PR here: link arrive soon.
