### PR TITLE
Upload media progress bar is missing while media is uploading new

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -124,7 +124,7 @@ class ImageEdit extends React.Component {
 	updateMediaProgress( payload ) {
 		const { setAttributes } = this.props;
 		this.setState( { progress: payload.progress, isUploadInProgress: true, isUploadFailed: false } );
-		if ( payload.mediaUrl !== undefined ) {
+		if ( payload.mediaUrl ) {
 			setAttributes( { url: payload.mediaUrl } );
 		}
 	}


### PR DESCRIPTION
[Upload media progress bar is missing while media is uploading](https://github.com/WordPress/gutenberg/issues/13984)