### PR TITLE
Plugin: Deprecate gutenberg_add_gutenberg_post_state

### DIFF
--- a/docs/designers-developers/developers/backward-compatibility/deprecations.md
+++ b/docs/designers-developers/developers/backward-compatibility/deprecations.md
@@ -22,6 +22,7 @@ The Gutenberg project's deprecation policy is intended to support backward compa
 - The PHP function `gutenberg_silence_rest_errors` has been removed.
 - The PHP function `gutenberg_filter_post_type_labels` has been removed.
 - The PHP function `gutenberg_remove_wpcom_markdown_support` has been removed.
+- The PHP function `gutenberg_add_gutenberg_post_state` has been removed.
 
 ## 4.5.0
 - `Dropdown.refresh()` has been deprecated as the contained `Popover` is now automatically refreshed.

--- a/lib/register.php
+++ b/lib/register.php
@@ -421,18 +421,16 @@ function gutenberg_content_block_version( $content ) {
 /**
  * Adds a "Gutenberg" post state for post tables, if the post contains blocks.
  *
- * @param  array   $post_states An array of post display states.
- * @param  WP_Post $post        The current post object.
- * @return array                A filtered array of post display states.
+ * @deprecated 5.0.0
+ *
+ * @param array $post_states An array of post display states.
+ * @return array A filtered array of post display states.
  */
-function gutenberg_add_gutenberg_post_state( $post_states, $post ) {
-	if ( has_blocks( $post ) ) {
-		$post_states[] = 'Gutenberg';
-	}
+function gutenberg_add_gutenberg_post_state( $post_states ) {
+	_deprecated_function( __FUNCTION__, '5.0.0' );
 
 	return $post_states;
 }
-add_filter( 'display_post_states', 'gutenberg_add_gutenberg_post_state', 10, 2 );
 
 /**
  * Registers custom post types required by the Gutenberg editor.

--- a/phpunit/class-admin-test.php
+++ b/phpunit/class-admin-test.php
@@ -142,21 +142,6 @@ class Admin_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests gutenberg_add_gutenberg_post_state().
-	 *
-	 * @covers ::gutenberg_add_gutenberg_post_state
-	 */
-	function test_add_gutenberg_post_state() {
-		// With blocks.
-		$post_states = apply_filters( 'display_post_states', array(), get_post( self::$post_with_blocks ) );
-		$this->assertEquals( array( 'Gutenberg' ), $post_states );
-
-		// Without blocks.
-		$post_states = apply_filters( 'display_post_states', array(), get_post( self::$post_without_blocks ) );
-		$this->assertEquals( array(), $post_states );
-	}
-
-	/**
 	 * Test that the revisions 'return to editor' links are set correctly for Classic & Gutenberg editors.
 	 *
 	 * @covers ::gutenberg_revisions_link_to_editor


### PR DESCRIPTION
Related: #11015

This pull request seeks to deprecate and remove logic from `gutenberg_add_gutenberg_post_state `. This added the "Gutenberg" text on a post in the post listing screen.

![image](https://user-images.githubusercontent.com/1779930/51651498-20d72880-1f5a-11e9-844d-65620ef2173f.png)

With 5.0 being released, this no longer really serves a purpose to distinguish posts.

**Testing instructions:**

Verify there is no "Gutenberg" label on posts in the post listing screen.