### PR TITLE
Fix: FocalPointPicker renders unlabelled input fields

### DIFF
--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -209,7 +209,7 @@ export class FocalPointPicker extends Component {
 					</div>
 				</div>
 				<div className="components-focal-point-picker_position-display-container">
-					<BaseControl label={ __( 'Horizontal Pos.' ) }>
+					<BaseControl label={ __( 'Horizontal Pos.' ) } id={ horizontalPositionId }>
 						<input
 							className="components-text-control__input"
 							id={ horizontalPositionId }
@@ -221,7 +221,7 @@ export class FocalPointPicker extends Component {
 						/>
 						<span>%</span>
 					</BaseControl>
-					<BaseControl label={ __( 'Vertical Pos.' ) }>
+					<BaseControl label={ __( 'Vertical Pos.' ) } id={ verticalPositionId }>
 						<input
 							className="components-text-control__input"
 							id={ verticalPositionId }


### PR DESCRIPTION
## Description
Fixes: FocalPointPicker renders unlabelled input fields

A generic problem to avoid this problem in the future via an eslint rule is proposed at https://github.com/WordPress/gutenberg/pull/14151.

## How has this been tested?
I verified that now we have a for attribute in the labels referencing the id of the input fields. I did not notice any visual change.
