### PR TITLE
Dropdown: add focusOnMount prop to pass onto Popover component

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 - Resolves a conflict where two instance of Slot would produce an inconsistent or duplicated rendering output.
 
+### New Feature
+
+- `Dropdown` now has a `focusOnMount` prop which is passed directly to the contained `Popover`.
+
 ## 7.0.5 (2019-01-03)
 
 ## 7.0.4 (2018-12-12)

--- a/packages/components/src/dropdown/README.md
+++ b/packages/components/src/dropdown/README.md
@@ -90,3 +90,13 @@ Opt-in prop to show popovers fullscreen on mobile, pass `false` in this prop to 
 
  - Type: `String`
  - Required: No
+ 
+ ### focusOnMount
+ 
+ By default, the *first tabblable element* in the popover will receive focus when it mounts. This is the same as setting `focusOnMount` to `"firstElement"`. If you want to focus the container instead, you can set `focusOnMount` to `"container"`.
+ 
+ Set this prop to `false` to disable focus changing entirely. This should only be set when an appropriately accessible substitute behavior exists.
+ 
+ - Type: `String` or `Boolean`
+ - Required: No
+ - Default: `"firstElement"`

--- a/packages/components/src/dropdown/index.js
+++ b/packages/components/src/dropdown/index.js
@@ -73,6 +73,7 @@ class Dropdown extends Component {
 			contentClassName,
 			expandOnMobile,
 			headerTitle,
+			focusOnMount,
 		} = this.props;
 
 		const args = { isOpen, onToggle: this.toggle, onClose: this.close };
@@ -88,6 +89,7 @@ class Dropdown extends Component {
 						onClickOutside={ this.closeIfClickOutside }
 						expandOnMobile={ expandOnMobile }
 						headerTitle={ headerTitle }
+						focusOnMount={ focusOnMount }
 					>
 						{ renderContent( args ) }
 					</Popover>


### PR DESCRIPTION
## Description
I'd like to use the functionality of the `<Dropdown />` component, but not bring focus to the dropdown as it gets mounted by making use of `<Popover />` prop `focusOnMount`.

This PR adds a `focusOnMount` prop to `<Dropdown />` and simple passes it down to `<Popover />`.

## How has this been tested?
I've tested via UI implementation, https://github.com/woocommerce/wc-admin/pull/1069. Changes in this PR will not affect other areas of the codebase.

## Screenshots <!-- if applicable -->

![screen shot 2018-12-12 at 4 36 44 pm](https://user-images.githubusercontent.com/1922453/49845600-34a45080-fe2c-11e8-8828-7b8b488e6106.png)

## Use case involving keyboard Interactions

The option to have the popover NOT take focus on mounting is useful in the case of the `<Dropdown />` button being an input. The contents of the `<Popover />` might be for information purposes, or in this case, provide additional methods of date selection beyond an input. 

As seen below, tabbing to the input opens the popover, but by not stealing focus, allows keyboard-only users to remain in the input with focus.

![datepicker](https://user-images.githubusercontent.com/1922453/50059864-46517380-01f1-11e9-9145-e8366bdb6033.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature: A non-breaking change that exposes `<Popover />`'s functionality.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
