### PR TITLE
Try/fix pasting links

### DIFF
--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -289,6 +289,7 @@ export class RichText extends Component {
 					},
 				} );
 				this.lastContent = this.valueToFormat( linkedRecord );
+				this.lastEventCount = undefined;
 				this.props.onChange( this.lastContent );
 
 				// Allows us to ask for this information when we get a report.


### PR DESCRIPTION
## Description

Gutenberg-mobile fix for pasting links in iOS.

Fixes pasting links. The content was being updated properly, but the native component was not being refreshed right in iOS, and the change was being lost.

The format bar was showing the existence of a link but the text was just not showing it.

## How has this been tested?

Tested through: https://github.com/wordpress-mobile/gutenberg-mobile/pull/644

## Types of changes

This PR simply makes sure the event count is eliminated to force an update in the native component.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->