### PR TITLE
Fixes plural messages POT generation.

### DIFF
--- a/packages/babel-plugin-makepot/CHANGELOG.md
+++ b/packages/babel-plugin-makepot/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.1.1 (Unreleased)
+
+### Bug Fix
+
+- Fixed Babel plugin for POT file generation to properly handle plural numbers specified in the passed header. ([#13577](https://github.com/WordPress/gutenberg/pull/13577))
+
 ## 2.1.0 (2018-09-05)
 
 ### New Feature

--- a/packages/babel-plugin-makepot/src/index.js
+++ b/packages/babel-plugin-makepot/src/index.js
@@ -246,13 +246,13 @@ module.exports = function() {
 					// Attempt to exract nplurals from header
 					const pluralsMatch = ( baseData.headers[ 'plural-forms' ] || '' ).match( /nplurals\s*=\s*(\d+);/ );
 					if ( pluralsMatch ) {
-						nplurals = pluralsMatch[ 1 ];
+						nplurals = parseInt( pluralsMatch[ 1 ], 10 );
 					}
 				}
 
 				// Create empty msgstr or array of empty msgstr by nplurals
 				if ( translation.msgid_plural ) {
-					translation.msgstr = Array.from( Array( parseInt( nplurals, 10 ) ) ).map( () => '' );
+					translation.msgstr = Array.from( Array( nplurals ) ).map( () => '' );
 				} else {
 					translation.msgstr = '';
 				}

--- a/packages/babel-plugin-makepot/src/index.js
+++ b/packages/babel-plugin-makepot/src/index.js
@@ -252,7 +252,7 @@ module.exports = function() {
 
 				// Create empty msgstr or array of empty msgstr by nplurals
 				if ( translation.msgid_plural ) {
-					translation.msgstr = Array.from( Array( nplurals ) ).map( () => '' );
+					translation.msgstr = Array.from( Array( parseInt( nplurals, 10 ) ) ).map( () => '' );
 				} else {
 					translation.msgstr = '';
 				}


### PR DESCRIPTION
## Description
In order for POT files to be generated with proper plural string templates, the `nplurals` variable had to be cast to int.

## How has this been tested?
To test you will need to have a test file that uses plural i18n functions:
```

/**
 * External dependencies
 */
import { _n, _nx } from '@wordpress/i18n';

_n( 'Singular string', 'Plural string', 'textdomain' );
_nx( 'Singular string', 'Plural string', 'context', 'textdomain' );
```

Also you need to be using the `makepot` plugin in your project when processing files with Babel:
```
 [
		'@wordpress/babel-plugin-makepot',
		{
			output: 'gettext.pot'
			headers: {
				'content-type': 'text/plain; charset=UTF-8',
				'plural-forms': 'nplurals=2; plural=n == 1 ? 0 : 1;',
			},
		},
	]
```
After you have set up your repository, run babel against this file:
```
$ npx babel test.js 
"use strict";

var _i18n = require("@wordpress/i18n");

/**
 * External dependencies
 */
(0, _i18n._n)('Singular string', 'Plural string', 'textdomain');
(0, _i18n._nx)('Singular string', 'Plural string', 'context', 'textdomain');
```

You will have an `gettext.pot` file generated in the folder where you ran the script from, it will have the following lines:

```
msgid ""
msgstr ""
"Content-Type: text/plain; charset=utf-8\n"
"X-Generator: calypso\n"
"Plural-Forms: nplurals=2; plural=n == 1 ? 0 : 1;\n"

#: test.js:8
msgid "Singular string"
msgid_plural "Plural string"
msgstr[0] ""

#: test.js:9
msgctxt "textdomain"
msgid "Singular string"
msgid_plural "Plural string"
msgstr[0] ""
```

Notice how the `msgstr` entry is only one per message, and there should be two of them, based on the `nplurals` setting in the header. Roll this patch on, see the different result:

```
msgid ""
msgstr ""
"Content-Type: text/plain; charset=utf-8\n"
"X-Generator: calypso\n"
"Plural-Forms: nplurals=2; plural=n == 1 ? 0 : 1;\n"

#: test.js:8
msgid "Singular string"
msgid_plural "Plural string"
msgstr[0] ""
msgstr[1] ""

#: test.js:9
msgctxt "textdomain"
msgid "Singular string"
msgid_plural "Plural string"
msgstr[0] ""
msgstr[1] ""
```

## Types of changes
* Minor change to the `babel-plugin-makepot` package: bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
