### PR TITLE
Fix: Quote to heading transform; Add end 2 end tests for the transform.

### DIFF
--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -186,21 +186,27 @@ export const settings = {
 					}
 
 					const pieces = split( create( { html: value, multilineTag: 'p' } ), '\u2028' );
+
+					const headingBlock = createBlock( 'core/heading', {
+						content: toHTMLString( { value: pieces[ 0 ] } ),
+					} );
+
+					if ( ! citation && pieces.length === 1 ) {
+						return headingBlock;
+					}
+
 					const quotePieces = pieces.slice( 1 );
 
-					return [
-						createBlock( 'core/heading', {
-							content: toHTMLString( { value: pieces[ 0 ] } ),
+					const quoteBlock = createBlock( 'core/quote', {
+						...attrs,
+						citation,
+						value: toHTMLString( {
+							value: quotePieces.length ? join( pieces.slice( 1 ), '\u2028' ) : create(),
+							multilineTag: 'p',
 						} ),
-						createBlock( 'core/quote', {
-							...attrs,
-							citation,
-							value: toHTMLString( {
-								value: quotePieces.length ? join( pieces.slice( 1 ), '\u2028' ) : create(),
-								multilineTag: 'p',
-							} ),
-						} ),
-					];
+					} );
+
+					return [ headingBlock, quoteBlock ];
 				},
 			},
 

--- a/packages/e2e-tests/specs/blocks/__snapshots__/quote.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/quote.test.js.snap
@@ -6,44 +6,6 @@ exports[`Quote can be converted to a pullquote 1`] = `
 <!-- /wp:pullquote -->"
 `;
 
-exports[`Quote can be converted to headings 1`] = `
-"<!-- wp:heading -->
-<h2>one</h2>
-<!-- /wp:heading -->
-
-<!-- wp:quote -->
-<blockquote class=\\"wp-block-quote\\"><p>two</p><cite>cite</cite></blockquote>
-<!-- /wp:quote -->"
-`;
-
-exports[`Quote can be converted to headings 2`] = `
-"<!-- wp:heading -->
-<h2>one</h2>
-<!-- /wp:heading -->
-
-<!-- wp:heading -->
-<h2>two</h2>
-<!-- /wp:heading -->
-
-<!-- wp:quote -->
-<blockquote class=\\"wp-block-quote\\"><p></p><cite>cite</cite></blockquote>
-<!-- /wp:quote -->"
-`;
-
-exports[`Quote can be converted to headings 3`] = `
-"<!-- wp:heading -->
-<h2>one</h2>
-<!-- /wp:heading -->
-
-<!-- wp:heading -->
-<h2>two</h2>
-<!-- /wp:heading -->
-
-<!-- wp:heading -->
-<h2>cite</h2>
-<!-- /wp:heading -->"
-`;
-
 exports[`Quote can be converted to paragraphs and renders a paragraph for the cite, if it exists 1`] = `
 "<!-- wp:paragraph -->
 <p>one</p>
@@ -116,4 +78,74 @@ exports[`Quote can be merged into from a paragraph 1`] = `
 "<!-- wp:quote -->
 <blockquote class=\\"wp-block-quote\\"><p>test</p></blockquote>
 <!-- /wp:quote -->"
+`;
+
+exports[`Quote is transformed to a heading and a quote if the quote contains a citation 1`] = `
+"<!-- wp:heading -->
+<h2>one</h2>
+<!-- /wp:heading -->
+
+<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p></p><cite>cite</cite></blockquote>
+<!-- /wp:quote -->"
+`;
+
+exports[`Quote is transformed to a heading and a quote if the quote contains multiple paragraphs 1`] = `
+"<!-- wp:heading -->
+<h2>one</h2>
+<!-- /wp:heading -->
+
+<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p>two</p><p>three</p></blockquote>
+<!-- /wp:quote -->"
+`;
+
+exports[`Quote is transformed to a heading if the quote just contains one paragraph 1`] = `
+"<!-- wp:heading -->
+<h2>one</h2>
+<!-- /wp:heading -->"
+`;
+
+exports[`Quote is transformed to an empty heading if the quote is empty 1`] = `
+"<!-- wp:heading -->
+<h2></h2>
+<!-- /wp:heading -->"
+`;
+
+exports[`Quote the resuling quote after transforming to a heading can be transformed again 1`] = `
+"<!-- wp:heading -->
+<h2>one</h2>
+<!-- /wp:heading -->
+
+<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p>two</p><cite>cite</cite></blockquote>
+<!-- /wp:quote -->"
+`;
+
+exports[`Quote the resuling quote after transforming to a heading can be transformed again 2`] = `
+"<!-- wp:heading -->
+<h2>one</h2>
+<!-- /wp:heading -->
+
+<!-- wp:heading -->
+<h2>two</h2>
+<!-- /wp:heading -->
+
+<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p></p><cite>cite</cite></blockquote>
+<!-- /wp:quote -->"
+`;
+
+exports[`Quote the resuling quote after transforming to a heading can be transformed again 3`] = `
+"<!-- wp:heading -->
+<h2>one</h2>
+<!-- /wp:heading -->
+
+<!-- wp:heading -->
+<h2>two</h2>
+<!-- /wp:heading -->
+
+<!-- wp:heading -->
+<h2>cite</h2>
+<!-- /wp:heading -->"
 `;

--- a/packages/e2e-tests/specs/blocks/quote.test.js
+++ b/packages/e2e-tests/specs/blocks/quote.test.js
@@ -116,7 +116,40 @@ describe( 'Quote', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
-	it( 'can be converted to headings', async () => {
+	it( 'is transformed to an empty heading if the quote is empty', async () => {
+		await insertBlock( 'Quote' );
+		await transformBlockTo( 'Heading' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'is transformed to a heading if the quote just contains one paragraph', async () => {
+		await insertBlock( 'Quote' );
+		await page.keyboard.type( 'one' );
+		await transformBlockTo( 'Heading' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'is transformed to a heading and a quote if the quote contains multiple paragraphs', async () => {
+		await insertBlock( 'Quote' );
+		await page.keyboard.type( 'one' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'two' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'three' );
+		await transformBlockTo( 'Heading' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'is transformed to a heading and a quote if the quote contains a citation', async () => {
+		await insertBlock( 'Quote' );
+		await page.keyboard.type( 'one' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.type( 'cite' );
+		await transformBlockTo( 'Heading' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'the resuling quote after transforming to a heading can be transformed again', async () => {
 		await insertBlock( 'Quote' );
 		await page.keyboard.type( 'one' );
 		await page.keyboard.press( 'Enter' );


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/14313

Quote to heading transform was not working properly and empty quote blocks were created as part of the transform for some quotes e.g: an empty quote, and quote with just one paragraph.

This is not the first time we had this regression so I am adding end 2 end tests with this PR. 

## How has this been tested?
I checked transforming an empty quote to a heading produces an empty heading.
I checked transforming a quote with one paragraph to a heading produces a heading.