### PR TITLE
RichText: fix wordwise selection on Windows

### DIFF
--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -573,12 +573,13 @@ export class RichText extends Component {
 	/**
 	 * Handles a keydown event.
 	 *
-	 * @param {KeyboardEvent} event The keydown event.
+	 * @param {SyntheticEvent} event A synthetic keyboard event.
 	 */
 	onKeyDown( event ) {
 		const { keyCode, shiftKey, altKey, metaKey, ctrlKey } = event;
 
 		if (
+			// Only override left and right keys without modifiers pressed.
 			! shiftKey && ! altKey && ! metaKey && ! ctrlKey &&
 			( keyCode === LEFT || keyCode === RIGHT )
 		) {
@@ -661,6 +662,13 @@ export class RichText extends Component {
 		}
 	}
 
+	/**
+	 * Handles horizontal keyboard navigation when no modifiers are pressed. The
+	 * navigation is handled separately to move correctly around format
+	 * boundaries.
+	 *
+	 * @param  {SyntheticEvent} event A synthetic keyboard event.
+	 */
 	handleHorizontalNavigation( event ) {
 		const value = this.createRecord();
 		const { formats, text, start, end } = value;

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -576,10 +576,10 @@ export class RichText extends Component {
 	 * @param {KeyboardEvent} event The keydown event.
 	 */
 	onKeyDown( event ) {
-		const { keyCode, shiftKey, altKey, metaKey } = event;
+		const { keyCode, shiftKey, altKey, metaKey, crtlKey } = event;
 
 		if (
-			! shiftKey && ! altKey && ! metaKey &&
+			! shiftKey && ! altKey && ! metaKey && ! crtlKey &&
 			( keyCode === LEFT || keyCode === RIGHT )
 		) {
 			this.handleHorizontalNavigation( event );

--- a/packages/editor/src/components/rich-text/index.js
+++ b/packages/editor/src/components/rich-text/index.js
@@ -576,10 +576,10 @@ export class RichText extends Component {
 	 * @param {KeyboardEvent} event The keydown event.
 	 */
 	onKeyDown( event ) {
-		const { keyCode, shiftKey, altKey, metaKey, crtlKey } = event;
+		const { keyCode, shiftKey, altKey, metaKey, ctrlKey } = event;
 
 		if (
-			! shiftKey && ! altKey && ! metaKey && ! crtlKey &&
+			! shiftKey && ! altKey && ! metaKey && ! ctrlKey &&
 			( keyCode === LEFT || keyCode === RIGHT )
 		) {
 			this.handleHorizontalNavigation( event );


### PR DESCRIPTION
## Description

@afercia I think this should fix #14170, but I can't be sure as I can't test on Windows.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->