### PR TITLE
Plugin: Deprecate gutenberg_bulk_post_updated_messages

### DIFF
--- a/docs/designers-developers/developers/backward-compatibility/deprecations.md
+++ b/docs/designers-developers/developers/backward-compatibility/deprecations.md
@@ -22,6 +22,7 @@ The Gutenberg project's deprecation policy is intended to support backward compa
 - The PHP function `gutenberg_silence_rest_errors` has been removed.
 - The PHP function `gutenberg_filter_post_type_labels` has been removed.
 - The PHP function `gutenberg_remove_wpcom_markdown_support` has been removed.
+- The PHP function `gutenberg_bulk_post_updated_messages` has been removed.
 
 ## 4.5.0
 - `Dropdown.refresh()` has been deprecated as the contained `Popover` is now automatically refreshed.

--- a/lib/register.php
+++ b/lib/register.php
@@ -538,30 +538,17 @@ add_action( 'init', 'gutenberg_register_post_types' );
  * Apply the correct labels for Reusable Blocks in the bulk action updated messages.
  *
  * @since 4.3.0
+ * @deprecated 5.0.0
  *
- * @param array $messages    Arrays of messages, each keyed by the corresponding post type.
- * @param array $bulk_counts Array of item counts for each message, used to build internationalized strings.
+ * @param array $messages Arrays of messages, each keyed by the corresponding post type.
  *
  * @return array
  */
-function gutenberg_bulk_post_updated_messages( $messages, $bulk_counts ) {
-	$messages['wp_block'] = array(
-		// translators: Number of blocks updated.
-		'updated'   => _n( '%s block updated.', '%s blocks updated.', $bulk_counts['updated'], 'gutenberg' ),
-		// translators: Blocks not updated because they're locked.
-		'locked'    => ( 1 == $bulk_counts['locked'] ) ? __( '1 block not updated, somebody is editing it.', 'gutenberg' ) : _n( '%s block not updated, somebody is editing it.', '%s blocks not updated, somebody is editing them.', $bulk_counts['locked'], 'gutenberg' ),
-		// translators: Number of blocks deleted.
-		'deleted'   => _n( '%s block permanently deleted.', '%s blocks permanently deleted.', $bulk_counts['deleted'], 'gutenberg' ),
-		// translators: Number of blocks trashed.
-		'trashed'   => _n( '%s block moved to the Trash.', '%s blocks moved to the Trash.', $bulk_counts['trashed'], 'gutenberg' ),
-		// translators: Number of blocks untrashed.
-		'untrashed' => _n( '%s block restored from the Trash.', '%s blocks restored from the Trash.', $bulk_counts['untrashed'], 'gutenberg' ),
-	);
+function gutenberg_bulk_post_updated_messages( $messages ) {
+	_deprecated_function( __FUNCTION__, '5.0.0' );
 
 	return $messages;
 }
-
-add_filter( 'bulk_post_updated_messages', 'gutenberg_bulk_post_updated_messages', 10, 2 );
 
 /**
  * Injects a hidden input in the edit form to propagate the information that classic editor is selected.


### PR DESCRIPTION
Related: #11015

This pull request seeks to deprecate and remove logic from `gutenberg_bulk_post_updated_messages ` . This is now handled automatically in core as of WordPress 5.0.

See:

- https://core.trac.wordpress.org/changeset/43849

**Testing instructions:**

Verify that bulk editing posts of type `wp_block` (reusable blocks) use the block-specific assigned labels.