### PR TITLE
Allow templates to change list block placeholder by adding it as an attribute

### DIFF
--- a/packages/block-library/src/list/index.js
+++ b/packages/block-library/src/list/index.js
@@ -49,6 +49,9 @@ const schema = {
 		multiline: 'li',
 		default: '',
 	},
+	placeholder: {
+		type: 'string',
+	},
 };
 
 export const name = 'core/list';
@@ -220,7 +223,7 @@ export const settings = {
 		onReplace,
 		className,
 	} ) {
-		const { ordered, values } = attributes;
+		const { ordered, values, placeholder } = attributes;
 
 		return (
 			<RichText
@@ -231,7 +234,7 @@ export const settings = {
 				value={ values }
 				wrapperClassName="block-library-list"
 				className={ className }
-				placeholder={ __( 'Write list…' ) }
+				placeholder={ placeholder || __( 'Write list…' ) }
 				onMerge={ mergeBlocks }
 				unstableOnSplit={
 					insertBlocksAfter ?


### PR DESCRIPTION
## Description
Heading blocks and paragraph blocks allows templates (for CPT/InnerBlocks) to set a custom placeholder via attributes - like so:

`const TEMPLATE =[
    ['core/heading', { placeholder: 'Enter recipe title...'  }]
]`

This is not possible with the list block, as its placeholder is only defined on the `<RichText />`-component.

## Types of changes
This PR updates the list block to insert placeholders the same way the [paragraph](https://github.com/WordPress/gutenberg/blob/47950c3c3214a80401ee895413312a8691716e45/packages/block-library/src/paragraph/edit.js#L250) and [heading](https://github.com/WordPress/gutenberg/blob/47950c3c3214a80401ee895413312a8691716e45/packages/block-library/src/heading/edit.js#L65) blocks do. They do this by adding the placeholder as an empty attribute - so the standard placeholder defined on the RichText-component is used when it's not defined.

## Screenshots <!-- if applicable -->
List block with default placeholder
![image](https://user-images.githubusercontent.com/38467445/50220423-9287e980-0392-11e9-9071-c32fb91cc212.png)
List block as part of a custom block that uses an `<InnerBlocks />` component with a template that sets the list block's placeholder to be _Enter steps..._
![image](https://user-images.githubusercontent.com/38467445/50220462-a7fd1380-0392-11e9-8d09-635012dc49e9.png)

I tried to search the GitHub repo to see if there has been any discussion around what blocks can set placeholder text in a template and which can't - but I didn't find anything.

It seems like it's possible to set the placeholder attributes for:
* Heading block
* Paragraph block

But not for (I didn't check all blocks, but are willing to):
* List block
* Button block
* Code block
* Quote (neither quote field or citation field)
* Pullquote (same)

Is this a conscious decision/is there a reason for this?
Allowing templates to have custom placeholders really increase their usefulness (in my humble opinion).

## How has this been tested?
Tested defining the placeholder attribute for a list block as part of a template for <InnerBlocks/> and a custom post type.
Tested on a local install with WordPress 5.0.1

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->

_(I'm quite new at this is, so if you have to tell I've done something wrong/it's terrible/it can't be used there will be no hard feelings.)_
