### PR TITLE
onReplace: select the last block

### DIFF
--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -15,7 +15,6 @@ import {
 	isEqual,
 	isEmpty,
 	overSome,
-	get,
 } from 'lodash';
 
 /**
@@ -887,9 +886,11 @@ export function blockSelection( state = {
 				return state;
 			}
 
-			// If there is replacement block(s), assign first's client ID as
-			// the next selected block. If empty replacement, reset to null.
-			const nextSelectedBlockClientId = get( action.blocks, [ 0, 'clientId' ], null );
+			// If there are replacement blocks, assign last block as the next
+			// selected block, otherwise set to null.
+			const lastBlock = last( action.blocks );
+			const nextSelectedBlockClientId = lastBlock ? lastBlock.clientId : null;
+
 			if ( nextSelectedBlockClientId === state.start && nextSelectedBlockClientId === state.end ) {
 				return state;
 			}

--- a/packages/editor/src/store/test/reducer.js
+++ b/packages/editor/src/store/test/reducer.js
@@ -1826,7 +1826,12 @@ describe( 'state', () => {
 					} ],
 			} );
 
-			expect( state ).toBe( original );
+			expect( state ).toEqual( {
+				start: 'wings',
+				end: 'wings',
+				initialPosition: null,
+				isMultiSelecting: false,
+			} );
 		} );
 
 		it( 'should reset if replacing with empty set', () => {

--- a/packages/editor/src/store/test/reducer.js
+++ b/packages/editor/src/store/test/reducer.js
@@ -1810,7 +1810,26 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should not replace the selected block if we keep it when replacing blocks', () => {
+		it( 'should not replace the selected block if we keep it at the end when replacing blocks', () => {
+			const original = deepFreeze( { start: 'wings', end: 'wings' } );
+			const state = blockSelection( original, {
+				type: 'REPLACE_BLOCKS',
+				clientIds: [ 'wings' ],
+				blocks: [
+					{
+						clientId: 'chicken',
+						name: 'core/freeform',
+					},
+					{
+						clientId: 'wings',
+						name: 'core/freeform',
+					} ],
+			} );
+
+			expect( state ).toBe( original );
+		} );
+
+		it( 'should replace the selected block if we keep it not at the end when replacing blocks', () => {
 			const original = deepFreeze( { start: 'chicken', end: 'chicken' } );
 			const state = blockSelection( original, {
 				type: 'REPLACE_BLOCKS',


### PR DESCRIPTION
Partly fixes #5317. Currently `onReplace` sets the block selection to the first block. This makes it so that `onReplace` sets it to the last block, so when you paste some blocks, the selection is set to the last block.

This seems to be a good default for `onReplace` in general, rather than selecting the first block.

I also tried setting `initialPosition` to `-1`, but that resulted in some failing tests for the quote block. Because it has two input fields, selection would be set to the cite field when creating a quote block through the `/quote` shortcut.

So this PR is not a complete fix, but it alleviates the issue.