### PR TITLE
Meta Boxes: Don't hide disabled meta boxes by modifying DOM

### DIFF
--- a/packages/edit-post/src/components/meta-boxes/meta-box-visibility.js
+++ b/packages/edit-post/src/components/meta-boxes/meta-box-visibility.js
@@ -17,9 +17,16 @@ class MetaBoxVisibility extends Component {
 
 	updateDOM() {
 		const { id, isVisible } = this.props;
+
 		const element = document.getElementById( id );
-		if ( element ) {
-			element.style.display = isVisible ? '' : 'none';
+		if ( ! element ) {
+			return;
+		}
+
+		if ( isVisible ) {
+			element.classList.remove( 'is-hidden' );
+		} else {
+			element.classList.add( 'is-hidden' );
 		}
 	}
 

--- a/packages/edit-post/src/components/meta-boxes/meta-boxes-area/style.scss
+++ b/packages/edit-post/src/components/meta-boxes/meta-boxes-area/style.scss
@@ -75,6 +75,12 @@
 		right: 20px;
 		z-index: z-index(".edit-post-meta-boxes-area .spinner");
 	}
+
+	// Hide disabled meta boxes using CSS so that we don't interfere with plugins
+	// that modify `element.style.display` on the meta box.
+	.is-hidden {
+		display: none;
+	}
 }
 
 .edit-post-meta-boxes-area__clear {


### PR DESCRIPTION
Fixes #12571.

Hiding disabled meta boxes by setting `element.style.display = 'none'` interferes with plugins like ACF which rely on being able to show and hide meta boxes using `$.hide()` and `$.show()`.

Hiding the meta box using a new `.edit-post-meta-boxes-area .is-hidden` class ensures that we don't interfere with third party code.

#### Testing

1. Register a meta box which hides itself using JavaScript:

```php
<?php

add_action( 'add_meta_boxes', 'test_add_meta_boxes' );

function test_add_meta_boxes() {
	add_meta_box( 'test-meta-box', 'Test Meta Box', 'test_render_meta_box' );
}

function test_render_meta_box() {
	?>
	This should be hidden!
	<script>
	( function( $ ) {
		$( '#test-meta-box' ).hide();
	} )( jQuery );	
	</script>
	<?php
}
```

2. Create a new post. The meta box should be hidden.

3. Open _Show more tools & options_ and select _Options_.

4. Toggle the meta box off and on. The meta box should remain hidden.

I've also tested this by repeating the steps above with an additional non-hidden meta box registered, and by installing ACF and attempting to recreate the scenario described in #12571.