### PR TITLE
Docs: fix minor spelling mistakes

### DIFF
--- a/docs/contributors/copy-guide.md
+++ b/docs/contributors/copy-guide.md
@@ -75,7 +75,7 @@ Here, every line has different phrasing (some start with a verb, some with a nou
 
 Reading this list takes more work because the reader has to parse each bullet anew. They can’t assume each bullet will contain similar information.
 
-Note: this doesn't mean every bullet has to be super short and start with an action verb! “Predicable” doesn’t have to mean “simple.” It just means that each bullet should have the same sentence structure. This list would also be fine:
+Note: this doesn't mean every bullet has to be super short and start with an action verb! “Predictable” doesn’t have to mean “simple.” It just means that each bullet should have the same sentence structure. This list would also be fine:
 
 > What can you do with this block? Lots of things!
 > * Try adding a quote. Sometimes someone else said things best!

--- a/docs/contributors/readme.md
+++ b/docs/contributors/readme.md
@@ -6,7 +6,7 @@ The following guidelines are in place to create consistency across the project a
 
 ## Philosophy
 
-* [Architecturial and UX Principles of Gutenberg](/docs/contributors/principles.md)
+* [Architectural and UX Principles of Gutenberg](/docs/contributors/principles.md)
 
 ## Sections
 

--- a/docs/contributors/scripts.md
+++ b/docs/contributors/scripts.md
@@ -30,7 +30,7 @@ The editor includes a number of packages to enable various pieces of functionali
 | [I18N](/packages/i18n/README.md) | wp-i18n | Internationalization utilities for client-side localization |
 | [Is Shallow Equal](/packages/is-shallow-equal/README.md) | wp-is-shallow-equal | A function for performing a shallow comparison between two objects or arrays |
 | [Keycodes](/packages/keycodes/README.md) | wp-keycodes | Keycodes utilities for WordPress, used to check the key pressed in events like `onKeyDown` |
-| [List Reusable Bocks](/packages/list-reusable-blocks/README.md) | wp-list-reusable-blocks | Package used to add import/export links to the listing page of the reusable blocks |
+| [List Reusable Blocks](/packages/list-reusable-blocks/README.md) | wp-list-reusable-blocks | Package used to add import/export links to the listing page of the reusable blocks |
 | [NUX](/packages/nux/README.md) | wp-nux | Components, and wp.data methods useful for onboarding a new user to the WordPress admin interface |
 | [Plugins](/packages/plugins/README.md) | wp-plugins | Plugins module for WordPress |
 | [Redux Routine](/packages/redux-routine/README.md) | wp-redux-routine | Redux middleware for generator coroutines |
@@ -55,7 +55,7 @@ The editor also uses some popular third-party packages and scripts. Plugin devel
 ## Polyfill Scripts
 
 The editor also provides polyfills for certain features that may not be available in all modern browsers.
-It is recommened to use the main `wp-polyfill` script handle which takes care of loading all the below mentioned polyfills.
+It is recommended to use the main `wp-polyfill` script handle which takes care of loading all the below mentioned polyfills.
 
 | Script Name | Handle | Description |
 |-------------|--------|-------------|


### PR DESCRIPTION
Fixes a few minor spelling mistakes in the docs.

When in doubt:
- "Predicable": a few lines above is mentioned that bulleted lists should be "predictable".
- "Architecturial": the [linked page](/WordPress/gutenberg/blob/master/docs/contributors/principles.md) talks about "architectural" principles

I don't know if these micro-PRs are appreciated, but gave it a shot anyway :wink: