### PR TITLE
Correct visual error in the quote block icon

### DIFF
--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -15,7 +15,7 @@ import {
 	RichText,
 } from '@wordpress/editor';
 import { join, split, create, toHTMLString } from '@wordpress/rich-text';
-import { G, Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/components';
 
 const ATTRIBUTE_QUOTE = 'value';
 const ATTRIBUTE_CITATION = 'citation';
@@ -44,7 +44,7 @@ export const name = 'core/quote';
 export const settings = {
 	title: __( 'Quote' ),
 	description: __( 'Give quoted text visual emphasis. "In quoting others, we cite ourselves." — Julio Cortázar' ),
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M19 18h-6l2-4h-2V6h8v7l-2 5zm-2-2l2-3V8h-4v4h4l-2 4zm-8 2H3l2-4H3V6h8v7l-2 5zm-2-2l2-3V8H5v4h4l-2 4z" /></G></SVG>,
+	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><Path d="M18.62 18h-5.24l2-4H13V6h8v7.24L18.62 18zm-2-2h.76L19 12.76V8h-4v4h3.62l-2 4zm-8 2H3.38l2-4H3V6h8v7.24L8.62 18zm-2-2h.76L9 12.76V8H5v4h3.62l-2 4z" /></SVG>,
 	category: 'common',
 	keywords: [ __( 'blockquote' ) ],
 


### PR DESCRIPTION
Fixes #9194 

The current quote block icon appears to have some over-simplified edges. This replaces it with a fresh, crisp version from [material.io](https://material.io/tools/icons/?search=quote&icon=format_quote&style=outline).

_(Our current icon on left, new Material icon on the right)_
<img width="947" alt="44401539-f6052600-a51c-11e8-80a5-e78afe36ead7" src="https://user-images.githubusercontent.com/1202812/53356841-4f9a4300-38fa-11e9-850d-e4535608409a.png">


---

_Before:_ 
![screen shot 2019-02-25 at 12 37 08 pm](https://user-images.githubusercontent.com/1202812/53356750-1eba0e00-38fa-11e9-99ac-73cb01214705.png)


_After:_
![screen shot 2019-02-25 at 12 37 16 pm](https://user-images.githubusercontent.com/1202812/53356746-1cf04a80-38fa-11e9-8194-efaebbb76f13.png)