### PR TITLE
[Enhancement] Add ability to transform video shortcodes to video blocks

### DIFF
--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -98,6 +98,42 @@ export const settings = {
 					return block;
 				},
 			},
+			{
+				type: 'shortcode',
+				tag: 'video',
+				attributes: {
+					src: {
+						type: 'string',
+						shortcode: ( { named: { src } } ) => {
+							return src;
+						},
+					},
+					poster: {
+						type: 'string',
+						shortcode: ( { named: { poster } } ) => {
+							return poster;
+						},
+					},
+					loop: {
+						type: 'string',
+						shortcode: ( { named: { loop } } ) => {
+							return loop;
+						},
+					},
+					autoplay: {
+						type: 'string',
+						shortcode: ( { named: { autoplay } } ) => {
+							return autoplay;
+						},
+					},
+					preload: {
+						type: 'string',
+						shortcode: ( { named: { preload } } ) => {
+							return preload;
+						},
+					},
+				},
+			},
 		],
 	},
 


### PR DESCRIPTION
## Description
This PR closes #14002 which requests the ability to transform `[video]` shortcodes to video blocks, like the gallery and caption shortcodes have.

## How has this been tested?
This PR has been tested by going through the following steps:

1. Using the Classic Editor, added a `[video]` shortcode to the content, e.g. `[video src="https://gutenberg.local/wp-content/uploads/2018/12/snow.mp4"]`
2. Using the Gutenberg editor, convert the Classic block contents to Gutenberg blocks using "Convert to Blocks".
3. Made sure that the shortcode converts to an appropriate video block and transform contains all the existing attributes of the shortcode.

## Screenshots <!-- if applicable -->
![14002-min](https://user-images.githubusercontent.com/20284937/53229490-8419bf00-36ae-11e9-8eda-d7f3fb0b4575.gif)

## Types of changes
This PR follows the shortcode transformation structure of the gallery and caption blocks and implements them accordingly in the video block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
