### PR TITLE
Try: Fix issue where block fails validation when a default attribute is deprecated

### DIFF
--- a/packages/blocks/src/api/test/parser.js
+++ b/packages/blocks/src/api/test/parser.js
@@ -551,7 +551,7 @@ describe( 'block parser', () => {
 					{
 						attributes: {
 							fruit: {
-								type: 'number',
+								type: 'string',
 								default: 'Bananas',
 							},
 						},


### PR DESCRIPTION
## Description
Fixes #11705

Block implementors are unable update their code to change the default value for an attribute, even when adding a deprecation. Block validation fails for posts that contain blocks still using an old default.

Note - this is only for attributes that aren't sourced

## How has this been tested?
1. Add a columns block to a new post (keeping the number of columns at the default of 2) and save the post
2. Modify the code of the columns block, changing the `columns` attribute default from 2 to 3. 
3. Load the post created in step 1 and observe that the columns block failed validation.
4. Add a deprecation for the columns block to try to solve the failed validation, ensure this new deprecation still has the old default value for the `columns` attribute of 2.
5. Load the post created in step 1.

**Expected Result**
The deprecation with the column count of 2 should be applied.

**Actual Result**
The block fails validation.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Diagnosis

The bug occurs because the attempt to apply the deprecation fails validation here and so the deprecation is skipped (`isValid` is false):
https://github.com/WordPress/gutenberg/blob/40d1282a992702e1933118ef626f0666692baf2b/packages/blocks/src/api/parser.js#L338-L353

This is happening because the `attributes` variable in the above call to `getBlockAttributes` has the default value from the failed initial attempt to create the block (in case of the columns example above, that would be the new default of 3). Because of that the deprecation's default is not applied (as there's already an existing value).

## Fix
Instead of using the attributes from the failed first attempt to create the block when validating a deprecation, this fix instead uses the attributes as they were when the block markup was parsed (those initially passed into `createBlockWithFallback`):
https://github.com/WordPress/gutenberg/blob/40d1282a992702e1933118ef626f0666692baf2b/packages/blocks/src/api/parser.js#L386-L392

This means that a deprecation receives the same attributes that normal block creation would receive, which to me seems logical.

## Types of changes
Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
