### PR TITLE
Update/menu item

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-convert-button.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-convert-button.js
@@ -15,7 +15,6 @@ export default function BlockConvertButton( { shouldRender, onClick, small } ) {
 			className="editor-block-settings-menu__control"
 			onClick={ onClick }
 			icon="screenoptions"
-			label={ small ? label : undefined }
 		>
 			{ ! small && label }
 		</MenuItem>

--- a/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
@@ -26,7 +26,6 @@ export function BlockModeToggle( { blockType, mode, onToggleMode, small = false 
 			className="editor-block-settings-menu__control"
 			onClick={ onToggleMode }
 			icon="html"
-			label={ small ? label : undefined }
 		>
 			{ ! small && label }
 		</MenuItem>

--- a/packages/components/src/menu-item/README.md
+++ b/packages/components/src/menu-item/README.md
@@ -34,15 +34,6 @@ Element to render as child of button.
 
 Element
 
-### `label`
-
-- Type: `string`
-- Required: No
-
-String to use as primary button label text, applied as `aria-label`. Useful in cases where an `info` prop is passed, where `label` should be the minimal text of the button, described in further detail by `info`.
-
-Defaults to the value of `children`, if `children` is passed as a string.
-
 ### `info`
 
 - Type: `string`

--- a/packages/components/src/menu-item/index.js
+++ b/packages/components/src/menu-item/index.js
@@ -30,7 +30,6 @@ export function MenuItem( {
 	shortcut,
 	isSelected,
 	role = 'menuitem',
-	instanceId,
 	...props
 } ) {
 	className = classnames( 'components-menu-item__button', className, {
@@ -38,16 +37,10 @@ export function MenuItem( {
 	} );
 
 	if ( info ) {
-		const infoId = 'edit-post-feature-toggle__info-' + instanceId;
-
-		// Deconstructed props is scoped to the function; mutation is fine.
-		props[ 'aria-describedby' ] = infoId;
-
 		children = (
 			<span className="components-menu-item__info-wrapper">
 				{ children }
 				<span
-					id={ infoId }
 					className="components-menu-item__info">
 					{ info }
 				</span>

--- a/packages/components/src/menu-item/test/__snapshots__/index.js.snap
+++ b/packages/components/src/menu-item/test/__snapshots__/index.js.snap
@@ -18,7 +18,6 @@ exports[`MenuItem should match snapshot when all props provided 1`] = `
 
 exports[`MenuItem should match snapshot when info is provided 1`] = `
 <ForwardRef(Button)
-  aria-describedby="edit-post-feature-toggle__info-1"
   className="components-menu-item__button"
   role="menuitem"
 >
@@ -28,7 +27,6 @@ exports[`MenuItem should match snapshot when info is provided 1`] = `
     My item
     <span
       className="components-menu-item__info"
-      id="edit-post-feature-toggle__info-1"
     >
       Extended description of My Item
     </span>

--- a/packages/components/src/menu-item/test/index.js
+++ b/packages/components/src/menu-item/test/index.js
@@ -54,7 +54,7 @@ describe( 'MenuItem', () => {
 
 	it( 'should match snapshot when info is provided', () => {
 		const wrapper = shallow(
-			<MenuItem info="Extended description of My Item" instanceId={ 1 }>
+			<MenuItem info="Extended description of My Item">
 				My item
 			</MenuItem>
 		);

--- a/packages/edit-post/src/components/header/feature-toggle/index.js
+++ b/packages/edit-post/src/components/header/feature-toggle/index.js
@@ -26,7 +26,6 @@ function FeatureToggle( { onToggle, isActive, label, info, messageActivated, mes
 			isSelected={ isActive }
 			onClick={ flow( onToggle, speakMessage ) }
 			role="menuitemcheckbox"
-			label={ label }
 			info={ info }
 		>
 			{ label }

--- a/packages/edit-post/src/components/header/plugin-more-menu-item/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/header/plugin-more-menu-item/test/__snapshots__/index.js.snap
@@ -18,6 +18,7 @@ exports[`PluginMoreMenuItem renders menu item as button properly 1`] = `
   >
     <button
       className="components-button components-icon-button components-menu-item__button has-icon has-text"
+      instanceId={0}
       onClick={[Function]}
       role="menuitem"
       type="button"

--- a/packages/edit-post/src/components/visual-editor/block-inspector-button.js
+++ b/packages/edit-post/src/components/visual-editor/block-inspector-button.js
@@ -39,7 +39,6 @@ export function BlockInspectorButton( {
 			className="editor-block-settings-menu__control"
 			onClick={ flow( areAdvancedSettingsOpened ? closeSidebar : openEditorSidebar, speakMessage, onClick ) }
 			icon="admin-generic"
-			label={ small ? label : undefined }
 			shortcut={ shortcuts.toggleSidebar }
 		>
 			{ ! small && label }


### PR DESCRIPTION
## Description
Fix  #13903 

## How has this been tested?

- [X] Local unit tests
- [X] Local e2e tests
- [X] Browser testing

## Types of changes
Removed id, infoid, label and aria-describedby the menuItem component because they are redundant. Also update the documentation and test files accordingly.

## Checklist:
- [x] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
