### PR TITLE
Fix/unhandled promise rejection warning when returning null from action generator

### DIFF
--- a/packages/redux-routine/CHANGELOG.md
+++ b/packages/redux-routine/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.0.4
+## 3.0.4 (Unreleased)
 
 ### Bug Fixes
 

--- a/packages/redux-routine/CHANGELOG.md
+++ b/packages/redux-routine/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.4
+
+### Bug Fixes
+
+- Fix unhandled promise rejection error caused by returning null from registered generator ([#13314](https://github.com/WordPress/gutenberg/pull/13314)
+
 ## 3.0.3 (2018-10-19)
 
 ## 3.0.2 (2018-10-18)

--- a/packages/redux-routine/src/runtime.js
+++ b/packages/redux-routine/src/runtime.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { create } from 'rungen';
-import { map, isString } from 'lodash';
+import { map } from 'lodash';
 import isPromise from 'is-promise';
 
 /**
@@ -51,7 +51,7 @@ export default function createRuntime( controls = {}, dispatch ) {
 
 	return ( action ) => new Promise( ( resolve, reject ) =>
 		rungenRuntime( action, ( result ) => {
-			if ( typeof result === 'object' && isString( result.type ) ) {
+			if ( isAction( result ) ) {
 				dispatch( result );
 			}
 			resolve( result );

--- a/packages/redux-routine/src/test/index.js
+++ b/packages/redux-routine/src/test/index.js
@@ -50,6 +50,7 @@ describe( 'createMiddleware', () => {
 	} );
 
 	it( 'should throw if promise rejects', async () => {
+		expect.hasAssertions();
 		const middleware = createMiddleware( {
 			WAIT_FAIL: () => new Promise( ( resolve, reject ) =>
 				reject( 'Message' )
@@ -68,6 +69,7 @@ describe( 'createMiddleware', () => {
 	} );
 
 	it( 'should throw if promise throws', () => {
+		expect.hasAssertions();
 		const middleware = createMiddleware( {
 			WAIT_FAIL: () => new Promise( () => {
 				throw new Error( 'Message' );
@@ -83,6 +85,33 @@ describe( 'createMiddleware', () => {
 		}
 
 		return store.dispatch( createAction() );
+	} );
+
+	/**
+	 * Currently this test will not error even under conditions producing it but
+	 * instead will have an uncaught error/warning printed in the cli console:
+	 * - (node:37109) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'type' of null
+	 * (and others)
+	 *
+	 * See this github thread for context: https://github.com/facebook/jest/issues/3251
+	 */
+	it( 'should handle a null returned from a caught promise error', () => {
+		expect.hasAssertions();
+		const middleware = createMiddleware( {
+			WAIT_FAIL: () => new Promise( () => {
+				throw new Error( 'Message' );
+			} ),
+		} );
+		const store = createStoreWithMiddleware( middleware );
+		function* createAction() {
+			try {
+				yield { type: 'WAIT_FAIL' };
+			} catch ( error ) {
+				expect( error.message ).toBe( 'Message' );
+				return null;
+			}
+		}
+		store.dispatch( createAction() );
 	} );
 
 	it( 'assigns sync controlled return value into yield assignment', () => {

--- a/packages/redux-routine/src/test/index.js
+++ b/packages/redux-routine/src/test/index.js
@@ -87,14 +87,12 @@ describe( 'createMiddleware', () => {
 		return store.dispatch( createAction() );
 	} );
 
-	/**
-	 * Currently this test will not error even under conditions producing it but
-	 * instead will have an uncaught error/warning printed in the cli console:
-	 * - (node:37109) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'type' of null
-	 * (and others)
-	 *
-	 * See this github thread for context: https://github.com/facebook/jest/issues/3251
-	 */
+	// Currently this test will not error even under conditions producing it but
+	// instead will have an uncaught error/warning printed in the cli console:
+	// - (node:37109) UnhandledPromiseRejectionWarning: TypeError: Cannot read
+	// property 'type' of null (and others)
+	// See this github thread for context:
+	// https://github.com/facebook/jest/issues/3251
 	it( 'should handle a null returned from a caught promise error', () => {
 		expect.hasAssertions();
 		const middleware = createMiddleware( {


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

While working on adding fetch control error handling in a resolver for my plugin I discovered that if `null` is returned from the catch block, the function created by `createRuntime` will throw a `TypeError`:

![example of console error](https://www.evernote.com/l/AAN67yXp8bZI2qMJ3ncbBnZ7pvuP2oU02RMB/image.png)

The fix here is to implement the `isAction` method for the conditional triggering the error.

Note: a couple other things introduced in this pull:

- added `expect.hasAssertions()` to tests in `redux-routine/src/test/index.js` that had assertions happening inside a callback.  This improves the test.
- I added a test for catching the error but there's a known issue documented inline with the test.  I'm not sure how much time we want to try resolving that issue (see the code).

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- [x] unit tests and verification fixes problems reproducing it.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

- Non-breaking bug-fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
