### PR TITLE
Use codetabs to label ESNext code as such

### DIFF
--- a/packages/components/src/button/README.md
+++ b/packages/components/src/button/README.md
@@ -10,6 +10,8 @@ Note that this component may sometimes be confused with the Button block, which 
 
 Renders a button with default style.
 
+{% codetabs %}
+{% ESNext %}
 ```jsx
 import { Button } from "@wordpress/components";
 
@@ -19,6 +21,7 @@ const MyButton = () => (
 	</Button>
 );
 ```
+{% end %}
 
 ## Props
 


### PR DESCRIPTION
## Description

This PR tests using the {% codetabs %} markup to label an ESNext block of code as such, even without the alternative ES5 tab included.

There can be confusion on what type of code is being displayed/copied/pasted, so being able to label ESNext code as such will help people working in an ES5 only environment that there might be a potential for problems if they copy/paste the code as shown.

## Types of changes

Documentation.
