### PR TITLE
Plugin: Remove wp-editor-font stylesheet override

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -200,27 +200,6 @@ function gutenberg_register_scripts_and_styles() {
 	// Editor Styles.
 	// This empty stylesheet is defined to ensure backward compatibility.
 	gutenberg_override_style( 'wp-blocks', false );
-	$fonts_url = '';
-
-	/*
-	 * Translators: Use this to specify the proper Google Font name and variants
-	 * to load that is supported by your language. Do not translate.
-	 * Set to 'off' to disable loading.
-	 */
-	$font_family = _x( 'Noto Serif:400,400i,700,700i', 'Google Font Name and Variants', 'gutenberg' );
-	if ( 'off' !== $font_family ) {
-		$query_args = array(
-			'family' => urlencode( $font_family ),
-		);
-		$fonts_url  = esc_url_raw( add_query_arg( $query_args, 'https://fonts.googleapis.com/css' ) );
-	}
-
-	gutenberg_override_style(
-		'wp-editor-font',
-		$fonts_url,
-		array(),
-		null
-	);
 
 	gutenberg_override_style(
 		'wp-editor',


### PR DESCRIPTION
Extracted from: #13569
Previously: #11826
Core ticket: https://core.trac.wordpress.org/ticket/45382

This pull request seeks to remove Gutenberg's own `wp-editor-font` stylesheet registration, instead falling back to the one provided by core as of [rWP43919](https://core.trac.wordpress.org/changeset/43919) ([source](https://github.com/WordPress/wordpress-develop/blob/a16cbba2fd644b97bfeb468b01fb4d3b58f70013/src/wp-includes/script-loader.php#L1930-L1939)).

This is part of a larger effort to limit Gutenberg's stylesheets and scripts registration to only those which are overridden as being generated by its own bundled packages. In this instance, the stylesheet registration is entirely separate from the packages, and Gutenberg is fine to lean on the core-provided value.

There is a [subsequent reference to Noto Serif](https://github.com/WordPress/gutenberg/blob/c3cacd3d88014c913478d76e8bc24c849638f848/lib/client-assets.php#L774-L778) later in the file, which will be removed as part of #13569, allowing deference to core's block editor screen to assign this ([source](https://github.com/WordPress/wordpress-develop/blob/a16cbba2fd644b97bfeb468b01fb4d3b58f70013/src/wp-admin/edit-form-blocks.php#L177-L181)).

**Testing instructions:**

Verify that Gutenberg respects the Noto Serif style registration provided by core (optionally respecting that it be localized as disabled).

