### PR TITLE
Plugin: Resolve warning notice displayed for deprecated function

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -187,10 +187,6 @@ function gutenberg_pre_init() {
 
 	require_once dirname( __FILE__ ) . '/lib/load.php';
 
-	if ( function_exists( 'gutenberg_silence_rest_errors' ) ) {
-		gutenberg_silence_rest_errors();
-	}
-
 	add_filter( 'replace_editor', 'gutenberg_init', 10, 2 );
 }
 


### PR DESCRIPTION
Regression introduced in: #13408

This pull request seeks to resolve an issue where a warning notice is printed to the page when the site is configured to use [the `WP_DEBUG` constant](https://codex.wordpress.org/WP_DEBUG). Further, it adds a new `observePageWarnings` to `@wordpress/e2e-test-utils`, used in the end-to-end test suite to fail tests immediately if there are any warnings present on the page.

**Testing instructions:**

Verify end-to-end tests pass:

```
npm run test-e2e
```

Verify end-to-end tests fail after `git revert 5c604f5` in your local copy of the branch:

```
npm run test-e2e
```