### PR TITLE
Testing: Trash existing posts as admin user

### DIFF
--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -13,6 +13,8 @@ import {
 	setBrowserViewport,
 	visitAdminPage,
 	activatePlugin,
+	switchUserToAdmin,
+	switchUserToTest,
 } from '@wordpress/e2e-test-utils';
 
 /**
@@ -54,6 +56,7 @@ async function setupBrowser() {
  * @return {Promise} Promise resolving once posts have been trashed.
  */
 async function trashExistingPosts() {
+	await switchUserToAdmin();
 	// Visit `/wp-admin/edit.php` so we can see a list of posts and delete them.
 	await visitAdminPage( 'edit.php' );
 
@@ -70,9 +73,10 @@ async function trashExistingPosts() {
 	await page.select( '#bulk-action-selector-top', 'trash' );
 	// Submit the form to send all draft/scheduled/published posts to the trash.
 	await page.click( '#doaction' );
-	return page.waitForXPath(
+	await page.waitForXPath(
 		'//*[contains(@class, "updated notice")]/p[contains(text(), "moved to the Trash.")]'
 	);
+	await switchUserToTest();
 }
 
 /**


### PR DESCRIPTION
This pull request seeks to improve E2E test stability by always trashing existing posts as the administrator user. I had found that running tests as the author user, trashing the posts would silently fail if there were existing posts which had been created by any other user.

While this may not be expected to occur in most test execution due to the [resetting behavior of test scripts](https://github.com/WordPress/gutenberg/blob/29b3dc5f26bef7b991ed0556ed6bfcc1be754396/bin/install-wordpress.sh#L44-L49), the presence of this function seems to indicate that we don't rely on these scripts to run beforehand. In my experience, I tend to run E2E tests directly via `wp-scripts test-e2e`.

**Testing instructions:**

Verify that E2E tests pass:

```
npm run test-e2e
```