### PR TITLE
Image settings button

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -145,7 +145,7 @@ export default class ImageEdit extends React.Component {
 
 		const onImageSettingsButtonPressed = () => {
 
-		}
+		};
 
 		const toolbarEditButton = (
 			<Toolbar>

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -14,7 +14,7 @@ import {
 /**
  * Internal dependencies
  */
-import { MediaPlaceholder, RichText, BlockControls } from '@wordpress/editor';
+import { MediaPlaceholder, RichText, BlockControls, InspectorControls } from '@wordpress/editor';
 import { Toolbar, ToolbarButton, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import ImageSize from './image-size';
@@ -143,6 +143,10 @@ export default class ImageEdit extends React.Component {
 			);
 		}
 
+		const onImageSettingsButtonPressed = () => {
+
+		}
+
 		const toolbarEditButton = (
 			<Toolbar>
 				<ToolbarButton
@@ -151,6 +155,14 @@ export default class ImageEdit extends React.Component {
 					onClick={ onMediaLibraryButtonPressed }
 				/>
 			</Toolbar>
+		);
+
+		const inlineToolbarButtons = (
+			<ToolbarButton
+				label={ __( 'Image Settings' ) }
+				icon="admin-generic"
+				onClick={ onImageSettingsButtonPressed }
+			/>
 		);
 
 		const showSpinner = this.state.isUploadInProgress;
@@ -163,6 +175,9 @@ export default class ImageEdit extends React.Component {
 				<BlockControls>
 					{ toolbarEditButton }
 				</BlockControls>
+				<InspectorControls>
+					{ inlineToolbarButtons }
+				</InspectorControls>
 				<ImageSize src={ url } >
 					{ ( sizes ) => {
 						const {

--- a/packages/editor/src/components/index.native.js
+++ b/packages/editor/src/components/index.native.js
@@ -10,3 +10,4 @@ export { default as DefaultBlockAppender } from './default-block-appender';
 export { default as PostTitle } from './post-title';
 export { default as EditorHistoryRedo } from './editor-history/redo';
 export { default as EditorHistoryUndo } from './editor-history/undo';
+export { default as InspectorControls } from './inspector-controls';


### PR DESCRIPTION
## Description
This PR exports `InspectorControls` to be used on Mobile.
Using this, the `Image Settings` button is added to the image block to be displayed in the inline toolbar.

This is the simpler first step for https://github.com/wordpress-mobile/gutenberg-mobile/issues/202

## Screenshots <!-- if applicable -->
![simulator screen shot - iphone x - 2019-01-30 at 14 47 46](https://user-images.githubusercontent.com/9772967/51988347-bca9ec80-24a4-11e9-923e-3ec5c3607712.png)

To test:
- Follow the instruction on `gutenberg-mobile` PR https://github.com/wordpress-mobile/gutenberg-mobile/pull/527