### PR TITLE
Added minimum font-size - prevent negative values

### DIFF
--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -91,6 +91,7 @@ function FontSizePicker( {
 					<input
 						className="components-range-control__number"
 						type="number"
+						min="9"
 						onChange={ onChangeValue }
 						aria-label={ __( 'Custom font size' ) }
 						value={ value || '' }


### PR DESCRIPTION
## Description
Added minimum font-size value to the 'font-size-picker' to prevent negative values. Set number input "min" attribute to 9 px as reasonable minimum font-size.

## Types of changes
Fixing negative font sizes that makes text 'disappear'.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
