### PR TITLE
Update Wording of Sticky Checkbox

### DIFF
--- a/packages/editor/src/components/post-sticky/index.js
+++ b/packages/editor/src/components/post-sticky/index.js
@@ -15,7 +15,7 @@ export function PostSticky( { onUpdateSticky, postSticky = false } ) {
 	return (
 		<PostStickyCheck>
 			<CheckboxControl
-				label={ __( 'Stick to the Front Page' ) }
+				label={ __( 'Stick to the top' ) }
 				checked={ postSticky }
 				onChange={ () => onUpdateSticky( ! postSticky ) }
 			/>

--- a/packages/editor/src/components/post-sticky/index.js
+++ b/packages/editor/src/components/post-sticky/index.js
@@ -15,7 +15,7 @@ export function PostSticky( { onUpdateSticky, postSticky = false } ) {
 	return (
 		<PostStickyCheck>
 			<CheckboxControl
-				label={ __( 'Stick to the top' ) }
+				label={ __( 'Stick to the top of the blog' ) }
 				checked={ postSticky }
 				onChange={ () => onUpdateSticky( ! postSticky ) }
 			/>


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Changes the wording from "Stick to the Front Page" to "Stick to the top". 

## How has this been tested?

This is only a change of text which occurs once and is very minor, so it doesn't require any special testing. 

## Screenshots <!-- if applicable -->

This is the string which will be changed. 

![screenshot_20181227-215422](https://user-images.githubusercontent.com/43215253/50495610-1476b300-0a22-11e9-816a-df96a82a2e52.jpg)


## Reasoning 

See Automattic/wp-calypso#29735 and Automattic/wp-calypso#28125. This quote from the PR over at Calypso effectively summarises the reasoning for the change:

> Yes, "Stick to the top" is more clear, since a user's blog isn't always on the front page.

## Checklist:

As this is just a change in text, it's a relatively safe change. 