### PR TITLE
Convert Gutenberg word use away from referring to the editor

### DIFF
--- a/docs/designers-developers/developers/README.md
+++ b/docs/designers-developers/developers/README.md
@@ -1,10 +1,10 @@
 # Developer Documentation
 
-Gutenberg is highly flexible, like most of WordPress. You can build custom blocks, modify the editor's appearance, add special plugins, and much more.
+The new editor is highly flexible, like most of WordPress. You can build custom blocks, modify the editor's appearance, add special plugins, and much more.
 
 ## Creating Blocks
 
-Gutenberg is about blocks, and the main extensibility API of Gutenberg is the Block API. It allows you to create your own static blocks, dynamic blocks rendered on the server and also blocks capable of saving data to Post Meta for more structured content.
+The editor is about blocks, and the main extensibility API is the Block API. It allows you to create your own static blocks, dynamic blocks rendered on the server and also blocks capable of saving data to Post Meta for more structured content.
 
 If you want to learn more about block creation, the [Blocks Tutorial](../../../docs/designers-developers/developers/tutorials/block-tutorial/readme.md) is the best place to start.
 
@@ -24,9 +24,9 @@ You can also filter certain aspects of the editor; this is documented on the [Ed
 
 ## Meta Boxes
 
-**Porting PHP meta boxes to blocks and Gutenberg plugins is highly encouraged!**
+**Porting PHP meta boxes to blocks or sidebar plugins is highly encouraged!**
 
-Discover how [Meta Box](../../../docs/designers-developers/developers/backward-compatibility/meta-box.md) support works in Gutenberg.
+Discover how [Meta Box](../../../docs/designers-developers/developers/backward-compatibility/meta-box.md) support works in the new editor.
 
 ## Theme Support
 

--- a/docs/designers-developers/developers/backward-compatibility/deprecations.md
+++ b/docs/designers-developers/developers/backward-compatibility/deprecations.md
@@ -1,6 +1,6 @@
 # Deprecations
 
-Gutenberg's deprecation policy is intended to support backward compatibility for releases, when possible. The current deprecations are listed below and are grouped by _the version at which they will be removed completely_. If your plugin depends on these behaviors, you must update to the recommended alternative before the noted version.
+The Gutenberg project's deprecation policy is intended to support backward compatibility for releases, when possible. The current deprecations are listed below and are grouped by _the version at which they will be removed completely_. If your plugin depends on these behaviors, you must update to the recommended alternative before the noted version.
 
 ## 4.5.0
 - `Dropdown.refresh()` has been deprecated as the contained `Popover` is now automatically refreshed.

--- a/docs/designers-developers/developers/block-api/README.md
+++ b/docs/designers-developers/developers/block-api/README.md
@@ -1,6 +1,6 @@
 # Block API Reference
 
-Blocks are the fundamental element of the Gutenberg editor. They are the primary way in which plugins and themes can register their own functionality and extend the capabilities of the editor.
+Blocks are the fundamental element of the editor. They are the primary way in which plugins and themes can register their own functionality and extend the capabilities of the editor.
 
 ## Registering a block
 

--- a/docs/designers-developers/developers/filters/README.md
+++ b/docs/designers-developers/developers/filters/README.md
@@ -1,7 +1,7 @@
 # Filter Reference
 
-[Hooks](https://developer.wordpress.org/plugins/hooks/) are a way for one piece of code to interact/modify another piece of code. They provide one way for plugins and themes interact with Gutenberg, but they’re also used extensively by WordPress Core itself.
+[Hooks](https://developer.wordpress.org/plugins/hooks/) are a way for one piece of code to interact/modify another piece of code. They provide one way for plugins and themes interact with the editor, but they’re also used extensively by WordPress Core itself.
 
-There are two types of hooks: [Actions](https://developer.wordpress.org/plugins/hooks/actions/) and [Filters](https://developer.wordpress.org/plugins/hooks/filters/). In addition to PHP actions and filters, Gutenberg also provides a mechanism for registering and executing hooks in JavaScript. This functionality is also available on npm as the [@wordpress/hooks](https://www.npmjs.com/package/@wordpress/hooks) package, for general purpose use.
+There are two types of hooks: [Actions](https://developer.wordpress.org/plugins/hooks/actions/) and [Filters](https://developer.wordpress.org/plugins/hooks/filters/). In addition to PHP actions and filters, WordPress also provides a mechanism for registering and executing hooks in JavaScript. This functionality is also available on npm as the [@wordpress/hooks](https://www.npmjs.com/package/@wordpress/hooks) package, for general purpose use.
 
 You can also learn more about both APIs: [PHP](https://codex.wordpress.org/Plugin_API/) and [JavaScript](https://github.com/WordPress/packages/tree/master/packages/hooks).

--- a/docs/designers-developers/developers/filters/autocomplete-filters.md
+++ b/docs/designers-developers/developers/filters/autocomplete-filters.md
@@ -1,6 +1,6 @@
 # Autocomplete
 
-Gutenberg provides an `editor.Autocomplete.completers` filter for extending and overriding the list of autocompleters used by blocks.
+The `editor.Autocomplete.completers` filter is for extending and overriding the list of autocompleters used by blocks.
 
 The `Autocomplete` component found in `@wordpress/editor` applies this filter. The `@wordpress/components` package provides the foundational `Autocomplete` component that does not apply such a filter, but blocks should generally use the component provided by `@wordpress/editor`.
 

--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -1,6 +1,6 @@
 # Block Filters
 
-To modify the behavior of existing blocks, Gutenberg exposes several APIs:
+To modify the behavior of existing blocks, WordPress exposes several APIs:
 
 ### Block Style Variations
 

--- a/docs/designers-developers/developers/filters/editor-filters.md
+++ b/docs/designers-developers/developers/filters/editor-filters.md
@@ -1,6 +1,6 @@
 # Editor Filters (Experimental)
 
-To modify the behavior of the editor experience, Gutenberg exposes the following Filters:
+To modify the behavior of the editor experience, the following Filters are exposed:
 
 ### `editor.PostFeaturedImage.imageSize`
 

--- a/docs/designers-developers/developers/internationalization.md
+++ b/docs/designers-developers/developers/internationalization.md
@@ -1,6 +1,6 @@
 # Internationalization
 
-This document aims to give an overview of the possibilities for both internationalization and localization when developing with Gutenberg.
+This document aims to give an overview of the possibilities for both internationalization and localization when developing with WordPress.
 
 ## PHP
 
@@ -13,7 +13,7 @@ For years, WordPress has been providing the necessary tools and functions to int
 - `_e( 'Hello World', 'my-text-domain' )`: Translate and print a certain string.
 - `esc_html__( 'Hello World', 'my-text-domain' )`: Translate a certain string and escape it for safe use in HTML output.
 - `esc_html_e( 'Hello World', 'my-text-domain' )`: Translate a certain string, escape it for safe use in HTML output, and print it.
-- `_n( '%s Comment', '%s Comments', $number, 'my-text-domain' )`: Translate and retrieve the singular or plural form based on the supplied number.  
+- `_n( '%s Comment', '%s Comments', $number, 'my-text-domain' )`: Translate and retrieve the singular or plural form based on the supplied number.
   Usually used in combination with `sprintf()` and `number_format_i18n()`.
 
 ## JavaScript

--- a/docs/designers-developers/developers/packages.md
+++ b/docs/designers-developers/developers/packages.md
@@ -1,6 +1,6 @@
 # Packages
 
-Gutenberg exposes a list of JavaScript packages and tools for WordPress development.
+WordPress exposes a list of JavaScript packages and tools for WordPress development.
 
 ## Using the packages via WordPress global
 

--- a/docs/designers-developers/readme.md
+++ b/docs/designers-developers/readme.md
@@ -1,6 +1,6 @@
 # Designer & Developer Handbook
 
-Gutenberg is a transformation of the WordPress editor for working with content.
+The Gutenberg project is transforming the way content is created on WordPress. A block editor was the first product launched creating a new methodology for working with content. This handbook provides documentation for how designers and developers can extend the editor.
 
 ![Gutenberg Demo](https://cldup.com/kZXGDcGPMU.gif)
 


### PR DESCRIPTION
## Description

An initial pass of converting the use of "Gutenberg" to refer to the project and not the editor.
The documentation is going to take several passes to update the usage to be consistent.

## Types of changes

Documentation.
