### PR TITLE
docs: added correct name for font site 50

### DIFF
--- a/docs/designers-developers/developers/themes/theme-support.md
+++ b/docs/designers-developers/developers/themes/theme-support.md
@@ -137,22 +137,22 @@ Blocks may allow the user to configure the font sizes they use, e.g., the paragr
 ```php
 add_theme_support( 'editor-font-sizes', array(
 	array(
-		'name' => __( 'small', 'themeLangDomain' ),
+		'name' => __( 'Small', 'themeLangDomain' ),
 		'size' => 12,
 		'slug' => 'small'
 	),
 	array(
-		'name' => __( 'regular', 'themeLangDomain' ),
+		'name' => __( 'Normal', 'themeLangDomain' ),
 		'size' => 16,
-		'slug' => 'regular'
+		'slug' => 'normal'
 	),
 	array(
-		'name' => __( 'large', 'themeLangDomain' ),
+		'name' => __( 'Large', 'themeLangDomain' ),
 		'size' => 36,
 		'slug' => 'large'
 	),
 	array(
-		'name' => __( 'huge', 'themeLangDomain' ),
+		'name' => __( 'Huge', 'themeLangDomain' ),
 		'size' => 50,
 		'slug' => 'huge'
 	)

--- a/docs/designers-developers/developers/themes/theme-support.md
+++ b/docs/designers-developers/developers/themes/theme-support.md
@@ -152,9 +152,9 @@ add_theme_support( 'editor-font-sizes', array(
 		'slug' => 'large'
 	),
 	array(
-		'name' => __( 'larger', 'themeLangDomain' ),
+		'name' => __( 'huge', 'themeLangDomain' ),
 		'size' => 50,
-		'slug' => 'larger'
+		'slug' => 'huge'
 	)
 ) );
 ```


### PR DESCRIPTION
In Theme Support you will find section called 'Block Font Sizes'; initially there were two sizes of 36 and 50 defined under one common name e.g. Large. Now changes has been made to display 'Large' for size of 36 and 'Huge' for size of 50.