### PR TITLE
Add Hide teaser help text in More block.

### DIFF
--- a/packages/block-library/src/more/edit.js
+++ b/packages/block-library/src/more/edit.js
@@ -40,11 +40,17 @@ export default class MoreEdit extends Component {
 		}
 	}
 
+	getHideExcerptHelp( checked ) {
+		return checked ?
+			__( 'The excerpt is hidden.' ) :
+			__( 'The excerpt is visible.' );
+	}
+
 	render() {
 		const { customText, noTeaser } = this.props.attributes;
 		const { setAttributes } = this.props;
 
-		const toggleNoTeaser = () => setAttributes( { noTeaser: ! noTeaser } );
+		const toggleHideExcerpt = () => setAttributes( { noTeaser: ! noTeaser } );
 		const { defaultText } = this.state;
 		const value = customText !== undefined ? customText : defaultText;
 		const inputLength = value.length + 1;
@@ -54,9 +60,10 @@ export default class MoreEdit extends Component {
 				<InspectorControls>
 					<PanelBody>
 						<ToggleControl
-							label={ __( 'Hide the teaser before the "More" tag' ) }
+							label={ __( 'Hide the excerpt on the full content page' ) }
 							checked={ !! noTeaser }
-							onChange={ toggleNoTeaser }
+							onChange={ toggleHideExcerpt }
+							help={ this.getHideExcerptHelp }
 						/>
 					</PanelBody>
 				</InspectorControls>

--- a/packages/block-library/src/more/index.js
+++ b/packages/block-library/src/more/index.js
@@ -25,7 +25,7 @@ export const name = 'core/more';
 export const settings = {
 	title: _x( 'More', 'block name' ),
 
-	description: __( 'Mark the excerpt of this content. Content before this block will be shown in the excerpt on your archives page.' ),
+	description: __( 'Content before this block will be shown in the excerpt on your archives page.' ),
 
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M2 9v2h19V9H2zm0 6h5v-2H2v2zm7 0h5v-2H9v2zm7 0h5v-2h-5v2z" /></G></SVG>,
 

--- a/packages/block-library/src/more/test/__snapshots__/edit.js.snap
+++ b/packages/block-library/src/more/test/__snapshots__/edit.js.snap
@@ -6,7 +6,8 @@ exports[`core/more/edit should match snapshot when noTeaser is false 1`] = `
     <ForwardRef(PanelBody)>
       <WithInstanceId(ToggleControl)
         checked={false}
-        label="Hide the teaser before the \\"More\\" tag"
+        help={[Function]}
+        label="Hide the excerpt on the full content page"
         onChange={[Function]}
       />
     </ForwardRef(PanelBody)>
@@ -31,7 +32,8 @@ exports[`core/more/edit should match snapshot when noTeaser is true 1`] = `
     <ForwardRef(PanelBody)>
       <WithInstanceId(ToggleControl)
         checked={true}
-        label="Hide the teaser before the \\"More\\" tag"
+        help={[Function]}
+        label="Hide the excerpt on the full content page"
         onChange={[Function]}
       />
     </ForwardRef(PanelBody)>


### PR DESCRIPTION
## Description
Replaces #6561 which was started by @samikeijonen. 

Adds Hide teaser help text in More block as mentioned in #2146.

This implementation is based on feedback shared by @afercia in https://github.com/WordPress/gutenberg/issues/8974#issuecomment-450347737:

> The help text has been changed in #11587, but still not so clear:
> 
> ```
> More
> Mark the excerpt of this content.
> Content before this block will be
> shown in the excerpt on your
> archives page.
> 
> 
> Hide the teaser before the "More" tag
> ```
> I'd like to suggest to change it into:
> 
> ```
> More
> Content before this block will be
> shown in the excerpt on your
> archive pages.
> 
> 
> Hide the excerpt on the full content page
> ```

https://github.com/WordPress/gutenberg/pull/6561#issuecomment-450362108:
> I'd like to propose something along the lines of the screenshot below:
> 
> <img width="606" alt="screenshot 2018-12-28 at 14 44 09" src="https://user-images.githubusercontent.com/1682452/50517224-8cd78580-0aaf-11e9-8a31-c95516270fa1.png">
> 
> As discussed at length during the implementation of the switch toggle, for better accessibility:
> - an UI control accessible name (the label) should not change dynamically
> - the state should indicated separately: a textual representation of the state is the only guarantee this information can be perceived by everyone


## Screenshots

![screen shot 2019-02-01 at 08 35 20](https://user-images.githubusercontent.com/699132/52109033-5801a580-25fc-11e9-9081-c1d732eafe90.png)
![screen shot 2019-02-01 at 08 35 25](https://user-images.githubusercontent.com/699132/52109034-5801a580-25fc-11e9-9f0d-0a6af07ae4e5.png)
