### PR TITLE
[Mobile] Implement pasteHandler with plain text fallback

### DIFF
--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -42,6 +42,27 @@ const unescapeSpaces = ( text ) => {
 	return text.replace( /&nbsp;|&#160;/gi, ' ' );
 };
 
+/**
+ * Calls {@link pasteHandler} with a fallback to plain text when HTML processing
+ * results in errors
+ *
+ * @param {Object}  [options]     The options to pass to {@link pasteHandler}
+ *
+ * @return {Array|string}         A list of blocks or a string, depending on
+ *                                `handlerMode`.
+ */
+const saferPasteHandler = ( options ) => {
+	try {
+		return pasteHandler( options );
+	} catch ( error ) {
+		window.console.log( 'Pasting HTML failed:', error );
+		window.console.log( 'HTML:', options.HTML );
+		window.console.log( 'Falling back to plain text.' );
+		// fallback to plain text
+		return pasteHandler( { ...options, HTML: '' } );
+	}
+};
+
 const gutenbergFormatNamesToAztec = {
 	'core/bold': 'bold',
 	'core/italic': 'italic',
@@ -308,7 +329,7 @@ export class RichText extends Component {
 			mode = 'AUTO';
 		}
 
-		const pastedContent = pasteHandler( {
+		const pastedContent = saferPasteHandler( {
 			HTML: pastedHtml,
 			plainText: pastedText,
 			mode,


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This PR aims to guard against errors in production during a paste event on mobile. As there are potentially many unexplored code paths (not yet covered by tests), the goal here is to call the original `pasteHandler` in a try/catch block, and fallback to plain text if an error is encountered.

Note that even in the plain text case, the `pasteHandler` may still call into some of the complex web code.

## How has this been tested?

Tested through: https://github.com/wordpress-mobile/gutenberg-mobile/pull/646

## Types of changes

This PR is to add a wrapper function around pasteHandler to try/catch HTML processing errors and fallback to plain text in the mobile environment.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
