### PR TITLE
Switch the Travis badge from travis-ci.org to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Gutenberg
-[![Build Status](https://img.shields.io/travis/WordPress/gutenberg/master.svg)](https://travis-ci.org/WordPress/gutenberg)
+[![Build Status](https://img.shields.io/travis/com/WordPress/gutenberg/master.svg)](https://travis-ci.com/WordPress/gutenberg)
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lernajs.io/)
 
 ![Screenshot of the Gutenberg Editor, editing a post in WordPress](https://cldup.com/H0oKBfpidk.png)


### PR DESCRIPTION
## Description

We're moving the WordPress GitHub organisation over to travis-ci.com, so the Travis badge needs updating to match.
