### PR TITLE
Make taxonomies test relieable

### DIFF
--- a/packages/e2e-tests/specs/taxonomies.test.js
+++ b/packages/e2e-tests/specs/taxonomies.test.js
@@ -8,6 +8,11 @@ import {
 	publishPost,
 } from '@wordpress/e2e-test-utils';
 
+/**
+ * Module constants
+ */
+const TAG_TOKEN_SELECTOR = '.components-form-token-field__token-text span:not(.screen-reader-text)';
+
 describe( 'Taxonomies', () => {
 	const canCreatTermInTaxonomy = ( taxonomy ) => {
 		return page.evaluate(
@@ -38,13 +43,13 @@ describe( 'Taxonomies', () => {
 
 	const getCurrentTags = async () => {
 		const tagsPanel = await findSidebarPanelWithTitle( 'Tags' );
-		return page.evaluate( ( node ) => {
+		return page.evaluate( ( node, selector ) => {
 			return Array.from( node.querySelectorAll(
-				'.components-form-token-field__token-text span:not(.screen-reader-text)'
+				selector
 			) ).map( ( field ) => {
 				return field.innerText;
 			} );
-		}, tagsPanel );
+		}, tagsPanel, TAG_TOKEN_SELECTOR );
 	};
 
 	it( 'should be able to open the categories panel and create a new main category if the user has the right capabilities', async () => {
@@ -123,6 +128,13 @@ describe( 'Taxonomies', () => {
 		// Open the tags panel.
 		await tagsPanel.click( 'button' );
 
+		// At the start there are no tag tokens
+		expect(
+			await page.$$(
+				TAG_TOKEN_SELECTOR
+			)
+		).toHaveLength( 0 );
+
 		const tagInput = await tagsPanel.$( '.components-form-token-field__input' );
 
 		// Click the tag input field.
@@ -134,7 +146,7 @@ describe( 'Taxonomies', () => {
 		// Press enter to create a new tag.
 		await tagInput.press( 'Enter' );
 
-		await page.waitForSelector( '.components-form-token-field__token' );
+		await page.waitForSelector( TAG_TOKEN_SELECTOR );
 
 		// Get an array with the tags of the post.
 		let tags = await getCurrentTags();


### PR DESCRIPTION
I think this change will make the test reliable. Previously the wait for selector probably was rendered before the span child that contained the tag, now we select a span child so the when the selector returns tags should exist.

I checked the end 2 end taxonomy test never failed after executing it many times on my machine and on the CI server.