### PR TITLE
Add example usage for MediaPlaceholder

### DIFF
--- a/packages/editor/src/components/media-placeholder/README.md
+++ b/packages/editor/src/components/media-placeholder/README.md
@@ -12,17 +12,18 @@ const { MediaPlaceholder } = wp.editor;
 
 ...
 
-	edit: ({ attributes, setAttributes }) {
-		<MediaPlaceholder
+	edit: ( { attributes, setAttributes } ) {
+		const mediaPlaceholder = <MediaPlaceholder
 			onSelect = {
 				( el ) => {
 					setAttributes( { theImage: el.url } );
 				}
 			}
-			allowedTypes = {[ 'image' ]}
+			allowedTypes = { [ 'image' ] }
 			multiple = { false }
-			labels = { {title: 'The Image'} }
-		/>
+			labels = { { title: 'The Image' } }
+		/>;
+		...
 	}
 ```
 

--- a/packages/editor/src/components/media-placeholder/README.md
+++ b/packages/editor/src/components/media-placeholder/README.md
@@ -3,7 +3,30 @@ MediaPlaceholder
 
 `MediaPlaceholder` is a React component used to render either the media associated with a block, or an editing interface to replace the media for a block.
 
-## Setup
+## Usage
+
+An example usage which sets the URL of the selected image to `theImage` attributes.
+
+```
+const { MediaPlaceholder } = wp.editor;
+
+...
+
+	edit: ({ attributes, setAttributes }) {
+		<MediaPlaceholder
+			onSelect = {
+				( el ) => {
+					setAttributes( { theImage: el.url } );
+				}
+			}
+			allowedTypes = {[ 'image' ]}
+			multiple = { false }
+			labels = { {title: 'The Image'} }
+		/>
+	}
+```
+
+## Extend
 
 It includes a `wp.hooks` filter `editor.MediaPlaceholder` that enables developers to replace or extend it.
 
@@ -12,18 +35,18 @@ _Example:_
 Replace implementation of the placeholder:
 
 ```js
-function replaceMediaPlaceholder() { 
-	return function() { 
-		return wp.element.createElement( 
-			'div', 
-			{}, 
-			'The replacement contents or components.' 
-		); 
-	} 
-} 
+function replaceMediaPlaceholder() {
+	return function() {
+		return wp.element.createElement(
+			'div',
+			{},
+			'The replacement contents or components.'
+		);
+	}
+}
 
-wp.hooks.addFilter( 
-	'editor.MediaPlaceholder', 
+wp.hooks.addFilter(
+	'editor.MediaPlaceholder',
 	'my-plugin/replace-media-placeholder',
 	replaceMediaPlaceholder
 );


### PR DESCRIPTION
## Description
Adds an example of how to use the MediaPlaceholder and setting
the url for an image attribute.

Fixes #13377 

## How has this been tested?

Documentation. 

To test, follow example and see if it works for placing a MediaPlaceholder component.

