### PR TITLE
Catch possible errors in listeners to avoid breaking execution

### DIFF
--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -46,7 +46,14 @@ export function createRegistry( storeConfigs = {} ) {
 	 * Global listener called for each store's update.
 	 */
 	function globalListener() {
-		listeners.forEach( ( listener ) => listener() );
+		listeners.forEach( ( listener ) => {
+			try {
+				listener();
+			} catch ( error ) {
+				// eslint-disable-next-line no-console
+				console.error( error );
+			}
+		} );
 	}
 
 	/**


### PR DESCRIPTION
## Description
Imagine we have two plugins (or code fragments) that subscribe to changes in the block editor. The first listener function subscribed is:
```
wp.data.subscribe( () => {
  console.log( 'Hey!' );
  let a; const b = a.b; // Error: Cannot read property ‘b’ of undefined
} );
```

and the second listener function subscribed is:
```
wp.data.subscribe( () => {
  console.log( 'S.O.S' ); // This log won't go out because of others breaking execution
} );
```

An error thrown in the first listener will prevent the execution of the second listener when a change in the editor triggers the execution of all listeners subscribed to changes. This may cause careless programmers to break the execution of others' code.

The proposed solution here surrounds the execution of each listener with a `try/catch` statement that avoids the execution break.

Some may say that code inside listeners should be developed in a way to avoid throwing errors. But adding the `try/catch` we make sure this will not happen.

## How has this been tested?
Just copy the previous pair of listeners, paste them in the web browser JS console when editing a post in the block editor, and make some change to trigger their execution.

## Types of changes
I added a `try/catch` statement with a `console.log` printing the error.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
