### PR TITLE
Added testcases for isKeyboardEvent in keycodes module

### DIFF
--- a/packages/keycodes/src/test/index.js
+++ b/packages/keycodes/src/test/index.js
@@ -247,19 +247,22 @@ describe( 'isKeyboardEvent', () => {
 		} );
 	}
 
-	function attachEventListeners( target, eventHandler ) {
+	function attachEventListeners( eventHandler ) {
+		const attachNode = document.createElement( 'div' );
+		document.body.appendChild( attachNode );
+
 		[ 'keydown', 'keypress', 'keyup' ].forEach( ( eventName ) => {
-			target.addEventListener( eventName, eventHandler );
+			attachNode.addEventListener( eventName, eventHandler );
 		} );
+
+		return attachNode;
 	}
 
 	describe( 'primary', () => {
-		it( 'should identify modifier key when Ctrl is pressed', ( done ) => {
-			const attachNode = document.createElement( 'div' );
-			document.body.appendChild( attachNode );
-			attachEventListeners( attachNode, ( event ) => {
+		it( 'should identify modifier key when Ctrl is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
 				expect( isKeyboardEvent.primary( event, undefined, isAppleOSFalse ) ).toBe( true );
-				done();
 			} );
 
 			keyPress( attachNode, {
@@ -268,12 +271,10 @@ describe( 'isKeyboardEvent', () => {
 			} );
 		} );
 
-		it( 'should identify modifier key when ⌘ is pressed', ( done ) => {
-			const attachNode = document.createElement( 'div' );
-			document.body.appendChild( attachNode );
-			attachEventListeners( attachNode, ( event ) => {
+		it( 'should identify modifier key when ⌘ is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
 				expect( isKeyboardEvent.primary( event, undefined, isAppleOSTrue ) ).toBe( true );
-				done();
 			} );
 
 			keyPress( attachNode, {
@@ -282,12 +283,10 @@ describe( 'isKeyboardEvent', () => {
 			} );
 		} );
 
-		it( 'should identify modifier key when Ctrl + M is pressed', ( done ) => {
-			const attachNode = document.createElement( 'div' );
-			document.body.appendChild( attachNode );
-			attachEventListeners( attachNode, ( event ) => {
+		it( 'should identify modifier key when Ctrl + M is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
 				expect( isKeyboardEvent.primary( event, 'm', isAppleOSFalse ) ).toBe( true );
-				done();
 			} );
 
 			keyPress( attachNode, {
@@ -296,12 +295,10 @@ describe( 'isKeyboardEvent', () => {
 			} );
 		} );
 
-		it( 'should identify modifier key when ⌘M is pressed', ( done ) => {
-			const attachNode = document.createElement( 'div' );
-			document.body.appendChild( attachNode );
-			attachEventListeners( attachNode, ( event ) => {
+		it( 'should identify modifier key when ⌘M is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
 				expect( isKeyboardEvent.primary( event, 'm', isAppleOSTrue ) ).toBe( true );
-				done();
 			} );
 
 			keyPress( attachNode, {
@@ -312,12 +309,10 @@ describe( 'isKeyboardEvent', () => {
 	} );
 
 	describe( 'primaryShift', () => {
-		it( 'should identify modifier key when Shift + Ctrl is pressed', ( done ) => {
-			const attachNode = document.createElement( 'div' );
-			document.body.appendChild( attachNode );
-			attachEventListeners( attachNode, ( event ) => {
+		it( 'should identify modifier key when Shift + Ctrl is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
 				expect( isKeyboardEvent.primary( event, undefined, isAppleOSFalse ) ).toBe( true );
-				done();
 			} );
 
 			keyPress( attachNode, {
@@ -327,12 +322,10 @@ describe( 'isKeyboardEvent', () => {
 			} );
 		} );
 
-		it( 'should identify modifier key when ⇧⌘ is pressed', ( done ) => {
-			const attachNode = document.createElement( 'div' );
-			document.body.appendChild( attachNode );
-			attachEventListeners( attachNode, ( event ) => {
+		it( 'should identify modifier key when ⇧⌘ is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
 				expect( isKeyboardEvent.primary( event, undefined, isAppleOSTrue ) ).toBe( true );
-				done();
 			} );
 
 			keyPress( attachNode, {
@@ -342,12 +335,10 @@ describe( 'isKeyboardEvent', () => {
 			} );
 		} );
 
-		it( 'should identify modifier key when Shift + Ctrl + M is pressed', ( done ) => {
-			const attachNode = document.createElement( 'div' );
-			document.body.appendChild( attachNode );
-			attachEventListeners( attachNode, ( event ) => {
+		it( 'should identify modifier key when Shift + Ctrl + M is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
 				expect( isKeyboardEvent.primary( event, 'm', isAppleOSFalse ) ).toBe( true );
-				done();
 			} );
 
 			keyPress( attachNode, {
@@ -357,12 +348,10 @@ describe( 'isKeyboardEvent', () => {
 			} );
 		} );
 
-		it( 'should identify modifier key when ⇧⌘M is pressed', ( done ) => {
-			const attachNode = document.createElement( 'div' );
-			document.body.appendChild( attachNode );
-			attachEventListeners( attachNode, ( event ) => {
+		it( 'should identify modifier key when ⇧⌘M is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
 				expect( isKeyboardEvent.primary( event, 'm', isAppleOSTrue ) ).toBe( true );
-				done();
 			} );
 
 			keyPress( attachNode, {
@@ -374,12 +363,10 @@ describe( 'isKeyboardEvent', () => {
 	} );
 
 	describe( 'secondary', () => {
-		it( 'should identify modifier key when Shift + Alt + Ctrl is pressed', ( done ) => {
-			const attachNode = document.createElement( 'div' );
-			document.body.appendChild( attachNode );
-			attachEventListeners( attachNode, ( event ) => {
+		it( 'should identify modifier key when Shift + Alt + Ctrl is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
 				expect( isKeyboardEvent.primary( event, undefined, isAppleOSFalse ) ).toBe( true );
-				done();
 			} );
 
 			keyPress( attachNode, {
@@ -390,12 +377,10 @@ describe( 'isKeyboardEvent', () => {
 			} );
 		} );
 
-		it( 'should identify modifier key when ⇧⌥⌘ is pressed', ( done ) => {
-			const attachNode = document.createElement( 'div' );
-			document.body.appendChild( attachNode );
-			attachEventListeners( attachNode, ( event ) => {
+		it( 'should identify modifier key when ⇧⌥⌘ is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
 				expect( isKeyboardEvent.primary( event, undefined, isAppleOSTrue ) ).toBe( true );
-				done();
 			} );
 
 			keyPress( attachNode, {
@@ -406,12 +391,10 @@ describe( 'isKeyboardEvent', () => {
 			} );
 		} );
 
-		it( 'should identify modifier key when Shift + Ctrl + ALt + M is pressed', ( done ) => {
-			const attachNode = document.createElement( 'div' );
-			document.body.appendChild( attachNode );
-			attachEventListeners( attachNode, ( event ) => {
+		it( 'should identify modifier key when Shift + Ctrl + ALt + M is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
 				expect( isKeyboardEvent.primary( event, 'm', isAppleOSFalse ) ).toBe( true );
-				done();
 			} );
 
 			keyPress( attachNode, {
@@ -422,12 +405,10 @@ describe( 'isKeyboardEvent', () => {
 			} );
 		} );
 
-		it( 'should identify modifier key when ⇧⌥⌘M is pressed', ( done ) => {
-			const attachNode = document.createElement( 'div' );
-			document.body.appendChild( attachNode );
-			attachEventListeners( attachNode, ( event ) => {
+		it( 'should identify modifier key when ⇧⌥⌘M is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
 				expect( isKeyboardEvent.primary( event, 'm', isAppleOSTrue ) ).toBe( true );
-				done();
 			} );
 
 			keyPress( attachNode, {
@@ -440,12 +421,10 @@ describe( 'isKeyboardEvent', () => {
 	} );
 
 	describe( 'access', () => {
-		it( 'should identify modifier key when Alt + Ctrl is pressed', ( done ) => {
-			const attachNode = document.createElement( 'div' );
-			document.body.appendChild( attachNode );
-			attachEventListeners( attachNode, ( event ) => {
+		it( 'should identify modifier key when Alt + Ctrl is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
 				expect( isKeyboardEvent.primary( event, undefined, isAppleOSFalse ) ).toBe( true );
-				done();
 			} );
 
 			keyPress( attachNode, {
@@ -455,12 +434,10 @@ describe( 'isKeyboardEvent', () => {
 			} );
 		} );
 
-		it( 'should identify modifier key when ⌥⌘ is pressed', ( done ) => {
-			const attachNode = document.createElement( 'div' );
-			document.body.appendChild( attachNode );
-			attachEventListeners( attachNode, ( event ) => {
+		it( 'should identify modifier key when ⌥⌘ is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
 				expect( isKeyboardEvent.primary( event, undefined, isAppleOSTrue ) ).toBe( true );
-				done();
 			} );
 
 			keyPress( attachNode, {
@@ -470,12 +447,10 @@ describe( 'isKeyboardEvent', () => {
 			} );
 		} );
 
-		it( 'should identify modifier key when Ctrl + ALt + M is pressed', ( done ) => {
-			const attachNode = document.createElement( 'div' );
-			document.body.appendChild( attachNode );
-			attachEventListeners( attachNode, ( event ) => {
+		it( 'should identify modifier key when Ctrl + ALt + M is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
 				expect( isKeyboardEvent.primary( event, 'm', isAppleOSFalse ) ).toBe( true );
-				done();
 			} );
 
 			keyPress( attachNode, {
@@ -485,12 +460,10 @@ describe( 'isKeyboardEvent', () => {
 			} );
 		} );
 
-		it( 'should identify modifier key when ⌥⌘M is pressed', ( done ) => {
-			const attachNode = document.createElement( 'div' );
-			document.body.appendChild( attachNode );
-			attachEventListeners( attachNode, ( event ) => {
+		it( 'should identify modifier key when ⌥⌘M is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
 				expect( isKeyboardEvent.primary( event, 'm', isAppleOSTrue ) ).toBe( true );
-				done();
 			} );
 
 			keyPress( attachNode, {

--- a/packages/keycodes/src/test/index.js
+++ b/packages/keycodes/src/test/index.js
@@ -6,6 +6,7 @@ import {
 	displayShortcut,
 	rawShortcut,
 	shortcutAriaLabel,
+	isKeyboardEvent,
 } from '../';
 
 const isAppleOSFalse = () => false;
@@ -227,6 +228,276 @@ describe( 'rawShortcut', () => {
 		it( 'should output ctrl+alt on MacOS', () => {
 			const shortcut = rawShortcut.access( 'm', isAppleOSTrue );
 			expect( shortcut ).toEqual( 'ctrl+alt+m' );
+		} );
+	} );
+} );
+
+describe( 'isKeyboardEvent', () => {
+	afterEach( () => {
+		while ( document.body.firstChild ) {
+			document.body.removeChild( document.body.firstChild );
+		}
+	} );
+
+	function keyPress( target, modifiers = {} ) {
+		[ 'keydown', 'keypress', 'keyup' ].forEach( ( eventName ) => {
+			const event = new window.Event( eventName, { bubbles: true } );
+			Object.assign( event, modifiers );
+			target.dispatchEvent( event );
+		} );
+	}
+
+	function attachEventListeners( target, eventHandler ) {
+		[ 'keydown', 'keypress', 'keyup' ].forEach( ( eventName ) => {
+			target.addEventListener( eventName, eventHandler );
+		} );
+	}
+
+	describe( 'primary', () => {
+		it( 'should identify modifier key when Ctrl is pressed', ( done ) => {
+			const attachNode = document.createElement( 'div' );
+			document.body.appendChild( attachNode );
+			attachEventListeners( attachNode, ( event ) => {
+				expect( isKeyboardEvent.primary( event, undefined, isAppleOSFalse ) ).toBe( true );
+				done();
+			} );
+
+			keyPress( attachNode, {
+				ctrlKey: true,
+				key: 'Ctrl',
+			} );
+		} );
+
+		it( 'should identify modifier key when ⌘ is pressed', ( done ) => {
+			const attachNode = document.createElement( 'div' );
+			document.body.appendChild( attachNode );
+			attachEventListeners( attachNode, ( event ) => {
+				expect( isKeyboardEvent.primary( event, undefined, isAppleOSTrue ) ).toBe( true );
+				done();
+			} );
+
+			keyPress( attachNode, {
+				metaKey: true,
+				key: 'Meta',
+			} );
+		} );
+
+		it( 'should identify modifier key when Ctrl + M is pressed', ( done ) => {
+			const attachNode = document.createElement( 'div' );
+			document.body.appendChild( attachNode );
+			attachEventListeners( attachNode, ( event ) => {
+				expect( isKeyboardEvent.primary( event, 'm', isAppleOSFalse ) ).toBe( true );
+				done();
+			} );
+
+			keyPress( attachNode, {
+				ctrlKey: true,
+				key: 'm',
+			} );
+		} );
+
+		it( 'should identify modifier key when ⌘M is pressed', ( done ) => {
+			const attachNode = document.createElement( 'div' );
+			document.body.appendChild( attachNode );
+			attachEventListeners( attachNode, ( event ) => {
+				expect( isKeyboardEvent.primary( event, 'm', isAppleOSTrue ) ).toBe( true );
+				done();
+			} );
+
+			keyPress( attachNode, {
+				metaKey: true,
+				key: 'm',
+			} );
+		} );
+	} );
+
+	describe( 'primaryShift', () => {
+		it( 'should identify modifier key when Shift + Ctrl is pressed', ( done ) => {
+			const attachNode = document.createElement( 'div' );
+			document.body.appendChild( attachNode );
+			attachEventListeners( attachNode, ( event ) => {
+				expect( isKeyboardEvent.primary( event, undefined, isAppleOSFalse ) ).toBe( true );
+				done();
+			} );
+
+			keyPress( attachNode, {
+				ctrlKey: true,
+				shiftKey: true,
+				key: 'Ctrl',
+			} );
+		} );
+
+		it( 'should identify modifier key when ⇧⌘ is pressed', ( done ) => {
+			const attachNode = document.createElement( 'div' );
+			document.body.appendChild( attachNode );
+			attachEventListeners( attachNode, ( event ) => {
+				expect( isKeyboardEvent.primary( event, undefined, isAppleOSTrue ) ).toBe( true );
+				done();
+			} );
+
+			keyPress( attachNode, {
+				metaKey: true,
+				shiftKey: true,
+				key: 'Meta',
+			} );
+		} );
+
+		it( 'should identify modifier key when Shift + Ctrl + M is pressed', ( done ) => {
+			const attachNode = document.createElement( 'div' );
+			document.body.appendChild( attachNode );
+			attachEventListeners( attachNode, ( event ) => {
+				expect( isKeyboardEvent.primary( event, 'm', isAppleOSFalse ) ).toBe( true );
+				done();
+			} );
+
+			keyPress( attachNode, {
+				ctrlKey: true,
+				shiftKey: true,
+				key: 'm',
+			} );
+		} );
+
+		it( 'should identify modifier key when ⇧⌘M is pressed', ( done ) => {
+			const attachNode = document.createElement( 'div' );
+			document.body.appendChild( attachNode );
+			attachEventListeners( attachNode, ( event ) => {
+				expect( isKeyboardEvent.primary( event, 'm', isAppleOSTrue ) ).toBe( true );
+				done();
+			} );
+
+			keyPress( attachNode, {
+				metaKey: true,
+				shiftKey: true,
+				key: 'm',
+			} );
+		} );
+	} );
+
+	describe( 'secondary', () => {
+		it( 'should identify modifier key when Shift + Alt + Ctrl is pressed', ( done ) => {
+			const attachNode = document.createElement( 'div' );
+			document.body.appendChild( attachNode );
+			attachEventListeners( attachNode, ( event ) => {
+				expect( isKeyboardEvent.primary( event, undefined, isAppleOSFalse ) ).toBe( true );
+				done();
+			} );
+
+			keyPress( attachNode, {
+				ctrlKey: true,
+				shiftKey: true,
+				altKey: true,
+				key: 'Ctrl',
+			} );
+		} );
+
+		it( 'should identify modifier key when ⇧⌥⌘ is pressed', ( done ) => {
+			const attachNode = document.createElement( 'div' );
+			document.body.appendChild( attachNode );
+			attachEventListeners( attachNode, ( event ) => {
+				expect( isKeyboardEvent.primary( event, undefined, isAppleOSTrue ) ).toBe( true );
+				done();
+			} );
+
+			keyPress( attachNode, {
+				metaKey: true,
+				shiftKey: true,
+				altKey: true,
+				key: 'Meta',
+			} );
+		} );
+
+		it( 'should identify modifier key when Shift + Ctrl + ALt + M is pressed', ( done ) => {
+			const attachNode = document.createElement( 'div' );
+			document.body.appendChild( attachNode );
+			attachEventListeners( attachNode, ( event ) => {
+				expect( isKeyboardEvent.primary( event, 'm', isAppleOSFalse ) ).toBe( true );
+				done();
+			} );
+
+			keyPress( attachNode, {
+				ctrlKey: true,
+				shiftKey: true,
+				altKey: true,
+				key: 'm',
+			} );
+		} );
+
+		it( 'should identify modifier key when ⇧⌥⌘M is pressed', ( done ) => {
+			const attachNode = document.createElement( 'div' );
+			document.body.appendChild( attachNode );
+			attachEventListeners( attachNode, ( event ) => {
+				expect( isKeyboardEvent.primary( event, 'm', isAppleOSTrue ) ).toBe( true );
+				done();
+			} );
+
+			keyPress( attachNode, {
+				metaKey: true,
+				shiftKey: true,
+				altKey: true,
+				key: 'm',
+			} );
+		} );
+	} );
+
+	describe( 'access', () => {
+		it( 'should identify modifier key when Alt + Ctrl is pressed', ( done ) => {
+			const attachNode = document.createElement( 'div' );
+			document.body.appendChild( attachNode );
+			attachEventListeners( attachNode, ( event ) => {
+				expect( isKeyboardEvent.primary( event, undefined, isAppleOSFalse ) ).toBe( true );
+				done();
+			} );
+
+			keyPress( attachNode, {
+				ctrlKey: true,
+				altKey: true,
+				key: 'Ctrl',
+			} );
+		} );
+
+		it( 'should identify modifier key when ⌥⌘ is pressed', ( done ) => {
+			const attachNode = document.createElement( 'div' );
+			document.body.appendChild( attachNode );
+			attachEventListeners( attachNode, ( event ) => {
+				expect( isKeyboardEvent.primary( event, undefined, isAppleOSTrue ) ).toBe( true );
+				done();
+			} );
+
+			keyPress( attachNode, {
+				metaKey: true,
+				altKey: true,
+				key: 'Meta',
+			} );
+		} );
+
+		it( 'should identify modifier key when Ctrl + ALt + M is pressed', ( done ) => {
+			const attachNode = document.createElement( 'div' );
+			document.body.appendChild( attachNode );
+			attachEventListeners( attachNode, ( event ) => {
+				expect( isKeyboardEvent.primary( event, 'm', isAppleOSFalse ) ).toBe( true );
+				done();
+			} );
+
+			keyPress( attachNode, {
+				ctrlKey: true,
+				altKey: true,
+				key: 'm',
+			} );
+		} );
+
+		it( 'should identify modifier key when ⌥⌘M is pressed', ( done ) => {
+			const attachNode = document.createElement( 'div' );
+			document.body.appendChild( attachNode );
+			attachEventListeners( attachNode, ( event ) => {
+				expect( isKeyboardEvent.primary( event, 'm', isAppleOSTrue ) ).toBe( true );
+				done();
+			} );
+
+			keyPress( attachNode, {
+				metaKey: true,
+				altKey: true,
+				key: 'm',
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Description
Unit Test for isKeyboardEvent function in @wordpress/keycodes. Referencing issue #13812.

## How has this been tested?
The test cases cover the following modifiers:
- primary
- primaryShift
- secondary
- access

For each of the modifiers the respective key event both with and without the character key is tested.

## Screenshots 
![image](https://user-images.githubusercontent.com/20453492/53297009-e8d73580-37e4-11e9-9d36-ae973b7b0e54.png)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
