### PR TITLE
Babel Preset Default: Avoid disabling regenerator option

### DIFF
--- a/packages/babel-preset-default/CHANGELOG.md
+++ b/packages/babel-preset-default/CHANGELOG.md
@@ -1,13 +1,17 @@
 ## 4.0.0 (Unreleased)
 
-## Breaking Change
+### Breaking Change
 
 - Removed `babel-core` dependency acting as Babel 7 bridge ([#13922](https://github.com/WordPress/gutenberg/pull/13922). Ensure all references to `babel-core` are replaced with `@babel/core` .
 - Preset updated to include `@wordpress/babel-plugin-import-jsx-pragma` plugin integration ([#13540](https://github.com/WordPress/gutenberg/pull/13540)).
 
+### Bug Fix
+
+- The runtime transform no longer disables [the `regenerator` option](https://babeljs.io/docs/en/babel-plugin-transform-runtime#regenerator). This should resolve issues where a file generated using the preset would assume the presence of a `regeneratorRuntime` object in the global scope. While this is not considered a breaking change, you may be mindful to consider that with transformed output now explicitly importing the runtime regenerator, bundle sizes may increase if you do not otherwise mitigate the additional import by either (a) overriding the option in your own Babel configuration extensions or (b) redefining the resolved value of `@babel/runtime/regenerator` using a feature like [Webpack's `externals` option](https://webpack.js.org/configuration/externals/).
+
 ## 3.0.0 (2018-09-30)
 
-## Breaking Change
+### Breaking Change
 
 - The configured `@babel/preset-env` preset will no longer pass `useBuiltIns: 'usage'` as an option. It is therefore expected that a polyfill serve in its place, if necessary.
 

--- a/packages/babel-preset-default/index.js
+++ b/packages/babel-preset-default/index.js
@@ -28,7 +28,6 @@ module.exports = function( api ) {
 			} ],
 			'@babel/plugin-proposal-async-generator-functions',
 			! isTestEnv && [ '@babel/plugin-transform-runtime', {
-				corejs: false, // We polyfill so we don't need core-js.
 				helpers: true,
 				regenerator: false, // We polyfill so we don't need regenerator.
 				useESModules: false,

--- a/packages/babel-preset-default/index.js
+++ b/packages/babel-preset-default/index.js
@@ -29,7 +29,6 @@ module.exports = function( api ) {
 			'@babel/plugin-proposal-async-generator-functions',
 			! isTestEnv && [ '@babel/plugin-transform-runtime', {
 				helpers: true,
-				regenerator: false, // We polyfill so we don't need regenerator.
 				useESModules: false,
 			} ],
 		].filter( Boolean ),

--- a/packages/babel-preset-default/test/__snapshots__/index.js.snap
+++ b/packages/babel-preset-default/test/__snapshots__/index.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Babel preset default transpilation works properly 1`] = `
 "import _asyncToGenerator from \\"@babel/runtime/helpers/asyncToGenerator\\";
+import _regeneratorRuntime from \\"@babel/runtime/regenerator\\";
 import _awaitAsyncGenerator from \\"@babel/runtime/helpers/awaitAsyncGenerator\\";
 import _wrapAsyncGenerator from \\"@babel/runtime/helpers/wrapAsyncGenerator\\";
 describe('Babel preset default', function () {
@@ -12,8 +13,8 @@ describe('Babel preset default', function () {
   function _foo() {
     _foo = _wrapAsyncGenerator(
     /*#__PURE__*/
-    regeneratorRuntime.mark(function _callee() {
-      return regeneratorRuntime.wrap(function _callee$(_context) {
+    _regeneratorRuntime.mark(function _callee() {
+      return _regeneratorRuntime.wrap(function _callee$(_context) {
         while (1) {
           switch (_context.prev = _context.next) {
             case 0:
@@ -38,9 +39,9 @@ describe('Babel preset default', function () {
   /*#__PURE__*/
   _asyncToGenerator(
   /*#__PURE__*/
-  regeneratorRuntime.mark(function _callee2() {
+  _regeneratorRuntime.mark(function _callee2() {
     var generator;
-    return regeneratorRuntime.wrap(function _callee2$(_context2) {
+    return _regeneratorRuntime.wrap(function _callee2$(_context2) {
       while (1) {
         switch (_context2.prev = _context2.next) {
           case 0:

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -51,6 +51,14 @@ const externals = [
 		jquery: 'jQuery',
 		lodash: 'lodash',
 		'lodash-es': 'lodash',
+
+		// Distributed NPM packages may depend on Babel's runtime regenerator.
+		// In a WordPress context, the regenerator is assigned to the global
+		// scope via the `wp-polyfill` script. It is reassigned here as an
+		// externals to reduce the size of generated bundles.
+		//
+		// See: https://github.com/WordPress/gutenberg/issues/13890
+		'@babel/runtime/regenerator': 'regeneratorRuntime',
 	},
 	wordpressExternals,
 ];


### PR DESCRIPTION
Closes #13890 

This pull request seeks to resolve an issue where files transformed using the Babel preset provided by `@wordpress/babel-preset-default` would implicitly depend on a `regeneratorRuntime` global. As of these changes, the runtime transform no longer disables [the `regenerator` option](https://babeljs.io/docs/en/babel-plugin-transform-runtime#regenerator). While this is not considered a breaking change, developers may be mindful to consider that with transformed output now explicitly importing the runtime regenerator, bundle sizes may increase if you do not otherwise mitigate the additional import by either (a) overriding the option in your own Babel configuration extensions or (b) redefining the resolved value of `@babel/runtime/regenerator` using a feature like [Webpack's `externals` option](https://webpack.js.org/configuration/externals/).

**Testing instructions:**

Observe the changed output from the default Babel preset snapshot, and ensure it passes:

```
npm run test-unit packages/babel-preset-default
```

You may confirm that for files transformed using the Babel preset, the regenerator is imported explicitly.

Additionally, you may verify the output from `npm run dev` and see that the Webpack-generated resulting files include both the reference to the `@babel/runtime/regenerator` import and that the import is externalized to the `window.regeneratorRuntime` global.

For example, from `build/data/index.js`:

```js
/* harmony import */ var _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! @babel/runtime/regenerator */ "@babel/runtime/regenerator");
```

```js
/***/ "@babel/runtime/regenerator":
/*!*************************************!*\
  !*** external "regeneratorRuntime" ***!
  \*************************************/
/*! no static exports found */
/***/ (function(module, exports) {

(function() { module.exports = this["regeneratorRuntime"]; }());

/***/ }),
```