### PR TITLE
Avoid JS error when pasing a caption without image

### DIFF
--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -203,7 +203,9 @@ export const settings = {
 							const { body } = document.implementation.createHTMLDocument( '' );
 
 							body.innerHTML = shortcode.content;
-							body.removeChild( body.firstElementChild );
+							if ( body.firstElementChild ) {
+								body.removeChild( body.firstElementChild );
+							}
 
 							return body.innerHTML.trim();
 						},


### PR DESCRIPTION
fixes #13527

I'm not sure this is the right fix but I noticed that sometimes the caption shortcode can be "image-less" which means `body.firstElementChild` is not defined causing a JS error. This patches the issue but I was wondering if we should just ignore the transformation entirely if the caption don't contain an image. (I'm not familiar enough with the shortcode transforms API to explore this).

