### PR TITLE
Fix small regression introduced in the region navigation styles

### DIFF
--- a/packages/components/src/higher-order/navigate-regions/style.scss
+++ b/packages/components/src/higher-order/navigate-regions/style.scss
@@ -20,19 +20,8 @@
 		&:focus {
 			outline-style: solid;
 			outline-color: $blue-medium-400;
-			animation: editor-animation__region-focus 0.1s ease-out;
-			animation-fill-mode: forwards;
+			outline-width: 4px;
+			outline-offset: -4px;
 		}
-	}
-}
-
-@keyframes editor-animation__region-focus {
-	from {
-		outline-width: 0;
-		outline-offset: 0;
-	}
-	to {
-		outline-width: 4px;
-		outline-offset: -4px;
 	}
 }


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/pull/8554#issuecomment-464015076

Try navigation the aria regions in both full screen and normal mode.