### PR TITLE
Docs: Fix Notices documentation data handbook reference

### DIFF
--- a/packages/notices/README.md
+++ b/packages/notices/README.md
@@ -20,6 +20,6 @@ When imported, the notices module registers a data store on the `core/notices` n
 
 For more information about consuming from a data store, refer to [the `@wordpress/data` documentation on _Data Access and Manipulation_](/packages/data/README.md#data-access-and-manipulation).
 
-For a full list of actions and selectors available in the `core/notices` namespace, refer to the [_Notices Data_ Handbook page](https://wordpress.org/gutenberg/handbook/packages/packages-data/packages-data-core-edit-post/).
+For a full list of actions and selectors available in the `core/notices` namespace, refer to the [_Notices Data_ Handbook page](https://wordpress.org/gutenberg/handbook/designers-developers/developers/data/data-core-notices/).
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/notices/README.md
+++ b/packages/notices/README.md
@@ -20,6 +20,6 @@ When imported, the notices module registers a data store on the `core/notices` n
 
 For more information about consuming from a data store, refer to [the `@wordpress/data` documentation on _Data Access and Manipulation_](/packages/data/README.md#data-access-and-manipulation).
 
-For a full list of actions and selectors available in the `core/notices` namespace, refer to the [_Notices Data_ Handbook page](https://wordpress.org/gutenberg/handbook/designers-developers/developers/data/data-core-notices/).
+For a full list of actions and selectors available in the `core/notices` namespace, refer to the [_Notices Data_ Handbook page](/docs/designers-developers/developers/data/data-core-notices.md).
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/11604#issuecomment-455876765

This pull request seeks to resolve a broken link in the Notices module documentation.

**Broken:** https://wordpress.org/gutenberg/handbook/packages/packages-data/packages-data-core-edit-post/
**Fixed:** https://wordpress.org/gutenberg/handbook/designers-developers/developers/data/data-core-notices/

**Testing instructions:**

Verify from the [preview](https://github.com/WordPress/gutenberg/blob/c8836017b81b633583a92417ed406c82a7a9dcfe/packages/notices/README.md) that the "Notices Data Handbook page" link navigates to a non-404 page.