### PR TITLE
Fix: Latest posts: Title is clickable across the full width of the row

### DIFF
--- a/packages/block-library/src/latest-posts/editor.scss
+++ b/packages/block-library/src/latest-posts/editor.scss
@@ -4,3 +4,6 @@
 		padding-left: 0;
 	}
 }
+.wp-block-latest-posts li a > div {
+	display: inline;
+}


### PR DESCRIPTION
## Description
The title in latest posts block was clickable across the full width of the row, making it easy to click on the title by mistake.
This problem only affects the editor on the front end things worked as expected.

## How has this been tested?
I added the latest posts block.
I verified that the title is only clickable if the mouse is above the title and not above any part of its row.


## Screenshots <!-- if applicable -->
Before:
![feb-25-2019 21-49-15](https://user-images.githubusercontent.com/11271197/53371643-b3e3f380-3948-11e9-95f5-a8f235fabab2.gif)

After:
![feb-25-2019 21-53-30](https://user-images.githubusercontent.com/11271197/53371657-c2320f80-3948-11e9-8dfd-ab7ae4640955.gif)


