### PR TITLE
Data: Avoid persistence on unchanging subset of keys

### DIFF
--- a/packages/data/src/plugins/persistence/index.js
+++ b/packages/data/src/plugins/persistence/index.js
@@ -38,7 +38,7 @@ const DEFAULT_STORAGE_KEY = 'WP_DATA';
  * Higher-order reducer to provides an initial value when state is undefined.
  *
  * @param {Function} reducer      Original reducer.
- * @param {*}         initialState Value to use as initial state.
+ * @param {*}        initialState Value to use as initial state.
  *
  * @return {Function} Enhanced reducer.
  */
@@ -47,6 +47,23 @@ export function withInitialState( reducer, initialState ) {
 		return reducer( state, action );
 	};
 }
+
+/**
+ * Higher-order reducer which invokes the original reducer only if state is
+ * inequal from that of the action's `nextState` property, otherwise returning
+ * the original state reference.
+ *
+ * @param {Function} reducer Original reducer.
+ *
+ * @return {Function} Enhanced reducer.
+ */
+export const withLazySameState = ( reducer ) => ( state, action ) => {
+	if ( action.nextState === state ) {
+		return state;
+	}
+
+	return reducer( state, action );
+};
 
 /**
  * Creates a persistence interface, exposing getter and setter methods (`get`
@@ -137,7 +154,7 @@ export default function( registry, pluginOptions ) {
 				[ key ]: ( state, action ) => action.nextState[ key ],
 			} ), {} );
 
-			getPersistedState = combineReducers( reducers );
+			getPersistedState = withLazySameState( combineReducers( reducers ) );
 		} else {
 			getPersistedState = ( state, action ) => action.nextState;
 		}

--- a/packages/data/src/plugins/persistence/test/index.js
+++ b/packages/data/src/plugins/persistence/test/index.js
@@ -138,6 +138,34 @@ describe( 'persistence', () => {
 		expect( objectStorage.setItem ).toHaveBeenCalledWith( 'WP_DATA', '{"test":{"foo":1}}' );
 	} );
 
+	it( 'should not persist an unchanging subset', () => {
+		const initialState = { foo: 'bar' };
+		function reducer( state = initialState, action ) {
+			const { type, key, value } = action;
+			if ( type === 'SET_KEY_VALUE' ) {
+				return { ...state, [ key ]: value };
+			}
+
+			return state;
+		}
+
+		registry.registerStore( 'test', {
+			reducer,
+			persist: [ 'foo' ],
+			actions: {
+				setKeyValue( key, value ) {
+					return { type: 'SET_KEY_VALUE', key, value };
+				},
+			},
+		} );
+
+		registry.dispatch( 'test' ).setKeyValue( 'foo', 1 );
+		objectStorage.setItem.mockClear();
+
+		registry.dispatch( 'test' ).setKeyValue( 'foo', 1 );
+		expect( objectStorage.setItem ).not.toHaveBeenCalled();
+	} );
+
 	describe( 'createPersistenceInterface', () => {
 		const storage = objectStorage;
 		const storageKey = 'FOO';

--- a/packages/data/src/plugins/persistence/test/index.js
+++ b/packages/data/src/plugins/persistence/test/index.js
@@ -4,6 +4,7 @@
 import plugin, {
 	createPersistenceInterface,
 	withInitialState,
+	withLazySameState,
 } from '../';
 import objectStorage from '../storage/object';
 import { createRegistry } from '../../../';
@@ -220,6 +221,32 @@ describe( 'persistence', () => {
 			const enhanced = withInitialState( reducer, 2 );
 
 			expect( enhanced() ).toBe( 2 );
+		} );
+	} );
+
+	describe( 'withLazySameState', () => {
+		it( 'should call the original reducer if action.nextState differs from state', () => {
+			const reducer = jest.fn().mockImplementation( ( state, action ) => action.nextState );
+			const enhanced = withLazySameState( reducer );
+
+			reducer.mockClear();
+
+			const state = enhanced( 1, { nextState: 2 } );
+
+			expect( state ).toBe( 2 );
+			expect( reducer ).toHaveBeenCalled();
+		} );
+
+		it( 'should not call the original reducer if action.nextState equals state', () => {
+			const reducer = jest.fn().mockImplementation( ( state, action ) => action.nextState );
+			const enhanced = withLazySameState( reducer );
+
+			reducer.mockClear();
+
+			const state = enhanced( 1, { nextState: 1 } );
+
+			expect( state ).toBe( 1 );
+			expect( reducer ).not.toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/test/e2e/specs/new-post.test.js
+++ b/test/e2e/specs/new-post.test.js
@@ -7,11 +7,13 @@ import { activatePlugin, deactivatePlugin } from '../support/plugins';
 describe( 'new editor state', () => {
 	beforeAll( async () => {
 		await activatePlugin( 'gutenberg-test-plugin-post-formats-support' );
+	} );
+
+	beforeEach( async () => {
 		await newPost();
 	} );
 
 	afterAll( async () => {
-		await newPost();
 		await deactivatePlugin( 'gutenberg-test-plugin-post-formats-support' );
 	} );
 
@@ -38,16 +40,6 @@ describe( 'new editor state', () => {
 	} );
 
 	it( 'should focus the title if the title is empty', async () => {
-		// We need to remove the tips to make sure they aren't clicked/removed
-		// during our check of the title `textarea`'s focus.
-		await page.evaluate( () => {
-			return wp.data.dispatch( 'core/nux' ).disableTips();
-		} );
-
-		// And then reload the page to ensure we get a new page that should
-		// autofocus the title, without any NUX tips.
-		await page.reload();
-
 		const activeElementClasses = await page.evaluate( () => {
 			return Object.values( document.activeElement.classList );
 		} );


### PR DESCRIPTION
This pull request seeks to fix an issue where the data module persistence plugin inconsistently persists a subset of state keys when those values are unchanging. The plugin already has logic to avoid persisting when state does not change, but this is only enforced for top-level state when a store opts in using `persist: true`. Gutenberg's usage exclusively uses the keys variant (e.g. `persist: [ 'preferences' ]`), thus it has never been able to take advantage of this optimization. In practice, this means that Gutenberg `master` calls `localStorage.setItem` for each persisted store for each state change, which the changes here seek to address.

Further, the reimplementation of subset "picking" using `turbo-combine-reducer` over Lodash's `pick` demonstrates a ~15x performance improvement ([benchmark](https://jsperf.com/turbo-combine-reducers-vs-lodash-pick/1)).

**Testing instructions:**

Ensure unit tests pass:

```
npm run test-unit
```

Bonus: Ensure `localStorage.setItem` is only called when a preference actually changes by applying the following diff, and contrasting with `master`:

```diff
diff --git a/packages/data/src/plugins/persistence/index.js b/packages/data/src/plugins/persistence/index.js
index b619f2622..62667f4d3 100644
--- a/packages/data/src/plugins/persistence/index.js
+++ b/packages/data/src/plugins/persistence/index.js
@@ -97,6 +97,7 @@ export function createPersistenceInterface( options ) {
 	 */
 	function set( key, value ) {
 		data = { ...data, [ key ]: value };
+		console.count( 'storage.setItem' );
 		storage.setItem( storageKey, JSON.stringify( data ) );
 	}
```