### PR TITLE
File Block: Remove the "Show Download Button" toggle help text

### DIFF
--- a/packages/block-library/src/file/inspector.js
+++ b/packages/block-library/src/file/inspector.js
@@ -10,10 +10,6 @@ import {
 import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/editor';
 
-function getDownloadButtonHelp( checked ) {
-	return checked ? __( 'The download button is visible.' ) : __( 'The download button is hidden.' );
-}
-
 export default function FileBlockInspector( {
 	hrefs,
 	openInNewWindow,
@@ -51,7 +47,6 @@ export default function FileBlockInspector( {
 				<PanelBody title={ __( 'Download Button Settings' ) }>
 					<ToggleControl
 						label={ __( 'Show Download Button' ) }
-						help={ getDownloadButtonHelp }
 						checked={ showDownloadButton }
 						onChange={ changeShowDownloadButton }
 					/>


### PR DESCRIPTION
As per discussion in #13429, this help text is redundant and can be removed.

There's still some discussion to be had about adding some sort of "on/off" text to clarify the state for toggles like this, but that should be tackled globally.

Before:
![51555310-55a58b80-1e45-11e9-927e-de833e6c33be](https://user-images.githubusercontent.com/1202812/51685146-adfe9980-1fbb-11e9-9d78-e903003e8ef5.png)

After:
<img width="279" alt="screen shot 2019-01-24 at 9 37 48 am" src="https://user-images.githubusercontent.com/1202812/51685168-b9ea5b80-1fbb-11e9-8eff-56d6eca69778.png">

