### PR TITLE
Editor: Explicitly create undo levels for onChange block resets

### DIFF
--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -3,61 +3,13 @@
  */
 import { Component } from '@wordpress/element';
 import { DropZoneProvider, SlotFillProvider } from '@wordpress/components';
-import { withDispatch, RegistryConsumer } from '@wordpress/data';
-import { createHigherOrderComponent, compose } from '@wordpress/compose';
-
-/**
- * Higher-order component which renders the original component with the current
- * registry context passed as its `registry` prop.
- *
- * @param {WPComponent} OriginalComponent Original component.
- *
- * @return {WPComponent} Enhanced component.
- */
-const withRegistry = createHigherOrderComponent(
-	( OriginalComponent ) => ( props ) => (
-		<RegistryConsumer>
-			{ ( registry ) => (
-				<OriginalComponent
-					{ ...props }
-					registry={ registry }
-				/>
-			) }
-		</RegistryConsumer>
-	),
-	'withRegistry'
-);
+import { withSelect, withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
 
 class BlockEditorProvider extends Component {
 	componentDidMount() {
 		this.props.updateEditorSettings( this.props.settings );
 		this.props.resetBlocks( this.props.value );
-		this.attachChangeObserver( this.props.registry );
-	}
-
-	componentDidUpdate( prevProps ) {
-		const {
-			settings,
-			updateEditorSettings,
-			value,
-			resetBlocks,
-			registry,
-		} = this.props;
-
-		if ( settings !== prevProps.settings ) {
-			updateEditorSettings( settings );
-		}
-
-		if ( registry !== prevProps.registry ) {
-			this.attachChangeObserver( registry );
-		}
-
-		if ( this.isSyncingOutcomingValue ) {
-			this.isSyncingOutcomingValue = false;
-		} else if ( value !== prevProps.value ) {
-			this.isSyncingIncomingValue = true;
-			resetBlocks( value );
-		}
 	}
 
 	componentWillUnmount() {
@@ -66,61 +18,44 @@ class BlockEditorProvider extends Component {
 		}
 	}
 
-	/**
-	 * Given a registry object, overrides the default dispatch behavior for the
-	 * `core/block-editor` store to interpret a state change and decide whether
-	 * we should call `onChange` or `onInput` depending on whether the change
-	 * is persistent or not.
-	 *
-	 * This needs to be done synchronously after state changes (instead of using
-	 * `componentDidUpdate`) in order to avoid batching these changes.
-	 *
-	 * @param {WPDataRegistry} registry     Registry from which block editor
-	 *                                      dispatch is to be overriden.
-	 */
-	attachChangeObserver( registry ) {
-		if ( this.unsubscribe ) {
-			this.unsubscribe();
+	componentDidUpdate( prevProps ) {
+		const {
+			settings,
+			updateEditorSettings,
+			value,
+			resetBlocks,
+			blocks,
+			isLastBlockChangePersistent,
+			onChange,
+			onInput,
+		} = this.props;
+
+		if ( settings !== prevProps.settings ) {
+			updateEditorSettings( settings );
 		}
 
-		const {
-			getBlocks,
-			isLastBlockChangePersistent,
-		} = registry.select( 'core/block-editor' );
-
-		let blocks = getBlocks();
-		let isPersistent = isLastBlockChangePersistent();
-
-		this.unsubscribe = registry.subscribe( () => {
-			const {
-				onChange,
-				onInput,
-			} = this.props;
-			const newBlocks = getBlocks();
-			const newIsPersistent = isLastBlockChangePersistent();
-			if ( newBlocks !== blocks && this.isSyncingIncomingValue ) {
-				this.isSyncingIncomingValue = false;
-				blocks = newBlocks;
-				isPersistent = newIsPersistent;
-				return;
+		if ( ! this.syncedValue ) {
+			this.syncedValue = blocks;
+		} else if (
+			blocks !== prevProps.blocks ||
+			isLastBlockChangePersistent !== prevProps.isLastBlockChangePersistent
+		) {
+			const hasSyncedValue = this.syncedValue === blocks;
+			if ( ! hasSyncedValue ) {
+				this.syncedValue = blocks;
+				console.log( 'input' );
+				onInput( blocks );
 			}
 
-			if (
-				newBlocks !== blocks ||
-				// This happens when a previous input is explicitely marked as persistent.
-				( newIsPersistent && ! isPersistent )
-			) {
-				blocks = newBlocks;
-				isPersistent = newIsPersistent;
-
-				this.isSyncingOutcomingValue = true;
-				if ( isPersistent ) {
-					onChange( blocks );
-				} else {
-					onInput( blocks );
-				}
+			if ( isLastBlockChangePersistent ) {
+				console.log( 'change' );
+				onChange( blocks );
 			}
-		} );
+		} else if ( value !== prevProps.value && this.syncedValue !== value ) {
+			delete this.syncedValue;
+
+			resetBlocks( value );
+		}
 	}
 
 	render() {
@@ -137,6 +72,17 @@ class BlockEditorProvider extends Component {
 }
 
 export default compose( [
+	withSelect( ( select ) => {
+		const {
+			getBlocks,
+			isLastBlockChangePersistent,
+		} = select( 'core/block-editor' );
+
+		return {
+			blocks: getBlocks(),
+			isLastBlockChangePersistent: isLastBlockChangePersistent(),
+		};
+	} ),
 	withDispatch( ( dispatch ) => {
 		const {
 			updateEditorSettings,
@@ -148,5 +94,4 @@ export default compose( [
 			resetBlocks,
 		};
 	} ),
-	withRegistry,
 ] )( BlockEditorProvider );

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -80,13 +80,13 @@ class EditorProvider extends Component {
 		const {
 			children,
 			blocks,
-			resetEditorBlocks,
+			onInput,
+			onChange,
 			isReady,
 			settings,
 			meta,
 			onMetaChange,
 			reusableBlocks,
-			resetEditorBlocksWithoutUndoLevel,
 		} = this.props;
 
 		if ( ! isReady ) {
@@ -100,8 +100,8 @@ class EditorProvider extends Component {
 		return (
 			<BlockEditorProvider
 				value={ blocks }
-				onInput={ resetEditorBlocksWithoutUndoLevel }
-				onChange={ resetEditorBlocks }
+				onInput={ onInput }
+				onChange={ onChange }
 				settings={ editorSettings }
 			>
 				{ children }
@@ -130,6 +130,7 @@ export default compose( [
 			setupEditor,
 			updatePostLock,
 			resetEditorBlocks,
+			createUndoLevel,
 			editPost,
 		} = dispatch( 'core/editor' );
 		const { createWarningNotice } = dispatch( 'core/notices' );
@@ -138,11 +139,10 @@ export default compose( [
 			setupEditor,
 			updatePostLock,
 			createWarningNotice,
-			resetEditorBlocks,
-			resetEditorBlocksWithoutUndoLevel( blocks ) {
-				resetEditorBlocks( blocks, {
-					__unstableShouldCreateUndoLevel: false,
-				} );
+			onInput: resetEditorBlocks,
+			onChange( blocks ) {
+				createUndoLevel();
+				resetEditorBlocks( blocks );
 			},
 			onMetaChange( meta ) {
 				editPost( { meta } );

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -344,16 +344,14 @@ export function unlockPostSaving( lockName ) {
 /**
  * Returns an action object used to signal that the blocks have been updated.
  *
- * @param {Array}   blocks  Block Array.
- * @param {?Object} options Optional options.
+ * @param {Array} blocks Block Array.
  *
  * @return {Object} Action object
  */
-export function resetEditorBlocks( blocks, options = {} ) {
+export function resetEditorBlocks( blocks ) {
 	return {
 		type: 'RESET_EDITOR_BLOCKS',
 		blocks,
-		shouldCreateUndoLevel: options.__unstableShouldCreateUndoLevel !== false,
 	};
 }
 

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -104,7 +104,7 @@ export function isUpdatingSamePostProperty( action, previousAction ) {
  */
 export function shouldOverwriteState( action, previousAction ) {
 	if ( action.type === 'RESET_EDITOR_BLOCKS' ) {
-		return ! action.shouldCreateUndoLevel;
+		return true;
 	}
 
 	if ( ! previousAction || action.type !== previousAction.type ) {
@@ -148,9 +148,6 @@ export const editor = flow( [
 	} )( ( state = { value: [] }, action ) => {
 		switch ( action.type ) {
 			case 'RESET_EDITOR_BLOCKS':
-				if ( action.blocks === state.value ) {
-					return state;
-				}
 				return { value: action.blocks };
 		}
 


### PR DESCRIPTION
Related: #13088 

This pull request seeks to explore consider improvements to blocks history management. Particularly, it seeks to address a point raised at https://github.com/WordPress/gutenberg/pull/13088#discussion_r260012597 where trying to create an undo level explicitly within the same dispatch may fail when the next state is equal to current. The implementation of `withHistory` is such that it expects an undo level creation to be a separate action, in this case immediately preceding the action which incurs the change (`onChange` calling `resetEditorBlocks`).

cc @iseulde in case you have some feedback here, since I think you originally implemented the explicit "create undo level" mechanism.

Separate explorations in a3aa1e5 , while not directly related, were the original changes considered here. It may make sense to fork these off separately. They were motivated by a desire to understand what was meant in a comment about "avoiding batching changes" with a subscriber within `BlockEditorProvider`.