### PR TITLE
Typo fix

### DIFF
--- a/docs/contributors/testing-overview.md
+++ b/docs/contributors/testing-overview.md
@@ -286,7 +286,7 @@ describe( 'SolarSystem', () => {
 } );
 ```
 
-Reducer tests are also be a great fit for snapshots. They are often large, complex data structures that shouldn't change unexpectedly, exactly what snapshots excel at!
+Reducer tests are also a great fit for snapshots. They are often large, complex data structures that shouldn't change unexpectedly, exactly what snapshots excel at!
 
 #### Working with snapshots
 


### PR DESCRIPTION


## Description
Update the first sentence on line 289 from:
 "Reducer tests are also be a great fit for snapshots."

to:
 "Reducer tests are also a great fit for snapshots."

## How has this been tested?
Visual

## Screenshots <!-- if applicable -->
n/a

## Types of changes
Text update only.

## Checklist:
n/a
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
