### PR TITLE
jest-console: add Typescript definition

### DIFF
--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -24,10 +24,12 @@
 	},
 	"files": [
 		"build",
-		"build-module"
+		"build-module",
+		"types.d.ts"
 	],
 	"main": "build/index.js",
 	"module": "build-module/index.js",
+	"types": "types.d.ts",
 	"dependencies": {
 		"@babel/runtime": "^7.3.1",
 		"jest-matcher-utils": "^24.0.0",

--- a/packages/jest-console/types.d.ts
+++ b/packages/jest-console/types.d.ts
@@ -1,0 +1,49 @@
+/// <reference types="jest" />
+
+declare namespace jest {
+
+    interface Matchers<R> {
+
+        /**
+         * Ensure that `console.error` function was called.
+         */
+        toHaveErrored(): R;
+
+        /**
+         * Ensure that `console.error` function was called with specific arguments.
+         */
+        toHaveErroredWith(...args: any[]): R;
+
+        /**
+         * Ensure that `console.info` function was called.
+         */
+        toHaveInformed(): R;
+
+        /**
+         * Ensure that `console.info` function was called with specific arguments.
+         */
+        toHaveInformedWith(...args: any[]): R;
+
+        /**
+         * Ensure that `console.log` function was called.
+         */
+        toHaveLogged(): R;
+
+        /**
+         * Ensure that `console.log` function was called with specific arguments.
+         */
+        toHaveLoggedWith(...args: any[]): R;
+
+        /**
+         * Ensure that `console.warn` function was called.
+         */
+        toHaveWarned(): R;
+
+        /**
+         * Ensure that `console.warn` function was called with specific arguments.
+         */
+        toHaveWarnedWith(...args: any[]): R;
+
+    }
+
+}


### PR DESCRIPTION
## Description
This adds the Typescript definition for Jest Console matchers.

## How has this been tested?
Integrated in an Angular application and made calls in the spec files.

```ts
expect(console).not.toHaveWarned();

expect(console).toHaveWarnedWith('Cannot find icon');
```

## Types of changes
New feature
