### PR TITLE
Lowercase classic editor when not in reference to the plugin.

### DIFF
--- a/docs/designers-developers/developers/backward-compatibility/meta-box.md
+++ b/docs/designers-developers/developers/backward-compatibility/meta-box.md
@@ -30,7 +30,7 @@ add_meta_box( 'my-meta-box', 'My Meta Box', 'my_meta_box_callback',
 );
 ```
 
-When Gutenberg is used, this meta box will no longer be displayed in the meta box area, as it now only exists for backward compatibility purposes. It will continue to display correctly in the Classic editor.
+When Gutenberg is used, this meta box will no longer be displayed in the meta box area, as it now only exists for backward compatibility purposes. It will continue to display correctly in the classic editor.
 
 ### Meta Box Data Collection
 

--- a/docs/designers-developers/developers/filters/editor-filters.md
+++ b/docs/designers-developers/developers/filters/editor-filters.md
@@ -4,7 +4,7 @@ To modify the behavior of the editor experience, the following Filters are expos
 
 ### `editor.PostFeaturedImage.imageSize`
 
-Used to modify the image size displayed in the Post Featured Image component. It defaults to `'post-thumbnail'`, and will fail back to the `full` image size when the specified image size doesn't exist in the media object. It's modeled after the `admin_post_thumbnail_size` filter in the Classic Editor.
+Used to modify the image size displayed in the Post Featured Image component. It defaults to `'post-thumbnail'`, and will fail back to the `full` image size when the specified image size doesn't exist in the media object. It's modeled after the `admin_post_thumbnail_size` filter in the classic editor.
 
 _Example:_
 

--- a/docs/designers-developers/developers/tutorials/notices/README.md
+++ b/docs/designers-developers/developers/tutorials/notices/README.md
@@ -2,13 +2,13 @@
 
 Notices are informational UI displayed near the top of admin pages. WordPress core, themes, and plugins all use notices to indicate the result of an action, or to draw the user's attention to necessary information.
 
-In the Classic Editor, notices hooked onto the `admin_notices` action can render whatever HTML they'd like. In the Block Editor, notices are restricted to a more formal API.
+In the classic editor, notices hooked onto the `admin_notices` action can render whatever HTML they'd like. In the Block Editor, notices are restricted to a more formal API.
 
-## Notices in the Classic Editor
+## Notices in the classic editor
 
-In the Classic Editor, here's an example of the "Post draft updated" notice:
+In the classic editor, here's an example of the "Post draft updated" notice:
 
-![Post draft updated in the Classic Editor](https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/notices/classic-editor-notice.png)
+![Post draft updated in the classic editor](https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/notices/classic-editor-notice.png)
 
 Producing an equivalent "Post draft updated" notice would require code like this:
 

--- a/docs/designers-developers/developers/tutorials/notices/README.md
+++ b/docs/designers-developers/developers/tutorials/notices/README.md
@@ -4,7 +4,7 @@ Notices are informational UI displayed near the top of admin pages. WordPress co
 
 In the classic editor, notices hooked onto the `admin_notices` action can render whatever HTML they'd like. In the Block Editor, notices are restricted to a more formal API.
 
-## Notices in the classic editor
+## Notices in the Classic Editor
 
 In the classic editor, here's an example of the "Post draft updated" notice:
 

--- a/docs/designers-developers/faq.md
+++ b/docs/designers-developers/faq.md
@@ -322,7 +322,7 @@ We realize it's a big change. We also think there will be many new opportunities
 
 There is a “Classic” block, which is virtually the same as the current editor, except in block form.
 
-There is also the [Classic Editor Plugin](https://wordpress.org/plugins/classic-editor/) which restores the previous editor, see the plugin for more information. The WordPress Core team has committed to supporting the Classic Editor Plugin [until December 2021](https://make.wordpress.org/core/2018/11/07/classic-editor-plugin-support-window/).
+There is also the [Classic Editor plugin](https://wordpress.org/plugins/classic-editor/) which restores the previous editor, see the plugin for more information. The WordPress Core team has committed to supporting the Classic Editor plugin [until December 2021](https://make.wordpress.org/core/2018/11/07/classic-editor-plugin-support-window/).
 
 
 ## How will custom TinyMCE buttons work in Gutenberg?

--- a/packages/e2e-tests/specs/__snapshots__/compatibility-classic-editor.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/compatibility-classic-editor.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Compatibility with Classic Editor Should not apply autop when rendering blocks 1`] = `
+exports[`Compatibility with classic editor Should not apply autop when rendering blocks 1`] = `
 "<a>
 Random Link
 </a>"

--- a/packages/e2e-tests/specs/compatibility-classic-editor.test.js
+++ b/packages/e2e-tests/specs/compatibility-classic-editor.test.js
@@ -3,7 +3,7 @@
  */
 import { createNewPost, insertBlock, publishPost } from '@wordpress/e2e-test-utils';
 
-describe( 'Compatibility with Classic Editor', () => {
+describe( 'Compatibility with classic editor', () => {
 	beforeEach( async () => {
 		await createNewPost();
 	} );


### PR DESCRIPTION
## Description
I've updated all references to Classic Editor which aren't in reference to the plugin to be lowercase as they aren't proper nouns. Also lowercased two instances of Plugin where appropriate.

This ties back into the convention outlined in #12856.

## How has this been tested?
Just to confirm nothing was broken.

## Types of changes
Verbiage change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
