### PR TITLE
Fix Travis CI not detecting uncommitted changes to package-lock.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,8 @@ jobs:
       env: WP_VERSION=latest
       before_install:
         - nvm install --latest-npm
-      install:
-        - npm ci
       script:
+        - npm ci
         - npm run lint
         - npm run check-local-changes
         - npm run test-unit -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2427,6 +2427,7 @@
 				"@babel/runtime": "^7.0.0",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/data": "file:packages/data",
+				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/url": "file:packages/url",
 				"equivalent-key-map": "^0.2.2",
 				"lodash": "^4.17.10",


### PR DESCRIPTION
Fixes issue identified in https://github.com/WordPress/gutenberg/pull/12378#discussion_r250342848.

`npm run check-local-changes` was not detecting uncommited changes to `package-lock.json` because Travis CI was set to use `npm ci` instead of `npm install`.

Having Travis cache `node_modules` ensures that there is no regression of CI performance, see https://github.com/WordPress/gutenberg/pull/13103#discussion_r244245891.