### PR TITLE
Plugin: Deprecate gutenberg_can_edit_* functions

### DIFF
--- a/docs/designers-developers/developers/backward-compatibility/deprecations.md
+++ b/docs/designers-developers/developers/backward-compatibility/deprecations.md
@@ -7,6 +7,8 @@ The Gutenberg project's deprecation policy is intended to support backward compa
 - The PHP function `gutenberg_redirect_to_classic_editor_when_saving_posts` has been removed.
 - The PHP function `gutenberg_revisions_link_to_editor` has been removed.
 - The PHP function `gutenberg_remember_classic_editor_when_saving_posts` has been removed.
+- The PHP function `gutenberg_can_edit_post_type` has been removed. Use [`use_block_editor_for_post_type`](https://developer.wordpress.org/reference/functions/use_block_editor_for_post_type/) instead.
+- The PHP function `gutenberg_can_edit_post` has been removed. Use [`use_block_editor_for_post`](https://developer.wordpress.org/reference/functions/use_block_editor_for_post/) instead.
 
 ## 5.2.0
 

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -118,7 +118,7 @@ function is_gutenberg_page() {
 		return false;
 	}
 
-	if ( ! gutenberg_can_edit_post( $post ) ) {
+	if ( ! use_block_editor_for_post( $post ) ) {
 		return false;
 	}
 

--- a/lib/register.php
+++ b/lib/register.php
@@ -25,44 +25,15 @@ function gutenberg_collect_meta_box_data() {
  * Return whether the post can be edited in Gutenberg and by the current user.
  *
  * @since 0.5.0
+ * @deprecated 5.0.0 use_block_editor_for_post
  *
  * @param int|WP_Post $post Post ID or WP_Post object.
  * @return bool Whether the post can be edited with Gutenberg.
  */
 function gutenberg_can_edit_post( $post ) {
-	$post     = get_post( $post );
-	$can_edit = true;
+	_deprecated_function( __FUNCTION__, '5.0.0', 'use_block_editor_for_post' );
 
-	if ( ! $post ) {
-		$can_edit = false;
-	}
-
-	if ( $can_edit && 'trash' === $post->post_status ) {
-		$can_edit = false;
-	}
-
-	if ( $can_edit && ! gutenberg_can_edit_post_type( $post->post_type ) ) {
-		$can_edit = false;
-	}
-
-	if ( $can_edit && ! current_user_can( 'edit_post', $post->ID ) ) {
-		$can_edit = false;
-	}
-
-	// Disable the editor if on the blog page and there is no content.
-	if ( $can_edit && absint( get_option( 'page_for_posts' ) ) === $post->ID && empty( $post->post_content ) ) {
-		$can_edit = false;
-	}
-
-	/**
-	 * Filter to allow plugins to enable/disable Gutenberg for particular post.
-	 *
-	 * @since 3.5
-	 *
-	 * @param bool $can_edit Whether the post can be edited or not.
-	 * @param WP_Post $post The post being checked.
-	 */
-	return apply_filters( 'gutenberg_can_edit_post', $can_edit, $post );
+	return use_block_editor_for_post( $post );
 
 }
 
@@ -73,34 +44,15 @@ function gutenberg_can_edit_post( $post ) {
  * REST API, then the post cannot be edited in Gutenberg.
  *
  * @since 1.5.2
+ * @deprecated 5.0.0 use_block_editor_for_post_type
  *
  * @param string $post_type The post type.
  * @return bool Whether the post type can be edited with Gutenberg.
  */
 function gutenberg_can_edit_post_type( $post_type ) {
-	$can_edit = true;
-	if ( ! post_type_exists( $post_type ) ) {
-		$can_edit = false;
-	}
+	_deprecated_function( __FUNCTION__, '5.0.0', 'use_block_editor_for_post_type' );
 
-	if ( ! post_type_supports( $post_type, 'editor' ) ) {
-		$can_edit = false;
-	}
-
-	$post_type_object = get_post_type_object( $post_type );
-	if ( $post_type_object && ! $post_type_object->show_in_rest ) {
-		$can_edit = false;
-	}
-
-	/**
-	 * Filter to allow plugins to enable/disable Gutenberg for particular post types.
-	 *
-	 * @since 1.5.2
-	 *
-	 * @param bool   $can_edit  Whether the post type can be edited or not.
-	 * @param string $post_type The post type being checked.
-	 */
-	return apply_filters( 'gutenberg_can_edit_post_type', $can_edit, $post_type );
+	return use_block_editor_for_post_type( $post_type );
 }
 
 /**

--- a/phpunit/class-admin-test.php
+++ b/phpunit/class-admin-test.php
@@ -11,13 +11,6 @@
 class Admin_Test extends WP_UnitTestCase {
 
 	/**
-	 * Editor user ID.
-	 *
-	 * @var int
-	 */
-	protected static $editor_user_id;
-
-	/**
 	 * ID for a post containing blocks.
 	 *
 	 * @var int
@@ -35,11 +28,6 @@ class Admin_Test extends WP_UnitTestCase {
 	 * Set up before class.
 	 */
 	public static function wpSetUpBeforeClass() {
-		self::$editor_user_id      = self::factory()->user->create(
-			array(
-				'role' => 'editor',
-			)
-		);
 		self::$post_with_blocks    = self::factory()->post->create(
 			array(
 				'post_title'   => 'Example',
@@ -52,68 +40,6 @@ class Admin_Test extends WP_UnitTestCase {
 				'post_content' => 'Tester',
 			)
 		);
-	}
-
-	/**
-	 * Tests gutenberg_can_edit_post().
-	 *
-	 * @covers ::gutenberg_can_edit_post
-	 */
-	function test_gutenberg_can_edit_post() {
-		$this->assertFalse( gutenberg_can_edit_post( -1 ) );
-		$bogus_post_id = $this->factory()->post->create(
-			array(
-				'post_type' => 'bogus',
-			)
-		);
-		$this->assertFalse( gutenberg_can_edit_post( $bogus_post_id ) );
-
-		register_post_type(
-			'restless',
-			array(
-				'show_in_rest' => false,
-			)
-		);
-		$restless_post_id = $this->factory()->post->create(
-			array(
-				'post_type' => 'restless',
-			)
-		);
-		$this->assertFalse( gutenberg_can_edit_post( $restless_post_id ) );
-
-		$generic_post_id = $this->factory()->post->create();
-
-		wp_set_current_user( 0 );
-		$this->assertFalse( gutenberg_can_edit_post( $generic_post_id ) );
-
-		wp_set_current_user( self::$editor_user_id );
-		$this->assertTrue( gutenberg_can_edit_post( $generic_post_id ) );
-
-		$blog_page_without_content = self::factory()->post->create(
-			array(
-				'post_title'   => 'Blog',
-				'post_content' => '',
-			)
-		);
-		update_option( 'page_for_posts', $blog_page_without_content );
-		$this->assertFalse( gutenberg_can_edit_post( $blog_page_without_content ) );
-
-		$blog_page_with_content = self::factory()->post->create(
-			array(
-				'post_title'   => 'Blog',
-				'post_content' => 'Hello World!',
-			)
-		);
-		update_option( 'page_for_posts', $blog_page_with_content );
-		$this->assertTrue( gutenberg_can_edit_post( $blog_page_with_content ) );
-
-		add_filter( 'gutenberg_can_edit_post', '__return_false' );
-		$this->assertFalse( gutenberg_can_edit_post( $generic_post_id ) );
-		remove_filter( 'gutenberg_can_edit_post', '__return_false' );
-
-		add_filter( 'gutenberg_can_edit_post', '__return_true' );
-		$this->assertTrue( gutenberg_can_edit_post( $restless_post_id ) );
-		remove_filter( 'gutenberg_can_edit_post', '__return_true' );
 	}
 
 	/**


### PR DESCRIPTION
Related: #11015

This pull request seeks to deprecate the `gutenberg_can_edit_post_type` and `gutenberg_can_edit_post` functions in favor of the core-equivalent `use_block_editor_for_post_type` and `use_block_editor_for_post` functions.

See:

- https://developer.wordpress.org/reference/functions/use_block_editor_for_post_type/
- https://developer.wordpress.org/reference/functions/use_block_editor_for_post/

**Testing instructions:**

Verify that one can edit a Gutenberg post if and only if the post type and user are capable of editing (e.g. `show_in_rest`, supports `editor`, etc). The logic is not identical in core, and this will continue to be aligned until eventually Gutenberg merely extends the `edit-form-blocks.php` interface. 

The core implementations also use the `meta-box-loader` query parameter for meta boxes, which is not the same as what's used in Gutenberg. However, this is already slated for removal as of #13449.