### PR TITLE
Packages: Add missing expect-puppeteer dependency to e2e-tests package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2742,6 +2742,7 @@
 				"@wordpress/e2e-test-utils": "file:packages/e2e-test-utils",
 				"@wordpress/jest-console": "file:packages/jest-console",
 				"@wordpress/scripts": "file:packages/scripts",
+				"expect-puppeteer": "^4.0.0",
 				"lodash": "^4.17.11"
 			}
 		},

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -25,6 +25,7 @@
 		"@wordpress/e2e-test-utils": "file:../e2e-test-utils",
 		"@wordpress/jest-console": "file:../jest-console",
 		"@wordpress/scripts": "file:../scripts",
+		"expect-puppeteer": "^4.0.0",
 		"lodash": "^4.17.11"
 	},
 	"peerDependencies": {


### PR DESCRIPTION
## Description
Follow-up for https://github.com/WordPress/gutenberg/pull/13922#discussion_r259112342 where I removed `expect-puppeteer` from the list of dependencies. In retrospect, I think it shouldn't happen. Props to @aduth for helping to decide what would be the best practice as this one is really tricky. It's a dependency of `jest-puppeteer` which is added through the preset. However we are overriding the part of the config which sets it up, so we have to re-apply it thus the need to put is as a dependency.

This change is added only for better discoverability of our dependencies. There is no change for the codebase at all.