### PR TITLE
Component: date-time: Remove comparison to "now" when testing getMomentDate

### DIFF
--- a/packages/components/src/date-time/test/date.js
+++ b/packages/components/src/date-time/test/date.js
@@ -29,7 +29,6 @@ describe( 'DatePicker', () => {
 		const wrapper = shallow( <DatePicker /> );
 		const date = wrapper.children().props().date;
 		expect( moment.isMoment( date ) ).toBe( true );
-		expect( date.isSame( moment(), 'second' ) ).toBe( true );
 	} );
 
 	describe( 'getMomentDate', () => {
@@ -55,7 +54,6 @@ describe( 'DatePicker', () => {
 			const momentDate = wrapper.instance().getMomentDate();
 
 			expect( moment.isMoment( momentDate ) ).toBe( true );
-			expect( momentDate.isSame( moment(), 'second' ) ).toBe( true );
 		} );
 	} );
 


### PR DESCRIPTION
## Description

https://github.com/WordPress/gutenberg/pull/12963 Introduced logic to the `<DatePicker />` component such that a `currentDate` prop with value `undefined` resulted in a selection of the current day, but a  `currentDate` prop with value `null` resulted in no selection.

The accompanying tests compared values created for the current time against `moment()`, which caused intermittent failures (See https://github.com/WordPress/gutenberg/pull/12963#issuecomment-467571260), despite a a granularity of `minute` when comparing times.

The solution proposed here is to remove the comparison of current time against `moment()`, but keep the checks of the resulting `date` value using `isMoment` and Jest's `toBeNull()`. While not being able to check the exact date isn't ideal, the spirit of the logic described above is being tested. Any manipulation of that logic by future development will cause a failure, as it should.

Another alternative is to mock momentjs, which is possible, but causes validation errors in the `react-dates` propType validation which expects a real Moment object. 

## How has this been tested?

Testing can be accomplished by running the js test suite.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
