### PR TITLE
Try: Show background and increased opacity on disabled switcher

### DIFF
--- a/packages/editor/src/components/block-switcher/style.scss
+++ b/packages/editor/src/components/block-switcher/style.scss
@@ -11,13 +11,21 @@
 	padding: 3px;
 }
 
-
 .components-icon-button.editor-block-switcher__no-switcher-icon {
 	width: $icon-button-size + 6px + 6px;
+
 	.editor-block-icon {
 		margin-right: auto;
 		margin-left: auto;
 	}
+}
+
+// When the block switcher does not have any transformations, we show it but as disabled.
+// The background and opacity change helps make the icon legible, despite being disabled.
+.components-button.editor-block-switcher__no-switcher-icon:disabled {
+	background: $light-gray-100;
+	border-radius: 0;
+	opacity: 0.8;
 }
 
 // Style this the same as the block buttons in the library.

--- a/packages/editor/src/components/block-switcher/style.scss
+++ b/packages/editor/src/components/block-switcher/style.scss
@@ -23,9 +23,16 @@
 // When the block switcher does not have any transformations, we show it but as disabled.
 // The background and opacity change helps make the icon legible, despite being disabled.
 .components-button.editor-block-switcher__no-switcher-icon:disabled {
-	background: $light-gray-100;
+	background: $light-gray-200;
 	border-radius: 0;
-	opacity: 0.8;
+	opacity: 0.84;
+
+	// Also make the icon monochrome to further imply disabled state.
+	// We use !important here because icon colors are set as inline styles,
+	// and should be overridden when disabled.
+	.editor-block-icon.has-colors {
+		color: $dark-gray-500 !important;
+	}
 }
 
 // Style this the same as the block buttons in the library.


### PR DESCRIPTION
This one goes out to all the @chrivanpatten's in the crowd!

Well, specifically, it is in response to this conversation we had here: https://github.com/WordPress/gutenberg/issues/11669#issuecomment-456808244

The problem: we always show the Block Switcher interface, even if no transformations are available. When no transformations are available, the buttonis _disabled_, which usually means it needs to have very contrast.

However in this case, the block switcher also works as a block type indicator, which makes it valuable to be able to see the icon in question.

This PR tries to marry the two challenges and shows the button as disabled adding a light gray background, but still increasing the opacity.

Thoughts?

Before:

<img width="1100" alt="screenshot 2019-02-07 at 09 59 37" src="https://user-images.githubusercontent.com/1204802/52400920-c6dd7380-2ac0-11e9-834b-3ffe6578bf1e.png">

After:

<img width="280" alt="screenshot 2019-02-07 at 10 13 08" src="https://user-images.githubusercontent.com/1204802/52401016-04da9780-2ac1-11e9-9ea1-22e25f712b7c.png">

<img width="225" alt="screenshot 2019-02-07 at 10 13 19" src="https://user-images.githubusercontent.com/1204802/52401020-060bc480-2ac1-11e9-8eb6-eaa93f2fcec2.png">
