### PR TITLE
chore: Fix: Links pointing to the block icon documentation

### DIFF
--- a/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
@@ -82,7 +82,7 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-01', {
 ```
 {% end %}
 
-Once a block is registered, you should immediately see that it becomes available as an option in the editor inserter dialog, using values from `title`, `icon`, and `category` to organize its display. You can choose an icon from any included in the built-in [Dashicons icon set](https://developer.wordpress.org/resource/dashicons/), or provide a [custom svg element](https://wordpress.org/gutenberg/handbook/block-api/#icon-optional).
+Once a block is registered, you should immediately see that it becomes available as an option in the editor inserter dialog, using values from `title`, `icon`, and `category` to organize its display. You can choose an icon from any included in the built-in [Dashicons icon set](https://developer.wordpress.org/resource/dashicons/), or provide a [custom svg element](https://wordpress.org/gutenberg/handbook/designers-developers/developers/block-api/block-registration/#icon-optional).
 
 A block name must be prefixed with a namespace specific to your plugin. This helps prevent conflicts when more than one plugin registers a block with the same name.
 

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -141,7 +141,7 @@ export function registerBlockType( name, settings ) {
 	if ( ! isValidIcon( settings.icon.src ) ) {
 		console.error(
 			'The icon passed is invalid. ' +
-			'The icon should be a string, an element, a function, or an object following the specifications documented in https://wordpress.org/gutenberg/handbook/block-api/#icon-optional'
+			'The icon should be a string, an element, a function, or an object following the specifications documented in https://wordpress.org/gutenberg/handbook/designers-developers/developers/block-api/block-registration/#icon-optional'
 		);
 		return;
 	}


### PR DESCRIPTION
## Description
The documentation handbook passed by some restructures and the links we had pointing to the block icon documentation are no longer valid.
This PR just updates the links.


## Types of changes
I checked that the new link points to the block icon documentation https://wordpress.org/gutenberg/handbook/designers-developers/developers/block-api/block-registration/#icon-optional.

I tried to register a block with an invalid icon:
```
( function() {
	var registerBlockType = wp.blocks.registerBlockType;

	registerBlockType( 'test/block', {
		title: 'Test Block',
		icon: {
            icon: 'cart',
            background: '#ff0000',
        },
		category: 'common',

		edit: function() {
		},

		save: function() {
		},
	} );
} )();
```

And I checked that the error message link in the browser console correctly pointed to the block icon documentation.