### PR TITLE
Add repository.directory fields (fixes #13946)

### DIFF
--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -12,7 +12,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/a11y/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/a11y"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -11,7 +11,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/annotations/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/annotations"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/api-fetch/package.json
+++ b/packages/api-fetch/package.json
@@ -12,7 +12,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/api-fetch/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/api-fetch"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/autop/package.json
+++ b/packages/autop/package.json
@@ -11,7 +11,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/autop/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/autop"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/babel-plugin-import-jsx-pragma/package.json
+++ b/packages/babel-plugin-import-jsx-pragma/package.json
@@ -14,7 +14,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/babel-plugin-import-jsx-pragma/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/babel-plugin-import-jsx-pragma"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/babel-plugin-makepot/package.json
+++ b/packages/babel-plugin-makepot/package.json
@@ -13,7 +13,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/babel-plugin-makepot/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/babel-plugin-makepot"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -13,7 +13,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/babel-preset-default/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/babel-preset-default"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -11,7 +11,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/blob/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/blob"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -12,7 +12,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/block-editor/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/block-editor"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -11,7 +11,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/block-library/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/block-library"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/block-serialization-default-parser/package.json
+++ b/packages/block-serialization-default-parser/package.json
@@ -12,7 +12,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/block-serialization-default-parser/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/block-serialization-default-parser"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/block-serialization-spec-parser/package.json
+++ b/packages/block-serialization-spec-parser/package.json
@@ -13,7 +13,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/block-serialization-spec-parser/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/block-serialization-spec-parser"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -11,7 +11,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/blocks/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/blocks"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -12,7 +12,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/browserslist-config/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/browserslist-config"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -11,7 +11,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/components/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/components"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -12,7 +12,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/compose/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/compose"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -12,7 +12,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/core-data/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/core-data"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/custom-templated-path-webpack-plugin/package.json
+++ b/packages/custom-templated-path-webpack-plugin/package.json
@@ -12,7 +12,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/blob/master/packages/custom-templated-path-webpack-plugin/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/custom-templated-path-webpack-plugin"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -12,7 +12,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/data/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/data"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -11,7 +11,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/date/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/date"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/deprecated/package.json
+++ b/packages/deprecated/package.json
@@ -11,7 +11,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/deprecated/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/deprecated"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/dom-ready/package.json
+++ b/packages/dom-ready/package.json
@@ -11,7 +11,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/dom-ready/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/dom-ready"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -12,7 +12,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/dom/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/dom"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/e2e-test-utils/package.json
+++ b/packages/e2e-test-utils/package.json
@@ -12,7 +12,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/e2e-test-utils/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/e2e-test-utils"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -12,7 +12,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/e2e-tests/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/e2e-tests"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -11,7 +11,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/edit-post/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/edit-post"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -11,7 +11,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/edit-widgets/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/edit-widgets"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -11,7 +11,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/editor/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/editor"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -12,7 +12,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/element/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/element"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/escape-html/package.json
+++ b/packages/escape-html/package.json
@@ -10,7 +10,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/escape-html/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/escape-html"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -11,7 +11,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/eslint-plugin/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/eslint-plugin"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/format-library/package.json
+++ b/packages/format-library/package.json
@@ -11,7 +11,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/format-library/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/format-library"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -11,7 +11,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/hooks/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/hooks"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/html-entities/package.json
+++ b/packages/html-entities/package.json
@@ -13,7 +13,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/html-entities/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/html-entities"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -11,7 +11,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/i18n/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/i18n"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/is-shallow-equal/package.json
+++ b/packages/is-shallow-equal/package.json
@@ -13,7 +13,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/is-shallow-equal/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/is-shallow-equal"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -13,7 +13,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/jest-console/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/jest-console"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/jest-preset-default/package.json
+++ b/packages/jest-preset-default/package.json
@@ -15,7 +15,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/jest-preset-default/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/jest-preset-default"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/jest-puppeteer-axe/package.json
+++ b/packages/jest-puppeteer-axe/package.json
@@ -14,7 +14,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/jest-puppeteer-axe/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/jest-puppeteer-axe"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -11,7 +11,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/keycodes/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/keycodes"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/library-export-default-webpack-plugin/package.json
+++ b/packages/library-export-default-webpack-plugin/package.json
@@ -12,7 +12,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/library-export-default-webpack-plugin/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/library-export-default-webpack-plugin"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/list-reusable-blocks/package.json
+++ b/packages/list-reusable-blocks/package.json
@@ -11,7 +11,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/list-reusable-blocks/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/list-reusable-blocks"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/notices/package.json
+++ b/packages/notices/package.json
@@ -11,7 +11,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/notices/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/notices"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/npm-package-json-lint-config/package.json
+++ b/packages/npm-package-json-lint-config/package.json
@@ -12,7 +12,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/npm-package-json-lint-config/README.md",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/WordPress/gutenberg.git"
+		"url": "git+https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/npm-package-json-lint-config"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/nux/package.json
+++ b/packages/nux/package.json
@@ -11,7 +11,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/nux/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/nux"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -11,7 +11,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/plugins/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/plugins"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/postcss-themes/package.json
+++ b/packages/postcss-themes/package.json
@@ -15,7 +15,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/postcss-themes/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/postcss-themes"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/priority-queue/package.json
+++ b/packages/priority-queue/package.json
@@ -12,7 +12,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/priority-queue/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/priority-queue"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/redux-routine/package.json
+++ b/packages/redux-routine/package.json
@@ -13,7 +13,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/redux-routine/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/redux-routine"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -11,7 +11,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/rich-text/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/rich-text"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -13,7 +13,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/scripts/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/scripts"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/shortcode/package.json
+++ b/packages/shortcode/package.json
@@ -11,7 +11,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/shortcode/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/shortcode"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/token-list/package.json
+++ b/packages/token-list/package.json
@@ -10,7 +10,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/token-list/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/token-list"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -11,7 +11,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/url/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/url"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -11,7 +11,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/viewport/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WordPress/gutenberg.git"
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/viewport"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"

--- a/packages/wordcount/package.json
+++ b/packages/wordcount/package.json
@@ -11,7 +11,8 @@
 	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/wordcount/README.md",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/WordPress/gutenberg.git"
+		"url": "git+https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/wordcount"
 	},
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"


### PR DESCRIPTION
## Description
Closes #13946.

This PR adds `repository.directory` fields to all packages.

## How has this been tested?
Changes linted using `npm run lint`.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->