### PR TITLE
Enable Archive's Block Dropdown in Editor

### DIFF
--- a/packages/block-library/src/archives/edit.js
+++ b/packages/block-library/src/archives/edit.js
@@ -5,7 +5,6 @@ import { Fragment } from '@wordpress/element';
 import {
 	PanelBody,
 	ToggleControl,
-	Disabled,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -47,9 +46,7 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 					controls={ [ 'left', 'center', 'right' ] }
 				/>
 			</BlockControls>
-			<Disabled>
-				<ServerSideRender block="core/archives" attributes={ attributes } />
-			</Disabled>
+			<ServerSideRender block="core/archives" attributes={ attributes } />
 		</Fragment>
 	);
 }


### PR DESCRIPTION
## Description
Closes #13771.
Currently the Archive's Block Block Dropdown is disabled and this PR enables it.

## How has this been tested?
Created Archive Block with dropdown option and have seen that the dropdown is enabled.
Ran `npm run test`.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
