### PR TITLE
Fix: Permalink editor rtl languages

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-link/index.js
+++ b/packages/edit-post/src/components/sidebar/post-link/index.js
@@ -98,18 +98,20 @@ function PostLink( {
 			<p className="edit-post-post-link__preview-label">
 				{ postTypeLabel || __( 'View Post' ) }
 			</p>
-			<ExternalLink
-				className="edit-post-post-link__link"
-				href={ postLink }
-				target="_blank"
-			>
-				{ isEditable ?
-					( <>
-						{ prefixElement }{ postNameElement }{ suffixElement }
-					</> ) :
-					postLink
-				}
-			</ExternalLink>
+			<div className="edit-post-post-link__preview-link-container">
+				<ExternalLink
+					className="edit-post-post-link__link"
+					href={ postLink }
+					target="_blank"
+				>
+					{ isEditable ?
+						( <>
+							{ prefixElement }{ postNameElement }{ suffixElement }
+						</> ) :
+						postLink
+					}
+				</ExternalLink>
+			</div>
 		</PanelBody>
 	);
 }

--- a/packages/edit-post/src/components/sidebar/post-link/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-link/style.scss
@@ -7,5 +7,13 @@
 }
 
 .edit-post-post-link__link {
+	text-align: left;
 	word-wrap: break-word;
+	display: block;
 }
+
+/* rtl:begin:ignore */
+.edit-post-post-link__preview-link-container {
+	direction: ltr;
+}
+/* rtl:end:ignore */

--- a/packages/editor/src/components/post-permalink/style.scss
+++ b/packages/editor/src/components/post-permalink/style.scss
@@ -71,12 +71,6 @@
 	overflow: hidden;
 	position: relative;
 	white-space: nowrap;
-
-	&::after {
-		@include long-content-fade($size: 20%, $edge: 1px);
-		right: 0;
-		right: 0;
-	}
 	text-align: left;
 }
 
@@ -140,9 +134,15 @@
 }
 
 /* rtl:begin:ignore */
+.editor-post-permalink__link {
+	text-align: left;
+}
 .editor-post-permalink__editor-container,
 .editor-post-permalink__link {
 	direction: ltr;
+}
+.editor-post-permalink__link::after {
+	@include long-content-fade($direction:right, $size: 20%, $edge: 0);
 }
 /* rtl:end:ignore */
 

--- a/packages/editor/src/components/post-permalink/style.scss
+++ b/packages/editor/src/components/post-permalink/style.scss
@@ -74,7 +74,10 @@
 
 	&::after {
 		@include long-content-fade($size: 20%, $edge: 1px);
+		right: 0;
+		right: 0;
 	}
+	text-align: left;
 }
 
 .editor-post-permalink-editor {
@@ -131,3 +134,15 @@
 	margin-right: 6px;
 	flex: 0 0 0%;
 }
+
+.editor-post-permalink-editor__prefix {
+	text-align: left;
+}
+
+/* rtl:begin:ignore */
+.editor-post-permalink__editor-container,
+.editor-post-permalink__link {
+	direction: ltr;
+}
+/* rtl:end:ignore */
+


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/12729
Improves the permalink editors on RTL languages.
The new design follows the screens shared by @desrosj in https://github.com/WordPress/gutenberg/issues/12729.

## How has this been tested?
I switched to an RTL language and verified the result I got is the one rendered on the screenshots.

## Screenshots <!-- if applicable -->
Before:
<img width="1749" alt="screenshot 2019-02-18 at 12 56 54" src="https://user-images.githubusercontent.com/11271197/52952668-3420bc80-337d-11e9-85f1-04a9210b15e9.png">

After:
<img width="1563" alt="screenshot 2019-02-18 at 12 55 30" src="https://user-images.githubusercontent.com/11271197/52952683-43a00580-337d-11e9-8a03-a3c9cc6ec4ef.png">

Before:
<img width="276" alt="screenshot 2019-02-18 at 12 28 50" src="https://user-images.githubusercontent.com/11271197/52952700-4f8bc780-337d-11e9-8c57-a79692efab42.png">

After:
<img width="280" alt="screenshot 2019-02-18 at 12 07 12" src="https://user-images.githubusercontent.com/11271197/52952708-587c9900-337d-11e9-9ab7-d60e153539ae.png">



