### PR TITLE
Fix: Searching for inline image suggests no blocks found even though they are

### DIFF
--- a/packages/editor/src/components/inserter/inline-elements.js
+++ b/packages/editor/src/components/inserter/inline-elements.js
@@ -14,20 +14,33 @@ import { PanelBody, Slot } from '@wordpress/components';
  */
 import BlockTypesList from '../block-types-list';
 
-const InserterInlineElements = ( { filterValue } ) => {
+const InserterInlineElements = ( {
+	filterValue,
+	onPanelToggle,
+	panelOpened,
+	panelRef,
+	whenEmpty,
+} ) => {
 	return (
 		<Slot name="Inserter.InlineElements" fillProps={ { filterValue } }>
-			{ ( fills ) => ! isEmpty( fills ) && (
-				<PanelBody
-					title={ __( 'Inline Elements' ) }
-					initialOpen={ false }
-					className="editor-inserter__inline-elements"
-				>
-					<BlockTypesList>
-						{ fills }
-					</BlockTypesList>
-				</PanelBody>
-			) }
+			{ ( fills ) => {
+				if ( isEmpty( fills ) ) {
+					return whenEmpty;
+				}
+				return (
+					<PanelBody
+						title={ __( 'Inline Elements' ) }
+						opened={ panelOpened }
+						onToggle={ onPanelToggle }
+						ref={ panelRef }
+						className="editor-inserter__inline-elements"
+					>
+						<BlockTypesList>
+							{ fills }
+						</BlockTypesList>
+					</PanelBody>
+				);
+			} }
 		</Slot>
 	);
 };

--- a/packages/editor/src/components/inserter/menu.js
+++ b/packages/editor/src/components/inserter/menu.js
@@ -204,6 +204,12 @@ export class InserterMenu extends Component {
 				const firstCategory = find( getCategories(), ( { slug } ) => itemsPerCategory[ slug ] && itemsPerCategory[ slug ].length );
 				openPanels = [ firstCategory.slug ];
 			}
+
+			// Each time filter value changes if a filter exists make sure inline panel is open.
+			// If no inline items exist nothing will be rendered.
+			if ( filterValue ) {
+				openPanels.push( 'inline' );
+			}
 		}
 
 		this.setState( {
@@ -291,7 +297,21 @@ export class InserterMenu extends Component {
 						</PanelBody>
 					}
 
-					<InserterInlineElements filterValue={ filterValue } />
+					<InserterInlineElements
+						filterValue={ filterValue }
+						panelRef={ this.bindPanel( 'inline' ) }
+						onPanelToggle={ this.onTogglePanel( 'inline' ) }
+						panelOpened={ isPanelOpen( 'inline' ) }
+						whenEmpty={
+							isEmpty( suggestedItems ) &&
+							isEmpty( reusableItems ) &&
+							isEmpty( itemsPerCategory ) && (
+								<p className="editor-inserter__no-results">
+									{ __( 'No blocks found.' ) }
+								</p>
+							)
+						}
+					/>
 
 					{ map( getCategories(), ( category ) => {
 						const categoryItems = itemsPerCategory[ category.slug ];
@@ -329,9 +349,6 @@ export class InserterMenu extends Component {
 								{ __( 'Manage All Reusable Blocks' ) }
 							</a>
 						</PanelBody>
-					) }
-					{ isEmpty( suggestedItems ) && isEmpty( reusableItems ) && isEmpty( itemsPerCategory ) && (
-						<p className="editor-inserter__no-results">{ __( 'No blocks found.' ) }</p>
 					) }
 				</div>
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/13762

## Description
We had two problems with inline elements on the inserter:
	- In contrast to other block categories when searching for inline elements, the inline elements panel did open automatically like the other panels.
	- Even if inline elements were found, we continued to show a message saying no blocks were found.

This PR fixes both problems.
## How has this been tested?
I added a paragraph I wrote some text.
I went to the inserter I opened the inline elements panel and closed it again without problems.
I searched for "in" I verified the panel opened automatically when I searched. I closed the panel without any problem.
I continued my search to "inline" I verified the inline image element appeared, and there was no message referring no blocks were found.
I searched for "sdsdfsdfdsf" and I verified the no blocks found message appeared.

