### PR TITLE
Escape HTML characters

### DIFF
--- a/packages/autop/src/index.js
+++ b/packages/autop/src/index.js
@@ -112,7 +112,7 @@ function replaceInHtmlTags( haystack, replacePairs ) {
  *
  * A group of regex replaces used to identify text formatted with newlines and
  * replace double line-breaks with HTML paragraph tags. The remaining line-
- * breaks after conversion become <<br />> tags, unless br is set to 'false'.
+ * breaks after conversion become `<br />` tags, unless br is set to 'false'.
  *
  * @param  {string}    text The text which has to be formatted.
  * @param  {boolean}   br   Optional. If set, will convert all remaining line-
@@ -278,10 +278,10 @@ export function autop( text, br = true ) {
 }
 
 /**
- * Replaces <p> tags with two line breaks. "Opposite" of autop().
+ * Replaces `<p>` tags with two line breaks. "Opposite" of autop().
  *
- * Replaces <p> tags with two line breaks except where the <p> has attributes.
- * Unifies whitespace. Indents <li>, <dt> and <dd> for better readability.
+ * Replaces `<p>` tags with two line breaks except where the `<p>` has attributes.
+ * Unifies whitespace. Indents `<li>`, `<dt>` and `<dd>` for better readability.
  *
  * @param  {string} html The content from the editor.
  * @return {string}      The content with stripped paragraph tags.


### PR DESCRIPTION
We are about to use JSDoc comment description to generate some documentation in Markdown format (and potentially others).

HTML tags need to be escaped for Markdown not to consider them HTML.
