### PR TITLE
add note about wp-editor dependancy

### DIFF
--- a/docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md
@@ -120,6 +120,8 @@ Earlier examples used the `createElement` function to create DOM nodes, but it's
 
 The `RichText` component can be considered as a super-powered `textarea` element, enabling rich content editing including bold, italics, hyperlinks, etc. It is not too much unlike the single editor region of the legacy post editor, and is in fact powered by the same TinyMCE library.
 
+To use the `RichText` component, add `wp-editor` to the array of registered script handles when calling `wp_register_script`.
+
 Implementing this behavior as a component enables you as the block implementer to be much more granular about editable fields. Your block may not need `RichText` at all, or it may need many independent `RichText` elements, each operating on a subset of the overall block state.
 
 Because `RichText` allows for nested nodes, you'll most often use it in conjunction with the `html` attribute source when extracting the value from saved content. You'll also use `RichText.Content` in the `save` function to output RichText values.

--- a/docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md
@@ -120,24 +120,19 @@ Earlier examples used the `createElement` function to create DOM nodes, but it's
 
 The `RichText` component can be considered as a super-powered `textarea` element, enabling rich content editing including bold, italics, hyperlinks, etc. It is not too much unlike the single editor region of the legacy post editor, and is in fact powered by the same TinyMCE library.
 
-```php
-<?php
-
-function gutenberg_boilerplate_block() {
-	wp_register_script(
-		'gutenberg-boilerplate-es5-step03',
-		plugins_url( 'step-03/block.js', __FILE__ ),
-		array( 'wp-blocks', 'wp-element', 'wp-editor' )
-	);
-
-	register_block_type( 'gutenberg-boilerplate-es5/hello-world-step-03', array(
-		'editor_script' => 'gutenberg-boilerplate-es5-step03',
-	) );
-}
-add_action( 'init', 'gutenberg_boilerplate_block' );
-```
-
 To use the `RichText` component, add `wp-editor` to the array of registered script handles when calling `wp_register_script`.
+
+```php
+wp_register_script(
+	'gutenberg-boilerplate-es5-step03',
+	plugins_url( 'step-03/block.js', __FILE__ ),
+	array( 
+		'wp-blocks', 
+		'wp-element', 
+		'wp-editor', // Note the addition of wp-editor to the dependencies
+	)
+);
+```
 
 Implementing this behavior as a component enables you as the block implementer to be much more granular about editable fields. Your block may not need `RichText` at all, or it may need many independent `RichText` elements, each operating on a subset of the overall block state.
 

--- a/docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md
@@ -120,6 +120,23 @@ Earlier examples used the `createElement` function to create DOM nodes, but it's
 
 The `RichText` component can be considered as a super-powered `textarea` element, enabling rich content editing including bold, italics, hyperlinks, etc. It is not too much unlike the single editor region of the legacy post editor, and is in fact powered by the same TinyMCE library.
 
+```php
+<?php
+
+function gutenberg_boilerplate_block() {
+	wp_register_script(
+		'gutenberg-boilerplate-es5-step03',
+		plugins_url( 'step-03/block.js', __FILE__ ),
+		array( 'wp-blocks', 'wp-element', 'wp-editor' )
+	);
+
+	register_block_type( 'gutenberg-boilerplate-es5/hello-world-step-03', array(
+		'editor_script' => 'gutenberg-boilerplate-es5-step03',
+	) );
+}
+add_action( 'init', 'gutenberg_boilerplate_block' );
+```
+
 To use the `RichText` component, add `wp-editor` to the array of registered script handles when calling `wp_register_script`.
 
 Implementing this behavior as a component enables you as the block implementer to be much more granular about editable fields. Your block may not need `RichText` at all, or it may need many independent `RichText` elements, each operating on a subset of the overall block state.


### PR DESCRIPTION
If you don't add wp-editor as a dependency, the example code will throw an error.

## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
