### PR TITLE
Add myself as a code owner to the annotations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 /packages/block-library                         @youknowriad @gziolo @Soean @ajitbohra @jorgefilipecosta
 
 # Editor
-/packages/annotations                           @youknowriad @gziolo @aduth
+/packages/annotations                           @youknowriad @gziolo @aduth @atimmer
 /packages/autop                                 @youknowriad @aduth
 /packages/block-serialization-spec-parser       @youknowriad @gziolo @aduth
 /packages/block-serialization-default-parser    @youknowriad @gziolo @aduth


### PR DESCRIPTION
As I have mainly worked on this it only seems logical to have me as a code owner there.