### PR TITLE
Use platform based SCSS vars for block minHeight

### DIFF
--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -19,9 +19,7 @@ import { createBlock } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import './editor.scss';
-
-const minHeight = 24;
+import styles from './style.scss';
 
 class HeadingEdit extends Component {
 	constructor( props ) {
@@ -47,6 +45,9 @@ class HeadingEdit extends Component {
 		} = attributes;
 
 		const tagName = 'h' + level;
+
+		const minHeight = styles.blockText.minHeight;
+
 		return (
 			<View>
 				<BlockControls>

--- a/packages/block-library/src/heading/style.native.scss
+++ b/packages/block-library/src/heading/style.native.scss
@@ -1,5 +1,5 @@
 @import "variables.scss";
 
 .blockText {
-	min-height: $min-height-paragraph;
+	min-height: $min-height-heading;
 }

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -18,8 +18,6 @@ import { withInstanceId, compose } from '@wordpress/compose';
  */
 import styles from './style.scss';
 
-const minHeight = 30;
-
 class PostTitle extends Component {
 	constructor() {
 		super( ...arguments );
@@ -71,6 +69,8 @@ class PostTitle extends Component {
 
 		const decodedPlaceholder = decodeEntities( placeholder );
 		const borderColor = this.state.isSelected ? focusedBorderColor : 'transparent';
+
+		const minHeight = styles.blockText.minHeight;
 
 		return (
 			<View style={ [ styles.titleContainer, borderStyle, { borderColor } ] }>

--- a/packages/editor/src/components/post-title/style.native.scss
+++ b/packages/editor/src/components/post-title/style.native.scss
@@ -1,6 +1,10 @@
 
 @import "variables.scss";
 
+.blockText {
+	min-height: $min-height-title;
+}
+
 .titleContainer {
 	padding-left: 16;
 	padding-right: 16;


### PR DESCRIPTION
## Description
Introduced SCSS variables to set the min-height for the paragraph, heading and post title blocks on native mobile. At the moment, Aztec has different internal padding on iOS than on Android so, need to have platform-based min-height to avoid a noticeable glitch when the block first renders and resizes.

The variables values themselves are defined in SCSS files that live in the gutenberg-mobile repo ([Android](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/src/variables.android.scss), [iOS](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/src/variables.ios.scss)).

## How has this been tested?
Using this gutenberg-mobile side PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/664

## Types of changes
SCSS variables to set the min-height for the paragraph, heading and post title blocks.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
