### PR TITLE
12647 fix css color picker

### DIFF
--- a/packages/components/src/color-picker/style.scss
+++ b/packages/components/src/color-picker/style.scss
@@ -35,7 +35,7 @@
 	position: relative;
 }
 .components-color-picker__body {
-	padding: 16px 16px 12px;
+	padding: 16px 0 12px;
 }
 .components-color-picker__controls {
 	display: flex;
@@ -198,6 +198,9 @@
 
 	fieldset {
 		flex: 1;
+	}
+	.components-color-picker__inputs-fields .components-text-control__input {
+		padding: 2px;
 	}
 }
 .components-color-picker__inputs-fields {

--- a/packages/components/src/color-picker/style.scss
+++ b/packages/components/src/color-picker/style.scss
@@ -199,7 +199,7 @@
 	fieldset {
 		flex: 1;
 	}
-	.components-color-picker__inputs-fields .components-text-control__input {
+	.components-color-picker__inputs-fields .components-text-control__input[type="number"] {
 		padding: 2px;
 	}
 }

--- a/packages/components/src/color-picker/style.scss
+++ b/packages/components/src/color-picker/style.scss
@@ -35,7 +35,7 @@
 	position: relative;
 }
 .components-color-picker__body {
-	padding: 16px 0 12px;
+	padding: $grid-size-large 0 #{ $grid-size-small * 3 };
 }
 .components-color-picker__controls {
 	display: flex;
@@ -199,6 +199,7 @@
 	fieldset {
 		flex: 1;
 	}
+
 	.components-color-picker__inputs-fields .components-text-control__input[type="number"] {
 		padding: 2px;
 	}


### PR DESCRIPTION
## Description
Tweaked CSS padding for input fields within the colorPicker

Fixes: #12647 
<!-- Please describe what you have changed or added -->

## How has this been tested?
Tested Manually
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
Before CSS Change:
<img width="261" alt="color_before_css" src="https://user-images.githubusercontent.com/4762451/49703440-bdbc4d00-fbca-11e8-82b4-df3c00ce4021.png">

After CSS Change:
<img width="260" alt="color_after_css" src="https://user-images.githubusercontent.com/4762451/49703474-41763980-fbcb-11e8-94d8-944d7933aa2a.png">


## Types of changes
Added specific CSS styling to the input fields

<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
