### PR TITLE
Reduce rerendering on startup

### DIFF
--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.16 (Unreleased)
+
+### Bug Fixes
+
+- Fixed the `hasUploadPermissions` selector to always return a boolean. Previously, it may have returned an empty object. This should have no impact for most consumers, assuming usage as a [truthy value](https://developer.mozilla.org/en-US/docs/Glossary/Truthy) in conditions.
+
 ## 2.0.15 (2018-12-12)
 
 ## 2.0.14 (2018-11-20)

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -225,7 +225,7 @@ export function embedPreviews( state = {}, action ) {
  *
  * @return {Object} Updated state.
  */
-export function hasUploadPermissions( state = {}, action ) {
+export function hasUploadPermissions( state = true, action ) {
 	switch ( action.type ) {
 		case 'RECEIVE_UPLOAD_PERMISSIONS':
 			return action.hasUploadPermissions;

--- a/packages/core-data/src/test/reducer.js
+++ b/packages/core-data/src/test/reducer.js
@@ -7,7 +7,7 @@ import { filter } from 'lodash';
 /**
  * Internal dependencies
  */
-import { terms, entities, embedPreviews } from '../reducer';
+import { terms, entities, embedPreviews, hasUploadPermissions } from '../reducer';
 
 describe( 'terms()', () => {
 	it( 'returns an empty object by default', () => {
@@ -115,5 +115,24 @@ describe( 'embedPreviews()', () => {
 		expect( state ).toEqual( {
 			'http://twitter.com/notnownikki': { data: 42 },
 		} );
+	} );
+} );
+
+describe( 'hasUploadPermissions()', () => {
+	it( 'returns true by default', () => {
+		const state = hasUploadPermissions( undefined, {} );
+
+		expect( state ).toEqual( true );
+	} );
+
+	it( 'returns with updated upload permissions value', () => {
+		const originalState = true;
+
+		const state = hasUploadPermissions( originalState, {
+			type: 'RECEIVE_UPLOAD_PERMISSIONS',
+			hasUploadPermissions: false,
+		} );
+
+		expect( state ).toEqual( false );
 	} );
 } );

--- a/packages/viewport/CHANGELOG.md
+++ b/packages/viewport/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.0 (Unreleased)
+
+### Improvements
+
+- The initial viewport state is assigned synchronously, rather than on the next process tick. This should have an impact of fewer callbacks made to data subscribers.
+
 ## 2.0.13 (2018-12-12)
 
 ## 2.0.12 (2018-11-20)

--- a/packages/viewport/src/index.js
+++ b/packages/viewport/src/index.js
@@ -76,3 +76,4 @@ window.addEventListener( 'orientationchange', setIsMatching );
 
 // Set initial values
 setIsMatching();
+setIsMatching.flush();


### PR DESCRIPTION
## Description
Small tweaks that result in less unnecessary work during startup. This is a very modest speed improvement (after the changes, the time spent in JS during startup goes down by about 3-5%), but it doesn't introduce much additional complexity at just 2 lines of code.

## How has this been tested?
Unit tests, ad-hoc testing. Changes are minor and easy to analyse.

For performance measuring, I tried to create as stable an environment as possible on my local machine (with as few applications running as possible), throttled the CPU by 6x, and ran startup profiles for a large post with many blocks, repeatedly. For each of these runs, I measured how much time the sum of the two long frames during startup took.

![image](https://user-images.githubusercontent.com/409615/49952244-7e0ba300-fef3-11e8-8839-2ef018287fc6.png)

## Types of changes

**Ensure viewport calculations happen synchronously instead of waiting on event loop.**

We need to call `flush`, so that the changes happen synchronously, rather than asynchronously, on the next event loop. This avoids the re-rendering of all `BlockListBlock` instances during startup.

**Ensure `state.hasUploadPermissions` is always a boolean.**

The reducer for this property defaults to an empty object, which not only is incorrect (since this is a boolean), but also causes unnecessary re-renders by changing reference. By defaulting to `true` instead, we fix both problems.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows the accessibility standards.
- [X] My code has proper inline documentation.

refs #11782