### PR TITLE
Plugin: Deprecate gutenberg_load_list_reusable_blocks

### DIFF
--- a/docs/designers-developers/developers/backward-compatibility/deprecations.md
+++ b/docs/designers-developers/developers/backward-compatibility/deprecations.md
@@ -36,6 +36,7 @@ The Gutenberg project's deprecation policy is intended to support backward compa
 - The PHP function `gutenberg_register_post_types` has been removed.
 - The `gutenberg` theme support option has been removed. Use [`align-wide`](https://wordpress.org/gutenberg/handbook/designers-developers/developers/themes/theme-support/#wide-alignment) instead.
 - The PHP function `gutenberg_prepare_blocks_for_js` has been removed. Use [`get_block_editor_server_block_settings`](https://developer.wordpress.org/reference/functions/get_block_editor_server_block_settings/) instead.
+- The PHP function `gutenberg_load_list_reusable_blocks` has been removed.
 
 ## 4.5.0
 - `Dropdown.refresh()` has been deprecated as the contained `Popover` is now automatically refreshed.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1325,14 +1325,8 @@ JS;
 /**
  * Enqueue the reusable blocks listing page's script
  *
- * @param string $hook Screen name.
+ * @deprecated 5.0.0
  */
-function gutenberg_load_list_reusable_blocks( $hook ) {
-	$is_reusable_blocks_list_page = 'edit.php' === $hook && isset( $_GET['post_type'] ) && 'wp_block' === $_GET['post_type'];
-	if ( $is_reusable_blocks_list_page ) {
-		gutenberg_load_locale_data();
-		wp_enqueue_script( 'wp-list-reusable-blocks' );
-		wp_enqueue_style( 'wp-list-reusable-blocks' );
-	}
+function gutenberg_load_list_reusable_blocks() {
+	_deprecated_function( __FUNCTION__, '5.0.0' );
 }
-add_action( 'admin_enqueue_scripts', 'gutenberg_load_list_reusable_blocks' );


### PR DESCRIPTION
Related: #11015

This pull request seeks to deprecate `gutenberg_load_list_reusable_blocks`. The enqueuing of these scripts is already handled in core.

See:

- https://core.trac.wordpress.org/changeset/43804
- https://core.trac.wordpress.org/ticket/45098

Gutenberg still overrides the script with its own variant, should their be any future changes to this script handle.

**Testing Instructions:**

Verify the Import from JSON / Export to JSON functionality on the reusable blocks list screen is still functional. This can be found under More > Manage All Reusable Blocks from the block editor.