### PR TITLE
Adds details about the isResolving selector to the docs

### DIFF
--- a/docs/designers-developers/developers/data/data-core.md
+++ b/docs/designers-developers/developers/data/data-core.md
@@ -12,6 +12,17 @@ otherwise.
  * state: Data state.
  * url: URL the preview would be for.
 
+### isResolving
+
+Returns true if resolution has been triggered but has not yet completed for a given reducer key, selector name, and arguments set, or false otherwise
+
+*Parameters*
+
+ * state: Data state.
+ * reducerKey: Registered store reducer key.
+ * selectorName: Selector name.
+ * args: Arguments passed to selector
+
 ### getAuthors
 
 Returns all available authors.


### PR DESCRIPTION
## Description
Just a small addition to core data docs of the isResolving selector - couldn't find details anywhere else in docs about this other than in the deprecation notes. Not sure if this is the correction part of the docs to add it - happy to move it elsewhere if not.

## How has this been tested?
Just a documentation change.

## Types of changes
Documentation change only

## Checklist:
- [X ] I've included developer documentation if appropriate. 
