### PR TITLE
Expand PHPCS scanning to all PHP in Gutenberg

### DIFF
--- a/packages/block-serialization-default-parser/parser.php
+++ b/packages/block-serialization-default-parser/parser.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Block Serialization Parser
+ *
+ * @package WordPress
+ */
 
 /**
  * Class WP_Block_Parser_Block
@@ -62,6 +67,19 @@ class WP_Block_Parser_Block {
 	 */
 	public $innerContent;
 
+	/**
+	 * Constructor.
+	 *
+	 * Will populate object properties from the provided arguments.
+	 *
+	 * @since 3.8.0
+	 *
+	 * @param string $name         Name of block.
+	 * @param array  $attrs        Optional set of attributes from block comment delimiters.
+	 * @param array  $innerBlocks  List of inner blocks (of this same class).
+	 * @param string $innerHTML    Resultant HTML from inside block comment delimiters after removing inner blocks.
+	 * @param array  $innerContent List of string fragments and null markers where inner blocks were found.
+	 */
 	function __construct( $name, $attrs, $innerBlocks, $innerHTML, $innerContent ) {
 		$this->blockName    = $name;
 		$this->attrs        = $attrs;
@@ -121,6 +139,19 @@ class WP_Block_Parser_Frame {
 	 */
 	public $leading_html_start;
 
+	/**
+	 * Constructor
+	 *
+	 * Will populate object properties from the provided arguments.
+	 *
+	 * @since 3.8.0
+	 *
+	 * @param WP_Block_Parser_Block $block              Full or partial block.
+	 * @param int                   $token_start        Byte offset into document for start of parse token.
+	 * @param int                   $token_length       Byte length of entire parse token string.
+	 * @param int                   $prev_offset        Byte offset into document for after parse token ends.
+	 * @param int                   $leading_html_start Byte offset into document where leading HTML before token starts.
+	 */
 	function __construct( $block, $token_start, $token_length, $prev_offset = null, $leading_html_start = null ) {
 		$this->block              = $block;
 		$this->token_start        = $token_start;
@@ -190,7 +221,7 @@ class WP_Block_Parser {
 	 *
 	 * @since 3.8.0
 	 *
-	 * @param string $document
+	 * @param string $document Input document being parsed.
 	 * @return WP_Block_Parser_Block[]
 	 */
 	function parse( $document ) {
@@ -201,7 +232,7 @@ class WP_Block_Parser {
 		$this->empty_attrs = json_decode( '{}', true );
 
 		do {
-			// twiddle our thumbs
+			// twiddle our thumbs.
 		} while ( $this->proceed() );
 
 		return $this->output;
@@ -226,12 +257,12 @@ class WP_Block_Parser {
 		list( $token_type, $block_name, $attrs, $start_offset, $token_length ) = $next_token;
 		$stack_depth = count( $this->stack );
 
-		// we may have some HTML soup before the next block
+		// we may have some HTML soup before the next block.
 		$leading_html_start = $start_offset > $this->offset ? $this->offset : null;
 
 		switch ( $token_type ) {
 			case 'no-more-tokens':
-				// if not in a block then flush output
+				// if not in a block then flush output.
 				if ( 0 === $stack_depth ) {
 					$this->add_freeform();
 					return false;
@@ -246,7 +277,7 @@ class WP_Block_Parser {
 				 * - assume an implicit closer (easiest when not nesting)
 				 */
 
-				// for the easy case we'll assume an implicit closer
+				// for the easy case we'll assume an implicit closer.
 				if ( 1 === $stack_depth ) {
 					$this->add_block_from_stack();
 					return false;
@@ -269,19 +300,21 @@ class WP_Block_Parser {
 				 */
 				if ( 0 === $stack_depth ) {
 					if ( isset( $leading_html_start ) ) {
-						$this->output[] = (array) self::freeform( substr(
-							$this->document,
-							$leading_html_start,
-							$start_offset - $leading_html_start
-						) );
+						$this->output[] = (array) self::freeform(
+							substr(
+								$this->document,
+								$leading_html_start,
+								$start_offset - $leading_html_start
+							)
+						);
 					}
 
 					$this->output[] = (array) new WP_Block_Parser_Block( $block_name, $attrs, array(), '', array() );
-					$this->offset = $start_offset + $token_length;
+					$this->offset   = $start_offset + $token_length;
 					return true;
 				}
 
-				// otherwise we found an inner block
+				// otherwise we found an inner block.
 				$this->add_inner_block(
 					new WP_Block_Parser_Block( $block_name, $attrs, array(), '', array() ),
 					$start_offset,
@@ -291,14 +324,17 @@ class WP_Block_Parser {
 				return true;
 
 			case 'block-opener':
-				// track all newly-opened blocks on the stack
-				array_push( $this->stack, new WP_Block_Parser_Frame(
-					new WP_Block_Parser_Block( $block_name, $attrs, array(), '', array() ),
-					$start_offset,
-					$token_length,
-					$start_offset + $token_length,
-					$leading_html_start
-				) );
+				// track all newly-opened blocks on the stack.
+				array_push(
+					$this->stack,
+					new WP_Block_Parser_Frame(
+						new WP_Block_Parser_Block( $block_name, $attrs, array(), '', array() ),
+						$start_offset,
+						$token_length,
+						$start_offset + $token_length,
+						$leading_html_start
+					)
+				);
 				$this->offset = $start_offset + $token_length;
 				return true;
 
@@ -318,7 +354,7 @@ class WP_Block_Parser {
 					return false;
 				}
 
-				// if we're not nesting then this is easy - close the block
+				// if we're not nesting then this is easy - close the block.
 				if ( 1 === $stack_depth ) {
 					$this->add_block_from_stack( $start_offset );
 					$this->offset = $start_offset + $token_length;
@@ -329,11 +365,11 @@ class WP_Block_Parser {
 				 * otherwise we're nested and we have to close out the current
 				 * block and add it as a new innerBlock to the parent
 				 */
-				$stack_top = array_pop( $this->stack );
-				$html = substr( $this->document, $stack_top->prev_offset, $start_offset - $stack_top->prev_offset );
-				$stack_top->block->innerHTML .= $html;
+				$stack_top                        = array_pop( $this->stack );
+				$html                             = substr( $this->document, $stack_top->prev_offset, $start_offset - $stack_top->prev_offset );
+				$stack_top->block->innerHTML     .= $html;
 				$stack_top->block->innerContent[] = $html;
-				$stack_top->prev_offset = $start_offset + $token_length;
+				$stack_top->prev_offset           = $start_offset + $token_length;
 
 				$this->add_inner_block(
 					$stack_top->block,
@@ -345,7 +381,7 @@ class WP_Block_Parser {
 				return true;
 
 			default:
-				// This is an error
+				// This is an error.
 				$this->add_freeform();
 				return false;
 		}
@@ -381,32 +417,32 @@ class WP_Block_Parser {
 			$this->offset
 		);
 
-		// if we get here we probably have catastrophic backtracking or out-of-memory in the PCRE
+		// if we get here we probably have catastrophic backtracking or out-of-memory in the PCRE.
 		if ( false === $has_match ) {
 			return array( 'no-more-tokens', null, null, null, null );
 		}
 
-		// we have no more tokens
+		// we have no more tokens.
 		if ( 0 === $has_match ) {
 			return array( 'no-more-tokens', null, null, null, null );
 		}
 
-		list( $match, $started_at ) = $matches[ 0 ];
+		list( $match, $started_at ) = $matches[0];
 
 		$length    = strlen( $match );
-		$is_closer = isset( $matches[ 'closer' ] ) && -1 !== $matches[ 'closer' ][ 1 ];
-		$is_void   = isset( $matches[ 'void' ] ) && -1 !== $matches[ 'void' ][ 1 ];
-		$namespace = $matches[ 'namespace' ];
-		$namespace = ( isset( $namespace ) && -1 !== $namespace[ 1 ] ) ? $namespace[ 0 ] : 'core/';
-		$name      = $namespace . $matches[ 'name' ][ 0 ];
-		$has_attrs = isset( $matches[ 'attrs' ] ) && -1 !== $matches[ 'attrs' ][ 1 ];
+		$is_closer = isset( $matches['closer'] ) && -1 !== $matches['closer'][1];
+		$is_void   = isset( $matches['void'] ) && -1 !== $matches['void'][1];
+		$namespace = $matches['namespace'];
+		$namespace = ( isset( $namespace ) && -1 !== $namespace[1] ) ? $namespace[0] : 'core/';
+		$name      = $namespace . $matches['name'][0];
+		$has_attrs = isset( $matches['attrs'] ) && -1 !== $matches['attrs'][1];
 
 		/*
 		 * Fun fact! It's not trivial in PHP to create "an empty associative array" since all arrays
 		 * are associative arrays. If we use `array()` we get a JSON `[]`
 		 */
 		$attrs = $has_attrs
-			? json_decode( $matches[ 'attrs' ][ 0 ], /* as-associative */ true )
+			? json_decode( $matches['attrs'][0], /* as-associative */ true )
 			: $this->empty_attrs;
 
 		/*
@@ -414,7 +450,7 @@ class WP_Block_Parser {
 		 * This is an error
 		 */
 		if ( $is_closer && ( $is_void || $has_attrs ) ) {
-			// we can ignore them since they don't hurt anything
+			// we can ignore them since they don't hurt anything.
 		}
 
 		if ( $is_void ) {
@@ -434,8 +470,8 @@ class WP_Block_Parser {
 	 * @internal
 	 * @since 3.9.0
 	 *
-	 * @param string $innerHTML HTML content of block
-	 * @return WP_Block_Parser_Block freeform block object
+	 * @param string $innerHTML HTML content of block.
+	 * @return WP_Block_Parser_Block freeform block object.
 	 */
 	function freeform( $innerHTML ) {
 		return new WP_Block_Parser_Block( null, $this->empty_attrs, array(), $innerHTML, array( $innerHTML ) );
@@ -443,11 +479,11 @@ class WP_Block_Parser {
 
 	/**
 	 * Pushes a length of text from the input document
-	 * to the output list as a freeform block
+	 * to the output list as a freeform block.
 	 *
 	 * @internal
 	 * @since 3.8.0
-	 * @param null $length how many bytes of document text to output
+	 * @param null $length how many bytes of document text to output.
 	 */
 	function add_freeform( $length = null ) {
 		$length = $length ? $length : strlen( $this->document ) - $this->offset;
@@ -461,35 +497,35 @@ class WP_Block_Parser {
 
 	/**
 	 * Given a block structure from memory pushes
-	 * a new block to the output list
+	 * a new block to the output list.
 	 *
 	 * @internal
 	 * @since 3.8.0
-	 * @param WP_Block_Parser_Block $block the block to add to the output
-	 * @param int $token_start byte offset into the document where the first token for the block starts
-	 * @param int $token_length byte length of entire block from start of opening token to end of closing token
-	 * @param int|null $last_offset last byte offset into document if continuing form earlier output
+	 * @param WP_Block_Parser_Block $block        The block to add to the output.
+	 * @param int                   $token_start  Byte offset into the document where the first token for the block starts.
+	 * @param int                   $token_length Byte length of entire block from start of opening token to end of closing token.
+	 * @param int|null              $last_offset  Last byte offset into document if continuing form earlier output.
 	 */
 	function add_inner_block( WP_Block_Parser_Block $block, $token_start, $token_length, $last_offset = null ) {
-		$parent = $this->stack[ count( $this->stack ) - 1 ];
+		$parent                       = $this->stack[ count( $this->stack ) - 1 ];
 		$parent->block->innerBlocks[] = (array) $block;
-		$html = substr( $this->document, $parent->prev_offset, $token_start - $parent->prev_offset );
+		$html                         = substr( $this->document, $parent->prev_offset, $token_start - $parent->prev_offset );
 
 		if ( ! empty( $html ) ) {
-			$parent->block->innerHTML .= $html;
+			$parent->block->innerHTML     .= $html;
 			$parent->block->innerContent[] = $html;
 		}
 
 		$parent->block->innerContent[] = null;
-		$parent->prev_offset = $last_offset ? $last_offset : $token_start + $token_length;
+		$parent->prev_offset           = $last_offset ? $last_offset : $token_start + $token_length;
 	}
 
 	/**
-	 * Pushes the top block from the parsing stack to the output list
+	 * Pushes the top block from the parsing stack to the output list.
 	 *
 	 * @internal
 	 * @since 3.8.0
-	 * @param int|null $end_offset byte offset into document for where we should stop sending text output as HTML
+	 * @param int|null $end_offset byte offset into document for where we should stop sending text output as HTML.
 	 */
 	function add_block_from_stack( $end_offset = null ) {
 		$stack_top   = array_pop( $this->stack );
@@ -500,16 +536,18 @@ class WP_Block_Parser {
 			: substr( $this->document, $prev_offset );
 
 		if ( ! empty( $html ) ) {
-			$stack_top->block->innerHTML .= $html;
+			$stack_top->block->innerHTML     .= $html;
 			$stack_top->block->innerContent[] = $html;
 		}
 
 		if ( isset( $stack_top->leading_html_start ) ) {
-			$this->output[] = (array) self::freeform( substr(
-				$this->document,
-				$stack_top->leading_html_start,
-				$stack_top->token_start - $stack_top->leading_html_start
-			) );
+			$this->output[] = (array) self::freeform(
+				substr(
+					$this->document,
+					$stack_top->leading_html_start,
+					$stack_top->token_start - $stack_top->leading_html_start
+				)
+			);
 		}
 
 		$this->output[] = (array) $stack_top->block;

--- a/packages/block-serialization-default-parser/test/test-parser.php
+++ b/packages/block-serialization-default-parser/test/test-parser.php
@@ -1,6 +1,14 @@
 <?php
+/**
+ * PHP Test Helper
+ *
+ * Facilitates running PHP parser against same tests as the JS parser implementation.
+ *
+ * @package gutenberg
+ */
 
-require_once __DIR__ . '/../parser.php';
+// Include the default parser.
+require_once dirname( __FILE__ ) . '/../parser.php';
 
 $parser = new WP_Block_Parser();
 

--- a/packages/block-serialization-spec-parser/test/test-parser.php
+++ b/packages/block-serialization-spec-parser/test/test-parser.php
@@ -1,6 +1,14 @@
 <?php
+/**
+ * PHP Test Helper
+ *
+ * Facilitates running PHP parser against same tests as the JS parser implementation.
+ *
+ * @package gutenberg
+ */
 
-require_once __DIR__ . '/../../../lib/parser.php';
+// Include the generated parser.
+require_once dirname( __FILE__ ) . '/../../../lib/parser.php';
 
 $parser = new Gutenberg_PEG_Parser();
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -25,12 +25,15 @@
 	<arg value="ps"/>
 	<arg name="extensions" value="php"/>
 
-	<file>./bin</file>
-	<file>./packages/block-library/src</file>
-	<file>./lib</file>
+	<file>.</file>
+
+	<!-- Exclude 3rd party libraries -->
+	<exclude-pattern>./node_modules</exclude-pattern>
+	<exclude-pattern>./vendor</exclude-pattern>
+
+	<!-- Exclude generated files -->
+	<exclude-pattern>./languages/gutenberg-translations.php</exclude-pattern>
 	<exclude-pattern>./lib/parser.php</exclude-pattern>
-	<file>./phpunit</file>
-	<file>gutenberg.php</file>
 
 	<rule ref="PHPCompatibility.PHP.NewKeywords.t_namespaceFound">
 		<exclude-pattern>lib/class-wp-rest-block-renderer-controller.php</exclude-pattern>
@@ -65,5 +68,20 @@
 	</rule>
 	<rule ref="Squiz.Commenting.FunctionCommentThrowTag.Missing">
 		<exclude-pattern>phpunit/*</exclude-pattern>
+	</rule>
+
+	<!-- Ignore snake case error in parser -->
+	<rule ref="WordPress.NamingConventions.ValidVariableName.NotSnakeCase">
+		<exclude-pattern>./packages/block-serialization-default-parser/parser.php</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar">
+		<exclude-pattern>./packages/block-serialization-default-parser/parser.php</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.NamingConventions.ValidVariableName.MemberNotSnakeCase">
+		<exclude-pattern>./packages/block-serialization-default-parser/parser.php</exclude-pattern>
+	</rule>
+	<!-- Ignore filename error since it requires WP core build process change -->
+	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
+		<exclude-pattern>./packages/block-serialization-default-parser/parser.php</exclude-pattern>
 	</rule>
 </ruleset>

--- a/post-content.php
+++ b/post-content.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * Default content of the demo page
+ *
+ * @package gutenberg
+ */
+
+?>
 <!-- wp:cover {"url":"https://cldup.com/Fz-ASbo2s3.jpg","align":"wide"} -->
 <div class="wp-block-cover has-background-dim alignwide" style="background-image:url(https://cldup.com/Fz-ASbo2s3.jpg)"><p class="wp-block-cover-text"><?php _e( 'Of Mountains &amp; Printing Presses', 'gutenberg' ); ?></p></div>
 <!-- /wp:cover -->

--- a/test/e2e/test-mu-plugins/disable-login-autofocus.php
+++ b/test/e2e/test-mu-plugins/disable-login-autofocus.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Plugin Name: Gutenberg Test Plugin, Disable Login Autofocus
  * Plugin URI: https://github.com/WordPress/gutenberg

--- a/test/e2e/test-plugins/align-hook.php
+++ b/test/e2e/test-plugins/align-hook.php
@@ -6,6 +6,7 @@
  *
  * @package gutenberg-test-align-hook
  */
+
 wp_enqueue_script(
 	'gutenberg-test-align-hook',
 	plugins_url( 'align-hook/index.js', __FILE__ ),
@@ -13,7 +14,7 @@ wp_enqueue_script(
 		'wp-blocks',
 		'wp-element',
 		'wp-editor',
-		'wp-i18n'
+		'wp-i18n',
 	),
 	filemtime( plugin_dir_path( __FILE__ ) . 'align-hook/index.js' ),
 	true

--- a/test/e2e/test-plugins/block-icons.php
+++ b/test/e2e/test-plugins/block-icons.php
@@ -6,6 +6,7 @@
  *
  * @package gutenberg-test-block-icons
  */
+
 wp_enqueue_script(
 	'gutenberg-test-block-icons',
 	plugins_url( 'block-icons/index.js', __FILE__ ),

--- a/test/e2e/test-plugins/container-without-paragraph.php
+++ b/test/e2e/test-plugins/container-without-paragraph.php
@@ -6,6 +6,7 @@
  *
  * @package gutenberg-test-container-without-paragraph
  */
+
 wp_enqueue_script(
 	'gutenberg-test-container-without-paragraph',
 	plugins_url( 'container-without-paragraph/index.js', __FILE__ ),

--- a/test/e2e/test-plugins/default-post-content.php
+++ b/test/e2e/test-plugins/default-post-content.php
@@ -10,20 +10,23 @@
 /**
  * Change the default title.
  */
-add_filter( 'default_title', function() {
+function gutenberg_test_default_title() {
 	return 'My default title';
-} );
+}
+add_filter( 'default_title', 'gutenberg_test_default_title' );
 
 /**
- * Change teh default post content.
+ * Change the default post content.
  */
-add_filter( 'default_content', function() {
+function gutenberg_test_default_content() {
 	return 'My default content';
-} );
+}
+add_filter( 'default_content', 'gutenberg_test_default_content' );
 
 /**
  * Change the default excerpt.
  */
-add_filter( 'default_excerpt', function() {
+function gutenberg_test_default_excerpt() {
 	return 'My default excerpt';
-} );
+}
+add_filter( 'default_excerpt', 'gutenberg_test_default_excerpt' );

--- a/test/e2e/test-plugins/deprecated-node-matcher.php
+++ b/test/e2e/test-plugins/deprecated-node-matcher.php
@@ -6,6 +6,7 @@
  *
  * @package gutenberg-test-deprecated-node-matcher
  */
+
 wp_enqueue_script(
 	'gutenberg-test-deprecated-node-matcher',
 	plugins_url( 'deprecated-node-matcher/index.js', __FILE__ ),
@@ -13,7 +14,7 @@ wp_enqueue_script(
 		'lodash',
 		'wp-blocks',
 		'wp-element',
-		'wp-editor'
+		'wp-editor',
 	),
 	filemtime( plugin_dir_path( __FILE__ ) . 'deprecated-node-matcher/index.js' ),
 	true

--- a/test/e2e/test-plugins/hooks-api.php
+++ b/test/e2e/test-plugins/hooks-api.php
@@ -6,6 +6,7 @@
  *
  * @package gutenberg-test-hooks-api
  */
+
 wp_enqueue_script(
 	'gutenberg-test-hooks-api',
 	plugins_url( 'hooks-api/index.js', __FILE__ ),
@@ -15,7 +16,7 @@ wp_enqueue_script(
 		'wp-element',
 		'wp-editor',
 		'wp-hooks',
-		'wp-i18n'
+		'wp-i18n',
 	),
 	filemtime( plugin_dir_path( __FILE__ ) . 'hooks-api/index.js' ),
 	true

--- a/test/e2e/test-plugins/inner-blocks-templates.php
+++ b/test/e2e/test-plugins/inner-blocks-templates.php
@@ -6,6 +6,7 @@
  *
  * @package gutenberg-test-inner-blocks-templates
  */
+
 wp_enqueue_script(
 	'gutenberg-test-inner-blocks-templates',
 	plugins_url( 'inner-blocks-templates/index.js', __FILE__ ),
@@ -15,7 +16,7 @@ wp_enqueue_script(
 		'wp-element',
 		'wp-editor',
 		'wp-hooks',
-		'wp-i18n'
+		'wp-i18n',
 	),
 	filemtime( plugin_dir_path( __FILE__ ) . 'inner-blocks-templates/index.js' ),
 	true

--- a/test/e2e/test-plugins/meta-box.php
+++ b/test/e2e/test-plugins/meta-box.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Plugin Name: Gutenberg Test Plugin, Meta Box
  * Plugin URI: https://github.com/WordPress/gutenberg
@@ -8,10 +7,16 @@
  * @package gutenberg-test-meta-box
  */
 
+/**
+ * Prints string for meta box
+ */
 function gutenberg_test_meta_box_render_meta_box() {
 	echo 'Hello World';
 }
 
+/**
+ * Add a test meta box
+ */
 function gutenberg_test_meta_box_add_meta_box() {
 	add_meta_box(
 		'gutenberg-test-meta-box',
@@ -24,7 +29,9 @@ function gutenberg_test_meta_box_add_meta_box() {
 }
 add_action( 'add_meta_boxes', 'gutenberg_test_meta_box_add_meta_box' );
 
-
+/**
+ * Print excerpt in <meta> tag in wp_head
+ */
 function gutenberg_test_meta_box_render_head() {
 	// Emulates what plugins like Yoast do with meta data on the front end.
 	// Tests that our excerpt processing does not interfere with dynamic blocks.
@@ -33,5 +40,4 @@ function gutenberg_test_meta_box_render_head() {
 	<meta property="gutenberg:hello" content="<?php echo esc_attr( $excerpt ); ?>" />
 	<?php
 }
-
 add_action( 'wp_head', 'gutenberg_test_meta_box_render_head' );

--- a/test/e2e/test-plugins/post-formats.php
+++ b/test/e2e/test-plugins/post-formats.php
@@ -10,6 +10,9 @@
 add_theme_support( 'post-formats', array( 'image', 'gallery' ) );
 add_action( 'init', 'gutenberg_test_plugin_post_formats_add_post_support', 11 );
 
+/**
+ * Add post-formats support to pages
+ */
 function gutenberg_test_plugin_post_formats_add_post_support() {
-    add_post_type_support( 'page', 'post-formats' );
+	add_post_type_support( 'page', 'post-formats' );
 }

--- a/test/e2e/test-plugins/templates.php
+++ b/test/e2e/test-plugins/templates.php
@@ -12,10 +12,10 @@
  */
 function gutenberg_test_templates_register_book_type() {
 	$args = array(
-		'public' => true,
-		'label'  => 'Books',
+		'public'       => true,
+		'label'        => 'Books',
 		'show_in_rest' => true,
-		'template' => array(
+		'template'     => array(
 			array( 'core/image' ),
 			array(
 				'core/paragraph',

--- a/test/e2e/test-plugins/wp-editor-metabox.php
+++ b/test/e2e/test-plugins/wp-editor-metabox.php
@@ -7,21 +7,50 @@
  * @package gutenberg-test-wp-editor-metabox
  */
 
-add_action( 'add_meta_boxes', function(){
-	add_meta_box( 'test_tinymce', 'Test TinyMCE', function( $post ){
-		 $field_value = get_post_meta( $post->ID, 'test_tinymce', true );
-		 wp_editor( $field_value, 'test_tinymce_id', array(
+add_action( 'add_meta_boxes', 'gutenberg_test_add_tinymce_meta_box' );
+/**
+ * Adds a TinyMCE meta box for testing
+ */
+function gutenberg_test_add_tinymce_meta_box() {
+	add_meta_box(
+		'test_tinymce',
+		'Test TinyMCE',
+		'gutenberg_test_render_tinymce_meta_box',
+		null,
+		'advanced',
+		'high'
+	);
+}
+
+/**
+ * Render the TinyMCE meta box
+ *
+ * @param WP_Post $post The current post object.
+ */
+function gutenberg_test_render_tinymce_meta_box( $post ) {
+	$field_value = get_post_meta( $post->ID, 'test_tinymce', true );
+	wp_editor(
+		$field_value,
+		'test_tinymce_id',
+		array(
 			'wpautop'       => true,
 			'media_buttons' => false,
 			'textarea_name' => 'test_tinymce',
 			'textarea_rows' => 10,
-			'teeny'         => true
-		) );
-	}, null, 'advanced', 'high' );
-});
-add_action( 'save_post', function( $post_id ){
+			'teeny'         => true,
+		)
+	);
+}
+
+/**
+ * Save the TinyMCE meta box
+ *
+ * @param int $post_id The ID of the current post.
+ */
+function gutenberg_test_save_tinymce_meta_box( $post_id ) {
 	if ( ! isset( $_POST['test_tinymce'] ) ) {
 		return;
 	}
 	update_post_meta( $post_id, 'test_tinymce', $_POST['test_tinymce'] );
-});
+}
+add_action( 'save_post', 'gutenberg_test_save_tinymce_meta_box' );


### PR DESCRIPTION
## Description
As noted in #13002, our PHPCS config is fairly limited in scope. This has [caused a few issues](https://wordpress.slack.com/archives/C18723MQ8/p1545165911452000) when porting PHP over into WP core. 

This PR broadens it to include all PHP in the plugin, minus auto-generated files and 3rd party libraries. 

Because it expands the scanning, the PR also fixes any issues that currently exist in that code that was not getting scanned before. 

There were a few error exceptions for the block serialization parser that needed to be added due to their integration with JS and naming conventions. 

Fixes #13002