### PR TITLE
Updated all references of classic editor to be a proper noun (Classic Editor)

### DIFF
--- a/docs/designers-developers/developers/backward-compatibility/meta-box.md
+++ b/docs/designers-developers/developers/backward-compatibility/meta-box.md
@@ -17,7 +17,7 @@ add_meta_box( 'my-meta-box', 'My Meta Box', 'my_meta_box_callback',
 );
 ```
 
-WordPress will fall back to the Classic editor, where the meta box will continue working as before.
+WordPress will fall back to the Classic Editor, where the meta box will continue working as before.
 
 Explicitly setting `__block_editor_compatible_meta_box` to `true` will cause WordPress to stay in Gutenberg (assuming another meta box doesn't cause a fallback).
 
@@ -32,7 +32,7 @@ add_meta_box( 'my-meta-box', 'My Meta Box', 'my_meta_box_callback',
 );
 ```
 
-When Gutenberg is used, this meta box will no longer be displayed in the meta box area, as it now only exists for backward compatibility purposes. It will continue to display correctly in the Classic editor, should some other meta box cause a fallback.
+When Gutenberg is used, this meta box will no longer be displayed in the meta box area, as it now only exists for backward compatibility purposes. It will continue to display correctly in the Classic Editor, should some other meta box cause a fallback.
 
 ### Meta Box Data Collection
 

--- a/docs/designers-developers/developers/themes/theme-support.md
+++ b/docs/designers-developers/developers/themes/theme-support.md
@@ -200,9 +200,9 @@ This flag will make sure users are only able to choose colors from the `editor-c
 
 ## Editor styles
 
-Gutenberg supports the theme's [editor styles](https://codex.wordpress.org/Editor_Style), however it works a little differently than in the classic editor.
+Gutenberg supports the theme's [editor styles](https://codex.wordpress.org/Editor_Style), however it works a little differently than in the Classic Editor.
 
-In the classic editor, the editor stylesheet is loaded directly into the iframe of the WYSIWYG editor, with no changes. Gutenberg, however, doesn't use iframes. To make sure your styles are applied only to the content of the editor, we automatically transform your editor styles by selectively rewriting or adjusting certain CSS selectors. This also allows Gutenberg to leverage your editor style in block variation previews.
+In the Classic Editor, the editor stylesheet is loaded directly into the iframe of the WYSIWYG editor, with no changes. Gutenberg, however, doesn't use iframes. To make sure your styles are applied only to the content of the editor, we automatically transform your editor styles by selectively rewriting or adjusting certain CSS selectors. This also allows Gutenberg to leverage your editor style in block variation previews.
 
 For example, if you write `body { ... }` in your editor style, this is rewritten to `.editor-styles-wrapper { ... }`.  This also means that you should _not_ target any of the editor class names directly.
 
@@ -212,7 +212,7 @@ Because it works a little differently, you need to opt-in to this by adding an e
 add_theme_support('editor-styles');
 ```
 
-You shouldn't need to change your editor styles too much; most themes can add the snippet above and get similar results in the classic editor and inside Gutenberg.
+You shouldn't need to change your editor styles too much; most themes can add the snippet above and get similar results in the Classic Editor and inside Gutenberg.
 
 ### Dark backgrounds
 

--- a/docs/designers-developers/faq.md
+++ b/docs/designers-developers/faq.md
@@ -327,7 +327,7 @@ There is also the [Classic Editor Plugin](https://wordpress.org/plugins/classic-
 
 ## How will custom TinyMCE buttons work in Gutenberg?
 
-Custom TinyMCE buttons will still work in the “Classic” block, which is a block version of the classic editor you know today.
+Custom TinyMCE buttons will still work in the “Classic” block, which is a block version of the Classic Editor you know today.
 
 (Gutenberg comes with a new universal inserter tool, which gives you access to every block available, searchable, sorted by recency and categories. This inserter tool levels the playing field for every plugin that adds content to the editor, and provides a single interface to learn how to use.)
 

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -35,7 +35,7 @@ function the_gutenberg_project() {
 		if ( is_plugin_active( 'gutenberg/gutenberg.php' ) ) {
 			$current_url = esc_url( add_query_arg( 'classic-editor', true, $_SERVER['REQUEST_URI'] ) );
 			printf(
-				// Translators: link is to current page specify classic editor.
+				// Translators: link is to current page specify Classic Editor.
 				__( 'The Block Editor requires JavaScript. You can use the <a href="%s">Classic Editor</a>.', 'gutenberg' ),
 				$current_url
 			);
@@ -283,7 +283,7 @@ add_action( 'admin_init', 'gutenberg_add_edit_link_filters' );
 
 /**
  * Registers an additional link in the post/page screens to edit any post/page in
- * the Classic editor.
+ * the Classic Editor.
  *
  * @since 1.5.0
  *
@@ -335,7 +335,7 @@ function gutenberg_add_edit_link( $actions, $post ) {
 			esc_attr(
 				sprintf(
 					/* translators: %s: post title */
-					__( 'Edit &#8220;%s&#8221; in the classic editor', 'gutenberg' ),
+					__( 'Edit &#8220;%s&#8221; in the Classic Editor', 'gutenberg' ),
 					$title
 				)
 			),

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -70,7 +70,7 @@ function _gutenberg_utf8_split( $str ) {
 }
 
 /**
- * Disables wpautop behavior in classic editor when post contains blocks, to
+ * Disables wpautop behavior in Classic Editor when post contains blocks, to
  * prevent removep from invalidating paragraph blocks.
  *
  * @param  array  $settings  Original editor settings.

--- a/lib/meta-box-partial-page.php
+++ b/lib/meta-box-partial-page.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function gutenberg_meta_box_save() {
 	/**
-	 * Needs classic editor to be active.
+	 * Needs Classic Editor to be active.
 	 *
 	 * @see https://github.com/WordPress/gutenberg/commit/bdf94e65ac0c10b3ce5d8e214f0c9e1081997d9b
 	 */

--- a/lib/register.php
+++ b/lib/register.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Collect information about meta_boxes registered for the current post.
  *
- * Redirects to classic editor if a meta box is incompatible.
+ * Redirects to Classic Editor if a meta box is incompatible.
  *
  * @since 1.5.0
  */
@@ -196,7 +196,7 @@ function gutenberg_collect_meta_box_data() {
 	 */
 	$_meta_boxes_copy = apply_filters( 'filter_gutenberg_meta_boxes', $_meta_boxes_copy );
 
-	// Redirect to classic editor if a meta box is incompatible.
+	// Redirect to Classic Editor if a meta box is incompatible.
 	foreach ( $locations as $location ) {
 		if ( ! isset( $_meta_boxes_copy[ $post->post_type ][ $location ] ) ) {
 			continue;
@@ -564,7 +564,7 @@ function gutenberg_bulk_post_updated_messages( $messages, $bulk_counts ) {
 add_filter( 'bulk_post_updated_messages', 'gutenberg_bulk_post_updated_messages', 10, 2 );
 
 /**
- * Injects a hidden input in the edit form to propagate the information that classic editor is selected.
+ * Injects a hidden input in the edit form to propagate the information that Classic Editor is selected.
  *
  * @since 1.5.2
  */
@@ -576,7 +576,7 @@ function gutenberg_remember_classic_editor_when_saving_posts() {
 add_action( 'edit_form_top', 'gutenberg_remember_classic_editor_when_saving_posts' );
 
 /**
- * Appends a query argument to the redirect url to make sure it gets redirected to the classic editor.
+ * Appends a query argument to the redirect url to make sure it gets redirected to the Classic Editor.
  *
  * @since 1.5.2
  *

--- a/packages/blocks/src/api/parser.js
+++ b/packages/blocks/src/api/parser.js
@@ -412,7 +412,7 @@ export function createBlockWithFallback( blockNode ) {
 		name = 'core/paragraph';
 	}
 
-	// Fallback content may be upgraded from classic editor expecting implicit
+	// Fallback content may be upgraded from Classic Editor expecting implicit
 	// automatic paragraphs, so preserve them. Assumes wpautop is idempotent,
 	// meaning there are no negative consequences to repeated autop calls.
 	if ( name === freeformContentFallbackBlock ) {


### PR DESCRIPTION
## Description
This PR is mostly text change and no functionality change. It updates all reference to 'classic editor' and 'Classic editor' to be a proper noun 'Classic Editor' so as to be consistent with the current naming convention in core.

## How has this been tested?
Only tested that it didn't break anything.

## Types of changes
Mostly comment changes, there was one string change and a couple translator comment changes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
