### PR TITLE
[Mobile]: Send blockType prop to RNAztecView

### DIFF
--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -372,6 +372,7 @@ export class RichText extends Component {
 					onContentSizeChange={ this.onContentSizeChange }
 					onActiveFormatsChange={ this.onActiveFormatsChange }
 					isSelected={ this.props.isSelected }
+					blockType={ { tag: tagName } }
 					color={ 'black' }
 					maxImagesWidth={ 200 }
 					style={ style }


### PR DESCRIPTION
This PR is part of fixing https://github.com/wordpress-mobile/gutenberg-mobile/issues/355 

It sends the necessary information (`blockType`) back to `RNAztecView`.
It's an object so it's easily extensible with more info in the future if it's needed.

To test:
See https://github.com/wordpress-mobile/react-native-aztec/pull/98 