### PR TITLE
[Fix] Remove options to use Classic Editor from posts list unless the Classic Editor plugin is activated

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -325,6 +325,10 @@ function gutenberg_add_edit_link( $actions, $post ) {
 		return $actions;
 	}
 
+	if ( ! is_plugin_active( 'classic-editor/classic-editor.php' ) ) {
+		return $actions;
+	}
+
 	$edit_url = get_edit_post_link( $post->ID, 'raw' );
 	$edit_url = add_query_arg( 'classic-editor', '', $edit_url );
 
@@ -388,6 +392,10 @@ function gutenberg_replace_default_add_new_button() {
 	}
 
 	if ( ! gutenberg_can_edit_post_type( $typenow ) ) {
+		return;
+	}
+
+	if ( ! is_plugin_active( 'classic-editor/classic-editor.php' ) ) {
 		return;
 	}
 


### PR DESCRIPTION
## Description
This PR closes #12888 which reports the availability of options for usage of the Classic Editor, even if the Classic Editor plugin is not activated.

## How has this been tested?
This PR has been tested by going through the following steps:

1. Made sure the toggle to choose either Gutenberg or Classic Editor is not displayed by default.
2. Made sure the Classic Editor option isn't available in the post actions list by default.
3. Activated the Classic Editor plugin and made sure both of the above are displayed as expected.

## Types of changes
This PR just simply uses the `is_plugin_active()` function to determine if the Classic Editor plugin is active, and shows the content accordingly.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
