### PR TITLE
[Mobile]Rename ref as innerRef in PostTitle

### DIFF
--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -30,8 +30,8 @@ class PostTitle extends Component {
 	}
 
 	componentDidMount() {
-		if ( this.props.ref ) {
-			this.props.ref( this );
+		if ( this.props.innerRef ) {
+			this.props.innerRef( this );
 		}
 	}
 


### PR DESCRIPTION
## Description
We are fixing the ref as innerRef because ref is not working maybe because it is reserved or sth.


## How has this been tested?
Tested with https://github.com/wordpress-mobile/gutenberg-mobile/pull/622


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->