### PR TITLE
Fix: missing className on latest comments block

### DIFF
--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -117,6 +117,9 @@ function render_block_core_latest_comments( $attributes = array() ) {
 	}
 
 	$class = 'wp-block-latest-comments';
+	if ( ! empty( $attributes['className'] ) ) {
+		$class .= ' ' . $attributes['className'];
+	}
 	if ( isset( $attributes['align'] ) ) {
 		$class .= " align{$attributes['align']}";
 	}


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/13773
The custom className was not being applied on the latest comments block.

## How has this been tested?
I added a latest comments block; I checked using the browser inspector that on the editor by default no class name is applied and no unrequired empty spaces exist on the class field. I published the post and repeated the same checks on the frontend.

I added a custom className to the block and verified it was applied on the editor and the frontend.

I removed the className and verified the className was removed, and no unrequired empty spaces were added.

