### PR TITLE
Simplify hierarchical term selector strings

### DIFF
--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -370,21 +370,15 @@ class HierarchicalTermSelector extends Component {
 		const newTermSubmitLabel = newTermButtonLabel;
 		const inputId = `editor-post-taxonomies__hierarchical-terms-input-${ instanceId }`;
 		const filterInputId = `editor-post-taxonomies__hierarchical-terms-filter-${ instanceId }`;
-		const filterLabel = sprintf(
-			_x( 'Search %s', 'term' ),
-			get(
-				this.props.taxonomy,
-				[ 'name' ],
-				slug === 'category' ? __( 'Categories' ) : __( 'Terms' )
-			)
+		const filterLabel = get(
+			this.props.taxonomy,
+			[ 'labels', 'search_items' ],
+			__( 'Search Terms' )
 		);
-		const groupLabel = sprintf(
-			_x( 'Available %s', 'term' ),
-			get(
-				this.props.taxonomy,
-				[ 'name' ],
-				slug === 'category' ? __( 'Categories' ) : __( 'Terms' )
-			)
+		const groupLabel = get(
+			this.props.taxonomy,
+			[ 'name' ],
+			__( 'Terms' )
 		);
 		const showFilter = availableTerms.length >= MIN_TERMS_COUNT_FOR_FILTER;
 


### PR DESCRIPTION
This PR seeks to simplify the translatable strings used for the hierarchical terms (categories) selector. Introduced in #10138.

Placeholder must not be used for variables representing taxonomy/post names etc. Due to structural differences in languages, that simply doesn't work. Please refer to the related issue #13936 for more details.

- first string: uses the existing `search_items` label
- second string: removes the placeholder and just uses the taxonomy name

An alternative option would be introducing in core new taxonomy labels and then use them e.g.

`'available_items'  => array( __( 'Available Tags' ), __( 'Available Categories' ) )`

But I'd say that's not necessary: this is used for an `aria-label` on the group of available terms and it's now announced by screen readers as "Categories, group", which is fine.

Fixes #13936 