### PR TITLE
Block API: Parse entity only when valid character reference

### DIFF
--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Blocks' `transforms` will receive `innerBlocks` as the second argument (or an array of each block's respective `innerBlocks` for a multi-transform).
 
+### Bug Fixes
+
+- Block validation will now correctly validate character references, resolving some issues where a standalone ampersand `&` followed later in markup by a character reference (e.g. `&amp;`) could wrongly mark a block as being invalid. ([#13512](https://github.com/WordPress/gutenberg/pull/13512))
+
 ## 6.0.5 (2019-01-03)
 
 ## 6.0.4 (2018-12-12)

--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import {
+	isValidCharacterReference,
 	DecodeEntityParser,
 	getTextPiecesSplitOnWhitespace,
 	getTextWithCollapsedWhitespace,
@@ -38,6 +39,32 @@ describe( 'validation', () => {
 	afterEach( () => {
 		getBlockTypes().forEach( ( block ) => {
 			unregisterBlockType( block.name );
+		} );
+	} );
+
+	describe( 'isValidCharacterReference', () => {
+		it( 'returns true for a named character reference', () => {
+			const result = isValidCharacterReference( 'blk12' );
+
+			expect( result ).toBe( true );
+		} );
+
+		it( 'returns true for a decimal character reference', () => {
+			const result = isValidCharacterReference( '#33' );
+
+			expect( result ).toBe( true );
+		} );
+
+		it( 'returns true for a hexadecimal character reference', () => {
+			const result = isValidCharacterReference( '#xC6' );
+
+			expect( result ).toBe( true );
+		} );
+
+		it( 'returns false for an invalid character reference', () => {
+			const result = isValidCharacterReference( ' Test</h2><h2>Test &amp' );
+
+			expect( result ).toBe( false );
 		} );
 	} );
 
@@ -392,6 +419,20 @@ describe( 'validation', () => {
 			const isEquivalent = isEquivalentHTML(
 				'<div>&quot; Hello<span   class="b a" id="foo" data-foo="here &mdash; there"> World! &#128517;</  span>  "</div>',
 				'<div  >" Hello\n<span id="foo" class="a  b" data-foo="here — there">World! 😅</span>"</div>'
+			);
+
+			expect( isEquivalent ).toBe( true );
+		} );
+
+		it( 'should account for character reference validity', () => {
+			// Regression: Previously the validator would wrongly evaluate the
+			// segment of text ` Test</h2><h2>Test &amp` as a character
+			// reference, as it's between an opening `&` and terminating `;`.
+			//
+			// See: https://github.com/WordPress/gutenberg/issues/12448
+			const isEquivalent = isEquivalentHTML(
+				'<h2>Test &amp; Test</h2><h2>Test &amp; Test</h2>',
+				'<h2>Test & Test</h2><h2>Test &amp; Test</h2>'
 			);
 
 			expect( isEquivalent ).toBe( true );

--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import {
-	IdentityEntityParser,
+	DecodeEntityParser,
 	getTextPiecesSplitOnWhitespace,
 	getTextWithCollapsedWhitespace,
 	getMeaningfulAttributePairs,
@@ -41,13 +41,13 @@ describe( 'validation', () => {
 		} );
 	} );
 
-	describe( 'IdentityEntityParser', () => {
+	describe( 'DecodeEntityParser', () => {
 		it( 'can be constructed', () => {
-			expect( new IdentityEntityParser() instanceof IdentityEntityParser ).toBe( true );
+			expect( new DecodeEntityParser() instanceof DecodeEntityParser ).toBe( true );
 		} );
 
 		it( 'returns parse as decoded value', () => {
-			expect( new IdentityEntityParser().parse( 'quot' ) ).toBe( '"' );
+			expect( new DecodeEntityParser().parse( 'quot' ) ).toBe( '"' );
 		} );
 	} );
 

--- a/packages/blocks/src/api/validation.js
+++ b/packages/blocks/src/api/validation.js
@@ -154,17 +154,16 @@ const TEXT_NORMALIZATIONS = [
 ];
 
 /**
- * Subsitute EntityParser class for `simple-html-tokenizer` which bypasses
- * entity substitution in favor of validator's internal normalization.
+ * Subsitute EntityParser class for `simple-html-tokenizer` which uses the
+ * implementation of `decodeEntities` from `html-entities`, in order to avoid
+ * bundling a massive named character reference.
  *
  * @see https://github.com/tildeio/simple-html-tokenizer/tree/master/src/entity-parser.ts
  */
-export class IdentityEntityParser {
+export class DecodeEntityParser {
 	/**
 	 * Returns a substitute string for an entity string sequence between `&`
 	 * and `;`, or undefined if no substitution should occur.
-	 *
-	 * In this implementation, undefined is always returned.
 	 *
 	 * @param {string} entity Entity fragment discovered in HTML.
 	 *
@@ -451,7 +450,7 @@ export function getNextNonWhitespaceToken( tokens ) {
  */
 function getHTMLTokens( html ) {
 	try {
-		return new Tokenizer( new IdentityEntityParser() ).tokenize( html );
+		return new Tokenizer( new DecodeEntityParser() ).tokenize( html );
 	} catch ( e ) {
 		log.warning( 'Malformed HTML detected: %s', html );
 	}

--- a/packages/blocks/src/api/validation.js
+++ b/packages/blocks/src/api/validation.js
@@ -154,6 +154,72 @@ const TEXT_NORMALIZATIONS = [
 ];
 
 /**
+ * Regular expression matching a named character reference. In lieu of bundling
+ * a full set of references, the pattern covers the minimal necessary to test
+ * positively against the full set.
+ *
+ * "The ampersand must be followed by one of the names given in the named
+ * character references section, using the same case."
+ *
+ * Tested aginst "12.5 Named character references":
+ *
+ * ```
+ * const references = [ ...document.querySelectorAll(
+ *     '#named-character-references-table tr[id^=entity-] td:first-child'
+ * ) ].map( ( code ) => code.textContent )
+ * references.every( ( reference ) => /^[\da-z]+$/i.test( reference ) )
+ * ```
+ *
+ * @link https://html.spec.whatwg.org/multipage/syntax.html#character-references
+ * @link https://html.spec.whatwg.org/multipage/named-characters.html#named-character-references
+ *
+ * @type {RegExp}
+ */
+const REGEXP_NAMED_CHARACTER_REFERENCE = /^[\da-z]+$/i;
+
+/**
+ * Regular expression matching a decimal character reference.
+ *
+ * "The ampersand must be followed by a U+0023 NUMBER SIGN character (#),
+ * followed by one or more ASCII digits, representing a base-ten integer"
+ *
+ * @link https://html.spec.whatwg.org/multipage/syntax.html#character-references
+ *
+ * @type {RegExp}
+ */
+const REGEXP_DECIMAL_CHARACTER_REFERENCE = /^#\d+$/;
+
+/**
+ * Regular expression matching a hexadecimal character reference.
+ *
+ * "The ampersand must be followed by a U+0023 NUMBER SIGN character (#), which
+ * must be followed by either a U+0078 LATIN SMALL LETTER X character (x) or a
+ * U+0058 LATIN CAPITAL LETTER X character (X), which must then be followed by
+ * one or more ASCII hex digits, representing a hexadecimal integer"
+ *
+ * @link https://html.spec.whatwg.org/multipage/syntax.html#character-references
+ *
+ * @type {RegExp}
+ */
+const REGEXP_HEXADECIMAL_CHARACTER_REFERENCE = /^#x[\da-f]+$/i;
+
+/**
+ * Returns true if the given string is a valid character reference segment, or
+ * false otherwise. The text should be stripped of `&` and `;` demarcations.
+ *
+ * @param {string} text Text to test.
+ *
+ * @return {boolean} Whether text is valid character reference.
+ */
+export function isValidCharacterReference( text ) {
+	return (
+		REGEXP_NAMED_CHARACTER_REFERENCE.test( text ) ||
+		REGEXP_DECIMAL_CHARACTER_REFERENCE.test( text ) ||
+		REGEXP_HEXADECIMAL_CHARACTER_REFERENCE.test( text )
+	);
+}
+
+/**
  * Subsitute EntityParser class for `simple-html-tokenizer` which uses the
  * implementation of `decodeEntities` from `html-entities`, in order to avoid
  * bundling a massive named character reference.
@@ -170,7 +236,9 @@ export class DecodeEntityParser {
 	 * @return {?string} Entity substitute value.
 	 */
 	parse( entity ) {
-		return decodeEntities( '&' + entity + ';' );
+		if ( isValidCharacterReference( entity ) ) {
+			return decodeEntities( '&' + entity + ';' );
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #12448 
Supersedes #13406

This pull request seeks to resolve an issue where certain HTML strings may result in a block being incorrectly marked as invalid.

**Implementation notes:**

The root issue is that in the HTML tokenization which occurs during block validation, the entity decoder wrongly evaluates invalid character references.

For example, given the markup:

```
<h2>Test & Test</h2><h2>Test &amp; Test</h2>
```

Previously, the entity decoder would wrongly produce a value for every segment of text between `&` and `;`. With this string, producing a value for the segment ` Test</h2><h2>Test &amp` would confuse the tokenizer into considering the entire string as a continuous set of character data, thus missing the EndTag (`</h2>`) and StartTag (`<h2>`) within.

**Testing instructions:**

Repeat steps to reproduce from https://github.com/WordPress/gutenberg/issues/12448#issuecomment-455370390, verifying that no block invalidation occurs.

Ensure unit tests pass:

```
npm run test-unit packages/blocks/src/api/test/validation.js
```

cc @fastlinemedia