### PR TITLE
Add test case for pending to isEditedPostDateFloating suite (#13256)

### DIFF
--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -1940,6 +1940,24 @@ describe( 'selectors', () => {
 
 			expect( isEditedPostDateFloating( state ) ).toBe( false );
 		} );
+
+		it( 'should return true for pending posts', () => {
+			const state = {
+				currentPost: {
+					date: '2018-09-27T01:23:45.678Z',
+					modified: '2018-09-27T01:23:45.678Z',
+					status: 'pending',
+				},
+				editor: {
+					present: {
+						edits: {},
+					},
+				},
+				initialEdits: {},
+			};
+
+			expect( isEditedPostDateFloating( state ) ).toBe( true );
+		} );
 	} );
 
 	describe( 'getBlockDependantsCacheBust', () => {


### PR DESCRIPTION
This is just a follow up for #13256. It was opened against the `fix/13176-post-date-pending` branch instead of `master`. It should have been merged there first prior to #13178 getting merged. 

This just brings that test over to `master`. 