### PR TITLE
Fix issue with mover colors in dark themes.

### DIFF
--- a/packages/editor/src/components/block-mover/style.scss
+++ b/packages/editor/src/components/block-mover/style.scss
@@ -42,6 +42,11 @@
 		color: $light-opacity-300;
 	}
 
+	// Nested movers have a background, so don't invert the colors there.
+	.is-dark-theme .wp-block .wp-block & {
+		color: $dark-opacity-300;
+	}
+
 	&[aria-disabled="true"] {
 		cursor: default;
 		pointer-events: none;
@@ -71,6 +76,11 @@
 
 		.is-dark-theme & {
 			color: $light-opacity-500;
+		}
+
+		// Nested movers have a background, so don't invert the colors there.
+		.is-dark-theme .wp-block .wp-block & {
+			color: $dark-opacity-500;
 		}
 	}
 


### PR DESCRIPTION
The block editor supports an inverted UI to ensure contrast in themes that register themselves as having dark backgrounds (see https://wordpress.org/gutenberg/handbook/designers-developers/developers/themes/theme-support/#dark-backgrounds).

What this mode does, is invert the UI wherever it can, so dark gray borders are light gray on black backgrounds, and the mover icons are white instead of black.

But they shouldn't be in nested contexts, because in nested contexts the movers have a white background.

This PR fixes that.

Before:

<img width="512" alt="before" src="https://user-images.githubusercontent.com/1204802/52772885-ed0f9000-3039-11e9-9c2a-01c345a41212.png">

After:

<img width="492" alt="after" src="https://user-images.githubusercontent.com/1204802/52772887-eed95380-3039-11e9-865d-114af72331ef.png">
