### PR TITLE
RichText: List: fix indentation

### DIFF
--- a/packages/rich-text/src/indent-list-items.js
+++ b/packages/rich-text/src/indent-list-items.js
@@ -19,7 +19,7 @@ function getTargetLevelLineIndex( { text, formats }, lineIndex ) {
 
 	let index = lineIndex;
 
-	while ( index-- ) {
+	while ( index-- >= 0 ) {
 		if ( text[ index ] !== LINE_SEPARATOR ) {
 			continue;
 		}

--- a/packages/rich-text/src/indent-list-items.js
+++ b/packages/rich-text/src/indent-list-items.js
@@ -7,6 +7,36 @@ import { normaliseFormats } from './normalise-formats';
 import { getLineIndex } from './get-line-index';
 
 /**
+ * Gets the line index of the first previous list item with higher indentation.
+ *
+ * @param {Object} value      Value to search.
+ * @param {number} lineIndex  Line index of the list item to compare with.
+ *
+ * @return {boolean} The line index.
+ */
+function getTargetLevelLineIndex( { text, formats }, lineIndex ) {
+	const startFormats = formats[ lineIndex ] || [];
+
+	let index = lineIndex;
+
+	while ( index-- ) {
+		if ( text[ index ] !== LINE_SEPARATOR ) {
+			continue;
+		}
+
+		const formatsAtIndex = formats[ index ] || [];
+
+		// Return the first line index that is one level higher. If the level is
+		// lower or equal, there is no result.
+		if ( formatsAtIndex.length === startFormats.length + 1 ) {
+			return index;
+		} else if ( formatsAtIndex.length <= startFormats.length ) {
+			return;
+		}
+	}
+}
+
+/**
  * Indents any selected list items if possible.
  *
  * @param {Object} value      Value to change.
@@ -23,61 +53,38 @@ export function indentListItems( value, rootFormat ) {
 	}
 
 	const { text, formats, start, end } = value;
+	const previousLineIndex = getLineIndex( value, lineIndex );
 	const formatsAtLineIndex = formats[ lineIndex ] || [];
-	const targetFormats = formats[ getLineIndex( value, lineIndex ) ] || [];
+	const formatsAtPreviousLineIndex = formats[ previousLineIndex ] || [];
 
 	// The the indentation of the current line is greater than previous line,
 	// then the line cannot be furter indented.
-	if ( formatsAtLineIndex.length > targetFormats.length ) {
+	if ( formatsAtLineIndex.length > formatsAtPreviousLineIndex.length ) {
 		return value;
 	}
 
 	const newFormats = formats.slice();
+	const targetLevelLineIndex = getTargetLevelLineIndex( value, lineIndex );
 
 	for ( let index = lineIndex; index < end; index++ ) {
 		if ( text[ index ] !== LINE_SEPARATOR ) {
 			continue;
 		}
 
-		// If the indentation of the previous line is the same as the current
-		// line, then duplicate the type and append all current types. E.g.
-		//
-		// 1. one
-		// 2. two <= Selected
-		//   * three <= Selected
-		//
-		// should become:
-		//
-		// 1. one
-		//   1. two <= Selected
-		//     * three <= Selected
-		//
-		//   ^ Inserted list
-		//
-		// Otherwise take the target formats and append traling lists. E.g.
-		//
-		// 1. one
-		//   * target
-		// 2. two <= Selected
-		//   * three <= Selected
-		//
-		// should become:
-		//
-		// 1. one
-		//   * target
-		//   * two <= Selected
-		//     * three <= Selected
-		//
-		if ( targetFormats.length === formatsAtLineIndex.length ) {
+		// Get the previous list, and if there's a child list, take over the
+		// formats. If not, duplicate the last level and create a new level.
+		if ( targetLevelLineIndex ) {
+			const targetFormats = formats[ targetLevelLineIndex ] || [];
+			newFormats[ index ] = targetFormats.concat(
+				( newFormats[ index ] || [] ).slice( targetFormats.length - 1 )
+			);
+		} else {
+			const targetFormats = formats[ previousLineIndex ] || [];
 			const lastformat = targetFormats[ targetFormats.length - 1 ] || rootFormat;
 
 			newFormats[ index ] = targetFormats.concat(
 				[ lastformat ],
 				( newFormats[ index ] || [] ).slice( targetFormats.length )
-			);
-		} else {
-			newFormats[ index ] = targetFormats.concat(
-				( newFormats[ index ] || [] ).slice( targetFormats.length - 1 )
 			);
 		}
 	}

--- a/packages/rich-text/src/outdent-list-items.js
+++ b/packages/rich-text/src/outdent-list-items.js
@@ -38,9 +38,12 @@ export function outdentListItems( value ) {
 			continue;
 		}
 
+		// In the case of level 0, the formats at the index are undefined.
+		const currentFormats = newFormats[ index ] || [];
+
 		// Omit the indentation level where the selection starts.
 		newFormats[ index ] = parentFormats.concat(
-			newFormats[ index ].slice( parentFormats.length + 1 )
+			currentFormats.slice( parentFormats.length + 1 )
 		);
 
 		if ( newFormats[ index ].length === 0 ) {

--- a/packages/rich-text/src/test/indent-list-items.js
+++ b/packages/rich-text/src/test/indent-list-items.js
@@ -130,4 +130,26 @@ describe( 'indentListItems', () => {
 		expect( result ).not.toBe( record );
 		expect( getSparseArrayLength( result.formats ) ).toBe( 2 );
 	} );
+
+	it( 'should indent one level at a time', () => {
+		// As we're testing list formats, the text should remain the same.
+		const text = `1${ LINE_SEPARATOR }2${ LINE_SEPARATOR }3${ LINE_SEPARATOR }4`;
+		const record = {
+			formats: [ , [ ul ], , [ ul, ul ], , , , ],
+			text,
+			start: 6,
+			end: 6,
+		};
+		const expected = {
+			formats: [ , [ ul ], , [ ul, ul ], , [ ul ], , ],
+			text,
+			start: 6,
+			end: 6,
+		};
+		const result = indentListItems( deepFreeze( record ), ul );
+
+		expect( result ).toEqual( expected );
+		expect( result ).not.toBe( record );
+		expect( getSparseArrayLength( result.formats ) ).toBe( 3 );
+	} );
 } );

--- a/packages/rich-text/src/test/indent-list-items.js
+++ b/packages/rich-text/src/test/indent-list-items.js
@@ -140,16 +140,38 @@ describe( 'indentListItems', () => {
 			start: 6,
 			end: 6,
 		};
-		const expected = {
+
+		const result1 = indentListItems( deepFreeze( record ), ul );
+
+		expect( result1 ).not.toBe( record );
+		expect( getSparseArrayLength( result1.formats ) ).toBe( 3 );
+		expect( result1 ).toEqual( {
 			formats: [ , [ ul ], , [ ul, ul ], , [ ul ], , ],
 			text,
 			start: 6,
 			end: 6,
-		};
-		const result = indentListItems( deepFreeze( record ), ul );
+		} );
 
-		expect( result ).toEqual( expected );
-		expect( result ).not.toBe( record );
-		expect( getSparseArrayLength( result.formats ) ).toBe( 3 );
+		const result2 = indentListItems( deepFreeze( result1 ), ul );
+
+		expect( result2 ).not.toBe( result1 );
+		expect( getSparseArrayLength( result2.formats ) ).toBe( 3 );
+		expect( result2 ).toEqual( {
+			formats: [ , [ ul ], , [ ul, ul ], , [ ul, ul ], , ],
+			text,
+			start: 6,
+			end: 6,
+		} );
+
+		const result3 = indentListItems( deepFreeze( result2 ), ul );
+
+		expect( result3 ).not.toBe( result2 );
+		expect( getSparseArrayLength( result3.formats ) ).toBe( 3 );
+		expect( result3 ).toEqual( {
+			formats: [ , [ ul ], , [ ul, ul ], , [ ul, ul, ul ], , ],
+			text,
+			start: 6,
+			end: 6,
+		} );
 	} );
 } );

--- a/packages/rich-text/src/test/outdent-list-items.js
+++ b/packages/rich-text/src/test/outdent-list-items.js
@@ -137,4 +137,26 @@ describe( 'outdentListItems', () => {
 		expect( result ).not.toBe( record );
 		expect( getSparseArrayLength( result.formats ) ).toBe( 2 );
 	} );
+
+	it( 'should outdent when a selected item is at level 0', () => {
+		// As we're testing list formats, the text should remain the same.
+		const text = `1${ LINE_SEPARATOR }2${ LINE_SEPARATOR }3`;
+		const record = {
+			formats: [ , [ ul ], , , , ],
+			text,
+			start: 2,
+			end: 5,
+		};
+		const expected = {
+			formats: [ , , , , , ],
+			text,
+			start: 2,
+			end: 5,
+		};
+		const result = outdentListItems( deepFreeze( record ) );
+
+		expect( result ).toEqual( expected );
+		expect( result ).not.toBe( record );
+		expect( getSparseArrayLength( result.formats ) ).toBe( 0 );
+	} );
 } );


### PR DESCRIPTION
## Description
Fixes https://github.com/WordPress/gutenberg/pull/13559#issuecomment-458516217. We should check the previous list item's direct children, not the trailing list item, to copy formats from.

## How has this been tested?

See https://github.com/WordPress/gutenberg/pull/13559#issuecomment-458516217.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->