### PR TITLE
Fix: Cannot access separator block settings by clicking

### DIFF
--- a/packages/block-library/src/separator/theme.scss
+++ b/packages/block-library/src/separator/theme.scss
@@ -1,5 +1,6 @@
 .wp-block-separator {
 	border: none;
+	padding: 10px;
 	border-bottom: 2px solid $dark-gray-100;
 	margin: 1.65em auto;
 
@@ -7,4 +8,9 @@
 	&:not(.is-style-wide):not(.is-style-dots) {
 		max-width: 100px;
 	}
+}
+
+/* Allows users to understand the clickable area (height) since it is small */
+.wp-block-separator:hover {
+    cursor: pointer;
 }


### PR DESCRIPTION
## Description
Added a padding to `.wp-block-separator` class to fix #12080.

## How has this been tested?
Tested with in `twentyseventeen` and `twentynineteen` themes.

## Screenshots <!-- if applicable -->
Screencast: https://drive.google.com/file/d/1V8hMsHCJKANl6T3zVOoyNsq6EEor0Kuw/view

## Types of changes
<!-- What types of changes does your code introduce?  -->
New attribute in added .wp-block-separator class

<!-- Bug fix (non-breaking change which fixes an issue) -->
Separator block cannot be selected by clicking on it

<!-- New feature (non-breaking change which adds functionality) -->
N/A

<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
N/A

## Checklist:
- [ x ] My code is tested.
- [ x ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ x ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ x ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ x ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
