### PR TITLE
Async mode in the data module

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -726,6 +726,12 @@
 		"parent": "packages"
 	},
 	{
+		"title": "@wordpress/priority-queue",
+		"slug": "packages-priority-queue",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/priority-queue/README.md",
+		"parent": "packages"
+	},
+	{
 		"title": "@wordpress/redux-routine",
 		"slug": "packages-redux-routine",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/redux-routine/README.md",

--- a/lib/packages-dependencies.php
+++ b/lib/packages-dependencies.php
@@ -91,6 +91,7 @@ return array(
 		'wp-compose',
 		'wp-element',
 		'wp-is-shallow-equal',
+		'wp-priority-queue',
 		'wp-redux-routine',
 	),
 	'wp-date'                               => array(
@@ -211,6 +212,7 @@ return array(
 		'wp-element',
 		'wp-hooks',
 	),
+	'wp-priority-queue'                     => array(),
 	'wp-redux-routine'                      => array(),
 	'wp-rich-text'                          => array(
 		'lodash',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2469,6 +2469,7 @@
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
+				"@wordpress/priority-queue": "file:packages/priority-queue",
 				"@wordpress/redux-routine": "file:packages/redux-routine",
 				"equivalent-key-map": "^0.2.2",
 				"is-promise": "^2.1.0",
@@ -2757,6 +2758,12 @@
 				"autoprefixer": "^8.2.0",
 				"postcss": "^6.0.16",
 				"postcss-color-function": "^4.0.1"
+			}
+		},
+		"@wordpress/priority-queue": {
+			"version": "file:packages/priority-queue",
+			"requires": {
+				"@babel/runtime": "^7.0.0"
 			}
 		},
 		"@wordpress/redux-routine": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"@wordpress/notices": "file:packages/notices",
 		"@wordpress/nux": "file:packages/nux",
 		"@wordpress/plugins": "file:packages/plugins",
+		"@wordpress/priority-queue": "file:packages/priority-queue",
 		"@wordpress/redux-routine": "file:packages/redux-routine",
 		"@wordpress/rich-text": "file:packages/rich-text",
 		"@wordpress/shortcode": "file:packages/shortcode",

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -25,6 +25,7 @@
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/element": "file:../element",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
+		"@wordpress/priority-queue": "file:../priority-queue",
 		"@wordpress/redux-routine": "file:../redux-routine",
 		"equivalent-key-map": "^0.2.2",
 		"is-promise": "^2.1.0",

--- a/packages/data/src/components/async-mode-provider/index.js
+++ b/packages/data/src/components/async-mode-provider/index.js
@@ -1,0 +1,10 @@
+/**
+ * WordPress dependencies
+ */
+import { createContext } from '@wordpress/element';
+
+const { Consumer, Provider } = createContext( false );
+
+export const AsyncModeConsumer = Consumer;
+
+export default Provider;

--- a/packages/data/src/components/with-select/index.js
+++ b/packages/data/src/components/with-select/index.js
@@ -115,7 +115,6 @@ const withSelect = ( mapSelectToProps ) => createHigherOrderComponent( ( Wrapped
 			// Cycle subscription if registry changes.
 			const hasRegistryChanged = nextProps.registry !== this.props.registry;
 			const hasSyncRenderingChanged = nextProps.isAsync !== this.props.isAsync;
-			let shouldComputeProps = false;
 
 			if ( hasRegistryChanged ) {
 				this.unsubscribe();
@@ -123,7 +122,7 @@ const withSelect = ( mapSelectToProps ) => createHigherOrderComponent( ( Wrapped
 			}
 
 			if ( hasSyncRenderingChanged ) {
-				shouldComputeProps = flushComponent( this );
+				flushComponent( this );
 			}
 
 			// Treat a registry change as equivalent to `ownProps`, to reflect
@@ -135,11 +134,11 @@ const withSelect = ( mapSelectToProps ) => createHigherOrderComponent( ( Wrapped
 
 			// Only render if props have changed or merge props have been updated
 			// from the store subscriber.
-			if ( this.state === nextState && ! hasPropsChanged && ! shouldComputeProps ) {
+			if ( this.state === nextState && ! hasPropsChanged && ! hasSyncRenderingChanged ) {
 				return false;
 			}
 
-			if ( hasPropsChanged || shouldComputeProps ) {
+			if ( hasPropsChanged || hasSyncRenderingChanged ) {
 				const nextMergeProps = getNextMergeProps( nextProps );
 				if ( ! isShallowEqualObjects( this.mergeProps, nextMergeProps ) ) {
 					// If merge props change as a result of the incoming props,

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -12,7 +12,7 @@ import * as plugins from './plugins';
 export { default as withSelect } from './components/with-select';
 export { default as withDispatch } from './components/with-dispatch';
 export { default as RegistryProvider, RegistryConsumer } from './components/registry-provider';
-export { default as AsyncModeProvider } from './components/async-mode-provider';
+export { default as __experimentalAsyncModeProvider } from './components/async-mode-provider';
 export { createRegistry } from './registry';
 export { plugins };
 

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -12,6 +12,7 @@ import * as plugins from './plugins';
 export { default as withSelect } from './components/with-select';
 export { default as withDispatch } from './components/with-dispatch';
 export { default as RegistryProvider, RegistryConsumer } from './components/registry-provider';
+export { default as AsyncModeProvider } from './components/async-mode-provider';
 export { createRegistry } from './registry';
 export { plugins };
 

--- a/packages/e2e-tests/specs/plugins/meta-attribute-block.test.js
+++ b/packages/e2e-tests/specs/plugins/meta-attribute-block.test.js
@@ -40,6 +40,9 @@ describe( 'Block with a meta attribute', () => {
 		await insertBlock( 'Test Meta Attribute Block' );
 		await page.keyboard.type( 'Meta Value' );
 
+		// Wait for all async blocks to update
+		await new Promise( ( resolve ) => setTimeout( resolve, 500 ) );
+
 		const persistedValues = await page.evaluate( () => Array.from( document.querySelectorAll( '.my-meta-input' ) ).map( ( input ) => input.value ) );
 		persistedValues.forEach( ( val ) => {
 			expect( val ).toBe( 'Meta Value' );

--- a/packages/e2e-tests/specs/plugins/meta-attribute-block.test.js
+++ b/packages/e2e-tests/specs/plugins/meta-attribute-block.test.js
@@ -40,12 +40,12 @@ describe( 'Block with a meta attribute', () => {
 		await insertBlock( 'Test Meta Attribute Block' );
 		await page.keyboard.type( 'Meta Value' );
 
-		// Wait for all async blocks to update
-		await new Promise( ( resolve ) => setTimeout( resolve, 500 ) );
-
-		const persistedValues = await page.evaluate( () => Array.from( document.querySelectorAll( '.my-meta-input' ) ).map( ( input ) => input.value ) );
-		persistedValues.forEach( ( val ) => {
-			expect( val ).toBe( 'Meta Value' );
+		const inputs = await page.$$( '.my-meta-input' );
+		await inputs.forEach( async ( input ) => {
+			// Clicking the input selects the block,
+			// and selecting the block enables the sync data mode.
+			await input.click();
+			expect( await input.getProperty( 'value' ) ).toBe( 'Meta Value' );
 		} );
 	} );
 } );

--- a/packages/e2e-tests/specs/plugins/meta-attribute-block.test.js
+++ b/packages/e2e-tests/specs/plugins/meta-attribute-block.test.js
@@ -43,7 +43,9 @@ describe( 'Block with a meta attribute', () => {
 		const inputs = await page.$$( '.my-meta-input' );
 		await inputs.forEach( async ( input ) => {
 			// Clicking the input selects the block,
-			// and selecting the block enables the sync data mode.
+			// and selecting the block enables the sync data mode
+			// as otherwise the asynchronous rerendering of unselected blocks
+			// may cause the input to have not yet been updated for the other blocks
 			await input.click();
 			expect( await input.getProperty( 'value' ) ).toBe( 'Meta Value' );
 		} );

--- a/packages/editor/src/components/block-list/index.js
+++ b/packages/editor/src/components/block-list/index.js
@@ -195,18 +195,20 @@ class BlockList extends Component {
 			isDraggable,
 			selectedBlockClientId,
 			multiSelectedBlockClientIds,
+			hasMultiSelection,
 		} = this.props;
 
 		return (
 			<div className="editor-block-list__layout">
 				{ map( blockClientIds, ( clientId, blockIndex ) => {
+					const isBlockInSelection = hasMultiSelection ?
+						multiSelectedBlockClientIds.includes( clientId ) :
+						selectedBlockClientId === clientId;
+
 					return (
 						<AsyncModeProvider
 							key={ 'block-' + clientId }
-							value={
-								selectedBlockClientId !== clientId &&
-							( !! selectedBlockClientId || multiSelectedBlockClientIds.indexOf( clientId ) === -1 )
-							}
+							value={ ! isBlockInSelection }
 						>
 							<BlockListBlock
 								clientId={ clientId }
@@ -241,6 +243,7 @@ export default compose( [
 			getMultiSelectedBlocksEndClientId,
 			getSelectedBlockClientId,
 			getMultiSelectedBlockClientIds,
+			hasMultiSelection,
 		} = select( 'core/editor' );
 		const { rootClientId } = ownProps;
 
@@ -252,6 +255,7 @@ export default compose( [
 			isMultiSelecting: isMultiSelecting(),
 			selectedBlockClientId: getSelectedBlockClientId(),
 			multiSelectedBlockClientIds: getMultiSelectedBlockClientIds(),
+			hasMultiSelection: hasMultiSelection(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/editor/src/components/block-list/index.js
+++ b/packages/editor/src/components/block-list/index.js
@@ -21,6 +21,7 @@ import { compose } from '@wordpress/compose';
  * Internal dependencies
  */
 import BlockListBlock from './block';
+// import RenderingProvider from './rendering-provider';
 import BlockListAppender from '../block-list-appender';
 import { getBlockDOMNode } from '../../utils/dom';
 
@@ -182,16 +183,16 @@ class BlockList extends Component {
 			blockClientIds,
 			rootClientId,
 			isDraggable,
+			selectedBlockClientId,
 		} = this.props;
 
 		return (
-			<AsyncModeProvider value={ true }>
-				<div className="editor-block-list__layout">
-					{ map( blockClientIds, ( clientId, blockIndex ) => (
+			<div className="editor-block-list__layout">
+				{ map( blockClientIds, ( clientId, blockIndex ) => (
+					<AsyncModeProvider key={ 'block-' + clientId } value={ selectedBlockClientId !== clientId }>
 						<BlockListBlock
-							key={ 'block-' + clientId }
-							index={ blockIndex }
 							clientId={ clientId }
+							index={ blockIndex }
 							blockRef={ this.setBlockRef }
 							onSelectionStart={ this.onSelectionStart }
 							rootClientId={ rootClientId }
@@ -199,10 +200,10 @@ class BlockList extends Component {
 							isLast={ blockIndex === blockClientIds.length - 1 }
 							isDraggable={ isDraggable }
 						/>
-					) ) }
-					<BlockListAppender rootClientId={ rootClientId } />
-				</div>
-			</AsyncModeProvider>
+					</AsyncModeProvider>
+				) ) }
+				<BlockListAppender rootClientId={ rootClientId } />
+			</div>
 		);
 	}
 }
@@ -215,6 +216,7 @@ export default compose( [
 			isMultiSelecting,
 			getMultiSelectedBlocksStartClientId,
 			getMultiSelectedBlocksEndClientId,
+			getSelectedBlockClientId,
 		} = select( 'core/editor' );
 		const { rootClientId } = ownProps;
 
@@ -224,6 +226,7 @@ export default compose( [
 			selectionEnd: getMultiSelectedBlocksEndClientId(),
 			isSelectionEnabled: isSelectionEnabled(),
 			isMultiSelecting: isMultiSelecting(),
+			selectedBlockClientId: getSelectedBlockClientId(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/editor/src/components/block-list/index.js
+++ b/packages/editor/src/components/block-list/index.js
@@ -14,7 +14,7 @@ import {
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { withSelect, withDispatch, AsyncModeProvider } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
 /**
@@ -185,22 +185,24 @@ class BlockList extends Component {
 		} = this.props;
 
 		return (
-			<div className="editor-block-list__layout">
-				{ map( blockClientIds, ( clientId, blockIndex ) => (
-					<BlockListBlock
-						key={ 'block-' + clientId }
-						index={ blockIndex }
-						clientId={ clientId }
-						blockRef={ this.setBlockRef }
-						onSelectionStart={ this.onSelectionStart }
-						rootClientId={ rootClientId }
-						isFirst={ blockIndex === 0 }
-						isLast={ blockIndex === blockClientIds.length - 1 }
-						isDraggable={ isDraggable }
-					/>
-				) ) }
-				<BlockListAppender rootClientId={ rootClientId } />
-			</div>
+			<AsyncModeProvider value={ true }>
+				<div className="editor-block-list__layout">
+					{ map( blockClientIds, ( clientId, blockIndex ) => (
+						<BlockListBlock
+							key={ 'block-' + clientId }
+							index={ blockIndex }
+							clientId={ clientId }
+							blockRef={ this.setBlockRef }
+							onSelectionStart={ this.onSelectionStart }
+							rootClientId={ rootClientId }
+							isFirst={ blockIndex === 0 }
+							isLast={ blockIndex === blockClientIds.length - 1 }
+							isDraggable={ isDraggable }
+						/>
+					) ) }
+					<BlockListAppender rootClientId={ rootClientId } />
+				</div>
+			</AsyncModeProvider>
 		);
 	}
 }

--- a/packages/editor/src/components/block-list/index.js
+++ b/packages/editor/src/components/block-list/index.js
@@ -14,7 +14,11 @@ import {
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { withSelect, withDispatch, AsyncModeProvider } from '@wordpress/data';
+import {
+	withSelect,
+	withDispatch,
+	__experimentalAsyncModeProvider as AsyncModeProvider,
+} from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
 /**

--- a/packages/editor/src/components/block-list/index.js
+++ b/packages/editor/src/components/block-list/index.js
@@ -21,7 +21,6 @@ import { compose } from '@wordpress/compose';
  * Internal dependencies
  */
 import BlockListBlock from './block';
-// import RenderingProvider from './rendering-provider';
 import BlockListAppender from '../block-list-appender';
 import { getBlockDOMNode } from '../../utils/dom';
 

--- a/packages/editor/src/components/block-list/index.js
+++ b/packages/editor/src/components/block-list/index.js
@@ -25,6 +25,13 @@ import BlockListBlock from './block';
 import BlockListAppender from '../block-list-appender';
 import { getBlockDOMNode } from '../../utils/dom';
 
+const forceSyncUpdates = ( WrappedComponent ) => ( props ) => {
+	return (
+		<AsyncModeProvider value={ false }>
+			<WrappedComponent { ...props } />
+		</AsyncModeProvider>
+	);
+};
 class BlockList extends Component {
 	constructor( props ) {
 		super( props );
@@ -189,26 +196,28 @@ class BlockList extends Component {
 
 		return (
 			<div className="editor-block-list__layout">
-				{ map( blockClientIds, ( clientId, blockIndex ) => (
-					<AsyncModeProvider
-						key={ 'block-' + clientId }
-						value={
-							selectedBlockClientId !== clientId &&
+				{ map( blockClientIds, ( clientId, blockIndex ) => {
+					return (
+						<AsyncModeProvider
+							key={ 'block-' + clientId }
+							value={
+								selectedBlockClientId !== clientId &&
 							( !! selectedBlockClientId || multiSelectedBlockClientIds.indexOf( clientId ) === -1 )
-						}
-					>
-						<BlockListBlock
-							clientId={ clientId }
-							index={ blockIndex }
-							blockRef={ this.setBlockRef }
-							onSelectionStart={ this.onSelectionStart }
-							rootClientId={ rootClientId }
-							isFirst={ blockIndex === 0 }
-							isLast={ blockIndex === blockClientIds.length - 1 }
-							isDraggable={ isDraggable }
-						/>
-					</AsyncModeProvider>
-				) ) }
+							}
+						>
+							<BlockListBlock
+								clientId={ clientId }
+								index={ blockIndex }
+								blockRef={ this.setBlockRef }
+								onSelectionStart={ this.onSelectionStart }
+								rootClientId={ rootClientId }
+								isFirst={ blockIndex === 0 }
+								isLast={ blockIndex === blockClientIds.length - 1 }
+								isDraggable={ isDraggable }
+							/>
+						</AsyncModeProvider>
+					);
+				} ) }
 				<BlockListAppender rootClientId={ rootClientId } />
 			</div>
 		);
@@ -216,6 +225,10 @@ class BlockList extends Component {
 }
 
 export default compose( [
+	// This component needs to always be synchronous
+	// as it's the one changing the async mode
+	// depending on the block selection.
+	forceSyncUpdates,
 	withSelect( ( select, ownProps ) => {
 		const {
 			getBlockOrder,

--- a/packages/editor/src/components/block-list/index.js
+++ b/packages/editor/src/components/block-list/index.js
@@ -194,7 +194,7 @@ class BlockList extends Component {
 						key={ 'block-' + clientId }
 						value={
 							selectedBlockClientId !== clientId &&
-							( selectedBlockClientId || ! multiSelectedBlockClientIds.includes( clientId ) )
+							( !! selectedBlockClientId || multiSelectedBlockClientIds.indexOf( clientId ) === -1 )
 						}
 					>
 						<BlockListBlock

--- a/packages/editor/src/components/block-list/index.js
+++ b/packages/editor/src/components/block-list/index.js
@@ -184,12 +184,19 @@ class BlockList extends Component {
 			rootClientId,
 			isDraggable,
 			selectedBlockClientId,
+			multiSelectedBlockClientIds,
 		} = this.props;
 
 		return (
 			<div className="editor-block-list__layout">
 				{ map( blockClientIds, ( clientId, blockIndex ) => (
-					<AsyncModeProvider key={ 'block-' + clientId } value={ selectedBlockClientId !== clientId }>
+					<AsyncModeProvider
+						key={ 'block-' + clientId }
+						value={
+							selectedBlockClientId !== clientId &&
+							( selectedBlockClientId || ! multiSelectedBlockClientIds.includes( clientId ) )
+						}
+					>
 						<BlockListBlock
 							clientId={ clientId }
 							index={ blockIndex }
@@ -217,6 +224,7 @@ export default compose( [
 			getMultiSelectedBlocksStartClientId,
 			getMultiSelectedBlocksEndClientId,
 			getSelectedBlockClientId,
+			getMultiSelectedBlockClientIds,
 		} = select( 'core/editor' );
 		const { rootClientId } = ownProps;
 
@@ -227,6 +235,7 @@ export default compose( [
 			isSelectionEnabled: isSelectionEnabled(),
 			isMultiSelecting: isMultiSelecting(),
 			selectedBlockClientId: getSelectedBlockClientId(),
+			multiSelectedBlockClientIds: getMultiSelectedBlockClientIds(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/priority-queue/.npmrc
+++ b/packages/priority-queue/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/priority-queue/CHANGELOG.md
+++ b/packages/priority-queue/CHANGELOG.md
@@ -1,0 +1,3 @@
+### 1.0.0 (Unreleased)
+
+Initial release.

--- a/packages/priority-queue/README.md
+++ b/packages/priority-queue/README.md
@@ -1,6 +1,6 @@
 # Priority Queue
 
-This module allows you to run a queue of callback while on the browser's idle time making sure the higher-priority work is performed before.
+This module allows you to run a queue of callback while on the browser's idle time making sure the higher-priority work is performed first.
 
 ## Installation
 
@@ -18,9 +18,12 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 import { createQueue } from '@wordpress/priority-queue';
 
 const queue = createQueue();
+
+// Context objects.
 const ctx1 = {};
 const ctx2 = {}; 
 
+// For a given context in the queue, only the last callback is executed.
 queue.add( ctx1, () => console.log( 'This will be printed first' ) );
 queue.add( ctx2, () => console.log( 'This won\'t be printed' ) );
 queue.add( ctx2, () => console.log( 'This will be printed second' ) );

--- a/packages/priority-queue/README.md
+++ b/packages/priority-queue/README.md
@@ -1,0 +1,29 @@
+# Priority Queue
+
+This module allows you to run a queue of callback while on the browser's idle time making sure the higher-priority work is performed before.
+
+## Installation
+
+Install the module
+
+```bash
+npm install @wordpress/priority-queue --save
+```
+
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats).
+
+## Usage
+
+```js
+import { createQueue } from '@wordpress/priority-queue';
+
+const queue = createQueue();
+const ctx1 = {};
+const ctx2 = {}; 
+
+queue.add( ctx1, () => console.log( 'This will be printed first' ) );
+queue.add( ctx2, () => console.log( 'This won\'t be printed' ) );
+queue.add( ctx2, () => console.log( 'This will be printed second' ) );
+```
+
+<br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/priority-queue/package.json
+++ b/packages/priority-queue/package.json
@@ -1,0 +1,29 @@
+{
+	"name": "@wordpress/priority-queue",
+	"version": "1.0.0-alpha.0",
+	"description": "Generic browser priority queue.",
+	"author": "The WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress",
+		"browser",
+		"async"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/priority-queue/README.md",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"main": "build/index.js",
+	"module": "build-module/index.js",
+	"react-native": "src/index",
+	"dependencies": {
+		"@babel/runtime": "^7.0.0"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/priority-queue/src/index.js
+++ b/packages/priority-queue/src/index.js
@@ -1,4 +1,4 @@
-const requestFrame = window.requestIdleCallback ? window.requestIdleCallback : window.requestAnimationFrame;
+const requestIdleCallback = window.requestIdleCallback ? window.requestIdleCallback : window.requestAnimationFrame;
 
 export const createQueue = () => {
 	const waitingList = [];
@@ -17,7 +17,7 @@ export const createQueue = () => {
 			elementsMap.delete( nextElement );
 		} while ( deadline && deadline.timeRemaining && deadline.timeRemaining() > 0 );
 
-		requestFrame( runWaitingList );
+		requestIdleCallback( runWaitingList );
 	};
 
 	const add = ( element, item ) => {
@@ -27,7 +27,7 @@ export const createQueue = () => {
 		elementsMap.set( element, item );
 		if ( ! isRunning ) {
 			isRunning = true;
-			requestFrame( runWaitingList );
+			requestIdleCallback( runWaitingList );
 		}
 	};
 

--- a/packages/priority-queue/src/index.js
+++ b/packages/priority-queue/src/index.js
@@ -1,0 +1,46 @@
+const requestFrame = window.requestIdleCallback ? window.requestIdleCallback : window.requestAnimationFrame;
+
+export const createQueue = () => {
+	const waitingList = [];
+	const elementsMap = new WeakMap();
+	let isRunning = false;
+
+	const runWaitingList = () => {
+		if ( waitingList.length === 0 ) {
+			isRunning = false;
+			return;
+		}
+		const nextElement = waitingList.shift();
+		elementsMap.get( nextElement )();
+		elementsMap.delete( nextElement );
+		requestFrame( runWaitingList );
+	};
+
+	const add = ( element, item ) => {
+		if ( ! elementsMap.has( element ) ) {
+			waitingList.push( element );
+		}
+		elementsMap.set( element, item );
+		if ( ! isRunning ) {
+			isRunning = true;
+			requestFrame( runWaitingList );
+		}
+	};
+
+	const flush = ( element ) => {
+		if ( ! elementsMap.has( element ) ) {
+			return false;
+		}
+
+		elementsMap.delete( element );
+		const index = waitingList.indexOf( element );
+		waitingList.splice( index, 1 );
+
+		return true;
+	};
+
+	return {
+		add,
+		flush,
+	};
+};

--- a/packages/priority-queue/src/index.js
+++ b/packages/priority-queue/src/index.js
@@ -1,5 +1,3 @@
-const requestFrame = window.requestIdleCallback ? window.requestIdleCallback : window.requestAnimationFrame;
-
 export const createQueue = () => {
 	const waitingList = [];
 	const elementsMap = new WeakMap();
@@ -13,7 +11,7 @@ export const createQueue = () => {
 		const nextElement = waitingList.shift();
 		elementsMap.get( nextElement )();
 		elementsMap.delete( nextElement );
-		requestFrame( runWaitingList );
+		window.requestAnimationFrame( runWaitingList );
 	};
 
 	const add = ( element, item ) => {
@@ -23,7 +21,7 @@ export const createQueue = () => {
 		elementsMap.set( element, item );
 		if ( ! isRunning ) {
 			isRunning = true;
-			requestFrame( runWaitingList );
+			window.requestAnimationFrame( runWaitingList );
 		}
 	};
 


### PR DESCRIPTION
This is a crazy experiment :)

The idea is to build an async mode into the data module. Allowing some part of the React Tree to declare them selves as "async" which basically means low priority.

If a component is in async mode, it won't react synchronously to store changes, instead it will wait for all the browser's high-priority work (typing, rendering...)

In its current state, this PR declares the whole block list (the content of the post) as low priority, which means this part won't rerender synchronously when you type for instance but the chrome (save buttons, sidebar...) will rerender in sync.

I think this may introduce some small bugs we need to track and see how to fix (slot/fill maybe others).

That said, the feeling of responsiveness is highly improved with this PR. For instance you can try with this post https://gist.github.com/florianbrinkmann/4e9e4d23eaefb8b23484badddd848196 (convert it to blocks first) and compare the feeling with master.

Refs #11782