### PR TITLE
Fix: Warning on end 2 end metabox test. Add: Test cases for the excerpt in meta logic.

### DIFF
--- a/packages/tests-e2e/plugins/meta-box.php
+++ b/packages/tests-e2e/plugins/meta-box.php
@@ -33,6 +33,8 @@ add_action( 'add_meta_boxes', 'gutenberg_test_meta_box_add_meta_box' );
  * Print excerpt in <meta> tag in wp_head
  */
 function gutenberg_test_meta_box_render_head() {
+	global $post;
+	setup_postdata( $post );
 	// Emulates what plugins like Yoast do with meta data on the front end.
 	// Tests that our excerpt processing does not interfere with dynamic blocks.
 	$excerpt = wp_strip_all_tags( get_the_excerpt() );


### PR DESCRIPTION
The plugin "Gutenberg Test Plugin, Meta Box" used in our end two end tests may trigger a warning.

> Warning: count(): Parameter must be an array or an object that implements Countable in /var/www/html/wp-includes/post-template.php on line 284

To reproduce the problem start the docker environment, activate the "Gutenberg Test Plugin, Meta Box" plugin. Write a post with a title preview and the warning will appear.

The fix applied here is the recommendation available the [get_the_exercept](https://codex.wordpress.org/Function_Reference/get_the_excerpt) function 
> In order to avoid the issues, use setup_postdata() prior to calling get_the_excerpt() to set up the global $post object.

Besides fixing the issue, two test cases were added.
This test cases test that the excerpt is corrected added to the head if explicitly set or if generated from the content.


## Types of changes
Verify the end 2 end tests pass.
