### PR TITLE
Support storing blocks in sidebars

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -45,3 +45,35 @@ function gutenberg_reregister_core_block_types() {
 	}
 }
 add_action( 'init', 'gutenberg_reregister_core_block_types' );
+
+function serialize_blocks( $blocks ) {
+	return implode( array_map( 'serialize_block', $blocks ) );
+}
+
+function serialize_block( $block ) {
+	$name = $block['blockName'];
+	if ( 0 === strpos( $name, 'core/' ) ) {
+		$name = substr( $name, strlen( 'core/' ) );
+	}
+
+	if ( empty( $block['attrs'] ) ) {
+		$opening_tag_suffix = '';
+	} else {
+		$opening_tag_suffix = ' ' . json_encode( $block['attrs'] );
+	}
+
+	if ( empty( $block['innerHTML'] ) ) {
+		return sprintf(
+			'<!-- wp:%s%s /-->',
+			$name,
+			$opening_tag_suffix
+		);
+	} else {
+		return sprintf(
+			'<!-- wp:%1$s%2$s -->%3$s<!-- /wp:%1$s -->',
+			$name,
+			$opening_tag_suffix,
+			$block['innerHTML']
+		);
+	}
+}

--- a/lib/class-wp-rest-sidebars-controller.php
+++ b/lib/class-wp-rest-sidebars-controller.php
@@ -1,0 +1,200 @@
+<?php
+
+class WP_REST_Sidebars_Controller extends WP_REST_Controller {
+	public function __construct() {
+		$this->namespace = 'wp/v2';
+		$this->rest_base = 'sidebars';
+	}
+
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>.+)',
+			array(
+				'args' => array(
+					'id' => array(
+						'description' => __( 'The sidebar’s ID.', 'gutenberg' ),
+						'type'        => 'string',
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_item' ),
+					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	public function get_items_permissions_check( $request ) {
+		if ( ! current_user_can( 'edit_theme_options' ) ) {
+			return new WP_Error(
+				'rest_user_cannot_edit',
+				__( 'Sorry, you are not allowed to edit sidebars.', 'gutenberg' )
+			);
+		}
+
+		return true;
+	}
+
+	public function get_items( $request ) {
+		global $wp_registered_sidebars;
+
+		$data = array();
+
+		foreach ( array_keys( $wp_registered_sidebars ) as $sidebar_id ) {
+			$data[ $sidebar_id ] = $this->get_sidebar_data( $sidebar_id );
+		}
+
+		return rest_ensure_response( $data );
+	}
+
+	public function get_item_permissions_check( $request ) {
+		if ( ! current_user_can( 'edit_theme_options' ) ) {
+			return new WP_Error(
+				'rest_user_cannot_edit',
+				__( 'Sorry, you are not allowed to edit sidebars.', 'gutenberg' )
+			);
+		}
+
+		return true;
+	}
+
+	public function get_item( $request ) {
+		$data = $this->get_sidebar_data( $request['id'] );
+		return rest_ensure_response( $data );
+	}
+
+	public function update_item_permissions_check( $request ) {
+		if ( ! current_user_can( 'edit_theme_options' ) ) {
+			return new WP_Error(
+				'rest_user_cannot_edit',
+				__( 'Sorry, you are not allowed to edit sidebars.', 'gutenberg' )
+			);
+		}
+
+		return true;
+	}
+
+	public function update_item( $request ) {
+		$result = $this->update_sidebar_blocks( $request['id'], $request );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$data = $this->get_sidebar_data( $request['id'] );
+		return rest_ensure_response( $data );
+	}
+
+	// TODO: Add schema
+
+	protected function get_sidebar_data( $sidebar_id ) {
+		global $wp_registered_sidebars;
+
+		if ( ! isset( $wp_registered_sidebars[ $sidebar_id ] ) ) {
+			return new WP_Error(
+				'rest_sidebar_invalid_id',
+				__( 'Invalid sidebar ID.', 'gutenberg' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		// TODO: How should we format blocks in the REST API? Or should we send down
+		// HTML so that we're consistent with the /posts and /blocks endpoints?
+		$blocks = array();
+
+		$sidebars_items = gutenberg_get_sidebars_items();
+		if ( ! empty( $sidebars_items[ $sidebar_id ] ) ) {
+			foreach ( $sidebars_items[ $sidebar_id ] as $item ) {
+				if ( is_array( $item ) && isset( $item['blockName'] ) ) {
+					$blocks[] = array(
+						'name'         => $item['blockName'],
+						'attributes'   => $item['attrs'],
+						'innerBlocks'  => $item['innerBlocks'],
+						'innerHTML'    => $item['innerHTML'],
+						'innerContent' => $item['innerContent'],
+					);
+				} else {
+					$blocks[] = array(
+						'name'         => 'core/legacy-widget',
+						'attributes'   => array( 'identifier' => $item ),
+						'innerBlocks'  => array(),
+						'innerHTML'    => '',
+						'innerContent' => array(),
+					);
+				}
+			}
+		}
+
+		return array_merge(
+			$wp_registered_sidebars[ $sidebar_id ],
+			array( 'blocks' => $blocks )
+		);
+	}
+
+	protected function update_sidebar_blocks( $sidebar_id, $request ) {
+		global $wp_registered_sidebars;
+
+		if ( ! isset( $wp_registered_sidebars[ $sidebar_id ] ) ) {
+			return new WP_Error(
+				'rest_sidebar_invalid_id',
+				__( 'Invalid sidebar ID.', 'gutenberg' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$items = array();
+
+		if ( isset( $request['blocks'] ) && is_array( $request['blocks'] ) ) {
+			foreach ( $request['blocks'] as $block ) {
+				if (
+					! isset( $block['name'] ) || ! is_string( $block['name'] ) ||
+					! isset( $block['attributes'] ) || ! is_array( $block['attributes'] ) ||
+					! isset( $block['innerBlocks'] ) || ! is_array( $block['innerBlocks'] ) ||
+					! isset( $block['innerHTML'] ) || ! is_string( $block['innerHTML'] ) ||
+					! isset( $block['innerContent'] ) || ! is_array( $block['innerContent'] )
+				) {
+					continue;
+				}
+
+				if ( 'core/legacy-widget' === $block['name'] ) {
+					$items[] = $block['attributes']['identifier'];
+				} else {
+					$items[] = array(
+						'blockName'    => $block['name'],
+						'attrs'        => $block['attributes'],
+						'innerBlocks'  => $block['innerBlocks'],
+						'innerHTML'    => $block['innerHTML'],
+						'innerContent' => $block['innerContent'],
+					);
+				}
+			}
+		}
+
+		if ( ! empty( $items ) ) {
+			gutenberg_set_sidebars_items( array_merge(
+				gutenberg_get_sidebars_items(),
+				array( $sidebar_id => $items )
+			) );
+		}
+	}
+}

--- a/lib/class-wp-rest-sidebars-controller.php
+++ b/lib/class-wp-rest-sidebars-controller.php
@@ -162,9 +162,9 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 			);
 		}
 
-		$items = array();
-
 		if ( isset( $request['blocks'] ) && is_array( $request['blocks'] ) ) {
+			$items = array();
+
 			foreach ( $request['blocks'] as $block ) {
 				if (
 					! isset( $block['name'] ) || ! is_string( $block['name'] ) ||
@@ -188,9 +188,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 					);
 				}
 			}
-		}
 
-		if ( ! empty( $items ) ) {
 			gutenberg_set_sidebars_items( array_merge(
 				gutenberg_get_sidebars_items(),
 				array( $sidebar_id => $items )

--- a/lib/class-wp-rest-sidebars-controller.php
+++ b/lib/class-wp-rest-sidebars-controller.php
@@ -2,7 +2,7 @@
 
 class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 	public function __construct() {
-		$this->namespace = 'wp/v2';
+		$this->namespace = '__experimental';
 		$this->rest_base = 'sidebars';
 	}
 

--- a/lib/class-wp-rest-widget-updater-controller.php
+++ b/lib/class-wp-rest-widget-updater-controller.php
@@ -22,7 +22,7 @@ class WP_REST_Widget_Updater_Controller extends WP_REST_Controller {
 	 * @access public
 	 */
 	public function __construct() {
-		$this->namespace = 'wp/v2';
+		$this->namespace = '__experimental';
 		$this->rest_base = 'widgets';
 	}
 

--- a/lib/load.php
+++ b/lib/load.php
@@ -18,6 +18,9 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	if ( ! class_exists( 'WP_REST_Widget_Updater_Controller' ) ) {
 		require dirname( __FILE__ ) . '/class-wp-rest-widget-updater-controller.php';
 	}
+	if ( ! class_exists( 'WP_REST_Sidebars_Controller' ) ) {
+		require dirname( __FILE__ ) . '/class-wp-rest-sidebars-controller.php';
+	}
 	/**
 	* End: Include for phase 2
 	*/
@@ -26,6 +29,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 
 require dirname( __FILE__ ) . '/blocks.php';
 require dirname( __FILE__ ) . '/client-assets.php';
+require dirname( __FILE__ ) . '/register.php';
 require dirname( __FILE__ ) . '/demo.php';
 require dirname( __FILE__ ) . '/widgets.php';
 require dirname( __FILE__ ) . '/widgets-page.php';

--- a/lib/register.php
+++ b/lib/register.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Initialization and wp-admin integration for the Gutenberg editor plugin.
+ *
+ * @package gutenberg
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Silence is golden.' );
+}
+
+function gutenberg_output_block_widget( $options, $block ) {
+	echo $options['before_widget'];
+	echo render_block( $block );
+	echo $options['after_widget'];
+}
+
+function gutenberg_swap_out_sidebars_blocks_for_block_widgets( $sidebars_items ) {
+	global $wp_registered_widgets;
+
+	foreach ( $sidebars_items as $sidebar_id => $items ) {
+		foreach ( $items as $index => $item ) {
+			if ( ! is_array( $item ) || ! isset( $item['blockName'] ) ) {
+				continue;
+			}
+
+			$widget_id = 'block-widget-' . md5( serialize( $item ) );
+
+			$sidebars_items[ $sidebar_id ][ $index ] = $widget_id;
+
+			if ( isset( $wp_registered_widgets[ $widget_id ] ) ) {
+				continue;
+			}
+
+			wp_register_sidebar_widget(
+				$widget_id,
+				// TODO: Can we get the block's title somehow?
+				/* translators: %s: Name of the block */
+				sprintf( __( 'Block: %s', 'gutenberg' ), $item['blockName'] ),
+				'gutenberg_output_block_widget',
+				array(
+					'classname'   => 'block-widget',
+					'description' => sprintf(
+						/* translators: %s: Name of the block */
+						__( 'Displays a ‘%s’ block.', 'gutenberg' ),
+						$item['blockName']
+					),
+				),
+				$item
+			);
+		}
+	}
+
+	return $sidebars_items;
+}
+add_filter( 'sidebars_widgets', 'gutenberg_swap_out_sidebars_blocks_for_block_widgets' );
+
+function gutenberg_swap_out_sidebars_block_widgets_for_blocks( $sidebars_widgets ) {
+	global $wp_registered_widgets;
+
+	foreach ( $sidebars_widgets as $sidebar_id => $widgets ) {
+		foreach ( $widgets as $index => $widget_id ) {
+			if ( 0 !== strpos( $widget_id, 'block-widget-' ) ) {
+				continue;
+			}
+
+			if ( ! isset( $wp_registered_widgets[ $widget_id ] ) ) {
+				unset( $sidebars_widgets[ $sidebar_id ][ $index ] );
+				continue;
+			}
+
+			$block = $wp_registered_widgets[ $widget_id ]['params'][0];
+
+			$sidebars_widgets[ $sidebar_id ][ $index ] = $block;
+		}
+	}
+
+	return $sidebars_widgets;
+}
+add_filter( 'pre_update_option_sidebars_widgets', 'gutenberg_swap_out_sidebars_block_widgets_for_blocks' );
+
+function gutenberg_get_sidebars_items() {
+	remove_filter( 'sidebars_widgets', 'gutenberg_swap_out_sidebars_blocks_for_block_widgets' );
+	$sidebars_widgets = wp_get_sidebars_widgets();
+	add_filter( 'sidebars_widgets', 'gutenberg_swap_out_sidebars_blocks_for_block_widgets' );
+	return $sidebars_widgets;
+}
+
+function gutenberg_set_sidebars_items( $sidebars_items ) {
+	remove_filter( 'pre_update_option_sidebars_widgets', 'gutenberg_swap_out_sidebars_block_widgets_for_blocks' );
+	wp_set_sidebars_widgets( $sidebars_items );
+	add_filter( 'pre_update_option_sidebars_widgets', 'gutenberg_swap_out_sidebars_block_widgets_for_blocks' );
+}

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -67,6 +67,12 @@ function gutenberg_register_rest_widget_updater_routes() {
 	$widgets_controller->register_routes();
 }
 add_action( 'rest_api_init', 'gutenberg_register_rest_widget_updater_routes' );
+
+function gutenberg_register_rest_sidebars_routes() {
+	$sidebar_controller = new WP_REST_Sidebars_Controller();
+	$sidebar_controller->register_routes();
+}
+add_action( 'rest_api_init', 'gutenberg_register_rest_sidebars_routes' );
 /**
  * End: Include for phase 2
  */

--- a/packages/block-library/src/legacy-widget/WidgetEditHandler.js
+++ b/packages/block-library/src/legacy-widget/WidgetEditHandler.js
@@ -92,7 +92,7 @@ class WidgetEditHandler extends Component {
 		}
 
 		apiFetch( {
-			path: `/wp/v2/widgets/${ identifier }/`,
+			path: `/__experimental/widgets/${ identifier }/`,
 			data: {
 				identifier,
 				instance,


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/14182 — see this issue for a lot of useful context and terminology.

Adds the ability to store blocks in WordPress sidebars alongside widgets.

A new `GET /__experimental/sidebars/<id>` endpoint allows you to view a sidebar. Any blocks in the sidebar are shown as is. Any widgets in the sidebar are shown as `core/legacy-block` blocks which are to be added in https://github.com/WordPress/gutenberg/pull/13511.

```
$ http -a admin:password GET http://localhost:9999/wp-json/__experimental/sidebars/sidebar-1
HTTP/1.1 200 OK
Access-Control-Allow-Headers: Authorization, Content-Type
Access-Control-Expose-Headers: X-WP-Total, X-WP-TotalPages
Allow: GET, POST, PUT, PATCH
Cache-Control: no-cache, must-revalidate, max-age=0
Connection: keep-alive
Content-Type: application/json; charset=UTF-8
Date: Fri, 29 Mar 2019 03:33:13 GMT
Expires: Wed, 11 Jan 1984 05:00:00 GMT
Link: <http://localhost:9999/wp-json/>; rel="https://api.w.org/"
Server: nginx/1.15.9
Transfer-Encoding: chunked
X-Content-Type-Options: nosniff
X-Powered-By: PHP/7.3.2
X-Robots-Tag: noindex

{
    "after_title": "</h2>",
    "after_widget": "</section>",
    "before_title": "<h2 class=\"widget-title\">",
    "before_widget": "<section id=\"%1$s\" class=\"widget %2$s\">",
    "class": "",
    "content": "<!-- wp:paragraph {\"backgroundColor\":\"primary\"} --><p class=\"has-background has-primary-background-color\">Hello there! How are you?</p><!-- /wp:paragraph --><!-- wp:legacy-widget {\"identifier\":\"search-2\",\"instance\":{\"title\":\"My search widget\"}} /--><!-- wp:legacy-widget {\"identifier\":\"recent-posts-2\",\"instance\":{\"title\":\"\",\"number\":5,\"show_date\":false}} /--><!-- wp:legacy-widget {\"identifier\":\"recent-comments-2\",\"instance\":{\"title\":\"\",\"number\":5}} /--><!-- wp:legacy-widget {\"identifier\":\"archives-2\",\"instance\":{\"title\":\"\",\"count\":0,\"dropdown\":0}} /--><!-- wp:legacy-widget {\"identifier\":\"categories-2\",\"instance\":{\"title\":\"\",\"count\":0,\"hierarchical\":0,\"dropdown\":0}} /--><!-- wp:legacy-widget {\"identifier\":\"meta-2\",\"instance\":{\"title\":\"\"}} /-->",
    "description": "Add widgets here to appear in your footer.",
    "id": "sidebar-1",
    "name": "Footer"
}

```

A new `PUT /__experimental/sidebars/<id>` endpoint allows you to update the blocks in a sidebar.

**Blocks are stored directly in the existing `sidebars_widgets` site option as a serialised PHP array.** We intercept `wp_get_sidebars_widgets()` and `wp_set_sidebars_widgets()` and swap out blocks for a `block-widget` widget which is lazily registered using `wp_register_sidebar_widget()`. 

Callers that wish to see the block data can use the new `gutenberg_get_sidebars_items()` and `gutenberg_set_sidebars_items()` methods.

This approach has some big benefits:

- Theme compatibility: Themes that use `dynamic_sidebar()` will continue to work and will support blocks in sidebars appear without requiring any changes.
- Plugin compatibility: Code that uses `wp_get_sidebars_widgets()` or `wp_set_sidebars_widgets()` will continue to work without requiring any changes.
- WP Admin compatibility: The existing `/wp-admin/widgets.php` screen in WP Admin continues to work. Blocks can be re-ordered and removed, just not updated. 
- Seamless upgrades: A user's widgets will continue to work upon upgrade. Conversion from a widget to a block can happen via the frontend editor using block transforms. This aligns with how the block editor works for posts.
- "Simple" (if you grok how widgets work 😛): Very little code is required as we are using the existing widgets infrastructure in WordPress.

When merged into WordPress Core, this approach will be a little simpler to implement as we can modify `wp_get_sidebars_widgets()` and `wp_set_sidebars_widgets()` directly instead of abusing filters.

## Outstanding questions

1. ~How should blocks look when sent down via the API? Should we send down objects containing `name`, `attributes` and `innerBlocks`? Or should we send down HTML containing block delimiters so that the `/sidebar` endpoint matches the `/posts` and `/blocks` endpoints?~ Going to go with HTML, at least to start. See https://github.com/WordPress/gutenberg/pull/14251#issuecomment-477491945.
2. ~Does fetching and updating one sidebar at a time with `GET /sidebars/<id>` and `PUT /sidebars/<id>` make sense? Will the new widgets screen display an editor for all sidebars at the same time? Should we instead support viewing and updating multiple sidebars at once?~ Let's mark the API as experimental and iterate on this. See https://github.com/WordPress/gutenberg/pull/14251#issuecomment-477491945.
3. ~How will conversion from `core/legacy-widget` to e.g. `core/search` work on the frontend? Are we sending down enough data for this to happen? This depends a lot what happens with https://github.com/WordPress/gutenberg/pull/13511.~ Conversion will happen on the frontend. See https://github.com/WordPress/gutenberg/pull/14251#issuecomment-471410232.

## Outstanding tasks

- [x] Handle the `instance` attribute on a `core/legacy-widget` block 
- [x] Use HTML to represent widgets in the API 
- [ ] Handle case where legacy widget is used as an inner block
- [ ] Test with real third party widgets
- [ ] Implement `get_schema()`
- [ ] Add inline PHPDoc documentation 
- [ ] Unit tests for the new filters, methods, and REST API endpoint