### PR TITLE
Align Spinner circles in RTL locales

### DIFF
--- a/packages/components/src/spinner/style.scss
+++ b/packages/components/src/spinner/style.scss
@@ -10,6 +10,7 @@
 	position: relative;
 
 	&::before {
+		/* rtl:begin:ignore */
 		content: "";
 		position: absolute;
 		background-color: $white;
@@ -20,6 +21,7 @@
 		border-radius: 100%;
 		transform-origin: 6px 6px;
 		animation: components-spinner__animation 1s infinite linear;
+		/* rtl:end:ignore */
 	}
 }
 


### PR DESCRIPTION
## Description
Fixes #14417.

Using a RTL locale, the Spinner circles were misaligned (see screenshots below).

We found this issue while working on adding RTL support to `wc-admin`: https://github.com/woocommerce/woocommerce-admin/issues/1776

## How has this been tested?
Verifying it renders correctly in the browser. It's a small CSS change, so it shouldn't affect other parts of the codebase.

## Screenshots
_Before:_
![spinner-before](https://user-images.githubusercontent.com/3616980/54298169-8c339300-45b8-11e9-9aed-e599d0bcd88b.gif)

_After:_
![spinner-after](https://user-images.githubusercontent.com/3616980/54298154-876edf00-45b8-11e9-9604-cf12eb171354.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
