### PR TITLE
Plugin: Remove core-defined block detection functions

### DIFF
--- a/lib/register.php
+++ b/lib/register.php
@@ -310,32 +310,6 @@ function gutenberg_can_edit_post_type( $post_type ) {
 	return apply_filters( 'gutenberg_can_edit_post_type', $can_edit, $post_type );
 }
 
-if ( ! function_exists( 'has_blocks' ) ) {
-	/**
-	 * Determine whether a post or content string has blocks.
-	 *
-	 * This test optimizes for performance rather than strict accuracy, detecting
-	 * the pattern of a block but not validating its structure. For strict accuracy
-	 * you should use the block parser on post content.
-	 *
-	 * @since 3.6.0
-	 * @see gutenberg_parse_blocks()
-	 *
-	 * @param int|string|WP_Post|null $post Optional. Post content, post ID, or post object. Defaults to global $post.
-	 * @return bool Whether the post has blocks.
-	 */
-	function has_blocks( $post = null ) {
-		if ( ! is_string( $post ) ) {
-			$wp_post = get_post( $post );
-			if ( $wp_post instanceof WP_Post ) {
-				$post = $wp_post->post_content;
-			}
-		}
-
-		return false !== strpos( (string) $post, '<!-- wp:' );
-	}
-}
-
 /**
  * Determine whether a post has blocks. This test optimizes for performance
  * rather than strict accuracy, detecting the pattern of a block but not
@@ -372,35 +346,6 @@ function gutenberg_post_has_blocks( $post ) {
 function gutenberg_content_has_blocks( $content ) {
 	_deprecated_function( __FUNCTION__, '3.6.0', 'has_blocks()' );
 	return has_blocks( $content );
-}
-
-if ( ! function_exists( 'has_block' ) ) {
-	/**
-	 * Determine whether a $post or a string contains a specific block type.
-	 * This test optimizes for performance rather than strict accuracy, detecting
-	 * the block type exists but not validating its structure.
-	 * For strict accuracy, you should use the block parser on post content.
-	 *
-	 * @since 3.6.0
-	 *
-	 * @param string                  $block_type Full Block type to look for.
-	 * @param int|string|WP_Post|null $post Optional. Post content, post ID, or post object. Defaults to global $post.
-	 * @return bool Whether the post content contains the specified block.
-	 */
-	function has_block( $block_type, $post = null ) {
-		if ( ! has_blocks( $post ) ) {
-			return false;
-		}
-
-		if ( ! is_string( $post ) ) {
-			$wp_post = get_post( $post );
-			if ( $wp_post instanceof WP_Post ) {
-				$post = $wp_post->post_content;
-			}
-		}
-
-		return false !== strpos( $post, '<!-- wp:' . $block_type . ' ' );
-	}
 }
 
 /**


### PR DESCRIPTION
Related: #11015

This pull request seeks to remove the function definitions for `has_blocks` and `has_block` from the Gutenberg plugin. These are already defined in core as of 5.0 (Gutenberg's minimum required function) and thus this is effectively dead code.

See:

- https://developer.wordpress.org/reference/functions/has_blocks/
- https://developer.wordpress.org/reference/functions/has_block/