### PR TITLE
Deprecate RichTextInputEvent on mobile too

### DIFF
--- a/packages/editor/src/components/index.native.js
+++ b/packages/editor/src/components/index.native.js
@@ -5,7 +5,7 @@ export {
 	default as RichText,
 	RichTextShortcut,
 	RichTextToolbarButton,
-	RichTextInputEvent,
+	UnstableRichTextInputEvent,
 } from './rich-text';
 export { default as MediaPlaceholder } from './media-placeholder';
 export { default as BlockFormatControls } from './block-format-controls';

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -568,4 +568,4 @@ RichTextContainer.Content.defaultProps = {
 export default RichTextContainer;
 export { RichTextShortcut } from './shortcut';
 export { RichTextToolbarButton } from './toolbar-button';
-export { RichTextInputEvent } from './input-event';
+export { UnstableRichTextInputEvent } from './input-event';

--- a/packages/editor/src/components/rich-text/input-event.native.js
+++ b/packages/editor/src/components/rich-text/input-event.native.js
@@ -3,7 +3,7 @@
  */
 import { Component } from '@wordpress/element';
 
-export class RichTextInputEvent extends Component {
+export class UnstableRichTextInputEvent extends Component {
 	render() {
 		return null;
 	}


### PR DESCRIPTION
## Description
Rename/deprecate `RichTextInputEvent` for native mobile too.

## How has this been tested?
Use this gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/625

## Types of changes
Rename/deprecate `RichTextInputEvent` for native mobile too.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
