### PR TITLE
Fix character newlines in pre

### DIFF
--- a/packages/block-library/src/preformatted/index.js
+++ b/packages/block-library/src/preformatted/index.js
@@ -68,7 +68,7 @@ export const settings = {
 		return (
 			<RichText
 				tagName="pre"
-				value={ content }
+				value={ content.replace( /\n/g, '<br>' ) }
 				onChange={ ( nextContent ) => {
 					setAttributes( {
 						content: nextContent,

--- a/packages/e2e-tests/specs/blocks/__snapshots__/preformatted.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/preformatted.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Preformatted should preserve character newlines 1`] = `
+"<!-- wp:html -->
+<pre>1
+2</pre>
+<!-- /wp:html -->"
+`;
+
+exports[`Preformatted should preserve character newlines 2`] = `
+"<!-- wp:preformatted -->
+<pre class=\\"wp-block-preformatted\\">0<br>1<br>2</pre>
+<!-- /wp:preformatted -->"
+`;

--- a/packages/e2e-tests/specs/blocks/preformatted.test.js
+++ b/packages/e2e-tests/specs/blocks/preformatted.test.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	getEditedPostContent,
+	createNewPost,
+	insertBlock,
+	clickButton,
+} from '@wordpress/e2e-test-utils';
+
+describe( 'Preformatted', () => {
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	it( 'should preserve character newlines', async () => {
+		await insertBlock( 'Custom HTML' );
+		await page.keyboard.type( '<pre>1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '2</pre>' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await page.keyboard.press( 'Escape' );
+		await page.click( 'button[aria-label="More options"]' );
+		await clickButton( 'Convert to Blocks' );
+		// Once it's edited, it should be saved as BR tags.
+		await page.keyboard.type( '0' );
+		await page.keyboard.press( 'Enter' );
+		await page.click( 'button[aria-label="More options"]' );
+		await clickButton( 'Edit as HTML' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
## Description

Fixes #12109. Alternative of #13606. See https://github.com/WordPress/gutenberg/pull/13606#issuecomment-460950301.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->