### PR TITLE
Fix allowed_block_types regression

### DIFF
--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -17,7 +17,7 @@ export const PREFERENCES_DEFAULTS = {
  *  disableCustomFontSizes boolean        Whether or not the custom font sizes are disabled
  *  imageSizes             Array          Available image sizes
  *  maxWidth               number         Max width to constraint resizing
- *  blockTypes             boolean|Array  Allowed block types
+ *  allowedBlockTypes      boolean|Array  Allowed block types
  *  hasFixedToolbar        boolean        Whether or not the editor toolbar is fixed
  *  focusMode              boolean        Whether the focus mode is enabled or not
  *  styles                 Array          Editor Styles

--- a/packages/e2e-tests/plugins/allowed-blocks.php
+++ b/packages/e2e-tests/plugins/allowed-blocks.php
@@ -9,12 +9,16 @@
 
 /**
  * Restrict the allowed blocks in the editor.
+ *
+ * @param  Array   $allowed_block_types An array of strings containing the previously allowed blocks.
+ * @param  WP_Post $post                The current post object.
+ * @return Array                        An array of strings containing the new allowed blocks after the filter is applied.
  */
 function my_plugin_allowed_block_types( $allowed_block_types, $post ) {
-    if ( $post->post_type !== 'post' ) {
-        return $allowed_block_types;
-    }
-    return array( 'core/paragraph', 'core/image' );
+	if ( 'post' !== $post->post_type ) {
+		return $allowed_block_types;
+	}
+	return array( 'core/paragraph', 'core/image' );
 }
 
 add_filter( 'allowed_block_types', 'my_plugin_allowed_block_types', 10, 2 );

--- a/packages/e2e-tests/plugins/allowed-blocks.php
+++ b/packages/e2e-tests/plugins/allowed-blocks.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Allowed Blocks
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-allowed-blocks
+ */
+
+/**
+ * Restrict the allowed blocks in the editor.
+ */
+function my_plugin_allowed_block_types( $allowed_block_types, $post ) {
+    if ( $post->post_type !== 'post' ) {
+        return $allowed_block_types;
+    }
+    return array( 'core/paragraph', 'core/image' );
+}
+
+add_filter( 'allowed_block_types', 'my_plugin_allowed_block_types', 10, 2 );

--- a/packages/e2e-tests/specs/plugins/allowed-blocks.test.js
+++ b/packages/e2e-tests/specs/plugins/allowed-blocks.test.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	activatePlugin,
+	createNewPost,
+	deactivatePlugin,
+	searchForBlock,
+} from '@wordpress/e2e-test-utils';
+
+describe( 'Allowed Blocks Filter', () => {
+	beforeAll( async () => {
+		await activatePlugin( 'gutenberg-test-allowed-blocks' );
+	} );
+
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	afterAll( async () => {
+		await deactivatePlugin( 'gutenberg-test-allowed-blocks' );
+	} );
+
+	it( 'should restrict the allowed blocks in the inserter', async () => {
+		// The paragraph block is available.
+		await searchForBlock( 'Paragraph' );
+		const paragraphBlock = await page.$( `button[aria-label="Paragraph"]` );
+		expect( paragraphBlock ).not.toBeNull();
+		await paragraphBlock.click();
+
+		// The gallery block is not available.
+		await searchForBlock( 'Gallery' );
+		const galleryBlock = await page.$( `button[aria-label="Gallery"]` );
+		expect( galleryBlock ).toBeNull();
+	} );
+} );

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -61,7 +61,7 @@ class EditorProvider extends Component {
 				'disableCustomFontSizes',
 				'imageSizes',
 				'maxWidth',
-				'blockTypes',
+				'allowedBlockTypes',
 				'hasFixedToolbar',
 				'focusMode',
 				'styles',


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/pull/14082#discussion_r262135287

The generic block editor refactoring introduced a small regression when applying the allowed_block_types filter. This PR should fix it and add an e2e test to avoid future regressions.