### PR TITLE
Fix: Clear floats on specific successive blocks that use alignment tool (Issue 13784)

### DIFF
--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -305,6 +305,11 @@
 			border-bottom: $border-width solid $light-gray-500;
 			bottom: auto;
 		}
+
+		// Clear floats of centered block when previous sibling block has left/right float.
+		& + .editor-block-list__block[data-align="center"] {
+			clear: both;
+		}
 	}
 
 	// Unlike most explicit left/right alignments, this one should be flipped by the auto-RTL system.

--- a/packages/editor/src/components/block-list/style.scss
+++ b/packages/editor/src/components/block-list/style.scss
@@ -306,10 +306,6 @@
 			bottom: auto;
 		}
 
-		// Clear floats of centered block when previous sibling block has left/right float.
-		& + .editor-block-list__block[data-align="center"] {
-			clear: both;
-		}
 	}
 
 	// Unlike most explicit left/right alignments, this one should be flipped by the auto-RTL system.
@@ -371,6 +367,11 @@
 				/*!rtl:end:ignore*/
 			}
 		}
+	}
+
+	// Center
+	&[data-align="center"] {
+		clear: both;
 	}
 
 	// Wide and full-wide


### PR DESCRIPTION
## Description
Fixes #13784  

If you have two blocks that can be aligned (i.e. Image block), and the first block is aligned to the 'left', while the second is aligned to 'center' - The second block doesn't have `clear: both;` and therefore appears next to the floated left block. 

**Steps to reproduce the behavior:**
1. Add an Image block and align it to the left
2. Duplicate the block and align this one to center

**Expected behavior**
The container of a block with an explicit center alignment should be full width and be cleared correctly, regardless of any blocks that exist before it.