### PR TITLE
Fix alignment of property assignments in the `__construct()` function

### DIFF
--- a/packages/block-serialization-default-parser/parser.php
+++ b/packages/block-serialization-default-parser/parser.php
@@ -63,10 +63,10 @@ class WP_Block_Parser_Block {
 	public $innerContent;
 
 	function __construct( $name, $attrs, $innerBlocks, $innerHTML, $innerContent ) {
-		$this->blockName   = $name;
-		$this->attrs       = $attrs;
-		$this->innerBlocks = $innerBlocks;
-		$this->innerHTML   = $innerHTML;
+		$this->blockName    = $name;
+		$this->attrs        = $attrs;
+		$this->innerBlocks  = $innerBlocks;
+		$this->innerHTML    = $innerHTML;
 		$this->innerContent = $innerContent;
 	}
 }


### PR DESCRIPTION
When `grunt build` is run in WordPress core, the parser is copied to the appropriate place in the core code base. But, because these lines are not aligned correctly, the `wp-includes/class-wp-block-parser.php` file always shows changes.

This fix will prevent that from happening.

See the [Slack discussion](https://wordpress.slack.com/archives/C18723MQ8/p1545165911452000) for more information.