### PR TITLE
ToggleControl allows setting custom classes

### DIFF
--- a/packages/components/src/toggle-control/README.md
+++ b/packages/components/src/toggle-control/README.md
@@ -55,3 +55,10 @@ A function that receives the checked state (boolean) as input.
 - Type: `function`
 - Required: Yes
 
+### className
+
+The class that will be added with "components-base-control" and "components-toggle-control" to the classes of the wrapper div. If no className is passed only components-base-control and components-toggle-control are used.
+
+Type: String
+Required: No
+

--- a/packages/components/src/toggle-control/README.md
+++ b/packages/components/src/toggle-control/README.md
@@ -57,7 +57,7 @@ A function that receives the checked state (boolean) as input.
 
 ### className
 
-The class that will be added with "components-base-control" and "components-toggle-control" to the classes of the wrapper div. If no className is passed only components-base-control and components-toggle-control are used.
+The class that will be added with `components-base-control` and `components-toggle-control` to the classes of the wrapper div. If no className is passed only `components-base-control` and `components-toggle-control` are used.
 
 Type: String
 Required: No

--- a/packages/components/src/toggle-control/index.js
+++ b/packages/components/src/toggle-control/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { isFunction } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -29,7 +30,7 @@ class ToggleControl extends Component {
 	}
 
 	render() {
-		const { label, checked, help, instanceId } = this.props;
+		const { label, checked, help, instanceId, className } = this.props;
 		const id = `inspector-toggle-control-${ instanceId }`;
 
 		let describedBy, helpLabel;
@@ -42,7 +43,7 @@ class ToggleControl extends Component {
 			<BaseControl
 				id={ id }
 				help={ helpLabel }
-				className="components-toggle-control"
+				className={ classnames( 'components-toggle-control', className ) }
 			>
 				<FormToggle
 					id={ id }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Closes [WordPress#11349](https://github.com/WordPress/gutenberg/issues/11349)
This pull request fixes the "ToggleControl does not allow setting custom classes" problem. This lets the user to add a custom classname on the element, just like in TextControl.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Ran `npm run test`
Added another class 'example' to ToggleControl and have seen that it is being rendered in the browser

## Screenshots <!-- if applicable -->
<img width="1277" alt="screen shot 2019-02-10 at 10 22 01 am" src="https://user-images.githubusercontent.com/44530193/52535851-61d48880-2d21-11e9-9cd2-f0286ef14de2.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug Fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->