### PR TITLE
Remove stroke from CSS rules that colorize plugin icons

### DIFF
--- a/packages/edit-post/src/components/header/pinned-plugins/style.scss
+++ b/packages/edit-post/src/components/header/pinned-plugins/style.scss
@@ -12,17 +12,23 @@
 	// Colorize plugin icons to ensure contrast and cohesion, but allow plugin developers to override.
 	.components-icon-button:not(.is-toggled) svg,
 	.components-icon-button:not(.is-toggled) svg * {
+		stroke: $dark-gray-500;
 		fill: $dark-gray-500;
+		stroke-width: 0; // !important is omitted here, so stroke-only icons can override easily.
 	}
 
 	// Forcefully colorize hover and toggled plugin icon states to ensure legibility and consistency.
 	.components-icon-button.is-toggled svg,
 	.components-icon-button.is-toggled svg * {
+		stroke: $white !important;
 		fill: $white !important;
+		stroke-width: 0; // !important is omitted here, so stroke-only icons can override easily.
 	}
 
 	.components-icon-button:hover svg,
 	.components-icon-button:hover svg * {
+		stroke: $dark-gray-900 !important;
 		fill: $dark-gray-900 !important;
+		stroke-width: 0; // !important is omitted here, so stroke-only icons can override easily.
 	}
 }

--- a/packages/edit-post/src/components/header/pinned-plugins/style.scss
+++ b/packages/edit-post/src/components/header/pinned-plugins/style.scss
@@ -12,20 +12,17 @@
 	// Colorize plugin icons to ensure contrast and cohesion, but allow plugin developers to override.
 	.components-icon-button:not(.is-toggled) svg,
 	.components-icon-button:not(.is-toggled) svg * {
-		stroke: $dark-gray-500;
 		fill: $dark-gray-500;
 	}
 
 	// Forcefully colorize hover and toggled plugin icon states to ensure legibility and consistency.
 	.components-icon-button.is-toggled svg,
 	.components-icon-button.is-toggled svg * {
-		stroke: $white !important;
 		fill: $white !important;
 	}
 
 	.components-icon-button:hover svg,
 	.components-icon-button:hover svg * {
-		stroke: $dark-gray-900 !important;
 		fill: $dark-gray-900 !important;
 	}
 }


### PR DESCRIPTION
## Description
There are some CSS rules that add stroke to colorize plugin icons. That makes plugin icons look weird as you can see here:

![with stroke](https://user-images.githubusercontent.com/2486539/52399966-12dae900-2abe-11e9-82e1-b023d731318c.png)

After removing the stroke from the CSS rules, plugin icons look great:

![without stroke](https://user-images.githubusercontent.com/2486539/52400001-271ee600-2abe-11e9-847b-ba13d6b9a30e.png)

This happens with both SVG files and dashicons when filling the `icon` argument of `wp.plugins.registerPlugin`.

## How has this been tested?
I just registered a plugin with the following:

```
wp.plugins.registerPlugin( 'my-plugin', {
	icon: 'translation', // the dashicon
	render: Component,
} );
```

## Types of changes
My code just removes the stroke property in three CSS rules.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
