### PR TITLE
Add filter to disable PostAuthor

### DIFF
--- a/docs/designers-developers/developers/filters/editor-filters.md
+++ b/docs/designers-developers/developers/filters/editor-filters.md
@@ -16,17 +16,3 @@ var withImageSize = function( size, mediaId, postId ) {
 wp.hooks.addFilter( 'editor.PostFeaturedImage.imageSize', 'my-plugin/with-image-size', withImageSize );
 ```
 
-
-### `editor.PostAuthor.component`
-
-Used to specify a different component for PostAuthor, this is the author list in the sidebar.
-
-If you simply want to disable the PostAuthor field for a post type, you can use [remove_post_type_support](https://developer.wordpress.org/reference/functions/remove_post_type_support/) to disable the component by post type.
-
-_Example:_
-
-```js
-const myAuthorComponent = wp.element( 'div', {}, 'My Authors Content' );
-wp.hooks.addFilter( 'editor.PostAuthor.component', 'my_callback', function() { return myAuthorComponent; } );
-```
-

--- a/docs/designers-developers/developers/filters/editor-filters.md
+++ b/docs/designers-developers/developers/filters/editor-filters.md
@@ -16,3 +16,17 @@ var withImageSize = function( size, mediaId, postId ) {
 wp.hooks.addFilter( 'editor.PostFeaturedImage.imageSize', 'my-plugin/with-image-size', withImageSize );
 ```
 
+
+### `editor.PostAuthor.component`
+
+Used to specify a different component for PostAuthor, this is the author list in the sidebar.
+
+If you simply want to disable the PostAuthor field for a post type, you can use [remove_post_type_support](https://developer.wordpress.org/reference/functions/remove_post_type_support/) to disable the component by post type.
+
+_Example:_
+
+```js
+const myAuthorComponent = wp.element( 'div', {}, 'My Authors Content' );
+wp.hooks.addFilter( 'editor.PostAuthor.component', 'my_callback', function() { return myAuthorComponent; } );
+```
+

--- a/packages/editor/src/components/post-author/README.md
+++ b/packages/editor/src/components/post-author/README.md
@@ -1,0 +1,59 @@
+PostAuthor
+===========
+
+`PostAuthor` is a React component used to render the Post Author selection tool.
+
+## Setup
+
+It includes a `wp.hooks` filter `editor.PostAuthor` that enables developers to replace or extend it.
+
+_Examples:_
+
+Replace the contents of the panel:
+
+```js
+function replacePostAuthor() {
+	return function() {
+		return wp.element.createElement(
+			'div',
+			{},
+			'My Post Author component.'
+		);
+	}
+}
+
+wp.hooks.addFilter(
+	'editor.PostAuthor',
+	'my-plugin/replace-post-author',
+	replacePostAuthor
+);
+```
+
+Prepend and append to the panel contents:
+
+```js
+var el = wp.element.createElement;
+
+function wrapPostAuthor( OriginalComponent ) {
+	return function( props ) {
+		return (
+			el(
+				wp.element.Fragment,
+				{},
+				'Prepend above',
+				el(
+					OriginalComponent,
+					props
+				),
+				'Append below'
+			)
+		);
+	}
+}
+
+wp.hooks.addFilter(
+	'editor.PostAuthor',
+	'my-plugin/wrap-post-author',
+	wrapPostAuthor
+);
+```

--- a/packages/editor/src/components/post-author/index.js
+++ b/packages/editor/src/components/post-author/index.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { withInstanceId, compose } from '@wordpress/compose';
 import { Component } from '@wordpress/element';
+import { withFilters } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
@@ -63,4 +64,5 @@ export default compose( [
 		},
 	} ) ),
 	withInstanceId,
+	withFilters( 'editor.PostAuthor' ),
 ] )( PostAuthor );


### PR DESCRIPTION
## Description

Adds a filter to the PostAuthor component which allows to override with a custom component.


## How has this been tested?

* Confirm the author field shows fine before/after apply the patch

* In the plugin or theme that wants to override the component, use the following JavaScript code, remember to include `'wp-hooks', 'wp-element'` in your enqueue dependency array.

```
var MyComponent = wp.element.createElement( 'div', {}, 'My Authors Content' );
wp.hooks.addFilter( 'editor.PostAuthor', 'myplugin', function() { return MyComponent; } );
```

* Confirm the Author box no longer displays, instead you should see "My Authors Content"


## Types of changes

This extends gutenberg with the `editor.PostAuthor` filter giving developers a hook to control the component for PostAuthor.


## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
