### PR TITLE
[RNMobile] Make placeholder text working on RichText

### DIFF
--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -362,7 +362,7 @@ export class RichText extends Component {
 		// Save back to HTML from React tree
 		let html = '<' + tagName + '>' + value + '</' + tagName + '>';
 		// We need to check if the value is undefined or empty, and then assign it properly otherwise the placeholder is not visible
-		if ( this.props.placeholder && ( value === undefined || value === '' ) ) {
+		if ( value === undefined || value === '' ) {
 			html = '';
 			this.lastEventCount = undefined; // force a refresh on the native side
 		}

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -360,8 +360,12 @@ export class RichText extends Component {
 			} ) );
 
 		// Save back to HTML from React tree
+		let html = '<' + tagName + '>' + value + '</' + tagName + '>';
 		// We need to check if the value is undefined or empty, and then assign it properly otherwise the placeholder is not visible
-		const html = this.props.placeholder && ( value === undefined || value === '' ) ? '' : '<' + tagName + '>' + value + '</' + tagName + '>';
+		if ( this.props.placeholder && ( value === undefined || value === '' ) ) {
+			html = '';
+			this.lastEventCount = undefined; // force a refresh on the native side
+		}
 
 		return (
 			<View>

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -360,7 +360,8 @@ export class RichText extends Component {
 			} ) );
 
 		// Save back to HTML from React tree
-		const html = '<' + tagName + '>' + value + '</' + tagName + '>';
+		// We need to check if the value is undefined or empty, and then assign it properly otherwise the placeholder is not visible
+		const html = this.props.placeholder && ( value === undefined || value === '' ) ? '' : '<' + tagName + '>' + value + '</' + tagName + '>';
 
 		return (
 			<View>
@@ -373,6 +374,7 @@ export class RichText extends Component {
 					}
 					}
 					text={ { text: html, eventCount: this.lastEventCount } }
+					placeholder={ this.props.placeholder }
 					onChange={ this.onChange }
 					onFocus={ this.props.onFocus }
 					onBlur={ this.props.onBlur }


### PR DESCRIPTION
This PR does fix an issue where the `placeholder` text wasn't working fie on `RichText` for mobile.

The issue was noticed and reported since the Title block is now using the RichText component, but the problem was there on other blocks already. See Para and Heading.

Not sure when we broke it, but i guess long time ago. 
Now the placeholder is visible on Para/Heading/Title blocks.

GB-mobile side PR is here: https://github.com/wordpress-mobile/gutenberg-mobile/pull/544

