### PR TITLE
Fix: Add button styles to notice actions without url. Allow custom classes on notice actions.

### DIFF
--- a/packages/components/src/notice/README.md
+++ b/packages/components/src/notice/README.md
@@ -31,4 +31,4 @@ The following props are used to control the display of the component.
 * `status`: (string) can be `warning` (yellow), `success` (green), `error` (red).
 * `onRemove`: function called when dismissing the notice
 * `isDismissible`: (boolean) defaults to true, whether the notice should be dismissible or not
-* `actions`: (array) an array of action objects. Each member object should contain a `label` and either a `url` link string or `onClick` callback function.
+* `actions`: (array) an array of action objects. Each member object should contain a `label` and either a `url` link string or `onClick` callback function. A `className` property can be used to add custom classes to the button styles. By default, some classes are used (e.g: is-link or is-default) the default classes can be removed by setting property `noDefaultClasses` to `false`.

--- a/packages/components/src/notice/index.js
+++ b/packages/components/src/notice/index.js
@@ -36,17 +36,35 @@ function Notice( {
 		<div className={ classes }>
 			<div className="components-notice__content">
 				{ children }
-				{ actions.map( ( { label, url, onClick }, index ) => (
-					<Button
-						key={ index }
-						href={ url }
-						isLink={ !! url }
-						onClick={ onClick }
-						className="components-notice__action"
-					>
-						{ label }
-					</Button>
-				) ) }
+				{ actions.map(
+					(
+						{
+							className: buttonCustomClasses,
+							label,
+							noDefaultClasses = false,
+							onClick,
+							url,
+						},
+						index
+					) => {
+						return (
+							<Button
+								key={ index }
+								href={ url }
+								isDefault={ ! noDefaultClasses && ! url }
+								isLink={ ! noDefaultClasses && !! url }
+								onClick={ url ? undefined : onClick }
+								className={ classnames(
+									'components-notice__action',
+									buttonCustomClasses
+								) }
+							>
+								{ label }
+							</Button>
+						);
+					}
+
+				) }
 			</div>
 			{ isDismissible && (
 				<IconButton

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -34,6 +34,9 @@
 	&.is-link {
 		margin-left: 4px;
 	}
+	&.is-default {
+		vertical-align: initial;
+	}
 }
 
 .components-notice__dismiss {

--- a/packages/components/src/notice/test/__snapshots__/index.js.snap
+++ b/packages/components/src/notice/test/__snapshots__/index.js.snap
@@ -11,6 +11,7 @@ exports[`Notice should match snapshot 1`] = `
     <ForwardRef(Button)
       className="components-notice__action"
       href="https://example.com"
+      isDefault={false}
       isLink={true}
     >
       View


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/13009

This PR applies the following changes:
- Currently, if a notice action did not contained a URL the button was totally unstyled. Now we apply default button styles.
- Although the documentation said ```actions: (array) an array of action objects. Each member object should contain a `label` and either a `url` link string or `onClick` callback function.```, we accepted actions with both an URL and an onClick event creating a normal link with programmatic actions which is not recommended because of a11y reasons as raised by @afercia. Now we accept only one of the properties if an URL exist onClick is ignored.
- We now allow the use of custom classes, so, for example, one can have a programmatic action that is rendered on the dom using a button but make it look like a link by adding the is-link class.


## How has this been tested?
I executed the following code on the console:
```
wp.data.dispatch('core/notices').createNotice( 'error', 'Normal onClick Action', { actions: [ {label: 'Action', onClick: () => { alert( 'learn' ) } } ] } );

wp.data.dispatch('core/notices').createNotice( 'error', 'Link style onClick Action', { actions: [ {label: 'Action', onClick: () => { alert( 'learn' ) }, className: 'is-link' } ] } );

wp.data.dispatch('core/notices').createNotice( 'error', 'Normal link', { actions: [ {label: 'Link', url:"http://www.wordpress.org" } ] } );
```

I observed the following notices were displayed:
<img width="1008" alt="screenshot 2018-12-27 at 16 29 20" src="https://user-images.githubusercontent.com/11271197/50487061-a071e600-09f4-11e9-943a-d4d1fd7f4c91.png">
