### PR TITLE
[Mobile]Update caret position on insert link

### DIFF
--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -198,6 +198,12 @@ export class RichText extends Component {
 		} );
 		if ( newContent && newContent !== this.props.value ) {
 			this.props.onChange( newContent );
+			if ( record.needsSelectionUpdate && record.start && record.end ) {
+				this.setState( { start: record.start, end: record.end } );
+			}
+			this.setState( {
+				needsSelectionUpdate: record.needsSelectionUpdate,
+			} );
 		} else {
 			// make sure the component rerenders without refreshing the text on gutenberg
 			// (this can trigger other events that might update the active formats on aztec)
@@ -512,6 +518,8 @@ export class RichText extends Component {
 			minHeight = style.minHeight;
 		}
 
+		const selection = this.state.needsSelectionUpdate ? { start: this.state.start, end: this.state.end } : null;
+
 		return (
 			<View>
 				{ isSelected && (
@@ -531,7 +539,7 @@ export class RichText extends Component {
 						...style,
 						minHeight: Math.max( minHeight, this.state.height ),
 					} }
-					text={ { text: html, eventCount: this.lastEventCount } }
+					text={ { text: html, eventCount: this.lastEventCount, selection } }
 					placeholder={ this.props.placeholder }
 					placeholderTextColor={ this.props.placeholderTextColor || styles[ 'editor-rich-text' ].textDecorationColor }
 					onChange={ this.onChange }

--- a/packages/format-library/src/link/modal.native.js
+++ b/packages/format-library/src/link/modal.native.js
@@ -86,12 +86,14 @@ class ModalLinkUI extends Component {
 
 		if ( isCollapsed( value ) && ! isActive ) { // insert link
 			const toInsert = applyFormat( create( { text: linkText } ), [ ...placeholderFormats, format ], 0, linkText.length );
-			onChange( insert( value, toInsert ) );
+			const newAttributes = insert( value, toInsert );
+			onChange( { ...newAttributes, needsSelectionUpdate: true } );
 		} else if ( text !== getTextContent( slice( value ) ) ) { // edit text in selected link
 			const toInsert = applyFormat( create( { text } ), [ ...placeholderFormats, format ], 0, text.length );
 			onChange( insert( value, toInsert, value.start, value.end ) );
 		} else { // transform selected text into link
-			onChange( applyFormat( value, [ ...placeholderFormats, format ] ) );
+			const newAttributes = applyFormat( value, [ ...placeholderFormats, format ] );
+			onChange( { ...newAttributes, start: newAttributes.end, needsSelectionUpdate: true } ); //put caret at the end of the link
 		}
 
 		if ( ! isValidHref( url ) ) {

--- a/packages/format-library/src/link/modal.native.js
+++ b/packages/format-library/src/link/modal.native.js
@@ -94,7 +94,7 @@ class ModalLinkUI extends Component {
 			onChange( { ...newAttributes, needsSelectionUpdate: true } );
 		} else { // transform selected text into link
 			const newAttributes = applyFormat( value, [ ...placeholderFormats, format ] );
-			onChange( { ...newAttributes, start: newAttributes.end, needsSelectionUpdate: true } ); //put caret at the end of the link
+			onChange( { ...newAttributes, needsSelectionUpdate: true } );
 		}
 
 		if ( ! isValidHref( url ) ) {

--- a/packages/format-library/src/link/modal.native.js
+++ b/packages/format-library/src/link/modal.native.js
@@ -90,7 +90,8 @@ class ModalLinkUI extends Component {
 			onChange( { ...newAttributes, needsSelectionUpdate: true } );
 		} else if ( text !== getTextContent( slice( value ) ) ) { // edit text in selected link
 			const toInsert = applyFormat( create( { text } ), [ ...placeholderFormats, format ], 0, text.length );
-			onChange( insert( value, toInsert, value.start, value.end ) );
+			const newAttributes = insert( value, toInsert, value.start, value.end );
+			onChange( { ...newAttributes, needsSelectionUpdate: true } );
 		} else { // transform selected text into link
 			const newAttributes = applyFormat( value, [ ...placeholderFormats, format ] );
 			onChange( { ...newAttributes, start: newAttributes.end, needsSelectionUpdate: true } ); //put caret at the end of the link


### PR DESCRIPTION
## Description
Fix: https://github.com/wordpress-mobile/gutenberg-mobile/issues/679 

## How has this been tested?

Steps described in the gutenberg-mobile PR https://github.com/wordpress-mobile/gutenberg-mobile/pull/716

## Types of changes
Whenever we insert/update a link we now put a flag(`needsSelectionUpdate`) inside the change event so that we are able to know we need to update caret position at aztec side.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->