### PR TITLE
Assign default font and font size styles to the notice component

### DIFF
--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -1,4 +1,6 @@
 .components-notice {
+	font-family: $default-font;
+	font-size: $default-font-size;
 	background-color: $blue-medium-100;
 	border-left: 4px solid $blue-medium-500;
 	margin: 5px 15px 2px;


### PR DESCRIPTION
Our standard notices all appear using our default sans-serif system font stack, at 13px: 

![screen shot 2019-02-11 at 11 09 23 am](https://user-images.githubusercontent.com/1202812/52576120-85fd9b80-2ded-11e9-887e-e4cf3ae6b3b2.png)

However, these font styles are all inherited. If a notice component is inserted into a custom block, its styles will usually be overridden by the theme's stylesheet: 

![screen shot 2019-02-11 at 11 05 43 am](https://user-images.githubusercontent.com/1202812/52576241-b3e2e000-2ded-11e9-960b-11c4c67391dc.png)

Notices are a system-level alert, so their styles should not vary based on the user's theme. This PR adds basic font and font size rules to the Notice component to prevent that: 

![screen shot 2019-02-11 at 11 04 24 am](https://user-images.githubusercontent.com/1202812/52576368-e8ef3280-2ded-11e9-90c1-13a7a81a748a.png)
