### PR TITLE
Update lodash to 4.17.10

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -548,7 +548,7 @@ function gutenberg_register_vendor_scripts() {
 	);
 	gutenberg_register_vendor_script(
 		'lodash',
-		'https://unpkg.com/lodash@4.17.5/lodash' . $suffix . '.js'
+		'https://unpkg.com/lodash@4.17.10/lodash' . $suffix . '.js'
 	);
 	wp_add_inline_script( 'lodash', 'window.lodash = _.noConflict();' );
 	gutenberg_register_vendor_script(


### PR DESCRIPTION
## Description
Requesting lodash 4.17.5 from unpkg was systematically failing making building the zip of the plugin impossible.
```
https://unpkg.com/react-dom@16.6.3/umd/react-dom.production.min.js
 > vendor/react-dom.min.713f0afa.js ... done!
https://unpkg.com/moment@2.22.1/min/moment.min.js
 > vendor/moment.min.42810f9e.js ... done!
https://unpkg.com/lodash@4.17.5/lodash.min.js
 > vendor/lodash.min.59550321.js ... 
HTTP 500
```
Requesting 4.17.10 was working perfectly fine. There are many references to 4.17.10 across our packages so I think it is fine to update the version downloaded from unpkg.

Meanwhile after many tries to download https://unpkg.com/lodash@4.17.5/lodash.min.js and getting error 500, it started working.
I guess older versions are not widely distributed in the CDN and this update is an improvement to avoid problems while building the zip in the future.

## How has this been tested?
I checked Gutenberg works normally (smoke testing).
I checked building Gutenberg zip works correctly `./bin/build-plugin-zip.sh`
I checked I can download https://unpkg.com/lodash@4.17.10/lodash.min.js without any problem.
