### PR TITLE
Plugin: Deprecate gutenberg_add_admin_body_class

### DIFF
--- a/docs/designers-developers/developers/backward-compatibility/deprecations.md
+++ b/docs/designers-developers/developers/backward-compatibility/deprecations.md
@@ -58,6 +58,7 @@ The Gutenberg project's deprecation policy is intended to support backward compa
 - The PHP function `gutenberg_collect_meta_box_data` has been removed. Use [`register_and_do_post_meta_boxes`](https://developer.wordpress.org/reference/functions/register_and_do_post_meta_boxes/) instead.
 - `window._wpLoadGutenbergEditor` has been removed. Use `window._wpLoadBlockEditor` instead. Note: This is a private API, not intended for public use. It may be removed in the future.
 - The PHP function `gutenberg_get_script_polyfill` has been removed. Use [`wp_get_script_polyfill`](https://developer.wordpress.org/reference/functions/wp_get_script_polyfill/) instead.
+- The PHP function `gutenberg_add_admin_body_class` has been removed.
 
 ## 4.5.0
 - `Dropdown.refresh()` has been deprecated as the contained `Popover` is now automatically refreshed.

--- a/docs/designers-developers/developers/backward-compatibility/deprecations.md
+++ b/docs/designers-developers/developers/backward-compatibility/deprecations.md
@@ -58,7 +58,7 @@ The Gutenberg project's deprecation policy is intended to support backward compa
 - The PHP function `gutenberg_collect_meta_box_data` has been removed. Use [`register_and_do_post_meta_boxes`](https://developer.wordpress.org/reference/functions/register_and_do_post_meta_boxes/) instead.
 - `window._wpLoadGutenbergEditor` has been removed. Use `window._wpLoadBlockEditor` instead. Note: This is a private API, not intended for public use. It may be removed in the future.
 - The PHP function `gutenberg_get_script_polyfill` has been removed. Use [`wp_get_script_polyfill`](https://developer.wordpress.org/reference/functions/wp_get_script_polyfill/) instead.
-- The PHP function `gutenberg_add_admin_body_class` has been removed.
+- The PHP function `gutenberg_add_admin_body_class` has been removed. Use the `.block-editor-page` class selector in your stylesheets if you need to scope styles to the block editor screen.
 
 ## 4.5.0
 - `Dropdown.refresh()` has been deprecated as the contained `Popover` is now automatically refreshed.

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -220,7 +220,6 @@ function gutenberg_init( $return, $post ) {
 
 	add_action( 'admin_enqueue_scripts', 'gutenberg_editor_scripts_and_styles' );
 	add_filter( 'screen_options_show_screen', '__return_false' );
-	add_filter( 'admin_body_class', 'gutenberg_add_admin_body_class' );
 
 	/*
 	 * Remove the emoji script as it is incompatible with both React and any
@@ -299,18 +298,15 @@ function gutenberg_replace_default_add_new_button() {
  * Adds the block-editor-page class to the body tag on the Gutenberg page.
  *
  * @since 1.5.0
+ * @deprecated 5.0.0
  *
  * @param string $classes Space separated string of classes being added to the body tag.
  * @return string The $classes string, with block-editor-page appended.
  */
 function gutenberg_add_admin_body_class( $classes ) {
-	// gutenberg-editor-page is left for backward compatibility.
-	if ( current_theme_supports( 'editor-styles' ) && current_theme_supports( 'dark-editor-style' ) ) {
-		return "$classes block-editor-page gutenberg-editor-page is-fullscreen-mode wp-embed-responsive is-dark-theme";
-	} else {
-		// Default to is-fullscreen-mode to avoid jumps in the UI.
-		return "$classes block-editor-page gutenberg-editor-page is-fullscreen-mode wp-embed-responsive";
-	}
+	_deprecated_function( __FUNCTION__, '5.0.0' );
+
+	return $classes;
 }
 
 /**


### PR DESCRIPTION
This pull request seeks to deprecate `gutenberg_add_admin_body_class` in favor of the [equivalent core behavior](https://github.com/WordPress/wordpress-develop/blob/dce18c1d04bbb98a25aa1c46d0b05f7a86515a3e/src/wp-admin/admin-header.php#L189-L196) which assigns block editor classes. As of #13449, Gutenberg [declares itself as the block editor screen](https://github.com/WordPress/gutenberg/blob/4a717ae81c1c0637be338ed5cc8b6ce65038e74a/gutenberg.php#L219). You can confirm from the master branch that these classes are in-fact added twice to the page.

The notable omission here is the `gutenberg-editor-page` class. An alternative implementation here is to keep the filter, but apply only the Gutenberg-specific class, if it could serve of any value. Most any plugin should extend block editor styles using the `block-editor-page` class name instead, however. See also #10783.

**Testing instructions:**

Verify when viewing the editor while Gutenberg is active, that the `block-editor-page`, `is-fullscreen-mode`, `wp-embed-responsive`, and `is-dark-theme` (as applicable) are applied.