### PR TITLE
Plugin: Update server blocks script to use core equivalent function

### DIFF
--- a/bin/get-server-blocks.php
+++ b/bin/get-server-blocks.php
@@ -24,10 +24,10 @@ wp_initial_constants();
 require_once ABSPATH . WPINC . '/functions.php';
 wp_load_translations_early();
 wp_set_lang_dir();
-require_once dirname( dirname( __FILE__ ) ) . '/lib/blocks.php';
-require_once dirname( dirname( __FILE__ ) ) . '/lib/class-wp-block-type-registry.php';
-require_once dirname( dirname( __FILE__ ) ) . '/lib/class-wp-block-type.php';
-require_once dirname( dirname( __FILE__ ) ) . '/lib/client-assets.php';
+require_once ABSPATH . WPINC . '/blocks.php';
+require_once ABSPATH . WPINC . '/class-wp-block-type-registry.php';
+require_once ABSPATH . WPINC . '/class-wp-block-type.php';
+require_once ABSPATH . '/wp-admin/includes/post.php';
 
 // Register server-side code for individual blocks.
 foreach ( glob( dirname( dirname( __FILE__ ) ) . '/packages/block-library/src/*/index.php' ) as $block_logic ) {
@@ -36,4 +36,4 @@ foreach ( glob( dirname( dirname( __FILE__ ) ) . '/packages/block-library/src/*/
 
 do_action( 'init' );
 
-echo json_encode( gutenberg_prepare_blocks_for_js() );
+echo json_encode( get_block_editor_server_block_settings() );


### PR DESCRIPTION
Extracted from #14090

This pull request seeks to update the `bin/get-server-blocks.php` script to avoid use of the deprecated `gutenberg_prepare_blocks_for_js`, using instead the equivalent `get_block_editor_server_block_settings` function from core. This requires updating a few require paths to ensure the requisite functions are defined, as expected from the previous `blocks.php`, `class-wp-block-type-registry.php`, `class-wp-block-type.php`, and `client-assets.php` files, where all but the last are inevitably slated for removal.

**Testing instructions:**

Ensure the fixtures regenerations performs successfully:

```
npm run fixtures:regenerate
```

You will likely notice some modified files in your local branch after the script completes, as noted in both #14090 and at https://github.com/WordPress/gutenberg/pull/13583#discussion_r259921366 .