### PR TITLE
Reinstate "underline" in default formats list

### DIFF
--- a/packages/format-library/src/default-formats.js
+++ b/packages/format-library/src/default-formats.js
@@ -7,6 +7,7 @@ import { image } from './image';
 import { italic } from './italic';
 import { link } from './link';
 import { strikethrough } from './strikethrough';
+import { underline } from './underline';
 
 export default [
 	bold,
@@ -15,4 +16,5 @@ export default [
 	italic,
 	link,
 	strikethrough,
+	underline,
 ];


### PR DESCRIPTION
## Description
Fixes a regression introduced with #12249 where the "underline" format was deleted from the default list of supported formats.

## How has this been tested?
No manual testing has been performed yet.

## Types of changes
Add the `underline` format to the list of default formats

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
