### PR TITLE
Editor: Return previewLink from post link only if available

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 - `getEditedPostAttribute` now correctly returns the merged result of edits as a partial change when given `'meta'` as the `attributeName`.
+- Fixes an error and unrecoverable state which occurs on autosave completion for a `'publicly_queryable' => false` post type.
 
 ## 9.0.4 (2018-11-30)
 

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -1205,17 +1205,24 @@ export function autosave( state = null, action ) {
 }
 
 /**
- * Reducer returning the poost preview link
+ * Reducer returning the post preview link.
  *
- * @param  {string?} state  The preview link
- * @param  {Object} action Dispatched action.
+ * @param {string?} state  The preview link
+ * @param {Object}  action Dispatched action.
  *
  * @return {string?} Updated state.
  */
 export function previewLink( state = null, action ) {
 	switch ( action.type ) {
 		case 'REQUEST_POST_UPDATE_SUCCESS':
-			return action.post.preview_link || addQueryArgs( action.post.link, { preview: true } );
+			const { preview_link: previewLink, link } = action.post;
+			if ( previewLink ) {
+				return previewLink;
+			} else if ( link ) {
+				return addQueryArgs( link, { preview: true } );
+			}
+
+			return state;
 
 		case 'REQUEST_POST_UPDATE_START':
 			// Invalidate known preview link when autosave starts.

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -1215,11 +1215,10 @@ export function autosave( state = null, action ) {
 export function previewLink( state = null, action ) {
 	switch ( action.type ) {
 		case 'REQUEST_POST_UPDATE_SUCCESS':
-			const { preview_link: previewLink, link } = action.post;
-			if ( previewLink ) {
-				return previewLink;
-			} else if ( link ) {
-				return addQueryArgs( link, { preview: true } );
+			if ( action.post.preview_link ) {
+				return action.post.preview_link;
+			} else if ( action.post.link ) {
+				return addQueryArgs( action.post.link, { preview: true } );
 			}
 
 			return state;

--- a/packages/editor/src/store/test/reducer.js
+++ b/packages/editor/src/store/test/reducer.js
@@ -2528,6 +2528,10 @@ describe( 'state', () => {
 		} );
 
 		it( 'returns same state if save success without preview link or post link', () => {
+			// Bug: This can occur for post types which are defined as
+			// `publicly_queryable => false` (non-viewable).
+			//
+			// See: https://github.com/WordPress/gutenberg/issues/12677
 			const state = previewLink( null, {
 				type: 'REQUEST_POST_UPDATE_SUCCESS',
 				post: {

--- a/packages/editor/src/store/test/reducer.js
+++ b/packages/editor/src/store/test/reducer.js
@@ -2509,8 +2509,8 @@ describe( 'state', () => {
 			const state = previewLink( null, {
 				type: 'REQUEST_POST_UPDATE_SUCCESS',
 				post: {
-					preview_link: 'https://example.com/?p=2611&preview=true'
-				}
+					preview_link: 'https://example.com/?p=2611&preview=true',
+				},
 			} );
 
 			expect( state ).toBe( 'https://example.com/?p=2611&preview=true' );
@@ -2520,8 +2520,8 @@ describe( 'state', () => {
 			const state = previewLink( null, {
 				type: 'REQUEST_POST_UPDATE_SUCCESS',
 				post: {
-					link: 'https://example.com/sample-post/'
-				}
+					link: 'https://example.com/sample-post/',
+				},
 			} );
 
 			expect( state ).toBe( 'https://example.com/sample-post/?preview=true' );
@@ -2532,7 +2532,7 @@ describe( 'state', () => {
 				type: 'REQUEST_POST_UPDATE_SUCCESS',
 				post: {
 					preview_link: '',
-				}
+				},
 			} );
 
 			expect( state ).toBe( null );

--- a/packages/editor/src/store/test/reducer.js
+++ b/packages/editor/src/store/test/reducer.js
@@ -37,6 +37,7 @@ import {
 	blockListSettings,
 	autosave,
 	postSavingLock,
+	previewLink,
 } from '../reducer';
 import { INITIAL_EDITS_DEFAULTS } from '../defaults';
 
@@ -2494,6 +2495,67 @@ describe( 'state', () => {
 			} );
 
 			expect( state ).toEqual( {} );
+		} );
+	} );
+
+	describe( 'previewLink', () => {
+		it( 'returns null by default', () => {
+			const state = previewLink( undefined, {} );
+
+			expect( state ).toBe( null );
+		} );
+
+		it( 'returns preview link from save success', () => {
+			const state = previewLink( null, {
+				type: 'REQUEST_POST_UPDATE_SUCCESS',
+				post: {
+					preview_link: 'https://example.com/?p=2611&preview=true'
+				}
+			} );
+
+			expect( state ).toBe( 'https://example.com/?p=2611&preview=true' );
+		} );
+
+		it( 'returns post link with query arg from save success if no preview link', () => {
+			const state = previewLink( null, {
+				type: 'REQUEST_POST_UPDATE_SUCCESS',
+				post: {
+					link: 'https://example.com/sample-post/'
+				}
+			} );
+
+			expect( state ).toBe( 'https://example.com/sample-post/?preview=true' );
+		} );
+
+		it( 'returns same state if save success without preview link or post link', () => {
+			const state = previewLink( null, {
+				type: 'REQUEST_POST_UPDATE_SUCCESS',
+				post: {
+					preview_link: '',
+				}
+			} );
+
+			expect( state ).toBe( null );
+		} );
+
+		it( 'returns resets on preview start', () => {
+			const state = previewLink( 'https://example.com/sample-post/', {
+				type: 'REQUEST_POST_UPDATE_START',
+				options: {
+					isPreview: true,
+				},
+			} );
+
+			expect( state ).toBe( null );
+		} );
+
+		it( 'returns state on non-preview save start', () => {
+			const state = previewLink( 'https://example.com/sample-post/', {
+				type: 'REQUEST_POST_UPDATE_START',
+				options: {},
+			} );
+
+			expect( state ).toBe( 'https://example.com/sample-post/' );
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #12677

This pull request seeks to resolve an error which occurs when autosaving a post whose post type is registered using `'publicly_queryable' => false`.

An in-depth explanation of the issue can be found at https://github.com/WordPress/gutenberg/issues/12677#issuecomment-446259428 .

**Testing instructions:**

Verify using the following example post type definition that autosave occurs without error:

```php
<?php

/**
 * Plugin Name: Demo CPT
 */
add_action( 'init', function() {
	register_post_type( 'book', [
		'label' => 'Book',
		'show_in_rest' => true,
		'public' => true,
		'publicly_queryable' => false,
		'supports' => [ 'title', 'editor', 'revisions' ],
	] );
} );
```