### PR TITLE
Update edit-save documentation 

### DIFF
--- a/docs/designers-developers/developers/block-api/block-edit-save.md
+++ b/docs/designers-developers/developers/block-api/block-edit-save.md
@@ -235,7 +235,125 @@ save( { attributes } ) {
 
 When saving your block, you want save the attributes in the same format specified by the attribute source definition.  If no attribute source is specified, the attribute will be saved to the block's comment delimiter. See the [Block Attributes documentation](/docs/designers-developers/developers/block-api/block-attributes.md) for more details.
 
-For a full example, see the [Introducing Attributes and Editable Fields](/docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md) section of the Block Tutorial.
+## Examples
+
+Here are a couple examples of using attributes, edit, and save all together.  For a full working example, see the [Introducing Attributes and Editable Fields](/docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md) section of the Block Tutorial.
+
+### Saving Attributes to Child Elements
+
+{% codetabs %}
+{% ES5 %}
+```js
+attributes: {
+	content: {
+		type: 'string',
+		source: 'html',
+		selector: 'p'
+	}
+},
+
+edit: ( props ) => {
+	updateFieldValue = function( val ) {
+		props.setAttributes( { content: val } );
+	}
+	return wp.element.createElement(
+		wp.components.TextControl,
+		{
+			label: 'My Text Field',
+			value: props.attributes.content,
+			onChange: updateFieldValue,
+
+		}
+	);
+},
+
+save: ( props ) => {
+	return el( 'p', {}, props.attributes.content );
+},
+```
+{% ESNext %}
+```jsx
+attributes: {
+	content: {
+		type: 'string',
+		source: 'html',
+		selector: 'p'
+	}
+},
+
+edit: ( { attributes, setAttributes } ) => {
+	updateFieldValue = ( val ) {
+		setAttributes( { content: val } );
+	}
+	return <TextControl
+			label='My Text Field'
+			value={ attributes.content }
+			onChange={ updateFieldValue }
+		/>;
+},
+
+save: ( { attributes } ) => {
+	return <p> { attributes.content } </p>;
+},
+```
+{% end %}
+
+### Saving Attributes via Serialization
+
+Ideally, the attributes saved should be included in the markup. However, there are times when this is not practical, so if no attribute source is specified the attribute is serialized and saved to the block's comment delimiter.
+
+This example could be for a dynamic block, such as the [Latest Posts block](https://github.com/WordPress/gutenberg/blob/master/packages/block-library/src/latest-posts/index.js), which renders the markup server-side. The save function is still required, however in this case it simply returns null since the block is not saving content from the editor.
+
+{% codetabs %}
+{% ES5 %}
+```js
+attributes: {
+	postsToShow: {
+		type: 'number',
+	}
+},
+
+edit: ( props ) => {
+	return wp.element.createElement(
+		wp.components.TextControl,
+		{
+			label: 'Number Posts to Show',
+			value: props.attributes.postsToShow,
+			onChange: ( val ) => {
+				props.setAttributes( { postsToShow: parseInt( val ) } );
+			},
+		}
+	);
+},
+
+save: () => {
+	return null;
+}
+```
+{% ESNext %}
+```jsx
+attributes: {
+	postsToShow: {
+		type: 'number',
+	}
+},
+
+edit: ( { attributes, setAttributes } ) => {
+	return <TextControl
+			label='Number Posts to Show'
+			value={ attributes.postsToShow }
+			onChange={ ( val ) => {
+				setAttributes( { postsToShow: parseInt( val ) } );
+			}},
+		}
+	);
+},
+
+save: () => {
+	return null;
+}
+```
+{% end %}
 
 
 ## Validation

--- a/docs/designers-developers/developers/block-api/block-edit-save.md
+++ b/docs/designers-developers/developers/block-api/block-edit-save.md
@@ -10,7 +10,7 @@ The `edit` function describes the structure of your block in the context of the 
 {% ES5 %}
 ```js
 // A static div
-edit() {
+edit: function() {
 	return wp.element.createElement(
 		'div',
 		null,
@@ -20,7 +20,7 @@ edit() {
 ```
 {% ESNext %}
 ```jsx
-edit() {
+edit: () => {
 	return <div>Your block.</div>;
 }
 ```
@@ -37,7 +37,7 @@ In this case, assuming we had defined an attribute of `content` during block reg
 {% codetabs %}
 {% ES5 %}
 ```js
-edit( props ) {
+edit: function( props ) {
 	return wp.element.createElement(
 		'div',
 		null,
@@ -47,7 +47,7 @@ edit( props ) {
 ```
 {% ESNext %}
 ```js
-edit( { attributes } ) {
+edit: ( { attributes } ) => {
 	return <div>{ attributes.content }</div>;
 }
 ```
@@ -62,7 +62,7 @@ This property returns the class name for the wrapper element. This is automatica
 {% codetabs %}
 {% ES5 %}
 ```js
-edit( props ) {
+edit: function( props ) {
 	return wp.element.createElement(
 		'div',
 		{ className: props.className },
@@ -72,7 +72,7 @@ edit( props ) {
 ```
 {% ESNext %}
 ```js
-edit( { attributes, className } ) {
+edit: ( { attributes, className } ) => {
 	return <div className={ className }>{ attributes.content }</div>;
 }
 ```
@@ -85,7 +85,7 @@ The isSelected property is an object that communicates whether the block is curr
 {% codetabs %}
 {% ES5 %}
 ```js
-edit( props ) {
+edit: function( props ) {
 	return wp.element.createElement(
 		'div',
 		{ className: props.className },
@@ -102,7 +102,7 @@ edit( props ) {
 ```
 {% ESNext %}
 ```jsx
-edit( { attributes, className, isSelected } ) {
+edit: ( { attributes, className, isSelected } ) => {
 	return (
 		<div className={ className }>
 			Your block.
@@ -122,7 +122,7 @@ This function allows the block to update individual attributes based on user int
 {% codetabs %}
 {% ES5 %}
 ```js
-edit: ( props ) => {
+edit: function( props ) {
 	// Simplify access to attributes
 	let content = props.attributes.content;
 	let mySetting = props.attributes.mySetting;
@@ -145,7 +145,7 @@ edit: ( props ) => {
 ```
 {% ESNext %}
 ```jsx
-edit( { attributes, setAttributes, className, isSelected } ) {
+edit: ( { attributes, setAttributes, className, isSelected } ) => {
 	// Simplify access to attributes
 	const { content, mySetting } = attributes;
 
@@ -187,7 +187,7 @@ The `save` function defines the way in which the different attributes should be 
 {% codetabs %}
 {% ES5 %}
 ```js
-save() {
+save: function() {
 	return wp.element.createElement(
 		'div',
 		null,
@@ -197,7 +197,7 @@ save() {
 ```
 {% ESNext %}
 ```jsx
-save() {
+save: () => {
 	return <div> Your block. </div>;
 }
 ```
@@ -216,7 +216,7 @@ As with `edit`, the `save` function also receives an object argument including a
 {% codetabs %}
 {% ES5 %}
 ```js
-save( props ) {
+save: function( props ) {
 	return wp.element.createElement(
 		'div',
 		null,
@@ -226,7 +226,7 @@ save( props ) {
 ```
 {% ESNext %}
 ```jsx
-save( { attributes } ) {
+save: ( { attributes } ) => {
 	return <div>{ attributes.content }</div>;
 }
 ```
@@ -252,7 +252,7 @@ attributes: {
 	}
 },
 
-edit: ( props ) => {
+edit: function( props ) {
 	var updateFieldValue = function( val ) {
 		props.setAttributes( { content: val } );
 	}
@@ -267,7 +267,7 @@ edit: ( props ) => {
 	);
 },
 
-save: ( props ) => {
+save: function( props ) {
 	return el( 'p', {}, props.attributes.content );
 },
 ```
@@ -313,7 +313,7 @@ attributes: {
 	}
 },
 
-edit: ( props ) => {
+edit: function( props ) {
 	return wp.element.createElement(
 		wp.components.TextControl,
 		{
@@ -326,7 +326,7 @@ edit: ( props ) => {
 	);
 },
 
-save: () => {
+save: function() {
 	return null;
 }
 ```

--- a/docs/designers-developers/developers/block-api/block-edit-save.md
+++ b/docs/designers-developers/developers/block-api/block-edit-save.md
@@ -21,7 +21,7 @@ edit() {
 {% ESNext %}
 ```jsx
 edit() {
-	return <div> Your block. </div>;
+	return <div>Your block.</div>;
 }
 ```
 {% end %}

--- a/docs/designers-developers/developers/block-api/block-edit-save.md
+++ b/docs/designers-developers/developers/block-api/block-edit-save.md
@@ -6,25 +6,52 @@ When registering a block, the `edit` and `save` functions provide the interface 
 
 The `edit` function describes the structure of your block in the context of the editor. This represents what the editor will render when the block is used.
 
+{% codetabs %}
+{% ES5 %}
 ```js
-// Defining the edit interface
+// A static div
 edit() {
-	return <hr />;
+	return wp.element.createElement(
+		'div',
+		null,
+		'Your block.'
+	);
 }
 ```
+{% ESNext %}
+```jsx
+edit() {
+	return <div> Your block. </div>;
+}
+```
+{% end %}
 
 The function receives the following properties through an object argument:
 
 ### attributes
 
-This property surfaces all the available attributes and their corresponding values, as described by the `attributes` property when the block type was registered. In this case, assuming we had defined an attribute of `content` during block registration, we would receive and use that value in our edit function:
+This property surfaces all the available attributes and their corresponding values, as described by the `attributes` property when the block type was registered. See [attributes documentation](/docs/designers-developers/developers/block-api/block-attributes/) for how to specify attribute sources.
 
+In this case, assuming we had defined an attribute of `content` during block registration, we would receive and use that value in our edit function:
+
+{% codetabs %}
+{% ES5 %}
 ```js
-// Defining the edit interface
+edit( props ) {
+	return wp.element.createElement(
+		'div',
+		null,
+		props.attributes.content
+	);
+}
+```
+{% ESNext %}
+```js
 edit( { attributes } ) {
 	return <div>{ attributes.content }</div>;
 }
 ```
+{% end %}
 
 The value of `attributes.content` will be displayed inside the `div` when inserting the block in the editor.
 
@@ -32,23 +59,53 @@ The value of `attributes.content` will be displayed inside the `div` when insert
 
 This property returns the class name for the wrapper element. This is automatically added in the `save` method, but not on `edit`, as the root element may not correspond to what is _visually_ the main element of the block. You can request it to add it to the correct element in your function.
 
+{% codetabs %}
+{% ES5 %}
 ```js
-// Defining the edit interface
+edit( props ) {
+	return wp.element.createElement(
+		'div',
+		{ className: props.className },
+		props.attributes.content
+	);
+}
+```
+{% ESNext %}
+```js
 edit( { attributes, className } ) {
 	return <div className={ className }>{ attributes.content }</div>;
 }
 ```
+{% end %}
 
 ### isSelected
 
 The isSelected property is an object that communicates whether the block is currently selected.
 
+{% codetabs %}
+{% ES5 %}
 ```js
-// Defining the edit interface
+edit( props ) {
+	return wp.element.createElement(
+		'div',
+		{ className: props.className },
+		[
+			'Your block.',
+			props.isSelected ? wp.element.createElement(
+				'span',
+				null,
+				'Shows only when the block is selected.'
+			)
+		]
+	);
+}
+```
+{% ESNext %}
+```jsx
 edit( { attributes, className, isSelected } ) {
 	return (
 		<div className={ className }>
-			{ attributes.content }
+			Your block.
 			{ isSelected &&
 				<span>Shows only when the block is selected.</span>
 			}
@@ -56,13 +113,38 @@ edit( { attributes, className, isSelected } ) {
 	);
 }
 ```
+{% end %}
 
 ### setAttributes
 
 This function allows the block to update individual attributes based on user interactions.
 
+{% codetabs %}
+{% ES5 %}
 ```js
-// Defining the edit interface
+edit: ( props ) => {
+	// Simplify access to attributes
+	let content = props.attributes.content;
+	let mySetting = props.attributes.mySetting;
+
+	// Toggle a setting when the user clicks the button
+	let toggleSetting = () => props.setAttributes( { mySetting: ! mySetting } );
+	return wp.element.createElement(
+		'div',
+		{ className: props.className },
+		[
+			count,
+			props.isSelected ? wp.element.createElement(
+				'button',
+				{ onClick: toggleSetting },
+				'Toggle setting'
+			) : null
+		]
+	);
+},
+```
+{% ESNext %}
+```jsx
 edit( { attributes, setAttributes, className, isSelected } ) {
 	// Simplify access to attributes
 	const { content, mySetting } = attributes;
@@ -79,6 +161,7 @@ edit( { attributes, setAttributes, className, isSelected } ) {
 	);
 }
 ```
+{% end %}
 
 When using attributes that are objects or arrays it's a good idea to copy or clone the attribute prior to updating it:
 
@@ -93,7 +176,6 @@ const addListItem = ( newListItem ) => {
 	list.push( newListItem );
 	setAttributes( { list } );
 };
-
 ```
 
 Why do this? In JavaScript, arrays and objects are passed by reference, so this practice ensures changes won't affect other code that might hold references to the same data. Furthermore, Gutenberg follows the philosophy of the Redux library that [state should be immutable](https://redux.js.org/faq/immutable-data#what-are-the-benefits-of-immutability)—data should not be changed directly, but instead a new version of the data created containing the changes.
@@ -106,13 +188,17 @@ The `save` function defines the way in which the different attributes should be 
 {% ES5 %}
 ```js
 save() {
-	return wp.element.createElement( 'hr' );
+	return wp.element.createElement(
+		'div',
+		null,
+		'Your block.'
+	);
 }
 ```
 {% ESNext %}
 ```jsx
 save() {
-	return <hr />;
+	return <div> Your block. </div>;
 }
 ```
 {% end %}

--- a/docs/designers-developers/developers/block-api/block-edit-save.md
+++ b/docs/designers-developers/developers/block-api/block-edit-save.md
@@ -30,7 +30,7 @@ The function receives the following properties through an object argument:
 
 ### attributes
 
-This property surfaces all the available attributes and their corresponding values, as described by the `attributes` property when the block type was registered. See [attributes documentation](/docs/designers-developers/developers/block-api/block-attributes/) for how to specify attribute sources.
+This property surfaces all the available attributes and their corresponding values, as described by the `attributes` property when the block type was registered. See [attributes documentation](/docs/designers-developers/developers/block-api/block-attributes.md) for how to specify attribute sources.
 
 In this case, assuming we had defined an attribute of `content` during block registration, we would receive and use that value in our edit function:
 
@@ -231,6 +231,12 @@ save( { attributes } ) {
 }
 ```
 {% end %}
+
+
+When saving your block, you want save the attributes in the same format specified by the attribute source definition.  If no attribute source is specified, the attribute will be saved to the block's comment delimiter. See the [Block Attributes documentation](/docs/designers-developers/developers/block-api/block-attributes.md) for more details.
+
+For a full example, see the [Introducing Attributes and Editable Fields](/docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md) section of the Block Tutorial.
+
 
 ## Validation
 

--- a/docs/designers-developers/developers/block-api/block-edit-save.md
+++ b/docs/designers-developers/developers/block-api/block-edit-save.md
@@ -133,7 +133,7 @@ edit: function( props ) {
 		'div',
 		{ className: props.className },
 		[
-			count,
+			content,
 			props.isSelected ? wp.element.createElement(
 				'button',
 				{ onClick: toggleSetting },

--- a/docs/designers-developers/developers/block-api/block-edit-save.md
+++ b/docs/designers-developers/developers/block-api/block-edit-save.md
@@ -168,12 +168,8 @@ When using attributes that are objects or arrays it's a good idea to copy or clo
 {% codetabs %}
 {% ES5 %}
 ```js
-// Good - cloning the old list to a new array and then adding item
-
-var listObj = Object.assign( {}, attributes.list );
-
-// convert listObj back to array
-var newList = Object.keys( listObj ).map( i => listObj[i] );
+// Good - cloning the old list
+var newList = attributes.list.slice();
 
 var addListItem = function( newListItem ) {
 	setAttributes( { list: newList.concat( [ newListItem ] ) } );

--- a/docs/designers-developers/developers/block-api/block-edit-save.md
+++ b/docs/designers-developers/developers/block-api/block-edit-save.md
@@ -319,7 +319,7 @@ edit: ( props ) => {
 		{
 			label: 'Number Posts to Show',
 			value: props.attributes.postsToShow,
-			onChange: ( val ) => {
+			onChange: function( val ) {
 				props.setAttributes( { postsToShow: parseInt( val ) } );
 			},
 		}

--- a/docs/designers-developers/developers/block-api/block-edit-save.md
+++ b/docs/designers-developers/developers/block-api/block-edit-save.md
@@ -165,18 +165,41 @@ edit: ( { attributes, setAttributes, className, isSelected } ) => {
 
 When using attributes that are objects or arrays it's a good idea to copy or clone the attribute prior to updating it:
 
+{% codetabs %}
+{% ES5 %}
 ```js
-// Good - here a new array is created from the old list attribute and a new list item:
+// Good - cloning the old list to a new array and then adding item
+
+var listObj = Object.assign( {}, attributes.list );
+
+// convert listObj back to array
+var newList = Object.keys( listObj ).map( i => listObj[i] );
+
+var addListItem = function( newListItem ) {
+	setAttributes( { list: newList.concat( [ newListItem ] ) } );
+};
+
+// Bad - the list from the existing attribute is modified directly to add the new list item:
+var list = attributes.list;
+var addListItem = function( newListItem ) {
+	list.push( newListItem );
+	setAttributes( { list: list } );
+};
+```
+{% ESNext %}
+```js
+// Good - a new array is created from the old list attribute and a new list item:
 const { list } = attributes;
 const addListItem = ( newListItem ) => setAttributes( { list: [ ...list, newListItem ] } );
 
-// Bad - here the list from the existing attribute is modified directly to add the new list item:
+// Bad - the list from the existing attribute is modified directly to add the new list item:
 const { list } = attributes;
 const addListItem = ( newListItem ) => {
 	list.push( newListItem );
 	setAttributes( { list } );
 };
 ```
+{% end %}
 
 Why do this? In JavaScript, arrays and objects are passed by reference, so this practice ensures changes won't affect other code that might hold references to the same data. Furthermore, Gutenberg follows the philosophy of the Redux library that [state should be immutable](https://redux.js.org/faq/immutable-data#what-are-the-benefits-of-immutability)—data should not be changed directly, but instead a new version of the data created containing the changes.
 

--- a/docs/designers-developers/developers/block-api/block-edit-save.md
+++ b/docs/designers-developers/developers/block-api/block-edit-save.md
@@ -233,7 +233,7 @@ save( { attributes } ) {
 {% end %}
 
 
-When saving your block, you want save the attributes in the same format specified by the attribute source definition.  If no attribute source is specified, the attribute will be saved to the block's comment delimiter. See the [Block Attributes documentation](/docs/designers-developers/developers/block-api/block-attributes.md) for more details.
+When saving your block, you want to save the attributes in the same format specified by the attribute source definition. If no attribute source is specified, the attribute will be saved to the block's comment delimiter. See the [Block Attributes documentation](/docs/designers-developers/developers/block-api/block-attributes.md) for more details.
 
 ## Examples
 

--- a/docs/designers-developers/developers/block-api/block-edit-save.md
+++ b/docs/designers-developers/developers/block-api/block-edit-save.md
@@ -253,7 +253,7 @@ attributes: {
 },
 
 edit: ( props ) => {
-	updateFieldValue = function( val ) {
+	var updateFieldValue = function( val ) {
 		props.setAttributes( { content: val } );
 	}
 	return wp.element.createElement(

--- a/docs/designers-developers/developers/block-api/block-edit-save.md
+++ b/docs/designers-developers/developers/block-api/block-edit-save.md
@@ -282,7 +282,7 @@ attributes: {
 },
 
 edit: ( { attributes, setAttributes } ) => {
-	updateFieldValue = ( val ) {
+	const updateFieldValue = ( val ) => {
 		setAttributes( { content: val } );
 	}
 	return <TextControl


### PR DESCRIPTION
## Description

* Add ES5 code samples for `edit()` documentation
* Add links to additional information around attributes
* Update save documentation with additional examples

[View branch documentation](https://github.com/WordPress/gutenberg/blob/docs/4070/save/docs/designers-developers/developers/block-api/block-edit-save.md).

Fixes #4070

## How has this been tested?

Confirm example code works as explained.

## Types of changes

Documentation.

