### PR TITLE
Fix recursion in sync routine.

### DIFF
--- a/packages/redux-routine/CHANGELOG.md
+++ b/packages/redux-routine/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Fix unhandled promise rejection error caused by returning null from registered generator ([#13314](https://github.com/WordPress/gutenberg/pull/13314))
 - The middleware will no longer attempt to coerce an error to an instance of `Error`, and instead passes through the thrown value directly. This resolves issues where an `Error` would be thrown when the underlying values were not of type `Error` or `string` (e.g. a thrown object) and the message would end up not being useful (e.g. `[Object object]`).
 ([#13315](https://github.com/WordPress/gutenberg/pull/13315))
-- Fix unintended recursion when invoking sync routine ([#13716](https://github.com/WordPress/gutenberg/pull/13716))
+- Fix unintended recursion when invoking sync routine ([#13818](https://github.com/WordPress/gutenberg/pull/13818))
 
 ## 3.0.3 (2018-10-19)
 

--- a/packages/redux-routine/CHANGELOG.md
+++ b/packages/redux-routine/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Fix unhandled promise rejection error caused by returning null from registered generator ([#13314](https://github.com/WordPress/gutenberg/pull/13314))
 - The middleware will no longer attempt to coerce an error to an instance of `Error`, and instead passes through the thrown value directly. This resolves issues where an `Error` would be thrown when the underlying values were not of type `Error` or `string` (e.g. a thrown object) and the message would end up not being useful (e.g. `[Object object]`).
-([#13315](https://github.com/WordPress/gutenberg/pull/13315)) 
+([#13315](https://github.com/WordPress/gutenberg/pull/13315))
+- Fix unintended recursion when invoking sync routine ([#13716](https://github.com/WordPress/gutenberg/pull/13716))
 
 ## 3.0.3 (2018-10-19)
 

--- a/packages/redux-routine/src/runtime.js
+++ b/packages/redux-routine/src/runtime.js
@@ -28,7 +28,7 @@ export default function createRuntime( controls = {}, dispatch ) {
 			// Async control routine awaits resolution.
 			routine.then( yieldNext, yieldError );
 		} else {
-			next( routine );
+			yieldNext( routine );
 		}
 		return true;
 	} );

--- a/packages/redux-routine/src/test/index.js
+++ b/packages/redux-routine/src/test/index.js
@@ -144,7 +144,7 @@ describe( 'createMiddleware', () => {
 		expect( store.getState() ).toBe( 2 );
 	} );
 
-	it( 'does not recurse when for action like returns from a sync ' +
+	it( 'does not recurse when action like object returns from a sync ' +
 		'control', () => {
 		const post = { type: 'post' };
 		const middleware = createMiddleware( {

--- a/packages/redux-routine/src/test/index.js
+++ b/packages/redux-routine/src/test/index.js
@@ -143,4 +143,21 @@ describe( 'createMiddleware', () => {
 
 		expect( store.getState() ).toBe( 2 );
 	} );
+
+	it( 'does not recurse when for action like returns from a sync ' +
+		'control', () => {
+		const post = { type: 'post' };
+		const middleware = createMiddleware( {
+			UPDATE: () => post,
+		} );
+		const store = createStoreWithMiddleware( middleware );
+		function* getPostAction() {
+			const nextState = yield { type: 'UPDATE' };
+			return { type: 'CHANGE', nextState };
+		}
+
+		store.dispatch( getPostAction() );
+
+		expect( store.getState() ).toEqual( post );
+	} );
 } );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

While working on #13716 I discovered a bug where when a control returns the results with an object that has a `type` property, `redux-routine` was recursing into that returned object treating it as an action.

When I brought this up in [slack](https://wordpress.slack.com/archives/C02QB2JS7/p1549904073023400), @youknowriad suggested it could be a bug in `redux-routine` and I tried his suggested fix and that seemed to work so this is the pull applying it.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

* [x] existing unit tests pass
* [x] e2e tests pass
* [x] Fixes the bugs reported in #13716
* [x] Testing against a plugin I've written that uses redux-routine to verify nothing is borked there.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

As far as I can tell, this is a non-breaking change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
