### PR TITLE
Scripts: Remove npm run build from test-e2e default run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,7 @@ jobs:
         - ./bin/setup-local-env.sh
       script:
         - $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --listTests > ~/.jest-e2e-tests
+        - npm run build
         - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 2 == 0' < ~/.jest-e2e-tests )
 
     - name: E2E tests (Admin with plugins) (2/2)
@@ -76,6 +77,7 @@ jobs:
         - ./bin/setup-local-env.sh
       script:
         - $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --listTests > ~/.jest-e2e-tests
+        - npm run build
         - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 2 == 1' < ~/.jest-e2e-tests )
 
     - name: E2E tests (Author without plugins) (1/2)
@@ -84,6 +86,7 @@ jobs:
         - ./bin/setup-local-env.sh
       script:
         - $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --listTests > ~/.jest-e2e-tests
+        - npm run build
         - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 2 == 0' < ~/.jest-e2e-tests )
 
     - name: E2E tests (Author without plugins) (2/2)
@@ -92,4 +95,5 @@ jobs:
         - ./bin/setup-local-env.sh
       script:
         - $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --listTests > ~/.jest-e2e-tests
+        - npm run build
         - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 2 == 1' < ~/.jest-e2e-tests )

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
 		"publish:dev": "npm run build:packages && lerna publish --npm-tag next",
 		"publish:prod": "npm run build:packages && lerna publish",
 		"test": "npm run lint && npm run test-unit",
-		"pretest-e2e": "concurrently \"./bin/reset-e2e-tests.sh\" \"npm run build\"",
+		"pretest-e2e": "./bin/reset-e2e-tests.sh",
 		"test-e2e": "wp-scripts test-e2e --config packages/e2e-tests/jest.config.js",
 		"test-e2e:watch": "npm run test-e2e -- --watch",
 		"test-php": "npm run lint-php && npm run test-unit-php",


### PR DESCRIPTION
## Description
This PR remove `npm run build` from `pretest-e2e` script which triggered build when running `npm run test-e2e`. This was introduced to ensure that files are built before running e2e tests. However, it is inconsistent with unit tests and causes issues when someone has `npm run dev` running in the background when developing code. Another issue is that this command was executed even when there were no changes introduced in the codebase since the last run. 