### PR TITLE
Restore more specific CSS for paragraph block custom color classes

### DIFF
--- a/packages/block-library/src/paragraph/style.scss
+++ b/packages/block-library/src/paragraph/style.scss
@@ -35,10 +35,10 @@
 	padding-top: $block-padding;
 }
 
-.has-background {
+p.has-background {
 	padding: 20px 30px;
 }
 
-.has-text-color a {
+p.has-text-color a {
 	color: inherit;
 }


### PR DESCRIPTION
This extra specificity was removed in #13025, but should be restored because other blocks (buttons, pullquotes, etc),  use the `has-background` and `has-text-color` classes. We don't want the styles here to interfere. 

Related discussion in #13025: 
https://github.com/WordPress/gutenberg/pull/13025/files#r255619634

**Before:**
![screen shot 2019-02-11 at 2 51 55 pm](https://user-images.githubusercontent.com/1202812/52589374-a8eb7800-2e0c-11e9-835f-4e54588a855f.png)
^ Button is inheriting additional padding because of the `has-background-color` class. 

**After:** 
![screen shot 2019-02-11 at 2 52 18 pm](https://user-images.githubusercontent.com/1202812/52589383-ab4dd200-2e0c-11e9-8c52-a5131b1e584c.png)
^ Button is no longer inheriting additional padding. 

---

A couple minor notes: 

- This uses a `p` selector here, rather than something like `.wp-block-paragraph` so that the styles get picked up correctly on the front-end as well.
- The other specificity changes in that file (font size and dropcap) aren't causing issues because those classnames are only used in this context for now. 