### PR TITLE
Add onCaretVerticalPositionChange event

### DIFF
--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -58,6 +58,7 @@ class HeadingEdit extends Component {
 					isSelected={ this.props.isSelected }
 					onFocus={ this.props.onFocus } // always assign onFocus as a props
 					onBlur={ this.props.onBlur } // always assign onBlur as a props
+					onCaretVerticalPositionChange={ this.props.onCaretVerticalPositionChange }
 					style={ {
 						minHeight: Math.max( minHeight, this.state.aztecHeight ),
 					} }

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -94,6 +94,7 @@ class ParagraphEdit extends Component {
 					isSelected={ this.props.isSelected }
 					onFocus={ this.props.onFocus } // always assign onFocus as a props
 					onBlur={ this.props.onBlur } // always assign onBlur as a props
+					onCaretVerticalPositionChange={ this.props.onCaretVerticalPositionChange }
 					style={ {
 						...style,
 						minHeight: Math.max( minHeight, this.state.aztecHeight ),

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -379,6 +379,7 @@ export class RichText extends Component {
 					onBackspace={ this.onBackspace }
 					onContentSizeChange={ this.onContentSizeChange }
 					onActiveFormatsChange={ this.onActiveFormatsChange }
+					onCaretVerticalPositionChange={ this.props.onCaretVerticalPositionChange }
 					isSelected={ this.props.isSelected }
 					blockType={ { tag: tagName } }
 					color={ 'black' }


### PR DESCRIPTION
## Description
This PR adds onCaretVerticalPositionChange event to fix https://github.com/wordpress-mobile/gutenberg-mobile/issues/464

## How has this been tested?
Tested with steps on [gutenberg-mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/474)

## Types of changes

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
