### PR TITLE
Remove no longer used z-index.

### DIFF
--- a/assets/stylesheets/_z-index.scss
+++ b/assets/stylesheets/_z-index.scss
@@ -37,9 +37,6 @@ $z-layers: (
 	// Active pill button
 	".components-button.is-button {:focus or .is-primary}": 1,
 
-	// Reusable blocks UI, needs to be above sibling inserter.
-	".editor-block-list__layout .reusable-block-edit-panel": 7,
-
 	// The draggable element should show up above the entire UI
 	".components-draggable__clone": 1000000000,
 

--- a/packages/block-library/src/block/edit-panel/style.scss
+++ b/packages/block-library/src/block/edit-panel/style.scss
@@ -11,7 +11,6 @@
 	margin: 0 (-$block-padding);
 	padding: $grid-size $block-padding;
 	position: relative;
-	z-index: z-index(".editor-block-list__layout .reusable-block-edit-panel");
 
 	// Show a smaller padding when nested.
 	.editor-block-list__layout & {


### PR DESCRIPTION
Fixes #13308.

The z-index was initially added to address some issues with the Edit button on a reusable block having a microscopic hit area. This no longer appears to be the case, perhaps due to other refactors. This PR removes the redundant rule.

Please test for regressions around reusable blocks.

Before:

![master](https://user-images.githubusercontent.com/1204802/51169993-92094280-18ad-11e9-98ec-b0a0966b0dbd.gif)


After:

![this branch](https://user-images.githubusercontent.com/1204802/51169966-81f16300-18ad-11e9-92dd-ec8477f0e6b3.gif)
