### PR TITLE
Testing: Disable post locking in E2E tests

### DIFF
--- a/packages/e2e-tests/mu-plugins/disable-post-lock.php
+++ b/packages/e2e-tests/mu-plugins/disable-post-lock.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Plugin, Disable Post Lock
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-disable-post-lock
+ */
+
+/**
+ * Filters whether to update metadata of a specific type, disabling meta
+ * updates for post edit lock keys.
+ *
+ * @param null|bool $check      Whether to allow updating metadata for the
+ *                              given type.
+ * @param int       $object_id  Object ID.
+ * @param string    $meta_key   Meta key.
+ *
+ * @return null|bool Whether to allow updating metadata for the given type.
+ */
+function gutenberg_test_disable_post_lock( $check, $object_id, $meta_key ) {
+	if ( '_edit_lock' === $meta_key ) {
+		return false;
+	}
+
+	return $check;
+}
+add_filter( 'update_post_metadata', 'gutenberg_test_disable_post_lock', 10, 3 );


### PR DESCRIPTION
This pull request seeks to improve E2E test stability when running tests locally. I had experienced that when running the tests multiple times, I often witnessed that the `trashExistingPosts` function would silently fail when attempting to mass-trash posts if there was a post lock remaining from the previous test run. By default, post locks last 150 seconds and prevent posts from being removed via bulk trash.

**Implementation notes:**

Two notes:

- I had seen some feedback before about not using `mu-plugins` for E2E test plugins, specifically around the implementation of `disable-animations.php` (https://github.com/WordPress/gutenberg/pull/13769#discussion_r255071794). It's not very clear to me why these plugins would be loaded into a non-E2E context? cc @youknowriad @gziolo 
- Between this and #14244, using bulk edit to trash posts seems fairly unreliable due to silent failures. I wonder if there might be a better way to reset the site, and in a way which removes redundancy with `bin/reset-e2e-tests.sh` [doing the same](https://github.com/WordPress/gutenberg/blob/29b3dc5f26bef7b991ed0556ed6bfcc1be754396/bin/install-wordpress.sh#L44-L49).

**Testing instructions:**

Verify that E2E tests pass:

```
npm run test-e2e
```