### PR TITLE
RichText: don't use DOM to add line padding

### DIFF
--- a/packages/e2e-tests/specs/__snapshots__/writing-flow.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/writing-flow.test.js.snap
@@ -72,7 +72,7 @@ exports[`adding blocks should create valid paragraph blocks when rapidly pressin
 
 exports[`adding blocks should insert line break at end 1`] = `
 "<!-- wp:paragraph -->
-<p>a<br><br></p>
+<p>a<br></p>
 <!-- /wp:paragraph -->"
 `;
 
@@ -90,7 +90,7 @@ exports[`adding blocks should insert line break at start 1`] = `
 
 exports[`adding blocks should insert line break in empty container 1`] = `
 "<!-- wp:paragraph -->
-<p><br><br></p>
+<p><br></p>
 <!-- /wp:paragraph -->"
 `;
 

--- a/packages/e2e-tests/specs/blocks/__snapshots__/list.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/list.test.js.snap
@@ -146,13 +146,13 @@ exports[`List should indent and outdent level 2 3`] = `
 
 exports[`List should insert a line break on shift+enter 1`] = `
 "<!-- wp:list -->
-<ul><li>a<br><br></li></ul>
+<ul><li>a<br></li></ul>
 <!-- /wp:list -->"
 `;
 
 exports[`List should insert a line break on shift+enter in a non trailing list item 1`] = `
 "<!-- wp:list -->
-<ul><li>a</li><li>b<br><br></li><li>c</li></ul>
+<ul><li>a</li><li>b<br></li><li>c</li></ul>
 <!-- /wp:list -->"
 `;
 

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -195,6 +195,7 @@ export class RichText extends Component {
 			multilineTag: this.multilineTag,
 			multilineWrapperTags: this.multilineWrapperTags,
 			prepareEditableTree: this.props.prepareEditableTree,
+			isEditableTree: true,
 		} );
 	}
 

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -195,7 +195,7 @@ export class RichText extends Component {
 			multilineTag: this.multilineTag,
 			multilineWrapperTags: this.multilineWrapperTags,
 			prepareEditableTree: this.props.prepareEditableTree,
-			isEditableTree: true,
+			__unstableIsEditableTree: true,
 		} );
 	}
 

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -108,7 +108,7 @@ export function create( {
 	range,
 	multilineTag,
 	multilineWrapperTags,
-	isEditableTree,
+	__unstableIsEditableTree: isEditableTree,
 } = {} ) {
 	if ( typeof text === 'string' && text.length > 0 ) {
 		return {

--- a/packages/rich-text/src/insert-line-break.js
+++ b/packages/rich-text/src/insert-line-break.js
@@ -3,32 +3,14 @@
  */
 
 import { insert } from './insert';
-import { LINE_SEPARATOR } from './special-characters';
 
 /**
- * Inserts a line break at the given or selected position. Inserts two line
- * breaks if at the end of a line.
+ * Inserts a line break at the given or selected position.
  *
  * @param {Object} value Value to modify.
  *
- * @return {Object} The value with the line break(s) inserted.
+ * @return {Object} The value with the line break inserted.
  */
 export function insertLineBreak( value ) {
-	const { text, end } = value;
-	const length = text.length;
-
-	let toInsert = '\n';
-
-	// If the caret is at the end of the text, and there is no
-	// trailing line break or no text at all, we have to insert two
-	// line breaks in order to create a new line visually and place
-	// the caret there.
-	if (
-		( end === length || text[ end ] === LINE_SEPARATOR ) &&
-		( text[ end - 1 ] !== '\n' || length === 0 )
-	) {
-		toInsert = '\n\n';
-	}
-
-	return insert( value, toInsert );
+	return insert( value, '\n' );
 }

--- a/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
+++ b/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
@@ -132,7 +132,9 @@ exports[`recordToDom should filter format boundary attributes 1`] = `
 exports[`recordToDom should handle br 1`] = `
 <body>
   
-  <br />
+  <br
+    data-rich-text-line-break="true"
+  />
   
   <br
     data-rich-text-padding="true"
@@ -146,7 +148,9 @@ exports[`recordToDom should handle br with formatting 1`] = `
     data-rich-text-format-boundary="true"
   >
     
-    <br />
+    <br
+      data-rich-text-line-break="true"
+    />
     
   </em>
   
@@ -159,7 +163,9 @@ exports[`recordToDom should handle br with formatting 1`] = `
 exports[`recordToDom should handle br with text 1`] = `
 <body>
   te
-  <br />
+  <br
+    data-rich-text-line-break="true"
+  />
   st
 </body>
 `;
@@ -167,9 +173,13 @@ exports[`recordToDom should handle br with text 1`] = `
 exports[`recordToDom should handle double br 1`] = `
 <body>
   a
-  <br />
+  <br
+    data-rich-text-line-break="true"
+  />
   
-  <br />
+  <br
+    data-rich-text-line-break="true"
+  />
   b
 </body>
 `;
@@ -303,9 +313,13 @@ exports[`recordToDom should handle nested empty list value 1`] = `
 exports[`recordToDom should handle selection before br 1`] = `
 <body>
   a
-  <br />
+  <br
+    data-rich-text-line-break="true"
+  />
   
-  <br />
+  <br
+    data-rich-text-line-break="true"
+  />
   b
 </body>
 `;

--- a/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
+++ b/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
@@ -134,6 +134,9 @@ exports[`recordToDom should handle br 1`] = `
   
   <br />
   
+  <br
+    data-rich-text-padding="true"
+  />
 </body>
 `;
 
@@ -147,6 +150,9 @@ exports[`recordToDom should handle br with formatting 1`] = `
     
   </em>
   
+  <br
+    data-rich-text-padding="true"
+  />
 </body>
 `;
 
@@ -197,12 +203,14 @@ exports[`recordToDom should handle middle empty list value 1`] = `
     <br
       data-rich-text-padding="true"
     />
+    
   </li>
   <li>
     
     <br
       data-rich-text-padding="true"
     />
+    
   </li>
   <li>
     
@@ -276,6 +284,7 @@ exports[`recordToDom should handle multiline value with empty 1`] = `
 exports[`recordToDom should handle nested empty list value 1`] = `
 <body>
   <li>
+    
     <br
       data-rich-text-padding="true"
     />

--- a/packages/rich-text/src/test/helpers/index.js
+++ b/packages/rich-text/src/test/helpers/index.js
@@ -459,8 +459,8 @@ export const spec = [
 			endOffset: 0,
 			endContainer: element.querySelector( 'ul > li' ),
 		} ),
-		startPath: [ 0, 0, 0, 0, 0 ],
-		endPath: [ 0, 0, 0, 0, 0 ],
+		startPath: [ 0, 2, 0, 0, 0 ],
+		endPath: [ 0, 2, 0, 0, 0 ],
 		record: {
 			start: 1,
 			end: 1,
@@ -479,8 +479,8 @@ export const spec = [
 			endOffset: 0,
 			endContainer: element.firstChild.nextSibling,
 		} ),
-		startPath: [ 1, 0, 0 ],
-		endPath: [ 1, 0, 0 ],
+		startPath: [ 1, 2, 0 ],
+		endPath: [ 1, 2, 0 ],
 		record: {
 			start: 1,
 			end: 1,

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -113,39 +113,6 @@ function remove( node ) {
 	return node.parentNode.removeChild( node );
 }
 
-function createLinePadding( doc ) {
-	const element = doc.createElement( 'br' );
-	element.setAttribute( 'data-rich-text-padding', 'true' );
-	return element;
-}
-
-function padEmptyLines( { element, multilineWrapperTags } ) {
-	const length = element.childNodes.length;
-	const doc = element.ownerDocument;
-
-	for ( let index = 0; index < length; index++ ) {
-		const child = element.childNodes[ index ];
-
-		if ( child.nodeType === TEXT_NODE ) {
-			if ( length === 1 && ! child.nodeValue ) {
-				// Pad if the only child is an empty text node.
-				element.appendChild( createLinePadding( doc ) );
-			}
-		} else {
-			if (
-				multilineWrapperTags &&
-				! child.previousSibling &&
-				multilineWrapperTags.indexOf( child.nodeName.toLowerCase() ) !== -1
-			) {
-				// Pad the line if there is no content before a nested wrapper.
-				element.insertBefore( createLinePadding( doc ), child );
-			}
-
-			padEmptyLines( { element: child, multilineWrapperTags } );
-		}
-	}
-}
-
 function prepareFormats( prepareEditableTree = [], value ) {
 	return prepareEditableTree.reduce( ( accumlator, fn ) => {
 		return fn( accumlator, value.text );
@@ -185,10 +152,6 @@ export function toDom( {
 		},
 		isEditableTree,
 	} );
-
-	if ( isEditableTree ) {
-		padEmptyLines( { element: tree, multilineWrapperTags } );
-	}
 
 	return {
 		body: tree,

--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -242,7 +242,13 @@ export function toTree( {
 
 		if ( character !== OBJECT_REPLACEMENT_CHARACTER ) {
 			if ( character === '\n' ) {
-				pointer = append( getParent( pointer ), { type: 'br', object: true } );
+				pointer = append( getParent( pointer ), {
+					type: 'br',
+					attributes: isEditableTree ? {
+						'data-rich-text-line-break': 'true',
+					} : undefined,
+					object: true,
+				} );
 				// Ensure pointer is text node.
 				pointer = append( getParent( pointer ), '' );
 			} else if ( ! isText( pointer ) ) {

--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -124,6 +124,15 @@ export function toTree( {
 
 	for ( let i = 0; i < formatsLength; i++ ) {
 		const character = text.charAt( i );
+		const shouldInsertPadding = isEditableTree && (
+			// Pad the line if the line is empty.
+			! lastCharacter ||
+			lastCharacter === LINE_SEPARATOR ||
+			// Pad the line if the previous character is a line break, otherwise
+			// the line break won't be visible.
+			lastCharacter === '\n'
+		);
+
 		let characterFormats = formats[ i ];
 
 		// Set multiline tags in queue for building the tree.
@@ -144,21 +153,15 @@ export function toTree( {
 
 		let pointer = getLastChild( tree );
 
-		if ( isEditableTree && character === LINE_SEPARATOR ) {
+		if ( shouldInsertPadding && character === LINE_SEPARATOR ) {
 			let node = pointer;
 
 			while ( ! isText( node ) ) {
 				node = getLastChild( node );
 			}
 
-			if (
-				! lastCharacter ||
-				lastCharacter === LINE_SEPARATOR ||
-				lastCharacter === '\n'
-			) {
-				append( getParent( node ), padding );
-				append( getParent( node ), '' );
-			}
+			append( getParent( node ), padding );
+			append( getParent( node ), '' );
 		}
 
 		// Set selection for the start of line.
@@ -257,11 +260,7 @@ export function toTree( {
 			onEndIndex( tree, pointer );
 		}
 
-		if ( i === text.length && isEditableTree && (
-			! lastCharacter ||
-			lastCharacter === LINE_SEPARATOR ||
-			lastCharacter === '\n'
-		) ) {
+		if ( shouldInsertPadding && i === text.length ) {
 			append( getParent( pointer ), padding );
 		}
 

--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -80,6 +80,14 @@ function getDeepestActiveFormat( value ) {
 	return activeFormats[ selectedFormat - 1 ];
 }
 
+const padding = {
+	type: 'br',
+	attributes: {
+		'data-rich-text-padding': 'true',
+	},
+	object: true,
+};
+
 export function toTree( {
 	value,
 	multilineTag,
@@ -135,6 +143,23 @@ export function toTree( {
 		}
 
 		let pointer = getLastChild( tree );
+
+		if ( isEditableTree && character === LINE_SEPARATOR ) {
+			let node = pointer;
+
+			while ( ! isText( node ) ) {
+				node = getLastChild( node );
+			}
+
+			if (
+				! lastCharacter ||
+				lastCharacter === LINE_SEPARATOR ||
+				lastCharacter === '\n'
+			) {
+				append( getParent( node ), padding );
+				append( getParent( node ), '' );
+			}
+		}
 
 		// Set selection for the start of line.
 		if ( lastCharacter === LINE_SEPARATOR ) {
@@ -230,6 +255,14 @@ export function toTree( {
 
 		if ( onEndIndex && end === i + 1 ) {
 			onEndIndex( tree, pointer );
+		}
+
+		if ( i === text.length && isEditableTree && (
+			! lastCharacter ||
+			lastCharacter === LINE_SEPARATOR ||
+			lastCharacter === '\n'
+		) ) {
+			append( getParent( pointer ), padding );
 		}
 
 		lastCharacterFormats = characterFormats;


### PR DESCRIPTION
## Description

Fixes #13982 and #7630. Blocks #13838.

* It reduces complexity in `insertLineBreak`, which would no longer have to insert two line breaks when at the end of a line. This can lead to strange behaviour: you can never really get rid anymore of this second line break. With an "invisible" line break already there, there's no need for it any longer.
* Reduces complexity in adding the padding. Previously it was only added for empty lines and we used the DOM for it. Now we use `toTree` for it.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->