### PR TITLE
Add content to Contributors index page

### DIFF
--- a/docs/contributors/readme.md
+++ b/docs/contributors/readme.md
@@ -1,0 +1,15 @@
+# Contributors Guide
+
+Welcome to the Gutenberg Project Contributors Guide.
+
+The following guidelines are in place to create consistency across the project and the numerous contributors. See also the [Contributing Documentation](https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTING.md) for technical details around setup, and submitting your contributions.
+
+
+* [Coding Guidelines](../contributors/coding-guidelines.md) outline additional patterns and conventions used in the Gutenberg project.
+
+* [Copy Guidelines](../contributors/copy-guide.md)
+
+* [Design Principles & Vision](../contributors/design.md)
+
+
+Please see the table of contents on the left side of the Gutenberg Handbook for the full list of contributor resources.

--- a/docs/contributors/readme.md
+++ b/docs/contributors/readme.md
@@ -4,12 +4,8 @@ Welcome to the Gutenberg Project Contributors Guide.
 
 The following guidelines are in place to create consistency across the project and the numerous contributors. See also the [Contributing Documentation](https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTING.md) for technical details around setup, and submitting your contributions.
 
-
-* [Coding Guidelines](../contributors/coding-guidelines.md) outline additional patterns and conventions used in the Gutenberg project.
-
-* [Copy Guidelines](../contributors/copy-guide.md)
-
-* [Design Principles & Vision](../contributors/design.md)
-
+* [Coding Guidelines](../../docs/contributors/coding-guidelines.md) outline additional patterns and conventions used in the Gutenberg project.
+* [Copy Guidelines](../../docs/contributors/copy-guide.md)
+* [Design Principles & Vision](../../docs/contributors/design.md)
 
 Please see the table of contents on the left side of the Gutenberg Handbook for the full list of contributor resources.


### PR DESCRIPTION
## Description

When visiting the Gutenberg Handbook the Contributors index page is
blank. See: https://wordpress.org/gutenberg/handbook/contributors/

This PR adds some basic content and links to find more, including
linking back to the repo's contributing document.

Preview: https://github.com/WordPress/gutenberg/blob/docs/contrib-readme/docs/contributors/readme.md

## Types of changes

Documentation.

