### PR TITLE
Number and Boolean block attributes stored as an HTML attribute should be parsed properly

### DIFF
--- a/packages/blocks/src/api/parser.js
+++ b/packages/blocks/src/api/parser.js
@@ -77,7 +77,26 @@ export const toBooleanAttributeMatcher = ( matcher ) => flow( [
  */
 export const toNumberAttributeMatcher = ( matcher ) => flow( [
 	matcher,
-	( value ) => Number( value ) || 0,
+	// <input>
+	// - Value: `undefined`
+	// - Transformed: `undefined`
+	//
+	// <input data-number>
+	// - Value: `''`
+	// - Transformed: `undefined`
+	//
+	// <input data-number="10">
+	// - Value: `'10'`
+	// - Transformed: `10`
+	//
+	// <input data-number="2.5">
+	// - Value: `'2.5'`
+	// - Transformed: `2.5`
+	//
+	// <input data-number="not-a-number">
+	// - Value: `'not-a-number'`
+	// - Transformed: `undefined`
+	( value ) => isNaN( Number( value ) ) ? undefined : Number( value ),
 ] );
 
 /**

--- a/packages/blocks/src/api/parser.js
+++ b/packages/blocks/src/api/parser.js
@@ -67,6 +67,19 @@ export const toBooleanAttributeMatcher = ( matcher ) => flow( [
 ] );
 
 /**
+ * Higher-order hpq matcher which enhances an attribute matcher to return a
+ * number.
+ *
+ * @param {Function} matcher Original hpq matcher.
+ *
+ * @return {Function} Enhanced hpq matcher.
+ */
+export const toNumberAttributeMatcher = ( matcher ) => flow( [
+	matcher,
+	( value ) => Number( value ) || 0,
+] );
+
+/**
  * Returns true if value is of the given JSON schema type, or false otherwise.
  *
  * @see http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.25
@@ -189,8 +202,15 @@ export function matcherFromSource( sourceConfig ) {
 	switch ( sourceConfig.source ) {
 		case 'attribute':
 			let matcher = attr( sourceConfig.selector, sourceConfig.attribute );
-			if ( sourceConfig.type === 'boolean' ) {
-				matcher = toBooleanAttributeMatcher( matcher );
+
+			switch ( sourceConfig.type ) {
+				case 'boolean':
+					matcher = toBooleanAttributeMatcher( matcher );
+					break;
+				case 'integer':
+				case 'number':
+					matcher = toNumberAttributeMatcher( matcher );
+					break;
 			}
 
 			return matcher;

--- a/packages/blocks/src/api/parser.js
+++ b/packages/blocks/src/api/parser.js
@@ -39,10 +39,11 @@ const STRING_SOURCES = new Set( [
 
 /**
  * Higher-order hpq matcher which enhances an attribute matcher to return true
- * or false depending on whether the original matcher returns undefined. This
- * is useful for boolean attributes (e.g. disabled) whose attribute values may
- * be technically falsey (empty string), though their mere presence should be
- * enough to infer as true.
+ * or false depending on whether the original matcher returns undefined or the
+ * "false" string. This is useful for boolean attributes (e.g. disabled) whose
+ * attribute values may be technically falsey (empty string), though their
+ * mere presence should be enough to infer as true. It's also useful for those
+ * boolean attributes whose value is either "true" or "false".
  *
  * @param {Function} matcher Original hpq matcher.
  *
@@ -63,7 +64,7 @@ export const toBooleanAttributeMatcher = ( matcher ) => flow( [
 	// <input disabled="disabled">
 	// - Value:       `'disabled'`
 	// - Transformed: `true`
-	( value ) => value !== undefined,
+	( value ) => value !== undefined && value !== 'false',
 ] );
 
 /**

--- a/packages/blocks/src/api/test/parser.js
+++ b/packages/blocks/src/api/test/parser.js
@@ -290,7 +290,26 @@ describe( 'block parser', () => {
 	} );
 
 	describe( 'getBlockAttributes()', () => {
-		it( 'should reject the value with a wrong type', () => {
+		it( 'should reject a number attribute with a wrong value', () => {
+			const blockType = {
+				attributes: {
+					number: {
+						type: 'number',
+						source: 'attribute',
+						attribute: 'data-number',
+						selector: 'div',
+					},
+				},
+			};
+
+			const innerHTML = '<div data-number="not-a-number">Ribs</div>';
+
+			expect( getBlockAttributes( blockType, innerHTML, {} ) ).toEqual( {
+				number: undefined,
+			} );
+		} );
+
+		it( 'should accept a number value as an HTML attribute', () => {
 			const blockType = {
 				attributes: {
 					number: {
@@ -305,7 +324,7 @@ describe( 'block parser', () => {
 			const innerHTML = '<div data-number="10">Ribs</div>';
 
 			expect( getBlockAttributes( blockType, innerHTML, {} ) ).toEqual( {
-				number: undefined,
+				number: 10,
 			} );
 		} );
 


### PR DESCRIPTION
## Description
Closes  #13949.

This pull requests fixes two issues I identified while storing a block attribute in an HTML attribute:

* Boolean attributes such as `data-show-button="true|false"` didn't work, as the source code didn't parse the `"false"` value as `false`. This was first reported here: #13949.
* Number/integer attributes such as `data-height="50"` couldn't be saved in an attribute either.

## How has this been tested?
I created a simple block and stored boolean and number attributes in HTML attributes. Before the PR, Gutenberg complained about expected and actual values not matching. With this PR, Gutenberg pulls the proper values and things work as expected.

## Types of changes
I think both changes are _Breaking changes_, as they change Gutenberg's behaviour regarding Boolean and Number HTML attributes.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
- [x] I've included developer documentation if appropriate.
