### PR TITLE
RichText: Fix undo after pattern

### DIFF
--- a/packages/e2e-tests/specs/blocks/__snapshots__/list.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/list.test.js.snap
@@ -76,7 +76,7 @@ exports[`List can be created by using an asterisk at the start of a paragraph bl
 
 exports[`List can undo asterisk transform 1`] = `
 "<!-- wp:paragraph -->
-<p>1.</p>
+<p>1. </p>
 <!-- /wp:paragraph -->"
 `;
 

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -133,9 +133,7 @@ export class RichText extends Component {
 		this.savedContent = value;
 		this.patterns = getPatterns( {
 			onReplace,
-			onCreateUndoLevel: this.onCreateUndoLevel,
 			valueToFormat: this.valueToFormat,
-			onChange: this.onChange,
 		} );
 		this.enterPatterns = getBlockTransforms( 'from' )
 			.filter( ( { type } ) => type === 'enter' );
@@ -395,10 +393,7 @@ export class RichText extends Component {
 		}
 
 		let { selectedFormat } = this.state;
-		const { formats, text, start, end } = this.patterns.reduce(
-			( accumlator, transform ) => transform( accumlator ),
-			this.createRecord()
-		);
+		const { formats, text, start, end } = this.createRecord();
 
 		if ( this.formatPlaceholder ) {
 			formats[ this.state.start ] = formats[ this.state.start ] || [];
@@ -420,9 +415,21 @@ export class RichText extends Component {
 			delete formats[ this.state.start ];
 		}
 
-		this.onChange( { formats, text, start, end, selectedFormat }, {
+		const change = { formats, text, start, end, selectedFormat };
+
+		this.onChange( change, {
 			withoutHistory: true,
 		} );
+
+		const transformed = this.patterns.reduce(
+			( accumlator, transform ) => transform( accumlator ),
+			change
+		);
+
+		if ( transformed !== change ) {
+			this.onCreateUndoLevel();
+			this.onChange( { ...transformed, selectedFormat } );
+		}
 
 		// Create an undo level when input stops for over a second.
 		this.props.clearTimeout( this.onInput.timeout );

--- a/packages/editor/src/components/rich-text/patterns.js
+++ b/packages/editor/src/components/rich-text/patterns.js
@@ -10,7 +10,7 @@ import {
 	slice,
 } from '@wordpress/rich-text';
 
-export function getPatterns( { onReplace, valueToFormat, onCreateUndoLevel, onChange } ) {
+export function getPatterns( { onReplace, valueToFormat } ) {
 	const prefixTransforms = getBlockTransforms( 'from' )
 		.filter( ( { type } ) => type === 'prefix' );
 
@@ -40,7 +40,6 @@ export function getPatterns( { onReplace, valueToFormat, onCreateUndoLevel, onCh
 			const content = valueToFormat( slice( record, start, text.length ) );
 			const block = transformation.transform( content );
 
-			onCreateUndoLevel();
 			onReplace( [ block ] );
 
 			return record;
@@ -69,8 +68,6 @@ export function getPatterns( { onReplace, valueToFormat, onCreateUndoLevel, onCh
 			if ( startIndex === endIndex ) {
 				return record;
 			}
-
-			onChange( record );
 
 			record = remove( record, startIndex, startIndex + 1 );
 			record = remove( record, endIndex, endIndex + 1 );


### PR DESCRIPTION
## Description

Fixes #13134. `onChange` after user input should run first, after which we can call it again for automatic transforms (patterns). When transforming then before calling `onChange`, there will be no record of the user input right before the transform, so it's not possible to undo the transform correctly.

Note: this only affects restored content. Selection won't be restored correctly because it's not in the editor state. See #12002.

## How has this been tested?

Create an empty paragraph and type `* `. It will be converted to a list. Undo. It should create a paragraph with `* `. Ensure that there is a trailing space.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->