### PR TITLE
Add speak messages to the feature toggle component.

### DIFF
--- a/packages/edit-post/src/components/header/feature-toggle/index.js
+++ b/packages/edit-post/src/components/header/feature-toggle/index.js
@@ -1,16 +1,37 @@
 /**
+ * External dependencies
+ */
+import { flow } from 'lodash';
+
+/**
  * WordPress Dependencies
  */
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
-import { MenuItem } from '@wordpress/components';
+import { MenuItem, withSpokenMessages } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
-function FeatureToggle( { onToggle, isActive, label, info } ) {
+function FeatureToggle( { onToggle, isActive, label, info, messages, speak } ) {
+	const defaultMessages = {
+		activated: __( 'Feature activated' ),
+		deactivated: __( 'Feature deactivated' ),
+	};
+
+	messages = Object.assign( defaultMessages, messages );
+
+	const speakMessage = () => {
+		if ( isActive ) {
+			speak( messages.deactivated );
+		} else {
+			speak( messages.activated );
+		}
+	};
+
 	return (
 		<MenuItem
 			icon={ isActive && 'yes' }
 			isSelected={ isActive }
-			onClick={ onToggle }
+			onClick={ flow( onToggle, speakMessage ) }
 			role="menuitemcheckbox"
 			label={ label }
 			info={ info }
@@ -30,4 +51,5 @@ export default compose( [
 			ownProps.onToggle();
 		},
 	} ) ),
+	withSpokenMessages,
 ] )( FeatureToggle );

--- a/packages/edit-post/src/components/header/feature-toggle/index.js
+++ b/packages/edit-post/src/components/header/feature-toggle/index.js
@@ -11,19 +11,12 @@ import { compose } from '@wordpress/compose';
 import { MenuItem, withSpokenMessages } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-function FeatureToggle( { onToggle, isActive, label, info, messages, speak } ) {
-	const defaultMessages = {
-		activated: __( 'Feature activated' ),
-		deactivated: __( 'Feature deactivated' ),
-	};
-
-	messages = Object.assign( defaultMessages, messages );
-
+function FeatureToggle( { onToggle, isActive, label, info, messageActivated, messageDeactivated, speak } ) {
 	const speakMessage = () => {
 		if ( isActive ) {
-			speak( messages.deactivated );
+			speak( messageDeactivated || __( 'Feature deactivated' ) );
 		} else {
-			speak( messages.activated );
+			speak( messageActivated || __( 'Feature activated' ) );
 		}
 	};
 

--- a/packages/edit-post/src/components/header/writing-menu/index.js
+++ b/packages/edit-post/src/components/header/writing-menu/index.js
@@ -20,30 +20,24 @@ function WritingMenu( { onClose } ) {
 				label={ __( 'Top Toolbar' ) }
 				info={ __( 'Access all block and document tools in a single place' ) }
 				onToggle={ onClose }
-				messages={ {
-					activated: __( 'Top toolbar activated' ),
-					deactivated: __( 'Top toolbar deactivated' ),
-				} }
+				messageActivated={ __( 'Top toolbar activated' ) }
+				messageDeactivated={ __( 'Top toolbar deactivated' ) }
 			/>
 			<FeatureToggle
 				feature="focusMode"
 				label={ __( 'Spotlight Mode' ) }
 				info={ __( 'Focus on one block at a time' ) }
 				onToggle={ onClose }
-				messages={ {
-					activated: __( 'Spotlight mode activated' ),
-					deactivated: __( 'Spotlight mode deactivated' ),
-				} }
+				messageActivated={ __( 'Spotlight mode activated' ) }
+				messageDeactivated={ __( 'Spotlight mode deactivated' ) }
 			/>
 			<FeatureToggle
 				feature="fullscreenMode"
 				label={ __( 'Fullscreen Mode' ) }
 				info={ __( 'Work without distraction' ) }
 				onToggle={ onClose }
-				messages={ {
-					activated: __( 'Fullscreen mode activated' ),
-					deactivated: __( 'Fullscreen mode deactivated' ),
-				} }
+				messageActivated={ __( 'Fullscreen mode activated' ) }
+				messageDeactivated={ __( 'Fullscreen mode deactivated' ) }
 			/>
 		</MenuGroup>
 	);

--- a/packages/edit-post/src/components/header/writing-menu/index.js
+++ b/packages/edit-post/src/components/header/writing-menu/index.js
@@ -19,17 +19,32 @@ function WritingMenu( { onClose } ) {
 				feature="fixedToolbar"
 				label={ __( 'Top Toolbar' ) }
 				info={ __( 'Access all block and document tools in a single place' ) }
-				onToggle={ onClose } />
+				onToggle={ onClose }
+				messages={ {
+					activated: __( 'Top toolbar activated' ),
+					deactivated: __( 'Top toolbar deactivated' ),
+				} }
+			/>
 			<FeatureToggle
 				feature="focusMode"
 				label={ __( 'Spotlight Mode' ) }
 				info={ __( 'Focus on one block at a time' ) }
-				onToggle={ onClose } />
+				onToggle={ onClose }
+				messages={ {
+					activated: __( 'Spotlight mode activated' ),
+					deactivated: __( 'Spotlight mode deactivated' ),
+				} }
+			/>
 			<FeatureToggle
 				feature="fullscreenMode"
 				label={ __( 'Fullscreen Mode' ) }
 				info={ __( 'Work without distraction' ) }
-				onToggle={ onClose } />
+				onToggle={ onClose }
+				messages={ {
+					activated: __( 'Fullscreen mode activated' ),
+					deactivated: __( 'Fullscreen mode deactivated' ),
+				} }
+			/>
 		</MenuGroup>
 	);
 }


### PR DESCRIPTION
This PR adds `speak()` messages to the `FeatureToggle` component.

<img width="257" alt="screenshot 2019-01-20 at 15 55 37" src="https://user-images.githubusercontent.com/1682452/51441136-bfe7f000-1cce-11e9-9b5b-6adc74cfa25a.png">

When toggling one of these features, screen reader users have no clue what happened. The menu closes, focus is moved back to the menu toggle button, and there's no audible feedback.

While the messages could be added to the store effects using `TOGGLE_FEATURE`, I've opted to add them directly in the component for a few reasons:
- I'd tend to think sending the messages should be responsibility of the component
- it makes sense to pass the messages strings as props so they can be easily found in the codebase together with the passed label and they're not buried down in the effects; this will also help maintenance as the strings are all in the same place
- implementation is similar to the one used for `BlockInspectorButton` see `packages/edit-post/src/components/visual-editor/block-inspector-button.js`

I've opted for a `polite` message instead of an `assertive` one because focus is moved back to the toggle button and the button needs to be announced. An `assertive` message would interrupt the screen reader preventing it from announcing where focus has been moved.

To test:
- activate / deactivate the features
- verify the `polite` ARIA live region in the DOM gets the correct messages

Fixes #13384 