### PR TITLE
Fix: Converting a <pre> to blocks drops new lines

### DIFF
--- a/packages/block-library/src/preformatted/index.js
+++ b/packages/block-library/src/preformatted/index.js
@@ -67,6 +67,7 @@ export const settings = {
 
 		return (
 			<RichText
+				filterWhiteSpaceChars={ false }
 				tagName="pre"
 				value={ content }
 				onChange={ ( nextContent ) => {

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -167,6 +167,7 @@ export class RichText extends Component {
 			removeAttribute: ( attribute ) => attribute.indexOf( 'data-mce-' ) === 0,
 			filterString: ( string ) => string.replace( TINYMCE_ZWSP, '' ),
 			prepareEditableTree: this.props.prepareEditableTree,
+			filterWhiteSpaceChars: this.props.filterWhiteSpaceChars,
 		} );
 	}
 
@@ -296,7 +297,10 @@ export class RichText extends Component {
 		} );
 
 		if ( typeof content === 'string' ) {
-			const recordToInsert = create( { html: content } );
+			const recordToInsert = create( {
+				html: content,
+				filterWhiteSpaceChars: this.props.filterWhiteSpaceChars,
+			} );
 			this.onChange( insert( record, recordToInsert ) );
 		} else if ( this.onSplit ) {
 			if ( ! content.length ) {
@@ -714,6 +718,7 @@ export class RichText extends Component {
 				html: children.toHTML( value ),
 				multilineTag: this.multilineTag,
 				multilineWrapperTags: this.multilineWrapperTags,
+				filterWhiteSpaceChars: this.props.filterWhiteSpaceChars,
 			} );
 		}
 
@@ -722,6 +727,7 @@ export class RichText extends Component {
 				html: value,
 				multilineTag: this.multilineTag,
 				multilineWrapperTags: this.multilineWrapperTags,
+				filterWhiteSpaceChars: this.props.filterWhiteSpaceChars,
 			} );
 		}
 

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -120,6 +120,7 @@ export function create( {
 	unwrapNode,
 	filterString,
 	removeAttribute,
+	filterWhiteSpaceChars = true,
 } = {} ) {
 	if ( typeof text === 'string' && text.length > 0 ) {
 		return {
@@ -144,6 +145,7 @@ export function create( {
 			unwrapNode,
 			filterString,
 			removeAttribute,
+			filterWhiteSpaceChars,
 		} );
 	}
 
@@ -156,6 +158,7 @@ export function create( {
 		unwrapNode,
 		filterString,
 		removeAttribute,
+		filterWhiteSpaceChars,
 	} );
 }
 
@@ -283,6 +286,7 @@ function createFromElement( {
 	unwrapNode,
 	filterString,
 	removeAttribute,
+	filterWhiteSpaceChars = true,
 } ) {
 	const accumulator = createEmptyValue();
 
@@ -298,9 +302,11 @@ function createFromElement( {
 	const length = element.childNodes.length;
 
 	const filterStringComplete = ( string ) => {
-		// Reduce any whitespace used for HTML formatting to one space
-		// character, because it will also be displayed as such by the browser.
-		string = string.replace( /[\n\r\t]+/g, ' ' );
+		if ( filterWhiteSpaceChars ) {
+			// Reduce any whitespace used for HTML formatting to one space
+			// character, because it will also be displayed as such by the browser.
+			string = string.replace( /[\n\r\t]+/g, ' ' );
+		}
 
 		if ( filterString ) {
 			string = filterString( string );
@@ -379,6 +385,7 @@ function createFromElement( {
 				filterString,
 				removeAttribute,
 				currentWrapperTags: [ ...currentWrapperTags, format ],
+				filterWhiteSpaceChars,
 			} );
 			format = undefined;
 		} else {
@@ -391,6 +398,7 @@ function createFromElement( {
 				unwrapNode,
 				filterString,
 				removeAttribute,
+				filterWhiteSpaceChars,
 			} );
 		}
 
@@ -481,6 +489,7 @@ function createFromMultilineElement( {
 	filterString,
 	removeAttribute,
 	currentWrapperTags = [],
+	filterWhiteSpaceChars = true,
 } ) {
 	const accumulator = createEmptyValue();
 
@@ -508,6 +517,7 @@ function createFromMultilineElement( {
 			unwrapNode,
 			filterString,
 			removeAttribute,
+			filterWhiteSpaceChars,
 		} );
 
 		// If a line consists of one single line break (invisible), consider the

--- a/packages/rich-text/src/test/create.js
+++ b/packages/rich-text/src/test/create.js
@@ -100,4 +100,14 @@ describe( 'create', () => {
 		const value = create( { html: '<a href="#">a</a><a href="#a">a</a>' } );
 		expect( value.formats[ 0 ][ 0 ] ).not.toBe( value.formats[ 1 ][ 0 ] );
 	} );
+
+	it( 'should remove new lines when filterWhiteSpaceChars is true', () => {
+		const value = create( { html: 'line1\nline2', filterWhiteSpaceChars: true } );
+		expect( value.text ).toBe( 'line1 line2' );
+	} );
+
+	it( 'should not remove new lines when filterWhiteSpaceChars is false', () => {
+		const value = create( { html: 'line1\nline2', filterWhiteSpaceChars: false } );
+		expect( value.text ).toBe( 'line1\nline2' );
+	} );
 } );


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/12109

Previously wp.richText.create always replaced newline character with a space character.
This PR adds a flag that allows disabling this behavior: filterWhiteSpaceChars = false.
Normally browsers ignore newline chars inside HTML documents, but inside pre tag newlines are rendered as a newline.
This PR's fixes a bug wherein the editor newlines inside pre-block were not rendered.


## How has this been tested?
I pasted the following block into Gutenberg:
```
<!-- wp:preformatted -->
<pre class="wp-block-preformatted">line1
      line2
line3</pre>
<!-- /wp:preformatted -->
```

I verified newline and whitespaces were kept.