### PR TITLE
Try to make change image flow clearer

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Added the `addToGallery` property to the `MediaPlaceholder` component. The component passes the property to the `MediaUpload` component used inside the placeholder.
 - Added the `isAppender` property to the `MediaPlaceholder` component. The property changes the look of the placeholder to be adequate to scenarios where new files are added to an already existing set of files, e.g., adding files to a gallery.
 - Added the `dropZoneUIOnly` property to the `MediaPlaceholder` component. The property makes the `MediaPlaceholder` only render a dropzone without any other additional UI.
+- Added a cancel link to the list of buttons in the `MediaPlaceholder` component which appears if an `onCancel` handler exists
+- Added the usage of `mediaPreview` for the `Placeholder` component to the `MediaPlaceholder` component
+- Added a an `onDoubleClick` event handler to the `MediaPlaceholder` component
 
 ### Breaking Changes
 

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -154,6 +154,7 @@ export class MediaPlaceholder extends Component {
 			icon,
 			isAppender,
 			labels = {},
+			onDoubleClick,
 			notices,
 			onSelectURL,
 			mediaUpload,
@@ -212,6 +213,7 @@ export class MediaPlaceholder extends Component {
 				className={ placeholderClassName }
 				notices={ notices }
 				onClick={ onClick }
+				onDoubleClick={ onDoubleClick }
 			>
 				{ content }
 			</Placeholder>

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -233,6 +233,7 @@ export class MediaPlaceholder extends Component {
 	renderUrlSelectionUI() {
 		const {
 			onSelectURL,
+			onCancel,
 		} = this.props;
 		if ( ! onSelectURL ) {
 			return null;
@@ -258,6 +259,16 @@ export class MediaPlaceholder extends Component {
 						onSubmit={ this.onSubmitSrc }
 						onClose={ this.closeURLInput }
 					/>
+				) }
+				{ onCancel && (
+					<Button
+						className="block-editor-media-placeholder__button__link"
+						title={ __( 'Cancel' ) }
+						isLink={ true }
+						onClick={ onCancel }
+					>
+						{ __( 'Cancel' ) }
+					</Button>
 				) }
 			</div>
 		);

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -243,34 +243,36 @@ export class MediaPlaceholder extends Component {
 			src,
 		} = this.state;
 		return (
-			<div className="editor-media-placeholder__url-input-container block-editor-media-placeholder__url-input-container">
-				<Button
-					className="editor-media-placeholder__button block-editor-media-placeholder__button"
-					onClick={ this.openURLInput }
-					isToggled={ isURLInputVisible }
-					isLarge
-				>
-					{ __( 'Insert from URL' ) }
-				</Button>
-				{ isURLInputVisible && (
-					<InsertFromURLPopover
-						src={ src }
-						onChange={ this.onChangeSrc }
-						onSubmit={ this.onSubmitSrc }
-						onClose={ this.closeURLInput }
-					/>
-				) }
+			<Fragment>
+				<div className="editor-media-placeholder__url-input-container block-editor-media-placeholder__url-input-container">
+					<Button
+						className="editor-media-placeholder__button block-editor-media-placeholder__button"
+						onClick={ this.openURLInput }
+						isToggled={ isURLInputVisible }
+						isLarge
+					>
+						{ __( 'Insert from URL' ) }
+					</Button>
+					{ isURLInputVisible && (
+						<InsertFromURLPopover
+							src={ src }
+							onChange={ this.onChangeSrc }
+							onSubmit={ this.onSubmitSrc }
+							onClose={ this.closeURLInput }
+						/>
+					) }
+				</div>
 				{ onCancel && (
 					<Button
-						className="block-editor-media-placeholder__button__link"
+						className="block-editor-media-placeholder__cancel-button"
 						title={ __( 'Cancel' ) }
-						isLink={ true }
+						isLink
 						onClick={ onCancel }
 					>
 						{ __( 'Cancel' ) }
 					</Button>
 				) }
-			</div>
+			</Fragment>
 		);
 	}
 

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -63,6 +63,7 @@ export class MediaPlaceholder extends Component {
 		this.state = {
 			src: '',
 			isURLInputVisible: false,
+			mediaPreview: false,
 		};
 		this.onChangeSrc = this.onChangeSrc.bind( this );
 		this.onSubmitSrc = this.onSubmitSrc.bind( this );
@@ -155,6 +156,7 @@ export class MediaPlaceholder extends Component {
 			isAppender,
 			labels = {},
 			onDoubleClick,
+			mediaPreview,
 			notices,
 			onSelectURL,
 			mediaUpload,
@@ -214,6 +216,7 @@ export class MediaPlaceholder extends Component {
 				notices={ notices }
 				onClick={ onClick }
 				onDoubleClick={ onDoubleClick }
+				mediaPreview={ mediaPreview }
 			>
 				{ content }
 			</Placeholder>
@@ -230,10 +233,25 @@ export class MediaPlaceholder extends Component {
 		);
 	}
 
+	renderCancelLink() {
+		const {
+			onCancel,
+		} = this.props;
+		return ( onCancel &&
+			<Button
+				className="block-editor-media-placeholder__cancel-button"
+				title={ __( 'Cancel' ) }
+				isLink
+				onClick={ onCancel }
+			>
+				{ __( 'Cancel' ) }
+			</Button>
+		);
+	}
+
 	renderUrlSelectionUI() {
 		const {
 			onSelectURL,
-			onCancel,
 		} = this.props;
 		if ( ! onSelectURL ) {
 			return null;
@@ -262,16 +280,6 @@ export class MediaPlaceholder extends Component {
 						/>
 					) }
 				</div>
-				{ onCancel && (
-					<Button
-						className="block-editor-media-placeholder__cancel-button"
-						title={ __( 'Cancel' ) }
-						isLink
-						onClick={ onCancel }
-					>
-						{ __( 'Cancel' ) }
-					</Button>
-				) }
 			</Fragment>
 		);
 	}
@@ -344,6 +352,7 @@ export class MediaPlaceholder extends Component {
 									</IconButton>
 									{ mediaLibraryButton }
 									{ this.renderUrlSelectionUI() }
+									{ this.renderCancelLink() }
 								</Fragment>
 							);
 							return this.renderPlaceholder( content, openFileDialog );
@@ -371,6 +380,7 @@ export class MediaPlaceholder extends Component {
 					</FormFileUpload>
 					{ mediaLibraryButton }
 					{ this.renderUrlSelectionUI() }
+					{ this.renderCancelLink() }
 				</Fragment>
 			);
 			return this.renderPlaceholder( content );

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -63,7 +63,6 @@ export class MediaPlaceholder extends Component {
 		this.state = {
 			src: '',
 			isURLInputVisible: false,
-			mediaPreview: false,
 		};
 		this.onChangeSrc = this.onChangeSrc.bind( this );
 		this.onSubmitSrc = this.onSubmitSrc.bind( this );
@@ -261,26 +260,24 @@ export class MediaPlaceholder extends Component {
 			src,
 		} = this.state;
 		return (
-			<Fragment>
-				<div className="editor-media-placeholder__url-input-container block-editor-media-placeholder__url-input-container">
-					<Button
-						className="editor-media-placeholder__button block-editor-media-placeholder__button"
-						onClick={ this.openURLInput }
-						isToggled={ isURLInputVisible }
-						isLarge
-					>
-						{ __( 'Insert from URL' ) }
-					</Button>
-					{ isURLInputVisible && (
-						<InsertFromURLPopover
-							src={ src }
-							onChange={ this.onChangeSrc }
-							onSubmit={ this.onSubmitSrc }
-							onClose={ this.closeURLInput }
-						/>
-					) }
-				</div>
-			</Fragment>
+			<div className="editor-media-placeholder__url-input-container block-editor-media-placeholder__url-input-container">
+				<Button
+					className="editor-media-placeholder__button block-editor-media-placeholder__button"
+					onClick={ this.openURLInput }
+					isToggled={ isURLInputVisible }
+					isLarge
+				>
+					{ __( 'Insert from URL' ) }
+				</Button>
+				{ isURLInputVisible && (
+					<InsertFromURLPopover
+						src={ src }
+						onChange={ this.onChangeSrc }
+						onSubmit={ this.onSubmitSrc }
+						onClose={ this.closeURLInput }
+					/>
+				) }
+			</div>
 		);
 	}
 

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -215,7 +215,7 @@ export class MediaPlaceholder extends Component {
 				notices={ notices }
 				onClick={ onClick }
 				onDoubleClick={ onDoubleClick }
-				mediaPreview={ mediaPreview }
+				preview={ mediaPreview }
 			>
 				{ content }
 			</Placeholder>

--- a/packages/block-editor/src/components/media-placeholder/style.scss
+++ b/packages/block-editor/src/components/media-placeholder/style.scss
@@ -42,6 +42,11 @@
 	}
 }
 
+.block-editor-media-placeholder__button__link.is-link {
+	margin: 1em;
+	display: block;
+}
+
 .components-form-file-upload .block-editor-media-placeholder__button {
 	margin-right: $grid-size-small;
 }

--- a/packages/block-editor/src/components/media-placeholder/style.scss
+++ b/packages/block-editor/src/components/media-placeholder/style.scss
@@ -42,7 +42,7 @@
 	}
 }
 
-.block-editor-media-placeholder__button__link.is-link {
+.block-editor-media-placeholder__cancel-button.is-link {
 	margin: 1em;
 	display: block;
 }

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `wide` and `full` alignments to Categories block ([#14533](https://github.com/WordPress/gutenberg/pull/14533)).
 - Add all alignment options to RSS block ([#14533](https://github.com/WordPress/gutenberg/pull/14533)).
 - Add all alignment options to Search block ([#14533](https://github.com/WordPress/gutenberg/pull/14533)).
+- Updated the edit flow of the `image` block, updated the edit icon and unified the image editing in only one UI based on `MediaPlaceholder`
 
 ### Bug Fixes
 

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -421,6 +421,7 @@ class ImageEdit extends Component {
 					{ controls }
 					<MediaPlaceholder
 						icon={ <BlockIcon icon={ icon } /> }
+						className={ className }
 						labels={ labels }
 						onSelect={ this.onSelectImage }
 						onSelectURL={ this.onSelectURL }

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -375,57 +375,57 @@ class ImageEdit extends Component {
 		} = attributes;
 		const isExternal = isExternalImage( id, url );
 
-		let toolbarEditButton;
-
-		if ( url ) {
-			toolbarEditButton = (
-				<Toolbar>
-					<IconButton
-						className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': this.state.isEditing }
-						) }
-						label={ __( 'Edit image' ) }
-						onClick={ this.toggleIsEditing }
-						icon={ <SVG width={ 24 } height={ 24 } viewBox="0 0 24 24"><Rect x={ 14 } y={ 3 } width={ 8 } height={ 6 } rx={ 1 } /><Rect x={ 2 } y={ 15 } width={ 8 } height={ 6 } rx={ 1 } /><Path d="M16,15h1.87c-.63,2.35-3.38,4-5.87,4v2c3.47,0,7.29-2.42,7.91-6H22l-3-3.5Z" /><Path d="M8,9H6.13C6.76,6.65,9.51,5,12,5V3C8.53,3,4.71,5.42,4.09,9H2l3,3.5Z" /></SVG> }
-					/>
-				</Toolbar>
-			);
-		}
-
 		const controls = (
 			<BlockControls>
 				<BlockAlignmentToolbar
 					value={ align }
 					onChange={ this.updateAlignment }
 				/>
-				{ toolbarEditButton }
+				{ url && (
+					<Toolbar>
+						<IconButton
+							className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': this.state.isEditing }
+							) }
+							label={ __( 'Edit image' ) }
+							onClick={ this.toggleIsEditing }
+							icon={ <SVG width={ 24 } height={ 24 } viewBox="0 0 24 24"><Rect x={ 14 } y={ 3 } width={ 8 } height={ 6 } rx={ 1 } /><Rect x={ 2 } y={ 15 } width={ 8 } height={ 6 } rx={ 1 } /><Path d="M16,15h1.87c-.63,2.35-3.38,4-5.87,4v2c3.47,0,7.29-2.42,7.91-6H22l-3-3.5Z" /><Path d="M8,9H6.13C6.76,6.65,9.51,5,12,5V3C8.53,3,4.71,5.42,4.09,9H2l3,3.5Z" /></SVG> }
+						/>
+					</Toolbar>
+				) }
 			</BlockControls>
 		);
-
 		if ( isEditing || ! url ) {
 			const src = isExternal ? url : undefined;
+			const replaceImageLabel = (
+				<span className={ 'replace-image-preview__title' }>
+					{ __( 'Replace image' ) }
+				</span>
+			);
+			const labels = {
+				title: ! url ? __( 'Image' ) : replaceImageLabel,
+			};
+			let replaceImageIcon = ( <BlockIcon icon={ icon } /> );
+			if ( url ) {
+				replaceImageIcon = ( <img
+					alt={ __( 'Replace image' ) }
+					title={ __( 'Replace image' ) }
+					className={ 'replace-image-preview' }
+					src={ url }
+				/> );
+			}
 			return (
 				<Fragment>
 					{ controls }
 					<MediaPlaceholder
-						icon={ ! url ? <BlockIcon icon={ icon } /> : <img
-							alt={ __( 'Replace image' ) }
-							title={ __( 'Replace image' ) }
-							width={ '50%' }
-							className={ 'replace-image-preview' }
-							src={ url }
-						/> }
-						labels={ {
-							title: ! url ? __( 'Image' ) : <span
-								className={ 'replace-image-preview-title' }
-							>
-								{ __( 'Replace image' ) }
-							</span>,
-						} }
-						className={ classnames( className, ! url ? '' : 'wp-block-image-replace' ) }
+						icon={ replaceImageIcon }
+						labels={ labels }
+						className={ classnames( className, {
+							'wp-block-image-replace': url,
+						} ) }
 						onSelect={ this.onSelectImage }
 						onSelectURL={ this.onSelectURL }
 						onDoubleClick={ this.toggleIsEditing }
-						onCancel={ ! url ? false : this.toggleIsEditing }
+						onCancel={ !! url && this.toggleIsEditing }
 						notices={ noticeUI }
 						onError={ this.onUploadError }
 						accept="image/*"

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -407,12 +407,25 @@ class ImageEdit extends Component {
 				<Fragment>
 					{ controls }
 					<MediaPlaceholder
-						icon={ <BlockIcon icon={ icon } /> }
-						className={ className }
+						icon={ ! url ? <BlockIcon icon={ icon } /> : <img
+							alt={ __( 'Replace image' ) }
+							title={ __( 'Replace image' ) }
+							width={ '50%' }
+							className={ 'replace-image-preview' }
+							src={ url }
+						/> }
+						labels={ {
+							title: ! url ? __( 'Image' ) : <span
+								className={ 'replace-image-preview-title' }
+							>
+								{ __( 'Replace image' ) }
+							</span>,
+						} }
+						className={ classnames( className, ! url ? '' : 'wp-block-image-replace' ) }
 						onSelect={ this.onSelectImage }
 						onSelectURL={ this.onSelectURL }
 						onDoubleClick={ this.toggleIsEditing }
-						onCancel={ this.toggleIsEditing }
+						onCancel={ ! url ? false : this.toggleIsEditing }
 						notices={ noticeUI }
 						onError={ this.onUploadError }
 						accept="image/*"

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -390,8 +390,7 @@ class ImageEdit extends Component {
 				{ url && (
 					<Toolbar>
 						<IconButton
-							className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': this.state.isEditing }
-							) }
+							className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': this.state.isEditing } ) }
 							label={ __( 'Edit image' ) }
 							aria-pressed={ this.state.isEditing }
 							onClick={ this.toggleIsEditing }

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -20,9 +20,12 @@ import {
 	ButtonGroup,
 	IconButton,
 	PanelBody,
+	Path,
+	Rect,
 	ResizableBox,
 	SelectControl,
 	Spinner,
+	SVG,
 	TextareaControl,
 	TextControl,
 	ToggleControl,
@@ -378,10 +381,11 @@ class ImageEdit extends Component {
 			toolbarEditButton = (
 				<Toolbar>
 					<IconButton
-						className="components-icon-button components-toolbar__control"
+						className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': this.state.isEditing }
+						) }
 						label={ __( 'Edit image' ) }
 						onClick={ this.toggleIsEditing }
-						icon={ ( url && ! isEditing ) ? 'format-image' : 'dismiss' }
+						icon={ <SVG width={ 24 } height={ 24 } viewBox="0 0 24 24"><Rect x={ 14 } y={ 3 } width={ 8 } height={ 6 } rx={ 1 } /><Rect x={ 2 } y={ 15 } width={ 8 } height={ 6 } rx={ 1 } /><Path d="M16,15h1.87c-.63,2.35-3.38,4-5.87,4v2c3.47,0,7.29-2.42,7.91-6H22l-3-3.5Z" /><Path d="M8,9H6.13C6.76,6.65,9.51,5,12,5V3C8.53,3,4.71,5.42,4.09,9H2l3,3.5Z" /></SVG> }
 					/>
 				</Toolbar>
 			);

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -48,6 +48,7 @@ import { Component, Fragment } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { getPath } from '@wordpress/url';
 import { withViewportMatch } from '@wordpress/viewport';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
@@ -330,6 +331,11 @@ class ImageEdit extends Component {
 		this.setState( {
 			isEditing: ! this.state.isEditing,
 		} );
+		if ( this.state.isEditing ) {
+			speak( __( 'You are now editing the image in the image block.' ) );
+		} else {
+			speak( __( 'You are now viewing the image in the image block.' ) );
+		}
 	}
 
 	getImageSizeOptions() {
@@ -374,7 +380,7 @@ class ImageEdit extends Component {
 			linkTarget,
 		} = attributes;
 		const isExternal = isExternalImage( id, url );
-
+		const editImageIcon = ( <SVG width={ 24 } height={ 24 } viewBox="0 0 24 24"><Rect x={ 14 } y={ 3 } width={ 8 } height={ 6 } rx={ 1 } /><Rect x={ 2 } y={ 15 } width={ 8 } height={ 6 } rx={ 1 } /><Path d="M16,15h1.87c-.63,2.35-3.38,4-5.87,4v2c3.47,0,7.29-2.42,7.91-6H22l-3-3.5Z" /><Path d="M8,9H6.13C6.76,6.65,9.51,5,12,5V3C8.53,3,4.71,5.42,4.09,9H2l3,3.5Z" /></SVG> );
 		const controls = (
 			<BlockControls>
 				<BlockAlignmentToolbar
@@ -387,8 +393,9 @@ class ImageEdit extends Component {
 							className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': this.state.isEditing }
 							) }
 							label={ __( 'Edit image' ) }
+							aria-pressed={ this.state.isEditing }
 							onClick={ this.toggleIsEditing }
-							icon={ <SVG width={ 24 } height={ 24 } viewBox="0 0 24 24"><Rect x={ 14 } y={ 3 } width={ 8 } height={ 6 } rx={ 1 } /><Rect x={ 2 } y={ 15 } width={ 8 } height={ 6 } rx={ 1 } /><Path d="M16,15h1.87c-.63,2.35-3.38,4-5.87,4v2c3.47,0,7.29-2.42,7.91-6H22l-3-3.5Z" /><Path d="M8,9H6.13C6.76,6.65,9.51,5,12,5V3C8.53,3,4.71,5.42,4.09,9H2l3,3.5Z" /></SVG> }
+							icon={ editImageIcon }
 						/>
 					</Toolbar>
 				) }
@@ -398,18 +405,19 @@ class ImageEdit extends Component {
 			const src = isExternal ? url : undefined;
 			const replaceImageLabel = (
 				<span className={ 'replace-image-preview__title' }>
-					{ __( 'Replace image' ) }
+					{ __( 'Edit image' ) }
 				</span>
 			);
 			const labels = {
 				title: ! url ? __( 'Image' ) : replaceImageLabel,
+				instructions: __( 'Drag an image to upload, select a file from your library or add one from an URL.' ),
 			};
 			let replaceImageIcon = ( <BlockIcon icon={ icon } /> );
 			if ( url ) {
 				replaceImageIcon = ( <img
-					alt={ __( 'Replace image' ) }
-					title={ __( 'Replace image' ) }
-					className={ 'replace-image-preview' }
+					alt={ __( 'Edit image' ) }
+					title={ __( 'Edit image' ) }
+					className={ 'edit-image-preview' }
 					src={ url }
 				/> );
 			}

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -38,8 +38,6 @@ import {
 	BlockIcon,
 	InspectorControls,
 	MediaPlaceholder,
-	MediaUpload,
-	MediaUploadCheck,
 	RichText,
 } from '@wordpress/block-editor';
 import { mediaUpload } from '@wordpress/editor';
@@ -375,39 +373,18 @@ class ImageEdit extends Component {
 		const isExternal = isExternalImage( id, url );
 
 		let toolbarEditButton;
+
 		if ( url ) {
-			if ( isExternal ) {
-				toolbarEditButton = (
-					<Toolbar>
-						<IconButton
-							className="components-icon-button components-toolbar__control"
-							label={ __( 'Edit image' ) }
-							onClick={ this.toggleIsEditing }
-							icon="edit"
-						/>
-					</Toolbar>
-				);
-			} else {
-				toolbarEditButton = (
-					<MediaUploadCheck>
-						<Toolbar>
-							<MediaUpload
-								onSelect={ this.onSelectImage }
-								allowedTypes={ ALLOWED_MEDIA_TYPES }
-								value={ id }
-								render={ ( { open } ) => (
-									<IconButton
-										className="components-toolbar__control"
-										label={ __( 'Edit image' ) }
-										icon="edit"
-										onClick={ open }
-									/>
-								) }
-							/>
-						</Toolbar>
-					</MediaUploadCheck>
-				);
-			}
+			toolbarEditButton = (
+				<Toolbar>
+					<IconButton
+						className="components-icon-button components-toolbar__control"
+						label={ __( 'Edit image' ) }
+						onClick={ this.toggleIsEditing }
+						icon={ ( url && ! isEditing ) ? 'format-image' : 'dismiss' }
+					/>
+				</Toolbar>
+			);
 		}
 
 		const controls = (
@@ -430,6 +407,7 @@ class ImageEdit extends Component {
 						className={ className }
 						onSelect={ this.onSelectImage }
 						onSelectURL={ this.onSelectURL }
+						onDoubleClick={ this.toggleIsEditing }
 						notices={ noticeUI }
 						onError={ this.onUploadError }
 						accept="image/*"
@@ -594,7 +572,7 @@ class ImageEdit extends Component {
 								// should direct focus to block.
 								/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 								<Fragment>
-									<img src={ url } alt={ defaultedAlt } onClick={ this.onImageClick } onError={ () => this.onImageError( url ) } />
+									<img src={ url } alt={ defaultedAlt } onDoubleClick={ this.toggleIsEditing } onClick={ this.onImageClick } onError={ () => this.onImageError( url ) } />
 									{ isBlobURL( url ) && <Spinner /> }
 								</Fragment>
 								/* eslint-enable jsx-a11y/no-noninteractive-element-interactions */

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -331,10 +331,10 @@ class ImageEdit extends Component {
 		this.setState( {
 			isEditing: ! this.state.isEditing,
 		} );
-		if ( ! this.state.isEditing ) {
-			speak( __( 'You are now editing the image in the image block.' ) );
-		} else {
+		if ( this.state.isEditing ) {
 			speak( __( 'You are now viewing the image in the image block.' ) );
+		} else {
+			speak( __( 'You are now editing the image in the image block.' ) );
 		}
 	}
 

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -408,24 +408,24 @@ class ImageEdit extends Component {
 					{ __( 'Edit image' ) }
 				</span>
 			);
+
 			const labels = {
 				title: ! url ? __( 'Image' ) : replaceImageLabel,
 				instructions: __( 'Drag an image to upload, select a file from your library or add one from an URL.' ),
 			};
-			let replaceImageIcon = ( <BlockIcon icon={ icon } /> );
-			if ( url ) {
-				replaceImageIcon = ( <img
-					alt={ __( 'Edit image' ) }
-					title={ __( 'Edit image' ) }
-					className={ 'edit-image-preview' }
-					src={ url }
-				/> );
-			}
+
+			const mediaPreview = ( !! url && <img
+				alt={ __( 'Edit image' ) }
+				title={ __( 'Edit image' ) }
+				className={ 'edit-image-preview' }
+				src={ url }
+			/> );
+
 			return (
 				<Fragment>
 					{ controls }
 					<MediaPlaceholder
-						icon={ replaceImageIcon }
+						icon={ <BlockIcon icon={ icon } /> }
 						labels={ labels }
 						className={ classnames( className, {
 							'wp-block-image-replace': url,
@@ -439,6 +439,7 @@ class ImageEdit extends Component {
 						accept="image/*"
 						allowedTypes={ ALLOWED_MEDIA_TYPES }
 						value={ { id, src } }
+						mediaPreview={ mediaPreview }
 					/>
 				</Fragment>
 			);
@@ -598,7 +599,13 @@ class ImageEdit extends Component {
 								// should direct focus to block.
 								/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 								<Fragment>
-									<img src={ url } alt={ defaultedAlt } onDoubleClick={ this.toggleIsEditing } onClick={ this.onImageClick } onError={ () => this.onImageError( url ) } />
+									<img
+										src={ url }
+										alt={ defaultedAlt }
+										onDoubleClick={ this.toggleIsEditing }
+										onClick={ this.onImageClick }
+										onError={ () => this.onImageError( url ) }
+									/>
 									{ isBlobURL( url ) && <Spinner /> }
 								</Fragment>
 								/* eslint-enable jsx-a11y/no-noninteractive-element-interactions */

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -403,14 +403,9 @@ class ImageEdit extends Component {
 		);
 		if ( isEditing || ! url ) {
 			const src = isExternal ? url : undefined;
-			const replaceImageLabel = (
-				<span className={ 'replace-image-preview__title' }>
-					{ __( 'Edit image' ) }
-				</span>
-			);
 
 			const labels = {
-				title: ! url ? __( 'Image' ) : replaceImageLabel,
+				title: ! url ? __( 'Image' ) : __( 'Edit image' ),
 				instructions: __( 'Drag an image to upload, select a file from your library or add one from an URL.' ),
 			};
 
@@ -427,9 +422,6 @@ class ImageEdit extends Component {
 					<MediaPlaceholder
 						icon={ <BlockIcon icon={ icon } /> }
 						labels={ labels }
-						className={ classnames( className, {
-							'wp-block-image-replace': url,
-						} ) }
 						onSelect={ this.onSelectImage }
 						onSelectURL={ this.onSelectURL }
 						onDoubleClick={ this.toggleIsEditing }

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -412,6 +412,7 @@ class ImageEdit extends Component {
 						onSelect={ this.onSelectImage }
 						onSelectURL={ this.onSelectURL }
 						onDoubleClick={ this.toggleIsEditing }
+						onCancel={ this.toggleIsEditing }
 						notices={ noticeUI }
 						onError={ this.onUploadError }
 						accept="image/*"

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -331,7 +331,7 @@ class ImageEdit extends Component {
 		this.setState( {
 			isEditing: ! this.state.isEditing,
 		} );
-		if ( this.state.isEditing ) {
+		if ( ! this.state.isEditing ) {
 			speak( __( 'You are now editing the image in the image block.' ) );
 		} else {
 			speak( __( 'You are now viewing the image in the image block.' ) );

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -130,8 +130,8 @@
 		flex-direction: column;
 	}
 
-	.replace-image-preview {
-		margin: 5%;
+	.edit-image-preview {
+		margin: 3%;
 		width: 50%;
 	}
 }

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -124,14 +124,3 @@
 		caption-side: bottom;
 	}
 }
-
-.block-editor-block-list__block[data-type="core/image"] {
-	.wp-block-image-replace .components-placeholder__label {
-		flex-direction: column;
-	}
-
-	.edit-image-preview {
-		margin: 3%;
-		width: 50%;
-	}
-}

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -124,3 +124,13 @@
 		caption-side: bottom;
 	}
 }
+
+.block-editor-block-list__block[data-type="core/image"] {
+	.wp-block-image-replace .components-placeholder__label {
+		flex-direction: column;
+	}
+
+	.replace-image-preview {
+		margin: 5%;
+	}
+}

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -132,5 +132,6 @@
 
 	.replace-image-preview {
 		margin: 5%;
+		width: 50%;
 	}
 }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added a new `render` property to `FormFileUpload` component. Allowing users of the component to custom the UI for their needs.
 - Added a new `BaseControl.VisualLabel` component.
+- Added a new `mediaPreview` prop to the `Placeholder` component which allows to display a media when the placeholder is used in media editing contexts.
 
 ### Bug fixes
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Added a new `render` property to `FormFileUpload` component. Allowing users of the component to custom the UI for their needs.
 - Added a new `BaseControl.VisualLabel` component.
-- Added a new `mediaPreview` prop to the `Placeholder` component which allows to display a media when the placeholder is used in media editing contexts.
+- Added a new `preview` prop to the `Placeholder` component which allows to display a preview, for example a media preview when the Placeholder is used in media editing contexts.
 
 ### Bug fixes
 

--- a/packages/components/src/placeholder/index.js
+++ b/packages/components/src/placeholder/index.js
@@ -15,12 +15,17 @@ import Dashicon from '../dashicon';
 * @param  {Object} props The component props.
 * @return {Object}       The rendered placeholder.
 */
-function Placeholder( { icon, children, label, instructions, className, notices, ...additionalProps } ) {
+function Placeholder( { icon, children, label, instructions, className, notices, mediaPreview, ...additionalProps } ) {
 	const classes = classnames( 'components-placeholder', className );
 
 	return (
 		<div { ...additionalProps } className={ classes }>
 			{ notices }
+			{ mediaPreview &&
+				<div className="components-placeholder__preview">
+					{ mediaPreview }
+				</div>
+			}
 			<div className="components-placeholder__label">
 				{ isString( icon ) ? <Dashicon icon={ icon } /> : icon }
 				{ label }

--- a/packages/components/src/placeholder/index.js
+++ b/packages/components/src/placeholder/index.js
@@ -15,15 +15,15 @@ import Dashicon from '../dashicon';
 * @param  {Object} props The component props.
 * @return {Object}       The rendered placeholder.
 */
-function Placeholder( { icon, children, label, instructions, className, notices, mediaPreview, ...additionalProps } ) {
+function Placeholder( { icon, children, label, instructions, className, notices, preview, ...additionalProps } ) {
 	const classes = classnames( 'components-placeholder', className );
 
 	return (
 		<div { ...additionalProps } className={ classes }>
 			{ notices }
-			{ mediaPreview &&
+			{ preview &&
 				<div className="components-placeholder__preview">
-					{ mediaPreview }
+					{ preview }
 				</div>
 			}
 			<div className="components-placeholder__label">

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -57,3 +57,8 @@
 .components-placeholder__instructions {
 	margin-bottom: 1em;
 }
+
+.components-placeholder__preview img {
+	margin: 3%;
+	width: 50%;
+}


### PR DESCRIPTION
## Description
Trying to move #11952 forward by:

- changing the image block to have a single flow to edit the image: media placeholder -> image source selector -> image source UI -> image, and hence remove the current behaviour where the edit mode is different for uploaded media vs URL media
- having the toolbar icon changed to a (in my opinion) better icon and switching between modes, to make is visually clear that clicking it again returns the UI to the previous mode
- added double click as an extra way to enter the edit mode by dblClick on the image and exit the edit mode by dblClick on the media placeholder

## How has this been tested?
Localhost proof of concept

## Screenshots <!-- if applicable -->
![image-block-edit-mode](https://user-images.githubusercontent.com/107534/53488770-f536e900-3a97-11e9-8b57-0a2cb8d4762d.gif)


## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
