### PR TITLE
Editor: Reimplement select previous/next as independent controls

### DIFF
--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -1560,6 +1560,26 @@ reflects a reverse selection.
  * initialPosition: Optional initial position. Pass as -1 to
                                  reflect reverse selection.
 
+### selectPreviousBlock
+
+Returns an action object used in signalling that the block preceding the
+given clientId should be selected.
+
+*Parameters*
+
+ * clientId: Block client ID.
+
+### selectNextBlock
+
+Returns an action object used in signalling that the block following the
+given clientId should be selected.
+
+*Parameters*
+
+ * clientId: Block client ID.
+ * options: Optional selection options.
+ * options.isReverse: Whether to select preceding.
+
 ### toggleSelection
 
 Returns an action object that enables or disables block selection.

--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -1577,8 +1577,6 @@ given clientId should be selected.
 *Parameters*
 
  * clientId: Block client ID.
- * options: Optional selection options.
- * options.isReverse: Whether to select preceding.
 
 ### toggleSelection
 
@@ -1723,7 +1721,7 @@ be created.
 
 ### removeBlocks
 
-Returns an action object used in signalling that the blocks corresponding to
+Yields action objects used in signalling that the blocks corresponding to
 the set of specified client IDs are to be removed.
 
 *Parameters*

--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -1562,8 +1562,8 @@ reflects a reverse selection.
 
 ### selectPreviousBlock
 
-Returns an action object used in signalling that the block preceding the
-given clientId should be selected.
+Yields action objects used in signalling that the block preceding the given
+clientId should be selected.
 
 *Parameters*
 
@@ -1571,8 +1571,8 @@ given clientId should be selected.
 
 ### selectNextBlock
 
-Returns an action object used in signalling that the block following the
-given clientId should be selected.
+Yields action objects used in signalling that the block following the given
+clientId should be selected.
 
 *Parameters*
 

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -178,24 +178,34 @@ export function selectBlock( clientId, initialPosition = null ) {
 }
 
 /**
- * Returns an action object used in signalling that the block preceding the
- * given clientId should be selected.
+ * Yields action objects used in signalling that the block preceding the given
+ * clientId should be selected.
  *
  * @param {string} clientId Block client ID.
  */
-export function * selectPreviousBlock( clientId ) {
-	const previousBlockClientId = yield select( 'core/editor', 'getPreviousBlockClientId', clientId );
-	yield selectBlock( previousBlockClientId );
+export function* selectPreviousBlock( clientId ) {
+	const previousBlockClientId = yield select(
+		'core/editor',
+		'getPreviousBlockClientId',
+		clientId
+	);
+
+	yield selectBlock( previousBlockClientId, -1 );
 }
 
 /**
- * Returns an action object used in signalling that the block following the
- * given clientId should be selected.
+ * Yields action objects used in signalling that the block following the given
+ * clientId should be selected.
  *
  * @param {string} clientId Block client ID.
  */
-export function * selectNextBlock( clientId ) {
-	const nextBlockClientId = yield select( 'core/editor', 'getNextBlockClientId', clientId );
+export function* selectNextBlock( clientId ) {
+	const nextBlockClientId = yield select(
+		'core/editor',
+		'getNextBlockClientId',
+		clientId
+	);
+
 	yield selectBlock( nextBlockClientId );
 }
 

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -181,24 +181,24 @@ export function selectBlock( clientId, initialPosition = null ) {
  * @return {Object} Action object.
  */
 export function selectPreviousBlock( clientId ) {
-	return selectNextBlock( clientId, { isReverse: true } );
+	return {
+		type: 'SELECT_PREVIOUS_BLOCK',
+		clientId,
+	};
 }
 
 /**
  * Returns an action object used in signalling that the block following the
  * given clientId should be selected.
  *
- * @param {string}  clientId          Block client ID.
- * @param {?Object} options           Optional selection options.
- * @param {boolean} options.isReverse Whether to select preceding.
+ * @param {string} clientId Block client ID.
  *
  * @return {Object} Action object.
  */
-export function selectNextBlock( clientId, options ) {
+export function selectNextBlock( clientId ) {
 	return {
 		type: 'SELECT_NEXT_BLOCK',
 		clientId,
-		...options,
 	};
 }
 

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -172,6 +172,36 @@ export function selectBlock( clientId, initialPosition = null ) {
 	};
 }
 
+/**
+ * Returns an action object used in signalling that the block preceding the
+ * given clientId should be selected.
+ *
+ * @param {string} clientId Block client ID.
+ *
+ * @return {Object} Action object.
+ */
+export function selectPreviousBlock( clientId ) {
+	return selectNextBlock( clientId, { isReverse: true } );
+}
+
+/**
+ * Returns an action object used in signalling that the block following the
+ * given clientId should be selected.
+ *
+ * @param {string}  clientId          Block client ID.
+ * @param {?Object} options           Optional selection options.
+ * @param {boolean} options.isReverse Whether to select preceding.
+ *
+ * @return {Object} Action object.
+ */
+export function selectNextBlock( clientId, options ) {
+	return {
+		type: 'SELECT_NEXT_BLOCK',
+		clientId,
+		...options,
+	};
+}
+
 export function startMultiSelect() {
 	return {
 		type: 'START_MULTI_SELECT',
@@ -477,20 +507,23 @@ export function createUndoLevel() {
 }
 
 /**
- * Returns an action object used in signalling that the blocks corresponding to
+ * Yields action objects used in signalling that the blocks corresponding to
  * the set of specified client IDs are to be removed.
  *
  * @param {string|string[]} clientIds      Client IDs of blocks to remove.
  * @param {boolean}         selectPrevious True if the previous block should be
  *                                         selected when a block is removed.
- *
- * @return {Object} Action object.
  */
-export function removeBlocks( clientIds, selectPrevious = true ) {
-	return {
+export function* removeBlocks( clientIds, selectPrevious = true ) {
+	clientIds = castArray( clientIds );
+
+	if ( selectPrevious ) {
+		yield selectPreviousBlock( clientIds[ 0 ] );
+	}
+
+	yield {
 		type: 'REMOVE_BLOCKS',
-		clientIds: castArray( clientIds ),
-		selectPrevious,
+		clientIds,
 	};
 }
 

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -9,6 +9,11 @@ import { castArray } from 'lodash';
 import { getDefaultBlockName, createBlock } from '@wordpress/blocks';
 
 /**
+ * Internal dependencies
+ */
+import { select } from './controls';
+
+/**
  * Returns an action object used in signalling that editor has initialized with
  * the specified post object and editor settings.
  *
@@ -177,14 +182,10 @@ export function selectBlock( clientId, initialPosition = null ) {
  * given clientId should be selected.
  *
  * @param {string} clientId Block client ID.
- *
- * @return {Object} Action object.
  */
-export function selectPreviousBlock( clientId ) {
-	return {
-		type: 'SELECT_PREVIOUS_BLOCK',
-		clientId,
-	};
+export function * selectPreviousBlock( clientId ) {
+	const previousBlockClientId = yield select( 'core/editor', 'getPreviousBlockClientId', clientId );
+	yield selectBlock( previousBlockClientId );
 }
 
 /**
@@ -192,14 +193,10 @@ export function selectPreviousBlock( clientId ) {
  * given clientId should be selected.
  *
  * @param {string} clientId Block client ID.
- *
- * @return {Object} Action object.
  */
-export function selectNextBlock( clientId ) {
-	return {
-		type: 'SELECT_NEXT_BLOCK',
-		clientId,
-	};
+export function * selectNextBlock( clientId ) {
+	const nextBlockClientId = yield select( 'core/editor', 'getNextBlockClientId', clientId );
+	yield selectBlock( nextBlockClientId );
 }
 
 export function startMultiSelect() {

--- a/packages/editor/src/store/controls.js
+++ b/packages/editor/src/store/controls.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import { createRegistryControl } from '@wordpress/data';
+
+export const SELECT_NEXT_BLOCK = createRegistryControl( ( registry ) => ( action ) => {
+	const { clientId, isReverse } = action;
+	const {
+		getPreviousBlockClientId,
+		getNextBlockClientId,
+		getSelectedBlockClientId,
+	} = registry.select( 'core/editor' );
+
+	let targetClientId;
+	if ( isReverse ) {
+		targetClientId = getPreviousBlockClientId( clientId );
+	} else {
+		targetClientId = getNextBlockClientId( clientId );
+	}
+
+	// Only dispatch select block action if the currently selected block is
+	// is not already the block we want to be selected.
+	if ( ! targetClientId || targetClientId === getSelectedBlockClientId() ) {
+		return;
+	}
+
+	// When selecting in reverse, invert the default focus transition
+	// behavior, selecting the last available focusable.
+	let initialPosition;
+	if ( isReverse ) {
+		initialPosition = -1;
+	}
+
+	const { selectBlock } = registry.dispatch( 'core/editor' );
+	selectBlock( targetClientId, initialPosition );
+} );

--- a/packages/editor/src/store/controls.js
+++ b/packages/editor/src/store/controls.js
@@ -3,18 +3,28 @@
  */
 import { createRegistryControl } from '@wordpress/data';
 
-export const SELECT_PREVIOUS_BLOCK = createRegistryControl( ( registry ) => ( action ) => {
-	const { clientId } = action;
-	const { getPreviousBlockClientId } = registry.select( 'core/editor' );
-	const { selectBlock } = registry.dispatch( 'core/editor' );
+/**
+ * Calls a selector using the current state.
+ *
+ * @param {string} storeKey     Store key.
+ * @param {string} selectorName Selector name.
+ * @param  {Array} args         Selector arguments.
+ *
+ * @return {Object} control descriptor.
+ */
+export function select( storeKey, selectorName, ...args ) {
+	return {
+		type: 'SELECT',
+		storeKey,
+		selectorName,
+		args,
+	};
+}
 
-	selectBlock( getPreviousBlockClientId( clientId ), -1 );
-} );
+const controls = {
+	SELECT: createRegistryControl( ( registry ) => ( { storeKey, selectorName, args } ) => {
+		return registry.select( storeKey )[ selectorName ]( ...args );
+	} ),
+};
 
-export const SELECT_NEXT_BLOCK = createRegistryControl( ( registry ) => ( action ) => {
-	const { clientId } = action;
-	const { getNextBlockClientId } = registry.select( 'core/editor' );
-	const { selectBlock } = registry.dispatch( 'core/editor' );
-
-	selectBlock( getNextBlockClientId( clientId ) );
-} );
+export default controls;

--- a/packages/editor/src/store/controls.js
+++ b/packages/editor/src/store/controls.js
@@ -6,24 +6,24 @@ import { createRegistryControl } from '@wordpress/data';
 /**
  * Calls a selector using the current state.
  *
- * @param {string} storeKey     Store key.
+ * @param {string} storeName    Store name.
  * @param {string} selectorName Selector name.
  * @param  {Array} args         Selector arguments.
  *
  * @return {Object} control descriptor.
  */
-export function select( storeKey, selectorName, ...args ) {
+export function select( storeName, selectorName, ...args ) {
 	return {
 		type: 'SELECT',
-		storeKey,
+		storeName,
 		selectorName,
 		args,
 	};
 }
 
 const controls = {
-	SELECT: createRegistryControl( ( registry ) => ( { storeKey, selectorName, args } ) => {
-		return registry.select( storeKey )[ selectorName ]( ...args );
+	SELECT: createRegistryControl( ( registry ) => ( { storeName, selectorName, args } ) => {
+		return registry.select( storeName )[ selectorName ]( ...args );
 	} ),
 };
 

--- a/packages/editor/src/store/controls.js
+++ b/packages/editor/src/store/controls.js
@@ -3,34 +3,18 @@
  */
 import { createRegistryControl } from '@wordpress/data';
 
-export const SELECT_NEXT_BLOCK = createRegistryControl( ( registry ) => ( action ) => {
-	const { clientId, isReverse } = action;
-	const {
-		getPreviousBlockClientId,
-		getNextBlockClientId,
-		getSelectedBlockClientId,
-	} = registry.select( 'core/editor' );
-
-	let targetClientId;
-	if ( isReverse ) {
-		targetClientId = getPreviousBlockClientId( clientId );
-	} else {
-		targetClientId = getNextBlockClientId( clientId );
-	}
-
-	// Only dispatch select block action if the currently selected block is
-	// is not already the block we want to be selected.
-	if ( ! targetClientId || targetClientId === getSelectedBlockClientId() ) {
-		return;
-	}
-
-	// When selecting in reverse, invert the default focus transition
-	// behavior, selecting the last available focusable.
-	let initialPosition;
-	if ( isReverse ) {
-		initialPosition = -1;
-	}
-
+export const SELECT_PREVIOUS_BLOCK = createRegistryControl( ( registry ) => ( action ) => {
+	const { clientId } = action;
+	const { getPreviousBlockClientId } = registry.select( 'core/editor' );
 	const { selectBlock } = registry.dispatch( 'core/editor' );
-	selectBlock( targetClientId, initialPosition );
+
+	selectBlock( getPreviousBlockClientId( clientId ), -1 );
+} );
+
+export const SELECT_NEXT_BLOCK = createRegistryControl( ( registry ) => ( action ) => {
+	const { clientId } = action;
+	const { getNextBlockClientId } = registry.select( 'core/editor' );
+	const { selectBlock } = registry.dispatch( 'core/editor' );
+
+	selectBlock( getNextBlockClientId( clientId ) );
 } );

--- a/packages/editor/src/store/effects.js
+++ b/packages/editor/src/store/effects.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { compact, last, has } from 'lodash';
+import { compact, has } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -29,11 +29,8 @@ import {
 } from './actions';
 import {
 	getBlock,
-	getBlockRootClientId,
 	getBlocks,
 	getBlockCount,
-	getPreviousBlockClientId,
-	getSelectedBlockClientId,
 	getSelectedBlockCount,
 	getTemplate,
 	getTemplateLock,
@@ -83,43 +80,6 @@ export function validateBlocksToTemplate( action, store ) {
 	// Update if validity has changed.
 	if ( isBlocksValidToTemplate !== isValidTemplate( state ) ) {
 		return setTemplateValidity( isBlocksValidToTemplate );
-	}
-}
-
-/**
- * Effect handler which will return a block select action to select the block
- * occurring before the selected block in the previous state, unless it is the
- * same block or the action includes a falsey `selectPrevious` option flag.
- *
- * @param {Object} action Action which had initiated the effect handler.
- * @param {Object} store  Store instance.
- *
- * @return {?Object} Block select action to select previous, if applicable.
- */
-export function selectPreviousBlock( action, store ) {
-	// if the action says previous block should not be selected don't do anything.
-	if ( ! action.selectPrevious ) {
-		return;
-	}
-
-	const firstRemovedBlockClientId = action.clientIds[ 0 ];
-	const state = store.getState();
-	const selectedBlockClientId = getSelectedBlockClientId( state );
-
-	// recreate the state before the block was removed.
-	const previousState = { ...state, editor: { present: last( state.editor.past ) } };
-
-	// rootClientId of the removed block.
-	const rootClientId = getBlockRootClientId( previousState, firstRemovedBlockClientId );
-
-	// Client ID of the block that was before the removed block or the
-	// rootClientId if the removed block was first amongst its siblings.
-	const blockClientIdToSelect = getPreviousBlockClientId( previousState, firstRemovedBlockClientId ) || rootClientId;
-
-	// Dispatch select block action if the currently selected block
-	// is not already the block we want to be selected.
-	if ( blockClientIdToSelect !== selectedBlockClientId ) {
-		return selectBlock( blockClientIdToSelect, -1 );
 	}
 }
 
@@ -258,7 +218,6 @@ export default {
 	CONVERT_BLOCK_TO_STATIC: convertBlockToStatic,
 	CONVERT_BLOCK_TO_REUSABLE: convertBlockToReusable,
 	REMOVE_BLOCKS: [
-		selectPreviousBlock,
 		ensureDefaultBlock,
 	],
 	REPLACE_BLOCKS: [

--- a/packages/editor/src/store/index.js
+++ b/packages/editor/src/store/index.js
@@ -10,6 +10,7 @@ import reducer from './reducer';
 import applyMiddlewares from './middlewares';
 import * as selectors from './selectors';
 import * as actions from './actions';
+import * as controls from './controls';
 
 /**
  * Module Constants
@@ -20,6 +21,7 @@ const store = registerStore( MODULE_KEY, {
 	reducer,
 	selectors,
 	actions,
+	controls,
 	persist: [ 'preferences' ],
 } );
 applyMiddlewares( store );

--- a/packages/editor/src/store/index.js
+++ b/packages/editor/src/store/index.js
@@ -10,7 +10,7 @@ import reducer from './reducer';
 import applyMiddlewares from './middlewares';
 import * as selectors from './selectors';
 import * as actions from './actions';
-import * as controls from './controls';
+import controls from './controls';
 
 /**
  * Module Constants

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -19,6 +19,7 @@ import {
 	updateBlockAttributes,
 	updateBlock,
 	selectBlock,
+	selectPreviousBlock,
 	startMultiSelect,
 	stopMultiSelect,
 	multiSelect,
@@ -293,32 +294,47 @@ describe( 'actions', () => {
 
 	describe( 'removeBlocks', () => {
 		it( 'should return REMOVE_BLOCKS action', () => {
-			const clientIds = [ 'clientId' ];
-			expect( removeBlocks( clientIds ) ).toEqual( {
-				type: 'REMOVE_BLOCKS',
-				clientIds,
-				selectPrevious: true,
-			} );
+			const clientId = 'clientId';
+			const clientIds = [ clientId ];
+
+			const actions = Array.from( removeBlocks( clientIds ) );
+
+			expect( actions ).toEqual( [
+				selectPreviousBlock( clientId ),
+				{
+					type: 'REMOVE_BLOCKS',
+					clientIds,
+				},
+			] );
 		} );
 	} );
 
 	describe( 'removeBlock', () => {
 		it( 'should return REMOVE_BLOCKS action', () => {
 			const clientId = 'myclientid';
-			expect( removeBlock( clientId ) ).toEqual( {
-				type: 'REMOVE_BLOCKS',
-				clientIds: [
-					clientId,
-				],
-				selectPrevious: true,
-			} );
-			expect( removeBlock( clientId, false ) ).toEqual( {
-				type: 'REMOVE_BLOCKS',
-				clientIds: [
-					clientId,
-				],
-				selectPrevious: false,
-			} );
+
+			const actions = Array.from( removeBlock( clientId ) );
+
+			expect( actions ).toEqual( [
+				selectPreviousBlock( clientId ),
+				{
+					type: 'REMOVE_BLOCKS',
+					clientIds: [ clientId ],
+				},
+			] );
+		} );
+
+		it( 'should return REMOVE_BLOCKS action, opting out of remove previous', () => {
+			const clientId = 'myclientid';
+
+			const actions = Array.from( removeBlock( clientId, false ) );
+
+			expect( actions ).toEqual( [
+				{
+					type: 'REMOVE_BLOCKS',
+					clientIds: [ clientId ],
+				},
+			] );
 		} );
 	} );
 


### PR DESCRIPTION
Extracted from #13088

This pull request seeks to refactor the implementation where removing a block should select the block preceding the removed. Previously, this had been implemented as a side-effect, determining the block to select by recreating the state at the prior point in history when the block had existed. This will not be possible in #13088, since the block editor module will not retain its own history.

The changes here reimplement the behavior as [controls](https://wordpress.org/gutenberg/handbook/designers-developers/developers/packages/packages-data/#controls) assigned to a new pair of actions `selectNextBlock` and `selectPreviousBlock`. Technically only the latter is ever used, but the inverse is included for completeness.

**Implementation Notes:**

I feel slightly uneasy about this implementation only because it seems to leverage controls for the mere convenient access to selectors to determine the next/previous block client IDs. I think an alternative approach could be one where the actions are handled entirely within the reducer. However, this would require that `blockSelection` have some awareness of order, which is not presently true.

I had thought perhaps there may be a way to `yield` or `return` an action object from the control implementation, as the `selectBlock` action is local to the controls file and it's not strictly necessary to operate through the registry object. In my testing, however, this did not work.

**Testing instructions:**

Verify there are no regressions in the behavior to _select previous on remove block_. Notably, you should remove a block via the block toolbar extended options menu, or using the keyboard shortcut.

This is also encompassed in the block deletion end-to-end tests, as additional confirmation:

```
npm run test-e2e packages/e2e-tests/specs/block-deletion.test.js
```