### PR TITLE
Fix: Hide empty categories in categories block.

### DIFF
--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -201,7 +201,7 @@ export default compose(
 	withSelect( ( select ) => {
 		const { getEntityRecords } = select( 'core' );
 		const { isResolving } = select( 'core/data' );
-		const query = { per_page: -1 };
+		const query = { per_page: -1, hide_empty: true };
 
 		return {
 			categories: getEntityRecords( 'taxonomy', 'category', query ),


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/13440

This PR uses hide_empty option during categories request to make sure categories that have no posts are not displayed in the categories block edit view. On the frontend, they are not rendered so the edit view should replicate that.

Some categories may still show zero as a count. That happens because these categories have descendant categories with posts associated to them.

## How has this been tested?
Add the categories block.
Enable the show post count option.
Verify categories with no posts associated to them or one of their descendants don't appear in the edit view.