### PR TITLE
Quote Block: Remove left padding from quote block when its centred

### DIFF
--- a/packages/block-library/src/quote/theme.scss
+++ b/packages/block-library/src/quote/theme.scss
@@ -24,6 +24,7 @@
 	&[style*="text-align:center"],
 	&[style*="text-align: center"] {
 		border: none;
+		padding-left: 0;
 	}
 
 	&.is-style-large,


### PR DESCRIPTION
## Description
In this PR, the `padding-left` has been removed from the quote block when it's aligned centre.

Fixes #13845.

## How has this been tested?
This has been tested on my localhost set up (Laravel Valet) in Firefox 65.0, Mac OSX 10.14.

I've tested this change with Twenties Nineteen down to Twenty Fifteen; Twenties Seventeen, Sixteen and Fifteen all remove the left and right padding from this block, so this issue wasn't present in those themes (nor did this update change anything in them). 

When testing Twenty Nineteen, I tested the theme using the patch from https://core.trac.wordpress.org/ticket/46239. This patch fixes some visual issues in the theme, to get it lined up with changes made in #13248. 

## Screenshots

Before update:

![twentynineteen-centre-aligned-frontend](https://user-images.githubusercontent.com/177561/52683099-a1a09900-2ef6-11e9-8a87-a15a0e2f3f1f.png)

![twentynineteen-centre-aligned-editor](https://user-images.githubusercontent.com/177561/52683106-a82f1080-2ef6-11e9-8e5b-2efcfd55f7e0.png)

After update:

![twentynineteen-centre-aligned-frontend-after](https://user-images.githubusercontent.com/177561/52683124-b3823c00-2ef6-11e9-8b40-0357cdd789a0.png)

![twentynineteen-centre-aligned-editor-after](https://user-images.githubusercontent.com/177561/52683116-ae24f180-2ef6-11e9-8ef7-3abf2c4a9d57.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue) - strictly CSS, adding a `padding-left: 0` for when the text is aligned centre in the quote block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
