### PR TITLE
[RNMobile] Temporarily disable link formatting for alpha

### DIFF
--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -40,11 +40,12 @@ const FORMATTING_CONTROLS = [
 		title: __( 'Italic' ),
 		format: 'italic',
 	},
-	{
-		icon: 'admin-links',
-		title: __( 'Link' ),
-		format: 'link',
-	},
+	// TODO: get this back after alpha
+	// {
+	// 	icon: 'admin-links',
+	// 	title: __( 'Link' ),
+	// 	format: 'link',
+	// },
 	{
 		icon: 'editor-strikethrough',
 		title: __( 'Strikethrough' ),


### PR DESCRIPTION
## Description
Temporarily removes the `link` text formatting button from mobile Gutenberg

## How has this been tested?
Run the demo app, verify the link option is not displayed anymore when tapping into a Paragraph block and selecting a word

## Screenshots <!-- if applicable -->

#### Before
<img width="431" alt="screen shot 2018-12-20 at 09 06 03" src="https://user-images.githubusercontent.com/6597771/50284107-b997f700-0436-11e9-8a95-2428b7efd665.png">


#### After
<img width="407" alt="screen shot 2018-12-20 at 09 05 28" src="https://user-images.githubusercontent.com/6597771/50284115-c288c880-0436-11e9-8199-01a2894a6423.png">


## Types of changes
Hides a feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
