### PR TITLE
Use cloneDeep from lodash when cloning a block in wp.blocks.cloneBlock

### DIFF
--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -94,10 +94,11 @@ export function cloneBlock( block, mergeAttributes = {}, newInnerBlocks ) {
 	return {
 		...block,
 		clientId,
-		attributes: {
-			...cloneDeep( block.attributes ),
-			...cloneDeep( mergeAttributes ),
-		},
+		attributes: Object.assign(
+			{},
+			cloneDeep( block.attributes ),
+			cloneDeep( mergeAttributes )
+		),
 		innerBlocks: newInnerBlocks ||
 			block.innerBlocks.map( ( innerBlock ) => cloneBlock( innerBlock ) ),
 	};

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -95,7 +95,6 @@ export function cloneBlock( block, mergeAttributes = {}, newInnerBlocks ) {
 		...block,
 		clientId,
 		attributes: Object.assign(
-			{},
 			cloneDeep( block.attributes ),
 			cloneDeep( mergeAttributes )
 		),

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -6,6 +6,7 @@ import {
 	every,
 	reduce,
 	castArray,
+	cloneDeep,
 	findIndex,
 	isObjectLike,
 	filter,
@@ -94,8 +95,8 @@ export function cloneBlock( block, mergeAttributes = {}, newInnerBlocks ) {
 		...block,
 		clientId,
 		attributes: {
-			...block.attributes,
-			...mergeAttributes,
+			...cloneDeep( block.attributes ),
+			...cloneDeep( mergeAttributes ),
 		},
 		innerBlocks: newInnerBlocks ||
 			block.innerBlocks.map( ( innerBlock ) => cloneBlock( innerBlock ) ),

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -267,6 +267,28 @@ describe( 'block factory', () => {
 			expect( clonedBlock.innerBlocks[ 1 ].attributes ).not.toBe( block.innerBlocks[ 1 ].attributes );
 			expect( clonedBlock.innerBlocks[ 1 ].attributes ).toEqual( block.innerBlocks[ 1 ].attributes );
 		} );
+
+		it( 'should deeply clone attributes', () => {
+			registerBlockType( 'core/test-block', {
+				attributes: {
+					content: {
+						type: 'array',
+						default: [],
+					},
+				},
+				save: noop,
+				category: 'common',
+				title: 'test block',
+			} );
+			const block = createBlock(
+				'core/test-block',
+				{ content: [] }
+			);
+
+			const clonedBlock = cloneBlock( block );
+
+			expect( clonedBlock.attributes.content ).not.toBe( block.attributes.content );
+		} );
 	} );
 
 	describe( 'getPossibleBlockTransformations()', () => {


### PR DESCRIPTION
## Description
wp.blocks.cloneBlock( block ) creates a shallow clone of the block parameter. Therefore, the attributes of the cloned block, when objects, are a reference to the equivalent in the original block. Changes on these attributes in the cloned block affect also the original block, which is something we should avoid by using a deep clone function, like lodash.cloneDeep().

## How has this been tested?
Using cloneDeep from lodash inside wp.blocks.cloneBlock on blocks with attributes that are objects (i.e. 'core/table') now returns a real clone.

## Types of changes
Instead of just creating the clone copying the attributes of the original block, apply the lodash.cloneDeep() function to these attributes.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
