### PR TITLE
Don't do anything in RichTextInputEvent on native mobile

### DIFF
--- a/packages/editor/src/components/index.native.js
+++ b/packages/editor/src/components/index.native.js
@@ -5,6 +5,7 @@ export {
 	default as RichText,
 	RichTextShortcut,
 	RichTextToolbarButton,
+	RichTextInputEvent,
 } from './rich-text';
 export { default as MediaPlaceholder } from './media-placeholder';
 export { default as BlockFormatControls } from './block-format-controls';

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -450,3 +450,4 @@ RichTextContainer.Content.defaultProps = {
 export default RichTextContainer;
 export { RichTextShortcut } from './shortcut';
 export { RichTextToolbarButton } from './toolbar-button';
+export { RichTextInputEvent } from './input-event';

--- a/packages/editor/src/components/rich-text/input-event.native.js
+++ b/packages/editor/src/components/rich-text/input-event.native.js
@@ -1,0 +1,10 @@
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+export class RichTextInputEvent extends Component {
+	render() {
+		return null;
+	}
+}


### PR DESCRIPTION
## Description
Recent work (#13833) on the RichText implementation has introduced the `RichTextInputEvent` component but, that doesn't play well on native mobile since there is no real DOM available. This PR just "grounds" the component to just have it do nothing in the native mobile case.

## How has this been tested?
Use the gutenberg-mobile side PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/612


## Types of changes
Introduce a native mobile implementation of the `RichTextInputEvent` component that does nothing.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
