### PR TITLE
Slightly improve documentation navigation

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -6,7 +6,7 @@ The Gutenberg project provides three sources of documentation:
 
 Learn how to build blocks and extend the editor, best practices for designing block interfaces, and how to create themes that make the most of the new features Gutenberg provides.
 
-[Visit the Designer & Developer Handbook](/docs/designers-developers/readme.md)
+Start with [the Designer & Developer Handbook](/docs/designers-developers/readme.md) to learn the background and concepts, or jump straight to [Gutenberg Tutorials](/docs/designers-developers/developers/tutorials/readme.md) for detailed examples.
 
 ## User Handbook
 


### PR DESCRIPTION
## Description

This PR tries to improve navigation in the documentation in two ways.

First, it adds a link to the tutorials on the first Handbook index page. If you do not know the tutorials exist it is tricky to find in the left navigation, so adding a link at the start helps for those looking to learn and jump in.

Secondly, it moves the automated documentation for data, packages, and components lower in the table of contents so it does not push down links that are likely more valuable when starting out. This gives a better hierarchy for the links to people learning towards the top, and the reference which likely someone will be looking specifically for towards the bottom.

There is investigation and efforts to improve the side navigation to be collapsible, which is the larger work to improve navigation, but this PR should help slightly.

## Types of changes

Documentation.

