### PR TITLE
Update/e2e tests options

### DIFF
--- a/packages/scripts/scripts/test-e2e.js
+++ b/packages/scripts/scripts/test-e2e.js
@@ -20,6 +20,7 @@ const jest = require( 'jest' );
 const {
 	fromConfigRoot,
 	getCliArgs,
+	getCliArg,
 	hasCliArg,
 	hasProjectFile,
 	hasJestConfig,
@@ -41,5 +42,10 @@ const hasRunInBand = hasCliArg( '--runInBand' ) ||
 const runInBand = ! hasRunInBand ?
 	[ '--runInBand' ] :
 	[];
+
+if ( hasCliArg( 'interactive' ) ) {
+	process.env.PUPPETEER_HEADLESS = false;
+	process.env.PUPPETEER_SLOWMO = 80;
+}
 
 jest.run( [ ...config, ...runInBand, ...getCliArgs() ] );

--- a/packages/scripts/scripts/test-e2e.js
+++ b/packages/scripts/scripts/test-e2e.js
@@ -20,10 +20,10 @@ const jest = require( 'jest' );
 const {
 	fromConfigRoot,
 	getCliArg,
+	getCliArgs,
 	hasCliArg,
 	hasProjectFile,
 	hasJestConfig,
-	cleanUpArgs,
 } = require( '../utils' );
 
 // Provides a default config path for Puppeteer when jest-puppeteer.config.js
@@ -46,8 +46,8 @@ const runInBand = ! hasRunInBand ?
 const cleanUpPrefixes = [ '--puppeteer-' ];
 
 if ( hasCliArg( '--puppeteer-interactive' ) ) {
-	process.env.PUPPETEER_HEADLESS = false;
+	process.env.PUPPETEER_HEADLESS = 'false';
 	process.env.PUPPETEER_SLOWMO = getCliArg( '--puppeteer-slowmo' ) || 80;
 }
 
-jest.run( [ ...config, ...runInBand, ...cleanUpArgs( cleanUpPrefixes ) ] );
+jest.run( [ ...config, ...runInBand, ...getCliArgs( cleanUpPrefixes ) ] );

--- a/packages/scripts/scripts/test-e2e.js
+++ b/packages/scripts/scripts/test-e2e.js
@@ -19,10 +19,11 @@ const jest = require( 'jest' );
  */
 const {
 	fromConfigRoot,
-	getCliArgs,
+	getCliArg,
 	hasCliArg,
 	hasProjectFile,
 	hasJestConfig,
+	cleanUpArgs,
 } = require( '../utils' );
 
 // Provides a default config path for Puppeteer when jest-puppeteer.config.js
@@ -42,9 +43,11 @@ const runInBand = ! hasRunInBand ?
 	[ '--runInBand' ] :
 	[];
 
-if ( hasCliArg( 'interactive' ) ) {
+const cleanUpPrefixes = [ '--puppeteer-' ];
+
+if ( hasCliArg( '--puppeteer-interactive' ) ) {
 	process.env.PUPPETEER_HEADLESS = false;
-	process.env.PUPPETEER_SLOWMO = 80;
+	process.env.PUPPETEER_SLOWMO = getCliArg( '--puppeteer-slowmo' ) || 80;
 }
 
-jest.run( [ ...config, ...runInBand, ...getCliArgs() ] );
+jest.run( [ ...config, ...runInBand, ...cleanUpArgs( cleanUpPrefixes ) ] );

--- a/packages/scripts/scripts/test-e2e.js
+++ b/packages/scripts/scripts/test-e2e.js
@@ -20,7 +20,6 @@ const jest = require( 'jest' );
 const {
 	fromConfigRoot,
 	getCliArgs,
-	getCliArg,
 	hasCliArg,
 	hasProjectFile,
 	hasJestConfig,

--- a/packages/scripts/utils/cli.js
+++ b/packages/scripts/utils/cli.js
@@ -25,9 +25,17 @@ const getCliArg = ( arg ) => {
 };
 
 const cleanUpArgs = ( prefixes ) => {
-	return getCliArgs().filter( ( arg ) => {
-		return ! prefixes.some( ( prefix ) => arg.startsWith( prefix ) );
-	} );
+	const cliArgs = getCliArgs();
+	for ( let i = 0; i < cliArgs.length; i++ ) {
+		const cliArg = cliArgs[ i ];
+		const name = cliArg.split( '=' )[ 0 ];
+		for ( const prefix of prefixes ) {
+			if ( name.indexOf( prefix ) !== -1 ) {
+				cliArgs.splice( i, 1 );
+			}
+		}
+	}
+	return cliArgs;
 };
 
 const hasCliArg = ( arg ) => getCliArg( arg ) !== undefined;

--- a/packages/scripts/utils/cli.js
+++ b/packages/scripts/utils/cli.js
@@ -25,17 +25,9 @@ const getCliArg = ( arg ) => {
 };
 
 const cleanUpArgs = ( prefixes ) => {
-	const cliArgs = getCliArgs();
-	for ( let i = 0; i < cliArgs.length; i++ ) {
-		const cliArg = cliArgs[ i ];
-		const name = cliArg.split( '=' )[ 0 ];
-		for ( const prefix of prefixes ) {
-			if ( name.indexOf( prefix ) !== -1 ) {
-				cliArgs.splice( i, 1 );
-			}
-		}
-	}
-	return cliArgs;
+	return getCliArgs().filter( ( arg ) =>  {
+		return ! prefixes.some( ( prefix ) => arg.startsWith( prefix ) );
+	} );
 };
 
 const hasCliArg = ( arg ) => getCliArg( arg ) !== undefined;

--- a/packages/scripts/utils/cli.js
+++ b/packages/scripts/utils/cli.js
@@ -25,7 +25,7 @@ const getCliArg = ( arg ) => {
 };
 
 const cleanUpArgs = ( prefixes ) => {
-	return getCliArgs().filter( ( arg ) =>  {
+	return getCliArgs().filter( ( arg ) => {
 		return ! prefixes.some( ( prefix ) => arg.startsWith( prefix ) );
 	} );
 };

--- a/packages/scripts/utils/cli.js
+++ b/packages/scripts/utils/cli.js
@@ -24,6 +24,20 @@ const getCliArg = ( arg ) => {
 	}
 };
 
+const cleanUpArgs = ( prefixes ) => {
+	const cliArgs = getCliArgs();
+	for ( let i = 0; i < cliArgs.length; i++ ) {
+		const cliArg = cliArgs[ i ];
+		const name = cliArg.split( '=' )[ 0 ];
+		for ( const prefix of prefixes ) {
+			if ( name.indexOf( prefix ) !== -1 ) {
+				cliArgs.splice( i, 1 );
+			}
+		}
+	}
+	return cliArgs;
+};
+
 const hasCliArg = ( arg ) => getCliArg( arg ) !== undefined;
 
 const handleSignal = ( signal ) => {
@@ -82,4 +96,5 @@ module.exports = {
 	getCliArgs,
 	hasCliArg,
 	spawnScript,
+	cleanUpArgs,
 };

--- a/packages/scripts/utils/cli.js
+++ b/packages/scripts/utils/cli.js
@@ -24,12 +24,6 @@ const getCliArg = ( arg ) => {
 	}
 };
 
-const cleanUpArgs = ( prefixes ) => {
-	return getCliArgs().filter( ( arg ) => {
-		return ! prefixes.some( ( prefix ) => arg.startsWith( prefix ) );
-	} );
-};
-
 const hasCliArg = ( arg ) => getCliArg( arg ) !== undefined;
 
 const handleSignal = ( signal ) => {
@@ -88,5 +82,4 @@ module.exports = {
 	getCliArgs,
 	hasCliArg,
 	spawnScript,
-	cleanUpArgs,
 };

--- a/packages/scripts/utils/index.js
+++ b/packages/scripts/utils/index.js
@@ -6,6 +6,7 @@ const {
 	getCliArgs,
 	hasCliArg,
 	spawnScript,
+	cleanUpArgs,
 } = require( './cli' );
 const {
 	getWebpackArgs,
@@ -35,4 +36,5 @@ module.exports = {
 	hasPackageProp,
 	hasProjectFile,
 	spawnScript,
+	cleanUpArgs,
 };

--- a/packages/scripts/utils/process.js
+++ b/packages/scripts/utils/process.js
@@ -1,4 +1,12 @@
-const getCliArgs = () => process.argv.slice( 2 );
+const getCliArgs = ( excludePrefixes ) => {
+	const args = process.argv.slice( 2 );
+	if ( excludePrefixes ) {
+		return args.filter( ( arg ) => {
+			return ! excludePrefixes.some( ( prefix ) => arg.startsWith( prefix ) );
+		} );
+	}
+	return args;
+};
 
 module.exports = {
 	exit: process.exit,


### PR DESCRIPTION
## Description
Following #13993 and part of #8319 this adds the option to run all e2e test commands with an extra interactive commands, which shows Chrome at a human speed, so you can visually inspect your test.

So now we can run:

```
npm run test-e2e interactive // all tests interactively
npm run test-e2e interactive FILE_NAME // one test file interactively
npm run test-e2e:watch interactive // all tests interactively and watch for changes
npm run test-e2e:watch interactive FILE_NAME // one test file interactively and watch for changes
```
## How has this been tested?
Ran locally with the interactive command and appears to work as expected.

## Note
@talldan suggested we'd have

```
npm run test-e2e:watch --interactive
```

but the only way to have that is if we'd also append more '--' as in 

```
npm run test-e2e:watch -- --interactive
```

and I figured it'd be too many dashes, plus when passed to jest it would throw an unrecognised arg error so we'd have clean it before.

Just using the word seemed to work out of the box, maybe ;)