### PR TITLE
Project: Avoid additional native-file code owner notification

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -75,5 +75,5 @@
 # Documentation
 /docs                                           @youknowriad @gziolo @chrisvanpatten @mkaz @ajitbohra @nosolosw
 
-# Native
-*.native.js                                     @daniloercoli @diegoreymendez @etoledom @hypest @koke @marecar3 @mzorz @pinarol @SergioEstevao @tug
+# Native (Unowned)
+*.native.js                                     @ghost

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -77,3 +77,4 @@
 
 # Native (Unowned)
 *.native.js                                     @ghost
+*.native.scss                                   @ghost


### PR DESCRIPTION
This pull request seeks to propose two changes:

- Remove code ownership individuals from native files.
  - An entry must still be included for native files, to avoid file path matches on preceding entries, as those with ownership over colocated non-native files may not have expertise to weigh in on native pull requests.
  - It is not clear from the `CODEOWNERS` syntax that the users set can be empty. In lieu of that, I've opted to include GItHub's designated "deleted user"
    - Documentation reference as an official GitHub-owned user: https://help.github.com/articles/deleting-your-user-account/
    - Inspired precedent: https://github.com/NixOS/nixpkgs/pull/31534
    - Alternative: Since an email can be provided, this could be an unobserved mailbox
- Add path matching for `*.native.scss` files
    - Example: #13656 had notified many individuals for a mobile-related change