### PR TITLE
Docs: Move packages section out of CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,11 +2,11 @@
 
 Thank you for thinking about contributing to WordPress' Gutenberg project! If you're unsure of anything, know that you're 💯 welcome to submit an issue or pull request on any topic. The worst that can happen is that you'll be politely directed to the best location to ask your question or to change something in your pull request. We appreciate any sort of contribution and don't want a wall of rules to get in the way of that.
 
-As with all WordPress projects, we want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+As with all WordPress projects, we want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow our [Code of Conduct](/CODE_OF_CONDUCT.md).
 
-Before contributing, we encourage you to read our [Contributing Policy](CONTRIBUTING.md) (you're here already!) and our [Handbook](https://wordpress.org/gutenberg/handbook/). If you have any questions on any of these, please open an issue so we can help clarify them.
+Before contributing, we encourage you to read our [Contributing Policy](/CONTRIBUTING.md) (you're here already!) and our [Handbook](https://wordpress.org/gutenberg/handbook/). If you have any questions on any of these, please open an issue so we can help clarify them.
 
-All WordPress projects are [licensed under the GPLv2+](LICENSE.md), and all contributions to Gutenberg will be released under the GPLv2+ license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv2+ license.
+All WordPress projects are [licensed under the GPLv2+](/LICENSE.md), and all contributions to Gutenberg will be released under the GPLv2+ license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv2+ license.
 
 ## Getting Started
 
@@ -60,7 +60,7 @@ Welcome to...
 ```
 
 The WordPress installation should be available at `http://localhost:8888` (**Username**: `admin`, **Password**: `password`).
-Inside the "docker" directory, you can use any docker command to interact with your containers. If this port is in use, you can override it in your `docker-compose.override.yml` file. If you're running [e2e tests](https://wordpress.org/gutenberg/handbook/reference/testing-overview/#end-to-end-testing), this change will be used correctly.
+Inside the "docker" directory, you can use any docker command to interact with your containers. If this port is in use, you can override it in your `docker-compose.override.yml` file. If you're running [e2e tests](/docs/contributors/testing-overview.md#end-to-end-testing), this change will be used correctly.
 
 To bring down this local WordPress instance later run:
 ```
@@ -104,137 +104,17 @@ For example, `add/gallery-block` means you're working on adding a new gallery bl
 
 You can pick among all the <a href="https://github.com/WordPress/gutenberg/issues">tickets</a>, or some of the ones labelled <a href="https://github.com/WordPress/gutenberg/labels/Good%20First%20Issue">Good First Issue</a>.
 
-The workflow is documented in greater detail in the [repository management](./docs/contributors/repository-management.md) document.
+The workflow is documented in greater detail in the [repository management](/docs/contributors/repository-management.md) document.
 
 ## Testing
 
-Gutenberg contains both PHP and JavaScript code and encourages testing and code style linting for both. It also incorporates end-to-end testing using [Google Puppeteer](https://developers.google.com/web/tools/puppeteer/). You can find out more details in [Testing Overview document](./docs/contributors/testing-overview.md).
+Gutenberg contains both PHP and JavaScript code and encourages testing and code style linting for both. It also incorporates end-to-end testing using [Google Puppeteer](https://developers.google.com/web/tools/puppeteer/). You can find out more details in [Testing Overview document](/docs/contributors/testing-overview.md).
 
 ## Managing Packages
 
-This repository uses [lerna] to manage Gutenberg modules and publish them as packages to [npm].
+This repository uses [lerna] to manage Gutenberg modules and publish them as packages to [npm]. This enforces certain steps in the workflow which are described in details in [packages](/packages/README.md) documentation.
 
-### Creating a New Package
-
-When creating a new package, you need to provide at least the following:
-
-1. `package.json` based on the template:
-	```json
-	{
-		"name": "@wordpress/package-name",
-		"version": "1.0.0-beta.0",
-		"description": "Package description.",
-		"author": "The WordPress Contributors",
-		"license": "GPL-2.0-or-later",
-		"keywords": [
-			"wordpress"
-		],
-		"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/package-name/README.md",
-		"repository": {
-			"type": "git",
-			"url": "https://github.com/WordPress/gutenberg.git"
-		},
-		"bugs": {
-			"url": "https://github.com/WordPress/gutenberg/issues"
-		},
-		"main": "build/index.js",
-		"module": "build-module/index.js",
-		"react-native": "src/index",
-		"dependencies": {
-			"@babel/runtime": "^7.0.0"
-		},
-		"publishConfig": {
-			"access": "public"
-		}
-	}
-	```
-	This assumes that your code is located in the `src` folder and will be transpiled with `Babel`.
-2. `.npmrc` file which disables creating `package-lock.json` file for the package:
-	```
-	package-lock=false
-	```
-3. `README.md` file containing at least:
-	- Package name
-	- Package description
-	- Installation details
-	- Usage example
-	- `Code is Poetry` logo (`<br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>`)
-
-### Maintaining Changelogs
-
-Maintaining dozens of npm packages is difficult—it can be tough to keep track of changes. That's why we use `CHANGELOG.md` files for each package to simplify the release process. All packages should follow the [Semantic Versioning (`semver`) specification](https://semver.org/).
-
-The developer who proposes a change (pull request) is responsible for choosing the correct version increment (`major`, `minor`, or `patch`) according to the following guidelines:
-
-- Major version X (X.y.z | X > 0) should be changed with any backward incompatible/"breaking" change. This will usually occur at the final stage of deprecating and removing of a feature.
-- Minor version Y (x.Y.z | x > 0) should be changed when you add functionality or change functionality in a backward compatible manner. It must be incremented if any public API functionality is marked as deprecated.
-- Patch version Z (x.y.Z | x > 0) should be incremented when you make backward compatible bug fixes.
-
-When in doubt, refer to [Semantic Versioning specification](https://semver.org/).
-
-_Example:_
-
-```md
-## v1.2.2 (Unreleased)
-
-### Bug Fix
-
-- ...
-- ...
-```
-
-- If you need to add something considered a bug fix, you add the item to `Bug Fix` section and leave the version as 1.2.2.
-- If it's a new feature, you add the item to `New Feature` section and change version to 1.3.0.
-- If it's a breaking change you want to introduce, add the item to `Breaking Change` section and bump the version to 2.0.0.
-- If you struggle to classify a change as one of the above, then it might be not necessary to include it.
-
-The version bump is only necessary if one of the following applies:
- - There are no other unreleased changes.
- - The type of change you're introducing is incompatible (more severe) than the other unreleased changes.
-
-### Releasing Packages
-
-Lerna automatically releases all outdated packages. To check which packages are outdated and will be released, type `npm run publish:check`.
-
-If you have the ability to publish packages, you _must_ have [2FA enabled](https://docs.npmjs.com/getting-started/using-two-factor-authentication) on your [npm account][npm].
-
-#### Before Releasing
-
-Confirm that you're logged in to [npm], by running `npm whoami`. If you're not logged in, run `npm adduser` to login.
-
-If you're publishing a new package, ensure that its `package.json` file contains the correct `publishConfig` settings:
-
-```json
-{
-	"publishConfig": {
-		"access": "public"
-	}
-}
-```
-
-You can check your package configs by running `npm run lint-pkg-json`.
-
-#### Development Release
-
-Run the following command to release a dev version of the outdated packages, replacing `123456` with your 2FA code. Make sure you're using a freshly generated 2FA code, rather than one that's about to timeout. This is a little cumbersome but helps to prevent the release process from dying mid-deploy.
-
-```bash
-NPM_CONFIG_OTP=123456 npm run publish:dev
-```
-
-Lerna will ask you which version number you want to choose for each package. For a `dev` release, you'll more likely want to choose the "prerelease" option. Repeat the same for all the outdated packages and confirm your version updates.
-
-Lerna will then publish to [npm], commit the `package.json` changes and create the git tags.
-
-#### Production Release
-
-To release a production version for the outdated packages, run the following command, replacing `123456` with your (freshly generated, as above) 2FA code:
-
-```bash
-NPM_CONFIG_OTP=123456 npm run publish:prod
-```
-
-Choose the correct version based on `CHANGELOG.md` files, confirm your choices and let Lerna do its magic.
+Maintaining dozens of npm packages is difficult—it can be tough to keep track of changes. That's why we use `CHANGELOG.md` files for each package to simplify the release process. As a contributor you should add an entry to the aforementioned file each time you contribute adding production code as described in [Maintaining Changelogs](/packages/README.md#maintaining-changelogs) section. 
 
 ## How Can Designers Contribute?
 
@@ -244,15 +124,15 @@ If you'd like to contribute to the design or front-end, feel free to contribute 
 
 Documentation is automatically synced from master to the [Gutenberg Documentation Website](https://wordpress.org/gutenberg/handbook/) every 15 minutes.
 
-To add a new documentation page, you'll have to create a Markdown file in the [docs](https://github.com/WordPress/gutenberg/tree/master/docs) folder and add an item to the [root-manifest.json](https://github.com/WordPress/gutenberg/blob/master/docs/root-manifest.json).
+To add a new documentation page, you'll have to create a Markdown file in the [docs](https://github.com/WordPress/gutenberg/tree/master/docs) folder and add an item to the [toc.json](/docs/toc.json).
 
 ### `@wordpress/component`
 
-If you're contributing to the documentation of any component from the `@wordpress/component` package, take a look at its [guidelines for contributing](./packages/components/CONTRIBUTING.md).
+If you're contributing to the documentation of any component from the `@wordpress/component` package, take a look at its [guidelines for contributing](/packages/components/CONTRIBUTING.md).
 
 ## Reporting Security Issues
 
-Please see [SECURITY.md](./SECURITY.md).
+Please see [SECURITY.md](/SECURITY.md).
 
 ## Localizing Gutenberg Plugin
 

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
 		"*.js": [
 			"wp-scripts lint-js"
 		],
-		"{docs/{root-manifest.json,tool/*.js},packages/{*/README.md,*/src/{actions,selectors}.js,components/src/*/**/README.md}}": [
+		"{docs/{toc.json,tool/*.js},packages/{*/README.md,*/src/{actions,selectors}.js,components/src/*/**/README.md}}": [
 			"npm run docs:build"
 		]
 	}

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,0 +1,128 @@
+## Managing Packages
+
+This repository uses [lerna] to manage Gutenberg modules and publish them as packages to [npm].
+
+### Creating a New Package
+
+When creating a new package, you need to provide at least the following:
+
+1. `package.json` based on the template:
+	```json
+	{
+		"name": "@wordpress/package-name",
+		"version": "1.0.0-beta.0",
+		"description": "Package description.",
+		"author": "The WordPress Contributors",
+		"license": "GPL-2.0-or-later",
+		"keywords": [
+			"wordpress"
+		],
+		"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/package-name/README.md",
+		"repository": {
+			"type": "git",
+			"url": "https://github.com/WordPress/gutenberg.git"
+		},
+		"bugs": {
+			"url": "https://github.com/WordPress/gutenberg/issues"
+		},
+		"main": "build/index.js",
+		"module": "build-module/index.js",
+		"react-native": "src/index",
+		"dependencies": {
+			"@babel/runtime": "^7.0.0"
+		},
+		"publishConfig": {
+			"access": "public"
+		}
+	}
+	```
+	This assumes that your code is located in the `src` folder and will be transpiled with `Babel`.
+2. `.npmrc` file which disables creating `package-lock.json` file for the package:
+	```
+	package-lock=false
+	```
+3. `README.md` file containing at least:
+	- Package name
+	- Package description
+	- Installation details
+	- Usage example
+	- `Code is Poetry` logo (`<br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>`)
+
+### Maintaining Changelogs
+
+Maintaining dozens of npm packages is difficult—it can be tough to keep track of changes. That's why we use `CHANGELOG.md` files for each package to simplify the release process. All packages should follow the [Semantic Versioning (`semver`) specification](https://semver.org/).
+
+The developer who proposes a change (pull request) is responsible for choosing the correct version increment (`major`, `minor`, or `patch`) according to the following guidelines:
+
+- Major version X (X.y.z | X > 0) should be changed with any backward incompatible/"breaking" change. This will usually occur at the final stage of deprecating and removing of a feature.
+- Minor version Y (x.Y.z | x > 0) should be changed when you add functionality or change functionality in a backward compatible manner. It must be incremented if any public API functionality is marked as deprecated.
+- Patch version Z (x.y.Z | x > 0) should be incremented when you make backward compatible bug fixes.
+
+When in doubt, refer to [Semantic Versioning specification](https://semver.org/).
+
+_Example:_
+
+```md
+## v1.2.2 (Unreleased)
+
+### Bug Fix
+
+- ...
+- ...
+```
+
+- If you need to add something considered a bug fix, you add the item to `Bug Fix` section and leave the version as 1.2.2.
+- If it's a new feature, you add the item to `New Feature` section and change version to 1.3.0.
+- If it's a breaking change you want to introduce, add the item to `Breaking Change` section and bump the version to 2.0.0.
+- If you struggle to classify a change as one of the above, then it might be not necessary to include it.
+
+The version bump is only necessary if one of the following applies:
+ - There are no other unreleased changes.
+ - The type of change you're introducing is incompatible (more severe) than the other unreleased changes.
+
+### Releasing Packages
+
+Lerna automatically releases all outdated packages. To check which packages are outdated and will be released, type `npm run publish:check`.
+
+If you have the ability to publish packages, you _must_ have [2FA enabled](https://docs.npmjs.com/getting-started/using-two-factor-authentication) on your [npm account][npm].
+
+#### Before Releasing
+
+Confirm that you're logged in to [npm], by running `npm whoami`. If you're not logged in, run `npm adduser` to login.
+
+If you're publishing a new package, ensure that its `package.json` file contains the correct `publishConfig` settings:
+
+```json
+{
+	"publishConfig": {
+		"access": "public"
+	}
+}
+```
+
+You can check your package configs by running `npm run lint-pkg-json`.
+
+#### Development Release
+
+Run the following command to release a dev version of the outdated packages, replacing `123456` with your 2FA code. Make sure you're using a freshly generated 2FA code, rather than one that's about to timeout. This is a little cumbersome but helps to prevent the release process from dying mid-deploy.
+
+```bash
+NPM_CONFIG_OTP=123456 npm run publish:dev
+```
+
+Lerna will ask you which version number you want to choose for each package. For a `dev` release, you'll more likely want to choose the "prerelease" option. Repeat the same for all the outdated packages and confirm your version updates.
+
+Lerna will then publish to [npm], commit the `package.json` changes and create the git tags.
+
+#### Production Release
+
+To release a production version for the outdated packages, run the following command, replacing `123456` with your (freshly generated, as above) 2FA code:
+
+```bash
+NPM_CONFIG_OTP=123456 npm run publish:prod
+```
+
+Choose the correct version based on `CHANGELOG.md` files, confirm your choices and let Lerna do its magic.
+
+[lerna]: https://lernajs.io/
+[npm]: https://www.npmjs.com/


### PR DESCRIPTION
## Description
`CONTRIBUTING.md` has become quite big. This PR extracts the part about managing packages to its own file to make the guidelines more focused on the onboarding experience.

I also update internal links to follow the same patterns we started to apply recently.