### PR TITLE
Replace non breaking spaces inserted on space

### DIFF
--- a/packages/e2e-test-utils/src/get-edited-post-content.js
+++ b/packages/e2e-test-utils/src/get-edited-post-content.js
@@ -21,5 +21,6 @@ export async function getEditedPostContent() {
 		throw new Error( 'Unexpected zero-width space character in editor content.' );
 	}
 
-	return content;
+	// Encode non breaking spaces so they are visible in snapshots.
+	return content.replace( /\u00a0/g, '&nbsp;' );
 }

--- a/packages/e2e-tests/specs/__snapshots__/rich-text.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/rich-text.test.js.snap
@@ -24,6 +24,12 @@ exports[`RichText should handle change in tag name gracefully 1`] = `
 <!-- /wp:heading -->"
 `;
 
+exports[`RichText should not insert non breaking spaces 1`] = `
+"<!-- wp:paragraph -->
+<p>test <strong>test test</strong></p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`RichText should only mutate text data on input 1`] = `
 "<!-- wp:paragraph -->
 <p>1<strong>2</strong>34</p>

--- a/packages/e2e-tests/specs/__snapshots__/undo.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/undo.test.js.snap
@@ -28,7 +28,7 @@ exports[`undo should undo typing after a pause 2`] = `
 
 exports[`undo should undo typing after non input change 1`] = `
 "<!-- wp:paragraph -->
-<p>before keyboard <strong>after keyboard</strong></p>
+<p>before keyboard <strong>after keyboard</strong></p>
 <!-- /wp:paragraph -->"
 `;
 

--- a/packages/e2e-tests/specs/rich-text.test.js
+++ b/packages/e2e-tests/specs/rich-text.test.js
@@ -138,4 +138,13 @@ describe( 'RichText', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should not insert non breaking spaces', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'test ' );
+		await pressKeyWithModifier( 'primary', 'b' );
+		await page.keyboard.type( 'test test' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );

--- a/packages/editor/src/components/rich-text/tinymce.js
+++ b/packages/editor/src/components/rich-text/tinymce.js
@@ -345,7 +345,7 @@ export default class TinyMCE extends Component {
 	 * @param  {SyntheticEvent} event Synthetic key up event.
 	 */
 	onKeyUp( event ) {
-		if ( event.shiftKey || event.keyCode !== SPACE ) {
+		if ( event.altKey || event.keyCode !== SPACE ) {
 			return;
 		}
 
@@ -358,7 +358,7 @@ export default class TinyMCE extends Component {
 		const range = selection.getRangeAt( 0 );
 		const { startContainer, startOffset, collapsed } = range;
 
-		if ( ! collapsed ) {
+		if ( ! collapsed || startContainer.nodeType !== TEXT_NODE ) {
 			return;
 		}
 

--- a/packages/editor/src/components/rich-text/tinymce.js
+++ b/packages/editor/src/components/rich-text/tinymce.js
@@ -345,6 +345,7 @@ export default class TinyMCE extends Component {
 	 * @param  {SyntheticEvent} event Synthetic key up event.
 	 */
 	onKeyUp( event ) {
+		// Alt+Space *should* insert a non breaking space. Do not remove it.
 		if ( event.altKey || event.keyCode !== SPACE ) {
 			return;
 		}


### PR DESCRIPTION
## Description
Fixes #13198. Temporarily replace non breaking spaces inserted by TinyMCE until we find a better solution.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->