### PR TITLE
Block Editor: Consider RECEIVE_BLOCKS as non-persistent change

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -187,15 +187,30 @@ export function isUpdatingSameBlockAttribute( action, lastAction ) {
 function withPersistentBlockChange( reducer ) {
 	let lastAction;
 
+	/**
+	 * Set of action types for which a blocks state change should be considered
+	 * non-persistent.
+	 *
+	 * @type {Set}
+	 */
+	const IGNORED_ACTION_TYPES = new Set( [
+		'RECEIVE_BLOCKS',
+	] );
+
 	return ( state, action ) => {
 		let nextState = reducer( state, action );
+
 		const isExplicitPersistentChange = action.type === 'MARK_LAST_CHANGE_AS_PERSISTENT';
 
 		if ( state !== nextState || isExplicitPersistentChange ) {
+			// Some state changes should not be considered persistent, namely
+			// those which are not a direct result of user interaction.
+			const isPersistentStateChange = ! IGNORED_ACTION_TYPES.has( action.type );
+
 			nextState = {
 				...nextState,
-				isPersistentChange: (
-					isExplicitPersistentChange ||
+				isPersistentChange: isExplicitPersistentChange || (
+					isPersistentStateChange &&
 					! isUpdatingSameBlockAttribute( action, lastAction )
 				),
 			};

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -1090,6 +1090,19 @@ describe( 'state', () => {
 
 					expect( state.isPersistentChange ).toBe( false );
 				} );
+
+				it( 'should not consider received blocks as persistent change', () => {
+					const state = blocks( undefined, {
+						type: 'RECEIVE_BLOCKS',
+						blocks: [ {
+							clientId: 'kumquat',
+							attributes: {},
+							innerBlocks: [],
+						} ],
+					} );
+
+					expect( state.isPersistentChange ).toBe( false );
+				} );
 			} );
 		} );
 	} );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -1046,6 +1046,12 @@ describe( 'state', () => {
 			} );
 
 			describe( 'isPersistentChange', () => {
+				it( 'should default a changing state to true', () => {
+					const state = deepFreeze( blocks( undefined, {} ) );
+
+					expect( state.isPersistentChange ).toBe( true );
+				} );
+
 				it( 'should consider any non-exempt block change as persistent', () => {
 					const original = deepFreeze( blocks( undefined, {
 						type: 'RESET_BLOCKS',
@@ -1063,8 +1069,8 @@ describe( 'state', () => {
 					expect( state.isPersistentChange ).toBe( true );
 				} );
 
-				it( 'should consider same block attribute update as exempt', () => {
-					const original = deepFreeze( blocks( undefined, {
+				it( 'should consider any non-exempt block change as persistent across unchanging actions', () => {
+					let original = deepFreeze( blocks( undefined, {
 						type: 'RESET_BLOCKS',
 						blocks: [ {
 							clientId: 'kumquat',
@@ -1072,7 +1078,17 @@ describe( 'state', () => {
 							innerBlocks: [],
 						} ],
 					} ) );
-					let state = blocks( original, {
+					original = blocks( original, {
+						type: 'NOOP',
+					} );
+					original = blocks( original, {
+						// While RECEIVE_BLOCKS changes state, it's considered
+						// as ignored, confirmed by this test.
+						type: 'RECEIVE_BLOCKS',
+						blocks: [],
+					} );
+
+					const state = blocks( original, {
 						type: 'UPDATE_BLOCK_ATTRIBUTES',
 						clientId: 'kumquat',
 						attributes: {
@@ -1080,7 +1096,27 @@ describe( 'state', () => {
 						},
 					} );
 
-					state = blocks( state, {
+					expect( state.isPersistentChange ).toBe( true );
+				} );
+
+				it( 'should consider same block attribute update as exempt', () => {
+					let original = deepFreeze( blocks( undefined, {
+						type: 'RESET_BLOCKS',
+						blocks: [ {
+							clientId: 'kumquat',
+							attributes: {},
+							innerBlocks: [],
+						} ],
+					} ) );
+					original = blocks( original, {
+						type: 'UPDATE_BLOCK_ATTRIBUTES',
+						clientId: 'kumquat',
+						attributes: {
+							updated: false,
+						},
+					} );
+
+					const state = blocks( original, {
 						type: 'UPDATE_BLOCK_ATTRIBUTES',
 						clientId: 'kumquat',
 						attributes: {
@@ -1089,6 +1125,37 @@ describe( 'state', () => {
 					} );
 
 					expect( state.isPersistentChange ).toBe( false );
+				} );
+
+				it( 'should flag an explicitly marked persistent change', () => {
+					let original = deepFreeze( blocks( undefined, {
+						type: 'RESET_BLOCKS',
+						blocks: [ {
+							clientId: 'kumquat',
+							attributes: {},
+							innerBlocks: [],
+						} ],
+					} ) );
+					original = blocks( original, {
+						type: 'UPDATE_BLOCK_ATTRIBUTES',
+						clientId: 'kumquat',
+						attributes: {
+							updated: false,
+						},
+					} );
+					original = blocks( original, {
+						type: 'UPDATE_BLOCK_ATTRIBUTES',
+						clientId: 'kumquat',
+						attributes: {
+							updated: true,
+						},
+					} );
+
+					const state = blocks( original, {
+						type: 'MARK_LAST_CHANGE_AS_PERSISTENT',
+					} );
+
+					expect( state.isPersistentChange ).toBe( true );
 				} );
 
 				it( 'should not consider received blocks as persistent change', () => {

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -134,7 +134,6 @@ export const editor = flow( [
 	withHistory( {
 		resetTypes: [ 'SETUP_EDITOR_STATE' ],
 		ignoreTypes: [
-			'RECEIVE_BLOCKS',
 			'RESET_POST',
 			'UPDATE_POST',
 		],


### PR DESCRIPTION
This pull request seeks to update the block editor's `withPersistentBlockChange` to consider `RECEIVE_BLOCKS` as a non-persistent change. This is intended to mimic the equivalent behavior which had existed prior to #13088, where the block editor dispatches a `RECEIVE_BLOCKS` action when receiving reusable blocks. The data for reusable blocks is kept alongside other blocks data, though changes to this data should not be interpreted as the result of a user interaction.

It's hoped that these changes should bring some improved stability "Undo" end-to-end tests, where on a hunch I suspect the failures may be a result of delayed responses from reusable blocks fetch which occurs upon focusing a paragraph block (from the blocks autocomplete inserter). ([Related Slack conversation](https://wordpress.slack.com/archives/C02QB2JS7/p1551129563274100?thread_ts=1550846413.204800&cid=C02QB2JS7))

As noted at https://github.com/WordPress/gutenberg/pull/13088#discussion_r259094690 , the separation of reusable blocks across the `editor` and `block-editor` modules does not seem cohesive. As described above, the blocks data for reusable blocks is kept in the block editor's `state.blocks` state, but is cross-referenced on the editor module's `reusableBlocks` state.