### PR TITLE
Plugin: Deprecate window._wpLoadGutenbergEditor

### DIFF
--- a/docs/designers-developers/developers/backward-compatibility/deprecations.md
+++ b/docs/designers-developers/developers/backward-compatibility/deprecations.md
@@ -56,6 +56,7 @@ The Gutenberg project's deprecation policy is intended to support backward compa
 - The PHP function `gutenberg_meta_box_post_form_hidden_fields` has been removed. Use [`the_block_editor_meta_box_post_form_hidden_fields`](https://developer.wordpress.org/reference/functions/the_block_editor_meta_box_post_form_hidden_fields/) instead.
 - The PHP function `gutenberg_toggle_custom_fields` has been removed.
 - The PHP function `gutenberg_collect_meta_box_data` has been removed. Use [`register_and_do_post_meta_boxes`](https://developer.wordpress.org/reference/functions/register_and_do_post_meta_boxes/) instead.
+- `window._wpLoadGutenbergEditor` has been removed. Use `window._wpLoadBlockEditor` instead. Note: This is a private API, not intended for public use. It may be removed in the future.
 
 ## 4.5.0
 - `Dropdown.refresh()` has been deprecated as the contained `Popover` is now automatically refreshed.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1231,10 +1231,26 @@ JS;
 
 	$init_script = <<<JS
 	( function() {
-		window._wpLoadGutenbergEditor = window._wpLoadBlockEditor = new Promise( function( resolve ) {
+		window._wpLoadBlockEditor = new Promise( function( resolve ) {
 			wp.domReady( function() {
 				resolve( wp.editPost.initializeEditor( 'editor', "%s", %d, %s, %s ) );
 			} );
+		} );
+
+		Object.defineProperty( window, '_wpLoadGutenbergEditor', {
+			get: function() {
+				// TODO: Hello future maintainer. In removing this deprecation,
+				// ensure also to check whether `wp-editor`'s dependencies in
+				// `package-dependencies.php` still require `wp-deprecated`.
+				wp.deprecated( '`window._wpLoadGutenbergEditor`', {
+					plugin: 'Gutenberg',
+					version: '5.2',
+					alternative: '`window._wpLoadBlockEditor`',
+					hint: 'This is a private API, not intended for public use. It may be removed in the future.'
+				} );
+
+				return window._wpLoadBlockEditor;
+			}
 		} );
 } )();
 JS;


### PR DESCRIPTION
This pull request seeks to deprecate `window._wpLoadGutenbergEditor` in favor of the [core-defined `window._wpLoadBlockEditor`](https://github.com/WordPress/wordpress-develop/blob/48070a45a9368d81c8e7686729a7ea0c02a810bf/src/wp-admin/edit-form-blocks.php#L377). At this time, `_wpLoadBlockEditor` is in-fact defined by Gutenberg, but in subsequent revisions it will be dropped in favor of relying on the core behavior instead.

This is a private API and was not intended to be used by plugins, but is proposed to undergo the standard deprecation lifetime, since it's been seen to be used by plugins to act on the editor upon its being loaded.

Ideally a plugin should never use this promise, leveraging instead (depending on their use):

- Nothing; just execute code when the script is loaded. This also assumes that the plugin defines their dependencies correctly, rather than incidentally relying on the editor's own dependencies (which is fragile to begin with)
- Detect editor initialization by [responding to changes in data state](https://wordpress.org/gutenberg/handbook/designers-developers/developers/packages/packages-data/)

**Testing instructions:**

Verify there are no regressions in the loading of the editor, and no console warnings by default.

Verify that by attempting to reference the `_wpLoadGutenbergEditor` global variable, it (a) logs to the console and (b) still works as intended.

```
window._wpLoadGutenbergEditor.then( () => console.log( 'Loaded' ) );
```

_(Depending on your browser, the logging may occur without actually pressing Enter in your Developer Tools Console. For example, Chrome evaluates the variable before it's run, triggering the getter behavior to log the warning)_