### PR TITLE
Use globals instead of imports in tutorials

### DIFF
--- a/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md
+++ b/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md
@@ -60,8 +60,9 @@ Add this code to your JavaScript file (this tutorial will call the file `myguten
 ```
 {% ESNext %}
 ```jsx
-import { registerBlockType } from '@wordpress/blocks';
-import { TextControl } from '@wordpress/components';
+
+var registerBlockType = wp.blocks.registerBlockType;
+var TextControl = wp.components.TextControl;
 
 registerBlockType( 'myguten/meta-block', {
 	title: 'Meta Block',

--- a/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md
+++ b/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md
@@ -62,7 +62,7 @@ Add this code to your JavaScript file (this tutorial will call the file `myguten
 ```jsx
 
 var registerBlockType = wp.blocks.registerBlockType;
-var TextControl = wp.components.TextControl;
+const { TextControl } = wp.components;
 
 registerBlockType( 'myguten/meta-block', {
 	title: 'Meta Block',

--- a/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md
+++ b/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md
@@ -61,7 +61,7 @@ Add this code to your JavaScript file (this tutorial will call the file `myguten
 {% ESNext %}
 ```jsx
 
-var registerBlockType = wp.blocks.registerBlockType;
+const { registerBlockType } = wp.blocks;
 const { TextControl } = wp.components;
 
 registerBlockType( 'myguten/meta-block', {


### PR DESCRIPTION
For reference https://github.com/WordPress/gutenberg/pull/13954
