### PR TITLE
[RNMobile] Fix for Title that is not saving 

### DIFF
--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -56,8 +56,8 @@ class PostTitle extends Component {
 				} ] }
 				fontSize={ 24 }
 				fontWeight={ 'bold' }
-				onChange={ ( event ) => {
-					this.props.onUpdate( event.content );
+				onChange={ ( value ) => {
+					this.props.onUpdate( value );
 				} }
 				onContentSizeChange={ ( event ) => {
 					this.setState( { aztecHeight: event.aztecHeight } );


### PR DESCRIPTION
This PR fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/620 by making sure to use the correct value returned from the underlying RichText component.

The RichText component implementation was refactored few days ago and we forgot to update the PostTitle component.


Gutenberg-mobile side PR link here: https://github.com/wordpress-mobile/gutenberg-mobile/pull/621