### PR TITLE
Fix: Cannot read property 'prefix' of null when post is publicly_queryable but not public

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-link/index.js
+++ b/packages/edit-post/src/components/sidebar/post-link/index.js
@@ -124,8 +124,10 @@ export default compose( [
 		} = select( 'core' );
 
 		const { link, id } = getCurrentPost();
+
 		const postTypeName = getEditedPostAttribute( 'type' );
 		const postType = getPostType( postTypeName );
+
 		return {
 			isNew: isEditedPostNew(),
 			postLink: link,
@@ -140,8 +142,8 @@ export default compose( [
 			postID: id,
 		};
 	} ),
-	ifCondition( ( { isEnabled, isNew, postLink, isViewable } ) => {
-		return isEnabled && ! isNew && postLink && isViewable;
+	ifCondition( ( { isEnabled, isNew, postLink, isViewable, permalinkParts } ) => {
+		return isEnabled && ! isNew && postLink && isViewable && permalinkParts;
 	} ),
 	withDispatch( ( dispatch ) => {
 		const { toggleEditorPanelOpened } = dispatch( 'core/edit-post' );

--- a/packages/editor/src/components/post-permalink/index.js
+++ b/packages/editor/src/components/post-permalink/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -57,9 +58,19 @@ class PostPermalink extends Component {
 	}
 
 	render() {
-		const { isNew, postLink, permalinkParts, postSlug, postTitle, postID, isEditable, isPublished } = this.props;
+		const {
+			isEditable,
+			isNew,
+			isPublished,
+			isViewable,
+			permalinkParts,
+			postLink,
+			postSlug,
+			postID,
+			postTitle,
+		} = this.props;
 
-		if ( isNew || ! postLink ) {
+		if ( isNew || ! isViewable || ! permalinkParts || ! postLink ) {
 			return null;
 		}
 
@@ -138,8 +149,14 @@ export default compose( [
 			getEditedPostAttribute,
 			isCurrentPostPublished,
 		} = select( 'core/editor' );
+		const {
+			getPostType,
+		} = select( 'core' );
 
 		const { id, link } = getCurrentPost();
+
+		const postTypeName = getEditedPostAttribute( 'type' );
+		const postType = getPostType( postTypeName );
 
 		return {
 			isNew: isEditedPostNew(),
@@ -150,6 +167,7 @@ export default compose( [
 			isPublished: isCurrentPostPublished(),
 			postTitle: getEditedPostAttribute( 'title' ),
 			postID: id,
+			isViewable: get( postType, [ 'viewable' ], false ),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/12482
When the publicly_queryable but not public permalinkParts are undefined, but on the post type the viewable property is still true.
This PR makes sure we don't show permalink editing functionality if permalinkParts are not defined making sure we avoid this kind of unexpected errors.


## How has this been tested?
I added the following post type:
```
add_action( 'init', function() {
    register_post_type( 'book-error', [
        'label' => 'BookError',
        'show_in_rest' => true,
        'public' => false,
        'publicly_queryable' => true,
        'supports' => [ 'title', 'editor', 'revisions' ],
        'show_ui'             => true,
        'show_in_menu'        => true,
    ] );
} );
```

I created a new post of the book error post type;
I wrote some title and pressed saved the draft.
I focused the title, and I verified an option to change the permalink was not available.
On master when the title was focused the application crashed.



