### PR TITLE
Fixes tense on verb “assign” to correct tense

### DIFF
--- a/docs/designers-developers/developers/block-api/block-templates.md
+++ b/docs/designers-developers/developers/block-api/block-templates.md
@@ -88,7 +88,7 @@ add_action( 'init', 'my_add_template_to_posts' );
 
 ## Nested Templates
 
-Container blocks like the columns blocks also support templates. This is achieved by assigned a nested template to the block.
+Container blocks like the columns blocks also support templates. This is achieved by assigning a nested template to the block.
 
 ```php
 $template = array(


### PR DESCRIPTION
Updates the [Block Templates - Nested Templates](https://wordpress.org/gutenberg/handbook/designers-developers/developers/block-api/block-templates/#nested-templates) section of the docs.

Previously the verb “assign” was using the past tense. Corrected to use the right tense given the context.

