### PR TITLE
Use supports align in cover block to fix some align related bugs;

### DIFF
--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -23,7 +23,6 @@ import { compose } from '@wordpress/compose';
 import {
 	BlockControls,
 	InspectorControls,
-	BlockAlignmentToolbar,
 	MediaPlaceholder,
 	MediaUpload,
 	MediaUploadCheck,
@@ -34,8 +33,6 @@ import {
 	getColorClassName,
 } from '@wordpress/editor';
 
-const validAlignments = [ 'left', 'center', 'right', 'wide', 'full' ];
-
 const blockAttributes = {
 	title: {
 		type: 'string',
@@ -43,9 +40,6 @@ const blockAttributes = {
 		selector: 'p',
 	},
 	url: {
-		type: 'string',
-	},
-	align: {
 		type: 'string',
 	},
 	contentAlign: {
@@ -91,6 +85,10 @@ export const settings = {
 	category: 'common',
 
 	attributes: blockAttributes,
+
+	supports: {
+		align: true,
+	},
 
 	transforms: {
 		from: [
@@ -168,20 +166,12 @@ export const settings = {
 		],
 	},
 
-	getEditWrapperProps( attributes ) {
-		const { align } = attributes;
-		if ( -1 !== validAlignments.indexOf( align ) ) {
-			return { 'data-align': align };
-		}
-	},
-
 	edit: compose( [
 		withColors( { overlayColor: 'background-color' } ),
 		withNotices,
 	] )(
 		( { attributes, setAttributes, isSelected, className, noticeOperations, noticeUI, overlayColor, setOverlayColor } ) => {
 			const {
-				align,
 				backgroundType,
 				contentAlign,
 				dimRatio,
@@ -190,7 +180,6 @@ export const settings = {
 				title,
 				url,
 			} = attributes;
-			const updateAlignment = ( nextAlign ) => setAttributes( { align: nextAlign } );
 			const onSelectMedia = ( media ) => {
 				if ( ! media || ! media.url ) {
 					setAttributes( { url: undefined, id: undefined } );
@@ -248,10 +237,6 @@ export const settings = {
 			const controls = (
 				<Fragment>
 					<BlockControls>
-						<BlockAlignmentToolbar
-							value={ align }
-							onChange={ updateAlignment }
-						/>
 						{ !! url && (
 							<Fragment>
 								<AlignmentToolbar
@@ -381,7 +366,6 @@ export const settings = {
 
 	save( { attributes } ) {
 		const {
-			align,
 			backgroundType,
 			contentAlign,
 			customOverlayColor,
@@ -407,7 +391,6 @@ export const settings = {
 				'has-parallax': hasParallax,
 				[ `has-${ contentAlign }-content` ]: contentAlign !== 'center',
 			},
-			align ? `align${ align }` : null,
 		);
 
 		return (
@@ -429,6 +412,9 @@ export const settings = {
 	deprecated: [ {
 		attributes: {
 			...blockAttributes,
+			align: {
+				type: 'string',
+			},
 		},
 
 		supports: {
@@ -466,6 +452,9 @@ export const settings = {
 	}, {
 		attributes: {
 			...blockAttributes,
+			align: {
+				type: 'string',
+			},
 			title: {
 				type: 'string',
 				source: 'html',


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/12333
## Description
The cover block was not using the supports align mechanism, replicating its code on the block itself (when the block was created, I think the mechanism did not exist).
The supports align mechanism was improved with time, to for example not show wide and full alignments on the editor if the theme does not supports them.
As the cover block did not use the align mechanism it has not the logic to check wide and full theme support.
This causes two problems:
 - If pasting a block with aligning full support in the editor when the theme does not supports it the block is shown as full with no option to remove this alignment as described by issue https://github.com/WordPress/gutenberg/issues/12333.
 - If the site had a theme that supported wide alignments, and some blocks are created using wide alignments, and then the theme is changed to one that does not supports wide alignments, the wide blocks continue to be shown as wide.



## How has this been tested?
I copied the following blocks with all the possible alignments to a new post in a theme that does not support wide alignments:
```
<!-- wp:cover {"url":"https://mere-dark.jurassic.ninja/wp-content/uploads/2018/12/Porto_Panorama_2004.jpg","align":"left","id":6} -->
<div class="wp-block-cover has-background-dim alignleft" style="background-image:url(https://mere-dark.jurassic.ninja/wp-content/uploads/2018/12/Porto_Panorama_2004.jpg)"><p class="wp-block-cover-text">Left</p></div>
<!-- /wp:cover -->

<!-- wp:cover {"url":"https://mere-dark.jurassic.ninja/wp-content/uploads/2018/12/Porto_Panorama_2004.jpg","align":"center","id":6} -->
<div class="wp-block-cover has-background-dim aligncenter" style="background-image:url(https://mere-dark.jurassic.ninja/wp-content/uploads/2018/12/Porto_Panorama_2004.jpg)"><p class="wp-block-cover-text">Center</p></div>
<!-- /wp:cover -->

<!-- wp:cover {"url":"https://mere-dark.jurassic.ninja/wp-content/uploads/2018/12/Porto_Panorama_2004.jpg","align":"right","id":6} -->
<div class="wp-block-cover has-background-dim alignright" style="background-image:url(https://mere-dark.jurassic.ninja/wp-content/uploads/2018/12/Porto_Panorama_2004.jpg)"><p class="wp-block-cover-text">Right</p></div>
<!-- /wp:cover -->

<!-- wp:cover {"url":"https://mere-dark.jurassic.ninja/wp-content/uploads/2018/12/Porto_Panorama_2004.jpg","align":"wide","id":6} -->
<div class="wp-block-cover has-background-dim alignwide" style="background-image:url(https://mere-dark.jurassic.ninja/wp-content/uploads/2018/12/Porto_Panorama_2004.jpg)"><p class="wp-block-cover-text">Wide</p></div>
<!-- /wp:cover -->

<!-- wp:cover {"url":"https://mere-dark.jurassic.ninja/wp-content/uploads/2018/12/Porto_Panorama_2004.jpg","align":"full","id":6} -->
<div class="wp-block-cover has-background-dim alignfull" style="background-image:url(https://mere-dark.jurassic.ninja/wp-content/uploads/2018/12/Porto_Panorama_2004.jpg)"><p class="wp-block-cover-text">Full</p></div>
<!-- /wp:cover -->

<!-- wp:cover {"url":"https://mere-dark.jurassic.ninja/wp-content/uploads/2018/12/Porto_Panorama_2004.jpg","id":6,"overlayColor":"dark-gray"} -->
<div class="wp-block-cover has-dark-gray-background-color has-background-dim" style="background-image:url(https://mere-dark.jurassic.ninja/wp-content/uploads/2018/12/Porto_Panorama_2004.jpg)"><p class="wp-block-cover-text">None</p></div>
<!-- /wp:cover -->
```
This blocks were created with wordpress 5.0.1, to make sure we are not changing the markup and invalidating previous blocks.

I verified the wide and full blocks appear as standard blocks.

I published the post with all these blocks.

I changed to a theme that supports wide and full alignments, I opened the post again and verified the wide, and full blocks now appear as wide and full.