### PR TITLE
Improving interaction between parent and child blocks

### DIFF
--- a/packages/editor/src/components/inner-blocks/style.scss
+++ b/packages/editor/src/components/inner-blocks/style.scss
@@ -7,3 +7,7 @@
 	left: 0;
 	z-index: z-index(".editor-inner-blocks__small-screen-overlay:after");
 }
+
+.editor-inner-blocks {
+	padding: 10px;
+}

--- a/packages/editor/src/components/inner-blocks/style.scss
+++ b/packages/editor/src/components/inner-blocks/style.scss
@@ -9,5 +9,5 @@
 }
 
 .editor-inner-blocks {
-	padding: 10px;
+	padding: $block-padding;
 }


### PR DESCRIPTION
In response to the discussion in #9628, and relation to [this comment](https://github.com/WordPress/gutenberg/issues/9628#issuecomment-457165931) by @gziolo, I thought I'd try this out.

I added `10px` padding to `.editor-inner-blocks.` to help improve interaction between the parent and child inner blocks. The selector exists already for all blocks that have inner blocks. I just defined the attributes of that selector.

![padding2](https://user-images.githubusercontent.com/617986/53510332-9ad76180-3a72-11e9-9bee-348829ebb146.gif)

## How has this been tested?
I've tested locally.

## Types of changes
Pure CSS.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
