### PR TITLE
Mobile: Avoid adding empty link to text.

### DIFF
--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -18,18 +18,12 @@ import { createBlock } from '@wordpress/blocks';
 
 const name = 'core/heading';
 
-/**
- * Internal dependencies
- */
-import styles from './style.scss';
-
 class HeadingEdit extends Component {
 	constructor( props ) {
 		super( props );
 
 		this.splitBlock = this.splitBlock.bind( this );
 	}
-
 
 	/**
 	 * Split handler for RichText value, namely when content is pasted or the
@@ -79,7 +73,6 @@ class HeadingEdit extends Component {
 			attributes,
 			setAttributes,
 			mergeBlocks,
-			insertBlocksAfter,
 			style,
 		} = this.props;
 

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -98,11 +98,11 @@ export class RichText extends Component {
 	getRecord() {
 		const { formatPlaceholder, start, end } = this.state;
 
-		var value = this.props.value === undefined ? null : this.props.value;
+		let value = this.props.value === undefined ? null : this.props.value;
 
 		// Since we get the text selection from Aztec we need to be in sync with the HTML `value`
 		// Removing leading white spaces using `trim()` should make sure this is the case.
-		if (typeof value === 'string' || value instanceof String) {
+		if ( typeof value === 'string' || value instanceof String ) {
 			value = value.trimLeft();
 		}
 

--- a/packages/format-library/src/link/modal.native.js
+++ b/packages/format-library/src/link/modal.native.js
@@ -111,7 +111,7 @@ class ModalLinkUI extends Component {
 	}
 
 	onDismiss() {
-		if( this.state.inputValue === '') {
+		if ( this.state.inputValue === '' ) {
 			this.removeLink();
 		} else {
 			this.submitLink();
@@ -133,9 +133,9 @@ class ModalLinkUI extends Component {
 						label={ __( 'URL' ) }
 						value={ this.state.inputValue }
 						placeholder={ __( 'Add URL' ) }
-						autoCapitalize='none'
+						autoCapitalize="none"
 						autoCorrect={ false }
-						keyboardType='url'
+						keyboardType="url"
 						onChangeValue={ this.onChangeInputValue }
 						autoFocus={ Platform.OS === 'ios' }
 					/>

--- a/packages/format-library/src/link/modal.native.js
+++ b/packages/format-library/src/link/modal.native.js
@@ -39,6 +39,7 @@ class ModalLinkUI extends Component {
 		this.onChangeText = this.onChangeText.bind( this );
 		this.onChangeOpensInNewWindow = this.onChangeOpensInNewWindow.bind( this );
 		this.removeLink = this.removeLink.bind( this );
+		this.onDismiss = this.onDismiss.bind( this );
 
 		this.state = {
 			inputValue: '',
@@ -109,13 +110,21 @@ class ModalLinkUI extends Component {
 		this.props.onClose();
 	}
 
+	onDismiss() {
+		if( this.state.inputValue === '') {
+			this.removeLink();
+		} else {
+			this.submitLink();
+		}
+	}
+
 	render() {
 		const { isVisible } = this.props;
 
 		return (
 			<BottomSheet
 				isVisible={ isVisible }
-				onClose={ this.submitLink }
+				onClose={ this.onDismiss }
 				hideHeader
 			>
 				{ /* eslint-disable jsx-a11y/no-autofocus */

--- a/packages/format-library/src/link/modal.native.js
+++ b/packages/format-library/src/link/modal.native.js
@@ -133,9 +133,9 @@ class ModalLinkUI extends Component {
 						label={ __( 'URL' ) }
 						value={ this.state.inputValue }
 						placeholder={ __( 'Add URL' ) }
-						autoCapitalize="none"
+						autoCapitalize='none'
 						autoCorrect={ false }
-						textContentType="URL"
+						keyboardType='url'
 						onChangeValue={ this.onChangeInputValue }
 						autoFocus={ Platform.OS === 'ios' }
 					/>


### PR DESCRIPTION
This PR fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/703

When the Links UI is dismissed with an empty url field, now it will cancel the edition instead of creating an empty `https://` link.

![link](https://user-images.githubusercontent.com/9772967/53881183-43596880-4013-11e9-93c5-96a845483cba.gif)

From @iamthomasbishop's suggestions:
- I modified the keyboard type to be URL, but it just work on iOS. Didn't find a way to set it on Android.
- Dismissing the bottom-sheet on enter works, but the animation looks super bad, I'd prefer to give it more time later on.
- Adding the `https://`seems to be intended. I'd prefer to discuss it some more before modifying it :)

**To test:**
- Check out the `gutenberg-mobile` [PR's branch](https://github.com/wordpress-mobile/gutenberg-mobile/pull/706).
- Run the project.
- Select some text on a Paragraph block.
- Press the Links button to add a link to the selected text.
- Dismiss the BottomSheet without adding anything.
- Check that no link was added to the selected text.
- Check that adding a link actually works.