### PR TITLE
RichText: Fix browser formatting buttons

### DIFF
--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -23,6 +23,7 @@ export {
 	RichTextShortcut,
 	RichTextToolbarButton,
 	RichTextInserterItem,
+	RichTextInputEvent,
 } from './rich-text';
 export { default as ServerSideRender } from './server-side-render';
 export { default as MediaPlaceholder } from './media-placeholder';

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -348,6 +348,21 @@ export class RichText extends Component {
 			return;
 		}
 
+		if ( event ) {
+			const { inputType } = event.nativeEvent;
+
+			// The browser formatted something or tried to insert a list.
+			// Overwrite it. It will be handled later by the format library if
+			// needed.
+			if (
+				inputType.indexOf( 'format' ) === 0 ||
+				( inputType.indexOf( 'insert' ) === 0 && inputType !== 'insertText' )
+			) {
+				this.applyRecord( this.getRecord() );
+				return;
+			}
+		}
+
 		let { selectedFormat } = this.state;
 		const { formats, text, start, end } = this.patterns.reduce(
 			( accumlator, transform ) => transform( accumlator ),
@@ -1104,3 +1119,4 @@ export default RichTextContainer;
 export { RichTextShortcut } from './shortcut';
 export { RichTextToolbarButton } from './toolbar-button';
 export { RichTextInserterItem } from './inserter-list-item';
+export { RichTextInputEvent } from './input-event';

--- a/packages/editor/src/components/rich-text/input-event.js
+++ b/packages/editor/src/components/rich-text/input-event.js
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+export class RichTextInputEvent extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.onInput = this.onInput.bind( this );
+	}
+
+	onInput( event ) {
+		this.props.onInput( event );
+	}
+
+	componentWillMount() {
+		document.addEventListener( 'input', this.onInput, true );
+	}
+
+	componentWillUnmount() {
+		document.removeEventListener( 'input', this.onInput, true );
+	}
+
+	render() {
+		return null;
+	}
+}

--- a/packages/editor/src/components/rich-text/input-event.js
+++ b/packages/editor/src/components/rich-text/input-event.js
@@ -11,7 +11,9 @@ export class RichTextInputEvent extends Component {
 	}
 
 	onInput( event ) {
-		this.props.onInput( event );
+		if ( event.inputType === this.props.inputType ) {
+			this.props.onInput();
+		}
 	}
 
 	componentWillMount() {

--- a/packages/editor/src/components/rich-text/input-event.js
+++ b/packages/editor/src/components/rich-text/input-event.js
@@ -16,7 +16,7 @@ export class RichTextInputEvent extends Component {
 		}
 	}
 
-	componentWillMount() {
+	componentDidMount() {
 		document.addEventListener( 'input', this.onInput, true );
 	}
 

--- a/packages/format-library/src/bold/index.js
+++ b/packages/format-library/src/bold/index.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { toggleFormat } from '@wordpress/rich-text';
-import { RichTextToolbarButton, RichTextShortcut } from '@wordpress/editor';
+import { RichTextToolbarButton, RichTextShortcut, RichTextInputEvent } from '@wordpress/editor';
 
 const name = 'core/bold';
 
@@ -31,6 +31,13 @@ export const bold = {
 					isActive={ isActive }
 					shortcutType="primary"
 					shortcutCharacter="b"
+				/>
+				<RichTextInputEvent
+					onInput={ ( { inputType } ) => {
+						if ( inputType === 'formatBold' ) {
+							onToggle();
+						}
+					} }
 				/>
 			</Fragment>
 		);

--- a/packages/format-library/src/bold/index.js
+++ b/packages/format-library/src/bold/index.js
@@ -33,11 +33,8 @@ export const bold = {
 					shortcutCharacter="b"
 				/>
 				<RichTextInputEvent
-					onInput={ ( { inputType } ) => {
-						if ( inputType === 'formatBold' ) {
-							onToggle();
-						}
-					} }
+					inputType="formatBold"
+					onInput={ onToggle }
 				/>
 			</Fragment>
 		);

--- a/packages/format-library/src/italic/index.js
+++ b/packages/format-library/src/italic/index.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { toggleFormat } from '@wordpress/rich-text';
-import { RichTextToolbarButton, RichTextShortcut } from '@wordpress/editor';
+import { RichTextToolbarButton, RichTextShortcut, RichTextInputEvent } from '@wordpress/editor';
 
 const name = 'core/italic';
 
@@ -31,6 +31,13 @@ export const italic = {
 					isActive={ isActive }
 					shortcutType="primary"
 					shortcutCharacter="i"
+				/>
+				<RichTextInputEvent
+					onInput={ ( { inputType } ) => {
+						if ( inputType === 'formatItalic' ) {
+							onToggle();
+						}
+					} }
 				/>
 			</Fragment>
 		);

--- a/packages/format-library/src/italic/index.js
+++ b/packages/format-library/src/italic/index.js
@@ -33,11 +33,8 @@ export const italic = {
 					shortcutCharacter="i"
 				/>
 				<RichTextInputEvent
-					onInput={ ( { inputType } ) => {
-						if ( inputType === 'formatItalic' ) {
-							onToggle();
-						}
-					} }
+					inputType="formatItalic"
+					onInput={ onToggle }
 				/>
 			</Fragment>
 		);

--- a/packages/format-library/src/underline/index.js
+++ b/packages/format-library/src/underline/index.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { toggleFormat } from '@wordpress/rich-text';
-import { RichTextShortcut } from '@wordpress/editor';
+import { RichTextShortcut, RichTextInputEvent } from '@wordpress/editor';
 
 const name = 'core/underline';
 
@@ -33,6 +33,13 @@ export const underline = {
 					type="primary"
 					character="u"
 					onUse={ onToggle }
+				/>
+				<RichTextInputEvent
+					onInput={ ( { inputType } ) => {
+						if ( inputType === 'formatUnderline' ) {
+							onToggle();
+						}
+					} }
 				/>
 			</Fragment>
 		);

--- a/packages/format-library/src/underline/index.js
+++ b/packages/format-library/src/underline/index.js
@@ -35,11 +35,8 @@ export const underline = {
 					onUse={ onToggle }
 				/>
 				<RichTextInputEvent
-					onInput={ ( { inputType } ) => {
-						if ( inputType === 'formatUnderline' ) {
-							onToggle();
-						}
-					} }
+					inputType="formatUnderline"
+					onInput={ onToggle }
 				/>
 			</Fragment>
 		);


### PR DESCRIPTION
## Description

This PR fixes any formatting buttons that are provided by the browser, e.g. formatting buttons in Safari and iOS Safari.

![bc744485ab70fcb0bd108a8f371ec8a2](https://user-images.githubusercontent.com/4710635/52634917-bfefa000-2ec8-11e9-96f3-41349ab84031.png)

<img width="217" alt="screenshot 2019-02-12 at 13 35 45" src="https://user-images.githubusercontent.com/4710635/52635836-40af9b80-2ecb-11e9-9481-10e4103bcd9d.png">


What's the problem at the moment?

* We don't control what the button is inserting. E.g. Safari's bold button inserts `<b>` tags.
* Some buttons don't make any sense in `RichText`, such as the align and list buttons. They could be linked at a block level though. I've prevented them from doing anything, but ideally they should work at the block level (maybe a future PR). I've found no way to remove the buttons.
* When using the buttons, the first letter didn't receive any formatting.
* It also fixes the formatting added by Chrome when pressing `ctrl+u` on a Mac, a shortcut that wasn't overridden by us.

The most reliable solution I've found is checking the input event for `inputType`, and then resetting the DOM. After this a format in the format library may use `RichTextInputEvent` to do something based on that information.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
