### PR TITLE
Notices: Remove inaccurate createNotice sole argument feature

### DIFF
--- a/packages/notices/CHANGELOG.md
+++ b/packages/notices/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 ### New Feature
 
-- The `createNotice` can now optionally accept a WPNotice object as the sole argument.
 - New option `speak` enables control as to whether the notice content is announced to screen readers (defaults to `true`)
 
 ### Bug Fixes


### PR DESCRIPTION
The `@wordpress/notices` changelog contains an inaccurate mention of a sole object argument accepted by `createNotice`. This was part of an earlier iteration of #11604 which was later removed.

See:

- https://github.com/WordPress/gutenberg/pull/11604#discussion_r234644697
- d08fe3a59f42c4aec3ce7f1a5bf1c8aae7336a23

cc @mattwiebe
