### PR TITLE
Update Button block wording

### DIFF
--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -64,7 +64,7 @@ const colorsMigration = ( attributes ) => {
 export const settings = {
 	title: __( 'Button' ),
 
-	description: __( 'Prompt visitors to take action with a custom button.' ),
+	description: __( 'Prompt visitors to take action with a button styled link.' ),
 
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M19 6H5c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm0 10H5V8h14v8z" /></G></SVG>,
 

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -70,6 +70,8 @@ export const settings = {
 
 	category: 'layout',
 
+	keywords: [ __( 'link' ) ],
+
 	attributes: blockAttributes,
 
 	supports: {

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -64,7 +64,7 @@ const colorsMigration = ( attributes ) => {
 export const settings = {
 	title: __( 'Button' ),
 
-	description: __( 'Prompt visitors to take action with a button styled link.' ),
+	description: __( 'Prompt visitors to take action with a button-style link.' ),
 
 	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M19 6H5c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm0 10H5V8h14v8z" /></G></SVG>,
 


### PR DESCRIPTION
## Description
 - Update button block description to mention it's a link.
- Add keyword _link_.

Closes #13923.

## How has this been tested?
Tested on local, I see the wording change. And I can also search using keyword _link_.

## Screenshots <!-- if applicable -->
Button description:
<img width="280" alt="Button block description" src="https://user-images.githubusercontent.com/1820415/52971329-bc27b600-33bf-11e9-8967-2a83dd0851b1.png">

Search by keyword link:
<img width="395" alt="Search modal with keyword link" src="https://user-images.githubusercontent.com/1820415/52971402-03ae4200-33c0-11e9-84cc-487f02b26b3d.png">


## Types of changes
- Button block description wording.
- Add keyword.

## Checklist:
- [ x] My code is tested.
- [x ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
