### PR TITLE
[RNMobile] Fix undo/redo on new blocks

### DIFF
--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -274,8 +274,8 @@ export class RichText extends Component {
 
 		// If the component is changed React side (undo/redo/merging/splitting/custom text actions)
 		// we need to make sure the native is updated as well
-		if ( nextProps.value &&
-			this.lastContent &&
+		if ( ( typeof nextProps.value !== 'undefined' ) &&
+			( typeof this.lastContent !== 'undefined' ) &&
 			nextProps.value !== this.lastContent ) {
 			this.lastEventCount = undefined; // force a refresh on the native side
 		}


### PR DESCRIPTION
This PR fixes a problem with undo/redo not working on new (empty) blocks after writing some text.

the problem was due to the way we compare actual and previous value, without taking in consideration that empty variable != from undefined.

Testing steps in GB-side PR here: https://github.com/wordpress-mobile/gutenberg-mobile/pull/361