### PR TITLE
Check if thumbnail_url is set in getPhotoHtml

### DIFF
--- a/packages/block-library/src/embed/util.js
+++ b/packages/block-library/src/embed/util.js
@@ -51,8 +51,9 @@ export const isFromWordPress = ( html ) => {
 
 export const getPhotoHtml = ( photo ) => {
 	// 100% width for the preview so it fits nicely into the document, some "thumbnails" are
-	// actually the full size photo.
-	const photoPreview = <p><img src={ photo.thumbnail_url } alt={ photo.title } width="100%" /></p>;
+	// actually the full size photo. If thumbnails not found, use full image.
+	const imageUrl = ( photo.thumbnail_url ) ? photo.thumbnail_url : photo.url;
+	const photoPreview = <p><img src={ imageUrl } alt={ photo.title } width="100%" /></p>;
 	return renderToString( photoPreview );
 };
 


### PR DESCRIPTION

## Description
Thumbnail_url is an optional field in oembed endpoints. Check it is set first before using and fallback to url if not.

More details can be found in #13426

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
