### PR TITLE
Chore: Update: Code Quality:  Remove some editor store references from block-editor

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -107,7 +107,7 @@ export function selectBlock( clientId, initialPosition = null ) {
  */
 export function* selectPreviousBlock( clientId ) {
 	const previousBlockClientId = yield select(
-		'core/editor',
+		'core/block-editor',
 		'getPreviousBlockClientId',
 		clientId
 	);
@@ -123,7 +123,7 @@ export function* selectPreviousBlock( clientId ) {
  */
 export function* selectNextBlock( clientId ) {
 	const nextBlockClientId = yield select(
-		'core/editor',
+		'core/block-editor',
 		'getNextBlockClientId',
 		clientId
 	);


### PR DESCRIPTION
We missed to update the editor references from selectPreviousBlock, and selectNextBlock.

## Tests

I added multiple blocks, I verified that when I remove a block the previous block still gets selected.
