### PR TITLE
Plugin: Deprecate gutenberg_kses_allowedtags

### DIFF
--- a/docs/designers-developers/developers/backward-compatibility/deprecations.md
+++ b/docs/designers-developers/developers/backward-compatibility/deprecations.md
@@ -23,6 +23,7 @@ The Gutenberg project's deprecation policy is intended to support backward compa
 - The PHP function `gutenberg_filter_post_type_labels` has been removed.
 - The PHP function `gutenberg_remove_wpcom_markdown_support` has been removed.
 - The PHP function `gutenberg_bulk_post_updated_messages` has been removed.
+- The PHP function `gutenberg_kses_allowedtags` has been removed.
 
 ## 4.5.0
 - `Dropdown.refresh()` has been deprecated as the contained `Popover` is now automatically refreshed.

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -527,18 +527,16 @@ function gutenberg_add_admin_body_class( $classes ) {
  * Adds attributes to kses allowed tags that aren't in the default list
  * and that Gutenberg needs to save blocks such as the Gallery block.
  *
+ * @deprecated 5.0.0
+ *
  * @param array $tags Allowed HTML.
  * @return array (Maybe) modified allowed HTML.
  */
 function gutenberg_kses_allowedtags( $tags ) {
-	if ( isset( $tags['img'] ) ) {
-		$tags['img']['data-link'] = true;
-		$tags['img']['data-id']   = true;
-	}
+	_deprecated_function( __FUNCTION__, '5.0.0' );
+
 	return $tags;
 }
-
-add_filter( 'wp_kses_allowed_html', 'gutenberg_kses_allowedtags', 10, 2 );
 
 /**
  * Adds the wp-embed-responsive class to the body tag if the theme has opted in to


### PR DESCRIPTION
Related: #11015
Related: #9875

This pull request seeks to deprecate and remove logic from `gutenberg_kses_allowedtags`. `data-` attributes are now whitelisted in core as of v5.0, and thus it is no longer necessary.

See:

- https://core.trac.wordpress.org/changeset/43727
- https://core.trac.wordpress.org/ticket/33121

**Testing instructions:**

Repeat testing instructions from #9875 .