### PR TITLE
RSS block: excerpt length label

### DIFF
--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -137,7 +137,7 @@ class RSSEdit extends Component {
 						/>
 						{ displayExcerpt &&
 							<RangeControl
-								label={ __( 'Max length of the excerpt' ) }
+								label={ __( 'Max number of words in excerpt' ) }
 								value={ excerptLength }
 								onChange={ ( value ) => setAttributes( { excerptLength: value } ) }
 								min={ 0 }


### PR DESCRIPTION
## Description
Changes the label of max word length setting in the RSS block.

From `Max length of the excerpt` to `Max number of words in excerpt`

**Before:**
![bildschirmfoto 2019-01-25 um 11 58 07](https://user-images.githubusercontent.com/695201/51742195-55053300-2099-11e9-998e-3f63b042abbf.png)

**After:**
![bildschirmfoto 2019-01-25 um 12 00 54](https://user-images.githubusercontent.com/695201/51742197-56cef680-2099-11e9-8420-aafb60ca1ed4.png)


Part of this issue collection: #13498