### PR TITLE
Try removing the WP update for the e2e tests script

### DIFF
--- a/bin/install-wordpress.sh
+++ b/bin/install-wordpress.sh
@@ -78,6 +78,8 @@ if [ "$WP_VERSION" == "latest" ]; then
 	# Check for WordPress updates, to make sure we're running the very latest version.
 	echo -e $(status_message "Updating WordPress to the latest version...")
 	docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI core update --quiet
+	echo -e $(status_message "Updating The WordPress Database...")
+	docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI core update-db --quiet
 fi
 
 # If the 'wordpress' volume wasn't during the down/up earlier, but the post port has changed, we need to update it.


### PR DESCRIPTION
With the WordPress 5.1 release, the e2e tests are failing. Let's see if we can fix them.