### PR TITLE
apply root with higher priority

### DIFF
--- a/packages/editor/src/editor-styles/transforms/test/__snapshots__/wrap.js.snap
+++ b/packages/editor/src/editor-styles/transforms/test/__snapshots__/wrap.js.snap
@@ -17,20 +17,14 @@ opacity: 0;
 
 exports[`CSS selector wrap should ignore selectors 1`] = `
 ".my-namespace h1,
-.my-namespace:not(EDITOR_STYLES),
 body {
 color: red;
 }"
 `;
 
-exports[`CSS selector wrap should replace :root selectors 1`] = `
-".my-namespace:not(EDITOR_STYLES) {
---my-color: #ff0000;
-}"
-`;
-
 exports[`CSS selector wrap should replace root tags 1`] = `
 ".my-namespace,
+.my-namespace:not(EDITOR_STYLES),
 .my-namespace h1 {
 color: red;
 }"

--- a/packages/editor/src/editor-styles/transforms/test/__snapshots__/wrap.js.snap
+++ b/packages/editor/src/editor-styles/transforms/test/__snapshots__/wrap.js.snap
@@ -17,8 +17,15 @@ opacity: 0;
 
 exports[`CSS selector wrap should ignore selectors 1`] = `
 ".my-namespace h1,
+.my-namespace:not(EDITOR_STYLES),
 body {
 color: red;
+}"
+`;
+
+exports[`CSS selector wrap should replace :root selectors 1`] = `
+".my-namespace:not(EDITOR_STYLES) {
+--my-color: #ff0000;
 }"
 `;
 
@@ -39,11 +46,5 @@ color: red;
 exports[`CSS selector wrap should wrap regular selectors 1`] = `
 ".my-namespace h1 {
 color: red;
-}"
-`;
-
-exports[`CSS selector wrap should replace :root selectors 1`] = `
-".my-namespace {
---my-color: #ff0000;
 }"
 `;

--- a/packages/editor/src/editor-styles/transforms/test/wrap.js
+++ b/packages/editor/src/editor-styles/transforms/test/wrap.js
@@ -23,7 +23,7 @@ describe( 'CSS selector wrap', () => {
 
 	it( 'should ignore selectors', () => {
 		const callback = wrap( '.my-namespace', 'body' );
-		const input = `h1, body { color: red; }`;
+		const input = `h1, :root, body { color: red; }`;
 		const output = traverse( input, callback );
 
 		expect( output ).toMatchSnapshot();

--- a/packages/editor/src/editor-styles/transforms/test/wrap.js
+++ b/packages/editor/src/editor-styles/transforms/test/wrap.js
@@ -23,7 +23,7 @@ describe( 'CSS selector wrap', () => {
 
 	it( 'should ignore selectors', () => {
 		const callback = wrap( '.my-namespace', 'body' );
-		const input = `h1, :root, body { color: red; }`;
+		const input = `h1, body { color: red; }`;
 		const output = traverse( input, callback );
 
 		expect( output ).toMatchSnapshot();
@@ -31,7 +31,7 @@ describe( 'CSS selector wrap', () => {
 
 	it( 'should replace root tags', () => {
 		const callback = wrap( '.my-namespace' );
-		const input = `body, h1 { color: red; }`;
+		const input = `body, :root, h1 { color: red; }`;
 		const output = traverse( input, callback );
 
 		expect( output ).toMatchSnapshot();
@@ -56,17 +56,6 @@ describe( 'CSS selector wrap', () => {
 		@font-face {
 			font-family: myFirstFont;
 			src: url(sansation_light.woff);
-		}`;
-		const output = traverse( input, callback );
-
-		expect( output ).toMatchSnapshot();
-	} );
-
-	it( 'should replace :root selectors', () => {
-		const callback = wrap( '.my-namespace' );
-		const input = `
-		:root {
-			--my-color: #ff0000;
 		}`;
 		const output = traverse( input, callback );
 

--- a/packages/editor/src/editor-styles/transforms/wrap.js
+++ b/packages/editor/src/editor-styles/transforms/wrap.js
@@ -19,8 +19,14 @@ const wrap = ( namespace, ignore = [] ) => ( node ) => {
 			return namespace + ' ' + selector;
 		}}
 
+		// If explicity :root selector namespace with pseudo to respect original specificity intended on namespace.
+		if ( ':root' === selector.trim() ) {
+			// We use an invalid negation to inherit the negation's :pseudo specificity weight applied on namespace.
+			return selector.replace( ':root', `${ namespace }:not(EDITOR_STYLES)` );
+		}
+
 		// HTML and Body elements cannot be contained within our container so lets extract their styles.
-		return selector.replace( /^(body|html|:root)/, namespace );
+		return selector.replace( /^(body|html)/, namespace );
 	};
 
 	if ( node.type === 'rule' ) {


### PR DESCRIPTION
I see this has finally been given attention in PR https://github.com/WordPress/gutenberg/pull/13325  I opened an issue and pr for this before gutenberg was added to core, along with asking for review in slack a few times :(.  Anyways please check out some of the information from my original PR here: https://github.com/WordPress/gutenberg/pull/11957  Also read the original issue which overs more: https://github.com/WordPress/gutenberg/issues/11955

The current implementation that was merged in is giving priority to `:root` the same as `html`/`body` element, but `:root` needs to take precedence over those.  

As a way of introducing the same level specificity that `:root` has over `html` with how the editor-style wrap is working, I think this would be a better approach.  This gives `.namespace:root` applied as `.namespace:not(EDITOR_STYLES)`.  This uses a useless negation selector to increase the specificity, which is documented in the [w3 spec](https://www.w3.org/TR/2018/REC-selectors-3-20181106/#negation).  Also see note at bottom of that section for useless negations.

Checklist:
[ x ] My code is tested.
[ x ] My code follows the WordPress code style.
[ x ] My code follows the accessibility standards.
[ x ] My code has proper inline documentation.