### PR TITLE
RichText: try alternative list shortcuts (to tab)

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -600,6 +600,8 @@ export class RichText extends Component {
 			this.handleHorizontalNavigation( event );
 		}
 
+		// Use the space key in list items (at the start of an item) to indent
+		// the list item.
 		if ( keyCode === SPACE && this.multilineTag === 'li' ) {
 			const value = this.createRecord();
 
@@ -607,6 +609,7 @@ export class RichText extends Component {
 				const { text, start } = value;
 				const characterBefore = text[ start - 1 ];
 
+				// The caret must be at the start of a line.
 				if ( ! characterBefore || characterBefore === LINE_SEPARATOR ) {
 					this.onChange( indentListItems( value, { type: this.props.tagName } ) );
 					event.preventDefault();
@@ -634,7 +637,11 @@ export class RichText extends Component {
 					const index = start - 1;
 
 					if ( charAt( value, index ) === LINE_SEPARATOR ) {
-						if ( isCollapsed( value ) && formats[ index ] && formats[ index ].length ) {
+						const collapsed = isCollapsed( value );
+
+						// If the line separator that is about te be removed
+						// contains wrappers, remove the wrappers first.
+						if ( collapsed && formats[ index ] && formats[ index ].length ) {
 							const newFormats = formats.slice();
 
 							newFormats[ index ] = formats[ index ].slice( 0, -1 );
@@ -646,14 +653,18 @@ export class RichText extends Component {
 							newValue = remove(
 								value,
 								// Only remove the line if the selection is
-								// collapsed.
-								isCollapsed( value ) ? start - 1 : start,
+								// collapsed, otherwise remove the selection.
+								collapsed ? start - 1 : start,
 								end
 							);
 						}
 					}
 				} else if ( charAt( value, end ) === LINE_SEPARATOR ) {
-					if ( isCollapsed( value ) && formats[ end ] && formats[ end ].length ) {
+					const collapsed = isCollapsed( value );
+
+					// If the line separator that is about te be removed
+					// contains wrappers, remove the wrappers first.
+					if ( collapsed && formats[ end ] && formats[ end ].length ) {
 						const newFormats = formats.slice();
 
 						newFormats[ end ] = formats[ end ].slice( 0, -1 );
@@ -666,8 +677,8 @@ export class RichText extends Component {
 							value,
 							start,
 							// Only remove the line if the selection is
-							// collapsed.
-							isCollapsed( value ) ? end + 1 : end,
+							// collapsed, otherwise remove the selection.
+							collapsed ? end + 1 : end,
 						);
 					}
 				}

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -37,13 +37,10 @@ import {
 	insertLineSeparator,
 	isEmptyLine,
 	unstableToDom,
-	getSelectionStart,
-	getSelectionEnd,
 	remove,
 	removeFormat,
 	isCollapsed,
 	LINE_SEPARATOR,
-	charAt,
 	indentListItems,
 } from '@wordpress/rich-text';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -619,9 +616,7 @@ export class RichText extends Component {
 
 		if ( keyCode === DELETE || keyCode === BACKSPACE ) {
 			const value = this.createRecord();
-			const { formats } = value;
-			const start = getSelectionStart( value );
-			const end = getSelectionEnd( value );
+			const { replacements, text, start, end } = value;
 
 			// Always handle full content deletion ourselves.
 			if ( start === 0 && end !== 0 && end === value.text.length ) {
@@ -636,18 +631,18 @@ export class RichText extends Component {
 				if ( keyCode === BACKSPACE ) {
 					const index = start - 1;
 
-					if ( charAt( value, index ) === LINE_SEPARATOR ) {
+					if ( text[ index ] === LINE_SEPARATOR ) {
 						const collapsed = isCollapsed( value );
 
 						// If the line separator that is about te be removed
 						// contains wrappers, remove the wrappers first.
-						if ( collapsed && formats[ index ] && formats[ index ].length ) {
-							const newFormats = formats.slice();
+						if ( collapsed && replacements[ index ] && replacements[ index ].length ) {
+							const newReplacements = replacements.slice();
 
-							newFormats[ index ] = formats[ index ].slice( 0, -1 );
+							newReplacements[ index ] = replacements[ index ].slice( 0, -1 );
 							newValue = {
 								...value,
-								formats: newFormats,
+								replacements: newReplacements,
 							};
 						} else {
 							newValue = remove(
@@ -659,18 +654,18 @@ export class RichText extends Component {
 							);
 						}
 					}
-				} else if ( charAt( value, end ) === LINE_SEPARATOR ) {
+				} else if ( text[ end ] === LINE_SEPARATOR ) {
 					const collapsed = isCollapsed( value );
 
 					// If the line separator that is about te be removed
 					// contains wrappers, remove the wrappers first.
-					if ( collapsed && formats[ end ] && formats[ end ].length ) {
-						const newFormats = formats.slice();
+					if ( collapsed && replacements[ end ] && replacements[ end ].length ) {
+						const newReplacements = replacements.slice();
 
-						newFormats[ end ] = formats[ end ].slice( 0, -1 );
+						newReplacements[ end ] = replacements[ end ].slice( 0, -1 );
 						newValue = {
 							...value,
-							formats: newFormats,
+							replacements: newReplacements,
 						};
 					} else {
 						newValue = remove(

--- a/packages/block-editor/src/components/rich-text/list-edit.js
+++ b/packages/block-editor/src/components/rich-text/list-edit.js
@@ -149,6 +149,7 @@ export const ListEdit = ( {
 					{
 						icon: 'editor-outdent',
 						title: __( 'Outdent list item' ),
+						shortcut: '⌫',
 						onClick: () => {
 							onChange( outdentListItems( value ) );
 						},
@@ -156,6 +157,7 @@ export const ListEdit = ( {
 					{
 						icon: 'editor-indent',
 						title: __( 'Indent list item' ),
+						shortcut: '␣',
 						onClick: () => {
 							onChange( indentListItems( value, { type: tagName } ) );
 						},

--- a/packages/block-editor/src/components/rich-text/list-edit.js
+++ b/packages/block-editor/src/components/rich-text/list-edit.js
@@ -3,7 +3,7 @@
  */
 
 import { Toolbar } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import {
 	indentListItems,
@@ -149,7 +149,7 @@ export const ListEdit = ( {
 					{
 						icon: 'editor-outdent',
 						title: __( 'Outdent list item' ),
-						shortcut: '⌫',
+						shortcut: _x( 'Backspace', 'keyboard key' ),
 						onClick: () => {
 							onChange( outdentListItems( value ) );
 						},
@@ -157,7 +157,7 @@ export const ListEdit = ( {
 					{
 						icon: 'editor-indent',
 						title: __( 'Indent list item' ),
-						shortcut: '␣',
+						shortcut: _x( 'Space', 'keyboard key' ),
 						onClick: () => {
 							onChange( indentListItems( value, { type: tagName } ) );
 						},

--- a/packages/e2e-tests/specs/blocks/__snapshots__/list.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/list.test.js.snap
@@ -98,6 +98,44 @@ exports[`List should change the indented list type 1`] = `
 <!-- /wp:list -->"
 `;
 
+exports[`List should create and remove indented list with keyboard only 1`] = `
+"<!-- wp:list -->
+<ul><li>1<ul><li>a<ul><li>i</li></ul></li></ul></li></ul>
+<!-- /wp:list -->"
+`;
+
+exports[`List should create and remove indented list with keyboard only 2`] = `
+"<!-- wp:list -->
+<ul><li>1<ul><li>a</li><li></li></ul></li></ul>
+<!-- /wp:list -->"
+`;
+
+exports[`List should create and remove indented list with keyboard only 3`] = `
+"<!-- wp:list -->
+<ul><li>1<ul><li>a</li></ul></li><li></li></ul>
+<!-- /wp:list -->"
+`;
+
+exports[`List should create and remove indented list with keyboard only 4`] = `
+"<!-- wp:list -->
+<ul><li>1<ul><li>a</li></ul></li></ul>
+<!-- /wp:list -->"
+`;
+
+exports[`List should create and remove indented list with keyboard only 5`] = `
+"<!-- wp:list -->
+<ul><li>1</li><li></li></ul>
+<!-- /wp:list -->"
+`;
+
+exports[`List should create and remove indented list with keyboard only 6`] = `
+"<!-- wp:list -->
+<ul><li>1</li></ul>
+<!-- /wp:list -->"
+`;
+
+exports[`List should create and remove indented list with keyboard only 7`] = `""`;
+
 exports[`List should create paragraph on split at end and merge back with content 1`] = `
 "<!-- wp:list -->
 <ul><li>one</li></ul>

--- a/packages/e2e-tests/specs/blocks/list.test.js
+++ b/packages/e2e-tests/specs/blocks/list.test.js
@@ -304,4 +304,46 @@ describe( 'List', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should create and remove indented list with keyboard only', async () => {
+		await clickBlockAppender();
+
+		await page.keyboard.type( '* 1' ); // Should be at level 0.
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( ' a' ); // Should be at level 1.
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( ' i' ); // Should be at level 2.
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.press( 'Backspace' ); // Should be at level 1.
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await page.keyboard.press( 'Backspace' ); // Should be at level 0.
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await page.keyboard.press( 'Backspace' ); // Should be at level 1.
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.press( 'Backspace' ); // Should be at level 0.
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await page.keyboard.press( 'Backspace' ); // Should be at level 0.
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.press( 'Backspace' ); // Should remove list.
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		// That's 9 key presses to create the list, and 9 key presses to remove
+		// the list. ;)
+	} );
 } );


### PR DESCRIPTION
## Description

Fixes #9611. ~~Still needs tests.~~

I'm following up on the idea that @mcsf had regarding list indentation shortcuts in https://github.com/WordPress/gutenberg/issues/9611#issuecomment-454048403.

* `BACKSPACE` to remove indentation. This makes a TON of sense to me. It feels very intuitive.
* `SPACE` at the start to indent a list item. I like this!
  * Visually you want to *add* indentation (space), so it makes sense to use the space key for it.
  * It's a bit similar to Markdown, but then only one space.
  * I like how `SPACE` is the opposite of `BACKSPACE`.
  * Downside: it's hard to rewire the `TAB` habit, but I feel already used to it. On the other hand, it's much easier to remember than the complicated modifier shortcuts.
  * Downside: you cannot add spaces to the start of a line, but why would you? :)

Question: should we add any tooltips? If so, what symbols or words should we use?

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->