### PR TITLE
Data: Use type-specific isShallowEqual for withSelect

### DIFF
--- a/packages/data/src/components/with-select/index.js
+++ b/packages/data/src/components/with-select/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import isShallowEqual from '@wordpress/is-shallow-equal';
+import { isShallowEqualObjects } from '@wordpress/is-shallow-equal';
 import { createHigherOrderComponent } from '@wordpress/compose';
 
 /**
@@ -84,7 +84,7 @@ const withSelect = ( mapSelectToProps ) => createHigherOrderComponent( ( Wrapped
 			// `mergeProps` to rendered component if and only if updated.
 			const hasPropsChanged = (
 				hasRegistryChanged ||
-				! isShallowEqual( this.props.ownProps, nextProps.ownProps )
+				! isShallowEqualObjects( this.props.ownProps, nextProps.ownProps )
 			);
 
 			// Only render if props have changed or merge props have been updated
@@ -95,7 +95,7 @@ const withSelect = ( mapSelectToProps ) => createHigherOrderComponent( ( Wrapped
 
 			if ( hasPropsChanged ) {
 				const nextMergeProps = getNextMergeProps( nextProps );
-				if ( ! isShallowEqual( this.mergeProps, nextMergeProps ) ) {
+				if ( ! isShallowEqualObjects( this.mergeProps, nextMergeProps ) ) {
 					// If merge props change as a result of the incoming props,
 					// they should be reflected as such in the upcoming render.
 					// While side effects are discouraged in lifecycle methods,
@@ -120,7 +120,7 @@ const withSelect = ( mapSelectToProps ) => createHigherOrderComponent( ( Wrapped
 			}
 
 			const nextMergeProps = getNextMergeProps( this.props );
-			if ( isShallowEqual( this.mergeProps, nextMergeProps ) ) {
+			if ( isShallowEqualObjects( this.mergeProps, nextMergeProps ) ) {
 				return;
 			}
 

--- a/packages/is-shallow-equal/CHANGELOG.md
+++ b/packages/is-shallow-equal/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.0 (Unreleased)
+
+### New Feature
+
+- Type-specific variants are now exposed from the module root. In a WordPress context, this has the effect of making them available as `wp.isShallowEqual.isShallowEqualObjects` and `wp.isShallowEqual.isShallowEqualArrays`.
+
 ## 1.1.0 (2018-07-12)
 
 ### New Feature

--- a/packages/is-shallow-equal/README.md
+++ b/packages/is-shallow-equal/README.md
@@ -25,8 +25,8 @@ isShallowEqual( [ 1 ], [ 1 ] );
 You can import a specific implementation if you already know the types of values you are working with:
 
 ```js
-import isShallowEqualArrays from '@wordpress/is-shallow-equal/arrays';
-import isShallowEqualObjects from '@wordpress/is-shallow-equal/objects';
+import { isShallowEqualArrays } from '@wordpress/is-shallow-equal';
+import { isShallowEqualObjects } from '@wordpress/is-shallow-equal';
 ```
 
 ## Rationale

--- a/packages/is-shallow-equal/index.js
+++ b/packages/is-shallow-equal/index.js
@@ -30,3 +30,5 @@ function isShallowEqual( a, b ) {
 }
 
 module.exports = isShallowEqual;
+module.exports.isShallowEqualObjects = isShallowEqualObjects;
+module.exports.isShallowEqualArrays = isShallowEqualArrays;


### PR DESCRIPTION
This pull request seeks to optimize `withSelect` to use the type-specific variant of `isShallowEqual` to determine a change in props. The non-type-specific `isShallowEqual` includes small overhead in type sniffing. The difference is demonstrated and can be referenced in [the documentation for `@wordpress/is-shallow-equal`](https://github.com/WordPress/gutenberg/tree/master/packages/is-shallow-equal). Specifically, this should have an impact of roughly 10% improvement. `withSelect`'s broad usage should serve as justification for the micro-optimization.

```
@wordpress/is-shallow-equal (type specific) (object, equal) x 4,902,162 ops/sec ±0.40% (89 runs sampled)
@wordpress/is-shallow-equal (type specific) (object, same) x 558,234,287 ops/sec ±0.28% (92 runs sampled)
@wordpress/is-shallow-equal (type specific) (object, unequal) x 5,062,890 ops/sec ±0.71% (90 runs sampled)

@wordpress/is-shallow-equal (object, equal) x 4,449,938 ops/sec ±0.34% (91 runs sampled)
@wordpress/is-shallow-equal (object, same) x 516,101,448 ops/sec ±0.64% (90 runs sampled)
@wordpress/is-shallow-equal (object, unequal) x 4,925,231 ops/sec ±0.28% (91 runs sampled)
```

**Testing instructions:**

Ensure unit tests pass:

```
npm run test-unit
```