### PR TITLE
Account for "pending" status when evaluating floating post dates

### DIFF
--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -572,7 +572,7 @@ export function isEditedPostDateFloating( state ) {
 	const date = getEditedPostAttribute( state, 'date' );
 	const modified = getEditedPostAttribute( state, 'modified' );
 	const status = getEditedPostAttribute( state, 'status' );
-	if ( status === 'draft' || status === 'auto-draft' ) {
+	if ( status === 'draft' || status === 'auto-draft' || status === 'pending' ) {
 		return date === modified;
 	}
 	return false;


### PR DESCRIPTION
In #9967 we addressed the issue with post dates properly floating for posts with a status of `draft`, but we didn't account for posts that are marked for review and thus have a status of `pending`. This led to #13176. 

This simple fix checks for status of `pending` in addition to `draft` and `auto-draft` when evaluating whether a date is floating. 

Fixes #13176