### PR TITLE
Allow filtering min and max number of columns in blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2353,6 +2353,7 @@
 				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/editor": "file:packages/editor",
 				"@wordpress/element": "file:packages/element",
+				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/html-entities": "file:packages/html-entities",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/keycodes": "file:packages/keycodes",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -31,6 +31,7 @@
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/editor": "file:../editor",
 		"@wordpress/element": "file:../element",
+		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/keycodes": "file:../keycodes",

--- a/packages/block-library/src/columns/index.js
+++ b/packages/block-library/src/columns/index.js
@@ -11,6 +11,7 @@ import memoize from 'memize';
 import { __ } from '@wordpress/i18n';
 import { PanelBody, RangeControl, G, SVG, Path } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
 import { createBlock } from '@wordpress/blocks';
 import {
 	InspectorControls,
@@ -65,6 +66,27 @@ function getDeprecatedLayoutColumn( originalContent ) {
 	}
 }
 
+/**
+ * Filters the default number of columns of the core/columns block.
+ *
+ * @param {Number} number The column count. Defaults to 2.
+ */
+const DEFAULT_COLUMNS = applyFilters( 'blocks.columns.defaultColumns', 2 );
+
+/**
+ * Filters the minimum number of allowed columns of the core/columns block.
+ *
+ * @param {Number} number The column count. Defaults to 2.
+ */
+const MIN_COLUMNS = applyFilters( 'blocks.columns.minColumns', 2 );
+
+/**
+ * Filters the maximum number of allowed columns of the core/columns block.
+ *
+ * @param {Number} number The column count. Defaults to 6.
+ */
+const MAX_COLUMNS = applyFilters( 'blocks.columns.maxColumns', 6 );
+
 export const name = 'core/columns';
 
 export const settings = {
@@ -77,7 +99,7 @@ export const settings = {
 	attributes: {
 		columns: {
 			type: 'number',
-			default: 2,
+			default: parseInt( DEFAULT_COLUMNS, 10 ),
 		},
 	},
 
@@ -170,8 +192,8 @@ export const settings = {
 									columns: nextColumns,
 								} );
 							} }
-							min={ 2 }
-							max={ 6 }
+							min={ Math.max( parseInt( MIN_COLUMNS, 10 ), 1 ) }
+							max={ parseInt( MAX_COLUMNS, 10 ) }
 						/>
 					</PanelBody>
 				</InspectorControls>

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -8,6 +8,7 @@ import { filter, pick, map, get } from 'lodash';
  */
 import { Component, Fragment } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
 import {
 	IconButton,
 	DropZone,
@@ -32,7 +33,20 @@ import {
  */
 import GalleryImage from './gallery-image';
 
-const MAX_COLUMNS = 8;
+/**
+ * Filters the minimum number of allowed columns of the core/gallery block.
+ *
+ * @param {Number} number The column count. Defaults to 2.
+ */
+const MIN_COLUMNS = applyFilters( 'blocks.gallery.minColumns', 2 );
+
+/**
+ * Filters the maximum number of allowed columns of the core/gallery block.
+ *
+ * @param {Number} number The column count. Defaults to 6.
+ */
+const MAX_COLUMNS = applyFilters( 'blocks.gallery.maxColumns', 6 );
+
 const linkOptions = [
 	{ value: 'attachment', label: __( 'Attachment Page' ) },
 	{ value: 'media', label: __( 'Media File' ) },
@@ -243,8 +257,8 @@ class GalleryEdit extends Component {
 							label={ __( 'Columns' ) }
 							value={ columns }
 							onChange={ this.setColumnsNumber }
-							min={ 1 }
-							max={ Math.min( MAX_COLUMNS, images.length ) }
+							min={ Math.max( parseInt( MIN_COLUMNS, 10 ), 1 ) }
+							max={ Math.min( parseInt( MAX_COLUMNS, 10 ), images.length ) }
 						/> }
 						<ToggleControl
 							label={ __( 'Crop Images' ) }


### PR DESCRIPTION
## Description
Fixes #10791 by adding some filters to allow changing the minimum and maximum number of columns for both the gallery and the columns block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
