### PR TITLE
Clarify the block editor settings from the post editor settings

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -737,7 +737,7 @@ Returns the Block List settings of a block, if any exist.
 
 Block settings of the block if set.
 
-### getEditorSettings
+### getSettings
 
 Returns the editor settings.
 
@@ -1027,9 +1027,9 @@ Returns an action object that changes the nested settings of a given block.
                          being received.
  * settings: Object with the new settings for the nested block.
 
-### updateEditorSettings
+### updateSettings
 
-Returns an action object used in signalling that the editor settings have been updated.
+Returns an action object used in signalling that the block editor settings have been updated.
 
 *Parameters*
 

--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -718,6 +718,18 @@ Is the editor ready
 
 is Ready.
 
+### getEditorSettings
+
+Returns the post editor settings.
+
+*Parameters*
+
+ * state: Editor state.
+
+*Returns*
+
+The editor settings object.
+
 ## Actions
 
 ### setupEditor
@@ -968,3 +980,11 @@ Returns an action object used to signal that the blocks have been updated.
 
  * blocks: Block Array.
  * options: Optional options.
+
+### updateEditorSettings
+
+Returns an action object used in signalling that the post editor settings have been updated.
+
+*Parameters*
+
+ * settings: Updated settings

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -30,7 +30,7 @@ const withRegistry = createHigherOrderComponent(
 
 class BlockEditorProvider extends Component {
 	componentDidMount() {
-		this.props.updateEditorSettings( this.props.settings );
+		this.props.updateSettings( this.props.settings );
 		this.props.resetBlocks( this.props.value );
 		this.attachChangeObserver( this.props.registry );
 	}
@@ -38,14 +38,14 @@ class BlockEditorProvider extends Component {
 	componentDidUpdate( prevProps ) {
 		const {
 			settings,
-			updateEditorSettings,
+			updateSettings,
 			value,
 			resetBlocks,
 			registry,
 		} = this.props;
 
 		if ( settings !== prevProps.settings ) {
-			updateEditorSettings( settings );
+			updateSettings( settings );
 		}
 
 		if ( registry !== prevProps.registry ) {
@@ -139,12 +139,12 @@ class BlockEditorProvider extends Component {
 export default compose( [
 	withDispatch( ( dispatch ) => {
 		const {
-			updateEditorSettings,
+			updateSettings,
 			resetBlocks,
 		} = dispatch( 'core/block-editor' );
 
 		return {
-			updateEditorSettings,
+			updateSettings,
 			resetBlocks,
 		};
 	} ),

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -9,3 +9,5 @@ import '@wordpress/blocks';
 import './store';
 
 export * from './components';
+
+export { SETTINGS_DEFAULTS } from './store/defaults';

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -503,15 +503,15 @@ export function updateBlockListSettings( clientId, settings ) {
 }
 
 /*
- * Returns an action object used in signalling that the editor settings have been updated.
+ * Returns an action object used in signalling that the block editor settings have been updated.
  *
  * @param {Object} settings Updated settings
  *
  * @return {Object} Action object
  */
-export function updateEditorSettings( settings ) {
+export function updateSettings( settings ) {
 	return {
-		type: 'UPDATE_EDITOR_SETTINGS',
+		type: 'UPDATE_SETTINGS',
 		settings,
 	};
 }

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -10,17 +10,22 @@ export const PREFERENCES_DEFAULTS = {
 /**
  * The default editor settings
  *
- *  alignWide          boolean        Enable/Disable Wide/Full Alignments
- *  colors             Array          Palette colors
- *  fontSizes          Array          Available font sizes
- *  imageSizes         Array          Available image sizes
- *  maxWidth           number         Max width to constraint resizing
- *  blockTypes         boolean|Array  Allowed block types
- *  hasFixedToolbar    boolean        Whether or not the editor toolbar is fixed
- *  focusMode          boolean        Whether the focus mode is enabled or not
- *  richEditingEnabled boolean        Whether rich editing is enabled or not
+ *  alignWide              boolean        Enable/Disable Wide/Full Alignments
+ *  colors                 Array          Palette colors
+ *  disableCustomColors    boolean        Whether or not the custom colors are disabled
+ *  fontSizes              Array          Available font sizes
+ *  disableCustomFontSizes boolean        Whether or not the custom font sizes are disabled
+ *  imageSizes             Array          Available image sizes
+ *  maxWidth               number         Max width to constraint resizing
+ *  blockTypes             boolean|Array  Allowed block types
+ *  hasFixedToolbar        boolean        Whether or not the editor toolbar is fixed
+ *  focusMode              boolean        Whether the focus mode is enabled or not
+ *  styles                 Array          Editor Styles
+ *  isRTL                  boolean        Whether the editor is in RTL mode
+ *  bodyPlaceholder        string         Empty post placeholder
+ *  titlePlaceholder       string         Empty title placeholder
  */
-export const EDITOR_SETTINGS_DEFAULTS = {
+export const SETTINGS_DEFAULTS = {
 	alignWide: false,
 	colors: [
 		{
@@ -126,8 +131,5 @@ export const EDITOR_SETTINGS_DEFAULTS = {
 
 	// List of allowed mime types and file extensions.
 	allowedMimeTypes: null,
-
-	// Whether richs editing is enabled or not.
-	richEditingEnabled: true,
 };
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -26,7 +26,7 @@ import { isReusableBlock } from '@wordpress/blocks';
  */
 import {
 	PREFERENCES_DEFAULTS,
-	EDITOR_SETTINGS_DEFAULTS,
+	SETTINGS_DEFAULTS,
 } from './defaults';
 import { insertAt, moveTo } from './array';
 
@@ -830,9 +830,9 @@ export function template( state = { isValid: true }, action ) {
  *
  * @return {Object} Updated state.
  */
-export function settings( state = EDITOR_SETTINGS_DEFAULTS, action ) {
+export function settings( state = SETTINGS_DEFAULTS, action ) {
 	switch ( action.type ) {
-		case 'UPDATE_EDITOR_SETTINGS':
+		case 'UPDATE_SETTINGS':
 			return {
 				...state,
 				...action.settings,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1034,7 +1034,7 @@ const canInsertBlockTypeUnmemoized = ( state, blockName, rootClientId = null ) =
 		return false;
 	}
 
-	const { allowedBlockTypes } = getEditorSettings( state );
+	const { allowedBlockTypes } = getSettings( state );
 
 	const isBlockAllowedInEditor = checkAllowList( allowedBlockTypes, blockName, true );
 	if ( ! isBlockAllowedInEditor ) {
@@ -1350,7 +1350,7 @@ export function getBlockListSettings( state, clientId ) {
  *
  * @return {Object} The editor settings object.
  */
-export function getEditorSettings( state ) {
+export function getSettings( state ) {
 	return state.settings;
 }
 

--- a/packages/block-editor/src/store/test/effects.js
+++ b/packages/block-editor/src/store/test/effects.js
@@ -18,7 +18,7 @@ import { createRegistry } from '@wordpress/data';
  * Internal dependencies
  */
 import actions, {
-	updateEditorSettings,
+	updateSettings,
 	mergeBlocks,
 	replaceBlocks,
 	resetBlocks,
@@ -234,7 +234,7 @@ describe( 'effects', () => {
 		} );
 
 		it( 'should return undefined if invalid but unlocked', () => {
-			store.dispatch( updateEditorSettings( {
+			store.dispatch( updateSettings( {
 				template: [
 					[ 'core/foo', {} ],
 				],
@@ -248,7 +248,7 @@ describe( 'effects', () => {
 		} );
 
 		it( 'should return undefined if locked and valid', () => {
-			store.dispatch( updateEditorSettings( {
+			store.dispatch( updateSettings( {
 				template: [
 					[ 'core/test-block' ],
 				],
@@ -263,7 +263,7 @@ describe( 'effects', () => {
 		} );
 
 		it( 'should return validity set action if invalid on default state', () => {
-			store.dispatch( updateEditorSettings( {
+			store.dispatch( updateSettings( {
 				template: [
 					[ 'core/foo' ],
 				],

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -87,8 +87,8 @@ class HTMLEdit extends Component {
 	}
 }
 export default withSelect( ( select ) => {
-	const { getEditorSettings } = select( 'core/block-editor' );
+	const { getSettings } = select( 'core/block-editor' );
 	return {
-		styles: getEditorSettings().styles,
+		styles: getSettings().styles,
 	};
 } )( HTMLEdit );

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -705,9 +705,9 @@ class ImageEdit extends Component {
 export default compose( [
 	withSelect( ( select, props ) => {
 		const { getMedia } = select( 'core' );
-		const { getEditorSettings } = select( 'core/block-editor' );
+		const { getSettings } = select( 'core/block-editor' );
 		const { id } = props.attributes;
-		const { maxWidth, isRTL, imageSizes } = getEditorSettings();
+		const { maxWidth, isRTL, imageSizes } = getSettings();
 
 		return {
 			image: id ? getMedia( id ) : null,

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -259,10 +259,10 @@ const ParagraphEdit = compose( [
 	withFontSizes( 'fontSize' ),
 	applyFallbackStyles,
 	withSelect( ( select ) => {
-		const { getEditorSettings } = select( 'core/block-editor' );
+		const { getSettings } = select( 'core/block-editor' );
 
 		return {
-			isRTL: getEditorSettings().isRTL,
+			isRTL: getSettings().isRTL,
 		};
 	} ),
 ] )( ParagraphBlock );

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -100,7 +100,7 @@ export const settings = {
 		// Is normal style and a named color is being used, we need to retrieve the color value to set the style,
 		// as there is no expectation that themes create classes that set border colors.
 		} else if ( mainColor ) {
-			const colors = get( select( 'core/block-editor' ).getEditorSettings(), [ 'colors' ], [] );
+			const colors = get( select( 'core/block-editor' ).getSettings(), [ 'colors' ], [] );
 			const colorObject = getColorObjectByAttributeValues( colors, mainColor );
 			figureStyles = {
 				borderColor: colorObject.color,

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -57,7 +57,7 @@ export default compose( [
 	withSelect( ( select ) => ( {
 		hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' ),
 		// This setting (richEditingEnabled) should not live in the block editor's setting.
-		showInserter: select( 'core/edit-post' ).getEditorMode() === 'visual' && select( 'core/block-editor' ).getEditorSettings().richEditingEnabled,
+		showInserter: select( 'core/edit-post' ).getEditorMode() === 'visual' && select( 'core/editor' ).getEditorSettings().richEditingEnabled,
 		isTextModeEnabled: select( 'core/edit-post' ).getEditorMode() === 'text',
 	} ) ),
 	withViewportMatch( { isLargeViewport: 'medium' } ),

--- a/packages/edit-post/src/components/header/mode-switcher/index.js
+++ b/packages/edit-post/src/components/header/mode-switcher/index.js
@@ -49,7 +49,7 @@ function ModeSwitcher( { onSwitch, mode } ) {
 
 export default compose( [
 	withSelect( ( select ) => ( {
-		isRichEditingEnabled: select( 'core/block-editor' ).getEditorSettings().richEditingEnabled,
+		isRichEditingEnabled: select( 'core/editor' ).getEditorSettings().richEditingEnabled,
 		mode: select( 'core/edit-post' ).getEditorMode(),
 	} ) ),
 	ifCondition( ( { isRichEditingEnabled } ) => isRichEditingEnabled ),

--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -55,7 +55,7 @@ class EditorModeKeyboardShortcuts extends Component {
 
 export default compose( [
 	withSelect( ( select ) => ( {
-		isRichEditingEnabled: select( 'core/block-editor' ).getEditorSettings().richEditingEnabled,
+		isRichEditingEnabled: select( 'core/editor' ).getEditorSettings().richEditingEnabled,
 		mode: select( 'core/edit-post' ).getEditorMode(),
 		isEditorSidebarOpen: select( 'core/edit-post' ).isEditorSidebarOpened(),
 	} ) ),

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -137,7 +137,7 @@ export default compose(
 		hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' ),
 		hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
 		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
-		isRichEditingEnabled: select( 'core/block-editor' ).getEditorSettings().richEditingEnabled,
+		isRichEditingEnabled: select( 'core/editor' ).getEditorSettings().richEditingEnabled,
 	} ) ),
 	withDispatch( ( dispatch ) => {
 		const { closePublishSidebar, togglePublishSidebar } = dispatch( 'core/edit-post' );

--- a/packages/edit-post/src/components/options-modal/meta-boxes-section.js
+++ b/packages/edit-post/src/components/options-modal/meta-boxes-section.js
@@ -34,7 +34,7 @@ export function MetaBoxesSection( { areCustomFieldsRegistered, metaBoxes, ...sec
 }
 
 export default withSelect( ( select ) => {
-	const { getEditorSettings } = select( 'core/block-editor' );
+	const { getEditorSettings } = select( 'core/editor' );
 	const { getAllMetaBoxes } = select( 'core/edit-post' );
 
 	return {

--- a/packages/edit-post/src/components/options-modal/options/enable-custom-fields.js
+++ b/packages/edit-post/src/components/options-modal/options/enable-custom-fields.js
@@ -43,5 +43,5 @@ export class EnableCustomFieldsOption extends Component {
 }
 
 export default withSelect( ( select ) => ( {
-	isChecked: !! select( 'core/block-editor' ).getEditorSettings().enableCustomFields,
+	isChecked: !! select( 'core/editor' ).getEditorSettings().enableCustomFields,
 } ) )( EnableCustomFieldsOption );

--- a/packages/edit-post/src/components/text-editor/index.js
+++ b/packages/edit-post/src/components/text-editor/index.js
@@ -38,7 +38,7 @@ function TextEditor( { onExit, isRichEditingEnabled } ) {
 
 export default compose(
 	withSelect( ( select ) => ( {
-		isRichEditingEnabled: select( 'core/block-editor' ).getEditorSettings().richEditingEnabled,
+		isRichEditingEnabled: select( 'core/editor' ).getEditorSettings().richEditingEnabled,
 	} ) ),
 	withDispatch( ( dispatch ) => {
 		return {

--- a/packages/editor/src/components/alignment-toolbar/index.js
+++ b/packages/editor/src/components/alignment-toolbar/index.js
@@ -69,10 +69,10 @@ export default compose(
 	} ),
 	withViewportMatch( { isLargeViewport: 'medium' } ),
 	withSelect( ( select, { clientId, isLargeViewport, isCollapsed } ) => {
-		const { getBlockRootClientId, getEditorSettings } = select( 'core/block-editor' );
+		const { getBlockRootClientId, getSettings } = select( 'core/block-editor' );
 		return {
 			isCollapsed: isCollapsed || ! isLargeViewport || (
-				! getEditorSettings().hasFixedToolbar &&
+				! getSettings().hasFixedToolbar &&
 				getBlockRootClientId( clientId )
 			),
 		};

--- a/packages/editor/src/components/autosave-monitor/index.js
+++ b/packages/editor/src/components/autosave-monitor/index.js
@@ -66,8 +66,7 @@ export default compose( [
 			isAutosavingPost,
 		} = select( 'core/editor' );
 
-		// This settings should not live in the block editor.
-		const { autosaveInterval } = select( 'core/block-editor' ).getEditorSettings();
+		const { autosaveInterval } = select( 'core/editor' ).getEditorSettings();
 
 		return {
 			isDirty: isEditedPostDirty(),

--- a/packages/editor/src/components/block-alignment-toolbar/index.js
+++ b/packages/editor/src/components/block-alignment-toolbar/index.js
@@ -75,11 +75,12 @@ export default compose(
 	} ),
 	withViewportMatch( { isLargeViewport: 'medium' } ),
 	withSelect( ( select, { clientId, isLargeViewport, isCollapsed } ) => {
-		const { getBlockRootClientId, getEditorSettings } = select( 'core/block-editor' );
+		const { getBlockRootClientId, getSettings } = select( 'core/block-editor' );
+		const settings = getSettings();
 		return {
-			wideControlsEnabled: select( 'core/block-editor' ).getEditorSettings().alignWide,
+			wideControlsEnabled: settings.alignWide,
 			isCollapsed: isCollapsed || ! isLargeViewport || (
-				! getEditorSettings().hasFixedToolbar &&
+				! settings.hasFixedToolbar &&
 				getBlockRootClientId( clientId )
 			),
 		};

--- a/packages/editor/src/components/block-list/block.js
+++ b/packages/editor/src/components/block-list/block.js
@@ -633,14 +633,14 @@ const applyWithSelect = withSelect(
 			getBlockMode,
 			isSelectionEnabled,
 			getSelectedBlocksInitialCaretPosition,
-			getEditorSettings,
+			getSettings,
 			hasSelectedInnerBlock,
 			getTemplateLock,
 			__unstableGetBlockWithoutInnerBlocks,
 		} = select( 'core/block-editor' );
 		const block = __unstableGetBlockWithoutInnerBlocks( clientId );
 		const isSelected = isBlockSelected( clientId );
-		const { hasFixedToolbar, focusMode } = getEditorSettings();
+		const { hasFixedToolbar, focusMode } = getSettings();
 		const templateLock = getTemplateLock( rootClientId );
 		const isParentOfSelectedBlock = hasSelectedInnerBlock( clientId, true );
 
@@ -748,8 +748,8 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 			replaceBlocks( [ ownProps.clientId ], blocks );
 		},
 		onMetaChange( updatedMeta ) {
-			const { getEditorSettings } = select( 'core/block-editor' );
-			const onChangeMeta = getEditorSettings().__experimentalMetaSource.onChange;
+			const { getSettings } = select( 'core/block-editor' );
+			const onChangeMeta = getSettings().__experimentalMetaSource.onChange;
 			onChangeMeta( updatedMeta );
 		},
 		onShiftSelection() {

--- a/packages/editor/src/components/block-list/hover-area.js
+++ b/packages/editor/src/components/block-list/hover-area.js
@@ -76,7 +76,7 @@ class HoverArea extends Component {
 
 export default withSelect( ( select ) => {
 	return {
-		isRTL: select( 'core/block-editor' ).getEditorSettings().isRTL,
+		isRTL: select( 'core/block-editor' ).getSettings().isRTL,
 	};
 } )( HoverArea );
 

--- a/packages/editor/src/components/color-palette/with-color-context.js
+++ b/packages/editor/src/components/color-palette/with-color-context.js
@@ -13,7 +13,7 @@ import { withSelect } from '@wordpress/data';
 export default createHigherOrderComponent(
 	withSelect(
 		( select, ownProps ) => {
-			const settings = select( 'core/block-editor' ).getEditorSettings();
+			const settings = select( 'core/block-editor' ).getSettings();
 			const colors = ownProps.colors === undefined ?
 				settings.colors : ownProps.colors;
 

--- a/packages/editor/src/components/colors/with-colors.js
+++ b/packages/editor/src/components/colors/with-colors.js
@@ -36,7 +36,7 @@ const withCustomColorPalette = ( colorsArray ) => createHigherOrderComponent( ( 
  * @return {function} The higher order component.
  */
 const withEditorColorPalette = () => withSelect( ( select ) => {
-	const settings = select( 'core/block-editor' ).getEditorSettings();
+	const settings = select( 'core/block-editor' ).getSettings();
 	return {
 		colors: get( settings, [ 'colors' ], DEFAULT_COLORS ),
 	};

--- a/packages/editor/src/components/default-block-appender/index.js
+++ b/packages/editor/src/components/default-block-appender/index.js
@@ -74,12 +74,12 @@ export function DefaultBlockAppender( {
 export default compose(
 	withState( { hovered: false } ),
 	withSelect( ( select, ownProps ) => {
-		const { getBlockCount, getBlockName, isBlockValid, getEditorSettings, getTemplateLock } = select( 'core/block-editor' );
+		const { getBlockCount, getBlockName, isBlockValid, getSettings, getTemplateLock } = select( 'core/block-editor' );
 
 		const isEmpty = ! getBlockCount( ownProps.rootClientId );
 		const isLastBlockDefault = getBlockName( ownProps.lastBlockClientId ) === getDefaultBlockName();
 		const isLastBlockValid = isBlockValid( ownProps.lastBlockClientId );
-		const { bodyPlaceholder } = getEditorSettings();
+		const { bodyPlaceholder } = getSettings();
 
 		return {
 			isVisible: isEmpty || ! isLastBlockDefault || ! isLastBlockValid,

--- a/packages/editor/src/components/default-block-appender/index.native.js
+++ b/packages/editor/src/components/default-block-appender/index.native.js
@@ -49,10 +49,10 @@ export function DefaultBlockAppender( {
 
 export default compose(
 	withSelect( ( select, ownProps ) => {
-		const { getBlockCount, getEditorSettings, getTemplateLock } = select( 'core/block-editor' );
+		const { getBlockCount, getSettings, getTemplateLock } = select( 'core/block-editor' );
 
 		const isEmpty = ! getBlockCount( ownProps.rootClientId );
-		const { bodyPlaceholder } = getEditorSettings();
+		const { bodyPlaceholder } = getSettings();
 
 		return {
 			isVisible: isEmpty,

--- a/packages/editor/src/components/font-sizes/font-size-picker.js
+++ b/packages/editor/src/components/font-sizes/font-size-picker.js
@@ -9,7 +9,7 @@ export default withSelect(
 		const {
 			disableCustomFontSizes,
 			fontSizes,
-		} = select( 'core/block-editor' ).getEditorSettings();
+		} = select( 'core/block-editor' ).getSettings();
 
 		return {
 			disableCustomFontSizes,

--- a/packages/editor/src/components/font-sizes/with-font-sizes.js
+++ b/packages/editor/src/components/font-sizes/with-font-sizes.js
@@ -38,7 +38,7 @@ export default ( ...fontSizeNames ) => {
 	return createHigherOrderComponent(
 		compose( [
 			withSelect( ( select ) => {
-				const { fontSizes } = select( 'core/block-editor' ).getEditorSettings();
+				const { fontSizes } = select( 'core/block-editor' ).getSettings();
 				return {
 					fontSizes,
 				};

--- a/packages/editor/src/components/media-placeholder/index.js
+++ b/packages/editor/src/components/media-placeholder/index.js
@@ -263,11 +263,11 @@ export class MediaPlaceholder extends Component {
 
 const applyWithSelect = withSelect( ( select ) => {
 	const { canUser } = select( 'core' );
-	const { getEditorSettings } = select( 'core/block-editor' );
+	const { getSettings } = select( 'core/block-editor' );
 
 	return {
 		hasUploadPermissions: defaultTo( canUser( 'create', 'media' ), true ),
-		mediaUpload: getEditorSettings().__experimentalMediaUpload,
+		mediaUpload: getSettings().__experimentalMediaUpload,
 	};
 } );
 

--- a/packages/editor/src/components/page-attributes/check.js
+++ b/packages/editor/src/components/page-attributes/check.js
@@ -20,11 +20,8 @@ export function PageAttributesCheck( { availableTemplates, postType, children } 
 }
 
 export default withSelect( ( select ) => {
-	const { getEditedPostAttribute } = select( 'core/editor' );
-	const { getEditorSettings } = select( 'core/block-editor' );
+	const { getEditedPostAttribute, getEditorSettings } = select( 'core/editor' );
 	const { getPostType } = select( 'core' );
-
-	// This setting should not live in the block-editor module.
 	const { availableTemplates } = getEditorSettings();
 	return {
 		postType: getPostType( getEditedPostAttribute( 'type' ) ),

--- a/packages/editor/src/components/page-attributes/template.js
+++ b/packages/editor/src/components/page-attributes/template.js
@@ -33,8 +33,7 @@ export function PageTemplate( { availableTemplates, selectedTemplate, onUpdate }
 
 export default compose(
 	withSelect( ( select ) => {
-		const { getEditedPostAttribute } = select( 'core/editor' );
-		const { getEditorSettings } = select( 'core/block-editor' );
+		const { getEditedPostAttribute, getEditorSettings } = select( 'core/editor' );
 		const { availableTemplates } = getEditorSettings();
 		return {
 			selectedTemplate: getEditedPostAttribute( 'template' ),

--- a/packages/editor/src/components/post-format/check.js
+++ b/packages/editor/src/components/post-format/check.js
@@ -15,8 +15,7 @@ function PostFormatCheck( { disablePostFormats, ...props } ) {
 
 export default withSelect(
 	( select ) => {
-		// This setting should not live in the block-editor's store.
-		const editorSettings = select( 'core/block-editor' ).getEditorSettings();
+		const editorSettings = select( 'core/editor' ).getEditorSettings();
 		return {
 			disablePostFormats: editorSettings.disablePostFormats,
 		};

--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -220,17 +220,14 @@ export default compose(
 			getCurrentPostId,
 			getActivePostLock,
 			getEditedPostAttribute,
-		} = select( 'core/editor' );
-		const {
 			getEditorSettings,
-		} = select( 'core/block-editor' );
+		} = select( 'core/editor' );
 		const { getPostType } = select( 'core' );
 		return {
 			isLocked: isPostLocked(),
 			isTakeover: isPostLockTakeover(),
 			user: getPostLockUser(),
 			postId: getCurrentPostId(),
-			// This setting should not live in the block-editor's store.
 			postLockUtils: getEditorSettings().postLockUtils,
 			activePostLock: getActivePostLock(),
 			postType: getPostType( getEditedPostAttribute( 'type' ) ),

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -150,10 +150,10 @@ class PostTitle extends Component {
 
 const applyWithSelect = withSelect( ( select ) => {
 	const { getEditedPostAttribute, isCleanNewPost } = select( 'core/editor' );
-	const { getEditorSettings } = select( 'core/block-editor' );
+	const { getSettings } = select( 'core/block-editor' );
 	const { getPostType } = select( 'core' );
 	const postType = getPostType( getEditedPostAttribute( 'type' ) );
-	const { titlePlaceholder, focusMode, hasFixedToolbar } = getEditorSettings();
+	const { titlePlaceholder, focusMode, hasFixedToolbar } = getSettings();
 
 	return {
 		isCleanNewPost: isCleanNewPost(),

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -64,6 +64,8 @@ class EditorProvider extends Component {
 	}
 
 	componentDidMount() {
+		this.props.updateEditorSettings( this.props.settings );
+
 		if ( ! this.props.settings.styles ) {
 			return;
 		}
@@ -77,6 +79,12 @@ class EditorProvider extends Component {
 				document.body.appendChild( node );
 			}
 		} );
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( this.props.settings !== prevProps.settings ) {
+			this.props.updateEditorSettings( this.props.settings );
+		}
 	}
 
 	render() {
@@ -134,6 +142,7 @@ export default compose( [
 			updatePostLock,
 			resetEditorBlocks,
 			editPost,
+			updateEditorSettings,
 		} = dispatch( 'core/editor' );
 		const { createWarningNotice } = dispatch( 'core/notices' );
 
@@ -142,6 +151,7 @@ export default compose( [
 			updatePostLock,
 			createWarningNotice,
 			resetEditorBlocks,
+			updateEditorSettings,
 			resetEditorBlocksWithoutUndoLevel( blocks ) {
 				resetEditorBlocks( blocks, {
 					__unstableShouldCreateUndoLevel: false,

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { map } from 'lodash';
+import { map, pick } from 'lodash';
 import memize from 'memize';
 
 /**
@@ -53,7 +53,22 @@ class EditorProvider extends Component {
 
 	getBlockEditorSettings( settings, meta, onMetaChange, reusableBlocks ) {
 		return {
-			...settings,
+			...pick( settings, [
+				'alignWide',
+				'colors',
+				'disableCustomColors',
+				'fontSizes',
+				'disableCustomFontSizes',
+				'imageSizes',
+				'maxWidth',
+				'blockTypes',
+				'hasFixedToolbar',
+				'focusMode',
+				'styles',
+				'isRTL',
+				'bodyPlaceholder',
+				'titlePlaceholder',
+			] ),
 			__experimentalMetaSource: {
 				value: meta,
 				onChange: onMetaChange,

--- a/packages/editor/src/hooks/align.js
+++ b/packages/editor/src/hooks/align.js
@@ -168,9 +168,9 @@ export const withDataAlign = createHigherOrderComponent(
 	compose( [
 		withSelect(
 			( select ) => {
-				const { getEditorSettings } = select( 'core/block-editor' );
+				const { getSettings } = select( 'core/block-editor' );
 				return {
-					hasWideEnabled: !! getEditorSettings().alignWide,
+					hasWideEnabled: !! getSettings().alignWide,
 				};
 			}
 		),

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -699,6 +699,20 @@ export function resetEditorBlocks( blocks, options = {} ) {
 	};
 }
 
+/*
+ * Returns an action object used in signalling that the post editor settings have been updated.
+ *
+ * @param {Object} settings Updated settings
+ *
+ * @return {Object} Action object
+ */
+export function updateEditorSettings( settings ) {
+	return {
+		type: 'UPDATE_EDITOR_SETTINGS',
+		settings,
+	};
+}
+
 /**
  * Backward compatibility
  */
@@ -737,4 +751,3 @@ export const enterFormattedText = getBlockEditorAction( 'enterFormattedText' );
 export const exitFormattedText = getBlockEditorAction( 'exitFormattedText' );
 export const insertDefaultBlock = getBlockEditorAction( 'insertDefaultBlock' );
 export const updateBlockListSettings = getBlockEditorAction( 'updateBlockListSettings' );
-export const updateEditorSettings = getBlockEditorAction( 'updateEditorSettings' );

--- a/packages/editor/src/store/defaults.js
+++ b/packages/editor/src/store/defaults.js
@@ -1,3 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { SETTINGS_DEFAULTS } from '@wordpress/block-editor';
+
 export const PREFERENCES_DEFAULTS = {
 	isPublishSidebarEnabled: true,
 };
@@ -8,3 +13,22 @@ export const PREFERENCES_DEFAULTS = {
  * @type {Object}
  */
 export const INITIAL_EDITS_DEFAULTS = {};
+
+/**
+ * The default post editor settings
+ *
+ *  richEditingEnabled boolean  Whether rich editing is enabled or not
+ *  enableCustomFields boolean  Whether the WordPress custom fields are enabled or not
+ *  autosaveInterval   number   Autosave Interval
+ *  availableTemplates array?   The available post templates
+ *  disablePostFormats boolean  Whether or not the post formats are disabled
+ *  allowedMimeTypes   array?   List of allowed mime types and file extensions
+ *  maxUploadFileSize  number   Maximum upload file size
+ */
+export const EDITOR_SETTINGS_DEFAULTS = {
+	...SETTINGS_DEFAULTS,
+
+	richEditingEnabled: true,
+	enableCustomFields: false,
+};
+

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -24,6 +24,7 @@ import { addQueryArgs } from '@wordpress/url';
 import {
 	PREFERENCES_DEFAULTS,
 	INITIAL_EDITS_DEFAULTS,
+	EDITOR_SETTINGS_DEFAULTS,
 } from './defaults';
 import { EDIT_MERGE_PROPERTIES } from './constants';
 import withChangeDetection from '../utils/with-change-detection';
@@ -825,6 +826,26 @@ export function isReady( state = false, action ) {
 	return state;
 }
 
+/**
+ * Reducer returning the post editor setting.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function editorSettings( state = EDITOR_SETTINGS_DEFAULTS, action ) {
+	switch ( action.type ) {
+		case 'UPDATE_EDITOR_SETTINGS':
+			return {
+				...state,
+				...action.settings,
+			};
+	}
+
+	return state;
+}
+
 export default optimist( combineReducers( {
 	editor,
 	initialEdits,
@@ -838,4 +859,5 @@ export default optimist( combineReducers( {
 	previewLink,
 	postSavingLock,
 	isReady,
+	editorSettings,
 } ) );

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1084,6 +1084,17 @@ export function __unstableIsEditorReady( state ) {
 	return state.isReady;
 }
 
+/**
+ * Returns the post editor settings.
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {Object} The editor settings object.
+ */
+export function getEditorSettings( state ) {
+	return state.editorSettings;
+}
+
 /*
  * Backward compatibility
  */
@@ -1146,5 +1157,4 @@ export const getTemplateLock = getBlockEditorSelector( 'getTemplateLock' );
 export const canInsertBlockType = getBlockEditorSelector( 'canInsertBlockType' );
 export const getInserterItems = getBlockEditorSelector( 'getInserterItems' );
 export const hasInserterItems = getBlockEditorSelector( 'hasInserterItems' );
-export const getEditorSettings = getBlockEditorSelector( 'getEditorSettings' );
 export const getBlockListSettings = getBlockEditorSelector( 'getBlockListSettings' );

--- a/packages/editor/src/utils/media-upload/index.js
+++ b/packages/editor/src/utils/media-upload/index.js
@@ -33,10 +33,7 @@ export default function( {
 	onError = noop,
 	onFileChange,
 } ) {
-	const { getCurrentPostId } = select( 'core/editor' );
-	const { getEditorSettings } = select( 'core/block-editor' );
-
-	// These settings should not live in the block editor's store.
+	const { getCurrentPostId, getEditorSettings } = select( 'core/editor' );
 	const wpAllowedMimeTypes = getEditorSettings().allowedMimeTypes;
 	maxUploadFileSize = maxUploadFileSize || getEditorSettings().maxUploadFileSize;
 


### PR DESCRIPTION
Related #14043

On this PR, I'm backporting I'm adding some clarity to the settings of the different editor abstractions:

 - The block editor settings now have a dedicated "settings" reducer handling the options that are common to any block editor.
 - The post editor settings (the ones we had before) have been reverted as they should contain both the post specific ones and the block editor ones. 

This PR will help the next step (moving block editor specific components to the block editor module) as now, it's clear that these components only rely on block-editor state.