### PR TITLE
eslint-plugin: Add rule `no-unused-vars-before-return`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2782,7 +2782,7 @@
 				"chalk": "^2.4.1",
 				"check-node-version": "^3.1.1",
 				"cross-spawn": "^5.1.0",
-				"eslint": "^4.19.1",
+				"eslint": "^5.12.1",
 				"jest": "^23.6.0",
 				"jest-puppeteer": "3.2.1",
 				"npm-package-json-lint": "^3.3.1",
@@ -4331,23 +4331,6 @@
 			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
 			"dev": true
 		},
-		"caller-path": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-			"dev": true,
-			"requires": {
-				"callsites": "^0.2.0"
-			},
-			"dependencies": {
-				"callsites": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-					"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
-					"dev": true
-				}
-			}
-		},
 		"callsites": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
@@ -4475,9 +4458,9 @@
 			"dev": true
 		},
 		"chardet": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
 			"dev": true
 		},
 		"check-node-version": {
@@ -6280,21 +6263,6 @@
 			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
 			"dev": true
 		},
-		"del": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-			"dev": true,
-			"requires": {
-				"globby": "^5.0.0",
-				"is-path-cwd": "^1.0.0",
-				"is-path-in-cwd": "^1.0.0",
-				"object-assign": "^4.0.1",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0",
-				"rimraf": "^2.2.8"
-			}
-		},
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -6807,76 +6775,146 @@
 			}
 		},
 		"eslint": {
-			"version": "4.19.1",
-			"resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
-			"integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+			"version": "5.12.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.12.1.tgz",
+			"integrity": "sha512-54NV+JkTpTu0d8+UYSA8mMKAG4XAsaOrozA9rCW7tgneg1mevcL7wIotPC+fZ0SkWwdhNqoXoxnQCTBp7UvTsg==",
 			"dev": true,
 			"requires": {
-				"ajv": "^5.3.0",
-				"babel-code-frame": "^6.22.0",
+				"@babel/code-frame": "^7.0.0",
+				"ajv": "^6.5.3",
 				"chalk": "^2.1.0",
-				"concat-stream": "^1.6.0",
-				"cross-spawn": "^5.1.0",
-				"debug": "^3.1.0",
+				"cross-spawn": "^6.0.5",
+				"debug": "^4.0.1",
 				"doctrine": "^2.1.0",
-				"eslint-scope": "^3.7.1",
+				"eslint-scope": "^4.0.0",
+				"eslint-utils": "^1.3.1",
 				"eslint-visitor-keys": "^1.0.0",
-				"espree": "^3.5.4",
-				"esquery": "^1.0.0",
+				"espree": "^5.0.0",
+				"esquery": "^1.0.1",
 				"esutils": "^2.0.2",
 				"file-entry-cache": "^2.0.0",
 				"functional-red-black-tree": "^1.0.1",
 				"glob": "^7.1.2",
-				"globals": "^11.0.1",
-				"ignore": "^3.3.3",
+				"globals": "^11.7.0",
+				"ignore": "^4.0.6",
+				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
-				"inquirer": "^3.0.6",
-				"is-resolvable": "^1.0.0",
-				"js-yaml": "^3.9.1",
+				"inquirer": "^6.1.0",
+				"js-yaml": "^3.12.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.3.0",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.2",
+				"lodash": "^4.17.5",
+				"minimatch": "^3.0.4",
 				"mkdirp": "^0.5.1",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.8.2",
 				"path-is-inside": "^1.0.2",
 				"pluralize": "^7.0.0",
 				"progress": "^2.0.0",
-				"regexpp": "^1.0.1",
-				"require-uncached": "^1.0.3",
-				"semver": "^5.3.0",
+				"regexpp": "^2.0.1",
+				"semver": "^5.5.1",
 				"strip-ansi": "^4.0.0",
-				"strip-json-comments": "~2.0.1",
-				"table": "4.0.2",
-				"text-table": "~0.2.0"
+				"strip-json-comments": "^2.0.1",
+				"table": "^5.0.2",
+				"text-table": "^0.2.0"
 			},
 			"dependencies": {
-				"ajv-keywords": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-					"integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+				"acorn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz",
+					"integrity": "sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg==",
 					"dev": true
 				},
-				"regexpp": {
-					"version": "1.1.0",
-					"resolved": "http://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
-					"integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+				"acorn-jsx": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+					"integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
 					"dev": true
 				},
-				"table": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-					"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+				"ajv": {
+					"version": "6.7.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
+					"integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
 					"dev": true,
 					"requires": {
-						"ajv": "^5.2.3",
-						"ajv-keywords": "^2.1.0",
-						"chalk": "^2.1.0",
-						"lodash": "^4.17.4",
-						"slice-ansi": "1.0.0",
-						"string-width": "^2.1.1"
+						"fast-deep-equal": "^2.0.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
 					}
+				},
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"eslint-scope": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
+					"integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+					"dev": true,
+					"requires": {
+						"esrecurse": "^4.1.0",
+						"estraverse": "^4.1.1"
+					}
+				},
+				"espree": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/espree/-/espree-5.0.0.tgz",
+					"integrity": "sha512-1MpUfwsdS9MMoN7ZXqAr9e9UKdVHDcvrJpyx7mm1WuQlx/ygErEQBzgi5Nh5qBHIoYweprhtMkTCb9GhcAIcsA==",
+					"dev": true,
+					"requires": {
+						"acorn": "^6.0.2",
+						"acorn-jsx": "^5.0.0",
+						"eslint-visitor-keys": "^1.0.0"
+					}
+				},
+				"fast-deep-equal": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+					"dev": true
+				},
+				"ignore": {
+					"version": "4.0.6",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+					"dev": true
+				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				},
+				"semver": {
+					"version": "5.6.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+					"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+					"dev": true
 				}
 			}
 		},
@@ -6961,6 +6999,12 @@
 				"esrecurse": "^4.1.0",
 				"estraverse": "^4.1.1"
 			}
+		},
+		"eslint-utils": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+			"integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+			"dev": true
 		},
 		"eslint-visitor-keys": {
 			"version": "1.0.0",
@@ -7414,14 +7458,25 @@
 			}
 		},
 		"external-editor": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+			"integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
 			"dev": true,
 			"requires": {
-				"chardet": "^0.4.0",
-				"iconv-lite": "^0.4.17",
+				"chardet": "^0.7.0",
+				"iconv-lite": "^0.4.24",
 				"tmp": "^0.0.33"
+			},
+			"dependencies": {
+				"iconv-lite": {
+					"version": "0.4.24",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+					"dev": true,
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3"
+					}
+				}
 			}
 		},
 		"extglob": {
@@ -7879,14 +7934,14 @@
 			}
 		},
 		"flat-cache": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+			"integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
 			"dev": true,
 			"requires": {
 				"circular-json": "^0.3.1",
-				"del": "^2.0.2",
 				"graceful-fs": "^4.1.2",
+				"rimraf": "~2.6.2",
 				"write": "^0.2.1"
 			}
 		},
@@ -9088,20 +9143,6 @@
 			"integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
 			"dev": true
 		},
-		"globby": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-			"dev": true,
-			"requires": {
-				"array-union": "^1.0.1",
-				"arrify": "^1.0.0",
-				"glob": "^7.0.3",
-				"object-assign": "^4.0.1",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
-			}
-		},
 		"globjoin": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
@@ -9537,6 +9578,24 @@
 				"minimatch": "^3.0.4"
 			}
 		},
+		"import-fresh": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
+			"integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
+			"dev": true,
+			"requires": {
+				"parent-module": "^1.0.0",
+				"resolve-from": "^4.0.0"
+			},
+			"dependencies": {
+				"resolve-from": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+					"dev": true
+				}
+			}
+		},
 		"import-lazy": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-3.1.0.tgz",
@@ -9621,25 +9680,41 @@
 			}
 		},
 		"inquirer": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
+			"integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^3.0.0",
 				"chalk": "^2.0.0",
 				"cli-cursor": "^2.1.0",
 				"cli-width": "^2.0.0",
-				"external-editor": "^2.0.4",
+				"external-editor": "^3.0.0",
 				"figures": "^2.0.0",
-				"lodash": "^4.3.0",
+				"lodash": "^4.17.10",
 				"mute-stream": "0.0.7",
 				"run-async": "^2.2.0",
-				"rx-lite": "^4.0.8",
-				"rx-lite-aggregates": "^4.0.8",
+				"rxjs": "^6.1.0",
 				"string-width": "^2.1.0",
-				"strip-ansi": "^4.0.0",
+				"strip-ansi": "^5.0.0",
 				"through": "^2.3.6"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+					"integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+					"integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.0.0"
+					}
+				}
 			}
 		},
 		"interpret": {
@@ -9941,32 +10016,6 @@
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
 			"dev": true
-		},
-		"is-path-cwd": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-			"dev": true
-		},
-		"is-path-in-cwd": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-			"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
-			"dev": true,
-			"requires": {
-				"is-path-inside": "^1.0.0"
-			},
-			"dependencies": {
-				"is-path-inside": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-					"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-					"dev": true,
-					"requires": {
-						"path-is-inside": "^1.0.1"
-					}
-				}
-			}
 		},
 		"is-path-inside": {
 			"version": "2.0.0",
@@ -14564,6 +14613,23 @@
 				"readable-stream": "^2.1.5"
 			}
 		},
+		"parent-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
+			"integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
+			"dev": true,
+			"requires": {
+				"callsites": "^3.0.0"
+			},
+			"dependencies": {
+				"callsites": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
+					"integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
+					"dev": true
+				}
+			}
+		},
 		"parse-asn1": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
@@ -17356,6 +17422,12 @@
 				"safe-regex": "^1.1.0"
 			}
 		},
+		"regexpp": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+			"integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+			"dev": true
+		},
 		"regexpu-core": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
@@ -17556,24 +17628,6 @@
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
-		"require-uncached": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-			"dev": true,
-			"requires": {
-				"caller-path": "^0.1.0",
-				"resolve-from": "^1.0.0"
-			},
-			"dependencies": {
-				"resolve-from": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-					"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-					"dev": true
-				}
-			}
-		},
 		"requireindex": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
@@ -17770,21 +17824,6 @@
 			"resolved": "https://registry.npmjs.org/rx/-/rx-2.3.24.tgz",
 			"integrity": "sha1-FPlQpCF9fjXapxu8vljv9o6ksrc=",
 			"dev": true
-		},
-		"rx-lite": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-			"dev": true
-		},
-		"rx-lite-aggregates": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-			"dev": true,
-			"requires": {
-				"rx-lite": "*"
-			}
 		},
 		"rxjs": {
 			"version": "6.3.3",
@@ -18279,15 +18318,6 @@
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
 			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
 			"dev": true
-		},
-		"slice-ansi": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-			"dev": true,
-			"requires": {
-				"is-fullwidth-code-point": "^2.0.0"
-			}
 		},
 		"slide": {
 			"version": "1.1.6",

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - The `esnext` and `recommended` rulesets now enforce [`object-shorthand`](https://eslint.org/docs/rules/object-shorthand)
 
+### New Features
+
+- New Rule: [`@wordpress/no-unused-vars-before-return`](https://github.com/WordPress/gutenberg/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars-before-return.md)
+
 ## 1.0.0 (2018-12-12)
 
 ### New Features

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -10,7 +10,7 @@ Install the module
 npm install @wordpress/eslint-plugin --save-dev
 ```
 
-### Usage
+## Usage
 
 To opt-in to the default configuration, extend your own project's `.eslintrc` file:
 
@@ -24,7 +24,7 @@ Refer to the [ESLint documentation on Shareable Configs](http://eslint.org/docs/
 
 The `recommended` preset will include rules governing an ES2015+ environment, and includes rules from the [`eslint-plugin-jsx-a11y`](https://github.com/evcohen/eslint-plugin-jsx-a11y) and [`eslint-plugin-react`](https://github.com/yannickcr/eslint-plugin-react) projects.
 
-#### Rulesets
+### Rulesets
 
 Alternatively, you can opt-in to only the more granular rulesets offered by the plugin. These include:
 
@@ -45,7 +45,13 @@ These rules can be used additively, so you could extend both `esnext` and `custo
 
 The granular rulesets will not define any environment globals. As such, if they are required for your project, you will need to define them yourself.
 
-#### Legacy
+### Rules
+
+Rule|Description
+---|---
+[no-unused-vars-before-return](docs/rules/no-unused-vars-before-return.md)|Disallow assigning variable values if unused before a return
+
+### Legacy
 
 If you are using WordPress' `.jshintrc` JSHint configuration and you would like to take the first step to migrate to an ESLint equivalent it is also possible to define your own project's `.eslintrc` file as:
 

--- a/packages/eslint-plugin/configs/custom.js
+++ b/packages/eslint-plugin/configs/custom.js
@@ -1,5 +1,9 @@
 module.exports = {
+	plugins: [
+		'@wordpress',
+	],
 	rules: {
+		'@wordpress/no-unused-vars-before-return': 'error',
 		'no-restricted-syntax': [
 			'error',
 			{

--- a/packages/eslint-plugin/docs/rules/no-unused-vars-before-return.md
+++ b/packages/eslint-plugin/docs/rules/no-unused-vars-before-return.md
@@ -1,0 +1,31 @@
+# Avoid assigning variable values if unused before a return (no-unused-vars-before-return)
+
+To avoid wastefully computing the result of a function call when assigning a variable value, the variable should be declared as late as possible. In practice, if a function includes an early return path, any variable declared prior to the `return` must be referenced at least once. Otherwise, in the condition which satisfies that return path, the declared variable is effectively considered dead code. This can have a performance impact when the logic performed in assigning the value is non-trivial.
+
+## Rule details
+
+The following patterns are considered warnings:
+
+```js
+function example( number ) {
+	const foo = doSomeCostlyOperation();
+	if ( number > 10 ) {
+		return number + 1;
+	}
+
+	return number + foo;
+}
+```
+
+The following patterns are not considered warnings:
+
+```js
+function example( number ) {
+	if ( number > 10 ) {
+		return number + 1;
+	}
+
+	const foo = doSomeCostlyOperation();
+	return number + foo;
+}
+```

--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -1,3 +1,4 @@
 module.exports = {
 	configs: require( './configs' ),
+	rules: require( './rules' ),
 };

--- a/packages/eslint-plugin/rules/__tests__/no-unused-vars-before-return.js
+++ b/packages/eslint-plugin/rules/__tests__/no-unused-vars-before-return.js
@@ -39,7 +39,7 @@ function example( number ) {
 
 	return number + foo;
 }`,
-			errors: [ { message: 'Declared variable `foo` is unused before a return path' } ],
+			errors: [ { message: 'Variables should not be assigned until just prior its first reference. An early return statement may leave this variable unused.' } ],
 		},
 	],
 } );

--- a/packages/eslint-plugin/rules/__tests__/no-unused-vars-before-return.js
+++ b/packages/eslint-plugin/rules/__tests__/no-unused-vars-before-return.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { RuleTester } from 'eslint';
+
+/**
+ * Internal dependencies
+ */
+import rule from '../no-unused-vars-before-return';
+
+const ruleTester = new RuleTester( {
+	parserOptions: {
+		ecmaVersion: 6,
+	},
+} );
+
+ruleTester.run( 'no-unused-vars-before-return', rule, {
+	valid: [
+		{
+			code: `
+function example( number ) {
+	if ( number > 10 ) {
+		return number + 1;
+	}
+
+	const foo = doSomeCostlyOperation();
+	return number + foo;
+}`,
+		},
+	],
+	invalid: [
+		{
+			code: `
+function example( number ) {
+	const foo = doSomeCostlyOperation();
+	if ( number > 10 ) {
+		return number + 1;
+	}
+
+	return number + foo;
+}`,
+			errors: [ { message: 'Declared variable `foo` is unused before a return path' } ],
+		},
+	],
+} );

--- a/packages/eslint-plugin/rules/index.js
+++ b/packages/eslint-plugin/rules/index.js
@@ -1,0 +1,1 @@
+module.exports = require( 'requireindex' )( __dirname );

--- a/packages/eslint-plugin/rules/no-unused-vars-before-return.js
+++ b/packages/eslint-plugin/rules/no-unused-vars-before-return.js
@@ -16,7 +16,7 @@ module.exports = {
 				}
 
 				for ( const variable of functionScope.variables ) {
-					const isAssignmentCandidate = variable.defs.some( ( def ) => {
+					const declaratorCandidate = variable.defs.find( ( def ) => {
 						return (
 							def.node.type === 'VariableDeclarator' &&
 							// Allow declarations which are not initialized.
@@ -30,7 +30,7 @@ module.exports = {
 						);
 					} );
 
-					if ( ! isAssignmentCandidate ) {
+					if ( ! declaratorCandidate ) {
 						continue;
 					}
 
@@ -45,8 +45,9 @@ module.exports = {
 					}
 
 					context.report(
-						node,
-						`Declared variable \`${ variable.name }\` is unused before a return path`
+						declaratorCandidate.node,
+						'Variables should not be assigned until just prior its first reference. ' +
+						'An early return statement may leave this variable unused.'
 					);
 				}
 			},

--- a/packages/eslint-plugin/rules/no-unused-vars-before-return.js
+++ b/packages/eslint-plugin/rules/no-unused-vars-before-return.js
@@ -1,0 +1,55 @@
+module.exports = {
+	meta: {
+		type: 'problem',
+		schema: [],
+	},
+	create( context ) {
+		return {
+			ReturnStatement( node ) {
+				let functionScope = context.getScope();
+				while ( functionScope.type !== 'function' && functionScope.upper ) {
+					functionScope = functionScope.upper;
+				}
+
+				if ( ! functionScope ) {
+					return;
+				}
+
+				for ( const variable of functionScope.variables ) {
+					const isAssignmentCandidate = variable.defs.some( ( def ) => {
+						return (
+							def.node.type === 'VariableDeclarator' &&
+							// Allow declarations which are not initialized.
+							def.node.init &&
+							// Target function calls as "expensive".
+							def.node.init.type === 'CallExpression' &&
+							// Allow unused if part of an object destructuring.
+							def.node.id.type !== 'ObjectPattern' &&
+							// Only target assignments preceding `return`.
+							def.node.end < node.end
+						);
+					} );
+
+					if ( ! isAssignmentCandidate ) {
+						continue;
+					}
+
+					// The first entry in `references` is the declaration
+					// itself, which can be ignored.
+					const isUsedBeforeReturn = variable.references.slice( 1 ).some( ( reference ) => {
+						return reference.identifier.end < node.end;
+					} );
+
+					if ( isUsedBeforeReturn ) {
+						continue;
+					}
+
+					context.report(
+						node,
+						`Declared variable \`${ variable.name }\` is unused before a return path`
+					);
+				}
+			},
+		};
+	},
+};

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Breaking Changes
 
-- The bundled `eslint` dependency has been updated from requiring `^4.19.1` to requiring `^5.12.1`.
+- The bundled `eslint` dependency has been updated from requiring `^4.19.1` to requiring `^5.12.1` (see [Migration Guide](https://eslint.org/docs/user-guide/migrating-to-5.0.0)).
 
 ### New Features
 

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 2.6.0 (Unreleased)
+## 3.0.0 (Unreleased)
+
+### Breaking Changes
+
+- The bundled `eslint` dependency has been updated from requiring `^4.19.1` to requiring `^5.12.1`.
 
 ### New Features
 

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -38,7 +38,7 @@
 		"chalk": "^2.4.1",
 		"check-node-version": "^3.1.1",
 		"cross-spawn": "^5.1.0",
-		"eslint": "^4.19.1",
+		"eslint": "^5.12.1",
 		"jest": "^23.6.0",
 		"jest-puppeteer": "3.2.1",
 		"npm-package-json-lint": "^3.3.1",


### PR DESCRIPTION
Related: #12477 
~Blocked by #12827~ (since merged)

This pull request seeks to introduce a new ESLint rule `@wordpress/no-unused-vars-before-return`. This rule captures potential performance issues related to the assignment of a variable from the result of a function call expression, where the declared variable is not referenced prior to a possible return path of the function.

Practically speaking, this looks like:

```js
function example( number ) {
	const foo = doSomeCostlyOperation();
	if ( number > 10 ) {
		// Why did we bother doing the costly operation in the assignment
		// above, if it's never to be used when this logic path is satisfied?
		return number + 1;
	}

	// ...instead, it should have been assigned here, at the last possible point
	// before it's referenced.

	return number + foo;
}
```

Refer also to modified code in #12827 as example problematic code.

Try yourself: https://astexplorer.net/#/gist/43c7ba92c2ea5bce1cfdd870c0ad6c4e/432215c7751e8dcd2d50463c23459abd661c7572

**Testing instructions:**

~_(This is blocked by #12827 - You will observe lint errors in the meantime)_~

Ensure there are no lint errors:

```
npm run lint-js
```

**Pending tasks:**

- [x] Consider unit tests for the rule itself
- [x] Add documentation for rule usage