### PR TITLE
Introduce onImageQueryReattach interface

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -8,6 +8,7 @@ import {
 	onMediaLibraryPressed,
 	onUploadMediaPressed,
 	onCapturePhotoPressed,
+	onImageQueryReattach,
 } from 'react-native-gutenberg-bridge';
 
 /**
@@ -44,6 +45,7 @@ export default class ImageEdit extends React.Component {
 
 		if ( attributes.id && ! isURL( attributes.url ) ) {
 			this.addMediaUploadListener();
+			onImageQueryReattach();
 		}
 	}
 


### PR DESCRIPTION
### Note:
This builds on top of #13128, let's please merge this one first so these small changes get push into that other branch

## Description

This is the supporting PR for mobile [media upload progress reattach](https://github.com/wordpress-mobile/WordPress-Android/pull/9129)

## How has this been tested?
This PR can be tested from the [WPAndroid PR](https://github.com/wordpress-mobile/WordPress-Android/pull/9129)

## Screenshots <!-- if applicable -->
![reattachprogress](https://user-images.githubusercontent.com/6597771/51778465-8d7c2f80-20e0-11e9-8c37-4b1a34d73a13.gif)


