### PR TITLE
[rnmobile]: Merge rnmobile/release/0.3 into master

### DIFF
--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -291,6 +291,12 @@ export class RichText extends Component {
 		}
 	}
 
+	componentWillUnmount() {
+		if ( this._editor.isFocused() ) {
+			this._editor.blur();
+		}
+	}
+
 	componentDidUpdate( prevProps ) {
 		if ( this.props.isSelected && ! prevProps.isSelected ) {
 			this._editor.focus();

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -40,11 +40,12 @@ const FORMATTING_CONTROLS = [
 		title: __( 'Italic' ),
 		format: 'italic',
 	},
-	{
-		icon: 'admin-links',
-		title: __( 'Link' ),
-		format: 'link',
-	},
+	// TODO: get this back after alpha
+	// {
+	// 	icon: 'admin-links',
+	// 	title: __( 'Link' ),
+	// 	format: 'link',
+	// },
 	{
 		icon: 'editor-strikethrough',
 		title: __( 'Strikethrough' ),


### PR DESCRIPTION
## Description
Incorporate changes made for Alpha release of Gutenberg Mobile back into master.

### How to test:
- This have been already extensibly tested in the Alpha release.
- The `gutenberg-mobile` develop branch is already pointing to `96a73c5` (last commit of this PR).
- Checkout `gutenberg-mobile - develop` and check that it builds and displays the example content as usual.