### PR TITLE
Performance: Move unused variable initializations after early return

### DIFF
--- a/bin/packages/watch.js
+++ b/bin/packages/watch.js
@@ -34,12 +34,11 @@ getPackages().forEach( ( p ) => {
 	try {
 		fs.accessSync( srcDir, fs.F_OK );
 		fs.watch( path.resolve( p, 'src' ), { recursive: true }, ( event, filename ) => {
-			const filePath = path.resolve( srcDir, filename );
-
 			if ( ! isSourceFile( filename ) ) {
 				return;
 			}
 
+			const filePath = path.resolve( srcDir, filename );
 			if ( ( event === 'change' || event === 'rename' ) && exists( filePath ) ) {
 				// eslint-disable-next-line no-console
 				console.log( chalk.green( '->' ), `${ event }: ${ filename }` );

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -235,16 +235,6 @@ export const settings = {
 				backgroundColor: overlayColor.color,
 			};
 
-			const classes = classnames(
-				className,
-				contentAlign !== 'center' && `has-${ contentAlign }-content`,
-				dimRatioToClass( dimRatio ),
-				{
-					'has-background-dim': dimRatio !== 0,
-					'has-parallax': hasParallax,
-				}
-			);
-
 			const controls = (
 				<Fragment>
 					<BlockControls>
@@ -345,6 +335,16 @@ export const settings = {
 					</Fragment>
 				);
 			}
+
+			const classes = classnames(
+				className,
+				contentAlign !== 'center' && `has-${ contentAlign }-content`,
+				dimRatioToClass( dimRatio ),
+				{
+					'has-background-dim': dimRatio !== 0,
+					'has-parallax': hasParallax,
+				}
+			);
 
 			return (
 				<Fragment>

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -370,7 +370,6 @@ class ImageEdit extends Component {
 			linkTarget,
 		} = attributes;
 		const isExternal = isExternalImage( id, url );
-		const imageSizeOptions = this.getImageSizeOptions();
 
 		let toolbarEditButton;
 		if ( url ) {
@@ -446,6 +445,7 @@ class ImageEdit extends Component {
 
 		const isResizable = [ 'wide', 'full' ].indexOf( align ) === -1 && isLargeViewport;
 		const isLinkURLInputReadOnly = linkDestination !== LINK_DESTINATION_CUSTOM;
+		const imageSizeOptions = this.getImageSizeOptions();
 
 		const getInspectorControls = ( imageWidth, imageHeight ) => (
 			<InspectorControls>

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -116,10 +116,9 @@ const isPossibleTransformForSource = ( transform, direction, blocks ) => {
 	if ( isEmpty( blocks ) ) {
 		return false;
 	}
-	const isMultiBlock = blocks.length > 1;
-	const sourceBlock = first( blocks );
 
 	// If multiple blocks are selected, only multi block transforms are allowed.
+	const isMultiBlock = blocks.length > 1;
 	const isValidForMultiBlocks = ! isMultiBlock || transform.isMultiBlock;
 	if ( ! isValidForMultiBlocks ) {
 		return false;
@@ -132,6 +131,7 @@ const isPossibleTransformForSource = ( transform, direction, blocks ) => {
 	}
 
 	// Check if the transform's block name matches the source block only if this is a transform 'from'.
+	const sourceBlock = first( blocks );
 	const hasMatchingName = direction !== 'from' || transform.blocks.indexOf( sourceBlock.name ) !== -1;
 	if ( ! hasMatchingName ) {
 		return false;

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -268,10 +268,11 @@ export function serializeBlock( block ) {
 		case getUnregisteredTypeHandlerName():
 			return saveContent;
 
-		default:
+		default: {
 			const blockType = getBlockType( blockName );
 			const saveAttributes = getCommentAttributes( blockType, block.attributes );
 			return getCommentDelimitedContent( blockName, saveAttributes, saveContent );
+		}
 	}
 }
 

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -261,9 +261,7 @@ export function getCommentDelimitedContent( rawBlockName, attributes, content ) 
  */
 export function serializeBlock( block ) {
 	const blockName = block.name;
-	const blockType = getBlockType( blockName );
 	const saveContent = getBlockContent( block );
-	const saveAttributes = getCommentAttributes( blockType, block.attributes );
 
 	switch ( blockName ) {
 		case getFreeformContentHandlerName():
@@ -271,6 +269,8 @@ export function serializeBlock( block ) {
 			return saveContent;
 
 		default:
+			const blockType = getBlockType( blockName );
+			const saveAttributes = getCommentAttributes( blockType, block.attributes );
 			return getCommentDelimitedContent( blockName, saveAttributes, saveContent );
 	}
 }

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -380,7 +380,6 @@ export function placeCaretAtVerticalEdge( container, isReverse, rect, mayUseScro
 	const editableRect = container.getBoundingClientRect();
 	const x = rect.left;
 	const y = isReverse ? ( editableRect.bottom - buffer ) : ( editableRect.top + buffer );
-	const selection = window.getSelection();
 
 	let range = hiddenCaretRangeFromPoint( document, x, y, container );
 
@@ -413,6 +412,7 @@ export function placeCaretAtVerticalEdge( container, isReverse, rect, mayUseScro
 		}
 	}
 
+	const selection = window.getSelection();
 	selection.removeAllRanges();
 	selection.addRange( range );
 	container.focus();

--- a/packages/editor/src/components/block-switcher/index.js
+++ b/packages/editor/src/components/block-switcher/index.js
@@ -53,6 +53,9 @@ export class BlockSwitcher extends Component {
 			'desc'
 		);
 
+		const sourceBlockName = blocks[ 0 ].name;
+		const blockType = getBlockType( sourceBlockName );
+
 		if ( ! hasBlockStyles && ! possibleBlockTransformations.length ) {
 			if ( blocks.length > 1 ) {
 				return null;
@@ -69,9 +72,6 @@ export class BlockSwitcher extends Component {
 				</Toolbar>
 			);
 		}
-
-		const sourceBlockName = blocks[ 0 ].name;
-		const blockType = getBlockType( sourceBlockName );
 
 		return (
 			<Dropdown

--- a/packages/editor/src/components/block-switcher/index.js
+++ b/packages/editor/src/components/block-switcher/index.js
@@ -53,9 +53,6 @@ export class BlockSwitcher extends Component {
 			'desc'
 		);
 
-		const sourceBlockName = blocks[ 0 ].name;
-		const blockType = getBlockType( sourceBlockName );
-
 		if ( ! hasBlockStyles && ! possibleBlockTransformations.length ) {
 			if ( blocks.length > 1 ) {
 				return null;
@@ -72,6 +69,9 @@ export class BlockSwitcher extends Component {
 				</Toolbar>
 			);
 		}
+
+		const sourceBlockName = blocks[ 0 ].name;
+		const blockType = getBlockType( sourceBlockName );
 
 		return (
 			<Dropdown

--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -57,7 +57,6 @@ export class PostSavedState extends Component {
 			isLargeViewport,
 		} = this.props;
 		const { forceSavedMessage } = this.state;
-		const hasPublishAction = get( post, [ '_links', 'wp:action-publish' ], false );
 		if ( isSaving ) {
 			// TODO: Classes generation should be common across all return
 			// paths of this function, including proper naming convention for
@@ -93,6 +92,7 @@ export class PostSavedState extends Component {
 
 		// Once the post has been submitted for review this button
 		// is not needed for the contributor role.
+		const hasPublishAction = get( post, [ '_links', 'wp:action-publish' ], false );
 		if ( ! hasPublishAction && isPending ) {
 			return null;
 		}

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -215,7 +215,6 @@ export class RichText extends Component {
 		items = isNil( items ) ? [] : items;
 		files = isNil( files ) ? [] : files;
 
-		const item = find( [ ...items, ...files ], ( { type } ) => /^image\/(?:jpe?g|png|gif)$/.test( type ) );
 		let plainText = '';
 		let html = '';
 
@@ -244,6 +243,7 @@ export class RichText extends Component {
 
 		// Only process file if no HTML is present.
 		// Note: a pasted file may have the URL as plain text.
+		const item = find( [ ...items, ...files ], ( { type } ) => /^image\/(?:jpe?g|png|gif)$/.test( type ) );
 		if ( item && ! html ) {
 			const file = item.getAsFile ? item.getAsFile() : item;
 			const content = pasteHandler( {
@@ -605,12 +605,11 @@ export class RichText extends Component {
 	 * @param {Object} context The context for splitting.
 	 */
 	splitContent( blocks = [], context = {} ) {
-		const record = this.createRecord();
-
 		if ( ! this.onSplit ) {
 			return;
 		}
 
+		const record = this.createRecord();
 		let [ before, after ] = split( record );
 
 		// In case split occurs at the trailing or leading edge of the field,

--- a/packages/editor/src/editor-styles/ast/parse.js
+++ b/packages/editor/src/editor-styles/ast/parse.js
@@ -1,3 +1,5 @@
+/* eslint-disable @wordpress/no-unused-vars-before-return */
+
 // Adapted from https://github.com/reworkcss/css
 // because we needed to remove source map support.
 

--- a/packages/editor/src/editor-styles/ast/stringify/identity.js
+++ b/packages/editor/src/editor-styles/ast/stringify/identity.js
@@ -1,3 +1,5 @@
+/* eslint-disable @wordpress/no-unused-vars-before-return */
+
 // Adapted from https://github.com/reworkcss/css
 // because we needed to remove source map support.
 

--- a/packages/editor/src/store/effects.js
+++ b/packages/editor/src/store/effects.js
@@ -158,7 +158,6 @@ export default {
 		const state = store.getState();
 		const [ firstBlockClientId, secondBlockClientId ] = action.blocks;
 		const blockA = getBlock( state, firstBlockClientId );
-		const blockB = getBlock( state, secondBlockClientId );
 		const blockType = getBlockType( blockA.name );
 
 		// Only focus the previous block if it's not mergeable
@@ -169,6 +168,7 @@ export default {
 
 		// We can only merge blocks with similar types
 		// thus, we transform the block to merge first
+		const blockB = getBlock( state, secondBlockClientId );
 		const blocksWithTheSameType = blockA.name === blockB.name ?
 			[ blockB ] :
 			switchToBlockType( blockB, blockA.name );

--- a/packages/editor/src/store/effects/posts.js
+++ b/packages/editor/src/store/effects/posts.js
@@ -49,8 +49,6 @@ const TRASH_POST_NOTICE_ID = 'TRASH_POST_NOTICE_ID';
 export const requestPostUpdate = async ( action, store ) => {
 	const { dispatch, getState } = store;
 	const state = getState();
-	const post = getCurrentPost( state );
-	const isAutosave = !! action.options.isAutosave;
 
 	// Prevent save if not saveable.
 	// We don't check for dirtiness here as this can be overriden in the UI.
@@ -59,6 +57,7 @@ export const requestPostUpdate = async ( action, store ) => {
 	}
 
 	let edits = getPostEdits( state );
+	const isAutosave = !! action.options.isAutosave;
 	if ( isAutosave ) {
 		edits = pick( edits, [ 'title', 'content', 'excerpt' ] );
 	}
@@ -77,6 +76,8 @@ export const requestPostUpdate = async ( action, store ) => {
 	if ( isEditedPostNew( state ) ) {
 		edits = { status: 'draft', ...edits };
 	}
+
+	const post = getCurrentPost( state );
 
 	let toSend = {
 		...edits,

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -290,8 +290,6 @@ export function getCurrentPostAttribute( state, attributeName ) {
  * @return {*} Post attribute value.
  */
 export function getEditedPostAttribute( state, attributeName ) {
-	const edits = getPostEdits( state );
-
 	// Special cases
 	switch ( attributeName ) {
 		case 'content':
@@ -299,6 +297,7 @@ export function getEditedPostAttribute( state, attributeName ) {
 	}
 
 	// Fall back to saved post value if not edited.
+	const edits = getPostEdits( state );
 	if ( ! edits.hasOwnProperty( attributeName ) ) {
 		return getCurrentPostAttribute( state, attributeName );
 	}
@@ -349,13 +348,15 @@ export function getAutosaveAttribute( state, attributeName ) {
  */
 export function getEditedPostVisibility( state ) {
 	const status = getEditedPostAttribute( state, 'status' );
-	const password = getEditedPostAttribute( state, 'password' );
-
 	if ( status === 'private' ) {
 		return 'private';
-	} else if ( password ) {
+	}
+
+	const password = getEditedPostAttribute( state, 'password' );
+	if ( password ) {
 		return 'password';
 	}
+
 	return 'public';
 }
 


### PR DESCRIPTION
Related: #12477
Blocks #12828
refs #11782

This pull request seeks to optimize written code by order of assignment. It can be considered a stylistic change, since the logic has not been revised; but it is one which has a potential performance impact. These issues were surfaced by the new ESLint rule introduced in #12828, where the assignments may be wasteful in that there are `return` paths which occur earlier than the first reference to the assigned value.

**Testing instructions:**

Verify there are no regressions in impacted code.