### PR TITLE
Use only one button for Set featured image and image preview.

### DIFF
--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -46,30 +46,32 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 	return (
 		<PostFeaturedImageCheck>
 			<div className="editor-post-featured-image">
-				{ !! featuredImageId &&
-					<MediaUploadCheck fallback={ instructions }>
-						<MediaUpload
-							title={ postLabel.featured_image || DEFAULT_FEATURE_IMAGE_LABEL }
-							onSelect={ onUpdateImage }
-							allowedTypes={ ALLOWED_MEDIA_TYPES }
-							modalClass="editor-post-featured-image__media-modal"
-							render={ ( { open } ) => (
-								<Button className="editor-post-featured-image__preview" onClick={ open } aria-label={ __( 'Edit or update the image' ) }>
-									{ media &&
-										<ResponsiveWrapper
-											naturalWidth={ mediaWidth }
-											naturalHeight={ mediaHeight }
-										>
-											<img src={ mediaSourceUrl } alt="" />
-										</ResponsiveWrapper>
-									}
-									{ ! media && <Spinner /> }
-								</Button>
-							) }
-							value={ featuredImageId }
-						/>
-					</MediaUploadCheck>
-				}
+				<MediaUploadCheck fallback={ instructions }>
+					<MediaUpload
+						title={ postLabel.featured_image || DEFAULT_FEATURE_IMAGE_LABEL }
+						onSelect={ onUpdateImage }
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
+						modalClass={ ! featuredImageId ? 'editor-post-featured-image__media-modal' : 'editor-post-featured-image__media-modal' }
+						render={ ( { open } ) => (
+							<Button
+								className={ ! featuredImageId ? 'editor-post-featured-image__toggle' : 'editor-post-featured-image__preview' }
+								onClick={ open }
+								aria-label={ ! featuredImageId ? null : __( 'Edit or update the image' ) }>
+								{ !! featuredImageId && media &&
+									<ResponsiveWrapper
+										naturalWidth={ mediaWidth }
+										naturalHeight={ mediaHeight }
+									>
+										<img src={ mediaSourceUrl } alt="" />
+									</ResponsiveWrapper>
+								}
+								{ !! featuredImageId && ! media && <Spinner /> }
+								{ ! featuredImageId && ( postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL ) }
+							</Button>
+						) }
+						value={ featuredImageId }
+					/>
+				</MediaUploadCheck>
 				{ !! featuredImageId && media && ! media.isLoading &&
 					<MediaUploadCheck>
 						<MediaUpload
@@ -84,23 +86,6 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 							) }
 						/>
 					</MediaUploadCheck>
-				}
-				{ ! featuredImageId &&
-					<div>
-						<MediaUploadCheck fallback={ instructions }>
-							<MediaUpload
-								title={ postLabel.featured_image || DEFAULT_FEATURE_IMAGE_LABEL }
-								onSelect={ onUpdateImage }
-								allowedTypes={ ALLOWED_MEDIA_TYPES }
-								modalClass="editor-post-featured-image__media-modal"
-								render={ ( { open } ) => (
-									<Button className="editor-post-featured-image__toggle" onClick={ open }>
-										{ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
-									</Button>
-								) }
-							/>
-						</MediaUploadCheck>
-					</div>
 				}
 				{ !! featuredImageId &&
 					<MediaUploadCheck>


### PR DESCRIPTION
## Description
Refactors the featured image buttons to avoid a focus loss.

The "Set featured image" and the image preview are both buttons. Actually, they're two `MediaUploadCheck` components: very similar, only the props and children are different.

By using only one `MediaUploadCheck` and updating props and children, the reference to the "opener" DOM element is not lost and the Media Modal is able to move focus back properly when it closes.

To test:
- on master:
- set a featured image (use the mouse, it doesn't matter)
- observe that when the media modal closes, the image preview does not have the blue outline focus style: that means it's not focused
- actually, focus is on the body element
- on this branch:
- set a featured image
- when the media modal closes, the image preview does have the focus style

Fixes #14414