### PR TITLE
Testing: Await E2E promise interactions

### DIFF
--- a/packages/e2e-tests/plugins/disable-animations.php
+++ b/packages/e2e-tests/plugins/disable-animations.php
@@ -15,4 +15,4 @@ function enqueue_disable_animations_stylesheet() {
 	wp_add_inline_style( 'wp-components', $custom_css );
 }
 
-add_action( 'enqueue_block_editor_assets', 'enqueue_disable_animations_stylesheet' );
+add_action( 'admin_enqueue_scripts', 'enqueue_disable_animations_stylesheet' );

--- a/packages/e2e-tests/specs/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/block-hierarchy-navigation.test.js
@@ -31,10 +31,10 @@ describe( 'Navigating the block hierarchy', () => {
 
 		// Tweak the columns count.
 		await page.focus( '.edit-post-settings-sidebar__panel-block .components-range-control__number[aria-label="Columns"]' );
-		page.keyboard.down( 'Shift' );
-		page.keyboard.press( 'ArrowLeft' );
-		page.keyboard.up( 'Shift' );
-		page.keyboard.type( '3' );
+		await page.keyboard.down( 'Shift' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.up( 'Shift' );
+		await page.keyboard.type( '3' );
 
 		// Navigate to the last column block.
 		await page.click( '[aria-label="Block Navigation"]' );

--- a/packages/e2e-tests/specs/change-detection.test.js
+++ b/packages/e2e-tests/specs/change-detection.test.js
@@ -18,9 +18,9 @@ describe( 'Change detection', () => {
 		await createNewPost();
 	} );
 
-	afterEach( () => {
+	afterEach( async () => {
 		if ( handleInterceptedRequest ) {
-			releaseSaveIntercept();
+			await releaseSaveIntercept();
 		}
 	} );
 

--- a/packages/e2e-tests/specs/demo.test.js
+++ b/packages/e2e-tests/specs/demo.test.js
@@ -22,7 +22,7 @@ const stripIframeFromEmbed = ( embedObject ) => {
 
 describe( 'new editor state', () => {
 	beforeAll( async () => {
-		setUpResponseMocking( [
+		await setUpResponseMocking( [
 			{
 				match: createURLMatcher( 'oembed%2F1.0%2Fproxy' ),
 				onRequestMatch: mockOrTransform( couldNotBePreviewed, MOCK_VIMEO_RESPONSE, stripIframeFromEmbed ),

--- a/packages/e2e-tests/specs/manage-reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/manage-reusable-blocks.test.js
@@ -9,11 +9,23 @@ import path from 'path';
 import { visitAdminPage } from '@wordpress/e2e-test-utils';
 
 describe( 'Managing reusable blocks', () => {
+	/**
+	 * Returns a Promise which resolves to the number of post list entries on
+	 * the current page.
+	 *
+	 * @return {Promise} Promise resolving to number of post list entries.
+	 */
+	async function getNumberOfEntries() {
+		return page.evaluate( () => document.querySelectorAll( '.entry' ).length );
+	}
+
 	beforeAll( async () => {
 		await visitAdminPage( 'edit.php', 'post_type=wp_block' );
 	} );
 
 	it( 'Should import reusable blocks', async () => {
+		const originalEntries = await getNumberOfEntries();
+
 		// Import Reusable block
 		await page.waitForSelector( '.list-reusable-blocks__container' );
 		const importButton = await page.$( '.list-reusable-blocks__container button' );
@@ -36,7 +48,9 @@ describe( 'Managing reusable blocks', () => {
 		// Refresh the page
 		await visitAdminPage( 'edit.php', 'post_type=wp_block' );
 
-		// The reusable block has been imported
-		await page.waitForXPath( 'div[@class="post_title"][contains(text(), "Greeting")]' );
+		const expectedEntries = originalEntries + 1;
+		const actualEntries = await getNumberOfEntries();
+
+		expect( actualEntries ).toBe( expectedEntries );
 	} );
 } );

--- a/packages/e2e-tests/specs/manage-reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/manage-reusable-blocks.test.js
@@ -37,6 +37,6 @@ describe( 'Managing reusable blocks', () => {
 		await visitAdminPage( 'edit.php', 'post_type=wp_block' );
 
 		// The reusable block has been imported
-		page.waitForXPath( 'div[@class="post_title"][contains(text(), "Greeting")]' );
+		await page.waitForXPath( 'div[@class="post_title"][contains(text(), "Greeting")]' );
 	} );
 } );

--- a/packages/e2e-tests/specs/taxonomies.test.js
+++ b/packages/e2e-tests/specs/taxonomies.test.js
@@ -153,7 +153,7 @@ describe( 'Taxonomies', () => {
 		await page.reload();
 
 		// Wait for the tags to load.
-		page.waitForSelector( '.components-form-token-field__token' );
+		await page.waitForSelector( '.components-form-token-field__token' );
 
 		tags = await getCurrentTags();
 


### PR DESCRIPTION
Extracted from #13569 

This pull request seeks to fix a few occurrences within E2E test specs where we use async functions without properly awaiting their resolution. This should help with overall E2E test stability.

Notably:

- `block-hierarchy-navigation.test.js` has been a frequent intermittent failure in builds (failed snapshot around "Third Column"). I have reasonably high confidence the changes here will resolve these.
- I have low-moderate confidence the `change-detection.test.js` could resolve some failed test runs which result in messages along the lines of "the context has already been destroyed"

**Implementation notes:**

I sought these out using a combination of regular expression file searches of increasing breadth within `e2e-tests/specs`, identifying a pattern where a line does not begin with `await` but calls a function which may be async:

```regex
^\s*page\.waitFor
```
```regex
^\s*page\.
```
```regex
^\s*(?!describe|expect|it|beforeEach|before|after|afterEach)\w+\(
```

It would be nice if there were some way to automate this detection, as in almost all cases, a function which is asynchronous or which otherwise returns a promise should be `await`ed before proceeding (exceptions can include occurrences within `Promise.all`, etc).

**Testing instructions:**

Verify E2E tests run:

```
npm run test-e2e
```