### PR TITLE
Fix: Pasting captions without an image fails

### DIFF
--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -128,9 +128,15 @@ export function stripFirstImage( attributes, { shortcode } ) {
 
 	body.innerHTML = shortcode.content;
 
-	const firstImage = body.querySelector( 'img' );
-	if ( firstImage ) {
-		firstImage.parentNode.removeChild( firstImage );
+	let nodeToRemove = body.querySelector( 'img' );
+
+	// if an image has parents, find the topmost node to remove
+	while ( nodeToRemove && nodeToRemove.parentNode && nodeToRemove.parentNode !== body ) {
+		nodeToRemove = nodeToRemove.parentNode;
+	}
+
+	if ( nodeToRemove ) {
+		nodeToRemove.parentNode.removeChild( nodeToRemove );
 	}
 
 	return body.innerHTML.trim();

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -123,6 +123,19 @@ function getFirstAnchorAttributeFormHTML( html, attributeName ) {
 	}
 }
 
+export function stripFirstImage( attributes, { shortcode } ) {
+	const { body } = document.implementation.createHTMLDocument( '' );
+
+	body.innerHTML = shortcode.content;
+
+	const firstImage = body.querySelector( 'img' );
+	if ( firstImage ) {
+		firstImage.parentNode.removeChild( firstImage );
+	}
+
+	return body.innerHTML.trim();
+}
+
 export const settings = {
 	title: __( 'Image' ),
 
@@ -196,14 +209,7 @@ export const settings = {
 						selector: 'img',
 					},
 					caption: {
-						shortcode: ( attributes, { shortcode } ) => {
-							const { body } = document.implementation.createHTMLDocument( '' );
-
-							body.innerHTML = shortcode.content;
-							body.removeChild( body.firstElementChild );
-
-							return body.innerHTML.trim();
-						},
+						shortcode: stripFirstImage,
 					},
 					href: {
 						shortcode: ( attributes, { shortcode } ) => {

--- a/packages/block-library/src/image/test/index.js
+++ b/packages/block-library/src/image/test/index.js
@@ -25,4 +25,8 @@ describe( 'stripFirstImage', () => {
 	test( 'should strip out only the first of many images', () => {
 		expect( stripFirstImage( {}, { shortcode: { content: '<img><img>' } } ) ).toEqual( '<img>' );
 	} );
+
+	test( 'should strip out the first image and its wrapping parents', () => {
+		expect( stripFirstImage( {}, { shortcode: { content: '<p><a><img></a></p><p><img></p>' } } ) ).toEqual( '<p><img></p>' );
+	} );
 } );

--- a/packages/block-library/src/image/test/index.js
+++ b/packages/block-library/src/image/test/index.js
@@ -1,0 +1,28 @@
+/**
+ * Internal dependencies
+ */
+import { stripFirstImage } from '../';
+
+describe( 'stripFirstImage', () => {
+	test( 'should do nothing if no image is present', () => {
+		expect( stripFirstImage( {}, { shortcode: { content: '' } } ) ).toEqual( '' );
+		expect( stripFirstImage( {}, { shortcode: { content: 'Tucson' } } ) ).toEqual( 'Tucson' );
+		expect( stripFirstImage( {}, { shortcode: { content: '<em>Tucson</em>' } } ) ).toEqual( '<em>Tucson</em>' );
+	} );
+
+	test( 'should strip out image when leading as expected', () => {
+		expect( stripFirstImage( {}, { shortcode: { content: '<img>' } } ) ).toEqual( '' );
+		expect( stripFirstImage( {}, { shortcode: { content: '<img>Image!' } } ) ).toEqual( 'Image!' );
+		expect( stripFirstImage( {}, { shortcode: { content: '<img src="image.png">Image!' } } ) ).toEqual( 'Image!' );
+	} );
+
+	test( 'should strip out image when not in leading position as expected', () => {
+		expect( stripFirstImage( {}, { shortcode: { content: 'Before<img>' } } ) ).toEqual( 'Before' );
+		expect( stripFirstImage( {}, { shortcode: { content: 'Before<img>Image!' } } ) ).toEqual( 'BeforeImage!' );
+		expect( stripFirstImage( {}, { shortcode: { content: 'Before<img src="image.png">Image!' } } ) ).toEqual( 'BeforeImage!' );
+	} );
+
+	test( 'should strip out only the first of many images', () => {
+		expect( stripFirstImage( {}, { shortcode: { content: '<img><img>' } } ) ).toEqual( '<img>' );
+	} );
+} );


### PR DESCRIPTION
Fixes #13527
See original work in #12315
See [reduced input that produces the problem](https://gist.githubusercontent.com/dmsnell/7ff1976a42472978ae5193c75873b39e/raw/75fa1ab2bc49a679ab6887c7accc188e981327c7/gb-%252313527), shortened from [the original](https://gist.githubusercontent.com/florianbrinkmann/4e9e4d23eaefb8b23484badddd848196/raw/2627e95996e362e5f177b8e5c58b8f38d95de56c/much-content.html).

When pasting content which includes the `[caption]` shortcode we assume
that the content is well-formed (that there is not only an `<img />` in
there but also in the first position).

In this patch we fix the problem by removing the old code, which removed
the first `Element` node, and replaced it with code that removes the
first `IMG` node _if one is found_.

We're leaving other image nodes in place in case the caption contains
image nodes and we're not requiring that the `IMG` be the first child
of the caption shortcode in case people are wrapping the image in other
valid HTML like this...

```html
[caption]<a href="some.link"><img src="some.image"></a>[/caption]
```

See the new unit tests for a more complete specification of the
intended behaviors.

PR reviewed, debugged, and created by:
-> LANNISTER MOB <-
 - @codebykat
 - @dmsnell
 - @gwwar
 - @kwight
 - @mmtr
 - @obenland
 - @rodrigoi
 - @vindl

## Testing

Confirm that the new unit tests pass:

```bash
npm run test-unit packages/block-library/src/image
npm run test test/integration/blocks-raw-handling.spec.js
```

Also test by pasting in the [input text which triggers the bug](https://gist.githubusercontent.com/dmsnell/7ff1976a42472978ae5193c75873b39e/raw/75fa1ab2bc49a679ab6887c7accc188e981327c7/gb-%252313527). In `master` it
should fail as described with the error in the console but in this
branch it should paste as expected without error and an image block
should appear.

Finally verify that no regressions occur when converting a classic block
which contains images with the `[caption]` shortcode. This was the goal
of #12315 when it was merged.

![ReallyLongPostPaste mov](https://user-images.githubusercontent.com/5431237/54093971-64df8a80-435a-11e9-947a-02fcd9f54375.gif)
