### PR TITLE
added the more tag via the old editor's image

### DIFF
--- a/packages/block-library/src/classic/editor.scss
+++ b/packages/block-library/src/classic/editor.scss
@@ -109,12 +109,15 @@
 
 	.wp-more-tag {
 		width: 96%;
-		height: 0;
+		height: 20px;
 		display: block;
 		margin: 15px auto;
 		outline: 0;
 		cursor: default;
-		border: 2px dashed rgb(186, 186, 186);
+		background-image: url(/wp-includes/js/tinymce/skins/wordpress/images/more-2x.png);
+		background-size: 1900px 20px;
+		background-repeat: no-repeat;
+		background-position: center;
 	}
 
 	/**


### PR DESCRIPTION
Closes #8372

## Description
This uses the background image which the old editor uses to show the more tag as a dashed line with the MORE text in the middle. This looked like the most compatible and straightforward way to have the text in the more tag, as any other approach would probably not work in TinyMCE (e.g. altering the more tag's container). 

More elegant ways, say via a pseudo element won't work on this because it is rendered as an IMG tag which is a self contained element.

## How has this been tested?
Locally tested.

## Screenshots 
<img width="639" alt="screenshot 2019-02-28 at 19 50 52" src="https://user-images.githubusercontent.com/107534/53587104-33183800-3b92-11e9-8b50-23187dd53c97.png">

## Types of changes
Small UX improvement of the classic block. Probably there is some reasoning for the more tag's styling in the classic editor with a thicker dash and no text, @mcsf authored, but I agree with @kjellr that having the text in there makes the more tag be more clear.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
