### PR TITLE
Rnmobile/refactor rich text sizing code

### DIFF
--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -22,14 +22,6 @@ import { createBlock } from '@wordpress/blocks';
 import styles from './style.scss';
 
 class HeadingEdit extends Component {
-	constructor( props ) {
-		super( props );
-
-		this.state = {
-			aztecHeight: 0,
-		};
-	}
-
 	render() {
 		const {
 			attributes,

--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -16,11 +16,6 @@ import { Component } from '@wordpress/element';
 import { RichText, BlockControls } from '@wordpress/editor';
 import { createBlock } from '@wordpress/blocks';
 
-/**
- * Internal dependencies
- */
-import styles from './style.scss';
-
 class HeadingEdit extends Component {
 	render() {
 		const {
@@ -39,8 +34,6 @@ class HeadingEdit extends Component {
 
 		const tagName = 'h' + level;
 
-		const minHeight = styles.blockText.minHeight;
-
 		return (
 			<View>
 				<BlockControls>
@@ -50,7 +43,7 @@ class HeadingEdit extends Component {
 					tagName={ tagName }
 					value={ content }
 					isSelected={ this.props.isSelected }
-					style={ { ...style, minHeight } }
+					style={ style }
 					onFocus={ this.props.onFocus } // always assign onFocus as a props
 					onBlur={ this.props.onBlur } // always assign onBlur as a props
 					onCaretVerticalPositionChange={ this.props.onCaretVerticalPositionChange }

--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -36,6 +36,7 @@ class HeadingEdit extends Component {
 			setAttributes,
 			mergeBlocks,
 			insertBlocksAfter,
+			style,
 		} = this.props;
 
 		const {
@@ -57,12 +58,10 @@ class HeadingEdit extends Component {
 					tagName={ tagName }
 					value={ content }
 					isSelected={ this.props.isSelected }
+					style={ { ...style, minHeight } }
 					onFocus={ this.props.onFocus } // always assign onFocus as a props
 					onBlur={ this.props.onBlur } // always assign onBlur as a props
 					onCaretVerticalPositionChange={ this.props.onCaretVerticalPositionChange }
-					style={ {
-						minHeight: Math.max( minHeight, this.state.aztecHeight ),
-					} }
 					onChange={ ( value ) => setAttributes( { content: value } ) }
 					onMerge={ mergeBlocks }
 					onSplit={
@@ -76,9 +75,6 @@ class HeadingEdit extends Component {
 							} :
 							undefined
 					}
-					onContentSizeChange={ ( event ) => {
-						this.setState( { aztecHeight: event.aztecHeight } );
-					} }
 					placeholder={ placeholder || __( 'Write heading…' ) }
 				/>
 			</View>

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -14,7 +14,6 @@ import { RichText } from '@wordpress/editor';
 /**
  * Internal dependencies
  */
-import styles from './style.scss';
 
 const name = 'core/paragraph';
 
@@ -95,8 +94,6 @@ class ParagraphEdit extends Component {
 			content,
 		} = attributes;
 
-		const minHeight = styles.blockText.minHeight;
-
 		return (
 			<View>
 				<RichText
@@ -106,7 +103,7 @@ class ParagraphEdit extends Component {
 					onFocus={ this.props.onFocus } // always assign onFocus as a props
 					onBlur={ this.props.onBlur } // always assign onBlur as a props
 					onCaretVerticalPositionChange={ this.props.onCaretVerticalPositionChange }
-					style={ { ...style, minHeight } }
+					style={ style }
 					onChange={ ( nextContent ) => {
 						setAttributes( {
 							content: nextContent,

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -23,10 +23,6 @@ class ParagraphEdit extends Component {
 		super( props );
 		this.splitBlock = this.splitBlock.bind( this );
 		this.onReplace = this.onReplace.bind( this );
-
-		this.state = {
-			aztecHeight: 0,
-		};
 	}
 
 	/**
@@ -110,10 +106,7 @@ class ParagraphEdit extends Component {
 					onFocus={ this.props.onFocus } // always assign onFocus as a props
 					onBlur={ this.props.onBlur } // always assign onBlur as a props
 					onCaretVerticalPositionChange={ this.props.onCaretVerticalPositionChange }
-					style={ {
-						...style,
-						minHeight: Math.max( minHeight, this.state.aztecHeight ),
-					} }
+					style={ { ...style, minHeight } }
 					onChange={ ( nextContent ) => {
 						setAttributes( {
 							content: nextContent,
@@ -122,9 +115,6 @@ class ParagraphEdit extends Component {
 					onSplit={ this.splitBlock }
 					onMerge={ mergeBlocks }
 					onReplace={ this.onReplace }
-					onContentSizeChange={ ( event ) => {
-						this.setState( { aztecHeight: event.aztecHeight } );
-					} }
 					placeholder={ placeholder || __( 'Start writing…' ) }
 				/>
 			</View>

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -80,16 +80,11 @@ class PostTitle extends Component {
 					onFocus={ this.onSelect }
 					onBlur={ this.props.onBlur } // always assign onBlur as a props
 					multiline={ false }
-					style={ [ style, {
-						minHeight: Math.max( minHeight, this.state.aztecHeight ),
-					} ] }
+					style={ { ...style, minHeight } }
 					fontSize={ 24 }
 					fontWeight={ 'bold' }
 					onChange={ ( value ) => {
 						this.props.onUpdate( value );
-					} }
-					onContentSizeChange={ ( event ) => {
-						this.setState( { aztecHeight: event.aztecHeight } );
 					} }
 					placeholder={ decodedPlaceholder }
 					value={ title }

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -28,7 +28,6 @@ class PostTitle extends Component {
 
 		this.state = {
 			isSelected: false,
-			aztecHeight: 0,
 		};
 	}
 
@@ -70,8 +69,6 @@ class PostTitle extends Component {
 		const decodedPlaceholder = decodeEntities( placeholder );
 		const borderColor = this.state.isSelected ? focusedBorderColor : 'transparent';
 
-		const minHeight = styles.blockText.minHeight;
-
 		return (
 			<View style={ [ styles.titleContainer, borderStyle, { borderColor } ] }>
 				<RichText
@@ -80,7 +77,7 @@ class PostTitle extends Component {
 					onFocus={ this.onSelect }
 					onBlur={ this.props.onBlur } // always assign onBlur as a props
 					multiline={ false }
-					style={ { ...style, minHeight } }
+					style={ style }
 					fontSize={ 24 }
 					fontWeight={ 'bold' }
 					onChange={ ( value ) => {

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -500,6 +500,10 @@ export class RichText extends Component {
 			html = '';
 			this.lastEventCount = undefined; // force a refresh on the native side
 		}
+		let minHeight = 0;
+		if ( style && style.minHeight ) {
+			minHeight = style.minHeight;
+		}
 
 		return (
 			<View>
@@ -518,7 +522,7 @@ export class RichText extends Component {
 					} }
 					style={ {
 						...style,
-						minHeight: Math.max( style.minHeight, this.state.height ),
+						minHeight: Math.max( minHeight, this.state.height ),
 					} }
 					text={ { text: html, eventCount: this.lastEventCount } }
 					placeholder={ this.props.placeholder }

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -537,7 +537,6 @@ export class RichText extends Component {
 					blockType={ { tag: tagName } }
 					color={ 'black' }
 					maxImagesWidth={ 200 }
-					//style={ style }
 					fontFamily={ this.props.fontFamily || styles[ 'editor-rich-text' ].fontFamily }
 					fontSize={ this.props.fontSize }
 					fontWeight={ this.props.fontWeight }

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -86,6 +86,7 @@ export class RichText extends Component {
 			start: 0,
 			end: 0,
 			formatPlaceholder: null,
+			height: 0,
 		};
 	}
 
@@ -236,9 +237,7 @@ export class RichText extends Component {
 
 	onContentSizeChange( contentSize ) {
 		const contentHeight = contentSize.height;
-		this.props.onContentSizeChange( {
-			aztecHeight: contentHeight,
-		} );
+		this.setState( { height: contentHeight } );
 	}
 
 	// eslint-disable-next-line no-unused-vars
@@ -517,6 +516,10 @@ export class RichText extends Component {
 							this.props.setRef( ref );
 						}
 					} }
+					style={ {
+						...style,
+						minHeight: Math.max( style.minHeight, this.state.height ),
+					} }
 					text={ { text: html, eventCount: this.lastEventCount } }
 					placeholder={ this.props.placeholder }
 					placeholderTextColor={ this.props.placeholderTextColor || styles[ 'editor-rich-text' ].textDecorationColor }
@@ -534,7 +537,7 @@ export class RichText extends Component {
 					blockType={ { tag: tagName } }
 					color={ 'black' }
 					maxImagesWidth={ 200 }
-					style={ style }
+					//style={ style }
 					fontFamily={ this.props.fontFamily || styles[ 'editor-rich-text' ].fontFamily }
 					fontSize={ this.props.fontSize }
 					fontWeight={ this.props.fontWeight }


### PR DESCRIPTION
## Description

This PR refactor the RichText native component to hide the content size changes that happen in the component from components that use it.

## How has this been tested?

You can test this code using this PR in GB-mobile repo: https://github.com/wordpress-mobile/gutenberg-mobile/pull/691

## Screenshots <!-- if applicable -->

## Types of changes

Refactor

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
