### PR TITLE
Components: Render DropZone children only if dragging over element

### DIFF
--- a/packages/block-library/src/audio/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/audio/test/__snapshots__/index.js.snap
@@ -33,31 +33,7 @@ exports[`core/audio block edit matches snapshot 1`] = `
   >
     <div
       class="components-drop-zone"
-    >
-      <div
-        class="components-drop-zone__content"
-      >
-        <svg
-          aria-hidden="true"
-          class="dashicon dashicons-upload components-drop-zone__content-icon"
-          focusable="false"
-          height="40"
-          role="img"
-          viewBox="0 0 20 20"
-          width="40"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M8 14V8H5l5-6 5 6h-3v6H8zm-2 2v-6H4v8h12.01v-8H14v6H6z"
-          />
-        </svg>
-        <span
-          class="components-drop-zone__content-text"
-        >
-          Drop files to upload
-        </span>
-      </div>
-    </div>
+    />
     <div
       class="components-form-file-upload"
     >

--- a/packages/block-library/src/cover/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/cover/test/__snapshots__/index.js.snap
@@ -33,31 +33,7 @@ exports[`core/cover block edit matches snapshot 1`] = `
   >
     <div
       class="components-drop-zone"
-    >
-      <div
-        class="components-drop-zone__content"
-      >
-        <svg
-          aria-hidden="true"
-          class="dashicon dashicons-upload components-drop-zone__content-icon"
-          focusable="false"
-          height="40"
-          role="img"
-          viewBox="0 0 20 20"
-          width="40"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M8 14V8H5l5-6 5 6h-3v6H8zm-2 2v-6H4v8h12.01v-8H14v6H6z"
-          />
-        </svg>
-        <span
-          class="components-drop-zone__content-text"
-        >
-          Drop files to upload
-        </span>
-      </div>
-    </div>
+    />
     <div
       class="components-form-file-upload"
     >

--- a/packages/block-library/src/gallery/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/gallery/test/__snapshots__/index.js.snap
@@ -33,31 +33,7 @@ exports[`core/gallery block edit matches snapshot 1`] = `
   >
     <div
       class="components-drop-zone"
-    >
-      <div
-        class="components-drop-zone__content"
-      >
-        <svg
-          aria-hidden="true"
-          class="dashicon dashicons-upload components-drop-zone__content-icon"
-          focusable="false"
-          height="40"
-          role="img"
-          viewBox="0 0 20 20"
-          width="40"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M8 14V8H5l5-6 5 6h-3v6H8zm-2 2v-6H4v8h12.01v-8H14v6H6z"
-          />
-        </svg>
-        <span
-          class="components-drop-zone__content-text"
-        >
-          Drop files to upload
-        </span>
-      </div>
-    </div>
+    />
     <div
       class="components-form-file-upload"
     >

--- a/packages/block-library/src/video/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/video/test/__snapshots__/index.js.snap
@@ -33,31 +33,7 @@ exports[`core/video block edit matches snapshot 1`] = `
   >
     <div
       class="components-drop-zone"
-    >
-      <div
-        class="components-drop-zone__content"
-      >
-        <svg
-          aria-hidden="true"
-          class="dashicon dashicons-upload components-drop-zone__content-icon"
-          focusable="false"
-          height="40"
-          role="img"
-          viewBox="0 0 20 20"
-          width="40"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M8 14V8H5l5-6 5 6h-3v6H8zm-2 2v-6H4v8h12.01v-8H14v6H6z"
-          />
-        </svg>
-        <span
-          class="components-drop-zone__content-text"
-        >
-          Drop files to upload
-        </span>
-      </div>
-    </div>
+    />
     <div
       class="components-form-file-upload"
     >

--- a/packages/components/src/drop-zone/index.js
+++ b/packages/components/src/drop-zone/index.js
@@ -71,24 +71,25 @@ class DropZoneComponent extends Component {
 			[ `is-dragging-${ type }` ]: !! type,
 		} );
 
+		let children;
+		if ( isDraggingOverElement ) {
+			children = (
+				<div className="components-drop-zone__content">
+					<Dashicon
+						icon="upload"
+						size="40"
+						className="components-drop-zone__content-icon"
+					/>
+					<span className="components-drop-zone__content-text">
+						{ label ? label : __( 'Drop files to upload' ) }
+					</span>
+				</div>
+			);
+		}
+
 		return (
 			<div ref={ this.dropZoneElement } className={ classes }>
-				<div className="components-drop-zone__content">
-					{ [
-						<Dashicon
-							key="icon"
-							icon="upload"
-							size="40"
-							className="components-drop-zone__content-icon"
-						/>,
-						<span
-							key="text"
-							className="components-drop-zone__content-text"
-						>
-							{ label ? label : __( 'Drop files to upload' ) }
-						</span>,
-					] }
-				</div>
+				{ children }
 			</div>
 		);
 	}

--- a/packages/components/src/drop-zone/style.scss
+++ b/packages/components/src/drop-zone/style.scss
@@ -19,10 +19,6 @@
 
 	&.is-dragging-over-element {
 		background-color: rgba($blue-dark-900, 0.8);
-
-		.components-drop-zone__content {
-			display: block;
-		}
 	}
 }
 
@@ -37,7 +33,6 @@
 	text-align: center;
 	color: $white;
 	transition: transform 0.2s ease-in-out;
-	display: none;
 }
 
 .components-drop-zone.is-dragging-over-element .components-drop-zone__content {


### PR DESCRIPTION
Related: #12858
Refs #11782

This pull request seeks to optimize the rendering of the DropZone component to omit its own children in lieu of rendering them styled as `display: none;` when not hovered. A DropZone element is rendered for each block in the page, which can contribute significantly as the number of blocks in a post increases. In my testing for a post consisting of 20,000 words (500 paragraphs), the changes here have an impact in reducing the total number of DOM nodes by ~18%, from 15,390 to 12,614. Combined with #12858, the improvement totals a 35% reduction in total number of DOM nodes (to a final count of 9,956).

Further, it refactors the rendering to avoid rendering its static set of children as an array. This may have some negligible improvement in React's reconciliation, though it has not been measured.

**Testing instructions:**

Verify there are no regressions in the behavior of drag-n-drop media (default block appender, before/after block, on media placeholder).

Compare DOM nodes between this branch and master:

```
document.getElementsByTagName( '*' ).length
```