### PR TITLE
[Mobile]Re-add rootTagsToEliminate option to RichText

### DIFF
--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -48,6 +48,7 @@ class PostTitle extends Component {
 		return (
 			<RichText
 				tagName={ 'p' }
+				rootTagsToEliminate={ [ 'strong' ] }
 				onFocus={ this.onSelect }
 				onBlur={ this.props.onBlur } // always assign onBlur as a props
 				multiline={ false }


### PR DESCRIPTION
## Description
This PR is to re-add rootTagsToEliminate option to RichText component. Looks like it was lost by a merge regression here https://github.com/WordPress/gutenberg/pull/13874/files

Original issue was resolved here https://github.com/wordpress-mobile/gutenberg-mobile/pull/577.

## How has this been tested?

Test with steps on mobile-gutenberg PR. https://github.com/wordpress-mobile/gutenberg-mobile/pull/636

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
