### PR TITLE
Plugin: Deprecate gutenberg_add_responsive_body_class

### DIFF
--- a/docs/designers-developers/developers/backward-compatibility/deprecations.md
+++ b/docs/designers-developers/developers/backward-compatibility/deprecations.md
@@ -24,6 +24,7 @@ The Gutenberg project's deprecation policy is intended to support backward compa
 - The PHP function `gutenberg_remove_wpcom_markdown_support` has been removed.
 - The PHP function `gutenberg_bulk_post_updated_messages` has been removed.
 - The PHP function `gutenberg_kses_allowedtags` has been removed.
+- The PHP function `gutenberg_add_responsive_body_class` has been removed.
 
 ## 4.5.0
 - `Dropdown.refresh()` has been deprecated as the contained `Popover` is now automatically refreshed.

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -543,15 +543,13 @@ function gutenberg_kses_allowedtags( $tags ) {
  * Gutenberg responsive embeds.
  *
  * @since 4.1.0
+ * @deprecated 5.0.0
  *
  * @param Array $classes Array of classes being added to the body tag.
  * @return Array The $classes array, with wp-embed-responsive appended.
  */
 function gutenberg_add_responsive_body_class( $classes ) {
-	if ( current_theme_supports( 'responsive-embeds' ) ) {
-		$classes[] = 'wp-embed-responsive';
-	}
+	_deprecated_function( __FUNCTION__, '5.0.0' );
+
 	return $classes;
 }
-
-add_filter( 'body_class', 'gutenberg_add_responsive_body_class' );


### PR DESCRIPTION
Related: #11015
Related: #10477

This pull request seeks to deprecate and remove logic from `gutenberg_add_responsive_body_class` . This is now handled automatically in core as of WordPress 5.0.

See:

- https://core.trac.wordpress.org/changeset/43790
- https://core.trac.wordpress.org/ticket/45125

**Testing instructions:**

Repeat testing instructions from #10477.