### PR TITLE
FlatTermSelector: Set Correct Loading State

### DIFF
--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -78,7 +78,7 @@ class FlatTermSelector extends Component {
 
 	componentDidMount() {
 		if ( ! isEmpty( this.props.terms ) ) {
-			this.setState( { loading: false } );
+			this.setState( { loading: true } );
 			this.initRequest = this.fetchTerms( {
 				include: this.props.terms.join( ',' ),
 				per_page: -1,

--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -70,7 +70,7 @@ class FlatTermSelector extends Component {
 		this.searchTerms = throttle( this.searchTerms.bind( this ), 500 );
 		this.findOrCreateTerm = this.findOrCreateTerm.bind( this );
 		this.state = {
-			loading: false,
+			loading: ! isEmpty( this.props.terms ),
 			availableTerms: [],
 			selectedTerms: [],
 		};
@@ -78,7 +78,6 @@ class FlatTermSelector extends Component {
 
 	componentDidMount() {
 		if ( ! isEmpty( this.props.terms ) ) {
-			this.setState( { loading: true } );
 			this.initRequest = this.fetchTerms( {
 				include: this.props.terms.join( ',' ),
 				per_page: -1,


### PR DESCRIPTION
## Description
If the `FlatTermSelector` component mounts with one or more terms provided, it does not correctly set the internal `loading` state.

## How has this been tested?
Edit a post that has no tags assigned, and edit one that does have one tag assigned (see [Screenshots](#screenshots)).

## Screenshots
Showing a post with one tag assigned.

**Before:**
![flattermselector_before](https://user-images.githubusercontent.com/6049306/52461550-c6e87c80-2b6f-11e9-80ba-0a1790e360c4.gif)

**After:**
![flattermselector_after](https://user-images.githubusercontent.com/6049306/52461555-cbad3080-2b6f-11e9-9dc4-8398242e2cd0.gif)

## Types of changes
This change correctly sets the internal `loading` state when mounting.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
