### PR TITLE
[Native mobile] Bring release v1.0.1 back to "mobile develop"

### DIFF
--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -19,9 +19,7 @@ import { createBlock } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import './editor.scss';
-
-const minHeight = 24;
+import styles from './style.scss';
 
 class HeadingEdit extends Component {
 	constructor( props ) {
@@ -47,6 +45,9 @@ class HeadingEdit extends Component {
 		} = attributes;
 
 		const tagName = 'h' + level;
+
+		const minHeight = styles.blockText.minHeight;
+
 		return (
 			<View>
 				<BlockControls>

--- a/packages/block-library/src/heading/style.native.scss
+++ b/packages/block-library/src/heading/style.native.scss
@@ -1,5 +1,5 @@
 @import "variables.scss";
 
 .blockText {
-	min-height: $min-height-paragraph;
+	min-height: $min-height-heading;
 }

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -340,14 +340,6 @@ class ImageEdit extends React.Component {
 								imageHeightWithinContainer,
 							} = sizes;
 
-							if ( imageWidthWithinContainer === undefined ) {
-								return (
-									<View style={ styles.imageContainer } >
-										<Dashicon icon={ 'format-image' } size={ 300 } />
-									</View>
-								);
-							}
-
 							let finalHeight = imageHeightWithinContainer;
 							if ( height > 0 && height < imageHeightWithinContainer ) {
 								finalHeight = height;
@@ -362,6 +354,9 @@ class ImageEdit extends React.Component {
 								<View style={ { flex: 1 } } >
 									{ getInspectorControls() }
 									{ getMediaOptions() }
+									{ ! imageWidthWithinContainer && <View style={ styles.imageContainer } >
+										<Dashicon icon={ 'format-image' } size={ 300 } />
+									</View> }
 									<ImageBackground
 										style={ { width: finalWidth, height: finalHeight, opacity } }
 										resizeMethod="scale"

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -18,8 +18,6 @@ import { withInstanceId, compose } from '@wordpress/compose';
  */
 import styles from './style.scss';
 
-const minHeight = 30;
-
 class PostTitle extends Component {
 	constructor() {
 		super( ...arguments );
@@ -71,6 +69,8 @@ class PostTitle extends Component {
 
 		const decodedPlaceholder = decodeEntities( placeholder );
 		const borderColor = this.state.isSelected ? focusedBorderColor : 'transparent';
+
+		const minHeight = styles.blockText.minHeight;
 
 		return (
 			<View style={ [ styles.titleContainer, borderStyle, { borderColor } ] }>

--- a/packages/editor/src/components/post-title/style.native.scss
+++ b/packages/editor/src/components/post-title/style.native.scss
@@ -1,6 +1,10 @@
 
 @import "variables.scss";
 
+.blockText {
+	min-height: $min-height-title;
+}
+
 .titleContainer {
 	padding-left: 16;
 	padding-right: 16;


### PR DESCRIPTION
## Description
This PR brings the gutenberg-mobile release v1.0.1 back into `rnmobile/develop`.

Note: `rnmobile/develop` is the temporary "develop" branch for the native mobile work, only existing because there are breaking changes in master that we hadn't had the chance to port to mobile yet.

## How has this been tested?
All work has been tested as part of the 2 fixes included.

## Types of changes
Native mobile changes only, related to styling. See #14066, #14070.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
