### PR TITLE
REST Block Renderer: Accept the className attribute by default and add a filter

### DIFF
--- a/lib/class-wp-block-type.php
+++ b/lib/class-wp-block-type.php
@@ -207,7 +207,7 @@ class WP_Block_Type {
 				'className' => array(
 					'type' => 'string',
 				),
-				'layout' => array(
+				'layout'    => array(
 					'type' => 'string',
 				),
 			);

--- a/lib/class-wp-block-type.php
+++ b/lib/class-wp-block-type.php
@@ -191,19 +191,26 @@ class WP_Block_Type {
 	 * @return array Array of attributes.
 	 */
 	public function get_attributes() {
-		return is_array( $this->attributes ) ?
+		$attributes = is_array( $this->attributes ) ?
 			array_merge(
 				$this->attributes,
 				array(
+					'className' => array(
+						'type' => 'string',
+					),
 					'layout' => array(
 						'type' => 'string',
 					),
 				)
 			) :
 			array(
+				'className' => array(
+					'type' => 'string',
+				),
 				'layout' => array(
 					'type' => 'string',
 				),
 			);
+		return apply_filters( 'block_attributes', $attributes, $this );
 	}
 }

--- a/lib/class-wp-block-type.php
+++ b/lib/class-wp-block-type.php
@@ -198,7 +198,7 @@ class WP_Block_Type {
 					'className' => array(
 						'type' => 'string',
 					),
-					'layout' => array(
+					'layout'    => array(
 						'type' => 'string',
 					),
 				)


### PR DESCRIPTION
## Description
When creating a block with a `ServerSideRender` component and using the "Additional CSS Class" block option, the rendering breaks with this HTTP response:
```
{"code":"rest_invalid_param","message":"Invalid parameter(s): attributes","data":{"status":400,"params":{"attributes":"className is not a valid property of Object."}}}
```
## How has this been tested?

The above HTTP request works fine with this patch applied.

## Screenshots

<img width="431" alt="screenshot 2019-01-08 at 22 42 28" src="https://user-images.githubusercontent.com/203408/50860636-c1dcb580-1396-11e9-80a2-21ddb4d53e66.png">

<img width="267" alt="screenshot 2019-01-08 at 22 40 51" src="https://user-images.githubusercontent.com/203408/50860546-922dad80-1396-11e9-913a-e2844dcc66fa.png">

## Types of changes
This adds the `className` attribute by default. It also adds a filter that allows more properties to be added (for example when using https://wordpress.org/gutenberg/handbook/designers-developers/developers/filters/block-filters/#editor-blockedit)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
- [x] I've included developer documentation if appropriate.
