### PR TITLE
Update: Use new action REPLACE_INNER_BLOCKS for InnerBlocks replacement

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -980,6 +980,17 @@ specified client ID is to be removed.
  * selectPrevious: True if the previous block should be
                                 selected when a block is removed.
 
+### replaceInnerBlocks
+
+Returns an action object used in signalling that the inner blocks with the
+specified client ID should be replaced.
+
+*Parameters*
+
+ * rootClientId: Client ID of the block whose InnerBlocks will re replaced.
+ * blocks: Block objects to insert as new InnerBlocks
+ * updateSelection: If true block selection will be updated. If false, block selection will not change. Defaults to true.
+
 ### toggleBlockMode
 
 Returns an action object used to toggle the block editing mode between

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { pick, isEqual, map } from 'lodash';
+import { pick, isEqual } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -144,20 +144,14 @@ InnerBlocks = compose( [
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {
 		const {
-			replaceBlocks,
-			insertBlocks,
+			replaceInnerBlocks,
 			updateBlockListSettings,
 		} = dispatch( 'core/block-editor' );
 		const { block, clientId, templateInsertUpdatesSelection = true } = ownProps;
 
 		return {
 			replaceInnerBlocks( blocks ) {
-				const clientIds = map( block.innerBlocks, 'clientId' );
-				if ( clientIds.length ) {
-					replaceBlocks( clientIds, blocks );
-				} else {
-					insertBlocks( blocks, undefined, clientId, templateInsertUpdatesSelection );
-				}
+				replaceInnerBlocks( clientId, blocks, block.innerBlocks.length === 0 && templateInsertUpdatesSelection );
 			},
 			updateNestedSettings( settings ) {
 				dispatch( updateBlockListSettings( clientId, settings ) );

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -421,6 +421,26 @@ export function removeBlock( clientId, selectPrevious ) {
 }
 
 /**
+ * Returns an action object used in signalling that the inner blocks with the
+ * specified client ID should be replaced.
+ *
+ * @param {string}   rootClientId    Client ID of the block whose InnerBlocks will re replaced.
+ * @param {Object[]} blocks          Block objects to insert as new InnerBlocks
+ * @param {?boolean} updateSelection If true block selection will be updated. If false, block selection will not change. Defaults to true.
+ *
+ * @return {Object} Action object.
+ */
+export function replaceInnerBlocks( rootClientId, blocks, updateSelection = true ) {
+	return {
+		type: 'REPLACE_INNER_BLOCKS',
+		rootClientId,
+		blocks,
+		updateSelection,
+		time: Date.now(),
+	};
+}
+
+/**
  * Returns an action object used to toggle the block editing mode between
  * visual and HTML modes.
  *

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -2,30 +2,31 @@
  * Internal dependencies
  */
 import {
-	replaceBlocks,
-	startTyping,
-	stopTyping,
+	clearSelectedBlock,
 	enterFormattedText,
 	exitFormattedText,
-	toggleSelection,
-	resetBlocks,
-	updateBlockAttributes,
-	updateBlock,
-	selectBlock,
-	selectPreviousBlock,
-	startMultiSelect,
-	stopMultiSelect,
-	multiSelect,
-	clearSelectedBlock,
-	replaceBlock,
+	hideInsertionPoint,
 	insertBlock,
 	insertBlocks,
-	showInsertionPoint,
-	hideInsertionPoint,
 	mergeBlocks,
-	removeBlocks,
+	multiSelect,
 	removeBlock,
+	removeBlocks,
+	replaceBlock,
+	replaceBlocks,
+	replaceInnerBlocks,
+	resetBlocks,
+	selectBlock,
+	selectPreviousBlock,
+	showInsertionPoint,
+	startMultiSelect,
+	startTyping,
+	stopMultiSelect,
+	stopTyping,
 	toggleBlockMode,
+	toggleSelection,
+	updateBlock,
+	updateBlockAttributes,
 	updateBlockListSettings,
 } from '../actions';
 import { select } from '../controls';
@@ -343,6 +344,32 @@ describe( 'actions', () => {
 				type: 'UPDATE_BLOCK_LIST_SETTINGS',
 				clientId: 'chicken',
 				settings: { chicken: 'ribs' },
+			} );
+		} );
+	} );
+
+	describe( 'replaceInnerBlocks', () => {
+		const block = {
+			clientId: 'ribs',
+		};
+
+		it( 'should return the REPLACE_INNER_BLOCKS action with default values set', () => {
+			expect( replaceInnerBlocks( 'root', [ block ] ) ).toEqual( {
+				type: 'REPLACE_INNER_BLOCKS',
+				blocks: [ block ],
+				rootClientId: 'root',
+				time: expect.any( Number ),
+				updateSelection: true,
+			} );
+		} );
+
+		it( 'should return the REPLACE_INNER_BLOCKS action with updateSelection false', () => {
+			expect( replaceInnerBlocks( 'root', [ block ], false ) ).toEqual( {
+				type: 'REPLACE_INNER_BLOCKS',
+				blocks: [ block ],
+				rootClientId: 'root',
+				time: expect.any( Number ),
+				updateSelection: false,
 			} );
 		} );
 	} );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -162,7 +162,7 @@ describe( 'state', () => {
 			unregisterBlockType( 'core/test-block' );
 		} );
 
-		describe( 'replace innerblocks', () => {
+		describe( 'replace inner blocks', () => {
 			beforeAll( () => {
 				registerBlockType( 'core/test-parent-block', {
 					save: noop,

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -1905,7 +1905,7 @@ describe( 'state', () => {
 			expect( state ).toBe( original );
 		} );
 
-		it( 'should update the selection on innerblocks replace if updateSelection is true', () => {
+		it( 'should update the selection on inner blocks replace if updateSelection is true', () => {
 			const original = deepFreeze( {
 				start: 'chicken',
 				end: 'chicken',

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -433,7 +433,7 @@ describe( 'state', () => {
 				} );
 			} );
 
-			it( 'can replace a child block that has other childs', () => {
+			it( 'can replace a child block that has other children', () => {
 				const existingState = deepFreeze( {
 					byClientId: {
 						clicken: {

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -162,6 +162,348 @@ describe( 'state', () => {
 			unregisterBlockType( 'core/test-block' );
 		} );
 
+		describe( 'replace innerblocks', () => {
+			beforeAll( () => {
+				registerBlockType( 'core/test-parent-block', {
+					save: noop,
+					edit: noop,
+					category: 'common',
+					title: 'test parent block',
+				} );
+				registerBlockType( 'core/test-child-block', {
+					save: noop,
+					edit: noop,
+					category: 'common',
+					title: 'test child block 1',
+					attributes: {
+						attr: {
+							type: 'boolean',
+						},
+						attr2: {
+							type: 'string',
+						},
+					},
+				} );
+			} );
+
+			afterAll( () => {
+				unregisterBlockType( 'core/test-parent-block' );
+				unregisterBlockType( 'core/test-child-block' );
+			} );
+			it( 'can replace a child block', () => {
+				const existingState = deepFreeze( {
+					byClientId: {
+						clicken: {
+							clientId: 'chicken',
+							name: 'core/test-parent-block',
+							isValid: true,
+						},
+						'clicken-child': {
+							clientId: 'chicken-child',
+							name: 'core/test-child-block',
+							isValid: true,
+						},
+					},
+					attributes: {
+						clicken: {},
+						'clicken-child': {
+							attr: true,
+						},
+					},
+					order: {
+						'': [ 'clicken' ],
+						clicken: [ 'clicken-child' ],
+						'clicken-child': [],
+					},
+				} );
+
+				const newChildBlock = createBlock( 'core/test-child-block', {
+					attr: false,
+					attr2: 'perfect',
+				} );
+
+				const { clientId: newChildBlockId } = newChildBlock;
+
+				const action = {
+					type: 'REPLACE_INNER_BLOCKS',
+					rootClientId: 'clicken',
+					blocks: [ newChildBlock ],
+				};
+
+				const state = blocks( existingState, action );
+
+				expect( state ).toEqual( {
+					isPersistentChange: expect.anything(),
+					byClientId: {
+						clicken: {
+							clientId: 'chicken',
+							name: 'core/test-parent-block',
+							isValid: true,
+						},
+						[ newChildBlockId ]: {
+							clientId: newChildBlockId,
+							name: 'core/test-child-block',
+							isValid: true,
+						},
+					},
+					attributes: {
+						clicken: {},
+						[ newChildBlockId ]: {
+							attr: false,
+							attr2: 'perfect',
+						},
+					},
+					order: {
+						'': [ 'clicken' ],
+						clicken: [ newChildBlockId ],
+						[ newChildBlockId ]: [],
+					},
+				} );
+			} );
+
+			it( 'can insert a child block', () => {
+				const existingState = deepFreeze( {
+					byClientId: {
+						clicken: {
+							clientId: 'chicken',
+							name: 'core/test-parent-block',
+							isValid: true,
+						},
+					},
+					attributes: {
+						clicken: {},
+					},
+					order: {
+						'': [ 'clicken' ],
+						clicken: [],
+					},
+				} );
+
+				const newChildBlock = createBlock( 'core/test-child-block', {
+					attr: false,
+					attr2: 'perfect',
+				} );
+
+				const { clientId: newChildBlockId } = newChildBlock;
+
+				const action = {
+					type: 'REPLACE_INNER_BLOCKS',
+					rootClientId: 'clicken',
+					blocks: [ newChildBlock ],
+				};
+
+				const state = blocks( existingState, action );
+
+				expect( state ).toEqual( {
+					isPersistentChange: expect.anything(),
+					byClientId: {
+						clicken: {
+							clientId: 'chicken',
+							name: 'core/test-parent-block',
+							isValid: true,
+						},
+						[ newChildBlockId ]: {
+							clientId: newChildBlockId,
+							name: 'core/test-child-block',
+							isValid: true,
+						},
+					},
+					attributes: {
+						clicken: {},
+						[ newChildBlockId ]: {
+							attr: false,
+							attr2: 'perfect',
+						},
+					},
+					order: {
+						'': [ 'clicken' ],
+						clicken: [ newChildBlockId ],
+						[ newChildBlockId ]: [],
+					},
+				} );
+			} );
+
+			it( 'can replace multiple child blocks', () => {
+				const existingState = deepFreeze( {
+					byClientId: {
+						clicken: {
+							clientId: 'chicken',
+							name: 'core/test-parent-block',
+							isValid: true,
+						},
+						'clicken-child': {
+							clientId: 'chicken-child',
+							name: 'core/test-child-block',
+							isValid: true,
+						},
+						'clicken-child-2': {
+							clientId: 'chicken-child',
+							name: 'core/test-child-block',
+							isValid: true,
+						},
+					},
+					attributes: {
+						clicken: {},
+						'clicken-child': {
+							attr: true,
+						},
+						'clicken-child-2': {
+							attr2: 'ok',
+						},
+					},
+					order: {
+						'': [ 'clicken' ],
+						clicken: [ 'clicken-child', 'clicken-child-2' ],
+						'clicken-child': [],
+						'clicken-child-2': [],
+					},
+				} );
+
+				const newChildBlock1 = createBlock( 'core/test-child-block', {
+					attr: false,
+					attr2: 'perfect',
+				} );
+
+				const newChildBlock2 = createBlock( 'core/test-child-block', {
+					attr: true,
+					attr2: 'not-perfect',
+				} );
+
+				const newChildBlock3 = createBlock( 'core/test-child-block', {
+					attr2: 'hello',
+				} );
+
+				const { clientId: newChildBlockId1 } = newChildBlock1;
+				const { clientId: newChildBlockId2 } = newChildBlock2;
+				const { clientId: newChildBlockId3 } = newChildBlock3;
+
+				const action = {
+					type: 'REPLACE_INNER_BLOCKS',
+					rootClientId: 'clicken',
+					blocks: [ newChildBlock1, newChildBlock2, newChildBlock3 ],
+				};
+
+				const state = blocks( existingState, action );
+
+				expect( state ).toEqual( {
+					isPersistentChange: expect.anything(),
+					byClientId: {
+						clicken: {
+							clientId: 'chicken',
+							name: 'core/test-parent-block',
+							isValid: true,
+						},
+						[ newChildBlockId1 ]: {
+							clientId: newChildBlockId1,
+							name: 'core/test-child-block',
+							isValid: true,
+						},
+						[ newChildBlockId2 ]: {
+							clientId: newChildBlockId2,
+							name: 'core/test-child-block',
+							isValid: true,
+						},
+						[ newChildBlockId3 ]: {
+							clientId: newChildBlockId3,
+							name: 'core/test-child-block',
+							isValid: true,
+						},
+					},
+					attributes: {
+						clicken: {},
+						[ newChildBlockId1 ]: {
+							attr: false,
+							attr2: 'perfect',
+						},
+						[ newChildBlockId2 ]: {
+							attr: true,
+							attr2: 'not-perfect',
+						},
+						[ newChildBlockId3 ]: {
+							attr2: 'hello',
+						},
+					},
+					order: {
+						'': [ 'clicken' ],
+						clicken: [ newChildBlockId1, newChildBlockId2, newChildBlockId3 ],
+						[ newChildBlockId1 ]: [],
+						[ newChildBlockId2 ]: [],
+						[ newChildBlockId3 ]: [],
+					},
+				} );
+			} );
+
+			it( 'can replace a child block that has other childs', () => {
+				const existingState = deepFreeze( {
+					byClientId: {
+						clicken: {
+							clientId: 'chicken',
+							name: 'core/test-parent-block',
+							isValid: true,
+						},
+						'clicken-child': {
+							clientId: 'chicken-child',
+							name: 'core/test-child-block',
+							isValid: true,
+						},
+						'clicken-grand-child': {
+							clientId: 'chicken-child',
+							name: 'core/test-block',
+							isValid: true,
+						},
+					},
+					attributes: {
+						clicken: {},
+						'clicken-child': {},
+						'clicken-grand-child': {},
+					},
+					order: {
+						'': [ 'clicken' ],
+						clicken: [ 'clicken-child' ],
+						'clicken-child': [ 'clicken-grand-child' ],
+						'clicken-grand-child': [],
+					},
+				} );
+
+				const newChildBlock = createBlock( 'core/test-block' );
+
+				const { clientId: newChildBlockId } = newChildBlock;
+
+				const action = {
+					type: 'REPLACE_INNER_BLOCKS',
+					rootClientId: 'clicken',
+					blocks: [ newChildBlock ],
+				};
+
+				const state = blocks( existingState, action );
+
+				expect( state ).toEqual( {
+					isPersistentChange: expect.anything(),
+					byClientId: {
+						clicken: {
+							clientId: 'chicken',
+							name: 'core/test-parent-block',
+							isValid: true,
+						},
+						[ newChildBlockId ]: {
+							clientId: newChildBlockId,
+							name: 'core/test-block',
+							isValid: true,
+						},
+					},
+					attributes: {
+						clicken: {},
+						[ newChildBlockId ]: {},
+					},
+					order: {
+						'': [ 'clicken' ],
+						clicken: [ newChildBlockId ],
+						[ newChildBlockId ]: [],
+					},
+				} );
+			} );
+		} );
+
 		it( 'should return empty byClientId, attributes, order by default', () => {
 			const state = blocks( undefined, {} );
 
@@ -1558,6 +1900,55 @@ describe( 'state', () => {
 			const state = blockSelection( original, {
 				type: 'REMOVE_BLOCKS',
 				clientIds: [ 'ribs' ],
+			} );
+
+			expect( state ).toBe( original );
+		} );
+
+		it( 'should update the selection on innerblocks replace if updateSelection is true', () => {
+			const original = deepFreeze( {
+				start: 'chicken',
+				end: 'chicken',
+				initialPosition: null,
+				isMultiSelecting: false,
+			} );
+			const newBlock = {
+				name: 'core/test-block',
+				clientId: 'another-block',
+			};
+
+			const state = blockSelection( original, {
+				type: 'REPLACE_INNER_BLOCKS',
+				blocks: [ newBlock ],
+				rootClientId: 'parent',
+				updateSelection: true,
+			} );
+
+			expect( state ).toEqual( {
+				start: 'another-block',
+				end: 'another-block',
+				initialPosition: null,
+				isMultiSelecting: false,
+			} );
+		} );
+
+		it( 'should not update the selection on innerblocks replace if updateSelection is false', () => {
+			const original = deepFreeze( {
+				start: 'chicken',
+				end: 'chicken',
+				initialPosition: null,
+				isMultiSelecting: false,
+			} );
+			const newBlock = {
+				name: 'core/test-block',
+				clientId: 'another-block',
+			};
+
+			const state = blockSelection( original, {
+				type: 'REPLACE_INNER_BLOCKS',
+				blocks: [ newBlock ],
+				rootClientId: 'parent',
+				updateSelection: false,
 			} );
 
 			expect( state ).toBe( original );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -1932,7 +1932,7 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should not update the selection on innerblocks replace if updateSelection is false', () => {
+		it( 'should not update the selection on inner blocks replace if updateSelection is false', () => {
 			const original = deepFreeze( {
 				start: 'chicken',
 				end: 'chicken',


### PR DESCRIPTION
## Description
Adds a new action REPLACE_INNER_BLOCKS that is used during the inner block creation/update to set its template.
We are updating the insert/replace and move actions to restrict if the new blocks can be added in the specific locations. During the set of an inner blocks template even if restrictions exist e.g: locking, the blocks should be added, this would require flags in the existing actions to not apply restriction in that case.
@gziolo suggested that we use a new specific action, and this PR implements it.

Pending: test cases, after we check if this approach (use a High Order Reducer) is valid I will add them to this PR.

## How has this been tested?
I used the columns block, changed the number of columns, and verified everything still works as before.
I used the Media & Text block and verified the heading block still does not get selected by default.
I tried a sample block with inner blocks https://gist.github.com/jorgefilipecosta/b7194daac3ce26827522694fb4252c1c#file-testallowedblocksmiddleware-js and checked the block still work as before.