### PR TITLE
Change the inserter search result message from assertive to polite

### DIFF
--- a/packages/editor/src/components/inserter/menu.js
+++ b/packages/editor/src/components/inserter/menu.js
@@ -225,7 +225,7 @@ export class InserterMenu extends Component {
 			resultCount
 		);
 
-		debouncedSpeak( resultsFoundMessage, 'assertive' );
+		debouncedSpeak( resultsFoundMessage );
 	}
 
 	onKeyDown( event ) {


### PR DESCRIPTION
This PR seeks to improve screen readers behavior when using the Inserter. For more details please refer to the related issue #13387.

Please first test on current master:
- use Safari + VoiceOver
- tab to the main inserter button
- press Control Option Spacebar
- the inserter opens, focus is moved to the search field
- the search field label "Search for a block" is not announced
- the number of results is announced almost immediately

Switch to this branch
- repeats the steps above
- check the search field label "Search for a block" is announced correctly, followed by the number of results

![screenshot 2019-01-20 at 18 44 50](https://user-images.githubusercontent.com/1682452/51443061-0d228c80-1ce4-11e9-96c1-5000c279320f.png)



Fixes #13387