### PR TITLE
Add JSHint ESLint config

### DIFF
--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -47,7 +47,7 @@ The granular rulesets will not define any environment globals. As such, if they 
 
 #### Legacy
 
-An ESLint equivalent of WordPress' `.jshintrc` JSHint configuration is also available by defining your own project's `.eslintrc` file as:
+If you are using WordPress' `.jshintrc` JSHint configuration and you would like to take the first step to migrate to an ESLint equivalent it is also possible to define your own project's `.eslintrc` file as:
 
 ```json
 {

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -45,4 +45,14 @@ These rules can be used additively, so you could extend both `esnext` and `custo
 
 The granular rulesets will not define any environment globals. As such, if they are required for your project, you will need to define them yourself.
 
+#### Legacy
+
+An ESLint equivalent of WordPress' `.jshintrc` JSHint configuration is also available by defining your own project's `.eslintrc` file as:
+
+```json
+{
+	"extends": [ "plugin:@wordpress/eslint-plugin/jshint" ]
+}
+```
+
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/eslint-plugin/configs/jshint.js
+++ b/packages/eslint-plugin/configs/jshint.js
@@ -1,0 +1,17 @@
+module.exports = {
+	rules: {
+		curly: 'error',
+		eqeqeq: 'error',
+		'no-caller': 'error',
+		'no-cond-assign': [ 'error', 'except-parens' ],
+		'no-eq-null': 'error',
+		'no-irregular-whitespace': 'error',
+		'no-trailing-spaces': 'error',
+		'no-undef': 'error',
+		'no-unused-expressions': 'error',
+		'no-unused-vars': 'error',
+		'one-var': [ 'error', 'always' ],
+		quotes: [ 'error', 'single' ],
+		'wrap-iife': [ 'error', 'any' ],
+	},
+};


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

This pull request is a follow up to #12763 and seeks to add a new `jshint` ESLint shared configuration of the existing WordPress [`.jshintrc`](https://core.trac.wordpress.org/browser/trunk/.jshintrc) file.

This pull request makes available a "drop-in" ESLint JSHInt configuration that will allow WordPress to easily transition away from JSHint to ESLint per the [#WP31823](https://core.trac.wordpress.org/ticket/31823) ticket whilst the significant legacy JavaScript is updated to adhere to the WordPress JavaScript Coding Standards in the `@wordpress/eslint-plugin/recommended` ESLint configuration.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
