### PR TITLE
Plugin: Deprecate gutenberg_get_block_categories

### DIFF
--- a/docs/designers-developers/developers/backward-compatibility/deprecations.md
+++ b/docs/designers-developers/developers/backward-compatibility/deprecations.md
@@ -31,6 +31,7 @@ The Gutenberg project's deprecation policy is intended to support backward compa
 - The PHP function `gutenberg_block_bulk_actions` has been removed.
 - The PHP function `gutenberg_replace_default_add_new_button` has been removed.
 - The PHP function `gutenberg_content_block_version` has been removed. Use [`block_version`](https://developer.wordpress.org/reference/functions/block_version/) instead.
+- The PHP function `gutenberg_get_block_categories` has been removed. Use [`get_block_categories`](https://developer.wordpress.org/reference/functions/get_block_categories/) instead.
 
 ## 4.5.0
 - `Dropdown.refresh()` has been deprecated as the contained `Popover` is now automatically refreshed.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -889,45 +889,15 @@ function gutenberg_get_autosave_newer_than_post_save( $post ) {
  * Returns all the block categories.
  *
  * @since 2.2.0
+ * @deprecated 5.0.0 get_block_categories
  *
  * @param  WP_Post $post Post object.
  * @return Object[] Block categories.
  */
 function gutenberg_get_block_categories( $post ) {
-	$default_categories = array(
-		array(
-			'slug'  => 'common',
-			'title' => __( 'Common Blocks', 'gutenberg' ),
-			'icon'  => null,
-		),
-		array(
-			'slug'  => 'formatting',
-			'title' => __( 'Formatting', 'gutenberg' ),
-			'icon'  => null,
-		),
-		array(
-			'slug'  => 'layout',
-			'title' => __( 'Layout Elements', 'gutenberg' ),
-			'icon'  => null,
-		),
-		array(
-			'slug'  => 'widgets',
-			'title' => __( 'Widgets', 'gutenberg' ),
-			'icon'  => null,
-		),
-		array(
-			'slug'  => 'embed',
-			'title' => __( 'Embeds', 'gutenberg' ),
-			'icon'  => null,
-		),
-		array(
-			'slug'  => 'reusable',
-			'title' => __( 'Reusable Blocks', 'gutenberg' ),
-			'icon'  => null,
-		),
-	);
+	_deprecated_function( __FUNCTION__, '5.0.0', 'get_block_categories' );
 
-	return apply_filters( 'block_categories', $default_categories, $post );
+	return get_block_categories( $post );
 }
 
 /**
@@ -1092,7 +1062,7 @@ JS;
 
 	wp_add_inline_script(
 		'wp-blocks',
-		sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( gutenberg_get_block_categories( $post ) ) ),
+		sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( get_block_categories( $post ) ) ),
 		'after'
 	);
 


### PR DESCRIPTION
Related: #11015

This pull request seeks to deprecate Gutenberg's `gutenberg_get_block_categories` in favor of the equivalent core function `get_block_categories`.

**Testing instructions:**

Verify there are no regressions in the loading of the Gutenberg editor, importantly with regards to the display of block categories in the inserter.