### PR TITLE
RichText: only ignore input types that insert HTML

### DIFF
--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -23,7 +23,7 @@ export {
 	RichTextShortcut,
 	RichTextToolbarButton,
 	RichTextInserterItem,
-	RichTextInputEvent,
+	UnstableRichTextInputEvent,
 } from './rich-text';
 export { default as ServerSideRender } from './server-side-render';
 export { default as MediaPlaceholder } from './media-placeholder';

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -74,15 +74,15 @@ const { getSelection } = window;
  *
  * @see  https://www.w3.org/TR/input-events-2/#interface-InputEvent-Attributes
  *
- * @type {Array}
+ * @type {Set}
  */
-const INSERTION_INPUT_TYPES_TO_IGNORE = [
+const INSERTION_INPUT_TYPES_TO_IGNORE = new Set( [
 	'insertParagraph',
 	'insertOrderedList',
 	'insertUnorderedList',
 	'insertHorizontalRule',
 	'insertLink',
-];
+] );
 
 export class RichText extends Component {
 	constructor( { value, onReplace, multiline } ) {
@@ -374,7 +374,7 @@ export class RichText extends Component {
 			// needed.
 			if (
 				inputType.indexOf( 'format' ) === 0 ||
-				INSERTION_INPUT_TYPES_TO_IGNORE.indexOf( inputType ) !== -1
+				INSERTION_INPUT_TYPES_TO_IGNORE.has( inputType )
 			) {
 				this.applyRecord( this.getRecord() );
 				return;

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -69,6 +69,21 @@ import { RemoveBrowserShortcuts } from './remove-browser-shortcuts';
 
 const { getSelection } = window;
 
+/**
+ * All inserting input types that would insert HTML into the DOM.
+ *
+ * @see  https://www.w3.org/TR/input-events-2/#interface-InputEvent-Attributes
+ *
+ * @type {Array}
+ */
+const INSERTION_INPUT_TYPES_TO_IGNORE = [
+	'insertParagraph',
+	'insertOrderedList',
+	'insertUnorderedList',
+	'insertHorizontalRule',
+	'insertLink',
+];
+
 export class RichText extends Component {
 	constructor( { value, onReplace, multiline } ) {
 		super( ...arguments );
@@ -354,12 +369,12 @@ export class RichText extends Component {
 		if ( event ) {
 			const { inputType } = event.nativeEvent;
 
-			// The browser formatted something or tried to insert a list.
+			// The browser formatted something or tried to insert HTML.
 			// Overwrite it. It will be handled later by the format library if
 			// needed.
 			if (
 				inputType.indexOf( 'format' ) === 0 ||
-				( inputType.indexOf( 'insert' ) === 0 && inputType !== 'insertText' )
+				INSERTION_INPUT_TYPES_TO_IGNORE.indexOf( inputType ) !== -1
 			) {
 				this.applyRecord( this.getRecord() );
 				return;

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -1165,4 +1165,4 @@ export default RichTextContainer;
 export { RichTextShortcut } from './shortcut';
 export { RichTextToolbarButton } from './toolbar-button';
 export { RichTextInserterItem } from './inserter-list-item';
-export { RichTextInputEvent } from './input-event';
+export { UnstableRichTextInputEvent } from './input-event';

--- a/packages/editor/src/components/rich-text/input-event.js
+++ b/packages/editor/src/components/rich-text/input-event.js
@@ -3,7 +3,7 @@
  */
 import { Component } from '@wordpress/element';
 
-export class RichTextInputEvent extends Component {
+export class UnstableRichTextInputEvent extends Component {
 	constructor() {
 		super( ...arguments );
 

--- a/packages/format-library/src/bold/index.js
+++ b/packages/format-library/src/bold/index.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { toggleFormat } from '@wordpress/rich-text';
-import { RichTextToolbarButton, RichTextShortcut, RichTextInputEvent } from '@wordpress/editor';
+import { RichTextToolbarButton, RichTextShortcut, UnstableRichTextInputEvent } from '@wordpress/editor';
 
 const name = 'core/bold';
 
@@ -32,7 +32,7 @@ export const bold = {
 					shortcutType="primary"
 					shortcutCharacter="b"
 				/>
-				<RichTextInputEvent
+				<UnstableRichTextInputEvent
 					inputType="formatBold"
 					onInput={ onToggle }
 				/>

--- a/packages/format-library/src/italic/index.js
+++ b/packages/format-library/src/italic/index.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { toggleFormat } from '@wordpress/rich-text';
-import { RichTextToolbarButton, RichTextShortcut, RichTextInputEvent } from '@wordpress/editor';
+import { RichTextToolbarButton, RichTextShortcut, UnstableRichTextInputEvent } from '@wordpress/editor';
 
 const name = 'core/italic';
 
@@ -32,7 +32,7 @@ export const italic = {
 					shortcutType="primary"
 					shortcutCharacter="i"
 				/>
-				<RichTextInputEvent
+				<UnstableRichTextInputEvent
 					inputType="formatItalic"
 					onInput={ onToggle }
 				/>

--- a/packages/format-library/src/underline/index.js
+++ b/packages/format-library/src/underline/index.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { toggleFormat } from '@wordpress/rich-text';
-import { RichTextShortcut, RichTextInputEvent } from '@wordpress/editor';
+import { RichTextShortcut, UnstableRichTextInputEvent } from '@wordpress/editor';
 
 const name = 'core/underline';
 
@@ -34,7 +34,7 @@ export const underline = {
 					character="u"
 					onUse={ onToggle }
 				/>
-				<RichTextInputEvent
+				<UnstableRichTextInputEvent
 					inputType="formatUnderline"
 					onInput={ onToggle }
 				/>


### PR DESCRIPTION
## Description

Currently, some types of insertion by the browser are broken, e.g. try to replace text using the browser spell checker. Introduced by #13833.

We should only ignore input types that we know are inserting HTML. See https://www.w3.org/TR/input-events-2/#interface-InputEvent-Attributes.

Additionally I'm marking `RichTextInputEvent` as unstable.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->