### PR TITLE
Fix: Categories Block: hierarchical Dropdown

### DIFF
--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -106,7 +106,8 @@ class CategoriesEdit extends Component {
 	}
 
 	renderCategoryDropdown() {
-		const { showHierarchy, instanceId } = this.props;
+		const { instanceId } = this.props;
+		const { showHierarchy } = this.props.attributes;
 		const parentId = showHierarchy ? 0 : null;
 		const categories = this.getCategories( parentId );
 		const selectId = `blocks-category-select-${ instanceId }`;


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/13560

Previously higher than second levels categories here rendered multiple times on the categories block, when "Show Hierarchy" and "Display as Dropdown" options here true.
This PR fixes that problem.

## How has this been tested?
I created a Level 1 category without parent category.
I created a Level 2 category child of Level 1.
I created a Level 3 category child of Level 2.
I added a post with a Level 3 category.
I added the Category block and enable "Show Hierarchy" and "Display as Dropdown".
I checked the dropdown as displayed as expected without Level 2 and Level 3 being repeated.
## Screenshots <!-- if applicable -->
Before:
<img width="917" alt="screenshot 2019-01-29 at 18 56 20" src="https://user-images.githubusercontent.com/11271197/51932941-24562e00-23f8-11e9-80aa-5ed803f295aa.png">
After:
<img width="915" alt="screenshot 2019-01-29 at 18 55 24" src="https://user-images.githubusercontent.com/11271197/51932959-2cae6900-23f8-11e9-89bc-4bb870449d8a.png">


