### PR TITLE
Columns - fix margins, keep 2-col breakpoint

### DIFF
--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -77,6 +77,10 @@
 				margin-right: $block-padding;
 			}
 
+			// Because the columns wrap, each column container needs the same margin a block would have,
+			// otherwise there would be overlap.
+			margin-bottom: $block-padding * 2;
+
 			// Prevent the columns from growing wider than their distributed sizes.
 			min-width: 0;
 
@@ -91,7 +95,7 @@
 			@include break-small() {
 				// Size should be half the available width, minus the margins added below.
 				// In the editor, we also need to account for additional block padding.
-				flex-basis: calc(50% - #{$grid-size-large * 2} - #{$block-padding * 2});
+				flex-basis: calc(50% - #{ $grid-size-large } - #{$block-padding * 2});
 				flex-grow: 0;
 			}
 
@@ -102,15 +106,19 @@
 			// 2 columns at this breakpoint, and items beyond the second will wrap.
 			@include break-small() {
 				&:nth-child(odd) {
-					margin-right: $grid-size-large * 2 + $block-padding;
+					margin-right: $grid-size-large + $block-padding;
 				}
 
 				&:nth-child(even) {
-					margin-left: $grid-size-large * 2 + $block-padding;
+					margin-left: $grid-size-large + $block-padding;
 				}
 			}
 
+			// Beyond the medium breakpoint, show the user-set amount of columns.
 			@include break-medium() {
+				// Because columns do not wrap, reset the column margin.
+				margin-bottom: initial;
+
 				// Reset odd, even margins from small breakpoint.
 				&:nth-child(even) {
 					margin-left: $block-padding;
@@ -122,12 +130,12 @@
 
 				// Add left margin to all but first column.
 				&:not(:first-child) {
-					margin-left: ($grid-size-large * 2) + $block-padding;
+					margin-left: $grid-size-large + $block-padding;
 				}
 
 				// Add right margin to all but last column.
 				&:not(:last-child) {
-					margin-right: ($grid-size-large * 2) + $block-padding;
+					margin-right: $grid-size-large + $block-padding;
 				}
 			}
 		}

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -35,7 +35,7 @@
 		// Responsiveness: Allow wrapping on mobile.
 		flex-wrap: wrap;
 
-		@include break-small() {
+		@include break-medium() {
 			flex-wrap: nowrap;
 		}
 
@@ -89,7 +89,7 @@
 
 			// Beyond mobile, allow 2 columns.
 			@include break-small() {
-				flex-basis: 50%;
+				flex-basis: calc(50% - #{$grid-size-large * 2} - #{$block-padding * 2});
 				flex-grow: 0;
 			}
 
@@ -105,7 +105,13 @@
 				}
 			}
 
-			@include break-small() {
+			@include break-medium() {
+				&:nth-child(even) {
+					margin-left: initial;
+				}
+				&:nth-child(odd) {
+					margin-right: initial;
+				}
 				&:not(:first-child) {
 					margin-left: $grid-size-large * 2;
 				}

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -89,8 +89,8 @@
 
 			// Beyond mobile, allow 2 columns.
 			@include break-small() {
-				// Size should be half the available width, minus the margins added below
-				// In the editor, we also need to account for additional block padding
+				// Size should be half the available width, minus the margins added below.
+				// In the editor, we also need to account for additional block padding.
 				flex-basis: calc(50% - #{$grid-size-large * 2} - #{$block-padding * 2});
 				flex-grow: 0;
 			}
@@ -104,6 +104,7 @@
 				&:nth-child(odd) {
 					margin-right: $grid-size-large * 2;
 				}
+
 				&:nth-child(even) {
 					margin-left: $grid-size-large * 2;
 				}
@@ -114,14 +115,17 @@
 				&:nth-child(even) {
 					margin-left: initial;
 				}
+
 				&:nth-child(odd) {
 					margin-right: initial;
 				}
+
 				// Add left margin to all but first column
 				&:not(:first-child) {
 					margin-left: $grid-size-large * 2;
 				}
-				// add right margin to all but last column
+
+				// Add right margin to all but last column.
 				&:not(:last-child) {
 					margin-right: $grid-size-large * 2;
 				}

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -89,6 +89,8 @@
 
 			// Beyond mobile, allow 2 columns.
 			@include break-small() {
+				// Size should be half the available width, minus the margins added below
+				// In the editor, we also need to account for additional block padding
 				flex-basis: calc(50% - #{$grid-size-large * 2} - #{$block-padding * 2});
 				flex-grow: 0;
 			}
@@ -96,6 +98,8 @@
 			// Add space between columns. Themes can customize this if they wish to work differently.
 			// This has to match the same padding applied in style.scss.
 			// Only apply this beyond the mobile breakpoint, as there's only a single column on mobile.
+
+			// 2 columns at this breakpoint, and items beyond the second will wrap.
 			@include break-small() {
 				&:nth-child(odd) {
 					margin-right: $grid-size-large * 2;
@@ -106,16 +110,18 @@
 			}
 
 			@include break-medium() {
+				// Reset odd, even margins from small breakpoint.
 				&:nth-child(even) {
 					margin-left: initial;
 				}
 				&:nth-child(odd) {
 					margin-right: initial;
 				}
+				// Add left margin to all but first column
 				&:not(:first-child) {
 					margin-left: $grid-size-large * 2;
 				}
-
+				// add right margin to all but last column
 				&:not(:last-child) {
 					margin-right: $grid-size-large * 2;
 				}

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -102,32 +102,32 @@
 			// 2 columns at this breakpoint, and items beyond the second will wrap.
 			@include break-small() {
 				&:nth-child(odd) {
-					margin-right: $grid-size-large * 2;
+					margin-right: $grid-size-large * 2 + $block-padding;
 				}
 
 				&:nth-child(even) {
-					margin-left: $grid-size-large * 2;
+					margin-left: $grid-size-large * 2 + $block-padding;
 				}
 			}
 
 			@include break-medium() {
 				// Reset odd, even margins from small breakpoint.
 				&:nth-child(even) {
-					margin-left: initial;
+					margin-left: $block-padding;
 				}
 
 				&:nth-child(odd) {
-					margin-right: initial;
+					margin-right: $block-padding;
 				}
 
-				// Add left margin to all but first column
+				// Add left margin to all but first column.
 				&:not(:first-child) {
-					margin-left: $grid-size-large * 2;
+					margin-left: ($grid-size-large * 2) + $block-padding;
 				}
 
 				// Add right margin to all but last column.
 				&:not(:last-child) {
-					margin-right: $grid-size-large * 2;
+					margin-right: ($grid-size-large * 2) + $block-padding;
 				}
 			}
 		}

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -43,7 +43,6 @@
 		> [data-type="core/column"] {
 			display: flex;
 			flex-direction: column;
-			flex: 1;
 
 			// The Column block is a child of the Columns block and is mostly a passthrough container.
 			// Therefore it shouldn't add additional paddings and margins, so we reset these, and compensate for margins.
@@ -89,14 +88,13 @@
 			overflow-wrap: break-word; // New standard.
 
 			// Responsiveness: Show at most one columns on mobile.
-			flex-basis: 100%;
+			width: 100%;
 
 			// Beyond mobile, allow 2 columns.
 			@include break-small() {
 				// Size should be half the available width, minus the margins added below.
 				// In the editor, we also need to account for additional block padding.
-				flex-basis: calc(50% - #{ $grid-size-large } - #{$block-padding * 2});
-				flex-grow: 0;
+				width: calc(50% - #{ $grid-size-large } - #{$block-padding * 2});
 			}
 
 			// Add space between columns. Themes can customize this if they wish to work differently.
@@ -117,7 +115,7 @@
 			// Beyond the medium breakpoint, show the user-set amount of columns.
 			@include break-medium() {
 				// Because columns do not wrap, reset the column margin.
-				margin-bottom: initial;
+				margin-bottom: 0;
 
 				// Reset odd, even margins from small breakpoint.
 				&:nth-child(even) {

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -53,11 +53,11 @@
 		&:nth-child(odd) {
 			margin-right: initial;
 		}
-		// Add left margin to all but first item
+		// Add left margin to all but first column
 		&:not(:first-child) {
 			margin-left: $grid-size-large * 2;
 		}
-		// add right margin to all but last item
+		// add right margin to all but last column
 		&:not(:last-child) {
 			margin-right: $grid-size-large * 2;
 		}

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -18,7 +18,9 @@
 
 	// Beyond mobile, allow 2 columns.
 	@include break-small() {
-		flex-basis: 50%;
+
+		// Size should be half the available width, minus the margins added below
+		flex-basis: calc(50% - #{$grid-size-large * 2});
 		flex-grow: 0;
 	}
 
@@ -31,18 +33,31 @@
 
 	// Add space between columns. Themes can customize this if they wish to work differently.
 	// Only apply this beyond the mobile breakpoint, as there's only a single column on mobile.
+
+	// 2 columns at this breakpoint, and items beyond the second will wrap.
 	@include break-small() {
-		&:nth-child(odd) {
-			margin-right: $grid-size-large * 2;
-		}
 		&:nth-child(even) {
 			margin-left: $grid-size-large * 2;
 		}
+		&:nth-child(odd) {
+			margin-right: $grid-size-large * 2;
+		}
+	}
 
+	// N columns at this breakpoint.
+	// Reset odd, even margins from small breakpoint.
+	// Add margin to both sides on all inside columns.
+	// Add inner margin only on first and last items.
+	@include break-medium() {
+		&:nth-child(even) {
+			margin-left: initial;
+		}
+		&:nth-child(odd) {
+			margin-right: initial;
+		}
 		&:not(:first-child) {
 			margin-left: $grid-size-large * 2;
 		}
-
 		&:not(:last-child) {
 			margin-right: $grid-size-large * 2;
 		}

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -20,7 +20,7 @@
 	@include break-small() {
 
 		// Size should be half the available width, minus the margins added below.
-		flex-basis: calc(50% - #{$grid-size-large * 2});
+		flex-basis: calc(50% - #{ $grid-size-large });
 		flex-grow: 0;
 	}
 
@@ -37,11 +37,11 @@
 	// 2 columns at this breakpoint, and items beyond the second will wrap.
 	@include break-small() {
 		&:nth-child(even) {
-			margin-left: $grid-size-large * 2;
+			margin-left: $grid-size-large;
 		}
 
 		&:nth-child(odd) {
-			margin-right: $grid-size-large * 2;
+			margin-right: $grid-size-large;
 		}
 	}
 
@@ -58,12 +58,12 @@
 
 		// Add left margin to all but first column.
 		&:not(:first-child) {
-			margin-left: $grid-size-large * 2;
+			margin-left: $grid-size-large;
 		}
 
 		// Add right margin to all but last column.
 		&:not(:last-child) {
-			margin-right: $grid-size-large * 2;
+			margin-right: $grid-size-large;
 		}
 	}
 }

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -10,18 +10,16 @@
 }
 
 .wp-block-column {
-	flex: 1;
 	margin-bottom: 1em;
 
 	// Responsiveness: Show at most one columns on mobile.
-	flex-basis: 100%;
+	width: 100%;
 
 	// Beyond mobile, allow 2 columns.
 	@include break-small() {
 
 		// Size should be half the available width, minus the margins added below.
-		flex-basis: calc(50% - #{ $grid-size-large });
-		flex-grow: 0;
+		width: calc(50% - #{ $grid-size-large });
 	}
 
 	// Prevent the columns from growing wider than their distributed sizes.
@@ -49,11 +47,11 @@
 	@include break-medium() {
 		// Reset odd, even margins from small breakpoint.
 		&:nth-child(even) {
-			margin-left: initial;
+			margin-left: 0;
 		}
 
 		&:nth-child(odd) {
-			margin-right: initial;
+			margin-right: 0;
 		}
 
 		// Add left margin to all but first column.

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -19,7 +19,7 @@
 	// Beyond mobile, allow 2 columns.
 	@include break-small() {
 
-		// Size should be half the available width, minus the margins added below
+		// Size should be half the available width, minus the margins added below.
 		flex-basis: calc(50% - #{$grid-size-large * 2});
 		flex-grow: 0;
 	}
@@ -39,6 +39,7 @@
 		&:nth-child(even) {
 			margin-left: $grid-size-large * 2;
 		}
+
 		&:nth-child(odd) {
 			margin-right: $grid-size-large * 2;
 		}
@@ -50,14 +51,17 @@
 		&:nth-child(even) {
 			margin-left: initial;
 		}
+
 		&:nth-child(odd) {
 			margin-right: initial;
 		}
-		// Add left margin to all but first column
+
+		// Add left margin to all but first column.
 		&:not(:first-child) {
 			margin-left: $grid-size-large * 2;
 		}
-		// add right margin to all but last column
+
+		// Add right margin to all but last column.
 		&:not(:last-child) {
 			margin-right: $grid-size-large * 2;
 		}

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -44,20 +44,20 @@
 		}
 	}
 
-	// N columns at this breakpoint.
-	// Reset odd, even margins from small breakpoint.
-	// Add margin to both sides on all inside columns.
-	// Add inner margin only on first and last items.
+	// All columns fit in one row at this breakpoint.
 	@include break-medium() {
+		// Reset odd, even margins from small breakpoint.
 		&:nth-child(even) {
 			margin-left: initial;
 		}
 		&:nth-child(odd) {
 			margin-right: initial;
 		}
+		// Add left margin to all but first item
 		&:not(:first-child) {
 			margin-left: $grid-size-large * 2;
 		}
+		// add right margin to all but last item
 		&:not(:last-child) {
 			margin-right: $grid-size-large * 2;
 		}


### PR DESCRIPTION
This is a revision of #12408 which includes better comments and also applies the same fixes in the editor.

## Background
There should be 3 breakpoints:

**Mobile: less than 600px**
all columns full width and stacked. No margins.

**Small: 600px - 782px**
columns wrap in rows of 2. Margins on the inside.

**Medium: bigger than 782px**
all columns fit in one row. Margins on the inside.

## PROBLEMS!

**PROBLEM 1**
Columns don't wrap properly at Small breakpoint

![image](https://user-images.githubusercontent.com/1050936/49835575-3f47e280-fd65-11e8-975e-41e590392cbc.png)

**SOLUTION**
- move `not` selectors to Medium breakpoint
- adjust flex-basis to account for margins using calc()


**PROBLEM 2**
At the Medium breakpoint, when there is an odd number of columns, and extra margin is added to the last item.

![image](https://user-images.githubusercontent.com/1050936/49835697-a82f5a80-fd65-11e8-9ee2-504f1a12b68b.png)

**SOLUTION**
- reset `odd` and `even` selectors to `initial` at the Medium breakpoint

## How has this been tested?
tested in local wordpress docker env

ORIG:
https://codepen.io/drdogbot7/pen/NEOQPQ

FIX:
https://codepen.io/drdogbot7/pen/GwYVNz

## Types of changes
Only css affecting core/columns.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

closes #13035