### PR TITLE
Protect development mode constant from being re-defined

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -11,7 +11,7 @@
  */
 
 ### BEGIN AUTO-GENERATED DEFINES
-define( 'GUTENBERG_DEVELOPMENT_MODE', true );
+defined( 'GUTENBERG_DEVELOPMENT_MODE' ) or define( 'GUTENBERG_DEVELOPMENT_MODE', true );
 ### END AUTO-GENERATED DEFINES
 
 gutenberg_pre_init();


### PR DESCRIPTION
When defining `GUTENBERG_DEVELOPMENT_MODE` in `wp-config.php` and running Gutenberg `master` directly from the repository, we'd see PHP warnings:

```
[28-Feb-2019 11:39:14 UTC] PHP Notice:  Constant GUTENBERG_DEVELOPMENT_MODE already defined in /var/www/html/wp-content/plugins/gutenberg/gutenberg.php on line 13
[28-Feb-2019 11:39:14 UTC] PHP Stack trace:
[28-Feb-2019 11:39:14 UTC] PHP   1. {main}() /var/www/html/wp-cron.php:0
[28-Feb-2019 11:39:14 UTC] PHP   2. require_once() /var/www/html/wp-cron.php:39
[28-Feb-2019 11:39:14 UTC] PHP   3. require_once() /var/www/html/wp-load.php:37
[28-Feb-2019 11:39:14 UTC] PHP   4. require_once() /var/www/html/wp-config.php:89
[28-Feb-2019 11:39:14 UTC] PHP   5. include_once() /var/www/html/wp-settings.php:342
[28-Feb-2019 11:39:14 UTC] PHP   6. define() /var/www/html/wp-content/plugins/gutenberg/gutenberg.php:13
```

We basically wanted to install Gutenberg (plugin version, not this repo) in development mode to Jetpack-Docker development environment by default. That's not a problem until someone runs Gutenberg from `master` and then gets these PHP warnings.

Came up in https://github.com/Automattic/jetpack/pull/11439#pullrequestreview-209022877

Now, I get this is in between `AUTO-GENERATED DEFINES` comments so there's probably a place somewhere else where I should PR. Happy to do so. :-)

## How has this been tested?
Define constant in your `wp-config.php` or `wp-content/mu-plugins` folder and observe Gutenberg not trying to double-define it.

## Types of changes
<!-- Bug fix (non-breaking change which fixes an issue) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
