### PR TITLE
Plugin: Remove postinstall step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ jobs:
       install:
         - npm ci
       script:
+        - npm run build
         - npm run lint
         - npm run check-local-changes
         - npm run check-licenses

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ jobs:
       script:
         - npm run lint
         - npm run check-local-changes
+        - npm run check-licenses
         - npm run test-unit -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache"
 
     - name: PHP unit tests (Docker)

--- a/package.json
+++ b/package.json
@@ -175,7 +175,6 @@
 		"lint-css": "wp-scripts lint-style '**/*.scss'",
 		"lint-css:fix": "npm run lint-css -- --fix",
 		"package-plugin": "./bin/build-plugin-zip.sh",
-		"postinstall": "npm run check-licenses && npm run build:packages",
 		"pot-to-php": "./bin/pot-to-php.js",
 		"precommit": "lint-staged",
 		"publish:check": "npm run build:packages && lerna updated",


### PR DESCRIPTION
Extracted from: #14289

This pull request seeks to serve as a more conservative and immediate solution to the broader performance task explored in #14289. Specifically, it removes the `postinstall` script to avoid double-builds which occur in many Travis jobs and in the plugin build step (`bin/package-plugin.sh`).

**Testing instructions:**

Verify neither `check-licenses` nor `build` is run upon `npm install`.

Ensure `npm run check-licenses` is accounted for in Travis build under "JS unit tests" job.