### PR TITLE
Plugin: Populate demo content by default content filters

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -255,19 +255,6 @@ function gutenberg_init( $return, $post ) {
 }
 
 /**
- * Redirects the demo page to edit a new post.
- */
-function gutenberg_redirect_demo() {
-	global $pagenow;
-
-	if ( 'admin.php' === $pagenow && isset( $_GET['page'] ) && 'gutenberg' === $_GET['page'] ) {
-		wp_safe_redirect( admin_url( 'post-new.php?gutenberg-demo' ) );
-		exit;
-	}
-}
-add_action( 'admin_init', 'gutenberg_redirect_demo' );
-
-/**
  * Adds the filters to register additional links for the Gutenberg editor in
  * the post/page screens.
  *

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -865,8 +865,6 @@ function gutenberg_get_available_image_sizes() {
  * @param string $hook Screen name.
  */
 function gutenberg_editor_scripts_and_styles( $hook ) {
-	$is_demo = isset( $_GET['gutenberg-demo'] );
-
 	global $wp_scripts, $wp_meta_boxes;
 
 	// Add "wp-hooks" as dependency of "heartbeat".
@@ -983,17 +981,7 @@ JS;
 
 	// Assign initial edits, if applicable. These are not initially assigned
 	// to the persisted post, but should be included in its save payload.
-	if ( $is_new_post && $is_demo ) {
-		// Prepopulate with some test content in demo.
-		ob_start();
-		include gutenberg_dir_path() . 'post-content.php';
-		$demo_content = ob_get_clean();
-
-		$initial_edits = array(
-			'title'   => __( 'Welcome to the Gutenberg Editor', 'gutenberg' ),
-			'content' => $demo_content,
-		);
-	} elseif ( $is_new_post ) {
+	if ( $is_new_post ) {
 		// Override "(Auto Draft)" new post default title with empty string,
 		// or filtered value.
 		$initial_edits = array(

--- a/lib/demo.php
+++ b/lib/demo.php
@@ -38,12 +38,6 @@ function gutenberg_default_demo_content( $content ) {
 		ob_start();
 		include gutenberg_dir_path() . 'post-content.php';
 		return ob_get_clean();
-
-		$initial_edits = array(
-			'title'   => __( 'Welcome to the Gutenberg Editor', 'gutenberg' ),
-			'content' => $demo_content,
-		);
-
 	}
 
 	return $content;

--- a/lib/demo.php
+++ b/lib/demo.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Supports for populating the Gutenberg demo content new post.
+ *
+ * @package gutenberg
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Silence is golden.' );
+}
+
+/**
+ * Redirects the demo page to edit a new post.
+ */
+function gutenberg_redirect_demo() {
+	global $pagenow;
+
+	if ( 'admin.php' === $pagenow && isset( $_GET['page'] ) && 'gutenberg' === $_GET['page'] ) {
+		wp_safe_redirect( admin_url( 'post-new.php?gutenberg-demo' ) );
+		exit;
+	}
+}
+add_action( 'admin_init', 'gutenberg_redirect_demo' );
+
+/**
+ * Assigns the default content for the Gutenberg demo post.
+ *
+ * @param string  $content Default post content.
+ * @param WP_Post $post    Post object.
+ *
+ * @return string Demo content if creating a new Gutenberg demo post, or the
+ *                default content otherwise.
+ */
+function gutenberg_default_demo_content( $content, $post ) {
+	$is_new_post = 'auto-draft' === $post->post_status;
+	$is_demo     = $is_new_post && isset( $_GET['gutenberg-demo'] );
+
+	if ( $is_demo ) {
+		// Prepopulate with some test content in demo.
+		ob_start();
+		include gutenberg_dir_path() . 'post-content.php';
+		return ob_get_clean();
+
+		$initial_edits = array(
+			'title'   => __( 'Welcome to the Gutenberg Editor', 'gutenberg' ),
+			'content' => $demo_content,
+		);
+
+	}
+
+	return $content;
+}
+add_filter( 'default_content', 'gutenberg_default_demo_content', 10, 2 );
+
+/**
+ * Assigns the default title for the Gutenberg demo post.
+ *
+ * @param string  $title Default post title.
+ * @param WP_Post $post  Post object.
+ *
+ * @return string Demo title if creating a new Gutenberg demo post, or the
+ *                default title otherwise.
+ */
+function gutenberg_default_demo_title( $title, $post ) {
+	$is_new_post = 'auto-draft' === $post->post_status;
+	$is_demo     = $is_new_post && isset( $_GET['gutenberg-demo'] );
+
+	if ( $is_demo ) {
+		return __( 'Welcome to the Gutenberg Editor', 'gutenberg' );
+	}
+
+	return $title;
+}
+add_filter( 'default_title', 'gutenberg_default_demo_title', 10, 2 );

--- a/lib/demo.php
+++ b/lib/demo.php
@@ -25,15 +25,13 @@ add_action( 'admin_init', 'gutenberg_redirect_demo' );
 /**
  * Assigns the default content for the Gutenberg demo post.
  *
- * @param string  $content Default post content.
- * @param WP_Post $post    Post object.
+ * @param string $content Default post content.
  *
  * @return string Demo content if creating a new Gutenberg demo post, or the
  *                default content otherwise.
  */
-function gutenberg_default_demo_content( $content, $post ) {
-	$is_new_post = 'auto-draft' === $post->post_status;
-	$is_demo     = $is_new_post && isset( $_GET['gutenberg-demo'] );
+function gutenberg_default_demo_content( $content ) {
+	$is_demo = isset( $_GET['gutenberg-demo'] );
 
 	if ( $is_demo ) {
 		// Prepopulate with some test content in demo.
@@ -50,20 +48,18 @@ function gutenberg_default_demo_content( $content, $post ) {
 
 	return $content;
 }
-add_filter( 'default_content', 'gutenberg_default_demo_content', 10, 2 );
+add_filter( 'default_content', 'gutenberg_default_demo_content' );
 
 /**
  * Assigns the default title for the Gutenberg demo post.
  *
- * @param string  $title Default post title.
- * @param WP_Post $post  Post object.
+ * @param string $title Default post title.
  *
  * @return string Demo title if creating a new Gutenberg demo post, or the
  *                default title otherwise.
  */
-function gutenberg_default_demo_title( $title, $post ) {
-	$is_new_post = 'auto-draft' === $post->post_status;
-	$is_demo     = $is_new_post && isset( $_GET['gutenberg-demo'] );
+function gutenberg_default_demo_title( $title ) {
+	$is_demo = isset( $_GET['gutenberg-demo'] );
 
 	if ( $is_demo ) {
 		return __( 'Welcome to the Gutenberg Editor', 'gutenberg' );
@@ -71,4 +67,4 @@ function gutenberg_default_demo_title( $title, $post ) {
 
 	return $title;
 }
-add_filter( 'default_title', 'gutenberg_default_demo_title', 10, 2 );
+add_filter( 'default_title', 'gutenberg_default_demo_title' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -22,7 +22,7 @@ require dirname( __FILE__ ) . '/compat.php';
 require dirname( __FILE__ ) . '/plugin-compat.php';
 require dirname( __FILE__ ) . '/i18n.php';
 require dirname( __FILE__ ) . '/register.php';
-
+require dirname( __FILE__ ) . '/demo.php';
 
 // Register server-side code for individual blocks.
 if ( ! function_exists( 'render_block_core_archives' ) ) {


### PR DESCRIPTION
This pull request seeks to move handling of the demo content initialization from `gutenberg_editor_scripts_and_styles` to separate filter handlers in a new file dedicated for demo supports (one of the few PHP extensions Gutenberg will offer atop core from the initial 5.0 release). The reason for this change is to facilitate the removal of `gutenberg_editor_scripts_and_styles`. Core doesn't otherwise allow for filtering of [the `$initial_edits` it generates](https://github.com/WordPress/wordpress-develop/blob/6e80f7cebf06526df35fd62fda0ad3b753c4c157/src/wp-admin/edit-form-blocks.php#L93-L107) for editor initialization, but these can be alternatively provided through the `default_content` and `default_title` filters run by [`get_default_post_to_edit`](https://developer.wordpress.org/reference/functions/get_default_post_to_edit/) (the function responsible for generating a new post to edit).

**Testing instructions:**

Verify that the Gutenberg demo content is shown for a new post created via Gutenberg > Demo.

Verify that Gutenberg demo content is **not** shown for a new post created via Posts > Add New.

Verify that Gutenberg content is not considered even if manually adding a `&gutenberg-demo` query argument to the URL of any edited post.