### PR TITLE
Restore block prop for BlockListBlock filter

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 9.0.6 (Unreleased)
+
+### Bug Fixes
+
+- Restore the `block` prop in the `BlockListBlock` filter.
+
 ## 9.0.5 (2018-12-12)
 
 ### Bug Fixes

--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -3,7 +3,6 @@
  */
 import classnames from 'classnames';
 import { get, reduce, size, first, last } from 'lodash';
-import memize from 'memize';
 
 /**
  * WordPress dependencies
@@ -783,15 +782,31 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 	};
 } );
 
-const getBlock = memize( ( name, attributes ) => {
-	return {
-		name,
-		attributes,
-	};
-} );
+/**
+ * Function that returns a new block object instance only if the name or attributes change.
+ *
+ * @param {string} name       Block name.
+ * @param {Object} attributes Block attributes
+ *
+ * @return {Object} Block object.
+ */
+const getBlock = ( name, attributes ) => {
+	let nameCache = getBlock.cache.get( name );
+	if ( ! nameCache ) {
+		nameCache = new WeakMap();
+		getBlock.cache.set( name, nameCache );
+	}
+	let block = nameCache.get( attributes );
+	if ( ! block ) {
+		block = { name, attributes };
+		nameCache.set( attributes, block );
+	}
+
+	return block;
+};
+getBlock.cache = new Map();
 
 export default compose(
-	withFilters( 'editor.BlockListBlock' ),
 	withViewportMatch( { isLargeViewport: 'medium' } ),
 	applyWithSelect,
 	applyWithDispatch,

--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -3,6 +3,7 @@
  */
 import classnames from 'classnames';
 import { get, reduce, size, first, last } from 'lodash';
+import memize from 'memize';
 
 /**
  * WordPress dependencies
@@ -654,12 +655,10 @@ export class BlockListBlock extends Component {
 }
 
 const applyWithSelect = withSelect(
-	( select, { clientId, rootClientId, isLargeViewport } ) => {
+	( select, { clientId, rootClientId, isLargeViewport, block } ) => {
 		const {
 			isBlockSelected,
-			getBlockName,
 			isBlockValid,
-			getBlockAttributes,
 			isAncestorMultiSelected,
 			isBlockMultiSelected,
 			isFirstMultiSelectedBlock,
@@ -676,12 +675,11 @@ const applyWithSelect = withSelect(
 			getPreviousBlockClientId,
 			getNextBlockClientId,
 		} = select( 'core/editor' );
+		const { name, attributes } = block;
 		const isSelected = isBlockSelected( clientId );
 		const { hasFixedToolbar, focusMode } = getEditorSettings();
 		const templateLock = getTemplateLock( rootClientId );
 		const isParentOfSelectedBlock = hasSelectedInnerBlock( clientId, true );
-		const name = getBlockName( clientId );
-		const attributes = getBlockAttributes( clientId );
 
 		return {
 			isPartOfMultiSelection:
@@ -776,7 +774,25 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 	};
 } );
 
+const getBlock = memize( ( name, attributes ) => {
+	return {
+		name,
+		attributes,
+	};
+} );
+
 export default compose(
+	// This withSelect is only necessary for backward compatibility
+	// Users of the editor.BlockListBlock filter used to be able to access the block prop
+	// Ideally these blocks would rely on the clientId prop only.
+	withSelect( ( select, { clientId } ) => {
+		const { getBlockName, getBlockAttributes } = select( 'core/editor' );
+		const name = getBlockName( clientId );
+		const attributes = getBlockAttributes( clientId );
+		return {
+			block: getBlock( name, attributes ),
+		};
+	} ),
 	withFilters( 'editor.BlockListBlock' ),
 	withViewportMatch( { isLargeViewport: 'medium' } ),
 	applyWithSelect,

--- a/packages/editor/src/hooks/align.js
+++ b/packages/editor/src/hooks/align.js
@@ -206,7 +206,7 @@ export function addAssignedAlign( props, blockType, attributes ) {
 }
 
 addFilter( 'blocks.registerBlockType', 'core/align/addAttribute', addAttribute );
-addFilter( 'editor.__experimentalBlockListBlock', 'core/editor/align/with-data-align', withDataAlign );
+addFilter( 'editor.BlockListBlock', 'core/editor/align/with-data-align', withDataAlign );
 addFilter( 'editor.BlockEdit', 'core/editor/align/with-toolbar-controls', withToolbarControls );
 addFilter( 'blocks.getSaveContent.extraProps', 'core/align/addAssignedAlign', addAssignedAlign );
 

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -704,6 +704,24 @@ export const getBlock = createSelector(
 	]
 );
 
+export const __unstableGetBlockWithoutInnerBlocks = createSelector(
+	( state, clientId ) => {
+		const block = state.editor.present.blocks.byClientId[ clientId ];
+		if ( ! block ) {
+			return null;
+		}
+
+		return {
+			...block,
+			attributes: getBlockAttributes( state, clientId ),
+		};
+	},
+	( state, clientId ) => [
+		state.editor.present.blocks.byClientId[ clientId ],
+		...getBlockAttributes.getDependants( state, clientId ),
+	]
+);
+
 function getPostMeta( state, key ) {
 	return has( state, [ 'editor', 'present', 'edits', 'meta', key ] ) ?
 		get( state, [ 'editor', 'present', 'edits', 'meta', key ] ) :


### PR DESCRIPTION
closes #12938

Plugins used to be able to access the `block` prop in the `BlockListBlock` filter which was inadvertently removed when we moved the filter. The intention for this filter was to only allow plugins to use `clientId` and with this, and using selectors they can retrieve any information about the blocks.

This PR restores the `block` props for backward compatibility purpose.

**Testing instructions**

 - Repeat instructions in #12938 