### PR TITLE
Plugin: Deprecate gutenberg_preload_api_request

### DIFF
--- a/docs/designers-developers/developers/backward-compatibility/deprecations.md
+++ b/docs/designers-developers/developers/backward-compatibility/deprecations.md
@@ -21,6 +21,7 @@ The Gutenberg project's deprecation policy is intended to support backward compa
 - The PHP function `gutenberg_register_post_prepare_functions` has been removed.
 - The PHP function `gutenberg_silence_rest_errors` has been removed.
 - The PHP function `gutenberg_filter_post_type_labels` has been removed.
+- The PHP function `gutenberg_preload_api_request` has been removed. Use [`rest_preload_api_request`](https://developer.wordpress.org/reference/functions/rest_preload_api_request/) instead.
 
 ## 4.5.0
 - `Dropdown.refresh()` has been deprecated as the contained `Popover` is now automatically refreshed.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -510,68 +510,16 @@ add_action( 'admin_enqueue_scripts', 'gutenberg_register_scripts_and_styles', 5 
  * data to be attached to the page. Expected to be called in the context of
  * `array_reduce`.
  *
+ * @deprecated 5.0.0 rest_preload_api_request
+ *
  * @param  array  $memo Reduce accumulator.
  * @param  string $path REST API path to preload.
  * @return array        Modified reduce accumulator.
  */
 function gutenberg_preload_api_request( $memo, $path ) {
+	_deprecated_function( __FUNCTION__, '5.0.0', 'rest_preload_api_request' );
 
-	// array_reduce() doesn't support passing an array in PHP 5.2
-	// so we need to make sure we start with one.
-	if ( ! is_array( $memo ) ) {
-		$memo = array();
-	}
-
-	if ( empty( $path ) ) {
-		return $memo;
-	}
-
-	$method = 'GET';
-	if ( is_array( $path ) && 2 === count( $path ) ) {
-		$method = end( $path );
-		$path   = reset( $path );
-
-		if ( ! in_array( $method, array( 'GET', 'OPTIONS' ), true ) ) {
-			$method = 'GET';
-		}
-	}
-
-	$path_parts = parse_url( $path );
-	if ( false === $path_parts ) {
-		return $memo;
-	}
-
-	$request = new WP_REST_Request( $method, $path_parts['path'] );
-	if ( ! empty( $path_parts['query'] ) ) {
-		parse_str( $path_parts['query'], $query_params );
-		$request->set_query_params( $query_params );
-	}
-
-	$response = rest_do_request( $request );
-	if ( 200 === $response->status ) {
-		$server = rest_get_server();
-		$data   = (array) $response->get_data();
-		$links  = $server->get_compact_response_links( $response );
-		if ( ! empty( $links ) ) {
-			$data['_links'] = $links;
-		}
-
-		if ( 'OPTIONS' === $method ) {
-			$response = rest_send_allow_header( $response, $server, $request );
-
-			$memo[ $method ][ $path ] = array(
-				'body'    => $data,
-				'headers' => $response->headers,
-			);
-		} else {
-			$memo[ $path ] = array(
-				'body'    => $data,
-				'headers' => $response->headers,
-			);
-		}
-	}
-
-	return $memo;
+	return rest_preload_api_request( $memo, $path );
 }
 
 /**
@@ -1108,7 +1056,7 @@ JS;
 
 	$preload_data = array_reduce(
 		$preload_paths,
-		'gutenberg_preload_api_request',
+		'rest_preload_api_request',
 		array()
 	);
 

--- a/phpunit/class-admin-test.php
+++ b/phpunit/class-admin-test.php
@@ -192,13 +192,4 @@ class Admin_Test extends WP_UnitTestCase {
 		$link = apply_filters( 'wp_prepare_revision_for_js', array( 'restoreUrl' => 'http://test.com' ) );
 		$this->assertEquals( array( 'restoreUrl' => 'http://test.com' ), $link );
 	}
-
-	/**
-	 * Ensure gutenberg_preload_api_request() works without notices in PHP 5.2.
-	 *
-	 * The array_reduce() function only accepts mixed variables starting with PHP 5.3.
-	 */
-	function test_preload_api_request_no_notices_php_52() {
-		$this->assertTrue( is_array( gutenberg_preload_api_request( 0, '/' ) ) );
-	}
 }


### PR DESCRIPTION
Related: #11015

This pull request seeks to deprecate Gutenberg's `gutenberg_preload_api_request` in favor of the equivalent core function `rest_preload_api_request`.

**Testing instructions:**

Verify there are no regressions in the loading of the Gutenberg editor, importantly with regards to preloaded data (for example, there should be no XHR request for the post data).