### PR TITLE
Docs: Add accessbility specific page

### DIFF
--- a/docs/designers-developers/developers/accessibility.md
+++ b/docs/designers-developers/developers/accessibility.md
@@ -1,0 +1,15 @@
+# Accessibility
+
+Accessibility documentation for developers working on the Gutenberg Project.
+
+For more information on accessibility and WordPress see the [Make WordPress Accessibility Handbook](https://make.wordpress.org/accessibility/handbook/) and the [Accessibility Team section](https://make.wordpress.org/accessibility/).
+
+## Landmark Regions
+
+It is a best practice to include ALL content on the page in landmarks, so that screen reader users who rely on them to navigate from section to section do not lose track of content.
+
+Read more regarding landmark design from W3C:
+
+- [General Principles of Landmark Design](https://www.w3.org/TR/wai-aria-practices-1.1/#general-principles-of-landmark-design)
+- [ARIA Landmarks Example](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/)
+- [HTML5 elements that by default define ARIA landmarks](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/HTML5.html)

--- a/docs/designers-developers/developers/accessibility.md
+++ b/docs/designers-developers/developers/accessibility.md
@@ -8,6 +8,8 @@ For more information on accessibility and WordPress see the [Make WordPress Acce
 
 It is a best practice to include ALL content on the page in landmarks, so that screen reader users who rely on them to navigate from section to section do not lose track of content.
 
+For setting up navigation between different regions, see the [navigateRegions package](/packages/components/src/higher-order/navigate-regions/README.md) for additional documentation.
+
 Read more regarding landmark design from W3C:
 
 - [General Principles of Landmark Design](https://www.w3.org/TR/wai-aria-practices-1.1/#general-principles-of-landmark-design)

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -102,6 +102,12 @@
 		"parent": "developers"
 	},
 	{
+		"title": "Accessibility",
+		"slug": "accessibility",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/accessibility.md",
+		"parent": "developers"
+	},
+	{
 		"title": "Data Module Reference",
 		"slug": "data",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/data/README.md",

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -18,6 +18,7 @@
 				{"docs/designers-developers/developers/filters/autocomplete-filters.md": []}
 			]},
 			{"docs/designers-developers/developers/internationalization.md": []},
+			{"docs/designers-developers/developers/accessibility.md": []},
 			{"docs/designers-developers/developers/data/README.md": "{{data}}"},
 			{"docs/designers-developers/developers/packages.md": "{{packages}}"},
 			{"packages/components/README.md": "{{components}}"},


### PR DESCRIPTION
## Description

Adds an additional page to the developer handbook on accessibility
in particular the landmark regions.

Fixes #3217


## Types of changes

Documentation

