### PR TITLE
Avoid PHP notices in e2e tests plugins

### DIFF
--- a/test/e2e/test-plugins/align-hook.php
+++ b/test/e2e/test-plugins/align-hook.php
@@ -7,15 +7,22 @@
  * @package gutenberg-test-align-hook
  */
 
-wp_enqueue_script(
-	'gutenberg-test-align-hook',
-	plugins_url( 'align-hook/index.js', __FILE__ ),
-	array(
-		'wp-blocks',
-		'wp-element',
-		'wp-editor',
-		'wp-i18n',
-	),
-	filemtime( plugin_dir_path( __FILE__ ) . 'align-hook/index.js' ),
-	true
-);
+/**
+ * Registers a custom script for the plugin.
+ */
+function enqueue_align_plugin_script() {
+	wp_enqueue_script(
+		'gutenberg-test-align-hook',
+		plugins_url( 'align-hook/index.js', __FILE__ ),
+		array(
+			'wp-blocks',
+			'wp-element',
+			'wp-editor',
+			'wp-i18n',
+		),
+		filemtime( plugin_dir_path( __FILE__ ) . 'align-hook/index.js' ),
+		true
+	);
+}
+
+add_action( 'init', 'enqueue_align_plugin_script' );

--- a/test/e2e/test-plugins/block-icons.php
+++ b/test/e2e/test-plugins/block-icons.php
@@ -7,17 +7,24 @@
  * @package gutenberg-test-block-icons
  */
 
-wp_enqueue_script(
-	'gutenberg-test-block-icons',
-	plugins_url( 'block-icons/index.js', __FILE__ ),
-	array(
-		'wp-blocks',
-		'wp-components',
-		'wp-element',
-		'wp-editor',
-		'wp-hooks',
-		'wp-i18n',
-	),
-	filemtime( plugin_dir_path( __FILE__ ) . 'block-icons/index.js' ),
-	true
-);
+/**
+ * Registers a custom script for the plugin.
+ */
+function enqueue_block_icons_plugin_script() {
+	wp_enqueue_script(
+		'gutenberg-test-block-icons',
+		plugins_url( 'block-icons/index.js', __FILE__ ),
+		array(
+			'wp-blocks',
+			'wp-components',
+			'wp-element',
+			'wp-editor',
+			'wp-hooks',
+			'wp-i18n',
+		),
+		filemtime( plugin_dir_path( __FILE__ ) . 'block-icons/index.js' ),
+		true
+	);
+}
+
+add_action( 'init', 'enqueue_block_icons_plugin_script' );

--- a/test/e2e/test-plugins/container-without-paragraph.php
+++ b/test/e2e/test-plugins/container-without-paragraph.php
@@ -7,14 +7,21 @@
  * @package gutenberg-test-container-without-paragraph
  */
 
-wp_enqueue_script(
-	'gutenberg-test-container-without-paragraph',
-	plugins_url( 'container-without-paragraph/index.js', __FILE__ ),
-	array(
-		'wp-blocks',
-		'wp-element',
-		'wp-editor',
-	),
-	filemtime( plugin_dir_path( __FILE__ ) . 'container-without-paragraph/index.js' ),
-	true
-);
+/**
+ * Registers a custom script for the plugin.
+ */
+function enqueue_container_without_paragraph_plugin_script() {
+	wp_enqueue_script(
+		'gutenberg-test-container-without-paragraph',
+		plugins_url( 'container-without-paragraph/index.js', __FILE__ ),
+		array(
+			'wp-blocks',
+			'wp-element',
+			'wp-editor',
+		),
+		filemtime( plugin_dir_path( __FILE__ ) . 'container-without-paragraph/index.js' ),
+		true
+	);
+}
+
+add_action( 'init', 'enqueue_container_without_paragraph_plugin_script' );

--- a/test/e2e/test-plugins/deprecated-node-matcher.php
+++ b/test/e2e/test-plugins/deprecated-node-matcher.php
@@ -7,15 +7,22 @@
  * @package gutenberg-test-deprecated-node-matcher
  */
 
-wp_enqueue_script(
-	'gutenberg-test-deprecated-node-matcher',
-	plugins_url( 'deprecated-node-matcher/index.js', __FILE__ ),
-	array(
-		'lodash',
-		'wp-blocks',
-		'wp-element',
-		'wp-editor',
-	),
-	filemtime( plugin_dir_path( __FILE__ ) . 'deprecated-node-matcher/index.js' ),
-	true
-);
+/**
+ * Registers a custom script for the plugin.
+ */
+function enqueue_deprecated_node_matcher_plugin_script() {
+	wp_enqueue_script(
+		'gutenberg-test-deprecated-node-matcher',
+		plugins_url( 'deprecated-node-matcher/index.js', __FILE__ ),
+		array(
+			'lodash',
+			'wp-blocks',
+			'wp-element',
+			'wp-editor',
+		),
+		filemtime( plugin_dir_path( __FILE__ ) . 'deprecated-node-matcher/index.js' ),
+		true
+	);
+}
+
+add_action( 'init', 'enqueue_deprecated_node_matcher_plugin_script' );

--- a/test/e2e/test-plugins/hooks-api.php
+++ b/test/e2e/test-plugins/hooks-api.php
@@ -7,17 +7,24 @@
  * @package gutenberg-test-hooks-api
  */
 
-wp_enqueue_script(
-	'gutenberg-test-hooks-api',
-	plugins_url( 'hooks-api/index.js', __FILE__ ),
-	array(
-		'wp-blocks',
-		'wp-components',
-		'wp-element',
-		'wp-editor',
-		'wp-hooks',
-		'wp-i18n',
-	),
-	filemtime( plugin_dir_path( __FILE__ ) . 'hooks-api/index.js' ),
-	true
-);
+/**
+ * Registers a custom script for the plugin.
+ */
+function enqueue_hooks_plugin_script() {
+	wp_enqueue_script(
+		'gutenberg-test-hooks-api',
+		plugins_url( 'hooks-api/index.js', __FILE__ ),
+		array(
+			'wp-blocks',
+			'wp-components',
+			'wp-element',
+			'wp-editor',
+			'wp-hooks',
+			'wp-i18n',
+		),
+		filemtime( plugin_dir_path( __FILE__ ) . 'hooks-api/index.js' ),
+		true
+	);
+}
+
+add_action( 'init', 'enqueue_hooks_plugin_script' );

--- a/test/e2e/test-plugins/inner-blocks-templates.php
+++ b/test/e2e/test-plugins/inner-blocks-templates.php
@@ -7,17 +7,24 @@
  * @package gutenberg-test-inner-blocks-templates
  */
 
-wp_enqueue_script(
-	'gutenberg-test-inner-blocks-templates',
-	plugins_url( 'inner-blocks-templates/index.js', __FILE__ ),
-	array(
-		'wp-blocks',
-		'wp-components',
-		'wp-element',
-		'wp-editor',
-		'wp-hooks',
-		'wp-i18n',
-	),
-	filemtime( plugin_dir_path( __FILE__ ) . 'inner-blocks-templates/index.js' ),
-	true
-);
+/**
+ * Registers a custom script for the plugin.
+ */
+function enqueue_container_without_paragraph_plugin_script() {
+	wp_enqueue_script(
+		'gutenberg-test-inner-blocks-templates',
+		plugins_url( 'inner-blocks-templates/index.js', __FILE__ ),
+		array(
+			'wp-blocks',
+			'wp-components',
+			'wp-element',
+			'wp-editor',
+			'wp-hooks',
+			'wp-i18n',
+		),
+		filemtime( plugin_dir_path( __FILE__ ) . 'inner-blocks-templates/index.js' ),
+		true
+	);
+}
+
+add_action( 'init', 'enqueue_container_without_paragraph_plugin_script' );

--- a/test/e2e/test-plugins/plugins-api.php
+++ b/test/e2e/test-plugins/plugins-api.php
@@ -7,64 +7,71 @@
  * @package gutenberg-test-plugin-plugins-api
  */
 
-wp_enqueue_script(
-	'gutenberg-test-plugins-api-post-status-info',
-	plugins_url( 'plugins-api/post-status-info.js', __FILE__ ),
-	array(
-		'wp-edit-post',
-		'wp-element',
-		'wp-i18n',
-		'wp-plugins',
-	),
-	filemtime( plugin_dir_path( __FILE__ ) . 'plugins-api/post-status-info.js' ),
-	true
-);
+/**
+ * Registers custom scripts for the plugin.
+ */
+function enqueue_plugins_api_plugin_scripts() {
+	wp_enqueue_script(
+		'gutenberg-test-plugins-api-post-status-info',
+		plugins_url( 'plugins-api/post-status-info.js', __FILE__ ),
+		array(
+			'wp-edit-post',
+			'wp-element',
+			'wp-i18n',
+			'wp-plugins',
+		),
+		filemtime( plugin_dir_path( __FILE__ ) . 'plugins-api/post-status-info.js' ),
+		true
+	);
 
-wp_enqueue_script(
-	'gutenberg-test-plugins-api-publish-pane;',
-	plugins_url( 'plugins-api/publish-panel.js', __FILE__ ),
-	array(
-		'wp-edit-post',
-		'wp-element',
-		'wp-i18n',
-		'wp-plugins',
-	),
-	filemtime( plugin_dir_path( __FILE__ ) . 'plugins-api/publish-panel.js' ),
-	true
-);
+	wp_enqueue_script(
+		'gutenberg-test-plugins-api-publish-pane;',
+		plugins_url( 'plugins-api/publish-panel.js', __FILE__ ),
+		array(
+			'wp-edit-post',
+			'wp-element',
+			'wp-i18n',
+			'wp-plugins',
+		),
+		filemtime( plugin_dir_path( __FILE__ ) . 'plugins-api/publish-panel.js' ),
+		true
+	);
 
-wp_enqueue_script(
-	'gutenberg-test-plugins-api-sidebar',
-	plugins_url( 'plugins-api/sidebar.js', __FILE__ ),
-	array(
-		'wp-components',
-		'wp-compose',
-		'wp-data',
-		'wp-edit-post',
-		'wp-editor',
-		'wp-element',
-		'wp-i18n',
-		'wp-plugins',
-		'wp-annotations',
-	),
-	filemtime( plugin_dir_path( __FILE__ ) . 'plugins-api/sidebar.js' ),
-	true
-);
+	wp_enqueue_script(
+		'gutenberg-test-plugins-api-sidebar',
+		plugins_url( 'plugins-api/sidebar.js', __FILE__ ),
+		array(
+			'wp-components',
+			'wp-compose',
+			'wp-data',
+			'wp-edit-post',
+			'wp-editor',
+			'wp-element',
+			'wp-i18n',
+			'wp-plugins',
+			'wp-annotations',
+		),
+		filemtime( plugin_dir_path( __FILE__ ) . 'plugins-api/sidebar.js' ),
+		true
+	);
 
-wp_enqueue_script(
-	'gutenberg-test-annotations-sidebar',
-	plugins_url( 'plugins-api/annotations-sidebar.js', __FILE__ ),
-	array(
-		'wp-components',
-		'wp-compose',
-		'wp-data',
-		'wp-edit-post',
-		'wp-editor',
-		'wp-element',
-		'wp-i18n',
-		'wp-plugins',
-		'wp-annotations',
-	),
-	filemtime( plugin_dir_path( __FILE__ ) . 'plugins-api/annotations-sidebar.js' ),
-	true
-);
+	wp_enqueue_script(
+		'gutenberg-test-annotations-sidebar',
+		plugins_url( 'plugins-api/annotations-sidebar.js', __FILE__ ),
+		array(
+			'wp-components',
+			'wp-compose',
+			'wp-data',
+			'wp-edit-post',
+			'wp-editor',
+			'wp-element',
+			'wp-i18n',
+			'wp-plugins',
+			'wp-annotations',
+		),
+		filemtime( plugin_dir_path( __FILE__ ) . 'plugins-api/annotations-sidebar.js' ),
+		true
+	);
+}
+
+add_action( 'init', 'enqueue_plugins_api_plugin_scripts' );


### PR DESCRIPTION
Extracted from #13088

This PR fixes some small issues with the e2e tests plugins generating PHP notices causing the tests to fail if you run them in DEBUG mode.

