### PR TITLE
Take Two: Update the gallery block so it limits the columns to the the current number of images

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -109,8 +109,10 @@ class GalleryEdit extends Component {
 	}
 
 	onSelectImages( images ) {
+		const { columns } = this.props.attributes;
 		this.setAttributes( {
 			images: images.map( ( image ) => pickRelevantMediaFiles( image ) ),
+			columns: columns ? Math.min( images.length, columns ) : columns,
 		} );
 	}
 


### PR DESCRIPTION
This is a redo of PR #13443 as I rebased and royally messed my branch and that PR up, sorry @jorgefilipecosta

## Description
Update the columns attribute when the `onSelectImages` function fires so that if images are removed via the media modal, the columns will be updated. This way columns won't be higher than the new number of images. 

Previously this worked if removing images via the X in the editor, but not if you removed them via the media modal

Fixes #13423

## How has this been tested?
Add a gallery with multiple images, set the columns to be the maximum allowed. Edit the gallery via the media modal and remove images, when you save the media modal, the columns should be adjusted to match the new number of photos.


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->