### PR TITLE
remove broken 2-column breakpoint from columns block

### DIFF
--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -20,7 +20,7 @@
 	padding-left: $block-padding;
 	padding-right: $block-padding;
 
-	@include break-small() {
+	@include break-medium() {
 		padding-left: $block-padding + $block-padding + $block-side-ui-width + $block-side-ui-clearance + $block-side-ui-clearance;
 		padding-right: $block-padding + $block-padding + $block-side-ui-width + $block-side-ui-clearance + $block-side-ui-clearance;
 	}
@@ -35,7 +35,7 @@
 		// Responsiveness: Allow wrapping on mobile.
 		flex-wrap: wrap;
 
-		@include break-small() {
+		@include break-medium() {
 			flex-wrap: nowrap;
 		}
 
@@ -43,7 +43,7 @@
 		> [data-type="core/column"] {
 			display: flex;
 			flex-direction: column;
-			flex: 1;
+			margin-bottom: calc(1em + #{$block-padding});
 
 			// The Column block is a child of the Columns block and is mostly a passthrough container.
 			// Therefore it shouldn't add additional paddings and margins, so we reset these, and compensate for margins.
@@ -85,33 +85,15 @@
 			overflow-wrap: break-word; // New standard.
 
 			// Responsiveness: Show at most one columns on mobile.
-			flex-basis: 100%;
+			width: 100%;
 
-			// Beyond mobile, allow 2 columns.
-			@include break-small() {
-				flex-basis: 50%;
-				flex-grow: 0;
-			}
-
-			// Add space between columns. Themes can customize this if they wish to work differently.
-			// This has to match the same padding applied in style.scss.
-			// Only apply this beyond the mobile breakpoint, as there's only a single column on mobile.
-			@include break-small() {
-				&:nth-child(odd) {
-					margin-right: $grid-size-large * 2;
-				}
-				&:nth-child(even) {
-					margin-left: $grid-size-large * 2;
-				}
-			}
-
-			@include break-small() {
+			@include break-medium() {
 				&:not(:first-child) {
-					margin-left: $grid-size-large * 2;
+					margin-left: $grid-size-large + $block-padding;
 				}
 
 				&:not(:last-child) {
-					margin-right: $grid-size-large * 2;
+					margin-right: $grid-size-large + $block-padding;
 				}
 			}
 		}

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -10,17 +10,10 @@
 }
 
 .wp-block-column {
-	flex: 1;
 	margin-bottom: 1em;
 
 	// Responsiveness: Show at most one columns on mobile.
-	flex-basis: 100%;
-
-	// Beyond mobile, allow 2 columns.
-	@include break-small() {
-		flex-basis: 50%;
-		flex-grow: 0;
-	}
+	width: 100%;
 
 	// Prevent the columns from growing wider than their distributed sizes.
 	min-width: 0;
@@ -31,20 +24,14 @@
 
 	// Add space between columns. Themes can customize this if they wish to work differently.
 	// Only apply this beyond the mobile breakpoint, as there's only a single column on mobile.
-	@include break-small() {
-		&:nth-child(odd) {
-			margin-right: $grid-size-large * 2;
-		}
-		&:nth-child(even) {
-			margin-left: $grid-size-large * 2;
-		}
+	@include break-medium() {
 
 		&:not(:first-child) {
-			margin-left: $grid-size-large * 2;
+			margin-left: $grid-size-large;
 		}
 
 		&:not(:last-child) {
-			margin-right: $grid-size-large * 2;
+			margin-right: $grid-size-large;
 		}
 	}
 }


### PR DESCRIPTION
## Description
Removes the non-working 2-column breakpoint and resolves margin-related bugs caused by it.

This is discussed extensively in #12199 and #12816, both of which attempt to fix the bugs while retaining the 2-column breakpoint.

This is an alternative approach that simplifies the code significantly and which should make things easier on theme-creators in the future.

## How has this been tested?
Locally using Docker environment. Chrome, Safari, Firefox on Mac. Need to test IE11/Edge.

## Types of changes
SCSS changes only. Almost exclusively removing code that didn't work properly anyway. This may cause some minor disruption in themes (including Twenty-Nineteen) that already implemented their own fixes to this block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
