### PR TITLE
Focal point picker -use the input-number class and styles already available

### DIFF
--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -211,7 +211,7 @@ export class FocalPointPicker extends Component {
 				<div className="components-focal-point-picker_position-display-container">
 					<BaseControl label={ __( 'Horizontal Pos.' ) }>
 						<input
-							className="components-text-control__input"
+							className="components-range-control__number"
 							id={ horizontalPositionId }
 							max={ TEXTCONTROL_MAX }
 							min={ TEXTCONTROL_MIN }
@@ -223,7 +223,7 @@ export class FocalPointPicker extends Component {
 					</BaseControl>
 					<BaseControl label={ __( 'Vertical Pos.' ) }>
 						<input
-							className="components-text-control__input"
+							className="components-range-control__number"
 							id={ verticalPositionId }
 							max={ TEXTCONTROL_MAX }
 							min={ TEXTCONTROL_MIN }

--- a/packages/components/src/focal-point-picker/style.scss
+++ b/packages/components/src/focal-point-picker/style.scss
@@ -64,11 +64,6 @@
 		margin: 0 1em 0 0;
 	}
 
-	input[type="number"].components-text-control__input { // Needs specificity to override padding.
-		max-width: 4em;
-		padding: 6px 4px;
-	}
-
 	span {
 		margin: 0 0 0 0.2em;
 	}


### PR DESCRIPTION
## Description
Replaces the `class` on the number input from `components-text-control__input` to `components-range-control__number`.

Also removes the styles for that input since `components-range-control__number` already has number input styles. 

This keeps styles consistent with similar controls like "Background Opacity" and the "Columns" number range.

Visually looks the same. Might be a pixel or two different but it is consistent now.

![focalnum](https://user-images.githubusercontent.com/3585901/52373102-de1c5280-2a27-11e9-937b-5cf6d416aa79.png)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
