### PR TITLE
Expose `unregisterBlockType` to mobile

### DIFF
--- a/packages/blocks/src/api/index.native.js
+++ b/packages/blocks/src/api/index.native.js
@@ -14,6 +14,7 @@ export {
 } from './serializer';
 export {
 	registerBlockType,
+	unregisterBlockType,
 	getFreeformContentHandlerName,
 	setUnregisteredTypeHandlerName,
 	getUnregisteredTypeHandlerName,


### PR DESCRIPTION
## Description
This PR exports `unregisterBlockType` from the `@wordpress/blocks` package for the mobile build.

## How has this been tested?
Tested as part of https://github.com/wordpress-mobile/gutenberg-mobile/pull/406

## Types of changes
- Mobile compatibility changes

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
