### PR TITLE
Documentation: mention workflow and high priority labeled issues

### DIFF
--- a/docs/contributors/repository-management.md
+++ b/docs/contributors/repository-management.md
@@ -25,12 +25,16 @@ Any issues that are irrelevant or not actionable should be closed, because they 
 
 To better organize the issue backlog, all issues should have [one or more labels](https://github.com/WordPress/gutenberg/labels). Here are some you might commonly see:
 
-- [Accessibility](https://github.com/WordPress/gutenberg/labels/Accessibility) - Changes that impact accessibility and need corresponding review (e.g. markup changes).
+- [Needs Accessibility Feedback](https://github.com/WordPress/gutenberg/labels/Accessibility) - Changes that impact accessibility and need corresponding review (e.g. markup changes).
 - [Needs Design Feedback](https://github.com/WordPress/gutenberg/labels/Needs%20Design%20Feedback) - Changes that modify the design or user experience in some way and need sign-off.
 - [[Type] Bug](https://github.com/WordPress/gutenberg/labels/%5BType%5D%20Bug) - An existing feature is broken in some way.
 - [[Type] Enhancement](https://github.com/WordPress/gutenberg/labels/%5BType%5D%20Enhancement) - Gutenberg would be better with this improvement added.
 - [[Type] Plugin / Extension Conflict](https://github.com/WordPress/gutenberg/labels/%5BType%5D%20Plugin%20%2F%20Extension%20Conflict) - Documentation of a conflict between Gutenberg and a plugin or extension. The plugin author should be informed and provided documentation on how to address.
 - [[Status] Needs More Info](https://github.com/WordPress/gutenberg/labels/%5BStatus%5D%20Needs%20More%20Info) - The issue needs more information in order to be actionable and relevant. Typically this requires follow-up from the original reporter.
+
+Workflow labels may be applied as needed and start with “Needs”. Ideally, each workflow label will have a group that follows it, such as the Accessibility Team for `Needs Accessibility Feedback`, the Testing Team for `Needs Testing`, etc.
+
+`Priority High` and `Priority OMGWTFBBQ` issues should have an assignee and/or be in an active milestone.
 
 [Check out the label directory](https://github.com/WordPress/gutenberg/labels) for a listing of all labels.
 


### PR DESCRIPTION
Workflow labels are important for interacting with contributors at all levels and should be encouraged. We should also make sure to communicate well with other groups to ask them to use these workflows, such as the Design Team for the `Needs Design Feedback` label, the Gutenberg Team for the `Needs Decision` label, and all contributors or Support Team members who are developers for the `Needs Technical Feedback` label. 

This PR adds a note about workflow labels and also mentions that high priority issues should have an assignee and/or be in an active milestone. 

I also updated the `Accessibility` label to `Needs Accessibility Feedback` as it makes more sense for the description in this document.

https://wordpress.org/gutenberg/handbook/contributors/repository-management/