### PR TITLE
Make the modal title styling consistent

### DIFF
--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -81,8 +81,8 @@
 	}
 
 	.components-modal__header-heading {
-		font-size: 1em;
-		font-weight: 400;
+		font-size: 1rem;
+		font-weight: 600;
 	}
 
 	h1 {

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/index.js
@@ -69,12 +69,6 @@ const ShortcutSection = ( { title, shortcuts } ) => (
 );
 
 export function KeyboardShortcutHelpModal( { isModalActive, toggleModal } ) {
-	const title = (
-		<span className="edit-post-keyboard-shortcut-help__title">
-			{ __( 'Keyboard Shortcuts' ) }
-		</span>
-	);
-
 	return (
 		<Fragment>
 			<KeyboardShortcuts
@@ -86,7 +80,7 @@ export function KeyboardShortcutHelpModal( { isModalActive, toggleModal } ) {
 			{ isModalActive && (
 				<Modal
 					className="edit-post-keyboard-shortcut-help"
-					title={ title }
+					title={ __( 'Keyboard Shortcuts' ) }
 					closeLabel={ __( 'Close' ) }
 					onRequestClose={ toggleModal }
 				>

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/style.scss
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/style.scss
@@ -1,8 +1,4 @@
 .edit-post-keyboard-shortcut-help {
-	&__title {
-		font-size: 1rem;
-		font-weight: 600;
-	}
 
 	&__section {
 		margin: 0 0 2rem 0;

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
@@ -14,13 +14,7 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
     className="edit-post-keyboard-shortcut-help"
     closeLabel="Close"
     onRequestClose={[Function]}
-    title={
-      <span
-        className="edit-post-keyboard-shortcut-help__title"
-      >
-        Keyboard Shortcuts
-      </span>
-    }
+    title="Keyboard Shortcuts"
   >
     <ShortcutSection
       key="0"

--- a/packages/edit-post/src/components/options-modal/index.js
+++ b/packages/edit-post/src/components/options-modal/index.js
@@ -33,7 +33,7 @@ export function OptionsModal( { isModalActive, isViewable, closeModal } ) {
 	return (
 		<Modal
 			className="edit-post-options-modal"
-			title={ <span className="edit-post-options-modal__title">{ __( 'Options' ) }</span> }
+			title={ __( 'Options' ) }
 			closeLabel={ __( 'Close' ) }
 			onRequestClose={ closeModal }
 		>

--- a/packages/edit-post/src/components/options-modal/style.scss
+++ b/packages/edit-post/src/components/options-modal/style.scss
@@ -1,9 +1,4 @@
 .edit-post-options-modal {
-	&__title {
-		font-size: 1rem;
-		font-weight: 600;
-	}
-
 	&__section {
 		margin: 0 0 2rem 0;
 	}

--- a/packages/edit-post/src/components/options-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/options-modal/test/__snapshots__/index.js.snap
@@ -4,13 +4,7 @@ exports[`OptionsModal should match snapshot when the modal is active 1`] = `
 <WithInstanceId(Modal)
   className="edit-post-options-modal"
   closeLabel="Close"
-  title={
-    <span
-      className="edit-post-options-modal__title"
-    >
-      Options
-    </span>
-  }
+  title="Options"
 >
   <Section
     title="General"


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/13650

In core, we used different and inconsistent modal styles. The resolve modal used the default modal styles, and the keyboard shortcuts and options modals added a span in the title and used a custom version of the title styles (repeating each other).

This PR makes the title styles used by options and keyboard shortcuts modal then default ones making sure plugins can benefit from these styles and removing duplicate code.

Before:
<img width="501" alt="screenshot 2019-02-05 at 12 58 10" src="https://user-images.githubusercontent.com/11271197/52275543-c077bc00-2947-11e9-8e5e-43f7f19ef35f.png">


After:
<img width="530" alt="screenshot 2019-02-05 at 12 57 49" src="https://user-images.githubusercontent.com/11271197/52275549-c372ac80-2947-11e9-9992-771bda3727e3.png">


## How has this been tested?
I added the following content in the code-editor:
```
<!-- wp:paragraph -->
<ps>ssdfds</p>
<!-- /wp:paragraph -->
```

I switched to visual mode pressed the resolve button and verified the new styles were applied.
I checked the options and keyboard shortcut modals continue to work as before.