### PR TITLE
i18n: Use placeholder for minimum WordPress version notice

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -146,7 +146,8 @@ function is_gutenberg_page() {
  */
 function gutenberg_wordpress_version_notice() {
 	echo '<div class="error"><p>';
-	_e( 'Gutenberg requires WordPress 5.0.0 or later to function properly. Please upgrade WordPress before activating Gutenberg.', 'gutenberg' );
+	/* translators: %s: Minimum required version */
+	echo sprintf( __( 'Gutenberg requires WordPress %s or later to function properly. Please upgrade WordPress before activating Gutenberg.', 'gutenberg' ), '5.0.0' );
 	echo '</p></div>';
 
 	deactivate_plugins( array( 'gutenberg/gutenberg.php' ) );

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -147,7 +147,7 @@ function is_gutenberg_page() {
 function gutenberg_wordpress_version_notice() {
 	echo '<div class="error"><p>';
 	/* translators: %s: Minimum required version */
-	echo sprintf( __( 'Gutenberg requires WordPress %s or later to function properly. Please upgrade WordPress before activating Gutenberg.', 'gutenberg' ), '5.0.0' );
+	printf( __( 'Gutenberg requires WordPress %s or later to function properly. Please upgrade WordPress before activating Gutenberg.', 'gutenberg' ), '5.0.0' );
 	echo '</p></div>';
 
 	deactivate_plugins( array( 'gutenberg/gutenberg.php' ) );


### PR DESCRIPTION
See: https://github.com/WordPress/gutenberg/pull/13370#issuecomment-457194101

This pull request seeks to update the string used in the minimum required version notice to use placeholders. This is done to avoid the string changing for translators between revisions to the minimum required version.

**Testing instructions:**

[Downgrade](https://wordpress.org/plugins/wp-downgrade/) to an earlier version of WordPress while Gutenberg is active, and verify there are no regressions in the display of the version notice when Gutenberg self-deactivates.