### PR TITLE
Add ellipsis to post title placeholder

### DIFF
--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -118,14 +118,14 @@ class PostTitle extends Component {
 							} }
 						>
 							<label htmlFor={ `post-title-${ instanceId }` } className="screen-reader-text">
-								{ decodedPlaceholder || __( 'Add title' ) }
+								{ decodedPlaceholder || __( 'Add title…' ) }
 							</label>
 							<Textarea
 								id={ `post-title-${ instanceId }` }
 								className="editor-post-title__input"
 								value={ title }
 								onChange={ this.onChange }
-								placeholder={ decodedPlaceholder || __( 'Add title' ) }
+								placeholder={ decodedPlaceholder || __( 'Add title…' ) }
 								onFocus={ this.onSelect }
 								onKeyDown={ this.onKeyDown }
 								onKeyPress={ this.onUnselect }


### PR DESCRIPTION
## Description
Placeholders usually have an ellipsis at the end. See the end of [this comment](https://github.com/WordPress/gutenberg/pull/13583#issuecomment-459286922).

> MInor but worth mentioning: usually, default placeholders have a horizontal ellipsis at the end, e..g. `__( 'Write caption…' )` so I'd suggest to use `__( 'Optional placeholder…' )`

This PR adds an ellipsis to the post title placeholder in the editor.