### PR TITLE
Add: End to end test to verify that when all  blocks are removed the default block gets selected

### DIFF
--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -88,7 +88,7 @@ Clicks on More Menu item, searches for the button with the text provided and cli
 
 ### createEmbeddingMatcher
 
-[src/index.js#L47-L47](src/index.js#L47-L47)
+[src/index.js#L48-L48](src/index.js#L48-L48)
 
 Creates a function to determine if a request is embedding a certain URL.
 
@@ -102,7 +102,7 @@ Creates a function to determine if a request is embedding a certain URL.
 
 ### createJSONResponse
 
-[src/index.js#L47-L47](src/index.js#L47-L47)
+[src/index.js#L48-L48](src/index.js#L48-L48)
 
 Respond to a request with a JSON response.
 
@@ -141,7 +141,7 @@ Creates new URL by parsing base URL, WPPath and query string.
 
 ### createURLMatcher
 
-[src/index.js#L47-L47](src/index.js#L47-L47)
+[src/index.js#L48-L48](src/index.js#L48-L48)
 
 Creates a function to determine if a request is calling a URL with the substring present.
 
@@ -299,9 +299,19 @@ Checks if current URL is a WordPress path.
 
 `boolean`: Boolean represents whether current URL is or not a WordPress path.
 
-### loginUser
+### isInDefaultBlock
 
 [src/index.js#L25-L25](src/index.js#L25-L25)
+
+Checks if the block that is focused is the default block.
+
+**Returns**
+
+`Promise`: Promise resolving with a boolean indicating if the focused block is the default block.
+
+### loginUser
+
+[src/index.js#L26-L26](src/index.js#L26-L26)
 
 Performs log in with specified username and password.
 
@@ -312,7 +322,7 @@ Performs log in with specified username and password.
 
 ### mockOrTransform
 
-[src/index.js#L47-L47](src/index.js#L47-L47)
+[src/index.js#L48-L48](src/index.js#L48-L48)
 
 Mocks a request with the supplied mock object, or allows it to run with an optional transform, based on the
 deserialised JSON response for the request.
@@ -329,26 +339,26 @@ deserialised JSON response for the request.
 
 ### observeFocusLoss
 
-[src/index.js#L26-L26](src/index.js#L26-L26)
+[src/index.js#L27-L27](src/index.js#L27-L27)
 
 Binds to the document on page load which throws an error if a `focusout`
 event occurs without a related target (i.e. focus loss).
 
 ### openDocumentSettingsSidebar
 
-[src/index.js#L27-L27](src/index.js#L27-L27)
+[src/index.js#L28-L28](src/index.js#L28-L28)
 
 Clicks on the button in the header which opens Document Settings sidebar when it is closed.
 
 ### openPublishPanel
 
-[src/index.js#L28-L28](src/index.js#L28-L28)
+[src/index.js#L29-L29](src/index.js#L29-L29)
 
 Opens the publish panel.
 
 ### pressKeyTimes
 
-[src/index.js#L29-L29](src/index.js#L29-L29)
+[src/index.js#L30-L30](src/index.js#L30-L30)
 
 Presses the given keyboard key a number of times in sequence.
 
@@ -363,7 +373,7 @@ Presses the given keyboard key a number of times in sequence.
 
 ### pressKeyWithModifier
 
-[src/index.js#L30-L30](src/index.js#L30-L30)
+[src/index.js#L31-L31](src/index.js#L31-L31)
 
 Performs a key press with modifier (Shift, Control, Meta, Alt), where each modifier
 is normalized to platform-specific modifier.
@@ -375,7 +385,7 @@ is normalized to platform-specific modifier.
 
 ### publishPost
 
-[src/index.js#L31-L31](src/index.js#L31-L31)
+[src/index.js#L32-L32](src/index.js#L32-L32)
 
 Publishes the post, resolving once the request is complete (once a notice
 is displayed).
@@ -386,7 +396,7 @@ is displayed).
 
 ### publishPostWithPrePublishChecksDisabled
 
-[src/index.js#L32-L32](src/index.js#L32-L32)
+[src/index.js#L33-L33](src/index.js#L33-L33)
 
 Publishes the post without the pre-publish checks,
 resolving once the request is complete (once a notice is displayed).
@@ -397,7 +407,7 @@ resolving once the request is complete (once a notice is displayed).
 
 ### saveDraft
 
-[src/index.js#L33-L33](src/index.js#L33-L33)
+[src/index.js#L34-L34](src/index.js#L34-L34)
 
 Saves the post as a draft, resolving once the request is complete (once the
 "Saved" indicator is displayed).
@@ -408,7 +418,7 @@ Saves the post as a draft, resolving once the request is complete (once the
 
 ### searchForBlock
 
-[src/index.js#L34-L34](src/index.js#L34-L34)
+[src/index.js#L35-L35](src/index.js#L35-L35)
 
 Search for block in the global inserter
 
@@ -418,7 +428,7 @@ Search for block in the global inserter
 
 ### selectBlockByClientId
 
-[src/index.js#L35-L35](src/index.js#L35-L35)
+[src/index.js#L36-L36](src/index.js#L36-L36)
 
 Given the clientId of a block, selects the block on the editor.
 
@@ -428,7 +438,7 @@ Given the clientId of a block, selects the block on the editor.
 
 ### setBrowserViewport
 
-[src/index.js#L36-L36](src/index.js#L36-L36)
+[src/index.js#L37-L37](src/index.js#L37-L37)
 
 Sets browser viewport to specified type.
 
@@ -438,7 +448,7 @@ Sets browser viewport to specified type.
 
 ### setPostContent
 
-[src/index.js#L37-L37](src/index.js#L37-L37)
+[src/index.js#L38-L38](src/index.js#L38-L38)
 
 Sets code editor content
 
@@ -452,7 +462,7 @@ Sets code editor content
 
 ### setUpResponseMocking
 
-[src/index.js#L47-L47](src/index.js#L47-L47)
+[src/index.js#L48-L48](src/index.js#L48-L48)
 
 Sets up mock checks and responses. Accepts a list of mock settings with the following properties:
 
@@ -483,7 +493,7 @@ If none of the mock settings match the request, the request is allowed to contin
 
 ### switchEditorModeTo
 
-[src/index.js#L38-L38](src/index.js#L38-L38)
+[src/index.js#L39-L39](src/index.js#L39-L39)
 
 Switches editor mode.
 
@@ -493,21 +503,21 @@ Switches editor mode.
 
 ### switchUserToAdmin
 
-[src/index.js#L39-L39](src/index.js#L39-L39)
+[src/index.js#L40-L40](src/index.js#L40-L40)
 
 Switches the current user to the admin user (if the user
 running the test is not already the admin user).
 
 ### switchUserToTest
 
-[src/index.js#L40-L40](src/index.js#L40-L40)
+[src/index.js#L41-L41](src/index.js#L41-L41)
 
 Switches the current user to whichever user we should be
 running the tests as (if we're not already that user).
 
 ### toggleScreenOption
 
-[src/index.js#L41-L41](src/index.js#L41-L41)
+[src/index.js#L42-L42](src/index.js#L42-L42)
 
 Toggles the screen option with the given label.
 
@@ -518,7 +528,7 @@ Toggles the screen option with the given label.
 
 ### transformBlockTo
 
-[src/index.js#L42-L42](src/index.js#L42-L42)
+[src/index.js#L43-L43](src/index.js#L43-L43)
 
 Converts editor's block type.
 
@@ -528,7 +538,7 @@ Converts editor's block type.
 
 ### uninstallPlugin
 
-[src/index.js#L43-L43](src/index.js#L43-L43)
+[src/index.js#L44-L44](src/index.js#L44-L44)
 
 Uninstalls a plugin.
 
@@ -538,7 +548,7 @@ Uninstalls a plugin.
 
 ### visitAdminPage
 
-[src/index.js#L44-L44](src/index.js#L44-L44)
+[src/index.js#L45-L45](src/index.js#L45-L45)
 
 Visits admin page; if user is not logged in then it logging in it first, then visits admin page.
 
@@ -549,7 +559,7 @@ Visits admin page; if user is not logged in then it logging in it first, then vi
 
 ### waitForWindowDimensions
 
-[src/index.js#L45-L45](src/index.js#L45-L45)
+[src/index.js#L46-L46](src/index.js#L46-L46)
 
 Function that waits until the page viewport has the required dimensions.
 It is being used to address a problem where after using setViewport the execution may continue,

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -22,6 +22,7 @@ export { hasBlockSwitcher } from './has-block-switcher';
 export { insertBlock } from './insert-block';
 export { installPlugin } from './install-plugin';
 export { isCurrentURL } from './is-current-url';
+export { isInDefaultBlock } from './is-in-default-block';
 export { loginUser } from './login-user';
 export { observeFocusLoss } from './observe-focus-loss';
 export { openDocumentSettingsSidebar } from './open-document-settings-sidebar';

--- a/packages/e2e-test-utils/src/is-in-default-block.js
+++ b/packages/e2e-test-utils/src/is-in-default-block.js
@@ -1,0 +1,22 @@
+/**
+ * Checks if the block that is focused is the default block.
+ *
+ * @return {Promise} Promise resolving with a boolean indicating if the focused block is the default block.
+ */
+export function isInDefaultBlock() {
+	return page.evaluate( () => {
+		const activeElement = document.activeElement;
+		// activeElement may be null in that case we should return false
+		if ( ! activeElement ) {
+			return false;
+		}
+		const closestElementWithDataTpe = activeElement.closest( '[data-type]' );
+		if ( ! closestElementWithDataTpe ) {
+			return false;
+		}
+		const activeBlockName = closestElementWithDataTpe.getAttribute( 'data-type' );
+		const defaultBlockName = window.wp.blocks.getDefaultBlockName();
+
+		return activeBlockName === defaultBlockName;
+	} );
+}

--- a/packages/e2e-tests/specs/block-deletion.test.js
+++ b/packages/e2e-tests/specs/block-deletion.test.js
@@ -5,6 +5,7 @@ import {
 	clickBlockAppender,
 	getEditedPostContent,
 	createNewPost,
+	isInDefaultBlock,
 	pressKeyWithModifier,
 } from '@wordpress/e2e-test-utils';
 
@@ -107,5 +108,26 @@ describe( 'block deletion -', () => {
 			await page.keyboard.type( ' - caret was here' );
 			expect( await getEditedPostContent() ).toMatchSnapshot();
 		} );
+	} );
+} );
+
+describe( 'deleting all blocks', () => {
+	it( 'results in the default block getting selected', async () => {
+		await createNewPost();
+		await clickBlockAppender();
+		await page.keyboard.type( 'Paragraph' );
+
+		await page.keyboard.press( 'Escape' );
+
+		await clickOnBlockSettingsMenuItem( 'Remove Block' );
+
+		// There is a default block:
+		expect( await page.$$( '.editor-block-list__block' ) ).toHaveLength( 1 );
+
+		// But the effective saved content is still empty:
+		expect( await getEditedPostContent() ).toBe( '' );
+
+		// And focus is retained:
+		expect( await isInDefaultBlock() ).toBe( true );
 	} );
 } );

--- a/packages/e2e-tests/specs/splitting-merging.test.js
+++ b/packages/e2e-tests/specs/splitting-merging.test.js
@@ -4,6 +4,7 @@
 import {
 	createNewPost,
 	insertBlock,
+	isInDefaultBlock,
 	getEditedPostContent,
 	pressKeyTimes,
 	pressKeyWithModifier,
@@ -199,15 +200,6 @@ describe( 'splitting and merging blocks', () => {
 		expect( await getEditedPostContent() ).toBe( '' );
 
 		// And focus is retained:
-		const isInDefaultBlock = await page.evaluate( () => {
-			const activeBlockName = document.activeElement
-				.closest( '[data-type]' )
-				.getAttribute( 'data-type' );
-			const defaultBlockName = window.wp.blocks.getDefaultBlockName();
-
-			return activeBlockName === defaultBlockName;
-		} );
-
-		expect( isInDefaultBlock ).toBe( true );
+		expect( await isInDefaultBlock() ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
Catches the bug being addressed in https://github.com/WordPress/gutenberg/pull/14189.

Currently, if we remove all blocks the default block does not get selected and a focus loss occurs.

Exposes a new end 2 end test util isInDefaultBlock.

## How has this been tested?
I checked the end 2 end tests fail on this branch (based on master).
When I merged this branch with fix/deleting-the-last-block-triggers-a-focus-loss the end 2 end tests start passing. 
