### PR TITLE
Fix RTL support for datepicker

### DIFF
--- a/packages/components/src/date-time/date.js
+++ b/packages/components/src/date-time/date.js
@@ -13,6 +13,7 @@ import { Component } from '@wordpress/element';
  * Module Constants
  */
 const TIMEZONELESS_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
+const isRTL = () => document.documentElement.dir === 'rtl';
 
 class DatePicker extends Component {
 	constructor() {
@@ -55,6 +56,7 @@ class DatePicker extends Component {
 					onDateChange={ this.onChangeMoment }
 					transitionDuration={ 0 }
 					weekDayFormat="ddd"
+					isRTL={ isRTL() }
 				/>
 			</div>
 		);

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -1,5 +1,7 @@
 // We can't reference this package with ~ because of how Lerna handles packages. 😩
+/*rtl:begin:ignore*/
 @import "node_modules/react-dates/lib/css/_datepicker";
+/*rtl:end:ignore*/
 
 .components-datetime {
 	.components-datetime__calendar-help {

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -1,4 +1,5 @@
-// We can't reference this package with ~ because of how Lerna handles packages. 😩
+// We can't reference this package with ~ because of how Lerna handles packages.
+// Also, don't convert styles to RTL because react-dates uses an isRTL flag instead.
 /*rtl:begin:ignore*/
 @import "node_modules/react-dates/lib/css/_datepicker";
 /*rtl:end:ignore*/


### PR DESCRIPTION
## Description

Instead of converting the styles the `isRTL` flag needs to passed to `DayPickerSingleDateController`.

Fixes #12718.

## How has this been tested?
* Set site language to a RTL language
* Check that the arrows are pointing to the right direction.