### PR TITLE
Try to add a min-width to embeds.

### DIFF
--- a/packages/block-library/src/embed/editor.scss
+++ b/packages/block-library/src/embed/editor.scss
@@ -8,7 +8,9 @@
 	// Apply a min-width, or the embed can collapse when floated.
 	// Instagram widgets have a min-width of 326px, so go a bit beyond that.
 	@include break-small() {
-		min-width: 360px;
+		&:not(.components-placeholder) {
+			min-width: 360px;
+		}
 	}
 
 	&.is-loading {

--- a/packages/block-library/src/embed/editor.scss
+++ b/packages/block-library/src/embed/editor.scss
@@ -8,8 +8,11 @@
 	// Apply a min-width, or the embed can collapse when floated.
 	// Instagram widgets have a min-width of 326px, so go a bit beyond that.
 	@include break-small() {
-		&:not(.components-placeholder) {
-			min-width: 360px;
+		min-width: 360px;
+
+		// The placeholder should not have this min-width.
+		&.components-placeholder {
+			min-width: 0;
 		}
 	}
 

--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -22,6 +22,8 @@
 
 .wp-embed-responsive {
 	.wp-block-embed {
+		min-width: 0;
+
 		// Add responsiveness to common aspect ratios.
 		&.wp-embed-aspect-21-9 .wp-block-embed__wrapper,
 		&.wp-embed-aspect-18-9 .wp-block-embed__wrapper,

--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -22,8 +22,6 @@
 
 .wp-embed-responsive {
 	.wp-block-embed {
-		min-width: 0;
-
 		// Add responsiveness to common aspect ratios.
 		&.wp-embed-aspect-21-9 .wp-block-embed__wrapper,
 		&.wp-embed-aspect-18-9 .wp-block-embed__wrapper,


### PR DESCRIPTION
Embeds are increasingly responsive (as they should be). This branch is very much a "try" branch, in that it simply zeroes out the minimum width of embeds to make the Amazon book embed be responsive. This allows us to create a nice book recommendation grid like this.

<img width="963" alt="screenshot 2019-01-30 at 12 52 10" src="https://user-images.githubusercontent.com/1204802/51979864-8cefea00-248e-11e9-90b5-c7822f4bec34.png">

However, Amazon themselves include a "Share" modal inside, which is 320px wide and is `opacity: 0;` (until invoked) instead of `display: none;`. So even though the embed itself is smart enough to not even show the Share button when there isn't room, that zero opacity share sheet still causes a horizontal scrollbar, which due to the sandboxing of iframes, we cannot fix.

So this PR is more of a discussion point: what can we do with these embeds? I'm not sure we can do that much. Notably Instagram widgets can't be smaller than 326px, so we can't do this in a blanket way either, or it'll just mess up other embeds.

What are your thoughts?