### PR TITLE
WIP - Add an eslint rule for detecting package level side effects

### DIFF
--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -27,5 +27,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": [
+		"src/index.js"
+	]
 }

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -32,5 +32,9 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": [
+		"src/block/index.js",
+		"src/format/index.js"
+	]
 }

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -34,6 +34,7 @@
 		"access": "public"
 	},
 	"sideEffects": [
+		"src/index.js",
 		"src/block/index.js",
 		"src/format/index.js"
 	]

--- a/packages/api-fetch/package.json
+++ b/packages/api-fetch/package.json
@@ -28,5 +28,6 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": false
 }

--- a/packages/autop/package.json
+++ b/packages/autop/package.json
@@ -25,5 +25,6 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": false
 }

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -25,5 +25,6 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": false
 }

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -53,6 +53,7 @@
 		"access": "public"
 	},
 	"sideEffects": [
+		"src/index.js",
 		"src/store/index.js"
 	]
 }

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -51,5 +51,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": [
+		"src/store/index.js"
+	]
 }

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -45,5 +45,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": [
+		"src/index.native.js"
+	]
 }

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -47,6 +47,7 @@
 		"access": "public"
 	},
 	"sideEffects": [
+		"src/index.js",
 		"src/index.native.js"
 	]
 }

--- a/packages/block-serialization-default-parser/package.json
+++ b/packages/block-serialization-default-parser/package.json
@@ -26,5 +26,6 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": false
 }

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -46,6 +46,7 @@
 		"access": "public"
 	},
 	"sideEffects": [
+		"src/index.js",
 		"src/store/index.js"
 	]
 }

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -44,5 +44,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": [
+		"src/store/index.js"
+	]
 }

--- a/packages/blocks/src/api/raw-handling/phrasing-content.js
+++ b/packages/blocks/src/api/raw-handling/phrasing-content.js
@@ -21,6 +21,7 @@ const phrasingContentSchema = {
 // Recursion is needed.
 // Possible: strong > em > strong.
 // Impossible: strong > strong.
+// eslint-disable-next-line @wordpress/package-side-effects
 [ 'strong', 'em', 's', 'del', 'ins', 'a', 'code', 'abbr', 'sub', 'sup' ].forEach( ( tag ) => {
 	phrasingContentSchema[ tag ].children = omit( phrasingContentSchema, tag );
 } );

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -51,5 +51,8 @@
 	"publishConfig": {
 		"access": "public"
 	},
-	"sideEffects": false
+	"sideEffects": [
+		"src/date-time/index.js",
+		"src/keyboard-shortcuts/index.js"
+	]
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,5 +50,6 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": false
 }

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -29,5 +29,6 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": false
 }

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -33,5 +33,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": [
+		"src/index.js"
+	]
 }

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -37,5 +37,6 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": false
 }

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -27,5 +27,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": [
+		"src/index.js"
+	]
 }

--- a/packages/deprecated/package.json
+++ b/packages/deprecated/package.json
@@ -26,5 +26,6 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": false
 }

--- a/packages/dom-ready/package.json
+++ b/packages/dom-ready/package.json
@@ -24,5 +24,6 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": false
 }

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -27,5 +27,6 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": false
 }

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -50,7 +50,9 @@
 	},
 	"sideEffects": [
 		"src/hooks/components/index.js",
+		"src/hooks/index.js",
 		"src/hooks/validate-multiple-use/index.js",
+		"src/index.js",
 		"src/plugins/index.js",
 		"src/store/index.js"
 	]

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -47,5 +47,11 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": [
+		"src/hooks/components/index.js",
+		"src/hooks/validate-multiple-use/index.js",
+		"src/plugins/index.js",
+		"src/store/index.js"
+	]
 }

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -29,5 +29,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": [
+		"src/index.js"
+	]
 }

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -54,5 +54,14 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": [
+		"src/hooks/align.js",
+		"src/hooks/anchor.js",
+		"src/hooks/custom-class-name.js",
+		"src/hooks/custom-class-name.native.js",
+		"src/hooks/default-autocompleters.js",
+		"src/hooks/generated-class-name.js",
+		"src/store/index.js"
+	]
 }

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -62,6 +62,10 @@
 		"src/hooks/custom-class-name.native.js",
 		"src/hooks/default-autocompleters.js",
 		"src/hooks/generated-class-name.js",
+		"src/hooks/index.js",
+		"src/hooks/index.native.js",
+		"src/index.js",
+		"src/index.native.js",
 		"src/store/index.js"
 	]
 }

--- a/packages/editor/src/editor-styles/ast/stringify/compress.js
+++ b/packages/editor/src/editor-styles/ast/stringify/compress.js
@@ -28,7 +28,7 @@ function Compiler( options ) {
 /**
  * Inherit from `Base.prototype`.
  */
-
+// eslint-disable-next-line @wordpress/package-side-effects
 inherits( Compiler, Base );
 
 /**

--- a/packages/editor/src/editor-styles/ast/stringify/identity.js
+++ b/packages/editor/src/editor-styles/ast/stringify/identity.js
@@ -32,7 +32,7 @@ function Compiler( options ) {
 /**
  * Inherit from `Base.prototype`.
  */
-
+// eslint-disable-next-line @wordpress/package-side-effects
 inherits( Compiler, Base );
 
 /**

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -30,5 +30,6 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": false
 }

--- a/packages/escape-html/package.json
+++ b/packages/escape-html/package.json
@@ -24,5 +24,6 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": false
 }

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -51,10 +51,11 @@ Rule|Description|Recommended
 ---|---|---
 [dependency-group](/packages/eslint-plugin/docs/rules/dependency-group.md)|Enforce dependencies docblocks formatting|✓
 [gutenberg-phase](docs/rules/gutenberg-phase.md)|Governs the use of the `process.env.GUTENBERG_PHASE` constant|✓
+[no-base-control-with-label-without-id](/packages/eslint-plugin/docs/rules/no-base-control-with-label-without-id.md)| Disallow the usage of BaseControl component with a label prop set but omitting the id property|✓
 [no-unused-vars-before-return](/packages/eslint-plugin/docs/rules/no-unused-vars-before-return.md)|Disallow assigning variable values if unused before a return|✓
+[package-side-effects](/packages/eslint-plugin/docs/rules/package-side-effects.md)|Enforce the `package.json` sideEffects property|
 [react-no-unsafe-timeout](/packages/eslint-plugin/docs/rules/react-no-unsafe-timeout.md)|Disallow unsafe `setTimeout` in component|
 [valid-sprintf](/packages/eslint-plugin/docs/rules/valid-sprintf.md)|Enforce valid sprintf usage|✓
-[no-base-control-with-label-without-id](/packages/eslint-plugin/docs/rules/no-base-control-with-label-without-id.md)| Disallow the usage of BaseControl component with a label prop set but omitting the id property|✓
 
 ### Legacy
 

--- a/packages/eslint-plugin/configs/custom.js
+++ b/packages/eslint-plugin/configs/custom.js
@@ -32,6 +32,12 @@ module.exports = {
 				'@wordpress/no-base-control-with-label-without-id': 'off',
 			},
 		},
+		{
+			files: [ '**/test/*.js', '**/benchmark/*.js' ],
+			rules: {
+				'@wordpress/package-side-effects': 'off',
+			}
+		}
 	],
 	settings: {
 		react: {

--- a/packages/eslint-plugin/configs/custom.js
+++ b/packages/eslint-plugin/configs/custom.js
@@ -6,6 +6,7 @@ module.exports = {
 		'@wordpress/dependency-group': 'error',
 		'@wordpress/gutenberg-phase': 'error',
 		'@wordpress/no-unused-vars-before-return': 'error',
+		'@wordpress/package-side-effects': 'error',
 		'@wordpress/valid-sprintf': 'error',
 		'@wordpress/no-base-control-with-label-without-id': 'error',
 		'no-restricted-syntax': [

--- a/packages/eslint-plugin/docs/rules/package-side-effects.md
+++ b/packages/eslint-plugin/docs/rules/package-side-effects.md
@@ -10,7 +10,7 @@ This linter rule enforces this by detecting package-level side effects and check
 
 Examples of **incorrect** code for this rule:
 
-`src/index.js`
+This example shows side effects introduced in a file `src/index.js`.
 ```js
 // Module imports can introduce side effects.
 import 'module-with-side-effects';
@@ -19,29 +19,10 @@ import 'module-with-side-effects';
 window.addEventListener( 'resize', handleResize );
 registerStore( store );
 ```
-
-`package.json`
-```json
-{
-	// ...
-	"sideEffects": false,
-}
-```
-
 
 Examples of **correct** code for this rule:
 
-`src/index.js`
-```js
-// Module imports can introduce side effects.
-import 'module-with-side-effects';
-
-// Function calls can introduce side effects when the return value is not used.
-window.addEventListener( 'resize', handleResize );
-registerStore( store );
-```
-
-`package.json`
+Adding the `src/index.js` file to the `package.json` resolves the issue.
 ```json
 {
 	// ...

--- a/packages/eslint-plugin/docs/rules/package-side-effects.md
+++ b/packages/eslint-plugin/docs/rules/package-side-effects.md
@@ -1,0 +1,44 @@
+# Enforce package.json `sideEffects` property (package-side-effects)
+
+For tree-shaking to work correctly during a webpack build, packages should declare any files that cause side effects in the `sideEffects` property of the package's package.json.
+
+()[https://webpack.js.org/guides/tree-shaking/]
+
+This linter rule enforces this by detecting package-level side effects and checking the relevant file is defined under the `sideEffects` property.
+
+## Rule details
+
+Examples of **incorrect** code for this rule:
+
+`src/index.js`
+```js
+window.addEventListener( 'resize', handleResize );
+```
+
+`package.json`
+```json
+{
+	// ...
+	"sideEffects": false,
+}
+```
+
+
+Examples of **correct** code for this rule:
+
+`src/index.js`
+```js
+window.addEventListener( 'resize', handleResize );
+```
+
+`package.json`
+```json
+{
+	// ...
+	"sideEffects": [
+		"src/index.js"
+	]
+}
+```
+
+

--- a/packages/eslint-plugin/docs/rules/package-side-effects.md
+++ b/packages/eslint-plugin/docs/rules/package-side-effects.md
@@ -12,7 +12,12 @@ Examples of **incorrect** code for this rule:
 
 `src/index.js`
 ```js
+// Module imports can introduce side effects.
+import 'module-with-side-effects';
+
+// Function calls can introduce side effects when the return value is not used.
 window.addEventListener( 'resize', handleResize );
+registerStore( store );
 ```
 
 `package.json`
@@ -28,7 +33,12 @@ Examples of **correct** code for this rule:
 
 `src/index.js`
 ```js
+// Module imports can introduce side effects.
+import 'module-with-side-effects';
+
+// Function calls can introduce side effects when the return value is not used.
 window.addEventListener( 'resize', handleResize );
+registerStore( store );
 ```
 
 `package.json`

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -22,6 +22,7 @@
 		"eslint-plugin-jsx-a11y": "^6.2.1",
 		"eslint-plugin-react": "^7.12.4",
 		"eslint-plugin-react-hooks": "^1.6.0",
+		"read-pkg-up": "^4.0.0",
 		"requireindex": "^1.2.0"
 	},
 	"publishConfig": {

--- a/packages/eslint-plugin/rules/__tests__/package-side-effects.js
+++ b/packages/eslint-plugin/rules/__tests__/package-side-effects.js
@@ -26,6 +26,7 @@ jest.mock( 'read-pkg-up', () => {
 
 const ruleTester = new RuleTester( {
 	parserOptions: {
+		sourceType: 'module',
 		ecmaVersion: 6,
 	},
 } );
@@ -35,12 +36,19 @@ ruleTester.run( 'package-side-effects', rule, {
 		{ code: `window.addEventListener( 'resize', handleResize );`, filename: 'src/has-side-effects.js' },
 		{ code: `registerStore( store );`, filename: 'src/also-has-side-effects.js' },
 		{ code: `const value = functionCall();`, filename: 'src/index.js' },
+		{ code: `import 'bar';`, filename: 'src/has-side-effects.js' },
+		{ code: `import foo from 'bar';`, filename: 'src/index.js' },
 	],
 	invalid: [
 		{
 			code: `window.addEventListener( 'resize', handleResize );`,
 			filename: 'src/index.js',
 			errors: [ { message: `Call to function may introduce package level side-effects. Consider adding 'src/index.js' to the package's package.json sideEffect property.` } ],
+		},
+		{
+			code: `import 'bar';`,
+			filename: 'src/index.js',
+			errors: [ { message: `Import of module may introduce package level side-effects. Consider adding 'src/index.js' to the package's package.json sideEffect property.` } ],
 		},
 	],
 } );

--- a/packages/eslint-plugin/rules/__tests__/package-side-effects.js
+++ b/packages/eslint-plugin/rules/__tests__/package-side-effects.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { RuleTester } from 'eslint';
+
+/**
+ * Internal dependencies
+ */
+import rule from '../package-side-effects';
+
+const mockPackageJson = {
+	sideEffects: [
+		'src/has-side-effects.js',
+		'./src/also-has-side-effects.js',
+	],
+};
+
+jest.mock( 'read-pkg-up', () => {
+	return {
+		sync: jest.fn( () => ( {
+			pkg: mockPackageJson,
+			path: '',
+		} ) ),
+	};
+} );
+
+const ruleTester = new RuleTester( {
+	parserOptions: {
+		ecmaVersion: 6,
+	},
+} );
+
+ruleTester.run( 'package-side-effects', rule, {
+	valid: [
+		{ code: `window.addEventListener( 'resize', handleResize );`, filename: 'src/has-side-effects.js' },
+		{ code: `registerStore( store );`, filename: 'src/also-has-side-effects.js' },
+		{ code: `const value = functionCall();`, filename: 'src/index.js' },
+	],
+	invalid: [
+		{
+			code: `window.addEventListener( 'resize', handleResize );`,
+			filename: 'src/index.js',
+			errors: [ { message: `Call to function may introduce package level side-effects. Consider adding 'src/index.js' to the package's package.json sideEffect property.` } ],
+		},
+	],
+} );

--- a/packages/eslint-plugin/rules/package-side-effects.js
+++ b/packages/eslint-plugin/rules/package-side-effects.js
@@ -1,0 +1,60 @@
+const readPkgUp = require( 'read-pkg-up' );
+
+module.exports = {
+	meta: {
+		type: 'suggestion',
+		schema: [],
+	},
+	create( context ) {
+		const filename = context.getFilename();
+
+		// Don't lint files in the test folder (otherwise `describe` is flagged).
+		// TODO - accept a list of file or function names to ignore as a configuration option.
+		if ( filename.includes( '/test/' ) ) {
+			return {};
+		}
+
+		const { pkg: packageJson, path: packageJsonPath } = readPkgUp.sync( { cwd: filename } );
+
+		// Unable to find a package.json, so don't lint this file.
+		if ( ! packageJson ) {
+			return {};
+		}
+
+		const { sideEffects } = packageJson;
+
+		// Side effects is undefined or true, don't lint this file as side effects are expected.
+		if ( sideEffects === undefined || sideEffects === true ) {
+			return {};
+		}
+
+		const packageRoot = packageJsonPath.replace( 'package.json', '' );
+		const relativeFilePath = filename.replace( packageRoot, '' );
+
+		// Side effects is an array. If the filename is in the array, don't lint.
+		if ( typeof sideEffects === 'object' && sideEffects.includes ) {
+			if ( sideEffects.includes( relativeFilePath ) || sideEffects.includes( `./${ relativeFilePath }` ) ) {
+				return {};
+			}
+		}
+
+		return {
+			ExpressionStatement( node ) {
+				// Only lint function calls.
+				if ( node.expression && node.expression.type !== 'CallExpression' ) {
+					return;
+				}
+
+				// Only lint nodes in the upper-most scope.
+				if ( node.parent && node.parent.type !== 'Program' ) {
+					return;
+				}
+
+				context.report(
+					node,
+					`Call to function may introduce package level side-effects. Consider adding '${ relativeFilePath }' to the package's package.json sideEffect property.`
+				);
+			},
+		};
+	},
+};

--- a/packages/eslint-plugin/rules/package-side-effects.js
+++ b/packages/eslint-plugin/rules/package-side-effects.js
@@ -39,6 +39,16 @@ module.exports = {
 		}
 
 		return {
+			ImportDeclaration( node ) {
+				if ( node.specifiers && node.specifiers.length ) {
+					return;
+				}
+
+				context.report(
+					node,
+					`Import of module may introduce package level side-effects. Consider adding '${ relativeFilePath }' to the package's package.json sideEffect property.`
+				);
+			},
 			ExpressionStatement( node ) {
 				// Only lint function calls.
 				if ( node.expression && node.expression.type !== 'CallExpression' ) {

--- a/packages/eslint-plugin/rules/package-side-effects.js
+++ b/packages/eslint-plugin/rules/package-side-effects.js
@@ -7,13 +7,6 @@ module.exports = {
 	},
 	create( context ) {
 		const filename = context.getFilename();
-
-		// Don't lint files in the test folder (otherwise `describe` is flagged).
-		// TODO - accept a list of file or function names to ignore as a configuration option.
-		if ( filename.includes( '/test/' ) ) {
-			return {};
-		}
-
 		const { pkg: packageJson, path: packageJsonPath } = readPkgUp.sync( { cwd: filename } );
 
 		// Unable to find a package.json, so don't lint this file.

--- a/packages/eslint-plugin/rules/package-side-effects.js
+++ b/packages/eslint-plugin/rules/package-side-effects.js
@@ -33,7 +33,13 @@ module.exports = {
 
 		return {
 			ImportDeclaration( node ) {
+				// Only lint imports that don't specify variable names.
 				if ( node.specifiers && node.specifiers.length ) {
+					return;
+				}
+
+				// Ignore stylesheet imports.
+				if ( /\.scss$/.test( node.source.value ) ) {
 					return;
 				}
 

--- a/packages/format-library/package.json
+++ b/packages/format-library/package.json
@@ -33,5 +33,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": [
+		"src/index.js"
+	]
 }

--- a/packages/hooks/benchmark/index.js
+++ b/packages/hooks/benchmark/index.js
@@ -1,5 +1,3 @@
-/* eslint-disable @wordpress/package-side-effects */
-
 const Benchmark = require( 'benchmark' );
 const hooks = require( '../' );
 

--- a/packages/hooks/benchmark/index.js
+++ b/packages/hooks/benchmark/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @wordpress/package-side-effects */
+
 const Benchmark = require( 'benchmark' );
 const hooks = require( '../' );
 

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -25,5 +25,6 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": false
 }

--- a/packages/html-entities/package.json
+++ b/packages/html-entities/package.json
@@ -26,5 +26,6 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": false
 }

--- a/packages/i18n/benchmark/index.js
+++ b/packages/i18n/benchmark/index.js
@@ -1,5 +1,3 @@
-/* eslint-disable @wordpress/package-side-effects */
-
 const Benchmark = require( 'benchmark' );
 const { __ } = require( '../' );
 

--- a/packages/i18n/benchmark/index.js
+++ b/packages/i18n/benchmark/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @wordpress/package-side-effects */
+
 const Benchmark = require( 'benchmark' );
 const { __ } = require( '../' );
 

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -33,5 +33,6 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": false
 }

--- a/packages/i18n/tools/pot-to-php.js
+++ b/packages/i18n/tools/pot-to-php.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-disable @wordpress/package-side-effects */
 
 const gettextParser = require( 'gettext-parser' );
 const { isEmpty } = require( 'lodash' );

--- a/packages/is-shallow-equal/benchmark/index.js
+++ b/packages/is-shallow-equal/benchmark/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+/* eslint-disable @wordpress/package-side-effects */
+
 const Benchmark = require( 'benchmark' );
 
 const suite = new Benchmark.Suite;

--- a/packages/is-shallow-equal/package.json
+++ b/packages/is-shallow-equal/package.json
@@ -29,5 +29,6 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": false
 }

--- a/packages/is-shallow-equal/test/index.js
+++ b/packages/is-shallow-equal/test/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable @wordpress/package-side-effects */
+
 /**
  * Internal dependencies
  */

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -27,5 +27,6 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": false
 }

--- a/packages/list-reusable-blocks/package.json
+++ b/packages/list-reusable-blocks/package.json
@@ -30,5 +30,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": [
+		"src/index.js"
+	]
 }

--- a/packages/notices/package.json
+++ b/packages/notices/package.json
@@ -28,5 +28,6 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": false
 }

--- a/packages/notices/package.json
+++ b/packages/notices/package.json
@@ -29,5 +29,7 @@
 	"publishConfig": {
 		"access": "public"
 	},
-	"sideEffects": false
+	"sideEffects": [
+		"src/index.js"
+	]
 }

--- a/packages/nux/package.json
+++ b/packages/nux/package.json
@@ -32,5 +32,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": [
+		"src/store/index.js"
+	]
 }

--- a/packages/nux/package.json
+++ b/packages/nux/package.json
@@ -34,6 +34,7 @@
 		"access": "public"
 	},
 	"sideEffects": [
+		"src/index.js",
 		"src/store/index.js"
 	]
 }

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -28,5 +28,6 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": false
 }

--- a/packages/priority-queue/package.json
+++ b/packages/priority-queue/package.json
@@ -26,5 +26,6 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": false
 }

--- a/packages/redux-routine/package.json
+++ b/packages/redux-routine/package.json
@@ -29,5 +29,6 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": false
 }

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -33,6 +33,7 @@
 		"access": "public"
 	},
 	"sideEffects": [
+		"src/index.js",
 		"src/store/index.js"
 	]
 }

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -31,5 +31,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": [
+		"src/store/index.js"
+	]
 }

--- a/packages/shortcode/package.json
+++ b/packages/shortcode/package.json
@@ -27,5 +27,6 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": false
 }

--- a/packages/shortcode/src/index.js
+++ b/packages/shortcode/src/index.js
@@ -287,6 +287,7 @@ const shortcode = extend( function( options ) {
 	fromMatch,
 } );
 
+// eslint-disable-next-line @wordpress/package-side-effects
 extend( shortcode.prototype, {
 
 	/**

--- a/packages/token-list/package.json
+++ b/packages/token-list/package.json
@@ -24,5 +24,6 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": false
 }

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -26,5 +26,6 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": false
 }

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -29,5 +29,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": [
+		"src/index.js"
+	]
 }

--- a/packages/wordcount/package.json
+++ b/packages/wordcount/package.json
@@ -25,5 +25,6 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"sideEffects": false
 }


### PR DESCRIPTION
Fixes #13910

## Description
This checks for violations of the package.json `sideEffects` property. At the moment there are a couple of particular patterns it checks for:

- Function calls in the top-most scope where the return value isn't used. e.g.:
```
registerStore( // ... );
window.addEventListener( // ... );
```

- Imports of other modules that don't create any new variables. e.g.:
```
import './store';
```

When it detects these patterns and the file has not been added to the package.json `sideEffects` property it warns the developer to do so.

Other patterns that I've thought about:
- Mutation of an imported value. I think this is possible to add a lint rule for. I imagine there aren't (m)any instances of this, since I'd expect it to be considered bad practice and caught in a code review.
- Any others?

Patterns that are hard to lint for:
- If a mutation or side-effect happens as the result of a function call - e.g. `function initializeModule() { window.addEventListener( // ... ); }`, it's hard to catch since I'd have to trace back to the callsite.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
