### PR TITLE
Add a tooltip to the block list appender.

### DIFF
--- a/packages/editor/src/components/block-list-appender/index.js
+++ b/packages/editor/src/components/block-list-appender/index.js
@@ -9,7 +9,7 @@ import { last } from 'lodash';
 import { withSelect } from '@wordpress/data';
 import { getDefaultBlockName } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-import { Button, Dashicon } from '@wordpress/components';
+import { IconButton } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -44,16 +44,15 @@ function BlockListAppender( {
 			<Inserter
 				rootClientId={ rootClientId }
 				renderToggle={ ( { onToggle, disabled, isOpen } ) => (
-					<Button
-						aria-label={ __( 'Add block' ) }
+					<IconButton
+						label={ __( 'Add block' ) }
+						icon="insert"
 						onClick={ onToggle }
 						className="block-list-appender__toggle"
 						aria-haspopup="true"
 						aria-expanded={ isOpen }
 						disabled={ disabled }
-					>
-						<Dashicon icon="insert" />
-					</Button>
+					/>
 				) }
 			/>
 		</div>


### PR DESCRIPTION
This PR adds a tooltip to the block list appender, by changing the `Button` used in the component to an `IconButton`.

Screenshot:

<img width="900" alt="screenshot 2019-01-13 at 12 20 32" src="https://user-images.githubusercontent.com/1682452/51084798-32d1f380-1730-11e9-8d55-76e08b1a2add.png">

To test:
- follow the instructions in #10136 and paste in the console the example block required to make the block list appender available
- add in a post the `container` block you've just registered
- see the block list appender
- verify the tooltip appears on hover and focus

See #10136

Fixes #13305 