### PR TITLE
 RichText: fix br padding in multiline and nesting

### DIFF
--- a/packages/e2e-tests/specs/__snapshots__/writing-flow.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/writing-flow.test.js.snap
@@ -126,6 +126,12 @@ exports[`adding blocks should navigate around nested inline boundaries 2`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`adding blocks should not create extra line breaks in multiline value 1`] = `
+"<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p></p></blockquote>
+<!-- /wp:quote -->"
+`;
+
 exports[`adding blocks should not delete surrounding space when deleting a selected word 1`] = `
 "<!-- wp:paragraph -->
 <p>alpha  gamma</p>

--- a/packages/e2e-tests/specs/writing-flow.test.js
+++ b/packages/e2e-tests/specs/writing-flow.test.js
@@ -7,6 +7,7 @@ import {
 	createNewPost,
 	pressKeyTimes,
 	pressKeyWithModifier,
+	insertBlock,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'adding blocks', () => {
@@ -205,6 +206,13 @@ describe( 'adding blocks', () => {
 	it( 'should insert line break in empty container', async () => {
 		await clickBlockAppender();
 		await pressKeyWithModifier( 'shift', 'Enter' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should not create extra line breaks in multiline value', async () => {
+		await insertBlock( 'Quote' );
+		await page.keyboard.type( 'a' );
+		await page.keyboard.press( 'Backspace' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -337,6 +337,7 @@ function createFromElement( {
 				multilineTag,
 				multilineWrapperTags,
 				currentWrapperTags: [ ...currentWrapperTags, format ],
+				isEditableTree,
 			} );
 			format = undefined;
 		} else {
@@ -345,6 +346,7 @@ function createFromElement( {
 				range,
 				multilineTag,
 				multilineWrapperTags,
+				isEditableTree,
 			} );
 		}
 
@@ -423,6 +425,7 @@ function createFromMultilineElement( {
 	multilineTag,
 	multilineWrapperTags,
 	currentWrapperTags = [],
+	isEditableTree,
 } ) {
 	const accumulator = createEmptyValue();
 
@@ -446,6 +449,7 @@ function createFromMultilineElement( {
 			multilineTag,
 			multilineWrapperTags,
 			currentWrapperTags,
+			isEditableTree,
 		} );
 
 		// Multiline value text should be separated by a double line break.


### PR DESCRIPTION
## Description

In #13850, I forgot to pass `isEditableTree` to nested calls. As a result, extra line breaks may be created in e.g. a quote block. One way to reproduce this issue is by typing a letter, then deleting it again. You'll see that there are now two lines.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
