### PR TITLE
Avoid rerendering all the blocks when selecting a block

### DIFF
--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -214,7 +214,6 @@ export class BlockListBlock extends Component {
 			isHovered ||
 			isPartOfMultiSelection ||
 			isSelected ||
-			this.props.isMultiSelecting ||
 			this.hadTouchStart
 		) {
 			return;
@@ -376,7 +375,6 @@ export class BlockListBlock extends Component {
 						isFirstMultiSelected,
 						isTypingWithinBlock,
 						isCaretWithinFormattedText,
-						isMultiSelecting,
 						isEmptyDefaultBlock,
 						isMovable,
 						isParentOfSelectedBlock,
@@ -386,7 +384,7 @@ export class BlockListBlock extends Component {
 						isValid,
 						attributes,
 					} = this.props;
-					const isHovered = this.state.isHovered && ! isMultiSelecting;
+					const isHovered = this.state.isHovered && ! isPartOfMultiSelection;
 					const blockType = getBlockType( name );
 					// translators: %s: Type of block (i.e. Text, Image etc)
 					const blockLabel = sprintf( __( 'Block: %s' ), blockType.title );
@@ -416,7 +414,6 @@ export class BlockListBlock extends Component {
 						! isFocusMode &&
 						( isSelected || hoverArea === 'left' ) &&
 						! showEmptyBlockSideInserter &&
-						! isMultiSelecting &&
 						! isPartOfMultiSelection &&
 						! isTypingWithinBlock;
 					const shouldShowBreadcrumb =
@@ -635,7 +632,6 @@ const applyWithSelect = withSelect(
 			isAncestorMultiSelected,
 			isBlockMultiSelected,
 			isFirstMultiSelectedBlock,
-			isMultiSelecting,
 			isTyping,
 			isCaretWithinFormattedText,
 			getBlockIndex,
@@ -662,7 +658,6 @@ const applyWithSelect = withSelect(
 			isPartOfMultiSelection:
 				isBlockMultiSelected( clientId ) || isAncestorMultiSelected( clientId ),
 			isFirstMultiSelected: isFirstMultiSelectedBlock( clientId ),
-			isMultiSelecting: isMultiSelecting(),
 			// We only care about this prop when the block is selected
 			// Thus to avoid unnecessary rerenders we avoid updating the prop if the block is not selected.
 			isTypingWithinBlock:


### PR DESCRIPTION
refs #11782

When we click a block to select it, sometimes (often) we move the mouse a little bit like 1px or something, this has the effect of changing the value of the `isMultiselecting` prop back and forth. And since this prop is used in the `BlockListBlock` component, this means all the blocks rerender twice.

With this PR, I'm removing this prop entirely. It was only used to ensure we don't show the hover state "movers, label and border" when we're currently multi-selecting blocks. While the logic is correct, I think it can be approached by checking that the block is part of the multi-selection `isPartOfMultiselection` prop. 

**Testing instructions**

 - Check that when multi-selecting, the behavior is not changed too much, we don't have too much lingering borders, labels and movers around hovered blocks.