### PR TITLE
Fix/issue 12501 menu item aria label

### DIFF
--- a/packages/components/src/menu-item/index.js
+++ b/packages/components/src/menu-item/index.js
@@ -24,7 +24,6 @@ import IconButton from '../icon-button';
  */
 export function MenuItem( {
 	children,
-	label = children,
 	info,
 	className,
 	icon,
@@ -37,9 +36,6 @@ export function MenuItem( {
 	className = classnames( 'components-menu-item__button', className, {
 		'has-icon': icon,
 	} );
-
-	// Avoid using label if it is passed as non-string children.
-	label = isString( label ) ? label : undefined;
 
 	if ( info ) {
 		const infoId = 'edit-post-feature-toggle__info-' + instanceId;
@@ -77,7 +73,6 @@ export function MenuItem( {
 	return createElement(
 		tagName,
 		{
-			'aria-label': label,
 			// Make sure aria-checked matches spec https://www.w3.org/TR/wai-aria-1.1/#aria-checked
 			'aria-checked': ( role === 'menuitemcheckbox' || role === 'menuitemradio' ) ? isSelected : undefined,
 			role,

--- a/packages/components/src/menu-item/test/__snapshots__/index.js.snap
+++ b/packages/components/src/menu-item/test/__snapshots__/index.js.snap
@@ -3,7 +3,6 @@
 exports[`MenuItem should match snapshot when all props provided 1`] = `
 <IconButton
   aria-checked={true}
-  aria-label="My item"
   className="components-menu-item__button my-class has-icon"
   icon="wordpress"
   onClick={[Function]}
@@ -20,7 +19,6 @@ exports[`MenuItem should match snapshot when all props provided 1`] = `
 exports[`MenuItem should match snapshot when info is provided 1`] = `
 <Button
   aria-describedby="edit-post-feature-toggle__info-1"
-  aria-label="My item"
   className="components-menu-item__button"
   role="menuitem"
 >
@@ -43,7 +41,6 @@ exports[`MenuItem should match snapshot when info is provided 1`] = `
 
 exports[`MenuItem should match snapshot when isSelected and role are optionally provided 1`] = `
 <IconButton
-  aria-label="My item"
   className="components-menu-item__button my-class has-icon"
   icon="wordpress"
   onClick={[Function]}
@@ -59,7 +56,6 @@ exports[`MenuItem should match snapshot when isSelected and role are optionally 
 
 exports[`MenuItem should match snapshot when only label provided 1`] = `
 <Button
-  aria-label="My item"
   className="components-menu-item__button"
   role="menuitem"
 >

--- a/packages/components/src/menu-item/test/index.js
+++ b/packages/components/src/menu-item/test/index.js
@@ -61,7 +61,6 @@ describe( 'MenuItem', () => {
 			</MenuItem>
 		);
 
-		expect( wrapper.prop( 'aria-label' ) ).not.toBeUndefined();
 		expect( wrapper ).toMatchSnapshot();
 	} );
 

--- a/packages/edit-post/src/components/header/plugin-more-menu-item/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/header/plugin-more-menu-item/test/__snapshots__/index.js.snap
@@ -17,7 +17,6 @@ exports[`PluginMoreMenuItem renders menu item as button properly 1`] = `
     role="menu"
   >
     <button
-      aria-label="My plugin button menu item"
       className="components-button components-icon-button components-menu-item__button has-icon has-text"
       onClick={[Function]}
       role="menuitem"


### PR DESCRIPTION
## Description
Fixes https://github.com/WordPress/gutenberg/issues/12501

## How has this been tested?
- Local unit tests
- Local e2e tests
- Browser testing

## Screenshots
<img width="650" alt="screen shot 2018-12-17 at 1 34 59 pm" src="https://user-images.githubusercontent.com/459581/50107393-9b48b600-0200-11e9-9c54-6fcecf228a03.png">


## Types of changes
Removed aria-label on the menuItem component because it was redundant with the button text itself. Also update the tests and snapshots to match the new output.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
