### PR TITLE
**DO NOT MERGE** Attempt to trigger a Travis CI `npm ci` install error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ branches:
 before_install:
   - nvm install
 
-jobs:
+matrix:
   include:
     - name: JS unit tests
       env: WP_VERSION=latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_install:
   - nvm install
 
 matrix:
+  fast_finish: true
   include:
     - name: JS unit tests
       env: WP_VERSION=latest

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
 		"is-plain-obj": "1.1.0",
 		"is-equal-shallow": "0.1.3",
 		"jsdom": "11.12.0",
-		"lerna": "3.4.3",
+		"lerna": "3.10.7",
 		"lint-staged": "7.3.0",
 		"lodash": "4.17.10",
 		"mkdirp": "0.5.1",


### PR DESCRIPTION
## Description

**DO NOT MERGE**

Ref https://github.com/WordPress/gutenberg/pull/13462#issuecomment-457595901

> ...it begs the question then: Why isn't it currently failing, if `npm ci` is meant to exit with an error when a `package-lock.json` and when the Travis build is meant to error and stop immediately when a script in `install` errors?

This PR is attempting to trigger a Travis CI build job to terminate with an error due to `package.json` has been updated but **not* the `package-lock.json` file.

Currently `npm ci` is in the `install` section of `.travis.yml`: https://github.com/WordPress/gutenberg/blob/master/.travis.yml#L34-L35

Per the docs at https://docs.travis-ci.com/user/job-lifecycle#breaking-the-build

> > If `before_install`, `install` or `before_script` returns a non-zero exit code, the build is **errored** and stops immediately.
> > If `script` returns a non-zero exit code, the build is **failed**, but continues to run before being marked as **failed**.

Therefore the build _should_ throw `errored` and terminate immediately upon error.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
See above, this is a test PR for #13462
 
## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
