### PR TITLE
Update Panel Readme

### DIFF
--- a/packages/components/src/panel/README.md
+++ b/packages/components/src/panel/README.md
@@ -8,14 +8,14 @@ The `Panel` creates a container with a header that can take collapsible `PanelBo
 
 #### Props
 
-###### className
+##### className
 
 The class that will be added with `components-panel`. If no `className` is passed only `components-panel__body` and `is-opened` is used.
 
 - Type: `String`
 - Required: No
 
-###### header
+##### header
 
 Title of the `Panel`. Text will be rendered inside an `<h2>` tag.
 
@@ -72,6 +72,7 @@ Whether or not the panel will start open.
 - Type: `Boolean`
 - Required: No
 - Default: true
+
 ---
 ### PanelRow
 


### PR DESCRIPTION
## Description
This is a super basic fix. Just updates props for the Panel Readme from h6 to h5 to be consistent with other sections in this doc.

## How has this been tested?
NA

## Screenshots
MA

## Types of changes
Just Readme updates

## Checklist:
NA
