### PR TITLE
Add attributes to ServerSideRender readme

### DIFF
--- a/packages/components/src/server-side-render/README.md
+++ b/packages/components/src/server-side-render/README.md
@@ -32,5 +32,25 @@ Output uses the block's `render_callback` function, set when defining the block.
 
 ## API Endpoint
 
-The API endpoint for getting the output for ServerSideRender is `/wp/v2/block-renderer/:block`. It accepts any params, which are used as `attributes` for the block's `render_callback` method.
+The API endpoint for getting the output for ServerSideRender is `/wp/v2/block-renderer/:block`. It will use the block's `render_callback` method.
 
+If you pass `attributes` to ServerSideRender you must define these attributes when registering the block.
+
+```php
+register_block_type(
+	'core/archives',
+	array(
+		'attributes' => array(
+			'showPostCounts' => array(
+				'type' => 'boolean',
+				'default' => false,
+			),
+			'displayAsDropdown' => array(
+				'type' => 'boolean',
+				'default' => false,
+			),
+		),
+		'render_callback' => 'render_block_core_archives',
+	)
+);
+```

--- a/packages/components/src/server-side-render/README.md
+++ b/packages/components/src/server-side-render/README.md
@@ -34,20 +34,20 @@ Output uses the block's `render_callback` function, set when defining the block.
 
 The API endpoint for getting the output for ServerSideRender is `/wp/v2/block-renderer/:block`. It will use the block's `render_callback` method.
 
-If you pass `attributes` to ServerSideRender you must define these attributes when registering the block.
+If you pass `attributes` to `ServerSideRender`, the block must also be registered and have its attributes defined in PHP.
 
 ```php
 register_block_type(
 	'core/archives',
 	array(
-		'attributes' => array(
-			'showPostCounts' => array(
-				'type' => 'boolean',
-				'default' => false,
+		'attributes'      => array(
+			'showPostCounts'    => array(
+				'type'      => 'boolean',
+				'default'   => false,
 			),
 			'displayAsDropdown' => array(
-				'type' => 'boolean',
-				'default' => false,
+				'type'      => 'boolean',
+				'default'   => false,
 			),
 		),
 		'render_callback' => 'render_block_core_archives',


### PR DESCRIPTION
## Description
Adds a code example demonstrating how to define attributes when registering a block that will use attributes in a ServerSideRender component.

## How has this been tested?
No code changes were made or tested. The readme renders well in the GitHub preview.

## Screenshots <!-- if applicable -->
N/A

## Types of changes
Documentation

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
