### PR TITLE
Make inline image toolbar focussable by keyboard

### DIFF
--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -109,7 +109,7 @@ export const image = {
 				if ( isActive ) {
 					speak( sprintf(
 						__( 'Inline image selected. Press %s to focus the contextual toolbar.' ),
-						displayShortcut.primary( 'f6' )
+						displayShortcut.primary( 'f9' )
 					), 'assertive' );
 				} else {
 					speak( __( 'Inline image deselected.' ), 'assertive' );
@@ -127,7 +127,7 @@ export const image = {
 			return (
 				<MediaUploadCheck>
 					<KeyboardShortcuts bindGlobal shortcuts={ {
-						[ rawShortcut.primary( 'f6' ) ]: this.onShortcut,
+						[ rawShortcut.primary( 'f9' ) ]: this.onShortcut,
 					} } />
 					<RichTextInserterItem
 						name={ name }


### PR DESCRIPTION
## Description

Attempts to fix #10595. I added a keyboard shortcut to focus the contextual toolbar, currently only for inline images, but ideally, it should work the same for any contextual toolbar such as the one for links and ones added by plugins e.g. color. Also tells the user when on image gets selected and deselected, with the shortcut to focus the contextual toolbar.

Not expecting to be perfect from the start. Once it looks good I'll add an e2e test for it to avoid regressions.

**N.B.** There are boundaries around the image, which is a bug that will get fixed by #13948.

## How has this been tested?

In a rich text field, add an inline image. Select it. You should get a spoken message that the image has been selected and which shortcut to use to access the contextual toolbar. Try it. The popover content wrapper should receive focus. You can now tab to the form elements. Edit the width and apply. Selection should go back to the rich text field. Deselect the image and there should be a spoken message again.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->