### PR TITLE
Add new actions for invalidating resolution caches

### DIFF
--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Enhancements
 
 - The `registerStore` function now accepts an optional `initialState` option value.
+- Introduce new `invalidateResolutionForStore` dispatch action for signalling to invalidate the resolution cache for an entire given store.
+- Introduce new `invalidateResolutionForStoreSelector` dispatch action for signalling to invalidate the resolution cache for a store selector (and all variations of arguments on that selector).
 
 ### Bug Fix
 

--- a/packages/data/src/store/actions.js
+++ b/packages/data/src/store/actions.js
@@ -53,3 +53,39 @@ export function invalidateResolution( reducerKey, selectorName, args ) {
 		args,
 	};
 }
+
+/**
+ * Returns an action object used in signalling that the resolution cache for a
+ * given reducerKey should be invalidated.
+ *
+ * @param {string} reducerKey Registered store reducer key.
+ *
+ * @return {Object} Action object.
+ */
+export function invalidateResolutionForStore( reducerKey ) {
+	return {
+		type: 'INVALIDATE_RESOLUTION_FOR_STORE',
+		reducerKey,
+	};
+}
+
+/**
+ * Returns an action object used in signalling that the resolution cache for a
+ * given reducerKey and selectorName should be invalidated.
+ *
+ * @param {string} reducerKey   Registered store reducer key.
+ * @param {string} selectorName Name of selector for which all resolvers should
+ *                              be invalidated.
+ *
+ * @return  {Object} Action object.
+ */
+export function invalidateResolutionForStoreSelector(
+	reducerKey,
+	selectorName
+) {
+	return {
+		type: 'INVALIDATE_RESOLUTION_FOR_STORE_SELECTOR',
+		reducerKey,
+		selectorName,
+	};
+}

--- a/packages/data/src/store/reducer.js
+++ b/packages/data/src/store/reducer.js
@@ -10,7 +10,8 @@ import EquivalentKeyMap from 'equivalent-key-map';
 import { onSubKey } from './utils';
 
 /**
- * Reducer function returning next state for selector resolution, object form:
+ * Reducer function returning next state for selector resolution of
+ * subkeys, object form:
  *
  *  reducerKey -> selectorName -> EquivalentKeyMap<Array,boolean>
  *
@@ -19,7 +20,7 @@ import { onSubKey } from './utils';
  *
  * @returns {Object} Next state.
  */
-const isResolved = flowRight( [
+const subKeysIsResolved = flowRight( [
 	onSubKey( 'reducerKey' ),
 	onSubKey( 'selectorName' ),
 ] )( ( state = new EquivalentKeyMap(), action ) => {
@@ -50,7 +51,7 @@ const isResolved = flowRight( [
  *
  * @return {Object} Next state.
  */
-const topLevelIsResolved = ( state = {}, action ) => {
+const isResolved = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case 'INVALIDATE_RESOLUTION_FOR_STORE':
 			return has( state, action.reducerKey ) ?
@@ -66,8 +67,12 @@ const topLevelIsResolved = ( state = {}, action ) => {
 					),
 				} :
 				state;
+		case 'START_RESOLUTION':
+		case 'FINISH_RESOLUTION':
+		case 'INVALIDATE_RESOLUTION':
+			return subKeysIsResolved( state, action );
 	}
-	return isResolved( state, action );
+	return state;
 };
 
-export default topLevelIsResolved;
+export default isResolved;

--- a/packages/data/src/store/reducer.js
+++ b/packages/data/src/store/reducer.js
@@ -54,7 +54,7 @@ const topLevelIsResolved = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case 'INVALIDATE_RESOLUTION_FOR_STORE':
 			return has( state, action.reducerKey ) ?
-				omit( state, action.reducerKey ) :
+				omit( state, [ action.reducerKey ] ) :
 				state;
 		case 'INVALIDATE_RESOLUTION_FOR_STORE_SELECTOR':
 			return has( state, [ action.reducerKey, action.selectorName ] ) ?
@@ -62,7 +62,7 @@ const topLevelIsResolved = ( state = {}, action ) => {
 					...state,
 					[ action.reducerKey ]: omit(
 						state[ action.reducerKey ],
-						action.selectorName
+						[ action.selectorName ]
 					),
 				} :
 				state;

--- a/packages/data/src/store/reducer.js
+++ b/packages/data/src/store/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { flowRight } from 'lodash';
+import { flowRight, omit, has } from 'lodash';
 import EquivalentKeyMap from 'equivalent-key-map';
 
 /**
@@ -37,8 +37,37 @@ const isResolved = flowRight( [
 			return nextState;
 		}
 	}
-
 	return state;
 } );
 
-export default isResolved;
+/**
+ * Reducer function returning next state for selector resolution, object form:
+ *
+ *   reducerKey -> selectorName -> EquivalentKeyMap<Array, boolean>
+ *
+ * @param {Object} state   Current state.
+ * @param {Object} action  Dispatched action.
+ *
+ * @return {Object} Next state.
+ */
+const topLevelIsResolved = ( state = {}, action ) => {
+	switch ( action.type ) {
+		case 'INVALIDATE_RESOLUTION_FOR_STORE':
+			return has( state, action.reducerKey ) ?
+				omit( state, action.reducerKey ) :
+				state;
+		case 'INVALIDATE_RESOLUTION_FOR_STORE_SELECTOR':
+			return has( state, [ action.reducerKey, action.selectorName ] ) ?
+				{
+					...state,
+					[ action.reducerKey ]: omit(
+						state[ action.reducerKey ],
+						action.selectorName
+					),
+				} :
+				state;
+	}
+	return isResolved( state, action );
+};
+
+export default topLevelIsResolved;

--- a/packages/data/src/store/test/reducer.js
+++ b/packages/data/src/store/test/reducer.js
@@ -93,4 +93,53 @@ describe( 'reducer', () => {
 		expect( state.test.getFoo.get( [ 'post' ] ) ).toBe( false );
 		expect( state.test.getFoo.get( [ 'block' ] ) ).toBe( true );
 	} );
+
+	it( 'should remove invalidation for store level and leave others ' +
+		'intact', () => {
+		const original = reducer( undefined, {
+			type: 'FINISH_RESOLUTION',
+			reducerKey: 'testA',
+			selectorName: 'getFoo',
+			args: [ 'post' ],
+		} );
+		let state = reducer( deepFreeze( original ), {
+			type: 'FINISH_RESOLUTION',
+			reducerKey: 'testB',
+			selectorName: 'getBar',
+			args: [ 'postBar' ],
+		} );
+		state = reducer( deepFreeze( state ), {
+			type: 'INVALIDATE_RESOLUTION_FOR_STORE',
+			reducerKey: 'testA',
+		} );
+
+		expect( state.testA ).toBeUndefined();
+		// { testB: { getBar: EquivalentKeyMap( [] => false ) } }
+		expect( state.testB.getBar.get( [ 'postBar' ] ) ).toBe( false );
+	} );
+
+	it( 'should remove invalidation for store and selector name level and ' +
+		'leave other selectors at store level intact', () => {
+		const original = reducer( undefined, {
+			type: 'FINISH_RESOLUTION',
+			reducerKey: 'test',
+			selectorName: 'getFoo',
+			args: [ 'post' ],
+		} );
+		let state = reducer( deepFreeze( original ), {
+			type: 'FINISH_RESOLUTION',
+			reducerKey: 'test',
+			selectorName: 'getBar',
+			args: [ 'postBar' ],
+		} );
+		state = reducer( deepFreeze( state ), {
+			type: 'INVALIDATE_RESOLUTION_FOR_STORE_SELECTOR',
+			reducerKey: 'test',
+			selectorName: 'getBar',
+		} );
+
+		expect( state.test.getBar ).toBeUndefined();
+		// { test: { getFoo: EquivalentKeyMap( [] => false ) } }
+		expect( state.test.getFoo.get( [ 'post' ] ) ).toBe( false );
+	} );
 } );


### PR DESCRIPTION
## Description
Adds two new actions to `@wordpress/data`:

- `invalidateResolutionForStore( reducerKey )`
- `invalidateResolutionForStoreSelector( reducerKey, selectorName )`

A typical use-case for these new actions would be when refreshing the view in an app that results in needing to "reset" the state of a store. Usually when the state is reset its desirable that any selectors with resolution state would be reset as well (since the resolved value would no longer be in the reset state).

## How has this been tested?

* [x] Primarily tested via the new unit tests added and ensuring no existing e2e tests fail.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

This is a non-breaking enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
