### PR TITLE
Fix placeholder icon color

### DIFF
--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -28,6 +28,7 @@
 
 	.dashicon,
 	.editor-block-icon {
+		fill: currentColor;
 		margin-right: 1ch;
 	}
 }


### PR DESCRIPTION
## Description
Uses currentColor for the fill of the placeholder component's icon. This ensures the icon contrasts with the background color of a block (see screenshots).


<!-- Please describe what you have changed or added -->

## How has this been tested?
- Toggled a dark background color on the Media & Text block
- Observed that icon has correct contrast
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

*Before*
![screen shot 2019-03-06 at 5 49 53 pm](https://user-images.githubusercontent.com/677833/53872149-82e67b80-4038-11e9-8172-78e798706ed8.png)

*After*
![screen shot 2019-03-06 at 5 49 45 pm](https://user-images.githubusercontent.com/677833/53872168-8974f300-4038-11e9-8659-d65e8d9c9d33.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
