### PR TITLE
Fix: Inserter impossible to collapse panels while searching.

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -197,11 +197,16 @@ export class InserterMenu extends Component {
 		if ( filterValue !== this.state.filterValue ) {
 			if ( ! filterValue ) {
 				openPanels = [ 'suggested' ];
-			} else if ( reusableItems.length ) {
-				openPanels = [ 'reusable' ];
-			} else if ( filteredItems.length ) {
-				const firstCategory = find( getCategories(), ( { slug } ) => itemsPerCategory[ slug ] && itemsPerCategory[ slug ].length );
-				openPanels = [ firstCategory.slug ];
+			} else {
+				openPanels = [];
+				if ( reusableItems.length ) {
+					openPanels.push( 'reusable' );
+				}
+				if ( filteredItems.length ) {
+					openPanels = openPanels.concat(
+						Object.keys( itemsPerCategory )
+					);
+				}
 			}
 		}
 
@@ -238,7 +243,6 @@ export class InserterMenu extends Component {
 		const { instanceId, onSelect, rootClientId } = this.props;
 		const { childItems, filterValue, hoveredItem, suggestedItems, reusableItems, itemsPerCategory, openPanels } = this.state;
 		const isPanelOpen = ( panel ) => openPanels.indexOf( panel ) !== -1;
-		const isSearching = !! filterValue;
 
 		// Disable reason (no-autofocus): The inserter menu is a modal display, not one which
 		// is always visible, and one which already incurs this behavior of autoFocus via
@@ -300,7 +304,7 @@ export class InserterMenu extends Component {
 								key={ category.slug }
 								title={ category.title }
 								icon={ category.icon }
-								opened={ isSearching || isPanelOpen( category.slug ) }
+								opened={ isPanelOpen( category.slug ) }
 								onToggle={ this.onTogglePanel( category.slug ) }
 								ref={ this.bindPanel( category.slug ) }
 							>

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -170,6 +170,25 @@ export class InserterMenu extends Component {
 		};
 	}
 
+	filterOpenPanels( filterValue, itemsPerCategory, filteredItems, reusableItems ) {
+		if ( filterValue === this.state.filterValue ) {
+			return this.state.openPanels;
+		}
+		if ( ! filterValue ) {
+			return [ 'suggested' ];
+		}
+		let openPanels = [];
+		if ( reusableItems.length > 0 ) {
+			openPanels.push( 'reusable' );
+		}
+		if ( filteredItems.length > 0 ) {
+			openPanels = openPanels.concat(
+				Object.keys( itemsPerCategory )
+			);
+		}
+		return openPanels;
+	}
+
 	filter( filterValue = '' ) {
 		const { debouncedSpeak, items, rootChildBlocks } = this.props;
 		const filteredItems = searchItems( items, filterValue );
@@ -193,23 +212,6 @@ export class InserterMenu extends Component {
 			( itemList ) => groupBy( itemList, 'category' )
 		)( filteredItems );
 
-		let openPanels = this.state.openPanels;
-		if ( filterValue !== this.state.filterValue ) {
-			if ( ! filterValue ) {
-				openPanels = [ 'suggested' ];
-			} else {
-				openPanels = [];
-				if ( reusableItems.length ) {
-					openPanels.push( 'reusable' );
-				}
-				if ( filteredItems.length ) {
-					openPanels = openPanels.concat(
-						Object.keys( itemsPerCategory )
-					);
-				}
-			}
-		}
-
 		this.setState( {
 			hoveredItem: null,
 			childItems,
@@ -217,7 +219,12 @@ export class InserterMenu extends Component {
 			suggestedItems,
 			reusableItems,
 			itemsPerCategory,
-			openPanels,
+			openPanels: this.filterOpenPanels(
+				filterValue,
+				itemsPerCategory,
+				filteredItems,
+				reusableItems
+			),
 		} );
 
 		const resultCount = Object.keys( itemsPerCategory ).reduce( ( accumulator, currentCategorySlug ) => {
@@ -241,7 +248,14 @@ export class InserterMenu extends Component {
 
 	render() {
 		const { instanceId, onSelect, rootClientId } = this.props;
-		const { childItems, filterValue, hoveredItem, suggestedItems, reusableItems, itemsPerCategory, openPanels } = this.state;
+		const {
+			childItems,
+			hoveredItem,
+			itemsPerCategory,
+			openPanels,
+			reusableItems,
+			suggestedItems,
+		} = this.state;
 		const isPanelOpen = ( panel ) => openPanels.indexOf( panel ) !== -1;
 
 		// Disable reason (no-autofocus): The inserter menu is a modal display, not one which


### PR DESCRIPTION
## Description
The inserter logic has a problem. If we open the inserter search for something e.g: 'c' that returns many categories and we try to collapse a panel nothing happens.
This PR fixes this problem.
The behavior of opening all panels each time the search string changes was kept.

## How has this been tested?
Add a paragraph type something.
Go to the inserter, write a "c" on the search.
Navigate on the inserter category panel and verify all panel are open, but it is possible to close them and open them again without problems.

