### PR TITLE
Block Serialization Default Parser: Use PCRE v6.x-compatible subpattern syntax

### DIFF
--- a/packages/block-serialization-default-parser/parser.php
+++ b/packages/block-serialization-default-parser/parser.php
@@ -410,7 +410,7 @@ class WP_Block_Parser {
 		 * match back in PHP to see which one it was.
 		 */
 		$has_match = preg_match(
-			'/<!--\s+(?<closer>\/)?wp:(?<namespace>[a-z][a-z0-9_-]*\/)?(?<name>[a-z][a-z0-9_-]*)\s+(?<attrs>{(?:(?:[^}]+|}+(?=})|(?!}\s+\/?-->).)*+)?}\s+)?(?<void>\/)?-->/s',
+			'/<!--\s+(?P<closer>\/)?wp:(?P<namespace>[a-z][a-z0-9_-]*\/)?(?P<name>[a-z][a-z0-9_-]*)\s+(?P<attrs>{(?:(?:[^}]+|}+(?=})|(?!}\s+\/?-->).)*+)?}\s+)?(?P<void>\/)?-->/s',
 			$this->document,
 			$matches,
 			PREG_OFFSET_CAPTURE,


### PR DESCRIPTION
Closes #13310

This pull request seeks to use a PCRE 6.x-compatible subpattern syntax in the block serialization parser. See #13310 for more information for the rationale of this change.

**Testing instructions:**

The affected PHP code here does not override the behavior of the `WP_Block_Parser_Block` class defined in WordPress 5.x . Therefore, you must test either by using an older version of WordPress, or by manually commenting the following line in your WordPress installation (see also #11015):

https://github.com/WordPress/WordPress/blob/b7897c576141adee3686056aff147ea09566c918/wp-settings.php#L258

...and applying a patch update to your local Gutenberg plugin to force the load of the bundled parser class definition:

```diff
diff --git a/gutenberg.php b/gutenberg.php
index 2df698bd4..f62a78bab 100644
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -567,3 +567,5 @@ function gutenberg_add_responsive_body_class( $classes ) {
 }
 
 add_filter( 'body_class', 'gutenberg_add_responsive_body_class' );
+
+require_once dirname( __FILE__ ) . '/packages/block-serialization-default-parser/parser.php';
```

Then, confirm there are no regressions in the behavior of the parser. For example, a dynamic block such as the Latest Posts block should display in a front-end preview.

Ensure parser tests pass:

```
npm run test-unit-php
```