### PR TITLE
Plugin: Deprecate register_tinymce_scripts

### DIFF
--- a/docs/designers-developers/developers/backward-compatibility/deprecations.md
+++ b/docs/designers-developers/developers/backward-compatibility/deprecations.md
@@ -32,6 +32,7 @@ The Gutenberg project's deprecation policy is intended to support backward compa
 - The PHP function `gutenberg_replace_default_add_new_button` has been removed.
 - The PHP function `gutenberg_content_block_version` has been removed. Use [`block_version`](https://developer.wordpress.org/reference/functions/block_version/) instead.
 - The PHP function `gutenberg_get_block_categories` has been removed. Use [`get_block_categories`](https://developer.wordpress.org/reference/functions/get_block_categories/) instead.
+- The PHP function `register_tinymce_scripts` has been removed. Use [`wp_register_tinymce_scripts`](https://developer.wordpress.org/reference/functions/wp_register_tinymce_scripts/) instead.
 
 ## 4.5.0
 - `Dropdown.refresh()` has been deprecated as the contained `Popover` is now automatically refreshed.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -69,26 +69,14 @@ function gutenberg_get_script_polyfill( $tests ) {
 if ( ! function_exists( 'register_tinymce_scripts' ) ) {
 	/**
 	 * Registers the main TinyMCE scripts.
+	 *
+	 * @deprecated 5.0.0 wp_register_tinymce_scripts
 	 */
 	function register_tinymce_scripts() {
-		global $tinymce_version, $concatenate_scripts, $compress_scripts;
-		if ( ! isset( $concatenate_scripts ) ) {
-			script_concat_settings();
-		}
-		$suffix     = SCRIPT_DEBUG ? '' : '.min';
-		$compressed = $compress_scripts && $concatenate_scripts && isset( $_SERVER['HTTP_ACCEPT_ENCODING'] )
-			&& false !== stripos( $_SERVER['HTTP_ACCEPT_ENCODING'], 'gzip' );
-		// Load tinymce.js when running from /src, otherwise load wp-tinymce.js.gz (in production) or
-		// tinymce.min.js (when SCRIPT_DEBUG is true).
-		$mce_suffix = false !== strpos( get_bloginfo( 'version' ), '-src' ) ? '' : '.min';
-		if ( $compressed ) {
-			gutenberg_override_script( 'wp-tinymce', includes_url( 'js/tinymce/' ) . 'wp-tinymce.php', array(), $tinymce_version );
-		} else {
-			gutenberg_override_script( 'wp-tinymce-root', includes_url( 'js/tinymce/' ) . "tinymce{$mce_suffix}.js", array(), $tinymce_version );
-			gutenberg_override_script( 'wp-tinymce', includes_url( 'js/tinymce/' ) . "plugins/compat3x/plugin{$suffix}.js", array( 'wp-tinymce-root' ), $tinymce_version );
-		}
+		_deprecated_function( __FUNCTION__, '5.0.0', 'wp_register_tinymce_scripts' );
 
-		gutenberg_override_script( 'wp-tinymce-lists', includes_url( 'js/tinymce/' ) . "plugins/lists/plugin{$suffix}.js", array( 'wp-tinymce' ), $tinymce_version );
+		global $wp_scripts;
+		return wp_register_tinymce_scripts( $wp_scripts );
 	}
 }
 
@@ -166,8 +154,6 @@ function gutenberg_register_packages_scripts() {
  */
 function gutenberg_register_scripts_and_styles() {
 	gutenberg_register_vendor_scripts();
-
-	register_tinymce_scripts();
 
 	wp_add_inline_script(
 		'wp-polyfill',


### PR DESCRIPTION
Related: #11015

This pull request seeks to deprecate `register_tinymce_scripts` in favor of the core-equivalent `wp_register_tinymce_scripts`. In practice, it doesn't ever need to be called because it is executed as part of the `wp_default_scripts` action.

See:

- https://github.com/WordPress/wordpress-develop/blob/ad0a1a2f8280bb421d36a0f1080080e7c0f7c6d8/src/wp-includes/script-loader.php#L738
- https://core.trac.wordpress.org/changeset/43723

**Testing instructions:**

Verify there is no regressions in the load and basic use of TinyMCE (e.g. paragraph block field).