### PR TITLE
Only expose the select function in registry selectors

### DIFF
--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -25,8 +25,8 @@ import { getQueriedItems } from './queried-data';
  *
  * @return {boolean} Whether a request is in progress for an embed preview.
  */
-export const isRequestingEmbedPreview = createRegistrySelector( ( registry ) => ( state, url ) => {
-	return registry.select( 'core/data' ).isResolving( REDUCER_KEY, 'getEmbedPreview', [ url ] );
+export const isRequestingEmbedPreview = createRegistrySelector( ( select ) => ( state, url ) => {
+	return select( 'core/data' ).isResolving( REDUCER_KEY, 'getEmbedPreview', [ url ] );
 } );
 
 /**

--- a/packages/data/src/namespace-store.js
+++ b/packages/data/src/namespace-store.js
@@ -106,7 +106,7 @@ function createReduxStore( reducer, key, registry ) {
  */
 function mapSelectors( selectors, store, registry ) {
 	const createStateSelector = ( registeredSelector ) => {
-		const selector = registeredSelector.isRegistrySelector ? registeredSelector( registry ) : registeredSelector;
+		const selector = registeredSelector.isRegistrySelector ? registeredSelector( registry.select ) : registeredSelector;
 
 		return function runSelector() {
 			// This function is an optimized implementation of:

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -445,8 +445,8 @@ describe( 'createRegistry', () => {
 
 		it( 'should run the registry selectors properly', () => {
 			const selector1 = () => 'result1';
-			const selector2 = createRegistrySelector( ( reg ) => () =>
-				reg.select( 'reducer1' ).selector1()
+			const selector2 = createRegistrySelector( ( select ) => () =>
+				select( 'reducer1' ).selector1()
 			);
 			registry.registerStore( 'reducer1', {
 				reducer: () => 'state1',


### PR DESCRIPTION
This PR updates the API of the registry selector to only receive "select" instead of "registry" to match `withSelect` API.