### PR TITLE
Datepicker: Allow null value for currentDate on mounting

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - `Dropdown` now has a `focusOnMount` prop which is passed directly to the contained `Popover`.
 - `DatePicker` has new prop `isInvalidDate` exposing react-dates' `isOutsideRange`.
+- `DatePicker` allows `null` as accepted value for `currentDate` prop to signify no date selection.
 
 ## 7.0.5 (2019-01-03)
 

--- a/packages/components/src/date-time/README.md
+++ b/packages/components/src/date-time/README.md
@@ -41,10 +41,11 @@ The component accepts the following props:
 
 ### currentDate
 
-The current date and time at initialization.
+The current date and time at initialization. Optionally pass in a `null` value to specify no date is currently selected.
 
 - Type: `string`
-- Required: Yes
+- Required: No
+- Default: today's date
 
 ### onChange
 

--- a/packages/components/src/date-time/date.js
+++ b/packages/components/src/date-time/date.js
@@ -25,6 +25,7 @@ class DatePicker extends Component {
 	onChangeMoment( newDate ) {
 		const { currentDate, onChange } = this.props;
 
+		// If currentDate is null, use now as momentTime to designate hours, minutes, seconds.
 		const momentDate = currentDate ? moment( currentDate ) : moment();
 		const momentTime = {
 			hours: momentDate.hours(),
@@ -35,10 +36,24 @@ class DatePicker extends Component {
 		onChange( newDate.set( momentTime ).format( TIMEZONELESS_FORMAT ) );
 	}
 
+	/**
+	 * Create a Moment object from a date string. With no currentDate supplied, default to a Moment
+	 * object representing now. If a null value is passed, return a null value.
+	 *
+	 * @param {?string} currentDate Date representing the currently selected date or null to signify no selection.
+	 * @return {?Moment} Moment object for selected date or null.
+	 */
+	getMomentDate( currentDate ) {
+		if ( null === currentDate ) {
+			return null;
+		}
+		return currentDate ? moment( currentDate ) : moment();
+	}
+
 	render() {
 		const { currentDate, isInvalidDate } = this.props;
 
-		const momentDate = currentDate ? moment( currentDate ) : moment();
+		const momentDate = this.getMomentDate( currentDate );
 
 		return (
 			<div className="components-datetime__date">
@@ -49,7 +64,7 @@ class DatePicker extends Component {
 					hideKeyboardShortcutsPanel
 					// This is a hack to force the calendar to update on month or year change
 					// https://github.com/airbnb/react-dates/issues/240#issuecomment-361776665
-					key={ `datepicker-controller-${ momentDate.format( 'MM-YYYY' ) }` }
+					key={ `datepicker-controller-${ momentDate ? momentDate.format( 'MM-YYYY' ) : 'null' }` }
 					noBorder
 					numberOfMonths={ 1 }
 					onDateChange={ this.onChangeMoment }

--- a/packages/components/src/date-time/test/date.js
+++ b/packages/components/src/date-time/test/date.js
@@ -1,0 +1,114 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import moment from 'moment';
+
+/**
+ * Internal dependencies
+ */
+import DatePicker from '../date';
+
+const TIMEZONELESS_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
+
+describe( 'DatePicker', () => {
+	it( 'should pass down a moment object for currentDate', () => {
+		const currentDate = '1986-10-18T23:00:00';
+		const wrapper = shallow( <DatePicker currentDate={ currentDate } /> );
+		const date = wrapper.children().props().date;
+		expect( moment.isMoment( date ) ).toBe( true );
+		expect( date.isSame( moment( currentDate ) ) ).toBe( true );
+	} );
+
+	it( 'should pass down a null date when currentDate is set to null', () => {
+		const wrapper = shallow( <DatePicker currentDate={ null } /> );
+		expect( wrapper.children().props().date ).toBeNull();
+	} );
+
+	it( 'should pass down a moment object for now when currentDate is undefined', () => {
+		const wrapper = shallow( <DatePicker /> );
+		const date = wrapper.children().props().date;
+		expect( moment.isMoment( date ) ).toBe( true );
+		expect( date.isSame( moment(), 'second' ) ).toBe( true );
+	} );
+
+	describe( 'getMomentDate', () => {
+		it( 'should return a Moment object representing a given date string', () => {
+			const currentDate = '1986-10-18T23:00:00';
+			const wrapper = shallow( <DatePicker /> );
+			const momentDate = wrapper.instance().getMomentDate( currentDate );
+
+			expect( moment.isMoment( momentDate ) ).toBe( true );
+			expect( momentDate.isSame( moment( currentDate ) ) ).toBe( true );
+		} );
+
+		it( 'should return null when given a null agrument', () => {
+			const currentDate = null;
+			const wrapper = shallow( <DatePicker /> );
+			const momentDate = wrapper.instance().getMomentDate( currentDate );
+
+			expect( momentDate ).toBeNull();
+		} );
+
+		it( 'should return a Moment object representing now when given an undefined argument', () => {
+			const wrapper = shallow( <DatePicker /> );
+			const momentDate = wrapper.instance().getMomentDate();
+
+			expect( moment.isMoment( momentDate ) ).toBe( true );
+			expect( momentDate.isSame( moment(), 'second' ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'onChangeMoment', () => {
+		it( 'should call onChange with a formated date of the input', () => {
+			const onChangeSpy = jest.fn();
+			const currentDate = '1986-10-18T11:00:00';
+			const wrapper = shallow( <DatePicker currentDate={ currentDate } onChange={ onChangeSpy } /> );
+			const newDate = moment();
+
+			wrapper.instance().onChangeMoment( newDate );
+
+			expect( onChangeSpy ).toHaveBeenCalledWith( newDate.format( TIMEZONELESS_FORMAT ) );
+		} );
+
+		it( 'should call onChange with hours, minutes, seconds of the current time when currentDate is undefined', () => {
+			const onChangeSpy = jest.fn();
+			const wrapper = shallow( <DatePicker onChange={ onChangeSpy } /> );
+			const newDate = moment( '1986-10-18T11:00:00' );
+			const current = moment();
+			wrapper.instance().onChangeMoment( newDate );
+
+			expect( onChangeSpy ).toHaveBeenCalledWith(
+				newDate
+					.clone()
+					.set( {
+						hours: current.hours(),
+						minutes: current.minutes(),
+						seconds: current.seconds(),
+					} )
+					.format( TIMEZONELESS_FORMAT )
+			);
+		} );
+
+		it( 'should call onChange with hours, minutes, seconds of the current time when currentDate is null', () => {
+			const onChangeSpy = jest.fn();
+			const wrapper = shallow(
+				<DatePicker currentDate={ null } onChange={ onChangeSpy } />
+			);
+			const newDate = moment( '1986-10-18T11:00:00' );
+			const current = moment();
+			wrapper.instance().onChangeMoment( newDate );
+
+			expect( onChangeSpy ).toHaveBeenCalledWith(
+				newDate
+					.clone()
+					.set( {
+						hours: current.hours(),
+						minutes: current.minutes(),
+						seconds: current.seconds(),
+					} )
+					.format( TIMEZONELESS_FORMAT )
+			);
+		} );
+	} );
+} );

--- a/packages/components/src/date-time/test/date.js
+++ b/packages/components/src/date-time/test/date.js
@@ -72,43 +72,39 @@ describe( 'DatePicker', () => {
 		} );
 
 		it( 'should call onChange with hours, minutes, seconds of the current time when currentDate is undefined', () => {
-			const onChangeSpy = jest.fn();
+			let onChangeSpyArgument;
+			const onChangeSpy = ( arg ) => onChangeSpyArgument = arg;
 			const wrapper = shallow( <DatePicker onChange={ onChangeSpy } /> );
 			const newDate = moment( '1986-10-18T11:00:00' );
 			const current = moment();
+			const newDateWithCurrentTime = newDate
+				.clone()
+				.set( {
+					hours: current.hours(),
+					minutes: current.minutes(),
+					seconds: current.seconds(),
+				} );
 			wrapper.instance().onChangeMoment( newDate );
 
-			expect( onChangeSpy ).toHaveBeenCalledWith(
-				newDate
-					.clone()
-					.set( {
-						hours: current.hours(),
-						minutes: current.minutes(),
-						seconds: current.seconds(),
-					} )
-					.format( TIMEZONELESS_FORMAT )
-			);
+			expect( moment( onChangeSpyArgument ).isSame( newDateWithCurrentTime, 'minute' ) ).toBe( true );
 		} );
 
 		it( 'should call onChange with hours, minutes, seconds of the current time when currentDate is null', () => {
-			const onChangeSpy = jest.fn();
-			const wrapper = shallow(
-				<DatePicker currentDate={ null } onChange={ onChangeSpy } />
-			);
+			let onChangeSpyArgument;
+			const onChangeSpy = ( arg ) => onChangeSpyArgument = arg;
+			const wrapper = shallow( <DatePicker currentDate={ null } onChange={ onChangeSpy } /> );
 			const newDate = moment( '1986-10-18T11:00:00' );
 			const current = moment();
+			const newDateWithCurrentTime = newDate
+				.clone()
+				.set( {
+					hours: current.hours(),
+					minutes: current.minutes(),
+					seconds: current.seconds(),
+				} );
 			wrapper.instance().onChangeMoment( newDate );
 
-			expect( onChangeSpy ).toHaveBeenCalledWith(
-				newDate
-					.clone()
-					.set( {
-						hours: current.hours(),
-						minutes: current.minutes(),
-						seconds: current.seconds(),
-					} )
-					.format( TIMEZONELESS_FORMAT )
-			);
+			expect( moment( onChangeSpyArgument ).isSame( newDateWithCurrentTime, 'minute' ) ).toBe( true );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Description
When a `null` value is passed to `<DatePicker >`, don't set the date to current date. Instead, allow the value to remain null such that no selection is visible on the calendar.

`undefined` values for `currentDate` behave as they did previously, which is to fall back to the today's date.

## Testing
1. Confirm that a dependency on setting `currentDate` to todays date by default does not exist by pulling down the branch and seeing that nothing breaks. 
1. Force a `null` value for the `currentDate` prop on  `<DatePicker >` to ensure nothing breaks and no date is selected.
2. Remove the `currentDate` prop and see the date picker default to today's date.

https://github.com/WordPress/gutenberg/blob/0c734e1867b50a9ee1eb19a08d6b740d66c5f2ad/packages/components/src/date-time/index.js#L48-L51

## Screenshots <!-- if applicable -->

![screen shot 2018-12-18 at 2 33 12 pm](https://user-images.githubusercontent.com/1922453/50126466-e54d9c80-02d1-11e9-8c7c-840ba3adea62.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature: Allow null value of date selection to persist such that no date is selected on the calendar.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
