### PR TITLE
Avoid to reset html to empty string if block is heading and platform is android

### DIFF
--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -6,7 +6,7 @@ import HeadingToolbar from './heading-toolbar';
 /**
  * External dependencies
  */
-import { View } from 'react-native';
+import { View, Platform } from 'react-native';
 
 /**
  * WordPress dependencies
@@ -18,18 +18,13 @@ import { createBlock } from '@wordpress/blocks';
 
 const name = 'core/heading';
 
-/**
- * Internal dependencies
- */
-import styles from './style.scss';
-
 class HeadingEdit extends Component {
 	constructor( props ) {
 		super( props );
 
 		this.splitBlock = this.splitBlock.bind( this );
+		this.isAndroid = Platform.OS === 'android';
 	}
-
 
 	/**
 	 * Split handler for RichText value, namely when content is pasted or the
@@ -79,7 +74,6 @@ class HeadingEdit extends Component {
 			attributes,
 			setAttributes,
 			mergeBlocks,
-			insertBlocksAfter,
 			style,
 		} = this.props;
 
@@ -108,6 +102,9 @@ class HeadingEdit extends Component {
 					onMerge={ mergeBlocks }
 					onSplit={ this.splitBlock }
 					placeholder={ placeholder || __( 'Write heading…' ) }
+					// Fix for heading issue on Android https://github.com/wordpress-mobile/gutenberg-mobile/issues/627
+					// Intentionally introduces missing pleceholder issue on Android https://github.com/wordpress-mobile/gutenberg-mobile/issues/707
+					sendEmptyTag={ this.isAndroid }
 				/>
 			</View>
 		);

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -3,7 +3,6 @@
  */
 import RCTAztecView from 'react-native-aztec';
 import { View, Platform } from 'react-native';
-import { indexOf } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -69,10 +68,6 @@ const gutenbergFormatNamesToAztec = {
 	'core/italic': 'italic',
 	'core/strikethrough': 'strikethrough',
 };
-
-const headingTags = [
-	'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-];
 
 export class RichText extends Component {
 	constructor() {
@@ -501,6 +496,7 @@ export class RichText extends Component {
 			style,
 			formattingControls,
 			isSelected,
+			sendEmptyTag,
 		} = this.props;
 
 		const record = this.getRecord();
@@ -518,8 +514,7 @@ export class RichText extends Component {
 			// This fix will intentionally introduce original issue with placeholder (on Android)
 			// which has lower priority then heading issue .
 			// New issue is raised : https://github.com/wordpress-mobile/gutenberg-mobile/issues/707
-			const index = indexOf( headingTags, tagName );
-			if ( this.isIOS || index === -1 ) {
+			if ( ! sendEmptyTag ) {
 				html = '';
 			}
 


### PR DESCRIPTION
This PR fixes the issue : [Heading block shows no formatting at first](https://github.com/wordpress-mobile/gutenberg-mobile/issues/627)

**Summary:**

PR for placeholder fix https://github.com/WordPress/gutenberg/pull/13699/
has introduced heading issue on Android https://github.com/wordpress-mobile/gutenberg-mobile/issues/627

**Note for testing:**

This fix will intentionally introduce original issue with a placeholder (on Android)
 which has lower priority then heading issue.

The new issue is raised: https://github.com/wordpress-mobile/gutenberg-mobile/issues/707
