### PR TITLE
Fix: use checkValidity() to perform the validation in RangeControl

### DIFF
--- a/packages/block-library/src/columns/index.js
+++ b/packages/block-library/src/columns/index.js
@@ -172,6 +172,7 @@ export const settings = {
 							} }
 							min={ 2 }
 							max={ 6 }
+							required
 						/>
 					</PanelBody>
 				</InspectorControls>

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -214,6 +214,7 @@ class CoverEdit extends Component {
 									min={ 0 }
 									max={ 100 }
 									step={ 10 }
+									required
 								/>
 							</PanelColorSettings>
 						</PanelBody>

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -250,6 +250,7 @@ class GalleryEdit extends Component {
 							onChange={ this.setColumnsNumber }
 							min={ 1 }
 							max={ Math.min( MAX_COLUMNS, images.length ) }
+							required
 						/> }
 						<ToggleControl
 							label={ __( 'Crop Images' ) }

--- a/packages/block-library/src/latest-comments/edit.js
+++ b/packages/block-library/src/latest-comments/edit.js
@@ -85,6 +85,7 @@ class LatestComments extends Component {
 							onChange={ this.setCommentsToShow }
 							min={ MIN_COMMENTS }
 							max={ MAX_COMMENTS }
+							required
 						/>
 					</PanelBody>
 				</InspectorControls>

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -109,6 +109,7 @@ class LatestPostsEdit extends Component {
 							onChange={ ( value ) => setAttributes( { columns: value } ) }
 							min={ 2 }
 							max={ ! hasPosts ? MAX_POSTS_COLUMNS : Math.min( MAX_POSTS_COLUMNS, latestPosts.length ) }
+							required
 						/>
 					}
 				</PanelBody>

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -119,6 +119,7 @@ class RSSEdit extends Component {
 							onChange={ ( value ) => setAttributes( { itemsToShow: value } ) }
 							min={ DEFAULT_MIN_ITEMS }
 							max={ DEFAULT_MAX_ITEMS }
+							required
 						/>
 						<ToggleControl
 							label={ __( 'Display author' ) }
@@ -142,6 +143,7 @@ class RSSEdit extends Component {
 								onChange={ ( value ) => setAttributes( { excerptLength: value } ) }
 								min={ 10 }
 								max={ 100 }
+								required
 							/>
 						}
 						{ blockLayout === 'grid' &&
@@ -151,6 +153,7 @@ class RSSEdit extends Component {
 								onChange={ ( value ) => setAttributes( { columns: value } ) }
 								min={ 2 }
 								max={ 6 }
+								required
 							/>
 						}
 					</PanelBody>

--- a/packages/block-library/src/text-columns/index.js
+++ b/packages/block-library/src/text-columns/index.js
@@ -114,6 +114,7 @@ export const settings = {
 							onChange={ ( value ) => setAttributes( { columns: value } ) }
 							min={ 2 }
 							max={ 4 }
+							required
 						/>
 					</PanelBody>
 				</InspectorControls>

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Resolves a conflict where two instance of Slot would produce an inconsistent or duplicated rendering output.
 - Allow years between 0 and 1970 in DateTime component.
+- Fix a bug that made `RangeControl` not work as expected with float values; Started relying on the browser validations instead of our own.
 
 ### New Feature
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `withFilters` has been optimized to avoid binding hook handlers for each mounted instance of the component, instead using a single centralized hook delegator.
 - `withFilters` has been optimized to reuse a single shared component definition for all filtered instances of the component.
 - Make `RangeControl` validate min and max properties.
+- Allow users to choose if `RangeControl` input is required or not. Defaults to not be required.
 
 ### Bug Fixes
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 7.2.0 (Unreleased)
+
+### Improvements
+
+- Make `RangeControl` validation rely on the `checkValidity` provided by the browsers instead of using our own validation.
+
+### Bug Fixes
+
+- Fix a problem that made `RangeControl` not work as expected with float values.
+
 ## 7.1.0 (2019-03-06)
 
 ### New Features
@@ -9,13 +19,11 @@
 - `withFilters` has been optimized to avoid binding hook handlers for each mounted instance of the component, instead using a single centralized hook delegator.
 - `withFilters` has been optimized to reuse a single shared component definition for all filtered instances of the component.
 - Make `RangeControl` validate min and max properties.
-- Allow users to choose if `RangeControl` input is required or not. Defaults to not be required.
 
 ### Bug Fixes
 
 - Resolves a conflict where two instance of Slot would produce an inconsistent or duplicated rendering output.
 - Allow years between 0 and 1970 in DateTime component.
-- Fix a bug that made `RangeControl` not work as expected with float values; Started relying on the browser validations instead of our own.
 
 ### New Feature
 

--- a/packages/components/src/query-controls/index.js
+++ b/packages/components/src/query-controls/index.js
@@ -79,6 +79,7 @@ export default function QueryControls( {
 				onChange={ onNumberOfItemsChange }
 				min={ minItems }
 				max={ maxItems }
+				required
 			/>
 		),
 	];

--- a/packages/components/src/range-control/README.md
+++ b/packages/components/src/range-control/README.md
@@ -184,6 +184,14 @@ The maximum value accepted. If higher values are inserted onChange will not be c
 - Type: `Number`
 - Required: No
 
+#### required
+
+If true having the input field empty is invalid if false having the input field empty is valid.
+
+- Type: `Boolean`
+- Required: Yes
+- Default: true
+
 ## Related components
 
 - To collect a numerical input in a text field, use the `TextControl` component.

--- a/packages/components/src/range-control/README.md
+++ b/packages/components/src/range-control/README.md
@@ -184,14 +184,6 @@ The maximum value accepted. If higher values are inserted onChange will not be c
 - Type: `Number`
 - Required: No
 
-#### required
-
-If true having the input field empty is invalid. If false having the input field empty is valid.
-
-- Type: `Boolean`
-- Required: Yes
-- Default: false
-
 ## Related components
 
 - To collect a numerical input in a text field, use the `TextControl` component.

--- a/packages/components/src/range-control/README.md
+++ b/packages/components/src/range-control/README.md
@@ -186,11 +186,11 @@ The maximum value accepted. If higher values are inserted onChange will not be c
 
 #### required
 
-If true having the input field empty is invalid if false having the input field empty is valid.
+If true having the input field empty is invalid. If false having the input field empty is valid.
 
 - Type: `Boolean`
 - Required: Yes
-- Default: true
+- Default: false
 
 ## Related components
 

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -30,6 +30,7 @@ function RangeControl( {
 	min,
 	max,
 	setState,
+	required = true,
 	...props
 } ) {
 	const id = `inspector-range-control-${ instanceId }`;
@@ -48,14 +49,9 @@ function RangeControl( {
 
 	const onChangeValue = ( event ) => {
 		const newValue = event.target.value;
-		const newNumericValue = parseInt( newValue, 10 );
 		// If the input value is invalid temporarily save it to the state,
 		// without calling on change.
-		if (
-			isNaN( newNumericValue ) ||
-			( min !== undefined && newNumericValue < min ) ||
-			( max !== undefined && newNumericValue > max )
-		) {
+		if ( ! event.target.checkValidity() ) {
 			setState( {
 				currentInput: newValue,
 			} );
@@ -64,9 +60,9 @@ function RangeControl( {
 		// The input is valid, reset the local state property used to temporaly save the value,
 		// and call onChange with the new value as a number.
 		resetCurrentInput();
-		onChange( newNumericValue );
+		onChange( parseFloat( newValue ) );
 	};
-	const initialSliderValue = isFinite( value ) ?
+	const initialSliderValue = isFinite( currentInputValue ) ?
 		currentInputValue :
 		initialPosition || '';
 
@@ -82,6 +78,7 @@ function RangeControl( {
 				className="components-range-control__slider"
 				id={ id }
 				type="range"
+				required={ required }
 				value={ initialSliderValue }
 				onChange={ onChangeValue }
 				aria-describedby={ !! help ? id + '__help' : undefined }
@@ -92,6 +89,7 @@ function RangeControl( {
 			<input
 				className="components-range-control__number"
 				type="number"
+				required={ required }
 				onChange={ onChangeValue }
 				aria-label={ label }
 				value={ currentInputValue }

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -30,7 +30,7 @@ function RangeControl( {
 	min,
 	max,
 	setState,
-	required = true,
+	required = false,
 	...props
 } ) {
 	const id = `inspector-range-control-${ instanceId }`;
@@ -60,7 +60,10 @@ function RangeControl( {
 		// The input is valid, reset the local state property used to temporaly save the value,
 		// and call onChange with the new value as a number.
 		resetCurrentInput();
-		onChange( parseFloat( newValue ) );
+		onChange( ( newValue === undefined || newValue === '' ) ?
+			newValue :
+			parseFloat( newValue )
+		);
 	};
 	const initialSliderValue = isFinite( currentInputValue ) ?
 		currentInputValue :

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -30,7 +30,6 @@ function RangeControl( {
 	min,
 	max,
 	setState,
-	required = false,
 	...props
 } ) {
 	const id = `inspector-range-control-${ instanceId }`;
@@ -60,8 +59,8 @@ function RangeControl( {
 		// The input is valid, reset the local state property used to temporaly save the value,
 		// and call onChange with the new value as a number.
 		resetCurrentInput();
-		onChange( ( newValue === undefined || newValue === '' ) ?
-			newValue :
+		onChange( ( newValue === '' ) ?
+			undefined :
 			parseFloat( newValue )
 		);
 	};
@@ -81,7 +80,6 @@ function RangeControl( {
 				className="components-range-control__slider"
 				id={ id }
 				type="range"
-				required={ required }
 				value={ initialSliderValue }
 				onChange={ onChangeValue }
 				aria-describedby={ !! help ? id + '__help' : undefined }
@@ -92,7 +90,6 @@ function RangeControl( {
 			<input
 				className="components-range-control__number"
 				type="number"
-				required={ required }
 				onChange={ onChangeValue }
 				aria-label={ label }
 				value={ currentInputValue }

--- a/packages/components/src/range-control/test/index.js
+++ b/packages/components/src/range-control/test/index.js
@@ -42,13 +42,23 @@ describe( 'RangeControl', () => {
 			TestUtils.Simulate.change(
 				rangeInputElement(),
 				{
-					target: { value: '5' },
+					target: {
+						value: '5',
+						checkValidity() {
+							return true;
+						},
+					},
 				}
 			);
 			TestUtils.Simulate.change(
 				numberInputElement(),
 				{
-					target: { value: '10' },
+					target: {
+						value: '10',
+						checkValidity() {
+							return true;
+						},
+					},
 				}
 			);
 
@@ -96,7 +106,12 @@ describe( 'RangeControl', () => {
 			TestUtils.Simulate.change(
 				numberInputElement(),
 				{
-					target: { value: '10' },
+					target: {
+						value: '10',
+						checkValidity() {
+							return false;
+						},
+					},
 				}
 			);
 
@@ -116,7 +131,12 @@ describe( 'RangeControl', () => {
 			TestUtils.Simulate.change(
 				numberInputElement(),
 				{
-					target: { value: '21' },
+					target: {
+						value: '21',
+						checkValidity() {
+							return false;
+						},
+					},
 				}
 			);
 
@@ -136,14 +156,24 @@ describe( 'RangeControl', () => {
 			TestUtils.Simulate.change(
 				numberInputElement(),
 				{
-					target: { value: '10' },
+					target: {
+						value: '10',
+						checkValidity() {
+							return false;
+						},
+					},
 				}
 			);
 
 			TestUtils.Simulate.change(
 				numberInputElement(),
 				{
-					target: { value: '21' },
+					target: {
+						value: '21',
+						checkValidity() {
+							return false;
+						},
+					},
 				}
 			);
 
@@ -152,7 +182,12 @@ describe( 'RangeControl', () => {
 			TestUtils.Simulate.change(
 				numberInputElement(),
 				{
-					target: { value: '14' },
+					target: {
+						value: '14',
+						checkValidity() {
+							return true;
+						},
+					},
 				}
 			);
 
@@ -171,7 +206,12 @@ describe( 'RangeControl', () => {
 			TestUtils.Simulate.change(
 				numberInputElement(),
 				{
-					target: { value: '1' },
+					target: {
+						value: '1',
+						checkValidity() {
+							return false;
+						},
+					},
 				}
 			);
 
@@ -190,7 +230,12 @@ describe( 'RangeControl', () => {
 			TestUtils.Simulate.change(
 				numberInputElement(),
 				{
-					target: { value: '-101' },
+					target: {
+						value: '-101',
+						checkValidity() {
+							return false;
+						},
+					},
 				}
 			);
 
@@ -199,7 +244,12 @@ describe( 'RangeControl', () => {
 			TestUtils.Simulate.change(
 				numberInputElement(),
 				{
-					target: { value: '-49' },
+					target: {
+						value: '-49',
+						checkValidity() {
+							return false;
+						},
+					},
 				}
 			);
 
@@ -208,7 +258,49 @@ describe( 'RangeControl', () => {
 			TestUtils.Simulate.change(
 				numberInputElement(),
 				{
-					target: { value: '-50' },
+					target: {
+						value: '-50',
+						checkValidity() {
+							return true;
+						},
+					},
+				}
+			);
+
+			expect( onChange ).toHaveBeenCalled();
+		} );
+		it( 'takes into account the step starting from min', () => {
+			const onChange = jest.fn();
+			const wrapper = getWrapper( { onChange, min: 0.1, step: 0.125, value: 0.1 } );
+
+			const numberInputElement = () => TestUtils.findRenderedDOMComponentWithClass(
+				wrapper,
+				'components-range-control__number'
+			);
+
+			TestUtils.Simulate.change(
+				numberInputElement(),
+				{
+					target: {
+						value: '0.125',
+						checkValidity() {
+							return false;
+						},
+					},
+				}
+			);
+
+			expect( onChange ).not.toHaveBeenCalled();
+
+			TestUtils.Simulate.change(
+				numberInputElement(),
+				{
+					target: {
+						value: '0.225',
+						checkValidity() {
+							return true;
+						},
+					},
 				}
 			);
 

--- a/packages/components/src/range-control/test/index.js
+++ b/packages/components/src/range-control/test/index.js
@@ -267,7 +267,7 @@ describe( 'RangeControl', () => {
 				}
 			);
 
-			expect( onChange ).toHaveBeenCalled();
+			expect( onChange ).toHaveBeenCalledWith( -50 );
 		} );
 		it( 'takes into account the step starting from min', () => {
 			const onChange = jest.fn();
@@ -304,7 +304,7 @@ describe( 'RangeControl', () => {
 				}
 			);
 
-			expect( onChange ).toHaveBeenCalled();
+			expect( onChange ).toHaveBeenCalledWith( 0.225 );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Description
Fixes:https://github.com/WordPress/gutenberg/issues/14319

During the changes I did in https://github.com/WordPress/gutenberg/pull/12952, I missed the fact that RangeControl may be used with floats. This created a regression where the component did work as expected when float values are used.
Props to @kadencethemes for reporting this issue in https://github.com/WordPress/gutenberg/pull/12952#issuecomment-470285981.\

This PR proposes an alternative approach where we make use of checkValidity() function instead of redoing our own validation.

## How has this been tested?
I pasted the following code block inside the latest posts block to try the component with floats:
```
const MyRangeControl1 = withState( {
	columns: 2,
} )( ( { columns, setState } ) => (
	<RangeControl
		label="Columns"
		value={ columns }
		onChange={ ( columns ) => setState( { columns } ) }
		min={ 0.1 }
		max={ 0.9 }
		step={ 0.125 }
	/>
) );

const MyRangeControl2 = withState( {
	columns: 2,
} )( ( { columns, setState } ) => (
	<RangeControl
		label="Columns"
		value={ columns }
		onChange={ ( columns ) => setState( { columns } ) }
		max={ 0.9 }
		step={ 0.125 }
	/>
) );
```
...
			<InspectorControls>
```				
	<MyRangeControl1 />
	<MyRangeControl2 />
````
...


I created the following "codepen" to verify the results of  checkValidity() are the ones I expected https://codepen.io/anon/pen/drvgjj?editors=1111.


I checked the columns block continues to work as expected.
