### PR TITLE
Fix: Font size picker max width on mobile

### DIFF
--- a/packages/components/src/font-size-picker/style.scss
+++ b/packages/components/src/font-size-picker/style.scss
@@ -1,4 +1,5 @@
 .components-font-size-picker__buttons {
+	max-width: $sidebar-width - ( 2 * $panel-padding );
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
@@ -7,6 +8,7 @@
 	.components-range-control__number {
 		height: 24px;
 		line-height: 22px;
+		margin-left: 0;
 
 		// Show the reset button as disabled until a value is entered.
 		&[value=""] + .components-button {


### PR DESCRIPTION
## Description
The font size picker used `justify-content: space-between;` to render the items on the screen. On small screens the sidebar may be 750px wide and I think the display results on this screen were suboptimal.
This PR adds a max with to make sure the font size picker looks the same on mobile and desktop.

## How has this been tested?
I checked that the font size picker renders as shown in the screenshots


## Screenshots <!-- if applicable -->
Before:
![img_6639](https://user-images.githubusercontent.com/11271197/50912783-db2f4180-142a-11e9-9bac-79801f29b3b7.PNG)
<img width="778" alt="screenshot 2019-01-09 at 16 23 46" src="https://user-images.githubusercontent.com/11271197/50912840-fc902d80-142a-11e9-8ad6-58285050d80d.png">

After:
![img_6638](https://user-images.githubusercontent.com/11271197/50912858-06b22c00-142b-11e9-94d7-76f9b8483799.PNG)
<img width="775" alt="screenshot 2019-01-09 at 16 16 09" src="https://user-images.githubusercontent.com/11271197/50912879-129dee00-142b-11e9-8a72-bd4b4d996a7a.png">



