### PR TITLE
Fix: Global inserter does not validates block insert restrictions

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -397,7 +397,7 @@ export default compose(
 			__experimentalFetchReusableBlocks: fetchReusableBlocks,
 		} = dispatch( 'core/editor' );
 
-		// To avoid duplication, getInsertionPoint is extracted and used in two event handlers
+		// To avoid duplication, getInsertionIndex is extracted and used in two event handlers
 		// This breaks the withDispatch not containing any logic rule.
 		// Since it's a function only called when the event handlers are called,
 		// it's fine to extract it.


### PR DESCRIPTION
## Description
Regressed in https://github.com/WordPress/gutenberg/pull/13067

During changes applied in https://github.com/WordPress/gutenberg/pull/13067 the global inserter started showing all the time the blocks that can be inserted at the root instead of the blocks that can be inserted at the currently selected insertion point.

This causes some problems. If we are inside the content area of the "Media & text" block and we go to the global inserter we an insert any block in it and not just the allowed blocks.
If we insert a columns block we use the block navigation functionality to select the first column, and we go to the global inserter we are able to insert a block inside the columns in the middle of a column.

I will create another PR that proposes some end 2 end tests to these behaviors.


## How has this been tested?
I went to "Media & Text"; I selected to the content area; I clicked the global inserter and I verified only the allowed blocks appear.
I added a columns block; I used the block navigation to select the first column block; I went to the global inserter and verified no block are available.

## Screenshots <!-- if applicable -->
Before:
Header in the middle of column:
<img width="1301" alt="screenshot 2019-02-21 at 16 10 48" src="https://user-images.githubusercontent.com/11271197/53184263-a4854300-35f4-11e9-819a-cb38b8cbfa56.png">
Media text allows everything:
<img width="1914" alt="screenshot 2019-02-21 at 16 08 51" src="https://user-images.githubusercontent.com/11271197/53184286-afd86e80-35f4-11e9-8a6d-455a0678789f.png">

After:
<img width="1829" alt="screenshot 2019-02-21 at 16 06 03" src="https://user-images.githubusercontent.com/11271197/53184309-ba930380-35f4-11e9-94f8-4b4feab886a4.png">
<img width="1430" alt="screenshot 2019-02-21 at 16 22 13" src="https://user-images.githubusercontent.com/11271197/53184436-e615ee00-35f4-11e9-8695-23a0134af6b2.png">


