### PR TITLE
Remove "we" from messages

### DIFF
--- a/packages/block-library/src/embed/embed-placeholder.js
+++ b/packages/block-library/src/embed/embed-placeholder.js
@@ -24,7 +24,7 @@ const EmbedPlaceholder = ( props ) => {
 				</Button>
 				{ cannotEmbed &&
 					<p className="components-placeholder__error">
-						{ __( 'Sorry, we could not embed that content.' ) }<br />
+						{ __( 'Sorry, this content could not be embed.' ) }<br />
 						<Button isLarge onClick={ tryAgain }>{ _x( 'Try again', 'button label' ) }</Button> <Button isLarge onClick={ fallback }>{ _x( 'Convert to link', 'button label' ) }</Button>
 					</p>
 				}

--- a/packages/block-library/src/embed/embed-placeholder.js
+++ b/packages/block-library/src/embed/embed-placeholder.js
@@ -24,7 +24,7 @@ const EmbedPlaceholder = ( props ) => {
 				</Button>
 				{ cannotEmbed &&
 					<p className="components-placeholder__error">
-						{ __( 'Sorry, this content could not be embed.' ) }<br />
+						{ __( 'Sorry, this content could not be embedded.' ) }<br />
 						<Button isLarge onClick={ tryAgain }>{ _x( 'Try again', 'button label' ) }</Button> <Button isLarge onClick={ fallback }>{ _x( 'Convert to link', 'button label' ) }</Button>
 					</p>
 				}

--- a/packages/block-library/src/embed/embed-preview.js
+++ b/packages/block-library/src/embed/embed-preview.js
@@ -55,7 +55,7 @@ const EmbedPreview = ( props ) => {
 			{ ( cannotPreview ) ? (
 				<Placeholder icon={ <BlockIcon icon={ icon } showColors /> } label={ label }>
 					<p className="components-placeholder__error"><a href={ url }>{ url }</a></p>
-					<p className="components-placeholder__error">{ __( 'Sorry, we cannot preview this embedded content in the editor.' ) }</p>
+					<p className="components-placeholder__error">{ __( 'Sorry, this embedded content cannot be previewed in the editor.' ) }</p>
 				</Placeholder>
 			) : embedWrapper }
 			{ ( ! RichText.isEmpty( caption ) || isSelected ) && (


### PR DESCRIPTION
## Description
I've removed "we" from messages in embed preview and embed placeholder

closes: #13643 

## How has this been tested?
This has been tested with "npm test" and manually on Chrome and Firefox

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
