### PR TITLE
Fix: Do not remove selected block on document tab

### DIFF
--- a/packages/edit-post/src/components/sidebar/settings-header/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-header/index.js
@@ -57,11 +57,9 @@ const SettingsHeader = ( { openDocumentSettings, openBlockSettings, sidebarName 
 
 export default withDispatch( ( dispatch ) => {
 	const { openGeneralSidebar } = dispatch( 'core/edit-post' );
-	const { clearSelectedBlock } = dispatch( 'core/editor' );
 	return {
 		openDocumentSettings() {
 			openGeneralSidebar( 'edit-post/document' );
-			clearSelectedBlock();
 		},
 		openBlockSettings() {
 			openGeneralSidebar( 'edit-post/block' );


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/13309

Previously when we selected the document tab on the sidebar the block was unselected, with these changes the block remains selected.

## How has this been tested?
I added some block, I selected a block, I toggled the sidebar to the document tab and I verified the block kept selected.

