### PR TITLE
Fix #14319 Add parse float for steps less than 1

### DIFF
--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -48,7 +48,10 @@ function RangeControl( {
 
 	const onChangeValue = ( event ) => {
 		const newValue = event.target.value;
-		const newNumericValue = parseInt( newValue, 10 );
+		let newNumericValue = parseInt( newValue, 10 );
+		if ( props.step !== undefined && props.step < 1 ) {
+			newNumericValue = parseFloat( newValue );
+		}
 		// If the input value is invalid temporarily save it to the state,
 		// without calling on change.
 		if (


### PR DESCRIPTION
## Description
I added a check to see if the step property is set to less then 1. If so to change the newNumericValue variable to use parseFloat.

on [line 51](https://github.com/WordPress/gutenberg/blob/078041bd1f78b688eac133fb17838704ca0bc53c/packages/components/src/range-control/index.js#L51) changed this:

`const newNumericValue = parseInt( newValue, 10 );`

to this:

```
let newNumericValue = parseInt( newValue, 10 );
if ( props.step !== undefined && props.step < 1 ) {
	newNumericValue = parseFloat( newValue );
}
```

## How has this been tested?
Checked with all core blocks, as well as all Kadence Blocks :)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
