### PR TITLE
[Mobile]Remove unnecessary <strong> tags from post title

### DIFF
--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -48,6 +48,7 @@ class PostTitle extends Component {
 		return (
 			<RichText
 				tagName={ 'p' }
+				rootTagsToEliminate={ ['strong'] }
 				onFocus={ this.onSelect }
 				onBlur={ this.props.onBlur } // always assign onBlur as a props
 				multiline={ false }

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -48,7 +48,7 @@ class PostTitle extends Component {
 		return (
 			<RichText
 				tagName={ 'p' }
-				rootTagsToEliminate={ ['strong'] }
+				rootTagsToEliminate={ [ 'strong' ] }
 				onFocus={ this.onSelect }
 				onBlur={ this.props.onBlur } // always assign onBlur as a props
 				multiline={ false }

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -407,7 +407,6 @@ export class RichText extends Component {
 					fontSize={ this.props.fontSize }
 					fontWeight={ this.props.fontWeight }
 					fontStyle={ this.props.fontStyle }
-					contentType={ this.props.contentType }
 				/>
 			</View>
 		);

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -170,8 +170,18 @@ export class RichText extends Component {
 	 */
 
 	removeRootTagsProduceByAztec( html ) {
-		const openingTagRegexp = RegExp( '^<' + this.props.tagName + '>', 'gim' );
-		const closingTagRegexp = RegExp( '</' + this.props.tagName + '>$', 'gim' );
+		var result = this.removeRootTag(this.props.tagName, html)
+		if ( this.props.rootTagsToEliminate ) {
+			this.props.rootTagsToEliminate.forEach(element => {
+				result = this.removeRootTag(element, result)
+			});
+		}
+		return result
+	}
+
+	removeRootTag( tag, html ) {
+		const openingTagRegexp = RegExp( '^<' + tag + '>', 'gim' );
+		const closingTagRegexp = RegExp( '</' + tag + '>$', 'gim' );
 		return html.replace( openingTagRegexp, '' ).replace( closingTagRegexp, '' );
 	}
 
@@ -397,6 +407,7 @@ export class RichText extends Component {
 					fontSize={ this.props.fontSize }
 					fontWeight={ this.props.fontWeight }
 					fontStyle={ this.props.fontStyle }
+					contentType={ this.props.contentType }
 				/>
 			</View>
 		);

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -170,13 +170,13 @@ export class RichText extends Component {
 	 */
 
 	removeRootTagsProduceByAztec( html ) {
-		var result = this.removeRootTag(this.props.tagName, html)
+		let result = this.removeRootTag( this.props.tagName, html );
 		if ( this.props.rootTagsToEliminate ) {
-			this.props.rootTagsToEliminate.forEach(element => {
-				result = this.removeRootTag(element, result)
-			});
+			this.props.rootTagsToEliminate.forEach( ( element ) => {
+				result = this.removeRootTag( element, result );
+			} );
 		}
-		return result
+		return result;
 	}
 
 	removeRootTag( tag, html ) {


### PR DESCRIPTION
## Description

This is a quick workaround to remove `<strong>` tags from post title. We can see those tags on Aztec editor.

![title-strong-tag2](https://user-images.githubusercontent.com/5032900/52468314-68d08f00-2b99-11e9-9054-b88be3225980.gif)

## How has this been tested?
Tested with steps in [gutenberg mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/577)

**Implementation Details**

Firstly, this is a workaround solution made quickly to catch the WPiOS/WPAndroid release deadline.

The main problem is about the inner mechanisms of Aztec-iOS, and RNTAztec-iOS. whenever there's a bold text it generates the `<strong>` elements in the html. [We had made an extra development(https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1127) to prevent such cases for Heading blocks after we made them bold by default, maybe that could help in the future.] Classic editor made this problem visible(maybe because title is a plain UITextView there? ), I think there's sth different there between the Gutenberg/Classic editors and needs further investigation. So this needs a better solution in the future.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->