### PR TITLE
Tests: Disable a fragile link e2e test until it is improved

### DIFF
--- a/test/e2e/specs/links.test.js
+++ b/test/e2e/specs/links.test.js
@@ -272,7 +272,8 @@ describe( 'Links', () => {
 	};
 
 	// Test for regressions of https://github.com/WordPress/gutenberg/issues/10496.
-	it( 'allows autocomplete suggestions to be selected with the mouse', async () => {
+	// Disabled until improved as it wasn't reliable enough.
+	it.skip( 'allows autocomplete suggestions to be selected with the mouse', async () => {
 		// First create a post that we can search for using the link autocompletion.
 		const titleText = 'Test post mouse';
 		const postURL = await createPostWithTitle( titleText );


### PR DESCRIPTION
## Description
`allows autocomplete suggestions to be selected with the mouse` test from links spec fails very often on Travis. Let's disable it and try to improve until we enable it again.

When it fails, this is what is printed on the console:

> FAIL test/e2e/specs/links.test.js (57.317s)
>   ● Links › allows autocomplete suggestions to be selected with the mouse
>     expect(received).not.toBeNull()
>     Received: null
>       300 | 		// Expect that clicking on the autocomplete suggestion doesn't dismiss the link popover.
>       301 | 		await firstSuggestion.click();
>     > 302 | 		expect( await page.$( '.editor-url-popover' ) ).not.toBeNull();
>           | 		                                                    ^
>       303 | 
>       304 | 		// Expect the url input value to have been updated with the post url.
>       305 | 		const inputValue = await page.evaluate( () => document.querySelector( '.editor-url-input input[aria-label="URL"]' ).value );
>       at Object.toBeNull (test/e2e/specs/links.test.js:302:55)
>       at tryCatch (node_modules/regenerator-runtime/runtime.js:62:40)
>       at Generator.invoke [as _invoke] (node_modules/regenerator-runtime/runtime.js:288:22)
>       at Generator.prototype.(anonymous function) [as next] (node_modules/regenerator-runtime/runtime.js:114:21)
>       at asyncGeneratorStep (test/e2e/specs/links.test.js:15:103)
>       at _next (test/e2e/specs/links.test.js:17:194)

By the way, we should double check it works as expected at the same time :)

Edit: In my tests, it didn't regress. It would be nice to discover why this test doesn't work as intended with Puppeteer.