### PR TITLE
Align tutorial with example plugin repo code

### DIFF
--- a/docs/designers-developers/developers/tutorials/block-tutorial/block-controls-toolbars-and-inspector.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/block-controls-toolbars-and-inspector.md
@@ -165,6 +165,8 @@ registerBlockType( 'gutenberg-examples/example-04-controls-esnext', {
 ```
 {% end %}
 
+Note that internationalization is an important consideration for WordPress development. While the examples in this documentation do not include internationalization, the [accompanying WordPress example block plugin](https://github.com/WordPress/gutenberg-examples) includes the code necessary to support internationalization.
+
 Note that `BlockControls` is only visible when the block is currently selected and in visual editing mode. `BlockControls` are not shown when editing a block in HTML editing mode.
 
 ## Inspector

--- a/docs/designers-developers/developers/tutorials/block-tutorial/block-controls-toolbars-and-inspector.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/block-controls-toolbars-and-inspector.md
@@ -13,50 +13,45 @@ You can also customize the toolbar to include controls specific to your block ty
 {% codetabs %}
 {% ES5 %}
 ```js
-var el = wp.element.createElement,
-	Fragment = wp.element.Fragment
-	registerBlockType = wp.blocks.registerBlockType,
-	RichText = wp.editor.RichText,
-	BlockControls = wp.editor.BlockControls,
-	AlignmentToolbar = wp.editor.AlignmentToolbar;
+( function( blocks, editor, element ) {
+	var el = element.createElement;
+	var RichText = editor.RichText;
+	var AlignmentToolbar = editor.AlignmentToolbar;
+	var BlockControls = editor.BlockControls;
 
-registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-04', {
-	title: 'Hello World (Step 4)',
+	blocks.registerBlockType( 'gutenberg-examples/example-04-controls', {
+		title: 'Example: Controls',,
+		icon: 'universal-access-alt',
+		category: 'layout',
 
-	icon: 'universal-access-alt',
-
-	category: 'layout',
-
-	attributes: {
-		content: {
-			type: 'string',
-			source: 'html',
-			selector: 'p',
+		attributes: {
+			content: {
+				type: 'array',
+				source: 'children',
+				selector: 'p',
+			},
+			alignment: {
+				type: 'string',
+				default: 'none',
+			},
 		},
-		alignment: {
-			type: 'string',
-		},
-	},
 
-	edit: function( props ) {
-		var content = props.attributes.content,
-			alignment = props.attributes.alignment;
+		edit: function( props ) {
+			var content = props.attributes.content;
+			var alignment = props.attributes.alignment;
 
-		function onChangeContent( newContent ) {
-			props.setAttributes( { content: newContent } );
-		}
+			function onChangeContent( newContent ) {
+				props.setAttributes( { content: newContent } );
+			}
 
-		function onChangeAlignment( newAlignment ) {
-			props.setAttributes( { alignment: newAlignment } );
-		}
+			function onChangeAlignment( newAlignment ) {
+				props.setAttributes( { alignment: newAlignment === undefined ? 'none' : newAlignment } );
+			}
 
-		return (
-			el(
-				Fragment,
-				null,
+			return [
 				el(
 					BlockControls,
-					null,
+					{ key: 'controls' },
 					el(
 						AlignmentToolbar,
 						{
@@ -68,98 +63,101 @@ registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-04', {
 				el(
 					RichText,
 					{
-						key: 'editable',
+						key: 'richtext',
 						tagName: 'p',
-						className: props.className,
 						style: { textAlign: alignment },
+						className: props.className,
 						onChange: onChangeContent,
 						value: content,
 					}
-				)
-			)
-		);
-	},
+				),
+			];
+		},
 
-	save: function( props ) {
-		var content = props.attributes.content,
-			alignment = props.attributes.alignment;
-
-		return el( RichText.Content, {
-			tagName: 'p',
-			className: props.className,
-			style: { textAlign: alignment },
-			value: content
-		} );
-	},
-} );
+		save: function( props ) {
+			return el( RichText.Content, {
+				tagName: 'p',
+				className: 'gutenberg-examples-align-' + props.attributes.alignment,
+				value: props.attributes.content,
+			} );
+		},
+	} );
+}(
+	window.wp.blocks,
+	window.wp.editor,
+	window.wp.element
+) );
 ```
 {% ESNext %}
 ```js
-const { registerBlockType } = wp.blocks;
-const { Fragment } = wp.element;
+const {
+	registerBlockType,
+} = wp.blocks;
+
 const {
 	RichText,
-	BlockControls,
 	AlignmentToolbar,
+	BlockControls,
 } = wp.editor;
 
-registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-04', {
-	title: 'Hello World (Step 4)',
-
+registerBlockType( 'gutenberg-examples/example-04-controls-esnext', {
+	title: 'Example: Controls (esnext)',
 	icon: 'universal-access-alt',
-
 	category: 'layout',
-
 	attributes: {
 		content: {
-			type: 'string',
-			source: 'html',
+			type: 'array',
+			source: 'children',
 			selector: 'p',
 		},
 		alignment: {
 			type: 'string',
+			default: 'none',
 		},
 	},
+	edit: ( props ) => {
+		const {
+			attributes: {
+				content,
+				alignment,
+			},
+			className,
+		} = props;
 
-	edit( { attributes, className, setAttributes } ) {
-		const { content, alignment } = attributes;
+		const onChangeContent = ( newContent ) => {
+			props.setAttributes( { content: newContent } );
+		};
 
-		function onChangeContent( newContent ) {
-			setAttributes( { content: newContent } );
-		}
-
-		function onChangeAlignment( newAlignment ) {
-			setAttributes( { alignment: newAlignment } );
-		}
+		const onChangeAlignment = ( newAlignment ) => {
+			props.setAttributes( { alignment: newAlignment === undefined ? 'none' : newAlignment } );
+		};
 
 		return (
-			<Fragment>
-				<BlockControls>
-					<AlignmentToolbar
-						value={ alignment }
-						onChange={ onChangeAlignment }
-					/>
-				</BlockControls>
+			<div>
+				{
+					<BlockControls>
+						<AlignmentToolbar
+							value={ alignment }
+							onChange={ onChangeAlignment }
+						/>
+					</BlockControls>
+				}
 				<RichText
-					key="editable"
-					tagName="p"
 					className={ className }
 					style={ { textAlign: alignment } }
+					tagName="p"
 					onChange={ onChangeContent }
 					value={ content }
 				/>
-			</Fragment>
+			</div>
 		);
 	},
-
-	save( { attributes } ) {
-		const { content, alignment } = attributes;
-
+	save: ( props ) => {
 		return (
 			<RichText.Content
-				style={ { textAlign: alignment } }
-				value={ content }
+				className={ `gutenberg-examples-align-${ props.attributes.alignment }` }
 				tagName="p"
+				value={ props.attributes.content }
 			/>
 		);
 	},

--- a/docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md
@@ -94,6 +94,8 @@ registerBlockType( 'gutenberg-examples/example-03-editable-esnext', {
 ```
 {% end %}
 
+Note that internationalization is an important consideration for WordPress development. While the examples in this documentation do not include internationalization, the [accompanying WordPress example block plugin](https://github.com/WordPress/gutenberg-examples) includes the code necessary to support internationalization.
+
 When registering a new block type, the `attributes` property describes the shape of the attributes object you'd like to receive in the `edit` and `save` functions. Each value is a [source function](../../../../../docs/designers-developers/developers/block-api/block-attributes.md) to find the desired value from the markup of the block.
 
 In the code snippet above, when loading the editor, we will extract the `content` value as the HTML of the paragraph element in the saved post's markup.

--- a/docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md
@@ -11,81 +11,73 @@ One challenge of maintaining the representation of a block as a JavaScript objec
 {% codetabs %}
 {% ES5 %}
 ```js
-var el = wp.element.createElement,
-	registerBlockType = wp.blocks.registerBlockType,
-	RichText = wp.editor.RichText;
+( function( blocks, editor, element ) {
+	var el = element.createElement;
+	var RichText = editor.RichText;
 
-registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-03', {
-	title: 'Hello World (Step 3)',
+	blocks.registerBlockType( 'gutenberg-examples/example-03-editable', {
+		title: 'Example: Editable',
+		icon: 'universal-access-alt',
+		category: 'layout',
 
-	icon: 'universal-access-alt',
+		attributes: {
+			content: {
+				type: 'array',
+				source: 'children',
+				selector: 'p',
+			},
+		},
 
-	category: 'layout',
-
-	attributes: {
-		content: {
-			type: 'string',
-			source: 'html',
-			selector: 'p',
-		}
-	},
-
-	edit: function( props ) {
-		var content = props.attributes.content;
-
-		function onChangeContent( newContent ) {
-			props.setAttributes( { content: newContent } );
-		}
-
-		return el(
-			RichText,
-			{
-				tagName: 'p',
-				className: props.className,
-				onChange: onChangeContent,
-				value: content,
+		edit: function( props ) {
+			var content = props.attributes.content;
+			function onChangeContent( newContent ) {
+				props.setAttributes( { content: newContent } );
 			}
-		);
-	},
 
-	save: function( props ) {
-		var content = props.attributes.content;
+			return el(
+				RichText,
+				{
+					tagName: 'p',
+					className: props.className,
+					onChange: onChangeContent,
+					value: content,
+				}
+			);
+		},
 
-		return el( RichText.Content, {
-			tagName: 'p',
-			className: props.className,
-			value: content
-		} );
-	},
-} );
+		save: function( props ) {
+			return el( RichText.Content, {
+				tagName: 'p', value: props.attributes.content,
+			} );
+		},
+	} );
+}(
+	window.wp.blocks,
+	window.wp.editor,
+	window.wp.element
+) );
 ```
 {% ESNext %}
 ```js
 const { registerBlockType } = wp.blocks;
 const { RichText } = wp.editor;
 
-registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-03', {
-	title: 'Hello World (Step 3)',
-
+registerBlockType( 'gutenberg-examples/example-03-editable-esnext', {
+	title: 'Example: Editable (esnext)',
 	icon: 'universal-access-alt',
-
 	category: 'layout',
-
 	attributes: {
 		content: {
-			type: 'string',
-			source: 'html',
+			type: 'array',
+			source: 'children',
 			selector: 'p',
 		},
 	},
-
-	edit( { attributes, className, setAttributes } ) {
-		const { content } = attributes;
-
-		function onChangeContent( newContent ) {
+	edit: ( props ) => {
+		const { attributes: { content }, setAttributes, className } = props;
+		const onChangeContent = ( newContent ) => {
 			setAttributes( { content: newContent } );
-		}
-
+		};
 		return (
 			<RichText
 				tagName="p"
@@ -95,16 +87,8 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-03', {
 			/>
 		);
 	},
-
-	save( { attributes } ) {
-		const { content } = attributes;
-
-		return (
-			<RichText.Content
-				tagName="p"
-				value={ content }
-			/>
-		);
+	save: ( props ) => {
+		return <RichText.Content tagName="p" value={ props.attributes.content } />;
 	},
 } );
 ```

--- a/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
@@ -8,22 +8,43 @@ Blocks containing static content are implemented entirely in JavaScript using th
 
 While the block's editor behaviors are implemented in JavaScript, you'll need to register your block server-side to ensure that the script is enqueued when the editor loads. Register scripts and styles using [`wp_register_script`](https://developer.wordpress.org/reference/functions/wp_register_script/) and [`wp_register_style`](https://developer.wordpress.org/reference/functions/wp_register_style/), then assign these as handles associated with your block using the `script`, `style`, `editor_script`, and `editor_style` block type registration settings. The `editor_`-prefixed handles will only be enqueued in the context of the editor, while `script` and `style` will be enqueued both in the editor and when viewing a post on the front of your site.
 
+{% codetabs %}
+{% ES5 %}
 ```php
-<?php
+function gutenberg_examples_01_register_block() {
 
-function gutenberg_boilerplate_block() {
 	wp_register_script(
-		'gutenberg-boilerplate-es5-step01',
-		plugins_url( 'step-01/block.js', __FILE__ ),
-		array( 'wp-blocks', 'wp-element' )
+		'gutenberg-examples-01',
+		plugins_url( 'block.js', __FILE__ ),
+		array( 'wp-blocks', 'wp-element' ),
+		filemtime( plugin_dir_path( __FILE__ ) . 'block.js' )
 	);
 
-	register_block_type( 'gutenberg-boilerplate-es5/hello-world-step-01', array(
-		'editor_script' => 'gutenberg-boilerplate-es5-step01',
+	register_block_type( 'gutenberg-examples/example-01-basic', array(
+		'editor_script' => 'gutenberg-examples-01',
 	) );
 }
-add_action( 'init', 'gutenberg_boilerplate_block' );
+add_action( 'init', 'gutenberg_examples_01_register_block' );
 ```
+{% ESNext %}
+```php
+function gutenberg_examples_01_esnext_register_block() {
+
+	wp_register_script(
+		'gutenberg-examples-01-esnext',
+		plugins_url( 'block.build.js', __FILE__ ),
+		array( 'wp-blocks', 'wp-element' ),
+		filemtime( plugin_dir_path( __FILE__ ) . 'block.build.js' )
+	);
+
+	register_block_type( 'gutenberg-examples/example-01-basic-esnext', array(
+		'editor_script' => 'gutenberg-examples-01-esnext',
+	) );
+
+}
+add_action( 'init', 'gutenberg_examples_01_esnext_register_block' );
+```
+{% end %}
 
 Note the two script dependencies:
 
@@ -39,44 +60,59 @@ With the script enqueued, let's look at the implementation of the block itself:
 {% codetabs %}
 {% ES5 %}
 ```js
-var el = wp.element.createElement,
-	registerBlockType = wp.blocks.registerBlockType,
-	blockStyle = { backgroundColor: '#900', color: '#fff', padding: '20px' };
+( function( blocks, element ) {
+	var el = element.createElement;
 
-registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-01', {
-	title: 'Hello World (Step 1)',
+	var blockStyle = {
+		backgroundColor: '#900',
+		color: '#fff',
+		padding: '20px',
+	};
 
-	icon: 'universal-access-alt',
+	blocks.registerBlockType( 'gutenberg-examples/example-01-basic', {
+		title: 'Example: Basic',
+		icon: 'universal-access-alt',
+		category: 'layout',
+		edit: function() {
+			return el(
+				'p',
+				{ style: blockStyle },
+				'Hello World, step 1 (from the editor).'
+			);
+		},
+		save: function() {
+			return el(
+				'p',
+				{ style: blockStyle },
+				'Hello World, step 1 (from the frontend).'
+			);
+		},
+	} );
+}(
+	window.wp.blocks,
+	window.wp.element
+) );
 
-	category: 'layout',
-
-	edit: function() {
-		return el( 'p', { style: blockStyle }, 'Hello editor.' );
-	},
-
-	save: function() {
-		return el( 'p', { style: blockStyle }, 'Hello saved content.' );
-	},
-} );
 ```
 {% ESNext %}
 ```js
 const { registerBlockType } = wp.blocks;
-const blockStyle = { backgroundColor: '#900', color: '#fff', padding: '20px' };
 
-registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-01', {
-	title: 'Hello World (Step 1)',
+const blockStyle = {
+	backgroundColor: '#900',
+	color: '#fff',
+	padding: '20px',
+};
 
+registerBlockType( 'gutenberg-examples/example-01-basic-esnext', {
+	title: 'Example: Basic (esnext)',
 	icon: 'universal-access-alt',
-
 	category: 'layout',
-
 	edit() {
-		return <p style={ blockStyle }>Hello editor.</p>;
+		return <div style={ blockStyle }>Basic example with JSX! (editor)</div>;
 	},
-
 	save() {
-		return <p style={ blockStyle }>Hello saved content.</p>;
+		return <div style={ blockStyle }>Basic example with JSX! (front)</div>;
 	},
 } );
 ```

--- a/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
@@ -118,6 +118,8 @@ registerBlockType( 'gutenberg-examples/example-01-basic-esnext', {
 ```
 {% end %}
 
+Note that internationalization is an important consideration for WordPress development. While the examples in this documentation do not include internationalization, the [accompanying WordPress example block plugin](https://github.com/WordPress/gutenberg-examples) includes the code necessary to support internationalization.
+
 Once a block is registered, you should immediately see that it becomes available as an option in the editor inserter dialog, using values from `title`, `icon`, and `category` to organize its display. You can choose an icon from any included in the built-in [Dashicons icon set](https://developer.wordpress.org/resource/dashicons/), or provide a [custom svg element](https://wordpress.org/gutenberg/handbook/block-api/#icon-optional).
 
 A block name must be prefixed with a namespace specific to your plugin. This helps prevent conflicts when more than one plugin registers a block with the same name.


### PR DESCRIPTION
## Description

Contributing to #11251 from contributor day at WCUS18

I've updated the code references to more closely match the referenced example plugin repo  https://github.com/WordPress/gutenberg-examples

After discussion with @0aveRyan we decided to strip the internationalization from the code when outlining the tutorial. A note was added below the code samples to indicate this, but if there is a better suggestion I'm happy to help make changes.

Any other feedback & change requests please ping me - rookie contributor so I'm sure we will need to iterate :)

## How has this been tested?
Documentation changes only - not tested.

## Screenshots 
n/a

## Types of changes
* Documentation updates

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
