### PR TITLE
Fix: :root no longer causes invalid selectors

### DIFF
--- a/packages/editor/src/editor-styles/transforms/test/__snapshots__/wrap.js.snap
+++ b/packages/editor/src/editor-styles/transforms/test/__snapshots__/wrap.js.snap
@@ -41,3 +41,9 @@ exports[`CSS selector wrap should wrap regular selectors 1`] = `
 color: red;
 }"
 `;
+
+exports[`CSS selector wrap should replace :root selectors 1`] = `
+".my-namespace {
+--my-color: #ff0000;
+}"
+`;

--- a/packages/editor/src/editor-styles/transforms/test/wrap.js
+++ b/packages/editor/src/editor-styles/transforms/test/wrap.js
@@ -61,4 +61,15 @@ describe( 'CSS selector wrap', () => {
 
 		expect( output ).toMatchSnapshot();
 	} );
+
+	it( 'should replace :root selectors', () => {
+		const callback = wrap( '.my-namespace' );
+		const input = `
+		:root {
+			--my-color: #ff0000;
+		}`;
+		const output = traverse( input, callback );
+
+		expect( output ).toMatchSnapshot();
+	} );
 } );

--- a/packages/editor/src/editor-styles/transforms/wrap.js
+++ b/packages/editor/src/editor-styles/transforms/wrap.js
@@ -6,7 +6,7 @@ import { includes } from 'lodash';
 /**
  * @const string IS_ROOT_TAG Regex to check if the selector is a root tag selector.
  */
-const IS_ROOT_TAG = /^(body|html).*$/;
+const IS_ROOT_TAG = /^(body|html|:root).*$/;
 
 const wrap = ( namespace, ignore = [] ) => ( node ) => {
 	const updateSelector = ( selector ) => {
@@ -20,7 +20,7 @@ const wrap = ( namespace, ignore = [] ) => ( node ) => {
 		}}
 
 		// HTML and Body elements cannot be contained within our container so lets extract their styles.
-		return selector.replace( /^(body|html)/, namespace );
+		return selector.replace( /^(body|html|:root)/, namespace );
 	};
 
 	if ( node.type === 'rule' ) {


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
The `:root` selector caused invalid selectors because the namespace was added before it. This PR handles `:root` the same way as `html` and `body` are handled. This is useful for defined css variables. For example:
```ccc
:root {
	--color-primary: #FF0;
}
```
will now become:
```ccc
.editor-styles-wrapper {
	--color-primary: #FF0;
}
```

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I've build a test case and ran the tests

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
This is a bug fix. Without this PR `:root` will be ignored by the browser.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->