### PR TITLE
Make sure RichText resigns focus when unmounted

### DIFF
--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -291,6 +291,12 @@ export class RichText extends Component {
 		}
 	}
 
+	componentWillUnmount() {
+		if ( this._editor.isFocused() ) {
+			this._editor.blur();
+		}
+	}
+
 	componentDidUpdate( prevProps ) {
 		if ( this.props.isSelected && ! prevProps.isSelected ) {
 			this._editor.focus();


### PR DESCRIPTION
Fixes an issue where TextInputState would still believe a specific RichText instance was focused after it was removed from view, so selecting any non-text block (e.g. image) would try to blur a RichText that didn't exist anymore and crash.

This will check if RichText is focused and unfocus when the component is unmounted

To fix https://github.com/wordpress-mobile/gutenberg-mobile/issues/415
Relevant PR at https://github.com/wordpress-mobile/gutenberg-mobile/pull/423