### PR TITLE
Build: Only prompt clean if unclean

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -47,18 +47,21 @@ fi
 # Do a dry run of the repository reset. Prompting the user for a list of all
 # files that will be removed should prevent them from losing important files!
 status "Resetting the repository to pristine condition. ✨"
-git clean -xdf --dry-run
-warning "🚨 About to delete everything above! Is this okay? 🚨"
-echo -n "[y]es/[N]o: "
-read answer
-if [ "$answer" != "${answer#[Yy]}" ]; then
-	# Remove ignored files to reset repository to pristine condition. Previous
-	# test ensures that changed files abort the plugin build.
-	status "Cleaning working directory... 🛀"
-	git clean -xdf
-else
-	error "Fair enough; aborting. Tidy up your repo and try again. 🙂"
-	exit 1
+to_clean=$(git clean -xdf --dry-run)
+if [ ! -z "$to_clean" ]; then
+	echo $to_clean
+	warning "🚨 About to delete everything above! Is this okay? 🚨"
+	echo -n "[y]es/[N]o: "
+	read answer
+	if [ "$answer" != "${answer#[Yy]}" ]; then
+		# Remove ignored files to reset repository to pristine condition. Previous
+		# test ensures that changed files abort the plugin build.
+		status "Cleaning working directory... 🛀"
+		git clean -xdf
+	else
+		error "Fair enough; aborting. Tidy up your repo and try again. 🙂"
+		exit 1
+	fi
 fi
 
 # Download all vendor scripts


### PR DESCRIPTION
This pull request seeks to enhance the plugin build script to avoid prompting the user if the build environment is already pristine.

**Testing instructions:**

Reset everything to pristine:

```
git clean -fdx
```

Touch `node_modules`:

```
touch node_modules
```

Run package script:

```
npm run package-plugin
```

Verify prompt is shown.

Reset everything to pristine:

```
git clean -fdx
```

Run package script:

```
npm run package-plugin
```

Verify prompt is not shown.