### PR TITLE
Fix wp-settings permissions

### DIFF
--- a/bin/install-wordpress.sh
+++ b/bin/install-wordpress.sh
@@ -65,6 +65,7 @@ fi
 # Make sure the uploads and upgrade folders exist and we have permissions to add files.
 echo -e $(status_message "Ensuring that files can be uploaded...")
 docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CONTAINER chmod 767 /var/www/html/wp-content/plugins
+docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CONTAINER chmod 767 /var/www/html/wp-settings.php
 docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CONTAINER mkdir -p /var/www/html/wp-content/uploads
 docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CONTAINER chmod -v 767 /var/www/html/wp-content/uploads
 docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CONTAINER mkdir -p /var/www/html/wp-content/upgrade


### PR DESCRIPTION
This PR fixes an error with the `./bin/setup-environment.sh` command by setting the `wp-settings.php` permissions to something `wp-cli core update` won't complain about.

## Description

Upon exectuion, I've got the following error:

> The update cannot be installed because we will be unable to copy some files. This is usually due to inconsistent file permissions.: wp-settings.php

![screenshot from 2019-01-25 11-21-46](https://user-images.githubusercontent.com/583546/51841581-4b850080-230f-11e9-8968-c004339f0041.png)

It looks like the [WordPress core update](https://github.com/WordPress/gutenberg/blob/0b84e6717b6175dc62865d483d72894eba091e82/bin/install-wordpress.sh#L79) can't proceed due to wp-settings.php permissions.

## Test

Executing the command and check that it's able to upgrade to latest WordPress.

I've done this by trying a fresh start (removed docker images and containers, cloned repo, and executed `./bin/setup-environment.sh` command), but if you have a WordPress version < 5.0.3 as the offending line is [the `core update` command](https://github.com/WordPress/gutenberg/blob/0b84e6717b6175dc62865d483d72894eba091e82/bin/install-wordpress.sh#L79).
