### PR TITLE
Updates example code references

### DIFF
--- a/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
@@ -13,13 +13,13 @@ While the block's editor behaviors are implemented in JavaScript, you'll need to
 
 function gutenberg_boilerplate_block() {
 	wp_register_script(
-		'gutenberg-boilerplate-es5-step01',
-		plugins_url( 'step-01/block.js', __FILE__ ),
+		'gutenberg-examples-01-basic',
+		plugins_url( '01-basic/block.js', __FILE__ ),
 		array( 'wp-blocks', 'wp-element' )
 	);
 
-	register_block_type( 'gutenberg-boilerplate-es5/hello-world-step-01', array(
-		'editor_script' => 'gutenberg-boilerplate-es5-step01',
+	register_block_type( 'gutenberg-examples/01-basic', array(
+		'editor_script' => 'gutenberg-examples-01-basic',
 	) );
 }
 add_action( 'init', 'gutenberg_boilerplate_block' );
@@ -43,7 +43,7 @@ var el = wp.element.createElement,
 	registerBlockType = wp.blocks.registerBlockType,
 	blockStyle = { backgroundColor: '#900', color: '#fff', padding: '20px' };
 
-registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-01', {
+registerBlockType( 'gutenberg-examples/01-basic', {
 	title: 'Hello World (Step 1)',
 
 	icon: 'universal-access-alt',
@@ -64,7 +64,7 @@ registerBlockType( 'gutenberg-boilerplate-es5/hello-world-step-01', {
 const { registerBlockType } = wp.blocks;
 const blockStyle = { backgroundColor: '#900', color: '#fff', padding: '20px' };
 
-registerBlockType( 'gutenberg-boilerplate-esnext/hello-world-step-01', {
+registerBlockType( 'gutenberg-examples/01-basic-esnext', {
 	title: 'Hello World (Step 1)',
 
 	icon: 'universal-access-alt',

--- a/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
@@ -64,7 +64,7 @@ registerBlockType( 'gutenberg-examples/01-basic', {
 const { registerBlockType } = wp.blocks;
 const blockStyle = { backgroundColor: '#900', color: '#fff', padding: '20px' };
 
-registerBlockType( 'gutenberg-examples/01-basic-esnext', {
+registerBlockType( 'gutenberg-examples/example-01-basic-esnext', {
 	title: 'Hello World (Step 1)',
 
 	icon: 'universal-access-alt',

--- a/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
@@ -43,7 +43,7 @@ var el = wp.element.createElement,
 	registerBlockType = wp.blocks.registerBlockType,
 	blockStyle = { backgroundColor: '#900', color: '#fff', padding: '20px' };
 
-registerBlockType( 'gutenberg-examples/01-basic', {
+	register_block_type( 'gutenberg-examples/example-01-basic', array(
 	title: 'Hello World (Step 1)',
 
 	icon: 'universal-access-alt',

--- a/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md
@@ -18,7 +18,7 @@ function gutenberg_boilerplate_block() {
 		array( 'wp-blocks', 'wp-element' )
 	);
 
-	register_block_type( 'gutenberg-examples/01-basic', array(
+	register_block_type( 'gutenberg-examples/example-01-basic', array(
 		'editor_script' => 'gutenberg-examples-01-basic',
 	) );
 }


### PR DESCRIPTION
See original issue fore more details: closes https://github.com/WordPress/gutenberg/issues/14005

## Description
Updates references to the [actual repository](https://github.com/WordPress/gutenberg-examples) linked in [Blocks Tutorial](https://wordpress.org/gutenberg/handbook/designers-developers/developers/tutorials/block-tutorial/).

## How has this been tested?
Manually.

## Screenshots <!-- if applicable -->

## Types of changes
References in code snippets.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
