### PR TITLE
Update sidebar spacing

### DIFF
--- a/packages/components/src/base-control/style.scss
+++ b/packages/components/src/base-control/style.scss
@@ -21,6 +21,6 @@
 	}
 }
 
-.components-base-control+.components-base-control {
+.components-base-control + .components-base-control {
 	margin-bottom: $grid-size-large;
 }

--- a/packages/components/src/base-control/style.scss
+++ b/packages/components/src/base-control/style.scss
@@ -18,6 +18,9 @@
 	.components-base-control__help {
 		margin-top: -$grid-size;
 		font-style: italic;
-		margin-bottom: 0;
 	}
+}
+
+.components-base-control+.components-base-control {
+	margin-bottom: $grid-size-large;
 }

--- a/packages/edit-post/src/components/sidebar/settings-sidebar/style.scss
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/style.scss
@@ -1,10 +1,10 @@
 .edit-post-settings-sidebar__panel-block .components-panel__body {
 	border: none;
 	border-top: $border-width solid $light-gray-500;
-	margin: 0 -$grid-size-large;
+	margin: 0 #{ -$grid-size-large };
 
 	.components-base-control {
-		margin-bottom: $grid-size * 3;
+		margin-bottom: #{ $grid-size * 3 };
 
 		&:last-child {
 			margin-bottom: $grid-size;
@@ -20,6 +20,6 @@
 	}
 
 	&:last-child {
-		margin-bottom: -$grid-size;
+		margin-bottom: -$grid-size-large;
 	}
 }

--- a/packages/edit-post/src/components/sidebar/settings-sidebar/style.scss
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/style.scss
@@ -1,13 +1,13 @@
 .edit-post-settings-sidebar__panel-block .components-panel__body {
 	border: none;
 	border-top: $border-width solid $light-gray-500;
-	margin: 0 -$grid-size;
+	margin: 0 -$grid-size-large;
 
 	.components-base-control {
-		margin-bottom: $grid-size;
+		margin-bottom: $grid-size * 3;
 
 		&:last-child {
-			margin-bottom: $grid-size / 2;
+			margin-bottom: $grid-size;
 		}
 	}
 
@@ -16,7 +16,7 @@
 	}
 
 	&:first-child {
-		margin-top: $grid-size;
+		margin-top: $grid-size-large;
 	}
 
 	&:last-child {

--- a/packages/edit-post/src/components/sidebar/settings-sidebar/style.scss
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/style.scss
@@ -1,12 +1,13 @@
 .edit-post-settings-sidebar__panel-block .components-panel__body {
 	border: none;
 	border-top: $border-width solid $light-gray-500;
-	margin: 0 -16px;
+	margin: 0 -$grid-size;
 
 	.components-base-control {
-		margin: 0 0 1.5em 0;
+		margin-bottom: $grid-size;
+
 		&:last-child {
-			margin-bottom: 0.5em;
+			margin-bottom: $grid-size / 2;
 		}
 	}
 
@@ -15,10 +16,10 @@
 	}
 
 	&:first-child {
-		margin-top: 16px;
+		margin-top: $grid-size;
 	}
 
 	&:last-child {
-		margin-bottom: -16px;
+		margin-bottom: -$grid-size;
 	}
 }


### PR DESCRIPTION
## Description
Fixes #12652.

Fixing a spacing issue between block controls in the sidebar (issue #12652). I had previously submitted a pull request (PR #13106) for this but managed to screw up my repo (a rookie mistake) so I'm resubmitting now that I have a better idea of what I'm doing :)

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Testing in firefox, safari, and chrome
<!-- Include details of your testing environment, tests ran to see how -->
Testing in the standard docker environment
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

### Before

<img src="https://i.imgur.com/oSSavGE.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
Visual change to the sidebar which increases the spacing between elements
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->