### PR TITLE
Scripts: Add support for format-js script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2800,6 +2800,7 @@
 				"jest": "^23.6.0",
 				"jest-puppeteer": "3.2.1",
 				"npm-package-json-lint": "^3.3.1",
+				"prettier-eslint-cli": "^4.7.1",
 				"puppeteer": "1.6.1",
 				"read-pkg-up": "^1.0.1",
 				"resolve-bin": "^0.4.0",
@@ -4725,6 +4726,12 @@
 			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
 			"dev": true
 		},
+		"boolify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/boolify/-/boolify-1.0.1.tgz",
+			"integrity": "sha1-tcCeF8rNET0Rt7s+04TMASmU2Gs=",
+			"dev": true
+		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -5740,6 +5747,12 @@
 			"version": "2.16.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
 			"integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew==",
+			"dev": true
+		},
+		"common-tags": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+			"integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
 			"dev": true
 		},
 		"commondir": {
@@ -7189,6 +7202,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
 			"integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
+			"dev": true
+		},
+		"dlv": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.2.tgz",
+			"integrity": "sha512-xxD4VSH67GbRvSGUrckvha94RD7hjgOH7rqGxiytLpkaeMvixOHFZTGFK6EkIm3T761OVHT8ABHmGkq9gXgu6Q==",
 			"dev": true
 		},
 		"doctrine": {
@@ -14161,6 +14180,12 @@
 				"lodash._reinterpolate": "~3.0.0"
 			}
 		},
+		"lodash.unescape": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+			"integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
+			"dev": true
+		},
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -14216,6 +14241,64 @@
 						"exit-hook": "^1.0.0",
 						"onetime": "^1.0.0"
 					}
+				}
+			}
+		},
+		"loglevel": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
+			"integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=",
+			"dev": true
+		},
+		"loglevel-colored-level-prefix": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/loglevel-colored-level-prefix/-/loglevel-colored-level-prefix-1.0.0.tgz",
+			"integrity": "sha1-akAhj9x64V/HbD0PPmdsRlOIYD4=",
+			"dev": true,
+			"requires": {
+				"chalk": "^1.1.3",
+				"loglevel": "^1.4.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
 				}
 			}
 		},
@@ -14371,6 +14454,24 @@
 					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
 					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
 					"dev": true
+				}
+			}
+		},
+		"make-plural": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
+			"integrity": "sha512-xTYd4JVHpSCW+aqDof6w/MebaMVNTVYBZhbB/vi513xXdiPT92JMVCo0Jq8W2UZnzYRFeVbQiQ+I25l13JuKvA==",
+			"dev": true,
+			"requires": {
+				"minimist": "^1.2.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -14766,6 +14867,41 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.2.tgz",
 			"integrity": "sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg==",
+			"dev": true
+		},
+		"messageformat": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/messageformat/-/messageformat-1.1.1.tgz",
+			"integrity": "sha512-Q0uXcDtF5pEZsVSyhzDOGgZZK6ykN79VY9CwU3Nv0gsqx62BjdJW0MT+63UkHQ4exe3HE33ZlxR2/YwoJarRTg==",
+			"dev": true,
+			"requires": {
+				"glob": "~7.0.6",
+				"make-plural": "^4.1.1",
+				"messageformat-parser": "^1.1.0",
+				"nopt": "~3.0.6",
+				"reserved-words": "^0.1.2"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.0.6",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+					"integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.2",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				}
+			}
+		},
+		"messageformat-parser": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-1.1.0.tgz",
+			"integrity": "sha512-Hwem6G3MsKDLS1FtBRGIs8T50P1Q00r3srS6QJePCFbad9fq0nYxwf3rnU2BreApRGhmpKMV7oZI06Sy1c9TPA==",
 			"dev": true
 		},
 		"methods": {
@@ -18291,6 +18427,155 @@
 			"integrity": "sha512-KIU72UmYPGk4MujZGYMFwinB7lOf2LsDNGSOC8ufevsrPLISrZbNJlWstRi3m0AMuszbH+EFSQ/r6w56RSPK6w==",
 			"dev": true
 		},
+		"prettier-eslint": {
+			"version": "8.8.2",
+			"resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-8.8.2.tgz",
+			"integrity": "sha512-2UzApPuxi2yRoyMlXMazgR6UcH9DKJhNgCviIwY3ixZ9THWSSrUww5vkiZ3C48WvpFl1M1y/oU63deSy1puWEA==",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.26.0",
+				"common-tags": "^1.4.0",
+				"dlv": "^1.1.0",
+				"eslint": "^4.0.0",
+				"indent-string": "^3.2.0",
+				"lodash.merge": "^4.6.0",
+				"loglevel-colored-level-prefix": "^1.0.0",
+				"prettier": "^1.7.0",
+				"pretty-format": "^23.0.1",
+				"require-relative": "^0.8.7",
+				"typescript": "^2.5.1",
+				"typescript-eslint-parser": "^16.0.0",
+				"vue-eslint-parser": "^2.0.2"
+			}
+		},
+		"prettier-eslint-cli": {
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/prettier-eslint-cli/-/prettier-eslint-cli-4.7.1.tgz",
+			"integrity": "sha512-hQbsGaEVz97oBBcKdsJ46khv0kOGkMyWrXzcFOXW6X8UuetZ/j0yDJkNJgUTVc6PVFbbzBXk+qgd5vos9qzXPQ==",
+			"dev": true,
+			"requires": {
+				"arrify": "^1.0.1",
+				"babel-runtime": "^6.23.0",
+				"boolify": "^1.0.0",
+				"camelcase-keys": "^4.1.0",
+				"chalk": "2.3.0",
+				"common-tags": "^1.4.0",
+				"eslint": "^4.5.0",
+				"find-up": "^2.1.0",
+				"get-stdin": "^5.0.1",
+				"glob": "^7.1.1",
+				"ignore": "^3.2.7",
+				"indent-string": "^3.1.0",
+				"lodash.memoize": "^4.1.2",
+				"loglevel-colored-level-prefix": "^1.0.0",
+				"messageformat": "^1.0.2",
+				"prettier-eslint": "^8.5.0",
+				"rxjs": "^5.3.0",
+				"yargs": "10.0.3"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.1.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^4.0.0"
+					}
+				},
+				"cliui": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"dev": true,
+					"requires": {
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wrap-ansi": "^2.0.0"
+					},
+					"dependencies": {
+						"string-width": {
+							"version": "1.0.2",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"dev": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						}
+					}
+				},
+				"get-stdin": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+					"integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"dev": true,
+					"requires": {
+						"has-flag": "^2.0.0"
+					}
+				},
+				"yargs": {
+					"version": "10.0.3",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
+					"integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
+					"dev": true,
+					"requires": {
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^8.0.0"
+					}
+				}
+			}
+		},
 		"pretty-bytes": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
@@ -19412,6 +19697,12 @@
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
+		"require-relative": {
+			"version": "0.8.7",
+			"resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
+			"integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
+			"dev": true
+		},
 		"require-uncached": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
@@ -19434,6 +19725,12 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
 			"integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
+			"dev": true
+		},
+		"reserved-words": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.2.tgz",
+			"integrity": "sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE=",
 			"dev": true
 		},
 		"resolve": {
@@ -21755,6 +22052,22 @@
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 			"dev": true
 		},
+		"typescript": {
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
+			"integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+			"dev": true
+		},
+		"typescript-eslint-parser": {
+			"version": "16.0.1",
+			"resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-16.0.1.tgz",
+			"integrity": "sha512-IKawLTu4A2xN3aN/cPLxvZ0bhxZHILGDKTZWvWNJ3sLNhJ3PjfMEDQmR2VMpdRPrmWOadgWXRwjLBzSA8AGsaQ==",
+			"dev": true,
+			"requires": {
+				"lodash.unescape": "4.0.1",
+				"semver": "5.5.0"
+			}
+		},
 		"ua-parser-js": {
 			"version": "0.7.18",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
@@ -22339,6 +22652,20 @@
 			"dev": true,
 			"requires": {
 				"indexof": "0.0.1"
+			}
+		},
+		"vue-eslint-parser": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz",
+			"integrity": "sha512-ZezcU71Owm84xVF6gfurBQUGg8WQ+WZGxgDEQu1IHFBZNx7BFZg3L1yHxrCBNNwbwFtE1GuvfJKMtb6Xuwc/Bw==",
+			"dev": true,
+			"requires": {
+				"debug": "^3.1.0",
+				"eslint-scope": "^3.7.1",
+				"eslint-visitor-keys": "^1.0.0",
+				"espree": "^3.5.2",
+				"esquery": "^1.0.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"w3c-hr-time": {

--- a/packages/scripts/config/.eslintrc.js
+++ b/packages/scripts/config/.eslintrc.js
@@ -1,3 +1,4 @@
 module.exports = {
+	root: true,
 	extends: [ 'plugin:@wordpress/eslint-plugin/recommended' ],
 };

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -42,6 +42,7 @@
 		"jest": "^23.6.0",
 		"jest-puppeteer": "3.2.1",
 		"npm-package-json-lint": "^3.3.1",
+		"prettier-eslint-cli": "^4.7.1",
 		"puppeteer": "1.6.1",
 		"read-pkg-up": "^1.0.1",
 		"resolve-bin": "^0.4.0",

--- a/packages/scripts/scripts/format-js.js
+++ b/packages/scripts/scripts/format-js.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+const { sync: spawn } = require( 'cross-spawn' );
+const { sync: resolveBin } = require( 'resolve-bin' );
+
+/**
+ * Internal dependencies
+ */
+const {
+	fromConfigRoot,
+	getCliArgs,
+	hasCliArg,
+	hasPackageProp,
+	hasProjectFile,
+} = require( '../utils' );
+
+const hasLintConfig =
+	hasCliArg( '--eslint-config-path' ) ||
+	hasProjectFile( '.eslintrc.js' ) ||
+	hasProjectFile( '.eslintrc.yaml' ) ||
+	hasProjectFile( '.eslintrc.yml' ) ||
+	hasProjectFile( '.eslintrc.json' ) ||
+	hasProjectFile( '.eslintrc' ) ||
+	hasPackageProp( 'eslintConfig' );
+
+const lintConfig = ! hasLintConfig ?
+	[ '--eslint-config-path', fromConfigRoot( '.eslintrc.js' ) ] :
+	[];
+
+const result = spawn(
+	resolveBin( 'prettier-eslint-cli', { executable: 'prettier-eslint' } ),
+	[ ...lintConfig, '--write', ...getCliArgs() ],
+	{ stdio: 'inherit' }
+);
+
+process.exit( result.status );


### PR DESCRIPTION
## Description
Inspired by multiple chats with @zgordon based on the feedback he gets from his online courses.

This PR adds the formatting command for JavaScript code. It uses [Prettier](https://prettier.io/) behind the scenes to format code. In fact, it uses [prettier-eslint-cli](https://github.com/prettier/prettier-eslint-cli) which is a combination of `prettier` and `eslint --fix` calls to ensure that formatted code stays as close as possible to [WordPress JavaScript coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/). It is still experimental and in many cases will not work as expected.

I would be happy to see also a similar formatter for styles (*.scss).

**There is no plan to have these commands included in Gutenberg's workflow.** 

## How has this been tested?
`./node_modules/.bin/wp-scripts format-js "**/*.js"`

At the moment it doesn't fully work as expected on Gutenberg codebase. On the first run it fixes most of the issues. However, for some reasons, it updates again a few files on every subsequent run which isn't what I would expect. There might be some need to tweak Prettier's default config to make it work (e.g. `no-mixed-spaces-and-tabs` is very surprising to see). It's also possible that the end goal is not easy to achieve without tweaking the code manually.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
