### PR TITLE
Stop building the mobile release branch on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ cache:
 branches:
   only:
     - master
-    - rnmobile/release-v1.0
 
 before_install:
   - nvm install


### PR DESCRIPTION
Remove the Travis configuration that enabled us to have CI on the native mobile release branch, in preparation of merging the release branch to master.

Will self-merge this one, it's against the release branch anyway.