### PR TITLE
Components: Optimize withFilters, avoiding per-instance bindings

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 7.1.0 (Unreleased)
+
+### Improvements
+
+- `withFilters` has been optimized to avoid binding hook handlers for each mounted instance of the component, instead using a single centralized hook delegator.
+
 ## 7.0.5 (2019-01-03)
 
 ## 7.0.4 (2018-12-12)

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Improvements
 
 - `withFilters` has been optimized to avoid binding hook handlers for each mounted instance of the component, instead using a single centralized hook delegator.
+- `withFilters` has been optimized to reuse a single shared component definition for all filtered instances of the component.
 
 ## 7.0.5 (2019-01-03)
 

--- a/packages/components/src/higher-order/with-filters/index.js
+++ b/packages/components/src/higher-order/with-filters/index.js
@@ -24,7 +24,7 @@ const ANIMATION_FRAME_PERIOD = 16;
  */
 export default function withFilters( hookName ) {
 	return createHigherOrderComponent( ( OriginalComponent ) => {
-		const namespace = 'core/with-filters-' + hookName;
+		const namespace = 'core/with-filters/' + hookName;
 
 		/**
 		 * Since filtering is applied to the component, each filtered instance

--- a/packages/components/src/higher-order/with-filters/index.js
+++ b/packages/components/src/higher-order/with-filters/index.js
@@ -27,17 +27,29 @@ export default function withFilters( hookName ) {
 		const namespace = 'core/with-filters/' + hookName;
 
 		/**
-		 * Since filtering is applied to the component, each filtered instance
-		 * can reuse a shared reference to the definition. This optimizes to
-		 * avoid excessive calls to `applyFilters` when many instances exist.
+		 * The component definition with current filters applied. Each instance
+		 * reuse this shared reference as an optimization to avoid excessive
+		 * calls to `applyFilters` when many instances exist.
 		 *
-		 * @type {Component}
+		 * @type {?Component}
 		 */
-		let FilteredComponent = applyFilters( hookName, OriginalComponent );
+		let FilteredComponent;
+
+		/**
+		 * Initializes the FilteredComponent variable once, if not already
+		 * assigned. Subsequent calls are effectively a noop.
+		 */
+		function ensureFilteredComponent() {
+			if ( FilteredComponent === undefined ) {
+				FilteredComponent = applyFilters( hookName, OriginalComponent );
+			}
+		}
 
 		class FilteredComponentRenderer extends Component {
 			constructor( props ) {
 				super( props );
+
+				ensureFilteredComponent();
 
 				this.throttledForceUpdate = debounce(
 					() => this.forceUpdate(),


### PR DESCRIPTION
Related: #12824

This pull request seeks to optimize the implementation of `withFilters`. In my testing of a large post consisting of 20,000 words (70 headings, 501 paragraphs), ~400ms real-time is spent during initialization in `addHook`, `runHooks`, and `FilteredComponent#constructor`. These changes bring this down to roughly 170ms, with `runHooks` being the primary contributor (160ms), as it's also used extensively elsewhere in blocks parsing (i.e. `withFilters` contribution approaches negligible).

Before|After
---|---
![Before](https://user-images.githubusercontent.com/1779930/50794953-b015e800-129a-11e9-8fd4-16650e184ffe.png)|![After](https://user-images.githubusercontent.com/1779930/50794958-b6a45f80-129a-11e9-9612-bad4abd58804.png)

**Implementation notes:**

The specific optimizations include:

- Binding at most one hook handler for `addFilter` and `removeFilter` per hook name. Previously, a handler was added for each instance of a filtered component.
- Creating a single shared filtered component definition per hook name. Previously, each instance would create their own filtered component.

There has been one implementation change: Previously, the hooks were bound in the component's constructor. It has been changed here to occur during `componentDidMount`. This is in accordance with React recommendations, and avoids potential issues with lingering subscriptions in a server-rendered environment (see also #11819).

>Avoid introducing any side-effects or subscriptions in the constructor. For those use cases, use `componentDidMount()` instead.

https://reactjs.org/docs/react-component.html#constructor

**Testing instructions:**

Repeat testing instructions from #4428, substituting the hook name `blocks.BlockEdit` with the since-renamed `editor.BlockEdit`. In other words, insert this code in your console:

```
wp.hooks.addFilter( 'editor.BlockEdit', 'my/filters', () => () => wp.element.createElement( 'h1', {}, 'My block' ) );
```