### PR TITLE
Editor: RichText: Check for presence of inputType

### DIFF
--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -366,7 +366,7 @@ export class RichText extends Component {
 			return;
 		}
 
-		if ( event ) {
+		if ( event && event.nativeEvent.inputType ) {
 			const { inputType } = event.nativeEvent;
 
 			// The browser formatted something or tried to insert HTML.


### PR DESCRIPTION
Fixes #13979 
Regression introduced in #13833 

This pull request seeks to resolve an issue in Firefox (and presumably Internet Explorer) where pressing any key in a RichText field (e.g. paragraph block) will throw errors. Further, when pressing backspace after entering content, all content entered is removed.

As part of #13833 in addressing an issue with applying formats, logic was added to consider the `inputType` property of an `InputEvent`. Unfortunately, this property is not standard across all browsers:

https://developer.mozilla.org/en-US/docs/Web/API/InputEvent/inputType#Browser_compatibility

The changes here minimally address the issue in checking for the presence of the property before operating upon it. Separately, it may need to be considered whether an alternative implementation should be explored to resolve the original issue addressed by #13833, since the formatting events would not be identified in unsupporting browsers (it's not certain whether these browsers are relevant, since #13833 seems primarily aimed at Safari).

**Testing instructions:**

In Firefox, Internet Explorer, and your preferred browser, repeat Steps to Reproduce from #13979, verifying that content is not lost upon pressing Backspace, nor that any errors are logged to the console in entering text within a RichText field.