### PR TITLE
Fix icon size regression in Switcher

### DIFF
--- a/packages/components/src/icon-button/index.js
+++ b/packages/components/src/icon-button/index.js
@@ -23,7 +23,7 @@ class IconButton extends Component {
 		const { icon, children, label, className, tooltip, shortcut, labelPosition, ...additionalProps } = this.props;
 		const { 'aria-pressed': ariaPressed } = this.props;
 		const classes = classnames( 'components-icon-button', className, {
-			'has-text': children && children.length > 2,
+			'has-text': children,
 		} );
 		const tooltipText = tooltip || label;
 

--- a/packages/components/src/icon-button/index.js
+++ b/packages/components/src/icon-button/index.js
@@ -23,7 +23,7 @@ class IconButton extends Component {
 		const { icon, children, label, className, tooltip, shortcut, labelPosition, ...additionalProps } = this.props;
 		const { 'aria-pressed': ariaPressed } = this.props;
 		const classes = classnames( 'components-icon-button', className, {
-			'has-text': children,
+			'has-text': children && children.length > 2,
 		} );
 		const tooltipText = tooltip || label;
 

--- a/packages/editor/src/components/block-switcher/index.js
+++ b/packages/editor/src/components/block-switcher/index.js
@@ -116,10 +116,13 @@ export class BlockSwitcher extends Component {
 								label={ label }
 								tooltip={ label }
 								onKeyDown={ openOnArrowDown }
-							>
-								<BlockIcon icon={ icon } showColors />
-								<SVG className="editor-block-switcher__transform" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M6.5 8.9c.6-.6 1.4-.9 2.2-.9h6.9l-1.3 1.3 1.4 1.4L19.4 7l-3.7-3.7-1.4 1.4L15.6 6H8.7c-1.4 0-2.6.5-3.6 1.5l-2.8 2.8 1.4 1.4 2.8-2.8zm13.8 2.4l-2.8 2.8c-.6.6-1.3.9-2.1.9h-7l1.3-1.3-1.4-1.4L4.6 16l3.7 3.7 1.4-1.4L8.4 17h6.9c1.3 0 2.6-.5 3.5-1.5l2.8-2.8-1.3-1.4z" /></SVG>
-							</IconButton>
+								icon={ (
+									<Fragment>
+										<BlockIcon icon={ icon } showColors />
+										<SVG className="editor-block-switcher__transform" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M6.5 8.9c.6-.6 1.4-.9 2.2-.9h6.9l-1.3 1.3 1.4 1.4L19.4 7l-3.7-3.7-1.4 1.4L15.6 6H8.7c-1.4 0-2.6.5-3.6 1.5l-2.8 2.8 1.4 1.4 2.8-2.8zm13.8 2.4l-2.8 2.8c-.6.6-1.3.9-2.1.9h-7l1.3-1.3-1.4-1.4L4.6 16l3.7 3.7 1.4-1.4L8.4 17h6.9c1.3 0 2.6-.5 3.5-1.5l2.8-2.8-1.3-1.4z" /></SVG>
+									</Fragment>
+								) }
+							/>
 						</Toolbar>
 					);
 				} }


### PR DESCRIPTION
In #12901, a small margin was introduced to the IconButton component when text was present. This caused an issue with block icons, scaling them down when they shouldn't be. A 20x20px icon should show as 20x20, and a 24x24px icon should show as 24x24px.

The additional margin was applied even when the IconButton didn't actually have text. It simply needed `children`, and in the case of the Switcher, it has a dropdown arrow. Combined with the fixed width of the switcher, that meant a 24x24 icon would be rendered as 20x24.

This PR adds a length check so if your IconButton includes more than 2 letters, it's considered to have a text label. This fixes the issue. But as you can tell, maybe it's not the best way to check whether there's text or not. Suggestions most welcome.

Before:

<img width="750" alt="screenshot 2019-02-08 at 10 58 33" src="https://user-images.githubusercontent.com/1204802/52471169-7f261d00-2b90-11e9-955b-7083a5588b3a.png">

After:

<img width="711" alt="screenshot 2019-02-08 at 10 53 58" src="https://user-images.githubusercontent.com/1204802/52471175-81887700-2b90-11e9-9c5b-f471f2f75144.png">

A good way to test this is to insert an Image placeholder block. The "Upload" button is actually an IconButton, so it _should_ have margin, whereas the Switcher should not. 
