### PR TITLE
url: Return URL unmodified if no args to append in addQueryArgs

### DIFF
--- a/packages/url/CHANGELOG.md
+++ b/packages/url/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 - `addQueryArgs` will return only the querystring fragment if the passed `url` is undefined. Previously, an uncaught error would be thrown.
+- `addQueryArgs` will not append (or remove) a `?` if there are no query arguments to be added. Previously, `?` would be wrongly appended even if there was no querystring generated.
 
 ## 2.3.2 (2018-12-12)
 

--- a/packages/url/src/index.js
+++ b/packages/url/src/index.js
@@ -170,6 +170,11 @@ export function isValidFragment( fragment ) {
  * @return {string} URL with arguments applied.
  */
 export function addQueryArgs( url = '', args ) {
+	// If no arguments are to be appended, return original URL.
+	if ( ! Object.keys( args ).length ) {
+		return url;
+	}
+
 	let baseUrl = url;
 
 	// Determine whether URL already had query arguments.

--- a/packages/url/src/index.js
+++ b/packages/url/src/index.js
@@ -171,7 +171,7 @@ export function isValidFragment( fragment ) {
  */
 export function addQueryArgs( url = '', args ) {
 	// If no arguments are to be appended, return original URL.
-	if ( ! Object.keys( args ).length ) {
+	if ( ! args || ! Object.keys( args ).length ) {
 		return url;
 	}
 

--- a/packages/url/src/test/index.test.js
+++ b/packages/url/src/test/index.test.js
@@ -328,7 +328,18 @@ describe( 'addQueryArgs', () => {
 	} );
 
 	it( 'should return only querystring when passed undefined url', () => {
-		expect( addQueryArgs( undefined, { sun: 'true' } ) ).toBe( '?sun=true' );
+		const url = undefined;
+		const args = { sun: 'true' };
+
+		expect( addQueryArgs( url, args ) ).toBe( '?sun=true' );
+	} );
+
+	it( 'should return URL argument unaffected if no query arguments to append', () => {
+		const args = {};
+
+		[ '', 'https://example.com', 'https://example.com?' ].forEach( ( url ) => {
+			expect( addQueryArgs( url, args ) ).toBe( url );
+		} );
 	} );
 } );
 

--- a/packages/url/src/test/index.test.js
+++ b/packages/url/src/test/index.test.js
@@ -335,10 +335,10 @@ describe( 'addQueryArgs', () => {
 	} );
 
 	it( 'should return URL argument unaffected if no query arguments to append', () => {
-		const args = {};
-
 		[ '', 'https://example.com', 'https://example.com?' ].forEach( ( url ) => {
-			expect( addQueryArgs( url, args ) ).toBe( url );
+			[ undefined, {} ].forEach( ( args ) => {
+				expect( addQueryArgs( url, args ) ).toBe( url );
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/12803#pullrequestreview-184663658

This pull request seeks to fix an issue where the `url` module's `addQueryArgs` function appends a `?` even if there are no query arguments to be added. The changes here effectively have the result of returning the original `url` argument unaffected if there are no `args` to append.

This matches the behavior of the equivalent PHP `add_query_arg` function, which would not produce a `?` if there are no arguments to append.

```
wp> add_query_arg( array(), '' );
=> string(0) ""
wp> add_query_arg( array(), 'https://example.com' );
=> string(19) "https://example.com"
wp> add_query_arg( array(), 'https://example.com/?' );
=> string(20) "https://example.com/"
```

**Testing instructions:**

Ensure unit tests pass:

```
npm run test-unit packages/url
```