### PR TITLE
RichText: Prevent list conversions if onTagNameChange is not provided

### DIFF
--- a/packages/editor/src/components/rich-text/list-edit.js
+++ b/packages/editor/src/components/rich-text/list-edit.js
@@ -72,7 +72,7 @@ export const ListEdit = ( { editor, onTagNameChange, tagName, onSyncDOM } ) => (
 		<BlockFormatControls>
 			<Toolbar
 				controls={ [
-					{
+					onTagNameChange && {
 						icon: 'editor-ul',
 						title: __( 'Convert to unordered list' ),
 						isActive: isActiveListType( editor, 'ul', tagName ),
@@ -85,7 +85,7 @@ export const ListEdit = ( { editor, onTagNameChange, tagName, onSyncDOM } ) => (
 							}
 						},
 					},
-					{
+					onTagNameChange && {
 						icon: 'editor-ol',
 						title: __( 'Convert to ordered list' ),
 						isActive: isActiveListType( editor, 'ol', tagName ),
@@ -114,7 +114,7 @@ export const ListEdit = ( { editor, onTagNameChange, tagName, onSyncDOM } ) => (
 							onSyncDOM();
 						},
 					},
-				] }
+				].filter( Boolean ) }
 			/>
 		</BlockFormatControls>
 	</Fragment>


### PR DESCRIPTION
Fixes #13143 – Using RichText with multilineTag='li' turns on the ListEdit toolbar, including the "convert to ordered/unordered list" options, but expects a prop `onTagNameChange`. There is no way to opt out of allowing the list conversion. This PR checks for the `onTagNameChange` function before showing those buttons, so you can prevent the conversion by leaving out that prop.

## How has this been tested?

Using the following code in a custom block, I've manually tested (Chrome/Mac) that the buttons don't show here, but still show on the core list block.

```
<RichText
	multiline="li"
	tagName="ul"
	onChange={ ( nextValues ) => setAttributes( { list: nextValues } ) }
	value={ list }
	placeholder={ __( 'Write list…' ) }
/>
```

## Screenshots

Nothing changes for the core list block:

<img width="517" alt="list" src="https://user-images.githubusercontent.com/541093/50550622-f25b7b80-0c41-11e9-8a67-29b8bf1ba014.png">

But a custom block without `onTagNameChange` does not show the convert buttons:

<img width="401" alt="ul-only-list" src="https://user-images.githubusercontent.com/541093/50550626-fe473d80-0c41-11e9-9860-e7fca9897dcf.png">
