### PR TITLE
Allow plugins to add classes to the sidebar panel

### DIFF
--- a/packages/edit-post/CHANGELOG.md
+++ b/packages/edit-post/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.2.0 (Next)
+
+### Polish
+
+* Expose the `className` property to style the `PluginSidebar` component.
+
 ## 3.1.7 (2019-01-03)
 
 ## 3.1.6 (2018-12-18)

--- a/packages/edit-post/README.md
+++ b/packages/edit-post/README.md
@@ -112,6 +112,7 @@ The callback function to be executed when the user clicks the menu item.
 Renders a sidebar when activated. The contents within the `PluginSidebar` will appear as content within the sidebar.
 
 If you wish to display the sidebar, you can with use the [`PluginSidebarMoreMenuItem`](#pluginsidebarmoremenuitem) component or the `wp.data.dispatch` API:
+
 ```js
 wp.data.dispatch( 'core/edit-post' ).openGeneralSidebar( 'plugin-name/sidebar-name' );
 ```
@@ -173,6 +174,13 @@ A string identifying the sidebar. Must be unique for every sidebar registered wi
 
 - Type: `String`
 - Required: Yes
+
+##### className
+
+An optional class name added to the sidebar body.
+
+- Type: `String`
+- Required: No
 
 ##### title
 

--- a/packages/edit-post/src/components/sidebar/plugin-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-sidebar/index.js
@@ -25,6 +25,7 @@ import SidebarHeader from '../sidebar-header';
 function PluginSidebar( props ) {
 	const {
 		children,
+		className,
 		icon,
 		isActive,
 		isPinnable = true,
@@ -66,7 +67,7 @@ function PluginSidebar( props ) {
 						/>
 					) }
 				</SidebarHeader>
-				<Panel>
+				<Panel className={ className }>
 					{ children }
 				</Panel>
 			</Sidebar>


### PR DESCRIPTION
This will let authors manage panel global styles easily instead of doing it per component. For example, add padding to the sides of the panel.