### PR TITLE
ESLint Plugin: Add rule dependency-group

### DIFF
--- a/packages/a11y/src/index.js
+++ b/packages/a11y/src/index.js
@@ -1,6 +1,13 @@
+/**
+ * WordPress dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+
+/**
+ * Internal dependencies
+ */
 import addContainer from './addContainer';
 import clear from './clear';
-import domReady from '@wordpress/dom-ready';
 import filterMessage from './filterMessage';
 
 /**

--- a/packages/a11y/src/test/addContainer.test.js
+++ b/packages/a11y/src/test/addContainer.test.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import addContainer from '../addContainer';
 
 describe( 'addContainer', () => {

--- a/packages/a11y/src/test/clear.test.js
+++ b/packages/a11y/src/test/clear.test.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import clear from '../clear';
 
 describe( 'clear', () => {

--- a/packages/a11y/src/test/filterMessage.test.js
+++ b/packages/a11y/src/test/filterMessage.test.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import filterMessage from '../filterMessage';
 
 describe( 'filterMessage', () => {

--- a/packages/a11y/src/test/index.test.js
+++ b/packages/a11y/src/test/index.test.js
@@ -1,4 +1,14 @@
+/**
+ * WordPress dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+
+/**
+ * Internal dependencies
+ */
 import { setup, speak } from '../';
+import clear from '../clear';
+import filterMessage from '../filterMessage';
 
 jest.mock( '../clear', () => {
 	return jest.fn();
@@ -13,10 +23,6 @@ jest.mock( '../filterMessage', () => {
 		return message;
 	} );
 } );
-
-import clear from '../clear';
-import domReady from '@wordpress/dom-ready';
-import filterMessage from '../filterMessage';
 
 describe( 'speak', () => {
 	let containerPolite = document.getElementById( 'a11y-speak-polite' );

--- a/packages/blob/src/test/index.js
+++ b/packages/blob/src/test/index.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import {
 	isBlobURL,
 } from '../';

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -18,16 +18,20 @@ import {
 } from 'lodash';
 
 /**
- * Internal dependencies
+ * WordPress dependencies
  */
 import { MediaPlaceholder, RichText, BlockControls, InspectorControls, BottomSheet } from '@wordpress/editor';
 import { Toolbar, ToolbarButton, Spinner, Dashicon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import ImageSize from './image-size';
 import { isURL } from '@wordpress/url';
-import styles from './styles.scss';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import ImageSize from './image-size';
+import styles from './styles.scss';
 
 const MEDIA_UPLOAD_STATE_UPLOADING = 1;
 const MEDIA_UPLOAD_STATE_SUCCEEDED = 2;

--- a/packages/block-library/src/image/image-size.native.js
+++ b/packages/block-library/src/image/image-size.native.js
@@ -4,8 +4,8 @@
 import { Component } from '@wordpress/element';
 
 /**
-* External dependencies
-*/
+ * External dependencies
+ */
 import { View, Image } from 'react-native';
 
 /**

--- a/packages/block-library/src/nextpage/index.js
+++ b/packages/block-library/src/nextpage/index.js
@@ -5,6 +5,10 @@ import { __ } from '@wordpress/i18n';
 import { RawHTML } from '@wordpress/element';
 import { createBlock } from '@wordpress/blocks';
 import { G, Path, SVG } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
 import edit from './edit';
 
 export const name = 'core/nextpage';

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -12,7 +12,7 @@ import { parse, createBlock } from '@wordpress/blocks';
 import { RichText } from '@wordpress/editor';
 
 /**
- * Import style
+ * Internal dependencies
  */
 import styles from './style.scss';
 

--- a/packages/block-library/src/preformatted/index.js
+++ b/packages/block-library/src/preformatted/index.js
@@ -1,5 +1,5 @@
 /**
- * WordPress
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { createBlock, getPhrasingContentSchema } from '@wordpress/blocks';

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -18,6 +18,9 @@ import {
 } from '@wordpress/data';
 import { Path, Polygon, SVG } from '@wordpress/components';
 
+/**
+ * Internal dependencies
+ */
 import {
 	default as edit,
 	SOLID_COLOR_STYLE_NAME,

--- a/packages/block-library/src/spacer/index.js
+++ b/packages/block-library/src/spacer/index.js
@@ -4,7 +4,7 @@
 import classnames from 'classnames';
 
 /**
- * WordPress
+ * WordPress dependencies
  */
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';

--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -1,5 +1,5 @@
 /**
- * WordPress
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';

--- a/packages/block-serialization-default-parser/test/index.js
+++ b/packages/block-serialization-default-parser/test/index.js
@@ -4,9 +4,13 @@
 import path from 'path';
 
 /**
- * Internal dependencies
+ * WordPress dependencies
  */
 import { jsTester, phpTester } from '@wordpress/block-serialization-spec-parser';
+
+/**
+ * Internal dependencies
+ */
 import { parse } from '../';
 
 describe( 'block-serialization-default-parser-js', jsTester( parse ) );

--- a/packages/blocks/src/api/raw-handling/utils.js
+++ b/packages/blocks/src/api/raw-handling/utils.js
@@ -7,11 +7,11 @@ import { mapValues, mergeWith, includes, noop } from 'lodash';
  * WordPress dependencies
  */
 import { unwrap, insertAfter, remove } from '@wordpress/dom';
-import { hasBlockSupport } from '..';
 
 /**
  * Internal dependencies
  */
+import { hasBlockSupport } from '..';
 import { isPhrasingContent } from './phrasing-content';
 
 /**

--- a/packages/blocks/src/index.js
+++ b/packages/blocks/src/index.js
@@ -7,6 +7,11 @@
 //
 // Blocks are inferred from the HTML source of a post through a parsing mechanism
 // and then stored as objects in state, from which it is then rendered for editing.
+
+/**
+ * Internal dependencies
+ */
 import './store';
+
 export * from './api';
 export { withBlockContentContext } from './block-content-provider';

--- a/packages/components/src/checkbox-control/index.js
+++ b/packages/components/src/checkbox-control/index.js
@@ -1,5 +1,5 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
 import { withInstanceId } from '@wordpress/compose';
 

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -8,7 +8,6 @@ import { map } from 'lodash';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import Dashicon from '../dashicon';
 
 /**
  * Internal dependencies
@@ -17,6 +16,7 @@ import Button from '../button';
 import Dropdown from '../dropdown';
 import Tooltip from '../tooltip';
 import ColorPicker from '../color-picker';
+import Dashicon from '../dashicon';
 
 export default function ColorPalette( { colors, disableCustomColors = false, value, onChange, className } ) {
 	function applyOrUnset( color ) {

--- a/packages/components/src/form-token-field/test/lib/token-field-wrapper.js
+++ b/packages/components/src/form-token-field/test/lib/token-field-wrapper.js
@@ -1,8 +1,12 @@
 /**
+ * External dependencies
+ */
+import { unescape } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { unescape } from 'lodash';
 
 /**
  * Internal dependencies

--- a/packages/components/src/icon/index.js
+++ b/packages/components/src/icon/index.js
@@ -2,6 +2,10 @@
  * WordPress dependencies
  */
 import { cloneElement, createElement, Component, isValidElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
 import { Dashicon, SVG } from '../';
 
 function Icon( { icon = null, size, className } ) {

--- a/packages/components/src/icon/test/index.js
+++ b/packages/components/src/icon/test/index.js
@@ -7,12 +7,12 @@ import { shallow } from 'enzyme';
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { Path, SVG } from '../../';
 
 /**
  * Internal dependencies
  */
 import Icon from '../';
+import { Path, SVG } from '../../';
 
 describe( 'Icon', () => {
 	const className = 'example-class';

--- a/packages/components/src/isolated-event-container/index.js
+++ b/packages/components/src/isolated-event-container/index.js
@@ -1,5 +1,5 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
 

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import isShallowEqual from '@wordpress/is-shallow-equal';
 
 /**
  * WordPress dependencies
@@ -10,6 +9,7 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
 import { Component, createRef } from '@wordpress/element';
 import { focus } from '@wordpress/dom';
 import { ESCAPE } from '@wordpress/keycodes';
+import isShallowEqual from '@wordpress/is-shallow-equal';
 
 /**
  * Internal dependencies

--- a/packages/components/src/primitives/svg/index.js
+++ b/packages/components/src/primitives/svg/index.js
@@ -1,5 +1,5 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
 import { createElement } from '@wordpress/element';
 

--- a/packages/components/src/server-side-render/test/index.js
+++ b/packages/components/src/server-side-render/test/index.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { rendererPath } from '../index';
 
 describe( 'rendererPath', function() {

--- a/packages/components/src/spinner/index.native.js
+++ b/packages/components/src/spinner/index.native.js
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { View } from 'react-native';
 
 export default function Spinner( props 	) {

--- a/packages/components/src/toolbar/toolbar-container.native.js
+++ b/packages/components/src/toolbar/toolbar-container.native.js
@@ -3,6 +3,9 @@
  */
 import { View } from 'react-native';
 
+/**
+ * Internal dependencies
+ */
 import styles from './style.scss';
 
 const ToolbarContainer = ( props ) => (

--- a/packages/compose/src/with-global-events/test/index.js
+++ b/packages/compose/src/with-global-events/test/index.js
@@ -4,7 +4,7 @@
 import TestRenderer from 'react-test-renderer';
 
 /**
- * External dependencies
+ * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
 

--- a/packages/data/src/default-registry.js
+++ b/packages/data/src/default-registry.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { createRegistry } from './registry';
 
 export default createRegistry();

--- a/packages/dom-ready/src/test/index.test.js
+++ b/packages/dom-ready/src/test/index.test.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import domReady from '../';
 
 describe( 'domReady', () => {

--- a/packages/e2e-test-utils/src/create-url.js
+++ b/packages/e2e-test-utils/src/create-url.js
@@ -4,6 +4,9 @@
 import { join } from 'path';
 import { URL } from 'url';
 
+/**
+ * Internal dependencies
+ */
 import { WP_BASE_URL } from './shared/config';
 
 /**

--- a/packages/e2e-tests/specs/publish-button.test.js
+++ b/packages/e2e-tests/specs/publish-button.test.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import {
 	arePrePublishChecksEnabled,
 	disablePrePublishChecks,

--- a/packages/e2e-tests/specs/publish-panel.test.js
+++ b/packages/e2e-tests/specs/publish-panel.test.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import {
 	arePrePublishChecksEnabled,
 	disablePrePublishChecks,

--- a/packages/editor/src/components/block-mover/drag-handle.js
+++ b/packages/editor/src/components/block-mover/drag-handle.js
@@ -4,7 +4,7 @@
 import classnames from 'classnames';
 
 /**
- * WordPress dependencies
+ * Internal dependencies
  */
 import BlockDraggable from '../block-draggable';
 

--- a/packages/editor/src/components/default-block-appender/index.native.js
+++ b/packages/editor/src/components/default-block-appender/index.native.js
@@ -11,6 +11,9 @@ import { compose } from '@wordpress/compose';
 import { decodeEntities } from '@wordpress/html-entities';
 import { withSelect, withDispatch } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
 import styles from './style.scss';
 
 export function DefaultBlockAppender( {

--- a/packages/editor/src/components/media-placeholder/index.native.js
+++ b/packages/editor/src/components/media-placeholder/index.native.js
@@ -3,9 +3,15 @@
  */
 import { View, Text, Button } from 'react-native';
 
-import styles from './styles.scss';
-
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import styles from './styles.scss';
 
 function MediaPlaceholder( props ) {
 	return (

--- a/packages/editor/src/components/mobile/bottom-sheet/button.native.js
+++ b/packages/editor/src/components/mobile/bottom-sheet/button.native.js
@@ -1,6 +1,6 @@
 /**
-* External dependencies
-*/
+ * External dependencies
+ */
 import { TouchableOpacity, View, Text } from 'react-native';
 
 /**

--- a/packages/editor/src/components/mobile/bottom-sheet/cell.native.js
+++ b/packages/editor/src/components/mobile/bottom-sheet/cell.native.js
@@ -1,6 +1,6 @@
 /**
-* External dependencies
-*/
+ * External dependencies
+ */
 import { TouchableOpacity, Text, View, TextInput } from 'react-native';
 
 /**

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -12,6 +12,9 @@ import { compose, ifCondition } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { PanelBody } from '@wordpress/components';
 
+/**
+ * Internal dependencies
+ */
 import FlatTermSelector from '../post-taxonomies/flat-term-selector';
 
 const TagsPanel = () => {

--- a/packages/editor/src/editor-styles/index.js
+++ b/packages/editor/src/editor-styles/index.js
@@ -9,7 +9,7 @@ import { map } from 'lodash';
 import { compose } from '@wordpress/compose';
 
 /**
- * External dependencies
+ * Internal dependencies
  */
 import traverse from './traverse';
 import urlRewrite from './transforms/url-rewrite';

--- a/packages/editor/src/editor-styles/traverse.js
+++ b/packages/editor/src/editor-styles/traverse.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-import { parse, stringify } from './ast';
 import traverse from 'traverse';
+
+/**
+ * Internal dependencies
+ */
+import { parse, stringify } from './ast';
 
 function traverseCSS( css, callback ) {
 	try {

--- a/packages/editor/src/hooks/test/generated-class-name.js
+++ b/packages/editor/src/hooks/test/generated-class-name.js
@@ -4,7 +4,7 @@
 import { noop } from 'lodash';
 
 /**
- * External dependencies
+ * WordPress dependencies
  */
 import { applyFilters } from '@wordpress/hooks';
 

--- a/packages/element/src/raw-html.js
+++ b/packages/element/src/raw-html.js
@@ -1,5 +1,5 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
 import { createElement } from './react';
 

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### New Features
 
 - New Rule: [`@wordpress/no-unused-vars-before-return`](https://github.com/WordPress/gutenberg/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars-before-return.md)
+- New Rule: [`@wordpress/dependency-group`](https://github.com/WordPress/gutenberg/blob/master/packages/eslint-plugin/docs/rules/dependency-group.md)
 
 ## 1.0.0 (2018-12-12)
 

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -49,7 +49,8 @@ The granular rulesets will not define any environment globals. As such, if they 
 
 Rule|Description
 ---|---
-[no-unused-vars-before-return](docs/rules/no-unused-vars-before-return.md)|Disallow assigning variable values if unused before a return
+[no-unused-vars-before-return](/packages/eslint-plugin/docs/rules/no-unused-vars-before-return.md)|Disallow assigning variable values if unused before a return
+[dependency-group](/packages/eslint-plugin/docs/rules/dependency-group.md)|Enforce dependencies docblocks formatting
 
 ### Legacy
 

--- a/packages/eslint-plugin/configs/custom.js
+++ b/packages/eslint-plugin/configs/custom.js
@@ -3,6 +3,7 @@ module.exports = {
 		'@wordpress',
 	],
 	rules: {
+		'@wordpress/dependency-group': 'error',
 		'@wordpress/no-unused-vars-before-return': 'error',
 		'no-restricted-syntax': [
 			'error',

--- a/packages/eslint-plugin/docs/rules/dependency-group.md
+++ b/packages/eslint-plugin/docs/rules/dependency-group.md
@@ -1,0 +1,36 @@
+# Enforce dependencies docblocks formatting (dependency-group)
+
+Ensures that all top-level package imports adhere to the dependencies grouping conventions as outlined in the [Coding Guidelines](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/coding-guidelines.md#imports).
+
+Specifically, this ensures that:
+
+- An import is preceded by "External dependencies", "WordPress dependencies", or "Internal dependencies" as appropriate by the import source.
+
+## Rule details
+
+Examples of **incorrect** code for this rule:
+
+```js
+import { get } from 'lodash';
+import { Component } from '@wordpress/element';
+import edit from './edit';
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/*
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/*
+ * Internal dependencies
+ */
+import edit from './edit';
+```

--- a/packages/eslint-plugin/docs/rules/no-unused-vars-before-return.md
+++ b/packages/eslint-plugin/docs/rules/no-unused-vars-before-return.md
@@ -4,7 +4,7 @@ To avoid wastefully computing the result of a function call when assigning a var
 
 ## Rule details
 
-The following patterns are considered warnings:
+Examples of **incorrect** code for this rule:
 
 ```js
 function example( number ) {
@@ -17,7 +17,7 @@ function example( number ) {
 }
 ```
 
-The following patterns are not considered warnings:
+Examples of **correct** code for this rule:
 
 ```js
 function example( number ) {

--- a/packages/eslint-plugin/rules/__tests__/dependencies-docblocks.js
+++ b/packages/eslint-plugin/rules/__tests__/dependencies-docblocks.js
@@ -40,6 +40,7 @@ import edit from './edit';`,
 		{
 			code: `
 import { get } from 'lodash';
+import classnames from 'classnames';
 import { Component } from '@wordpress/element';
 import edit from './edit';`,
 			errors: [
@@ -47,6 +48,20 @@ import edit from './edit';`,
 				{ message: 'Expected preceding "WordPress dependencies" comment block' },
 				{ message: 'Expected preceding "Internal dependencies" comment block' },
 			],
+			output: `
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+import classnames from 'classnames';
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import edit from './edit';`,
 		},
 	],
 } );

--- a/packages/eslint-plugin/rules/__tests__/dependencies-docblocks.js
+++ b/packages/eslint-plugin/rules/__tests__/dependencies-docblocks.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { RuleTester } from 'eslint';
+
+/**
+ * Internal dependencies
+ */
+import rule from '../dependency-group';
+
+const ruleTester = new RuleTester( {
+	parserOptions: {
+		sourceType: 'module',
+		ecmaVersion: 6,
+	},
+} );
+
+ruleTester.run( 'dependency-group', rule, {
+	valid: [
+		{
+			code: `
+/*
+ * External dependencies
+ */
+import { get } from 'lodash';
+import classnames from 'classnames';
+
+/*
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/*
+ * Internal dependencies
+ */
+import edit from './edit';`,
+		},
+	],
+	invalid: [
+		{
+			code: `
+import { get } from 'lodash';
+import { Component } from '@wordpress/element';
+import edit from './edit';`,
+			errors: [
+				{ message: 'Expected preceding "External dependencies" comment block' },
+				{ message: 'Expected preceding "WordPress dependencies" comment block' },
+				{ message: 'Expected preceding "Internal dependencies" comment block' },
+			],
+		},
+	],
+} );

--- a/packages/eslint-plugin/rules/dependency-group.js
+++ b/packages/eslint-plugin/rules/dependency-group.js
@@ -1,0 +1,140 @@
+module.exports = {
+	meta: {
+		type: 'layout',
+		docs: {
+			description: 'Enforce dependencies docblocks formatting',
+			url: 'https://github.com/WordPress/gutenberg/blob/master/packages/eslint-plugin/docs/rules/dependency-group.md',
+		},
+		schema: [],
+	},
+	create( context ) {
+		const comments = context.getSourceCode().getAllComments();
+
+		/**
+		 * Locality classification of an import, one of "External",
+		 * "WordPress", "Internal".
+		 *
+		 * @typedef {string} WPPackageLocality
+		 */
+
+		/**
+		 * Given an import source string, returns the locality classification
+		 * of the import sort.
+		 *
+		 * @param {string} source Import source string.
+		 *
+		 * @return {WPPackageLocality} Package locality.
+		 */
+		function getPackageLocality( source ) {
+			if ( source.startsWith( '.' ) ) {
+				return 'Internal';
+			} else if ( source.startsWith( '@wordpress/' ) ) {
+				return 'WordPress';
+			}
+
+			return 'External';
+		}
+
+		/**
+		 * Returns true if the given comment node satisfies a desired locality,
+		 * or false otherwise.
+		 *
+		 * @param {espree.Node}       node     Comment node to check.
+		 * @param {WPPackageLocality} locality Desired package locality.
+		 *
+		 * @return {boolean} Whether comment node satisfies locality.
+		 */
+		function isLocalityDependencyBlock( node, locality ) {
+			const { type, value } = node;
+			if ( type !== 'Block' ) {
+				return false;
+			}
+
+			// (Temporary) Tolerances:
+			// - Normalize `/**` and `/*`
+			// - Case insensitive "Dependencies" vs. "dependencies"
+			// - Ending period
+			// - "Node" dependencies as an alias for External
+
+			if ( locality === 'External' ) {
+				locality = '(External|Node)';
+			}
+
+			const pattern = new RegExp( `^\\*?\\n \\* ${ locality } [dD]ependencies\\.?\\n $` );
+			return pattern.test( value );
+		}
+
+		/**
+		 * Returns true if the given node occurs prior in code to a reference,
+		 * or false otherwise.
+		 *
+		 * @param {espree.Node} node      Node to test being before reference.
+		 * @param {espree.Node} reference Node against which to compare.
+		 *
+		 * @return {boolean} Whether node occurs before reference.
+		 */
+		function isBefore( node, reference ) {
+			return node.start < reference.start;
+		}
+
+		/**
+		 * Returns true if a given node is preceded by a comment block
+		 * satisfying a locality requirement, or false otherwise.
+		 *
+		 * @param {espree.Node}       node     Node to test.
+		 * @param {WPPackageLocality} locality Desired package locality.
+		 *
+		 * @return {boolean} Whether node preceded by locality comment block.
+		 */
+		function isPrecededByDependencyBlock( node, locality ) {
+			return comments.some( ( comment ) => {
+				return isLocalityDependencyBlock( comment, locality ) && isBefore( comment, node );
+			} );
+		}
+
+		/**
+		 * Given an import source string and node occurrence from which the
+		 * source is derived, tests that the package source is satisfied by a
+		 * preceding comment block of appropriate locality.
+		 *
+		 * @param {string}      source Import source string.
+		 * @param {espree.Node} node   Node from which import source derived.
+		 */
+		function testPackage( source, node ) {
+			const locality = getPackageLocality( source );
+			if ( ! isPrecededByDependencyBlock( node, locality ) ) {
+				context.report( {
+					node,
+					message: `Expected preceding "${ locality } dependencies" comment block`,
+				} );
+			}
+		}
+
+		return {
+			Program( node ) {
+				// Since we only care to enforce imports which occur at the
+				// top-level scope, match on Program and test its children,
+				// rather than matching the import nodes directly.
+				node.body.forEach( ( child ) => {
+					switch ( child.type ) {
+						case 'ImportDeclaration':
+							testPackage( child.source.value, child );
+							break;
+
+						case 'CallExpression':
+							const { callee, arguments: args } = child;
+							if (
+								callee.name === 'require' &&
+								args.length === 1 &&
+								args[ 0 ].type === 'Literal' &&
+								typeof args[ 0 ].value === 'string'
+							) {
+								testPackage( args[ 0 ].value, child );
+							}
+							break;
+					}
+				} );
+			},
+		};
+	},
+};

--- a/packages/hooks/src/createAddHook.js
+++ b/packages/hooks/src/createAddHook.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import validateNamespace from './validateNamespace.js';
 import validateHookName from './validateHookName.js';
 import { doAction } from './';

--- a/packages/hooks/src/createDidHook.js
+++ b/packages/hooks/src/createDidHook.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import validateHookName from './validateHookName.js';
 
 /**

--- a/packages/hooks/src/createHooks.js
+++ b/packages/hooks/src/createHooks.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import createAddHook from './createAddHook';
 import createRemoveHook from './createRemoveHook';
 import createHasHook from './createHasHook';

--- a/packages/hooks/src/createRemoveHook.js
+++ b/packages/hooks/src/createRemoveHook.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import validateNamespace from './validateNamespace.js';
 import validateHookName from './validateHookName.js';
 import { doAction } from './';

--- a/packages/hooks/src/index.js
+++ b/packages/hooks/src/index.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import createHooks from './createHooks';
 
 const {

--- a/packages/redux-routine/src/is-action.js
+++ b/packages/redux-routine/src/is-action.js
@@ -1,5 +1,5 @@
 /**
- * External imports
+ * External dependencies
  */
 import { isPlainObject, isString } from 'lodash';
 

--- a/packages/rich-text/src/index.js
+++ b/packages/rich-text/src/index.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import './store';
 
 export { applyFormat } from './apply-format';

--- a/packages/rich-text/src/is-empty.js
+++ b/packages/rich-text/src/is-empty.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { LINE_SEPARATOR } from './special-characters';
 
 /**

--- a/packages/rich-text/src/to-html-string.js
+++ b/packages/rich-text/src/to-html-string.js
@@ -1,5 +1,5 @@
 /**
- * Internal dependencies
+ * WordPress dependencies
  */
 
 import {

--- a/packages/scripts/utils/test/index.js
+++ b/packages/scripts/utils/test/index.js
@@ -1,3 +1,24 @@
+/**
+ * External dependencies
+ */
+import crossSpawn from 'cross-spawn';
+
+/**
+ * Internal dependencies
+ */
+import {
+	hasCliArg,
+	hasProjectFile,
+	spawnScript,
+} from '../';
+import {
+	getPackagePath as getPackagePathMock,
+} from '../package';
+import {
+	exit as exitMock,
+	getCliArgs as getCliArgsMock,
+} from '../process';
+
 jest.mock( '../package', () => {
 	const module = require.requireActual( '../package' );
 
@@ -13,22 +34,6 @@ jest.mock( '../process', () => {
 
 	return module;
 } );
-/**
- * Internal dependencies
- */
-import crossSpawn from 'cross-spawn';
-import {
-	hasCliArg,
-	hasProjectFile,
-	spawnScript,
-} from '../';
-import {
-	getPackagePath as getPackagePathMock,
-} from '../package';
-import {
-	exit as exitMock,
-	getCliArgs as getCliArgsMock,
-} from '../process';
 
 describe( 'utils', () => {
 	const crossSpawnMock = jest.spyOn( crossSpawn, 'sync' );

--- a/packages/shortcode/src/index.js
+++ b/packages/shortcode/src/index.js
@@ -1,5 +1,5 @@
 /**
- * Internal dependencies
+ * External dependencies
  */
 import { extend, pick, isString, isEqual, forEach, isNumber } from 'lodash';
 import memize from 'memize';

--- a/packages/wordcount/src/index.js
+++ b/packages/wordcount/src/index.js
@@ -1,4 +1,11 @@
+/**
+ * External dependencies
+ */
 import { extend, flow } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
 import { defaultSettings } from './defaultSettings';
 import stripTags from './stripTags';
 import transposeAstralsToCountableChar from './transposeAstralsToCountableChar';

--- a/test/integration/is-valid-block.spec.js
+++ b/test/integration/is-valid-block.spec.js
@@ -1,5 +1,5 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
 import { isValidBlockContent } from '@wordpress/blocks';
 import { createElement } from '@wordpress/element';

--- a/test/unit/__mocks__/@wordpress/data.js
+++ b/test/unit/__mocks__/@wordpress/data.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
 import { use, plugins } from '../../../../packages/data/src';
+
 use( plugins.controls );
+
 export * from '../../../../packages/data/src';


### PR DESCRIPTION
This pull request seeks to introduce a new ESLint rule to enforce expectations around adherence to the dependencies grouping conventions as outlined in the [Coding Guidelines](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/coding-guidelines.md#imports).

Specifically, it enforces:

- An import is preceded by "External dependencies", "WordPress dependencies", or "Internal dependencies" as appropriate by the import source.

This is meant to be quite minimal in its current form, as there are a _shocking_ number of inconsistencies in the codebase.

To make review somewhat easier, current (assumed temporary) tolerances include:

- Normalize `/**` and `/*`
  - Aside: I think we need to make a decision here, and as much as it'll be a pain in that it requires changes to quite nearly every file in the codebase, my leaning is toward `/*` as these are not JSDoc
- Case insensitive "Dependencies" vs. "dependencies"
- Ending period
- "Node" dependencies as an alias for External

Future improvements will include:

- Guaranteed order "External", "WordPress", "Internal"
- Enforce expected (and only expected) newline placement around and between import statements

It may help simplify review to separately review individual commits.

**Testing instructions:**

While these changes touch many application files, it should not be in a way which impacts runtime behavior, as they are merely shuffling of imports and revisions to docblock comments.

Ensure tests pass:

```
npm test
```