### PR TITLE
Fix: Impossible to set empty array on editor-font-sizes.

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -1118,7 +1118,7 @@ function gutenberg_editor_scripts_and_styles( $hook ) {
 		$editor_settings['colors'] = $color_palette;
 	}
 
-	if ( ! empty( $font_sizes ) ) {
+	if ( false !== $font_sizes ) {
 		$editor_settings['fontSizes'] = $font_sizes;
 	}
 


### PR DESCRIPTION
## Description
When setting an empty array on editor-font-sizes nothing happens, and the default font-sizes are used.
This PR's fixes the problem and makes sure that when `add_theme_support('editor-color-palette', array());` is added no available font sizes appear in the font size picker. This PR uses the same approach used in colors and makes the behavior consistent with what happens when an empty array is set on editor-color-palette.

This change needs to be ported into core.

## How has this been tested?
I changed the default font sizes of twenty nineteen theme to:
```
		add_theme_support(
			'editor-font-sizes',
			array()
		);
```
I verified no default font sizes appear on the editor and just the custom size picker is available.