### PR TITLE
Set minHeight based on fontSize or style.

### DIFF
--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -520,7 +520,7 @@ export class RichText extends Component {
 
 			this.lastEventCount = undefined; // force a refresh on the native side
 		}
-		let minHeight = 0;
+		let minHeight = this.props.fontSize ? this.props.fontSize : styles[ 'editor-rich-text' ].minHeight;
 		if ( style && style.minHeight ) {
 			minHeight = style.minHeight;
 		}

--- a/packages/editor/src/components/rich-text/index.native.js
+++ b/packages/editor/src/components/rich-text/index.native.js
@@ -520,7 +520,7 @@ export class RichText extends Component {
 
 			this.lastEventCount = undefined; // force a refresh on the native side
 		}
-		let minHeight = this.props.fontSize ? this.props.fontSize : styles[ 'editor-rich-text' ].minHeight;
+		let minHeight = styles[ 'editor-rich-text' ].minHeight;
 		if ( style && style.minHeight ) {
 			minHeight = style.minHeight;
 		}

--- a/packages/editor/src/components/rich-text/style.native.scss
+++ b/packages/editor/src/components/rich-text/style.native.scss
@@ -4,4 +4,5 @@
 .editor-rich-text {
 	font-family: $default-regular-font;
 	text-decoration-color: $gray;
+	min-height: $min-height-paragraph;
 }


### PR DESCRIPTION
## Description
Make sure we have initial min-height that works properly for all platforms.

## How has this been tested?
This can be tested on this mobile GB PR:https://github.com/wordpress-mobile/gutenberg-mobile/pull/723

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
