### PR TITLE
[RNMobile] Hide keyboard when non textual block is selected

### DIFF
--- a/packages/editor/src/components/plain-text/index.native.js
+++ b/packages/editor/src/components/plain-text/index.native.js
@@ -21,6 +21,12 @@ export default class PlainText extends Component {
 		}
 	}
 
+	componentDidUpdate( prevProps ) {
+		if ( ! this.props.isSelected && prevProps.isSelected ) {
+			this._input.blur();
+		}
+	}
+
 	focus() {
 		this._input.focus();
 	}

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -292,6 +292,8 @@ export class RichText extends Component {
 	componentDidUpdate( prevProps ) {
 		if ( this.props.isSelected && ! prevProps.isSelected ) {
 			this._editor.focus();
+		} else if ( ! this.props.isSelected && prevProps.isSelected ) {
+			this._editor.blur();
 		}
 	}
 


### PR DESCRIPTION
This PR fixes an issue where moving the focus to a non textual block will keep the keyboard up and visible on the screen.

To test this PR follow the instruction in this gb-mobile PR here: https://github.com/wordpress-mobile/gutenberg-mobile/pull/341
