### PR TITLE
[Mobile]Update PostTitle to apply borders when it is focused

### DIFF
--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -60,14 +60,15 @@ class PostTitle extends Component {
 			placeholder,
 			style,
 			title,
+			focusedBorderColor,
+			borderStyle,
 		} = this.props;
 
 		const decodedPlaceholder = decodeEntities( placeholder );
-		const focusedStyle = this.props.focusedStyle;
-		const borderColor = this.state.isSelected ? focusedStyle.borderColor : 'transparent';
+		const borderColor = this.state.isSelected ? focusedBorderColor : 'transparent';
 
 		return (
-			<View style={ [ styles.titleContainer, focusedStyle, { borderColor } ] }>
+			<View style={ [ styles.titleContainer, borderStyle, { borderColor } ] }>
 				<RichText
 					tagName={ 'p' }
 					onFocus={ this.onSelect }

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -30,8 +30,8 @@ class PostTitle extends Component {
 	}
 
 	componentDidMount() {
-		if ( this.props.onRef ) {
-			this.props.onRef( this );
+		if ( this.props.ref ) {
+			this.props.ref( this );
 		}
 	}
 

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -29,11 +29,13 @@ class PostTitle extends Component {
 
 	onSelect() {
 		this.setState( { isSelected: true } );
+		this.props.onFocusStatusChange( true )
 		this.props.clearSelectedBlock();
 	}
 
 	onUnselect() {
 		this.setState( { isSelected: false } );
+		this.props.onFocusStatusChange( false );
 	}
 
 	render() {

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -29,7 +29,7 @@ class PostTitle extends Component {
 
 	onSelect() {
 		this.setState( { isSelected: true } );
-		this.props.onFocusStatusChange( true )
+		this.props.onFocusStatusChange( true );
 		this.props.clearSelectedBlock();
 	}
 

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -8,9 +8,15 @@ import { withDispatch } from '@wordpress/data';
 import { withFocusOutside } from '@wordpress/components';
 import { withInstanceId, compose } from '@wordpress/compose';
 
+import { View } from 'react-native';
+
+import styles from './style.scss';
+
 const minHeight = 30;
 
 class PostTitle extends Component {
+	titleViewRef: Object;
+
 	constructor() {
 		super( ...arguments );
 
@@ -23,19 +29,30 @@ class PostTitle extends Component {
 		};
 	}
 
+	componentDidMount() {
+		if ( this.props.onRef ) {
+			this.props.onRef( this );
+		}
+	}
+
 	handleFocusOutside() {
 		this.onUnselect();
 	}
 
+	focus() {
+		if ( this.titleViewRef ) {
+			this.titleViewRef.focus();
+			this.setState( { isSelected: true } );
+		}
+	}
+
 	onSelect() {
 		this.setState( { isSelected: true } );
-		this.props.onFocusStatusChange( true );
 		this.props.clearSelectedBlock();
 	}
 
 	onUnselect() {
 		this.setState( { isSelected: false } );
-		this.props.onFocusStatusChange( false );
 	}
 
 	render() {
@@ -46,30 +63,36 @@ class PostTitle extends Component {
 		} = this.props;
 
 		const decodedPlaceholder = decodeEntities( placeholder );
+		const focusedStyle = this.props.focusedStyle;
+		const borderColor = this.state.isSelected ? focusedStyle.borderColor : 'transparent';
 
 		return (
-			<RichText
-				tagName={ 'p' }
-				onFocus={ this.onSelect }
-				onBlur={ this.props.onBlur } // always assign onBlur as a props
-				multiline={ false }
-				style={ [ style, {
-					minHeight: Math.max( minHeight, this.state.aztecHeight ),
-				} ] }
-				fontSize={ 24 }
-				fontWeight={ 'bold' }
-				onChange={ ( value ) => {
-					this.props.onUpdate( value );
-				} }
-				onContentSizeChange={ ( event ) => {
-					this.setState( { aztecHeight: event.aztecHeight } );
-				} }
-				placeholder={ decodedPlaceholder }
-				value={ title }
-				onSplit={ this.props.onEnterPress }
-				setRef={ this.props.setRef }
-			>
-			</RichText>
+			<View style={ [ styles.titleContainer, focusedStyle, { borderColor } ] }>
+				<RichText
+					tagName={ 'p' }
+					onFocus={ this.onSelect }
+					onBlur={ this.props.onBlur } // always assign onBlur as a props
+					multiline={ false }
+					style={ [ style, {
+						minHeight: Math.max( minHeight, this.state.aztecHeight ),
+					} ] }
+					fontSize={ 24 }
+					fontWeight={ 'bold' }
+					onChange={ ( value ) => {
+						this.props.onUpdate( value );
+					} }
+					onContentSizeChange={ ( event ) => {
+						this.setState( { aztecHeight: event.aztecHeight } );
+					} }
+					placeholder={ decodedPlaceholder }
+					value={ title }
+					onSplit={ this.props.onEnterPress }
+					setRef={ ( ref ) => {
+						this.titleViewRef = ref;
+					} }
+				>
+				</RichText>
+			</View>
 		);
 	}
 }

--- a/packages/editor/src/components/post-title/style.native.scss
+++ b/packages/editor/src/components/post-title/style.native.scss
@@ -1,0 +1,7 @@
+
+.titleContainer {
+	padding-left: 16;
+	padding-right: 16;
+	padding-top: 32;
+	padding-bottom: 16;
+}

--- a/packages/editor/src/components/post-title/style.native.scss
+++ b/packages/editor/src/components/post-title/style.native.scss
@@ -2,6 +2,5 @@
 .titleContainer {
 	padding-left: 16;
 	padding-right: 16;
-	padding-top: 32;
-	padding-bottom: 16;
+	margin-top: 24;
 }


### PR DESCRIPTION
## Description

This change Update PostTitle to apply borders when it is focused.

Actually we always add borders with transparent color and when it is focused we change the colors. This way we are able to fix the unwanted re-render problem we had on Android when borders are applied the first time: https://github.com/wordpress-mobile/gutenberg-mobile/pull/622#issuecomment-465893024

## How has this been tested?
Steps at https://github.com/wordpress-mobile/gutenberg-mobile/pull/622

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
