### PR TITLE
URL input popover visual cleanup

### DIFF
--- a/packages/editor/src/components/url-popover/index.js
+++ b/packages/editor/src/components/url-popover/index.js
@@ -54,7 +54,7 @@ class URLPopover extends Component {
 					{ !! renderSettings && (
 						<IconButton
 							className="editor-url-popover__settings-toggle"
-							icon="ellipsis"
+							icon="arrow-down-alt2"
 							label={ __( 'Link Settings' ) }
 							onClick={ this.toggleSettingsVisibility }
 							aria-expanded={ isSettingsExpanded }

--- a/packages/editor/src/components/url-popover/style.scss
+++ b/packages/editor/src/components/url-popover/style.scss
@@ -14,8 +14,8 @@
 		width: $icon-button-size;
 		height: $icon-button-size;
 
-		.dashicon {
-			transform: rotate(90deg);
+		&[aria-expanded="true"] .dashicon {
+			transform: rotate(180deg);
 		}
 	}
 

--- a/packages/editor/src/components/url-popover/style.scss
+++ b/packages/editor/src/components/url-popover/style.scss
@@ -51,8 +51,11 @@
 	}
 
 	&__settings {
-		padding: 7px 8px;
+		padding: $panel-padding;
 		border-top: $border-width solid $light-gray-500;
-		padding-top: 7px + $border-width;
+
+		.components-base-control:last-child .components-base-control__field {
+			margin-bottom: 0;
+		}
 	}
 }

--- a/packages/editor/src/components/url-popover/style.scss
+++ b/packages/editor/src/components/url-popover/style.scss
@@ -40,6 +40,11 @@
 	&__settings-toggle {
 		flex-shrink: 0;
 
+		// Add a left divider to the toggle button
+		border-radius: 0;
+		border-left: $border-width solid $light-gray-500;
+		margin-left: 1px;
+
 		&[aria-expanded="true"] .dashicon {
 			transform: rotate(180deg);
 		}

--- a/packages/editor/src/components/url-popover/style.scss
+++ b/packages/editor/src/components/url-popover/style.scss
@@ -9,10 +9,36 @@
 		flex-grow: 1;
 	}
 
+	// Mimic toolbar component styles for the icons in this popover
+	.components-icon-button {
+		padding: 3px;
+
+		> svg {
+			padding: 5px;
+			border-radius: $radius-round-rectangle;
+			height: 30px;
+			width: 30px;
+		}
+
+		&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover {
+			box-shadow: none;
+
+			> svg {
+				@include formatting-button-style__hover;
+			}
+		}
+
+		&:not(:disabled):focus {
+			box-shadow: none;
+
+			> svg {
+				@include formatting-button-style__focus;
+			}
+		}
+	}
+
 	&__settings-toggle {
 		flex-shrink: 0;
-		width: $icon-button-size;
-		height: $icon-button-size;
 
 		&[aria-expanded="true"] .dashicon {
 			transform: rotate(180deg);

--- a/packages/editor/src/components/url-popover/style.scss
+++ b/packages/editor/src/components/url-popover/style.scss
@@ -9,7 +9,7 @@
 		flex-grow: 1;
 	}
 
-	// Mimic toolbar component styles for the icons in this popover
+	// Mimic toolbar component styles for the icons in this popover.
 	.components-icon-button {
 		padding: 3px;
 
@@ -40,7 +40,7 @@
 	&__settings-toggle {
 		flex-shrink: 0;
 
-		// Add a left divider to the toggle button
+		// Add a left divider to the toggle button.
 		border-radius: 0;
 		border-left: $border-width solid $light-gray-500;
 		margin-left: 1px;

--- a/packages/editor/src/components/url-popover/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/url-popover/test/__snapshots__/index.js.snap
@@ -16,7 +16,7 @@ exports[`URLPopover matches the snapshot in its default state 1`] = `
     <IconButton
       aria-expanded={false}
       className="editor-url-popover__settings-toggle"
-      icon="ellipsis"
+      icon="arrow-down-alt2"
       label="Link Settings"
       onClick={[Function]}
     />
@@ -40,7 +40,7 @@ exports[`URLPopover matches the snapshot when the settings are toggled open 1`] 
     <IconButton
       aria-expanded={true}
       className="editor-url-popover__settings-toggle"
-      icon="ellipsis"
+      icon="arrow-down-alt2"
       label="Link Settings"
       onClick={[Function]}
     />


### PR DESCRIPTION
This PR does a little bit of visual cleanup for the URL input popover: 

- It replaces the "Link Settings" ellipsis with a chevron icon, as discussed in https://github.com/WordPress/gutenberg/issues/8322#issuecomment-464841591
- It restyles the icons to mimic our usual toolbar hover + focus states. Previously, the light gray border on them bumped right up against the edges of the popover container.  
- It adjusts the padding within the expandable settings panel, to match the spacing we use in other panels throughout Gutenberg. 

_Before_

![url-field-old](https://user-images.githubusercontent.com/1202812/53095111-f0979100-34e9-11e9-8a4f-9cf63394ab9a.gif)

_After_

![url-field-new](https://user-images.githubusercontent.com/1202812/53095115-f5f4db80-34e9-11e9-991d-90eda36d51f8.gif)