### PR TITLE
Updating Embed URLs to Strip Trailing Slashes

### DIFF
--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -72,7 +72,8 @@ export function getEmbedEditComponent( title, icon, responsive = true ) {
 			if ( event ) {
 				event.preventDefault();
 			}
-			const { url } = this.state;
+			let { url } = this.state;
+			url = url.replace( /\/$/, '' );
 			const { setAttributes } = this.props;
 			this.setState( { editingURL: false } );
 			setAttributes( { url } );


### PR DESCRIPTION
## Description

Fixes #12664.

Updating oEmbed URLs to have the trailing slash stripped from them to prevent the "Sorry, we could not embed that content." when the url is actually a valid embeddable URL.

## How has this been tested?
Manually - Adding new embed blocks to the page and testing different valid and invalid embed urls, with and without trailing slashes to ensure behavior still works as expected

## Types of changes
Bug fix (non-breaking change which fixes an issue): #12664

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows the accessibility standards.
- [X] My code has proper inline documentation.
