### PR TITLE
Teach build and start commands to use Webpack default if none is provided

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.0 (unreleased)
+
+## New features
+
+- The `build` and `start` commands will use a default webpack config if none is provided.
+
 ## 3.0.0 (2019-03-06)
 
 ### Breaking Changes

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -38,7 +38,7 @@ _Example:_
 
 ### `build`
 
-Builds the code to the designated `build` folder in the configuration file. It correctly bundles code in production mode and optimizes the build for the best performance. Your code is ready to be deployed. It uses [Webpack](https://webpack.js.org/) behind the scenes and you still need to provide your own config as described in the [documentation](https://webpack.js.org/concepts/configuration/).
+Transforms your code according the configuration provided so it's ready for production and optimized for the best performance. It uses [Webpack](https://webpack.js.org/) behind the scenes. It'll lookup for a webpack config in the top-level directory of your package and will use it if it finds one. If none is found, it'll use the default config bundled within `@wordpress/scripts` packages. Learn more in the "Webpack config" section.
 
 _Example:_
 
@@ -51,8 +51,8 @@ _Example:_
 ```
 
 This is how you execute the script with presented setup:
-* `npm run build` - builds the code for production.
 
+* `npm run build` - builds the code for production.
 
 ### `check-engines`
 
@@ -69,6 +69,7 @@ _Example:_
 ```
 
 This is how you execute the script with presented setup:
+
 * `npm run check-engines` - checks installed version of `node` and `npm`.
 
 ### `check-licenses`
@@ -107,6 +108,7 @@ _Example:_
 ```
 
 This is how you execute the script with presented setup:
+
 * `npm run lint:js` - lints JavaScript files in the entire project's directories.
 
 ### `lint-pkg-json`
@@ -124,6 +126,7 @@ _Example:_
 ```
 
 This is how you execute those scripts using the presented setup:
+
 * `npm run lint:pkg-json` - lints `package.json` file in the project's root folder.
 
 ### `lint-style`
@@ -141,11 +144,12 @@ _Example:_
 ```
 
 This is how you execute the script with presented setup:
+
 * `npm run lint:css` - lints CSS files in the whole project's directory.
 
 ### `start`
 
-Builds the code for development to the designated `build` folder in the configuration file. The script will automatically rebuild if you make changes to the code. You will see the build errors in the console. It uses [Webpack](https://webpack.js.org/) behind the scenes and you still need to provide your own config as described in the [documentation](https://webpack.js.org/concepts/configuration/).
+Transforms your code according the configuration provided so it's ready for development. The script will automatically rebuild if you make changes to the code, and you will see the build errors in the console. It uses [Webpack](https://webpack.js.org/) behind the scenes. It'll lookup for a webpack config in the top-level directory of your package and will use it if it finds one. If none is found, it'll use the default config bundled within `@wordpress/scripts` packages. Learn more in the "Webpack config" section.
 
 _Example:_
 
@@ -158,6 +162,7 @@ _Example:_
 ```
 
 This is how you execute the script with presented setup:
+
 * `npm start` - starts the build for development.
 
 ### `test-e2e`
@@ -180,6 +185,7 @@ _Example:_
 ```
 
 This is how you execute those scripts using the presented setup:
+
 * `npm run test:e2e` - runs all unit tests.
 * `npm run test:e2e:help` - prints all available options to configure unit tests runner.
 
@@ -207,8 +213,13 @@ _Example:_
 ```
 
 This is how you execute those scripts using the presented setup:
+
 * `npm run test:unit` - runs all unit tests.
 * `npm run test:unit:help` - prints all available options to configure unit tests runner.
 * `npm run test:unit:watch` - runs all unit tests in the watch mode.
+
+## Webpack config
+
+The `build` and `start` commands.
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -226,9 +226,9 @@ The `build` and `start` commands use [Webpack](https://webpack.js.org/) behind t
 
 `@wordpress/scripts` bundles the default Webpack config used as a base by the WordPress editor. These are the defaults:
 
-- [Entry](https://webpack.js.org/configuration/entry-context/#entry): `src/index.js`
-- [Output](https://webpack.js.org/configuration/output): `build/index.js`
-- [Externals](https://webpack.js.org/configuration/externals). These are the transformations done to imports:
+* [Entry](https://webpack.js.org/configuration/entry-context/#entry): `src/index.js`
+* [Output](https://webpack.js.org/configuration/output): `build/index.js`
+* [Externals](https://webpack.js.org/configuration/externals). These are the transformations done to imports:
 
 Package | Input syntax | Output
 --- | --- | ---
@@ -244,8 +244,8 @@ Any WordPress package | `import x from '@wordpress/packageName` | `var x = this.
 
 Should there be any situation where you want to provide your own Webpack config, you can do so. The `build` and `start` commands will use your provided file when:
 
-- the command receives a `--config` argument. Example: `wp-scripts build --config my-own-webpack-config.js`.
-- there is a file called `webpack.config.js` or `webpack.config.babel.js` in the top-level directory of your package (at the same level than your `package.json`).
+* the command receives a `--config` argument. Example: `wp-scripts build --config my-own-webpack-config.js`.
+* there is a file called `webpack.config.js` or `webpack.config.babel.js` in the top-level directory of your package (at the same level than your `package.json`).
 
 ### Extend the default config
 
@@ -258,9 +258,13 @@ Let's say that you want Webpack to take as input a file named `my-plugin.js`. Th
 
 ```js
 const config = require( '@wordpress/scripts/config/webpack.config.js' );
-module.exports = Object.assign( {}, config, {
-	// your tweaks here
+module.exports = {
+	...config,
 	entry: 'my-plugin.js',
+	plugins: [
+		...config.plugins,
+		// add your own plugin after the default ones
+	],
 } );
 ```
 

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -220,6 +220,48 @@ This is how you execute those scripts using the presented setup:
 
 ## Webpack config
 
-The `build` and `start` commands.
+The `build` and `start` commands use [Webpack](https://webpack.js.org/) behind the scenes. Webpack is a tool that helps you transform your code into something else. For example: it can take code written in ESNext and output ES5 compatible code that is minified for production.
+
+### Default Webpack config
+
+`@wordpress/scripts` bundles the default Webpack config used as a base by the WordPress editor. These are the defaults:
+
+- [Entry](https://webpack.js.org/configuration/entry-context/#entry): `src/index.js`
+- [Output](https://webpack.js.org/configuration/output): `build/index.js`
+- [Externals](https://webpack.js.org/configuration/externals). These are the transformations done to imports:
+
+Package | Input syntax | Output
+--- | --- | ---
+React | `import x from React;` | `var x = this.wp.react.x;`
+ReactDOM | `import x from ReactDOM;` | `var x = this.wp.react-dom.x;`
+moment | `import x from moment;` | `var x = this.wp.moment.x;`
+jQuery | `import x from jQuery;` | `var x = this.wp.jQuery.x;`
+lodash | `import x from lodash;` | `var x = this.wp.lodash.x;`
+lodash-es | `import x from lodash-es;` | `var x = this.wp.lodash-es.x;`
+Any WordPress package | `import x from '@wordpress/packageName` | `var x = this.wp.package-name.x`
+
+### Provide your own Webpack config
+
+Should there be any situation where you want to provide your own Webpack config, you can do so. The `build` and `start` commands will use your provided file when:
+
+- the command receives a `--config` argument. Example: `wp-scripts build --config my-own-webpack-config.js`.
+- there is a file called `webpack.config.js` or `webpack.config.babel.js` in the top-level directory of your package (at the same level than your `package.json`).
+
+### Extend the default config
+
+The `build` and `start` commands will detect if you provided a Webpack config, as explained in the previous section. You can still use the default and extend it so you don't have to craft your own solution if you only want to tweak the default.
+
+Let's say that you want Webpack to take as input a file named `my-plugin.js`. This is how you'd do it:
+
+* Create a file called `webpack.config.js` at the top-level directory of your package.
+* Fill it with the following contents:
+
+```js
+const config = require( '@wordpress/scripts/config/webpack.config.js' );
+module.exports = Object.assign( {}, config, {
+	// your tweaks here
+	entry: 'my-plugin.js',
+} );
+```
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -247,25 +247,4 @@ Should there be any situation where you want to provide your own Webpack config,
 * the command receives a `--config` argument. Example: `wp-scripts build --config my-own-webpack-config.js`.
 * there is a file called `webpack.config.js` or `webpack.config.babel.js` in the top-level directory of your package (at the same level than your `package.json`).
 
-### Extend the default config
-
-The `build` and `start` commands will detect if you provided a Webpack config, as explained in the previous section. You can still use the default and extend it so you don't have to craft your own solution if you only want to tweak the default.
-
-Let's say that you want Webpack to take as input a file named `my-plugin.js`. This is how you'd do it:
-
-* Create a file called `webpack.config.js` at the top-level directory of your package.
-* Fill it with the following contents:
-
-```js
-const defaultConfig = require( '@wordpress/scripts/config/webpack.config.js' );
-module.exports = {
-	...defaultConfig,
-	entry: './my-plugin.js',
-	plugins: [
-		...defaultConfig.plugins,
-		// add your own plugin after the default ones
-	],
-};
-```
-
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -228,17 +228,17 @@ The `build` and `start` commands use [Webpack](https://webpack.js.org/) behind t
 
 * [Entry](https://webpack.js.org/configuration/entry-context/#entry): `src/index.js`
 * [Output](https://webpack.js.org/configuration/output): `build/index.js`
-* [Externals](https://webpack.js.org/configuration/externals). These are the transformations done to imports:
+* [Externals](https://webpack.js.org/configuration/externals). These are libraries that are to be found in the global scope:
 
 Package | Input syntax | Output
 --- | --- | ---
-React | `import x from React;` | `var x = this.wp.react.x;`
-ReactDOM | `import x from ReactDOM;` | `var x = this.wp.react-dom.x;`
-moment | `import x from moment;` | `var x = this.wp.moment.x;`
-jQuery | `import x from jQuery;` | `var x = this.wp.jQuery.x;`
-lodash | `import x from lodash;` | `var x = this.wp.lodash.x;`
-lodash-es | `import x from lodash-es;` | `var x = this.wp.lodash-es.x;`
-Any WordPress package | `import x from '@wordpress/packageName` | `var x = this.wp.package-name.x`
+React | `import x from React;` | `var x = window.React.x;`
+ReactDOM | `import x from ReactDOM;` | `var x = window.ReactDOM.x;`
+moment | `import x from moment;` | `var x = window.moment.x;`
+jQuery | `import x from jQuery;` | `var x = window.jQuery.x;`
+lodash | `import x from lodash;` | `var x = window.lodash.x;`
+lodash-es | `import x from lodash-es;` | `var x = window.lodash.x;`
+WordPress packages | `import x from '@wordpress/package-name` | `var x = window.wp.packageName.x`
 
 ### Provide your own Webpack config
 

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -257,15 +257,15 @@ Let's say that you want Webpack to take as input a file named `my-plugin.js`. Th
 * Fill it with the following contents:
 
 ```js
-const config = require( '@wordpress/scripts/config/webpack.config.js' );
+const defaultConfig = require( '@wordpress/scripts/config/webpack.config.js' );
 module.exports = {
-	...config,
-	entry: 'my-plugin.js',
+	...defaultConfig,
+	entry: './my-plugin.js',
 	plugins: [
-		...config.plugins,
+		...defaultConfig.plugins,
 		// add your own plugin after the default ones
 	],
-} );
+};
 ```
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -38,7 +38,7 @@ _Example:_
 
 ### `build`
 
-Transforms your code according the configuration provided so it's ready for production and optimized for the best performance. It uses [Webpack](https://webpack.js.org/) behind the scenes. It'll lookup for a webpack config in the top-level directory of your package and will use it if it finds one. If none is found, it'll use the default config bundled within `@wordpress/scripts` packages. Learn more in the "Webpack config" section.
+Transforms your code according the configuration provided so it's ready for production and optimized for the best performance. It uses [webpack](https://webpack.js.org/) behind the scenes. It'll lookup for a webpack config in the top-level directory of your package and will use it if it finds one. If none is found, it'll use the default config bundled within `@wordpress/scripts` packages. Learn more in the "webpack config" section.
 
 _Example:_
 
@@ -149,7 +149,7 @@ This is how you execute the script with presented setup:
 
 ### `start`
 
-Transforms your code according the configuration provided so it's ready for development. The script will automatically rebuild if you make changes to the code, and you will see the build errors in the console. It uses [Webpack](https://webpack.js.org/) behind the scenes. It'll lookup for a webpack config in the top-level directory of your package and will use it if it finds one. If none is found, it'll use the default config bundled within `@wordpress/scripts` packages. Learn more in the "Webpack config" section.
+Transforms your code according the configuration provided so it's ready for development. The script will automatically rebuild if you make changes to the code, and you will see the build errors in the console. It uses [webpack](https://webpack.js.org/) behind the scenes. It'll lookup for a webpack config in the top-level directory of your package and will use it if it finds one. If none is found, it'll use the default config bundled within `@wordpress/scripts` packages. Learn more in the "webpack config" section.
 
 _Example:_
 
@@ -218,13 +218,13 @@ This is how you execute those scripts using the presented setup:
 * `npm run test:unit:help` - prints all available options to configure unit tests runner.
 * `npm run test:unit:watch` - runs all unit tests in the watch mode.
 
-## Webpack config
+## webpack config
 
-The `build` and `start` commands use [Webpack](https://webpack.js.org/) behind the scenes. Webpack is a tool that helps you transform your code into something else. For example: it can take code written in ESNext and output ES5 compatible code that is minified for production.
+The `build` and `start` commands use [webpack](https://webpack.js.org/) behind the scenes. webpack is a tool that helps you transform your code into something else. For example: it can take code written in ESNext and output ES5 compatible code that is minified for production.
 
-### Default Webpack config
+### Default webpack config
 
-`@wordpress/scripts` bundles the default Webpack config used as a base by the WordPress editor. These are the defaults:
+`@wordpress/scripts` bundles the default webpack config used as a base by the WordPress editor. These are the defaults:
 
 * [Entry](https://webpack.js.org/configuration/entry-context/#entry): `src/index.js`
 * [Output](https://webpack.js.org/configuration/output): `build/index.js`
@@ -240,9 +240,9 @@ lodash | `import x from lodash;` | `var x = window.lodash.x;`
 lodash-es | `import x from lodash-es;` | `var x = window.lodash.x;`
 WordPress packages | `import x from '@wordpress/package-name` | `var x = window.wp.packageName.x`
 
-### Provide your own Webpack config
+### Provide your own webpack config
 
-Should there be any situation where you want to provide your own Webpack config, you can do so. The `build` and `start` commands will use your provided file when:
+Should there be any situation where you want to provide your own webpack config, you can do so. The `build` and `start` commands will use your provided file when:
 
 * the command receives a `--config` argument. Example: `wp-scripts build --config my-own-webpack-config.js`.
 * there is a file called `webpack.config.js` or `webpack.config.babel.js` in the top-level directory of your package (at the same level than your `package.json`).

--- a/packages/scripts/scripts/build.js
+++ b/packages/scripts/scripts/build.js
@@ -8,6 +8,7 @@ const { sync: resolveBin } = require( 'resolve-bin' );
  * Internal dependencies
  */
 const {
+	fromConfigRoot,
 	getCliArgs,
 	hasCliArg,
 	hasProjectFile,
@@ -28,7 +29,13 @@ if ( hasWebpackConfig ) {
 	);
 	process.exit( status );
 } else {
-	// eslint-disable-next-line no-console
-	console.log( 'Webpack config file is missing.' );
-	process.exit( 1 );
+	// Sets environment to production.
+	process.env.NODE_ENV = 'production';
+
+	const { status } = spawn(
+		resolveBin( 'webpack' ),
+		[ '--config', fromConfigRoot( 'webpack.config.js' ) ],
+		{ stdio: 'inherit' }
+	);
+	process.exit( status );
 }

--- a/packages/scripts/scripts/build.js
+++ b/packages/scripts/scripts/build.js
@@ -7,35 +7,12 @@ const { sync: resolveBin } = require( 'resolve-bin' );
 /**
  * Internal dependencies
  */
-const {
-	fromConfigRoot,
-	getCliArgs,
-	hasCliArg,
-	hasProjectFile,
-} = require( '../utils' );
+const { getWebpackArgs } = require( '../utils' );
 
-const hasWebpackConfig = hasCliArg( '--config' ) ||
-	hasProjectFile( 'webpack.config.js' ) ||
-	hasProjectFile( 'webpack.config.babel.js' );
-
-if ( hasWebpackConfig ) {
-	// Sets environment to production.
-	process.env.NODE_ENV = 'production';
-
-	const { status } = spawn(
-		resolveBin( 'webpack' ),
-		getCliArgs(),
-		{ stdio: 'inherit' }
-	);
-	process.exit( status );
-} else {
-	// Sets environment to production.
-	process.env.NODE_ENV = 'production';
-
-	const { status } = spawn(
-		resolveBin( 'webpack' ),
-		[ '--config', fromConfigRoot( 'webpack.config.js' ) ],
-		{ stdio: 'inherit' }
-	);
-	process.exit( status );
-}
+process.env.NODE_ENV = 'production';
+const { status } = spawn(
+	resolveBin( 'webpack' ),
+	getWebpackArgs(),
+	{ stdio: 'inherit' }
+);
+process.exit( status );

--- a/packages/scripts/scripts/start.js
+++ b/packages/scripts/scripts/start.js
@@ -7,25 +7,11 @@ const { sync: resolveBin } = require( 'resolve-bin' );
 /**
  * Internal dependencies
  */
-const {
-	getCliArgs,
-	hasCliArg,
-	hasProjectFile,
-} = require( '../utils' );
+const { getWebpackArgs } = require( '../utils' );
 
-const hasWebpackConfig = hasCliArg( '--config' ) ||
-	hasProjectFile( 'webpack.config.js' ) ||
-	hasProjectFile( 'webpack.config.babel.js' );
-
-if ( hasWebpackConfig ) {
-	const { status } = spawn(
-		resolveBin( 'webpack' ),
-		[ '--watch', ...getCliArgs() ],
-		{ stdio: 'inherit' }
-	);
-	process.exit( status );
-} else {
-	// eslint-disable-next-line no-console
-	console.log( 'Webpack config file is missing.' );
-	process.exit( 1 );
-}
+const { status } = spawn(
+	resolveBin( 'webpack' ),
+	getWebpackArgs( [ '--watch' ] ),
+	{ stdio: 'inherit' }
+);
+process.exit( status );

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-const { hasCliArg } = require( './cli' );
-const { hasProjectFile } = require( './file' );
+const { hasCliArg, getCliArgs } = require( './cli' );
+const { fromConfigRoot, hasProjectFile } = require( './file' );
 const { hasPackageProp } = require( './package' );
 
 const hasBabelConfig = () =>
@@ -17,7 +17,24 @@ const hasJestConfig = () =>
 	hasProjectFile( 'jest.config.json' ) ||
 	hasPackageProp( 'jest' );
 
+const hasWebpackConfig = () => hasCliArg( '--config' ) ||
+	hasProjectFile( 'webpack.config.js' ) ||
+	hasProjectFile( 'webpack.config.babel.js' );
+
+const getWebpackArgs = ( additionalArgs = [] ) => {
+	const webpackArgs = [];
+	if ( hasWebpackConfig() ) {
+		webpackArgs.push( ...getCliArgs() );
+	} else {
+		webpackArgs.push( ...[ '--config', fromConfigRoot( 'webpack.config.js' ) ] );
+	}
+	webpackArgs.push( ...additionalArgs );
+	return webpackArgs;
+};
+
 module.exports = {
+	getWebpackArgs,
 	hasBabelConfig,
 	hasJestConfig,
+	hasWebpackConfig,
 };

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -36,5 +36,4 @@ module.exports = {
 	getWebpackArgs,
 	hasBabelConfig,
 	hasJestConfig,
-	hasWebpackConfig,
 };

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -24,7 +24,7 @@ const hasWebpackConfig = () => hasCliArg( '--config' ) ||
 const getWebpackArgs = ( additionalArgs = [] ) => {
 	const webpackArgs = getCliArgs();
 	if ( ! hasWebpackConfig() ) {
-		webpackArgs.push( ...[ '--config', fromConfigRoot( 'webpack.config.js' ) ] );
+		webpackArgs.push( '--config', fromConfigRoot( 'webpack.config.js' ) );
 	}
 	webpackArgs.push( ...additionalArgs );
 	return webpackArgs;

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -22,7 +22,7 @@ const hasWebpackConfig = () => hasCliArg( '--config' ) ||
 	hasProjectFile( 'webpack.config.babel.js' );
 
 const getWebpackArgs = ( additionalArgs = [] ) => {
-	const webpackArgs = [ ...getCliArgs() ];
+	const webpackArgs = getCliArgs();
 	if ( ! hasWebpackConfig() ) {
 		webpackArgs.push( ...[ '--config', fromConfigRoot( 'webpack.config.js' ) ] );
 	}

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -22,10 +22,8 @@ const hasWebpackConfig = () => hasCliArg( '--config' ) ||
 	hasProjectFile( 'webpack.config.babel.js' );
 
 const getWebpackArgs = ( additionalArgs = [] ) => {
-	const webpackArgs = [];
-	if ( hasWebpackConfig() ) {
-		webpackArgs.push( ...getCliArgs() );
-	} else {
+	const webpackArgs = [ ...getCliArgs() ];
+	if ( ! hasWebpackConfig() ) {
 		webpackArgs.push( ...[ '--config', fromConfigRoot( 'webpack.config.js' ) ] );
 	}
 	webpackArgs.push( ...additionalArgs );

--- a/packages/scripts/utils/index.js
+++ b/packages/scripts/utils/index.js
@@ -8,6 +8,7 @@ const {
 	spawnScript,
 } = require( './cli' );
 const {
+	getWebpackArgs,
 	hasBabelConfig,
 	hasJestConfig,
 } = require( './config' );
@@ -27,6 +28,7 @@ module.exports = {
 	fromConfigRoot,
 	getCliArg,
 	getCliArgs,
+	getWebpackArgs,
 	hasBabelConfig,
 	hasCliArg,
 	hasJestConfig,


### PR DESCRIPTION
This PR seeks to improve the `build` and `start` commands by providing a default Webpack setup if none is provided. This was inspired by the [JavaScript Build Setup in the JavaScript tutorial](https://wordpress.org/gutenberg/handbook/designers-developers/developers/tutorials/javascript/js-build-setup/).

Example with testing instructions at https://github.com/nosolosw/understanding-gutenberg/pull/4
