### PR TITLE
Update default placeholder for the default block appender component

### DIFF
--- a/packages/editor/src/components/default-block-appender/index.native.js
+++ b/packages/editor/src/components/default-block-appender/index.native.js
@@ -6,7 +6,7 @@ import { TextInput, TouchableWithoutFeedback, View } from 'react-native';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { decodeEntities } from '@wordpress/html-entities';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -26,7 +26,7 @@ export function DefaultBlockAppender( {
 		return null;
 	}
 
-	const value = decodeEntities( placeholder ) || __( 'Start writing or press \u2295 to add content' );
+	const value = decodeEntities( placeholder ) || sprintf( __( 'Start writing or press %s to add content' ), '\u2295' );
 
 	return (
 		<TouchableWithoutFeedback


### PR DESCRIPTION
## Description
This PR updates a string which looks wrong on mobile, using the UTF8 `⊕` character instead of an icon. We want the string to not depend on the character for translation.
