### PR TITLE
Exit early from onClick handler when isButtonDisabled

### DIFF
--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -73,6 +73,9 @@ export class PostPublishButton extends Component {
 		}
 
 		const onClick = () => {
+			if ( isButtonDisabled ) {
+				return;
+			}
 			onSubmit();
 			onStatusChange( publishStatus );
 			onSave();

--- a/packages/editor/src/components/post-publish-button/test/index.js
+++ b/packages/editor/src/components/post-publish-button/test/index.js
@@ -103,7 +103,10 @@ describe( 'PostPublishButton', () => {
 				<PostPublishButton
 					hasPublishAction={ false }
 					onStatusChange={ onStatusChange }
-					onSave={ onSave } />
+					onSave={ onSave }
+					isSaveable={ true }
+					isPublishable={ true }
+				/>
 			);
 
 			wrapper.simulate( 'click' );
@@ -119,7 +122,9 @@ describe( 'PostPublishButton', () => {
 					hasPublishAction={ true }
 					onStatusChange={ onStatusChange }
 					onSave={ onSave }
-					isBeingScheduled />
+					isBeingScheduled
+					isSaveable={ true }
+					isPublishable={ true } />
 			);
 
 			wrapper.simulate( 'click' );
@@ -135,7 +140,9 @@ describe( 'PostPublishButton', () => {
 					hasPublishAction={ true }
 					onStatusChange={ onStatusChange }
 					onSave={ onSave }
-					visibility="private" />
+					visibility="private"
+					isSaveable={ true }
+					isPublishable={ true } />
 			);
 
 			wrapper.simulate( 'click' );
@@ -150,7 +157,9 @@ describe( 'PostPublishButton', () => {
 				<PostPublishButton
 					hasPublishAction={ true }
 					onStatusChange={ onStatusChange }
-					onSave={ onSave } />
+					onSave={ onSave }
+					isSaveable={ true }
+					isPublishable={ true } />
 			);
 
 			wrapper.simulate( 'click' );
@@ -167,7 +176,9 @@ describe( 'PostPublishButton', () => {
 				<PostPublishButton
 					hasPublishAction={ true }
 					onStatusChange={ onStatusChange }
-					onSave={ onSave } />
+					onSave={ onSave }
+					isSaveable={ true }
+					isPublishable={ true } />
 			);
 
 			wrapper.simulate( 'click' );


### PR DESCRIPTION
## Description
Fixes https://github.com/WordPress/gutenberg/issues/11809
Alternate/replaces https://github.com/WordPress/gutenberg/pull/11760

Return early from click action handling when button is disabled (`isButtonDisabled` is true)

Since https://github.com/WordPress/gutenberg/pull/11543 the post publish/update button is no longer `disabled` when `isButtonDisabled` is true (https://github.com/WordPress/gutenberg/pull/11543/files#diff-29409e4e3f779a199509ffadad068564L76) - instead `aria-diabled` is set to true (https://github.com/WordPress/gutenberg/pull/11543/files#diff-29409e4e3f779a199509ffadad068564L76) which still allows the button itself to be clicked.

This PR prevents the button from being clicked by returning early from the `onClick` handler, see @youknowriad's comment here: https://github.com/WordPress/gutenberg/pull/11760/files#r236177807

## How has this been tested?
Needs testing.

## Types of changes
Add a check for `isButtonDisabled` in the `onClick` handler, exit early if true - preventing click action handling.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
