### PR TITLE
Test transform from media to embed blocks

### DIFF
--- a/packages/e2e-tests/specs/embedding.test.js
+++ b/packages/e2e-tests/specs/embedding.test.js
@@ -217,4 +217,34 @@ describe( 'Embedding content', () => {
 		// Check the block has become a WordPress block.
 		await page.waitForSelector( '.wp-block-embed-wordpress' );
 	} );
+
+	it( 'should transform from video to embed block when YouTube URL is pasted', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '/video' );
+		await page.keyboard.press( 'Enter' );
+		await page.click( '.editor-media-placeholder__url-input-container button' );
+		await page.keyboard.type( 'https://www.youtube.com/watch?v=DQuhA5ZCV9M' );
+		await page.keyboard.press( 'Enter' );
+		await page.waitForSelector( '.wp-block-embed-youtube' );
+	} );
+
+	it( 'should transform from image to embed block when Instagram URL is pasted', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '/image' );
+		await page.keyboard.press( 'Enter' );
+		await page.click( '.editor-media-placeholder__url-input-container button' );
+		await page.keyboard.type( 'https://www.instagram.com/p/BtNsR8HFRif/' );
+		await page.keyboard.press( 'Enter' );
+		await page.waitForSelector( '.wp-block-embed-instagram' );
+	} );
+
+	it( 'should transform from audio to embed block when Soundcloud URL is pasted', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '/audio' );
+		await page.keyboard.press( 'Enter' );
+		await page.click( '.editor-media-placeholder__url-input-container button' );
+		await page.keyboard.type( 'https://soundcloud.com/a-boogie-wit-da-hoodie/swervin' );
+		await page.keyboard.press( 'Enter' );
+		await page.waitForSelector( '.wp-block-embed-soundcloud' );
+	} );
 } );

--- a/packages/e2e-tests/specs/embedding.test.js
+++ b/packages/e2e-tests/specs/embedding.test.js
@@ -50,7 +50,7 @@ const MOCK_EMBED_AUDIO_SUCCESS_RESPONSE = {
 };
 
 const MOCK_EMBED_IMAGE_SUCCESS_RESPONSE = {
-	url: 'https://www.instagram.com/p/BtNsR8HFRif/',
+	url: 'https://www.instagram.com/p/Bvl97o2AK6x/',
 	html: '<iframe width="16" height="9"></iframe>',
 	type: 'video',
 	provider_name: 'Instagram',
@@ -97,7 +97,7 @@ const MOCK_RESPONSES = [
 		onRequestMatch: createJSONResponse( MOCK_EMBED_AUDIO_SUCCESS_RESPONSE ),
 	},
 	{
-		match: createEmbeddingMatcher( 'https://www.instagram.com/p/BtNsR8HFRif/' ),
+		match: createEmbeddingMatcher( 'https://www.instagram.com/p/Bvl97o2AK6x/' ),
 		onRequestMatch: createJSONResponse( MOCK_EMBED_IMAGE_SUCCESS_RESPONSE ),
 	},
 	{
@@ -246,8 +246,7 @@ describe( 'Embedding content', () => {
 
 	it( 'should transform from video to embed block when YouTube URL is pasted', async () => {
 		await clickBlockAppender();
-		await page.keyboard.type( '/video' );
-		await page.keyboard.press( 'Enter' );
+		await insertBlock( 'Video' );
 		await page.click( '.editor-media-placeholder__url-input-container button' );
 		await page.keyboard.type( 'https://www.youtube.com/watch?v=lXMskKTw3Bc' );
 		await page.keyboard.press( 'Enter' );
@@ -259,7 +258,7 @@ describe( 'Embedding content', () => {
 		await page.keyboard.type( '/image' );
 		await page.keyboard.press( 'Enter' );
 		await page.click( '.editor-media-placeholder__url-input-container button' );
-		await page.keyboard.type( 'https://www.instagram.com/p/BtNsR8HFRif/' );
+		await page.keyboard.type( 'https://www.instagram.com/p/Bvl97o2AK6x/' );
 		await page.keyboard.press( 'Enter' );
 		await page.waitForSelector( '.wp-block-embed-instagram' );
 	} );

--- a/packages/e2e-tests/specs/embedding.test.js
+++ b/packages/e2e-tests/specs/embedding.test.js
@@ -40,6 +40,24 @@ const MOCK_EMBED_VIDEO_SUCCESS_RESPONSE = {
 	version: '1.0',
 };
 
+const MOCK_EMBED_AUDIO_SUCCESS_RESPONSE = {
+	url: 'https://soundcloud.com/a-boogie-wit-da-hoodie/swervin',
+	html: '<iframe width="16" height="9"></iframe>',
+	type: 'audio',
+	provider_name: 'SoundCloud',
+	provider_url: 'https://soundcloud.com',
+	version: '1.0',
+};
+
+const MOCK_EMBED_IMAGE_SUCCESS_RESPONSE = {
+	url: 'https://www.instagram.com/p/BtNsR8HFRif/',
+	html: '<iframe width="16" height="9"></iframe>',
+	type: 'video',
+	provider_name: 'Instagram',
+	provider_url: 'https://www.instagram.com',
+	version: '1.0',
+};
+
 const MOCK_BAD_EMBED_PROVIDER_RESPONSE = {
 	url: 'https://twitter.com/thatbunty',
 	html: false,
@@ -73,6 +91,14 @@ const MOCK_RESPONSES = [
 	{
 		match: createEmbeddingMatcher( 'https://www.youtube.com/watch?v=lXMskKTw3Bc' ),
 		onRequestMatch: createJSONResponse( MOCK_EMBED_VIDEO_SUCCESS_RESPONSE ),
+	},
+	{
+		match: createEmbeddingMatcher( 'https://soundcloud.com/a-boogie-wit-da-hoodie/swervin' ),
+		onRequestMatch: createJSONResponse( MOCK_EMBED_AUDIO_SUCCESS_RESPONSE ),
+	},
+	{
+		match: createEmbeddingMatcher( 'https://www.instagram.com/p/BtNsR8HFRif/' ),
+		onRequestMatch: createJSONResponse( MOCK_EMBED_IMAGE_SUCCESS_RESPONSE ),
 	},
 	{
 		match: createEmbeddingMatcher( 'https://cloudup.com/cQFlxqtY4ob' ),
@@ -223,7 +249,7 @@ describe( 'Embedding content', () => {
 		await page.keyboard.type( '/video' );
 		await page.keyboard.press( 'Enter' );
 		await page.click( '.editor-media-placeholder__url-input-container button' );
-		await page.keyboard.type( 'https://www.youtube.com/watch?v=DQuhA5ZCV9M' );
+		await page.keyboard.type( 'https://www.youtube.com/watch?v=lXMskKTw3Bc' );
 		await page.keyboard.press( 'Enter' );
 		await page.waitForSelector( '.wp-block-embed-youtube' );
 	} );


### PR DESCRIPTION
Closes #11901

Added e2e tests to test the transform of audio, video and image blocks in to embeds when embeddable URLs are provided

## Description
Added e2e tests to test the transform of audio, video and image blocks in to embeds when embeddable URLs are provided

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
