### PR TITLE
Fix meta save causing autosave deletion, resulting in preview not displaying unsaved changes

### DIFF
--- a/docs/designers-developers/developers/data/data-core-edit-post.md
+++ b/docs/designers-developers/developers/data/data-core-edit-post.md
@@ -352,6 +352,10 @@ what Meta boxes are available in which location.
 
 Returns an action object used to request meta box update.
 
+### metaBoxUpdatesStart
+
+Returns an action object used signal meta box updates have begun.
+
 ### metaBoxUpdatesSuccess
 
 Returns an action object used signal a successful meta box update.

--- a/docs/designers-developers/developers/filters/editor-filters.md
+++ b/docs/designers-developers/developers/filters/editor-filters.md
@@ -30,3 +30,21 @@ var customPreviewMessage = function() {
 wp.hooks.addFilter( 'editor.PostPreview.interstitialMarkup', 'my-plugin/custom-preview-message', customPreviewMessage );
 ```
 
+## `editor.updatePost`
+
+Used to perform other steps before, during or after the post update process.
+
+The filter recieves a function `updatePost` that when called triggers the post update. It should return a function that wraps `updatePost` (or returns `updatePost` itself if no actions need to be performed).
+
+_Example:_
+
+```js
+var updatePostFilter = function( updatePost ) {
+	return function() {
+		// make an API request prior to updating the post.
+		myApiRequest().then( updatePost );
+	};
+};
+
+wp.hooks.addFilter( 'editor.updatePost', 'my-plugin/update-post-filter', updatePostFilter );
+```

--- a/packages/e2e-tests/specs/preview.test.js
+++ b/packages/e2e-tests/specs/preview.test.js
@@ -12,47 +12,75 @@ import {
 	createURL,
 	publishPost,
 	saveDraft,
+	clickOnMoreMenuItem,
+	pressKeyWithModifier,
 } from '@wordpress/e2e-test-utils';
+
+async function openPreviewPage( editorPage ) {
+	let openTabs = await browser.pages();
+	const expectedTabsCount = openTabs.length + 1;
+	await editorPage.click( '.editor-post-preview' );
+
+	// Wait for the new tab to open.
+	while ( openTabs.length < expectedTabsCount ) {
+		await editorPage.waitFor( 1 );
+		openTabs = await browser.pages();
+	}
+
+	const previewPage = last( openTabs );
+	// Wait for the preview to load. We can't do interstitial detection here,
+	// because it might load too quickly for us to pick up, so we wait for
+	// the preview to load by waiting for the title to appear.
+	await previewPage.waitForSelector( '.entry-title' );
+	return previewPage;
+}
+
+/**
+ * Given a Puppeteer Page instance for a preview window, clicks Preview, and
+ * awaits the window navigation.
+ *
+ * @param {puppeteer.Page} previewPage Page on which to await navigation.
+ *
+ * @return {Promise} Promise resolving once navigation completes.
+ */
+async function waitForPreviewNavigation( previewPage ) {
+	const navigationCompleted = previewPage.waitForNavigation();
+	await page.click( '.editor-post-preview' );
+	return navigationCompleted;
+}
+
+/**
+ * Enables or disables the custom fields option.
+ *
+ * Note that this is implemented separately from the `toggleScreenOptions`
+ * utility, since the custom fields option triggers a page reload and requires
+ * extra async logic to wait for navigation to complete.
+ *
+ * @param {boolean} shouldBeChecked If true, turns the option on. If false, off.
+ */
+async function toggleCustomFieldsOption( shouldBeChecked ) {
+	await clickOnMoreMenuItem( 'Options' );
+	const [ handle ] = await page.$x( `//label[contains(text(), "Custom Fields")]` );
+
+	const isChecked = await page.evaluate(
+		( element ) => element.control.checked,
+		handle
+	);
+	if ( isChecked !== shouldBeChecked ) {
+		const navigationCompleted = page.waitForNavigation();
+		await handle.click();
+		return navigationCompleted;
+	}
+
+	await page.click( 'button[aria-label="Close dialog"]' );
+}
 
 describe( 'Preview', () => {
 	beforeEach( async () => {
 		await createNewPost();
 	} );
 
-	async function openPreviewPage( editorPage ) {
-		let openTabs = await browser.pages();
-		const expectedTabsCount = openTabs.length + 1;
-		await editorPage.click( '.editor-post-preview' );
-
-		// Wait for the new tab to open.
-		while ( openTabs.length < expectedTabsCount ) {
-			await editorPage.waitFor( 1 );
-			openTabs = await browser.pages();
-		}
-
-		const previewPage = last( openTabs );
-		// Wait for the preview to load. We can't do interstitial detection here,
-		// because it might load too quickly for us to pick up, so we wait for
-		// the preview to load by waiting for the title to appear.
-		await previewPage.waitForSelector( '.entry-title' );
-		return previewPage;
-	}
-
-	/**
-	 * Given a Puppeteer Page instance for a preview window, clicks Preview, and
-	 * awaits the window navigation.
-	 *
-	 * @param {puppeteer.Page} previewPage Page on which to await navigation.
-	 *
-	 * @return {Promise} Promise resolving once navigation completes.
-	 */
-	async function waitForPreviewNavigation( previewPage ) {
-		const navigationCompleted = previewPage.waitForNavigation();
-		await page.click( '.editor-post-preview' );
-		return navigationCompleted;
-	}
-
-	it( 'Should open a preview window for a new post', async () => {
+	it( 'should open a preview window for a new post', async () => {
 		const editorPage = page;
 
 		// Disabled until content present.
@@ -129,7 +157,7 @@ describe( 'Preview', () => {
 		await previewPage.close();
 	} );
 
-	it( 'Should not revert title during a preview right after a save draft', async () => {
+	it( 'should not revert title during a preview right after a save draft', async () => {
 		const editorPage = page;
 
 		// Type aaaaa in the title filed.
@@ -164,5 +192,57 @@ describe( 'Preview', () => {
 		expect( previewTitle ).toBe( 'aaaaabbbbb' );
 
 		await previewPage.close();
+	} );
+} );
+
+describe( 'Preview + Custom Fields', async () => {
+	beforeEach( async () => {
+		await createNewPost();
+		await toggleCustomFieldsOption( true );
+	} );
+
+	afterEach( async () => {
+		await toggleCustomFieldsOption( false );
+	} );
+
+	it( 'displays edits to the post title and content in the preview', async () => {
+		const editorPage = page;
+
+		// Add an initial title and content.
+		await editorPage.type( '.editor-post-title__input', 'title 1' );
+		await editorPage.keyboard.press( 'Tab' );
+		await editorPage.keyboard.type( 'content 1' );
+
+		// Open the preview page.
+		const previewPage = await openPreviewPage( editorPage );
+
+		// Check the title and preview match.
+		let previewTitle = await previewPage.$eval( '.entry-title', ( node ) => node.textContent );
+		expect( previewTitle ).toBe( 'title 1' );
+		let previewContent = await previewPage.$eval( '.entry-content p', ( node ) => node.textContent );
+		expect( previewContent ).toBe( 'content 1' );
+
+		// Return to editor and modify the title and content.
+		await editorPage.bringToFront();
+		await editorPage.click( '.editor-post-title__input' );
+		await pressKeyWithModifier( 'shift', 'Home' );
+		await editorPage.keyboard.press( 'Delete' );
+		await editorPage.keyboard.type( 'title 2' );
+		await editorPage.keyboard.press( 'Tab' );
+		await pressKeyWithModifier( 'shift', 'Home' );
+		await editorPage.keyboard.press( 'Delete' );
+		await editorPage.keyboard.type( 'content 2' );
+
+		// Open the preview page.
+		await waitForPreviewNavigation( previewPage );
+
+		// Title in preview should match input.
+		previewTitle = await previewPage.$eval( '.entry-title', ( node ) => node.textContent );
+		expect( previewTitle ).toBe( 'title 2' );
+		previewContent = await previewPage.$eval( '.entry-content p', ( node ) => node.textContent );
+		expect( previewContent ).toBe( 'content 2' );
+
+		// Make sure the editor is active for the afterEach function.
+		await editorPage.bringToFront();
 	} );
 } );

--- a/packages/edit-post/CHANGELOG.md
+++ b/packages/edit-post/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bug Fixes
  - Fix 'save' keyboard shortcut not functioning in the Code Editor.
+ - Fix issue with preview not displaying unsaved changes when MetaBoxes are active.
 
 ## 3.1.7 (2019-01-03)
 

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -187,6 +187,17 @@ export function requestMetaBoxUpdates() {
 }
 
 /**
+ * Returns an action object used signal meta box updates have begun.
+ *
+ * @return {Object} Action object.
+ */
+export function metaBoxUpdatesStart() {
+	return {
+		type: 'META_BOX_UPDATES_START',
+	};
+}
+
+/**
  * Returns an action object used signal a successful meta box update.
  *
  * @return {Object} Action object.

--- a/packages/edit-post/src/store/effects.js
+++ b/packages/edit-post/src/store/effects.js
@@ -28,6 +28,12 @@ import { onChangeListener } from './utils';
 
 const VIEW_AS_LINK_SELECTOR = '#wp-admin-bar-view a';
 
+/**
+ * Updates MetaBoxes by making a POST request to post.php.
+ *
+ * @return {Promise} A promise when the request to update MetaBoxes is
+ * 				     complete.
+ */
 function updateMetaBoxes() {
 	// Inidicate that the MetaBox update process has started.
 	dispatch( 'core/edit-post' ).metaBoxUpdatesStart();

--- a/packages/edit-post/src/store/reducer.js
+++ b/packages/edit-post/src/store/reducer.js
@@ -188,7 +188,7 @@ export function publishSidebarActive( state = false, action ) {
  */
 export function isSavingMetaBoxes( state = false, action ) {
 	switch ( action.type ) {
-		case 'REQUEST_META_BOX_UPDATES':
+		case 'META_BOX_UPDATES_START':
 			return true;
 		case 'META_BOX_UPDATES_SUCCESS':
 			return false;

--- a/packages/edit-post/src/store/test/reducer.js
+++ b/packages/edit-post/src/store/test/reducer.js
@@ -275,7 +275,7 @@ describe( 'state', () => {
 
 		it( 'should set saving flag to true', () => {
 			const action = {
-				type: 'REQUEST_META_BOX_UPDATES',
+				type: 'META_BOX_UPDATES_START',
 			};
 			const actual = isSavingMetaBoxes( false, action );
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added `createCustomColorsHOC` for creating a higher order `withCustomColors` component.
 - Added a new `TextEditorGlobalKeyboardShortcuts` component.
+- Added `editor.updatePost` filter.
 
 ### Deprecations
 

--- a/packages/editor/src/store/effects/posts.js
+++ b/packages/editor/src/store/effects/posts.js
@@ -41,6 +41,12 @@ import { resolveSelector } from './utils';
 export const SAVE_POST_NOTICE_ID = 'SAVE_POST_NOTICE_ID';
 const TRASH_POST_NOTICE_ID = 'TRASH_POST_NOTICE_ID';
 
+/**
+ * Update the post using the REST API.
+ *
+ * @param {Object} action Action object.
+ * @param {Object} store  Redux Store.
+ */
 const handlePostUpdate = async ( action, store ) => {
 	const { dispatch, getState } = store;
 	const state = getState();
@@ -156,8 +162,8 @@ const handlePostUpdate = async ( action, store ) => {
 /**
  * Request Post Update Effect handler
  *
- * @param {Object} action  the fetchReusableBlocks action object.
- * @param {Object} store   Redux Store.
+ * @param {Object} action The fetchReusableBlocks action object.
+ * @param {Object} store  Redux Store.
  */
 export const requestPostUpdate = async ( action, store ) => {
 	const state = store.getState();
@@ -180,8 +186,8 @@ export const requestPostUpdate = async ( action, store ) => {
 /**
  * Request Post Update Success Effect handler
  *
- * @param {Object} action  action object.
- * @param {Object} store   Redux Store.
+ * @param {Object} action Action object.
+ * @param {Object} store  Redux Store.
  */
 export const requestPostUpdateSuccess = ( action ) => {
 	const { previousPost, post, postType } = action;
@@ -240,7 +246,7 @@ export const requestPostUpdateSuccess = ( action ) => {
 /**
  * Request Post Update Failure Effect handler
  *
- * @param {Object} action  action object.
+ * @param {Object} action Action object.
  */
 export const requestPostUpdateFailure = ( action ) => {
 	const { post, edits, error } = action;
@@ -272,8 +278,8 @@ export const requestPostUpdateFailure = ( action ) => {
 /**
  * Trash Post Effect handler
  *
- * @param {Object} action  action object.
- * @param {Object} store   Redux Store.
+ * @param {Object} action Action object.
+ * @param {Object} store  Redux Store.
  */
 export const trashPost = async ( action, store ) => {
 	const { dispatch, getState } = store;
@@ -301,8 +307,8 @@ export const trashPost = async ( action, store ) => {
 /**
  * Trash Post Failure Effect handler
  *
- * @param {Object} action  action object.
- * @param {Object} store   Redux Store.
+ * @param {Object} action Action object.
+ * @param {Object} store  Redux Store.
  */
 export const trashPostFailure = ( action ) => {
 	const message = action.error.message && action.error.code !== 'unknown_error' ? action.error.message : __( 'Trashing failed' );
@@ -314,8 +320,8 @@ export const trashPostFailure = ( action ) => {
 /**
  * Refresh Post Effect handler
  *
- * @param {Object} action  action object.
- * @param {Object} store   Redux Store.
+ * @param {Object} action Action object.
+ * @param {Object} store  Redux Store.
  */
 export const refreshPost = async ( action, store ) => {
 	const { dispatch, getState } = store;

--- a/packages/editor/src/store/effects/posts.js
+++ b/packages/editor/src/store/effects/posts.js
@@ -160,7 +160,7 @@ const handlePostUpdate = async ( action, store ) => {
 };
 
 /**
- * Request Post Update Effect handler
+ * Request Post Update Effect handler.
  *
  * @param {Object} action The fetchReusableBlocks action object.
  * @param {Object} store  Redux Store.

--- a/packages/editor/src/store/effects/posts.js
+++ b/packages/editor/src/store/effects/posts.js
@@ -13,6 +13,7 @@ import { __ } from '@wordpress/i18n';
 // refactoring editor actions to yielded controls, or replacing direct dispatch
 // on the editor store with action creators (e.g. `REQUEST_POST_UPDATE_START`).
 import { dispatch as dataDispatch } from '@wordpress/data';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -54,6 +55,11 @@ export const requestPostUpdate = async ( action, store ) => {
 	// We don't check for dirtiness here as this can be overridden in the UI.
 	if ( ! isEditedPostSaveable( state ) ) {
 		return;
+	}
+
+	const promise = applyFilters( 'editor.beforePostUpdate', Promise.resolve(), action.options );
+	if ( promise ) {
+		await promise;
 	}
 
 	let edits = getPostEdits( state );


### PR DESCRIPTION
## Description
Fixes #12617 - when metaboxes are active, the preview does not show unsaved changes to posts.

A quick summary of the cause:
1. The user clicks 'preview', which first triggers an autosave.
2. After the autosave is complete, we POST to post.php to update metaboxes (with some special query arguments to ensure a full post update is not carried out).
3. The request to post.php updates the modified date of the post and triggers some housecleaning logic to remove old autosaves—now that the post is newer the autosave from step 1 is removed.
4. The preview is displayed, but since the autosave has been deleted, the preview falls back to the outdated post content.

This PR fixes the issue by changing the save order. First save the metaboxes, then the autosave.

It does so by introducing a new filter 'editor.updatePost', which the metabox code (in the edit-post package) uses to defer the post update until after metaboxes have been saved.

## How has this been tested?
1. Create a new post.
2. Enable 'custom fields' from the options menu.
3. Add a custom field.
4. Add some post content.
5. Save the post.
6. Add more post content.
7. Click preview.

Expected:
The preview displays the content added in step 4.

Previous Behaviour:
The content added in step 4 wasn't displayed.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
