### PR TITLE
Link fixes

### DIFF
--- a/packages/format-library/src/link/modal.native.js
+++ b/packages/format-library/src/link/modal.native.js
@@ -84,7 +84,7 @@ class ModalLinkUI extends Component {
 		const placeholderFormats = ( value.formatPlaceholder && value.formatPlaceholder.formats ) || [];
 
 		if ( isCollapsed( value ) && ! isActive ) { // insert link
-			const toInsert = applyFormat( create( { text: linkText } ), [ ...placeholderFormats, format ], 0, text.length );
+			const toInsert = applyFormat( create( { text: linkText } ), [ ...placeholderFormats, format ], 0, linkText.length );
 			onChange( insert( value, toInsert ) );
 		} else if ( text !== getTextContent( slice( value ) ) ) { // edit text in selected link
 			const toInsert = applyFormat( create( { text } ), [ ...placeholderFormats, format ], 0, text.length );


### PR DESCRIPTION
## Description
Fix the link interface in order to support correctly links to empty text.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

This can be tested in GB-mobile here: https://github.com/wordpress-mobile/gutenberg-mobile/pull/649


