### PR TITLE
is-shallow-equal: Use ES5 ruleset from eslint-plugin module

### DIFF
--- a/packages/is-shallow-equal/.eslintrc.json
+++ b/packages/is-shallow-equal/.eslintrc.json
@@ -1,5 +1,7 @@
 {
-	"rules": {
-		"no-var": 0
+	"root": true,
+	"extends": "plugin:@wordpress/eslint-plugin/es5",
+	"env": {
+		"node": true
 	}
 }

--- a/packages/is-shallow-equal/CHANGELOG.md
+++ b/packages/is-shallow-equal/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Type-specific variants are now exposed from the module root. In a WordPress context, this has the effect of making them available as `wp.isShallowEqual.isShallowEqualObjects` and `wp.isShallowEqual.isShallowEqualArrays`.
 
+### Internal
+
+- Development source code linting extends the `@wordpress/eslint-plugin/es5` ruleset.
+
 ## 1.1.0 (2018-07-12)
 
 ### New Feature

--- a/packages/is-shallow-equal/benchmark/.eslintrc.json
+++ b/packages/is-shallow-equal/benchmark/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+	"root": true,
+	"extends": "../../../.eslintrc.js"
+}

--- a/packages/is-shallow-equal/test/.eslintrc.json
+++ b/packages/is-shallow-equal/test/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+	"root": true,
+	"extends": "../../../.eslintrc.js"
+}


### PR DESCRIPTION
Related: [Discussion](https://wordpress.slack.com/archives/C5UNMSU4R/p1548167439203800) ([link requires registration](https://make.wordpress.org/chat/))

This pull request seeks to update the ESLint configuration for `is-shallow-equal` to extend the ES5 ruleset provided through `@wordpress/eslint-plugin`. The `is-shallow-equal` package is an exception to most in its omission from Babel build.

**Testing instructions:**

Verify there are no lint errors:

```
npm run lint-js
```