### PR TITLE
Make Babel import JSX pragma plugin aware of `wp.element.createElement`

### DIFF
--- a/packages/babel-plugin-import-jsx-pragma/CHANGELOG.md
+++ b/packages/babel-plugin-import-jsx-pragma/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0 (Unreleased)
+
+### Breaking Change
+
+- Plugin skips now adding import JSX pragma when the scope variable is defined for all JSX elements ([#13809](https://github.com/WordPress/gutenberg/pull/13809)). 
+
 ## 1.1.0 (2018-09-05)
 
 ### New Feature

--- a/packages/babel-plugin-import-jsx-pragma/README.md
+++ b/packages/babel-plugin-import-jsx-pragma/README.md
@@ -4,7 +4,7 @@ Babel transform plugin for automatically injecting an import to be used as the p
 
 [JSX](https://reactjs.org/docs/jsx-in-depth.html) is merely a syntactic sugar for a function call, typically to `React.createElement` when used with [React](https://reactjs.org/). As such, it requires that the function referenced by this transform be within the scope of the file where the JSX occurs. In a typical React project, this means React must be imported in any file where JSX exists.
 
-**Babel Plugin Import JSX Pragma** automates this process by introducing the necessary import automatically wherever JSX exists, allowing you to use JSX in your code without thinking to ensure the transformed function is within scope.
+**Babel Plugin Import JSX Pragma** automates this process by introducing the necessary import automatically wherever JSX exists, allowing you to use JSX in your code without thinking to ensure the transformed function is within scope. It respects existing import statements, as well as scope variable declarations.
 
 ## Installation
 

--- a/packages/babel-plugin-import-jsx-pragma/src/index.js
+++ b/packages/babel-plugin-import-jsx-pragma/src/index.js
@@ -69,9 +69,18 @@ export default function( babel ) {
 					}
 				} );
 			},
+			VariableDeclaration( path, state ) {
+				if ( state.hasDeclaredScopeVariable ) {
+					return;
+				}
+
+				const { scopeVariable } = getOptions( state );
+
+				state.hasDeclaredScopeVariable = ! path.scope.parent && path.scope.hasOwnBinding( scopeVariable );
+			},
 			Program: {
 				exit( path, state ) {
-					if ( ! state.hasJSX || state.hasImportedScopeVariable ) {
+					if ( ! state.hasJSX || state.hasImportedScopeVariable || state.hasDeclaredScopeVariable ) {
 						return;
 					}
 

--- a/packages/babel-plugin-import-jsx-pragma/src/index.js
+++ b/packages/babel-plugin-import-jsx-pragma/src/index.js
@@ -44,6 +44,13 @@ export default function( babel ) {
 		visitor: {
 			JSXElement( path, state ) {
 				state.hasJSX = true;
+				if ( state.hasUndeclaredScopeVariable ) {
+					return;
+				}
+
+				const { scopeVariable } = getOptions( state );
+
+				state.hasUndeclaredScopeVariable = ! path.scope.hasBinding( scopeVariable );
 			},
 			ImportDeclaration( path, state ) {
 				if ( state.hasImportedScopeVariable ) {
@@ -69,18 +76,9 @@ export default function( babel ) {
 					}
 				} );
 			},
-			VariableDeclaration( path, state ) {
-				if ( state.hasDeclaredScopeVariable ) {
-					return;
-				}
-
-				const { scopeVariable } = getOptions( state );
-
-				state.hasDeclaredScopeVariable = ! path.scope.parent && path.scope.hasOwnBinding( scopeVariable );
-			},
 			Program: {
 				exit( path, state ) {
-					if ( ! state.hasJSX || state.hasImportedScopeVariable || state.hasDeclaredScopeVariable ) {
+					if ( ! state.hasJSX || state.hasImportedScopeVariable || ! state.hasUndeclaredScopeVariable ) {
 						return;
 					}
 

--- a/packages/babel-plugin-import-jsx-pragma/test/index.js
+++ b/packages/babel-plugin-import-jsx-pragma/test/index.js
@@ -35,11 +35,18 @@ describe( 'babel-plugin-import-jsx-pragma', () => {
 		expect( string ).toBe( original );
 	} );
 
+	it( 'does nothing if the scope variable is already defined', () => {
+		const original = 'const React = require("react");\n\nlet foo = <bar />;';
+		const string = getTransformedCode( original );
+
+		expect( string ).toBe( original );
+	} );
+
 	it( 'adds import for scope variable', () => {
 		const original = 'let foo = <bar />;';
 		const string = getTransformedCode( original );
 
-		expect( string ).toBe( 'import React from "react";\nlet foo = <bar />;' );
+		expect( string ).toBe( 'import React from "react";\n' + original );
 	} );
 
 	it( 'allows options customization', () => {
@@ -50,15 +57,24 @@ describe( 'babel-plugin-import-jsx-pragma', () => {
 			isDefault: false,
 		} );
 
-		expect( string ).toBe( 'import { createElement } from "@wordpress/element";\nlet foo = <bar />;' );
+		expect( string ).toBe( 'import { createElement } from "@wordpress/element";\n' + original );
 	} );
 
-	it( 'does nothing if the scope variable is already defined when using custom options', () => {
-		const original = 'const { createElement } = wp.element;\nlet foo = <bar />;';
+	it( 'adds import for scope variable even when defined inside the local scope', () => {
+		const original = 'let foo = <bar />;\n\nfunction local() {\n  const createElement = wp.element.createElement;\n}';
 		const string = getTransformedCode( original, {
 			scopeVariable: 'createElement',
 			source: '@wordpress/element',
 			isDefault: false,
+		} );
+
+		expect( string ).toBe( 'import { createElement } from "@wordpress/element";\n' + original );
+	} );
+
+	it( 'does nothing if the scope variable is already defined when using custom options', () => {
+		const original = 'const {\n  createElement\n} = wp.element;\nlet foo = <bar />;';
+		const string = getTransformedCode( original, {
+			scopeVariable: 'createElement',
 		} );
 
 		expect( string ).toBe( original );

--- a/packages/babel-plugin-import-jsx-pragma/test/index.js
+++ b/packages/babel-plugin-import-jsx-pragma/test/index.js
@@ -53,7 +53,7 @@ describe( 'babel-plugin-import-jsx-pragma', () => {
 		expect( string ).toBe( 'import { createElement } from "@wordpress/element";\nlet foo = <bar />;' );
 	} );
 
-	it( 'does nothing if there scope variable already defined when using custom options', () => {
+	it( 'does nothing if the scope variable is already defined when using custom options', () => {
 		const original = 'const { createElement } = wp.element;\nlet foo = <bar />;';
 		const string = getTransformedCode( original, {
 			scopeVariable: 'createElement',

--- a/packages/babel-plugin-import-jsx-pragma/test/index.js
+++ b/packages/babel-plugin-import-jsx-pragma/test/index.js
@@ -52,4 +52,15 @@ describe( 'babel-plugin-import-jsx-pragma', () => {
 
 		expect( string ).toBe( 'import { createElement } from "@wordpress/element";\nlet foo = <bar />;' );
 	} );
+
+	it( 'does nothing if there scope variable already defined when using custom options', () => {
+		const original = 'const { createElement } = wp.element;\nlet foo = <bar />;';
+		const string = getTransformedCode( original, {
+			scopeVariable: 'createElement',
+			source: '@wordpress/element',
+			isDefault: false,
+		} );
+
+		expect( string ).toBe( original );
+	} );
 } );

--- a/packages/babel-plugin-import-jsx-pragma/test/index.js
+++ b/packages/babel-plugin-import-jsx-pragma/test/index.js
@@ -71,8 +71,17 @@ describe( 'babel-plugin-import-jsx-pragma', () => {
 		expect( string ).toBe( 'import { createElement } from "@wordpress/element";\n' + original );
 	} );
 
-	it( 'does nothing if the scope variable is already defined when using custom options', () => {
+	it( 'does nothing if the outer scope variable is already defined when using custom options', () => {
 		const original = 'const {\n  createElement\n} = wp.element;\nlet foo = <bar />;';
+		const string = getTransformedCode( original, {
+			scopeVariable: 'createElement',
+		} );
+
+		expect( string ).toBe( original );
+	} );
+
+	it( 'does nothing if the inner scope variable is already defined when using custom options', () => {
+		const original = '(function () {\n  const {\n    createElement\n  } = wp.element;\n  let foo = <bar />;\n})();';
 		const string = getTransformedCode( original, {
 			scopeVariable: 'createElement',
 		} );


### PR DESCRIPTION
## Description
As suggested by @aduth in https://github.com/WordPress/gutenberg/pull/13540#issuecomment-458946828:

> Would it make sense to do as its own separate pull request as an enhancement to the Babel plugin?

This PR is opened to make `@wordpress/babel-plugin-import-jsx-pragma` Babel plugin more flexible. In particular, it adds new behavior where it does nothing if the scope variable is already defined when using custom options.

Implementation is going to be based on the suggestions from @nerrad and @aduth:

> the plugin docs are [here](https://github.com/jamiebuilds/babel-handbook/blob/master/translations/en/plugin-handbook.md) (which you may already know, just linking in case you didn't).

> Something I picked up from #12828 is the concept of context scope, on which all known variables are enumerated.
> 
> https://github.com/WordPress/gutenberg/pull/12828/files#diff-86d15238abb96bf543d1fd070227274eR18
> 
> Haven't looked deep enough yet to know whether this is exposed for the top-level of a file, but it would certainly help simplify things.

It solves the issue raised by @youknowriad:

> If you don't use externals and you rely on `const { createElement } = wp.element;` this pull request will increase your bundle size by bundling `@wordpress/element` and will also create an ambiguity as you'd have two `createElement` variables on these files. 

## TODO

- [x] Add an entry to the changelog, breaking?
- [x] Update README file to include the note about the variable in the scope