### PR TITLE
Performance: Optimize the isEditedPostEmpty selector

### DIFF
--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -454,18 +454,18 @@ export function isEditedPostSaveable( state ) {
  * @return {boolean} Whether post has content.
  */
 export function isEditedPostEmpty( state ) {
-	const rootBlocks = getBlockOrder( state );
+	const rootClientIds = getBlockOrder( state );
 
 	// While the condition of truthy content string is sufficient to determine
 	// emptiness, testing saveable blocks length is a trivial operation. Since
 	// this function can be called frequently, optimize for the fast case as a
 	// condition of the mere existence of blocks. Note that the value of edited
 	// content is used in place of blocks, thus allowed to fall through.
-	if ( rootBlocks.length && ! ( 'content' in getPostEdits( state ) ) ) {
+	if ( rootClientIds.length && ! ( 'content' in getPostEdits( state ) ) ) {
 		// Pierce the abstraction of the serializer in knowing that blocks are
 		// joined with with newlines such that even if every individual block
 		// produces an empty save result, the serialized content is non-empty.
-		if ( rootBlocks.length > 1 ) {
+		if ( rootClientIds.length > 1 ) {
 			return false;
 		}
 
@@ -474,7 +474,7 @@ export function isEditedPostEmpty( state ) {
 		// to save. In the case of a single freeform block, fall through to the
 		// full serialize. Otherwise, the single block is assumed non-empty by
 		// virtue of its comment delimiters.
-		if ( getBlockName( state, rootBlocks[ 0 ] ) !== getFreeformContentHandlerName() ) {
+		if ( getBlockName( state, rootClientIds[ 0 ] ) !== getFreeformContentHandlerName() ) {
 			return false;
 		}
 	}

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -454,18 +454,18 @@ export function isEditedPostSaveable( state ) {
  * @return {boolean} Whether post has content.
  */
 export function isEditedPostEmpty( state ) {
-	const blocks = getBlocksForSerialization( state );
+	const rootBlocks = getBlockOrder( state );
 
 	// While the condition of truthy content string is sufficient to determine
 	// emptiness, testing saveable blocks length is a trivial operation. Since
 	// this function can be called frequently, optimize for the fast case as a
 	// condition of the mere existence of blocks. Note that the value of edited
 	// content is used in place of blocks, thus allowed to fall through.
-	if ( blocks.length && ! ( 'content' in getPostEdits( state ) ) ) {
+	if ( rootBlocks.length && ! ( 'content' in getPostEdits( state ) ) ) {
 		// Pierce the abstraction of the serializer in knowing that blocks are
 		// joined with with newlines such that even if every individual block
 		// produces an empty save result, the serialized content is non-empty.
-		if ( blocks.length > 1 ) {
+		if ( rootBlocks.length > 1 ) {
 			return false;
 		}
 
@@ -474,7 +474,7 @@ export function isEditedPostEmpty( state ) {
 		// to save. In the case of a single freeform block, fall through to the
 		// full serialize. Otherwise, the single block is assumed non-empty by
 		// virtue of its comment delimiters.
-		if ( blocks[ 0 ].name !== getFreeformContentHandlerName() ) {
+		if ( getBlockName( state, rootBlocks[ 0 ] ) !== getFreeformContentHandlerName() ) {
 			return false;
 		}
 	}

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -10,7 +10,6 @@ import {
 	registerBlockType,
 	unregisterBlockType,
 	createBlock,
-	getBlockTypes,
 	getDefaultBlockName,
 	setDefaultBlockName,
 	setFreeformContentHandlerName,
@@ -89,6 +88,7 @@ const {
 	didPostSaveRequestSucceed,
 	didPostSaveRequestFail,
 	getSuggestedPostFormat,
+	getBlocksForSerialization,
 	getEditedPostContent,
 	__experimentalGetReusableBlock: getReusableBlock,
 	__experimentalIsSavingReusableBlock: isSavingReusableBlock,
@@ -171,7 +171,20 @@ describe( 'selectors', () => {
 			},
 		} );
 
+		registerBlockType( 'core/test-default', {
+			category: 'common',
+			title: 'default',
+			attributes: {
+				modified: {
+					type: 'boolean',
+					default: false,
+				},
+			},
+			save: () => null,
+		} );
+
 		setFreeformContentHandlerName( 'core/test-freeform' );
+		setDefaultBlockName( 'core/test-default' );
 
 		cachedSelectors.forEach( ( { clear } ) => clear() );
 	} );
@@ -182,8 +195,10 @@ describe( 'selectors', () => {
 		unregisterBlockType( 'core/test-block-b' );
 		unregisterBlockType( 'core/test-block-c' );
 		unregisterBlockType( 'core/test-freeform' );
+		unregisterBlockType( 'core/test-default' );
 
 		setFreeformContentHandlerName( undefined );
+		setDefaultBlockName( undefined );
 	} );
 
 	describe( 'hasEditorUndo', () => {
@@ -3995,33 +4010,109 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'getEditedPostContent', () => {
-		let originalDefaultBlockName;
-
-		beforeAll( () => {
-			originalDefaultBlockName = getDefaultBlockName();
-
-			registerBlockType( 'core/default', {
-				category: 'common',
-				title: 'default',
-				attributes: {
-					modified: {
-						type: 'boolean',
-						default: false,
+	describe( 'getBlocksForSerialization', () => {
+		it( 'should return blocks', () => {
+			const state = {
+				editor: {
+					present: {
+						blocks: {
+							byClientId: {
+								block1: {
+									clientId: 'block1',
+									name: 'core/test-default',
+								},
+								block2: {
+									clientId: 'block2',
+									name: 'core/heading',
+								},
+							},
+							attributes: {
+								block1: {
+									modified: false,
+								},
+								block2: {},
+							},
+							order: {
+								'': [ 'block1', 'block2' ],
+							},
+						},
+						edits: {},
 					},
 				},
-				save: () => null,
-			} );
-			setDefaultBlockName( 'core/default' );
+				initialEdits: {},
+				currentPost: {},
+			};
+
+			expect( getBlocksForSerialization( state ) ).toEqual( [
+				{ clientId: 'block1', name: 'core/test-default', attributes: { modified: false }, innerBlocks: [] },
+				{ clientId: 'block2', name: 'core/heading', attributes: {}, innerBlocks: [] },
+			] );
 		} );
 
-		afterAll( () => {
-			setDefaultBlockName( originalDefaultBlockName );
-			getBlockTypes().forEach( ( block ) => {
-				unregisterBlockType( block.name );
-			} );
+		it( 'should return an empty set if content is a single unmodified default block', () => {
+			const state = {
+				editor: {
+					present: {
+						blocks: {
+							byClientId: {
+								block1: {
+									clientId: 'block1',
+									name: 'core/test-default',
+								},
+							},
+							attributes: {
+								block1: {
+									modified: false,
+								},
+							},
+							order: {
+								'': [ 'block1' ],
+							},
+						},
+						edits: {},
+					},
+				},
+				initialEdits: {},
+				currentPost: {},
+			};
+
+			expect( getBlocksForSerialization( state ) ).toEqual( [] );
 		} );
 
+		it( 'should return a set including a single modified default block', () => {
+			const state = {
+				editor: {
+					present: {
+						blocks: {
+							byClientId: {
+								block1: {
+									clientId: 'block1',
+									name: 'core/test-default',
+								},
+							},
+							attributes: {
+								block1: {
+									modified: true,
+								},
+							},
+							order: {
+								'': [ 'block1' ],
+							},
+						},
+						edits: {},
+					},
+				},
+				initialEdits: {},
+				currentPost: {},
+			};
+
+			expect( getBlocksForSerialization( state ) ).toEqual( [
+				{ clientId: 'block1', name: 'core/test-default', attributes: { modified: true }, innerBlocks: [] },
+			] );
+		} );
+	} );
+
+	describe( 'getEditedPostContent', () => {
 		it( 'defers to returning an edited post attribute', () => {
 			const block = createBlock( 'core/block' );
 
@@ -4205,7 +4296,7 @@ describe( 'selectors', () => {
 
 			const content = getEditedPostContent( state );
 
-			expect( content ).toBe( '<!-- wp:default {\"modified\":true} /-->' );
+			expect( content ).toBe( '<!-- wp:test-default {\"modified\":true} /-->' );
 		} );
 	} );
 
@@ -4643,6 +4734,7 @@ describe( 'selectors', () => {
 				'core/block/1',
 				'core/test-block-b',
 				'core/test-freeform',
+				'core/test-default',
 				'core/test-block-a',
 			] );
 		} );
@@ -4701,6 +4793,7 @@ describe( 'selectors', () => {
 			expect( firstBlockFirstCall.map( ( item ) => item.id ) ).toEqual( [
 				'core/test-block-b',
 				'core/test-freeform',
+				'core/test-default',
 				'core/test-block-a',
 				'core/block/1',
 				'core/block/2',
@@ -4711,6 +4804,7 @@ describe( 'selectors', () => {
 			expect( secondBlockFirstCall.map( ( item ) => item.id ) ).toEqual( [
 				'core/test-block-b',
 				'core/test-freeform',
+				'core/test-default',
 				'core/test-block-a',
 				'core/block/1',
 				'core/block/2',

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -1569,6 +1569,41 @@ describe( 'selectors', () => {
 			expect( isEditedPostEmpty( state ) ).toBe( false );
 		} );
 
+		it( 'should account for filtering logic of getBlocksForSerialization', () => {
+			// Note: As an optimization, isEditedPostEmpty avoids using the
+			// getBlocksForSerialization selector and instead makes assumptions
+			// about its filtering. The behavior should still be reflected.
+			//
+			// See: https://github.com/WordPress/gutenberg/pull/13086
+			const state = {
+				editor: {
+					present: {
+						blocks: {
+							byClientId: {
+								block1: {
+									clientId: 'block1',
+									name: 'core/test-default',
+								},
+							},
+							attributes: {
+								block1: {
+									modified: false,
+								},
+							},
+							order: {
+								'': [ 'block1' ],
+							},
+						},
+						edits: {},
+					},
+				},
+				initialEdits: {},
+				currentPost: {},
+			};
+
+			expect( isEditedPostEmpty( state ) ).toBe( true );
+		} );
+
 		it( 'should return true if blocks, but empty content edit', () => {
 			const state = {
 				editor: {


### PR DESCRIPTION
Refs #11782 

The `isEditedPostEmpty` is a selector called on each key stroke, so optimizing it has an impact on the feeling of smoothness while typing in long posts, in this PR I avoid using the slow `getBlocks` selector in the `isEditedPostEmpty` selector.

Noting that I'm making this optimization because when I tried merging a lot of pending performance PRs together, this selector was taking 1/2 of the key strike time in a long post.

In the current state of master, I'm noticing a `13%` improvement while typing but I expect this number to be way bigger once all the other PRs are merged.
