### PR TITLE
Fix: Calendar block: Always show current month for non post types on the editor

### DIFF
--- a/packages/block-library/src/calendar/edit.js
+++ b/packages/block-library/src/calendar/edit.js
@@ -61,7 +61,16 @@ class CalendarEdit extends Component {
 }
 
 export default withSelect( ( select ) => {
+	const {
+		getEditedPostAttribute,
+	} = select( 'core/editor' );
+	const postType = getEditedPostAttribute( 'type' );
+	// Dates are used to overwrite year and month used on the calendar.
+	// This overwrite should only happen for 'post' post types.
+	// For other post types the calendar always displays the current month.
 	return {
-		date: select( 'core/editor' ).getEditedPostAttribute( 'date' ),
+		date: postType === 'post' ?
+			getEditedPostAttribute( 'date' ) :
+			undefined,
 	};
 } )( CalendarEdit );

--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -13,18 +13,22 @@
  * @return string Returns the block content.
  */
 function render_block_core_calendar( $attributes ) {
-	global $monthnum, $year, $post;
+	global $monthnum, $year;
+
 	$previous_monthnum = $monthnum;
 	$previous_year     = $year;
 
-	if ( isset( $attributes['month'] ) ) {
-		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
-		$monthnum = $attributes['month'];
-	}
-
-	if ( isset( $attributes['year'] ) ) {
-		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
-		$year = $attributes['year'];
+	if ( isset( $attributes['month'] ) && isset( $attributes['year'] ) ) {
+		$permalink_structure = get_option( 'permalink_structure' );
+		if (
+			strpos( $permalink_structure, '%monthnum%' ) !== false &&
+			strpos( $permalink_structure, '%year%' ) !== false
+		) {
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
+			$monthnum = $attributes['month'];
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
+			$year = $attributes['year'];
+		}
 	}
 
 	$custom_class_name = empty( $attributes['className'] ) ? '' : ' ' . $attributes['className'];


### PR DESCRIPTION
Follow up on: https://github.com/WordPress/gutenberg/pull/13772

The calendar block on the front for "post" post types displays the calendar of the month the post was published in and other post types like "pages" always shows the current month. Following the behavior, we had on the calendar widget.

@gziolo found out that on the editor even for non post types we showed the calendar the calendar of the month the "post" was published in, this PR fixes this problem to make sure the editor view matches frontend view and the existing widget view.

## Types of changes
I added a post; I added the calendar block; I changed the publish date for a different month/year; I verified the calendar block updated; I saved the post and I verified the same calendar was displayed on the front end.
I added a post; I added the calendar block; I changed the publish date for a different month/year; I verified the calendar block did not update to a different month/year and continue to show the current month. I verified the same calendar was displayed on the front end.
I repeated the previous page test for a CPT created with the CPT UI plugin and I verified the result was the same.
