### PR TITLE
Set a default icon margin for buttons with icon and text.

### DIFF
--- a/packages/block-library/src/audio/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/audio/test/__snapshots__/index.js.snap
@@ -38,7 +38,7 @@ exports[`core/audio block edit matches snapshot 1`] = `
       class="components-form-file-upload"
     >
       <button
-        class="components-button components-icon-button editor-media-placeholder__button is-button is-default is-large"
+        class="components-button components-icon-button editor-media-placeholder__button has-text is-button is-default is-large"
         type="button"
       >
         <svg

--- a/packages/block-library/src/cover/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/cover/test/__snapshots__/index.js.snap
@@ -38,7 +38,7 @@ exports[`core/cover block edit matches snapshot 1`] = `
       class="components-form-file-upload"
     >
       <button
-        class="components-button components-icon-button editor-media-placeholder__button is-button is-default is-large"
+        class="components-button components-icon-button editor-media-placeholder__button has-text is-button is-default is-large"
         type="button"
       >
         <svg

--- a/packages/block-library/src/gallery/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/gallery/test/__snapshots__/index.js.snap
@@ -38,7 +38,7 @@ exports[`core/gallery block edit matches snapshot 1`] = `
       class="components-form-file-upload"
     >
       <button
-        class="components-button components-icon-button editor-media-placeholder__button is-button is-default is-large"
+        class="components-button components-icon-button editor-media-placeholder__button has-text is-button is-default is-large"
         type="button"
       >
         <svg

--- a/packages/block-library/src/video/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/video/test/__snapshots__/index.js.snap
@@ -38,7 +38,7 @@ exports[`core/video block edit matches snapshot 1`] = `
       class="components-form-file-upload"
     >
       <button
-        class="components-button components-icon-button editor-media-placeholder__button is-button is-default is-large"
+        class="components-button components-icon-button editor-media-placeholder__button has-text is-button is-default is-large"
         type="button"
       >
         <svg

--- a/packages/components/src/icon-button/index.js
+++ b/packages/components/src/icon-button/index.js
@@ -22,7 +22,9 @@ class IconButton extends Component {
 	render() {
 		const { icon, children, label, className, tooltip, shortcut, labelPosition, ...additionalProps } = this.props;
 		const { 'aria-pressed': ariaPressed } = this.props;
-		const classes = classnames( 'components-icon-button', className );
+		const classes = classnames( 'components-icon-button', className, {
+			'has-text': children,
+		} );
 		const tooltipText = tooltip || label;
 
 		// Should show the tooltip if...

--- a/packages/components/src/icon-button/style.scss
+++ b/packages/components/src/icon-button/style.scss
@@ -19,10 +19,10 @@
 	svg {
 		fill: currentColor;
 		outline: none;
+	}
 
-		&:not:only-child {
-			margin-right: 4px;
-		}
+	&.has-text svg {
+		margin-right: 4px;
 	}
 
 	&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover {

--- a/packages/edit-post/src/components/header/plugin-more-menu-item/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/header/plugin-more-menu-item/test/__snapshots__/index.js.snap
@@ -18,7 +18,7 @@ exports[`PluginMoreMenuItem renders menu item as button properly 1`] = `
   >
     <button
       aria-label="My plugin button menu item"
-      className="components-button components-icon-button components-menu-item__button has-icon"
+      className="components-button components-icon-button components-menu-item__button has-icon has-text"
       onClick={[Function]}
       role="menuitem"
       type="button"


### PR DESCRIPTION
## Description

This small PR seeks to improve the IconButton component by making sure there's some spacing between the button's icon and text.

- removes the CSS rule `:not:only-child` as it doesn't work with text nodes (it was also missing the parenthesis)
- adds a CSS selector modifier when the IconButton has visible text and uses that to set a margin

Notes:
- other components that reuse the IconButton set their own CSS rules to have a margin, for example: the Revisions link, the buttons in the More menu, and the buttons in the Block menu. Now that there's a default margin, maybe all those _ad-hoc_ rules could be removed
- I've kept the original `4px` margin but I've seen the other cases mentioned above use a `5px` value, not sure which is the one to use

/Cc @jasmussen 

Example screenshot before:

<img width="143" alt="screenshot 2018-12-15 at 11 03 43" src="https://user-images.githubusercontent.com/1682452/50042498-e6799200-0063-11e9-8d3b-683e10a58eb2.png">

After:

<img width="162" alt="screenshot 2018-12-15 at 12 20 23" src="https://user-images.githubusercontent.com/1682452/50042499-ed080980-0063-11e9-9312-8de99b415ca5.png">

Fixes #12900 