### PR TITLE
REST API: Remove oEmbed proxy HTML filtering

### DIFF
--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -23,7 +23,7 @@ function gutenberg_register_rest_routes() {
 /**
  * Handle a failing oEmbed proxy request to try embedding as a shortcode.
  *
- * @see https://core.trac.wordpress.org/ticket/45142
+ * @see https://core.trac.wordpress.org/ticket/46138
  *
  * @since 2.3.0
  *

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -23,7 +23,7 @@ function gutenberg_register_rest_routes() {
 /**
  * Handle a failing oEmbed proxy request to try embedding as a shortcode.
  *
- * @see https://core.trac.wordpress.org/ticket/46138
+ * @see https://core.trac.wordpress.org/ticket/45447
  *
  * @since 2.3.0
  *

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -21,12 +21,9 @@ function gutenberg_register_rest_routes() {
 }
 
 /**
- * Make sure oEmbed REST Requests apply the WP Embed security mechanism for WordPress embeds.
+ * Handle a failing oEmbed proxy request to try embedding as a shortcode.
  *
- * @see  https://core.trac.wordpress.org/ticket/32522
- *
- * TODO: This is a temporary solution. Next step would be to edit the WP_oEmbed_Controller,
- * once merged into Core.
+ * @see https://core.trac.wordpress.org/ticket/45142
  *
  * @since 2.3.0
  *
@@ -36,50 +33,32 @@ function gutenberg_register_rest_routes() {
  * @return WP_HTTP_Response|object|WP_Error    The REST Request response.
  */
 function gutenberg_filter_oembed_result( $response, $handler, $request ) {
-	if ( 'GET' !== $request->get_method() ) {
+	if ( ! is_wp_error( $response ) || 'oembed_invalid_url' !== $response->get_error_code() ||
+			'/oembed/1.0/proxy' !== $request->get_route() ) {
 		return $response;
 	}
 
-	if ( is_wp_error( $response ) && 'oembed_invalid_url' !== $response->get_error_code() ) {
+	// Try using a classic embed instead.
+	global $wp_embed;
+	$html = $wp_embed->shortcode( array(), $_GET['url'] );
+	if ( ! $html ) {
 		return $response;
 	}
 
-	// External embeds.
-	if ( '/oembed/1.0/proxy' === $request->get_route() ) {
-		if ( is_wp_error( $response ) ) {
-			// It's possibly a local post, so lets try and retrieve it that way.
-			$post_id = url_to_postid( $_GET['url'] );
-			$data    = get_oembed_response_data( $post_id, apply_filters( 'oembed_default_width', 600 ) );
+	global $wp_scripts;
 
-			if ( $data ) {
-				// It's a local post!
-				$response = (object) $data;
-			} else {
-				// Try using a classic embed, instead.
-				global $wp_embed;
-				$html = $wp_embed->shortcode( array(), $_GET['url'] );
-				if ( $html ) {
-					global $wp_scripts;
-					// Check if any scripts were enqueued by the shortcode, and
-					// include them in the response.
-					$enqueued_scripts = array();
-					foreach ( $wp_scripts->queue as $script ) {
-						$enqueued_scripts[] = $wp_scripts->registered[ $script ]->src;
-					}
-					return array(
-						'provider_name' => __( 'Embed Handler', 'gutenberg' ),
-						'html'          => $html,
-						'scripts'       => $enqueued_scripts,
-					);
-				}
-			}
-		}
-
-		// Make sure the HTML is run through the oembed sanitisation routines.
-		$response->html = wp_oembed_get( $_GET['url'], $_GET );
+	// Check if any scripts were enqueued by the shortcode, and include them in
+	// the response.
+	$enqueued_scripts = array();
+	foreach ( $wp_scripts->queue as $script ) {
+		$enqueued_scripts[] = $wp_scripts->registered[ $script ]->src;
 	}
 
-	return $response;
+	return array(
+		'provider_name' => __( 'Embed Handler', 'gutenberg' ),
+		'html'          => $html,
+		'scripts'       => $enqueued_scripts,
+	);
 }
 add_filter( 'rest_request_after_callbacks', 'gutenberg_filter_oembed_result', 10, 3 );
 


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/9734/files#r252005662
Related: #13408

This pull request seeks to remove Gutenberg's filtering of the oEmbed proxy endpoint responsible for filtering HTML from the response. This was implemented as part of the following Trac ticket and corresponding changeset:

- https://core.trac.wordpress.org/ticket/45142
- https://core.trac.wordpress.org/changeset/44154

Per #9734, the function serves a secondary purpose of handling a failing oEmbed proxy request which could be handled as a shortcode. This was never merged as part of the WordPress 5.0 release, and thus has been left as an extension provided by Gutenberg. The task to bring this in core can be found at the following link:

- https://core.trac.wordpress.org/ticket/45447

In the meantime, the function `gutenberg_filter_oembed_result` has been paired down to include only this specific handling. 

**Testing instructions:**

Repeat testing instructions from #9734