### PR TITLE
Do not render font size picker when no font sizes are available and custom font sizes are disabled

### DIFF
--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -26,6 +26,9 @@ function FontSizePicker( {
 	value,
 	withSlider = false,
 } ) {
+	if ( disableCustomFontSizes && ! fontSizes.length ) {
+		return null;
+	}
 	const onChangeValue = ( event ) => {
 		const newValue = event.target.value;
 		if ( newValue === '' ) {


### PR DESCRIPTION

## Description
If the theme sets an empty array as font sizes and disables custom font sizes the user is not able to select any font size so the font size picker should not render.

## How has this been tested?
I added the following code snippet in functions.php:
```
add_theme_support('disable-custom-font-sizes');
add_theme_support( 'editor-font-sizes',  array() );
```

I added a paragraph, and I verified the font size picker does not appear.

## Screenshots <!-- if applicable -->
Before:
<img width="353" alt="screenshot 2019-02-12 at 20 10 57" src="https://user-images.githubusercontent.com/11271197/52667122-f1d42700-2f07-11e9-9167-473097122cb7.png">


After:
<img width="350" alt="screenshot 2019-02-12 at 20 51 42" src="https://user-images.githubusercontent.com/11271197/52667181-0d3f3200-2f08-11e9-8f8d-e0636bbf26b3.png">

