### PR TITLE
Add link to WordPress Support documentation

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -10,7 +10,9 @@ Start with [the Designer & Developer Handbook](/docs/designers-developers/readme
 
 ## User Handbook
 
-Discover the new features Gutenberg offers, learn how your site will be affected by the new editor and how to keep using the old interface, and tips for creating beautiful posts and pages.
+Discover the new features WordPress offers, learn how your site will be affected by the new editor and how to keep using the old interface, and tips for creating beautiful posts and pages.
+
+See [the WordPress Editor](https://wordpress.org/support/article/wordpress-editor/) support documentation.
 
 
 ## Contributor Handbook


### PR DESCRIPTION
## Description

User Documentation was created on the Support site, this PR adds a link from the User handbook section to the new support docs.

 ## How has this been tested?

Documentation, confirm link works.
