### PR TITLE
Update Question template for new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/Custom.md
+++ b/.github/ISSUE_TEMPLATE/Custom.md
@@ -4,10 +4,10 @@ about: Questions or 'how to' about Gutenberg
 
 ---
 
-If you have a question you have a few places that you can ask this:
+Please post general help requests in the support forum at https://wordpress.org/support/forum/how-to-and-troubleshooting/.
 
-- Support Forums: https://wordpress.org/support/plugin/gutenberg
-- Handbook: https://wordpress.org/gutenberg/handbook
-- https://chat.wordpress.org #core-editor
+Please post technical help requests in the support forum at https://wordpress.org/support/forum/wp-advanced/.
 
-If you are unable to ask in those places you can ask here, however you will get faster responses through those recommended places.
+Make sure you have checked the Handbook at https://wordpress.org/gutenberg/handbook before asking your question.
+
+Thank you!

--- a/.github/ISSUE_TEMPLATE/Custom.md
+++ b/.github/ISSUE_TEMPLATE/Custom.md
@@ -1,15 +1,17 @@
 ---
-name: Question
-about: Questions or 'how to' about Gutenberg
+name: Help Request
+about: Please post help requests or ‘how to’ questions in support channels first
 
 ---
+
+Search first! Your issue may have already been reported.
+
+Make sure you have checked the Handbook at https://wordpress.org/gutenberg/handbook before asking your question.
 
 Please post general help requests in the support forum at https://wordpress.org/support/forum/how-to-and-troubleshooting/.
 
 Please post technical help requests in the support forum at https://wordpress.org/support/forum/wp-advanced/. 
 
 You may also ask for technical support at https://wordpress.stackexchange.com/.
-
-Make sure you have checked the Handbook at https://wordpress.org/gutenberg/handbook before asking your question.
 
 Thank you!

--- a/.github/ISSUE_TEMPLATE/Custom.md
+++ b/.github/ISSUE_TEMPLATE/Custom.md
@@ -6,12 +6,12 @@ about: Please post help requests or ‘how to’ questions in support channels f
 
 Search first! Your issue may have already been reported.
 
-Make sure you have checked the Handbook at https://wordpress.org/gutenberg/handbook before asking your question.
-
 Please post general help requests in the support forum at https://wordpress.org/support/forum/how-to-and-troubleshooting/.
 
 Please post technical help requests in the support forum at https://wordpress.org/support/forum/wp-advanced/. 
 
 You may also ask for technical support at https://wordpress.stackexchange.com/.
+
+Please make sure you have checked the Handbook at https://wordpress.org/gutenberg/handbook before asking your question.
 
 Thank you!

--- a/.github/ISSUE_TEMPLATE/Custom.md
+++ b/.github/ISSUE_TEMPLATE/Custom.md
@@ -6,9 +6,9 @@ about: Please post help requests or ‘how to’ questions in support channels f
 
 Search first! Your issue may have already been reported.
 
-Please post general help requests in the support forum at https://wordpress.org/support/forum/how-to-and-troubleshooting/.
+For general help requests, please post in the support forum at https://wordpress.org/support/forum/how-to-and-troubleshooting/.
 
-Please post technical help requests in the support forum at https://wordpress.org/support/forum/wp-advanced/. 
+Technical help requests have their own section of the support forum at https://wordpress.org/support/forum/wp-advanced/. 
 
 You may also ask for technical support at https://wordpress.stackexchange.com/.
 

--- a/.github/ISSUE_TEMPLATE/Custom.md
+++ b/.github/ISSUE_TEMPLATE/Custom.md
@@ -6,7 +6,9 @@ about: Questions or 'how to' about Gutenberg
 
 Please post general help requests in the support forum at https://wordpress.org/support/forum/how-to-and-troubleshooting/.
 
-Please post technical help requests in the support forum at https://wordpress.org/support/forum/wp-advanced/.
+Please post technical help requests in the support forum at https://wordpress.org/support/forum/wp-advanced/. 
+
+You may also ask for technical support at https://wordpress.stackexchange.com/.
 
 Make sure you have checked the Handbook at https://wordpress.org/gutenberg/handbook before asking your question.
 


### PR DESCRIPTION
Now that Gutenberg has shipped in WordPress 5.0, we should consider updating the Question template for new issues to gently help people move their Gutenberg help requests to the main support forum as a first stop. This is because the ideal workflow is to ask for help and complete any troubleshooting needed with support first, which can then be moved to GitHub as a bug report once sufficient details are uncovered. This will help reduce duplicate requests posted to GitHub, increase the quality of bug reports, and help developers working on the project focus on feature work and bug fixes for verified bug reports.