### PR TITLE
Expose additionalData in mediaUpload function

### DIFF
--- a/packages/editor/src/utils/media-upload/index.js
+++ b/packages/editor/src/utils/media-upload/index.js
@@ -18,6 +18,7 @@ import { mediaUpload } from './media-upload';
  * Wrapper around mediaUpload() that injects the current post ID.
  *
  * @param   {Object}   $0                   Parameters object passed to the function.
+ * @param   {?Object}  $0.additionalData    Additional data to include in the request.
  * @param   {string}   $0.allowedTypes      Array with the types of media that can be uploaded, if unset all types are allowed.
  * @param   {Array}    $0.filesList         List of files.
  * @param   {?number}  $0.maxUploadFileSize Maximum upload size in bytes allowed for the site.
@@ -25,6 +26,7 @@ import { mediaUpload } from './media-upload';
  * @param   {Function} $0.onFileChange      Function called each time a file or a temporary representation of the file is available.
  */
 export default function( {
+	additionalData = {},
 	allowedTypes,
 	filesList,
 	maxUploadFileSize,
@@ -44,6 +46,7 @@ export default function( {
 		onFileChange,
 		additionalData: {
 			post: getCurrentPostId(),
+			...additionalData,
 		},
 		maxUploadFileSize,
 		onError: ( { message } ) => onError( message ),


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/13077

The `mediaUpload()` function (https://github.com/WordPress/gutenberg/blob/d8f3ec309de365fd37f3d8d56bb9388f0305043b/packages/editor/src/utils/media-upload/index.js) sends the current post ID as part of `additionalData`, but it was not possible to add additional data in the request.

This PR makes sure the media upload function accepts an additionalData object containing additional data to send in the request besides the post id. The current post id set can also be overwritten using this property.

Now a block or plugin can pass `additionalData: { fromBlockX: true }` and that data is sent in the request making it possible to do some custom logic on the server.

## How has this been tested?
I temporarily added the following lines of code to the media upload call in https://github.com/WordPress/gutenberg/blob/update/expose-additionalData-in-mediaUpload-function/packages/editor/src/components/media-placeholder/index.js#L109:
```
			additionalData: {
				myCustomData: true,
			},
```
I verified on the browser dev tools that the request to upload images using the placeholder upload button contains myCustomData=true.

