### PR TITLE
Mobile: Fix links ui on landscape iOS v2

### DIFF
--- a/packages/editor/src/components/mobile/bottom-sheet/index.native.js
+++ b/packages/editor/src/components/mobile/bottom-sheet/index.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Text, View, KeyboardAvoidingView, Platform, PanResponder, Dimensions } from 'react-native';
+import { Text, View, Platform, PanResponder, Dimensions } from 'react-native';
 import Modal from 'react-native-modal';
 import SafeArea from 'react-native-safe-area';
 
@@ -17,6 +17,7 @@ import styles from './styles.scss';
 import Button from './button';
 import Cell from './cell';
 import PickerCell from './picker-cell';
+import KeyboardAvoidingView from './keyboard-avoiding-view';
 
 class BottomSheet extends Component {
 	constructor() {

--- a/packages/editor/src/components/mobile/bottom-sheet/keyboard-avoiding-view.native.js
+++ b/packages/editor/src/components/mobile/bottom-sheet/keyboard-avoiding-view.native.js
@@ -1,0 +1,231 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+const Keyboard = require('Keyboard');
+const LayoutAnimation = require('LayoutAnimation');
+const Platform = require('Platform');
+const React = require('React');
+const StyleSheet = require('StyleSheet');
+const View = require('View');
+
+import type EmitterSubscription from 'EmitterSubscription';
+import type {ViewStyleProp} from 'StyleSheet';
+import type {ViewProps, ViewLayout, ViewLayoutEvent} from 'ViewPropTypes';
+import type {KeyboardEvent} from 'Keyboard';
+
+type Props = $ReadOnly<{|
+  ...ViewProps,
+
+  /**
+   * Specify how to react to the presence of the keyboard.
+   */
+  behavior?: ?('height' | 'position' | 'padding'),
+
+  /**
+   * Style of the content container when `behavior` is 'position'.
+   */
+  contentContainerStyle?: ?ViewStyleProp,
+
+  /**
+   * Controls whether this `KeyboardAvoidingView` instance should take effect.
+   * This is useful when more than one is on the screen. Defaults to true.
+   */
+  enabled: ?boolean,
+
+  /**
+   * Distance between the top of the user screen and the React Native view. This
+   * may be non-zero in some cases. Defaults to 0.
+   */
+  keyboardVerticalOffset: number,
+|}>;
+
+type State = {|
+  bottom: number,
+|};
+
+const viewRef = 'VIEW';
+
+/**
+ * View that moves out of the way when the keyboard appears by automatically
+ * adjusting its height, position, or bottom padding.
+ */
+class KeyboardAvoidingView extends React.Component<Props, State> {
+  static defaultProps = {
+    enabled: true,
+    keyboardVerticalOffset: 0,
+  };
+
+  _frame: ?ViewLayout = null;
+  _subscriptions: Array<EmitterSubscription> = [];
+
+  state = {
+    bottom: 0,
+  };
+
+  _relativeKeyboardHeight(keyboardFrame): number {
+    const frame = this._frame;
+    if (!frame || !keyboardFrame) {
+      return 0;
+    }
+
+    const keyboardY = keyboardFrame.screenY - this.props.keyboardVerticalOffset;
+
+    // Calculate the displacement needed for the view such that it
+    // no longer overlaps with the keyboard
+    return Math.max(frame.y + frame.height - keyboardY, 0);
+  }
+
+  _onKeyboardChange = (event: ?KeyboardEvent) => {
+    if (event == null) {
+      this.setState({bottom: 0});
+      return;
+    }
+
+    const {duration, easing, endCoordinates} = event;
+    const height = this._relativeKeyboardHeight(endCoordinates);
+
+    if (this.state.bottom === height) {
+      return;
+    }
+
+    if (duration && easing) {
+      LayoutAnimation.configureNext({
+        duration: duration,
+        update: {
+          duration: duration,
+          type: LayoutAnimation.Types[easing] || 'keyboard',
+        },
+      });
+    }
+    this.setState({bottom: height});
+  };
+
+  _onLayout = (event: ViewLayoutEvent) => {
+    this._frame = event.nativeEvent.layout;
+  };
+
+  UNSAFE_componentWillUpdate(nextProps: Props, nextState: State): void {
+    if (
+      nextState.bottom === this.state.bottom &&
+      this.props.behavior === 'height' &&
+      nextProps.behavior === 'height'
+    ) {
+      // If the component rerenders without an internal state change, e.g.
+      // triggered by parent component re-rendering, no need for bottom to change.
+      nextState.bottom = 0;
+    }
+  }
+
+  componentDidMount(): void {
+    if (Platform.OS === 'ios') {
+      this._subscriptions = [
+        Keyboard.addListener('keyboardWillChangeFrame', this._onKeyboardChange),
+      ];
+    } else {
+      this._subscriptions = [
+        Keyboard.addListener('keyboardDidHide', this._onKeyboardChange),
+        Keyboard.addListener('keyboardDidShow', this._onKeyboardChange),
+      ];
+    }
+  }
+
+  componentWillUnmount(): void {
+    this._subscriptions.forEach(subscription => {
+      subscription.remove();
+    });
+  }
+
+  render(): React.Node {
+    const {
+      behavior,
+      children,
+      contentContainerStyle,
+      enabled,
+      keyboardVerticalOffset, // eslint-disable-line no-unused-vars
+      style,
+      ...props
+    } = this.props;
+    const bottomHeight = enabled ? this.state.bottom : 0;
+    switch (behavior) {
+      case 'height':
+        let heightStyle;
+        if (this._frame != null) {
+          // Note that we only apply a height change when there is keyboard present,
+          // i.e. this.state.bottom is greater than 0. If we remove that condition,
+          // this.frame.height will never go back to its original value.
+          // When height changes, we need to disable flex.
+          heightStyle = {
+            height: this._frame.height - bottomHeight,
+            flex: 0,
+          };
+        }
+        return (
+          <View
+            ref={viewRef}
+            style={StyleSheet.compose(
+              style,
+              heightStyle,
+            )}
+            onLayout={this._onLayout}
+            {...props}>
+            {children}
+          </View>
+        );
+
+      case 'position':
+        return (
+          <View
+            ref={viewRef}
+            style={style}
+            onLayout={this._onLayout}
+            {...props}>
+            <View
+              style={StyleSheet.compose(
+                contentContainerStyle,
+                {
+                  bottom: bottomHeight,
+                },
+              )}>
+              {children}
+            </View>
+          </View>
+        );
+
+      case 'padding':
+        return (
+          <View
+            ref={viewRef}
+            style={StyleSheet.compose(
+              style,
+              {paddingBottom: bottomHeight},
+            )}
+            onLayout={this._onLayout}
+            {...props}>
+            {children}
+          </View>
+        );
+
+      default:
+        return (
+          <View
+            ref={viewRef}
+            onLayout={this._onLayout}
+            style={style}
+            {...props}>
+            {children}
+          </View>
+        );
+    }
+  }
+}
+
+module.exports = KeyboardAvoidingView;

--- a/packages/editor/src/components/mobile/bottom-sheet/keyboard-avoiding-view.native.js
+++ b/packages/editor/src/components/mobile/bottom-sheet/keyboard-avoiding-view.native.js
@@ -1,231 +1,114 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- * @format
- * @flow
- */
-
-'use strict';
-
-const Keyboard = require('Keyboard');
-const LayoutAnimation = require('LayoutAnimation');
-const Platform = require('Platform');
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const View = require('View');
-
-import type EmitterSubscription from 'EmitterSubscription';
-import type {ViewStyleProp} from 'StyleSheet';
-import type {ViewProps, ViewLayout, ViewLayoutEvent} from 'ViewPropTypes';
-import type {KeyboardEvent} from 'Keyboard';
-
-type Props = $ReadOnly<{|
-  ...ViewProps,
-
-  /**
-   * Specify how to react to the presence of the keyboard.
-   */
-  behavior?: ?('height' | 'position' | 'padding'),
-
-  /**
-   * Style of the content container when `behavior` is 'position'.
-   */
-  contentContainerStyle?: ?ViewStyleProp,
-
-  /**
-   * Controls whether this `KeyboardAvoidingView` instance should take effect.
-   * This is useful when more than one is on the screen. Defaults to true.
-   */
-  enabled: ?boolean,
-
-  /**
-   * Distance between the top of the user screen and the React Native view. This
-   * may be non-zero in some cases. Defaults to 0.
-   */
-  keyboardVerticalOffset: number,
-|}>;
-
-type State = {|
-  bottom: number,
-|};
-
-const viewRef = 'VIEW';
 
 /**
- * View that moves out of the way when the keyboard appears by automatically
- * adjusting its height, position, or bottom padding.
+ * External dependencies
  */
-class KeyboardAvoidingView extends React.Component<Props, State> {
-  static defaultProps = {
-    enabled: true,
-    keyboardVerticalOffset: 0,
-  };
+import React from 'react';
+import {
+	Keyboard,
+	LayoutAnimation,
+	Platform,
+	StyleSheet,
+	View,
+	Dimensions,
+} from 'react-native';
 
-  _frame: ?ViewLayout = null;
-  _subscriptions: Array<EmitterSubscription> = [];
+/**
+ * This is a simplified version of Facebook's KeyboardAvoidingView.
+ * It's meant to work specifically with BottomSheets.
+ * This fixes an issue in the bottom padding calculation, when the
+ * BottomSheet was presented on Landscape, with the keyboard already present,
+ * and a TextField on Autofocus (situation present on Links UI)
+ */
+class KeyboardAvoidingView extends React.Component {
+	static defaultProps = {
+		enabled: true,
+		keyboardVerticalOffset: 0,
+	};
 
-  state = {
-    bottom: 0,
-  };
+	_subscriptions = [];
 
-  _relativeKeyboardHeight(keyboardFrame): number {
-    const frame = this._frame;
-    if (!frame || !keyboardFrame) {
-      return 0;
-    }
+	state = {
+		bottom: 0,
+	};
 
-    const keyboardY = keyboardFrame.screenY - this.props.keyboardVerticalOffset;
+	_relativeKeyboardHeight( keyboardFrame ) {
+		if ( ! keyboardFrame ) {
+			return 0;
+		}
 
-    // Calculate the displacement needed for the view such that it
-    // no longer overlaps with the keyboard
-    return Math.max(frame.y + frame.height - keyboardY, 0);
-  }
+		const windowHeight = Dimensions.get( 'window' ).height;
+		const keyboardY = keyboardFrame.screenY - this.props.keyboardVerticalOffset;
 
-  _onKeyboardChange = (event: ?KeyboardEvent) => {
-    if (event == null) {
-      this.setState({bottom: 0});
-      return;
-    }
+		const final = Math.max( windowHeight - keyboardY, 0 );
+		return final;
+	}
 
-    const {duration, easing, endCoordinates} = event;
-    const height = this._relativeKeyboardHeight(endCoordinates);
+	/**
+	 * @param {Object} event Keyboard event.
+	 */
+	_onKeyboardChange = ( event ) => {
+		if ( event === null ) {
+			this.setState( { bottom: 0 } );
+			return;
+		}
 
-    if (this.state.bottom === height) {
-      return;
-    }
+		const { duration, easing, endCoordinates } = event;
+		const height = this._relativeKeyboardHeight( endCoordinates );
 
-    if (duration && easing) {
-      LayoutAnimation.configureNext({
-        duration: duration,
-        update: {
-          duration: duration,
-          type: LayoutAnimation.Types[easing] || 'keyboard',
-        },
-      });
-    }
-    this.setState({bottom: height});
-  };
+		if ( this.state.bottom === height ) {
+			return;
+		}
 
-  _onLayout = (event: ViewLayoutEvent) => {
-    this._frame = event.nativeEvent.layout;
-  };
+		if ( duration && easing ) {
+			LayoutAnimation.configureNext( {
+				duration,
+				update: {
+					duration,
+					type: LayoutAnimation.Types[ easing ] || 'keyboard',
+				},
+			} );
+		}
+		this.setState( { bottom: height } );
+	};
 
-  UNSAFE_componentWillUpdate(nextProps: Props, nextState: State): void {
-    if (
-      nextState.bottom === this.state.bottom &&
-      this.props.behavior === 'height' &&
-      nextProps.behavior === 'height'
-    ) {
-      // If the component rerenders without an internal state change, e.g.
-      // triggered by parent component re-rendering, no need for bottom to change.
-      nextState.bottom = 0;
-    }
-  }
+	componentDidMount() {
+		if ( Platform.OS === 'ios' ) {
+			this._subscriptions = [
+				Keyboard.addListener( 'keyboardWillChangeFrame', this._onKeyboardChange ),
+			];
+		}
+	}
 
-  componentDidMount(): void {
-    if (Platform.OS === 'ios') {
-      this._subscriptions = [
-        Keyboard.addListener('keyboardWillChangeFrame', this._onKeyboardChange),
-      ];
-    } else {
-      this._subscriptions = [
-        Keyboard.addListener('keyboardDidHide', this._onKeyboardChange),
-        Keyboard.addListener('keyboardDidShow', this._onKeyboardChange),
-      ];
-    }
-  }
+	componentWillUnmount() {
+		this._subscriptions.forEach( ( subscription ) => {
+			subscription.remove();
+		} );
+	}
 
-  componentWillUnmount(): void {
-    this._subscriptions.forEach(subscription => {
-      subscription.remove();
-    });
-  }
+	render() {
+		const {
+			children,
+			enabled,
+			keyboardVerticalOffset, // eslint-disable-line no-unused-vars
+			style,
+			...props
+		} = this.props;
 
-  render(): React.Node {
-    const {
-      behavior,
-      children,
-      contentContainerStyle,
-      enabled,
-      keyboardVerticalOffset, // eslint-disable-line no-unused-vars
-      style,
-      ...props
-    } = this.props;
-    const bottomHeight = enabled ? this.state.bottom : 0;
-    switch (behavior) {
-      case 'height':
-        let heightStyle;
-        if (this._frame != null) {
-          // Note that we only apply a height change when there is keyboard present,
-          // i.e. this.state.bottom is greater than 0. If we remove that condition,
-          // this.frame.height will never go back to its original value.
-          // When height changes, we need to disable flex.
-          heightStyle = {
-            height: this._frame.height - bottomHeight,
-            flex: 0,
-          };
-        }
-        return (
-          <View
-            ref={viewRef}
-            style={StyleSheet.compose(
-              style,
-              heightStyle,
-            )}
-            onLayout={this._onLayout}
-            {...props}>
-            {children}
-          </View>
-        );
+		let finalStyle = style;
+		if ( Platform.OS === 'ios' ) {
+			const bottomHeight = enabled ? this.state.bottom : 0;
+			finalStyle = StyleSheet.compose( style, { paddingBottom: bottomHeight } );
+		}
 
-      case 'position':
-        return (
-          <View
-            ref={viewRef}
-            style={style}
-            onLayout={this._onLayout}
-            {...props}>
-            <View
-              style={StyleSheet.compose(
-                contentContainerStyle,
-                {
-                  bottom: bottomHeight,
-                },
-              )}>
-              {children}
-            </View>
-          </View>
-        );
-
-      case 'padding':
-        return (
-          <View
-            ref={viewRef}
-            style={StyleSheet.compose(
-              style,
-              {paddingBottom: bottomHeight},
-            )}
-            onLayout={this._onLayout}
-            {...props}>
-            {children}
-          </View>
-        );
-
-      default:
-        return (
-          <View
-            ref={viewRef}
-            onLayout={this._onLayout}
-            style={style}
-            {...props}>
-            {children}
-          </View>
-        );
-    }
-  }
+		return (
+			<View
+				style={ finalStyle }
+				{ ...props }
+			>
+				{ children }
+			</View>
+		);
+	}
 }
 
-module.exports = KeyboardAvoidingView;
+export default KeyboardAvoidingView;


### PR DESCRIPTION
`gutenberg-mobile` reference: https://github.com/wordpress-mobile/gutenberg-mobile/pull/701

## Description

This PR fixes an issue on KeyboardAvoidingView, that was adding extra bottom padding on specific circumstances:

- iOS.
- Landscape.
- Keyboard already present.
- BottomSheet presenting with a TextInput on Autofocus.

With some debugging I noticed a problem on the way the extra padding is calculated, so I made a simplified version of the component that will work well on the BottomSheet.

![links-ui-landscape](https://user-images.githubusercontent.com/9772967/53235365-ed3f0980-3691-11e9-92f9-3e453263229e.png)

**Note:** The BottomSheet is not scrollable (yet).

**To test:**
- Check that the Links UI presents properly on Landscape mode.
- If possible, test WPiOS and Android.
- Android should work exactly as before.
