### PR TITLE
WIP: make shift+enter work in lists

### DIFF
--- a/packages/e2e-tests/specs/blocks/__snapshots__/list.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/list.test.js.snap
@@ -144,6 +144,18 @@ exports[`List should indent and outdent level 2 3`] = `
 <!-- /wp:list -->"
 `;
 
+exports[`List should insert a line break on shift+enter 1`] = `
+"<!-- wp:list -->
+<ul><li>a<br><br></li></ul>
+<!-- /wp:list -->"
+`;
+
+exports[`List should insert a line break on shift+enter in a non trailing list item 1`] = `
+"<!-- wp:list -->
+<ul><li>a</li><li>b<br><br></li><li>c</li></ul>
+<!-- /wp:list -->"
+`;
+
 exports[`List should outdent with children 1`] = `
 "<!-- wp:list -->
 <ul><li>a<ul><li>b<ul><li>c</li></ul></li></ul></li></ul>

--- a/packages/e2e-tests/specs/blocks/list.test.js
+++ b/packages/e2e-tests/specs/blocks/list.test.js
@@ -280,4 +280,25 @@ describe( 'List', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should insert a line break on shift+enter', async () => {
+		await insertBlock( 'List' );
+		await page.keyboard.type( 'a' );
+		await pressKeyWithModifier( 'shift', 'Enter' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should insert a line break on shift+enter in a non trailing list item', async () => {
+		await insertBlock( 'List' );
+		await page.keyboard.type( 'a' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'b' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'c' );
+		await page.keyboard.press( 'ArrowUp' );
+		await pressKeyWithModifier( 'shift', 'Enter' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -599,7 +599,24 @@ export class RichText extends Component {
 			}
 
 			if ( this.multilineTag ) {
-				if ( this.onSplit && isEmptyLine( record ) ) {
+				if ( event.shiftKey ) {
+					const text = getTextContent( record );
+					const end = getSelectionEnd( record );
+					const length = text.length;
+					let toInsert = '\n';
+
+					// If the caret is at the end of the text, and there is no
+					// trailing line break or no text at all, we have to insert two
+					// line breaks in order to create a new line visually and place
+					// the caret there.
+					if ( ( end === length || charAt( record, end ) === LINE_SEPARATOR ) && (
+						text.charAt( end - 1 ) !== '\n' || length === 0
+					) ) {
+						toInsert = '\n\n';
+					}
+
+					this.onChange( insert( record, toInsert ) );
+				} else if ( this.onSplit && isEmptyLine( record ) ) {
 					this.onSplit( ...split( record ).map( this.valueToFormat ) );
 				} else {
 					this.onChange( insertLineSeparator( record ) );

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -33,6 +33,7 @@ import {
 	toHTMLString,
 	getTextContent,
 	insert,
+	insertLineBreak,
 	insertLineSeparator,
 	isEmptyLine,
 	unstableToDom,
@@ -600,43 +601,14 @@ export class RichText extends Component {
 
 			if ( this.multilineTag ) {
 				if ( event.shiftKey ) {
-					const text = getTextContent( record );
-					const end = getSelectionEnd( record );
-					const length = text.length;
-					let toInsert = '\n';
-
-					// If the caret is at the end of the text, and there is no
-					// trailing line break or no text at all, we have to insert two
-					// line breaks in order to create a new line visually and place
-					// the caret there.
-					if ( ( end === length || charAt( record, end ) === LINE_SEPARATOR ) && (
-						text.charAt( end - 1 ) !== '\n' || length === 0
-					) ) {
-						toInsert = '\n\n';
-					}
-
-					this.onChange( insert( record, toInsert ) );
+					this.onChange( insertLineBreak( record ) );
 				} else if ( this.onSplit && isEmptyLine( record ) ) {
 					this.onSplit( ...split( record ).map( this.valueToFormat ) );
 				} else {
 					this.onChange( insertLineSeparator( record ) );
 				}
 			} else if ( event.shiftKey || ! this.onSplit ) {
-				const text = getTextContent( record );
-				const length = text.length;
-				let toInsert = '\n';
-
-				// If the caret is at the end of the text, and there is no
-				// trailing line break or no text at all, we have to insert two
-				// line breaks in order to create a new line visually and place
-				// the caret there.
-				if ( record.end === length && (
-					text.charAt( length - 1 ) !== '\n' || length === 0
-				) ) {
-					toInsert = '\n\n';
-				}
-
-				this.onChange( insert( record, toInsert ) );
+				this.onChange( insertLineBreak( record ) );
 			} else {
 				this.splitContent();
 			}

--- a/packages/rich-text/src/index.js
+++ b/packages/rich-text/src/index.js
@@ -19,6 +19,7 @@ export { removeFormat } from './remove-format';
 export { remove } from './remove';
 export { replace } from './replace';
 export { insert } from './insert';
+export { insertLineBreak } from './insert-line-break';
 export { insertLineSeparator } from './insert-line-separator';
 export { insertObject } from './insert-object';
 export { slice } from './slice';

--- a/packages/rich-text/src/insert-line-break.js
+++ b/packages/rich-text/src/insert-line-break.js
@@ -1,0 +1,34 @@
+/**
+ * Internal dependencies
+ */
+
+import { insert } from './insert';
+import { LINE_SEPARATOR } from './special-characters';
+
+/**
+ * Inserts a line break at the given or selected position. Inserts two line
+ * breaks if at the end of a line.
+ *
+ * @param {Object} value Value to modify.
+ *
+ * @return {Object} The value with the line break(s) inserted.
+ */
+export function insertLineBreak( value ) {
+	const { text, end } = value;
+	const length = text.length;
+
+	let toInsert = '\n';
+
+	// If the caret is at the end of the text, and there is no
+	// trailing line break or no text at all, we have to insert two
+	// line breaks in order to create a new line visually and place
+	// the caret there.
+	if (
+		( end === length || text[ end ] === LINE_SEPARATOR ) &&
+		( text[ end - 1 ] !== '\n' || length === 0 )
+	) {
+		toInsert = '\n\n';
+	}
+
+	return insert( value, toInsert );
+}


### PR DESCRIPTION
## Description
Fixes #11215. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->