### PR TITLE
Fix post title native syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ cache:
 branches:
   only:
     - master
+    - rnmobile/release-v1.0
 
 before_install:
   - nvm install

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -21,13 +21,12 @@ import styles from './style.scss';
 const minHeight = 30;
 
 class PostTitle extends Component {
-	titleViewRef: Object;
-
 	constructor() {
 		super( ...arguments );
 
 		this.onSelect = this.onSelect.bind( this );
 		this.onUnselect = this.onUnselect.bind( this );
+		this.titleViewRef = null;
 
 		this.state = {
 			isSelected: false,


### PR DESCRIPTION
## Description
This PR fixes a simple syntax issue when running the linter on the `rnmobile/release-v1.0` branch.

We need this fixed if we want to be able to merge back to `master`.

Fixes the following error when running `npm install`:
```
SyntaxError: /Users/tug/Work/Automattic/gutenberg/packages/editor/src/components/post-title/index.native.js: Unexpected token (24:13)

  22 |
  23 | class PostTitle extends Component {
> 24 |     titleViewRef: Object;
     |                 ^
  25 |
  26 |     constructor() {
  27 |         super( ...arguments );
```