### PR TITLE
Editor: Avoid scheduling autosave if same edit reference as last completion

### DIFF
--- a/packages/editor/src/components/autosave-monitor/index.js
+++ b/packages/editor/src/components/autosave-monitor/index.js
@@ -7,14 +7,33 @@ import { withSelect, withDispatch } from '@wordpress/data';
 
 export class AutosaveMonitor extends Component {
 	componentDidUpdate( prevProps ) {
-		const { isDirty, editsReference, isAutosaveable } = this.props;
+		const { isDirty, editsReference, isAutosaveable, isAutosaving } = this.props;
+
+		// The edits reference is held for comparison to avoid scheduling an
+		// autosave if an edit has not been made since the last autosave
+		// completion. This is assigned when the autosave completes, and reset
+		// when an edit occurs.
+		//
+		// See: https://github.com/WordPress/gutenberg/issues/12318
+
+		if ( editsReference !== prevProps.editsReference ) {
+			this.didAutosaveForEditsReference = false;
+		}
+
+		if ( ! isAutosaving && prevProps.isAutosaving ) {
+			this.didAutosaveForEditsReference = true;
+		}
 
 		if (
 			prevProps.isDirty !== isDirty ||
 			prevProps.isAutosaveable !== isAutosaveable ||
 			prevProps.editsReference !== editsReference
 		) {
-			this.toggleTimer( isDirty && isAutosaveable );
+			this.toggleTimer(
+				isDirty &&
+				isAutosaveable &&
+				! this.didAutosaveForEditsReference
+			);
 		}
 	}
 
@@ -45,6 +64,7 @@ export default compose( [
 			isEditedPostAutosaveable,
 			getEditorSettings,
 			getReferenceByDistinctEdits,
+			isAutosavingPost,
 		} = select( 'core/editor' );
 
 		const { autosaveInterval } = getEditorSettings();
@@ -53,6 +73,7 @@ export default compose( [
 			isDirty: isEditedPostDirty(),
 			isAutosaveable: isEditedPostAutosaveable(),
 			editsReference: getReferenceByDistinctEdits(),
+			isAutosaving: isAutosavingPost(),
 			autosaveInterval,
 		};
 	} ),

--- a/packages/editor/src/components/autosave-monitor/test/index.js
+++ b/packages/editor/src/components/autosave-monitor/test/index.js
@@ -82,6 +82,28 @@ describe( 'AutosaveMonitor', () => {
 
 			expect( toggleTimer ).toHaveBeenCalledWith( false );
 		} );
+
+		it( 'should avoid scheduling autosave if still dirty but already autosaved for edits', () => {
+			// Explanation: When a published post is autosaved, it's still in a
+			// dirty state since the edits are not saved to the post until the
+			// user clicks "Update". To avoid recurring autosaves, ensure that
+			// an edit has occurred since the last autosave had completed.
+
+			const beforeReference = [];
+			const afterReference = [];
+
+			// A post is non-dirty while autosave is in-flight.
+			wrapper.setProps( { isDirty: false, isAutosaving: true, isAutosaveable: true, editsReference: beforeReference } );
+			toggleTimer.mockClear();
+			wrapper.setProps( { isDirty: true, isAutosaving: false, isAutosaveable: true, editsReference: beforeReference } );
+
+			expect( toggleTimer ).toHaveBeenCalledWith( false );
+
+			// Once edit occurs after autosave, resume scheduling.
+			wrapper.setProps( { isDirty: true, isAutosaving: false, isAutosaveable: true, editsReference: afterReference } );
+
+			expect( toggleTimer.mock.calls[ 1 ][ 0 ] ).toBe( true );
+		} );
 	} );
 
 	describe( '#componentWillUnmount()', () => {


### PR DESCRIPTION
Fixes #12318 

This pull request seeks to resolve an issue where autosaves will repeatedly occur when an edit is made to a published post. As explained in https://github.com/WordPress/gutenberg/issues/12318#issuecomment-441671741 , this is a consequence of a published post's autosave occurring as a revision, not a proper save. The post is still in an "unsaved" state, in the sense that the user has not yet Updated the post.

With these changes, an autosave will not be scheduled after a prior autosave had completed until an explicit edit occurs, even if the post is dirty or autosaveable. 

**Implementation notes:**

For posterity's sake, there are some specific intricacies of the autosave flow which may appear to be redundant with the logic included here, but which still serve an independent role. Namely, the re-dirtying of an autosaved published post performed as a consequence of:

https://github.com/WordPress/gutenberg/blob/874321773aff9be87b591e63c5fc606ede9872ac/packages/editor/src/store/effects/posts.js#L143-L150

https://github.com/WordPress/gutenberg/blob/874321773aff9be87b591e63c5fc606ede9872ac/packages/editor/src/store/selectors.js#L124-L150

To reiterate, it is _correct_ that a post is considered dirty after a published post is autosaved. The user should be prompted when attempting to navigate away. It's because of this distinction that an additional "has autosaved for edits reference" is included here.

It may, however, be worth considering for future refactoring to remove [the `isEditedPostAutosaveable` selector](https://github.com/WordPress/gutenberg/blob/874321773aff9be87b591e63c5fc606ede9872ac/packages/editor/src/store/selectors.js#L484-L515) in favor of dirtiness conditions, or reflecting the last autosave which had occurred. Currently, the recurring autosave occurs because `hasChangedContent` will return `true` due to the re-dirtying behavior described above.

**Testing instructions:**

Repeat steps to reproduce from #12318, verifying by Network DevTools activity that only a single autosave occurs for a single edit to a published post.

Verify that after an autosave occurs, continued edits will still autosave.

**Pending:**

This is worth testing via an end-to-end test.