### PR TITLE
RichText: Fix prepareEditableTree

### DIFF
--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -57,6 +57,13 @@ function toFormat( { type, attributes } ) {
 		return attributes ? { type, attributes } : { type };
 	}
 
+	if (
+		formatType.__experimentalCreatePrepareEditableTree &&
+		! formatType.__experimentalCreateOnChangeEditableValue
+	) {
+		return null;
+	}
+
 	if ( ! attributes ) {
 		return { type: formatType.name };
 	}

--- a/packages/rich-text/src/register-format-type.js
+++ b/packages/rich-text/src/register-format-type.js
@@ -139,7 +139,7 @@ export function registerFormatType( name, settings ) {
 	} );
 
 	if (
-		settings.__experimentalGetPropsForEditableTreePreparation
+		settings.__experimentalCreatePrepareEditableTree
 	) {
 		addFilter( 'experimentalRichText', name, ( OriginalComponent ) => {
 			let Component = OriginalComponent;
@@ -193,8 +193,10 @@ export function registerFormatType( name, settings ) {
 				};
 			}
 
-			const hocs = [
-				withSelect( ( sel, { clientId, identifier } ) => ( {
+			const hocs = [];
+
+			if ( settings.__experimentalGetPropsForEditableTreePreparation ) {
+				hocs.push( withSelect( ( sel, { clientId, identifier } ) => ( {
 					[ `format_${ name }` ]: settings.__experimentalGetPropsForEditableTreePreparation(
 						sel,
 						{
@@ -202,8 +204,8 @@ export function registerFormatType( name, settings ) {
 							blockClientId: clientId,
 						}
 					),
-				} ) ),
-			];
+				} ) ) );
+			}
 
 			if ( settings.__experimentalGetPropsForEditableTreeChangeHandler ) {
 				hocs.push( withDispatch( ( disp, { clientId, identifier } ) => {

--- a/packages/rich-text/src/test/helpers/index.js
+++ b/packages/rich-text/src/test/helpers/index.js
@@ -650,4 +650,42 @@ export const specWithRegistration = [
 			text: 'a',
 		},
 	},
+	{
+		description: 'should not create format if editable tree only',
+		formatName: 'my-plugin/link',
+		formatType: {
+			title: 'Custom Link',
+			tagName: 'a',
+			className: 'custom-format',
+			edit() {},
+			__experimentalCreatePrepareEditableTree() {},
+		},
+		html: '<a class="custom-format">a</a>',
+		value: {
+			formats: [ , ],
+			text: 'a',
+		},
+		noToHTMLString: true,
+	},
+	{
+		description: 'should create format if editable tree only but changes need to be recorded',
+		formatName: 'my-plugin/link',
+		formatType: {
+			title: 'Custom Link',
+			tagName: 'a',
+			className: 'custom-format',
+			edit() {},
+			__experimentalCreatePrepareEditableTree() {},
+			__experimentalCreateOnChangeEditableValue() {},
+		},
+		html: '<a class="custom-format">a</a>',
+		value: {
+			formats: [ [ {
+				type: 'my-plugin/link',
+				attributes: {},
+				unregisteredAttributes: {},
+			} ] ],
+			text: 'a',
+		},
+	},
 ];

--- a/packages/rich-text/src/test/to-html-string.js
+++ b/packages/rich-text/src/test/to-html-string.js
@@ -35,7 +35,12 @@ describe( 'toHTMLString', () => {
 		formatType,
 		html,
 		value,
+		noToHTMLString,
 	} ) => {
+		if ( noToHTMLString ) {
+			return;
+		}
+
 		it( description, () => {
 			if ( formatName ) {
 				registerFormatType( formatName, formatType );


### PR DESCRIPTION
## Description

~~This is still a work-in-progress. Some test will likely fail. @atimmer Your help would be appreciated for the annotations. What was the motive behind allowing editable-tree-only formats to be sent through `RichText`?~~

This PR filters out editable-tree-only formats during value creation. This was introduced in #11595, but removed in https://github.com/WordPress/gutenberg/pull/11861/files#r234544682.

To test, add the run the following in the console:

```js
wp.richText.registerFormatType( 'plugin/mark-gutenberg', {
	title: 'invisible',
	tagName: 'mark',
	className: 'gutenberg',
	__experimentalCreatePrepareEditableTree( props ) {
		return ( formats, text ) => {
			const search = 'Gutenberg';
			const index = text.indexOf( search );

			if ( index === -1 ) {
				return formats;
			}

			const start = index;
			const end = index + search.length;

			const newValue = wp.richText.applyFormat( { text, formats }, { type: 'plugin/mark-gutenberg' }, start, end );

			return newValue.formats;
		};
	},
} );
```

It should mark the first occurrence of Gutenberg that you type in a rich text field. This currently works in `master`, but the marking is not properly removed if you type in the marking or remove some letters. It is meant to strictly match "Gutenberg" and disappear when it no longer matches.

In addition, it fixes registration logic so that `__experimentalCreatePrepareEditableTree` can again be used by itself.

I'll add a test for this case.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->