### PR TITLE
Datepicker: Add isInvalidDay support

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### New Feature
 
 - `Dropdown` now has a `focusOnMount` prop which is passed directly to the contained `Popover`.
+- `DatePicker` has new prop `isInvalidDate` exposing react-dates' `isOutsideRange`.
 
 ## 7.0.5 (2019-01-03)
 

--- a/packages/components/src/date-time/README.md
+++ b/packages/components/src/date-time/README.md
@@ -60,3 +60,10 @@ Whether we use a 12-hour clock. With a 12-hour clock, an AM/PM widget is display
 
 - Type: `bool`
 - Required: No
+
+### isInvalidDate
+
+A callback function which receives a Date object representing a day as an argument, and should return a Boolean to signify if the day is valid or not.
+
+- Type: `Function`
+- Required: No

--- a/packages/components/src/date-time/date.js
+++ b/packages/components/src/date-time/date.js
@@ -36,7 +36,7 @@ class DatePicker extends Component {
 	}
 
 	render() {
-		const { currentDate } = this.props;
+		const { currentDate, isInvalidDate } = this.props;
 
 		const momentDate = currentDate ? moment( currentDate ) : moment();
 
@@ -56,6 +56,9 @@ class DatePicker extends Component {
 					transitionDuration={ 0 }
 					weekDayFormat="ddd"
 					isRTL={ isRTL() }
+					isOutsideRange={ ( date ) => {
+						return isInvalidDate && isInvalidDate( date.toDate() );
+					} }
 				/>
 			</div>
 		);


### PR DESCRIPTION
## Description
Add the concept of unselectable days to the DatePicker's calendar by exposing `react-dates` prop [`isOutsideRange`](https://github.com/airbnb/react-dates/blob/b002152c6229b2e9b0c5c2d80a15469015ada680/src/components/DayPickerSingleDateController.jsx#L43). Here is an example with Mondays made as invalid selections:

![screen shot 2018-12-18 at 12 52 13 pm](https://user-images.githubusercontent.com/1922453/50123136-6d2caa00-02c4-11e9-9a18-f237d6d6b5ac.png)

## What about invalidating dates via the inputs?

The changes here affect only the calendar (`<DatePicker />` component) and not the inputs (`<TimePicker />`). Ideally, the same validation is passed along to the inputs to prevent selection of invalid days via the keyboard. That will take some design work to surface why an invalidation has occurred. I propose to handle that separately.

## Testing instructions

Since the concept of invalid days has no meaning for the text editor, changing code temporarily is the only way to evaluate this change.

1. Add this prop to invalidate Mondays
```js
isInvalidDate={ ( date ) => 1 === date.getDay() }
```
to the implementation of `<DatePicker />`, https://github.com/WordPress/gutenberg/blob/0c734e1867b50a9ee1eb19a08d6b740d66c5f2ad/packages/components/src/date-time/index.js#L48-L51

2. Go to a new post `/wp-admin/post-new.php#/`.
3. Open the date picker.
4. See Mondays are not selectable via the calendar.
5. Using VoiceOver, confirm focus of an invalid calendar date adds a "Not available" to the description.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature: Expose a prop, `isInvalidDay `, to `<DatePicker />`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
