### PR TITLE
Rnmobile/clean up styles

### DIFF
--- a/packages/block-library/src/heading/style.native.scss
+++ b/packages/block-library/src/heading/style.native.scss
@@ -1,5 +1,0 @@
-@import "variables.scss";
-
-.blockText {
-	min-height: $min-height-heading;
-}

--- a/packages/block-library/src/paragraph/style.native.scss
+++ b/packages/block-library/src/paragraph/style.native.scss
@@ -1,5 +1,0 @@
-@import "variables.scss";
-
-.blockText {
-	min-height: $min-height-paragraph;
-}

--- a/packages/editor/src/components/post-title/style.native.scss
+++ b/packages/editor/src/components/post-title/style.native.scss
@@ -1,10 +1,6 @@
 
 @import "variables.scss";
 
-.blockText {
-	min-height: $min-height-title;
-}
-
 .titleContainer {
 	padding-left: 16;
 	padding-right: 16;


### PR DESCRIPTION
## Description
Clean up unused styles that were left behind after RichText content size cleanup.

## How has this been tested?
This can be tested on this mobile GB PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/722

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
