### PR TITLE
CSS to remove the clipping of the toolbar in RTL languages

### DIFF
--- a/packages/block-library/src/classic/editor.scss
+++ b/packages/block-library/src/classic/editor.scss
@@ -187,6 +187,12 @@
 		color: $dark-gray-800;
 	}
 
+	// Prevent toolbar clipping on heading style in RTL languages
+	.mce-rtl .mce-flow-layout-item.mce-last {
+		margin-right: 0;
+		margin-left: 8px;
+	}
+
 	// Prevent i tags in buttons from picking up theme editor styles.
 	.mce-btn i {
 		font-style: normal;


### PR DESCRIPTION
## Description
Fixes #8672 - Classic Block: Text style listbox is clipped off with RTL languages. 

## How has this been tested?
Set the admin to use an RTL language and add to a Gutenberg post or page a classic editor block. With this patch there is no more clipping on the text style listbox.

## Screenshots

<img width="618" alt="screenshot 2019-02-25 at 17 38 00" src="https://user-images.githubusercontent.com/107534/53348726-4756fd80-3924-11e9-9bcd-057795f6731c.png">


## Types of changes
Small CSS update to the editor.scss for the classic editor block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
