### PR TITLE
[Enhancement] Add ability to transform audio shortcodes to audio blocks

### DIFF
--- a/packages/block-library/src/audio/index.js
+++ b/packages/block-library/src/audio/index.js
@@ -77,6 +77,36 @@ export const settings = {
 					return block;
 				},
 			},
+			{
+				type: 'shortcode',
+				tag: 'audio',
+				attributes: {
+					src: {
+						type: 'string',
+						shortcode: ( { named: { src } } ) => {
+							return src;
+						},
+					},
+					loop: {
+						type: 'string',
+						shortcode: ( { named: { loop } } ) => {
+							return loop;
+						},
+					},
+					autoplay: {
+						type: 'srting',
+						shortcode: ( { named: { autoplay } } ) => {
+							return autoplay;
+						},
+					},
+					preload: {
+						type: 'string',
+						shortcode: ( { named: { preload } } ) => {
+							return preload;
+						},
+					},
+				},
+			},
 		],
 	},
 


### PR DESCRIPTION
## Description
This PR adds the ability to transform `[audio]` shortcodes to audio blocks, like the gallery and caption shortcodes have.

## How has this been tested?
This PR has been tested by going through the following steps:

1. Using the Classic Editor, added a `[audio]` shortcode to the content, e.g. `[audio src="https://gutenberg.local/wp-content/uploads/2018/12/snow.mp3"]`
2. Using the Gutenberg editor, convert the Classic block contents to Gutenberg blocks using "Convert to Blocks".
3. Made sure that the shortcode converts to an appropriate audio block and transform contains all the existing attributes of the shortcode.

## Screenshots <!-- if applicable -->
![gutenberg-audio-shortcode-transform-block-min](https://user-images.githubusercontent.com/20284937/53230820-c09aea00-36b1-11e9-980d-54df2043f659.gif)

## Types of changes
This PR follows the shortcode transformation structure of the gallery and caption blocks and implements them accordingly in the audio block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
