### PR TITLE
Hooks: Optimize addHook as appending operation

### DIFF
--- a/packages/hooks/src/createAddHook.js
+++ b/packages/hooks/src/createAddHook.js
@@ -45,15 +45,22 @@ function createAddHook( hooks ) {
 		if ( hooks[ hookName ] ) {
 			// Find the correct insert index of the new hook.
 			const handlers = hooks[ hookName ].handlers;
-			let i = 0;
-			while ( i < handlers.length ) {
-				if ( handlers[ i ].priority > priority ) {
+
+			let i;
+			for ( i = handlers.length; i > 0; i-- ) {
+				if ( priority >= handlers[ i - 1 ].priority ) {
 					break;
 				}
-				i++;
 			}
-			// Insert (or append) the new hook.
-			handlers.splice( i, 0, handler );
+
+			if ( i === handlers.length ) {
+				// If append, operate via direct assignment.
+				handlers[ i ] = handler;
+			} else {
+				// Otherwise, insert before index via splice.
+				handlers.splice( i, 0, handler );
+			}
+
 			// We may also be currently executing this hook.  If the callback
 			// we're adding would come after the current callback, there's no
 			// problem; otherwise we need to increase the execution index of


### PR DESCRIPTION
This pull request seeks to refactor `addFilter` and `addAction` as an appending operation. Due to its use via `withFilters`, in the extreme case of a post consisting of ~20,000 words (70 headings, 501 paragraphs), this function is called 3000+ times, occupying 800ms real time in a page initialization. The result of this refactoring is an improvement of **16-to-180x improved performance** in common usage.

**Before:**

```
hooks|update/hooks-perf⚡ ⇒ node benchmark addFilter
addFilter - append last x 9,673 ops/sec ±41.59% (10 runs sampled)
addFilter - default before higher priority x 9,667 ops/sec ±37.76% (11 runs sampled)
```

![before](https://user-images.githubusercontent.com/1779930/49895301-16cfef00-fe1e-11e8-8aa4-26d1e6e7b01a.png)

**After:**

```
hooks|update/hooks-perf⚡ ⇒ node benchmark addFilter
addFilter - append last x 1,741,114 ops/sec ±35.09% (64 runs sampled)
addFilter - default before higher priority x 155,109 ops/sec ±61.31% (12 runs sampled)
```

![after](https://user-images.githubusercontent.com/1779930/49895311-1cc5d000-fe1e-11e8-8563-ac930d15a09f.png)

**Implementation notes:**

There were two main problems with the previous implementation:

- It would step all the way through the entire stack of hook handlers for identical priority. In typical usage with default priority 10, this means the performance would degrade linear to the number of handlers present.
   - In this implementation, working backward it will immediately append to the set when determining that a priority matches that of the last-added handler.
- The use of `Array#splice` is a non-trivial operation relative direct assignment in an appending operation ([jsperf](https://jsperf.com/splice-vs-push-vs-assign/1))

I believe there is an opportunity for additional micro-optimizations here:

- Tracking handlers as a [linked list](https://en.wikipedia.org/wiki/Linked_list) to avoid `Array#splice` altogether
- Tracking handlers as an arrangement of `handlers[ priority ] = [ handlersForPriority ]`, leveraging the behavior of `Array#forEach` in sparse arrays (["callbackfn is called only for elements of the array which actually exist; it is not called for missing elements of the array."](https://www.ecma-international.org/ecma-262/5.1/#sec-15.4.4.18)), to avoid needing to iterate existing handlers to find an insertion point.

However, these are technically breaking changes, since we had chosen to both expose and document `actions` and `filters` directly from the module. In retrospect, these should not have been exposed, as they are implementation details.

Further investigation should be done on whether it's possible to limit the number of hooks added.

**Testing instructions:**

Ensure unit tests pass:

```
npm run test-unit
```

refs #11782