### PR TITLE
Update target link in core/image when an image is selected

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -183,33 +183,41 @@ class ImageEdit extends Component {
 			isEditing: false,
 		} );
 
+		const mediaAttributes = pickRelevantMediaFiles( media );
+		const linkAttributes = this.buildLinkAttributes(
+			this.props.attributes.linkDestination,
+			{ ...this.props.attributes, ...mediaAttributes }
+		);
+
 		this.props.setAttributes( {
-			...pickRelevantMediaFiles( media ),
+			...mediaAttributes,
+			...linkAttributes,
 			width: undefined,
 			height: undefined,
 		} );
-
-		// Update target link in case the default has been changed (e.g. by a plugin).
-		this.onSetLinkDestination( this.props.attributes.linkDestination );
 	}
 
 	onSetLinkDestination( value ) {
+		this.props.setAttributes( this.buildLinkAttributes( value, this.props.attributes ) );
+	}
+
+	buildLinkAttributes( destination, attributes ) {
 		let href;
 
-		if ( value === LINK_DESTINATION_NONE ) {
+		if ( destination === LINK_DESTINATION_NONE ) {
 			href = undefined;
-		} else if ( value === LINK_DESTINATION_MEDIA ) {
-			href = ( this.props.image && this.props.image.source_url ) || this.props.attributes.url;
-		} else if ( value === LINK_DESTINATION_ATTACHMENT ) {
-			href = this.props.image && this.props.image.link;
+		} else if ( destination === LINK_DESTINATION_MEDIA ) {
+			href = attributes.source_url || attributes.url;
+		} else if ( destination === LINK_DESTINATION_ATTACHMENT ) {
+			href = attributes.link;
 		} else {
 			href = this.props.attributes.href;
 		}
 
-		this.props.setAttributes( {
-			linkDestination: value,
+		return {
+			linkDestination: destination,
 			href,
-		} );
+		};
 	}
 
 	onSelectURL( newURL ) {

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -188,6 +188,9 @@ class ImageEdit extends Component {
 			width: undefined,
 			height: undefined,
 		} );
+
+		// Update target link in case the default has been changed (e.g. by a plugin).
+		this.onSetLinkDestination( this.props.attributes.linkDestination );
 	}
 
 	onSetLinkDestination( value ) {


### PR DESCRIPTION
Closes #13749.

## Description
The image block currently assumes that the default media target is always `none`, so it doesn't update the target link when the user selects an image; it only does this when the user explicitly changes the target using the drop-down box in the sidebar (using the `onSetLinkDestination` callback). This means plugins cannot control the default link target by simply setting `linkDestination.default` to something other than `none`: the drop-down box will show the new default, but the target link will not be properly set when an image is chosen/uploaded (it will still be blank, and the saved post will not therefore link to e.g. the media or attachment page).

This patch simply runs the callback `onSetLinkDestination`, which is already called when a new target selection is made by the user explicitly, when an image is uploaded or selected from the media manager. This ensures that if a plugin changes the default link target, the URL for that target is properly set when the image is selected.

## How has this been tested?
I used the latest development release of Gutenberg (cloned at a59aaf24ce0e081e772e19a2ce0e5c88afa62c77), and WordPress 5.0.3, using VVV. I created a plugin to change the default link target to `media`:

```javascript
function modifyImageLinkDestinationDefault( settings, name ) {
    // Link target to override core default.
    var target = "media";

    if ( name == "core/image" ) {
        // Set image block default destination.
        settings.attributes.linkDestination.default = target;
    } else if ( name == "core/gallery" ) {
        // Set gallery block default destination.
        settings.attributes.linkTo.default = target;
    }

    return settings;
}

// Add settings filter to block registration.
wp.hooks.addFilter(
    "blocks.registerBlockType",
    "my-plugin/modify-image-link-destination-default",
    modifyImageLinkDestinationDefault
);
```

and enqueued it on `enqueue_block_editor_assets` using:

```php
wp_enqueue_script(
	'modify-image-link-destination-default',
	'/path/to/plugin/js/index.js',
	array(
		'wp-hooks',
	)
);
```

## Screenshots
Default behaviour. My plugin changes the default target, but the link URL is not properly set when I select the image:
![image](https://user-images.githubusercontent.com/5225190/52522385-a4905500-2c7c-11e9-819e-b78888ec110e.png)

Patch applied, the link URL is properly set when an image is selected:
![image](https://user-images.githubusercontent.com/5225190/52522343-056b5d80-2c7c-11e9-821a-b211f878449c.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate.
