### PR TITLE
Plugin: Remove redundant core compatibility from plugin

### DIFF
--- a/docs/designers-developers/developers/backward-compatibility/deprecations.md
+++ b/docs/designers-developers/developers/backward-compatibility/deprecations.md
@@ -38,6 +38,12 @@ The Gutenberg project's deprecation policy is intended to support backward compa
 - The `gutenberg` theme support option has been removed. Use [`align-wide`](https://wordpress.org/gutenberg/handbook/designers-developers/developers/themes/theme-support/#wide-alignment) instead.
 - The PHP function `gutenberg_prepare_blocks_for_js` has been removed. Use [`get_block_editor_server_block_settings`](https://developer.wordpress.org/reference/functions/get_block_editor_server_block_settings/) instead.
 - The PHP function `gutenberg_load_list_reusable_blocks` has been removed.
+- The PHP function `_gutenberg_utf8_split` has been removed. Use `_mb_substr` instead.
+- The PHP function `gutenberg_disable_editor_settings_wpautop` has been removed.
+- The PHP function `gutenberg_add_rest_nonce_to_heartbeat_response_headers` has been removed.
+- The PHP function `gutenberg_check_if_classic_needs_warning_about_blocks` has been removed.
+- The PHP function `gutenberg_warn_classic_about_blocks` has been removed.
+- The PHP function `gutenberg_show_privacy_policy_help_text` has been removed.
 
 ## 4.5.0
 - `Dropdown.refresh()` has been deprecated as the contained `Popover` is now automatically refreshed.

--- a/lib/compat.php
+++ b/lib/compat.php
@@ -14,277 +14,67 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Splits a UTF-8 string into an array of UTF-8-encoded codepoints.
  *
  * @since 0.5.0
+ * @deprecated 5.0.0 _mb_substr
  *
- * Based on WordPress' _mb_substr() compat function.
- *
- * @param string $str        The string to split.
- * @return array
+ * @param string $str The string to split.
+ * @return string Extracted substring.
  */
 function _gutenberg_utf8_split( $str ) {
-	if ( _wp_can_use_pcre_u() ) {
-		// Use the regex unicode support to separate the UTF-8 characters into
-		// an array.
-		preg_match_all( '/./us', $str, $match );
-		return $match[0];
-	}
+	_deprecated_function( __FUNCTION__, '5.0.0', '_mb_substr' );
 
-	$regex = '/(
-		  [\x00-\x7F]                  # single-byte sequences   0xxxxxxx
-		| [\xC2-\xDF][\x80-\xBF]       # double-byte sequences   110xxxxx 10xxxxxx
-		| \xE0[\xA0-\xBF][\x80-\xBF]   # triple-byte sequences   1110xxxx 10xxxxxx * 2
-		| [\xE1-\xEC][\x80-\xBF]{2}
-		| \xED[\x80-\x9F][\x80-\xBF]
-		| [\xEE-\xEF][\x80-\xBF]{2}
-		| \xF0[\x90-\xBF][\x80-\xBF]{2} # four-byte sequences   11110xxx 10xxxxxx * 3
-		| [\xF1-\xF3][\x80-\xBF]{3}
-		| \xF4[\x80-\x8F][\x80-\xBF]{2}
-	)/x';
-
-	// Start with 1 element instead of 0 since the first thing we do is pop.
-	$chars = array( '' );
-	do {
-		// We had some string left over from the last round, but we counted it
-		// in that last round.
-		array_pop( $chars );
-
-		// Split by UTF-8 character, limit to 1000 characters (last array
-		// element will contain the rest of the string).
-		$pieces = preg_split(
-			$regex,
-			$str,
-			1000,
-			PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY
-		);
-
-		$chars = array_merge( $chars, $pieces );
-
-		// If there's anything left over, repeat the loop.
-		if ( count( $pieces ) > 1 ) {
-			$str = array_pop( $pieces );
-		} else {
-			break;
-		}
-	} while ( $str );
-
-	return $chars;
+	return _mb_substr( $str );
 }
 
 /**
  * Disables wpautop behavior in classic editor when post contains blocks, to
  * prevent removep from invalidating paragraph blocks.
  *
- * @param  array  $settings  Original editor settings.
- * @param  string $editor_id ID for the editor instance.
- * @return array             Filtered settings.
+ * @link https://core.trac.wordpress.org/ticket/45113
+ * @link https://core.trac.wordpress.org/changeset/43758
+ * @deprecated 5.0.0
+ *
+ * @param array $settings Original editor settings.
+ * @return array Filtered settings.
  */
-function gutenberg_disable_editor_settings_wpautop( $settings, $editor_id ) {
-	$post = get_post();
-	if ( 'content' === $editor_id && is_object( $post ) && has_blocks( $post ) ) {
-		$settings['wpautop'] = false;
-	}
+function gutenberg_disable_editor_settings_wpautop( $settings ) {
+	_deprecated_function( __FUNCTION__, '5.0.0' );
 
 	return $settings;
 }
-add_filter( 'wp_editor_settings', 'gutenberg_disable_editor_settings_wpautop', 10, 2 );
 
 /**
  * Add rest nonce to the heartbeat response.
  *
- * @param  array $response Original heartbeat response.
- * @return array           New heartbeat response.
+ * @link https://core.trac.wordpress.org/ticket/45113
+ * @link https://core.trac.wordpress.org/changeset/43939
+ * @deprecated 5.0.0
+ *
+ * @param array $response Original heartbeat response.
+ * @return array New heartbeat response.
  */
 function gutenberg_add_rest_nonce_to_heartbeat_response_headers( $response ) {
-	$response['rest-nonce'] = wp_create_nonce( 'wp_rest' );
+	_deprecated_function( __FUNCTION__, '5.0.0' );
+
 	return $response;
 }
-add_filter( 'wp_refresh_nonces', 'gutenberg_add_rest_nonce_to_heartbeat_response_headers' );
 
 /**
  * Check if we need to load the block warning in the Classic Editor.
  *
- * @since 3.4.0
+ * @deprecated 5.0.0
  */
 function gutenberg_check_if_classic_needs_warning_about_blocks() {
-	global $pagenow;
-
-	if ( ! in_array( $pagenow, array( 'post.php', 'post-new.php' ), true ) || ! isset( $_REQUEST['classic-editor'] ) ) {
-		return;
-	}
-
-	$post = get_post();
-	if ( ! $post ) {
-		return;
-	}
-
-	if ( ! has_blocks( $post ) ) {
-		return;
-	}
-
-	// Enqueue the JS we're going to need in the dialog.
-	wp_enqueue_script( 'wp-a11y' );
-	wp_enqueue_script( 'wp-sanitize' );
-
-	add_action( 'admin_footer', 'gutenberg_warn_classic_about_blocks' );
+	_deprecated_function( __FUNCTION__, '5.0.0' );
 }
-add_action( 'admin_enqueue_scripts', 'gutenberg_check_if_classic_needs_warning_about_blocks' );
 
 /**
  * Adds a warning to the Classic Editor when trying to edit a post containing blocks.
  *
  * @since 3.4.0
+ * @deprecated 5.0.0
  */
 function gutenberg_warn_classic_about_blocks() {
-	$post = get_post();
-
-	$gutenberg_edit_link = get_edit_post_link( $post->ID, 'raw' );
-
-	$classic_edit_link = $gutenberg_edit_link;
-	$classic_edit_link = add_query_arg(
-		array(
-			'classic-editor'     => '',
-			'hide-block-warning' => '',
-		),
-		$classic_edit_link
-	);
-
-	$revisions_link = '';
-	if ( wp_revisions_enabled( $post ) ) {
-		$revisions = wp_get_post_revisions( $post );
-
-		// If there's only one revision, that won't help.
-		if ( count( $revisions ) > 1 ) {
-			reset( $revisions ); // Reset pointer for key().
-			$revisions_link = get_edit_post_link( key( $revisions ) );
-		}
-	}
-	?>
-		<style type="text/css">
-			#blocks-in-post-dialog .notification-dialog {
-				position: fixed;
-				top: 50%;
-				left: 50%;
-				width: 500px;
-				box-sizing: border-box;
-				transform: translate(-50%, -50%);
-				margin: 0;
-				padding: 25px;
-				max-height: 90%;
-				background: #fff;
-				box-shadow: 0 3px 6px rgba(0, 0, 0, 0.3);
-				line-height: 1.5;
-				z-index: 1000005;
-				overflow-y: auto;
-			}
-
-			@media only screen and (max-height: 480px), screen and (max-width: 450px) {
-				#blocks-in-post-dialog .notification-dialog {
-					top: 0;
-					left: 0;
-					width: 100%;
-					height: 100%;
-					transform: none;
-					max-height: 100%;
-				}
-			}
-		</style>
-
-		<div id="blocks-in-post-dialog" class="notification-dialog-wrap">
-			<div class="notification-dialog-background"></div>
-			<div class="notification-dialog">
-				<div class="blocks-in-post-message">
-					<p><?php _e( 'This post was previously edited in Gutenberg. You can continue in the Classic Editor, but you may lose data and formatting.', 'gutenberg' ); ?></p>
-					<?php
-					if ( $revisions_link ) {
-						?>
-							<p>
-							<?php
-								/* translators: link to the post revisions page */
-								printf( __( 'You can also <a href="%s">browse previous revisions</a> and restore a version of the post before it was edited in Gutenberg.', 'gutenberg' ), esc_url( $revisions_link ) );
-							?>
-							</p>
-						<?php
-					} else {
-						?>
-							<p><strong><?php _e( 'Because this post does not have revisions, you will not be able to revert any changes you make in the Classic Editor.', 'gutenberg' ); ?></strong></p>
-						<?php
-					}
-					?>
-				</div>
-				<p>
-					<a class="button button-primary blocks-in-post-gutenberg-button" href="<?php echo esc_url( $gutenberg_edit_link ); ?>"><?php _e( 'Edit in Gutenberg', 'gutenberg' ); ?></a>
-					<button type="button" class="button blocks-in-post-classic-button"><?php _e( 'Continue to Classic Editor', 'gutenberg' ); ?></button>
-				</p>
-			</div>
-		</div>
-
-		<script type="text/javascript">
-			/* <![CDATA[ */
-			( function( $ ) {
-				var dialog = {};
-
-				dialog.init = function() {
-					// The modal
-					dialog.warning = $( '#blocks-in-post-dialog' );
-					// Get the links and buttons within the modal.
-					dialog.warningTabbables = dialog.warning.find( 'a, button' );
-
-					// Get the text within the modal.
-					dialog.rawMessage = dialog.warning.find( '.blocks-in-post-message' ).text();
-
-					// Hide all the #wpwrap content from assistive technologies.
-					$( '#wpwrap' ).attr( 'aria-hidden', 'true' );
-
-					// Detach the warning modal from its position and append it to the body.
-					$( document.body )
-						.addClass( 'modal-open' )
-						.append( dialog.warning.detach() );
-
-					// Reveal the modal and set focus on the Gutenberg button.
-					dialog.warning
-						.removeClass( 'hidden' )
-						.find( '.blocks-in-post-gutenberg-button' ).focus();
-
-					// Attach event handlers.
-					dialog.warningTabbables.on( 'keydown', dialog.constrainTabbing );
-					dialog.warning.on( 'click', '.blocks-in-post-classic-button', dialog.dismissWarning );
-
-					// Make screen readers announce the warning message after a short delay (necessary for some screen readers).
-					setTimeout( function() {
-						wp.a11y.speak( wp.sanitize.stripTags( dialog.rawMessage.replace( /\s+/g, ' ' ) ), 'assertive' );
-					}, 1000 );
-				};
-
-				dialog.constrainTabbing = function( event ) {
-					var firstTabbable, lastTabbable;
-
-					if ( 9 !== event.which ) {
-						return;
-					}
-
-					firstTabbable = dialog.warningTabbables.first()[0];
-					lastTabbable = dialog.warningTabbables.last()[0];
-
-					if ( lastTabbable === event.target && ! event.shiftKey ) {
-						firstTabbable.focus();
-						event.preventDefault();
-					} else if ( firstTabbable === event.target && event.shiftKey ) {
-						lastTabbable.focus();
-						event.preventDefault();
-					}
-				};
-
-				dialog.dismissWarning = function() {
-					// Hide modal.
-					dialog.warning.remove();
-					$( '#wpwrap' ).removeAttr( 'aria-hidden' );
-					$( 'body' ).removeClass( 'modal-open' );
-				};
-
-				$( document ).ready( dialog.init );
-			} )( jQuery );
-			/* ]]> */
-		</script>
-	<?php
+	_deprecated_function( __FUNCTION__, '5.0.0' );
 }
 
 /**
@@ -296,12 +86,8 @@ function gutenberg_warn_classic_about_blocks() {
  * consume the notice and display it with the Notices API.
  *
  * @since 4.5.0
+ * @deprecated 5.0.0
  */
 function gutenberg_show_privacy_policy_help_text() {
-	if ( is_gutenberg_page() && has_action( 'edit_form_after_title', array( 'WP_Privacy_Policy_Content', 'notice' ) ) ) {
-		remove_action( 'edit_form_after_title', array( 'WP_Privacy_Policy_Content', 'notice' ) );
-
-		WP_Privacy_Policy_Content::notice( get_post() );
-	}
+	_deprecated_function( __FUNCTION__, '5.0.0' );
 }
-add_action( 'admin_notices', 'gutenberg_show_privacy_policy_help_text' );


### PR DESCRIPTION
Related: #11015

This pull request seeks to remove (deprecated) logic in `lib/compat.php` assumed to be present in core.

The primary core tracking issue is:

- https://core.trac.wordpress.org/ticket/45113

The only remaining compatibility is that of `gutenberg_show_privacy_policy_help_text`. I could not find an equivalent core compatibility. The one here assumes wrongly that Gutenberg will upgrade the notices, which was removed as part of #12444 . This requires more work. In the meantime, the code in `lib/compat.php` has been left as-is.

**Testing instructions:**

Verify there are no regressions in the loading of the editor.