### PR TITLE
RichText: remove obsolete rule from stylesheet

### DIFF
--- a/packages/editor/src/components/rich-text/style.scss
+++ b/packages/editor/src/components/rich-text/style.scss
@@ -19,16 +19,8 @@
 	// to be saved.
 	white-space: pre-wrap;
 
-	> p:empty {
-		min-height: $editor-font-size * $editor-line-height;
-	}
-
 	> p:first-child {
 		margin-top: 0;
-	}
-
-	&:focus {
-		outline: none;
 	}
 
 	a {
@@ -49,6 +41,9 @@
 	}
 
 	&:focus {
+		// Removes outline added by the browser.
+		outline: none;
+
 		*[data-rich-text-format-boundary] {
 			border-radius: 2px;
 			box-shadow: 0 0 0 1px $light-gray-400;


### PR DESCRIPTION
## Description

Removes the `p:empty` rule. There's no way it can ever be empty. It's always padded with a `<br>` element. I believe this is a remnant from the early TinyMCE days when we didn't have a rich text state yet. There would be cases were TinyMCE wouldn't pad with a `<br>` element. Now this is impossible.

## How has this been tested?


## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->