### PR TITLE
Update packages used by eslint plugin to remove warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2832,9 +2832,73 @@
 			"dev": true,
 			"requires": {
 				"babel-eslint": "^8.0.3",
-				"eslint-plugin-jsx-a11y": "6.0.2",
-				"eslint-plugin-react": "7.7.0",
+				"eslint-plugin-jsx-a11y": "^6.2.1",
+				"eslint-plugin-react": "^7.12.4",
 				"requireindex": "^1.2.0"
+			},
+			"dependencies": {
+				"emoji-regex": {
+					"version": "7.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"eslint-plugin-jsx-a11y": {
+					"version": "6.2.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"aria-query": "^3.0.0",
+						"array-includes": "^3.0.3",
+						"ast-types-flow": "^0.0.7",
+						"axobject-query": "^2.0.2",
+						"damerau-levenshtein": "^1.0.4",
+						"emoji-regex": "^7.0.2",
+						"has": "^1.0.3",
+						"jsx-ast-utils": "^2.0.1"
+					}
+				},
+				"eslint-plugin-react": {
+					"version": "7.12.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"array-includes": "^3.0.3",
+						"doctrine": "^2.1.0",
+						"has": "^1.0.3",
+						"jsx-ast-utils": "^2.0.1",
+						"object.fromentries": "^2.0.0",
+						"prop-types": "^15.6.2",
+						"resolve": "^1.9.0"
+					}
+				},
+				"path-parse": {
+					"version": "1.0.6",
+					"bundled": true,
+					"dev": true
+				},
+				"prop-types": {
+					"version": "15.7.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"loose-envify": "^1.4.0",
+						"object-assign": "^4.1.1",
+						"react-is": "^16.8.1"
+					}
+				},
+				"react-is": {
+					"version": "16.8.3",
+					"bundled": true,
+					"dev": true
+				},
+				"resolve": {
+					"version": "1.10.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"path-parse": "^1.0.6"
+					}
+				}
 			}
 		},
 		"@wordpress/format-library": {
@@ -3299,6 +3363,16 @@
 				}
 			}
 		},
+		"aria-query": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
+			"integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+			"dev": true,
+			"requires": {
+				"ast-types-flow": "0.0.7",
+				"commander": "^2.11.0"
+			}
+		},
 		"arr-diff": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -3584,6 +3658,15 @@
 			"dev": true,
 			"requires": {
 				"axe-core": "^3.1.2"
+			}
+		},
+		"axobject-query": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
+			"integrity": "sha512-MCeek8ZH7hKyO1rWUbKNQBbl4l2eY0ntk7OGi+q0RlafrCnfPxC06WZA+uebCfmYp4mNU9jRBP1AhGyf8+W3ww==",
+			"dev": true,
+			"requires": {
+				"ast-types-flow": "0.0.7"
 			}
 		},
 		"babel-eslint": {
@@ -7255,12 +7338,6 @@
 				"minimalistic-crypto-utils": "^1.0.0"
 			}
 		},
-		"emoji-regex": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
-			"integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==",
-			"dev": true
-		},
 		"emojis-list": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
@@ -7697,72 +7774,6 @@
 			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-21.5.0.tgz",
 			"integrity": "sha512-4fxfe2RcqzU+IVNQL5n4pqibLcUhKKxihYsA510+6kC/FTdGInszDDHgO4ntBzPWu8mcHAvKJLs8o3AQw6eHTg==",
 			"dev": true
-		},
-		"eslint-plugin-jsx-a11y": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.0.2.tgz",
-			"integrity": "sha1-ZZJ3p1iwNsMFp+ShMFfDAc075z8=",
-			"dev": true,
-			"requires": {
-				"aria-query": "^0.7.0",
-				"array-includes": "^3.0.3",
-				"ast-types-flow": "0.0.7",
-				"axobject-query": "^0.1.0",
-				"damerau-levenshtein": "^1.0.0",
-				"emoji-regex": "^6.1.0",
-				"jsx-ast-utils": "^1.4.0"
-			},
-			"dependencies": {
-				"aria-query": {
-					"version": "0.7.1",
-					"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-0.7.1.tgz",
-					"integrity": "sha1-Jsu1r/ZBRLCoJb4YRuCxbPoAsR4=",
-					"dev": true,
-					"requires": {
-						"ast-types-flow": "0.0.7",
-						"commander": "^2.11.0"
-					}
-				},
-				"axobject-query": {
-					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-0.1.0.tgz",
-					"integrity": "sha1-YvWdvFnJ+SQnWco0mWDnov48NsA=",
-					"dev": true,
-					"requires": {
-						"ast-types-flow": "0.0.7"
-					}
-				},
-				"jsx-ast-utils": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
-					"integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
-					"dev": true
-				}
-			}
-		},
-		"eslint-plugin-react": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
-			"integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
-			"dev": true,
-			"requires": {
-				"doctrine": "^2.0.2",
-				"has": "^1.0.1",
-				"jsx-ast-utils": "^2.0.1",
-				"prop-types": "^15.6.0"
-			},
-			"dependencies": {
-				"prop-types": {
-					"version": "15.6.2",
-					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-					"integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
-					"dev": true,
-					"requires": {
-						"loose-envify": "^1.3.1",
-						"object-assign": "^4.1.1"
-					}
-				}
-			}
 		},
 		"eslint-scope": {
 			"version": "3.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2835,70 +2835,6 @@
 				"eslint-plugin-jsx-a11y": "^6.2.1",
 				"eslint-plugin-react": "^7.12.4",
 				"requireindex": "^1.2.0"
-			},
-			"dependencies": {
-				"emoji-regex": {
-					"version": "7.0.3",
-					"bundled": true,
-					"dev": true
-				},
-				"eslint-plugin-jsx-a11y": {
-					"version": "6.2.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"aria-query": "^3.0.0",
-						"array-includes": "^3.0.3",
-						"ast-types-flow": "^0.0.7",
-						"axobject-query": "^2.0.2",
-						"damerau-levenshtein": "^1.0.4",
-						"emoji-regex": "^7.0.2",
-						"has": "^1.0.3",
-						"jsx-ast-utils": "^2.0.1"
-					}
-				},
-				"eslint-plugin-react": {
-					"version": "7.12.4",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"array-includes": "^3.0.3",
-						"doctrine": "^2.1.0",
-						"has": "^1.0.3",
-						"jsx-ast-utils": "^2.0.1",
-						"object.fromentries": "^2.0.0",
-						"prop-types": "^15.6.2",
-						"resolve": "^1.9.0"
-					}
-				},
-				"path-parse": {
-					"version": "1.0.6",
-					"bundled": true,
-					"dev": true
-				},
-				"prop-types": {
-					"version": "15.7.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"loose-envify": "^1.4.0",
-						"object-assign": "^4.1.1",
-						"react-is": "^16.8.1"
-					}
-				},
-				"react-is": {
-					"version": "16.8.3",
-					"bundled": true,
-					"dev": true
-				},
-				"resolve": {
-					"version": "1.10.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"path-parse": "^1.0.6"
-					}
-				}
 			}
 		},
 		"@wordpress/format-library": {
@@ -7338,6 +7274,12 @@
 				"minimalistic-crypto-utils": "^1.0.0"
 			}
 		},
+		"emoji-regex": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+			"dev": true
+		},
 		"emojis-list": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
@@ -7774,6 +7716,71 @@
 			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-21.5.0.tgz",
 			"integrity": "sha512-4fxfe2RcqzU+IVNQL5n4pqibLcUhKKxihYsA510+6kC/FTdGInszDDHgO4ntBzPWu8mcHAvKJLs8o3AQw6eHTg==",
 			"dev": true
+		},
+		"eslint-plugin-jsx-a11y": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.1.tgz",
+			"integrity": "sha512-cjN2ObWrRz0TTw7vEcGQrx+YltMvZoOEx4hWU8eEERDnBIU00OTq7Vr+jA7DFKxiwLNv4tTh5Pq2GUNEa8b6+w==",
+			"dev": true,
+			"requires": {
+				"aria-query": "^3.0.0",
+				"array-includes": "^3.0.3",
+				"ast-types-flow": "^0.0.7",
+				"axobject-query": "^2.0.2",
+				"damerau-levenshtein": "^1.0.4",
+				"emoji-regex": "^7.0.2",
+				"has": "^1.0.3",
+				"jsx-ast-utils": "^2.0.1"
+			}
+		},
+		"eslint-plugin-react": {
+			"version": "7.12.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz",
+			"integrity": "sha512-1puHJkXJY+oS1t467MjbqjvX53uQ05HXwjqDgdbGBqf5j9eeydI54G3KwiJmWciQ0HTBacIKw2jgwSBSH3yfgQ==",
+			"dev": true,
+			"requires": {
+				"array-includes": "^3.0.3",
+				"doctrine": "^2.1.0",
+				"has": "^1.0.3",
+				"jsx-ast-utils": "^2.0.1",
+				"object.fromentries": "^2.0.0",
+				"prop-types": "^15.6.2",
+				"resolve": "^1.9.0"
+			},
+			"dependencies": {
+				"path-parse": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+					"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+					"dev": true
+				},
+				"prop-types": {
+					"version": "15.7.2",
+					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+					"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+					"dev": true,
+					"requires": {
+						"loose-envify": "^1.4.0",
+						"object-assign": "^4.1.1",
+						"react-is": "^16.8.1"
+					}
+				},
+				"react-is": {
+					"version": "16.8.3",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.3.tgz",
+					"integrity": "sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==",
+					"dev": true
+				},
+				"resolve": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+					"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+					"dev": true,
+					"requires": {
+						"path-parse": "^1.0.6"
+					}
+				}
+			}
 		},
 		"eslint-scope": {
 			"version": "3.7.3",

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -86,7 +86,7 @@ class CategoriesEdit extends Component {
 
 		return (
 			<li key={ category.id }>
-				<a href={ category.link } target="_blank">{ this.renderCategoryName( category ) }</a>
+				<a href={ category.link } target="_blank" rel="noreferrer noopener">{ this.renderCategoryName( category ) }</a>
 				{ showPostCounts &&
 					<span className="wp-block-categories__post-count">
 						{ ' ' }({ category.count })

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -178,7 +178,7 @@ class LatestPostsEdit extends Component {
 						const titleTrimmed = post.title.rendered.trim();
 						return (
 							<li key={ i }>
-								<a href={ post.link } target="_blank">
+								<a href={ post.link } target="_blank" rel="noreferrer noopener">
 									{ titleTrimmed ? (
 										<RawHTML>
 											{ titleTrimmed }

--- a/packages/components/src/external-link/index.js
+++ b/packages/components/src/external-link/index.js
@@ -24,7 +24,7 @@ export function ExternalLink( { href, children, className, rel = '', ...addition
 	] ) ).join( ' ' );
 	const classes = classnames( 'components-external-link', className );
 	return (
-		<a { ...additionalProps } className={ classes } href={ href } target="_blank" rel={ rel } ref={ ref }>
+		<a { ...additionalProps } className={ classes } href={ href } target="_blank" rel={ rel } ref={ ref }> { /* eslint-disable-line react/jsx-no-target-blank */ }
 			{ children }
 			<span className="screen-reader-text">
 				{

--- a/packages/eslint-plugin/configs/custom.js
+++ b/packages/eslint-plugin/configs/custom.js
@@ -23,4 +23,9 @@ module.exports = {
 			},
 		],
 	},
+	settings: {
+		react: {
+			version: '16.6',
+		},
+	},
 };

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -19,8 +19,8 @@
 	},
 	"dependencies": {
 		"babel-eslint": "^8.0.3",
-		"eslint-plugin-jsx-a11y": "6.0.2",
-		"eslint-plugin-react": "7.7.0",
+		"eslint-plugin-jsx-a11y": "^6.2.1",
+		"eslint-plugin-react": "^7.12.4",
 		"requireindex": "^1.2.0"
 	},
 	"publishConfig": {


### PR DESCRIPTION
## Description

I got the following npm warnings when using that package:

```
npm WARN eslint-plugin-jsx-a11y@6.0.2 requires a peer of eslint@^3 || ^4 but none is installed. You must install peer dependencies yourself.
npm WARN eslint-plugin-react@7.7.0 requires a peer of eslint@^3.0.0 || ^4.0.0 but none is installed. You must install peer dependencies yourself.
```

This PR updates the affected packages to their latest version and uses caret ranges like for the rest of the packages in that file to leverage semver.

## How has this been tested?
Updated packages, verified that everything still works and warnings went away.

## Types of changes
Maintenance update

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
