### PR TITLE
Add whole babelrc configuration example

### DIFF
--- a/packages/babel-plugin-makepot/README.md
+++ b/packages/babel-plugin-makepot/README.md
@@ -3,9 +3,11 @@
 Babel plugin used to scan JavaScript files for use of localization functions. It then compiles these into a [gettext POT formatted](https://en.wikipedia.org/wiki/Gettext) file as a template for translation. By default the output file will be written to `gettext.pot` of the root project directory. This can be overridden using the `"output"` option of the plugin.
 
 ```json
-[ "@wordpress/babel-plugin-makepot", {
-	"output": "languages/myplugin.pot"
-} ]
+{
+	"plugins": [
+		[ "@wordpress/babel-plugin-makepot", { "output": "languages/myplugin.pot" } ],
+	]
+}
 ```
 
 ## Installation


### PR DESCRIPTION
## Description
Fix README of @wordpress/babel-plugin-makepot and provide whole babelrc configuration example.
This makes the document easier for the Babel begginers.

## How has this been tested?
none

## Screenshots <!-- if applicable -->

## Types of changes
This commit includes enhancement of readme for the @wordpress/i18n package.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
