### PR TITLE
[RNMobile] Revert hiding keyboard when non textual block is selected

### DIFF
--- a/packages/editor/src/components/plain-text/index.native.js
+++ b/packages/editor/src/components/plain-text/index.native.js
@@ -21,12 +21,6 @@ export default class PlainText extends Component {
 		}
 	}
 
-	componentDidUpdate( prevProps ) {
-		if ( ! this.props.isSelected && prevProps.isSelected ) {
-			this._input.blur();
-		}
-	}
-
 	focus() {
 		this._input.focus();
 	}

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -292,8 +292,6 @@ export class RichText extends Component {
 	componentDidUpdate( prevProps ) {
 		if ( this.props.isSelected && ! prevProps.isSelected ) {
 			this._editor.focus();
-		} else if ( ! this.props.isSelected && prevProps.isSelected ) {
-			this._editor.blur();
 		}
 	}
 


### PR DESCRIPTION
This PR reverts the changes introduced in https://github.com/WordPress/gutenberg/pull/12765 that were introduced to fix an issue where moving the focus to a non textual block kept the keyboard visible on the screen.

Unfortunately, We found out that it has introduced a bigger problem when typing on a paragraph, or Heading/Title block, and tapping Enter to create a new block. The soft keyboard is dismissed in this case interrupting the writing flow. https://github.com/wordpress-mobile/gutenberg-mobile/issues/381

Reverting the changes for the upcoming alpha.

Testing steps in the gb-side PR here: https://github.com/wordpress-mobile/gutenberg-mobile/pull/383