### PR TITLE
Make clickOnMoreMenuItem not dependent on aria labels

### DIFF
--- a/packages/e2e-test-utils/src/click-on-more-menu-item.js
+++ b/packages/e2e-test-utils/src/click-on-more-menu-item.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { first } from 'lodash';
+
+/**
  * Clicks on More Menu item, searches for the button with the text provided and clicks it.
  *
  * @param {string} buttonLabel The label to search the button for.
@@ -7,7 +12,18 @@ export async function clickOnMoreMenuItem( buttonLabel ) {
 	await expect( page ).toClick(
 		'.edit-post-more-menu [aria-label="Show more tools & options"]'
 	);
-	await page.click(
-		`.edit-post-more-menu__content button[aria-label="${ buttonLabel }"]`
-	);
+	const moreMenuContainerSelector =
+		'//*[contains(concat(" ", @class, " "), " edit-post-more-menu__content ")]';
+	let elementToClick = first( await page.$x(
+		`${ moreMenuContainerSelector }//button[contains(text(), "${ buttonLabel }")]`
+	) );
+	// If button is not found, the label should be on the info wrapper.
+	if ( ! elementToClick ) {
+		elementToClick = first( await page.$x(
+			moreMenuContainerSelector +
+			'//button' +
+			`/*[contains(concat(" ", @class, " "), " components-menu-item__info-wrapper ")][contains(text(), "${ buttonLabel }")]`
+		) );
+	}
+	await elementToClick.click();
 }


### PR DESCRIPTION
The clickOnMoreMenuItem end 2 end test util was dependent on aria labels being present on each menu item.
This aria labels are redundant and just duplicate the inner text menu item, they will be removed as soon as https://github.com/WordPress/gutenberg/pull/12955 is merged.
This PR updates an end 2 end test util that relied on this aria labels being present.
This way we will make sure tests pass on https://github.com/WordPress/gutenberg/pull/12955 as soon as this PR is merged.

## How has this been tested?
I verified the end 2 end tests pass.
I reverted all snapshot updates in https://github.com/WordPress/gutenberg/pull/12955 and merge that PR with this and I checked the end 2 end tests continue to pass.
