### PR TITLE
Add a line to PR template for developer documentation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,4 +19,4 @@
 - [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
 - [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
 - [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
-- [ ] I've included developer documentation when appropriate <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
+- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,3 +19,4 @@
 - [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
 - [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
 - [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
+- [ ] I've included developer documentation when appropriate <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->


### PR DESCRIPTION
## Description

A meta change that applies only to Github repo, adding a line to the PR template around developer documentation.

Developer documentation is critical for making a platform extendable, developers need to know the proper way to extend a feature, or in a sense that does may not even exist.

We discussed the importance of documentation in #docs Slack channel, and thought updating PR template is one way to call out to developers to keep it in mind. 
