### PR TITLE
Plugin: Deprecate gutenberg_content_block_version

### DIFF
--- a/docs/designers-developers/developers/backward-compatibility/deprecations.md
+++ b/docs/designers-developers/developers/backward-compatibility/deprecations.md
@@ -30,6 +30,7 @@ The Gutenberg project's deprecation policy is intended to support backward compa
 - The PHP function `gutenberg_add_edit_link` has been removed.
 - The PHP function `gutenberg_block_bulk_actions` has been removed.
 - The PHP function `gutenberg_replace_default_add_new_button` has been removed.
+- The PHP function `gutenberg_content_block_version` has been removed. Use [`block_version`](https://developer.wordpress.org/reference/functions/block_version/) instead.
 
 ## 4.5.0
 - `Dropdown.refresh()` has been deprecated as the contained `Popover` is now automatically refreshed.

--- a/lib/register.php
+++ b/lib/register.php
@@ -355,12 +355,15 @@ function gutenberg_content_has_blocks( $content ) {
  *
  * @since 2.8.0
  * @see gutenberg_content_has_blocks()
+ * @deprecated 5.0.0 block_version
  *
  * @param string $content Content to test.
  * @return int The block format version.
  */
 function gutenberg_content_block_version( $content ) {
-	return has_blocks( $content ) ? 1 : 0;
+	_deprecated_function( __FUNCTION__, '5.0.0', 'block_version' );
+
+	return block_version( $content );
 }
 
 /**


### PR DESCRIPTION
Related: #11015

This pull request seeks to deprecate the `gutenberg_content_block_version` function in favor of the core-equivalent `block_version`.

See:

- https://developer.wordpress.org/reference/functions/block_version/

**Testing instructions:**

The function had not been referenced at all in the Gutenberg plugin. There should be no affected behavior.