### PR TITLE
Add calendar block v1

### DIFF
--- a/lib/load.php
+++ b/lib/load.php
@@ -36,6 +36,9 @@ if ( ! function_exists( 'render_block_core_categories' ) ) {
 }
 // Currently merged in core as `gutenberg_render_block_core_latest_comments`,
 // expected to change soon.
+if ( ! function_exists( 'render_block_core_calendar' ) ) {
+	require dirname( __FILE__ ) . '/../packages/block-library/src/calendar/index.php';
+}
 if ( ! function_exists( 'render_block_core_latest_comments' )
 	&& ! function_exists( 'gutenberg_render_block_core_latest_comments' ) ) {
 	require dirname( __FILE__ ) . '/../packages/block-library/src/latest-comments/index.php';

--- a/packages/block-library/src/calendar/edit.js
+++ b/packages/block-library/src/calendar/edit.js
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import moment from 'moment';
+import memoize from 'memize';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	Disabled,
+	ServerSideRender,
+} from '@wordpress/components';
+import { Component } from '@wordpress/element';
+import { withSelect } from '@wordpress/data';
+
+class CalendarEdit extends Component {
+	constructor() {
+		super( ...arguments );
+		this.getYearMonth = memoize(
+			this.getYearMonth.bind( this ),
+			{ maxSize: 1 }
+		);
+		this.getServerSideAttributes = memoize(
+			this.getServerSideAttributes.bind( this ),
+			{ maxSize: 1 }
+		);
+	}
+
+	getYearMonth( date ) {
+		if ( ! date ) {
+			return {};
+		}
+		const momentDate = moment( date );
+		return {
+			year: momentDate.year(),
+			month: momentDate.month() + 1,
+		};
+	}
+
+	getServerSideAttributes( attributes, date ) {
+		return {
+			...attributes,
+			...this.getYearMonth( date ),
+		};
+	}
+
+	render() {
+		return (
+			<Disabled>
+				<ServerSideRender
+					block="core/calendar"
+					attributes={ this.getServerSideAttributes(
+						this.props.attributes,
+						this.props.date
+					) }
+				/>
+			</Disabled>
+		);
+	}
+}
+
+export default withSelect( ( select ) => {
+	return {
+		date: select( 'core/editor' ).getEditedPostAttribute( 'date' ),
+	};
+} )( CalendarEdit );

--- a/packages/block-library/src/calendar/index.js
+++ b/packages/block-library/src/calendar/index.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+
+export const name = 'core/calendar';
+
+export const settings = {
+	title: __( 'Calendar' ),
+
+	description: __( 'A calendar of your site’s posts.' ),
+
+	icon: 'calendar',
+
+	category: 'widgets',
+
+	keywords: [ __( 'posts' ), __( 'archive' ) ],
+
+	supports: {
+		align: true,
+	},
+
+	edit,
+
+	save() {
+		return null;
+	},
+};

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Server-side rendering of the `core/calendar` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `core/calendar` block on server.
+ *
+ * @param array $attributes The block attributes.
+ *
+ * @return string Returns the block content.
+ */
+function render_block_core_calendar( $attributes ) {
+	global $monthnum, $year;
+	if ( isset( $attributes['month'] ) ) {
+		$monthnum = $attributes['month'];
+	}
+
+	if ( isset( $attributes['year'] ) ) {
+		$year = $attributes['year'];
+	}
+	$custom_class_name = empty( $attributes['className'] ) ? '' : ' ' . $attributes['className'];
+	$align_class_name  = empty( $attributes['align'] ) ? '' : ' ' . "align{$attributes['align']}";
+
+	return sprintf(
+		'<div class="%1$s">%2$s</div>',
+		esc_attr( 'wp-block-calendar' . $custom_class_name . $align_class_name ),
+		get_calendar( true, false )
+	);
+}
+
+/**
+ * Registers the `core/calendar` block on server.
+ */
+function register_block_core_calendar() {
+	register_block_type(
+		'core/calendar',
+		array(
+			'attributes'      => array(
+				'align'     => array(
+					'type' => 'string',
+				),
+				'className' => array(
+					'type' => 'string',
+				),
+				'month'  => array(
+					'type' => 'integer',
+				),
+				'year'      => array(
+					'type' => 'integer',
+				),
+			),
+			'render_callback' => 'render_block_core_calendar',
+		)
+	);
+}
+
+add_action( 'init', 'register_block_core_calendar' );

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -13,14 +13,22 @@
  * @return string Returns the block content.
  */
 function render_block_core_calendar( $attributes ) {
-	global $monthnum, $year;
+	global $monthnum, $year, $post;
+	$previous_monthnum;
+	$previous_year;
+
+	// phpcs:disable WordPress.WP.GlobalVariablesOverride.OverrideProhibited
 	if ( isset( $attributes['month'] ) ) {
-		$monthnum = $attributes['month'];
+		$previous_monthnum = $monthnum;
+		$monthnum          = $attributes['month'];
 	}
 
 	if ( isset( $attributes['year'] ) ) {
-		$year = $attributes['year'];
+		$previous_year = $year;
+		$year          = $attributes['year'];
 	}
+	// phpcs:enable WordPress.WP.GlobalVariablesOverride.OverrideProhibited
+
 	$custom_class_name = empty( $attributes['className'] ) ? '' : ' ' . $attributes['className'];
 	$align_class_name  = empty( $attributes['align'] ) ? '' : ' ' . "align{$attributes['align']}";
 
@@ -29,6 +37,16 @@ function render_block_core_calendar( $attributes ) {
 		esc_attr( 'wp-block-calendar' . $custom_class_name . $align_class_name ),
 		get_calendar( true, false )
 	);
+
+	// phpcs:disable WordPress.WP.GlobalVariablesOverride.OverrideProhibited
+	if ( isset( $attributes['month'] ) ) {
+		$monthnum = $previous_monthnum;
+	}
+
+	if ( isset( $attributes['year'] ) ) {
+		$year = $previous_year;
+	}
+	// phpcs:enable WordPress.WP.GlobalVariablesOverride.OverrideProhibited
 }
 
 /**
@@ -45,7 +63,7 @@ function register_block_core_calendar() {
 				'className' => array(
 					'type' => 'string',
 				),
-				'month'  => array(
+				'month'     => array(
 					'type' => 'integer',
 				),
 				'year'      => array(

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -14,20 +14,18 @@
  */
 function render_block_core_calendar( $attributes ) {
 	global $monthnum, $year, $post;
-	$previous_monthnum;
-	$previous_year;
+	$previous_monthnum = $monthnum;
+	$previous_year     = $year;
 
-	// phpcs:disable WordPress.WP.GlobalVariablesOverride.OverrideProhibited
 	if ( isset( $attributes['month'] ) ) {
-		$previous_monthnum = $monthnum;
-		$monthnum          = $attributes['month'];
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
+		$monthnum = $attributes['month'];
 	}
 
 	if ( isset( $attributes['year'] ) ) {
-		$previous_year = $year;
-		$year          = $attributes['year'];
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
+		$year = $attributes['year'];
 	}
-	// phpcs:enable WordPress.WP.GlobalVariablesOverride.OverrideProhibited
 
 	$custom_class_name = empty( $attributes['className'] ) ? '' : ' ' . $attributes['className'];
 	$align_class_name  = empty( $attributes['align'] ) ? '' : ' ' . "align{$attributes['align']}";
@@ -38,15 +36,10 @@ function render_block_core_calendar( $attributes ) {
 		get_calendar( true, false )
 	);
 
-	// phpcs:disable WordPress.WP.GlobalVariablesOverride.OverrideProhibited
-	if ( isset( $attributes['month'] ) ) {
-		$monthnum = $previous_monthnum;
-	}
-
-	if ( isset( $attributes['year'] ) ) {
-		$year = $previous_year;
-	}
-	// phpcs:enable WordPress.WP.GlobalVariablesOverride.OverrideProhibited
+	// phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
+	$monthnum = $previous_monthnum;
+	// phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
+	$year = $previous_year;
 }
 
 /**

--- a/packages/block-library/src/calendar/style.scss
+++ b/packages/block-library/src/calendar/style.scss
@@ -1,0 +1,62 @@
+.wp-block-calendar {
+	text-align: center;
+	border: 2px solid $light-gray-500;
+
+	table {
+		width: 100%;
+		border-collapse: collapse;
+		font-family: $default-font;
+	}
+
+	table thead {
+		display: table-row-group;
+	}
+
+	table tfoot {
+		display: table-header-group;
+		border-bottom: 2px solid $light-gray-500;
+	}
+
+	table tfoot,
+	caption {
+		font-weight: 600;
+		background: $light-gray-300;
+	}
+
+	table tfoot tr td#prev a,
+	table tfoot tr td#next a {
+		color: transparent;
+		overflow: hidden;
+		max-height: 40px;
+		width: 16px;
+
+	}
+
+	table tfoot tr td#prev a::before,
+	table tfoot tr td#next a::after {
+		// Disabling lint because in this case we need dashicons and not
+		// a generic font.
+		/* stylelint-disable */
+		font-family: dashicons;
+		/* stylelint-enable */
+		display: inline-block;
+		color: $black;
+	}
+
+	table tfoot tr td#prev a::before {
+		content: "\f141";
+	}
+
+	table tfoot tr td#next a::after {
+		content: "\f139";
+	}
+
+	table td,
+	table th {
+		border: none;
+	}
+
+	a {
+		text-decoration: underline;
+	}
+}

--- a/packages/block-library/src/calendar/style.scss
+++ b/packages/block-library/src/calendar/style.scss
@@ -1,6 +1,15 @@
 .wp-block-calendar {
 	text-align: center;
-	border: 2px solid $light-gray-500;
+
+	th,
+	tbody td {
+		padding: 4px;
+		border: 1px solid $light-gray-500;
+	}
+
+	tfoot td {
+		border: none;
+	}
 
 	table {
 		width: 100%;
@@ -8,55 +17,21 @@
 		font-family: $default-font;
 	}
 
-	table thead {
-		display: table-row-group;
-	}
-
-	table tfoot {
-		display: table-header-group;
-		border-bottom: 2px solid $light-gray-500;
-	}
-
-	table tfoot,
-	caption {
-		font-weight: 600;
-		background: $light-gray-300;
-	}
-
-	table tfoot tr td#prev a,
-	table tfoot tr td#next a {
-		color: transparent;
-		overflow: hidden;
-		max-height: 40px;
-		width: 16px;
-
-	}
-
-	table tfoot tr td#prev a::before,
-	table tfoot tr td#next a::after {
-		// Disabling lint because in this case we need dashicons and not
-		// a generic font.
-		/* stylelint-disable */
-		font-family: dashicons;
-		/* stylelint-enable */
-		display: inline-block;
-		color: $black;
-	}
-
-	table tfoot tr td#prev a::before {
-		content: "\f141";
-	}
-
-	table tfoot tr td#next a::after {
-		content: "\f139";
-	}
-
-	table td,
 	table th {
-		border: none;
+		font-weight: 440;
+		background: $light-gray-300;
 	}
 
 	a {
 		text-decoration: underline;
+	}
+
+	tfoot a {
+		color: #0073aa;
+	}
+
+	table tbody,
+	table caption {
+		color: $dark-gray-600;
 	}
 }

--- a/packages/block-library/src/calendar/style.scss
+++ b/packages/block-library/src/calendar/style.scss
@@ -27,7 +27,7 @@
 	}
 
 	tfoot a {
-		color: #0073aa;
+		color: $blue-medium-800;
 	}
 
 	table tbody,

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -20,6 +20,7 @@ import * as gallery from './gallery';
 import * as archives from './archives';
 import * as audio from './audio';
 import * as button from './button';
+import * as calendar from './calendar';
 import * as categories from './categories';
 import * as code from './code';
 import * as columns from './columns';
@@ -68,6 +69,7 @@ export const registerCoreBlocks = () => {
 		archives,
 		audio,
 		button,
+		calendar,
 		categories,
 		code,
 		columns,

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -2,6 +2,7 @@
 @import "./block/edit-panel/style.scss";
 @import "./block/indicator/style.scss";
 @import "./button/style.scss";
+@import "./calendar/style.scss";
 @import "./categories/style.scss";
 @import "./columns/style.scss";
 @import "./cover/style.scss";

--- a/test/integration/full-content/fixtures/core__calendar.html
+++ b/test/integration/full-content/fixtures/core__calendar.html
@@ -1,0 +1,1 @@
+<!-- wp:calendar /-->

--- a/test/integration/full-content/fixtures/core__calendar.json
+++ b/test/integration/full-content/fixtures/core__calendar.json
@@ -1,0 +1,10 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/calendar",
+        "isValid": true,
+        "attributes": {},
+        "innerBlocks": [],
+        "originalContent": ""
+    }
+]

--- a/test/integration/full-content/fixtures/core__calendar.parsed.json
+++ b/test/integration/full-content/fixtures/core__calendar.parsed.json
@@ -1,0 +1,18 @@
+[
+    {
+        "blockName": "core/calendar",
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "",
+        "innerContent": []
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/test/integration/full-content/fixtures/core__calendar.serialized.html
+++ b/test/integration/full-content/fixtures/core__calendar.serialized.html
@@ -1,0 +1,1 @@
+<!-- wp:calendar /-->


### PR DESCRIPTION
## Description
Closes #1462.

The first version of the calendar block.
The design tries to follow the mockup proposed but is not exactly equal as getting the desired result would need a change of markup while this version is a pure CSS solution.

If we decide to change the markup to get to the desired design I think we will not be able to use get_calendar as it is right now and the best option seems to be using a custom version of get_calendar creating a new function in core that abstracts get_calendar logic and allows both get_calendar and the version we use in this block to be created in a simple way.
We can also use current filters on get_calenger plus some regex replaces to get the markup in the desired state, but that is very hacky and probably not a long term solution.



## How has this been tested?
Verify the calendar block works as expected in the editor and in the front end.
Verify that when we change the publish date month and/or year the calendar updates.

## Screenshots <!-- if applicable -->
<img width="1450" alt="screenshot 2019-02-08 at 12 30 59" src="https://user-images.githubusercontent.com/11271197/52478506-75ef7d00-2b9d-11e9-8a4b-999d6f16c0b1.png">
<img width="913" alt="screenshot 2019-02-08 at 12 30 16" src="https://user-images.githubusercontent.com/11271197/52478516-7f78e500-2b9d-11e9-8c89-5d98df4455a2.png">

