### PR TITLE
Try: Improve typographic rhythm

### DIFF
--- a/assets/stylesheets/_variables.scss
+++ b/assets/stylesheets/_variables.scss
@@ -10,7 +10,7 @@ $editor-font: "Noto Serif", serif;
 $editor-html-font: Menlo, Consolas, monaco, monospace;
 $editor-font-size: 16px;
 $text-editor-font-size: 14px;
-$editor-line-height: 1.8;
+$editor-line-height: 1.6;
 $big-font-size: 18px;
 $mobile-text-min-font-size: 16px; // Any font size below 16px will cause Mobile Safari to "zoom in"
 


### PR DESCRIPTION
This PR is intended to explore adopting a change that is being explored for mobile Gutenberg in https://github.com/wordpress-mobile/gutenberg-mobile/issues/550. It simply changes the lineheight from 1.8 to 1.6.

Before:

<img width="776" alt="before" src="https://user-images.githubusercontent.com/1204802/52469413-a62e2000-2b8b-11e9-8e68-355419f222bd.png">

After:

<img width="723" alt="after" src="https://user-images.githubusercontent.com/1204802/52469417-a8907a00-2b8b-11e9-8e10-7aa0ae2d04ad.png">


It is very important to note that this change affects only the vanilla Gutenberg style — themes can, through editor styles, still customize this to their hearts content.

Thoughts?

CC: @iamthomasbishop