### PR TITLE
Editor: Show block inserter only when focused, hovered, or opened

### DIFF
--- a/packages/editor/src/components/block-list/insertion-point.js
+++ b/packages/editor/src/components/block-list/insertion-point.js
@@ -6,8 +6,9 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, createRef } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
+import { focus } from '@wordpress/dom';
 
 /**
  * Internal dependencies
@@ -17,12 +18,30 @@ import Inserter from '../inserter';
 class BlockInsertionPoint extends Component {
 	constructor() {
 		super( ...arguments );
-		this.state = {
-			isInserterFocused: false,
-		};
 
 		this.onBlurInserter = this.onBlurInserter.bind( this );
 		this.onFocusInserter = this.onFocusInserter.bind( this );
+		this.toggleIsInserterHovered = this.toggleIsInserterHovered.bind( this );
+		this.toggleIsInserterOpened = this.toggleIsInserterOpened.bind( this );
+
+		this.inserterWrapperRef = createRef();
+
+		this.state = {
+			isInserterFocused: false,
+			isInserterHovered: false,
+			isInserterOpened: false,
+		};
+	}
+
+	componentDidUpdate() {
+		if ( this.forceFocusToInserter ) {
+			delete this.forceFocusToInserter;
+
+			const tabbable = focus.tabbable.find( this.inserterWrapperRef.current )[ 0 ];
+			if ( tabbable ) {
+				tabbable.focus();
+			}
+		}
 	}
 
 	onFocusInserter( event ) {
@@ -31,24 +50,59 @@ class BlockInsertionPoint extends Component {
 		// insertion and conflicts with contextual toolbar placement.
 		event.stopPropagation();
 
+		if ( this.state.isInserterFocused ) {
+			return;
+		}
+
+		const isFocusOnInserterWrapper = event.target === event.currentTarget;
+		if ( isFocusOnInserterWrapper ) {
+			this.forceFocusToInserter = true;
+		}
+
 		this.setState( {
 			isInserterFocused: true,
 		} );
 	}
 
-	onBlurInserter() {
+	onBlurInserter( event ) {
+		if ( event.target === this.inserterWrapperRef.current ) {
+			return;
+		}
+
+		if ( ! this.state.isInserterFocused ) {
+			return;
+		}
+
 		this.setState( {
 			isInserterFocused: false,
 		} );
 	}
 
+	toggleIsInserterHovered( event ) {
+		this.setState( {
+			isInserterHovered: event.type === 'mouseenter',
+		} );
+	}
+
+	toggleIsInserterOpened( isOpen ) {
+		this.setState( {
+			isInserterOpened: isOpen,
+		} );
+	}
+
 	render() {
-		const { isInserterFocused } = this.state;
+		const {
+			isInserterFocused,
+			isInserterHovered,
+			isInserterOpened,
+		} = this.state;
 		const {
 			showInsertionPoint,
 			rootClientId,
 			insertIndex,
 		} = this.props;
+
+		const isInserterVisible = isInserterFocused || isInserterHovered || isInserterOpened;
 
 		return (
 			<div className="editor-block-list__insertion-point">
@@ -56,25 +110,25 @@ class BlockInsertionPoint extends Component {
 					<div className="editor-block-list__insertion-point-indicator" />
 				) }
 				<div
+					ref={ this.inserterWrapperRef }
 					onFocus={ this.onFocusInserter }
 					onBlur={ this.onBlurInserter }
-					// While ideally it would be enough to capture the
-					// bubbling focus event from the Inserter, due to the
-					// characteristics of click focusing of `button`s in
-					// Firefox and Safari, it is not reliable.
-					//
-					// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
-					tabIndex={ -1 }
+					onMouseEnter={ this.toggleIsInserterHovered }
+					onMouseLeave={ this.toggleIsInserterHovered }
+					tabIndex={ 0 }
 					className={
 						classnames( 'editor-block-list__insertion-point-inserter', {
-							'is-visible': isInserterFocused,
+							'is-visible': isInserterVisible,
 						} )
 					}
 				>
-					<Inserter
-						rootClientId={ rootClientId }
-						index={ insertIndex }
-					/>
+					{ isInserterVisible && (
+						<Inserter
+							rootClientId={ rootClientId }
+							index={ insertIndex }
+							onToggle={ this.toggleIsInserterOpened }
+						/>
+					) }
 				</div>
 			</div>
 		);

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -657,6 +657,7 @@
 	bottom: auto;
 	left: 0;
 	right: 0;
+	height: $block-padding * 2 + 8px;
 	justify-content: center;
 
 	// Show a clickable plus.


### PR DESCRIPTION
Related: #12852

This pull request seeks to optimize the rendering of the block sibling inserter component to omit its rendering of the Inserter component except when known to be relevant: after a hover, a focus, or whilst the user is focused within the inserter menu itself. A sibling inserter is rendered for each block in the page, which can contribute significantly as the number of blocks in a post increases. In my testing for a post consisting of 20,000 words (500 paragraphs), the changes here have an impact in reducing the total number of DOM nodes by ~18%, from 15,390 to 12,668. Combined with #12852, the improvement totals a 35% reduction in total number of DOM nodes (to a final count of 9,956).

Furthermore, the Inserter component [runs the `hasInserterItems` selector](https://github.com/WordPress/gutenberg/blob/ff0ca733a8ed862f19e6557d6702237a00a171bf/packages/editor/src/components/inserter/index.js#L121), which is especially expensive. The logic here will prevent that selector from being run for each block.

_Marking as "In Progress" because I've not personally tested this exhaustively, or checked whether relevant unit or end-to-end tests require updates. The code could do for some additional inline comments, as the logic is quite indirect._

**Testing instructions:**

Verify there are no regressions in the behavior of the sibling inserter.

Compare DOM nodes between this branch and master:

```
document.getElementsByTagName( '*' ).length
```