### PR TITLE
chore: Replace wrong usage of map with a forEach

### DIFF
--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -172,7 +172,7 @@ class DropZoneProvider extends Component {
 		}
 
 		// Notifying the dropzones
-		toUpdate.map( ( dropZone ) => {
+		toUpdate.forEach( ( dropZone ) => {
 			const index = this.dropZones.indexOf( dropZone );
 			const isDraggingOverDropZone = index === hoveredDropZoneIndex;
 			dropZone.setState( {


### PR DESCRIPTION
## Description
closes: https://github.com/WordPress/gutenberg/issues/13952
We had a map that had no return as a result issue was opened https://github.com/WordPress/gutenberg/issues/1395. In fact, the return was not needed, because the map was being used as a way to iterate the array and call the setState method.
Ideally, a map should receive its input and return an output without having side effects, for this reason, I think a forEach call is more applicable in this situation.

## How has this been tested?
I checked it is still possible to drag & drop blocks.
I checked it is still possible to drag & drop files from the desktop.

