### PR TITLE
Add missing module entry point to notices package.json file

### DIFF
--- a/packages/notices/package.json
+++ b/packages/notices/package.json
@@ -18,6 +18,7 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"main": "build/index.js",
+	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.3.1",


### PR DESCRIPTION
## Description

When discussing how Gutenberg for Drupal with https://github.com/front team, @SofiaSousa mentioned that they had to override `@wordpress/notices` package because of missing `build-module` folder. It turns out the folder is there but it isn't exposed in `package.json` file with `module` field. This PR fixes it.