### PR TITLE
Check that .rel is available too

### DIFF
--- a/packages/blocks/src/api/raw-handling/phrasing-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/phrasing-content-reducer.js
@@ -38,7 +38,7 @@ export default function( node, doc ) {
 	} else if ( node.nodeName === 'A' ) {
 		// In jsdom-jscore, 'node.target' can be null.
 		// TODO: Explore fixing this by patching jsdom-jscore.
-		if ( node.target && node.target.toLowerCase() === '_blank' ) {
+		if ( node.target && node.target.toLowerCase() === '_blank' && node.rel ) {
 			node.rel = 'noreferrer noopener';
 		} else {
 			node.removeAttribute( 'target' );


### PR DESCRIPTION
## Description
`node.rel` can be missing on native mobile so, guard for it.

## How has this been tested?
Using this gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/630

## Types of changes
Adds a guard for `node.rel` to be present before setting it.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
