### PR TITLE
Use <s> for strikethrough, not <del>

### DIFF
--- a/packages/e2e-tests/specs/__snapshots__/rich-text.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/rich-text.test.js.snap
@@ -8,7 +8,7 @@ exports[`RichText should apply formatting when selection is collapsed 1`] = `
 
 exports[`RichText should apply formatting with access shortcut 1`] = `
 "<!-- wp:paragraph -->
-<p><del>test</del></p>
+<p><s>test</s></p>
 <!-- /wp:paragraph -->"
 `;
 

--- a/packages/format-library/src/strikethrough/index.js
+++ b/packages/format-library/src/strikethrough/index.js
@@ -11,7 +11,7 @@ const name = 'core/strikethrough';
 export const strikethrough = {
 	name,
 	title: __( 'Strikethrough' ),
-	tagName: 'del',
+	tagName: 's',
 	className: null,
 	edit( { isActive, value, onChange } ) {
 		const onToggle = () => onChange( toggleFormat( value, { type: name } ) );


### PR DESCRIPTION
## Description

## The s element falls under text-level semantics, just like bold and italic.

> The s element represents contents that are no longer accurate or no longer relevant.
>
> The s element is not appropriate when indicating document edits; to mark a span of text as having been removed from a document, use the del element.
>
> In this example a recommended retail price has been marked as no longer relevant as the product in question has a new sale price.
>
> ```html
> <p>Buy our Iced Tea and Lemonade!</p>
> <p><s>Recommended retail price: $3.99 per bottle</s></p>
> <p><strong>Now selling for just $2.99 a bottle!</strong></p>
> ```
>
> https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-s-element

## [The ins and del elements represent edits to the document.](https://html.spec.whatwg.org/multipage/edits.html#edits)

The `ins` and `del` element are meant to be used together. They also share the same attribute spec (`cite` and `datetime`).

> The del element represents a removal from the document.
>
> del elements should not cross implied paragraph boundaries.
>
> The following shows a "to do" list where items that have been done are crossed-off with the date and time of their completion.
> 
> ```html
> <h1>To Do</h1>
> <ul>
>  <li>Empty the dishwasher</li>
>  <li><del datetime="2009-10-11T01:25-07:00">Watch Walter Lewin's lectures</del></li>
>  <li><del datetime="2009-10-10T23:38-07:00">Download more tracks</del></li>
>  <li>Buy a printer</li>
> </ul>
> ```
>
> https://html.spec.whatwg.org/multipage/edits.html#the-del-element

## What about other editors?

* TinyMCE has always used inline styles for it. It was WordPress that mapped it to the del element.
* CKEditor uses the s element. [Some interesting discussion](https://github.com/ckeditor/editor-recommendations/issues/3).
* Someone from CKEditor put together a [table](https://gist.github.com/Comandeer/623b317e09af53c75e46) of what elements are used for different formats in a bunch of editors.

Thoughts?

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->