### PR TITLE
Disable animations completely in e2e tests

### DIFF
--- a/packages/e2e-tests/plugins/disable-animations.php
+++ b/packages/e2e-tests/plugins/disable-animations.php
@@ -11,7 +11,7 @@
  * Enqueue CSS stylesheet disabling animations.
  */
 function enqueue_disable_animations_stylesheet() {
-	$custom_css = '* { animation-duration: 1ms !important; }';
+	$custom_css = '* { animation-duration: 0ms !important; }';
 	wp_add_inline_style( 'wp-components', $custom_css );
 }
 


### PR DESCRIPTION
## Description
Follow-up for #13697 

https://github.com/WordPress/gutenberg/pull/13769#issuecomment-461818348

> If we can change it to `0`, we should change it to `0`.

It looks like we can and it makes NUX tests more reliable.