### PR TITLE
Project: Update code owners (Parser modules, RichText component)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,8 +10,8 @@
 # Editor
 /packages/annotations                           @youknowriad @gziolo @aduth @atimmer
 /packages/autop                                 @youknowriad @aduth
-/packages/block-serialization-spec-parser       @youknowriad @gziolo @aduth
-/packages/block-serialization-default-parser    @youknowriad @gziolo @aduth
+/packages/block-serialization-spec-parser       @youknowriad @gziolo @aduth @dmsnell
+/packages/block-serialization-default-parser    @youknowriad @gziolo @aduth @dmsnell
 /packages/blocks                                @youknowriad @gziolo @aduth @noisysocks
 /packages/edit-post                             @youknowriad @gziolo @talldan @noisysocks
 /packages/editor                                @youknowriad @gziolo @talldan @noisysocks


### PR DESCRIPTION
This pull request seeks to make a few additions to the code owners file:

- Add @dmsnell as code owner of parser packages (`block-serialization-spec-parser`, `block-serialization-default-parser`)
- ~Add @aduth and @iseulde as code owners of RichText component~ (see https://github.com/WordPress/gutenberg/pull/13820#issuecomment-462468032)

The latter of these is interesting to implement. Since at most one code owner match can be made in the `CODEOWNERS` file, it's necessary to duplicate the entries from the `/packages/editor` "fallback". I think it may be more something to consider more often to include ownership over more granular paths _within_ a package (e.g. specific editor components, or specific blocks), but hand-crafting these is potentially error-prone. It may be worth considering some automation of `CODEOWNERS` being directory-specific, and aggregated up through ancestry to the top-level directory (e.g. combine `packages/editor/src/components/rich-text/CODEOWNERS`, `packages/editor/CODEOWNERS` to generate the root `CODEOWNERS` file)