### PR TITLE
Block API: Add sprintf-js as defined dependency of blocks module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2372,6 +2372,7 @@
 				"rememo": "^3.0.0",
 				"showdown": "^1.8.6",
 				"simple-html-tokenizer": "^0.4.1",
+				"sprintf-js": "^1.1.1",
 				"tinycolor2": "^1.4.1",
 				"uuid": "^3.3.2"
 			}

--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
 		"shallow-equal": "1.0.0",
 		"shallow-equals": "1.0.0",
 		"shallowequal": "1.1.0",
-		"sprintf-js": "1.1.1",
 		"source-map-loader": "0.2.3",
 		"stylelint-config-wordpress": "13.1.0",
 		"uuid": "3.3.2",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -38,6 +38,7 @@
 		"rememo": "^3.0.0",
 		"showdown": "^1.8.6",
 		"simple-html-tokenizer": "^0.4.1",
+		"sprintf-js": "^1.1.1",
 		"tinycolor2": "^1.4.1",
 		"uuid": "^3.3.2"
 	},


### PR DESCRIPTION
This pull request seeks to add a missing dependency to the block's module `package.json`. `sprintf-js` is referenced in `src/api/validation.js` but is not defined as a dependency of the module. It happens to work anyways, but only because `sprintf-js` is a common module, so something else happens to ensure it's in the project's `node_modules`. A module should be explicit with its dependencies to avoid future breakage.

https://github.com/WordPress/gutenberg/blob/31b6b175af43862dbdcfb9a05ca4887f3ad60116/packages/blocks/src/api/validation.js#L262

There was a top-level `devDependencies` for `sprintf-js`, but the only other occurrence of this module being imported is as part of the `i18n` module (which already had it defined appropriately in its own dependencies, and is not a `devDependency`).

**Testing instructions:**

There should be no local changes after a fresh `npm install`, and all tests should pass.