### PR TITLE
Docs: update links

### DIFF
--- a/docs/contributors/reference.md
+++ b/docs/contributors/reference.md
@@ -1,9 +1,9 @@
 # Reference
 
-- [Glossary](../../docs/designers-developers/glossary.md)
-- [Coding Guidelines](../../docs/contributors/coding-guidelines.md)
-- [Testing Overview](../../docs/contributors/testing-overview.md)
-- [Frequently Asked Questions](../../docs/designers-developers/faq.md)
+- [Glossary](/docs/designers-developers/glossary.md)
+- [Coding Guidelines](/docs/contributors/coding-guidelines.md)
+- [Testing Overview](/docs/contributors/testing-overview.md)
+- [Frequently Asked Questions](/docs/designers-developers/faq.md)
 
 ## Logo
 <img width="200" src="https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/final-g-wapuu-black.svg?sanitize=true" alt="Gutenberg Logo" />

--- a/docs/contributors/reference.md
+++ b/docs/contributors/reference.md
@@ -14,4 +14,4 @@ Released under GPL license, made by [Cristel Rossignol](https://twitter.com/cris
 
 ## Mockups
 
-Mockup Sketch files are available in <a href="https://wordpress.org/gutenberg/handbook/designers-developers/designers/design-resources/">the Design section</a>.
+Mockup Sketch files are available in [the Design section](/docs/designers-developers/designers/design-resources.md)</a>.

--- a/docs/contributors/scripts.md
+++ b/docs/contributors/scripts.md
@@ -8,38 +8,38 @@ The editor includes a number of packages to enable various pieces of functionali
 
 | Script Name | Handle | Description |
 |-------------|--------|-------------|
-| [Blob](/packages/blob/src/README.md) | wp-blob | Blob utilities |
-| [Block Library](/packages/block-library/src/README.md) | wp-block-library | Block library for the editor |
-| [Blocks](/packages/blocks/src/README.md) | wp-blocks | Block creations |
-| [Block Serialization Default Parser](/packages/block-serialization-default-parser/src/README.md) | wp-block-serialization-default-parser | Default block serialization parser implementations for WordPress documents |
-| [Block Serialization Spec Parser](/packages/block-serialization-spec-parser/src/README.md) | wp-block-serialization-spec-parser | Grammar file (grammar.pegjs) for WordPress posts |
-| [Components](/packages/components/src/README.md) | wp-components | Generic components to be used for creating common UI elements |
-| [Compose](/packages/compose/src/README.md) | wp-compose | Collection of handy Higher Order Components (HOCs)  |
-| [Core Data](/packages/core-data/src/README.md) | wp-core-data | Simplify access to and manipulation of core WordPress entities |
-| [Data](/packages/data/src/README.md) | wp-data | Data module serves as a hub to manage application state for both plugins and WordPress itself |
-| [Date](/packages/date/src/README.md) | wp-date | Date module for WordPress |
-| [Deprecated](/packages/deprecated/src/README.md) | wp-deprecated | Utility to log a message to notify developers about a deprecated feature |
-| [Dom](/packages/dom/src/README.md) | wp-dom | DOM utilities module for WordPress |
-| [Dom Ready](/packages/dom-ready/src/README.md) | wp-dom-ready | Execute callback after the DOM is loaded |
-| [Editor](/packages/editor/src/README.md) | wp-editor | Building blocks for WordPress editors |
-| [Edit Post](/packages/edit-post/src/README.md) | wp-edit-post | Edit Post Module for WordPress |
-| [Element](/packages/element/src/README.md) | wp-element |Element is, quite simply, an abstraction layer atop [React](https://reactjs.org/src/README.md) |
-| [Escape Html](/packages/escape-html/src/README.md) | wp-escape-html | Escape HTML utils |
-| [Hooks](/packages/hooks/src/README.md) | wp-hooks | A lightweight and efficient EventManager for JavaScript |
-| [Html Entities](/packages/html-entities/src/README.md) | wp-html-entities | HTML entity utilities for WordPress |
-| [I18N](/packages/i18n/src/README.md) | wp-i18n | Internationalization utilities for client-side localization |
-| [Is Shallow Equal](/packages/is-shallow-equal/src/README.md) | wp-is-shallow-equal | A function for performing a shallow comparison between two objects or arrays |
-| [Keycodes](/packages/keycodes/src/README.md) | wp-keycodes | Keycodes utilities for WordPress, used to check the key pressed in events like `onKeyDown` |
-| [List Reusable Bocks](/packages/list-reusable-blocks/src/README.md) | wp-list-reusable-blocks | Package used to add import/export links to the listing page of the reusable blocks |
-| [NUX](/packages/nux/src/README.md) | wp-nux | Components, and wp.data methods useful for onboarding a new user to the WordPress admin interface |
-| [Plugins](/packages/plugins/src/README.md) | wp-plugins | Plugins module for WordPress |
-| [Redux Routine](/packages/redux-routine/src/README.md) | wp-redux-routine | Redux middleware for generator coroutines |
-| [Rich Text](/packages/rich-text/src/README.md) | wp-rich-text | Helper functions to convert HTML or a DOM tree into a rich text value and back |
-| [Shortcode](/packages/shortcode/src/README.md) | wp-shortcode | Shortcode module for WordPress |
-| [Token List](/packages/token-list/src/README.md) | wp-token-list | Constructable, plain JavaScript [DOMTokenList](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList) implementation, supporting non-browser runtimes |
-| [URL](/packages/url/src/README.md) | wp-url | A collection of utilities to manipulate URLs |
-| [Viewport](/packages/viewport/src/README.md) | wp-viewport | Module for responding to changes in the browser viewport size |
-| [Wordcount](/packages/wordcount/src/README.md) | wp-wordcount | WordPress word count utility |
+| [Blob](/packages/blob/README.md) | wp-blob | Blob utilities |
+| [Block Library](/packages/block-library/README.md) | wp-block-library | Block library for the editor |
+| [Blocks](/packages/blocks/README.md) | wp-blocks | Block creations |
+| [Block Serialization Default Parser](/packages/block-serialization-default-parser/README.md) | wp-block-serialization-default-parser | Default block serialization parser implementations for WordPress documents |
+| [Block Serialization Spec Parser](/packages/block-serialization-spec-parser/README.md) | wp-block-serialization-spec-parser | Grammar file (grammar.pegjs) for WordPress posts |
+| [Components](/packages/components/README.md) | wp-components | Generic components to be used for creating common UI elements |
+| [Compose](/packages/compose/README.md) | wp-compose | Collection of handy Higher Order Components (HOCs)  |
+| [Core Data](/packages/core-data/README.md) | wp-core-data | Simplify access to and manipulation of core WordPress entities |
+| [Data](/packages/data/README.md) | wp-data | Data module serves as a hub to manage application state for both plugins and WordPress itself |
+| [Date](/packages/date/README.md) | wp-date | Date module for WordPress |
+| [Deprecated](/packages/deprecated/README.md) | wp-deprecated | Utility to log a message to notify developers about a deprecated feature |
+| [Dom](/packages/dom/README.md) | wp-dom | DOM utilities module for WordPress |
+| [Dom Ready](/packages/dom-ready/README.md) | wp-dom-ready | Execute callback after the DOM is loaded |
+| [Editor](/packages/editor/README.md) | wp-editor | Building blocks for WordPress editors |
+| [Edit Post](/packages/edit-post/README.md) | wp-edit-post | Edit Post Module for WordPress |
+| [Element](/packages/element/README.md) | wp-element |Element is, quite simply, an abstraction layer atop [React](https://reactjs.org/) |
+| [Escape Html](/packages/escape-html/README.md) | wp-escape-html | Escape HTML utils |
+| [Hooks](/packages/hooks/README.md) | wp-hooks | A lightweight and efficient EventManager for JavaScript |
+| [Html Entities](/packages/html-entities/README.md) | wp-html-entities | HTML entity utilities for WordPress |
+| [I18N](/packages/i18n/README.md) | wp-i18n | Internationalization utilities for client-side localization |
+| [Is Shallow Equal](/packages/is-shallow-equal/README.md) | wp-is-shallow-equal | A function for performing a shallow comparison between two objects or arrays |
+| [Keycodes](/packages/keycodes/README.md) | wp-keycodes | Keycodes utilities for WordPress, used to check the key pressed in events like `onKeyDown` |
+| [List Reusable Bocks](/packages/list-reusable-blocks/README.md) | wp-list-reusable-blocks | Package used to add import/export links to the listing page of the reusable blocks |
+| [NUX](/packages/nux/README.md) | wp-nux | Components, and wp.data methods useful for onboarding a new user to the WordPress admin interface |
+| [Plugins](/packages/plugins/README.md) | wp-plugins | Plugins module for WordPress |
+| [Redux Routine](/packages/redux-routine/README.md) | wp-redux-routine | Redux middleware for generator coroutines |
+| [Rich Text](/packages/rich-text/README.md) | wp-rich-text | Helper functions to convert HTML or a DOM tree into a rich text value and back |
+| [Shortcode](/packages/shortcode/README.md) | wp-shortcode | Shortcode module for WordPress |
+| [Token List](/packages/token-list/README.md) | wp-token-list | Constructable, plain JavaScript [DOMTokenList](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList) implementation, supporting non-browser runtimes |
+| [URL](/packages/url/README.md) | wp-url | A collection of utilities to manipulate URLs |
+| [Viewport](/packages/viewport/README.md) | wp-viewport | Module for responding to changes in the browser viewport size |
+| [Wordcount](/packages/wordcount/README.md) | wp-wordcount | WordPress word count utility |
 
 ## Vendor Scripts
 

--- a/docs/contributors/scripts.md
+++ b/docs/contributors/scripts.md
@@ -8,38 +8,38 @@ The editor includes a number of packages to enable various pieces of functionali
 
 | Script Name | Handle | Description |
 |-------------|--------|-------------|
-| [Blob](https://wordpress.org/gutenberg/handbook/packages/packages-blob/) | wp-blob | Blob utilities |
-| [Block Library](https://wordpress.org/gutenberg/handbook/packages/packages-block-library/) | wp-block-library | Block library for the editor |
-| [Blocks](https://wordpress.org/gutenberg/handbook/packages/packages-blocks/) | wp-blocks | Block creations |
-| [Block Serialization Default Parser](https://wordpress.org/gutenberg/handbook/packages/packages-block-serialization-default-parser/) | wp-block-serialization-default-parser | Default block serialization parser implementations for WordPress documents |
-| [Block Serialization Spec Parser](https://wordpress.org/gutenberg/handbook/packages/packages-block-serialization-spec-parser/) | wp-block-serialization-spec-parser | Grammar file (grammar.pegjs) for WordPress posts |
-| [Components](https://wordpress.org/gutenberg/handbook/packages/packages-components/) | wp-components | Generic components to be used for creating common UI elements |
-| [Compose](https://wordpress.org/gutenberg/handbook/packages/packages-compose/) | wp-compose | Collection of handy Higher Order Components (HOCs)  |
-| [Core Data](https://wordpress.org/gutenberg/handbook/packages/packages-core-data/) | wp-core-data | Simplify access to and manipulation of core WordPress entities |
-| [Data](https://wordpress.org/gutenberg/handbook/packages/packages-data/) | wp-data | Data module serves as a hub to manage application state for both plugins and WordPress itself |
-| [Date](https://wordpress.org/gutenberg/handbook/packages/packages-date/) | wp-date | Date module for WordPress |
-| [Deprecated](https://wordpress.org/gutenberg/handbook/packages/packages-deprecated/) | wp-deprecated | Utility to log a message to notify developers about a deprecated feature |
-| [Dom](https://wordpress.org/gutenberg/handbook/packages/packages-dom/) | wp-dom | DOM utilities module for WordPress |
-| [Dom Ready](https://wordpress.org/gutenberg/handbook/packages/packages-dom-ready/) | wp-dom-ready | Execute callback after the DOM is loaded |
-| [Editor](https://wordpress.org/gutenberg/handbook/packages/packages-editor/) | wp-editor | Building blocks for WordPress editors |
-| [Edit Post](https://wordpress.org/gutenberg/handbook/packages/packages-edit-post/) | wp-edit-post | Edit Post Module for WordPress |
-| [Element](https://wordpress.org/gutenberg/handbook/packages/packages-element/) | wp-element |Element is, quite simply, an abstraction layer atop [React](https://reactjs.org/) |
-| [Escape Html](https://wordpress.org/gutenberg/handbook/packages/packages-escape-html/) | wp-escape-html | Escape HTML utils |
-| [Hooks](https://wordpress.org/gutenberg/handbook/packages/packages-hooks/) | wp-hooks | A lightweight and efficient EventManager for JavaScript |
-| [Html Entities](https://wordpress.org/gutenberg/handbook/packages/packages-html-entities/) | wp-html-entities | HTML entity utilities for WordPress |
-| [I18N](https://wordpress.org/gutenberg/handbook/packages/packages-i18n/) | wp-i18n | Internationalization utilities for client-side localization |
-| [Is Shallow Equal](https://wordpress.org/gutenberg/handbook/packages/packages-is-shallow-equal/) | wp-is-shallow-equal | A function for performing a shallow comparison between two objects or arrays |
-| [Keycodes](https://wordpress.org/gutenberg/handbook/packages/packages-keycodes/) | wp-keycodes | Keycodes utilities for WordPress, used to check the key pressed in events like `onKeyDown` |
-| [List Reusable Bocks](https://wordpress.org/gutenberg/handbook/packages/packages-list-reusable-blocks/) | wp-list-reusable-blocks | Package used to add import/export links to the listing page of the reusable blocks |
-| [NUX](https://wordpress.org/gutenberg/handbook/packages/packages-nux/) | wp-nux | Components, and wp.data methods useful for onboarding a new user to the WordPress admin interface |
-| [Plugins](https://wordpress.org/gutenberg/handbook/packages/packages-plugins/) | wp-plugins | Plugins module for WordPress |
-| [Redux Routine](https://wordpress.org/gutenberg/handbook/packages/packages-redux-routine/) | wp-redux-routine | Redux middleware for generator coroutines |
-| [Rich Text](https://wordpress.org/gutenberg/handbook/packages/packages-rich-text/) | wp-rich-text | Helper functions to convert HTML or a DOM tree into a rich text value and back |
-| [Shortcode](https://wordpress.org/gutenberg/handbook/packages/packages-shortcode/) | wp-shortcode | Shortcode module for WordPress |
-| [Token List](https://wordpress.org/gutenberg/handbook/packages/packages-token-list/) | wp-token-list | Constructable, plain JavaScript [DOMTokenList](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList) implementation, supporting non-browser runtimes |
-| [URL](https://wordpress.org/gutenberg/handbook/packages/packages-url/) | wp-url | A collection of utilities to manipulate URLs |
-| [Viewport](https://wordpress.org/gutenberg/handbook/packages/packages-viewport/) | wp-viewport | Module for responding to changes in the browser viewport size |
-| [Wordcount](https://wordpress.org/gutenberg/handbook/packages/packages-wordcount/) | wp-wordcount | WordPress word count utility |
+| [Blob](/packages/blob/src/README.md) | wp-blob | Blob utilities |
+| [Block Library](/packages/block-library/src/README.md) | wp-block-library | Block library for the editor |
+| [Blocks](/packages/blocks/src/README.md) | wp-blocks | Block creations |
+| [Block Serialization Default Parser](/packages/block-serialization-default-parser/src/README.md) | wp-block-serialization-default-parser | Default block serialization parser implementations for WordPress documents |
+| [Block Serialization Spec Parser](/packages/block-serialization-spec-parser/src/README.md) | wp-block-serialization-spec-parser | Grammar file (grammar.pegjs) for WordPress posts |
+| [Components](/packages/components/src/README.md) | wp-components | Generic components to be used for creating common UI elements |
+| [Compose](/packages/compose/src/README.md) | wp-compose | Collection of handy Higher Order Components (HOCs)  |
+| [Core Data](/packages/core-data/src/README.md) | wp-core-data | Simplify access to and manipulation of core WordPress entities |
+| [Data](/packages/data/src/README.md) | wp-data | Data module serves as a hub to manage application state for both plugins and WordPress itself |
+| [Date](/packages/date/src/README.md) | wp-date | Date module for WordPress |
+| [Deprecated](/packages/deprecated/src/README.md) | wp-deprecated | Utility to log a message to notify developers about a deprecated feature |
+| [Dom](/packages/dom/src/README.md) | wp-dom | DOM utilities module for WordPress |
+| [Dom Ready](/packages/dom-ready/src/README.md) | wp-dom-ready | Execute callback after the DOM is loaded |
+| [Editor](/packages/editor/src/README.md) | wp-editor | Building blocks for WordPress editors |
+| [Edit Post](/packages/edit-post/src/README.md) | wp-edit-post | Edit Post Module for WordPress |
+| [Element](/packages/element/src/README.md) | wp-element |Element is, quite simply, an abstraction layer atop [React](https://reactjs.org/src/README.md) |
+| [Escape Html](/packages/escape-html/src/README.md) | wp-escape-html | Escape HTML utils |
+| [Hooks](/packages/hooks/src/README.md) | wp-hooks | A lightweight and efficient EventManager for JavaScript |
+| [Html Entities](/packages/html-entities/src/README.md) | wp-html-entities | HTML entity utilities for WordPress |
+| [I18N](/packages/i18n/src/README.md) | wp-i18n | Internationalization utilities for client-side localization |
+| [Is Shallow Equal](/packages/is-shallow-equal/src/README.md) | wp-is-shallow-equal | A function for performing a shallow comparison between two objects or arrays |
+| [Keycodes](/packages/keycodes/src/README.md) | wp-keycodes | Keycodes utilities for WordPress, used to check the key pressed in events like `onKeyDown` |
+| [List Reusable Bocks](/packages/list-reusable-blocks/src/README.md) | wp-list-reusable-blocks | Package used to add import/export links to the listing page of the reusable blocks |
+| [NUX](/packages/nux/src/README.md) | wp-nux | Components, and wp.data methods useful for onboarding a new user to the WordPress admin interface |
+| [Plugins](/packages/plugins/src/README.md) | wp-plugins | Plugins module for WordPress |
+| [Redux Routine](/packages/redux-routine/src/README.md) | wp-redux-routine | Redux middleware for generator coroutines |
+| [Rich Text](/packages/rich-text/src/README.md) | wp-rich-text | Helper functions to convert HTML or a DOM tree into a rich text value and back |
+| [Shortcode](/packages/shortcode/src/README.md) | wp-shortcode | Shortcode module for WordPress |
+| [Token List](/packages/token-list/src/README.md) | wp-token-list | Constructable, plain JavaScript [DOMTokenList](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList) implementation, supporting non-browser runtimes |
+| [URL](/packages/url/src/README.md) | wp-url | A collection of utilities to manipulate URLs |
+| [Viewport](/packages/viewport/src/README.md) | wp-viewport | Module for responding to changes in the browser viewport size |
+| [Wordcount](/packages/wordcount/src/README.md) | wp-wordcount | WordPress word count utility |
 
 ## Vendor Scripts
 

--- a/docs/designers-developers/developers/backward-compatibility/deprecations.md
+++ b/docs/designers-developers/developers/backward-compatibility/deprecations.md
@@ -195,11 +195,11 @@ The Gutenberg project's deprecation policy is intended to support backward compa
 ## 3.0.0
 
  - `wp.blocks.registerCoreBlocks` function removed. Please use `wp.coreBlocks.registerCoreBlocks` instead.
- - Raw TinyMCE event handlers for `RichText` have been deprecated. Please use [documented props](https://wordpress.org/gutenberg/handbook/block-api/rich-text-api/), ancestor event handler, or onSetup access to the internal editor instance event hub instead.
+ - Raw TinyMCE event handlers for `RichText` have been deprecated. Please use [documented props](/packages/editor/src/components/rich-text/README.md), ancestor event handler, or onSetup access to the internal editor instance event hub instead.
 
 ## 2.8.0
 
- - `Original autocompleter interface in wp.components.Autocomplete` updated. Please use `latest autocompleter interface` instead. See: https://github.com/WordPress/gutenberg/blob/master/components/autocomplete/README.md.
+ - `Original autocompleter interface in wp.components.Autocomplete` updated. Please use `latest autocompleter interface` instead. See [autocomplete](/packages/components/src/autocomplete/README.md) for more info.
  - `getInserterItems`: the `allowedBlockTypes` argument is now mandatory.
  - `getFrecentInserterItems`: the `allowedBlockTypes` argument is now mandatory.
 
@@ -221,6 +221,6 @@ The Gutenberg project's deprecation policy is intended to support backward compa
 
  - `wp.blocks.BlockDescription` component removed. Please use the `description` block property instead.
  - `wp.blocks.InspectorControls.*` components removed. Please use `wp.components.*` components instead.
- - `wp.blocks.source.*` matchers removed. Please use the declarative attributes instead. See: https://wordpress.org/gutenberg/handbook/block-api/attributes/.
+ - `wp.blocks.source.*` matchers removed. Please use the declarative attributes instead. See [block attributes](/docs/designers-developers/developers/block-api/block-attributes.md) for more info.
  - `wp.data.select( 'selector', ...args )` removed. Please use `wp.data.select( reducerKey' ).*` instead.
  - `wp.blocks.MediaUploadButton` component removed. Please use `wp.blocks.MediaUpload` component instead.

--- a/docs/designers-developers/developers/block-api/README.md
+++ b/docs/designers-developers/developers/block-api/README.md
@@ -4,8 +4,8 @@ Blocks are the fundamental element of the editor. They are the primary way in wh
 
 ## Registering a block
 
-All blocks must be registered before they can be used in the editor. You can learn about block registration, and the available options, in the [block registration](../../../../docs/designers-developers/developers/block-api/block-registration.md) documentation.
+All blocks must be registered before they can be used in the editor. You can learn about block registration, and the available options, in the [block registration](/docs/designers-developers/developers/block-api/block-registration.md) documentation.
 
 ## Block `edit` and `save`
 
-The `edit` and `save` functions define the editor interface with which a user would interact, and the markup to be serialized back when a post is saved. They are the heart of how a block operates, so they are [covered separately](../../../../docs/designers-developers/developers/block-api/block-edit-save.md).
+The `edit` and `save` functions define the editor interface with which a user would interact, and the markup to be serialized back when a post is saved. They are the heart of how a block operates, so they are [covered separately](/docs/designers-developers/developers/block-api/block-edit-save.md).

--- a/docs/designers-developers/developers/block-api/block-attributes.md
+++ b/docs/designers-developers/developers/block-api/block-attributes.md
@@ -4,7 +4,7 @@
 
 Attribute sources are used to define the strategy by which block attribute values are extracted from saved post content. They provide a mechanism to map from the saved markup to a JavaScript representation of a block.
 
-If no attribute source is specified, the attribute will be saved to (and read from) the block's [comment delimiter](../../../../docs/designers-developers/key-concepts.md#delimiters-and-parsing-expression-grammar).
+If no attribute source is specified, the attribute will be saved to (and read from) the block's [comment delimiter](/docs/designers-developers/key-concepts.md#delimiters-and-parsing-expression-grammar).
 
 Each source accepts an optional selector as the first argument. If a selector is specified, the source behavior will be run against the corresponding element(s) contained within the block. Otherwise it will be run against the block's root node.
 

--- a/docs/designers-developers/developers/block-api/block-deprecation.md
+++ b/docs/designers-developers/developers/block-api/block-deprecation.md
@@ -9,9 +9,9 @@ A block can have several deprecated versions. A deprecation will be tried if a p
 
 Deprecations are defined on a block type as its `deprecated` property, an array of deprecation objects where each object takes the form:
 
-- `attributes` (Object): The [attributes definition](../../../../docs/designers-developers/developers/block-api/block-attributes.md) of the deprecated form of the block.
-- `support` (Object): The [supports definition](../../../../docs/designers-developers/developers/block-api/block-registration.md) of the deprecated form of the block.
-- `save` (Function): The [save implementation](../../../../docs/designers-developers/developers/block-api/block-edit-save.md) of the deprecated form of the block.
+- `attributes` (Object): The [attributes definition](/docs/designers-developers/developers/block-api/block-attributes.md) of the deprecated form of the block.
+- `support` (Object): The [supports definition](/docs/designers-developers/developers/block-api/block-registration.md) of the deprecated form of the block.
+- `save` (Function): The [save implementation](/docs/designers-developers/developers/block-api/block-edit-save.md) of the deprecated form of the block.
 - `migrate` (Function, Optional): A function which, given the attributes and inner blocks of the parsed block, is expected to return either the attributes compatible with the deprecated block, or a tuple array of `[ attributes, innerBlocks ]`.
 - `isEligible` (Function, Optional): A function which, given the attributes and inner blocks of the parsed block, returns true if the deprecation can handle the block migration. This is particularly useful in cases where a block is technically valid even once deprecated, and requires updates to its attributes or inner blocks.
 

--- a/docs/designers-developers/developers/block-api/block-deprecation.md
+++ b/docs/designers-developers/developers/block-api/block-deprecation.md
@@ -275,4 +275,4 @@ registerBlockType( 'gutenberg/block-with-deprecated-version', {
 
 In the example above we updated the block to use an inner paragraph block with a title instead of a title attribute.
 
-*Above are example cases of block deprecation. For more, real-world examples, check for deprecations in the [core block library](https://github.com/WordPress/gutenberg/tree/master/packages/block-library/src). Core blocks have been updated across releases and contain simple and complex deprecations.*
+*Above are example cases of block deprecation. For more, real-world examples, check for deprecations in the [core block library](/packages/block-library/src/README.md). Core blocks have been updated across releases and contain simple and complex deprecations.*

--- a/docs/designers-developers/developers/block-api/block-edit-save.md
+++ b/docs/designers-developers/developers/block-api/block-edit-save.md
@@ -121,7 +121,7 @@ For most blocks, the return value of `save` should be an [instance of WordPress 
 
 _Note:_ While it is possible to return a string value from `save`, it _will be escaped_. If the string includes HTML markup, the markup will be shown on the front of the site verbatim, not as the equivalent HTML node content. If you must return raw HTML from `save`, use `wp.element.RawHTML`. As the name implies, this is prone to [cross-site scripting](https://en.wikipedia.org/wiki/Cross-site_scripting) and therefore is discouraged in favor of a WordPress Element hierarchy whenever possible.
 
-For [dynamic blocks](../../../../docs/designers-developers/developers/tutorials/block-tutorial/creating-dynamic-blocks.md), the return value of `save` could either represent a cached copy of the block's content to be shown only in case the plugin implementing the block is ever disabled. Alternatively, return a `null` (empty) value to save no markup in post content for the dynamic block, instead deferring this to always be calculated when the block is shown on the front of the site.
+For [dynamic blocks](/docs/designers-developers/developers/tutorials/block-tutorial/creating-dynamic-blocks.md), the return value of `save` could either represent a cached copy of the block's content to be shown only in case the plugin implementing the block is ever disabled. Alternatively, return a `null` (empty) value to save no markup in post content for the dynamic block, instead deferring this to always be calculated when the block is shown on the front of the site.
 
 ### attributes
 
@@ -171,10 +171,10 @@ The two most common sources of block invalidations are:
 
 Before starting to debug, be sure to familiarize yourself with the validation step described above documenting the process for detecting whether a block is invalid. A block is invalid if its regenerated markup does not match what is saved in post content, so often this can be caused by the attributes of a block being parsed incorrectly from the saved content.
 
-If you're using [attribute sources](../../../../docs/designers-developers/developers/block-api/block-attributes.md), be sure that attributes sourced from markup are saved exactly as you expect, and in the correct type (usually a `'string'` or `'number'`).
+If you're using [attribute sources](/docs/designers-developers/developers/block-api/block-attributes.md), be sure that attributes sourced from markup are saved exactly as you expect, and in the correct type (usually a `'string'` or `'number'`).
 
 When a block is detected as invalid, a warning will be logged into your browser's developer tools console. The warning will include specific details about the exact point at which a difference in markup occurred. Be sure to look closely at any differences in the expected and actual markups to see where problems are occurring.
 
 **I've changed my block's `save` behavior and old content now includes invalid blocks. How can I fix this?**
 
-Refer to the guide on [Deprecated Blocks](../../../../docs/designers-developers/developers/block-api/block-deprecations.md) to learn more about how to accommodate legacy content in intentional markup changes.
+Refer to the guide on [Deprecated Blocks](/docs/designers-developers/developers/block-api/block-deprecations.md) to learn more about how to accommodate legacy content in intentional markup changes.

--- a/docs/designers-developers/developers/block-api/block-edit-save.md
+++ b/docs/designers-developers/developers/block-api/block-edit-save.md
@@ -117,7 +117,7 @@ save() {
 ```
 {% end %}
 
-For most blocks, the return value of `save` should be an [instance of WordPress Element](https://github.com/WordPress/gutenberg/blob/master/packages/element/README.md) representing how the block is to appear on the front of the site.
+For most blocks, the return value of `save` should be an [instance of WordPress Element](/packages/element/README.md) representing how the block is to appear on the front of the site.
 
 _Note:_ While it is possible to return a string value from `save`, it _will be escaped_. If the string includes HTML markup, the markup will be shown on the front of the site verbatim, not as the equivalent HTML node content. If you must return raw HTML from `save`, use `wp.element.RawHTML`. As the name implies, this is prone to [cross-site scripting](https://en.wikipedia.org/wiki/Cross-site_scripting) and therefore is discouraged in favor of a WordPress Element hierarchy whenever possible.
 

--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -66,7 +66,7 @@ The core provided categories are:
 category: 'widgets',
 ```
 
-Plugins and Themes can also register [custom block categories](../docs/extensibility/extending-blocks/#managing-block-categories).
+Plugins and Themes can also register [custom block categories](/docs/extensibility/extending-blocks/#managing-block-categories).
 
 #### Icon (optional)
 
@@ -138,7 +138,7 @@ styles: [
 ],
 ```
 
-Plugins and Themes can also register [custom block style](../docs/extensibility/extending-blocks/#block-style-variations) for existing blocks.
+Plugins and Themes can also register [custom block style](/docs/extensibility/extending-blocks/#block-style-variations) for existing blocks.
 
 #### Attributes (optional)
 
@@ -166,7 +166,7 @@ attributes: {
 },
 ```
 
-* **See: [Attributes](../docs/block-api/attributes.md).**
+* **See: [Attributes](/docs/block-api/attributes.md).**
 
 #### Transforms (optional)
 
@@ -492,7 +492,7 @@ attributes: {
 }
 ```
 
-- `alignWide` (default `true`): This property allows to enable [wide alignment](../docs/extensibility/theme-support.md#wide-alignment) for your theme. To disable this behavior for a single block, set this flag to `false`.
+- `alignWide` (default `true`): This property allows to enable [wide alignment](/docs/extensibility/theme-support.md#wide-alignment) for your theme. To disable this behavior for a single block, set this flag to `false`.
 
 ```js
 // Remove the support for wide alignment.

--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -66,7 +66,7 @@ The core provided categories are:
 category: 'widgets',
 ```
 
-Plugins and Themes can also register [custom block categories](/docs/extensibility/extending-blocks/#managing-block-categories).
+Plugins and Themes can also register [custom block categories](/docs/designers-developers/developers/filters/block-filters.md#managing-block-categories).
 
 #### Icon (optional)
 
@@ -82,7 +82,7 @@ icon: 'book-alt',
 icon: <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="none" d="M0 0h24v24H0V0z" /><path d="M19 13H5v-2h14v2z" /></svg>,
 ```
 
-**Note:** Custom SVG icons are automatically wrapped in the [`wp.components.SVG` component](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/primitives/svg/) to add accessibility attributes (`aria-hidden`, `role`, and `focusable`).
+**Note:** Custom SVG icons are automatically wrapped in the [`wp.components.SVG` component](/packages/components/src/primitives/svg/) to add accessibility attributes (`aria-hidden`, `role`, and `focusable`).
 
 An object can also be passed as icon, in this case, icon, as specified above, should be included in the src property.
 Besides src the object can contain background and foreground colors, this colors will appear with the icon
@@ -138,7 +138,7 @@ styles: [
 ],
 ```
 
-Plugins and Themes can also register [custom block style](/docs/extensibility/extending-blocks/#block-style-variations) for existing blocks.
+Plugins and Themes can also register [custom block style](/docs/designers-developers/developers/filters/block-filters.md#block-style-variations) for existing blocks.
 
 #### Attributes (optional)
 
@@ -166,7 +166,7 @@ attributes: {
 },
 ```
 
-* **See: [Attributes](/docs/block-api/attributes.md).**
+* **See: [Attributes](/docs/designers-developers/developers/block-api/block-attributes.md).**
 
 #### Transforms (optional)
 
@@ -453,7 +453,7 @@ transforms: {
 
 * **Type:** `Array`
 
-Blocks are able to be inserted into blocks that use [`InnerBlocks`](https://github.com/WordPress/gutenberg/blob/master/packages/editor/src/components/inner-blocks/README.md) as nested content. Sometimes it is useful to restrict a block so that it is only available as a nested block. For example, you might want to allow an 'Add to Cart' block to only be available within a 'Product' block.
+Blocks are able to be inserted into blocks that use [`InnerBlocks`](/packages/editor/src/components/inner-blocks/README.md) as nested content. Sometimes it is useful to restrict a block so that it is only available as a nested block. For example, you might want to allow an 'Add to Cart' block to only be available within a 'Product' block.
 
 Setting `parent` lets a block require that it is only available when nested within the specified blocks.
 
@@ -492,7 +492,7 @@ attributes: {
 }
 ```
 
-- `alignWide` (default `true`): This property allows to enable [wide alignment](/docs/extensibility/theme-support.md#wide-alignment) for your theme. To disable this behavior for a single block, set this flag to `false`.
+- `alignWide` (default `true`): This property allows to enable [wide alignment](/docs/designers-developers/developers/themes/theme-support.md#wide-alignment) for your theme. To disable this behavior for a single block, set this flag to `false`.
 
 ```js
 // Remove the support for wide alignment.

--- a/docs/designers-developers/developers/data/README.md
+++ b/docs/designers-developers/developers/data/README.md
@@ -1,10 +1,10 @@
 # Data Module Reference
 
- - [**core**: WordPress Core Data](../../docs/designers-developers/developers/data/data-core.md)
- - [**core/annotations**: Annotations](../../docs/designers-developers/developers/data/data-core-annotations.md)
- - [**core/blocks**: Block Types Data](../../docs/designers-developers/developers/data/data-core-blocks.md)
- - [**core/editor**: The Editor’s Data](../../docs/designers-developers/developers/data/data-core-editor.md)
- - [**core/edit-post**: The Editor’s UI Data](../../docs/designers-developers/developers/data/data-core-edit-post.md)
- - [**core/notices**: Notices Data](../../docs/designers-developers/developers/data/data-core-notices.md)
- - [**core/nux**: The NUX (New User Experience) Data](../../docs/designers-developers/developers/data/data-core-nux.md)
- - [**core/viewport**: The Viewport Data](../../docs/designers-developers/developers/data/data-core-viewport.md)
+ - [**core**: WordPress Core Data](/docs/designers-developers/developers/data/data-core.md)
+ - [**core/annotations**: Annotations](/docs/designers-developers/developers/data/data-core-annotations.md)
+ - [**core/blocks**: Block Types Data](/docs/designers-developers/developers/data/data-core-blocks.md)
+ - [**core/editor**: The Editor’s Data](/docs/designers-developers/developers/data/data-core-editor.md)
+ - [**core/edit-post**: The Editor’s UI Data](/docs/designers-developers/developers/data/data-core-edit-post.md)
+ - [**core/notices**: Notices Data](/docs/designers-developers/developers/data/data-core-notices.md)
+ - [**core/nux**: The NUX (New User Experience) Data](/docs/designers-developers/developers/data/data-core-nux.md)
+ - [**core/viewport**: The Viewport Data](/docs/designers-developers/developers/data/data-core-viewport.md)

--- a/docs/designers-developers/developers/filters/README.md
+++ b/docs/designers-developers/developers/filters/README.md
@@ -4,4 +4,4 @@
 
 There are two types of hooks: [Actions](https://developer.wordpress.org/plugins/hooks/actions/) and [Filters](https://developer.wordpress.org/plugins/hooks/filters/). In addition to PHP actions and filters, WordPress also provides a mechanism for registering and executing hooks in JavaScript. This functionality is also available on npm as the [@wordpress/hooks](https://www.npmjs.com/package/@wordpress/hooks) package, for general purpose use.
 
-You can also learn more about both APIs: [PHP](https://codex.wordpress.org/Plugin_API/) and [JavaScript](https://github.com/WordPress/packages/tree/master/packages/hooks).
+You can also learn more about both APIs: [PHP](https://codex.wordpress.org/Plugin_API/) and [JavaScript](/packages/tree/master/packages/hooks).

--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -113,7 +113,7 @@ wp.hooks.addFilter(
 );
 ```
 
-_Note:_ This filter must always be run on every page load, and not in your browser's developer tools console. Otherwise, a [block validation](../../../../docs/designers-developers/developers/block-api/block-edit-save.md#validation) error will occur the next time the post is edited. This is due to the fact that block validation occurs by verifying that the saved output matches what is stored in the post's content during editor initialization. So, if this filter does not exist when the editor loads, the block will be marked as invalid.
+_Note:_ This filter must always be run on every page load, and not in your browser's developer tools console. Otherwise, a [block validation](/docs/designers-developers/developers/block-api/block-edit-save.md#validation) error will occur the next time the post is edited. This is due to the fact that block validation occurs by verifying that the saved output matches what is stored in the post's content during editor initialization. So, if this filter does not exist when the editor loads, the block will be marked as invalid.
 
 #### `blocks.getBlockDefaultClassName`
 

--- a/docs/designers-developers/developers/themes/theme-support.md
+++ b/docs/designers-developers/developers/themes/theme-support.md
@@ -266,7 +266,7 @@ To change the main column width of the editor, add the following CSS to `style-e
 
 You can use those editor widths to match those in your theme. You can use any CSS width unit, including `%` or `px`.
 
-Further reading: [Applying Styles with Stylesheets](https://wordpress.org/gutenberg/handbook/blocks/applying-styles-with-stylesheets/).
+Further reading: [Applying Styles with Stylesheets](/docs/designers-developers/developers/tutorials/block-tutorial/applying-styles-with-stylesheets.md).
 
 ## Default block styles
 

--- a/docs/designers-developers/developers/tutorials/block-tutorial/creating-dynamic-blocks.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/creating-dynamic-blocks.md
@@ -124,7 +124,7 @@ There are a few things to notice:
 
 ## Live rendering in Gutenberg editor
 
-Gutenberg 2.8 added the [`<ServerSideRender>`](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/server-side-render) block which enables rendering to take place on the server using PHP rather than in JavaScript. 
+Gutenberg 2.8 added the [`<ServerSideRender>`](/packages/components/src/server-side-render) block which enables rendering to take place on the server using PHP rather than in JavaScript. 
 
 *Server-side render is meant as a fallback; client-side rendering in JavaScript is always preferred (client rendering is faster and allows better editor manipulation).*
 

--- a/docs/designers-developers/developers/tutorials/block-tutorial/generate-blocks-with-wp-cli.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/generate-blocks-with-wp-cli.md
@@ -5,7 +5,7 @@ It turns out that writing the simplest possible block which contains only static
 - [zgordon/gutenberg-course](https://github.com/zgordon/gutenberg-course) - a repository for Zac Gordon's Gutenberg Development Course
 - [ahmadawais/create-guten-block](https://github.com/ahmadawais/create-guten-block) - A zero-configuration developer toolkit for building WordPress Gutenberg block plugins
 
-It might be also a good idea to browse the folder with [all core blocks](https://github.com/WordPress/gutenberg/tree/master/packages/block-library/src) to see how they are implemented.
+It might be also a good idea to browse the folder with [all core blocks](/packages/block-library/src) to see how they are implemented.
 
 ## WP-CLI
 
@@ -62,7 +62,7 @@ This will generate 4 files inside the `movies` plugin directory. All files conta
  * Registers all block assets so that they can be enqueued through Gutenberg in
  * the corresponding context.
  *
- * @see https://wordpress.org/gutenberg/handbook/blocks/writing-your-first-block-type/#enqueuing-block-scripts
+ * @see https://wordpress.org/gutenberg/handbook/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type/
  */
 function movie_block_init() {
 	$dir = dirname( __FILE__ );
@@ -109,23 +109,23 @@ add_action( 'init', 'movie_block_init' );
 ( function( wp ) {
 	/**
 	 * Registers a new block provided a unique name and an object defining its behavior.
-	 * @see https://github.com/WordPress/gutenberg/tree/master/blocks#api
+	 * @see https://wordpress.org/gutenberg/handbook/designers-developers/developers/block-api/#registering-a-block
 	 */
 	var registerBlockType = wp.blocks.registerBlockType;
 	/**
 	 * Returns a new element of given type. Element is an abstraction layer atop React.
-	 * @see https://github.com/WordPress/gutenberg/tree/master/packages/element#element
+	 * @see https://wordpress.org/gutenberg/handbook/designers-developers/developers/packages/packages-element/
 	 */
 	var el = wp.element.createElement;
 	/**
 	 * Retrieves the translation of text.
-	 * @see https://github.com/WordPress/gutenberg/tree/master/i18n#api
+	 * @see https://wordpress.org/gutenberg/handbook/designers-developers/developers/packages/packages-i18n/
 	 */
 	var __ = wp.i18n.__;
 
 	/**
 	 * Every block starts by registering a new block type definition.
-	 * @see https://wordpress.org/gutenberg/handbook/block-api/
+	 * @see https://wordpress.org/gutenberg/handbook/designers-developers/developers/block-api/#registering-a-block
 	 */
 	registerBlockType( 'movies/movie', {
 		/**
@@ -151,7 +151,7 @@ add_action( 'init', 'movie_block_init' );
 		/**
 		 * The edit function describes the structure of your block in the context of the editor.
 		 * This represents what the editor will render when the block is used.
-		 * @see https://wordpress.org/gutenberg/handbook/block-edit-save/#edit
+		 * @see https://wordpress.org/gutenberg/handbook/designers-developers/developers/block-api/block-edit-save/#edit
 		 *
 		 * @param {Object} [props] Properties passed from the editor.
 		 * @return {Element}       Element to render.
@@ -167,7 +167,7 @@ add_action( 'init', 'movie_block_init' );
 		/**
 		 * The save function defines the way in which the different attributes should be combined
 		 * into the final markup, which is then serialized by Gutenberg into `post_content`.
-		 * @see https://wordpress.org/gutenberg/handbook/block-edit-save/#save
+		 * @see https://wordpress.org/gutenberg/handbook/designers-developers/developers/block-api/block-edit-save/#save
 		 *
 		 * @return {Element}       Element to render.
 		 */

--- a/docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md
@@ -110,7 +110,7 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-03', {
 ```
 {% end %}
 
-When registering a new block type, the `attributes` property describes the shape of the attributes object you'd like to receive in the `edit` and `save` functions. Each value is a [source function](../../../../../docs/designers-developers/developers/block-api/block-attributes.md) to find the desired value from the markup of the block.
+When registering a new block type, the `attributes` property describes the shape of the attributes object you'd like to receive in the `edit` and `save` functions. Each value is a [source function](/docs/designers-developers/developers/block-api/block-attributes.md) to find the desired value from the markup of the block.
 
 In the code snippet above, when loading the editor, we will extract the `content` value as the HTML of the paragraph element in the saved post's markup.
 

--- a/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
@@ -28,7 +28,7 @@ add_action( 'init', 'gutenberg_boilerplate_block' );
 Note the two script dependencies:
 
 - __`wp-blocks`__ includes block type registration and related functions
-- __`wp-element`__ includes the [WordPress Element abstraction](https://github.com/WordPress/gutenberg/tree/master/packages/element) for describing the structure of your blocks
+- __`wp-element`__ includes the [WordPress Element abstraction](/packages/element/README.md) for describing the structure of your blocks
 
 If you were to use a component from the `wp-editor` package, for example the RichText component, you would also need to add `wp-editor` to the dependency list.
 
@@ -82,7 +82,7 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-01', {
 ```
 {% end %}
 
-Once a block is registered, you should immediately see that it becomes available as an option in the editor inserter dialog, using values from `title`, `icon`, and `category` to organize its display. You can choose an icon from any included in the built-in [Dashicons icon set](https://developer.wordpress.org/resource/dashicons/), or provide a [custom svg element](https://wordpress.org/gutenberg/handbook/designers-developers/developers/block-api/block-registration/#icon-optional).
+Once a block is registered, you should immediately see that it becomes available as an option in the editor inserter dialog, using values from `title`, `icon`, and `category` to organize its display. You can choose an icon from any included in the built-in [Dashicons icon set](https://developer.wordpress.org/resource/dashicons/), or provide a [custom svg element](/docs/designers-developers/developers/block-api/block-registration/#icon-optional).
 
 A block name must be prefixed with a namespace specific to your plugin. This helps prevent conflicts when more than one plugin registers a block with the same name.
 

--- a/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
@@ -82,7 +82,7 @@ registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-01', {
 ```
 {% end %}
 
-Once a block is registered, you should immediately see that it becomes available as an option in the editor inserter dialog, using values from `title`, `icon`, and `category` to organize its display. You can choose an icon from any included in the built-in [Dashicons icon set](https://developer.wordpress.org/resource/dashicons/), or provide a [custom svg element](/docs/designers-developers/developers/block-api/block-registration/#icon-optional).
+Once a block is registered, you should immediately see that it becomes available as an option in the editor inserter dialog, using values from `title`, `icon`, and `category` to organize its display. You can choose an icon from any included in the built-in [Dashicons icon set](https://developer.wordpress.org/resource/dashicons/), or provide a [custom svg element](/docs/designers-developers/developers/block-api/block-registration.md#icon-optional).
 
 A block name must be prefixed with a namespace specific to your plugin. This helps prevent conflicts when more than one plugin registers a block with the same name.
 

--- a/docs/designers-developers/developers/tutorials/javascript/extending-the-block-editor.md
+++ b/docs/designers-developers/developers/tutorials/javascript/extending-the-block-editor.md
@@ -1,6 +1,6 @@
 # Extending the Block Editor
 
-Let's look at using the [Block Style Variation example](../../../../../docs/designers-developers/developers/filters/block-filters.md#block-style-variations) to extend the editor. This example allows you to add your own custom CSS class name to any core block type.
+Let's look at using the [Block Style Variation example](/docs/designers-developers/developers/filters/block-filters.md#block-style-variations) to extend the editor. This example allows you to add your own custom CSS class name to any core block type.
 
 Replace the existing `console.log()` code in your `myguten.js` file with:
 
@@ -30,7 +30,7 @@ add_action( 'enqueue_block_editor_assets', 'myguten_enqueue' );
 
 The last argument in the `wp_enqueue_script()` function is an array of dependencies. WordPress makes packages available under the `wp` namespace. In the example, you use `wp.blocks` to access the items that the blocks package exports (in this case the `registerBlockStyle()` function).
 
-See [Packages](../../../../../docs/designers-developers/developers/packages.md) for list of available packages and what objects they export.
+See [Packages](/docs/designers-developers/developers/packages.md) for list of available packages and what objects they export.
 
 After you have updated both JavaScript and PHP files, go to the Block Editor and create a new post.
 

--- a/docs/designers-developers/developers/tutorials/javascript/readme.md
+++ b/docs/designers-developers/developers/tutorials/javascript/readme.md
@@ -11,9 +11,9 @@ The Block Editor introduced in WordPress 5.0 is written entirely in JavaScript, 
 
 ### Table of Contents
 
-1. [Plugins Background](../../../../../docs/designers-developers/developers/tutorials/javascript/plugins-background.md)
-2. [Loading JavaScript](../../../../../docs/designers-developers/developers/tutorials/javascript/loading-javascript.md)
-3. [Extending the Block Editor](../../../../../docs/designers-developers/developers/tutorials/javascript/extending-the-block-editor.md)
-4. [Troubleshooting](../../../../../docs/designers-developers/developers/tutorials/javascript/troubleshooting.md)
-5. [JavaScript Versions and Building](../../../../../docs/designers-developers/developers/tutorials/javascript/versions-and-building.md)
-6. [Scope your code](../../../../../docs/designers-developers/developers/tutorials/javascript/scope-your-code.md)
+1. [Plugins Background](/docs/designers-developers/developers/tutorials/javascript/plugins-background.md)
+2. [Loading JavaScript](/docs/designers-developers/developers/tutorials/javascript/loading-javascript.md)
+3. [Extending the Block Editor](/docs/designers-developers/developers/tutorials/javascript/extending-the-block-editor.md)
+4. [Troubleshooting](/docs/designers-developers/developers/tutorials/javascript/troubleshooting.md)
+5. [JavaScript Versions and Building](/docs/designers-developers/developers/tutorials/javascript/versions-and-building.md)
+6. [Scope your code](/docs/designers-developers/developers/tutorials/javascript/scope-your-code.md)

--- a/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md
+++ b/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md
@@ -2,7 +2,7 @@
 
 With the meta field registered in the previous step, next you will create a new block used to display the field value to the user. See the [Block Tutorial](/docs/designers-developers/developers/tutorials/block-tutorial/readme.md) for a deeper understanding of creating custom blocks.
 
-For this block, you will use the TextControl component, which is similar to an HTML input text field. For additional components, check out the [components](https://github.com/WordPress/gutenberg/tree/master/packages/components/src) and [editor](https://github.com/WordPress/gutenberg/tree/master/packages/editor/src/components) packages repositories.
+For this block, you will use the TextControl component, which is similar to an HTML input text field. For additional components, check out the [components](/packages/components/src) and [editor](/packages/editor/src/components) packages repositories.
 
 Attributes are the information displayed in blocks. As shown in the block tutorial, the source of attributes come from the text or HTML a user writes in the editor. For your meta block, the attribute will come from the post meta field.
 

--- a/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-0.md
+++ b/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-0.md
@@ -1,12 +1,12 @@
 # Creating a sidebar for your plugin
 
-This tutorial starts with you having an existing plugin setup and ready to add PHP and JavaScript code. Please, refer to [Getting started with JavaScript](../../../../../docs/designers-developers/developers/tutorials/javascript/) tutorial for an introduction to WordPress plugins and how to use JavaScript to extend the block editor.
+This tutorial starts with you having an existing plugin setup and ready to add PHP and JavaScript code. Please, refer to [Getting started with JavaScript](/docs/designers-developers/developers/tutorials/javascript/) tutorial for an introduction to WordPress plugins and how to use JavaScript to extend the block editor.
 
  In the next sections, you're going to create a custom sidebar for a plugin that contains a text control so the user can update a value that is stored in the `post_meta` table.
 
-1. [Get a sidebar up and running](../../../../../docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-1-up-and-running.md)
-2. [Tweak the sidebar style and add controls](../../../../../docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-2-styles-and-controls.md)
-3. [Register a new meta field](../../../../../docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-3-register-meta.md)
-4. [Initialize the input control with the meta field value](../../../../../docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-4-initialize-input.md)
-5. [Update the meta field value when input's content changes](../../../../../docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-5-update-meta.md)
-6. [Finishing touches](../../../../../docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-6-finishing-touches.md)
+1. [Get a sidebar up and running](/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-1-up-and-running.md)
+2. [Tweak the sidebar style and add controls](/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-2-styles-and-controls.md)
+3. [Register a new meta field](/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-3-register-meta.md)
+4. [Initialize the input control with the meta field value](/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-4-initialize-input.md)
+5. [Update the meta field value when input's content changes](/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-5-update-meta.md)
+6. [Finishing touches](/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-6-finishing-touches.md)

--- a/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-1-up-and-running.md
+++ b/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-1-up-and-running.md
@@ -1,6 +1,6 @@
 # Get a sidebar up and running
 
-The first step in the journey is to tell the editor that there is a new plugin that will have its own sidebar. You can do so by using the [registerPlugin](/docs/designers-developers/developers/packages/packages-plugins/), [PluginSidebar](/docs/designers-developers/developers/packages/packages-edit-post/#pluginsidebar), and [createElement](/docs/designers-developers/developers/packages/packages-element/) utilities provided by WordPress, to be found in the `@wordpress/plugins`, `@wordpress/edit-post`, and `@wordpress/element` [packages](/docs/designers-developers/developers/packages/), respectively.
+The first step in the journey is to tell the editor that there is a new plugin that will have its own sidebar. You can do so by using the [registerPlugin](/packages/plugins/REAMDE.md), [PluginSidebar](/packages/edit-post/README.md#pluginsidebar), and [createElement](/packages/element/README.md) utilities provided by WordPress, to be found in the `@wordpress/plugins`, `@wordpress/edit-post`, and `@wordpress/element` [packages](/docs/designers-developers/developers/packages.md), respectively.
 
 Add the following code to a JavaScript file called `plugin-sidebar.js` and save it within your plugin's directory:
 

--- a/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-1-up-and-running.md
+++ b/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-1-up-and-running.md
@@ -1,6 +1,6 @@
 # Get a sidebar up and running
 
-The first step in the journey is to tell the editor that there is a new plugin that will have its own sidebar. You can do so by using the [registerPlugin](../../../../../docs/designers-developers/developers/packages/packages-plugins/), [PluginSidebar](../../../../../docs/designers-developers/developers/packages/packages-edit-post/#pluginsidebar), and [createElement](../../../../../docs/designers-developers/developers/packages/packages-element/) utilities provided by WordPress, to be found in the `@wordpress/plugins`, `@wordpress/edit-post`, and `@wordpress/element` [packages](../../../../../docs/designers-developers/developers/packages/), respectively.
+The first step in the journey is to tell the editor that there is a new plugin that will have its own sidebar. You can do so by using the [registerPlugin](/docs/designers-developers/developers/packages/packages-plugins/), [PluginSidebar](/docs/designers-developers/developers/packages/packages-edit-post/#pluginsidebar), and [createElement](/docs/designers-developers/developers/packages/packages-element/) utilities provided by WordPress, to be found in the `@wordpress/plugins`, `@wordpress/edit-post`, and `@wordpress/element` [packages](/docs/designers-developers/developers/packages/), respectively.
 
 Add the following code to a JavaScript file called `plugin-sidebar.js` and save it within your plugin's directory:
 

--- a/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-2-styles-and-controls.md
+++ b/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-2-styles-and-controls.md
@@ -2,7 +2,7 @@
 
 After the sidebar is up and running, the next step is to fill it up with the necessary components and basic styling.
 
-To visualize and edit the meta field value you'll use an input component. The `@wordpress/components` package contains many components available for you to reuse, and, specifically, the [TextControl](../../../../../docs/designers-developers/developers/components/text-control/) is aimed at creating an input field:
+To visualize and edit the meta field value you'll use an input component. The `@wordpress/components` package contains many components available for you to reuse, and, specifically, the [TextControl](/docs/designers-developers/developers/components/text-control/) is aimed at creating an input field:
 
 ```js
 ( function( wp ) {

--- a/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-2-styles-and-controls.md
+++ b/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-2-styles-and-controls.md
@@ -2,7 +2,7 @@
 
 After the sidebar is up and running, the next step is to fill it up with the necessary components and basic styling.
 
-To visualize and edit the meta field value you'll use an input component. The `@wordpress/components` package contains many components available for you to reuse, and, specifically, the [TextControl](/docs/designers-developers/developers/components/text-control/) is aimed at creating an input field:
+To visualize and edit the meta field value you'll use an input component. The `@wordpress/components` package contains many components available for you to reuse, and, specifically, the [TextControl](/packages/components/src/text-control/README.md) is aimed at creating an input field:
 
 ```js
 ( function( wp ) {

--- a/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-3-register-meta.md
+++ b/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-3-register-meta.md
@@ -12,7 +12,7 @@ register_meta( 'post', 'sidebar_plugin_meta_block_field', array(
 ) );
 ```
 
-To make sure the field has been loaded, query the block editor [internal data structures](../../../../../docs/designers-developers/developers/data/), also known as _stores_. Open your browser's console, and execute this piece of code:
+To make sure the field has been loaded, query the block editor [internal data structures](/docs/designers-developers/developers/data/), also known as _stores_. Open your browser's console, and execute this piece of code:
 
 ```js
 wp.data.select( 'core/editor' ).getCurrentPost().meta;

--- a/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-4-initialize-input.md
+++ b/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-4-initialize-input.md
@@ -39,7 +39,7 @@ Now that the field is available in the editor store, it can be surfaced to the U
 
 Now you can focus solely on the `MetaBlockField` component. The goal is to initialize it with the value of `sidebar_plugin_meta_block_field`, but also to keep it updated when that value changes.
 
-WordPress has [some utilities to work with data](/docs/designers-developers/developers/packages/packages-data/) from the stores. The first you're going to use is [withSelect](/docs/designers-developers/developers/packages/packages-data/#withselect-mapselecttoprops-function-function), whose signature is:
+WordPress has [some utilities to work with data](/packages/data/README.md) from the stores. The first you're going to use is [withSelect](/packages/data/README.md#withselect-mapselecttoprops-function-function), whose signature is:
 
 ```js
 withSelect(

--- a/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-4-initialize-input.md
+++ b/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-4-initialize-input.md
@@ -39,7 +39,7 @@ Now that the field is available in the editor store, it can be surfaced to the U
 
 Now you can focus solely on the `MetaBlockField` component. The goal is to initialize it with the value of `sidebar_plugin_meta_block_field`, but also to keep it updated when that value changes.
 
-WordPress has [some utilities to work with data](../../../../../docs/designers-developers/developers/packages/packages-data/) from the stores. The first you're going to use is [withSelect](../../../../../docs/designers-developers/developers/packages/packages-data/#withselect-mapselecttoprops-function-function), whose signature is:
+WordPress has [some utilities to work with data](/docs/designers-developers/developers/packages/packages-data/) from the stores. The first you're going to use is [withSelect](/docs/designers-developers/developers/packages/packages-data/#withselect-mapselecttoprops-function-function), whose signature is:
 
 ```js
 withSelect(
@@ -105,7 +105,7 @@ This is how the code changes from the previous section:
 
 * The `MetaBlockField` function has now a `props` argument as input. It contains the data object returned by the `mapSelectToProps` function, which it uses to initialize its value property.
 * The component rendered within the `div` element was also updated, the plugin now uses `MetaBlockFieldWithData`. This will be updated every time the original data changes.
-* [getEditedPostAttribute](../../../../../docs/designers-developers/developers/data/data-core-editor/#geteditedpostattribute) is used to retrieve data instead of [getCurrentPost](../../../../../docs/designers-developers/developers/data/data-core-editor/#getcurrentpost) because it returns the most recent values of the post, including user editions that haven't been yet saved.
+* [getEditedPostAttribute](/docs/designers-developers/developers/data/data-core-editor/#geteditedpostattribute) is used to retrieve data instead of [getCurrentPost](/docs/designers-developers/developers/data/data-core-editor/#getcurrentpost) because it returns the most recent values of the post, including user editions that haven't been yet saved.
 
 Update the code and open the sidebar. The input's content is no longer `Initial value` but a void string. Users can't type values yet, but let's check that the component is updated if the value in the store changes. Open the browser's console, execute
 

--- a/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-4-initialize-input.md
+++ b/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-4-initialize-input.md
@@ -105,7 +105,7 @@ This is how the code changes from the previous section:
 
 * The `MetaBlockField` function has now a `props` argument as input. It contains the data object returned by the `mapSelectToProps` function, which it uses to initialize its value property.
 * The component rendered within the `div` element was also updated, the plugin now uses `MetaBlockFieldWithData`. This will be updated every time the original data changes.
-* [getEditedPostAttribute](/docs/designers-developers/developers/data/data-core-editor/#geteditedpostattribute) is used to retrieve data instead of [getCurrentPost](/docs/designers-developers/developers/data/data-core-editor/#getcurrentpost) because it returns the most recent values of the post, including user editions that haven't been yet saved.
+* [getEditedPostAttribute](/docs/designers-developers/developers/data/data-core-editor.md#geteditedpostattribute) is used to retrieve data instead of [getCurrentPost](/docs/designers-developers/developers/data/data-core-editor.md#getcurrentpost) because it returns the most recent values of the post, including user editions that haven't been yet saved.
 
 Update the code and open the sidebar. The input's content is no longer `Initial value` but a void string. Users can't type values yet, but let's check that the component is updated if the value in the store changes. Open the browser's console, execute
 

--- a/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-5-update-meta.md
+++ b/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-5-update-meta.md
@@ -1,6 +1,6 @@
 # Update the meta field when the input's content changes
 
-The last step in the journey is to update the meta field when the input content changes. To do that, you'll use another utility from the `@wordpress/data` package, [withDispatch](../../../../../docs/designers-developers/developers/packages/packages-data/#withdispatch-mapdispatchtoprops-function-function).
+The last step in the journey is to update the meta field when the input content changes. To do that, you'll use another utility from the `@wordpress/data` package, [withDispatch](/docs/designers-developers/developers/packages/packages-data/#withdispatch-mapdispatchtoprops-function-function).
 
 `withDispatch` works similarly to `withSelect`. It takes two functions, the first returns an object with data, and the second takes that data object as input and returns a new UI component. Let's see how to use it:
 

--- a/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-5-update-meta.md
+++ b/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-5-update-meta.md
@@ -1,6 +1,6 @@
 # Update the meta field when the input's content changes
 
-The last step in the journey is to update the meta field when the input content changes. To do that, you'll use another utility from the `@wordpress/data` package, [withDispatch](/docs/designers-developers/developers/packages/packages-data/#withdispatch-mapdispatchtoprops-function-function).
+The last step in the journey is to update the meta field when the input content changes. To do that, you'll use another utility from the `@wordpress/data` package, [withDispatch](/packages/data/README.md#withdispatch-mapdispatchtoprops-function-function).
 
 `withDispatch` works similarly to `withSelect`. It takes two functions, the first returns an object with data, and the second takes that data object as input and returns a new UI component. Let's see how to use it:
 

--- a/docs/designers-developers/faq.md
+++ b/docs/designers-developers/faq.md
@@ -251,7 +251,7 @@ Our [list of supported browsers can be found in the Make WordPress handbook](htt
 
 ## How do I make my own block?
 
-The API for creating blocks is a crucial aspect of the project. We are working on improved documentation and tutorials. Check out the [Creating Block Types](../../docs/designers-developers/developers/tutorials/block-tutorial/readme.md) section to get started.
+The API for creating blocks is a crucial aspect of the project. We are working on improved documentation and tutorials. Check out the [Creating Block Types](/docs/designers-developers/developers/tutorials/block-tutorial/readme.md) section to get started.
 
 ## Does Gutenberg involve editing posts/pages in the front-end?
 
@@ -295,7 +295,7 @@ Blocks will be able to provide base structural CSS styles, and themes can add st
 
 Other features, like the new _wide_ and _full-wide_ alignment options, will simply be CSS classes applied to blocks that offer this alignment. We are looking at how a theme can opt in to this feature, for example using `add_theme_support`.
 
-*See:* [Theme Support](../../docs/designers-developers/developers/themes/theme-support.md)
+*See:* [Theme Support](/docs/designers-developers/developers/themes/theme-support.md)
 
 ## How will editor styles work?
 
@@ -308,7 +308,7 @@ function gutenbergtheme_editor_styles() {
 add_action( 'enqueue_block_editor_assets', 'gutenbergtheme_editor_styles' );
 ```
 
-*See:* [Editor Styles](../../docs/designers-developers/developers/themes/theme-support.md#editor-styles)
+*See:* [Editor Styles](/docs/designers-developers/developers/themes/theme-support.md#editor-styles)
 
 ## Should I be concerned that Gutenberg will make my plugin obsolete?
 
@@ -353,7 +353,7 @@ Our approach—as outlined in [the technical overview introduction](https://make
 
 This also [gives us the flexibility](https://github.com/WordPress/gutenberg/issues/1516) to store those blocks that are inherently separate from the content stream (reusable pieces like widgets or small post type elements) elsewhere, and just keep token references for their placement.
 
-We suggest you look at the [Gutenberg key concepts](../../docs/designers-developers/key-concepts.md) to learn more about how this aspect of the project works.
+We suggest you look at the [Gutenberg key concepts](/docs/designers-developers/key-concepts.md) to learn more about how this aspect of the project works.
 
 ## How can I parse the post content back out into blocks in PHP or JS?
 In JS:

--- a/docs/designers-developers/key-concepts.md
+++ b/docs/designers-developers/key-concepts.md
@@ -123,7 +123,7 @@ After running this through the parser we're left with a simple object we can man
 
 This has dramatic implications for how simple and performant we can make our parser. These explicit boundaries also protect damage in a single block from bleeding into other blocks or tarnishing the entire document. It also allows the system to identify unrecognized blocks before rendering them.
 
-_N.B.:_ The defining aspect of blocks are their semantics and the isolation mechanism they provide; in other words, their identity. On the other hand, where their data is stored is a more liberal aspect. Blocks support more than just static local data (via JSON literals inside the HTML comment or within the block's HTML), and more mechanisms (_e.g._, global blocks or otherwise resorting to storage in complementary `WP_Post` objects) are expected. See [attributes](../../docs/designers-developers/developers/block-api/block-attributes.md) for details.
+_N.B.:_ The defining aspect of blocks are their semantics and the isolation mechanism they provide; in other words, their identity. On the other hand, where their data is stored is a more liberal aspect. Blocks support more than just static local data (via JSON literals inside the HTML comment or within the block's HTML), and more mechanisms (_e.g._, global blocks or otherwise resorting to storage in complementary `WP_Post` objects) are expected. See [attributes](/docs/designers-developers/developers/block-api/block-attributes.md) for details.
 
 ## The Anatomy of a Serialized Block
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -6,7 +6,7 @@ The Gutenberg project provides three sources of documentation:
 
 Learn how to build blocks and extend the editor, best practices for designing block interfaces, and how to create themes that make the most of the new features Gutenberg provides.
 
-[Visit the Designer & Developer Handbook](../docs/designers-developers/readme.md)
+[Visit the Designer & Developer Handbook](/docs/designers-developers/readme.md)
 
 ## User Handbook
 
@@ -17,4 +17,4 @@ Discover the new features Gutenberg offers, learn how your site will be affected
 
 Help make Gutenberg better by contributing ideas, code, testing, and more.
 
-[Visit the Contributor Handbook](../docs/contributors/readme.md)
+[Visit the Contributor Handbook](/docs/contributors/readme.md)

--- a/docs/tool/generator.js
+++ b/docs/tool/generator.js
@@ -17,7 +17,7 @@ function generateTableOfContent( parsedNamespaces ) {
 		'# Data Module Reference',
 		'',
 		Object.values( parsedNamespaces ).map( ( parsedNamespace ) => {
-			return ` - [**${ parsedNamespace.name }**: ${ parsedNamespace.title }](../../docs/designers-developers/developers/data/data-${ kebabCase( parsedNamespace.name ) }.md)`;
+			return ` - [**${ parsedNamespace.name }**: ${ parsedNamespace.title }](/docs/designers-developers/developers/data/data-${ kebabCase( parsedNamespace.name ) }.md)`;
 		} ).join( '\n' ),
 	].join( '\n' );
 }

--- a/packages/components/CONTRIBUTING.md
+++ b/packages/components/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for taking the time to contribute.
 
-The following is a set of guidelines for contributing to the `@wordpress/components` package to be considered in addition to the general ones described in our [Contributing Policy](../../CONTRIBUTING.md).
+The following is a set of guidelines for contributing to the `@wordpress/components` package to be considered in addition to the general ones described in our [Contributing Policy](/CONTRIBUTING.md).
 
 ## Examples
 

--- a/test/integration/full-content/fixtures/README.md
+++ b/test/integration/full-content/fixtures/README.md
@@ -45,5 +45,5 @@ However, when using this command, please be sure to manually verify that the
 contents of the `.json` and `.serialized.html` files are as expected.
 
 See the
-[`full-content.spec.js`](/full-content.spec.js)
+[`full-content.spec.js`](../full-content.spec.js)
 test file for the code that runs these tests.

--- a/test/integration/full-content/fixtures/README.md
+++ b/test/integration/full-content/fixtures/README.md
@@ -45,5 +45,5 @@ However, when using this command, please be sure to manually verify that the
 contents of the `.json` and `.serialized.html` files are as expected.
 
 See the
-[`full-content.spec.js`](../full-content.spec.js)
+[`full-content.spec.js`](/full-content.spec.js)
 test file for the code that runs these tests.


### PR DESCRIPTION
Updates links across docs for consitency.

Ref:
https://wordpress.org/gutenberg/handbook/contributors/document/#using-links