### PR TITLE
Plugin: Extract block editor styles replacement as filter

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -859,7 +859,6 @@ function gutenberg_extend_block_editor_styles( $settings ) {
 		return $settings;
 	}
 
-	$i = 0;
 	if ( empty( $settings['styles'] ) ) {
 		$settings['styles'] = array();
 	} else {
@@ -877,21 +876,26 @@ function gutenberg_extend_block_editor_styles( $settings ) {
 
 		/*
 		 * Iterate backwards from the end of the array since the preferred
-		 * insertion point in case not found is as the first entry.
+		 * insertion point in case not found is prepended as first entry.
 		 */
-
-		$i = count( $settings['styles'] );
-		while ( --$i >= 0 ) {
+		for ( $i = count( $settings['styles'] ) - 1; $i >= 0; $i-- ) {
 			if ( isset( $settings['styles'][ $i ]['css'] ) &&
-					$settings['styles'][ $i ]['css'] === $default_styles ) {
+					$default_styles === $settings['styles'][ $i ]['css'] ) {
 				break;
 			}
 		}
 	}
 
-	$settings['styles'][ $i ] = array(
+	$editor_styles = array(
 		'css' => file_get_contents( $editor_styles_file ),
 	);
+
+	// Substitute default styles if found. Otherwise, prepend to setting array.
+	if ( isset( $i ) && $i >= 0 ) {
+		$settings['styles'][ $i ] = $editor_styles;
+	} else {
+		array_unshift( $settings['styles'], $editor_styles );
+	}
 
 	return $settings;
 }

--- a/phpunit/class-extend-styles-test.php
+++ b/phpunit/class-extend-styles-test.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Test `gutenberg_extend_block_editor_styles`.
+ *
+ * @package Gutenberg
+ */
+
+class Extend_Styles_Test extends WP_UnitTestCase {
+
+	/**
+	 * Path of the `editor-styles.css` stub file created, or null if one had
+	 * already existed on the filesystem.
+	 *
+	 * @var string|null
+	 */
+	protected static $stub_file;
+
+	/**
+	 * Contents of the `editor-styles.css` file.
+	 *
+	 * @var string
+	 */
+	protected static $style_contents;
+
+	public static function wpSetUpBeforeClass() {
+		self::ensure_editor_styles();
+	}
+
+	public static function wpTearDownAfterClass() {
+		if ( self::$stub_file ) {
+			unlink( self::$stub_file );
+		}
+	}
+
+	/**
+	 * Verifies that an `editor-styles.css` file exists, creating it otherwise,
+	 * and assigning the `style_contents` and `stub_file` class properties.
+	 */
+	protected static function ensure_editor_styles() {
+		$path = gutenberg_dir_path() . 'build/editor/editor-styles.css';
+
+		if ( file_exists( $path ) ) {
+			self::$style_contents = file_get_contents( $path );
+			self::$stub_file      = null;
+		} else {
+			self::$style_contents = '';
+			file_put_contents( $path, self::$style_contents );
+			self::$stub_file = $path;
+		}
+	}
+
+	/**
+	 * Tests an unset `styles` setting.
+	 */
+	function test_unset_editor_settings_style() {
+		$settings = array();
+
+		$settings = gutenberg_extend_block_editor_styles( $settings );
+
+		$this->assertEquals(
+			array( array( 'css' => self::$style_contents ) ),
+			$settings['styles']
+		);
+	}
+
+	/**
+	 * Tests a default `styles` setting.
+	 */
+	function test_default_editor_settings_style() {
+		$settings = array(
+			'styles' => array(
+				array( 'css' => 'original' ),
+				array( 'css' => 'someother' ),
+			),
+		);
+
+		$settings = gutenberg_extend_block_editor_styles( $settings );
+
+		$this->assertEquals(
+			array(
+				array( 'css' => self::$style_contents ),
+				array( 'css' => 'someother' ),
+			),
+			$settings['styles']
+		);
+	}
+
+}

--- a/phpunit/class-extend-styles-test.php
+++ b/phpunit/class-extend-styles-test.php
@@ -8,68 +8,115 @@
 class Extend_Styles_Test extends WP_UnitTestCase {
 
 	/**
-	 * Path of the `editor-styles.css` stub file created, or null if one had
-	 * already existed on the filesystem.
+	 * Path of the original `editor-styles.css` file.
 	 *
 	 * @var string|null
 	 */
-	protected static $stub_file;
+	protected $orignal_file = null;
 
 	/**
 	 * Contents of the `editor-styles.css` file.
 	 *
 	 * @var string
 	 */
-	protected static $style_contents;
+	protected $style_contents = null;
 
-	public static function wpSetUpBeforeClass() {
-		self::ensure_editor_styles();
+	public function wpTearDown() {
+		parent::wpTearDown();
+
+		$this->restore_editor_styles();
 	}
 
-	public static function wpTearDownAfterClass() {
-		if ( self::$stub_file ) {
-			unlink( self::$stub_file );
+	/**
+	 * Restores the existence of `editor-styles.css` to its original state.
+	 */
+	protected function restore_editor_styles() {
+		$path = gutenberg_dir_path() . 'build/editor/editor-styles.css';
+
+		if ( $this->original_file ) {
+			if ( $this->original_file !== $path ) {
+				rename( $this->original_file, $path );
+			}
+		} elseif ( file_exists( $path ) ) {
+			unlink( $path );
+		}
+
+		$this->style_contents = null;
+		$this->original_file  = null;
+	}
+
+	/**
+	 * Guarantees that an `editor-styles.css` file exists, if and only if it
+	 * should exist. Assigns `style_contents` according to the contents of the
+	 * file if it should exist. Renames the existing file temporarily if it
+	 * exists but should not.
+	 *
+	 * @param bool $should_exist Whether the editor styles file should exist.
+	 */
+	protected function ensure_editor_styles( $should_exist = true ) {
+		$path = gutenberg_dir_path() . 'build/editor/editor-styles.css';
+
+		if ( file_exists( $path ) ) {
+			if ( $should_exist ) {
+				$this->style_contents = file_get_contents( $path );
+				$this->original_file  = $path;
+			} else {
+				rename( $path, $path . '.bak' );
+				$this->original_file = $path . '.bak';
+			}
+		} elseif ( $should_exist ) {
+			$this->style_contents = '';
+			file_put_contents( $path, $this->style_contents );
+			$this->original_file = null;
 		}
 	}
 
 	/**
-	 * Verifies that an `editor-styles.css` file exists, creating it otherwise,
-	 * and assigning the `style_contents` and `stub_file` class properties.
+	 * Tests a non-existent build `styles`.
 	 */
-	protected static function ensure_editor_styles() {
-		$path = gutenberg_dir_path() . 'build/editor/editor-styles.css';
+	function test_without_built_styles() {
+		$this->ensure_editor_styles( false );
 
-		if ( file_exists( $path ) ) {
-			self::$style_contents = file_get_contents( $path );
-			self::$stub_file      = null;
-		} else {
-			self::$style_contents = '';
-			file_put_contents( $path, self::$style_contents );
-			self::$stub_file = $path;
-		}
+		$settings = array(
+			'styles' => array(
+				array( 'css' => 'original' ),
+				array( 'css' => 'someother' ),
+			),
+		);
+
+		$result = gutenberg_extend_block_editor_styles( $settings );
+
+		$this->assertEquals( $settings, $result );
 	}
 
 	/**
 	 * Tests an unset `styles` setting.
 	 */
 	function test_unset_editor_settings_style() {
+		$this->ensure_editor_styles();
+
 		$settings = array();
 
 		$settings = gutenberg_extend_block_editor_styles( $settings );
 
 		$this->assertEquals(
-			array( array( 'css' => self::$style_contents ) ),
+			array( array( 'css' => $this->style_contents ) ),
 			$settings['styles']
 		);
 	}
 
 	/**
-	 * Tests a default `styles` setting.
+	 * Tests replacing the default styles.
 	 */
-	function test_default_editor_settings_style() {
+	function test_replace_default_editor_styles() {
+		$this->ensure_editor_styles();
+		$default_styles = file_get_contents(
+			ABSPATH . WPINC . '/css/dist/editor/editor-styles.css'
+		);
+
 		$settings = array(
 			'styles' => array(
-				array( 'css' => 'original' ),
+				array( 'css' => $default_styles ),
 				array( 'css' => 'someother' ),
 			),
 		);
@@ -78,7 +125,57 @@ class Extend_Styles_Test extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			array(
-				array( 'css' => self::$style_contents ),
+				array( 'css' => $this->style_contents ),
+				array( 'css' => 'someother' ),
+			),
+			$settings['styles']
+		);
+	}
+
+	/**
+	 * Tests replacing the rearranged default styles.
+	 */
+	function test_replace_rearranged_default_editor_styles() {
+		$this->ensure_editor_styles();
+		$default_styles = file_get_contents(
+			ABSPATH . WPINC . '/css/dist/editor/editor-styles.css'
+		);
+
+		$settings = array(
+			'styles' => array(
+				array( 'css' => 'someother' ),
+				array( 'css' => $default_styles ),
+			),
+		);
+
+		$settings = gutenberg_extend_block_editor_styles( $settings );
+
+		$this->assertEquals(
+			array(
+				array( 'css' => 'someother' ),
+				array( 'css' => $this->style_contents ),
+			),
+			$settings['styles']
+		);
+	}
+
+	/**
+	 * Tests when the default styles aren't in the styles setting.
+	 */
+	function test_without_default_editor_styles() {
+		$this->ensure_editor_styles();
+
+		$settings = array(
+			'styles' => array(
+				array( 'css' => 'someother' ),
+			),
+		);
+
+		$settings = gutenberg_extend_block_editor_styles( $settings );
+
+		$this->assertEquals(
+			array(
+				array( 'css' => $this->style_contents ),
 				array( 'css' => 'someother' ),
 			),
 			$settings['styles']


### PR DESCRIPTION
Extracted from: #13569
Related: #9008

This pull request seeks to implement Gutenberg's replacement `editor-styles` setting value as a filter on `block_settings`. This was allow for compatibility with the core implementation once Gutenberg stops reimplementing its own replacement editor (#13569).

**Implementation notes:**

The change to assign `$styles` with `ABSPATH . WPINC . '/css/dist/editor/editor-styles.css'` is merely meant to provide [direct alignment to the core implementation](https://github.com/WordPress/wordpress-develop/blob/ffead81f2282d756f2fe2f7efdfd4c5d0424b6b5/src/wp-admin/edit-form-blocks.php#L168-L181). It's never actually used, since the filtering behavior will substitute the styles with its own implementation. But it needs to exist because the filtering assumes that the styles would be the first entry of the default `$settings['styles']` array. Unfortunately, we must operate on assumptions since the entries of styles are the contents of the stylesheets themselves, not named or assigned as paths. An alternative implementation could consider reading from the `ABSPATH . WPINC` to find and substitute the value by the actual file contents assigned, but there'd be a small amount of overhead in reading from the filesystem.

**Testing instructions:**

Verify that the contents of the built copy of [`packages/editor/src/editor-styles`](https://github.com/WordPress/gutenberg/blob/master/packages/editor/src/editor-styles.scss) are present on the page. This may require inspecting the source of the page. It's easier to verify that it's in-fact the Gutenberg copy by making a change to the source file and rebuilding it.

Additionally, verify that the [separate locale font family assignment](https://github.com/WordPress/gutenberg/blob/62f61631bef4b97be519773eb1b949a847dc493c/lib/client-assets.php#L1045-L1049) (`font-family: 'Noto Serif'`) is not impacted by these changes, meaning that it is still present and occurs after the `editor-styles.css`.