### PR TITLE
[WIP] Check if a block can be inserted when finding raw transforms

### DIFF
--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -20,6 +20,7 @@ import {
  * WordPress dependencies
  */
 import { createHooks, applyFilters } from '@wordpress/hooks';
+import { select } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -285,6 +286,8 @@ export function findTransform( transforms, predicate ) {
  * @return {Array} Block transforms for direction.
  */
 export function getBlockTransforms( direction, blockTypeOrName ) {
+	const { canInsertBlockType } = select( 'core/editor' );
+
 	// When retrieving transforms for all block types, recurse into self.
 	if ( blockTypeOrName === undefined ) {
 		return flatMap(
@@ -296,7 +299,7 @@ export function getBlockTransforms( direction, blockTypeOrName ) {
 	// Validate that block type exists and has array of direction.
 	const blockType = normalizeBlockType( blockTypeOrName );
 	const { name: blockName, transforms } = blockType || {};
-	if ( ! transforms || ! Array.isArray( transforms[ direction ] ) ) {
+	if ( ! canInsertBlockType( blockName ) || ! transforms || ! Array.isArray( transforms[ direction ] ) ) {
 		return [];
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/11245

Needs discussion on the approach, as this introduces a dependency from `blocks` to `editor`.

## Description

When blocks are disabled, pasting content that matches their transforms should not insert them.

## How has this been tested?

Disable the embed blocks, paste a URL. You should not get an embed block.

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
