### PR TITLE
RichText: introduce onEnterAtEnd

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -46,6 +46,7 @@ import { Component, Fragment } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { getPath } from '@wordpress/url';
 import { withViewportMatch } from '@wordpress/viewport';
+import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -356,6 +357,7 @@ class ImageEdit extends Component {
 			noticeUI,
 			toggleSelection,
 			isRTL,
+			insertBlocksAfter,
 		} = this.props;
 		const {
 			url,
@@ -693,6 +695,7 @@ class ImageEdit extends Component {
 							onChange={ ( value ) => setAttributes( { caption: value } ) }
 							isSelected={ this.state.captionFocused }
 							inlineToolbar
+							onEnterAtEnd={ () => insertBlocksAfter( createBlock( 'core/paragraph' ) ) }
 						/>
 					) }
 				</figure>

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -645,15 +645,21 @@ export class RichText extends Component {
 				}
 			}
 
-			if ( this.multilineTag ) {
-				if ( event.shiftKey ) {
-					this.onChange( insertLineBreak( record ) );
-				} else if ( this.onSplit && isEmptyLine( record ) ) {
+			if ( event.shiftKey ) {
+				this.onChange( insertLineBreak( record ) );
+			} else if ( this.multilineTag ) {
+				if ( this.onSplit && isEmptyLine( record ) ) {
 					this.onSplit( ...split( record ).map( this.valueToFormat ) );
 				} else {
 					this.onChange( insertLineSeparator( record ) );
 				}
-			} else if ( event.shiftKey || ! this.onSplit ) {
+			} else if (
+				this.props.onEnterAtEnd &&
+				isCollapsed( record ) &&
+				record.text.length === record.start
+			) {
+				this.props.onEnterAtEnd();
+			} else if ( ! this.onSplit ) {
 				this.onChange( insertLineBreak( record ) );
 			} else {
 				this.splitContent();


### PR DESCRIPTION
## Description

~~Fixes #14114.~~ (Does not fix that issue.) Not sure if this is the right behaviour. Are there any other cases when a new paragraph should be created? What if the user presses enter in the middle? Then I think we should only insert a line break.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->