### PR TITLE
Update broken links

### DIFF
--- a/docs/designers-developers/developers/block-api/README.md
+++ b/docs/designers-developers/developers/block-api/README.md
@@ -4,7 +4,7 @@ Blocks are the fundamental element of the Gutenberg editor. They are the primary
 
 ## Registering a block
 
-All blocks must be registered before they can be used in the editor. You can learn about block registration, and the available options, in the [block registration](../../docs/designers-developers/developers/block-api/block-registration.md) documentation.
+All blocks must be registered before they can be used in the editor. You can learn about block registration, and the available options, in the [block registration](../../../../docs/designers-developers/developers/block-api/block-registration.md) documentation.
 
 ## Block `edit` and `save`
 

--- a/docs/designers-developers/developers/block-api/README.md
+++ b/docs/designers-developers/developers/block-api/README.md
@@ -8,4 +8,4 @@ All blocks must be registered before they can be used in the editor. You can lea
 
 ## Block `edit` and `save`
 
-The `edit` and `save` functions define the editor interface with which a user would interact, and the markup to be serialized back when a post is saved. They are the heart of how a block operates, so they are [covered separately](../../docs/designers-developers/developers/block-api/block-edit-save.md).
+The `edit` and `save` functions define the editor interface with which a user would interact, and the markup to be serialized back when a post is saved. They are the heart of how a block operates, so they are [covered separately](../../../../docs/designers-developers/developers/block-api/block-edit-save.md).

--- a/docs/designers-developers/developers/block-api/README.md
+++ b/docs/designers-developers/developers/block-api/README.md
@@ -4,8 +4,8 @@ Blocks are the fundamental element of the Gutenberg editor. They are the primary
 
 ## Registering a block
 
-All blocks must be registered before they can be used in the editor. You can learn about block registration, and the available options, in the [block registration](block-api/block-registration.md) documentation.
+All blocks must be registered before they can be used in the editor. You can learn about block registration, and the available options, in the [block registration](../../docs/designers-developers/developers/block-api/block-registration.md) documentation.
 
 ## Block `edit` and `save`
 
-The `edit` and `save` functions define the editor interface with which a user would interact, and the markup to be serialized back when a post is saved. They are the heart of how a block operates, so they are [covered separately](block-api/block-edit-save.md).
+The `edit` and `save` functions define the editor interface with which a user would interact, and the markup to be serialized back when a post is saved. They are the heart of how a block operates, so they are [covered separately](../../docs/designers-developers/developers/block-api/block-edit-save.md).


### PR DESCRIPTION
There was 2 broken links. I changed same way with Data Module Reference page.

## Description
There was 2 broken links. I changed same way with Data Module Reference page.

## How has this been tested?
I changed same way with Data Module Reference page. It can't be problem because I looked to this page: https://github.com/WordPress/gutenberg/edit/master/docs/designers-developers/developers/data/README.md

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- My code follows the WordPress code style.
- My code follows the accessibility standards.
- My code has proper inline documentation.
