### PR TITLE
Data: withSelect: Subscribe only to reducer keys referenced in mapSelectToProps

### DIFF
--- a/packages/data/src/namespace-store.js
+++ b/packages/data/src/namespace-store.js
@@ -54,7 +54,7 @@ export default function createNamespace( key, options, registry ) {
 			lastState = state;
 
 			if ( hasChanged ) {
-				listener();
+				listener( key );
 			}
 		} );
 	};


### PR DESCRIPTION
This pull request seeks to explore a possible optimization to the implementation of `withSelect`, such that it becomes subscribed only to the stores on which it is selecting data.

**Background:**

When the editor loads, we have a number of state changes which occur across many distinct stores. Notably, there are a number of data resolutions which occur via the `core-data` package. While the stores themselves are lightweight, each of these changes forces every connected component to rerun its selectors. Particularly for large posts, this can severely bog down the initial load time of the editor. In my experience, there can be [upwards of a 30-40 store changes after the first render of the editor](https://gist.github.com/aduth/d5fe89923878af9fbc9f3556a7adbbf2). It can also have a runtime impact; for example, any change in, say, Yoast's own store would incur a `mapSelectToProps` to again be called for every single connected component in the page.

**Implementation:**

The changes here enable a developer, when subscribing to a registry, to provide a set of `reducerKeys` as a condition on which their listener is to be called. When a `withSelect`-connected component is mounted, it observes its initial call to `mapSelectToProps` to determine the reducer keys for which `select` is called. These are used as the set of `reducerKeys` in its own subscription. Thus, the `mapSelectToProps` for the component is only called when the store for those specific reducer keys has changed.

**Implications:**

Due to how the `reducerKeys` for the subscription is determined at the initial mounting of the connected component, this has a few implications:

- **`mapSelectToProps` must call `select` consistently.** This is already a best-practice anyways, but a `mapSelectToProps` must not have conditional logic under which it calls `select` with a different reducer key(s).
- **Selectors cannot have side effects, including `select` calls to operate on other stores.** If a selector derives its value including data from another store, changes to that other store will not cause the top-level selector call to be made.
   - Technically, there may be some options to explore here with having an observer similar to the one implemented for `withSelect`, but for the entire registry.
   - _But_... I think we must move away from this pattern, as calling `wp.data.select` from a selector should be considered an anti-pattern because it is not contextualized to a specific registry, and thus would produce wrong values when in the non-default registry (see also #7119). Separately, I think we should explore patterns for supporting selection across stores by making the registry (or, specifically its `select` function) available to a selector in some form (e.g. a bound `this.registry`, or a `( registry ) => ( state, a, b ) => {}` higher-order function).

**Results:**

I was slightly underwhelmed by the result, but it is still a notable improvement. Using the content of the text from https://github.com/WordPress/gutenberg/issues/11782#issuecomment-438213916 converted to blocks, I see a reduction of initial load (`DOMContentLoaded`) from ~22 to 16 seconds (roughly 27% improvement). As mentioned earlier, this should also have some noted improvement for general runtime usage, though not as much, since the majority of runtime behaviors impact the `core/editor` store, which is also the store subscribed to by the bulk of mounted components in the editor.

**Other Ideas:**

The fact that there are dozens of actions dispatched during the initialization of the editor could be argued as an issue in and of itself. I think there are some opportunities to limit this.

A few thoughts on this:

- We shouldn't want to discourage a module having its internal state management being implemented on the registry if it needs to make frequent changes to its own internal state. There is both a convenience and a consisting in adopting the data store pattern.
- We could explore letting the editor mount so that all data initialization is kicked off, and only on the next tick perform the parse on post content to populate the blocks in the editor. This way (a) something is shown to the user immediately and prior to the parse, and (b) the rendered blocks (which account for the majority of the connected components in a large post) aren't impacted by the initial data resolution because they're not mounted at the time they are initiated.
- For prepopulated data, we should consider whether there are options to nullify the resolver. The idea would be to "pre-resolve" state with the data provided from the server.
- As seen in the [aforementioned Gist console log](https://gist.github.com/aduth/d5fe89923878af9fbc9f3556a7adbbf2), core block registration is another major contributor to store changes during initialization. I think there ought to be a way to bulk-register blocks, either within the blocks module itself, or deferring the store dispatch to the `initializeCoreBlocks` function. However, since this occurs prior to the initial render, I'm not sure whether this actually contributes much to a delayed first load.