### PR TITLE
Improve the flat terms sidebar panel's user information

### DIFF
--- a/packages/components/src/form-token-field/index.js
+++ b/packages/components/src/form-token-field/index.js
@@ -530,6 +530,7 @@ class FormTokenField extends Component {
 			label = __( 'Add item' ),
 			instanceId,
 			className,
+			help,
 		} = this.props;
 		const { isExpanded } = this.state;
 		const classes = classnames( className, 'components-form-token-field__input-container', {
@@ -550,6 +551,14 @@ class FormTokenField extends Component {
 				onFocus: this.onFocus,
 			} );
 		}
+
+		const howTo = !! help ? {
+			className: 'components-form-token-field__help',
+			text: help,
+		} : {
+			className: 'screen-reader-text',
+			text: __( 'Separate with commas' ),
+		};
 
 		// Disable reason: There is no appropriate role which describes the
 		// input container intended accessible usability.
@@ -583,8 +592,8 @@ class FormTokenField extends Component {
 						/>
 					) }
 				</div>
-				<div id={ `components-form-token-suggestions-howto-${ instanceId }` } className="screen-reader-text">
-					{ __( 'Separate with commas' ) }
+				<div id={ `components-form-token-suggestions-howto-${ instanceId }` } className={ howTo.className }>
+					{ howTo.text }
 				</div>
 			</div>
 		);
@@ -608,6 +617,7 @@ FormTokenField.defaultProps = {
 		removed: __( 'Item removed.' ),
 		remove: __( 'Remove item' ),
 	},
+	help: '',
 };
 
 export default withSpokenMessages( withInstanceId( FormTokenField ) );

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -51,6 +51,12 @@
 	margin-bottom: $grid-size-small;
 }
 
+.components-form-token-field__help {
+	margin-top: $grid-size;
+	font-style: italic;
+	margin-bottom: 0;
+}
+
 // Tokens
 .components-form-token-field__token {
 	font-size: $default-font-size;

--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -185,6 +185,11 @@ class FlatTermSelector extends Component {
 		const termAddedLabel = sprintf( _x( '%s added', 'term' ), singularName );
 		const termRemovedLabel = sprintf( _x( '%s removed', 'term' ), singularName );
 		const removeTermLabel = sprintf( _x( 'Remove %s', 'term' ), singularName );
+		const help = get(
+			taxonomy,
+			[ 'labels', 'separate_items_with_commas' ],
+			_x( 'Separate terms with commas', 'how to separate term items' )
+		);
 
 		return (
 			<FormTokenField
@@ -201,6 +206,7 @@ class FlatTermSelector extends Component {
 					removed: termRemovedLabel,
 					remove: removeTermLabel,
 				} }
+				help={ help }
 			/>
 		);
 	}


### PR DESCRIPTION
It's not obvious for a user a comma needs to be used to separate tags.
Using the `separate_items_with_commas` label to display it under the tags input should help him to understand how he can do it.

## Description
I've added a paragraph under the flat terms input field displaying the `separate_items_with_commas` label of the taxonomy object.

## How has this been tested?
Tested using VVV, WordPress 4.9.8, Gutenberg master.

## Screenshots
![separate-tags](https://user-images.githubusercontent.com/1834524/49557089-c977ed00-f906-11e8-8e0d-83e2af987838.png)

The "how to" paragraph.

## Types of changes
Bug fix (for new users it can be challenging)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
