### PR TITLE
Fix broken Link

### DIFF
--- a/docs/designers-developers/developers/block-api/README.md
+++ b/docs/designers-developers/developers/block-api/README.md
@@ -4,7 +4,7 @@ Blocks are the fundamental element of the Gutenberg editor. They are the primary
 
 ## Registering a block
 
-All blocks must be registered before they can be used in the editor. You can learn about block registration, and the available options, in the [block registration](block-api/block-registration.md) documentation.
+All blocks must be registered before they can be used in the editor. You can learn about block registration, and the available options, in the [block registration](block-api/block-registration) documentation.
 
 ## Block `edit` and `save`
 


### PR DESCRIPTION
'Registering a block' section currently includes a link that eventually leads to 404. Have updated the link to rightly point to the actual page.

## Description
Updated/fixed the URL to point to actual resource. Previously, a bad URL.

## How has this been tested?
Have verified the intended location for the link to point to and made the change.

## Types of changes
Updated the link.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
