### PR TITLE
Try better color swatch selection indicator

### DIFF
--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -8,6 +8,7 @@ import { map } from 'lodash';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
+import Dashicon from '../dashicon';
 
 /**
  * Internal dependencies
@@ -49,6 +50,7 @@ export default function ColorPalette( { colors, disableCustomColors = false, val
 								aria-pressed={ value === color }
 							/>
 						</Tooltip>
+						{ value === color && <Dashicon icon="saved" /> }
 					</div>
 				);
 			} ) }

--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -44,6 +44,13 @@ $color-palette-circle-spacing: 14px;
 
 	&.is-active {
 		box-shadow: inset 0 0 0 4px;
+		border: $border-width solid $dark-gray-400;
+
+		& + .dashicons-saved {
+			position: absolute;
+			left: 4px;
+			top: 4px;
+		}
 	}
 
 	&::after {
@@ -53,7 +60,7 @@ $color-palette-circle-spacing: 14px;
 		left: 0;
 		bottom: 0;
 		right: 0;
-		border-radius: 50%;
+		border-radius: $radius-round;
 		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
 	}
 
@@ -61,13 +68,15 @@ $color-palette-circle-spacing: 14px;
 		outline: none;
 		&::after {
 			content: "";
-			border: $border-width solid $dark-gray-400;
+			position: absolute;
+			border: #{ $border-width * 2 } solid $dark-gray-400;
 			width: 32px;
 			height: 32px;
 			position: absolute;
 			top: -2px;
 			left: -2px;
-			border-radius: 50%;
+			border-radius: $radius-round;
+			box-shadow: inset 0 0 0 2px $white;
 		}
 	}
 }

--- a/packages/components/src/color-palette/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.js.snap
@@ -133,6 +133,9 @@ exports[`ColorPalette should allow disabling custom color picker 1`] = `
         type="button"
       />
     </Tooltip>
+    <Dashicon
+      icon="saved"
+    />
   </div>
   <div
     className="components-color-palette__item-wrapper"
@@ -212,6 +215,9 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
         type="button"
       />
     </Tooltip>
+    <Dashicon
+      icon="saved"
+    />
   </div>
   <div
     className="components-color-palette__item-wrapper"


### PR DESCRIPTION
This fixes #12923.

This provides a checkmark, better focus and select styles, so even a white swatch is visibly selected.

Before:

![problem](https://user-images.githubusercontent.com/1204802/50957494-a371d980-14be-11e9-95fb-dc73605e1687.gif)

After:

![fix](https://user-images.githubusercontent.com/1204802/50957517-af5d9b80-14be-11e9-9723-cd5586b1495d.gif)

Jorge I sense that I may have done some of the Dashicon importing wrong. Please feel free to push a fix directly to this branch if you have time, and if it is indeed suboptimal. Thank you. 
