### PR TITLE
Audio: Don't render empty audio element

### DIFF
--- a/packages/block-library/src/audio/index.js
+++ b/packages/block-library/src/audio/index.js
@@ -14,41 +14,6 @@ import { createBlobURL } from '@wordpress/blob';
 
 export const name = 'core/audio';
 
-const blockAttributes = {
-	src: {
-		type: 'string',
-		source: 'attribute',
-		selector: 'audio',
-		attribute: 'src',
-	},
-	caption: {
-		type: 'string',
-		source: 'html',
-		selector: 'figcaption',
-	},
-	id: {
-		type: 'number',
-	},
-	autoplay: {
-		type: 'boolean',
-		source: 'attribute',
-		selector: 'audio',
-		attribute: 'autoplay',
-	},
-	loop: {
-		type: 'boolean',
-		source: 'attribute',
-		selector: 'audio',
-		attribute: 'loop',
-	},
-	preload: {
-		type: 'string',
-		source: 'attribute',
-		selector: 'audio',
-		attribute: 'preload',
-	},
-};
-
 export const settings = {
 	title: __( 'Audio' ),
 
@@ -58,7 +23,40 @@ export const settings = {
 
 	category: 'common',
 
-	attributes: blockAttributes,
+	attributes: {
+		src: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'audio',
+			attribute: 'src',
+		},
+		caption: {
+			type: 'string',
+			source: 'html',
+			selector: 'figcaption',
+		},
+		id: {
+			type: 'number',
+		},
+		autoplay: {
+			type: 'boolean',
+			source: 'attribute',
+			selector: 'audio',
+			attribute: 'autoplay',
+		},
+		loop: {
+			type: 'boolean',
+			source: 'attribute',
+			selector: 'audio',
+			attribute: 'loop',
+		},
+		preload: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'audio',
+			attribute: 'preload',
+		},
+	},
 
 	transforms: {
 		from: [

--- a/packages/block-library/src/audio/index.js
+++ b/packages/block-library/src/audio/index.js
@@ -108,13 +108,7 @@ export const settings = {
 
 	deprecated: [
 		{
-			save() {
-				return (
-					<figure>
-						<audio controls />
-					</figure>
-				);
-			},
+			save: () => ( <figure><audio controls /></figure> ),
 		},
 	],
 };

--- a/packages/block-library/src/audio/index.js
+++ b/packages/block-library/src/audio/index.js
@@ -14,6 +14,41 @@ import { createBlobURL } from '@wordpress/blob';
 
 export const name = 'core/audio';
 
+const blockAttributes = {
+	src: {
+		type: 'string',
+		source: 'attribute',
+		selector: 'audio',
+		attribute: 'src',
+	},
+	caption: {
+		type: 'string',
+		source: 'html',
+		selector: 'figcaption',
+	},
+	id: {
+		type: 'number',
+	},
+	autoplay: {
+		type: 'boolean',
+		source: 'attribute',
+		selector: 'audio',
+		attribute: 'autoplay',
+	},
+	loop: {
+		type: 'boolean',
+		source: 'attribute',
+		selector: 'audio',
+		attribute: 'loop',
+	},
+	preload: {
+		type: 'string',
+		source: 'attribute',
+		selector: 'audio',
+		attribute: 'preload',
+	},
+};
+
 export const settings = {
 	title: __( 'Audio' ),
 
@@ -23,40 +58,7 @@ export const settings = {
 
 	category: 'common',
 
-	attributes: {
-		src: {
-			type: 'string',
-			source: 'attribute',
-			selector: 'audio',
-			attribute: 'src',
-		},
-		caption: {
-			type: 'string',
-			source: 'html',
-			selector: 'figcaption',
-		},
-		id: {
-			type: 'number',
-		},
-		autoplay: {
-			type: 'boolean',
-			source: 'attribute',
-			selector: 'audio',
-			attribute: 'autoplay',
-		},
-		loop: {
-			type: 'boolean',
-			source: 'attribute',
-			selector: 'audio',
-			attribute: 'loop',
-		},
-		preload: {
-			type: 'string',
-			source: 'attribute',
-			selector: 'audio',
-			attribute: 'preload',
-		},
-	},
+	attributes: blockAttributes,
 
 	transforms: {
 		from: [
@@ -90,9 +92,31 @@ export const settings = {
 		const { autoplay, caption, loop, preload, src } = attributes;
 		return (
 			<figure>
-				<audio controls="controls" src={ src } autoPlay={ autoplay } loop={ loop } preload={ preload } />
-				{ ! RichText.isEmpty( caption ) && <RichText.Content tagName="figcaption" value={ caption } /> }
+				{ src && (
+					<audio
+						controls="controls"
+						src={ src }
+						autoPlay={ autoplay }
+						loop={ loop }
+						preload={ preload }
+					/>
+				) }
+				{ ! RichText.isEmpty( caption ) && (
+					<RichText.Content tagName="figcaption" value={ caption } />
+				) }
 			</figure>
 		);
 	},
+
+	deprecated: [
+		{
+			save() {
+				return (
+					<figure>
+						<audio controls />
+					</figure>
+				);
+			},
+		},
+	],
 };


### PR DESCRIPTION
## Description
The HTML audio element should just be rendered if there is a source file. We already have the same behavior in the Video block. This could be useful, if you use the Audio Block in a template and don't select a audio file.
For already created Audio blocks with no source file, we need the deprecated function.

Test: 
1. Create a Audio block with no source selected, on the master branch
2. Apply the PR and there should be no error in the editor after reload
3. The Audio element should not be rendered on the frontend

Fixes #13556