### PR TITLE
QueryControls: Export CategorySelect

### DIFF
--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -43,7 +43,7 @@ export { default as PanelHeader } from './panel/header';
 export { default as PanelRow } from './panel/row';
 export { default as Placeholder } from './placeholder';
 export { default as Popover } from './popover';
-export { default as QueryControls } from './query-controls';
+export { CategorySelect, QueryControls } from './query-controls';
 export { default as RadioControl } from './radio-control';
 export { default as RangeControl } from './range-control';
 export { default as ResizableBox } from './resizable-box';

--- a/packages/components/src/query-controls/index.js
+++ b/packages/components/src/query-controls/index.js
@@ -9,10 +9,12 @@ import { __ } from '@wordpress/i18n';
 import { RangeControl, SelectControl } from '../';
 import CategorySelect from './category-select';
 
+export { CategorySelect };
+
 const DEFAULT_MIN_ITEMS = 1;
 const DEFAULT_MAX_ITEMS = 100;
 
-export default function QueryControls( {
+export function QueryControls( {
 	categoriesList,
 	selectedCategoryId,
 	numberOfItems,


### PR DESCRIPTION
## Description
Currently, the `QueryControls` component is the only way to make use of the `CategorySelect` component.

If the latter is all I want to use, though, it would be nice to be able to just go ahead and import it. No detour.

## How has this been tested?
I created a custom block using the `CategorySelect` component.

## Types of changes
This PR contains the following changes:
* export the `CategorySelect` component both from the `query-controls/index.js` file and the `index.js` file;
* change the export of the `QueryControls` in the `query-controls/index.js` file (**not** the main `index.js`!) from default to named;
* and obviously: adapt the import/export in the `index.js` file according to the new exports.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
