### PR TITLE
RSS block: excerpt minimum length

### DIFF
--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -140,7 +140,7 @@ class RSSEdit extends Component {
 								label={ __( 'Max length of the excerpt' ) }
 								value={ excerptLength }
 								onChange={ ( value ) => setAttributes( { excerptLength: value } ) }
-								min={ 0 }
+								min={ 10 }
 								max={ 100 }
 							/>
 						}


### PR DESCRIPTION
## Description
Set the minimum word length of the excerpt to 10 words.

**Before: (0 words)** 
![bildschirmfoto 2019-01-25 um 12 13 18](https://user-images.githubusercontent.com/695201/51742853-2d16cf00-209b-11e9-99a7-8b5cfc3e367b.png)

**After: (10 words)**
![bildschirmfoto 2019-01-25 um 12 12 35](https://user-images.githubusercontent.com/695201/51742877-415acc00-209b-11e9-993b-712f02b96788.png)

**Default (55 words)**
![bildschirmfoto 2019-01-25 um 12 14 49](https://user-images.githubusercontent.com/695201/51742881-43bd2600-209b-11e9-8f64-fc6ec3775da5.png)

Part of this issue collection: #13498