### PR TITLE
[RNMobile] Fix for deleting text on the more block resets it to the default text

### DIFF
--- a/packages/block-library/src/more/edit.native.js
+++ b/packages/block-library/src/more/edit.native.js
@@ -54,7 +54,7 @@ export default class MoreEdit extends Component {
 	renderText() {
 		const { attributes, onFocus, onBlur } = this.props;
 		const { customText } = attributes;
-		const defaultText = __( 'Read more' );
+		const { defaultText } = this.state;
 		const value = customText !== undefined ? customText : defaultText;
 
 		return (


### PR DESCRIPTION
This PR fixes an issue where deleting all the text on the more block resets it to the default text. See https://github.com/wordpress-mobile/gutenberg-mobile/issues/359 for details about the problem.

Steps to test: follow the instructions in the gb-mobile side PR here: https://github.com/wordpress-mobile/gutenberg-mobile/pull/363