### PR TITLE
Fix: wrong markup when columns input is empty

### DIFF
--- a/packages/block-library/src/columns/index.js
+++ b/packages/block-library/src/columns/index.js
@@ -29,6 +29,15 @@ import {
 const ALLOWED_BLOCKS = [ 'core/column' ];
 
 /**
+ * The default number of columns.
+ * When columns attribute is not set this value should be used.
+ *
+ * @constant
+ * @type {number}
+*/
+const DEFAULT_NUMBER_OF_COLUMNS = 2;
+
+/**
  * Returns the layouts configuration for a given number of columns.
  *
  * @param {number} columns Number of columns.
@@ -77,7 +86,7 @@ export const settings = {
 	attributes: {
 		columns: {
 			type: 'number',
-			default: 2,
+			default: DEFAULT_NUMBER_OF_COLUMNS,
 		},
 	},
 
@@ -167,7 +176,7 @@ export const settings = {
 							value={ columns }
 							onChange={ ( nextColumns ) => {
 								setAttributes( {
-									columns: nextColumns,
+									columns: nextColumns || DEFAULT_NUMBER_OF_COLUMNS,
 								} );
 							} }
 							min={ 2 }


### PR DESCRIPTION
## Description
Depends: https://github.com/WordPress/gutenberg/pull/12952
When the columns input field was empty previously we generated invalid markup with `has-undefined-columns` class. The block also started showing empty in the editor.

With this change when the input field is empty the default value for the columns attribute is used and it looks the same as if the user used two columns.

## How has this been tested?
Add a columns block.
Write some content.
Make the columns input field empty, and verify no invalid markup is produce and a value of two is used. (previous the block got broken in the editor and invalid markup was produced).
