### PR TITLE
Ensure sourcemaps published to npm contain safe relative paths

### DIFF
--- a/bin/packages/build.js
+++ b/bin/packages/build.js
@@ -166,7 +166,7 @@ function buildJsFileFor( file, silent, environment ) {
 	const destPath = getBuildPath( file, buildDir );
 	const babelOptions = getBabelConfig( environment );
 	babelOptions.sourceMaps = true;
-	babelOptions.sourceFileName = file;
+	babelOptions.sourceFileName = file.replace( PACKAGES_DIR, '@wordpress' );
 
 	mkdirp.sync( path.dirname( destPath ) );
 	const transformed = babel.transformFileSync( file, babelOptions );


### PR DESCRIPTION
## Description
Fixes #13883.

This PR fixes the issue as explained by @jsnajdr:

> I don't know what the right solution is. Some projects use webpack: pseudo-URLs, others ship relative paths: `../src/index.js`. That's what RxJS does, for example. But they ship the untranspiled sources in src, too, unlike Gutenberg, so the file references are valid.
> 
> At least the file paths in the error stacktrace would make more sense:
> 
> `node_modules/@wordpress/api-fetch/src/middlewares/fetch-all-middleware.js`

I went with:
`@wordpress/api-fetch/src/middlewares/fetch-all-middleware.js` 

It works properly as presented in the following screencast where I added code which throws the error to be able to see how it behaves in Dev Tools:

![screencast](https://user-images.githubusercontent.com/699132/54280464-deb08780-4597-11e9-8be1-05e6efcfc05f.gif)


