### PR TITLE
Fix: Remove alignundefined class from gallery block edit markup

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -1,6 +1,7 @@
 /**
  * External Dependencies
  */
+import classnames from 'classnames';
 import { filter, pick, map, get } from 'lodash';
 
 /**
@@ -261,7 +262,16 @@ class GalleryEdit extends Component {
 					</PanelBody>
 				</InspectorControls>
 				{ noticeUI }
-				<ul className={ `${ className } align${ align } columns-${ columns } ${ imageCrop ? 'is-cropped' : '' }` }>
+				<ul
+					className={ classnames(
+						className,
+						{
+							[ `align${ align }` ]: align,
+							[ `columns-${ columns }` ]: columns,
+							'is-cropped': imageCrop,
+						}
+					) }
+				>
 					{ dropZone }
 					{ images.map( ( img, index ) => {
 						/* translators: %1$d is the order number of the image, %2$d is the total number of images. */


### PR DESCRIPTION
## Description
Related: https://github.com/WordPress/gutenberg/issues/13170
Previously when no align was set an alignundefined class was added in the edit markup of the gallery block.
This PR makes use of classnames util to conditionally add the class when an align is set.

## How has this been tested?
I added a gallery block, and select some images.
I Verified using the browser dom inspector that no alignundefined class is added to the gallery ul element.
I selected a wide alignment and I verified alignwide class was added.
I removed the wide aligment and I verified alignwide class was removed without an alignundefined class being added.


