### PR TITLE
Performance: optimize the usage of getBlockIndex

### DIFF
--- a/packages/editor/src/components/block-actions/index.js
+++ b/packages/editor/src/components/block-actions/index.js
@@ -33,7 +33,6 @@ export default compose( [
 	withSelect( ( select, props ) => {
 		const {
 			getBlocksByClientId,
-			getBlockIndex,
 			getTemplateLock,
 			getBlockRootClientId,
 		} = select( 'core/editor' );
@@ -45,8 +44,6 @@ export default compose( [
 		const rootClientId = getBlockRootClientId( props.clientIds[ 0 ] );
 
 		return {
-			firstSelectedIndex: getBlockIndex( first( castArray( props.clientIds ) ), rootClientId ),
-			lastSelectedIndex: getBlockIndex( last( castArray( props.clientIds ) ), rootClientId ),
 			isLocked: !! getTemplateLock( rootClientId ),
 			blocks,
 			canDuplicate,
@@ -54,13 +51,11 @@ export default compose( [
 			extraProps: props,
 		};
 	} ),
-	withDispatch( ( dispatch, props ) => {
+	withDispatch( ( dispatch, props, { select } ) => {
 		const {
 			clientIds,
 			rootClientId,
 			blocks,
-			firstSelectedIndex,
-			lastSelectedIndex,
 			isLocked,
 			canDuplicate,
 		} = props;
@@ -78,6 +73,8 @@ export default compose( [
 					return;
 				}
 
+				const { getBlockIndex } = select( 'core/editor' );
+				const lastSelectedIndex = getBlockIndex( last( castArray( clientIds ) ), rootClientId );
 				const clonedBlocks = blocks.map( ( block ) => cloneBlock( block ) );
 				insertBlocks(
 					clonedBlocks,
@@ -98,11 +95,15 @@ export default compose( [
 			},
 			onInsertBefore() {
 				if ( ! isLocked ) {
+					const { getBlockIndex } = select( 'core/editor' );
+					const firstSelectedIndex = getBlockIndex( first( castArray( clientIds ) ), rootClientId );
 					insertDefaultBlock( {}, rootClientId, firstSelectedIndex );
 				}
 			},
 			onInsertAfter() {
 				if ( ! isLocked ) {
+					const { getBlockIndex } = select( 'core/editor' );
+					const lastSelectedIndex = getBlockIndex( last( castArray( clientIds ) ), rootClientId );
 					insertDefaultBlock( {}, rootClientId, lastSelectedIndex + 1 );
 				}
 			},

--- a/packages/editor/src/components/block-draggable/index.js
+++ b/packages/editor/src/components/block-draggable/index.js
@@ -33,8 +33,9 @@ const BlockDraggable = ( { children, clientId, rootClientId, blockElementId, ind
 
 export default withSelect( ( select, { clientId } ) => {
 	const { getBlockIndex, getBlockRootClientId } = select( 'core/editor' );
+	const rootClientId = getBlockRootClientId( clientId );
 	return {
-		index: getBlockIndex( clientId ),
-		rootClientId: getBlockRootClientId( clientId ),
+		index: getBlockIndex( clientId, rootClientId ),
+		rootClientId,
 	};
 } )( BlockDraggable );

--- a/packages/editor/src/components/block-drop-zone/index.js
+++ b/packages/editor/src/components/block-drop-zone/index.js
@@ -55,8 +55,9 @@ class BlockDropZone extends Component {
 	}
 
 	getInsertIndex( position ) {
-		const { index } = this.props;
-		if ( index !== undefined ) {
+		const { clientId, rootClientId, getBlockIndex } = this.props;
+		if ( clientId !== undefined ) {
+			const index = getBlockIndex( clientId, rootClientId );
 			return position.y === 'top' ? index : index + 1;
 		}
 	}
@@ -83,7 +84,7 @@ class BlockDropZone extends Component {
 	}
 
 	onDrop( event, position ) {
-		const { rootClientId: dstRootClientId, clientId: dstClientId, index: dstIndex, getClientIdsOfDescendants } = this.props;
+		const { rootClientId: dstRootClientId, clientId: dstClientId, getClientIdsOfDescendants, getBlockIndex } = this.props;
 		const { srcRootClientId, srcClientId, srcIndex, type } = parseDropEvent( event );
 
 		const isBlockDropType = ( dropType ) => dropType === 'block';
@@ -101,6 +102,7 @@ class BlockDropZone extends Component {
 			return;
 		}
 
+		const dstIndex = dstClientId ? getBlockIndex( dstClientId, dstRootClientId ) : undefined;
 		const positionIndex = this.getInsertIndex( position );
 		// If the block is kept at the same level and moved downwards,
 		// subtract to account for blocks shifting upward to occupy its old position.
@@ -154,10 +156,11 @@ export default compose(
 		};
 	} ),
 	withSelect( ( select, { rootClientId } ) => {
-		const { getClientIdsOfDescendants, getTemplateLock } = select( 'core/editor' );
+		const { getClientIdsOfDescendants, getTemplateLock, getBlockIndex } = select( 'core/editor' );
 		return {
 			isLocked: !! getTemplateLock( rootClientId ),
 			getClientIdsOfDescendants,
+			getBlockIndex,
 		};
 	} ),
 	withFilters( 'editor.BlockDropZone' )

--- a/packages/editor/src/components/block-list-appender/index.js
+++ b/packages/editor/src/components/block-list-appender/index.js
@@ -54,6 +54,7 @@ function BlockListAppender( {
 						disabled={ disabled }
 					/>
 				) }
+				isAppender
 			/>
 		</div>
 	);

--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -391,11 +391,9 @@ export class BlockListBlock extends Component {
 					// Empty paragraph blocks should always show up as unselected.
 					const showEmptyBlockSideInserter =
 						( isSelected || isHovered ) && isEmptyDefaultBlock && isValid;
-					const showSideInserter =
-						( isSelected || isHovered ) && isEmptyDefaultBlock;
 					const shouldAppearSelected =
 						! isFocusMode &&
-						! showSideInserter &&
+						! showEmptyBlockSideInserter &&
 						isSelected &&
 						! isTypingWithinBlock;
 					const shouldAppearHovered =
@@ -414,7 +412,7 @@ export class BlockListBlock extends Component {
 						! isFocusMode && isHovered && ! isEmptyDefaultBlock;
 					const shouldShowContextualToolbar =
 						! hasFixedToolbar &&
-						! showSideInserter &&
+						! showEmptyBlockSideInserter &&
 						( ( isSelected &&
 							( ! isTypingWithinBlock || isCaretWithinFormattedText ) ) ||
 							isFirstMultiSelected );
@@ -606,6 +604,7 @@ export class BlockListBlock extends Component {
 											position="top right"
 											onToggle={ this.selectOnOpen }
 											rootClientId={ rootClientId }
+											clientId={ clientId }
 										/>
 									</div>
 								</Fragment>

--- a/packages/editor/src/components/block-list/index.js
+++ b/packages/editor/src/components/block-list/index.js
@@ -212,7 +212,6 @@ class BlockList extends Component {
 						>
 							<BlockListBlock
 								clientId={ clientId }
-								index={ blockIndex }
 								blockRef={ this.setBlockRef }
 								onSelectionStart={ this.onSelectionStart }
 								rootClientId={ rootClientId }

--- a/packages/editor/src/components/block-list/insertion-point.js
+++ b/packages/editor/src/components/block-list/insertion-point.js
@@ -47,7 +47,7 @@ class BlockInsertionPoint extends Component {
 		const {
 			showInsertionPoint,
 			rootClientId,
-			insertIndex,
+			clientId,
 		} = this.props;
 
 		return (
@@ -73,7 +73,7 @@ class BlockInsertionPoint extends Component {
 				>
 					<Inserter
 						rootClientId={ rootClientId }
-						index={ insertIndex }
+						clientId={ clientId }
 					/>
 				</div>
 			</div>
@@ -87,13 +87,12 @@ export default withSelect( ( select, { clientId, rootClientId } ) => {
 		isBlockInsertionPointVisible,
 	} = select( 'core/editor' );
 	const blockIndex = getBlockIndex( clientId, rootClientId );
-	const insertIndex = blockIndex;
 	const insertionPoint = getBlockInsertionPoint();
 	const showInsertionPoint = (
 		isBlockInsertionPointVisible() &&
-		insertionPoint.index === insertIndex &&
+		insertionPoint.index === blockIndex &&
 		insertionPoint.rootClientId === rootClientId
 	);
 
-	return { showInsertionPoint, insertIndex };
+	return { showInsertionPoint };
 } )( BlockInsertionPoint );

--- a/packages/editor/src/components/default-block-appender/index.js
+++ b/packages/editor/src/components/default-block-appender/index.js
@@ -67,7 +67,7 @@ export function DefaultBlockAppender( {
 				value={ showPrompt ? value : '' }
 			/>
 			{ hovered && <InserterWithShortcuts rootClientId={ rootClientId } /> }
-			<Inserter rootClientId={ rootClientId } position="top right" />
+			<Inserter rootClientId={ rootClientId } position="top right" isAppender />
 		</div>
 	);
 }

--- a/packages/editor/src/components/default-block-appender/index.js
+++ b/packages/editor/src/components/default-block-appender/index.js
@@ -67,7 +67,7 @@ export function DefaultBlockAppender( {
 				value={ showPrompt ? value : '' }
 			/>
 			{ hovered && <InserterWithShortcuts rootClientId={ rootClientId } /> }
-			<Inserter position="top right" />
+			<Inserter rootClientId={ rootClientId } position="top right" />
 		</div>
 	);
 }

--- a/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/default-block-appender/test/__snapshots__/index.js.snap
@@ -25,6 +25,7 @@ exports[`DefaultBlockAppender should append a default block when input focused 1
     value="Start writing or type / to choose a block"
   />
   <WithSelect(IfCondition(Inserter))
+    isAppender={true}
     position="top right"
   />
 </div>
@@ -48,6 +49,7 @@ exports[`DefaultBlockAppender should match snapshot 1`] = `
     value="Start writing or type / to choose a block"
   />
   <WithSelect(IfCondition(Inserter))
+    isAppender={true}
     position="top right"
   />
 </div>
@@ -71,6 +73,7 @@ exports[`DefaultBlockAppender should optionally show without prompt 1`] = `
     value=""
   />
   <WithSelect(IfCondition(Inserter))
+    isAppender={true}
     position="top right"
   />
 </div>

--- a/packages/editor/src/components/inserter/index.js
+++ b/packages/editor/src/components/inserter/index.js
@@ -70,13 +70,14 @@ class Inserter extends Component {
 	 * @return {WPElement} Dropdown content element.
 	 */
 	renderContent( { onClose } ) {
-		const { rootClientId, clientId } = this.props;
+		const { rootClientId, clientId, isAppender } = this.props;
 
 		return (
 			<InserterMenu
 				onSelect={ onClose }
 				rootClientId={ rootClientId }
 				clientId={ clientId }
+				isAppender={ isAppender }
 			/>
 		);
 	}

--- a/packages/editor/src/components/inserter/index.js
+++ b/packages/editor/src/components/inserter/index.js
@@ -112,7 +112,7 @@ export default compose( [
 		return {
 			title: getEditedPostAttribute( 'title' ),
 			hasItems: hasInserterItems( rootClientId ),
-			rootClientId: rootClientId || getBlockInsertionPoint().rootClientId,
+			rootClientId,
 		};
 	} ),
 	ifCondition( ( { hasItems } ) => hasItems ),

--- a/packages/editor/src/components/inserter/index.js
+++ b/packages/editor/src/components/inserter/index.js
@@ -70,13 +70,13 @@ class Inserter extends Component {
 	 * @return {WPElement} Dropdown content element.
 	 */
 	renderContent( { onClose } ) {
-		const { rootClientId, index } = this.props;
+		const { rootClientId, clientId } = this.props;
 
 		return (
 			<InserterMenu
 				onSelect={ onClose }
 				rootClientId={ rootClientId }
-				index={ index }
+				clientId={ clientId }
 			/>
 		);
 	}
@@ -100,27 +100,19 @@ class Inserter extends Component {
 }
 
 export default compose( [
-	withSelect( ( select, { rootClientId, index } ) => {
+	withSelect( ( select, { rootClientId } ) => {
 		const {
 			getEditedPostAttribute,
 			getBlockInsertionPoint,
 			hasInserterItems,
 		} = select( 'core/editor' );
 
-		if ( rootClientId === undefined && index === undefined ) {
-			// Unless explicitly provided, the default insertion point provided
-			// by the store occurs immediately following the selected block.
-			// Otherwise, the default behavior for an undefined index is to
-			// append block to the end of the rootClientId context.
-			const insertionPoint = getBlockInsertionPoint();
-			( { rootClientId, index } = insertionPoint );
-		}
+		rootClientId = rootClientId || getBlockInsertionPoint().rootClientId;
 
 		return {
 			title: getEditedPostAttribute( 'title' ),
 			hasItems: hasInserterItems( rootClientId ),
-			rootClientId,
-			index,
+			rootClientId: rootClientId || getBlockInsertionPoint().rootClientId,
 		};
 	} ),
 	ifCondition( ( { hasItems } ) => hasItems ),

--- a/packages/editor/src/components/inserter/index.js
+++ b/packages/editor/src/components/inserter/index.js
@@ -103,16 +103,12 @@ export default compose( [
 	withSelect( ( select, { rootClientId } ) => {
 		const {
 			getEditedPostAttribute,
-			getBlockInsertionPoint,
 			hasInserterItems,
 		} = select( 'core/editor' );
-
-		rootClientId = rootClientId || getBlockInsertionPoint().rootClientId;
 
 		return {
 			title: getEditedPostAttribute( 'title' ),
 			hasItems: hasInserterItems( rootClientId ),
-			rootClientId,
 		};
 	} ),
 	ifCondition( ( { hasItems } ) => hasItems ),

--- a/packages/editor/src/components/inserter/menu.js
+++ b/packages/editor/src/components/inserter/menu.js
@@ -368,6 +368,10 @@ export default compose(
 			hideInsertionPoint,
 		} = dispatch( 'core/editor' );
 
+		// To avoid duplication, getInsertionPoint is extracted and used in two event handlers
+		// This breaks the withDispatch not containing any logic rule.
+		// Since it's a function only called when the event handlers are called,
+		// it's fine to extract it.
 		// eslint-disable-next-line no-restricted-syntax
 		function getInsertionPoint() {
 			const {

--- a/packages/editor/src/components/inserter/menu.js
+++ b/packages/editor/src/components/inserter/menu.js
@@ -380,7 +380,7 @@ export default compose(
 				getBlockSelectionEnd,
 				getBlockOrder,
 			} = select( 'core/editor' );
-			const { clientId, rootClientId } = ownProps;
+			const { clientId, rootClientId, isAppender } = ownProps;
 
 			// If the clientId is defined, we insert at the position of the block.
 			if ( clientId ) {
@@ -392,7 +392,7 @@ export default compose(
 
 			// If there a selected block, we insert after the selected block.
 			const end = getBlockSelectionEnd();
-			if ( end ) {
+			if ( ! isAppender && end ) {
 				const selectedBlockRootClientId = getBlockRootClientId( end ) || undefined;
 				return {
 					index: getBlockIndex( end, selectedBlockRootClientId ) + 1,
@@ -422,13 +422,14 @@ export default compose(
 				const {
 					getSelectedBlock,
 				} = select( 'core/editor' );
+				const { isAppender } = ownProps;
 				const { name, initialAttributes } = item;
-				const { index, rootClientId } = getInsertionPoint();
 				const selectedBlock = getSelectedBlock();
 				const insertedBlock = createBlock( name, initialAttributes );
-				if ( selectedBlock && isUnmodifiedDefaultBlock( selectedBlock ) ) {
+				if ( ! isAppender && selectedBlock && isUnmodifiedDefaultBlock( selectedBlock ) ) {
 					replaceBlocks( selectedBlock.clientId, insertedBlock );
 				} else {
+					const { index, rootClientId } = getInsertionPoint();
 					insertBlock( insertedBlock, index, rootClientId );
 				}
 

--- a/packages/editor/src/components/inserter/menu.js
+++ b/packages/editor/src/components/inserter/menu.js
@@ -375,26 +375,35 @@ export default compose(
 		// eslint-disable-next-line no-restricted-syntax
 		function getInsertionPoint() {
 			const {
-				getBlockInsertionPoint,
 				getBlockIndex,
+				getBlockRootClientId,
+				getBlockSelectionEnd,
+				getBlockOrder,
 			} = select( 'core/editor' );
 			const { clientId, rootClientId } = ownProps;
-			let insertionRootClientId, insertionIndex;
-			if ( rootClientId === undefined && clientId === undefined ) {
-				// Unless explicitly provided, the default insertion point provided
-				// by the store occurs immediately following the selected block.
-				// Otherwise, the default behavior for an undefined index is to
-				// append block to the end of the rootClientId context.
-				const insertionPoint = getBlockInsertionPoint();
-				( { rootClientId: insertionRootClientId, index: insertionIndex } = insertionPoint );
-			} else {
-				insertionIndex = getBlockIndex( clientId, rootClientId );
-				insertionRootClientId = rootClientId;
+
+			// If the clientId is defined, we insert at the position of the block.
+			if ( clientId ) {
+				return {
+					index: getBlockIndex( clientId, rootClientId ),
+					rootClientId,
+				};
 			}
 
+			// If there a selected block, we insert after the selected block.
+			const end = getBlockSelectionEnd();
+			if ( end ) {
+				const selectedBlockRootClientId = getBlockRootClientId( end ) || undefined;
+				return {
+					index: getBlockIndex( end, selectedBlockRootClientId ) + 1,
+					rootClientId: selectedBlockRootClientId,
+				};
+			}
+
+			// Otherwise, we insert at the end of the current rootClientId
 			return {
-				index: insertionIndex,
-				rootClientId: insertionRootClientId,
+				index: getBlockOrder( rootClientId ).length,
+				rootClientId,
 			};
 		}
 

--- a/packages/editor/src/components/inserter/menu.js
+++ b/packages/editor/src/components/inserter/menu.js
@@ -409,8 +409,10 @@ export default compose(
 				const {
 					replaceBlocks,
 					insertBlock,
-					getSelectedBlock,
 				} = dispatch( 'core/editor' );
+				const {
+					getSelectedBlock,
+				} = select( 'core/editor' );
 				const { name, initialAttributes } = item;
 				const { index, rootClientId } = getInsertionPoint();
 				const selectedBlock = getSelectedBlock();


### PR DESCRIPTION
refs #11782 closes #13349

When adding blocks or pressing "Enter", the index of the blocks following the insertion point changes which means all the blocks following this block rerender because they have the `order` as a prop.

In this PR, I move the `getBlockIndex` selector usage to the event handlers instead of computing it in `withSelect` and passing it as a prop to the component to avoid heavy rerenders when pressing "Enter".