### PR TITLE
<CategorySelect> support post_tags and hierarchical = false taxonomy.

### DIFF
--- a/packages/components/src/query-controls/terms.js
+++ b/packages/components/src/query-controls/terms.js
@@ -11,7 +11,13 @@ import { groupBy } from 'lodash';
  * @return {Array} Array of terms in tree format.
  */
 export function buildTermsTree( flatTerms ) {
-	const termsByParent = groupBy( flatTerms, 'parent' );
+	const flatTermsWithParent = flatTerms.map( ( term ) => {
+		return {
+			parent: 0,
+			...term,
+		};
+	} );
+	const termsByParent = groupBy( flatTermsWithParent, 'parent' );
 	const fillWithChildren = ( terms ) => {
 		return terms.map( ( term ) => {
 			const children = termsByParent[ term.id ];

--- a/packages/components/src/query-controls/terms.js
+++ b/packages/components/src/query-controls/terms.js
@@ -11,13 +11,18 @@ import { groupBy } from 'lodash';
  * @return {Array} Array of terms in tree format.
  */
 export function buildTermsTree( flatTerms ) {
-	const flatTermsWithParent = flatTerms.map( ( term ) => {
+	const flatTermsWithParentAndChildren = flatTerms.map( ( term ) => {
 		return {
-			parent: 0,
+			children: [],
+			parent: null,
 			...term,
 		};
 	} );
-	const termsByParent = groupBy( flatTermsWithParent, 'parent' );
+
+	const termsByParent = groupBy( flatTermsWithParentAndChildren, 'parent' );
+	if ( termsByParent.null && termsByParent.null.length ) {
+		return flatTermsWithParentAndChildren;
+	}
 	const fillWithChildren = ( terms ) => {
 		return terms.map( ( term ) => {
 			const children = termsByParent[ term.id ];

--- a/packages/components/src/query-controls/test/terms.js
+++ b/packages/components/src/query-controls/test/terms.js
@@ -1,0 +1,61 @@
+/**
+ * Internal dependencies
+ */
+import { buildTermsTree } from '../terms';
+
+describe( 'buildTermsTree()', () => {
+	it( 'Should return same array as input with zero parentand empty children added if parent is never specified.', () => {
+		const input = Object.freeze( [
+			{ id: 2232, dummy: true },
+			{ id: 2245, dummy: true },
+		] );
+		const output = Object.freeze( [
+			{ id: 2232, parent: 0, children: [], dummy: true },
+			{ id: 2245, parent: 0, children: [], dummy: true },
+		] );
+		const termsTreem = buildTermsTree( input );
+		expect( termsTreem ).toEqual( output );
+	} );
+	it( 'Should return same array as input with empty children added if all the elements are top level', () => {
+		const input = Object.freeze( [
+			{ id: 2232, parent: 0, dummy: true },
+			{ id: 2245, parent: 0, dummy: false },
+		] );
+		const output = [
+			{ id: 2232, parent: 0, children: [], dummy: true },
+			{ id: 2245, parent: 0, children: [], dummy: false },
+		];
+		const termsTreem = buildTermsTree( input );
+		expect( termsTreem ).toEqual( output );
+	} );
+	it( 'Should return element with its child if a child exists', () => {
+		const input = Object.freeze( [
+			{ id: 2232, parent: 0 },
+			{ id: 2245, parent: 2232 },
+		] );
+		const output = [
+			{ id: 2232, parent: 0, children: [
+				{ id: 2245, parent: 2232, children: [] },
+			] },
+		];
+		const termsTreem = buildTermsTree( input );
+		expect( termsTreem ).toEqual( output );
+	} );
+	it( 'Should return elements with multiple children and elements with no children', () => {
+		const input = Object.freeze( [
+			{ id: 2232, parent: 0 },
+			{ id: 2245, parent: 2232 },
+			{ id: 2249, parent: 0 },
+			{ id: 2246, parent: 2232 },
+		] );
+		const output = [
+			{ id: 2232, parent: 0, children: [
+				{ id: 2245, parent: 2232, children: [] },
+				{ id: 2246, parent: 2232, children: [] },
+			] },
+			{ id: 2249, parent: 0, children: [] },
+		];
+		const termsTreem = buildTermsTree( input );
+		expect( termsTreem ).toEqual( output );
+	} );
+} );

--- a/packages/components/src/query-controls/test/terms.js
+++ b/packages/components/src/query-controls/test/terms.js
@@ -4,14 +4,14 @@
 import { buildTermsTree } from '../terms';
 
 describe( 'buildTermsTree()', () => {
-	it( 'Should return same array as input with zero parentand empty children added if parent is never specified.', () => {
+	it( 'Should return same array as input with null parent and empty children added if parent is never specified.', () => {
 		const input = Object.freeze( [
 			{ id: 2232, dummy: true },
 			{ id: 2245, dummy: true },
 		] );
 		const output = Object.freeze( [
-			{ id: 2232, parent: 0, children: [], dummy: true },
-			{ id: 2245, parent: 0, children: [], dummy: true },
+			{ id: 2232, parent: null, children: [], dummy: true },
+			{ id: 2245, parent: null, children: [], dummy: true },
 		] );
 		const termsTreem = buildTermsTree( input );
 		expect( termsTreem ).toEqual( output );

--- a/packages/editor/src/utils/terms.js
+++ b/packages/editor/src/utils/terms.js
@@ -11,7 +11,13 @@ import { groupBy } from 'lodash';
  * @return {Array} Array of terms in tree format.
  */
 export function buildTermsTree( flatTerms ) {
-	const termsByParent = groupBy( flatTerms, 'parent' );
+	const flatTermsWithParent = flatTerms.map( ( term ) => {
+		return {
+			parent: 0,
+			...term,
+		};
+	} );
+	const termsByParent = groupBy( flatTermsWithParent, 'parent' );
 	const fillWithChildren = ( terms ) => {
 		return terms.map( ( term ) => {
 			const children = termsByParent[ term.id ];

--- a/packages/editor/src/utils/terms.js
+++ b/packages/editor/src/utils/terms.js
@@ -11,13 +11,18 @@ import { groupBy } from 'lodash';
  * @return {Array} Array of terms in tree format.
  */
 export function buildTermsTree( flatTerms ) {
-	const flatTermsWithParent = flatTerms.map( ( term ) => {
+	const flatTermsWithParentAndChildren = flatTerms.map( ( term ) => {
 		return {
-			parent: 0,
+			children: [],
+			parent: null,
 			...term,
 		};
 	} );
-	const termsByParent = groupBy( flatTermsWithParent, 'parent' );
+
+	const termsByParent = groupBy( flatTermsWithParentAndChildren, 'parent' );
+	if ( termsByParent.null && termsByParent.null.length ) {
+		return flatTermsWithParentAndChildren;
+	}
 	const fillWithChildren = ( terms ) => {
 		return terms.map( ( term ) => {
 			const children = termsByParent[ term.id ];

--- a/packages/editor/src/utils/test/terms.js
+++ b/packages/editor/src/utils/test/terms.js
@@ -4,14 +4,14 @@
 import { buildTermsTree } from '../terms';
 
 describe( 'buildTermsTree()', () => {
-	it( 'Should return same array as input with zero parentand empty children added if parent is never specified.', () => {
+	it( 'Should return same array as input with null parent and empty children added if parent is never specified.', () => {
 		const input = Object.freeze( [
 			{ id: 2232, dummy: true },
 			{ id: 2245, dummy: true },
 		] );
 		const output = Object.freeze( [
-			{ id: 2232, parent: 0, children: [], dummy: true },
-			{ id: 2245, parent: 0, children: [], dummy: true },
+			{ id: 2232, parent: null, children: [], dummy: true },
+			{ id: 2245, parent: null, children: [], dummy: true },
 		] );
 		const termsTreem = buildTermsTree( input );
 		expect( termsTreem ).toEqual( output );

--- a/packages/editor/src/utils/test/terms.js
+++ b/packages/editor/src/utils/test/terms.js
@@ -4,10 +4,17 @@
 import { buildTermsTree } from '../terms';
 
 describe( 'buildTermsTree()', () => {
-	it( 'Should return empty array if parent is never specified.', () => {
-		const input = Object.freeze( [ { term: 2232 }, { term: 2245 } ] );
+	it( 'Should return same array as input with zero parentand empty children added if parent is never specified.', () => {
+		const input = Object.freeze( [
+			{ id: 2232, dummy: true },
+			{ id: 2245, dummy: true },
+		] );
+		const output = Object.freeze( [
+			{ id: 2232, parent: 0, children: [], dummy: true },
+			{ id: 2245, parent: 0, children: [], dummy: true },
+		] );
 		const termsTreem = buildTermsTree( input );
-		expect( termsTreem ).toEqual( [] );
+		expect( termsTreem ).toEqual( output );
 	} );
 	it( 'Should return same array as input with empty children added if all the elements are top level', () => {
 		const input = Object.freeze( [


### PR DESCRIPTION
## Description
`<CategorySelect>` support custom taxonomy with `hierarchical = true` now. but not working 
`hierarchical = false`. fixed it.

## How has this been tested?

Add this code. and check `core/latest-posts` block.

```php
add_filter( 'register_taxonomy_args', function ( $args, $taxonomy ) {
	if ( $taxonomy === 'category' ) {
		$args['hierarchical'] = false;
	}
	return $args;
}, 10, 2 );
```

## Types of changes
New feature (non-breaking change which adds functionality) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
