### PR TITLE
List Block: Do not split on line breaks when multiple blocks are transformed

### DIFF
--- a/packages/block-library/src/list/index.js
+++ b/packages/block-library/src/list/index.js
@@ -73,9 +73,17 @@ export const settings = {
 				transform: ( blockAttributes ) => {
 					return createBlock( 'core/list', {
 						values: toHTMLString( {
-							value: join( blockAttributes.map( ( { content } ) =>
-								replace( create( { html: content } ), /\n/g, LINE_SEPARATOR )
-							), LINE_SEPARATOR ),
+							value: join( blockAttributes.map( ( { content } ) => {
+								const value = create( { html: content } );
+
+								if ( blockAttributes.length > 1 ) {
+									return value;
+								}
+
+								// When converting only one block, transform
+								// every line to a list item.
+								return replace( value, /\n/g, LINE_SEPARATOR );
+							} ), LINE_SEPARATOR ),
 							multilineTag: 'li',
 						} ),
 					} );

--- a/packages/e2e-tests/specs/blocks/__snapshots__/list.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/list.test.js.snap
@@ -156,6 +156,12 @@ exports[`List should insert a line break on shift+enter in a non trailing list i
 <!-- /wp:list -->"
 `;
 
+exports[`List should not transform lines in block when transforming multiple blocks 1`] = `
+"<!-- wp:list -->
+<ul><li>one<br>...</li><li>two</li></ul>
+<!-- /wp:list -->"
+`;
+
 exports[`List should outdent with children 1`] = `
 "<!-- wp:list -->
 <ul><li>a<ul><li>b<ul><li>c</li></ul></li></ul></li></ul>

--- a/packages/e2e-tests/specs/blocks/list.test.js
+++ b/packages/e2e-tests/specs/blocks/list.test.js
@@ -95,6 +95,21 @@ describe( 'List', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
+	it( 'should not transform lines in block when transforming multiple blocks', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'one' );
+		await pressKeyWithModifier( 'shift', 'Enter' );
+		await page.keyboard.type( '...' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'two' );
+		await page.keyboard.down( 'Shift' );
+		await page.click( '[data-type="core/paragraph"]' );
+		await page.keyboard.up( 'Shift' );
+		await transformBlockTo( 'List' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
 	it( 'can be converted to paragraphs', async () => {
 		await insertBlock( 'List' );
 		await page.keyboard.type( 'one' );


### PR DESCRIPTION
## Description

Title should be clear. It doesn't make so much sense to create a list item for every line in a paragraph if multiple paragraphs are transformed. Let's only do that when transforming one.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->