### PR TITLE
Add ESNext syntax to meta block tutorial

### DIFF
--- a/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md
+++ b/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md
@@ -10,6 +10,8 @@ By specifying the source of the attributes as `meta`, the Block Editor automatic
 
 Add this code to your JavaScript file (this tutorial will call the file `myguten.js`):
 
+{% codetabs %}
+{% ES5 %}
 ```js
 ( function( wp ) {
 	var el = wp.element.createElement;
@@ -56,6 +58,49 @@ Add this code to your JavaScript file (this tutorial will call the file `myguten
 	});
 })( window.wp );
 ```
+{% ESNext %}
+```jsx
+const { registerBlockType } = wp.blocks;
+const TextField = wp.components.TextControl;
+
+registerBlockType("myguten/meta-block", {
+	title: "Meta Block",
+	icon: "smiley",
+	category: "common",
+
+	attributes: {
+		blockValue: {
+			type: "string",
+			source: "meta",
+			meta: "myguten_meta_block_field"
+		}
+	},
+
+	edit( { className, setAttributes, attributes } ) {
+
+		function updateBlockValue( blockValue ) {
+			setAttributes({ blockValue });
+		}
+
+		return (
+			<div className={ className }>
+				<TextField
+					label="Meta Block Field"
+					value={ attributes }
+					onChange={ updateBlockValue }
+				/>
+			</div>
+		);
+	},
+
+	// No information saved to the block
+	// Data is saved to post meta via attributes
+	save() {
+		return null;
+	}
+});
+```
+{% end %}
 
 **Important:** Before you test, you need to enqueue your JavaScript file and its dependencies. Note the WordPress packages used above are `wp.element`, `wp.blocks`, and `wp.components`. Each of these need to be included in the array of dependencies. Update the `myguten-meta-block.php` file adding the enqueue function:
 

--- a/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md
+++ b/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md
@@ -60,8 +60,8 @@ Add this code to your JavaScript file (this tutorial will call the file `myguten
 ```
 {% ESNext %}
 ```jsx
-const { registerBlockType } = wp.blocks;
-const { TextControl } = wp.components;
+import { registerBlockType } from '@wordpress/blocks';
+import { TextControl } from '@wordpress/components';
 
 registerBlockType( 'myguten/meta-block', {
 	title: 'Meta Block',

--- a/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md
+++ b/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md
@@ -16,22 +16,22 @@ Add this code to your JavaScript file (this tutorial will call the file `myguten
 ( function( wp ) {
 	var el = wp.element.createElement;
 	var registerBlockType = wp.blocks.registerBlockType;
-	var TextField = wp.components.TextControl;
+	var TextControl = wp.components.TextControl;
 
-	registerBlockType("myguten/meta-block", {
-		title: "Meta Block",
-		icon: "smiley",
-		category: "common",
+	registerBlockType( 'myguten/meta-block', {
+		title: 'Meta Block',
+		icon: 'smiley',
+		category: 'common',
 
 		attributes: {
 			blockValue: {
-				type: "string",
-				source: "meta",
-				meta: "myguten_meta_block_field"
+				type: 'string',
+				source: 'meta',
+				meta: 'myguten_meta_block_field'
 			}
 		},
 
-		edit: function(props) {
+		edit: function( props ) {
 			var className = props.className;
 			var setAttributes = props.setAttributes;
 
@@ -39,11 +39,11 @@ Add this code to your JavaScript file (this tutorial will call the file `myguten
 				setAttributes({ blockValue });
 			}
 
-		return el(
-				"div",
+			return el(
+				'div',
 				{ className: className },
-				el( TextField, {
-					label: "Meta Block Field",
+				el( TextControl, {
+					label: 'Meta Block Field',
 					value: props.attributes.blockValue,
 					onChange: updateBlockValue
 				} )
@@ -55,38 +55,38 @@ Add this code to your JavaScript file (this tutorial will call the file `myguten
 		save: function() {
 			return null;
 		}
-	});
-})( window.wp );
+	} );
+} )( window.wp );
 ```
 {% ESNext %}
 ```jsx
 const { registerBlockType } = wp.blocks;
-const TextField = wp.components.TextControl;
+const { TextControl } = wp.components;
 
-registerBlockType("myguten/meta-block", {
-	title: "Meta Block",
-	icon: "smiley",
-	category: "common",
+registerBlockType( 'myguten/meta-block', {
+	title: 'Meta Block',
+	icon: 'smiley',
+	category: 'common',
 
 	attributes: {
 		blockValue: {
-			type: "string",
-			source: "meta",
-			meta: "myguten_meta_block_field"
-		}
+			type: 'string',
+			source: 'meta',
+			meta: 'myguten_meta_block_field',
+		},
 	},
 
 	edit( { className, setAttributes, attributes } ) {
 
 		function updateBlockValue( blockValue ) {
-			setAttributes({ blockValue });
+			setAttributes( { blockValue } );
 		}
 
 		return (
 			<div className={ className }>
-				<TextField
+				<TextControl
 					label="Meta Block Field"
-					value={ attributes }
+					value={ attributes.blockValue }
 					onChange={ updateBlockValue }
 				/>
 			</div>
@@ -98,7 +98,7 @@ registerBlockType("myguten/meta-block", {
 	save() {
 		return null;
 	}
-});
+} );
 ```
 {% end %}
 


### PR DESCRIPTION
## Description

Adds ESNext syntax example for the Meta Block tutorial
It initially was only written using ES5

## How has this been tested?

Documentation, confirm works as expected.
