### PR TITLE
Editor: Fix second welcome tip instructs the user to open a control that's already open.

### DIFF
--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -69,7 +69,7 @@ function Header( {
 						shortcut={ shortcuts.toggleSidebar }
 					/>
 					<DotTip tipId="core/editor.settings">
-						{ __( 'You’ll find more settings for your page and blocks in the sidebar. Click "Settings" allows toggling the sidebar.' ) }
+						{ __( 'You’ll find more settings for your page and blocks in the sidebar. Click “Settings” allows toggling the sidebar.' ) }
 					</DotTip>
 				</div>
 				<PinnedPlugins.Slot />

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -69,7 +69,7 @@ function Header( {
 						shortcut={ shortcuts.toggleSidebar }
 					/>
 					<DotTip tipId="core/editor.settings">
-						{ __( 'You’ll find more settings for your page and blocks in the sidebar. Click “Settings” allows toggling the sidebar.' ) }
+						{ __( 'You’ll find more settings for your page and blocks in the sidebar. Click the cog icon to toggle the sidebar open and closed.' ) }
 					</DotTip>
 				</div>
 				<PinnedPlugins.Slot />

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -69,7 +69,7 @@ function Header( {
 						shortcut={ shortcuts.toggleSidebar }
 					/>
 					<DotTip tipId="core/editor.settings">
-						{ __( 'You’ll find more settings for your page and blocks in the sidebar. Click “Settings” to open it.' ) }
+						{ __( 'You’ll find more settings for your page and blocks in the sidebar. Click "Settings" allows toggling the sidebar.' ) }
 					</DotTip>
 				</div>
 				<PinnedPlugins.Slot />


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
I fixed the text of second welcome tip's instruction `Click “Settings” to open it` to `Click “Settings” allows toggling the sidebar`.

https://github.com/WordPress/gutenberg/blob/master/packages/edit-post/src/components/header/index.js#L72 

### Discussed in here.
https://github.com/WordPress/gutenberg/issues/12359

## Types of changes
Change text.