### PR TITLE
Plugin: Require includes for deprecated `use_block_editor_for_` functions

### DIFF
--- a/lib/register.php
+++ b/lib/register.php
@@ -25,16 +25,15 @@ function gutenberg_collect_meta_box_data() {
  * Return whether the post can be edited in Gutenberg and by the current user.
  *
  * @since 0.5.0
- * @deprecated 5.0.0 use_block_editor_for_post
+ * @deprecated 5.1.0 use_block_editor_for_post
  *
  * @param int|WP_Post $post Post ID or WP_Post object.
  * @return bool Whether the post can be edited with Gutenberg.
  */
 function gutenberg_can_edit_post( $post ) {
-	_deprecated_function( __FUNCTION__, '5.0.0', 'use_block_editor_for_post' );
+	_deprecated_function( __FUNCTION__, '5.1.0', 'use_block_editor_for_post' );
 
 	return use_block_editor_for_post( $post );
-
 }
 
 /**
@@ -44,13 +43,13 @@ function gutenberg_can_edit_post( $post ) {
  * REST API, then the post cannot be edited in Gutenberg.
  *
  * @since 1.5.2
- * @deprecated 5.0.0 use_block_editor_for_post_type
+ * @deprecated 5.1.0 use_block_editor_for_post_type
  *
  * @param string $post_type The post type.
  * @return bool Whether the post type can be edited with Gutenberg.
  */
 function gutenberg_can_edit_post_type( $post_type ) {
-	_deprecated_function( __FUNCTION__, '5.0.0', 'use_block_editor_for_post_type' );
+	_deprecated_function( __FUNCTION__, '5.1.0', 'use_block_editor_for_post_type' );
 
 	return use_block_editor_for_post_type( $post_type );
 }
@@ -155,23 +154,23 @@ function gutenberg_bulk_post_updated_messages( $messages ) {
  * Injects a hidden input in the edit form to propagate the information that classic editor is selected.
  *
  * @since 1.5.2
- * @deprecated 5.0.0
+ * @deprecated 5.1.0
  */
 function gutenberg_remember_classic_editor_when_saving_posts() {
-	_deprecated_function( __FUNCTION__, '5.0.0' );
+	_deprecated_function( __FUNCTION__, '5.1.0' );
 }
 
 /**
  * Appends a query argument to the redirect url to make sure it gets redirected to the classic editor.
  *
  * @since 1.5.2
- * @deprecated 5.0.0
+ * @deprecated 5.1.0
  *
  * @param string $url Redirect url.
  * @return string Redirect url.
  */
 function gutenberg_redirect_to_classic_editor_when_saving_posts( $url ) {
-	_deprecated_function( __FUNCTION__, '5.0.0' );
+	_deprecated_function( __FUNCTION__, '5.1.0' );
 
 	return $url;
 }
@@ -181,13 +180,13 @@ function gutenberg_redirect_to_classic_editor_when_saving_posts( $url ) {
  * the editor from which the user navigated.
  *
  * @since 1.5.2
- * @deprecated 5.0.0
+ * @deprecated 5.1.0
  *
  * @param string $url Edit url.
  * @return string Edit url.
  */
 function gutenberg_revisions_link_to_editor( $url ) {
-	_deprecated_function( __FUNCTION__, '5.0.0' );
+	_deprecated_function( __FUNCTION__, '5.1.0' );
 
 	return $url;
 }

--- a/lib/register.php
+++ b/lib/register.php
@@ -33,6 +33,7 @@ function gutenberg_collect_meta_box_data() {
 function gutenberg_can_edit_post( $post ) {
 	_deprecated_function( __FUNCTION__, '5.1.0', 'use_block_editor_for_post' );
 
+	require_once ABSPATH . 'wp-admin/includes/post.php';
 	return use_block_editor_for_post( $post );
 }
 
@@ -51,6 +52,7 @@ function gutenberg_can_edit_post( $post ) {
 function gutenberg_can_edit_post_type( $post_type ) {
 	_deprecated_function( __FUNCTION__, '5.1.0', 'use_block_editor_for_post_type' );
 
+	require_once ABSPATH . 'wp-admin/includes/post.php';
 	return use_block_editor_for_post_type( $post_type );
 }
 


### PR DESCRIPTION
Fixes #14012
Cherry-picks d6fd4b2 from #14090 

This pull request seeks to resolve a fatal error which can occur when using the deprecated `gutenberg_can_edit_post` or `gutenberg_can_edit_post_type` in a non-wp-admin context. These functions are slated for removal in Gutenberg 5.3, and should be updated by plugin authors to use the respective core equivalents `use_block_editor_for_post` and `use_block_editor_for_post_type`.

**Testing instructions:**

Verify that no fatal errors occur, either in the editor (wp-admin) or otherwise, when calling one or the other of `gutenberg_can_edit_post` or `gutenberg_can_edit_post_type`.

An example in Gutenberg is to apply the following patch, confirming deprecation notice (if applicable logging level) but otherwise unaffected behavior:

```diff
diff --git a/gutenberg.php b/gutenberg.php
index 40da12a8c..e42ff9286 100644
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -127,7 +127,7 @@ function is_gutenberg_page() {
 		return false;
 	}
 
-	if ( ! use_block_editor_for_post( $post ) ) {
+	if ( ! gutenberg_can_edit_post( $post ) ) {
 		return false;
 	}
```