### PR TITLE
Change header level in BlockCompare component (fix #12504)

### DIFF
--- a/packages/editor/src/components/block-compare/block-view.js
+++ b/packages/editor/src/components/block-compare/block-view.js
@@ -7,7 +7,7 @@ const BlockView = ( { title, rawContent, renderedContent, action, actionText, cl
 	return (
 		<div className={ className }>
 			<div className="editor-block-compare__content">
-				<h1 className="editor-block-compare__heading">{ title }</h1>
+				<h2 className="editor-block-compare__heading">{ title }</h2>
 
 				<div className="editor-block-compare__html">
 					{ rawContent }

--- a/packages/editor/src/components/block-compare/style.scss
+++ b/packages/editor/src/components/block-compare/style.scss
@@ -74,5 +74,6 @@
 	.editor-block-compare__heading {
 		font-size: 1em;
 		font-weight: 400;
+		margin: 0.67em 0;
 	}
 }

--- a/packages/editor/src/components/block-compare/test/__snapshots__/block-view.js.snap
+++ b/packages/editor/src/components/block-compare/test/__snapshots__/block-view.js.snap
@@ -7,11 +7,11 @@ exports[`BlockView should match snapshot 1`] = `
   <div
     className="editor-block-compare__content"
   >
-    <h1
+    <h2
       className="editor-block-compare__heading"
     >
       title
-    </h1>
+    </h2>
     <div
       className="editor-block-compare__html"
     >


### PR DESCRIPTION
## Description
Fixes #12504 (change header level to `<h2>` in BlockCompare component).

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
