### PR TITLE
[Mobile]Update post title padding

### DIFF
--- a/packages/editor/src/components/post-title/style.native.scss
+++ b/packages/editor/src/components/post-title/style.native.scss
@@ -2,5 +2,7 @@
 .titleContainer {
 	padding-left: 16;
 	padding-right: 16;
+	padding-top: 12;
+	padding-bottom: 12;
 	margin-top: 24;
 }


### PR DESCRIPTION
## Description
This PR re-adds the post title vertical paddings. Paddings were removed in this PR https://github.com/WordPress/gutenberg/pull/13970#issuecomment-466053834 But after merging that we realized that title seems too tight somehow:

<img width="356" alt="screen shot 2019-02-21 at 21 58 15" src="https://user-images.githubusercontent.com/5032900/53227436-3e013300-368f-11e9-9015-57bfb251c6a8.png">

## How has this been tested?

Test using gutenberg-mobile PR https://github.com/wordpress-mobile/gutenberg-mobile/pull/645

## Screenshots <!-- if applicable -->

After:

Android:

![screenshot_1550821946](https://user-images.githubusercontent.com/5032900/53227748-3726f000-3690-11e9-9562-55e8cd29f9c9.png)


iOS:

<img width="360" alt="screen shot 2019-02-22 at 10 35 58" src="https://user-images.githubusercontent.com/5032900/53227153-83713080-368e-11e9-92aa-6fce0c6b3733.png">

<img width="338" alt="screen shot 2019-02-22 at 10 37 49" src="https://user-images.githubusercontent.com/5032900/53227154-83713080-368e-11e9-86d6-78601bdd1d4a.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
