### PR TITLE
Project: Add styles and project management groups to CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -86,3 +86,6 @@
 *.native.scss                                   @ghost
 *.android.scss                                  @ghost
 *.ios.scss                                      @ghost
+
+# Project Management
+/.github                                        @youknowriad @mapk

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -76,6 +76,9 @@
 # Documentation
 /docs                                           @youknowriad @gziolo @chrisvanpatten @mkaz @ajitbohra @nosolosw @notnownikki
 
+# Styles (Unowned)
+*.scss                                          @ghost
+
 # Native (Unowned)
 *.native.js                                     @ghost
 *.android.js                                    @ghost

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -88,4 +88,4 @@
 *.ios.scss                                      @ghost
 
 # Project Management
-/.github                                        @youknowriad @mapk
+/.github                                        @youknowriad @mapk @karmatosed


### PR DESCRIPTION
## Description

Based on the discussion from yesterday (https://github.com/WordPress/gutenberg/pull/13820#issuecomment-462817137):

> > I would also love we create a new section where people interested in reviewing `*.scss` files could opt in. In many cases I got notifications about such changes and I would be fine skipping them as they usually require some design feedback anyways.
> 
> Is it the sort of thing where we adopt what we did with native files, assigning them to @ghost until someone chooses to take ownership?

New styles group is going to be unowned unless there are some volunteers focused on design contributions.

I also added the project management group where I assigned @mapk and @youknowriad - we should discuss whether they want to be included or someone else wants to be notified there. When opening this PR I noticed that there is nobody assigned as a reviewer.