### PR TITLE
Update recommended config provided for lint-js script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2762,9 +2762,9 @@
 			"dev": true,
 			"requires": {
 				"@wordpress/babel-preset-default": "file:packages/babel-preset-default",
+				"@wordpress/eslint-plugin": "file:packages/eslint-plugin",
 				"@wordpress/jest-preset-default": "file:packages/jest-preset-default",
 				"@wordpress/npm-package-json-lint-config": "file:packages/npm-package-json-lint-config",
-				"babel-eslint": "8.0.3",
 				"chalk": "^2.4.1",
 				"check-node-version": "^3.1.1",
 				"cross-spawn": "^5.1.0",

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.6.0 (Unreleased)
+
+- Update default config provided for `lint-js` script.
+
 ## 2.5.0 (Unreleased)
 
 ### New Feature

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,12 +1,9 @@
-## 2.6.0 (Unreleased)
-
-- Update default config provided for `lint-js` script.
-
 ## 2.5.0 (Unreleased)
 
-### New Feature
+### New Features
 
 - Added support for `check-engines` script ([#12721](https://github.com/WordPress/gutenberg/pull/12721))
+- Update default config provided for `lint-js` script ([#12845](https://github.com/WordPress/gutenberg/pull/12845)).
 
 ## 2.4.4 (2018-11-20)
 

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -48,7 +48,7 @@ This is how you execute the script with presented setup:
 
 ### `wp-scripts lint-js`
 
-Helps enforce coding style guidelines for your JavaScript files. It uses [eslint](https://eslint.org/) with no rules provided (we plan to add zero config support in the near future). You can specify your own rules as described in [eslint docs](https://eslint.org/docs/rules/).
+Helps enforce coding style guidelines for your JavaScript files. It uses [eslint](https://eslint.org/) with the set of default rules provided. You can override them with your own rules as described in [eslint docs](https://eslint.org/docs/rules/).
 
 _Example:_
 

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -30,7 +30,7 @@ _Example:_
 
 ### `check-engines`
 
-Check if the current `node`, `npm` (or `yarn`) versions match the given [semantic version](https://semver.org/) ranges. If the given version is not satisfied, information about installing the needed version is printed and the program exits with an error code. It uses [check-node-version](https://www.npmjs.com/package/check-node-version) behind the scenes with the default configuration provided. You can specify your own ranges as described in [check-node-version docs](https://www.npmjs.com/package/check-node-version).
+Check if the current `node`, `npm` (or `yarn`) versions match the given [semantic version](https://semver.org/) ranges. If the given version is not satisfied, information about installing the needed version is printed and the program exits with an error code. It uses [check-node-version](https://www.npmjs.com/package/check-node-version) behind the scenes with the recommended configuration provided. You can specify your own ranges as described in [check-node-version docs](https://www.npmjs.com/package/check-node-version).
 
 _Example:_
 
@@ -48,7 +48,7 @@ This is how you execute the script with presented setup:
 
 ### `wp-scripts lint-js`
 
-Helps enforce coding style guidelines for your JavaScript files. It uses [eslint](https://eslint.org/) with the set of default rules provided. You can override them with your own rules as described in [eslint docs](https://eslint.org/docs/rules/).
+Helps enforce coding style guidelines for your JavaScript files. It uses [eslint](https://eslint.org/) with the set of recommended rules defined in [@wordpress/eslint-plugin](https://www.npmjs.com/package/@wordpress/eslint-plugin) npm package. You can override default rules with your own as described in [eslint docs](https://eslint.org/docs/rules/).
 
 _Example:_
 
@@ -65,7 +65,7 @@ This is how you execute the script with presented setup:
 
 ### `wp-scripts lint-pkg-json`
 
-Helps enforce standards for your package.json files. It uses [npm-package-json-lint](https://www.npmjs.com/package/npm-package-json-lint) with the set of default rules provided. You can override them with your own rules as described in [npm-package-json-lint wiki](https://github.com/tclindner/npm-package-json-lint/wiki).
+Helps enforce standards for your package.json files. It uses [npm-package-json-lint](https://www.npmjs.com/package/npm-package-json-lint) with the set of recommended rules defined in [@wordpress/npm-package-json-lint-config](https://www.npmjs.com/package/@wordpress/npm-package-json-lint-config) npm package. You can override default rules with your own as described in [npm-package-json-lint wiki](https://github.com/tclindner/npm-package-json-lint/wiki).
 
 _Example:_
 
@@ -84,7 +84,7 @@ This is how you execute those scripts using the presented setup:
 
 _Alias_: `wp-scripts test-unit-jest` 
 
-Launches the test runner. It uses [Jest](https://facebook.github.io/jest/) behind the scenes and you are able to utilize all of its [CLI options](https://facebook.github.io/jest/docs/en/cli.html). You can also run `./node_modules/.bin/wp-scripts test-unit-js --help` or `npm run test:help` (as presented below) to view all of the available options.
+Launches the test runner. It uses [Jest](https://facebook.github.io/jest/) behind the scenes and you are able to utilize all of its [CLI options](https://facebook.github.io/jest/docs/en/cli.html). You can also run `./node_modules/.bin/wp-scripts test-unit-js --help` or `npm run test:help` (as presented below) to view all of the available options. By default, it uses the set of recommended options defined in [@wordpress/jest-preset-default](https://www.npmjs.com/package/@wordpress/jest-preset-default) npm package. You can override them with your own options as described in [Jest documentation](https://jestjs.io/docs/en/configuration).
 
 _Example:_
 

--- a/packages/scripts/config/.eslintrc.js
+++ b/packages/scripts/config/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-	parser: 'babel-eslint',
+	extends: [ 'plugin:@wordpress/eslint-plugin/recommended' ],
 };

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -32,9 +32,9 @@
 	},
 	"dependencies": {
 		"@wordpress/babel-preset-default": "file:../babel-preset-default",
+		"@wordpress/eslint-plugin": "file:../eslint-plugin",
 		"@wordpress/jest-preset-default": "file:../jest-preset-default",
 		"@wordpress/npm-package-json-lint-config": "file:../npm-package-json-lint-config",
-		"babel-eslint": "8.0.3",
 		"chalk": "^2.4.1",
 		"check-node-version": "^3.1.1",
 		"cross-spawn": "^5.1.0",


### PR DESCRIPTION
## Description
With #12763 we introduced `@wordpress/eslint-plugin` package which offers the recommended config for WordPress development. This PR updates `wp-scripts lint-js` script to use this config as a default when there is no config provided in the project.

## How has this been tested?
* `npm run lint-js` in the project` - it should work as before.
* `./node_modules/.bin/wp-scripts lint-js .` - it will produce tons of errors because the default config doesn't support Jest tests or Puppeteer API by default.

## To consider

Should we also include support for Jest and Puppeteer in the recommended config? The thing is that we offer them in other scripts exposed (or planned to be exposed) as part of `@wordpress/scripts` package.