### PR TITLE
Fix: Sibling inserter adds block in the wrong position if a block is selected

### DIFF
--- a/packages/editor/src/components/inserter/menu.js
+++ b/packages/editor/src/components/inserter/menu.js
@@ -386,7 +386,6 @@ export default compose(
 				getBlockOrder,
 			} = select( 'core/block-editor' );
 			const { clientId, rootClientId, isAppender } = ownProps;
-
 			// If the clientId is defined, we insert at the position of the block.
 			if ( clientId ) {
 				return {
@@ -401,6 +400,7 @@ export default compose(
 				const selectedBlockRootClientId = getBlockRootClientId( end ) || undefined;
 				return {
 					index: getBlockIndex( end, selectedBlockRootClientId ) + 1,
+					isInsertingAfterSelectedBlock: true,
 					rootClientId: selectedBlockRootClientId,
 				};
 			}
@@ -431,13 +431,21 @@ export default compose(
 				const { name, initialAttributes } = item;
 				const selectedBlock = getSelectedBlock();
 				const insertedBlock = createBlock( name, initialAttributes );
-				if ( ! isAppender && selectedBlock && isUnmodifiedDefaultBlock( selectedBlock ) ) {
+				const {
+					index,
+					isInsertingAfterSelectedBlock,
+					rootClientId,
+				} = getInsertionPoint();
+				if (
+					! isAppender &&
+					isInsertingAfterSelectedBlock &&
+					selectedBlock &&
+					isUnmodifiedDefaultBlock( selectedBlock )
+				) {
 					replaceBlocks( selectedBlock.clientId, insertedBlock );
 				} else {
-					const { index, rootClientId } = getInsertionPoint();
 					insertBlock( insertedBlock, index, rootClientId );
 				}
-
 				ownProps.onSelect();
 			},
 		};


### PR DESCRIPTION
If an empty paragraph block was selected the sibling inserter inserted the block at the position where the empty paragraph block was instead of inserting in the position the sibling inserter is being rendered.

Fixes: https://github.com/WordPress/gutenberg/issues/14087
props to @pilou for reporting this issue. 


## How has this been tested?
I created 4 empty paragraph blocks, with an empty gallery and an image after.
I selected one of the empty paragraph blocks.
I passed the mouse over the image and made the sibling inserter appear between the gallery and the image block.
I added the latest posts block using the sibling inserter and I verified the block was added in the middle of the gallery and the image as expected.

## Screenshots <!-- if applicable -->
Before:

![feb-25-2019 21-38-42](https://user-images.githubusercontent.com/11271197/53370723-68304a80-3946-11e9-8c9f-6271a20dc677.gif)

After:
![feb-25-2019 21-33-33](https://user-images.githubusercontent.com/11271197/53370734-70888580-3946-11e9-99bf-5e57ef194351.gif)
