### PR TITLE
Avoid mutating imported default config in webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ const { basename } = require( 'path' );
  */
 const CustomTemplatedPathPlugin = require( '@wordpress/custom-templated-path-webpack-plugin' );
 const LibraryExportDefaultPlugin = require( '@wordpress/library-export-default-webpack-plugin' );
-const config = require( '@wordpress/scripts/config/webpack.config' );
+const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 const { camelCaseDash } = require( '@wordpress/scripts/utils' );
 
 /**
@@ -27,82 +27,82 @@ const gutenbergPackages = Object.keys( dependencies )
 	.filter( ( packageName ) => packageName.startsWith( WORDPRESS_NAMESPACE ) )
 	.map( ( packageName ) => packageName.replace( WORDPRESS_NAMESPACE, '' ) );
 
-config.entry = gutenbergPackages.reduce( ( memo, packageName ) => {
-	const name = camelCaseDash( packageName );
-	memo[ name ] = `./packages/${ packageName }`;
-	return memo;
-}, {} );
+module.exports = {
+	...defaultConfig,
+	entry: gutenbergPackages.reduce( ( memo, packageName ) => {
+		const name = camelCaseDash( packageName );
+		memo[ name ] = `./packages/${ packageName }`;
+		return memo;
+	}, {} ),
+	output: {
+		filename: './build/[basename]/index.js',
+		path: __dirname,
+		library: [ 'wp', '[name]' ],
+		libraryTarget: 'this',
+	},
+	plugins: [
+		...defaultConfig.plugins,
+		new DefinePlugin( {
+			// Inject the `GUTENBERG_PHASE` global, used for feature flagging.
+			// eslint-disable-next-line @wordpress/gutenberg-phase
+			'process.env.GUTENBERG_PHASE': JSON.stringify( parseInt( process.env.npm_package_config_GUTENBERG_PHASE, 10 ) || 1 ),
+		} ),
+		// Create RTL files with a -rtl suffix
+		new WebpackRTLPlugin( {
+			suffix: '-rtl',
+			minify: defaultConfig.mode === 'production' ? { safe: true } : false,
+		} ),
+		new CustomTemplatedPathPlugin( {
+			basename( path, data ) {
+				let rawRequest;
 
-config.output = {
-	filename: './build/[basename]/index.js',
-	path: __dirname,
-	library: [ 'wp', '[name]' ],
-	libraryTarget: 'this',
-};
+				const entryModule = get( data, [ 'chunk', 'entryModule' ], {} );
+				switch ( entryModule.type ) {
+					case 'javascript/auto':
+						rawRequest = entryModule.rawRequest;
+						break;
 
-config.plugins.push(
-	new DefinePlugin( {
-		// Inject the `GUTENBERG_PHASE` global, used for feature flagging.
-		// eslint-disable-next-line @wordpress/gutenberg-phase
-		'process.env.GUTENBERG_PHASE': JSON.stringify( parseInt( process.env.npm_package_config_GUTENBERG_PHASE, 10 ) || 1 ),
-	} ),
-	// Create RTL files with a -rtl suffix
-	new WebpackRTLPlugin( {
-		suffix: '-rtl',
-		minify: config.mode === 'production' ? { safe: true } : false,
-	} ),
-	new CustomTemplatedPathPlugin( {
-		basename( path, data ) {
-			let rawRequest;
-
-			const entryModule = get( data, [ 'chunk', 'entryModule' ], {} );
-			switch ( entryModule.type ) {
-				case 'javascript/auto':
-					rawRequest = entryModule.rawRequest;
-					break;
-
-				case 'javascript/esm':
-					rawRequest = entryModule.rootModule.rawRequest;
-					break;
-			}
-
-			if ( rawRequest ) {
-				return basename( rawRequest );
-			}
-
-			return path;
-		},
-	} ),
-	new LibraryExportDefaultPlugin( [
-		'api-fetch',
-		'deprecated',
-		'dom-ready',
-		'redux-routine',
-		'token-list',
-	].map( camelCaseDash ) ),
-	new CopyWebpackPlugin(
-		gutenbergPackages.map( ( packageName ) => ( {
-			from: `./packages/${ packageName }/build-style/*.css`,
-			to: `./build/${ packageName }/`,
-			flatten: true,
-			transform: ( content ) => {
-				if ( config.mode === 'production' ) {
-					return postcss( [
-						require( 'cssnano' )( {
-							preset: [ 'default', {
-								discardComments: {
-									removeAll: true,
-								},
-							} ],
-						} ),
-					] )
-						.process( content, { from: 'src/app.css', to: 'dest/app.css' } )
-						.then( ( result ) => result.css );
+					case 'javascript/esm':
+						rawRequest = entryModule.rootModule.rawRequest;
+						break;
 				}
-				return content;
-			},
-		} ) )
-	)
-);
 
-module.exports = config;
+				if ( rawRequest ) {
+					return basename( rawRequest );
+				}
+
+				return path;
+			},
+		} ),
+		new LibraryExportDefaultPlugin( [
+			'api-fetch',
+			'deprecated',
+			'dom-ready',
+			'redux-routine',
+			'token-list',
+		].map( camelCaseDash ) ),
+		new CopyWebpackPlugin(
+			gutenbergPackages.map( ( packageName ) => ( {
+				from: `./packages/${ packageName }/build-style/*.css`,
+				to: `./build/${ packageName }/`,
+				flatten: true,
+				transform: ( content ) => {
+					if ( defaultConfig.mode === 'production' ) {
+						return postcss( [
+							require( 'cssnano' )( {
+								preset: [ 'default', {
+									discardComments: {
+										removeAll: true,
+									},
+								} ],
+							} ),
+						] )
+							.process( content, { from: 'src/app.css', to: 'dest/app.css' } )
+							.then( ( result ) => result.css );
+					}
+					return content;
+				},
+			} ) )
+		),
+	],
+};


### PR DESCRIPTION
## Description
It addresses the comment from @aduth in https://github.com/WordPress/gutenberg/pull/13814#discussion_r259065393:

> I think for the purpose it serves, it shouldn't prove to be an issue, but it's generally poor form to be mutating the exported value of a node dependency, as it will impact any other loaded file which imports the same reference.

This PR adds `Object.assign` call to copy the default webpack config rather than mutating it directly.

## Testing

`npm run dev` and `npm run build` should work as before.