### PR TITLE
Fix JS error when removing a block

### DIFF
--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -679,7 +679,11 @@ const applyWithSelect = withSelect(
 		const { hasFixedToolbar, focusMode } = getEditorSettings();
 		const templateLock = getTemplateLock( rootClientId );
 		const isParentOfSelectedBlock = hasSelectedInnerBlock( clientId, true );
-		const { name, attributes, isValid } = block;
+
+		// The fallback to `{}` is a temporary fix.
+		// This function should never be called when a block is not present in the state.
+		// It happens now because the order in withSelect rendering is not correct.
+		const { name, attributes, isValid } = block || {};
 
 		return {
 			isPartOfMultiSelection:


### PR DESCRIPTION
It looks like when unmounting components, the `withSelect` callbacks are still executed. Let's explore the fix for this separately. In the meantime, I'm fixing the symptoms.

**Testing instructions**

 - Insert a block
 - Remove it
 - No JS errors on the console.