### PR TITLE
Update docs for unregisterBlockType

### DIFF
--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -261,8 +261,9 @@ Adding blocks is easy enough, removing them is as easy. Plugin or theme authors 
 
 ```js
 // my-plugin.js
-
-wp.blocks.unregisterBlockType( 'core/verse' );
+wp.domReady( function() {
+	wp.blocks.unregisterBlockType( 'core/verse' );
+} );
 ```
 
 and load this script in the Editor
@@ -275,7 +276,7 @@ function my_plugin_blacklist_blocks() {
 	wp_enqueue_script(
 		'my-plugin-blacklist-blocks',
 		plugins_url( 'my-plugin.js', __FILE__ ),
-		array( 'wp-blocks' )
+		array( 'wp-blocks', 'wp-dom-ready', 'wp-edit-post' )
 	);
 }
 add_action( 'enqueue_block_editor_assets', 'my_plugin_blacklist_blocks' );


### PR DESCRIPTION
## Description

Updates code for unregisterBlockType including the dependencies for `wp-dom-ready` and `wp-edit-post` and using `wp.domReady()`

Fixes #11723 

## Types of changes

Documentation.
