### PR TITLE
Replace the fullscreen "exit" icon with a back arrow

### DIFF
--- a/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
@@ -19,12 +19,12 @@ function FullscreenModeClose( { isActive, postType } ) {
 	return (
 		<Toolbar className="edit-post-fullscreen-mode-close__toolbar">
 			<IconButton
-				icon="exit"
+				icon="arrow-left-alt2"
 				href={ addQueryArgs( 'edit.php', { post_type: postType.slug } ) }
 				label={ get(
 					postType,
 					[ 'labels', 'view_items' ],
-					__( 'View Posts' )
+					__( 'Back' )
 				) }
 			/>
 		</Toolbar>


### PR DESCRIPTION
As per the notes in #10813, this PR updates the full screen "Exit" icon with a "Back" icon and label instead.

This icon is more common across the web, and will thus be a bit less confusing for users.

Note: The original issue suggested using a Material icon, but I've just swapped this out with the equivalent Dashicon for simplicity in implementtion. If someone knows how to swap that out with a SVG, go for it. :thumbsup: