### PR TITLE
DateTimePicker: fix prop warning for

### DIFF
--- a/packages/components/src/date-time/date.js
+++ b/packages/components/src/date-time/date.js
@@ -43,7 +43,6 @@ class DatePicker extends Component {
 		return (
 			<div className="components-datetime__date">
 				<DayPickerSingleDateController
-					block
 					date={ momentDate }
 					daySize={ 30 }
 					focused


### PR DESCRIPTION
## Description
Address react propTypes warning for `react-dates` `DayPickerSingleDateController` component.

![screen shot 2018-12-17 at 12 47 09 pm](https://user-images.githubusercontent.com/1922453/50060642-42c2ea00-01fb-11e9-9bfa-1c844b72b068.png)

It appears the `block` prop was intended for inputs, which this component does not have, https://github.com/airbnb/react-dates/pull/871.

## How has this been tested?

Usage of the `<DatePicker />` component does not produce any changes and the warning is removed.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix: remove unused prop warning.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
