### PR TITLE
Improve scrolling in fullscreen mode, notably for Edge

### DIFF
--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -114,11 +114,10 @@
 			margin-left: $admin-sidebar-width-collapsed;
 		}
 
-		// Undo the above rules for fullscreen mode.
+		// Provide special rules for fullscreen mode.
 		body.is-fullscreen-mode & {
 			margin-left: 0 !important;
-			position: relative;
-			top: inherit;
+			top: $header-height;
 		}
 	}
 


### PR DESCRIPTION
In https://github.com/WordPress/gutenberg/pull/12644, we changed the behavior of scrolling for the main content area slightly, to address issues with scrolling on small screens.

As part of that, there was one small issue that made it slightly harder to scroll this main content area, only when in fullscreen mode in Microsoft Edge. This PR fixes that.

Another side effect of that prior PR was that it unset some of the scrolling rules that prevented CSS bleed (when you scroll to the end of the Block Library and proceed to scroll the body content). This PR restores that.

Before:

<img width="2058" alt="before" src="https://user-images.githubusercontent.com/1204802/51176693-e1576f00-18bd-11e9-9746-97a6f33be3f7.png">

After:

<img width="2057" alt="after" src="https://user-images.githubusercontent.com/1204802/51176699-e3213280-18bd-11e9-9783-8d448a5daeae.png">

Also tested in IE:

<img width="2056" alt="ie11" src="https://user-images.githubusercontent.com/1204802/51176705-e6b4b980-18bd-11e9-81fc-e2d3a5ecbc8b.png">
