### PR TITLE
Improve color contrast of the default block inserter shortcuts.

### DIFF
--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -250,12 +250,12 @@
 	&.is-typing .editor-block-list__empty-block-inserter,
 	&.is-typing .editor-block-list__side-inserter {
 		opacity: 0;
+		animation: none;
 	}
 
 	.editor-block-list__empty-block-inserter,
 	.editor-block-list__side-inserter {
-		opacity: 1;
-		transition: opacity 0.2s;
+		@include edit-post__fade-in-animation;
 	}
 
 	// Reusable blocks

--- a/packages/editor/src/components/default-block-appender/style.scss
+++ b/packages/editor/src/components/default-block-appender/style.scss
@@ -26,20 +26,17 @@
 		}
 	}
 
-	// Show quick insertion icons faded until hover.
-	.editor-inserter-with-shortcuts {
-		opacity: 0.5;
-		transition: opacity 0.2s;
-	}
-
 	// Don't show the inserter until mousing over.
 	.editor-inserter__toggle:not([aria-expanded="true"]) {
 		opacity: 0;
+		transition: opacity 0.2s;
 	}
+
 	&:hover {
 		.editor-inserter-with-shortcuts {
-			opacity: 1;
+			@include edit-post__fade-in-animation;
 		}
+
 		.editor-inserter__toggle {
 			opacity: 1;
 		}
@@ -95,7 +92,6 @@
 	}
 
 	.editor-inserter__toggle {
-		transition: opacity 0.2s;
 		border-radius: 50%;
 		width: $block-side-ui-width;
 		height: $block-side-ui-width;

--- a/packages/editor/src/components/default-block-appender/style.scss
+++ b/packages/editor/src/components/default-block-appender/style.scss
@@ -30,14 +30,6 @@
 	.editor-inserter-with-shortcuts {
 		opacity: 0.5;
 		transition: opacity 0.2s;
-
-		.components-icon-button:not(:hover) {
-			// Use opacity to work in various editor styles.
-			color: $dark-opacity-500;
-			.is-dark-theme & {
-				color: $light-opacity-500;
-			}
-		}
 	}
 
 	// Don't show the inserter until mousing over.

--- a/packages/editor/src/components/inserter-with-shortcuts/style.scss
+++ b/packages/editor/src/components/inserter-with-shortcuts/style.scss
@@ -19,8 +19,8 @@
 	padding-top: 8px;
 
 	// Use opacity to work in various editor styles.
-	color: $dark-opacity-light-700;
+	color: $dark-opacity-500;
 	.is-dark-theme & {
-		color: $light-opacity-light-700;
+		color: $light-opacity-500;
 	}
 }


### PR DESCRIPTION
As mentioned in https://github.com/WordPress/gutenberg/issues/10519#issuecomment-447649419 the _default appender_ shortcuts icons and the _default block_ shortcuts icons are styled differently.

In the default appender, the shortcuts do have a sufficient color contrast:

<img width="996" alt="default appender" src="https://user-images.githubusercontent.com/1682452/50054965-c2dc4780-0148-11e9-8236-8c230c8d1ec6.png">

However, when the default appender is clicked, it becomes the "default block" and the icons don't have a sufficient color contrast:

<img width="1001" alt="default block" src="https://user-images.githubusercontent.com/1682452/50055010-4ac25180-0149-11e9-86d1-5465596524bc.png">

This small PR seeks to improve the contrast and simplify the CSS:
- removes specific styling from the default-block-appender 
- uses the colors removed from the default-block-appender directly into the inserter-with-shortcuts, as part of its default styling

Worth noting there are also some CSS rules related to the opacity transition that don't work as expected after https://github.com/WordPress/gutenberg/pull/12510. I guess this should be addressed separately together with the refactoring proposed in #10519.