### PR TITLE
Provide warning if href passed to PluginMoreMenuItem is an incomplete…

### DIFF
--- a/packages/edit-post/src/components/header/plugin-more-menu-item/index.js
+++ b/packages/edit-post/src/components/header/plugin-more-menu-item/index.js
@@ -15,21 +15,34 @@ import { withPluginContext } from '@wordpress/plugins';
  */
 import PluginsMoreMenuGroup from '../plugins-more-menu-group';
 
-const PluginMoreMenuItem = ( { onClick = noop, ...props } ) => (
-	<PluginsMoreMenuGroup>
-		{ ( fillProps ) => (
-			<MenuItem
-				{ ...props }
-				onClick={ compose( onClick, fillProps.onClose ) }
-			/>
-		) }
-	</PluginsMoreMenuGroup>
-);
+const PluginMoreMenuItem = ( { onClick = noop, href, ...props } ) => {
+	// Provide console warning if the href prop value is #
+	if ( href === '#' ) {
+		// eslint-disable-next-line no-console
+		console.warn(
+			'Links should trigger navigation. Replace Menu Item href with a navigable URL.'
+		);
+	}
+
+	return (
+		<PluginsMoreMenuGroup>
+			{ ( fillProps ) => (
+				<MenuItem
+					{ ...props }
+					onClick={ compose(
+						onClick,
+						fillProps.onClose
+					) }
+				/>
+			) }
+		</PluginsMoreMenuGroup>
+	);
+};
 
 export default compose(
 	withPluginContext( ( context, ownProps ) => {
 		return {
 			icon: ownProps.icon || context.icon,
 		};
-	} ),
+	} )
 )( PluginMoreMenuItem );

--- a/packages/edit-post/src/components/header/plugin-more-menu-item/index.js
+++ b/packages/edit-post/src/components/header/plugin-more-menu-item/index.js
@@ -20,7 +20,7 @@ const PluginMoreMenuItem = ( { onClick = noop, href, ...props } ) => {
 	if ( href === '#' ) {
 		// eslint-disable-next-line no-console
 		console.warn(
-			'Links should trigger navigation. Replace Menu Item href with a navigable URL.'
+			'Links should trigger navigation. Replace href value for PluginMoreMenuItem component with a navigable URL.'
 		);
 	}
 

--- a/packages/edit-post/src/components/header/plugin-more-menu-item/index.js
+++ b/packages/edit-post/src/components/header/plugin-more-menu-item/index.js
@@ -15,9 +15,9 @@ import { withPluginContext } from '@wordpress/plugins';
  */
 import PluginsMoreMenuGroup from '../plugins-more-menu-group';
 
-const PluginMoreMenuItem = ( { onClick = noop, href, ...props } ) => {
+const PluginMoreMenuItem = ( { onClick = noop, ...props } ) => {
 	// Provide console warning if the href prop value is #
-	if ( href === '#' ) {
+	if ( props.href === '#' ) {
 		// eslint-disable-next-line no-console
 		console.warn(
 			'Links should trigger navigation. Replace href value for PluginMoreMenuItem component with a navigable URL.'

--- a/packages/edit-post/src/components/header/plugin-more-menu-item/test/index.js
+++ b/packages/edit-post/src/components/header/plugin-more-menu-item/test/index.js
@@ -53,10 +53,11 @@ describe( 'PluginMoreMenuItem', () => {
 	} );
 
 	test( 'it outputs console warning when href is #', () => {
+		const url = '#';
+
 		global.console = {
 			warn: jest.fn(),
 		};
-		const url = '#';
 
 		expect( global.console.warn ).not.toHaveBeenCalled();
 

--- a/packages/edit-post/src/components/header/plugin-more-menu-item/test/index.js
+++ b/packages/edit-post/src/components/header/plugin-more-menu-item/test/index.js
@@ -51,4 +51,26 @@ describe( 'PluginMoreMenuItem', () => {
 
 		expect( component.root.findByType( 'a' ).props.href ).toBe( url );
 	} );
+
+	test( 'it outputs console warning when href is #', () => {
+		global.console = {
+			warn: jest.fn(),
+		};
+		const url = '#';
+
+		expect( global.console.warn ).not.toHaveBeenCalled();
+
+		ReactTestRenderer.create(
+			<SlotFillProvider>
+				<PluginMoreMenuItem
+					href={ url }
+				>
+					My plugin link menu item
+				</PluginMoreMenuItem>
+				<PluginsMoreMenuGroup.Slot fillProps={ fillProps } />
+			</SlotFillProvider>
+		);
+
+		expect( global.console.warn ).toHaveBeenCalled();
+	} );
 } );


### PR DESCRIPTION
… URL fragment identifier (#)

## Description
<!-- Please describe what you have changed or added -->
Addresses #12535. Added a console warning if `href` value being passed to the `PluginMoreMenuItem` component is a `#` sign.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Paste the following in the console:

```
( function() {
	const { createElement } = wp.element;
	const { PluginMoreMenuItem } = wp.editPost;
	const { registerPlugin } = wp.plugins;

	registerPlugin( 'my-plugin-more-menu-button', {
		render() {
			return createElement(
				PluginMoreMenuItem,
				{
					href: '#',
				},
				'Test Link'
			);
		},
	} );
} )();
```

This should trigger the following console warning: 
`Links should trigger navigation. Replace href value for PluginMoreMenuItem component with a navigable URL.`

The above code adds the following link item in the More Items menu
<img width="300" alt="screen shot 2019-01-21 at 2 32 59 pm" src="https://user-images.githubusercontent.com/7535989/51495551-c471de80-1d8a-11e9-871b-226e41bc88af.png">

## Screenshots <!-- if applicable -->
<img width="799" alt="screen shot 2019-01-21 at 2 41 58 pm" src="https://user-images.githubusercontent.com/7535989/51495540-bcb23a00-1d8a-11e9-9a09-31c8f56c2afa.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
This is just introducing a console warning to encourage accessibility best practices when creating links. This affects the More Options menu.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
