### PR TITLE
Fix PostPublishButton toggle

### DIFF
--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -72,7 +72,7 @@ export class PostPublishButton extends Component {
 			publishStatus = 'publish';
 		}
 
-		const onClick = () => {
+		const onClickButton = () => {
 			if ( isButtonDisabled ) {
 				return;
 			}
@@ -81,13 +81,20 @@ export class PostPublishButton extends Component {
 			onSave();
 		};
 
+		const onClickToggle = () => {
+			if ( isToggleDisabled ) {
+				return;
+			}
+			onToggle();
+		};
+
 		const buttonProps = {
 			'aria-disabled': isButtonDisabled,
 			className: 'editor-post-publish-button',
 			isBusy: isSaving && isPublished,
 			isLarge: true,
 			isPrimary: true,
-			onClick,
+			onClick: onClickButton,
 		};
 
 		const toggleProps = {
@@ -96,7 +103,7 @@ export class PostPublishButton extends Component {
 			className: 'editor-post-publish-panel__toggle',
 			isBusy: isSaving && isPublished,
 			isPrimary: true,
-			onClick: onToggle,
+			onClick: onClickToggle,
 		};
 
 		const toggleChildren = isBeingScheduled ? __( 'Schedule…' ) : __( 'Publish…' );


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/13014
Complements https://github.com/WordPress/gutenberg/pull/12885

### Test

* open a bare new post
* make sure the pre-publish checks are enabled
* click the "publish..." button.

The current behavior is that the publish sidebar will be opened, but it shouldn't be.
