### PR TITLE
Editor: WritingFlow: Consider selection collapsed for Shift+Arrow at navigable edge

### DIFF
--- a/packages/dom/CHANGELOG.md
+++ b/packages/dom/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 2.0.9 (Unreleased)
+## 2.1.0 (Unreleased)
+
+### New Feature
+
+- New function: `isSelectionForward( selection: Selection )`
 
 ### Bug Fix
 

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -25,7 +25,7 @@ const {
  *
  * @return {boolean} Whether the selection is forward.
  */
-function isSelectionForward( selection ) {
+export function isSelectionForward( selection ) {
 	const {
 		anchorNode,
 		focusNode,

--- a/packages/e2e-tests/specs/__snapshots__/writing-flow.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/writing-flow.test.js.snap
@@ -161,3 +161,19 @@ exports[`adding blocks should not delete surrounding space when deleting a word 
 <p>1 2 3</p>
 <!-- /wp:paragraph -->"
 `;
+
+exports[`adding blocks should respect non-collapsed selection directionality in determining edge 1`] = `
+"<!-- wp:paragraph -->
+<p>As I expected</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`adding blocks should respect non-collapsed selection directionality in determining edge 2`] = `
+"<!-- wp:paragraph -->
+<p>As I expected</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>A<br>B- After B<br>C</p>
+<!-- /wp:paragraph -->"
+`;

--- a/packages/e2e-tests/specs/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/multi-block-selection.test.js
@@ -137,4 +137,19 @@ describe( 'Multi-block selection', () => {
 		const speakTextContent = await page.$eval( '#a11y-speak-assertive', ( element ) => element.textContent );
 		expect( speakTextContent.trim() ).toEqual( '3 blocks selected.' );
 	} );
+
+	it( 'should multi-select from the collapsed edge of a block', async () => {
+		// Explanation: Ensure that WritingFlow's consideration of a navigable
+		// edge of a block doesn't wrongly prevent multi-selection.
+		await clickBlockAppender();
+		await page.keyboard.type( 'First' );
+		await page.keyboard.press( 'Enter' );
+
+		// In a new paragraph, the selection is collapsed at the leading edge
+		// of the node. Shift+ArrowUp should multi-select with the prior block.
+		await pressKeyWithModifier( 'shift', 'ArrowUp' );
+
+		const count = await page.$$eval( '.is-multi-selected', ( blocks ) => blocks.length );
+		expect( count ).toBe( 2 );
+	} );
 } );


### PR DESCRIPTION
Closes #6164

This pull request seeks to resolve an issue with Shift+Arrow behavior of non-collapsed selections. Specifically, when a user selects text while holding Shift and pressing arrow keys, proceeding to press the reverse of those arrow keys while continuing to hold Shift should progressively collapse the selection.

Before|After
---|---
![master-uncollapse](https://user-images.githubusercontent.com/1779930/52131631-41167f80-260b-11e9-8a5c-917e56ac25b6.gif)|![fix-uncollapse](https://user-images.githubusercontent.com/1779930/52131630-41167f80-260b-11e9-8f69-619f58416639.gif)

**Implementation notes:**

I had considered trying to incorporate this into the logic of `isVerticalEdge` and `isHorizontalEdge` from the `dom` module, but it relies on "is Shift held" as a condition to be known, which is made available only by the event handled within `WritingFlow`. Optionally, it could also be considered to pass as an argument.

**Testing instructions:**

Verify the intended fix, that selecting text in a particular direction should inherit browser behavior when that is followed by arrow keys in the reverse direction of the selection.

(It may help to reference the included end-to-end tests to explain the behavior)

Verify expected behavior with WritingFlow continues to work, particularly:

- Arrow presses while the Shift key is _not_ held should navigate correctly within text and between text blocks
- Variations of selection direction (multi-selection should still occur while holding shift and selecting beyond the edges of a block)
