### PR TITLE
Add registry-aware controls

### DIFF
--- a/packages/core-data/src/controls.js
+++ b/packages/core-data/src/controls.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { default as triggerApiFetch } from '@wordpress/api-fetch';
-import { select as selectData } from '@wordpress/data';
+import { createRegistryControl } from '@wordpress/data';
 
 /**
  * Trigger an API Fetch request.
@@ -37,9 +37,9 @@ const controls = {
 		return triggerApiFetch( request );
 	},
 
-	SELECT( { selectorName, args } ) {
-		return selectData( 'core' )[ selectorName ]( ...args );
-	},
+	SELECT: createRegistryControl( ( registry ) => ( { selectorName, args } ) => {
+		return registry.select( 'core' )[ selectorName ]( ...args );
+	} ),
 };
 
 export default controls;

--- a/packages/data/src/factory.js
+++ b/packages/data/src/factory.js
@@ -1,5 +1,5 @@
 /**
- * Mark a function as a registry selector.
+ * Mark a selector as a registry selector.
  *
  * @param {function} registrySelector Function receiving a registry object and returning a state selector.
  *
@@ -9,4 +9,17 @@ export function createRegistrySelector( registrySelector ) {
 	registrySelector.isRegistrySelector = true;
 
 	return registrySelector;
+}
+
+/**
+ * Mark a control as a registry control.
+ *
+ * @param {function} registryControl Function receiving a registry object and returning a control.
+ *
+ * @return {function} marked registry control.
+ */
+export function createRegistryControl( registryControl ) {
+	registryControl.isRegistryControl = true;
+
+	return registryControl;
 }

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -15,7 +15,7 @@ export { default as RegistryProvider, RegistryConsumer } from './components/regi
 export { default as __experimentalAsyncModeProvider } from './components/async-mode-provider';
 export { createRegistry } from './registry';
 export { plugins };
-export { createRegistrySelector } from './factory';
+export { createRegistrySelector, createRegistryControl } from './factory';
 
 /**
  * The combineReducers helper function turns an object whose values are different

--- a/packages/data/src/namespace-store.js
+++ b/packages/data/src/namespace-store.js
@@ -105,24 +105,26 @@ function createReduxStore( reducer, key, registry ) {
  * @return {Object}           Selectors mapped to the redux store provided.
  */
 function mapSelectors( selectors, store, registry ) {
-	const createStateSelector = ( registeredSelector ) => function runSelector() {
+	const createStateSelector = ( registeredSelector ) => {
 		const selector = registeredSelector.isRegistrySelector ? registeredSelector( registry ) : registeredSelector;
 
-		// This function is an optimized implementation of:
-		//
-		//   selector( store.getState(), ...arguments )
-		//
-		// Where the above would incur an `Array#concat` in its application,
-		// the logic here instead efficiently constructs an arguments array via
-		// direct assignment.
-		const argsLength = arguments.length;
-		const args = new Array( argsLength + 1 );
-		args[ 0 ] = store.getState();
-		for ( let i = 0; i < argsLength; i++ ) {
-			args[ i + 1 ] = arguments[ i ];
-		}
+		return function runSelector() {
+			// This function is an optimized implementation of:
+			//
+			//   selector( store.getState(), ...arguments )
+			//
+			// Where the above would incur an `Array#concat` in its application,
+			// the logic here instead efficiently constructs an arguments array via
+			// direct assignment.
+			const argsLength = arguments.length;
+			const args = new Array( argsLength + 1 );
+			args[ 0 ] = store.getState();
+			for ( let i = 0; i < argsLength; i++ ) {
+				args[ i + 1 ] = arguments[ i ];
+			}
 
-		return selector( ...args );
+			return selector( ...args );
+		};
 	};
 
 	return mapValues( selectors, createStateSelector );

--- a/packages/data/src/plugins/controls/index.js
+++ b/packages/data/src/plugins/controls/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { applyMiddleware } from 'redux';
+import { mapValues } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -14,7 +15,10 @@ export default function( registry ) {
 			const store = registry.registerStore( reducerKey, options );
 
 			if ( options.controls ) {
-				const middleware = createMiddleware( options.controls );
+				const normalizedControls = mapValues( options.controls, ( control ) => {
+					return control.isRegistryControl ? control( registry ) : control;
+				} );
+				const middleware = createMiddleware( normalizedControls );
 				const enhancer = applyMiddleware( middleware );
 				const createStore = () => store;
 

--- a/packages/data/src/plugins/controls/test/index.js
+++ b/packages/data/src/plugins/controls/test/index.js
@@ -1,0 +1,44 @@
+/**
+ * Internal dependencies
+ */
+import { createRegistry } from '../../../registry';
+import { createRegistryControl } from '../../../factory';
+import controlsPlugin from '../';
+
+describe( 'controls', () => {
+	let registry;
+
+	beforeEach( () => {
+		registry = createRegistry();
+		registry.use( controlsPlugin );
+	} );
+
+	describe( 'should call registry-aware controls', () => {
+		it( 'registers multiple selectors to the public API', () => {
+			const action1 = jest.fn( () => ( { type: 'NOTHING' } ) );
+			const action2 = function * () {
+				yield { type: 'DISPATCH', store: 'store1', action: 'action1' };
+			};
+			registry.registerStore( 'store1', {
+				reducer: () => 'state1',
+				actions: {
+					action1,
+				},
+			} );
+			registry.registerStore( 'store2', {
+				reducer: () => 'state2',
+				actions: {
+					action2,
+				},
+				controls: {
+					DISPATCH: createRegistryControl( ( reg ) => ( { store, action } ) => {
+						return reg.dispatch( store )[ action ]();
+					} ),
+				},
+			} );
+
+			registry.dispatch( 'store2' ).action2();
+			expect( action1 ).toBeCalled();
+		} );
+	} );
+} );


### PR DESCRIPTION
Related #13662 Requirement for #13088

In some situations, you want to build controls that target another store from the registry. Until now we were relying on the global `select` or `dispatch` functions but the issue is that it only targets the default registry. If we have a separate provider, this might not work as expected. In this PR, I'm introducing a `createRegistryControl` helper used to mark a control a cross-stores control with access to the registry object.

```js
const controls = {
   TYPE_OF_CONTROL: createRegistryControl( registry => (args) => {
      // Do something with registry
   })
}
```

This PR also includes a follow-up performance improvement to the registry-aware selectors.