### PR TITLE
Tooling: Introduce pre-commit CHANGELOG verification

### DIFF
--- a/bin/check-changelog.js
+++ b/bin/check-changelog.js
@@ -1,0 +1,92 @@
+/**
+ * Given a set of file paths as arguments, checks whether the file paths also
+ * include a requisite CHANGELOG entry. The file paths should include packages
+ * maintained with a CHANGELOG at, e.g. `packages/i18n/CHANGELOG.md`.
+ *
+ * Example (Error):
+ *
+ * ```
+ * node bin/check-changelog.js /Gutenberg/packages/i18n/src/index.js
+ * ```
+ *
+ * Example (Success):
+ *
+ * ```
+ * node bin/check-changelog.js /Gutenberg/packages/i18n/src/index.js \
+ *  /Gutenberg/packages/i18n/CHANGELOG.md
+ * ```
+ */
+
+/**
+ * External dependencies
+ */
+
+const { relative, sep, join } = require( 'path' );
+const minimatch = require( 'minimatch' );
+
+/**
+ * Internal dependencies
+ */
+
+const { ignoreChanges = [] } = require( '../lerna' );
+
+/**
+ * Returns true if the given path is ignored by the Lerna `ignoreChanges`
+ * configuration, or false otherwise.
+ *
+ * @param {string} path Path to test.
+ *
+ * @return {boolean} Whether path is ignored.
+ */
+function isIgnored( path ) {
+	return ignoreChanges.some( ( pattern ) => minimatch( path, pattern ) );
+}
+
+/**
+ * An array of file paths relative the `packages` directory.
+ *
+ * @type {string[]}
+ */
+const paths = process.argv
+	.slice( 2 )
+	.map( ( path ) => relative( 'packages', path ) );
+
+/**
+ * The set of verified package names, i.e. those which have been confirmed to
+ * include an associated CHANGELOG revision.
+ *
+ * @type {Set}
+ */
+const verified = new Set;
+
+for ( let i = 0; i < paths.length; i++ ) {
+	const path = paths[ i ];
+
+	// Not necessary to include a CHANGELOG if only editing ignored files.
+	if ( isIgnored( path ) ) {
+		continue;
+	}
+
+	// Find the package name as up to the first directory slash.
+	const [ packageName ] = path.split( sep );
+
+	// Skip if already verified.
+	if ( verified.has( packageName ) ) {
+		continue;
+	}
+
+	// Generate an expected package path for a CHANGELOG file.
+	const changelogPath = join( packageName, 'CHANGELOG.md' );
+
+	// If the changes don't also include the CHANGELOG, exit as error.
+	if ( ! paths.includes( changelogPath ) ) {
+		process.stdout.write(
+			`\n⚠️  Missing CHANGELOG.md entry for ${ packageName } package edits.\n` +
+			`\u00A0\u00A0\u00A0More information: https://github.com/WordPress/gutenberg/blob/master/packages/README.md#maintaining-changelogs\n`
+		);
+
+		process.exit( 1 );
+	}
+
+	verified.add( packageName );
+}

--- a/package.json
+++ b/package.json
@@ -80,21 +80,22 @@
 		"core-js": "2.5.7",
 		"cross-env": "3.2.4",
 		"cssnano": "4.0.3",
-		"enzyme": "3.7.0",
 		"deasync": "0.1.13",
 		"deep-freeze": "0.0.1",
 		"doctrine": "2.1.0",
+		"enzyme": "3.7.0",
 		"eslint-plugin-jest": "21.5.0",
 		"espree": "3.5.4",
 		"fbjs": "0.8.17",
 		"glob": "7.1.2",
 		"husky": "0.14.3",
-		"is-plain-obj": "1.1.0",
 		"is-equal-shallow": "0.1.3",
+		"is-plain-obj": "1.1.0",
 		"jsdom": "11.12.0",
 		"lerna": "3.4.3",
 		"lint-staged": "7.3.0",
 		"lodash": "4.17.10",
+		"minimatch": "3.0.4",
 		"mkdirp": "0.5.1",
 		"node-sass": "4.11.0",
 		"node-watch": "0.6.0",
@@ -109,8 +110,8 @@
 		"shallow-equal": "1.0.0",
 		"shallow-equals": "1.0.0",
 		"shallowequal": "1.1.0",
-		"sprintf-js": "1.1.1",
 		"source-map-loader": "0.2.3",
+		"sprintf-js": "1.1.1",
 		"stylelint-config-wordpress": "13.1.0",
 		"uuid": "3.3.2",
 		"webpack-bundle-analyzer": "3.0.2",
@@ -150,6 +151,7 @@
 		"prebuild:packages": "npm run clean:packages && lerna run build && cross-env INCLUDE_PACKAGES=babel-plugin-import-jsx-pragma,postcss-themes,jest-console SKIP_JSX_PRAGMA_TRANSFORM=1 node ./bin/packages/build.js",
 		"build:packages": "cross-env EXCLUDE_PACKAGES=babel-plugin-import-jsx-pragma,jest-console,postcss-themes node ./bin/packages/build.js",
 		"build": "npm run build:packages && wp-scripts build",
+		"check-changelog": "node bin/check-changelog",
 		"check-engines": "wp-scripts check-engines",
 		"check-licenses": "concurrently \"wp-scripts check-licenses --prod --gpl2\" \"wp-scripts check-licenses --dev\"",
 		"precheck-local-changes": "npm run docs:build",
@@ -196,6 +198,9 @@
 		],
 		"*.js": [
 			"wp-scripts lint-js"
+		],
+		"packages/*/**": [
+			"npm run check-changelog"
 		],
 		"{docs/{toc.json,tool/*.js},packages/{*/README.md,*/src/{actions,selectors}.js,components/src/*/**/README.md}}": [
 			"npm run docs:build"


### PR DESCRIPTION
This pull request seeks to explore adding a pre-commit script which verifies that the contents of the pending commit include a `CHANGELOG.md` revision if applicable (i.e. within a packages directory, and not considered as an "ignored" change by Lerna).

**Testing instructions:**

With the branch checked out, verify a few combinations of commit attempts:

- A change outside of a package (e.g. root `README.md`)
   - Should succeed
- A change to a package-ignored file (e.g. `packages/i18n/benchmark/index.js`), without CHANGELOG
   - Should succeed
- A change to a package not-ignored file (e.g. `packages/i18n/src/index.js`), without CHANGELOG
   - Should error
- A change to a package not-ignored file (e.g. `packages/i18n/src/index.js`), with CHANGELOG
   - Should succeed

**Future tasks:**

It would be difficult to integrate this into a build step in its current form, as the script expects to receive the changed file paths as arguments. It should be enhanced to also retrieve a list of changed files from the current branch history.

The current incarnation can serve as a good, less-disruptive initial workflow to allow for some flexibility in the risk of false positives.