### PR TITLE
Don't send title during mediaUploads; Fix: Image Uploads don't use exif title

### DIFF
--- a/packages/editor/src/utils/media-upload/media-upload.js
+++ b/packages/editor/src/utils/media-upload/media-upload.js
@@ -210,7 +210,6 @@ function createMediaFromFile( file, additionalData ) {
 	// Create upload payload
 	const data = new window.FormData();
 	data.append( 'file', file, file.name || file.type.replace( '/', '.' ) );
-	data.append( 'title', file.name ? file.name.replace( /\.[^.]+$/, '' ) : file.type.replace( '/', '.' ) );
 	forEach( additionalData, ( ( value, key ) => data.append( key, value ) ) );
 	return apiFetch( {
 		path: '/wp/v2/media',


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/13136

We are automatically computing the title based on the file name and we send it during media uploads.
If the rest API receives an explicit title like we are sending the explicitly sent title is used instead of an automatic computed one.
Our automatic title computation on the client is very simple and does not use EXIF metadata. While the title computation of the server uses EXIF metadata if it is present and if not it uses the filename following similar logic to what we did on the client.

I think we should remove the title computation from the client because of the following reasons:
- Removes duplicate logic between server and client, now only the server generates automatic titles.
- Saves some bytes on each upload.
- Solves bug https://github.com/WordPress/gutenberg/issues/13136 where EXIF titles were not being used.

If a plugin or a block wants a specific title to be used that is still possible, the title can be passed in additionalData object and in this case, the title will be used.


## How has this been tested?
Test image: 
![300 meta](https://user-images.githubusercontent.com/11271197/50700733-3932e200-1043-11e9-8914-f303673f9067.jpg)

I used drag & drop on the test image to upload it. I pressed edit button on the created image block and I verified on the media modal that the caption was "My caption" and the title was "My title".
I added an image block, and I upload the same image using the upload button and verified the correct title and caption were applied.
I repeated the same tests using media & text and cover block.
I used other blocks with uploads cover, video, audio, file, I upload some files and images without EXIF data and I checked a title was generated based on their name.
