### PR TITLE
Add array-callback-return rule; Fix current code breaking the rule.

### DIFF
--- a/docs/tool/manifest.js
+++ b/docs/tool/manifest.js
@@ -70,7 +70,7 @@ function getRootManifest( tocFileName ) {
 
 function generateRootManifestFromTOCItems( items, parent = null ) {
 	let pageItems = [];
-	items.map( ( obj ) => {
+	items.forEach( ( obj ) => {
 		const fileName = Object.keys( obj )[ 0 ];
 		const children = obj[ fileName ];
 

--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -86,7 +86,7 @@ export const settings = {
 				transform: ( files ) => {
 					const blocks = [];
 
-					files.map( ( file ) => {
+					files.forEach( ( file ) => {
 						const blobURL = createBlobURL( file );
 
 						// File will be uploaded in componentDidMount()

--- a/packages/edit-post/src/hooks/components/media-upload/index.js
+++ b/packages/edit-post/src/hooks/components/media-upload/index.js
@@ -172,7 +172,7 @@ class MediaUpload extends Component {
 		}
 		if ( ! this.props.gallery ) {
 			const selection = this.frame.state().get( 'selection' );
-			castArray( this.props.value ).map( ( id ) => {
+			castArray( this.props.value ).forEach( ( id ) => {
 				selection.add( wp.media.attachment( id ) );
 			} );
 		}

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Breaking Changes
 
 - The `esnext` and `recommended` rulesets now enforce [`object-shorthand`](https://eslint.org/docs/rules/object-shorthand)
+- The `es5` and `recommended` rulesets now enforce [`array-callback-return`](https://eslint.org/docs/rules/array-callback-return)
 
 ### New Features
 

--- a/packages/eslint-plugin/configs/es5.js
+++ b/packages/eslint-plugin/configs/es5.js
@@ -1,6 +1,7 @@
 module.exports = {
 	rules: {
 		'array-bracket-spacing': [ 'error', 'always' ],
+		'array-callback-return': 'error',
 		'brace-style': [ 'error', '1tbs' ],
 		camelcase: [ 'error', {
 			properties: 'never',

--- a/packages/scripts/scripts/check-licenses.js
+++ b/packages/scripts/scripts/check-licenses.js
@@ -258,7 +258,7 @@ modules.forEach( ( path ) => {
 					}, stringDetectedType );
 				}, detectedType );
 			}
-			return false;
+			return detectedType;
 		}, false );
 	}
 

--- a/packages/scripts/scripts/check-licenses.js
+++ b/packages/scripts/scripts/check-licenses.js
@@ -258,6 +258,7 @@ modules.forEach( ( path ) => {
 					}, stringDetectedType );
 				}, detectedType );
 			}
+			return false;
 		}, false );
 	}
 


### PR DESCRIPTION
## Description
Adds a rule to make sure Array functions that iterate on the array and should return something contain the return statement, otherwise, a forEach should probably be used instead.
A case like this was fixed at https://github.com/WordPress/gutenberg/pull/13953.

In PR https://github.com/WordPress/gutenberg/pull/13953 @aduth suggested the implementation of a lint rule to catch these cases. While trying to implement the rule and researching the best ways to do it, I noticed a rule like that already existed in the community and this PR is enabling it.

We are also changing the code to respect the new rule no observable changes should be expected.

## How has this been tested?
Observe the tests pass.
Do some smoke testing, adding blocks, uploading files, and verify everything still works as before.
