### PR TITLE
Make editor p tag "go with the flow".

### DIFF
--- a/packages/editor/src/editor-styles.scss
+++ b/packages/editor/src/editor-styles.scss
@@ -6,8 +6,8 @@ body {
 }
 
 p {
-	font-size: $editor-font-size;
-	line-height: $editor-line-height;
+	font-size: inherit;
+	line-height: inherit;
 }
 
 ul,


### PR DESCRIPTION
## Description
This commit sets the `p` tag to inherit whatever `font-size` and `line-height` are set on the `body` i.e., `.editor-styles-wrapper`. 
Currently the `p` tag here overrides a theme's most basic of font styles unless `font-size` and `line-height` are set on `p` in that theme.
And from what I've seen, being that specific on `p` is an uncommon pattern.

This also makes it easier and requires less specificity to style paragraphs on a per block basis by simply adding the font-size to the block container.

## How has this been tested?
I see no visual changes on a fresh underscores theme with demo content.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
