### PR TITLE
Use example tag

### DIFF
--- a/packages/e2e-test-utils/src/mocks/set-up-response-mocking.js
+++ b/packages/e2e-test-utils/src/mocks/set-up-response-mocking.js
@@ -16,19 +16,19 @@ let requestMocks = [];
  *
  * @example
  *
- *```js
- *   const MOCK_RESPONSES = [
- *     {
- *       match: isEmbedding( 'https://wordpress.org/gutenberg/handbook/' ),
- *       onRequestMatch: JSONResponse( MOCK_BAD_WORDPRESS_RESPONSE ),
- *     },
- *     {
- *       match: isEmbedding( 'https://wordpress.org/gutenberg/handbook/block-api/attributes/' ),
- *       onRequestMatch: JSONResponse( MOCK_EMBED_WORDPRESS_SUCCESS_RESPONSE ),
- *     }
- *  ];
- *  setUpResponseMocking( MOCK_RESPONSES );
- *```
+ * ```js
+ * const MOCK_RESPONSES = [
+ *   {
+ *     match: isEmbedding( 'https://wordpress.org/gutenberg/handbook/' ),
+ *     onRequestMatch: JSONResponse( MOCK_BAD_WORDPRESS_RESPONSE ),
+ *   },
+ *   {
+ *     match: isEmbedding( 'https://wordpress.org/gutenberg/handbook/block-api/attributes/' ),
+ *     onRequestMatch: JSONResponse( MOCK_EMBED_WORDPRESS_SUCCESS_RESPONSE ),
+ *   }
+ * ];
+ * setUpResponseMocking( MOCK_RESPONSES );
+ * ```
  *
  * If none of the mock settings match the request, the request is allowed to continue.
  *

--- a/packages/e2e-test-utils/src/mocks/set-up-response-mocking.js
+++ b/packages/e2e-test-utils/src/mocks/set-up-response-mocking.js
@@ -10,10 +10,13 @@ let requestMocks = [];
 
 /**
  * Sets up mock checks and responses. Accepts a list of mock settings with the following properties:
- *   - match: function to check if a request should be mocked.
- *   - onRequestMatch: async function to respond to the request.
  *
- * Example:
+ * - `match`: function to check if a request should be mocked.
+ * - `onRequestMatch`: async function to respond to the request.
+ *
+ * @example
+ *
+ *```js
  *   const MOCK_RESPONSES = [
  *     {
  *       match: isEmbedding( 'https://wordpress.org/gutenberg/handbook/' ),
@@ -25,6 +28,7 @@ let requestMocks = [];
  *     }
  *  ];
  *  setUpResponseMocking( MOCK_RESPONSES );
+ *```
  *
  * If none of the mock settings match the request, the request is allowed to continue.
  *


### PR DESCRIPTION
We're about to create external documentation from the JSDoc comments. Using the `@example` tag makes the example to look nicer in the docs.
