### PR TITLE
Update meta box link to new tutorial

### DIFF
--- a/docs/designers-developers/developers/README.md
+++ b/docs/designers-developers/developers/README.md
@@ -12,15 +12,15 @@ If you want to learn more about block creation, the [Blocks Tutorial](/docs/desi
 
 It is also possible to modify the behavior of existing blocks or even remove them completely using filters.
 
-Learn more in the [Block Filters](/docs/designers-developers/developers/reference/hooks/block-filters.md) section.
+Learn more in the [Block Filters](/docs/designers-developers/developers/filters/block-filters.md) section.
 
 ## Extending the Editor UI
 
 Extending the editor UI can be accomplished with the `registerPlugin` API, allowing you to define all your plugin's UI elements in one place.
 
-Refer to the [Plugins](https://github.com/WordPress/gutenberg/blob/master/packages/plugins/README.md) and [Edit Post](https://github.com/WordPress/gutenberg/blob/master/packages/edit-post/README.md) section for more information.
+Refer to the [Plugins](/packages/plugins/README.md) and [Edit Post](/packages/edit-post/README.md) section for more information.
 
-You can also filter certain aspects of the editor; this is documented on the [Editor Filters](/docs/designers-developers/developers/reference/hooks/editor-filters.md) page.
+You can also filter certain aspects of the editor; this is documented on the [Editor Filters](/docs/designers-developers/developers/filters/editor-filters.md) page.
 
 ## Meta Boxes
 

--- a/docs/designers-developers/developers/README.md
+++ b/docs/designers-developers/developers/README.md
@@ -6,13 +6,13 @@ The new editor is highly flexible, like most of WordPress. You can build custom 
 
 The editor is about blocks, and the main extensibility API is the Block API. It allows you to create your own static blocks, dynamic blocks rendered on the server and also blocks capable of saving data to Post Meta for more structured content.
 
-If you want to learn more about block creation, the [Blocks Tutorial](../../../docs/designers-developers/developers/tutorials/block-tutorial/readme.md) is the best place to start.
+If you want to learn more about block creation, the [Blocks Tutorial](/docs/designers-developers/developers/tutorials/block-tutorial/readme.md) is the best place to start.
 
 ## Extending Blocks
 
 It is also possible to modify the behavior of existing blocks or even remove them completely using filters.
 
-Learn more in the [Block Filters](../../../docs/designers-developers/developers/reference/hooks/block-filters.md) section.
+Learn more in the [Block Filters](/docs/designers-developers/developers/reference/hooks/block-filters.md) section.
 
 ## Extending the Editor UI
 
@@ -20,26 +20,26 @@ Extending the editor UI can be accomplished with the `registerPlugin` API, allow
 
 Refer to the [Plugins](https://github.com/WordPress/gutenberg/blob/master/packages/plugins/README.md) and [Edit Post](https://github.com/WordPress/gutenberg/blob/master/packages/edit-post/README.md) section for more information.
 
-You can also filter certain aspects of the editor; this is documented on the [Editor Filters](../../../docs/designers-developers/developers/reference/hooks/editor-filters.md) page.
+You can also filter certain aspects of the editor; this is documented on the [Editor Filters](/docs/designers-developers/developers/reference/hooks/editor-filters.md) page.
 
 ## Meta Boxes
 
 **Porting PHP meta boxes to blocks or sidebar plugins is highly encouraged!**
 
-Discover how to work with [Meta Boxes](/docs/designers-developers/developers/tutorials/metabox/) in the new editor.
+Discover how to work with [Meta Boxes](/docs/designers-developers/developers/tutorials/metabox/readme.md) in the new editor.
 
 ## Theme Support
 
 By default, blocks provide their styles to enable basic support for blocks in themes without any change. Themes can add/override these styles, or rely on defaults.
 
-There are some advanced block features which require opt-in support in the theme. See [theme support](../../../docs/designers-developers/developers/themes/theme-support.md).
+There are some advanced block features which require opt-in support in the theme. See [theme support](/docs/designers-developers/developers/themes/theme-support.md).
 
 ## Autocomplete
 
-Autocompleters within blocks may be extended and overridden. Learn more about the [autocomplete](../../../docs/designers-developers/developers/filters/autocomplete-filters.md) filters.
+Autocompleters within blocks may be extended and overridden. Learn more about the [autocomplete](/docs/designers-developers/developers/filters/autocomplete-filters.md) filters.
 
 ## Block Parsing and Serialization
 
 Posts in the editor move through a couple of different stages between being stored in `post_content` and appearing in the editor. Since the blocks themselves are data structures that live in memory it takes a parsing and serialization step to transform out from and into the stored format in the database.
 
-Customizing the parser is an advanced topic that you can learn more about in the [Extending the Parser](../../../docs/designers-developers/developers/filters/parser-filters.md) section.
+Customizing the parser is an advanced topic that you can learn more about in the [Extending the Parser](/docs/designers-developers/developers/filters/parser-filters.md) section.

--- a/docs/designers-developers/developers/README.md
+++ b/docs/designers-developers/developers/README.md
@@ -26,7 +26,7 @@ You can also filter certain aspects of the editor; this is documented on the [Ed
 
 **Porting PHP meta boxes to blocks or sidebar plugins is highly encouraged!**
 
-Discover how [Meta Box](../../../docs/designers-developers/developers/backward-compatibility/meta-box.md) support works in the new editor.
+Discover how to work with [Meta Boxes](/docs/designers-developers/developers/tutorials/metabox/) in the new editor.
 
 ## Theme Support
 

--- a/docs/designers-developers/developers/README.md
+++ b/docs/designers-developers/developers/README.md
@@ -24,9 +24,9 @@ You can also filter certain aspects of the editor; this is documented on the [Ed
 
 ## Meta Boxes
 
-**Porting PHP meta boxes to blocks or sidebar plugins is highly encouraged!**
+Porting PHP meta boxes to blocks or sidebar plugins is highly encouraged, learn how through these [meta data tutorials](/docs/designers-developers/developers/tutorials/metabox/readme.md).
 
-Discover how to work with [Meta Boxes](/docs/designers-developers/developers/tutorials/metabox/readme.md) in the new editor.
+See how the new editor [supports existing Meta Boxes](/docs/designers-developers/developers/backward-compatibility/meta-box.md).
 
 ## Theme Support
 


### PR DESCRIPTION
## Description

Updates links in Developer overview to new tutorial explaining how to use meta boxes. The new tutorial section includes the previous link to the backward compatibility documentation.

Changed it this way since we want to encourage the development of meta boxes using the new Gutenberg methods, so updating the link to go to the tutorial first; with a subsequent link to the backward compatibility.

## Types of changes

Documentation.

