### PR TITLE
Annotations: Apply annotation className as string

### DIFF
--- a/packages/annotations/src/block/index.js
+++ b/packages/annotations/src/block/index.js
@@ -17,7 +17,7 @@ const addAnnotationClassName = ( OriginalComponent ) => {
 		return {
 			className: annotations.map( ( annotation ) => {
 				return 'is-annotated-by-' + annotation.source;
-			} ),
+			} ).join( ' ' ),
 		};
 	} )( OriginalComponent );
 };


### PR DESCRIPTION
Extracted from: #12186 (https://github.com/WordPress/gutenberg/pull/12186/commits/29694f13ff6f74e7abdd0fca2cf1387130185f12)

This pull request seeks to change the behavior of annotation class name extension to apply the class name as a string, rather than an array, to enable strict reference equality in avoiding unnecessary renders of unaffected blocks present in an editor.

**Testing instructions:**

Repeat testing instructions from #12186