### PR TITLE
Replace Polldaddy embed block with Crowdsignal

### DIFF
--- a/packages/block-library/src/embed/core-embeds.js
+++ b/packages/block-library/src/embed/core-embeds.js
@@ -149,6 +149,7 @@ export const others = [
 		settings: {
 			title: 'Crowdsignal',
 			icon: embedContentIcon,
+			keywords: [ 'polldaddy' ]
 			transform: [ {
 				type: 'block',
 				blocks: [ 'core-embed/polldaddy' ],

--- a/packages/block-library/src/embed/core-embeds.js
+++ b/packages/block-library/src/embed/core-embeds.js
@@ -158,7 +158,7 @@ export const others = [
 					} );
 				},
 			} ],
-			description: __( 'Embed Crowdsignal content.' ),
+			description: __( 'Embed Crowdsignal (formerly Polldaddy) content.' ),
 		},
 		patterns: [ /^https?:\/\/((.+\.)?polldaddy\.com|poll\.fm|.+\.survey\.fm)\/.+/i ],
 	},

--- a/packages/block-library/src/embed/core-embeds.js
+++ b/packages/block-library/src/embed/core-embeds.js
@@ -233,6 +233,9 @@ export const others = [
 			title: 'Polldaddy',
 			icon: embedContentIcon,
 			description: __( 'Embed Polldaddy content.' ),
+			supports: {
+				inserter: false,
+			},
 		},
 		patterns: [],
 	},

--- a/packages/block-library/src/embed/core-embeds.js
+++ b/packages/block-library/src/embed/core-embeds.js
@@ -149,7 +149,7 @@ export const others = [
 		settings: {
 			title: 'Crowdsignal',
 			icon: embedContentIcon,
-			keywords: [ 'polldaddy' ]
+			keywords: [ 'polldaddy' ],
 			transform: [ {
 				type: 'block',
 				blocks: [ 'core-embed/polldaddy' ],

--- a/packages/block-library/src/embed/core-embeds.js
+++ b/packages/block-library/src/embed/core-embeds.js
@@ -145,6 +145,24 @@ export const others = [
 		patterns: [ /^https?:\/\/(www\.)?collegehumor\.com\/.+/i ],
 	},
 	{
+		name: 'core-embed/crowdsignal',
+		settings: {
+			title: 'Crowdsignal',
+			icon: embedContentIcon,
+			transform: [ {
+				type: 'block',
+				blocks: [ 'core-embed/polldaddy' ],
+				transform: ( content ) => {
+					return createBlock( 'core-embed/crowdsignal', {
+						content,
+					} );
+				},
+			} ],
+			description: __( 'Embed Crowdsignal content.' ),
+		},
+		patterns: [ /^https?:\/\/((.+\.)?polldaddy\.com|poll\.fm|.+\.survey\.fm)\/.+/i ],
+	},
+	{
 		name: 'core-embed/dailymotion',
 		settings: {
 			title: 'Dailymotion',
@@ -209,13 +227,14 @@ export const others = [
 		patterns: [ /^https?:\/\/(www\.)?mixcloud\.com\/.+/i ],
 	},
 	{
+		// Deprecated in favour of the core-embed/crowdsignal block
 		name: 'core-embed/polldaddy',
 		settings: {
 			title: 'Polldaddy',
 			icon: embedContentIcon,
 			description: __( 'Embed Polldaddy content.' ),
 		},
-		patterns: [ /^https?:\/\/(www\.)?polldaddy\.com\/.+/i ],
+		patterns: [],
 	},
 	{
 		name: 'core-embed/reddit',


### PR DESCRIPTION
## Description
Given the recent rebranding of Polldaddy to Crowdsignal, this change replaces the existing Polldaddy embed type with Crowdsignal and updates the pattern to match Crowdsignal's updated URLs for polls and surveys.

Solves #11517.

## How has this been tested?

Before applying my changes, add a post with the current Polldaddy embed block.
After the changes have been applied the block should be automatically upgraded to Crowdsignal.

There should now also be a new `Crowdsignal` embed block available from the menu.

All current poll and survey links from Crowdsignal should trigger the Crowdsignal embed block when pasted directly into the editor, for example:

- https://poll.fm/10127225
- https://ice9js.survey.fm/test-survey

I have tested this locally.

## Screenshots

<img width="481" alt="screen shot 2018-12-13 at 21 38 58" src="https://user-images.githubusercontent.com/8056203/49966441-34857d00-ff20-11e8-8d84-24a9c6d26517.png">

## Types of changes

New feature: Added a Crowdsignal embed block

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
