### PR TITLE
661 image placeholder moves out of its bounds once we tap on it

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -340,14 +340,6 @@ class ImageEdit extends React.Component {
 								imageHeightWithinContainer,
 							} = sizes;
 
-							if ( imageWidthWithinContainer === undefined ) {
-								return (
-									<View style={ styles.imageContainer } >
-										<Dashicon icon={ 'format-image' } size={ 300 } />
-									</View>
-								);
-							}
-
 							let finalHeight = imageHeightWithinContainer;
 							if ( height > 0 && height < imageHeightWithinContainer ) {
 								finalHeight = height;
@@ -362,6 +354,9 @@ class ImageEdit extends React.Component {
 								<View style={ { flex: 1 } } >
 									{ getInspectorControls() }
 									{ getMediaOptions() }
+									{ ! imageWidthWithinContainer && <View style={ styles.imageContainer } >
+										<Dashicon icon={ 'format-image' } size={ 300 } />
+									</View> }
 									<ImageBackground
 										style={ { width: finalWidth, height: finalHeight, opacity } }
 										resizeMethod="scale"


### PR DESCRIPTION
## Description
Image placeholder moves out of its bounds once we tap on it

## How has this been tested?
Open a post that has at least 1 image block
See that there's a placeholder in the image block until it's downloaded
Tap to the placeholder
It doesn't move out of its bounds
