### PR TITLE
Docs: Fix typo

### DIFF
--- a/assets/stylesheets/_mixins.scss
+++ b/assets/stylesheets/_mixins.scss
@@ -278,7 +278,7 @@
 		}
 	}
 
-	/* In small screens with resposive menu expanded there is small white space. */
+	/* In small screens with responsive menu expanded there is small white space. */
 	@media (max-width: #{ ($break-small) }) {
 		.auto-fold .wp-responsive-open #{$selector} {
 			margin-left: -18px;


### PR DESCRIPTION
## Description
Fixes typo in code comment.
From `resposive menu` to `responsive menu`