### PR TITLE
Plugin: Remove `user_can_richedit` filtering

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -893,13 +893,6 @@ JS;
 		'after'
 	);
 
-	// Ignore Classic Editor's `rich_editing` user option, aka "Disable visual
-	// editor". Forcing this to be true guarantees that TinyMCE and its plugins
-	// are available in Gutenberg. Fixes
-	// https://github.com/WordPress/gutenberg/issues/5667.
-	$user_can_richedit = user_can_richedit();
-	add_filter( 'user_can_richedit', '__return_true' );
-
 	wp_enqueue_script( 'wp-edit-post' );
 	wp_enqueue_script( 'wp-format-library' );
 	wp_enqueue_style( 'wp-format-library' );
@@ -1134,7 +1127,7 @@ JS;
 		'allowedMimeTypes'       => get_allowed_mime_types(),
 		'styles'                 => $styles,
 		'imageSizes'             => gutenberg_get_available_image_sizes(),
-		'richEditingEnabled'     => $user_can_richedit,
+		'richEditingEnabled'     => user_can_richedit(),
 
 		// Ideally, we'd remove this and rely on a REST API endpoint.
 		'postLock'               => $lock_details,


### PR DESCRIPTION
Related: #13569
Related: https://github.com/WordPress/gutenberg/pull/5670#issuecomment-458757185
Related: #12151
Related: #12000

This pull request seeks to remove Gutenberg filtering originally introduced in #5670 to resolve an issue where an error could occur with the Classic Block when a user disabled the Visual Editing mode (#5667). This was later addressed by building in native handling for the setting to Gutenberg as part of #12151 (a previous attempt at #12000). Thus, the filter removed here is not necessary, and is in-fact not part of the core implementation of the block editor introduced with WordPress 5.0 ([reference](https://github.com/WordPress/wordpress-develop/blob/4b8e33fbee15be9a0cd06bea00df765636e812ae/src/wp-admin/edit-form-blocks.php#L281)).

**Testing instructions:**

Verify against regressions of #5667, #12148

Repeat testing instructions from #12151