### PR TITLE
Fix: Allow years lower than 1970 in DateTime component.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Bug Fixes
 
 - Resolves a conflict where two instance of Slot would produce an inconsistent or duplicated rendering output.
+- Allow years between 0 and 1970 in DateTime component.
 
 ### New Feature
 

--- a/packages/components/src/date-time/time.js
+++ b/packages/components/src/date-time/time.js
@@ -145,7 +145,7 @@ class TimePicker extends Component {
 		const { onChange } = this.props;
 		const { year, date } = this.state;
 		const value = parseInt( year, 10 );
-		if ( ! isInteger( value ) || value < 1970 || value > 9999 ) {
+		if ( ! isInteger( value ) || value < 0 || value > 9999 ) {
 			this.syncState( this.props );
 			return;
 		}


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/13579

This PR changes the DateTime component to allow years between 0 and 1970 that were previously unallowed.
The classic editor allows this set of years so we are updating the component to be equivalent.
Years lower than 0 and greater than 9999 are not allowed because JS error happens inside moment functions if these years are used. The classic editor and the quick edit form also don't allow this set of years.

## How has this been tested?
I checked I'm able to use years between  0 and 1970 on the publish date field with success

