### PR TITLE
Make Safari + VoiceOver announce the screen-reader-text within buttons in the correct order

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -225,6 +225,7 @@
 	}
 
 	// Fixes a Safari+VoiceOver bug, where the screen reader text is announced not respecting the source order.
+	// See https://core.trac.wordpress.org/ticket/42006 and https://github.com/h5bp/html5-boilerplate/issues/1985
 	.screen-reader-text {
 		height: auto;
 	}

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -223,6 +223,11 @@
 			color: color(theme(outlines) shade(25%));
 		}
 	}
+
+	// Fixes a Safari+VoiceOver bug, where the screen reader text is announced not respecting the source order.
+	.screen-reader-text {
+		height: auto;
+	}
 }
 
 @keyframes components-button__busy-animation {


### PR DESCRIPTION
## Description
Fixes a Safari + VoiceOver bug where the screen-reader-text within buttons is announced not respecting the source order. For more details, please see https://core.trac.wordpress.org/ticket/42006

- Adds `height: auto` to screen reader text within buttons


Fixes #13219 