### PR TITLE
Shortcode block: Change source of `text` attribute to `html`

### DIFF
--- a/packages/block-library/src/shortcode/index.js
+++ b/packages/block-library/src/shortcode/index.js
@@ -22,7 +22,7 @@ export const settings = {
 	attributes: {
 		text: {
 			type: 'string',
-			source: 'text',
+			source: 'html',
 		},
 	},
 


### PR DESCRIPTION
## Description

The Shortcode block has one attribute, `text`, representing the contents of a WordPress shortcode. This pull requests changes the `source` of said attribute from `text` to `html`, thus extending the field to support raw HTML, as may be required by certain shortcodes.

Quoting @aduth in https://github.com/WordPress/gutenberg/issues/13399#issuecomment-459070393:

> […] because it saves using `RawHTML`, there's no reason the shortcode block shouldn't also define its attribute as being sourced via `'html`'. I expect the original implementation didn't expect HTML to be embedded within a shortcode, so it defaulted to text.

Fixes #13399.

/cc @chunkyRice

## How has this been tested?

- Stress-test the Shortcode block by giving it shortcodes that may include HTML entities or HTML markup. To ensure the data is properly serialised, saved, loaded and validated, inspect saved posts with `wp-cli` and reload the editor while monitoring the browser console.
- Try reproducing the circumstances described in #13399 with that HTML-rich shortcode.
- Test the conversion from Classic to Shortcode.

## Types of changes
Enhancement.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
