### PR TITLE
chore: Fix: Linting problem in modal example code

### DIFF
--- a/packages/components/src/modal/README.md
+++ b/packages/components/src/modal/README.md
@@ -17,7 +17,7 @@ const MyModal = withState( {
 } )( ( { isOpen, setState } ) => (
 	<div>
 		<Button isDefault onClick={ () => setState( { isOpen: true } ) }>Open Modal</Button>
-		{ isOpen ?
+		{ isOpen && (
 			<Modal
 				title="This is my modal"
 				onRequestClose={ () => setState( { isOpen: false } ) }>
@@ -25,7 +25,7 @@ const MyModal = withState( {
 					My custom close button
 				</Button>
 			</Modal>
-			: null }
+		) }
 	</div>
 ) );
 ```


### PR DESCRIPTION
## Description
The modal sample code contains a lint error: `':' should be placed at the end of the line.`.
This PR updates the sample code to conform to the conventions we use in our own code.

## How has this been tested?
I added the new sample code to the file /packages/block-library/src/latest-posts/edit.js. I added the sample component <MyModal /> inside the inspector controls and checked the code works as expected without any lint errors.
