### PR TITLE
Update the embed block to show no preview for smugmug embeds

### DIFF
--- a/packages/block-library/src/embed/constants.js
+++ b/packages/block-library/src/embed/constants.js
@@ -1,5 +1,5 @@
 // These embeds do not work in sandboxes due to the iframe's security restrictions.
-export const HOSTS_NO_PREVIEWS = [ 'facebook.com' ];
+export const HOSTS_NO_PREVIEWS = [ 'facebook.com', 'smugmug.com' ];
 
 export const ASPECT_RATIOS = [
 	// Common video resolutions.

--- a/packages/block-library/src/embed/embed-preview.js
+++ b/packages/block-library/src/embed/embed-preview.js
@@ -28,10 +28,11 @@ const EmbedPreview = ( props ) => {
 	const { scripts } = preview;
 
 	const html = 'photo' === type ? getPhotoHtml( preview ) : preview.html;
-	const parsedUrl = parse( url );
-	const cannotPreview = includes( HOSTS_NO_PREVIEWS, parsedUrl.host.replace( /^www\./, '' ) );
+	const parsedHost = parse( url ).host.split( '.' );
+	const parsedHostBaseUrl = parsedHost.splice( parsedHost.length - 2, parsedHost.length - 1 ).join( '.' );
+	const cannotPreview = includes( HOSTS_NO_PREVIEWS, parsedHostBaseUrl );
 	// translators: %s: host providing embed content e.g: www.youtube.com
-	const iframeTitle = sprintf( __( 'Embedded content from %s' ), parsedUrl.host );
+	const iframeTitle = sprintf( __( 'Embedded content from %s' ), parsedHostBaseUrl );
 	const sandboxClassnames = classnames( type, className, 'wp-block-embed__wrapper' );
 
 	const embedWrapper = 'wp-embed' === type ? (


### PR DESCRIPTION
## Description
Fixes #11960 by adding smugmug.com to the array of domains that the "no-preview" screen is shown. Also adjusted the matching criteria to grab the base domain instead of just stripping "www." off of the host if found. This was necessary as smugmug embeds are in the format "username.smugmug.com"

## How has this been tested?
Manually tested to verify that both individual photos and galleries display the no preview message using:
[https://johndavis.smugmug.com/Nature/Landscape/i-NntLPZ8](https://johndavis.smugmug.com/Nature/Landscape/i-NntLPZ8)
[https://johndavis.smugmug.com/Nature/Landscape](https://johndavis.smugmug.com/Nature/Landscape)

## Screenshots
<img width="1123" alt="edit_post_ _gutenberg_dev_ _wordpress" src="https://user-images.githubusercontent.com/6653970/50122691-c09ee980-022b-11e9-8fb8-35765ee92dac.png">


## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
