### PR TITLE
Fix: Missing margin in blocks with child blocks

### DIFF
--- a/packages/editor/src/components/inserter/style.scss
+++ b/packages/editor/src/components/inserter/style.scss
@@ -134,4 +134,8 @@ $block-inserter-search-height: 38px;
 	h2 {
 		font-size: 13px;
 	}
+
+	.editor-block-icon {
+		margin-right: $grid-size;
+	}
 }


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/13010

A margin was missing for the parent block on the inserter child blocks area.
This PR just adds a small margin.

## How has this been tested?
I added the test block available in https://gist.github.com/jorgefilipecosta/60a0bf242e8c7c18805618558268315d.
I inserted the parent block, I used the sibling inserter inside the parent block and I verified a small margin appears between the parent block icon and the block name.

## Screenshots <!-- if applicable -->
Before:
<img width="747" alt="screenshot 2019-01-07 at 16 42 20" src="https://user-images.githubusercontent.com/11271197/50781511-74305200-129d-11e9-826f-5cf1628bad26.png">
After:
<img width="747" alt="screenshot 2019-01-07 at 16 42 00" src="https://user-images.githubusercontent.com/11271197/50781520-798d9c80-129d-11e9-80bc-9960db852d4c.png">
