### PR TITLE
Mark temporary eslint-config package as private

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@wordpress/eslint-config",
+	"private": true,
 	"version": "1.0.0-alpha.0",
 	"description": "ESLint config for WordPress development.",
 	"author": "The WordPress Contributors",


### PR DESCRIPTION
## Description
We discussed with @aduth that we should be using Eslint plugin rather than config to make it more flexible. To prevent publishing this package to npm I added `private` flag.

## How has this been tested?
Run `npm run publish:check` and ensure it is not listed.
