### PR TITLE
Fix: Display HTML in titles of latest posts block.

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -7,7 +7,11 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Component, Fragment } from '@wordpress/element';
+import {
+	Component,
+	Fragment,
+	RawHTML,
+} from '@wordpress/element';
 import {
 	PanelBody,
 	Placeholder,
@@ -21,7 +25,6 @@ import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
 import { dateI18n, format, __experimentalGetSettings } from '@wordpress/date';
-import { decodeEntities } from '@wordpress/html-entities';
 import {
 	InspectorControls,
 	BlockAlignmentToolbar,
@@ -171,16 +174,27 @@ class LatestPostsEdit extends Component {
 						[ `columns-${ columns }` ]: postLayout === 'grid',
 					} ) }
 				>
-					{ displayPosts.map( ( post, i ) =>
-						<li key={ i }>
-							<a href={ post.link } target="_blank">{ decodeEntities( post.title.rendered.trim() ) || __( '(Untitled)' ) }</a>
-							{ displayPostDate && post.date_gmt &&
-								<time dateTime={ format( 'c', post.date_gmt ) } className="wp-block-latest-posts__post-date">
-									{ dateI18n( dateFormat, post.date_gmt ) }
-								</time>
-							}
-						</li>
-					) }
+					{ displayPosts.map( ( post, i ) => {
+						const titleTrimmed = post.title.rendered.trim();
+						return (
+							<li key={ i }>
+								<a href={ post.link } target="_blank">
+									{ titleTrimmed ? (
+										<RawHTML>
+											{ titleTrimmed }
+										</RawHTML>
+									) :
+										__( '(Untitled)' )
+									}
+								</a>
+								{ displayPostDate && post.date_gmt &&
+									<time dateTime={ format( 'c', post.date_gmt ) } className="wp-block-latest-posts__post-date">
+										{ dateI18n( dateFormat, post.date_gmt ) }
+									</time>
+								}
+							</li>
+						);
+					} ) }
 				</ul>
 			</Fragment>
 		);

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -37,7 +37,7 @@ function render_block_core_latest_posts( $attributes ) {
 		$list_items_markup .= sprintf(
 			'<li><a href="%1$s">%2$s</a>',
 			esc_url( get_permalink( $post ) ),
-			esc_html( $title )
+			$title
 		);
 
 		if ( isset( $attributes['displayPostDate'] ) && $attributes['displayPostDate'] ) {


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/13603

This PR makes sure if the title of a post contains HTML tags, the HTML tags are rendered correctly in the frontend and in the editor of latest posts block.

## How has this been tested?
Create a new post write "<i>Hello</i> <b>World!</b>" in the title.
Publish the post.
Create another post add the latest posts block there. Verify the HTML in the title of the post we created before is correctly displayed in the block.
Publish the post verify the HTML is also correctly displayed on the frontend.