### PR TITLE
Plugin: Deprecate gutenberg_remove_wpcom_markdown_support

### DIFF
--- a/docs/designers-developers/developers/backward-compatibility/deprecations.md
+++ b/docs/designers-developers/developers/backward-compatibility/deprecations.md
@@ -21,6 +21,7 @@ The Gutenberg project's deprecation policy is intended to support backward compa
 - The PHP function `gutenberg_register_post_prepare_functions` has been removed.
 - The PHP function `gutenberg_silence_rest_errors` has been removed.
 - The PHP function `gutenberg_filter_post_type_labels` has been removed.
+- The PHP function `gutenberg_remove_wpcom_markdown_support` has been removed.
 
 ## 4.5.0
 - `Dropdown.refresh()` has been deprecated as the contained `Popover` is now automatically refreshed.

--- a/lib/plugin-compat.php
+++ b/lib/plugin-compat.php
@@ -21,14 +21,13 @@
  * plugins Jetpack, JP-Markdown, and WP Editor.MD
  *
  * @since 1.3.0
+ * @deprecated 5.0.0
  *
  * @param  array $post      Post object which contains content to check for block.
  * @return array $post      Post object.
  */
 function gutenberg_remove_wpcom_markdown_support( $post ) {
-	if ( class_exists( 'WPCom_Markdown' ) && has_blocks( $post['post_content'] ) ) {
-		WPCom_Markdown::get_instance()->unload_markdown_for_posts();
-	}
+	_deprecated_function( __FUNCTION__, '5.0.0' );
+
 	return $post;
 }
-add_filter( 'wp_insert_post_data', 'gutenberg_remove_wpcom_markdown_support', 9 );


### PR DESCRIPTION
Related: #11015

This pull request seeks to deprecate and remove logic from `gutenberg_remove_wpcom_markdown_support ` . This was a specific plugin compatibility targeting Jetpack. The root issue was fixed in Jetpack as of v6.8.

See:

- https://github.com/Automattic/jetpack/pull/10635

**Testing instructions:**

Repeat testing instructions from https://github.com/Automattic/jetpack/pull/10635 .

cc @tyxla , @kraftbj, @jeherve