### PR TITLE
Use select in withDispatch to avoid using unused props

### DIFF
--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -65,7 +65,7 @@ export default compose( [
 		},
 		openSidebar() {
 			const { getBlockSelectionStart } = select( 'core/editor' );
-			const sidebarToOpen = !! getBlockSelectionStart() ? 'edit-post/block' : 'edit-post/document';
+			const sidebarToOpen = getBlockSelectionStart() ? 'edit-post/block' : 'edit-post/document';
 			dispatch( 'core/edit-post' ).openGeneralSidebar( sidebarToOpen );
 		},
 		closeSidebar: dispatch( 'core/edit-post' ).closeGeneralSidebar,

--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -58,14 +58,14 @@ export default compose( [
 		isRichEditingEnabled: select( 'core/editor' ).getEditorSettings().richEditingEnabled,
 		mode: select( 'core/edit-post' ).getEditorMode(),
 		isEditorSidebarOpen: select( 'core/edit-post' ).isEditorSidebarOpened(),
-		hasBlockSelection: !! select( 'core/editor' ).getBlockSelectionStart(),
 	} ) ),
-	withDispatch( ( dispatch, { hasBlockSelection } ) => ( {
+	withDispatch( ( dispatch, ownProps, { select } ) => ( {
 		switchMode( mode ) {
 			dispatch( 'core/edit-post' ).switchEditorMode( mode );
 		},
 		openSidebar() {
-			const sidebarToOpen = hasBlockSelection ? 'edit-post/block' : 'edit-post/document';
+			const { getBlockSelectionStart } = select( 'core/editor' );
+			const sidebarToOpen = !! getBlockSelectionStart() ? 'edit-post/block' : 'edit-post/document';
 			dispatch( 'core/edit-post' ).openGeneralSidebar( sidebarToOpen );
 		},
 		closeSidebar: dispatch( 'core/edit-post' ).closeGeneralSidebar,

--- a/packages/edit-post/src/plugins/keyboard-shortcuts-help-menu-item/index.js
+++ b/packages/edit-post/src/plugins/keyboard-shortcuts-help-menu-item/index.js
@@ -20,7 +20,7 @@ export function KeyboardShortcutsHelpMenuItem( { openModal, onSelect } ) {
 	);
 }
 
-export default withDispatch( ( dispatch, ) => {
+export default withDispatch( ( dispatch ) => {
 	const {
 		openModal,
 	} = dispatch( 'core/edit-post' );

--- a/packages/editor/src/components/editor-global-keyboard-shortcuts/index.js
+++ b/packages/editor/src/components/editor-global-keyboard-shortcuts/index.js
@@ -183,8 +183,7 @@ export default compose( [
 			onSave() {
 				// TODO: This should be handled in the `savePost` effect in
 				// considering `isSaveable`. See note on `isEditedPostSaveable`
-				// selector about dirtiness and meta-boxes. When removing, also
-				// remember to remove `isEditedPostDirty` selector's usage.
+				// selector about dirtiness and meta-boxes.
 				//
 				// See: `isEditedPostSaveable`
 				const { isEditedPostDirty } = select( 'core/editor' );

--- a/packages/editor/src/components/editor-global-keyboard-shortcuts/index.js
+++ b/packages/editor/src/components/editor-global-keyboard-shortcuts/index.js
@@ -152,7 +152,6 @@ export default compose( [
 			getBlockOrder,
 			getMultiSelectedBlockClientIds,
 			hasMultiSelection,
-			isEditedPostDirty,
 			getBlockRootClientId,
 			getTemplateLock,
 			getSelectedBlockClientId,
@@ -167,11 +166,10 @@ export default compose( [
 				selectedBlockClientIds,
 				( clientId ) => !! getTemplateLock( getBlockRootClientId( clientId ) )
 			),
-			isDirty: isEditedPostDirty(),
 			selectedBlockClientIds,
 		};
 	} ),
-	withDispatch( ( dispatch, ownProps ) => {
+	withDispatch( ( dispatch, ownProps, { select } ) => {
 		const {
 			clearSelectedBlock,
 			multiSelect,
@@ -186,10 +184,11 @@ export default compose( [
 				// TODO: This should be handled in the `savePost` effect in
 				// considering `isSaveable`. See note on `isEditedPostSaveable`
 				// selector about dirtiness and meta-boxes. When removing, also
-				// remember to remove `isDirty` prop passing from `withSelect`.
+				// remember to remove `isEditedPostDirty` selector's usage.
 				//
 				// See: `isEditedPostSaveable`
-				if ( ! ownProps.isDirty ) {
+				const { isEditedPostDirty } = select( 'core/editor' );
+				if ( ! isEditedPostDirty() ) {
 					return;
 				}
 

--- a/packages/editor/src/components/inserter/menu.js
+++ b/packages/editor/src/components/inserter/menu.js
@@ -347,8 +347,6 @@ export class InserterMenu extends Component {
 export default compose(
 	withSelect( ( select, { rootClientId } ) => {
 		const {
-			getEditedPostAttribute,
-			getSelectedBlock,
 			getInserterItems,
 			getBlockName,
 		} = select( 'core/editor' );
@@ -359,14 +357,12 @@ export default compose(
 		const rootBlockName = getBlockName( rootClientId );
 
 		return {
-			selectedBlock: getSelectedBlock(),
 			rootChildBlocks: getChildBlockNames( rootBlockName ),
-			title: getEditedPostAttribute( 'title' ),
 			items: getInserterItems( rootClientId ),
 			rootClientId,
 		};
 	} ),
-	withDispatch( ( dispatch, ownProps ) => {
+	withDispatch( ( dispatch, ownProps, { select } ) => {
 		const {
 			__experimentalFetchReusableBlocks: fetchReusableBlocks,
 			showInsertionPoint,
@@ -382,9 +378,11 @@ export default compose(
 					replaceBlocks,
 					insertBlock,
 				} = dispatch( 'core/editor' );
-				const { selectedBlock, index, rootClientId } = ownProps;
+				const { getSelectedBlock } = select( 'core/editor' );
+				const { index, rootClientId } = ownProps;
 				const { name, initialAttributes } = item;
 
+				const selectedBlock = getSelectedBlock();
 				const insertedBlock = createBlock( name, initialAttributes );
 				if ( selectedBlock && isUnmodifiedDefaultBlock( selectedBlock ) ) {
 					replaceBlocks( selectedBlock.clientId, insertedBlock );


### PR DESCRIPTION
## Description
Partially addresses #12890.

With the changes introduced by #11851, we seek to refactor components which provide data through `withSelect` for the sole purpose of satisfying a dispatch callback. These components instead should use the new registry argument. This PR covers the following:
- [x] `EditorGlobalKeyboardShortcuts` (the `isDirty` prop)
- [x] `InserterMenu` (the `selectedBlock` prop)
- [x] `EditorModeKeyboardShortcuts` (the `hasBlockSelection` prop)

## How has this been tested?
`npm test` & `npm run test-e2e`

* Make sure that inserter still works.
* Make sure keyboard shortcuts still work.

## Types of changes
Refactoring.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->