### PR TITLE
Rename default block styles to "Default"

### DIFF
--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -78,7 +78,7 @@ export const settings = {
 	},
 
 	styles: [
-		{ name: 'default', label: _x( 'Rounded', 'block style' ), isDefault: true },
+		{ name: 'default', label: _x( 'Default', 'block style' ), isDefault: true },
 		{ name: 'outline', label: __( 'Outline' ) },
 		{ name: 'squared', label: _x( 'Squared', 'block style' ) },
 	],

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -66,7 +66,7 @@ export const settings = {
 	attributes: blockAttributes,
 
 	styles: [
-		{ name: 'default', label: _x( 'Regular', 'block style' ), isDefault: true },
+		{ name: 'default', label: _x( 'Default', 'block style' ), isDefault: true },
 		{ name: SOLID_COLOR_STYLE_NAME, label: __( 'Solid Color' ) },
 	],
 

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -51,7 +51,7 @@ export const settings = {
 	attributes: blockAttributes,
 
 	styles: [
-		{ name: 'default', label: _x( 'Regular', 'block style' ), isDefault: true },
+		{ name: 'default', label: _x( 'Default', 'block style' ), isDefault: true },
 		{ name: 'large', label: _x( 'Large', 'block style' ) },
 	],
 

--- a/packages/block-library/src/separator/index.js
+++ b/packages/block-library/src/separator/index.js
@@ -19,7 +19,7 @@ export const settings = {
 	keywords: [ __( 'horizontal-line' ), 'hr', __( 'divider' ) ],
 
 	styles: [
-		{ name: 'default', label: __( 'Short Line' ), isDefault: true },
+		{ name: 'default', label: __( 'Default' ), isDefault: true },
 		{ name: 'wide', label: __( 'Wide Line' ) },
 		{ name: 'dots', label: __( 'Dots' ) },
 	],

--- a/packages/block-library/src/table/index.js
+++ b/packages/block-library/src/table/index.js
@@ -95,7 +95,7 @@ export const settings = {
 	},
 
 	styles: [
-		{ name: 'regular', label: _x( 'Regular', 'block style' ), isDefault: true },
+		{ name: 'regular', label: _x( 'Default', 'block style' ), isDefault: true },
 		{ name: 'stripes', label: __( 'Stripes' ) },
 	],
 


### PR DESCRIPTION
Resolves #13660.

This aligns name we're using in the UI with the classname, and also lets us be a little less prescriptive about what exactly the default block styles per theme should look like.

* Separator block: `Short Line` ➡️ `Default`
* Blockquote block: `Regular` ➡️ `Default`
* Pullquote block: `Regular` ➡️ `Default`
* Table block: `Regular` ➡️ `Default`
* Button block: `Rounded` ➡️ `Default`