### PR TITLE
Fix incorrect values for __back_compat_meta_box in docs

### DIFF
--- a/docs/designers-developers/developers/backward-compatibility/meta-box.md
+++ b/docs/designers-developers/developers/backward-compatibility/meta-box.md
@@ -27,7 +27,7 @@ After a meta box is converted to a block, it can be declared as existing for bac
 add_meta_box( 'my-meta-box', 'My Meta Box', 'my_meta_box_callback',
 	null, 'normal', 'high',
 	array(
-		'__back_compat_meta_box' => false,
+		'__back_compat_meta_box' => true,
 	)
 );
 ```


### PR DESCRIPTION
## Description

The documentation has an example of the parameter to pass in to `add_meta_box` to disable once the meta box has been converted to a block. This value should be true, not false.
```js
__back_compat_meta_box => true
```

You can confirm this by looking at the code which is looking for the value to be true, and if so will unset from the list of meta boxes to be shown. 

```php
if ( isset( $data['args']['__back_compat_meta_box'] ) && $data['args']['__back_compat_meta_box'] ) {
    unset( $meta_boxes[ $page ][ $context ][ $priority ][ $name ] );
}
```

From: https://github.com/WordPress/gutenberg/blob/master/lib/meta-box-partial-page.php#L149


## How has this been tested?

Use an older WordPress plugin that has a metabox, and update with the parameter `__back_compat_meta_box` set to false and true to the `add_meta_box()`

It should not show in Gutenberg when set to true.


## Types of changes

Documentation update.
