### PR TITLE
Block Switcher: Render disabled button even if multi-selection

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Added `createCustomColorsHOC` for creating a higher order `withCustomColors` component.
 
+### Bug Fixes
+
+- BlockSwitcher will now consistently render an icon for block multi-selections.
+
 ### Internal
 
 - Removed `jQuery` dependency

--- a/packages/editor/src/components/block-switcher/index.js
+++ b/packages/editor/src/components/block-switcher/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { castArray, filter, first, mapKeys, orderBy } from 'lodash';
+import { castArray, filter, first, mapKeys, orderBy, uniq, map } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -53,13 +53,20 @@ export class BlockSwitcher extends Component {
 			'desc'
 		);
 
-		const sourceBlockName = blocks[ 0 ].name;
-		const blockType = getBlockType( sourceBlockName );
+		// When selection consists of blocks of multiple types, display an
+		// appropriate icon to communicate the non-uniformity.
+		const isSelectionOfSameType = uniq( map( blocks, 'name' ) ).length === 1;
+
+		let icon;
+		if ( isSelectionOfSameType ) {
+			const sourceBlockName = blocks[ 0 ].name;
+			const blockType = getBlockType( sourceBlockName );
+			icon = blockType.icon;
+		} else {
+			icon = 'layout';
+		}
 
 		if ( ! hasBlockStyles && ! possibleBlockTransformations.length ) {
-			if ( blocks.length > 1 ) {
-				return null;
-			}
 			return (
 				<Toolbar>
 					<IconButton
@@ -67,7 +74,7 @@ export class BlockSwitcher extends Component {
 						className="editor-block-switcher__no-switcher-icon"
 						label={ __( 'Block icon' ) }
 					>
-						<BlockIcon icon={ blockType.icon } showColors />
+						<BlockIcon icon={ icon } showColors />
 					</IconButton>
 				</Toolbar>
 			);
@@ -110,7 +117,7 @@ export class BlockSwitcher extends Component {
 								tooltip={ label }
 								onKeyDown={ openOnArrowDown }
 							>
-								<BlockIcon icon={ blockType.icon } showColors />
+								<BlockIcon icon={ icon } showColors />
 								<SVG className="editor-block-switcher__transform" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M6.5 8.9c.6-.6 1.4-.9 2.2-.9h6.9l-1.3 1.3 1.4 1.4L19.4 7l-3.7-3.7-1.4 1.4L15.6 6H8.7c-1.4 0-2.6.5-3.6 1.5l-2.8 2.8 1.4 1.4 2.8-2.8zm13.8 2.4l-2.8 2.8c-.6.6-1.3.9-2.1.9h-7l1.3-1.3-1.4-1.4L4.6 16l3.7 3.7 1.4-1.4L8.4 17h6.9c1.3 0 2.6-.5 3.5-1.5l2.8-2.8-1.3-1.4z" /></SVG>
 							</IconButton>
 						</Toolbar>

--- a/packages/editor/src/components/block-switcher/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/block-switcher/test/__snapshots__/index.js.snap
@@ -1,5 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`BlockSwitcher should render disabled block switcher with multi block of different types when no transforms 1`] = `
+<Toolbar>
+  <IconButton
+    className="editor-block-switcher__no-switcher-icon"
+    disabled={true}
+    label="Block icon"
+  >
+    <BlockIcon
+      icon="layout"
+      showColors={true}
+    />
+  </IconButton>
+</Toolbar>
+`;
+
+exports[`BlockSwitcher should render enabled block switcher with multi block when transforms exist 1`] = `
+<Dropdown
+  className="editor-block-switcher"
+  contentClassName="editor-block-switcher__popover"
+  position="bottom right"
+  renderContent={[Function]}
+  renderToggle={[Function]}
+/>
+`;
+
 exports[`BlockSwitcher should render switcher with blocks 1`] = `
 <Dropdown
   className="editor-block-switcher"

--- a/packages/editor/src/components/block-switcher/test/index.js
+++ b/packages/editor/src/components/block-switcher/test/index.js
@@ -42,7 +42,7 @@ describe( 'BlockSwitcher', () => {
 			level: 3,
 		},
 		isValid: true,
-		name: 'core/paragraph',
+		name: 'core/heading',
 		originalContent: '<h3>I am the greatest!</h3>',
 		clientId: 'c2403fd2-4e63-5ffa-b71c-1e0ea656c5b0',
 	};
@@ -54,11 +54,19 @@ describe( 'BlockSwitcher', () => {
 			edit: () => { },
 			save: () => {},
 			transforms: {
-				to: [ {
-					type: 'block',
-					blocks: [ 'core/paragraph' ],
-					transform: () => {},
-				} ],
+				to: [
+					{
+						type: 'block',
+						blocks: [ 'core/paragraph' ],
+						transform: () => {},
+					},
+					{
+						type: 'block',
+						blocks: [ 'core/paragraph' ],
+						transform: () => {},
+						isMultiBlock: true,
+					},
+				],
 			},
 		} );
 
@@ -93,6 +101,7 @@ describe( 'BlockSwitcher', () => {
 			headingBlock1,
 		];
 		const inserterItems = [
+			{ name: 'core/heading', frecency: 1 },
 			{ name: 'core/paragraph', frecency: 1 },
 		];
 
@@ -101,24 +110,28 @@ describe( 'BlockSwitcher', () => {
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
-	test( 'should not render block switcher with multi block of different types.', () => {
-		const blocks = [
-			headingBlock1,
-			textBlock,
+	test( 'should render disabled block switcher with multi block of different types when no transforms', () => {
+		const blocks = [ headingBlock1, textBlock ];
+		const inserterItems = [
+			{ name: 'core/heading', frecency: 1 },
+			{ name: 'core/paragraph', frecency: 1 },
 		];
-		const wrapper = shallow( <BlockSwitcher blocks={ blocks } /> );
 
-		expect( wrapper.html() ).toBeNull();
+		const wrapper = shallow( <BlockSwitcher blocks={ blocks } inserterItems={ inserterItems } /> );
+
+		expect( wrapper ).toMatchSnapshot();
 	} );
 
-	test( 'should not render a component when the multi selected types of blocks match.', () => {
-		const blocks = [
-			headingBlock1,
-			headingBlock2,
+	test( 'should render enabled block switcher with multi block when transforms exist', () => {
+		const blocks = [ headingBlock1, headingBlock2 ];
+		const inserterItems = [
+			{ name: 'core/heading', frecency: 1 },
+			{ name: 'core/paragraph', frecency: 1 },
 		];
-		const wrapper = shallow( <BlockSwitcher blocks={ blocks } /> );
 
-		expect( wrapper.html() ).toBeNull();
+		const wrapper = shallow( <BlockSwitcher blocks={ blocks } inserterItems={ inserterItems } /> );
+
+		expect( wrapper ).toMatchSnapshot();
 	} );
 
 	describe( 'Dropdown', () => {


### PR DESCRIPTION
Previously: https://github.com/WordPress/gutenberg/pull/11600#discussion_r245143694

This pull request seeks to remove a condition present in the `BlockSwitcher` component which causes it to render nothing if there are no possible transformations and there is a multi-selection of blocks.

Without these changes, there is an inconsistency based on an assumption that transformations can only apply to a set of blocks of the same type. While currently true, there is not a guarantee that this will always be the case, and the component itself otherwise makes no expectation that it would be (if transformations exist, a dropdown will be shown with the icon of the first block, regardless of whether all blocks in the selection are of the same type). Additionally, the current behavior would cause nothing to be rendered even if the multi-selection was of blocks of the same type, if there were no multi-transforms for multiple blocks of that type. This is inconsistent with both multi-selections of the same type where a transformation does exist (dropdown shown with icon of that block type), and singular selections of a type where no transformation exists (dropdown not shown, but disabled icon shown of that block type).

**Alternatives:**

This does present an awkward scenario where multiple blocks of different types shows an icon of the first type:

![image](https://user-images.githubusercontent.com/1779930/51559931-3e6c9b00-1e51-11e9-8c8a-ac21671ff705.png)

Instead, we may consider:

- Check earlier in the component whether the multi-selection is of a consistent type, and always return nothing if not. This still makes an assumption that transforms cannot apply to multiple blocks of differing types, but does so consistently. It also allows the disabled icon to be shown for multi-selections of the same type where no transforms exist (e.g. multiple Heading blocks selected).
- Show a different icon or an aggregate of icons for types in the selection

**Testing instructions:**

Verify that the BlockSwitcher is shown always, regardless of the blocks composing the selection. The icon should correspond to the first block in the selection, and should be disabled if and only if there are neither valid transforms nor applicable styles to choose from.