### PR TITLE
Fix: Legacy widget: callback widgets with a edit form.

### DIFF
--- a/packages/block-library/src/legacy-widget/edit/dom-manager.js
+++ b/packages/block-library/src/legacy-widget/edit/dom-manager.js
@@ -110,28 +110,24 @@ class LegacyWidgetEditDomManager extends Component {
 
 	retrieveUpdatedInstance() {
 		if ( this.formRef.current ) {
-			const { idBase, widgetNumber } = this.props;
 			const form = this.formRef.current;
 			const formData = new window.FormData( form );
 			const updatedInstance = {};
-			const keyPrefixLength = `widget-${ idBase }[${ widgetNumber }][`.length;
-			const keySuffixLength = `]`.length;
-			for ( const rawKey of formData.keys() ) {
+			for ( const key of formData.keys() ) {
 				// This fields are added to the form because the widget JavaScript code may use this values.
 				// They are not relevant for the update mechanism.
 				if ( includes(
 					[ 'widget-id', 'id_base', 'widget_number', 'multi_number', 'add_new' ],
-					rawKey,
+					key,
 				) ) {
 					continue;
 				}
-				const keyParsed = rawKey.substring( keyPrefixLength, rawKey.length - keySuffixLength );
 
-				const value = formData.getAll( rawKey );
+				const value = formData.getAll( key );
 				if ( value.length > 1 ) {
-					updatedInstance[ keyParsed ] = value;
+					updatedInstance[ key ] = value;
 				} else {
-					updatedInstance[ keyParsed ] = value[ 0 ];
+					updatedInstance[ key ] = value[ 0 ];
 				}
 			}
 			return updatedInstance;

--- a/packages/block-library/src/legacy-widget/edit/handler.js
+++ b/packages/block-library/src/legacy-widget/edit/handler.js
@@ -25,7 +25,9 @@ class LegacyWidgetEditHandler extends Component {
 
 	componentDidMount() {
 		this.isStillMounted = true;
-		this.requestWidgetUpdater();
+		this.requestWidgetUpdater( undefined, ( response ) => {
+			this.props.onInstanceChange( null, !! response.form );
+		} );
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -33,7 +35,9 @@ class LegacyWidgetEditHandler extends Component {
 			prevProps.instance !== this.props.instance &&
 			this.instanceUpdating !== this.props.instance
 		) {
-			this.requestWidgetUpdater();
+			this.requestWidgetUpdater( undefined, ( response ) => {
+				this.props.onInstanceChange( null, !! response.form );
+			} );
 		}
 		if ( this.instanceUpdating === this.props.instance ) {
 			this.instanceUpdating = null;
@@ -81,12 +85,12 @@ class LegacyWidgetEditHandler extends Component {
 	onInstanceChange( instanceChanges ) {
 		this.requestWidgetUpdater( instanceChanges, ( response ) => {
 			this.instanceUpdating = response.instance;
-			this.props.onInstanceChange( response.instance );
+			this.props.onInstanceChange( response.instance, !! response.form );
 		} );
 	}
 
 	requestWidgetUpdater( instanceChanges, callback ) {
-		const { identifier, instanceId, instance } = this.props;
+		const { identifier, instanceId, instance, isCallbackWidget } = this.props;
 		if ( ! identifier ) {
 			return;
 		}
@@ -98,6 +102,7 @@ class LegacyWidgetEditHandler extends Component {
 				instance,
 				// use negative ids to make sure the id does not exist on the database.
 				id_to_use: instanceId * -1,
+				is_callback_widget: isCallbackWidget,
 				instance_changes: instanceChanges,
 			},
 			method: 'POST',

--- a/packages/block-library/src/legacy-widget/edit/index.js
+++ b/packages/block-library/src/legacy-widget/edit/index.js
@@ -33,6 +33,7 @@ class LegacyWidgetEdit extends Component {
 	constructor() {
 		super( ...arguments );
 		this.state = {
+			hasEditForm: true,
 			isPreview: false,
 		};
 		this.switchToEdit = this.switchToEdit.bind( this );
@@ -47,7 +48,7 @@ class LegacyWidgetEdit extends Component {
 			hasPermissionsToManageWidgets,
 			setAttributes,
 		} = this.props;
-		const { isPreview } = this.state;
+		const { isPreview, hasEditForm } = this.state;
 		const { identifier, isCallbackWidget } = attributes;
 		const widgetObject = identifier && availableLegacyWidgets[ identifier ];
 		if ( ! widgetObject ) {
@@ -115,8 +116,8 @@ class LegacyWidgetEdit extends Component {
 							icon="update"
 						>
 						</IconButton>
-						{ ! isCallbackWidget && (
-							<>
+						{ hasEditForm && (
+							<Fragment>
 								<Button
 									className={ `components-tab-button ${ ! isPreview ? 'is-active' : '' }` }
 									onClick={ this.switchToEdit }
@@ -129,26 +130,34 @@ class LegacyWidgetEdit extends Component {
 								>
 									<span>{ __( 'Preview' ) }</span>
 								</Button>
-							</>
+							</Fragment>
 						) }
 					</Toolbar>
 				</BlockControls>
 				{ inspectorControls }
-				{ ! isCallbackWidget && (
+				{ hasEditForm && (
 					<LegacyWidgetEditHandler
 						isVisible={ ! isPreview }
 						identifier={ attributes.identifier }
 						instance={ attributes.instance }
+						isCallbackWidget={ isCallbackWidget }
 						onInstanceChange={
-							( newInstance ) => {
-								this.props.setAttributes( {
-									instance: newInstance,
-								} );
+							( newInstance, newHasEditForm ) => {
+								if ( newInstance ) {
+									this.props.setAttributes( {
+										instance: newInstance,
+									} );
+								}
+								if ( newHasEditForm !== this.hasEditForm ) {
+									this.setState( {
+										hasEditForm: newHasEditForm,
+									} );
+								}
 							}
 						}
 					/>
 				) }
-				{ ( isPreview || isCallbackWidget ) && this.renderWidgetPreview() }
+				{ ( isPreview || ! hasEditForm ) && this.renderWidgetPreview() }
 			</>
 		);
 	}
@@ -158,6 +167,9 @@ class LegacyWidgetEdit extends Component {
 		this.props.setAttributes( {
 			instance: {},
 			identifier: undefined,
+		} );
+		this.setState( {
+			hasEditForm: true,
 		} );
 	}
 


### PR DESCRIPTION
This PR enhances the work done in https://github.com/WordPress/gutenberg/pull/13511 to make sure we support call back widgets with a custom edit form.

# Testing 

As a test subject, I used "NattyWP feedburner widget". The widget comes with silesia theme that can be downloaded at https://wordpress.org/themes/silesia/. The theme is not updated to WordPress 5.0 and some warning messages appear. For testing purposes, the widget can also be used standalone by pasting the code available https://themes.trac.wordpress.org/browser/silesia/1.0.6/include/widgets/feedburner.php in the functions.php of any other theme.
