### PR TITLE
Documentation, moves tutorials higher in table of contents

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -114,24 +114,6 @@
 		"parent": "developers"
 	},
 	{
-		"title": "Data Module Reference",
-		"slug": "data",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/data/README.md",
-		"parent": "developers"
-	},
-	{
-		"title": "Packages",
-		"slug": "packages",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/packages.md",
-		"parent": "developers"
-	},
-	{
-		"title": "Components",
-		"slug": "components",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/README.md",
-		"parent": "developers"
-	},
-	{
 		"title": "Theming for Gutenberg",
 		"slug": "themes",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/themes/README.md",
@@ -364,6 +346,24 @@
 		"slug": "3-apply-format",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/format-api/3-apply-format.md",
 		"parent": "format-api"
+	},
+	{
+		"title": "Data Module Reference",
+		"slug": "data",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/data/README.md",
+		"parent": "developers"
+	},
+	{
+		"title": "Packages",
+		"slug": "packages",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/packages.md",
+		"parent": "developers"
+	},
+	{
+		"title": "Components",
+		"slug": "components",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/README.md",
+		"parent": "developers"
 	},
 	{
 		"title": "Designer Documentation",

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -20,9 +20,6 @@
 			{"docs/designers-developers/developers/internationalization.md": []},
 			{"docs/designers-developers/developers/accessibility.md": []},
 			{"docs/designers-developers/developers/feature-flags.md": []},
-			{"docs/designers-developers/developers/data/README.md": "{{data}}"},
-			{"docs/designers-developers/developers/packages.md": "{{packages}}"},
-			{"packages/components/README.md": "{{components}}"},
 			{"docs/designers-developers/developers/themes/README.md": [
 				{"docs/designers-developers/developers/themes/theme-support.md": []}
 			]},
@@ -69,7 +66,10 @@
 					{"docs/designers-developers/developers/tutorials/format-api/2-toolbar-button.md": []},
 					{"docs/designers-developers/developers/tutorials/format-api/3-apply-format.md": []}
 				]}
-			]}
+			]},
+			{"docs/designers-developers/developers/data/README.md": "{{data}}"},
+			{"docs/designers-developers/developers/packages.md": "{{packages}}"},
+			{"packages/components/README.md": "{{components}}"}
 		]},
 		{"docs/designers-developers/designers/README.md": [
 			{"docs/designers-developers/designers/block-design.md": []},


### PR DESCRIPTION
## Description

Broken out of #13906 - here for a larger discussion if needed.

This change moves tutorials higher up in the documentation, moving the automated reference docs lower down.

## Types of changes

Documentation.
