### PR TITLE
[Mobile]Fix placeholder position of block appender

### DIFF
--- a/packages/editor/src/components/default-block-appender/index.native.js
+++ b/packages/editor/src/components/default-block-appender/index.native.js
@@ -7,10 +7,10 @@ import { TouchableWithoutFeedback, View } from 'react-native';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { RichText } from '@wordpress/editor';
 import { compose } from '@wordpress/compose';
 import { decodeEntities } from '@wordpress/html-entities';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { RichText } from '@wordpress/editor';
 
 /**
  * Internal dependencies

--- a/packages/editor/src/components/default-block-appender/index.native.js
+++ b/packages/editor/src/components/default-block-appender/index.native.js
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { decodeEntities } from '@wordpress/html-entities';
 import { withSelect, withDispatch } from '@wordpress/data';
+import { RichText } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -21,6 +22,7 @@ export function DefaultBlockAppender( {
 	isVisible,
 	onAppend,
 	placeholder,
+	containerStyle,
 } ) {
 	if ( isLocked || ! isVisible ) {
 		return null;
@@ -33,13 +35,9 @@ export function DefaultBlockAppender( {
 			onPress={ onAppend }
 		>
 			<View style={ styles.blockHolder } pointerEvents="box-only">
-				<View style={ styles.blockContainer }>
-					<TextInput
-						style={ styles.textView }
-						textAlignVertical="top"
-						multiline
-						numberOfLines={ 0 }
-						value={ value }
+				<View style={ containerStyle }>
+					<RichText
+						placeholder={ value }
 					/>
 				</View>
 			</View>

--- a/packages/editor/src/components/default-block-appender/index.native.js
+++ b/packages/editor/src/components/default-block-appender/index.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { TextInput, TouchableWithoutFeedback, View } from 'react-native';
+import { TouchableWithoutFeedback, View } from 'react-native';
 
 /**
  * WordPress dependencies

--- a/packages/editor/src/components/default-block-appender/index.native.js
+++ b/packages/editor/src/components/default-block-appender/index.native.js
@@ -34,12 +34,10 @@ export function DefaultBlockAppender( {
 		<TouchableWithoutFeedback
 			onPress={ onAppend }
 		>
-			<View style={ styles.blockHolder } pointerEvents="box-only">
-				<View style={ containerStyle }>
-					<RichText
-						placeholder={ value }
-					/>
-				</View>
+			<View style={ [ styles.blockHolder, containerStyle ] } pointerEvents="box-only">
+				<RichText
+					placeholder={ value }
+				/>
 			</View>
 		</TouchableWithoutFeedback>
 	);

--- a/packages/editor/src/components/default-block-appender/style.native.scss
+++ b/packages/editor/src/components/default-block-appender/style.native.scss
@@ -1,8 +1,5 @@
 // @format
 
-@import "variables.scss";
-@import "colors.scss";
-
 .blockHolder {
 	flex: 1 1 auto;
 }

--- a/packages/editor/src/components/default-block-appender/style.native.scss
+++ b/packages/editor/src/components/default-block-appender/style.native.scss
@@ -6,16 +6,3 @@
 .blockHolder {
 	flex: 1 1 auto;
 }
-
-.blockContainer {
-	background-color: $white;
-	padding-top: 0;
-	padding-left: 16px;
-	padding-right: 16px;
-}
-
-.textView {
-	color: $gray;
-	font-size: 16px;
-	font-family: $default-regular-font;
-}


### PR DESCRIPTION
## Description
To fix: https://github.com/wordpress-mobile/gutenberg-mobile/issues/637

Updated block appender to match the placeholder position of paragraph block.

## How has this been tested?

Tested with steps on https://github.com/wordpress-mobile/gutenberg-mobile/pull/732

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
