### PR TITLE
Plugin: Deprecate `gutenberg` theme support

### DIFF
--- a/docs/designers-developers/developers/backward-compatibility/deprecations.md
+++ b/docs/designers-developers/developers/backward-compatibility/deprecations.md
@@ -34,6 +34,7 @@ The Gutenberg project's deprecation policy is intended to support backward compa
 - The PHP function `gutenberg_get_block_categories` has been removed. Use [`get_block_categories`](https://developer.wordpress.org/reference/functions/get_block_categories/) instead.
 - The PHP function `register_tinymce_scripts` has been removed. Use [`wp_register_tinymce_scripts`](https://developer.wordpress.org/reference/functions/wp_register_tinymce_scripts/) instead.
 - The PHP function `gutenberg_register_post_types` has been removed.
+- The `gutenberg` theme support option has been removed. Use [`align-wide`](https://wordpress.org/gutenberg/handbook/designers-developers/developers/themes/theme-support/#wide-alignment) instead.
 
 ## 4.5.0
 - `Dropdown.refresh()` has been deprecated as the contained `Popover` is now automatically refreshed.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1103,6 +1103,11 @@ JS;
 	$color_palette           = current( (array) get_theme_support( 'editor-color-palette' ) );
 	$font_sizes              = current( (array) get_theme_support( 'editor-font-sizes' ) );
 
+	if ( ! empty( $gutenberg_theme_support ) ) {
+		wp_enqueue_script( 'wp-deprecated' );
+		wp_add_inline_script( 'wp-deprecated', 'wp.deprecated( "`gutenberg` theme support", { plugin: "Gutenberg", version: "5.2", alternative: "`align-wide` theme support" } );' );
+	}
+
 	/**
 	 * Filters the allowed block types for the editor, defaulting to true (all
 	 * block types supported).


### PR DESCRIPTION
This pull request seeks to formally deprecate the `gutenberg` theme support option which had been renamed / repurposed to `align-wide` in #4153.

**Testing instructions:**

Verify there are no console warnings when visiting the editor. Verify once more when adding `add_theme_support( 'gutenberg' );` to your theme that a deprecated warning is shown.