### PR TITLE
Plugin: Remove list screens integrations

### DIFF
--- a/docs/designers-developers/developers/backward-compatibility/deprecations.md
+++ b/docs/designers-developers/developers/backward-compatibility/deprecations.md
@@ -26,6 +26,10 @@ The Gutenberg project's deprecation policy is intended to support backward compa
 - The PHP function `gutenberg_bulk_post_updated_messages` has been removed.
 - The PHP function `gutenberg_kses_allowedtags` has been removed.
 - The PHP function `gutenberg_add_responsive_body_class` has been removed.
+- The PHP function `gutenberg_add_edit_link_filters` has been removed.
+- The PHP function `gutenberg_add_edit_link` has been removed.
+- The PHP function `gutenberg_block_bulk_actions` has been removed.
+- The PHP function `gutenberg_replace_default_add_new_button` has been removed.
 
 ## 4.5.0
 - `Dropdown.refresh()` has been deprecated as the contained `Popover` is now automatically refreshed.

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -263,84 +263,25 @@ add_action( 'admin_init', 'gutenberg_redirect_demo' );
  * the post/page screens.
  *
  * @since 1.5.0
+ * @deprecated 5.0.0
  */
 function gutenberg_add_edit_link_filters() {
-	// For hierarchical post types.
-	add_filter( 'page_row_actions', 'gutenberg_add_edit_link', 10, 2 );
-	// For non-hierarchical post types.
-	add_filter( 'post_row_actions', 'gutenberg_add_edit_link', 10, 2 );
+	_deprecated_function( __FUNCTION__, '5.0.0' );
 }
-add_action( 'admin_init', 'gutenberg_add_edit_link_filters' );
 
 /**
  * Registers an additional link in the post/page screens to edit any post/page in
  * the Classic editor.
  *
  * @since 1.5.0
+ * @deprecated 5.0.0
  *
- * @param  array   $actions Post actions.
- * @param  WP_Post $post    Edited post.
+ * @param array $actions Post actions.
  *
- * @return array          Updated post actions.
+ * @return array Updated post actions.
  */
-function gutenberg_add_edit_link( $actions, $post ) {
-	// Build the classic edit action. See also: WP_Posts_List_Table::handle_row_actions().
-	$title = _draft_or_post_title( $post->ID );
-
-	if ( 'wp_block' === $post->post_type ) {
-		unset( $actions['inline hide-if-no-js'] );
-
-		// Export uses block raw content, which is only returned from the post
-		// REST endpoint via `context=edit`, requiring edit capability.
-		$post_type = get_post_type_object( $post->post_type );
-		if ( ! current_user_can( $post_type->cap->edit_post, $post->ID ) ) {
-			return $actions;
-		}
-
-		$actions['export'] = sprintf(
-			'<button type="button" class="wp-list-reusable-blocks__export button-link" data-id="%s" aria-label="%s">%s</button>',
-			$post->ID,
-			esc_attr(
-				sprintf(
-					/* translators: %s: post title */
-					__( 'Export &#8220;%s&#8221; as JSON', 'gutenberg' ),
-					$title
-				)
-			),
-			__( 'Export as JSON', 'gutenberg' )
-		);
-		return $actions;
-	}
-
-	if ( ! gutenberg_can_edit_post( $post ) ) {
-		return $actions;
-	}
-
-	$edit_url = get_edit_post_link( $post->ID, 'raw' );
-	$edit_url = add_query_arg( 'classic-editor', '', $edit_url );
-
-	$edit_action = array(
-		'classic' => sprintf(
-			'<a href="%s" aria-label="%s">%s</a>',
-			esc_url( $edit_url ),
-			esc_attr(
-				sprintf(
-					/* translators: %s: post title */
-					__( 'Edit &#8220;%s&#8221; in the classic editor', 'gutenberg' ),
-					$title
-				)
-			),
-			__( 'Classic Editor', 'gutenberg' )
-		),
-	);
-
-	// Insert the Classic Edit action after the Edit action.
-	$edit_offset = array_search( 'edit', array_keys( $actions ), true );
-	$actions     = array_merge(
-		array_slice( $actions, 0, $edit_offset + 1 ),
-		$edit_action,
-		array_slice( $actions, $edit_offset + 1 )
-	);
+function gutenberg_add_edit_link( $actions ) {
+	_deprecated_function( __FUNCTION__, '5.0.0' );
 
 	return $actions;
 }
@@ -349,162 +290,27 @@ function gutenberg_add_edit_link( $actions, $post ) {
  * Removes the Edit action from the reusable block list's Bulk Actions dropdown.
  *
  * @since 3.8.0
+ * @deprecated 5.0.0
  *
  * @param array $actions Bulk actions.
  *
  * @return array Updated bulk actions.
  */
 function gutenberg_block_bulk_actions( $actions ) {
-	unset( $actions['edit'] );
+	_deprecated_function( __FUNCTION__, '5.0.0' );
+
 	return $actions;
 }
-add_filter( 'bulk_actions-edit-wp_block', 'gutenberg_block_bulk_actions' );
 
 /**
  * Prints the JavaScript to replace the default "Add New" button.$_COOKIE
  *
  * @since 1.5.0
+ * @deprecated 5.0.0
  */
 function gutenberg_replace_default_add_new_button() {
-	global $typenow;
-
-	if ( 'wp_block' === $typenow ) {
-		?>
-		<style type="text/css">
-			.page-title-action {
-				display: none;
-			}
-		</style>
-		<?php
-	}
-
-	if ( ! gutenberg_can_edit_post_type( $typenow ) ) {
-		return;
-	}
-
-	?>
-	<style type="text/css">
-		.split-page-title-action {
-			display: inline-block;
-		}
-
-		.split-page-title-action a,
-		.split-page-title-action a:active,
-		.split-page-title-action .expander:after {
-			padding: 6px 10px;
-			position: relative;
-			top: -3px;
-			text-decoration: none;
-			border: 1px solid #ccc;
-			border-radius: 2px;
-			background: #f7f7f7;
-			text-shadow: none;
-			font-weight: 600;
-			font-size: 13px;
-			line-height: normal; /* IE8-IE11 need this for buttons */
-			color: #0073aa; /* some of these controls are button elements and don't inherit from links */
-			cursor: pointer;
-			outline: 0;
-		}
-
-		.split-page-title-action a:hover,
-		.split-page-title-action .expander:hover:after {
-			border-color: #008EC2;
-			background: #00a0d2;
-			color: #fff;
-		}
-
-		.split-page-title-action a:focus,
-		.split-page-title-action .expander:focus:after {
-			border-color: #5b9dd9;
-			box-shadow: 0 0 2px rgba( 30, 140, 190, 0.8 );
-		}
-
-		.split-page-title-action .expander:after {
-			content: "\f140";
-			font: 400 20px/.5 dashicons;
-			speak: none;
-			top: 1px;
-			<?php if ( is_rtl() ) : ?>
-			right: -1px;
-			<?php else : ?>
-			left: -1px;
-			<?php endif; ?>
-			position: relative;
-			vertical-align: top;
-			text-decoration: none !important;
-			padding: 4px 5px 4px 3px;
-		}
-
-		.split-page-title-action .dropdown {
-			display: none;
-		}
-
-		.split-page-title-action .dropdown.visible {
-			display: block;
-			position: absolute;
-			margin-top: 3px;
-			z-index: 1;
-		}
-
-		.split-page-title-action .dropdown.visible a {
-			display: block;
-			top: 0;
-			margin: -1px 0;
-			<?php if ( is_rtl() ) : ?>
-			padding-left: 9px;
-			<?php else : ?>
-			padding-right: 9px;
-			<?php endif; ?>
-		}
-
-		.split-page-title-action .expander {
-			outline: none;
-		}
-
-	</style>
-	<script type="text/javascript">
-		document.addEventListener( 'DOMContentLoaded', function() {
-			var buttons = document.getElementsByClassName( 'page-title-action' ),
-				button = buttons.item( 0 );
-
-			if ( ! button ) {
-				return;
-			}
-
-			var url = button.href;
-			var urlHasParams = ( -1 !== url.indexOf( '?' ) );
-			var classicUrl = url + ( urlHasParams ? '&' : '?' ) + 'classic-editor';
-
-			var newbutton = '<span id="split-page-title-action" class="split-page-title-action">';
-			newbutton += '<a href="' + url + '">' + button.innerText + '</a>';
-			newbutton += '<span class="expander" tabindex="0" role="button" aria-haspopup="true" aria-label="<?php echo esc_js( __( 'Toggle editor selection menu', 'gutenberg' ) ); ?>"></span>';
-			newbutton += '<span class="dropdown"><a href="' + url + '">Gutenberg</a>';
-			newbutton += '<a href="' + classicUrl + '"><?php echo esc_js( __( 'Classic Editor', 'gutenberg' ) ); ?></a></span></span><span class="page-title-action" style="display:none;"></span>';
-
-			button.insertAdjacentHTML( 'afterend', newbutton );
-			button.parentNode.removeChild( button );
-
-			var expander = document.getElementById( 'split-page-title-action' ).getElementsByClassName( 'expander' ).item( 0 );
-			var dropdown = expander.parentNode.querySelector( '.dropdown' );
-			function toggleDropdown() {
-				dropdown.classList.toggle( 'visible' );
-			}
-			expander.addEventListener( 'click', function( e ) {
-				e.preventDefault();
-				toggleDropdown();
-			} );
-			expander.addEventListener( 'keydown', function( e ) {
-				if ( 13 === e.which || 32 === e.which ) {
-					e.preventDefault();
-					toggleDropdown();
-				}
-			} );
-		} );
-	</script>
-	<?php
+	_deprecated_function( __FUNCTION__, '5.0.0' );
 }
-add_action( 'admin_print_scripts-edit.php', 'gutenberg_replace_default_add_new_button' );
 
 /**
  * Adds the block-editor-page class to the body tag on the Gutenberg page.


### PR DESCRIPTION
This pull request seeks to remove logic from and deprecate functions previously associated with extending post listing screens:

- The "Add New" dropdown option to choose from Classic Editor or Gutenberg
- The "Edit with Classic Editor" links when hovering individual list items
- Removing "Edit" from bulk actions on the Reusable Blocks list screen
   - Not really sure what this was all about, and it's not in core anyways, so apparently not very important

**Testing instructions:**

Verify the above integrations are gracefully removed from post listing screens.