### PR TITLE
ESLint Plugin: Restrict tolerances as fixable error

### DIFF
--- a/packages/annotations/src/store/index.js
+++ b/packages/annotations/src/store/index.js
@@ -1,5 +1,5 @@
 /**
- * WordPress Dependencies
+ * WordPress dependencies
  */
 import { registerStore } from '@wordpress/data';
 

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -1,5 +1,5 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import classnames from 'classnames';
 import { filter, pick, map, get } from 'lodash';

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -1,10 +1,10 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import classnames from 'classnames';
 
 /**
- * WordPress Dependencies
+ * WordPress dependencies
  */
 import { Component, Fragment } from '@wordpress/element';
 import { IconButton, Spinner } from '@wordpress/components';

--- a/packages/block-library/src/latest-comments/index.js
+++ b/packages/block-library/src/latest-comments/index.js
@@ -1,11 +1,11 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { G, Path, SVG } from '@wordpress/components';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import edit from './edit';
 

--- a/packages/components/src/draggable/index.js
+++ b/packages/components/src/draggable/index.js
@@ -4,7 +4,7 @@
 import { noop } from 'lodash';
 
 /**
- * WordPress Dependencies
+ * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
 import { withSafeTimeout } from '@wordpress/compose';

--- a/packages/components/src/higher-order/navigate-regions/index.js
+++ b/packages/components/src/higher-order/navigate-regions/index.js
@@ -1,16 +1,16 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import classnames from 'classnames';
 
 /**
- * WordPress Dependencies
+ * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import KeyboardShortcuts from '../../keyboard-shortcuts';
 

--- a/packages/components/src/modal/header.js
+++ b/packages/components/src/modal/header.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import IconButton from '../icon-button';
 

--- a/packages/components/src/navigable-container/container.js
+++ b/packages/components/src/navigable-container/container.js
@@ -1,10 +1,10 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import { omit, noop, isFunction } from 'lodash';
 
 /**
- * WordPress Dependencies
+ * WordPress dependencies
  */
 import { Component, forwardRef } from '@wordpress/element';
 import { focus } from '@wordpress/dom';

--- a/packages/components/src/navigable-container/menu.js
+++ b/packages/components/src/navigable-container/menu.js
@@ -1,10 +1,10 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import { includes } from 'lodash';
 
 /**
- * WordPress Dependencies
+ * WordPress dependencies
  */
 import { forwardRef } from '@wordpress/element';
 import { UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';

--- a/packages/components/src/navigable-container/tabbable.js
+++ b/packages/components/src/navigable-container/tabbable.js
@@ -1,5 +1,5 @@
 /**
- * WordPress Dependencies
+ * WordPress dependencies
  */
 import { forwardRef } from '@wordpress/element';
 import { TAB } from '@wordpress/keycodes';

--- a/packages/components/src/responsive-wrapper/index.js
+++ b/packages/components/src/responsive-wrapper/index.js
@@ -4,7 +4,7 @@
 import classnames from 'classnames';
 
 /**
- * WordPress Dependencies
+ * WordPress dependencies
  */
 import { cloneElement, Children } from '@wordpress/element';
 

--- a/packages/components/src/server-side-render/index.js
+++ b/packages/components/src/server-side-render/index.js
@@ -1,10 +1,10 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import { isEqual, debounce } from 'lodash';
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import {
 	Component,
@@ -15,7 +15,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import Placeholder from '../placeholder';
 import Spinner from '../spinner';

--- a/packages/components/src/slot-fill/test/slot.js
+++ b/packages/components/src/slot-fill/test/slot.js
@@ -12,7 +12,7 @@ import Fill from '../fill';
 import Provider from '../context';
 
 /**
- * WordPress Dependencies
+ * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
 

--- a/packages/e2e-test-utils/src/create-url.js
+++ b/packages/e2e-test-utils/src/create-url.js
@@ -1,5 +1,5 @@
 /**
- * Node dependencies
+ * External dependencies
  */
 import { join } from 'path';
 import { URL } from 'url';

--- a/packages/e2e-test-utils/src/is-current-url.js
+++ b/packages/e2e-test-utils/src/is-current-url.js
@@ -1,5 +1,5 @@
 /**
- * Node dependencies
+ * External dependencies
  */
 import { URL } from 'url';
 

--- a/packages/e2e-test-utils/src/visit-admin-page.js
+++ b/packages/e2e-test-utils/src/visit-admin-page.js
@@ -1,5 +1,5 @@
 /**
- * Node dependencies
+ * External dependencies
  */
 import { join } from 'path';
 

--- a/packages/e2e-tests/specs/adding-inline-tokens.test.js
+++ b/packages/e2e-tests/specs/adding-inline-tokens.test.js
@@ -1,5 +1,5 @@
 /**
- * Node dependencies
+ * External dependencies
  */
 import path from 'path';
 import fs from 'fs';

--- a/packages/e2e-tests/specs/manage-reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/manage-reusable-blocks.test.js
@@ -1,5 +1,5 @@
 /**
- * Node dependencies
+ * External dependencies
  */
 import path from 'path';
 

--- a/packages/edit-post/src/components/fullscreen-mode/test/index.js
+++ b/packages/edit-post/src/components/fullscreen-mode/test/index.js
@@ -4,7 +4,7 @@
 import { shallow } from 'enzyme';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { FullscreenMode } from '..';
 

--- a/packages/edit-post/src/components/header/feature-toggle/index.js
+++ b/packages/edit-post/src/components/header/feature-toggle/index.js
@@ -4,7 +4,7 @@
 import { flow } from 'lodash';
 
 /**
- * WordPress Dependencies
+ * WordPress dependencies
  */
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
@@ -1,10 +1,10 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import { get } from 'lodash';
 
 /**
- * WordPress Dependencies
+ * WordPress dependencies
  */
 import { withSelect } from '@wordpress/data';
 import { IconButton, Toolbar } from '@wordpress/components';

--- a/packages/edit-post/src/components/header/options-menu-item/index.js
+++ b/packages/edit-post/src/components/header/options-menu-item/index.js
@@ -1,5 +1,5 @@
 /**
- * WordPress Dependencies
+ * WordPress dependencies
  */
 import { withDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';

--- a/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
+++ b/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
@@ -1,10 +1,10 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import { get } from 'lodash';
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';

--- a/packages/edit-post/src/components/header/test/index.js
+++ b/packages/edit-post/src/components/header/test/index.js
@@ -4,7 +4,7 @@
 import { shallow } from 'enzyme';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { PostPublishButtonOrToggle } from '../post-publish-button-or-toggle';
 

--- a/packages/edit-post/src/components/header/writing-menu/index.js
+++ b/packages/edit-post/src/components/header/writing-menu/index.js
@@ -1,5 +1,5 @@
 /**
- * WordPress Dependencies
+ * WordPress dependencies
  */
 import { MenuGroup } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';

--- a/packages/edit-post/src/components/sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/index.js
@@ -1,5 +1,5 @@
 /**
- * WordPress Dependencies
+ * WordPress dependencies
  */
 import { createSlotFill, withFocusReturn } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';

--- a/packages/edit-post/src/components/sidebar/post-status/index.js
+++ b/packages/edit-post/src/components/sidebar/post-status/index.js
@@ -8,7 +8,7 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import PostVisibility from '../post-visibility';
 import PostTrash from '../post-trash';

--- a/packages/edit-post/src/components/sidebar/post-taxonomies/taxonomy-panel.js
+++ b/packages/edit-post/src/components/sidebar/post-taxonomies/taxonomy-panel.js
@@ -1,5 +1,5 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import { get } from 'lodash';
 

--- a/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
@@ -8,7 +8,7 @@ import { BlockInspector } from '@wordpress/editor';
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import Sidebar from '../';
 import SettingsHeader from '../settings-header';

--- a/packages/edit-post/src/hooks/components/media-upload/index.js
+++ b/packages/edit-post/src/hooks/components/media-upload/index.js
@@ -1,5 +1,5 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import { castArray, defaults, pick } from 'lodash';
 

--- a/packages/edit-post/src/plugins/keyboard-shortcuts-help-menu-item/index.js
+++ b/packages/edit-post/src/plugins/keyboard-shortcuts-help-menu-item/index.js
@@ -1,5 +1,5 @@
 /**
- * WordPress Dependencies
+ * WordPress dependencies
  */
 import { MenuItem } from '@wordpress/components';
 import { withDispatch } from '@wordpress/data';

--- a/packages/edit-post/src/store/index.js
+++ b/packages/edit-post/src/store/index.js
@@ -1,5 +1,5 @@
 /**
- * WordPress Dependencies
+ * WordPress dependencies
  */
 import { registerStore } from '@wordpress/data';
 

--- a/packages/editor/src/components/block-drop-zone/index.js
+++ b/packages/editor/src/components/block-drop-zone/index.js
@@ -1,5 +1,5 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import classnames from 'classnames';
 

--- a/packages/editor/src/components/block-inspector/index.js
+++ b/packages/editor/src/components/block-inspector/index.js
@@ -13,7 +13,7 @@ import { withSelect } from '@wordpress/data';
 import { Fragment } from '@wordpress/element';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import SkipToSelectedBlock from '../skip-to-selected-block';
 import BlockIcon from '../block-icon';

--- a/packages/editor/src/components/block-list/block-html.js
+++ b/packages/editor/src/components/block-list/block-html.js
@@ -1,12 +1,12 @@
 
 /**
- * External Dependencies
+ * External dependencies
  */
 import TextareaAutosize from 'react-autosize-textarea';
 import { isEqual } from 'lodash';
 
 /**
- * WordPress Dependencies
+ * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';

--- a/packages/editor/src/components/block-toolbar/index.js
+++ b/packages/editor/src/components/block-toolbar/index.js
@@ -1,11 +1,11 @@
 /**
- * WordPress Dependencies
+ * WordPress dependencies
  */
 import { withSelect } from '@wordpress/data';
 import { Fragment } from '@wordpress/element';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import BlockSwitcher from '../block-switcher';
 import MultiBlocksSwitcher from '../block-switcher/multi-blocks-switcher';

--- a/packages/editor/src/components/multi-selection-inspector/index.js
+++ b/packages/editor/src/components/multi-selection-inspector/index.js
@@ -11,7 +11,7 @@ import {
 } from '@wordpress/components';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import BlockIcon from '../block-icon';
 

--- a/packages/editor/src/components/post-permalink/index.js
+++ b/packages/editor/src/components/post-permalink/index.js
@@ -15,7 +15,7 @@ import { ClipboardButton, Button, ExternalLink } from '@wordpress/components';
 import { safeDecodeURI } from '@wordpress/url';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import PostPermalinkEditor from './editor.js';
 import { getWPAdminURL, cleanForSlug } from '../../utils/url';

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -19,7 +19,7 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import PostPublishButton from '../post-publish-button';
 import PostPublishPanelPrepublish from './prepublish';

--- a/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-post-format-panel.js
@@ -4,7 +4,7 @@
 import { find, get, includes } from 'lodash';
 
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { ifCondition, compose } from '@wordpress/compose';
@@ -12,7 +12,7 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import { Button, PanelBody } from '@wordpress/components';
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { POST_FORMATS } from '../post-format';
 

--- a/packages/editor/src/components/post-publish-panel/postpublish.js
+++ b/packages/editor/src/components/post-publish-panel/postpublish.js
@@ -1,10 +1,10 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import { get } from 'lodash';
 
 /**
- * WordPress Dependencies
+ * WordPress dependencies
  */
 import { PanelBody, Button, ClipboardButton, TextControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';

--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -12,7 +12,7 @@ import { PanelBody } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import PostVisibility from '../post-visibility';
 import PostVisibilityLabel from '../post-visibility/label';

--- a/packages/editor/src/components/post-taxonomies/check.js
+++ b/packages/editor/src/components/post-taxonomies/check.js
@@ -1,5 +1,5 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import { some, includes } from 'lodash';
 

--- a/packages/editor/src/components/post-taxonomies/index.js
+++ b/packages/editor/src/components/post-taxonomies/index.js
@@ -1,5 +1,5 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import { filter, identity, includes } from 'lodash';
 

--- a/packages/editor/src/components/post-visibility/index.js
+++ b/packages/editor/src/components/post-visibility/index.js
@@ -7,7 +7,7 @@ import { withInstanceId, compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import { visibilityOptions } from './utils';
 

--- a/packages/editor/src/components/post-visibility/label.js
+++ b/packages/editor/src/components/post-visibility/label.js
@@ -9,7 +9,7 @@ import { find } from 'lodash';
 import { withSelect } from '@wordpress/data';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import { visibilityOptions } from './utils';
 

--- a/packages/editor/src/components/post-visibility/utils.js
+++ b/packages/editor/src/components/post-visibility/utils.js
@@ -1,5 +1,5 @@
 /**
- * WordPress Dependencies
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -4,7 +4,7 @@
 import { flow, map } from 'lodash';
 
 /**
- * WordPress Dependencies
+ * WordPress dependencies
  */
 import { createElement, Component } from '@wordpress/element';
 import { DropZoneProvider, SlotFillProvider } from '@wordpress/components';

--- a/packages/editor/src/components/server-side-render/index.js
+++ b/packages/editor/src/components/server-side-render/index.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies.
+ * WordPress dependencies
  */
 import { ServerSideRender } from '@wordpress/components';
 import { select } from '@wordpress/data';

--- a/packages/editor/src/components/skip-to-selected-block/index.js
+++ b/packages/editor/src/components/skip-to-selected-block/index.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import { getBlockFocusableWrapper } from '../../utils/dom';
 

--- a/packages/editor/src/editor-styles/ast/stringify/index.js
+++ b/packages/editor/src/editor-styles/ast/stringify/index.js
@@ -2,7 +2,7 @@
 // because we needed to remove source map support.
 
 /**
- * Internal dependencies.
+ * Internal dependencies
  */
 import Compressed from './compress';
 import Identity from './identity';

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -1,5 +1,5 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import { castArray } from 'lodash';
 

--- a/packages/editor/src/store/index.js
+++ b/packages/editor/src/store/index.js
@@ -1,5 +1,5 @@
 /**
- * WordPress Dependencies
+ * WordPress dependencies
  */
 import { registerStore } from '@wordpress/data';
 

--- a/packages/editor/src/utils/media-upload/media-upload.js
+++ b/packages/editor/src/utils/media-upload/media-upload.js
@@ -1,5 +1,5 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import {
 	compact,

--- a/packages/eslint-plugin/rules/__tests__/dependency-group.js
+++ b/packages/eslint-plugin/rules/__tests__/dependency-group.js
@@ -19,18 +19,18 @@ ruleTester.run( 'dependency-group', rule, {
 	valid: [
 		{
 			code: `
-/*
+/**
  * External dependencies
  */
 import { get } from 'lodash';
 import classnames from 'classnames';
 
-/*
+/**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
 
-/*
+/**
  * Internal dependencies
  */
 import edit from './edit';`,
@@ -41,6 +41,9 @@ import edit from './edit';`,
 			code: `
 import { get } from 'lodash';
 import classnames from 'classnames';
+/*
+ * wordpress dependencies.
+ */
 import { Component } from '@wordpress/element';
 import edit from './edit';`,
 			errors: [

--- a/packages/is-shallow-equal/test/index.js
+++ b/packages/is-shallow-equal/test/index.js
@@ -1,5 +1,5 @@
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import isShallowEqual from '../';
 import isShallowEqualArrays from '../arrays';

--- a/packages/wordcount/src/test/index.test.js
+++ b/packages/wordcount/src/test/index.test.js
@@ -1,5 +1,5 @@
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 
 import { count } from '../';


### PR DESCRIPTION
Continues #13757

This pull request continues from #13757, eliminating tolerances as described in that pull request:

>* Normalize `/**` and `/*`
>* Case insensitive "Dependencies" vs. "dependencies"
>* Ending period
>* "Node" dependencies as an alias for External

Note: The tolerances still technically exist in the implementation, but are now used as part of the "fixer" behavior to identify the comment as eligible to have its value be substituted/upgrade using the corrected value.

([See example fixer output](https://astexplorer.net/#/gist/36badf935fe0e48572f4ad8076353fac/18b16866d5a9174a611aff8e6bc8b9c2c5f79e78))

**Testing instructions:**

Ensure lint passes:

```
npm run lint-js
```

Optional: Introduce an error case and verify fixer behavior:

```
npm run lint-js:fix
```