### PR TITLE
Framework: Update package-lock.json for new Enzyme adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2897,6 +2897,60 @@
 				"enzyme": "^3.9.0",
 				"enzyme-adapter-react-16": "^1.10.0",
 				"enzyme-to-json": "^3.3.5"
+			},
+			"dependencies": {
+				"define-properties": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+					"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+					"dev": true,
+					"requires": {
+						"object-keys": "^1.0.12"
+					}
+				},
+				"enzyme-adapter-react-16": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.10.0.tgz",
+					"integrity": "sha512-0QqwEZcBv1xEEla+a3H7FMci+y4ybLia9cZzsdIrId7qcig4MK0kqqf6iiCILH1lsKS6c6AVqL3wGPhCevv5aQ==",
+					"dev": true,
+					"requires": {
+						"enzyme-adapter-utils": "^1.10.0",
+						"object.assign": "^4.1.0",
+						"object.values": "^1.1.0",
+						"prop-types": "^15.6.2",
+						"react-is": "^16.7.0",
+						"react-test-renderer": "^16.0.0-0"
+					}
+				},
+				"object.values": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
+					"integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+					"dev": true,
+					"requires": {
+						"define-properties": "^1.1.3",
+						"es-abstract": "^1.12.0",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3"
+					}
+				},
+				"prop-types": {
+					"version": "15.7.2",
+					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+					"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+					"dev": true,
+					"requires": {
+						"loose-envify": "^1.4.0",
+						"object-assign": "^4.1.1",
+						"react-is": "^16.8.1"
+					}
+				},
+				"react-is": {
+					"version": "16.8.3",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.3.tgz",
+					"integrity": "sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==",
+					"dev": true
+				}
 			}
 		},
 		"@wordpress/jest-puppeteer-axe": {
@@ -7333,61 +7387,6 @@
 				"raf": "^3.4.0",
 				"rst-selector-parser": "^2.2.3",
 				"string.prototype.trim": "^1.1.2"
-			}
-		},
-		"enzyme-adapter-react-16": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.9.1.tgz",
-			"integrity": "sha512-Egzogv1y77DUxdnq/CyHxLHaNxmSSKDDSDNNB/EiAXCZVFXdFibaNy2uUuRQ1n24T2m6KH/1Rw16XDRq+1yVEg==",
-			"dev": true,
-			"requires": {
-				"enzyme-adapter-utils": "^1.10.0",
-				"function.prototype.name": "^1.1.0",
-				"object.assign": "^4.1.0",
-				"object.values": "^1.1.0",
-				"prop-types": "^15.6.2",
-				"react-is": "^16.7.0",
-				"react-test-renderer": "^16.0.0-0"
-			},
-			"dependencies": {
-				"define-properties": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-					"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-					"dev": true,
-					"requires": {
-						"object-keys": "^1.0.12"
-					}
-				},
-				"object.values": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
-					"integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
-					"dev": true,
-					"requires": {
-						"define-properties": "^1.1.3",
-						"es-abstract": "^1.12.0",
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3"
-					}
-				},
-				"prop-types": {
-					"version": "15.7.2",
-					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-					"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-					"dev": true,
-					"requires": {
-						"loose-envify": "^1.4.0",
-						"object-assign": "^4.1.1",
-						"react-is": "^16.8.1"
-					}
-				},
-				"react-is": {
-					"version": "16.8.2",
-					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.2.tgz",
-					"integrity": "sha512-D+NxhSR2HUCjYky1q1DwpNUD44cDpUXzSmmFyC3ug1bClcU/iDNy0YNn1iwme28fn+NFhpA13IndOd42CrFb+Q==",
-					"dev": true
-				}
 			}
 		},
 		"enzyme-adapter-utils": {


### PR DESCRIPTION
Previously: #14156

This pull request seeks to resolve an issue where running `npm install` on a clean clone of the repository will result in local changes to the `package-lock.json` file. The changes here commit those changes, as an expected result of the version bump to `enzyme-adapter-react-16` merged in #14156.

Separately it should be considered how this was not captured by a build failure, since we have tooling in place to avoid allowing these desyncs from occurring, between [`npm run check-local-changes`](https://github.com/WordPress/gutenberg/blob/535e0752051957f3e6ab7aca2e71e99ceffc9a6f/package.json#L159) and [`npm ci`'s behavior to exit with an error](https://docs.npmjs.com/cli/ci.html) on an invalid `package-lock.json`. The current running debugging theory is outlined at https://github.com/WordPress/gutenberg/pull/14156#issuecomment-468711353 .

**Testing instructions:**

Verify there are no local changes after running `npm install` in a clean clone of the repository.