### PR TITLE
fix(a11y): maintain focus when uploading an image

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -1,3 +1,4 @@
+/* global React */
 /**
  * External dependencies
  */
@@ -113,6 +114,7 @@ class ImageEdit extends Component {
 		this.toggleIsEditing = this.toggleIsEditing.bind( this );
 		this.onUploadError = this.onUploadError.bind( this );
 		this.onImageError = this.onImageError.bind( this );
+		this.myRef = React.createRef();
 
 		this.state = {
 			captionFocused: false,
@@ -152,6 +154,16 @@ class ImageEdit extends Component {
 				captionFocused: false,
 			} );
 		}
+
+		if ( this.state.autoFocus && this.myRef.current ) {
+			this.setState( {
+				autoFocus: false,
+			} );
+			const caption = this.myRef.current.querySelector( 'figcaption' );
+			if ( caption ) {
+				caption.focus();
+			}
+		}
 	}
 
 	onUploadError( message ) {
@@ -175,6 +187,7 @@ class ImageEdit extends Component {
 
 		this.setState( {
 			isEditing: false,
+			autoFocus: true,
 		} );
 
 		this.props.setAttributes( {
@@ -557,7 +570,7 @@ class ImageEdit extends Component {
 		return (
 			<Fragment>
 				{ controls }
-				<figure className={ classes }>
+				<figure className={ classes } ref={ this.myRef }>
 					<ImageSize src={ url } dirtynessTrigger={ align }>
 						{ ( sizes ) => {
 							const {


### PR DESCRIPTION
## Description
Changed the image block to maintain focus when uploading an image

## How has this been tested?
Tested this in the browser (Chrome) only and also tested with Voiceover on OS X

## Types of changes
Introduces the concept of an "autoFocus" state to the Image Block component, Introduces a ref to the same component, focuses the figcaption when the autoFocus state is set

Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
