### PR TITLE
Increase bottom padding on gallery image caption

### DIFF
--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -48,11 +48,11 @@
 			width: 100%;
 			max-height: 100%;
 			overflow: auto;
-			padding: 40px 10px 5px;
+			padding: 40px 10px 9px;
 			color: $white;
 			text-align: center;
 			font-size: $default-font-size;
-			background: linear-gradient(0deg, rgba($color: $black, $alpha: 0.7) 0, rgba($color: $black, $alpha: 0.3) 60%, transparent);
+			background: linear-gradient(0deg, rgba($color: $black, $alpha: 0.7) 0, rgba($color: $black, $alpha: 0.3) 70%, transparent);
 
 			img {
 				display: inline;


### PR DESCRIPTION
Resolves #8018 by increasing the bottom padding of gallery image captions by 4px. Also increases the coverage of our gradient background by 10% to help with text contrast.

(This is a mirror of #8459 by @johnwatkins0, but with the addition of the gradient background edit). 

**Before:** 

<img width="619" alt="screen shot 2019-01-31 at 2 30 54 pm" src="https://user-images.githubusercontent.com/1202812/52081061-4621f300-2567-11e9-83c0-a0194d09ae2f.png">

After: 

<img width="619" alt="screen shot 2019-01-31 at 2 30 54 pm" src="https://user-images.githubusercontent.com/1202812/52081084-5934c300-2567-11e9-9834-778dfd97bfc1.png">
