### PR TITLE
Improve default Babel preset to include JSX pragma

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,16 +3,6 @@ module.exports = function( api ) {
 
 	return {
 		presets: [ '@wordpress/babel-preset-default' ],
-		plugins: [
-			[
-				'@wordpress/babel-plugin-import-jsx-pragma',
-				{
-					scopeVariable: 'createElement',
-					source: '@wordpress/element',
-					isDefault: false,
-				},
-			],
-		],
 		env: {
 			production: {
 				plugins: [

--- a/bin/packages/get-babel-config.js
+++ b/bin/packages/get-babel-config.js
@@ -10,14 +10,7 @@ const babel = require( '@babel/core' );
 const { options: babelDefaultConfig } = babel.loadPartialConfig( {
 	configFile: '@wordpress/babel-preset-default',
 } );
-const plugins = babelDefaultConfig.plugins;
-if ( ! process.env.SKIP_JSX_PRAGMA_TRANSFORM ) {
-	plugins.push( [ '@wordpress/babel-plugin-import-jsx-pragma', {
-		scopeVariable: 'createElement',
-		source: '@wordpress/element',
-		isDefault: false,
-	} ] );
-}
+const { plugins, presets } = babelDefaultConfig;
 
 const overrideOptions = ( target, targetName, options ) => {
 	if ( get( target, [ 'file', 'request' ] ) === targetName ) {
@@ -37,7 +30,7 @@ const babelConfigs = {
 		{
 			plugins,
 			presets: map(
-				babelDefaultConfig.presets,
+				presets,
 				( preset ) => overrideOptions( preset, '@babel/preset-env', {
 					modules: 'commonjs',
 				} )
@@ -55,7 +48,7 @@ const babelConfigs = {
 				} )
 			),
 			presets: map(
-				babelDefaultConfig.presets,
+				presets,
 				( preset ) => overrideOptions( preset, '@babel/preset-env', {
 					modules: false,
 				} )

--- a/bin/packages/get-packages.js
+++ b/bin/packages/get-packages.js
@@ -3,7 +3,7 @@
  */
 const fs = require( 'fs' );
 const path = require( 'path' );
-const { overEvery, compact, includes, negate } = require( 'lodash' );
+const { overEvery } = require( 'lodash' );
 
 /**
  * Absolute path to packages directory.
@@ -11,36 +11,6 @@ const { overEvery, compact, includes, negate } = require( 'lodash' );
  * @type {string}
  */
 const PACKAGES_DIR = path.resolve( __dirname, '../../packages' );
-
-const {
-	/**
-	 * Comma-separated string of packages to include in build.
-	 *
-	 * @type {string}
-	 */
-	INCLUDE_PACKAGES,
-
-	/**
-	 * Comma-separated string of packages to exclude from build.
-	 *
-	 * @type {string}
-	 */
-	EXCLUDE_PACKAGES,
-} = process.env;
-
-/**
- * Given a comma-separated string, returns a filter function which returns true
- * if the item is contained within as a comma-separated entry.
- *
- * @param {Function} filterFn Filter function to call with item to test.
- * @param {string}   list     Comma-separated list of items.
- *
- * @return {Function} Filter function.
- */
-const createCommaSeparatedFilter = ( filterFn, list ) => {
-	const listItems = list.split( ',' );
-	return ( item ) => filterFn( listItems, item );
-};
 
 /**
  * Returns true if the given base file name for a file within the packages
@@ -62,11 +32,7 @@ function isDirectory( file ) {
  *
  * @return {boolean} Whether to include file in build.
  */
-const filterPackages = overEvery( compact( [
-	isDirectory,
-	INCLUDE_PACKAGES && createCommaSeparatedFilter( includes, INCLUDE_PACKAGES ),
-	EXCLUDE_PACKAGES && createCommaSeparatedFilter( negate( includes ), EXCLUDE_PACKAGES ),
-] ) );
+const filterPackages = overEvery( isDirectory );
 
 /**
  * Returns the absolute path of all WordPress packages

--- a/package-lock.json
+++ b/package-lock.json
@@ -2496,10 +2496,7 @@
 		},
 		"@wordpress/babel-plugin-import-jsx-pragma": {
 			"version": "file:packages/babel-plugin-import-jsx-pragma",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.3.1"
-			}
+			"dev": true
 		},
 		"@wordpress/babel-plugin-makepot": {
 			"version": "file:packages/babel-plugin-makepot",
@@ -2521,6 +2518,7 @@
 				"@babel/plugin-transform-runtime": "^7.2.0",
 				"@babel/preset-env": "^7.3.1",
 				"@babel/runtime": "^7.3.1",
+				"@wordpress/babel-plugin-import-jsx-pragma": "file:packages/babel-plugin-import-jsx-pragma",
 				"@wordpress/browserslist-config": "file:packages/browserslist-config"
 			}
 		},
@@ -2975,7 +2973,6 @@
 			"version": "file:packages/postcss-themes",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.3.1",
 				"autoprefixer": "^9.4.5",
 				"postcss": "^7.0.13",
 				"postcss-color-function": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -150,8 +150,8 @@
 	"scripts": {
 		"prebuild": "npm run check-engines",
 		"clean:packages": "rimraf ./packages/*/build ./packages/*/build-module ./packages/*/build-style",
-		"prebuild:packages": "npm run clean:packages && lerna run build && cross-env INCLUDE_PACKAGES=babel-plugin-import-jsx-pragma,postcss-themes,jest-console SKIP_JSX_PRAGMA_TRANSFORM=1 node ./bin/packages/build.js",
-		"build:packages": "cross-env EXCLUDE_PACKAGES=babel-plugin-import-jsx-pragma,jest-console,postcss-themes node ./bin/packages/build.js",
+		"prebuild:packages": "npm run clean:packages && lerna run build",
+		"build:packages": "node ./bin/packages/build.js",
 		"build": "npm run build:packages && wp-scripts build",
 		"check-engines": "wp-scripts check-engines",
 		"check-licenses": "concurrently \"wp-scripts check-licenses --prod --gpl2\" \"wp-scripts check-licenses --dev\"",

--- a/packages/babel-plugin-import-jsx-pragma/CHANGELOG.md
+++ b/packages/babel-plugin-import-jsx-pragma/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Breaking Change
 
 - Plugin skips now adding import JSX pragma when the scope variable is defined for all JSX elements ([#13809](https://github.com/WordPress/gutenberg/pull/13809)). 
+- Stop using Babel transpilation internally and set node 8 as a minimal version required ([#13540](https://github.com/WordPress/gutenberg/pull/13540)).
 
 ## 1.1.0 (2018-09-05)
 

--- a/packages/babel-plugin-import-jsx-pragma/index.js
+++ b/packages/babel-plugin-import-jsx-pragma/index.js
@@ -26,15 +26,12 @@ const DEFAULT_OPTIONS = {
  *
  * @return {Object} Babel transform plugin.
  */
-export default function( babel ) {
+module.exports = function( babel ) {
 	const { types: t } = babel;
 
 	function getOptions( state ) {
 		if ( ! state._options ) {
-			state._options = {
-				...DEFAULT_OPTIONS,
-				...state.opts,
-			};
+			state._options = Object.assign( {}, DEFAULT_OPTIONS, state.opts );
 		}
 
 		return state._options;
@@ -106,4 +103,4 @@ export default function( babel ) {
 			},
 		},
 	};
-}
+};

--- a/packages/babel-plugin-import-jsx-pragma/package.json
+++ b/packages/babel-plugin-import-jsx-pragma/package.json
@@ -19,15 +19,13 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
-	"files": [
-		"build",
-		"build-module"
-	],
-	"main": "build/index.js",
-	"module": "build-module/index.js",
-	"dependencies": {
-		"@babel/runtime": "^7.3.1"
+	"engines": {
+		"node": ">=8"
 	},
+	"files": [
+		"index.js"
+	],
+	"main": "index.js",
 	"peerDependencies": {
 		"@babel/core": "^7.0.0"
 	},

--- a/packages/babel-plugin-import-jsx-pragma/test/index.js
+++ b/packages/babel-plugin-import-jsx-pragma/test/index.js
@@ -6,7 +6,7 @@ import { transformSync } from '@babel/core';
 /**
  * Internal dependencies
  */
-import plugin from '../src';
+import plugin from '../';
 
 describe( 'babel-plugin-import-jsx-pragma', () => {
 	function getTransformedCode( source, options = {} ) {

--- a/packages/babel-plugin-makepot/package.json
+++ b/packages/babel-plugin-makepot/package.json
@@ -18,6 +18,9 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
+	"engines": {
+		"node": ">=8"
+	},
 	"files": [
 		"build",
 		"build-module"

--- a/packages/babel-preset-default/CHANGELOG.md
+++ b/packages/babel-preset-default/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Breaking Change
 
+- Plugin updated to include `@wordpress/babel-plugin-import-jsx-pragma` plugin integration.
 - Removed `babel-core` dependency acting as Babel 7 bridge ([#13922](https://github.com/WordPress/gutenberg/pull/13922). Ensure all references to `babel-core` are replaced with `@babel/core` .
 
 ## 3.0.0 (2018-09-30)

--- a/packages/babel-preset-default/CHANGELOG.md
+++ b/packages/babel-preset-default/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Breaking Change
 
-- Plugin updated to include `@wordpress/babel-plugin-import-jsx-pragma` plugin integration.
 - Removed `babel-core` dependency acting as Babel 7 bridge ([#13922](https://github.com/WordPress/gutenberg/pull/13922). Ensure all references to `babel-core` are replaced with `@babel/core` .
+- Preset updated to include `@wordpress/babel-plugin-import-jsx-pragma` plugin integration ([#13540](https://github.com/WordPress/gutenberg/pull/13540)).
 
 ## 3.0.0 (2018-09-30)
 

--- a/packages/babel-preset-default/index.js
+++ b/packages/babel-preset-default/index.js
@@ -15,6 +15,14 @@ module.exports = function( api ) {
 		].filter( Boolean ),
 		plugins: [
 			'@babel/plugin-proposal-object-rest-spread',
+			[
+				'@wordpress/babel-plugin-import-jsx-pragma',
+				{
+					scopeVariable: 'createElement',
+					source: '@wordpress/element',
+					isDefault: false,
+				},
+			],
 			[ '@babel/plugin-transform-react-jsx', {
 				pragma: 'createElement',
 			} ],

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -21,6 +21,9 @@
 	"engines": {
 		"node": ">=8"
 	},
+	"files": [
+		"index.js"
+	],
 	"main": "index.js",
 	"dependencies": {
 		"@babel/core": "^7.2.2",
@@ -30,6 +33,7 @@
 		"@babel/plugin-transform-runtime": "^7.2.0",
 		"@babel/preset-env": "^7.3.1",
 		"@babel/runtime": "^7.3.1",
+		"@wordpress/babel-plugin-import-jsx-pragma": "file:../babel-plugin-import-jsx-pragma",
 		"@wordpress/browserslist-config": "file:../browserslist-config"
 	},
 	"peerDependencies": {

--- a/packages/custom-templated-path-webpack-plugin/package.json
+++ b/packages/custom-templated-path-webpack-plugin/package.json
@@ -17,6 +17,9 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
+	"engines": {
+		"node": ">=8"
+	},
 	"files": [
 		"build",
 		"build-module"

--- a/packages/e2e-test-utils/package.json
+++ b/packages/e2e-test-utils/package.json
@@ -17,6 +17,9 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
+	"engines": {
+		"node": ">=8"
+	},
 	"files": [
 		"build",
 		"build-module"

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -17,6 +17,9 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
+	"engines": {
+		"node": ">=8"
+	},
 	"dependencies": {
 		"@wordpress/e2e-test-utils": "file:../e2e-test-utils",
 		"@wordpress/jest-console": "file:../jest-console",

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -18,6 +18,9 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
+	"engines": {
+		"node": ">=8"
+	},
 	"files": [
 		"build",
 		"build-module"

--- a/packages/jest-preset-default/package.json
+++ b/packages/jest-preset-default/package.json
@@ -20,6 +20,9 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
+	"engines": {
+		"node": ">=8"
+	},
 	"files": [
 		"scripts",
 		"jest-preset.json"

--- a/packages/jest-puppeteer-axe/package.json
+++ b/packages/jest-puppeteer-axe/package.json
@@ -19,6 +19,9 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
+	"engines": {
+		"node": ">=8"
+	},
 	"files": [
 		"build",
 		"build-module"

--- a/packages/library-export-default-webpack-plugin/package.json
+++ b/packages/library-export-default-webpack-plugin/package.json
@@ -17,6 +17,9 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
+	"engines": {
+		"node": ">=8"
+	},
 	"files": [
 		"build",
 		"build-module"

--- a/packages/npm-package-json-lint-config/package.json
+++ b/packages/npm-package-json-lint-config/package.json
@@ -17,6 +17,9 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
+	"engines": {
+		"node": ">=8"
+	},
 	"main": "index.js",
 	"peerDependencies": {
 		"npm-package-json-lint": ">=3.3.1"

--- a/packages/postcss-themes/CHANGELOG.md
+++ b/packages/postcss-themes/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 2.0.0 (Unreleased)
+
+### Breaking change
+
+- Stop using Babel transpilation internally and set node 8 as a minimal version required ([#13540](https://github.com/WordPress/gutenberg/pull/13540)).

--- a/packages/postcss-themes/index.js
+++ b/packages/postcss-themes/index.js
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 const postcss = require( 'postcss' );
 
 module.exports = postcss.plugin( 'postcss-themes', function( options ) {

--- a/packages/postcss-themes/package.json
+++ b/packages/postcss-themes/package.json
@@ -20,13 +20,14 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
+	"engines": {
+		"node": ">=8"
+	},
 	"files": [
-		"build",
-		"build-module"
+		"index.js"
 	],
-	"main": "build/index.js",
+	"main": "index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
 		"autoprefixer": "^9.4.5",
 		"postcss": "^7.0.13",
 		"postcss-color-function": "^4.0.1"

--- a/packages/postcss-themes/test/index.js
+++ b/packages/postcss-themes/test/index.js
@@ -6,7 +6,7 @@ import postcss from 'postcss';
 /**
  * Internal dependencies
  */
-import plugin from '../src';
+import plugin from '../';
 
 /**
  * Module constants


### PR DESCRIPTION
## Description

Depends on #13809.

This PR tries to include Babel transform plugin for automatically injecting an import to be used as the pragma for the React JSX Transform plugin in the default Babel preset for WordPress (`@wordpress/babel-plugin-import-jsx-pragma`). At the moment it is explicitly specified for Gutenberg. However, I noticed that this would be beneficial also for plugin developers as they need to provide their own Babel config if they want to use this plugin themselves. Example:
https://github.com/aduth/g-debugger/blob/master/.babelrc

To get there, this PR also had to update two existing packages which operate only in node environment. They were using transpilation from Babel to ES5 code. However, it turns out that it is possible to rewrite them to use node 8 and skip that phase. It allows simplifying the way packages are built. Instead of two steps with the whitelisting and blacklisting packages, there is now a way to do it in one go.

There was also a change introduced in #13809 which affects how import JSX pragma plugin is going to work with `wp.element.createElement`. It will only add this pragma when there JSX used and there is no `createElement` variable defined in the scope. This was necessary to ensure that this preset will continue to work with those project which use `wp.element.createElement` global explicitly for JSX.

## Testing
- `npm test`
- `npm run dev`
- `npm run test-e2e`

There should be no difference in the generated code for Gutenberg.