### PR TITLE
API Fetch: Expose nonce on created middleware function

### DIFF
--- a/lib/packages-dependencies.php
+++ b/lib/packages-dependencies.php
@@ -16,7 +16,6 @@ return array(
 		'wp-rich-text',
 	),
 	'wp-api-fetch'                          => array(
-		'wp-hooks',
 		'wp-i18n',
 		'wp-url',
 	),

--- a/package-lock.json
+++ b/package-lock.json
@@ -2271,7 +2271,6 @@
 			"version": "file:packages/api-fetch",
 			"requires": {
 				"@babel/runtime": "^7.0.0",
-				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/url": "file:packages/url"
 			}

--- a/packages/api-fetch/CHANGELOG.md
+++ b/packages/api-fetch/CHANGELOG.md
@@ -1,7 +1,12 @@
-## 2.3.0 (Unreleased)
+## 3.0.0 (Unreleased)
+
+### Breaking Changes
+
+- A created nonce middleware will no longer automatically listen for `heartbeat.tick` actions. Assign to the new `nonce` middleware property instead.
 
 ### New Feature
 
+- The function returned by `createNonceMiddleware` includes an assignable `nonce` property corresponding to the active nonce to be used.
 - Default fetch handler can be overridden with a custom fetch handler
 
 ## 2.2.6 (2018-12-12)

--- a/packages/api-fetch/README.md
+++ b/packages/api-fetch/README.md
@@ -76,6 +76,8 @@ const nonce = "nonce value";
 apiFetch.use( apiFetch.createNonceMiddleware( nonce ) );
 ```
 
+The function returned by `createNonceMiddleware` includes a `nonce` property corresponding to the actively used nonce. You may also assign to this property if you have a fresh nonce value to use.
+
 **Root URL middleware**
 
 ```js

--- a/packages/api-fetch/package.json
+++ b/packages/api-fetch/package.json
@@ -22,7 +22,6 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.0.0",
-		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/url": "file:../url"
 	},

--- a/packages/api-fetch/src/middlewares/nonce.js
+++ b/packages/api-fetch/src/middlewares/nonce.js
@@ -1,50 +1,27 @@
-/**
- * External dependencies
- */
-import { addAction } from '@wordpress/hooks';
+function createNonceMiddleware( nonce ) {
+	function middleware( options, next ) {
+		const { headers = {} } = options;
 
-const createNonceMiddleware = ( nonce ) => {
-	let usedNonce = nonce;
-
-	/**
-	 * This is not ideal but it's fine for now.
-	 *
-	 * Configure heartbeat to refresh the wp-api nonce, keeping the editor
-	 * authorization intact.
-	 */
-	addAction( 'heartbeat.tick', 'core/api-fetch/create-nonce-middleware', ( response ) => {
-		if ( response[ 'rest-nonce' ] ) {
-			usedNonce = response[ 'rest-nonce' ];
-		}
-	} );
-
-	return function( options, next ) {
-		let headers = options.headers || {};
 		// If an 'X-WP-Nonce' header (or any case-insensitive variation
 		// thereof) was specified, no need to add a nonce header.
-		let addNonceHeader = true;
 		for ( const headerName in headers ) {
-			if ( headers.hasOwnProperty( headerName ) ) {
-				if ( headerName.toLowerCase() === 'x-wp-nonce' ) {
-					addNonceHeader = false;
-					break;
-				}
+			if ( headerName.toLowerCase() === 'x-wp-nonce' ) {
+				return next( options );
 			}
-		}
-
-		if ( addNonceHeader ) {
-			// Do not mutate the original headers object, if any.
-			headers = {
-				...headers,
-				'X-WP-Nonce': usedNonce,
-			};
 		}
 
 		return next( {
 			...options,
-			headers,
+			headers: {
+				...headers,
+				'X-WP-Nonce': middleware.nonce,
+			},
 		} );
-	};
-};
+	}
+
+	middleware.nonce = nonce;
+
+	return middleware;
+}
 
 export default createNonceMiddleware;

--- a/packages/api-fetch/src/middlewares/test/nonce.js
+++ b/packages/api-fetch/src/middlewares/test/nonce.js
@@ -31,6 +31,7 @@ describe( 'Nonce middleware', () => {
 			headers: { 'X-WP-Nonce': 'existing nonce' },
 		};
 		const callback = ( options ) => {
+			expect( options ).toBe( requestOptions );
 			expect( options.headers[ 'X-WP-Nonce' ] ).toBe( 'existing nonce' );
 		};
 


### PR DESCRIPTION
Related: https://core.trac.wordpress.org/ticket/45113#comment:11

This pull request stemmed from a simple desire to rename the `rest-nonce` heartbeat response value to the core-preferred `rest_nonce`. It subsequently turned into a bit more of a refactor of how this nonce is assigned and handled within the API fetch middleware.

The proposed changes here avoid having the API Fetch module having any awareness of heartbeat at all, instead using an inline script to create the heartbeat action handler, assigning to the newly-introduced middleware `nonce` property.

**Note:** This will _require_ a change to the equivalent inline script handling in core. ([patch](https://gist.github.com/aduth/be5b13bfebec880d5cda3d5f6844e8f0))

**Testing Instructions:**

To simplify testing, I found it useful to create a simple plugin at `wp-content/mu-plugins/nonce-duration.php` to shorten the default lifetime of a nonce dramatically, since otherwise a new nonce won't be included by default with the heartbeat response:

```php
<?php

add_filter( 'nonce_life', function() { 
	return 5;
} );
```

Verify that a different nonce is used with API requests which are triggered at least 5 seconds apart with the above patch.