### PR TITLE
[WIP] Try caching compiled JavaScript when building packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ notifications:
 
 cache:
   directories:
+    - $HOME/.cache/wordpress-packages
     - $HOME/.composer/cache
     - $HOME/.jest-cache
     - $HOME/.npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -14859,9 +14859,9 @@
 			}
 		},
 		"minimist": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"version": "1.2.0",
+			"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 			"dev": true
 		},
 		"minimist-options": {
@@ -14965,6 +14965,14 @@
 			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"dev": true
+				}
 			}
 		},
 		"modify-values": {
@@ -15903,6 +15911,12 @@
 				"wordwrap": "~0.0.2"
 			},
 			"dependencies": {
+				"minimist": {
+					"version": "0.0.10",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+					"dev": true
+				},
 				"wordwrap": {
 					"version": "0.0.3",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
 		"lerna": "3.4.3",
 		"lint-staged": "7.3.0",
 		"lodash": "4.17.10",
+		"minimist": "1.2.0",
 		"mkdirp": "0.5.1",
 		"node-sass": "4.11.0",
 		"pegjs": "0.10.0",


### PR DESCRIPTION
Continuing on from yesterday's experimentation (https://github.com/WordPress/gutenberg/pull/13103) into improving some of our build times. 

This changes `npm run build:packages` to cache the compiled JavaScript that Babel generates. Doing so makes `npm install`, `npm run dev`, and `npm run build` run significantly quicker.

To test, run `npm run build:packages`. The first run will take a while but subsequent runs will be quicker.

```
$ time npm run build:packages
$ time npm run build:packages
```