### PR TITLE
Docs: Fix Typo in designers-developers/key-concepts.md

### DIFF
--- a/docs/designers-developers/key-concepts.md
+++ b/docs/designers-developers/key-concepts.md
@@ -4,9 +4,9 @@
 
 Blocks are an abstract unit for organizing and composing content, strung together to create content for a webpage.
 
-Blocks are hiearchical, in that a block can be a child or parent to another block. One example is a two-column Columns block can be the parent block to multiple child blocks in each column.
+Blocks are hierarchical, in that a block can be a child or parent to another block. One example is a two-column Columns block can be the parent block to multiple child blocks in each column.
 
-If it helps, you can think of blocks as a more graceful shortcode, with rich formatting tools for users to compose content. To this point, there is a new Block Grammar. Distilled, the block grammar is an HTML comment, either a self-closing tag or with a begining tag and ending tag. In the main tag, depending on the block type and user customizations, there can be a JSON object. This raw form of the block is referred to as serialized.
+If it helps, you can think of blocks as a more graceful shortcode, with rich formatting tools for users to compose content. To this point, there is a new Block Grammar. Distilled, the block grammar is an HTML comment, either a self-closing tag or with a beginning tag and ending tag. In the main tag, depending on the block type and user customizations, there can be a JSON object. This raw form of the block is referred to as serialized.
 
 ```html
 <!-- wp:paragraph {"key": "value"} -->
@@ -16,7 +16,7 @@ If it helps, you can think of blocks as a more graceful shortcode, with rich for
 
 Blocks can be static or dynamic. Static blocks contain rendered content and an object of Attributes used to re-render based on changes. Dynamic blocks require server-side data and rendering while the post content is being generated (rendering).
 
-Each block contains Attributes or configuration settings, which can be sourced from raw HTML in the content, via meta or other customizible origins.
+Each block contains Attributes or configuration settings, which can be sourced from raw HTML in the content, via meta or other customizable origins.
 
 The Paragraph is the default Block. Instead of a new line upon typing return on a keyboard, try to think of it as an empty paragraph block (type / to trigger an autocompleting Slash Inserter -- /image will pull up Images as well as Instagram embeds).
 


### PR DESCRIPTION
## Description

I fixed 3 typos in key-concepts.md.
https://github.com/WordPress/gutenberg/edit/master/docs/designers-developers/key-concepts.md

hiearchical -> hierarchical
key-concepts.md:7

begining -> beginning
key-concepts.md:9

customizible -> customizable
key-concepts.md:19

## Types of changes
Fix Typo