### PR TITLE
Fix: Only 10 taxonomies with 'show_in_rest' available in the editor's sidebar

### DIFF
--- a/packages/editor/src/components/post-taxonomies/check.js
+++ b/packages/editor/src/components/post-taxonomies/check.js
@@ -22,7 +22,7 @@ export default compose( [
 	withSelect( ( select ) => {
 		return {
 			postType: select( 'core/editor' ).getCurrentPostType(),
-			taxonomies: select( 'core' ).getTaxonomies(),
+			taxonomies: select( 'core' ).getTaxonomies( { per_page: -1 } ),
 		};
 	} ),
 ] )( PostTaxonomiesCheck );


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/12649
Props to @danielbachhuber, @VadymPogorelov, and @realworldev for the debugging and testing code.


## Description
In the taxonomies data request present in the PostTaxonomies component we had a per-page config of -1 to request all the taxonomies.
https://github.com/WordPress/gutenberg/blob/master/packages/editor/src/components/post-taxonomies/index.js#L41 

But on the checking component that verifies the post type relationship with the taxonomies we did set the per page config of -1 so only ten taxonomies were being requested.

## How has this been tested?
I added the following code snippet for testing purposes:
```
add_action( 'init', function() {
	for ( $j=0; $j < 12; $j++ ) {
		register_post_type( 'cpt_' . $j, array(
			'label' => 'cpt ' . $j,
			'show_in_rest' => true,
			'public' => true,
		) );
		for ( $i=0; $i < 4; $i++ ) {
			register_taxonomy( 'taxonomy_' . $j . '_' . $i, 'cpt_' . $j, array(
				'label' => 'taxonomy ' . $j . ' ' .$i,
				'show_in_rest' => true,
			) );
		}
	}
});
```
I verified that even in CPT greater than 2 the taxnomies appear as expected, on master that's not the case.
