### PR TITLE
URL: Return querystring fragment from  addQueryArgs when URL undefined

### DIFF
--- a/packages/url/CHANGELOG.md
+++ b/packages/url/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.3.3 (Unreleased)
+
+### Bug Fixes
+
+- `addQueryArgs` will return only the querystring fragment if the passed `url` is undefined. Previously, an uncaught error would be thrown.
+
 ## 2.3.2 (2018-12-12)
 
 ## 2.3.1 (2018-11-20)

--- a/packages/url/src/index.js
+++ b/packages/url/src/index.js
@@ -159,19 +159,33 @@ export function isValidFragment( fragment ) {
 }
 
 /**
- * Appends arguments to the query string of the url
+ * Appends arguments as querystring to the provided URL. If the URL already
+ * includes query arguments, the arguments are merged with (and take precedent
+ * over) the existing set.
  *
- * @param {string} url  URL
- * @param {Object} args Query Args
+ * @param {?string} url  URL to which arguments should be appended. If omitted,
+ *                       only the resulting querystring is returned.
+ * @param {Object}  args Query arguments to apply to URL.
  *
- * @return {string} Updated URL
+ * @return {string} URL with arguments applied.
  */
-export function addQueryArgs( url, args ) {
-	const queryStringIndex = url.indexOf( '?' );
-	const query = queryStringIndex !== -1 ? parse( url.substr( queryStringIndex + 1 ) ) : {};
-	const baseUrl = queryStringIndex !== -1 ? url.substr( 0, queryStringIndex ) : url;
+export function addQueryArgs( url = '', args ) {
+	let baseUrl = url;
 
-	return baseUrl + '?' + stringify( { ...query, ...args } );
+	// Determine whether URL already had query arguments.
+	const queryStringIndex = url.indexOf( '?' );
+	if ( queryStringIndex !== -1 ) {
+		// Merge into existing query arguments.
+		args = Object.assign(
+			parse( url.substr( queryStringIndex + 1 ) ),
+			args
+		);
+
+		// Change working base URL to omit previous query arguments.
+		baseUrl = baseUrl.substr( 0, queryStringIndex );
+	}
+
+	return baseUrl + '?' + stringify( args );
 }
 
 /**

--- a/packages/url/src/test/index.test.js
+++ b/packages/url/src/test/index.test.js
@@ -285,14 +285,14 @@ describe( 'isValidFragment', () => {
 } );
 
 describe( 'addQueryArgs', () => {
-	it( 'should append args to an URL without query string', () => {
+	it( 'should append args to a URL without query string', () => {
 		const url = 'https://andalouses.example/beach';
 		const args = { sun: 'true', sand: 'false' };
 
 		expect( addQueryArgs( url, args ) ).toBe( 'https://andalouses.example/beach?sun=true&sand=false' );
 	} );
 
-	it( 'should append args to an URL with query string', () => {
+	it( 'should append args to a URL with query string', () => {
 		const url = 'https://andalouses.example/beach?night=false';
 		const args = { sun: 'true', sand: 'false' };
 
@@ -325,6 +325,10 @@ describe( 'addQueryArgs', () => {
 		const args = { activity: 'fun in the sun' };
 
 		expect( addQueryArgs( url, args ) ).toBe( 'https://andalouses.example/beach?activity=fun%20in%20the%20sun' );
+	} );
+
+	it( 'should return only querystring when passed undefined url', () => {
+		expect( addQueryArgs( undefined, { sun: 'true' } ) ).toBe( '?sun=true' );
 	} );
 } );
 


### PR DESCRIPTION
Related: #12677 (specifically https://github.com/WordPress/gutenberg/issues/12677#issuecomment-446259428)

This pull request seeks to resolve an issue where `addQueryArgs` will throw an error when passed `undefined` as an argument. While there may be some argument to be made about not handling unexpected argument shapes, ...

1. The error should ideally be explicitly thrown as an unsupported argument. Here, it is an uncaught error by applying `indexOf` on the non-string argument.
2. The resulting behavior from these changes can be particularly handy in cases where someone intends to generate only a querystring fragment ([[1]](https://github.com/WordPress/gutenberg/blob/1a1dc7c15f556a5298c2549e219fdc79fb951304/packages/core-data/src/queried-data/get-query-parts.js#L66), [[2]](https://github.com/WordPress/gutenberg/blob/1a1dc7c15f556a5298c2549e219fdc79fb951304/test/e2e/support/utils/new-post.js#L23)).
3. The behavior here matches the PHP equivalent `add_query_arg` when passed `null` as an argument.

**Implementation notes:**

I've included some minor refactoring to the function, which should serve as a small performance optimization via:

- Only creating a clone of the arguments set when the prior URL included query arguments
- Limiting cloning behavior to occur a maximum of once (via mutative `Object.assign` into generated `parse` result) instead of twice (object spread `...` using two objects, which is effectively equivalent to `Object.assign( {}, a, b );`

**Testing instructions:**

Ensure unit tests pass:

```
npm run test-unit
```

Verify that no error occurs when repeating steps to reproduce from #12677. This is technically a tangential fix for #12677, but it would result in wrong state being tracked, which is otherwise fixed by #12800.