### PR TITLE
Update image link for meta block tutorial

### DIFF
--- a/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md
+++ b/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md
@@ -70,7 +70,7 @@ add_action( 'enqueue_block_editor_assets', 'myguten_enqueue' );
 
 You can now edit a draft post and add a Meta Block to the post. You will see your field that you can type a value in. When you save the post, either as a draft or published, the post meta value will be saved too. You can verify by saving and reloading your draft, the form will still be filled in on reload.
 
-![Meta Block](/docs/designers-developers/developers/tutorials/metabox/meta-block.png)
+![Meta Block](https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/metabox/meta-block.png)
 
 You can now use the post meta data in a template, or another block. See next section for [using post meta data](/docs/designers-developers/developers/tutorials/metabox/meta-block-4-use-data.md). You could also confirm the data is saved by checking the database table `wp_postmeta` and confirm the new post id contains the new field data.
 


### PR DESCRIPTION
## Description

Update image link for meta block tutorial, since /docs/ doesn't work.
Use absolute github URL for now.

## How has this been tested?

Confirm image shows [browsing branch source here](https://github.com/WordPress/gutenberg/blob/docs/fix-meta-img-link/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md)

## Types of changes

Documentation.
