### PR TITLE
Add test case for pending to isEditedPostDateFloating suite

### DIFF
--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -1890,6 +1890,24 @@ describe( 'selectors', () => {
 
 			expect( isEditedPostDateFloating( state ) ).toBe( false );
 		} );
+
+		it( 'should return true for pending posts', () => {
+			const state = {
+				currentPost: {
+					date: '2018-09-27T01:23:45.678Z',
+					modified: '2018-09-27T01:23:45.678Z',
+					status: 'pending',
+				},
+				editor: {
+					present: {
+						edits: {},
+					},
+				},
+				initialEdits: {},
+			};
+
+			expect( isEditedPostDateFloating( state ) ).toBe( true );
+		} );
 	} );
 
 	describe( 'getBlockDependantsCacheBust', () => {


### PR DESCRIPTION
Adds test case covering https://github.com/WordPress/gutenberg/pull/13178.