### PR TITLE
Fix: Font size picker does not work on mobile

### DIFF
--- a/assets/stylesheets/_z-index.scss
+++ b/assets/stylesheets/_z-index.scss
@@ -85,6 +85,7 @@ $z-layers: (
 
 	// Shows above edit post sidebar; Specificity needs to be higher than 3 classes.
 	".block-editor__container .components-popover.components-color-palette__picker.is-bottom": 100001,
+	".block-editor__container .components-popover.components-font-size-picker__dropdown-content.is-bottom": 100001,
 	".edit-post-post-visibility__dialog.components-popover.is-bottom": 100001,
 
 	".components-autocomplete__results": 1000000,

--- a/packages/editor/src/components/font-sizes/style.scss
+++ b/packages/editor/src/components/font-sizes/style.scss
@@ -1,0 +1,3 @@
+.block-editor__container .components-popover.components-font-size-picker__dropdown-content.is-bottom {
+	z-index: z-index(".block-editor__container .components-popover.components-font-size-picker__dropdown-content.is-bottom");
+}

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -18,6 +18,7 @@
 @import "./components/default-block-appender/style.scss";
 @import "./components/document-outline/style.scss";
 @import "./components/error-boundary/style.scss";
+@import "./components/font-sizes/style.scss";
 @import "./components/inner-blocks/style.scss";
 @import "./components/inserter-with-shortcuts/style.scss";
 @import "./components/inserter/style.scss";


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/13155
It had a z-index issue and the popover appeared below the sidebar.
This PR applies a fix to the z-index problem.

## How has this been tested?
Verify that the font size picker appears correctly on mobile.

## Screenshots <!-- if applicable -->
![img_6637](https://user-images.githubusercontent.com/11271197/50900418-04d97000-140d-11e9-92fd-7efb1af14f8e.PNG)

