### PR TITLE
Add section to setAttributes documentation about immutability of attributes

### DIFF
--- a/docs/designers-developers/developers/block-api/block-edit-save.md
+++ b/docs/designers-developers/developers/block-api/block-edit-save.md
@@ -80,6 +80,23 @@ edit( { attributes, setAttributes, className, isSelected } ) {
 }
 ```
 
+When calling `setAttributes`, it's important that attributes are not mutated in the process of updating them. This is considered bad practice, the core of Gutenberg has been written with the same philosophies as Redux and state is treated as immutable data. It can also cause bugs. Objects and arrays are passed as references in JavaScript, so mutating them can affect other bindings to those references, for example an attribute's default value.
+
+```js
+// Good - here a new array is created from the old list attribute and a new list item:
+const { list } = attributes;
+const addListItem = ( newListItem ) => setAttributes( { list: [ ...list, newListItem ] } );
+
+// Bad - here the list from the existing attributes is mutated to add the new list item:
+const { list } = attributes;
+const addListItem = ( newListItem ) => {
+	list.push( newListItem );
+	setAttributes( { list } );
+};
+
+```
+
+
 ## Save
 
 The `save` function defines the way in which the different attributes should be combined into the final markup, which is then serialized by Gutenberg into `post_content`.

--- a/docs/designers-developers/developers/block-api/block-edit-save.md
+++ b/docs/designers-developers/developers/block-api/block-edit-save.md
@@ -80,14 +80,14 @@ edit( { attributes, setAttributes, className, isSelected } ) {
 }
 ```
 
-When calling `setAttributes`, it's important that attributes are not mutated in the process of updating them. This is considered bad practice, the core of Gutenberg has been written with the same philosophies as Redux and state is treated as immutable data. It can also cause bugs. Objects and arrays are passed as references in JavaScript, so mutating them can affect other bindings to those references, for example an attribute's default value.
+When using attributes that are objects or arrays it's a good idea to copy or clone the attribute prior to updating it:
 
 ```js
 // Good - here a new array is created from the old list attribute and a new list item:
 const { list } = attributes;
 const addListItem = ( newListItem ) => setAttributes( { list: [ ...list, newListItem ] } );
 
-// Bad - here the list from the existing attributes is mutated to add the new list item:
+// Bad - here the list from the existing attribute is modified directly to add the new list item:
 const { list } = attributes;
 const addListItem = ( newListItem ) => {
 	list.push( newListItem );
@@ -96,6 +96,7 @@ const addListItem = ( newListItem ) => {
 
 ```
 
+Why do this? In JavaScript, arrays and objects are passed by reference, so this practice ensures changes won't affect other code that might hold references to the same data. Furthermore, Gutenberg follows the philisophy of the Redux library that state should be immutable—data should not be changed directly, but instead a new version of the data created containing the changes.
 
 ## Save
 

--- a/docs/designers-developers/developers/block-api/block-edit-save.md
+++ b/docs/designers-developers/developers/block-api/block-edit-save.md
@@ -96,7 +96,7 @@ const addListItem = ( newListItem ) => {
 
 ```
 
-Why do this? In JavaScript, arrays and objects are passed by reference, so this practice ensures changes won't affect other code that might hold references to the same data. Furthermore, Gutenberg follows the philisophy of the Redux library that state should be immutable—data should not be changed directly, but instead a new version of the data created containing the changes.
+Why do this? In JavaScript, arrays and objects are passed by reference, so this practice ensures changes won't affect other code that might hold references to the same data. Furthermore, Gutenberg follows the philosophy of the Redux library that [state should be immutable](https://redux.js.org/faq/immutable-data#what-are-the-benefits-of-immutability)—data should not be changed directly, but instead a new version of the data created containing the changes.
 
 ## Save
 


### PR DESCRIPTION
## Description
https://github.com/WordPress/gutenberg/pull/10890 raised an issue about side effects caused by mutating attributes. Looking through the docs there wasn't anything covering best practices around the handling of attributes, so I've added a bit to the documentation for `setAttributes`.


## Types of changes
Documentation update
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
