### PR TITLE
Docs: mention dark colour scheme in design docs

### DIFF
--- a/docs/designers-developers/designers/block-design.md
+++ b/docs/designers-developers/designers/block-design.md
@@ -116,6 +116,10 @@ Because the Drop Cap feature is not necessary for the basic operation of the blo
 
 Check how your block looks, feels, and works on as many devices and screen sizes as you can.
 
+### Support Gutenberg's dark background editor scheme
+
+Check how your block looks with [dark backgrounds](https://wordpress.org/gutenberg/handbook/designers-developers/developers/themes/theme-support/#dark-backgrounds) in the editor.
+
 ## Examples
 
 To demonstrate some of these practices, here are a few annotated examples of default Gutenberg blocks:

--- a/docs/designers-developers/designers/block-design.md
+++ b/docs/designers-developers/designers/block-design.md
@@ -118,7 +118,7 @@ Check how your block looks, feels, and works on as many devices and screen sizes
 
 ### Support Gutenberg's dark background editor scheme
 
-Check how your block looks with [dark backgrounds](https://wordpress.org/gutenberg/handbook/designers-developers/developers/themes/theme-support/#dark-backgrounds) in the editor.
+Check how your block looks with [dark backgrounds](/docs/designers-developers/developers/themes/theme-support.md#dark-backgrounds) in the editor.
 
 ## Examples
 


### PR DESCRIPTION
## Description
Adds a section about dark colour scheme in design docs.

It's easy enough to forget to test with [dark backgrounds](https://wordpress.org/gutenberg/handbook/designers-developers/developers/themes/theme-support/#dark-backgrounds), just like folks forget to test mobile. Would be great to remind folks to test.

Example what happens when you forget to test: https://github.com/Automattic/wp-calypso/issues/30198

## How has this been tested?
—

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
