### PR TITLE
Scripts: Add check-engines script to the package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2763,6 +2763,7 @@
 				"@wordpress/npm-package-json-lint-config": "file:packages/npm-package-json-lint-config",
 				"babel-eslint": "8.0.3",
 				"chalk": "^2.4.1",
+				"check-node-version": "^3.1.1",
 				"cross-spawn": "^5.1.0",
 				"eslint": "^4.19.1",
 				"jest": "^23.6.0",

--- a/package.json
+++ b/package.json
@@ -10,10 +10,6 @@
 		"WordPress",
 		"editor"
 	],
-	"engines": {
-		"node": ">=8.0.0",
-		"npm": ">=6.0.0"
-	},
 	"dependencies": {
 		"@wordpress/a11y": "file:packages/a11y",
 		"@wordpress/annotations": "file:packages/annotations",
@@ -72,7 +68,6 @@
 		"autoprefixer": "8.2.0",
 		"babel-loader": "8.0.0",
 		"chalk": "2.4.1",
-		"check-node-version": "3.1.1",
 		"concurrently": "3.5.0",
 		"copy-webpack-plugin": "4.5.2",
 		"core-js": "2.5.7",
@@ -145,7 +140,7 @@
 		"prebuild:packages": "npm run clean:packages && lerna run build && cross-env INCLUDE_PACKAGES=babel-plugin-import-jsx-pragma,postcss-themes,jest-console SKIP_JSX_PRAGMA_TRANSFORM=1 node ./bin/packages/build.js",
 		"build:packages": "cross-env EXCLUDE_PACKAGES=babel-plugin-import-jsx-pragma,jest-console,postcss-themes node ./bin/packages/build.js",
 		"build": "npm run build:packages && cross-env NODE_ENV=production webpack",
-		"check-engines": "check-node-version --package",
+		"check-engines": "wp-scripts check-engines",
 		"check-licenses": "concurrently \"wp-scripts check-licenses --prod --gpl2\" \"wp-scripts check-licenses --dev\"",
 		"precheck-local-changes": "npm run docs:build",
 		"check-local-changes": "( git diff -U0 | xargs -0 node bin/process-git-diff ) || ( echo \"There are local uncommitted changes after one or both of 'npm install' or 'npm run docs:build'!\" && exit 1 );",

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.5.0 (Unreleased)
+
+### New Feature
+
+- Added support for `check-engines` script ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX))
+
 ## 2.4.4 (2018-11-20)
 
 ## 2.4.3 (2018-11-09)

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### New Feature
 
-- Added support for `check-engines` script ([#XXXXX](https://github.com/WordPress/gutenberg/pull/XXXXX))
+- Added support for `check-engines` script ([#12721](https://github.com/WordPress/gutenberg/pull/12721))
 
 ## 2.4.4 (2018-11-20)
 

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -19,6 +19,7 @@ _Example:_
 ```json
 {
 	"scripts": {
+		"check-engines": "wp-scripts check-engines",
 		"lint:pkg-json": "wp-scripts lint-pkg-json .",
 		"test": "wp-scripts test-unit-js"
 	}
@@ -26,6 +27,24 @@ _Example:_
 ```
 
 ## Available Scripts
+
+### `check-engines`
+
+Check if the current `node`, `npm` (or `yarn`) versions match the given semver version ranges. If the given version is not satisfied, information about installing the needed version is printed and the program exits with an error code. It uses [check-node-version](https://www.npmjs.com/package/check-node-version) behind the scenes with the default configuration provided. You can specify your own ranges as described in [check-node-version docs](https://www.npmjs.com/package/check-node-version).
+
+_Example:_
+
+```json
+{
+	"scripts": {
+		"check-engines": "wp-scripts check-engines"
+	}
+}
+```
+
+This is how you execute the script with presented setup:
+* `npm run check-engines` - checks installed version of `node` and `npm`.
+
 
 ### `wp-scripts lint-js`
 

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -30,7 +30,7 @@ _Example:_
 
 ### `check-engines`
 
-Check if the current `node`, `npm` (or `yarn`) versions match the given semver version ranges. If the given version is not satisfied, information about installing the needed version is printed and the program exits with an error code. It uses [check-node-version](https://www.npmjs.com/package/check-node-version) behind the scenes with the default configuration provided. You can specify your own ranges as described in [check-node-version docs](https://www.npmjs.com/package/check-node-version).
+Check if the current `node`, `npm` (or `yarn`) versions match the given [semantic version](https://semver.org/) ranges. If the given version is not satisfied, information about installing the needed version is printed and the program exits with an error code. It uses [check-node-version](https://www.npmjs.com/package/check-node-version) behind the scenes with the default configuration provided. You can specify your own ranges as described in [check-node-version docs](https://www.npmjs.com/package/check-node-version).
 
 _Example:_
 

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -36,6 +36,7 @@
 		"@wordpress/npm-package-json-lint-config": "file:../npm-package-json-lint-config",
 		"babel-eslint": "8.0.3",
 		"chalk": "^2.4.1",
+		"check-node-version": "^3.1.1",
 		"cross-spawn": "^5.1.0",
 		"eslint": "^4.19.1",
 		"jest": "^23.6.0",

--- a/packages/scripts/scripts/check-engines.js
+++ b/packages/scripts/scripts/check-engines.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+const { sync: spawn } = require( 'cross-spawn' );
+const { sync: resolveBin } = require( 'resolve-bin' );
+
+/**
+ * Internal dependencies
+ */
+const {
+	getCliArgs,
+	hasCliArg,
+} = require( '../utils' );
+
+const args = getCliArgs();
+
+const hasConfig = hasCliArg( '--package' ) ||
+	hasCliArg( '--node' ) ||
+	hasCliArg( '--npm' ) ||
+	hasCliArg( '--yarn' );
+const config = ! hasConfig ?
+	[
+		'--node', '>=8.0.0',
+		'--npm', '>=6.0.0',
+	] :
+	[];
+
+const result = spawn(
+	resolveBin( 'check-node-version' ),
+	[ ...config, ...args ],
+	{ stdio: 'inherit' }
+);
+
+process.exit( result.status );

--- a/packages/scripts/scripts/check-engines.js
+++ b/packages/scripts/scripts/check-engines.js
@@ -20,7 +20,7 @@ const hasConfig = hasCliArg( '--package' ) ||
 	hasCliArg( '--yarn' );
 const config = ! hasConfig ?
 	[
-		'--node', '>=8.0.0',
+		'--node', '>=10.0.0',
 		'--npm', '>=6.0.0',
 	] :
 	[];


### PR DESCRIPTION
## Description
This PR adds `check-engines` to `wp-scripts` exposed by `@wordpress/scripts` package.

It checks if the current `node`, `npm` (or `yarn`) versions match the given semver version ranges. If the given version is not satisfied, information about installing the needed version is printed and the program exits with an error code. It uses [check-node-version](https://www.npmjs.com/package/check-node-version) behind the scenes with the default configuration provided. You can specify your own ranges as described in [check-node-version docs](https://www.npmjs.com/package/check-node-version).

## How has this been tested?
* `npm run check-engines` still works properly.
* `./node_modules/.bin/wp-scripts check-engines --node ">=11"` - shows error message
* `./node_modules/.bin/wp-scripts check-engines --npm ">=7"` - shows error message