### PR TITLE
Add CSS Custom Property for media-text media width

### DIFF
--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -175,6 +175,7 @@ export const settings = {
 		const style = {
 			backgroundColor: backgroundClass ? undefined : customBackgroundColor,
 			gridTemplateColumns,
+			'--media-text__media-width': mediaWidth !== DEFAULT_MEDIA_WIDTH ? `${ mediaWidth }%` : undefined,
 		};
 		return (
 			<div className={ className } style={ style }>

--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -1,5 +1,6 @@
 .wp-block-media-text {
 	display: grid;
+	--media-text__media-width: 50%;
 }
 
 .wp-block-media-text {


### PR DESCRIPTION
## Description
Adds a CSS Custom Property (CSS variable) to the inline style on the media-text block.

The style attribute will now look something like this `style="grid-template-columns:49% auto;--media-text__media-width:49%"`

Developers will no longer be forced into using grid if, for whatever reason, they choose not to.

Would help with this https://github.com/WordPress/gutenberg/issues/11268

## How has this been tested?
visual

## Screenshots <!-- if applicable -->

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
