### PR TITLE
Plugin: Bump minimum required WordPress version to 5.x

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -152,7 +152,7 @@ function is_gutenberg_page() {
  */
 function gutenberg_wordpress_version_notice() {
 	echo '<div class="error"><p>';
-	_e( 'Gutenberg requires WordPress 4.9.8 or later to function properly. Please upgrade WordPress before activating Gutenberg.', 'gutenberg' );
+	_e( 'Gutenberg requires WordPress 5.0.0 or later to function properly. Please upgrade WordPress before activating Gutenberg.', 'gutenberg' );
 	echo '</p></div>';
 
 	deactivate_plugins( array( 'gutenberg/gutenberg.php' ) );
@@ -186,7 +186,7 @@ function gutenberg_pre_init() {
 	// Strip '-src' from the version string. Messes up version_compare().
 	$version = str_replace( '-src', '', $wp_version );
 
-	if ( version_compare( $version, '4.9.8', '<' ) ) {
+	if ( version_compare( $version, '5.0.0', '<' ) ) {
 		add_action( 'admin_notices', 'gutenberg_wordpress_version_notice' );
 		return;
 	}


### PR DESCRIPTION
Related: #11015

This pull request seeks to change the minimum required WordPress version from 4.9.8 to 5.0.0 . This is a prerequisite to subsequent pull requests which will remove redundant PHP code to fall back to that which is provided by core itself, in an effort to (a) keep the code of the plugin focused, (b) reduce inconsistencies between the plugin and core, and (c) validate core extensibility through plugin use. See also #11015.

**Maintainer Note:** This will require a corresponding update to the plugin SVN repository in the plugin release following this merge. Specifically, the "Requires at least" field of `readme.txt` should be changed to 5.0.0.

**Testing instructions:**

You could use a downgrading plugin such as [WP Downgrade](https://wordpress.org/plugins/wp-downgrade/) to verify that Gutenberg deactivates itself with a WordPress 4.9.x installation.