### PR TITLE
Adding example for "blocks.getSaveElement" filter in docs

### DIFF
--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -67,6 +67,40 @@ A filter that applies to the result of a block's `save` function. This filter is
 
 The filter's callback receives an element, a block type and the block attributes as arguments. It should return an element.
 
+This example below wraps the existing save element inside of a wrapper element.
+
+_Example:_
+
+Adding a wrapper to core quote blocks
+
+{% codetabs %}
+{% ES5 %}
+```js
+var createElement = wp.element.createElement;
+const quoteSaveFilter = (el, type, attributes) => {
+  if (type.name === "core/quote") {
+    const newEl = createElement("div", {className: "MYWRAPPER"}, el);    
+    return newEl;
+  }
+  return el;
+};
+
+wp.hooks.addFilter("blocks.getSaveElement", "my-plugin/quote-save", quoteSaveFilter);
+```
+{% ESNext %}
+```js
+const quoteSaveFilter = (el, type, attributes) => {
+  if (type.name === "core/quote") {
+    const newEl = <div className="MYWRAPPER">{el}</div>;
+    return newEl;
+  }
+  return el;
+};
+
+addFilter("blocks.getSaveElement", "my-plugin/quote-save", quoteSaveFilter);
+```
+{% end %}
+
 #### `blocks.getSaveContent.extraProps`
 
 A filter that applies to all blocks returning a WP Element in the `save` function. This filter is used to add extra props to the root element of the `save` function. For example: to add a className, an id, or any valid prop for this element.
@@ -335,5 +369,4 @@ To set an SVG icon for the category shown in the previous example, add the follo
 	var svgIcon = el( SVG, { width: 20, height: 20, viewBox: '0 0 20 20'}, circle);
 	wp.blocks.updateCategory( 'my-category', { icon: svgIcon } );
 } )();
-``` 
-
+```

--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -77,27 +77,27 @@ Adding a wrapper to core quote blocks
 {% ES5 %}
 ```js
 var createElement = wp.element.createElement;
-const quoteSaveFilter = (el, type, attributes) => {
-  if (type.name === "core/quote") {
-    const newEl = createElement("div", {className: "MYWRAPPER"}, el);    
+var quoteSaveFilter = ( el, type, attributes ) => {
+  if ( type.name === "core/quote" ) {
+    var newEl = createElement( "div", { className: "MYWRAPPER" }, el );    
     return newEl;
   }
   return el;
 };
 
-wp.hooks.addFilter("blocks.getSaveElement", "my-plugin/quote-save", quoteSaveFilter);
+wp.hooks.addFilter( "blocks.getSaveElement", "my-plugin/quote-save", quoteSaveFilter );
 ```
 {% ESNext %}
 ```js
-const quoteSaveFilter = (el, type, attributes) => {
-  if (type.name === "core/quote") {
+const quoteSaveFilter = ( el, type, attributes ) => {
+  if ( type.name === "core/quote" ) {
     const newEl = <div className="MYWRAPPER">{el}</div>;
     return newEl;
   }
   return el;
 };
 
-addFilter("blocks.getSaveElement", "my-plugin/quote-save", quoteSaveFilter);
+addFilter( "blocks.getSaveElement", "my-plugin/quote-save", quoteSaveFilter );
 ```
 {% end %}
 


### PR DESCRIPTION
## Description
Added example code for blocks.getSaveElement in the documentation

## How has this been tested?
Tested with the latest version of GB that both the ES5 and ES6 examples both apply a wrapper div with class of MYWRAPPER to core quote blocks.

## Screenshots <!-- if applicable -->

## Types of changes
Adds an example to existing documentation description

## Checklist:
- [X ] My code is tested.
- [ X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
