### PR TITLE
Inline Link: Set link text to post title when post selected from dropdown

### DIFF
--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -164,8 +164,8 @@ class InlineLinkUI extends Component {
 		}
 	}
 
-	onChangeInputValue( inputValue ) {
-		this.setState( { inputValue } );
+	onChangeInputValue( inputValue, post ) {
+		this.setState( { inputValue, post } );
 	}
 
 	setLinkTarget( opensInNewWindow ) {
@@ -192,9 +192,10 @@ class InlineLinkUI extends Component {
 
 	submitLink( event ) {
 		const { isActive, value, onChange, speak } = this.props;
-		const { inputValue, opensInNewWindow } = this.state;
+		const { inputValue, opensInNewWindow, post } = this.state;
 		const url = prependHTTP( inputValue );
 		const selectedText = getTextContent( slice( value ) );
+
 		const format = createLinkFormat( {
 			url,
 			opensInNewWindow,
@@ -204,7 +205,8 @@ class InlineLinkUI extends Component {
 		event.preventDefault();
 
 		if ( isCollapsed( value ) && ! isActive ) {
-			const toInsert = applyFormat( create( { text: url } ), format, 0, url.length );
+			const linkText = ( post && post.title ) || url;
+			const toInsert = applyFormat( create( { text: linkText } ), format, 0, linkText.length );
 			onChange( insert( value, toInsert ) );
 		} else {
 			onChange( applyFormat( value, format ) );


### PR DESCRIPTION
Fixes #11930

## Description
<!-- Please describe what you have changed or added -->

In #11930, it was requested that the link selector insert the post title as the link text instead of the link href as the link text.

This PR will ensure that when creating a new link, after searching for and selecting a post, that new link does use the post title. Updating a link does not change the link's text.

Design consideration: When updating an existing link by searching for a post, should the link text become the post title of the post? For example, let's say I search for "Same Page" and insert a link to that page. The link text would be "Sample Page". Now, let's say I edit that link, search for "Hello World!" and select the "Hello World!" post. Should the link text now be "Hello World!"?

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I am on Mac and Chrome 70.0.3538.110 (Official Build) (64-bit). I tested by:

- Inserting `https://facebook.com` into the new link UI
- Searching for "Sample Page" and inserting a link via the new link UI
- Updating an existing link and searching for the "Hello World!" post 
- Updating an existing link and setting it to `https://facebook.com`

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
