### PR TITLE
Catch errors in subscribe listeners to avoid breaking execution

### DIFF
--- a/assets/stylesheets/_mixins.scss
+++ b/assets/stylesheets/_mixins.scss
@@ -195,8 +195,8 @@
 
 @mixin square-style__focus() {
 	color: $dark-gray-900;
-	outline: 1px solid $dark-gray-300;
-	box-shadow: none;
+	outline-offset: -1px;
+	outline: 1px dotted $dark-gray-500;
 }
 
 // Menu items.

--- a/bin/get-server-blocks.php
+++ b/bin/get-server-blocks.php
@@ -24,10 +24,10 @@ wp_initial_constants();
 require_once ABSPATH . WPINC . '/functions.php';
 wp_load_translations_early();
 wp_set_lang_dir();
-require_once dirname( dirname( __FILE__ ) ) . '/lib/blocks.php';
-require_once dirname( dirname( __FILE__ ) ) . '/lib/class-wp-block-type-registry.php';
-require_once dirname( dirname( __FILE__ ) ) . '/lib/class-wp-block-type.php';
-require_once dirname( dirname( __FILE__ ) ) . '/lib/client-assets.php';
+require_once ABSPATH . WPINC . '/blocks.php';
+require_once ABSPATH . WPINC . '/class-wp-block-type-registry.php';
+require_once ABSPATH . WPINC . '/class-wp-block-type.php';
+require_once ABSPATH . '/wp-admin/includes/post.php';
 
 // Register server-side code for individual blocks.
 foreach ( glob( dirname( dirname( __FILE__ ) ) . '/packages/block-library/src/*/index.php' ) as $block_logic ) {
@@ -36,4 +36,4 @@ foreach ( glob( dirname( dirname( __FILE__ ) ) . '/packages/block-library/src/*/
 
 do_action( 'init' );
 
-echo json_encode( gutenberg_prepare_blocks_for_js() );
+echo json_encode( get_block_editor_server_block_settings() );

--- a/docs/designers-developers/developers/tutorials/format-api/2-toolbar-button.md
+++ b/docs/designers-developers/developers/tutorials/format-api/2-toolbar-button.md
@@ -35,3 +35,54 @@ Let's check that everything is working as expected. Reload the post/page and sel
 ![Toolbar with custom button](https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/assets/toolbar-with-custom-button.png)
 
 You may also want to check that upon clicking the button the `toggle format` message is shown in your browser's console.
+
+## Show the button only for specific blocks
+
+By default, the button is rendered on every rich text toolbar (image captions, buttons, paragraphs, etc).
+It is possible to render the button only on blocks of a certain type by using `wp.data.withSelect` together with `wp.compose.ifCondition`.
+The following sample code renders the previously shown button only on paragraph blocks:
+
+```js
+( function( wp ) {
+	var withSelect = wp.data.withSelect;
+	var ifCondition = wp.compose.ifCondition;
+	var compose = wp.compose.compose;
+	var MyCustomButton = function( props ) {
+		return wp.element.createElement(
+			wp.editor.RichTextToolbarButton, {
+				icon: 'editor-code',
+				title: 'Sample output',
+				onClick: function() {
+					console.log( 'toggle format' );
+				},
+			}
+		);
+	}
+	var ConditionalButton = compose(
+		withSelect( function( select ) {
+			return {
+				selectedBlock: select( 'core/editor' ).getSelectedBlock()
+			}
+		} ),
+		ifCondition( function( props ) {
+			return (
+				props.selectedBlock &&
+				props.selectedBlock.name === 'core/paragraph'
+			); 
+		} )
+	)( MyCustomButton );
+
+	wp.richText.registerFormatType(
+		'my-custom-format/sample-output', {
+			title: 'Sample output',
+			tagName: 'samp',
+			className: null,
+			edit: ConditionalButton,
+		}
+	);
+} )( window.wp );
+```
+
+Don't forget adding `wp-compose` and `wp-data` to the dependencies array in the PHP script.
+
+More advanced conditions can be used, e.g., only render the button depending on specific attributes of the block.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -139,21 +139,6 @@ function gutenberg_register_scripts_and_styles() {
 	global $wp_scripts;
 
 	gutenberg_register_vendor_scripts();
-
-	wp_add_inline_script(
-		'wp-polyfill',
-		wp_get_script_polyfill(
-			$wp_scripts,
-			array(
-				'\'fetch\' in window' => 'wp-polyfill-fetch',
-				'document.contains'   => 'wp-polyfill-node-contains',
-				'window.FormData && window.FormData.prototype.keys' => 'wp-polyfill-formdata',
-				'Element.prototype.matches && Element.prototype.closest' => 'wp-polyfill-element-closest',
-			),
-			'after'
-		)
-	);
-
 	gutenberg_register_packages_scripts();
 
 	// Inline scripts.
@@ -240,33 +225,6 @@ function gutenberg_register_scripts_and_styles() {
 					'timezone' => array(
 						'offset' => get_option( 'gmt_offset', 0 ),
 						'string' => get_option( 'timezone_string', 'UTC' ),
-					),
-				)
-			)
-		),
-		'after'
-	);
-	wp_add_inline_script(
-		'moment',
-		sprintf(
-			"moment.locale( '%s', %s );",
-			get_user_locale(),
-			wp_json_encode(
-				array(
-					'months'         => array_values( $wp_locale->month ),
-					'monthsShort'    => array_values( $wp_locale->month_abbrev ),
-					'weekdays'       => array_values( $wp_locale->weekday ),
-					'weekdaysShort'  => array_values( $wp_locale->weekday_abbrev ),
-					'week'           => array(
-						'dow' => (int) get_option( 'start_of_week', 0 ),
-					),
-					'longDateFormat' => array(
-						'LT'   => get_option( 'time_format', __( 'g:i a', 'default' ) ),
-						'LTS'  => null,
-						'L'    => null,
-						'LL'   => get_option( 'date_format', __( 'F j, Y', 'default' ) ),
-						'LLL'  => __( 'F j, Y g:i a', 'default' ),
-						'LLLL' => null,
 					),
 				)
 			)
@@ -534,52 +492,10 @@ function gutenberg_preload_api_request( $memo, $path ) {
  * @since 0.1.0
  */
 function gutenberg_register_vendor_scripts() {
-	$suffix = SCRIPT_DEBUG ? '' : '.min';
-
-	// Vendor Scripts.
-	$react_suffix = ( SCRIPT_DEBUG ? '.development' : '.production' ) . $suffix;
-
-	gutenberg_register_vendor_script(
-		'react',
-		'https://unpkg.com/react@16.6.3/umd/react' . $react_suffix . '.js',
-		array( 'wp-polyfill' )
-	);
-	gutenberg_register_vendor_script(
-		'react-dom',
-		'https://unpkg.com/react-dom@16.6.3/umd/react-dom' . $react_suffix . '.js',
-		array( 'react' )
-	);
-	$moment_script = SCRIPT_DEBUG ? 'moment.js' : 'min/moment.min.js';
-	gutenberg_register_vendor_script(
-		'moment',
-		'https://unpkg.com/moment@2.22.1/' . $moment_script,
-		array()
-	);
-	gutenberg_register_vendor_script(
-		'lodash',
-		'https://unpkg.com/lodash@4.17.11/lodash' . $suffix . '.js'
-	);
-	wp_add_inline_script( 'lodash', 'window.lodash = _.noConflict();' );
-	gutenberg_register_vendor_script(
-		'wp-polyfill-fetch',
-		'https://unpkg.com/whatwg-fetch@3.0.0/dist/fetch.umd.js'
-	);
-	gutenberg_register_vendor_script(
-		'wp-polyfill-formdata',
-		'https://unpkg.com/formdata-polyfill@3.0.9/formdata.min.js'
-	);
-	gutenberg_register_vendor_script(
-		'wp-polyfill-node-contains',
-		'https://unpkg.com/polyfill-library@3.26.0-0/polyfills/Node/prototype/contains/polyfill.js'
-	);
-	gutenberg_register_vendor_script(
-		'wp-polyfill-element-closest',
-		'https://unpkg.com/element-closest@2.0.2/element-closest.js'
-	);
-	gutenberg_register_vendor_script(
-		'wp-polyfill',
-		'https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.0.0/polyfill' . $suffix . '.js'
-	);
+	/*
+	 * This function is kept as an empty stub, in case Gutenberg should need to
+	 * explicitly provide a version newer than that provided by core.
+	 */
 }
 
 /**

--- a/lib/register.php
+++ b/lib/register.php
@@ -25,16 +25,16 @@ function gutenberg_collect_meta_box_data() {
  * Return whether the post can be edited in Gutenberg and by the current user.
  *
  * @since 0.5.0
- * @deprecated 5.0.0 use_block_editor_for_post
+ * @deprecated 5.1.0 use_block_editor_for_post
  *
  * @param int|WP_Post $post Post ID or WP_Post object.
  * @return bool Whether the post can be edited with Gutenberg.
  */
 function gutenberg_can_edit_post( $post ) {
-	_deprecated_function( __FUNCTION__, '5.0.0', 'use_block_editor_for_post' );
+	_deprecated_function( __FUNCTION__, '5.1.0', 'use_block_editor_for_post' );
 
+	require_once ABSPATH . 'wp-admin/includes/post.php';
 	return use_block_editor_for_post( $post );
-
 }
 
 /**
@@ -44,14 +44,15 @@ function gutenberg_can_edit_post( $post ) {
  * REST API, then the post cannot be edited in Gutenberg.
  *
  * @since 1.5.2
- * @deprecated 5.0.0 use_block_editor_for_post_type
+ * @deprecated 5.1.0 use_block_editor_for_post_type
  *
  * @param string $post_type The post type.
  * @return bool Whether the post type can be edited with Gutenberg.
  */
 function gutenberg_can_edit_post_type( $post_type ) {
-	_deprecated_function( __FUNCTION__, '5.0.0', 'use_block_editor_for_post_type' );
+	_deprecated_function( __FUNCTION__, '5.1.0', 'use_block_editor_for_post_type' );
 
+	require_once ABSPATH . 'wp-admin/includes/post.php';
 	return use_block_editor_for_post_type( $post_type );
 }
 
@@ -155,23 +156,23 @@ function gutenberg_bulk_post_updated_messages( $messages ) {
  * Injects a hidden input in the edit form to propagate the information that classic editor is selected.
  *
  * @since 1.5.2
- * @deprecated 5.0.0
+ * @deprecated 5.1.0
  */
 function gutenberg_remember_classic_editor_when_saving_posts() {
-	_deprecated_function( __FUNCTION__, '5.0.0' );
+	_deprecated_function( __FUNCTION__, '5.1.0' );
 }
 
 /**
  * Appends a query argument to the redirect url to make sure it gets redirected to the classic editor.
  *
  * @since 1.5.2
- * @deprecated 5.0.0
+ * @deprecated 5.1.0
  *
  * @param string $url Redirect url.
  * @return string Redirect url.
  */
 function gutenberg_redirect_to_classic_editor_when_saving_posts( $url ) {
-	_deprecated_function( __FUNCTION__, '5.0.0' );
+	_deprecated_function( __FUNCTION__, '5.1.0' );
 
 	return $url;
 }
@@ -181,13 +182,13 @@ function gutenberg_redirect_to_classic_editor_when_saving_posts( $url ) {
  * the editor from which the user navigated.
  *
  * @since 1.5.2
- * @deprecated 5.0.0
+ * @deprecated 5.1.0
  *
  * @param string $url Edit url.
  * @return string Edit url.
  */
 function gutenberg_revisions_link_to_editor( $url ) {
-	_deprecated_function( __FUNCTION__, '5.0.0' );
+	_deprecated_function( __FUNCTION__, '5.1.0' );
 
 	return $url;
 }

--- a/packages/babel-plugin-import-jsx-pragma/CHANGELOG.md
+++ b/packages/babel-plugin-import-jsx-pragma/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ### Breaking Change
 
-- Plugin skips now adding import JSX pragma when the scope variable is defined for all JSX elements ([#13809](https://github.com/WordPress/gutenberg/pull/13809)). 
 - Stop using Babel transpilation internally and set node 8 as a minimal version required ([#13540](https://github.com/WordPress/gutenberg/pull/13540)).
+
+### Enhancement
+
+- Plugin skips now adding import JSX pragma when the scope variable is defined for all JSX elements ([#13809](https://github.com/WordPress/gutenberg/pull/13809)). 
 
 ## 1.1.0 (2018-09-05)
 

--- a/packages/babel-plugin-import-jsx-pragma/index.js
+++ b/packages/babel-plugin-import-jsx-pragma/index.js
@@ -40,42 +40,16 @@ module.exports = function( babel ) {
 	return {
 		visitor: {
 			JSXElement( path, state ) {
-				state.hasJSX = true;
 				if ( state.hasUndeclaredScopeVariable ) {
 					return;
 				}
 
 				const { scopeVariable } = getOptions( state );
-
 				state.hasUndeclaredScopeVariable = ! path.scope.hasBinding( scopeVariable );
-			},
-			ImportDeclaration( path, state ) {
-				if ( state.hasImportedScopeVariable ) {
-					return;
-				}
-
-				const { scopeVariable, isDefault } = getOptions( state );
-
-				// Test that at least one import specifier exists matching the
-				// scope variable name. The module source is not verified since
-				// we must avoid introducing a conflicting import name, even if
-				// the scope variable is referenced from a different source.
-				state.hasImportedScopeVariable = path.node.specifiers.some( ( specifier ) => {
-					switch ( specifier.type ) {
-						case 'ImportSpecifier':
-							return (
-								! isDefault &&
-								specifier.imported.name === scopeVariable
-							);
-
-						case 'ImportDefaultSpecifier':
-							return isDefault;
-					}
-				} );
 			},
 			Program: {
 				exit( path, state ) {
-					if ( ! state.hasJSX || state.hasImportedScopeVariable || ! state.hasUndeclaredScopeVariable ) {
+					if ( ! state.hasUndeclaredScopeVariable ) {
 						return;
 					}
 

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -15,7 +15,7 @@ import {
 	RichText,
 } from '@wordpress/editor';
 import { join, split, create, toHTMLString } from '@wordpress/rich-text';
-import { G, Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/components';
 
 const ATTRIBUTE_QUOTE = 'value';
 const ATTRIBUTE_CITATION = 'citation';
@@ -44,7 +44,7 @@ export const name = 'core/quote';
 export const settings = {
 	title: __( 'Quote' ),
 	description: __( 'Give quoted text visual emphasis. "In quoting others, we cite ourselves." — Julio Cortázar' ),
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M19 18h-6l2-4h-2V6h8v7l-2 5zm-2-2l2-3V8h-4v4h4l-2 4zm-8 2H3l2-4H3V6h8v7l-2 5zm-2-2l2-3V8H5v4h4l-2 4z" /></G></SVG>,
+	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><Path d="M18.62 18h-5.24l2-4H13V6h8v7.24L18.62 18zm-2-2h.76L19 12.76V8h-4v4h3.62l-2 4zm-8 2H3.38l2-4H3V6h8v7.24L8.62 18zm-2-2h.76L9 12.76V8H5v4h3.62l-2 4z" /></SVG>,
 	category: 'common',
 	keywords: [ __( 'blockquote' ) ],
 

--- a/packages/components/src/form-toggle/README.md
+++ b/packages/components/src/form-toggle/README.md
@@ -71,20 +71,6 @@ const MyFormToggle = withState( {
 
 The component accepts the following props:
 
-#### label
-
-If this property is added, a label will be generated using label property as the content.
-
-- Type: `String`
-- Required: No
-
-#### help
-
-If this property is added, a help text will be generated using help property as the content.
-
-- Type: `String` | `Function`
-- Required: No
-
 #### checked
 
 If checked is true the toggle will be checked. If checked is false the toggle will be unchecked.

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -46,7 +46,14 @@ export function createRegistry( storeConfigs = {} ) {
 	 * Global listener called for each store's update.
 	 */
 	function globalListener() {
-		listeners.forEach( ( listener ) => listener() );
+		listeners.forEach( ( listener ) => {
+			try {
+				listener();
+			} catch ( error ) {
+				// eslint-disable-next-line no-console
+				console.error( error );
+			}
+		} );
 	}
 
 	/**

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -21,7 +21,7 @@ import {
  */
 import FullscreenModeClose from '../fullscreen-mode-close';
 
-function HeaderToolbar( { hasFixedToolbar, isLargeViewport, showInserter } ) {
+function HeaderToolbar( { hasFixedToolbar, isLargeViewport, showInserter, isTextModeEnabled } ) {
 	const toolbarAriaLabel = hasFixedToolbar ?
 		/* translators: accessibility text for the editor toolbar when Top Toolbar is on */
 		__( 'Document and block tools' ) :
@@ -42,8 +42,8 @@ function HeaderToolbar( { hasFixedToolbar, isLargeViewport, showInserter } ) {
 			</div>
 			<EditorHistoryUndo />
 			<EditorHistoryRedo />
-			<TableOfContents />
-			<BlockNavigationDropdown />
+			<TableOfContents hasOutlineItemsDisabled={ isTextModeEnabled } />
+			<BlockNavigationDropdown isDisabled={ isTextModeEnabled } />
 			{ hasFixedToolbar && isLargeViewport && (
 				<div className="edit-post-header-toolbar__block-toolbar">
 					<BlockToolbar />
@@ -58,6 +58,7 @@ export default compose( [
 		hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' ),
 		// This setting (richEditingEnabled) should not live in the block editor's setting.
 		showInserter: select( 'core/edit-post' ).getEditorMode() === 'visual' && select( 'core/block-editor' ).getEditorSettings().richEditingEnabled,
+		isTextModeEnabled: select( 'core/edit-post' ).getEditorMode() === 'text',
 	} ) ),
 	withViewportMatch( { isLargeViewport: 'medium' } ),
 ] )( HeaderToolbar );

--- a/packages/edit-post/src/components/sidebar/settings-header/style.scss
+++ b/packages/edit-post/src/components/sidebar/settings-header/style.scss
@@ -18,14 +18,14 @@
 .edit-post-sidebar__panel-tab {
 	background: transparent;
 	border: none;
-	border-radius: 0;
+	box-shadow: none;
 	cursor: pointer;
-	height: $grid-size * 6;
 	padding: 3px 15px; // Use padding to offset the is-active border, this benefits Windows High Contrast mode
 	margin-left: 0;
 	font-weight: 400;
 	color: $dark-gray-900;
 	@include square-style__neutral;
+	transition: box-shadow 0.1s linear;
 
 	// This pseudo-element "duplicates" the tab label and sets the text to bold.
 	// This ensures that the tab doesn't change width when selected.
@@ -41,9 +41,20 @@
 	}
 
 	&.is-active {
-		padding-bottom: 0;
-		border-bottom: 3px solid theme(primary);
+		box-shadow: inset 0 -3px theme(outlines);
 		font-weight: 600;
+		position: relative;
+
+		// This border appears in Windows High Contrast mode instead of the box-shadow.
+		&::before {
+			content: "";
+			position: absolute;
+			top: 0;
+			bottom: 1px;
+			right: 0;
+			left: 0;
+			border-bottom: 3px solid transparent;
+		}
 	}
 
 	&:focus {

--- a/packages/edit-post/src/components/sidebar/style.scss
+++ b/packages/edit-post/src/components/sidebar/style.scss
@@ -163,18 +163,30 @@
 .edit-post-sidebar__panel-tab {
 	background: transparent;
 	border: none;
-	border-radius: 0;
+	box-shadow: none;
 	cursor: pointer;
 	height: 50px;
 	padding: 3px 15px; // Use padding to offset the is-active border, this benefits Windows High Contrast mode
 	margin-left: 0;
 	font-weight: 400;
 	@include square-style__neutral;
+	transition: box-shadow 0.1s linear;
 
 	&.is-active {
-		padding-bottom: 0;
-		border-bottom: 3px solid theme(primary);
+		box-shadow: inset 0 -3px theme(outlines);
 		font-weight: 600;
+		position: relative;
+
+		// This border appears in Windows High Contrast mode instead of the box-shadow.
+		&::before {
+			content: "";
+			position: absolute;
+			top: 0;
+			bottom: 1px;
+			right: 0;
+			left: 0;
+			border-bottom: 3px solid transparent;
+		}
 	}
 
 	&:focus {

--- a/packages/editor/src/components/block-navigation/dropdown.js
+++ b/packages/editor/src/components/block-navigation/dropdown.js
@@ -18,12 +18,14 @@ const MenuIcon = (
 	</SVG>
 );
 
-function BlockNavigationDropdown( { hasBlocks, isTextModeEnabled } ) {
+function BlockNavigationDropdown( { hasBlocks, isDisabled } ) {
+	const isEnabled = hasBlocks && ! isDisabled;
+
 	return	(
 		<Dropdown
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Fragment>
-					{ hasBlocks && ! isTextModeEnabled && <KeyboardShortcuts
+					{ isEnabled && <KeyboardShortcuts
 						bindGlobal
 						shortcuts={ {
 							[ rawShortcut.access( 'o' ) ]: onToggle,
@@ -33,11 +35,11 @@ function BlockNavigationDropdown( { hasBlocks, isTextModeEnabled } ) {
 					<IconButton
 						icon={ MenuIcon }
 						aria-expanded={ isOpen }
-						onClick={ hasBlocks ? onToggle : undefined }
+						onClick={ isEnabled ? onToggle : undefined }
 						label={ __( 'Block Navigation' ) }
 						className="editor-block-navigation"
 						shortcut={ displayShortcut.access( 'o' ) }
-						disabled={ ! hasBlocks || isTextModeEnabled }
+						aria-disabled={ ! isEnabled }
 					/>
 				</Fragment>
 			) }
@@ -51,6 +53,5 @@ function BlockNavigationDropdown( { hasBlocks, isTextModeEnabled } ) {
 export default withSelect( ( select ) => {
 	return {
 		hasBlocks: !! select( 'core/block-editor' ).getBlockCount(),
-		isTextModeEnabled: select( 'core/edit-post' ).getEditorMode() === 'text',
 	};
 } )( BlockNavigationDropdown );

--- a/packages/editor/src/components/block-navigation/index.js
+++ b/packages/editor/src/components/block-navigation/index.js
@@ -40,10 +40,9 @@ function BlockNavigationList( {
 						<div className="editor-block-navigation__item">
 							<Button
 								className={ classnames( 'editor-block-navigation__item-button', {
-									'is-selected': block.clientId === selectedBlockClientId,
+									'is-selected': isSelected,
 								} ) }
 								onClick={ () => selectBlock( block.clientId ) }
-								isSelected={ isSelected }
 							>
 								<BlockIcon icon={ blockType.icon } showColors />
 								{ blockType.title }

--- a/packages/editor/src/components/document-outline/index.js
+++ b/packages/editor/src/components/document-outline/index.js
@@ -142,7 +142,8 @@ export const DocumentOutline = ( { blocks = [], title, onSelect, isTitleSupporte
 
 export default compose(
 	withSelect( ( select ) => {
-		const { getEditedPostAttribute, getBlocks } = select( 'core/block-editor' );
+		const { getBlocks } = select( 'core/block-editor' );
+		const { getEditedPostAttribute } = select( 'core/editor' );
 		const { getPostType } = select( 'core' );
 		const postType = getPostType( getEditedPostAttribute( 'type' ) );
 

--- a/packages/editor/src/components/document-outline/index.js
+++ b/packages/editor/src/components/document-outline/index.js
@@ -64,7 +64,7 @@ const computeOutlineHeadings = ( blocks = [], path = [] ) => {
 
 const isEmptyHeading = ( heading ) => ! heading.attributes.content || heading.attributes.content.length === 0;
 
-export const DocumentOutline = ( { blocks = [], title, onSelect, isTitleSupported } ) => {
+export const DocumentOutline = ( { blocks = [], title, onSelect, isTitleSupported, hasOutlineItemsDisabled } ) => {
 	const headings = computeOutlineHeadings( blocks );
 
 	if ( headings.length < 1 ) {
@@ -96,6 +96,7 @@ export const DocumentOutline = ( { blocks = [], title, onSelect, isTitleSupporte
 						level={ __( 'Title' ) }
 						isValid
 						onClick={ focusTitle }
+						isDisabled={ hasOutlineItemsDisabled }
 					>
 						{ title }
 					</DocumentOutlineItem>
@@ -120,6 +121,7 @@ export const DocumentOutline = ( { blocks = [], title, onSelect, isTitleSupporte
 							isValid={ isValid }
 							onClick={ () => onSelectHeading( item.clientId ) }
 							path={ item.path }
+							isDisabled={ hasOutlineItemsDisabled }
 						>
 							{ item.isEmpty ?
 								emptyHeadingContent :

--- a/packages/editor/src/components/document-outline/item.js
+++ b/packages/editor/src/components/document-outline/item.js
@@ -18,6 +18,7 @@ const TableOfContentsItem = ( {
 	isValid,
 	level,
 	onClick,
+	isDisabled,
 	path = [],
 } ) => (
 	<li
@@ -31,7 +32,8 @@ const TableOfContentsItem = ( {
 	>
 		<button
 			className="document-outline__button"
-			onClick={ onClick }
+			onClick={ isDisabled ? undefined : onClick }
+			disabled={ isDisabled }
 		>
 			<span className="document-outline__emdash" aria-hidden="true"></span>
 			{
@@ -49,7 +51,7 @@ const TableOfContentsItem = ( {
 			<span className="document-outline__item-content">
 				{ children }
 			</span>
-			<span className="screen-reader-text">{ __( '(Click to focus this heading)' ) }</span>
+			{ ! isDisabled && <span className="screen-reader-text">{ __( '(Click to focus this heading)' ) }</span> }
 		</button>
 	</li>
 );

--- a/packages/editor/src/components/document-outline/style.scss
+++ b/packages/editor/src/components/document-outline/style.scss
@@ -43,8 +43,14 @@
 	border: none;
 	display: flex;
 	align-items: flex-start;
+	margin: 0 0 0 -1px;
+	padding: 2px 5px 2px 1px;
 	color: $dark-gray-800;
 	text-align: left;
+
+	&:disabled {
+		cursor: default;
+	}
 
 	&:focus {
 		@include button-style__focus-active;
@@ -62,4 +68,8 @@
 	.is-invalid & {
 		background: $alert-yellow;
 	}
+}
+
+.document-outline__item-content {
+	padding: 1px 0;
 }

--- a/packages/editor/src/components/table-of-contents/index.js
+++ b/packages/editor/src/components/table-of-contents/index.js
@@ -10,7 +10,7 @@ import { withSelect } from '@wordpress/data';
  */
 import TableOfContentsPanel from './panel';
 
-function TableOfContents( { hasBlocks } ) {
+function TableOfContents( { hasBlocks, hasOutlineItemsDisabled } ) {
 	return (
 		<Dropdown
 			position="bottom"
@@ -26,7 +26,7 @@ function TableOfContents( { hasBlocks } ) {
 					aria-disabled={ ! hasBlocks }
 				/>
 			) }
-			renderContent={ () => <TableOfContentsPanel /> }
+			renderContent={ () => <TableOfContentsPanel hasOutlineItemsDisabled={ hasOutlineItemsDisabled } /> }
 		/>
 	);
 }

--- a/packages/editor/src/components/table-of-contents/panel.js
+++ b/packages/editor/src/components/table-of-contents/panel.js
@@ -11,7 +11,7 @@ import { withSelect } from '@wordpress/data';
 import WordCount from '../word-count';
 import DocumentOutline from '../document-outline';
 
-function TableOfContentsPanel( { headingCount, paragraphCount, numberOfBlocks } ) {
+function TableOfContentsPanel( { headingCount, paragraphCount, numberOfBlocks, hasOutlineItemsDisabled } ) {
 	return (
 		<Fragment>
 			<div
@@ -49,7 +49,7 @@ function TableOfContentsPanel( { headingCount, paragraphCount, numberOfBlocks } 
 					<span className="table-of-contents__title">
 						{ __( 'Document Outline' ) }
 					</span>
-					<DocumentOutline />
+					<DocumentOutline hasOutlineItemsDisabled={ hasOutlineItemsDisabled } />
 				</Fragment>
 			) }
 		</Fragment>


### PR DESCRIPTION
## Description
Imagine we have two plugins (or code fragments) that subscribe to changes in the block editor. The first listener function subscribed is:
```
wp.data.subscribe( () => {
  console.log( 'Hey!' );
  let a; const b = a.b; // Error: Cannot read property ‘b’ of undefined
} );
```

and the second listener function subscribed is:
```
wp.data.subscribe( () => {
  console.log( 'S.O.S' ); // This log won't go out because of others breaking execution
} );
```

An error thrown in the first listener will prevent the execution of the second listener when a change in the editor triggers the execution of all listeners subscribed to changes. This may cause careless programmers to break the execution of others' code.

The proposed solution here surrounds the execution of each listener with a `try/catch` statement that avoids the execution break.

Some may say that code inside listeners should be developed in a way to avoid throwing errors. But adding the `try/catch` we make sure this will not happen.

## How has this been tested?
Just copy the previous pair of listeners, paste them in the web browser JS console when editing a post in the block editor, and make some change to trigger their execution.

## Types of changes
I added a `try/catch` statement with a `console.log` printing the error.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
