### PR TITLE
Scripts: Add missing root flag to the default Eslint config

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Added support for `build` script ([#12837](https://github.com/WordPress/gutenberg/pull/12837))
 - Added support for `start` script ([#12837](https://github.com/WordPress/gutenberg/pull/12837))
 
+### Bug Fix
+
+- Add missing `root` flag in the default Eslint config ([#13483](https://github.com/WordPress/gutenberg/pull/13483))
+
 ## 2.5.0 (2019-01-09)
 
 ### New Features

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Bug Fix
 
-- Add missing `root` flag in the default Eslint config ([#13483](https://github.com/WordPress/gutenberg/pull/13483))
+- Avoid inheriting from ESLint configurations in ancestor directories when using the default configuration ([#13483](https://github.com/WordPress/gutenberg/pull/13483))
 
 ## 2.5.0 (2019-01-09)
 

--- a/packages/scripts/config/.eslintrc.js
+++ b/packages/scripts/config/.eslintrc.js
@@ -1,3 +1,4 @@
 module.exports = {
+	root: true,
 	extends: [ 'plugin:@wordpress/eslint-plugin/recommended' ],
 };

--- a/packages/scripts/scripts/lint-js.js
+++ b/packages/scripts/scripts/lint-js.js
@@ -26,8 +26,11 @@ const hasLintConfig = hasCliArg( '-c' ) ||
 	hasProjectFile( '.eslintrc' ) ||
 	hasPackageProp( 'eslintConfig' );
 
+// When a configuration is not provided by the project, use from the default
+// provided with the scripts module. Instruct ESLint to avoid discovering via
+// the `--no-eslintrc` flag, as otherwise it will still merge with inherited.
 const config = ! hasLintConfig ?
-	[ '--config', fromConfigRoot( '.eslintrc.js' ) ] :
+	[ '--no-eslintrc', '--config', fromConfigRoot( '.eslintrc.js' ) ] :
 	[];
 
 const result = spawn(


### PR DESCRIPTION
## Description
Extracted from #13394 based on a suggestion from @aduth:
https://github.com/WordPress/gutenberg/pull/13394/files#r249797548

This PR adds missing `root` flag in the default ESlint config which works as explained in the docs (https://eslint.org/docs/user-guide/configuring):

> By default, ESLint will look for configuration files in all parent folders up to the root directory. This can be useful if you want all of your projects to follow a certain convention, but can sometimes lead to unexpected results. To limit ESLint to a specific project, place `"root": true` inside the `eslintConfig` field of the `package.json` file or in the `.eslintrc.*` file at your project’s root level. ESLint will stop looking in parent folders once it finds a configuration with `"root": true`.

## Testing

Not sure how to test with the recent configs added which depend on the `.eslintrc.js` in the root folder. Otherwise I would remove it and check whether `npm run lint-js` works.
