### PR TITLE
Try: Make it easier to select the Separator

### DIFF
--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -24,6 +24,7 @@
 @import "./quote/editor.scss";
 @import "./rss/editor.scss";
 @import "./search/editor.scss";
+@import "./separator/editor.scss";
 @import "./shortcode/editor.scss";
 @import "./spacer/editor.scss";
 @import "./subhead/editor.scss";

--- a/packages/block-library/src/separator/editor.scss
+++ b/packages/block-library/src/separator/editor.scss
@@ -1,0 +1,13 @@
+.wp-block-separator {
+	// Make the separator hit area bigger, to make it more easy to select.
+	&::after {
+		content: "";
+		display: block;
+		padding-bottom: $icon-button-size-small;
+		position: relative;
+		top: ($icon-button-size-small / 2);
+	}
+	margin-top: -($icon-button-size-small / 2);
+	margin-bottom: -$icon-button-size-small / 2;
+	transform: translateY(-$icon-button-size-small / 2);
+}


### PR DESCRIPTION
Fixes #12080

The separator is usually very thin, almost by definition. This makes it hard to select.

This PR tries to make the hit area for the block bigger, therefore easier to select.

It does so at the cost of a little overlap — but this seems worth it. What are your thoughts?

Before (barely selectable):

![before](https://user-images.githubusercontent.com/1204802/52338692-66d8c580-2a0b-11e9-9b51-b392c9cbca7c.gif)

After:

![after](https://user-images.githubusercontent.com/1204802/52338698-693b1f80-2a0b-11e9-9cd6-7b5b3425491f.gif)

Overlap:

![overlap](https://user-images.githubusercontent.com/1204802/52338700-6b04e300-2a0b-11e9-982a-79d738c629aa.gif)
