### PR TITLE
Consider making Fullscreen Mode effects visible only on larger screens

### DIFF
--- a/packages/edit-post/src/components/fullscreen-mode/style.scss
+++ b/packages/edit-post/src/components/fullscreen-mode/style.scss
@@ -1,8 +1,7 @@
 body.js.is-fullscreen-mode {
 
 	@include break-medium {
-
-		// Reset the html.wp-topbar padding
+		// Reset the html.wp-topbar padding.
 		// Because this uses negative margins, we have to compensate for the height.
 		margin-top: -$admin-bar-height-big;
 		height: calc(100% + #{ $admin-bar-height-big });
@@ -21,7 +20,7 @@ body.js.is-fullscreen-mode {
 			margin-left: 0;
 		}
 
-		// Animations
+		// Animations.
 		@include edit-post__fade-in-animation(0.3s);
 
 		.edit-post-header {

--- a/packages/edit-post/src/components/fullscreen-mode/style.scss
+++ b/packages/edit-post/src/components/fullscreen-mode/style.scss
@@ -1,29 +1,33 @@
 body.js.is-fullscreen-mode {
-	// Reset the html.wp-topbar padding
-	// Because this uses negative margins, we have to compensate for the height.
-	margin-top: -$admin-bar-height-big;
-	height: calc(100% + #{ $admin-bar-height-big });
-	@include break-medium() {
-		margin-top: -$admin-bar-height;
-		height: calc(100% + #{ $admin-bar-height });
-	}
 
-	#adminmenumain,
-	#wpadminbar {
-		display: none;
-	}
+	@include break-medium {
 
-	#wpcontent,
-	#wpfooter {
-		margin-left: 0;
-	}
+		// Reset the html.wp-topbar padding
+		// Because this uses negative margins, we have to compensate for the height.
+		margin-top: -$admin-bar-height-big;
+		height: calc(100% + #{ $admin-bar-height-big });
+		@include break-medium() {
+			margin-top: -$admin-bar-height;
+			height: calc(100% + #{ $admin-bar-height });
+		}
 
-	// Animations
-	@include edit-post__fade-in-animation(0.3s);
+		#adminmenumain,
+		#wpadminbar {
+			display: none;
+		}
 
-	.edit-post-header {
-		transform: translateY(-100%);
-		animation: edit-post-fullscreen-mode__slide-in-animation 0.1s forwards;
+		#wpcontent,
+		#wpfooter {
+			margin-left: 0;
+		}
+
+		// Animations
+		@include edit-post__fade-in-animation(0.3s);
+
+		.edit-post-header {
+			transform: translateY(-100%);
+			animation: edit-post-fullscreen-mode__slide-in-animation 0.1s forwards;
+		}
 	}
 }
 

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
@@ -1,7 +1,14 @@
 .edit-post-fullscreen-mode-close__toolbar {
-	border-top: 0;
-	border-bottom: 0;
-	border-left: 0;
-	margin: -9px 10px -9px -10px;
-	padding: 9px 10px;
+	// Do not show the toolbar icon on small screens,
+	// when Fullscreen Mode is not an option in the "More" menu.
+	display: none;
+
+	@include break-medium() {
+		display: block;
+		border-top: 0;
+		border-bottom: 0;
+		border-left: 0;
+		margin: -9px 10px -9px -10px;
+		padding: 9px 10px;
+	}
 }

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -20,10 +20,6 @@
 		position: fixed;
 		padding: $grid-size;
 		top: $admin-bar-height-big;
-
-		body.is-fullscreen-mode & {
-			top: 0;
-		}
 	}
 
 	@include break-medium() {

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -167,10 +167,6 @@
 	left: 0;
 	overflow: auto;
 
-	body.is-fullscreen-mode & {
-		top: 0;
-	}
-
 	@include break-medium() {
 		top: $admin-bar-height;
 		left: auto;

--- a/packages/edit-post/src/components/sidebar/style.scss
+++ b/packages/edit-post/src/components/sidebar/style.scss
@@ -17,10 +17,6 @@
 		height: auto;
 		overflow: auto;
 		-webkit-overflow-scrolling: touch;
-
-		body.is-fullscreen-mode & {
-			top: $header-height;
-		}
 	}
 
 	@include break-medium() {
@@ -41,17 +37,17 @@
 		margin-top: -1px;
 		margin-bottom: -1px;
 
-		body.is-fullscreen-mode & {
-			max-height: calc(100vh - #{ $panel-header-height });
-			@include break-small() {
-				max-height: none;
-			}
-		}
-
 		@include break-small() {
 			overflow: inherit;
 			height: auto;
 			max-height: none;
+		}
+
+		@include break-medium() {
+
+			body.is-fullscreen-mode & {
+				max-height: calc(100vh - #{ $panel-header-height });
+			}
 		}
 	}
 

--- a/packages/edit-post/src/components/text-editor/style.scss
+++ b/packages/edit-post/src/components/text-editor/style.scss
@@ -3,10 +3,6 @@
 
 	@include break-small() {
 		padding-top: ($grid-size * 5) + $admin-bar-height-big;
-
-		body.is-fullscreen-mode & {
-			padding-top: $grid-size * 5;
-		}
 	}
 
 	@include break-medium() {

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -120,10 +120,6 @@ body.block-editor-page {
 		bottom: 0;
 		left: 0;
 		min-height: calc(100vh - #{ $admin-bar-height-big });
-
-		body.is-fullscreen-mode & {
-			min-height: 100vh;
-		}
 	}
 
 	// The WP header height changes at this breakpoint


### PR DESCRIPTION
Currently, if you activate Fullscreen Mode while on a desktop screen, the editor takes up the full screen: the admin bar is hidden, and we show a close icon on the top left of your screen. This behavior persists on smaller screens:

_Left: Fullscreen Mode inactive, Right: Fullscreen Mode active_
<img width="1652" alt="frame" src="https://user-images.githubusercontent.com/1202812/51543525-c17afa80-1e2b-11e9-9074-c8b1b1755bfb.png">

This is a little confusing, since the Fullscreen Mode toggle is not available on small screens. If you're on mobile and you have fullscreen mode active, there's no way to toggle it back off. 

![fullscreen-current](https://user-images.githubusercontent.com/1202812/51543199-07838e80-1e2b-11e9-9e77-f0c287a0439a.gif)

In light of this, we should consider having fullscreen mode only effect desktop screens. This PR moves fullscreen styles into the `medium` breakpoint to try that out:

![fullscreen-edited](https://user-images.githubusercontent.com/1202812/51543640-0737c300-1e2c-11e9-9feb-6f21b254118d.gif)

Note that this mimics the behavior of the other two editing modes (Top Toolbar and Spotlight Mode, which are only available on desktop screens). 