### PR TITLE
Blocks: Re-register core blocks via build copy prefixing

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -107,14 +107,13 @@ npm run build
 php bin/generate-gutenberg-php.php > gutenberg.tmp.php
 mv gutenberg.tmp.php gutenberg.php
 
-build_files=$(ls build/*/*.{js,css})
+build_files=$(ls build/*/*.{js,css} build/block-library/blocks/*.php)
 
 # Generate the plugin zip file.
 status "Creating archive... 🎁"
 zip -r gutenberg.zip \
 	gutenberg.php \
 	lib/*.php \
-	packages/block-library/src/*/*.php \
 	packages/block-serialization-default-parser/*.php \
 	post-content.php \
 	$vendor_scripts \

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Block registration functions.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Substitutes the implementation of a core-registered block type, if exists,
+ * with the built result from the plugin.
+ */
+function gutenberg_reregister_core_block_types() {
+	// Blocks directory may not exist if working from a fresh clone.
+	$blocks_dir = dirname( __FILE__ ) . '/../build/block-library/blocks/';
+	if ( ! file_exists( $blocks_dir ) ) {
+		return;
+	}
+
+	$block_names = array(
+		'archives.php'        => 'core/archives',
+		'block.php'           => 'core/block',
+		'calendar.php'        => 'core/calendar',
+		'categories.php'      => 'core/categories',
+		'latest-comments.php' => 'core/latest-comments',
+		'latest-posts.php'    => 'core/latest-posts',
+		'legacy-widget.php'   => 'core/legacy-widget',
+		'rss.php'             => 'core/rss',
+		'shortcode.php'       => 'core/shortcode',
+		'search.php'          => 'core/search',
+		'tag-cloud.php'       => 'core/tag-cloud',
+	);
+
+	$registry = WP_Block_Type_Registry::get_instance();
+
+	foreach ( $block_names as $file => $block_name ) {
+		if ( ! file_exists( $blocks_dir . $file ) ) {
+			return;
+		}
+
+		if ( $registry->is_registered( $block_name ) ) {
+			$registry->unregister( $block_name );
+		}
+
+		require $blocks_dir . $file;
+	}
+}
+add_action( 'init', 'gutenberg_reregister_core_block_types' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -24,45 +24,9 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require dirname( __FILE__ ) . '/rest-api.php';
 }
 
+require dirname( __FILE__ ) . '/blocks.php';
 require dirname( __FILE__ ) . '/client-assets.php';
 require dirname( __FILE__ ) . '/i18n.php';
 require dirname( __FILE__ ) . '/demo.php';
 require dirname( __FILE__ ) . '/widgets.php';
 require dirname( __FILE__ ) . '/widgets-page.php';
-
-/**
- * Substitutes the implementation of a core-registered block type, if exists,
- * with the built result from the plugin.
- */
-function gutenberg_reregister_core_block_types() {
-	// Blocks directory may not exist if working from a fresh clone.
-	$blocks_dir = dirname( __FILE__ ) . '/../build/block-library/blocks/';
-	if ( ! file_exists( $blocks_dir ) ) {
-		return;
-	}
-	$block_names = array(
-		'archives.php'        => 'core/archives',
-		'block.php'           => 'core/block',
-		'calendar.php'        => 'core/calendar',
-		'categories.php'      => 'core/categories',
-		'latest-comments.php' => 'core/latest-comments',
-		'latest-posts.php'    => 'core/latest-posts',
-		'legacy-widget.php'   => 'core/legacy-widget',
-		'rss.php'             => 'core/rss',
-		'shortcode.php'       => 'core/shortcode',
-		'search.php'          => 'core/search',
-		'tag-cloud.php'       => 'core/tag-cloud',
-	);
-	$registry = WP_Block_Type_Registry::get_instance();
-	foreach ( $block_names as $file => $block_name ) {
-		if ( ! file_exists( $blocks_dir . $file ) ) {
-			return;
-		}
-		if ( $registry->is_registered( $block_name ) ) {
-			$registry->unregister( $block_name );
-		}
-		require $blocks_dir . $file;
-	}
-}
-add_action( 'init', 'gutenberg_reregister_core_block_types' );
-

--- a/lib/load.php
+++ b/lib/load.php
@@ -31,8 +31,8 @@ require dirname( __FILE__ ) . '/widgets.php';
 require dirname( __FILE__ ) . '/widgets-page.php';
 
 /**
- * Discovers block files from the plugin built artifact, unregistering the
- * equivalent in core if already defined, then includes the block file.
+ * Substitutes the implementation of a core-registered block type, if exists,
+ * with the built result from the plugin.
  */
 function gutenberg_reregister_core_block_types() {
 	// Blocks directory may not exist if working from a fresh clone.
@@ -40,16 +40,24 @@ function gutenberg_reregister_core_block_types() {
 	if ( ! file_exists( $blocks_dir ) ) {
 		return;
 	}
+	$block_names = array(
+		'archives.php'        => 'core/archives',
+		'block.php'           => 'core/block',
+		'calendar.php'        => 'core/calendar',
+		'categories.php'      => 'core/categories',
+		'latest-comments.php' => 'core/latest-comments',
+		'latest-posts.php'    => 'core/latest-posts',
+		'legacy-widget.php'   => 'core/legacy-widget',
+		'rss.php'             => 'core/rss',
+		'shortcode.php'       => 'core/shortcode',
+		'search.php'          => 'core/search',
+		'tag-cloud.php'       => 'core/tag-cloud',
+	);
 	$registry = WP_Block_Type_Registry::get_instance();
-	$files = scandir( $blocks_dir );
-	foreach ( $files as $file ) {
-		$parts = pathinfo( $file );
-		// Ignore all non-PHP files, subdirectories, path traversal.
-		if ( 'php' !== $parts['extension'] ) {
-			continue;
+	foreach ( $block_names as $file => $block_name ) {
+		if ( ! file_exists( $blocks_dir . $file ) ) {
+			return;
 		}
-		// Derive the assumed block name by file path.
-		$block_name = 'core/' . $parts['filename'];
 		if ( $registry->is_registered( $block_name ) ) {
 			$registry->unregister( $block_name );
 		}
@@ -57,3 +65,4 @@ function gutenberg_reregister_core_block_types() {
 	}
 }
 add_action( 'init', 'gutenberg_reregister_core_block_types' );
+

--- a/lib/load.php
+++ b/lib/load.php
@@ -30,49 +30,45 @@ require dirname( __FILE__ ) . '/demo.php';
 require dirname( __FILE__ ) . '/widgets.php';
 require dirname( __FILE__ ) . '/widgets-page.php';
 
-// Register server-side code for individual blocks.
-if ( ! function_exists( 'render_block_core_archives' ) ) {
-	require dirname( __FILE__ ) . '/../packages/block-library/src/archives/index.php';
-}
-if ( ! function_exists( 'render_block_core_block' ) ) {
-	require dirname( __FILE__ ) . '/../packages/block-library/src/block/index.php';
-}
-if ( ! function_exists( 'render_block_core_categories' ) ) {
-	require dirname( __FILE__ ) . '/../packages/block-library/src/categories/index.php';
-}
-// Currently merged in core as `gutenberg_render_block_core_latest_comments`,
-// expected to change soon.
-if ( ! function_exists( 'render_block_core_calendar' ) ) {
-	require dirname( __FILE__ ) . '/../packages/block-library/src/calendar/index.php';
-}
-if ( ! function_exists( 'render_block_core_latest_comments' )
-	&& ! function_exists( 'gutenberg_render_block_core_latest_comments' ) ) {
-	require dirname( __FILE__ ) . '/../packages/block-library/src/latest-comments/index.php';
-}
-if ( ! function_exists( 'render_block_core_latest_posts' ) ) {
-	require dirname( __FILE__ ) . '/../packages/block-library/src/latest-posts/index.php';
-}
-
-
 /**
- * Start: Include for phase 2
+ * Unregisters the core set of blocks. This should occur on the default
+ * priority, immediately prior to Gutenberg's own action binding.
  */
-if ( ! function_exists( 'render_block_legacy_widget' ) ) {
-	require dirname( __FILE__ ) . '/../packages/block-library/src/legacy-widget/index.php';
-}
-/**
- * End: Include for phase 2
- */
+function gutenberg_unregister_core_block_types() {
+	$registry    = WP_Block_Type_Registry::get_instance();
+	$block_names = array(
+		'core/archives',
+		'core/block',
+		'core/calendar',
+		'core/categories',
+		'core/latest-comments',
+		'core/latest-posts',
+		'core/legacy-widget',
+		'core/rss',
+		'core/shortcode',
+		'core/search',
+		'core/tag-cloud',
+	);
 
-if ( ! function_exists( 'render_block_core_rss' ) ) {
-	require dirname( __FILE__ ) . '/../packages/block-library/src/rss/index.php';
+	foreach ( $block_names as $block_name ) {
+		if ( $registry->is_registered( $block_name ) ) {
+			$registry->unregister( $block_name );
+		}
+	}
 }
-if ( ! function_exists( 'render_block_core_shortcode' ) ) {
-	require dirname( __FILE__ ) . '/../packages/block-library/src/shortcode/index.php';
-}
-if ( ! function_exists( 'render_block_core_tag_cloud' ) ) {
-	require dirname( __FILE__ ) . '/../packages/block-library/src/tag-cloud/index.php';
-}
-if ( ! function_exists( 'render_block_core_search' ) ) {
-	require dirname( __FILE__ ) . '/../packages/block-library/src/search/index.php';
+
+if ( file_exists( dirname( __FILE__ ) . '/../build/block-library/blocks' ) ) {
+	add_action( 'init', 'gutenberg_unregister_core_block_types' );
+
+	require dirname( __FILE__ ) . '/../build/block-library/blocks/archives.php';
+	require dirname( __FILE__ ) . '/../build/block-library/blocks/block.php';
+	require dirname( __FILE__ ) . '/../build/block-library/blocks/calendar.php';
+	require dirname( __FILE__ ) . '/../build/block-library/blocks/categories.php';
+	require dirname( __FILE__ ) . '/../build/block-library/blocks/latest-comments.php';
+	require dirname( __FILE__ ) . '/../build/block-library/blocks/latest-posts.php';
+	require dirname( __FILE__ ) . '/../build/block-library/blocks/legacy-widget.php';
+	require dirname( __FILE__ ) . '/../build/block-library/blocks/rss.php';
+	require dirname( __FILE__ ) . '/../build/block-library/blocks/shortcode.php';
+	require dirname( __FILE__ ) . '/../build/block-library/blocks/search.php';
+	require dirname( __FILE__ ) . '/../build/block-library/blocks/tag-cloud.php';
 }

--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -143,5 +143,4 @@ function register_block_core_archives() {
 		)
 	);
 }
-
 add_action( 'init', 'register_block_core_archives' );

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -29,15 +29,21 @@ function render_block_core_block( $attributes ) {
 	return do_blocks( $reusable_block->post_content );
 }
 
-register_block_type(
-	'core/block',
-	array(
-		'attributes'      => array(
-			'ref' => array(
-				'type' => 'number',
+/**
+ * Registers the `core/block` block.
+ */
+function register_block_core_block() {
+	register_block_type(
+		'core/block',
+		array(
+			'attributes'      => array(
+				'ref' => array(
+					'type' => 'number',
+				),
 			),
-		),
 
-		'render_callback' => 'render_block_core_block',
-	)
-);
+			'render_callback' => 'render_block_core_block',
+		)
+	);
+}
+add_action( 'init', 'register_block_core_block' );

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -98,5 +98,4 @@ function register_block_core_categories() {
 		)
 	);
 }
-
 add_action( 'init', 'register_block_core_categories' );

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -165,7 +165,7 @@ function register_block_core_latest_comments() {
 						'center',
 						'right',
 						'wide',
-						'full'
+						'full',
 					),
 				),
 				'className'      => array(

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -150,36 +150,49 @@ function render_block_core_latest_comments( $attributes = array() ) {
 	return $block_content;
 }
 
-register_block_type(
-	'core/latest-comments',
-	array(
-		'attributes'      => array(
-			'align'          => array(
-				'type' => 'string',
-				'enum' => array( 'left', 'center', 'right', 'wide', 'full' ),
+/**
+ * Registers the `core/latest-comments` block.
+ */
+function register_block_core_latest_comments() {
+	register_block_type(
+		'core/latest-comments',
+		array(
+			'attributes'      => array(
+				'align'          => array(
+					'type' => 'string',
+					'enum' => array(
+						'left',
+						'center',
+						'right',
+						'wide',
+						'full'
+					),
+				),
+				'className'      => array(
+					'type' => 'string',
+				),
+				'commentsToShow' => array(
+					'type'    => 'number',
+					'default' => 5,
+					'minimum' => 1,
+					'maximum' => 100,
+				),
+				'displayAvatar'  => array(
+					'type'    => 'boolean',
+					'default' => true,
+				),
+				'displayDate'    => array(
+					'type'    => 'boolean',
+					'default' => true,
+				),
+				'displayExcerpt' => array(
+					'type'    => 'boolean',
+					'default' => true,
+				),
 			),
-			'className'      => array(
-				'type' => 'string',
-			),
-			'commentsToShow' => array(
-				'type'    => 'number',
-				'default' => 5,
-				'minimum' => 1,
-				'maximum' => 100,
-			),
-			'displayAvatar'  => array(
-				'type'    => 'boolean',
-				'default' => true,
-			),
-			'displayDate'    => array(
-				'type'    => 'boolean',
-				'default' => true,
-			),
-			'displayExcerpt' => array(
-				'type'    => 'boolean',
-				'default' => true,
-			),
-		),
-		'render_callback' => 'render_block_core_latest_comments',
-	)
-);
+			'render_callback' => 'render_block_core_latest_comments',
+		)
+	);
+}
+
+add_action( 'init', 'register_block_core_latest_comments' );

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -127,5 +127,4 @@ function register_block_core_latest_posts() {
 		)
 	);
 }
-
 add_action( 'init', 'register_block_core_latest_posts' );

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -133,5 +133,4 @@ function register_block_core_rss() {
 		)
 	);
 }
-
 add_action( 'init', 'register_block_core_rss' );

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -78,5 +78,4 @@ function register_block_core_search() {
 		)
 	);
 }
-
 add_action( 'init', 'register_block_core_search' );

--- a/packages/block-library/src/shortcode/index.php
+++ b/packages/block-library/src/shortcode/index.php
@@ -28,5 +28,4 @@ function register_block_core_shortcode() {
 		)
 	);
 }
-
 add_action( 'init', 'register_block_core_shortcode' );

--- a/packages/block-library/src/tag-cloud/index.php
+++ b/packages/block-library/src/tag-cloud/index.php
@@ -67,5 +67,4 @@ function register_block_core_tag_cloud() {
 		)
 	);
 }
-
 add_action( 'init', 'register_block_core_tag_cloud' );

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -33,6 +33,7 @@
 
 	<!-- Exclude generated files -->
 	<exclude-pattern>./packages/block-serialization-spec-parser/parser.php</exclude-pattern>
+	<exclude-pattern>./build</exclude-pattern>
 
 	<rule ref="PHPCompatibility.PHP.NewKeywords.t_namespaceFound">
 		<exclude-pattern>lib/class-wp-rest-block-renderer-controller.php</exclude-pattern>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -127,7 +127,16 @@ module.exports = {
 								new RegExp( functionName, 'g' ),
 								( match ) => 'gutenberg_' + match.replace( /^wp_/, '' )
 							);
-						}, content );
+						}, content )
+						// The core blocks override procedure takes place in
+						// the init action default priority to ensure that core
+						// blocks would have been registered already. Since the
+						// blocks implementations occur at the default priority
+						// and due to WordPress hooks behavior not considering
+						// mutations to the same priority during another's
+						// callback, the Gutenberg build blocks are modified
+						// to occur at a later priority.
+						.replace( /(add_action\(\s*'init',\s*'register_block_[^']+'(?!,))/, '$1, 20' );
 				},
 			},
 		] ),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -136,7 +136,7 @@ module.exports = {
 						// mutations to the same priority during another's
 						// callback, the Gutenberg build blocks are modified
 						// to occur at a later priority.
-						.replace( /(add_action\(\s*'init',\s*'register_block_[^']+'(?!,))/, '$1, 20' );
+						.replace( /(add_action\(\s*'init',\s*'gutenberg_register_block_[^']+'(?!,))/, '$1, 20' );
 				},
 			},
 		] ),


### PR DESCRIPTION
This pull request seeks to try an approach for re-registering the core blocks as a Gutenberg-specific variant, while still allowing core to copy those distributed through the `@wordpress/block-library` module. The technique is rather primitive: using [`CopyWebpackPlugin`](https://github.com/webpack-contrib/copy-webpack-plugin), it copies PHP files from the `block-library` package, transforming them by looking for function definitions (by pattern) to prefix with `gutenberg_`. Gutenberg deregisters the core-registered blocks, and registers these instead. Since it's built-in to the Webpack pipeline, it also respects rebuilds on changes during `npm run dev`.

**Testing instructions:**

1. Run `npm run dev`
2. Make a change to a block-library PHP file
3. Observe that changes take effect