### PR TITLE
Webpack: remove TinyMCE external dependency mapping

### DIFF
--- a/docs/contributors/coding-guidelines.md
+++ b/docs/contributors/coding-guidelines.md
@@ -57,7 +57,7 @@ Example:
 /**
  * External dependencies
  */
-import TinyMCE from 'tinymce';
+import moment from 'moment';
 ```
 
 #### WordPress Dependencies
@@ -142,7 +142,7 @@ const name = 'Matt';
 
 // Bad:
 const pet = 'Matt\'s dog';
-// Also bad (not using an apostrophe): 
+// Also bad (not using an apostrophe):
 const pet = "Matt's dog";
 // Good:
 const pet = 'Matt’s dog';

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -39,7 +39,6 @@ export const F10 = 121;
 
 export const ALT = 'alt';
 export const CTRL = 'ctrl';
-// Understood in both Mousetrap and TinyMCE.
 export const COMMAND = 'meta';
 export const SHIFT = 'shift';
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,7 +48,6 @@ const gutenbergPackages = Object.keys( dependencies )
 const externals = {
 	react: 'React',
 	'react-dom': 'ReactDOM',
-	tinymce: 'tinymce',
 	moment: 'moment',
 	jquery: 'jQuery',
 	lodash: 'lodash',


### PR DESCRIPTION
## Description

This is no longer used. Additionally removes an old irrelevant comment.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
