### PR TITLE
Revert "Remove the call that does `blur` the undelying native component

### DIFF
--- a/packages/editor/src/components/plain-text/index.native.js
+++ b/packages/editor/src/components/plain-text/index.native.js
@@ -21,6 +21,12 @@ export default class PlainText extends Component {
 		}
 	}
 
+	componentDidUpdate( prevProps ) {
+		if ( ! this.props.isSelected && prevProps.isSelected ) {
+			this._input.blur();
+		}
+	}
+
 	focus() {
 		this._input.focus();
 	}

--- a/packages/editor/src/components/plain-text/index.native.js
+++ b/packages/editor/src/components/plain-text/index.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { TextInput } from 'react-native';
+import { TextInput, Platform } from 'react-native';
 
 /**
  * WordPress dependencies

--- a/packages/editor/src/components/plain-text/index.native.js
+++ b/packages/editor/src/components/plain-text/index.native.js
@@ -14,6 +14,8 @@ import { Component } from '@wordpress/element';
 import styles from './style.scss';
 
 export default class PlainText extends Component {
+	isIOS: boolean = Platform.OS === 'ios';
+
 	componentDidMount() {
 		// if isSelected is true, we should request the focus on this TextInput
 		if ( ( this._input.isFocused() === false ) && ( this._input.props.isSelected === true ) ) {
@@ -22,7 +24,7 @@ export default class PlainText extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		if ( ! this.props.isSelected && prevProps.isSelected ) {
+		if ( ! this.props.isSelected && prevProps.isSelected && this.isIOS ) {
 			this._input.blur();
 		}
 	}

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import RCTAztecView from 'react-native-aztec';
-import { View } from 'react-native';
+import { View, Platform } from 'react-native';
 import {
 	forEach,
 	merge,

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -292,6 +292,8 @@ export class RichText extends Component {
 	componentDidUpdate( prevProps ) {
 		if ( this.props.isSelected && ! prevProps.isSelected ) {
 			this._editor.focus();
+		} else if ( ! this.props.isSelected && prevProps.isSelected ) {
+			this._editor.blur();
 		}
 	}
 

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -64,6 +64,8 @@ export function getFormatValue( formatName ) {
 }
 
 export class RichText extends Component {
+	isIOS: boolean = Platform.OS === 'ios';
+
 	constructor() {
 		super( ...arguments );
 		this.onChange = this.onChange.bind( this );
@@ -292,7 +294,7 @@ export class RichText extends Component {
 	componentDidUpdate( prevProps ) {
 		if ( this.props.isSelected && ! prevProps.isSelected ) {
 			this._editor.focus();
-		} else if ( ! this.props.isSelected && prevProps.isSelected ) {
+		} else if ( ! this.props.isSelected && prevProps.isSelected && this.isIOS ) {
 			this._editor.blur();
 		}
 	}


### PR DESCRIPTION
## Description

This reverts commit d9fe45ed6251486f213daf3fc9a7568e2b4977c5 for iOS platform.

PR https://github.com/wordpress-mobile/gutenberg-mobile/pull/387 already handles focusing to TextInputs and the commit d9fe45ed6251486f213daf3fc9a7568e2b4977c5 makes that PR fail, is there any problem if we revert this commit? @daniloercoli I am adding you as reviewer, please let me know if any concerns.

## How has this been tested?

Tested with steps in https://github.com/wordpress-mobile/gutenberg-mobile/pull/387 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->