### PR TITLE
Fix HTML preview for themes applying global margins

### DIFF
--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -20,7 +20,22 @@ class HTMLEdit extends Component {
 
 	componentDidMount() {
 		const { styles } = this.props;
-		this.setState( { styles: transformStyles( styles ) } );
+
+		// Default styles used to unset some of the styles
+		// that might be inherited from the editor style.
+		const defaultStyles = `
+			html,body,:root {
+				margin: 0 !important;
+				padding: 0 !important;
+				overflow: visible !important;
+				min-height: auto !important;
+			}
+		`;
+
+		this.setState( { styles: [
+			defaultStyles,
+			...transformStyles( styles ),
+		] } );
 	}
 
 	switchToPreview() {


### PR DESCRIPTION
Some themes might apply global margins/paddings... For the HTML block preview, we need to reset those styles and only apply the content's editor styles.

Fixes #13414

Repeat instructions from the issue to ensure that it's working properly.