### PR TITLE
Add check to the merge function in heading and paragraph blocks

### DIFF
--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -168,7 +168,7 @@ export const settings = {
 
 	merge( attributes, attributesToMerge ) {
 		return {
-			content: attributes.content + attributesToMerge.content,
+			content: ( attributes.content || '' ) + ( attributesToMerge.content || '' ),
 		};
 	},
 

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -212,7 +212,7 @@ export const settings = {
 
 	merge( attributes, attributesToMerge ) {
 		return {
-			content: attributes.content + attributesToMerge.content,
+			content: ( attributes.content || '' ) + ( attributesToMerge.content || '' ),
 		};
 	},
 


### PR DESCRIPTION
## Description
If trying to merge a blank heading or paragraph, if this check isn't performed, the result is the string 'null' appearing in the text. Fixes #12616

## How has this been tested?
Start a post, create two paragraphs, select them, and cut them to the clipboard.
Start a new post, insert a heading.
*Don't type anything*
Paste the two paragraph blocks, which will insert them after the heading.
With the cursor at the start of the first paragraph, press delete (Backspace on a PC?)
See that the paragraph text is added to the header, without the word "null"
Click into a new paragraph at the bottom.
Again without typing anything, press delete.
See that you are moved to the previous paragraph, but "null" was not appended

*The key to testing this is to paste the blocks without typing anything while the cursor is still in the heading.*

A helpful video of the error happening was provided in the original issue: [https://gfycat.com/ZigzagFlawedIchthyostega](https://gfycat.com/ZigzagFlawedIchthyostega)

## Screenshot
![bkm1uuhq7r](https://user-images.githubusercontent.com/6653970/53111672-87c11080-350b-11e9-8518-3807c63bafc2.gif)

## Types of changes
Bug fix (non-breaking change which fixes an issue)
