### PR TITLE
Plugin: Avoid setting generic "Edit Post" title on load

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -201,8 +201,6 @@ function gutenberg_pre_init() {
  * @return bool   Whether Gutenberg was initialized.
  */
 function gutenberg_init( $return, $post ) {
-	global $title, $post_type;
-
 	if ( true === $return && current_filter() === 'replace_editor' ) {
 		return $return;
 	}
@@ -223,17 +221,6 @@ function gutenberg_init( $return, $post ) {
 	add_action( 'admin_enqueue_scripts', 'gutenberg_editor_scripts_and_styles' );
 	add_filter( 'screen_options_show_screen', '__return_false' );
 	add_filter( 'admin_body_class', 'gutenberg_add_admin_body_class' );
-
-	$post_type_object = get_post_type_object( $post_type );
-
-	/*
-	 * Always force <title> to 'Edit Post' (or equivalent)
-	 * because it needs to be in a generic state for both
-	 * post-new.php and post.php?post=<id>.
-	 */
-	if ( ! empty( $post_type_object ) ) {
-		$title = $post_type_object->labels->edit_item;
-	}
 
 	/*
 	 * Remove the emoji script as it is incompatible with both React and any


### PR DESCRIPTION
Previously: #8831 (786de1ef8580731ab78b42224708ff7d50e4b5f0)

This pull request seeks to remove special handling for the admin screen's `<title>` element by Gutenberg. As part of removing client-side title handling in #8831, logic was added to explicitly assign "Edit Post" (or as defined by custom post type label) as the title of the screen, regardless whether the user was adding a new post or editing an existing one. Presumably this was added to account for the fact that due to the lack of full page reload on save, a user would seamlessly transition from the state of adding a new post to editing an existing one.

However, this behavior was never incorporated into WordPress 5.0, and in retrospect, I don't know that it adds much value. To me, there is likely to be little confusion caused from a user seeing "Add New Post" in the title of a screen if they had in-fact started their editing session by creating a new post. In any case, an enhancement here should probably be proposed to core proper, as most PHP is being removed from the Gutenberg plugin when deferring to core is possible.

**Testing instructions:**

Verify that page titles of the post editor, both in adding a new post and editing an existing one, align between the Gutenberg plugin and in the block editor provided through WordPress 5.0.

Specifically, a new post should show "Add New Post", and editing an existing post should show "Edit Post".