### PR TITLE
Fixed incorrect example code

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -91,7 +91,7 @@ registerStore( 'my-shop', {
 	},
 
 	resolvers: {
-		* getPrice( state, item ) {
+		* getPrice( item ) {
 			const path = '/wp/v2/prices/' + item;
 			const price = yield actions.fetchFromAPI( path );
 			return actions.setPrice( item, price );
@@ -127,7 +127,7 @@ The **`selectors`** object includes a set of functions for accessing and derivin
 
 A **resolver** is a side-effect for a selector. If your selector result may need to be fulfilled from an external source, you can define a resolver such that the first time the selector is called, the fulfillment behavior is effected.
 
-The `resolvers` option should be passed as an object where each key is the name of the selector to act upon, the value a function which receives the same arguments passed to the selector. It can then dispatch as necessary to fulfill the requirements of the selector, taking advantage of the fact that most data consumers will subscribe to subsequent state changes (by `subscribe` or `withSelect`).
+The `resolvers` option should be passed as an object where each key is the name of the selector to act upon, the value a function which receives the same arguments passed to the selector, excluding the state argument. It can then dispatch as necessary to fulfill the requirements of the selector, taking advantage of the fact that most data consumers will subscribe to subsequent state changes (by `subscribe` or `withSelect`).
 
 ### `controls`
 


### PR DESCRIPTION
Hi, I fixed what I believe were some typos in the `registerStore` [example](https://github.com/WordPress/gutenberg/tree/master/packages/data/README.md) for the data package. When I tried the function the way it is in the documentation, the `state` argument in the `getPrice` resolver has the value expected to be defined in the `item` argument and the `item` argument is undefined.

It looks like maybe the function changed at some point and the documentation wasn't updated. 