### PR TITLE
Remove unused line height style for mce-content-body

### DIFF
--- a/packages/editor/src/components/rich-text/style.scss
+++ b/packages/editor/src/components/rich-text/style.scss
@@ -7,7 +7,6 @@
 .editor-rich-text__editable {
 	margin: 0;
 	position: relative;
-	line-height: $editor-line-height;
 	// In HTML, leading and trailing spaces are not visible, and multiple spaces
 	// elsewhere are visually reduced to one space. This rule prevents spaces
 	// from collapsing so all space is visible in the editor and can be removed.

--- a/packages/editor/src/editor-styles.scss
+++ b/packages/editor/src/editor-styles.scss
@@ -33,7 +33,3 @@ ul ul,
 ol ul {
 	list-style-type: circle;
 }
-
-.mce-content-body {
-	line-height: $editor-line-height;
-}


### PR DESCRIPTION
`mce-content-body` is no longer applied to editable rich text elements. (I think that changed with #13697). As a result, this style is no longer picked up. 

Since this style is unused, there should be no visual difference in removing it. But here are screenshots to show where it used to show up back when it was active: 

## Before (WordPress 5.0.3)

![screen shot 2019-02-13 at 2 55 49 pm](https://user-images.githubusercontent.com/1202812/52739887-da487d00-2f9f-11e9-9045-9262eaa73779.png)

## Current (in `master`, and in this PR)

![screen shot 2019-02-13 at 2 54 51 pm](https://user-images.githubusercontent.com/1202812/52739805-b4bb7380-2f9f-11e9-81e2-423f8ca3e64e.png)


---

As a sidenote, applying that `mce-content-body` style to the `editor-styles-wrapper` was causing some theme style issues like #10067, so it's good to have it removed. ([More discussion here](https://github.com/WordPress/gutenberg/pull/13765#issuecomment-462773568)) 🙂 

