### PR TITLE
Paste: preserve empty table cells

### DIFF
--- a/packages/block-library/src/table/index.js
+++ b/packages/block-library/src/table/index.js
@@ -18,11 +18,14 @@ import edit from './edit';
 
 const tableContentPasteSchema = {
 	tr: {
+		allowEmpty: true,
 		children: {
 			th: {
+				allowEmpty: true,
 				children: getPhrasingContentSchema(),
 			},
 			td: {
+				allowEmpty: true,
 				children: getPhrasingContentSchema(),
 			},
 		},
@@ -33,12 +36,15 @@ const tablePasteSchema = {
 	table: {
 		children: {
 			thead: {
+				allowEmpty: true,
 				children: tableContentPasteSchema,
 			},
 			tfoot: {
+				allowEmpty: true,
 				children: tableContentPasteSchema,
 			},
 			tbody: {
+				allowEmpty: true,
 				children: tableContentPasteSchema,
 			},
 		},

--- a/packages/blocks/src/api/raw-handling/utils.js
+++ b/packages/blocks/src/api/raw-handling/utils.js
@@ -185,11 +185,17 @@ function cleanNodeList( nodeList, doc, schema, inline ) {
 			( ! schema[ tag ].isMatch || schema[ tag ].isMatch( node ) )
 		) {
 			if ( node.nodeType === ELEMENT_NODE ) {
-				const { attributes = [], classes = [], children, require = [] } = schema[ tag ];
+				const {
+					attributes = [],
+					classes = [],
+					children,
+					require = [],
+					allowEmpty,
+				} = schema[ tag ];
 
 				// If the node is empty and it's supposed to have children,
 				// remove the node.
-				if ( isEmpty( node ) && children ) {
+				if ( children && ! allowEmpty && isEmpty( node ) ) {
 					remove( node );
 					return;
 				}

--- a/test/integration/fixtures/markdown-in.txt
+++ b/test/integration/fixtures/markdown-in.txt
@@ -23,6 +23,10 @@ First Header | Second Header
 Content from cell 1 | Content from cell 2
 Content in the first column | Content in the second column
 
+|   |   |
+|---|---|
+|   | Table with empty cells. |
+
 ## Quote
 
 > First

--- a/test/integration/fixtures/markdown-out.html
+++ b/test/integration/fixtures/markdown-out.html
@@ -31,6 +31,10 @@ line breaks please.</p>
 <table class="wp-block-table"><thead><tr><th>First Header</th><th>Second Header</th></tr></thead><tbody><tr><td>Content from cell 1</td><td>Content from cell 2</td></tr><tr><td>Content in the first column</td><td>Content in the second column</td></tr></tbody></table>
 <!-- /wp:table -->
 
+<!-- wp:table -->
+<table class="wp-block-table"><thead><tr><th></th><th></th></tr></thead><tbody><tr><td></td><td>Table with empty cells.</td></tr></tbody></table>
+<!-- /wp:table -->
+
 <!-- wp:heading -->
 <h2>Quote</h2>
 <!-- /wp:heading -->


### PR DESCRIPTION
## Description

Fixes #11547 and #8953. Allows the paste schema to define whether an element is allowed to be empty. This is needed for tables, as the structure should be preserved.

## How has this been tested?

A test has been added.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->