### PR TITLE
RichText: Fix React warning shown when unmounting a currently selected RichText

### DIFF
--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -129,6 +129,10 @@ export class RichText extends Component {
 		this.lastHistoryValue = value;
 	}
 
+	componentWillUnmount() {
+		document.removeEventListener( 'selectionchange', this.onSelectionChange );
+	}
+
 	setRef( node ) {
 		this.editableRef = node;
 	}


### PR DESCRIPTION
see https://github.com/WordPress/gutenberg/pull/12480#issuecomment-446619038

