### PR TITLE
Begin adding support for the `prefers-reduced-motion` setting, Add a11y notes to the animation docs. 

### DIFF
--- a/assets/stylesheets/_animations.scss
+++ b/assets/stylesheets/_animations.scss
@@ -5,4 +5,5 @@
 @mixin edit-post__fade-in-animation($speed: 0.2s, $delay: 0s) {
 	animation: edit-post__fade-in-animation $speed ease-out $delay;
 	animation-fill-mode: forwards;
+	@include reduce-motion;
 }

--- a/assets/stylesheets/_animations.scss
+++ b/assets/stylesheets/_animations.scss
@@ -5,5 +5,4 @@
 @mixin edit-post__fade-in-animation($speed: 0.2s, $delay: 0s) {
 	animation: edit-post__fade-in-animation $speed ease-out $delay;
 	animation-fill-mode: forwards;
-	@include reduce-motion;
 }

--- a/assets/stylesheets/_mixins.scss
+++ b/assets/stylesheets/_mixins.scss
@@ -333,3 +333,13 @@
 	// icon standards.
 	margin-right: 2px;
 }
+
+/**
+ * Allows users to opt-out of animations via OS-level preferences.
+ */
+
+@mixin reduce-motion {
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+	}
+}

--- a/assets/stylesheets/_mixins.scss
+++ b/assets/stylesheets/_mixins.scss
@@ -340,6 +340,6 @@
 
 @mixin reduce-motion {
 	@media (prefers-reduced-motion: reduce) {
-		animation: none;
+		animation-duration: 1ms !important;
 	}
 }

--- a/docs/designers-developers/designers/animation.md
+++ b/docs/designers-developers/designers/animation.md
@@ -33,7 +33,7 @@ Reuse animations if one already exists for your task.
 - Animations should be subtle. Be cognizent of users with [vestibular disorders triggered by motion](https://www.ncbi.nlm.nih.gov/pubmed/29017000).
 - Don't animate elements that are currently reporting content to adaptive technology (e.g., an `aria-live` region that's receiving updates). This can cause confusion wherein the technology tries to parse a region that's actively changing.
 - Avoid animations that aren't directly triggered by user behaviors.
-- Whenever possible, ensure that animations respect the OS-level "Reduce Motion" settings. This can be done by utilizing the [`prefers-reduce-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) media query. 
+- Whenever possible, ensure that animations respect the OS-level "Reduce Motion" settings. This can be done by utilizing the [`prefers-reduce-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) media query. Gutenberg includes a `@reduce-motion` mixin for this, to be used alongside rules that include a CSS `animate` property. 
 
 ## Inventory of Reused Animations
 

--- a/docs/designers-developers/designers/animation.md
+++ b/docs/designers-developers/designers/animation.md
@@ -30,7 +30,7 @@ Reuse animations if one already exists for your task.
 
 ## Accessibility Considerations
 
-- Animations should be subtle. Be cognizent of users with [motion triggering vestibular disorders](https://www.ncbi.nlm.nih.gov/pubmed/29017000).
+- Animations should be subtle. Be cognizent of users with [vestibular disorders triggered by motion](https://www.ncbi.nlm.nih.gov/pubmed/29017000).
 - Don't animate elements that are currently reporting content to adaptive technology (e.g., an `aria-live` region that's receiving updates). This can cause confusion wherein the technology tries to parse a region that's actively changing.
 - Avoid animations that aren't directly triggered by user behaviors.
 - Whenever possible, ensure that animations respect the OS-level "Reduce Motion" settings. This can be done by utilizing the [`prefers-reduce-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) media query. 

--- a/docs/designers-developers/designers/animation.md
+++ b/docs/designers-developers/designers/animation.md
@@ -28,6 +28,13 @@ In creating consistent animations, we have to establish physical rules for how e
 
 Reuse animations if one already exists for your task. 
 
+## Accessibility Considerations
+
+- Animations should be subtle. Be cognizent of users with [motion triggering vestibular disorders](https://www.ncbi.nlm.nih.gov/pubmed/29017000).
+- Don't animate elements that are currently reporting content to adaptive technology (e.g., an `aria-live` region that's receiving updates). This can cause confusion wherein the technology tries to parse a region that's actively changing.
+- Avoid animations that aren't directly triggered by user behaviors.
+- Whenever possible, ensure that animations respect the OS-level "Reduce Motion" settings. This can be done by utilizing the [`prefers-reduce-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) media query. 
+
 ## Inventory of Reused Animations
 
 The generic `Animate` component is used to animate different parts of the interface. See [the component documentation](/packages/components/src/animate/README.md) for more details about the available animations. 

--- a/packages/components/src/animate/style.scss
+++ b/packages/components/src/animate/style.scss
@@ -31,6 +31,7 @@
 .components-animate__slide-in {
 	animation: components-animate__slide-in-animation 0.1s cubic-bezier(0, 0, 0.2, 1);
 	animation-fill-mode: forwards;
+	@include reduce-motion;
 
 	&.is-from-left {
 		transform: translateX(+100%);

--- a/packages/components/src/animate/style.scss
+++ b/packages/components/src/animate/style.scss
@@ -1,6 +1,7 @@
 .components-animate__appear {
 	animation: components-animate__appear-animation 0.1s cubic-bezier(0, 0, 0.2, 1) 0s;
 	animation-fill-mode: forwards;
+	@include reduce-motion;
 
 	&.is-from-top,
 	&.is-from-top.is-from-left {

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -42,6 +42,7 @@
 		// Animate the modal frame/contents appearing on the page.
 		animation: components-modal__appear-animation 0.1s ease-out;
 		animation-fill-mode: forwards;
+		@include reduce-motion;
 	}
 }
 

--- a/packages/edit-post/src/components/fullscreen-mode/style.scss
+++ b/packages/edit-post/src/components/fullscreen-mode/style.scss
@@ -26,6 +26,7 @@ body.js.is-fullscreen-mode {
 		.edit-post-header {
 			transform: translateY(-100%);
 			animation: edit-post-fullscreen-mode__slide-in-animation 0.1s forwards;
+			@include reduce-motion;
 		}
 	}
 }

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -178,6 +178,7 @@
 		border-left: $border-width solid $light-gray-500;
 		transform: translateX(+100%);
 		animation: edit-post-post-publish-panel__slide-in-animation 0.1s forwards;
+		@include reduce-motion;
 
 		body.is-fullscreen-mode & {
 			top: 0;


### PR DESCRIPTION
As noted by @ryelle in https://github.com/WordPress/gutenberg/issues/8029#issuecomment-466038569, the [`prefers-reduced-motion` media query](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) is a way for websites to respect an OS-level reduce motion setting. 

In this PR, I've added a quick `@mixin` that we can apply as needed to opt-in to this setting. I've also begun adding it to a couple of our animations to start: 

- The menu appear animation added in #13617.
- The modal window fade/move animation added in #9900.

Unfortunately, this can't be added to all animations (yet). For example, the [menu slide-in animation](https://github.com/WordPress/gutenberg/blob/9dc1a33f2b175b639f9678aa94604bfb29b3838a/packages/components/src/animate/style.scss#L30-L43) moves the menu from its off-screen position into its intended position on screen. As written right now, if we remove the animation, the menu will never be moved on screen. 

It also can't be used in cases where the visibility/opacity of an item is only set by the animation. For instance, I tried applying it to [`edit-post__fade-in-animation`](https://github.com/WordPress/gutenberg/blob/88a69507e0bba453fd0f239b4be1567c94953396/assets/stylesheets/_animations.scss#L1-L3), which is used in a number of places to fade  in content. This worked in some cases, but a few elements (like the block mover icons) didn't appear at all when Reduce Motion was enabled. 

Both of those examples are totally solvable, but I wanted to keep this PR simple for now. 🙂

This PR also adds @joedolson and @ryelle's accessibility recommendations from #8029 to the animation design documentation for greater visibility. 

---

**Testing:** 

1. On a Mac, Open `System Preferences > Accessibility`. 
2. Select "Display" from the left-hand column.
3. Check the box labeled  "Reduce motion"
4. Open Gutenberg using Safari or Firefox (These are the only browsers that support this media query at the moment).
5. Make sure that the menus appear with no animation.
5. Make sure that modal windows appear with no animation. 