### PR TITLE
Mention how 'core/notices' data store is accessed

### DIFF
--- a/packages/notices/README.md
+++ b/packages/notices/README.md
@@ -16,7 +16,7 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 
 ## Usage
 
-When imported, the notices module registers a data store on the `core/notices` namespace.
+When imported, the notices module registers a data store on the `core/notices` namespace. In WordPress, this is accessed from `wp.data.dispatch( 'core/notices' )`.
 
 For more information about consuming from a data store, refer to [the `@wordpress/data` documentation on _Data Access and Manipulation_](/packages/data/README.md#data-access-and-manipulation).
 


### PR DESCRIPTION
This tiny amount of extra context is helpful for those who aren't fully oriented with the entire architecture.

Inspired from #13592