### PR TITLE
Refactor getBlockContentSchema to not mutate its input

### DIFF
--- a/packages/blocks/src/api/raw-handling/test/utils.js
+++ b/packages/blocks/src/api/raw-handling/test/utils.js
@@ -1,8 +1,31 @@
+
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
 /**
  * Internal dependencies
  */
 import { getPhrasingContentSchema } from '../phrasing-content';
-import { isEmpty, isPlain, removeInvalidHTML } from '../utils';
+import { getBlockContentSchema, isEmpty, isPlain, removeInvalidHTML } from '../utils';
+
+jest.mock( '@wordpress/data', () => {
+	return {
+		select: jest.fn( ( store ) => {
+			switch ( store ) {
+				case 'core/blocks': {
+					return {
+						hasBlockSupport: ( blockName, supports ) => {
+							return blockName === 'core/paragraph' &&
+								supports === 'anchor';
+						},
+					};
+				}
+			}
+		} ),
+	};
+} );
 
 describe( 'isEmpty', () => {
 	function isEmptyHTML( HTML ) {
@@ -162,5 +185,142 @@ describe( 'removeInvalidHTML', () => {
 		const input = '<figure><p>test</p><figcaption>test</figcaption></figure>';
 		const output = '<p>test</p>test';
 		expect( removeInvalidHTML( input, schema ) ).toBe( output );
+	} );
+} );
+
+describe( 'getBlockContentSchema', () => {
+	const myContentSchema = {
+		strong: {},
+		em: {},
+	};
+
+	it( 'should handle a single raw transform', () => {
+		const transforms = deepFreeze( [ {
+			blockName: 'core/paragraph',
+			type: 'raw',
+			selector: 'p',
+			schema: {
+				p: {
+					children: myContentSchema,
+				},
+			},
+		} ] );
+		const output = {
+			p: {
+				children: myContentSchema,
+				attributes: [ 'id' ],
+				isMatch: undefined,
+			},
+		};
+		expect(
+			getBlockContentSchema( transforms )
+		).toEqual( output );
+	} );
+
+	it( 'should handle multiple raw transforms', () => {
+		const preformattedIsMatch = ( input ) => {
+			return input === 4;
+		};
+		const transforms = deepFreeze( [ {
+			blockName: 'core/paragraph',
+			type: 'raw',
+			schema: {
+				p: {
+					children: myContentSchema,
+				},
+			},
+		}, {
+			blockName: 'core/preformatted',
+			type: 'raw',
+			isMatch: preformattedIsMatch,
+			schema: {
+				pre: {
+					children: myContentSchema,
+				},
+			},
+		} ] );
+		const output = {
+			p: {
+				children: myContentSchema,
+				attributes: [ 'id' ],
+				isMatch: undefined,
+			},
+			pre: {
+				children: myContentSchema,
+				attributes: [],
+				isMatch: preformattedIsMatch,
+			},
+		};
+		expect(
+			getBlockContentSchema( transforms )
+		).toEqual( output );
+	} );
+
+	it( 'should correctly merge the children', () => {
+		const transforms = deepFreeze( [ {
+			blockName: 'my/preformatted',
+			type: 'raw',
+			schema: {
+				pre: {
+					children: {
+						sub: {},
+						sup: {},
+						strong: {},
+					},
+				},
+			},
+		}, {
+			blockName: 'core/preformatted',
+			type: 'raw',
+			schema: {
+				pre: {
+					children: myContentSchema,
+				},
+			},
+		} ] );
+		const output = {
+			pre: {
+				children: {
+					strong: {},
+					em: {},
+					sub: {},
+					sup: {},
+				},
+			},
+		};
+		expect(
+			getBlockContentSchema( transforms )
+		).toEqual( output );
+	} );
+
+	it( 'should correctly merge the attributes', () => {
+		const transforms = deepFreeze( [ {
+			blockName: 'my/preformatted',
+			type: 'raw',
+			schema: {
+				pre: {
+					attributes: [ 'data-chicken' ],
+					children: myContentSchema,
+				},
+			},
+		}, {
+			blockName: 'core/preformatted',
+			type: 'raw',
+			schema: {
+				pre: {
+					attributes: [ 'data-ribs' ],
+					children: myContentSchema,
+				},
+			},
+		} ] );
+		const output = {
+			pre: {
+				children: myContentSchema,
+				attributes: [ 'data-chicken', 'data-ribs' ],
+			},
+		};
+		expect(
+			getBlockContentSchema( transforms )
+		).toEqual( output );
 	} );
 } );


### PR DESCRIPTION
## Description
This PR makes sure getBlockContentSchema does not mutate its inputs. Right now that's not a problem because its inputs have been copied before and we mutate them, but we never know where the function will be used in the future, and it is totally unexpected that a getter mutates its inputs.
More details in https://github.com/WordPress/gutenberg/pull/11244#discussion_r240046066.

## How has this been tested?
Execute the unit tests.
Verify there are no regressions in the copy and paste behavior.

