### PR TITLE
Babel Plugin Import JSX Pragma: Remove import visitor

### DIFF
--- a/packages/babel-plugin-import-jsx-pragma/CHANGELOG.md
+++ b/packages/babel-plugin-import-jsx-pragma/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ### Breaking Change
 
-- Plugin skips now adding import JSX pragma when the scope variable is defined for all JSX elements ([#13809](https://github.com/WordPress/gutenberg/pull/13809)). 
 - Stop using Babel transpilation internally and set node 8 as a minimal version required ([#13540](https://github.com/WordPress/gutenberg/pull/13540)).
+
+### Enhancement
+
+- Plugin skips now adding import JSX pragma when the scope variable is defined for all JSX elements ([#13809](https://github.com/WordPress/gutenberg/pull/13809)). 
 
 ## 1.1.0 (2018-09-05)
 

--- a/packages/babel-plugin-import-jsx-pragma/index.js
+++ b/packages/babel-plugin-import-jsx-pragma/index.js
@@ -40,42 +40,16 @@ module.exports = function( babel ) {
 	return {
 		visitor: {
 			JSXElement( path, state ) {
-				state.hasJSX = true;
 				if ( state.hasUndeclaredScopeVariable ) {
 					return;
 				}
 
 				const { scopeVariable } = getOptions( state );
-
 				state.hasUndeclaredScopeVariable = ! path.scope.hasBinding( scopeVariable );
-			},
-			ImportDeclaration( path, state ) {
-				if ( state.hasImportedScopeVariable ) {
-					return;
-				}
-
-				const { scopeVariable, isDefault } = getOptions( state );
-
-				// Test that at least one import specifier exists matching the
-				// scope variable name. The module source is not verified since
-				// we must avoid introducing a conflicting import name, even if
-				// the scope variable is referenced from a different source.
-				state.hasImportedScopeVariable = path.node.specifiers.some( ( specifier ) => {
-					switch ( specifier.type ) {
-						case 'ImportSpecifier':
-							return (
-								! isDefault &&
-								specifier.imported.name === scopeVariable
-							);
-
-						case 'ImportDefaultSpecifier':
-							return isDefault;
-					}
-				} );
 			},
 			Program: {
 				exit( path, state ) {
-					if ( ! state.hasJSX || state.hasImportedScopeVariable || ! state.hasUndeclaredScopeVariable ) {
+					if ( ! state.hasUndeclaredScopeVariable ) {
 						return;
 					}
 


### PR DESCRIPTION
Props to @aduth for coding this optimization:
https://github.com/WordPress/gutenberg/commit/8ca4fe96ea8a24b8772eb42e7fd91e1abaaf489d

I accidentally removed this commit from #13809 when rebasing changes with master and resolving conflicts. I probably force pushed my local branch :(

This is the original comment from @aduth related to those changes:

> Yes! `path.scope.hasBinding` is perfect. And I think it makes the entire `ImportDeclaration` redundant. Or, at least, all tests continue to pass after removing it in [8ca4fe9](https://github.com/WordPress/gutenberg/commit/8ca4fe96ea8a24b8772eb42e7fd91e1abaaf489d).
> 
> Basically, we should only care that when we see JSX, it has some scoped reference to `createElement` and, if not, the program should assign it.

This PR also includes a change which updates the changelog to better reflect the changes introduced:
- move an entry from `Breaking Change` to `Enhancement`.

## How has this been tested?
`npm test`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
