### PR TITLE
Cleanup URL Popover stylesheet

### DIFF
--- a/packages/editor/src/components/url-popover/style.scss
+++ b/packages/editor/src/components/url-popover/style.scss
@@ -1,61 +1,59 @@
-.editor-url-popover {
-	&__row {
-		display: flex;
+.editor-url-popover__row {
+	display: flex;
+}
+
+// Any children of the popover-row that are not the settings-toggle
+// should take up as much space as possible.
+.editor-url-popover__row > :not(.editor-url-popover__settings-toggle) {
+	flex-grow: 1;
+}
+
+// Mimic toolbar component styles for the icons in this popover.
+.editor-url-popover .components-icon-button {
+	padding: 3px;
+
+	> svg {
+		padding: 5px;
+		border-radius: $radius-round-rectangle;
+		height: 30px;
+		width: 30px;
 	}
 
-	// Any children of the popover-row that are not the settings-toggle
-	// should take up as much space as possible.
-	&__row > :not(.editor-url-popover__settings-toggle) {
-		flex-grow: 1;
-	}
-
-	// Mimic toolbar component styles for the icons in this popover.
-	.components-icon-button {
-		padding: 3px;
+	&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover {
+		box-shadow: none;
 
 		> svg {
-			padding: 5px;
-			border-radius: $radius-round-rectangle;
-			height: 30px;
-			width: 30px;
-		}
-
-		&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover {
-			box-shadow: none;
-
-			> svg {
-				@include formatting-button-style__hover;
-			}
-		}
-
-		&:not(:disabled):focus {
-			box-shadow: none;
-
-			> svg {
-				@include formatting-button-style__focus;
-			}
+			@include formatting-button-style__hover;
 		}
 	}
 
-	&__settings-toggle {
-		flex-shrink: 0;
+	&:not(:disabled):focus {
+		box-shadow: none;
 
-		// Add a left divider to the toggle button.
-		border-radius: 0;
-		border-left: $border-width solid $light-gray-500;
-		margin-left: 1px;
-
-		&[aria-expanded="true"] .dashicon {
-			transform: rotate(180deg);
+		> svg {
+			@include formatting-button-style__focus;
 		}
 	}
+}
 
-	&__settings {
-		padding: $panel-padding;
-		border-top: $border-width solid $light-gray-500;
+.editor-url-popover__settings-toggle {
+	flex-shrink: 0;
 
-		.components-base-control:last-child .components-base-control__field {
-			margin-bottom: 0;
-		}
+	// Add a left divider to the toggle button.
+	border-radius: 0;
+	border-left: $border-width solid $light-gray-500;
+	margin-left: 1px;
+
+	&[aria-expanded="true"] .dashicon {
+		transform: rotate(180deg);
+	}
+}
+
+.editor-url-popover__settings {
+	padding: $panel-padding;
+	border-top: $border-width solid $light-gray-500;
+
+	.components-base-control:last-child .components-base-control__field {
+		margin-bottom: 0;
 	}
 }


### PR DESCRIPTION
As noted in https://github.com/WordPress/gutenberg/pull/13973#discussion_r258813604, the URL Popover stylesheet uses a relatively non-standard SCSS method of nesting some classnames. For instance:

```
.editor-url-popover { 
    &__settings-toggle { 
        ...
    } 
}
```

... instead of:

```
.editor-url-popover__settings-toggle { 
    ...
}
```

This is different from the conventions used elsewhere in Gutenberg, and is a bit more difficult to follow for that reason.

This commit un-nests those styles, and should have no effect on the compiled CSS.