### PR TITLE
Update native more block styling

### DIFF
--- a/packages/block-library/src/more/edit.native.js
+++ b/packages/block-library/src/more/edit.native.js
@@ -47,18 +47,20 @@ export default class MoreEdit extends Component {
 		this.props.setAttributes( { customText: value } );
 	}
 
-	render() {
+    renderLine(key) {
+        return <View key={key} style={ styles[ 'block-library-more__line' ] } />
+    }
+
+    renderText(key: number) {
 		const { attributes, onFocus, onBlur } = this.props;
 		const { customText } = attributes;
 		const defaultText = __( 'Read more' );
 		const value = customText !== undefined ? customText : defaultText;
 
-		return (
-			<View style={ styles[ 'block-library-more__container' ] }>
-				<View style={ styles[ 'block-library-more__sub-container' ] }>
-					<Text style={ styles[ 'block-library-more__left-marker' ] }>&lt;!--</Text>
+        return (
+            <View key={key} >
 					<PlainText
-						style={ styles[ 'block-library-more__plain-text' ] }
+						style={ styles[ 'block-library-more__text' ] }
 						value={ value }
 						multiline={ true }
 						underlineColorAndroid="transparent"
@@ -68,8 +70,22 @@ export default class MoreEdit extends Component {
 						onFocus={ onFocus }
 						onBlur={ onBlur }
 					/>
-					<Text style={ styles[ 'block-library-more__right-marker' ] }>--&gt;</Text>
-				</View>
+            </View>
+        )
+    }
+
+	renderInner() {
+        return [
+            this.renderLine(1),
+            this.renderText(2),
+            this.renderLine(3)
+        ]
+	}
+	
+	render() {
+		return (
+			<View style={ styles[ 'block-library-more__container' ]}>
+				{ this.renderInner() }
 			</View>
 		);
 	}

--- a/packages/block-library/src/more/edit.native.js
+++ b/packages/block-library/src/more/edit.native.js
@@ -47,11 +47,11 @@ export default class MoreEdit extends Component {
 		this.props.setAttributes( { customText: value } );
 	}
 
-    renderLine(key) {
+	renderLine(key) {
         return <View key={key} style={ styles[ 'block-library-more__line' ] } />
     }
 
-    renderText(key) {
+	renderText(key) {
 		const { attributes, onFocus, onBlur } = this.props;
 		const { customText } = attributes;
 		const defaultText = __( 'Read more' );
@@ -79,7 +79,7 @@ export default class MoreEdit extends Component {
             this.renderLine(1),
             this.renderText(2),
             this.renderLine(3)
-        ]
+		]
 	}
 	
 	render() {

--- a/packages/block-library/src/more/edit.native.js
+++ b/packages/block-library/src/more/edit.native.js
@@ -51,7 +51,7 @@ export default class MoreEdit extends Component {
         return <View key={key} style={ styles[ 'block-library-more__line' ] } />
     }
 
-    renderText(key: number) {
+    renderText(key) {
 		const { attributes, onFocus, onBlur } = this.props;
 		const { customText } = attributes;
 		const defaultText = __( 'Read more' );

--- a/packages/block-library/src/more/edit.native.js
+++ b/packages/block-library/src/more/edit.native.js
@@ -48,8 +48,8 @@ export default class MoreEdit extends Component {
 	}
 
 	renderLine(key) {
-        return <View key={key} style={ styles[ 'block-library-more__line' ] } />
-    }
+		return <View key={key} style={ styles[ 'block-library-more__line' ] } />
+	}
 
 	renderText(key) {
 		const { attributes, onFocus, onBlur } = this.props;
@@ -71,8 +71,8 @@ export default class MoreEdit extends Component {
 						onBlur={ onBlur }
 					/>
             </View>
-        )
-    }
+		)
+	}
 
 	renderInner() {
         return [

--- a/packages/block-library/src/more/edit.native.js
+++ b/packages/block-library/src/more/edit.native.js
@@ -47,38 +47,38 @@ export default class MoreEdit extends Component {
 		this.props.setAttributes( { customText: value } );
 	}
 
-	renderLine(key) {
-		return <View key={key} style={ styles[ 'block-library-more__line' ] } />
+	renderLine( key ) {
+		return <View key={ key } style={ styles[ 'block-library-more__line' ] } />
 	}
 
-	renderText(key) {
+	renderText( key ) {
 		const { attributes, onFocus, onBlur } = this.props;
 		const { customText } = attributes;
 		const defaultText = __( 'Read more' );
 		const value = customText !== undefined ? customText : defaultText;
 
-        return (
-            <View key={key} >
-					<PlainText
-						style={ styles[ 'block-library-more__text' ] }
-						value={ value }
-						multiline={ true }
-						underlineColorAndroid="transparent"
-						onChange={ this.onChangeInput }
-						placeholder={ defaultText }
-						isSelected={ this.props.isSelected }
-						onFocus={ onFocus }
-						onBlur={ onBlur }
-					/>
-            </View>
+		return (
+			<View key={ key } >
+				<PlainText
+					style={ styles[ 'block-library-more__text' ] }
+					value={ value }
+					multiline={ true }
+					underlineColorAndroid="transparent"
+					onChange={ this.onChangeInput }
+					placeholder={ defaultText }
+					isSelected={ this.props.isSelected }
+					onFocus={ onFocus }
+					onBlur={ onBlur }
+				/>
+			</View>
 		)
 	}
 
 	renderInner() {
-        return [
-            this.renderLine(1),
-            this.renderText(2),
-            this.renderLine(3)
+		return [
+			this.renderLine(1),
+			this.renderText(2),
+			this.renderLine(3)
 		]
 	}
 	

--- a/packages/block-library/src/more/edit.native.js
+++ b/packages/block-library/src/more/edit.native.js
@@ -47,18 +47,18 @@ export default class MoreEdit extends Component {
 		this.props.setAttributes( { customText: value } );
 	}
 
-	renderLine( key ) {
-		return <View key={ key } style={ styles[ 'block-library-more__line' ] } />
+	renderLine() {
+		return <View style={ styles[ 'block-library-more__line' ] } />
 	}
 
-	renderText( key ) {
+	renderText() {
 		const { attributes, onFocus, onBlur } = this.props;
 		const { customText } = attributes;
 		const defaultText = __( 'Read more' );
 		const value = customText !== undefined ? customText : defaultText;
 
 		return (
-			<View key={ key } >
+			<View>
 				<PlainText
 					style={ styles[ 'block-library-more__text' ] }
 					value={ value }
@@ -74,18 +74,12 @@ export default class MoreEdit extends Component {
 		)
 	}
 
-	renderInner() {
-		return [
-			this.renderLine(1),
-			this.renderText(2),
-			this.renderLine(3)
-		]
-	}
-	
 	render() {
 		return (
 			<View style={ styles[ 'block-library-more__container' ]}>
-				{ this.renderInner() }
+				{ this.renderLine() }
+				{ this.renderText() }
+				{ this.renderLine() }
 			</View>
 		);
 	}

--- a/packages/block-library/src/more/editor.native.scss
+++ b/packages/block-library/src/more/editor.native.scss
@@ -2,21 +2,21 @@
 
 .block-library-more__container {
 	align-items: center;
-	padding-left: 4;
-	padding-right: 4;
-	padding-top: 4;
-	padding-bottom: 4;
-}
-
-.block-library-more__sub-container {
-	align-items: center;
+	padding: 4px;
 	flex-direction: row;
 }
 
-.block-library-more__left-marker {
-	padding-right: 4;
+.block-library-more__line {
+	background-color: #555d66;
+	height: 2;
+	flex: 1;
 }
 
-.block-library-more__right-marker {
-	padding-left: 4;
+.block-library-more__text {
+	text-decoration-style: solid;
+	flex: 1;
+	text-align: center;
+	margin-left: 15;
+	margin-right: 15;
+	margin-bottom: 5;
 }

--- a/packages/block-library/src/more/editor.native.scss
+++ b/packages/block-library/src/more/editor.native.scss
@@ -14,7 +14,8 @@
 
 .block-library-more__text {
 	text-decoration-style: solid;
-	flex: 1;
+	flex: 0;
+	width: 200;
 	text-align: center;
 	margin-left: 15;
 	margin-right: 15;


### PR DESCRIPTION
## Description
Update native more block styling as below.

## How has this been tested?

- Tested with steps in the [parent PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/342).

## Screenshots <!-- if applicable -->

<img width="342" alt="screen shot 2018-12-10 at 20 51 31" src="https://user-images.githubusercontent.com/5032900/49751009-68149d00-fcbd-11e8-9e0e-837fd73aaf61.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
