### PR TITLE
Plugin: Remove lingering references to integrated classic editor

### DIFF
--- a/docs/designers-developers/developers/backward-compatibility/deprecations.md
+++ b/docs/designers-developers/developers/backward-compatibility/deprecations.md
@@ -2,6 +2,12 @@
 
 The Gutenberg project's deprecation policy is intended to support backward compatibility for releases, when possible. The current deprecations are listed below and are grouped by _the version at which they will be removed completely_. If your plugin depends on these behaviors, you must update to the recommended alternative before the noted version.
 
+## 5.3.0
+
+- The PHP function `gutenberg_redirect_to_classic_editor_when_saving_posts` has been removed.
+- The PHP function `gutenberg_revisions_link_to_editor` has been removed.
+- The PHP function `gutenberg_remember_classic_editor_when_saving_posts` has been removed.
+
 ## 5.2.0
 
 - The PHP function `gutenberg_parse_blocks` has been removed. Use [`parse_blocks`](https://developer.wordpress.org/reference/functions/parse_blocks/) instead.

--- a/docs/designers-developers/developers/backward-compatibility/meta-box.md
+++ b/docs/designers-developers/developers/backward-compatibility/meta-box.md
@@ -38,11 +38,11 @@ When Gutenberg is used, this meta box will no longer be displayed in the meta bo
 
 On each Gutenberg page load, we register an action that collects the meta box data to determine if an area is empty. The original global state is reset upon collection of meta box data.
 
-See `lib/register.php gutenberg_trick_plugins_into_registering_meta_boxes()`
+See [`register_and_do_post_meta_boxes`](https://developer.wordpress.org/reference/functions/register_and_do_post_meta_boxes/).
 
-`gutenberg_collect_meta_box_data()` is hooked in later on `admin_head`. It will run through the functions and hooks that `post.php` runs to register meta boxes; namely `add_meta_boxes`, `add_meta_boxes_{$post->post_type}`, and `do_meta_boxes`.
+It will run through the functions and hooks that `post.php` runs to register meta boxes; namely `add_meta_boxes`, `add_meta_boxes_{$post->post_type}`, and `do_meta_boxes`.
 
-A copy of the global `$wp_meta_boxes` is made then filtered through `apply_filters( 'filter_gutenberg_meta_boxes', $_meta_boxes_copy );`, which will strip out any core meta boxes, standard custom taxonomy meta boxes, and any meta boxes that have declared themselves as only existing for backward compatibility purposes.
+Meta boxes are filtered to strip out any core meta boxes, standard custom taxonomy meta boxes, and any meta boxes that have declared themselves as only existing for backward compatibility purposes.
 
 Then each location for this particular type of meta box is checked for whether it is active. If it is not empty a value of true is stored, if it is empty a value of false is stored. This meta box location data is then dispatched by the editor Redux store in `INITIALIZE_META_BOX_STATE`.
 
@@ -63,13 +63,9 @@ When the post is updated, only meta box areas that are active will be submitted.
 
 When the meta box area is saving, we display an updating overlay, to prevent users from changing the form values while a save is in progress.
 
-After the new block editor is made into the default editor, it will be necessary to provide the classic-editor flag to access the meta box partial page.
+An example save url would look like:
 
-`gutenberg_meta_box_save()` saves meta box changes. A `meta_box` request parameter should be present and should match one of `'advanced'`, `'normal'`, or `'side'`. This value will determine which meta box area is served.
-
-So an example url would look like:
-
-`mysite.com/wp-admin/post.php?post=1&action=edit&meta_box=$location&classic-editor`
+`mysite.com/wp-admin/post.php?post=1&action=edit&meta-box-loader=1`
 
 This url is automatically passed into React via a `_wpMetaBoxUrl` global variable.
 

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -31,21 +31,11 @@ function the_gutenberg_project() {
 	<noscript>
 		<div class="error" style="position:absolute;top:32px;z-index:40"><p>
 		<?php
-		// Using Gutenberg as Plugin.
-		if ( is_plugin_active( 'gutenberg/gutenberg.php' ) ) {
-			$current_url = esc_url( add_query_arg( 'classic-editor', true, $_SERVER['REQUEST_URI'] ) );
-			printf(
-				// Translators: link is to current page specify classic editor.
-				__( 'The Block Editor requires JavaScript. You can use the <a href="%s">Classic Editor</a>.', 'gutenberg' ),
-				$current_url
-			);
-		} else { // Using Gutenberg in Core.
-			printf(
-				/* translators: %s: https://wordpress.org/plugins/classic-editor/ */
-				__( 'The Block Editor requires JavaScript. Please try the <a href="%s">Classic Editor plugin</a>.', 'gutenberg' ),
-				__( 'https://wordpress.org/plugins/classic-editor/', 'gutenberg' )
-			);
-		}
+		printf(
+			/* translators: %s: https://wordpress.org/plugins/classic-editor/ */
+			__( 'The Block Editor requires JavaScript. Please try the <a href="%s">Classic Editor plugin</a>.', 'gutenberg' ),
+			__( 'https://wordpress.org/plugins/classic-editor/', 'gutenberg' )
+		);
 		?>
 		</p></div>
 	</noscript>
@@ -125,10 +115,6 @@ function is_gutenberg_page() {
 	}
 
 	if ( get_current_screen()->base !== 'post' ) {
-		return false;
-	}
-
-	if ( isset( $_GET['classic-editor'] ) ) {
 		return false;
 	}
 

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1110,7 +1110,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 	$post_autosave = gutenberg_get_autosave_newer_than_post_save( $post );
 	if ( $post_autosave ) {
 		$editor_settings['autosave'] = array(
-			'editLink' => add_query_arg( 'gutenberg', true, get_edit_post_link( $post_autosave->ID ) ),
+			'editLink' => get_edit_post_link( $post_autosave->ID ),
 		);
 	}
 

--- a/lib/register.php
+++ b/lib/register.php
@@ -203,67 +203,55 @@ function gutenberg_bulk_post_updated_messages( $messages ) {
  * Injects a hidden input in the edit form to propagate the information that classic editor is selected.
  *
  * @since 1.5.2
+ * @deprecated 5.0.0
  */
 function gutenberg_remember_classic_editor_when_saving_posts() {
-	?>
-	<input type="hidden" name="classic-editor" />
-	<?php
+	_deprecated_function( __FUNCTION__, '5.0.0' );
 }
-add_action( 'edit_form_top', 'gutenberg_remember_classic_editor_when_saving_posts' );
 
 /**
  * Appends a query argument to the redirect url to make sure it gets redirected to the classic editor.
  *
  * @since 1.5.2
+ * @deprecated 5.0.0
  *
  * @param string $url Redirect url.
  * @return string Redirect url.
  */
 function gutenberg_redirect_to_classic_editor_when_saving_posts( $url ) {
-	if ( isset( $_REQUEST['classic-editor'] ) ) {
-		$url = add_query_arg( 'classic-editor', '', $url );
-	}
+	_deprecated_function( __FUNCTION__, '5.0.0' );
+
 	return $url;
 }
-add_filter( 'redirect_post_location', 'gutenberg_redirect_to_classic_editor_when_saving_posts', 10, 1 );
 
 /**
  * Appends a query argument to the edit url to make sure it is redirected to
  * the editor from which the user navigated.
  *
  * @since 1.5.2
+ * @deprecated 5.0.0
  *
  * @param string $url Edit url.
  * @return string Edit url.
  */
 function gutenberg_revisions_link_to_editor( $url ) {
-	global $pagenow;
-	if ( 'revision.php' !== $pagenow || isset( $_REQUEST['gutenberg'] ) ) {
-		return $url;
-	}
+	_deprecated_function( __FUNCTION__, '5.0.0' );
 
-	return add_query_arg( 'classic-editor', '', $url );
+	return $url;
 }
-add_filter( 'get_edit_post_link', 'gutenberg_revisions_link_to_editor' );
 
 /**
  * Modifies revisions data to preserve Gutenberg argument used in determining
  * where to redirect user returning to editor.
  *
  * @since 1.9.0
+ * @deprecated 5.0.0
  *
  * @param array $revisions_data The bootstrapped data for the revisions screen.
  * @return array Modified bootstrapped data for the revisions screen.
  */
 function gutenberg_revisions_restore( $revisions_data ) {
-	if ( isset( $_REQUEST['gutenberg'] ) ) {
-		$revisions_data['restoreUrl'] = add_query_arg(
-			'gutenberg',
-			$_REQUEST['gutenberg'],
-			$revisions_data['restoreUrl']
-		);
-	}
+	_deprecated_function( __FUNCTION__, '5.0.0' );
 
 	return $revisions_data;
 }
-add_filter( 'wp_prepare_revision_for_js', 'gutenberg_revisions_restore' );

--- a/phpunit/class-admin-test.php
+++ b/phpunit/class-admin-test.php
@@ -140,41 +140,4 @@ class Admin_Test extends WP_UnitTestCase {
 		$this->assertTrue( gutenberg_content_has_blocks( $content_with_blocks ) );
 		$this->assertFalse( gutenberg_content_has_blocks( $content_without_blocks ) );
 	}
-
-	/**
-	 * Test that the revisions 'return to editor' links are set correctly for Classic & Gutenberg editors.
-	 *
-	 * @covers ::gutenberg_revisions_link_to_editor
-	 */
-	function test_gutenberg_revisions_link_to_editor() {
-		global $pagenow;
-
-		// Set up $pagenow so the filter will work.
-		$pagenow = 'revision.php';
-
-		// Test the filter when Gutenberg is the active editor.
-		$_REQUEST['gutenberg'] = '1';
-		$link                  = apply_filters( 'get_edit_post_link', 'http://test.com' );
-		$this->assertEquals( 'http://test.com', $link );
-
-		// Test the filter when Gutenberg is not the active editor.
-		unset( $_REQUEST['gutenberg'] );
-		$link = apply_filters( 'get_edit_post_link', 'http://test.com' );
-		$this->assertEquals( 'http://test.com?classic-editor', $link );
-	}
-
-	/**
-	 * Test that the revisions 'restore this revision' button links correctly for Classic & Gutenberg editors.
-	 */
-	function test_gutenberg_revisions_restore() {
-		// Test the filter when Gutenberg is the active editor.
-		$_REQUEST['gutenberg'] = '1';
-		$link                  = apply_filters( 'wp_prepare_revision_for_js', array( 'restoreUrl' => 'http://test.com' ) );
-		$this->assertEquals( array( 'restoreUrl' => 'http://test.com?gutenberg=1' ), $link );
-
-		// Test the filter when Gutenberg is not the active editor.
-		unset( $_REQUEST['gutenberg'] );
-		$link = apply_filters( 'wp_prepare_revision_for_js', array( 'restoreUrl' => 'http://test.com' ) );
-		$this->assertEquals( array( 'restoreUrl' => 'http://test.com' ), $link );
-	}
 }


### PR DESCRIPTION
Closes #12888

This pull request seeks to remove all remaining references to the classic editor option which had been supported in Gutenberg versions preceding the release to WordPress 5.0. Since WordPress 5.0, this functionality has been broken in the Gutenberg plugin. Users should use the [Classic Editor plugin](https://wordpress.org/plugins/classic-editor/) instead for the classic editor experience.

Primarily impacted:

- There were a handful of filters affecting the behavior of revisions to ensure that the user would be directed back to either the classic editor or the Gutenberg editor, depending on from they had arrived at the revisions screen. Since this can be assumed to be the block editor, it is no longer necessary (including the `?gutenberg` query argument).
- The "JavaScript disabled" messaging would direct the user to the (broken) classic editor experience. It now directs to the [Classic Editor plugin](https://wordpress.org/plugins/classic-editor/) instead.
- While not entirely related to "classic editor", the Meta Box documentation was left outdated from the related pull request #13449 . (Aside: This serves as testament to the fact that user-facing documentation shouldn't be written as so tied to a specific implementation, as it was already quite out of date before these changes)

**Testing instructions:**

Verify there are no regressions in the behavior of:

- Navigating to and from the revisions screen
- Disabled JavaScript messaging directing to the Classic Editor plugin
