### PR TITLE
Implement setRef for post-title in Gutenberg Mobile.

### DIFF
--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { createElement, Component, forwardRef } from '@wordpress/element';
 import { RichText } from '@wordpress/editor';
 import { decodeEntities } from '@wordpress/html-entities';
 import { withDispatch } from '@wordpress/data';
@@ -10,7 +10,7 @@ import { withInstanceId, compose } from '@wordpress/compose';
 
 const minHeight = 53;
 
-class PostTitle extends Component {
+class PostTitleComponent extends Component {
 	constructor() {
 		super( ...arguments );
 
@@ -90,8 +90,25 @@ const applyWithDispatch = withDispatch( ( dispatch ) => {
 	};
 } );
 
-export default compose(
-	applyWithDispatch,
-	withInstanceId,
-	withFocusOutside
-)( PostTitle );
+export function PostTitle(props, ref) {
+/*
+	const component = (
+		<PostTitleComponent
+			{ ...props }
+			ref={ ref } />
+	);*/
+
+	//const component = PostTitleComponent({ ...props, ref })
+
+	//console.log("Component: " + JSON.stringify(component));
+
+	return compose(
+		applyWithDispatch,
+		withInstanceId,
+		withFocusOutside
+	)( PostTitleComponent );
+};
+
+
+
+export default forwardRef( PostTitle );

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createElement, Component, forwardRef } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { RichText } from '@wordpress/editor';
 import { decodeEntities } from '@wordpress/html-entities';
 import { withDispatch } from '@wordpress/data';
@@ -10,7 +10,7 @@ import { withInstanceId, compose } from '@wordpress/compose';
 
 const minHeight = 53;
 
-class PostTitleComponent extends Component {
+class PostTitle extends Component {
 	constructor() {
 		super( ...arguments );
 
@@ -48,7 +48,6 @@ class PostTitleComponent extends Component {
 		return (
 			<RichText
 				tagName={ 'p' }
-				rootTagsToEliminate={ [ 'strong' ] }
 				onFocus={ this.onSelect }
 				onBlur={ this.props.onBlur } // always assign onBlur as a props
 				multiline={ false }
@@ -90,25 +89,8 @@ const applyWithDispatch = withDispatch( ( dispatch ) => {
 	};
 } );
 
-export function PostTitle(props, ref) {
-/*
-	const component = (
-		<PostTitleComponent
-			{ ...props }
-			ref={ ref } />
-	);*/
-
-	//const component = PostTitleComponent({ ...props, ref })
-
-	//console.log("Component: " + JSON.stringify(component));
-
-	return compose(
-		applyWithDispatch,
-		withInstanceId,
-		withFocusOutside
-	)( PostTitleComponent );
-};
-
-
-
-export default forwardRef( PostTitle );
+export default compose(
+	applyWithDispatch,
+	withInstanceId,
+	withFocusOutside
+)( PostTitle );

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -65,6 +65,7 @@ class PostTitle extends Component {
 				placeholder={ decodedPlaceholder }
 				value={ title }
 				onSplit={ this.props.onEnterPress }
+				setRef={ this.props.setRef }
 			>
 			</RichText>
 		);

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -386,6 +386,10 @@ export class RichText extends Component {
 				<RCTAztecView
 					ref={ ( ref ) => {
 						this._editor = ref;
+
+						if ( this.props.setRef ) {
+							this.props.setRef( ref );
+						}
 					}
 					}
 					text={ { text: html, eventCount: this.lastEventCount } }


### PR DESCRIPTION
## Description

Implements setRef for post-title so that the native component of it can be focused.

## How has this been tested?

This has been tested in: https://github.com/wordpress-mobile/gutenberg-mobile/pull/599

## Types of changes

Modified post-title and rich-text native so that they forward setRef to the native componetn.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->