### PR TITLE
Underline text when cmd + u is pressed

### DIFF
--- a/packages/format-library/src/index.js
+++ b/packages/format-library/src/index.js
@@ -7,6 +7,7 @@ import { image } from './image';
 import { italic } from './italic';
 import { link } from './link';
 import { strikethrough } from './strikethrough';
+import { underline } from './underline';
 
 /**
  * WordPress dependencies
@@ -22,4 +23,5 @@ import {
 	italic,
 	link,
 	strikethrough,
+	underline,
 ].forEach( ( { name, ...settings } ) => registerFormatType( name, settings ) );

--- a/packages/format-library/src/underline/index.js
+++ b/packages/format-library/src/underline/index.js
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Fragment } from '@wordpress/element';
+import { toggleFormat } from '@wordpress/rich-text';
+import { RichTextShortcut } from '@wordpress/editor';
+
+const name = 'core/underline';
+
+export const underline = {
+	name,
+	title: __( 'Underline' ),
+	tagName: 'span',
+	className: null,
+	attributes: {
+		style: 'style',
+	},
+	edit( { value, onChange } ) {
+		const onToggle = () => {
+			onChange(
+				toggleFormat( value, {
+					type: name,
+					attributes: {
+						style: 'text-decoration: underline;',
+					},
+				} ) );
+		};
+
+		return (
+			<Fragment>
+				<RichTextShortcut
+					type="primary"
+					character="u"
+					onUse={ onToggle }
+				/>
+			</Fragment>
+		);
+	},
+};


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/13034

This PR adds a core/underline format option. This format option makes sure that when cmd + u is pressed the selected text gets the underline format.
This shortcut was documented but was not implemented.

## How has this been tested?
I tested in chrome and firefox that when I press cmd + u inside a paragraph (or other block containing a RichText component e.g: image caption) the selected text gets underline format.
