### PR TITLE
Workflow: Add repository CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,7 +19,6 @@
 /packages/edit-post                             @WordPress/gutenberg-core
 /packages/editor                                @WordPress/gutenberg-core @nosolosw
 /packages/list-reusable-blocks                  @WordPress/gutenberg-core
-/packages/rich-text                             @WordPress/gutenberg-core
 /packages/shortcode                             @WordPress/gutenberg-core
 
 # Tooling

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -57,7 +57,7 @@
 /packages/dom-ready                             @WordPress/gutenberg-core
 /packages/escape-html                           @WordPress/gutenberg-core
 /packages/html-entities                         @WordPress/gutenberg-core
-/packages/i18n                                  @WordPress/gutenberg-core
+/packages/i18n                                  @WordPress/gutenberg-core @swissspidy
 /packages/is-shallow-equal                      @WordPress/gutenberg-core
 /packages/keycodes                              @WordPress/gutenberg-core
 /packages/priority-queue                        @WordPress/gutenberg-core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,80 @@
+# Fallback Coverage
+*                                               @WordPress/gutenberg-core
+
+# Data
+/packages/api-fetch                             @WordPress/gutenberg-core @nerrad
+/packages/core-data                             @WordPress/gutenberg-core @nerrad
+/packages/data                                  @WordPress/gutenberg-core @nerrad
+/packages/redux-routine                         @WordPress/gutenberg-core @nerrad
+
+# Blocks
+/packages/block-library                         @WordPress/gutenberg-core @Soean @ajitbohra
+
+# Editor
+/packages/annotations                           @WordPress/gutenberg-core
+/packages/autop                                 @WordPress/gutenberg-core
+/packages/block-serialization-spec-parser       @WordPress/gutenberg-core
+/packages/block-serialization-default-parser    @WordPress/gutenberg-core
+/packages/blocks                                @WordPress/gutenberg-core
+/packages/edit-post                             @WordPress/gutenberg-core
+/packages/editor                                @WordPress/gutenberg-core @nosolosw
+/packages/list-reusable-blocks                  @WordPress/gutenberg-core
+/packages/rich-text                             @WordPress/gutenberg-core
+/packages/shortcode                             @WordPress/gutenberg-core
+
+# Tooling
+/bin                                            @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
+/packages/babel-plugin-import-jsx-pragma        @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
+/packages/babel-plugin-makepot                  @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
+/packages/babel-preset-default                  @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
+/packages/browserslist-config                   @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
+/packages/custom-templated-path-webpack-plugin  @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
+/packages/e2e-test-utils                        @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
+/packages/e2e-tests                             @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
+/packages/eslint-plugin                         @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
+/packages/jest-console                          @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
+/packages/jest-preset-default                   @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
+/packages/jest-puppeteer-axe                    @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
+/packages/library-export-default-webpack-plugin @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
+/packages/npm-package-json-lint-config          @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
+/packages/postcss-themes                        @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
+/packages/scripts                               @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
+
+# UI Components
+/packages/components                            @WordPress/gutenberg-core @jaymanpandya @chrisvanpatten @ajitbohra @jaymanpandya @nosolosw
+/packages/compose                               @WordPress/gutenberg-core @jaymanpandya @chrisvanpatten @ajitbohra @jaymanpandya
+/packages/element                               @WordPress/gutenberg-core @jaymanpandya @chrisvanpatten @ajitbohra @jaymanpandya
+/packages/notices                               @WordPress/gutenberg-core @jaymanpandya @chrisvanpatten @ajitbohra @jaymanpandya
+/packages/nux                                   @WordPress/gutenberg-core @jaymanpandya @chrisvanpatten @ajitbohra @jaymanpandya
+/packages/viewport                              @WordPress/gutenberg-core @jaymanpandya @chrisvanpatten @ajitbohra @jaymanpandya
+
+# Utilities
+/packages/a11y                                  @WordPress/gutenberg-core
+/packages/blob                                  @WordPress/gutenberg-core
+/packages/date                                  @WordPress/gutenberg-core
+/packages/deprecated                            @WordPress/gutenberg-core
+/packages/dom                                   @WordPress/gutenberg-core
+/packages/dom-ready                             @WordPress/gutenberg-core
+/packages/escape-html                           @WordPress/gutenberg-core
+/packages/html-entities                         @WordPress/gutenberg-core
+/packages/i18n                                  @WordPress/gutenberg-core
+/packages/is-shallow-equal                      @WordPress/gutenberg-core
+/packages/keycodes                              @WordPress/gutenberg-core
+/packages/priority-queue                        @WordPress/gutenberg-core
+/packages/token-list                            @WordPress/gutenberg-core
+/packages/url                                   @WordPress/gutenberg-core
+/packages/wordcount                             @WordPress/gutenberg-core
+
+# Extensibility
+/packages/hooks                                 @WordPress/gutenberg-core
+/packages/plugins                               @WordPress/gutenberg-core
+
+# Rich Text
+/packages/format-library                        @WordPress/gutenberg-core
+/packages/rich-text                             @WordPress/gutenberg-core
+
+# PHP
+/lib                                            @WordPress/gutenberg-core
+
+# Documentation
+/docs                                           @WordPress/gutenberg-core @chrisvanpatten @mkaz @ajitbohra @nosolosw

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,79 +1,76 @@
-# Fallback Coverage
-*                                               @WordPress/gutenberg-core
-
 # Data
-/packages/api-fetch                             @WordPress/gutenberg-core @nerrad
-/packages/core-data                             @WordPress/gutenberg-core @nerrad
-/packages/data                                  @WordPress/gutenberg-core @nerrad
-/packages/redux-routine                         @WordPress/gutenberg-core @nerrad
+/packages/api-fetch                             @youknowriad @gziolo @aduth @nerrad
+/packages/core-data                             @youknowriad @gziolo @aduth @nerrad
+/packages/data                                  @youknowriad @gziolo @aduth @nerrad
+/packages/redux-routine                         @youknowriad @gziolo @aduth @nerrad
 
 # Blocks
-/packages/block-library                         @WordPress/gutenberg-core @Soean @ajitbohra
+/packages/block-library                         @youknowriad @gziolo @Soean @ajitbohra @jorgefilipecosta
 
 # Editor
-/packages/annotations                           @WordPress/gutenberg-core
-/packages/autop                                 @WordPress/gutenberg-core
-/packages/block-serialization-spec-parser       @WordPress/gutenberg-core
-/packages/block-serialization-default-parser    @WordPress/gutenberg-core
-/packages/blocks                                @WordPress/gutenberg-core
-/packages/edit-post                             @WordPress/gutenberg-core
-/packages/editor                                @WordPress/gutenberg-core @nosolosw
-/packages/list-reusable-blocks                  @WordPress/gutenberg-core
-/packages/shortcode                             @WordPress/gutenberg-core
+/packages/annotations                           @youknowriad @gziolo @aduth
+/packages/autop                                 @youknowriad @gziolo @aduth
+/packages/block-serialization-spec-parser       @youknowriad @gziolo @aduth
+/packages/block-serialization-default-parser    @youknowriad @gziolo @aduth
+/packages/blocks                                @youknowriad @gziolo @aduth
+/packages/edit-post                             @youknowriad @gziolo
+/packages/editor                                @youknowriad @gziolo @nosolosw
+/packages/list-reusable-blocks                  @youknowriad @gziolo @aduth
+/packages/shortcode                             @youknowriad @gziolo @aduth
 
 # Tooling
-/bin                                            @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
-/packages/babel-plugin-import-jsx-pragma        @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
-/packages/babel-plugin-makepot                  @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
-/packages/babel-preset-default                  @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
-/packages/browserslist-config                   @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
-/packages/custom-templated-path-webpack-plugin  @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
-/packages/e2e-test-utils                        @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
-/packages/e2e-tests                             @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
-/packages/eslint-plugin                         @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
-/packages/jest-console                          @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
-/packages/jest-preset-default                   @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
-/packages/jest-puppeteer-axe                    @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
-/packages/library-export-default-webpack-plugin @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
-/packages/npm-package-json-lint-config          @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
-/packages/postcss-themes                        @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
-/packages/scripts                               @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
+/bin                                            @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
+/packages/babel-plugin-import-jsx-pragma        @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
+/packages/babel-plugin-makepot                  @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
+/packages/babel-preset-default                  @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
+/packages/browserslist-config                   @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
+/packages/custom-templated-path-webpack-plugin  @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
+/packages/e2e-test-utils                        @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
+/packages/e2e-tests                             @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
+/packages/eslint-plugin                         @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
+/packages/jest-console                          @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
+/packages/jest-preset-default                   @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
+/packages/jest-puppeteer-axe                    @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
+/packages/library-export-default-webpack-plugin @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
+/packages/npm-package-json-lint-config          @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
+/packages/postcss-themes                        @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
+/packages/scripts                               @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
 
 # UI Components
-/packages/components                            @WordPress/gutenberg-core @chrisvanpatten @ajitbohra @jaymanpandya @nosolosw
-/packages/compose                               @WordPress/gutenberg-core @chrisvanpatten @ajitbohra @jaymanpandya
-/packages/element                               @WordPress/gutenberg-core @chrisvanpatten @ajitbohra @jaymanpandya
-/packages/notices                               @WordPress/gutenberg-core @chrisvanpatten @ajitbohra @jaymanpandya
-/packages/nux                                   @WordPress/gutenberg-core @chrisvanpatten @ajitbohra @jaymanpandya
-/packages/viewport                              @WordPress/gutenberg-core @chrisvanpatten @ajitbohra @jaymanpandya
+/packages/components                            @youknowriad @gziolo @aduth @chrisvanpatten @ajitbohra @jaymanpandya @nosolosw @jorgefilipecosta
+/packages/compose                               @youknowriad @gziolo @aduth @chrisvanpatten @ajitbohra @jaymanpandya @jorgefilipecosta
+/packages/element                               @youknowriad @gziolo @aduth @chrisvanpatten @ajitbohra @jaymanpandya @jorgefilipecosta
+/packages/notices                               @youknowriad @gziolo @aduth @chrisvanpatten @ajitbohra @jaymanpandya @jorgefilipecosta
+/packages/nux                                   @youknowriad @gziolo @aduth @chrisvanpatten @ajitbohra @jaymanpandya @jorgefilipecosta
+/packages/viewport                              @youknowriad @gziolo @aduth @chrisvanpatten @ajitbohra @jaymanpandya @jorgefilipecosta
 
 # Utilities
-/packages/a11y                                  @WordPress/gutenberg-core
-/packages/blob                                  @WordPress/gutenberg-core
-/packages/date                                  @WordPress/gutenberg-core
-/packages/deprecated                            @WordPress/gutenberg-core
-/packages/dom                                   @WordPress/gutenberg-core
-/packages/dom-ready                             @WordPress/gutenberg-core
-/packages/escape-html                           @WordPress/gutenberg-core
-/packages/html-entities                         @WordPress/gutenberg-core
-/packages/i18n                                  @WordPress/gutenberg-core @swissspidy
-/packages/is-shallow-equal                      @WordPress/gutenberg-core
-/packages/keycodes                              @WordPress/gutenberg-core
-/packages/priority-queue                        @WordPress/gutenberg-core
-/packages/token-list                            @WordPress/gutenberg-core
-/packages/url                                   @WordPress/gutenberg-core
-/packages/wordcount                             @WordPress/gutenberg-core
+/packages/a11y                                  @youknowriad @gziolo @aduth
+/packages/blob                                  @youknowriad @gziolo @aduth
+/packages/date                                  @youknowriad @gziolo @aduth
+/packages/deprecated                            @youknowriad @gziolo @aduth
+/packages/dom                                   @youknowriad @gziolo @aduth
+/packages/dom-ready                             @youknowriad @gziolo @aduth
+/packages/escape-html                           @youknowriad @gziolo @aduth
+/packages/html-entities                         @youknowriad @gziolo @aduth
+/packages/i18n                                  @youknowriad @gziolo @aduth @swissspidy
+/packages/is-shallow-equal                      @youknowriad @gziolo @aduth
+/packages/keycodes                              @youknowriad @gziolo @aduth
+/packages/priority-queue                        @youknowriad @gziolo @aduth
+/packages/token-list                            @youknowriad @gziolo @aduth
+/packages/url                                   @youknowriad @gziolo @aduth
+/packages/wordcount                             @youknowriad @gziolo @aduth
 
 # Extensibility
-/packages/hooks                                 @WordPress/gutenberg-core
-/packages/plugins                               @WordPress/gutenberg-core
+/packages/hooks                                 @youknowriad @gziolo @aduth
+/packages/plugins                               @youknowriad @gziolo @aduth
 
 # Rich Text
-/packages/format-library                        @WordPress/gutenberg-core
-/packages/rich-text                             @WordPress/gutenberg-core
+/packages/format-library                        @youknowriad @gziolo @aduth @iseulde @jorgefilipecosta
+/packages/rich-text                             @youknowriad @gziolo @aduth @iseulde @jorgefilipecosta
 
 # PHP
-/lib                                            @WordPress/gutenberg-core
+/lib                                            @youknowriad @gziolo @aduth
 
 # Documentation
-/docs                                           @WordPress/gutenberg-core @chrisvanpatten @mkaz @ajitbohra @nosolosw
+/docs                                           @youknowriad @gziolo @chrisvanpatten @mkaz @ajitbohra @nosolosw

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -74,3 +74,6 @@
 
 # Documentation
 /docs                                           @youknowriad @gziolo @chrisvanpatten @mkaz @ajitbohra @nosolosw
+
+# Native
+*.native.js                                     @daniloercoli @diegoreymendez @etoledom @hypest @koke @marecar3 @mzorz @pinarol @SergioEstevao @tug

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,12 +41,12 @@
 /packages/scripts                               @WordPress/gutenberg-core @ntwb @nerrad @ajitbohra
 
 # UI Components
-/packages/components                            @WordPress/gutenberg-core @jaymanpandya @chrisvanpatten @ajitbohra @jaymanpandya @nosolosw
-/packages/compose                               @WordPress/gutenberg-core @jaymanpandya @chrisvanpatten @ajitbohra @jaymanpandya
-/packages/element                               @WordPress/gutenberg-core @jaymanpandya @chrisvanpatten @ajitbohra @jaymanpandya
-/packages/notices                               @WordPress/gutenberg-core @jaymanpandya @chrisvanpatten @ajitbohra @jaymanpandya
-/packages/nux                                   @WordPress/gutenberg-core @jaymanpandya @chrisvanpatten @ajitbohra @jaymanpandya
-/packages/viewport                              @WordPress/gutenberg-core @jaymanpandya @chrisvanpatten @ajitbohra @jaymanpandya
+/packages/components                            @WordPress/gutenberg-core @chrisvanpatten @ajitbohra @jaymanpandya @nosolosw
+/packages/compose                               @WordPress/gutenberg-core @chrisvanpatten @ajitbohra @jaymanpandya
+/packages/element                               @WordPress/gutenberg-core @chrisvanpatten @ajitbohra @jaymanpandya
+/packages/notices                               @WordPress/gutenberg-core @chrisvanpatten @ajitbohra @jaymanpandya
+/packages/nux                                   @WordPress/gutenberg-core @chrisvanpatten @ajitbohra @jaymanpandya
+/packages/viewport                              @WordPress/gutenberg-core @chrisvanpatten @ajitbohra @jaymanpandya
 
 # Utilities
 /packages/a11y                                  @WordPress/gutenberg-core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Data
 /packages/api-fetch                             @youknowriad @gziolo @aduth @nerrad
 /packages/core-data                             @youknowriad @gziolo @aduth @nerrad
-/packages/data                                  @youknowriad @gziolo @aduth @nerrad
+/packages/data                                  @youknowriad @gziolo @aduth @nerrad @coderkevin
 /packages/redux-routine                         @youknowriad @gziolo @aduth @nerrad
 
 # Blocks


### PR DESCRIPTION
Related: #13441

This pull request seeks to add an initial implementation of a [`CODEOWNERS` file](https://help.github.com/articles/about-code-owners/) to help notify interested parties of changes to specific areas of the codebase, and in an effort toward alleviating pressure for reviews to a concentrated few.

**Implementation notes:**

The formatting options for this file are rather limiting, inheriting the [`.gitignore` pattern format](https://git-scm.com/docs/gitignore#_pattern_format). I experimented with a few options here, either inlining several paths in the same line, or including wildcards for things like Babel plugins (always `babel-*`), Webpack plugins (always `*-webpack-plugin`), etc. As proposed here I find to be a nice compromise, though is open to future iterations.

The column alignment was hand-crafted, so could become a maintenance burden, but the expectation is that new path entries to this file may not be quite as frequent as adding/removing individuals from existing entries. The hope here is that it improves readability by providing a visual distinction between paths and owners. I can imagine some automation here in the future (see below, e.g. [`text-table`](https://www.npmjs.com/package/text-table)).

In implementing this, I found some interesting usage from other projects that could prove useful for future iterations, such as [DefinitelyTyped's auto-generation of the file](https://github.com/DefinitelyTyped/DefinitelyTyped#edit-an-existing-package) from package definition manifest headers.

The [syntax documentation](https://help.github.com/articles/about-code-owners/) notes that owners are chosen by last-match, not all-matches. Thus, `@WordPress/gutenberg-core` is included for each additional entry, in addition to the wildcard fallback.

To that point, it should be noted that _this will definitely increase notification noise for those on the Gutenberg Core team_, as they will now receive notifications for every single pull request which is opened. The alternative is to change the implementation here to strictly an opt-in on an individual basis (or creation of new sub-teams).

Coverage for all packages was verified using a [small script I put together](https://gist.github.com/aduth/8981b2ff1eb7db1e41b9a15f4843cbe5). We may want to reconsider organization of the specific packages, or abandon organization altogether in favor of a simple listing of packages (which could be more suitable to individuals hand-picking individual packages, rather than lumped into a suite, e.g. "UI Components").