### PR TITLE
Pass current selection data to the rich-text component

### DIFF
--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -500,6 +500,7 @@ export class RichText extends Component {
 						}
 					} }
 					text={ { text: html, eventCount: this.lastEventCount } }
+					selection={ { selectionStart: this.state.start, selectionEnd: this.state.end, eventCount: this.lastEventCount } }
 					placeholder={ this.props.placeholder }
 					placeholderTextColor={ this.props.placeholderTextColor || styles[ 'editor-rich-text' ].textDecorationColor }
 					onChange={ this.onChange }


### PR DESCRIPTION
## Description
Adds "setSelection" functionality to the rich-text component for native mobile. This is currently used to make sure the component sets the caret position to the beginning of the text when splitting a block into two.

## How has this been tested?
Use this gutenberg-mobile side PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/629

## Types of changes
Adds a "selection" prop to the `RichText` component and wires it up to the local state kept for `selectionStart` and `selectionEnd`. The (native) component itself ignores the re-render if the values passed are of an older `eventCount` event. This way, the `onSelectionChange` event doesn't cause a loop.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
