### PR TITLE
Docs: mention browserslist usage via browserslistrc file

### DIFF
--- a/packages/browserslist-config/README.md
+++ b/packages/browserslist-config/README.md
@@ -20,6 +20,12 @@ Add this to your `package.json` file:
 ]
 ```
 
+Alternatively, add this to `.browserslistrc` file:
+
+```
+extends @wordpress/browserslist-config
+```
+
 This package when imported returns an array of supported browsers, for more configuration examples including Autoprefixer, Babel, ESLint, PostCSS, and stylelint see the [Browserslist examples](https://github.com/ai/browserslist-example#browserslist-example) repo.
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>


### PR DESCRIPTION
Mention browserslist usage via `.browserslistrc` file in shareable `browserslist-config` package.

See docs https://github.com/browserslist/browserslist#readme
