### PR TITLE
Edited post-locked-modal button text to be actionable

### DIFF
--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -145,7 +145,7 @@ class PostLockedModal extends Component {
 		const allPostsUrl = getWPAdminURL( 'edit.php', {
 			post_type: get( postType, [ 'slug' ] ),
 		} );
-		const allPostsLabel = get( postType, [ 'labels', 'all_items' ] );
+		const allPostsLabel = __( 'Exit the Editor' );
 		return (
 			<Modal
 				title={ isTakeover ? __( 'Someone else has taken over this post.' ) : __( 'This post is already being edited.' ) }


### PR DESCRIPTION
## Description
Fixes #14345. Updated the text on the button "All Posts" to "Exit the Editor."

Props to @michelleweber and @kjellr 

## How has this been tested?
Tested locally.

## Screenshots 

**When taking over a screen**

![screen shot 2019-03-08 at 7 56 23 am](https://user-images.githubusercontent.com/617986/54039802-b4fef700-4178-11e9-8170-959afd34e492.png)

**When having screen taken over from you**

![screen shot 2019-03-08 at 7 55 58 am](https://user-images.githubusercontent.com/617986/54039815-bb8d6e80-4178-11e9-9d3d-acc4741a654e.png)


## Types of changes
Just button label text changes.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
