### PR TITLE
Plugin: Remove TinyMCE-specific vendor script handling

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -599,32 +599,21 @@ function gutenberg_register_vendor_scripts() {
  * @since 0.1.0
  */
 function gutenberg_vendor_script_filename( $handle, $src ) {
-	$match_tinymce_plugin = preg_match(
-		'@tinymce.*/plugins/([^/]+)/plugin(\.min)?\.js$@',
-		$src,
-		$tinymce_plugin_pieces
+	$filename = basename( $src );
+	$match    = preg_match(
+		'/^'
+		. '(?P<ignore>.*?)'
+		. '(?P<suffix>\.min)?'
+		. '(?P<extension>\.js)'
+		. '(?P<extra>.*)'
+		. '$/',
+		$filename,
+		$filename_pieces
 	);
-	if ( $match_tinymce_plugin ) {
-		$prefix = 'tinymce-plugin-' . $tinymce_plugin_pieces[1];
-		$suffix = isset( $tinymce_plugin_pieces[2] ) ? $tinymce_plugin_pieces[2] : '';
-	} else {
-		$filename = basename( $src );
-		$match    = preg_match(
-			'/^'
-			. '(?P<ignore>.*?)'
-			. '(?P<suffix>\.min)?'
-			. '(?P<extension>\.js)'
-			. '(?P<extra>.*)'
-			. '$/',
-			$filename,
-			$filename_pieces
-		);
 
-		$prefix = $handle;
-		$suffix = $match ? $filename_pieces['suffix'] : '';
-	}
-
-	$hash = substr( md5( $src ), 0, 8 );
+	$prefix = $handle;
+	$suffix = $match ? $filename_pieces['suffix'] : '';
+	$hash   = substr( md5( $src ), 0, 8 );
 
 	return "${prefix}${suffix}.${hash}.js";
 }

--- a/phpunit/class-vendor-script-filename-test.php
+++ b/phpunit/class-vendor-script-filename-test.php
@@ -19,16 +19,6 @@ class Vendor_Script_Filename_Test extends WP_UnitTestCase {
 				'https://unpkg.com/react-dom@16.6.3/umd/react-dom.development.js',
 				'react-dom-handle.HASH.js',
 			),
-			array(
-				'tinymce-handle',
-				'https://fiddle.azurewebsites.net/tinymce/nightly/tinymce.js',
-				'tinymce-handle.HASH.js',
-			),
-			array(
-				'tinymce-plugin-handle',
-				'https://fiddle.azurewebsites.net/tinymce/nightly/plugins/lists/plugin.js',
-				'tinymce-plugin-lists.HASH.js',
-			),
 			// Production mode scripts.
 			array(
 				'react-handle',
@@ -39,16 +29,6 @@ class Vendor_Script_Filename_Test extends WP_UnitTestCase {
 				'react-dom-handle',
 				'https://unpkg.com/react-dom@16.6.3/umd/react-dom.production.min.js',
 				'react-dom-handle.min.HASH.js',
-			),
-			array(
-				'tinymce-handle',
-				'https://fiddle.azurewebsites.net/tinymce/nightly/tinymce.min.js',
-				'tinymce-handle.min.HASH.js',
-			),
-			array(
-				'tinymce-plugin-handle',
-				'https://fiddle.azurewebsites.net/tinymce/nightly/plugins/lists/plugin.min.js',
-				'tinymce-plugin-lists.min.HASH.js',
 			),
 			// Other cases.
 			array(


### PR DESCRIPTION
Related: #12170

This pull request seeks to remove TinyMCE-specific handling in `gutenberg_vendor_script_filename`. This was previously needed when Gutenberg would load TinyMCE plugins using the `gutenberg_register_vendor_script` mechanism in producing a unique name. This was later removed in #12170, but the handling of TinyMCE plugin scripts was not removed from `gutenberg_vendor_script_filename`. The changes here account for these removals.

**Testing instructions:**

Repeat testing instructions from #12170.

In code, verify there are no lingering references to vendor-registered TinyMCE scripts from Gutenberg through `gutenberg_register_vendor_script`.