### PR TITLE
Plugin: Remove jQuery heartbeat-to-hooks proxying

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -851,47 +851,12 @@ function gutenberg_get_available_image_sizes() {
  * @param string $hook Screen name.
  */
 function gutenberg_editor_scripts_and_styles( $hook ) {
-	global $wp_scripts, $wp_meta_boxes;
-
-	// Add "wp-hooks" as dependency of "heartbeat".
-	$heartbeat_script = $wp_scripts->query( 'heartbeat', 'registered' );
-	if ( $heartbeat_script && ! in_array( 'wp-hooks', $heartbeat_script->deps ) ) {
-		$heartbeat_script->deps[] = 'wp-hooks';
-	}
+	global $wp_meta_boxes;
 
 	// Enqueue heartbeat separately as an "optional" dependency of the editor.
 	// Heartbeat is used for automatic nonce refreshing, but some hosts choose
 	// to disable it outright.
 	wp_enqueue_script( 'heartbeat' );
-
-	// Transforms heartbeat jQuery events into equivalent hook actions. This
-	// avoids a dependency on jQuery for listening to the event.
-	$heartbeat_hooks = <<<JS
-( function() {
-	jQuery( document ).on( [
-		'heartbeat-send',
-		'heartbeat-tick',
-		'heartbeat-error',
-		'heartbeat-connection-lost',
-		'heartbeat-connection-restored',
-		'heartbeat-nonces-expired',
-	].join( ' ' ), function( event ) {
-		var actionName = event.type.replace( /-/g, '.' ),
-			args;
-
-		// Omit the event argument in applying arguments to the hook callback.
-		// The remaining arguments are passed to the hook.
-		args = Array.prototype.slice.call( arguments, 1 );
-
-		wp.hooks.doAction.apply( null, [ actionName ].concat( args ) );
-	} );
-} )();
-JS;
-	wp_add_inline_script(
-		'heartbeat',
-		$heartbeat_hooks,
-		'after'
-	);
 
 	wp_enqueue_script( 'wp-edit-post' );
 	wp_enqueue_script( 'wp-format-library' );


### PR DESCRIPTION
Previously: #11781

This pull request seeks to remove the jQuery heartbeat event proxying introduced in #11781, which was intended to serve to automatically upgrade heartbeat events to corresponding hooks actions. Due to similar timeframe, it appears the changes from #11781 were made redundant as part of the following core changeset:

https://core.trac.wordpress.org/changeset/43939

Indeed, one can observe through Redux DevTools or a breakpoint in the `PostLockedModal`'s handling of `receivePostLock` that the heartbeat actions are handled twice in the most recent release of Gutenberg.

**Testing instructions:**

Repeat testing instructions from #11781, verifying there are no regressions in the behavior of the post locked modal.

Verify that each heartbeat action bound by `PostLockedModal` is handled only once. You can force a heartbeat connection in your console using the following command:

```
wp.heartbeat.connectNow()
```