### PR TITLE
Raw handling: expand phrasing content schema

### DIFF
--- a/packages/block-library/src/heading/transforms.js
+++ b/packages/block-library/src/heading/transforms.js
@@ -3,7 +3,6 @@
  */
 import {
 	createBlock,
-	getPhrasingContentSchema,
 	getBlockAttributes,
 } from '@wordpress/blocks';
 
@@ -26,14 +25,14 @@ const transforms = {
 		{
 			type: 'raw',
 			selector: 'h1,h2,h3,h4,h5,h6',
-			schema: {
-				h1: { children: getPhrasingContentSchema() },
-				h2: { children: getPhrasingContentSchema() },
-				h3: { children: getPhrasingContentSchema() },
-				h4: { children: getPhrasingContentSchema() },
-				h5: { children: getPhrasingContentSchema() },
-				h6: { children: getPhrasingContentSchema() },
-			},
+			schema: ( { phrasingContentSchema } ) => ( {
+				h1: { children: phrasingContentSchema },
+				h2: { children: phrasingContentSchema },
+				h3: { children: phrasingContentSchema },
+				h4: { children: phrasingContentSchema },
+				h5: { children: phrasingContentSchema },
+				h6: { children: phrasingContentSchema },
+			} ),
 			transform( node ) {
 				return createBlock( 'core/heading', {
 					...getBlockAttributes(

--- a/packages/block-library/src/html/transforms.js
+++ b/packages/block-library/src/html/transforms.js
@@ -1,14 +1,9 @@
-/**
- * WordPress dependencies
- */
-import { getPhrasingContentSchema } from '@wordpress/blocks';
-
 const transforms = {
 	from: [
 		{
 			type: 'raw',
 			isMatch: ( node ) => node.nodeName === 'FIGURE' && !! node.querySelector( 'iframe' ),
-			schema: {
+			schema: ( { phrasingContentSchema } ) => ( {
 				figure: {
 					require: [ 'iframe' ],
 					children: {
@@ -16,11 +11,11 @@ const transforms = {
 							attributes: [ 'src', 'allowfullscreen', 'height', 'width' ],
 						},
 						figcaption: {
-							children: getPhrasingContentSchema(),
+							children: phrasingContentSchema,
 						},
 					},
 				},
-			},
+			} ),
 		},
 	],
 };

--- a/packages/block-library/src/image/transforms.js
+++ b/packages/block-library/src/image/transforms.js
@@ -5,7 +5,6 @@ import { createBlobURL } from '@wordpress/blob';
 import {
 	createBlock,
 	getBlockAttributes,
-	getPhrasingContentSchema,
 } from '@wordpress/blocks';
 
 export function stripFirstImage( attributes, { shortcode } ) {
@@ -49,7 +48,7 @@ const imageSchema = {
 	},
 };
 
-const schema = {
+const schema = ( { phrasingContentSchema } ) => ( {
 	figure: {
 		require: [ 'img' ],
 		children: {
@@ -59,11 +58,11 @@ const schema = {
 				children: imageSchema,
 			},
 			figcaption: {
-				children: getPhrasingContentSchema(),
+				children: phrasingContentSchema,
 			},
 		},
 	},
-};
+} );
 
 const transforms = {
 	from: [

--- a/packages/block-library/src/paragraph/transforms.js
+++ b/packages/block-library/src/paragraph/transforms.js
@@ -1,8 +1,3 @@
-/**
- * WordPress dependencies
- */
-import { getPhrasingContentSchema } from '@wordpress/blocks';
-
 const transforms = {
 	from: [
 		{
@@ -10,11 +5,11 @@ const transforms = {
 			// Paragraph is a fallback and should be matched last.
 			priority: 20,
 			selector: 'p',
-			schema: {
+			schema: ( { phrasingContentSchema } ) => ( {
 				p: {
-					children: getPhrasingContentSchema(),
+					children: phrasingContentSchema,
 				},
-			},
+			} ),
 		},
 	],
 };

--- a/packages/block-library/src/preformatted/transforms.js
+++ b/packages/block-library/src/preformatted/transforms.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createBlock, getPhrasingContentSchema } from '@wordpress/blocks';
+import { createBlock } from '@wordpress/blocks';
 
 const transforms = {
 	from: [
@@ -22,11 +22,11 @@ const transforms = {
 					node.firstChild.nodeName === 'CODE'
 				)
 			),
-			schema: {
+			schema: ( { phrasingContentSchema } ) => ( {
 				pre: {
-					children: getPhrasingContentSchema(),
+					children: phrasingContentSchema,
 				},
-			},
+			} ),
 		},
 	],
 	to: [

--- a/packages/block-library/src/quote/transforms.js
+++ b/packages/block-library/src/quote/transforms.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createBlock, getPhrasingContentSchema } from '@wordpress/blocks';
+import { createBlock } from '@wordpress/blocks';
 import { create, join, split, toHTMLString } from '@wordpress/rich-text';
 
 const transforms = {
@@ -74,18 +74,18 @@ const transforms = {
 						isParagraphOrSingleCite
 					);
 			},
-			schema: {
+			schema: ( { phrasingContentSchema } ) => ( {
 				blockquote: {
 					children: {
 						p: {
-							children: getPhrasingContentSchema(),
+							children: phrasingContentSchema,
 						},
 						cite: {
-							children: getPhrasingContentSchema(),
+							children: phrasingContentSchema,
 						},
 					},
 				},
-			},
+			} ),
 		},
 	],
 	to: [

--- a/packages/block-library/src/table/transforms.js
+++ b/packages/block-library/src/table/transforms.js
@@ -1,43 +1,38 @@
-/**
- * WordPress dependencies
- */
-import { getPhrasingContentSchema } from '@wordpress/blocks';
-
-const tableContentPasteSchema = {
+const tableContentPasteSchema = ( { phrasingContentSchema } ) => ( {
 	tr: {
 		allowEmpty: true,
 		children: {
 			th: {
 				allowEmpty: true,
-				children: getPhrasingContentSchema(),
+				children: phrasingContentSchema,
 				attributes: [ 'scope' ],
 			},
 			td: {
 				allowEmpty: true,
-				children: getPhrasingContentSchema(),
+				children: phrasingContentSchema,
 			},
 		},
 	},
-};
+} );
 
-const tablePasteSchema = {
+const tablePasteSchema = ( args ) => ( {
 	table: {
 		children: {
 			thead: {
 				allowEmpty: true,
-				children: tableContentPasteSchema,
+				children: tableContentPasteSchema( args ),
 			},
 			tfoot: {
 				allowEmpty: true,
-				children: tableContentPasteSchema,
+				children: tableContentPasteSchema( args ),
 			},
 			tbody: {
 				allowEmpty: true,
-				children: tableContentPasteSchema,
+				children: tableContentPasteSchema( args ),
 			},
 		},
 	},
-};
+} );
 
 const transforms = {
 	from: [

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -401,6 +401,10 @@ _Related_
 
 -   <https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#Phrasing_content>
 
+_Parameters_
+
+-   _context_ `string`: Set to "paste" to exclude invisible elements and sensitive data.
+
 _Returns_
 
 -   `Object`: Schema.

--- a/packages/blocks/src/api/raw-handling/index.js
+++ b/packages/blocks/src/api/raw-handling/index.js
@@ -19,8 +19,10 @@ import {
 	getBlockContentSchema,
 } from './utils';
 
-export { getPhrasingContentSchema } from './phrasing-content';
+import { getPhrasingContentSchema } from './phrasing-content';
+
 export { pasteHandler } from './paste-handler';
+export { getPhrasingContentSchema };
 
 function getRawTransformations() {
 	return filter( getBlockTransforms( 'from' ), { type: 'raw' } )
@@ -96,7 +98,8 @@ export function rawHandler( { HTML = '' } ) {
 	// shortcodes.
 	const pieces = shortcodeConverter( HTML );
 	const rawTransforms = getRawTransformations();
-	const blockContentSchema = getBlockContentSchema( rawTransforms );
+	const phrasingContentSchema = getPhrasingContentSchema();
+	const blockContentSchema = getBlockContentSchema( rawTransforms, phrasingContentSchema );
 
 	return compact( flatMap( pieces, ( piece ) => {
 		// Already a block from shortcode.

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -47,7 +47,7 @@ const { console } = window;
  */
 function filterInlineHTML( HTML ) {
 	HTML = deepFilterHTML( HTML, [ googleDocsUIDRemover, phrasingContentReducer, commentRemover ] );
-	HTML = removeInvalidHTML( HTML, getPhrasingContentSchema(), { inline: true } );
+	HTML = removeInvalidHTML( HTML, getPhrasingContentSchema( 'paste' ), { inline: true } );
 
 	// Allows us to ask for this information when we get a report.
 	console.log( 'Processed inline HTML:\n\n', HTML );
@@ -190,8 +190,8 @@ export function pasteHandler( { HTML = '', plainText = '', mode = 'AUTO', tagNam
 	}
 
 	const rawTransforms = getRawTransformations();
-	const phrasingContentSchema = getPhrasingContentSchema();
-	const blockContentSchema = getBlockContentSchema( rawTransforms );
+	const phrasingContentSchema = getPhrasingContentSchema( 'paste' );
+	const blockContentSchema = getBlockContentSchema( rawTransforms, phrasingContentSchema );
 
 	const blocks = compact( flatMap( pieces, ( piece ) => {
 		// Already a block from shortcode.

--- a/packages/blocks/src/api/raw-handling/phrasing-content.js
+++ b/packages/blocks/src/api/raw-handling/phrasing-content.js
@@ -1,8 +1,13 @@
 /**
  * External dependencies
  */
-import { omit } from 'lodash';
+import { omit, without } from 'lodash';
 
+/**
+ * All text-level semantic elements.
+ *
+ * @see https://html.spec.whatwg.org/multipage/text-level-semantics.html
+ */
 const phrasingContentSchema = {
 	strong: {},
 	em: {},
@@ -15,13 +20,33 @@ const phrasingContentSchema = {
 	sub: {},
 	sup: {},
 	br: {},
+	small: {},
+	// To do: fix blockquote.
+	// cite: {},
+	q: { attributes: [ 'cite' ] },
+	dfn: { attributes: [ 'title' ] },
+	data: { attributes: [ 'value' ] },
+	time: { attributes: [ 'datetime' ] },
+	var: {},
+	samp: {},
+	kbd: {},
+	i: {},
+	b: {},
+	u: {},
+	mark: {},
+	ruby: {},
+	rt: {},
+	rp: {},
+	bdi: { attributes: [ 'dir' ] },
+	bdo: { attributes: [ 'dir' ] },
+	wbr: {},
 	'#text': {},
 };
 
 // Recursion is needed.
 // Possible: strong > em > strong.
 // Impossible: strong > strong.
-[ 'strong', 'em', 's', 'del', 'ins', 'a', 'code', 'abbr', 'sub', 'sup' ].forEach( ( tag ) => {
+without( Object.keys( phrasingContentSchema ), '#text', 'br' ).forEach( ( tag ) => {
 	phrasingContentSchema[ tag ].children = omit( phrasingContentSchema, tag );
 } );
 
@@ -30,10 +55,31 @@ const phrasingContentSchema = {
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#Phrasing_content
  *
+ * @param {string} context Set to "paste" to exclude invisible elements and
+ *                         sensitive data.
+ *
  * @return {Object} Schema.
  */
-export function getPhrasingContentSchema() {
-	return phrasingContentSchema;
+export function getPhrasingContentSchema( context ) {
+	if ( context !== 'paste' ) {
+		return phrasingContentSchema;
+	}
+
+	return omit( {
+		...phrasingContentSchema,
+		// We shouldn't paste potentially sensitive information which is not
+		// visible to the user when pasted, so strip the attributes.
+		ins: { children: phrasingContentSchema.ins.children },
+		del: { children: phrasingContentSchema.del.children },
+	}, [
+		'u', // Used to mark misspelling. Shouldn't be pasted.
+		'abbr', // Invisible.
+		'data', // Invisible.
+		'time', // Invisible.
+		'wbr', // Invisible.
+		'bdi', // Invisible.
+		'bdo', // Invisible.
+	] );
 }
 
 /**

--- a/packages/blocks/src/api/raw-handling/utils.js
+++ b/packages/blocks/src/api/raw-handling/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { mapValues, mergeWith, includes, noop } from 'lodash';
+import { mapValues, mergeWith, includes, noop, isFunction } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -22,13 +22,17 @@ const { ELEMENT_NODE, TEXT_NODE } = window.Node;
 /**
  * Given raw transforms from blocks, merges all schemas into one.
  *
- * @param {Array} transforms Block transforms, of the `raw` type.
+ * @param {Array}  transforms            Block transforms, of the `raw` type.
+ * @param {Object} phrasingContentSchema The phrasing content schema.
  *
  * @return {Object} A complete block content schema.
  */
-export function getBlockContentSchema( transforms ) {
+export function getBlockContentSchema( transforms, phrasingContentSchema ) {
 	const schemas = transforms.map( ( { isMatch, blockName, schema } ) => {
 		const hasAnchorSupport = hasBlockSupport( blockName, 'anchor' );
+
+		schema = isFunction( schema ) ? schema( { phrasingContentSchema } ) : schema;
+
 		// If the block does not has anchor support and the transform does not
 		// provides an isMatch we can return the schema right away.
 		if ( ! hasAnchorSupport && ! isMatch ) {

--- a/test/integration/__snapshots__/blocks-raw-handling.test.js.snap
+++ b/test/integration/__snapshots__/blocks-raw-handling.test.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Blocks raw handling pasteHandler should strip some text-level elements 1`] = `
+"<!-- wp:paragraph -->
+<p>This is ncorect</p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`rawHandler should convert HTML post to blocks with minimal content changes 1`] = `
 "<!-- wp:heading -->
 <h2>Howdy</h2>
@@ -81,4 +87,10 @@ exports[`rawHandler should convert a list with attributes 1`] = `
         </ol>
     </li></ol>
 <!-- /wp:list -->"
+`;
+
+exports[`rawHandler should not strip any text-level elements 1`] = `
+"<!-- wp:paragraph -->
+<p>This is <u>ncorect</u></p>
+<!-- /wp:paragraph -->"
 `;

--- a/test/integration/blocks-raw-handling.test.js
+++ b/test/integration/blocks-raw-handling.test.js
@@ -73,9 +73,9 @@ describe( 'Blocks raw handling', () => {
 		const filtered = pasteHandler( {
 			HTML: '<b id="docs-internal-guid-0"><em>test</em></b>',
 			mode: 'AUTO',
-		} ).map( getBlockContent ).join( '' );
+		} );
 
-		expect( filtered ).toBe( '<p><em>test</em></p>' );
+		expect( filtered ).toBe( '<em>test</em>' );
 		expect( console ).toHaveLogged();
 	} );
 
@@ -302,6 +302,12 @@ describe( 'Blocks raw handling', () => {
 				}
 			} );
 		} );
+
+		it( 'should strip some text-level elements', () => {
+			const HTML = '<p>This is <u>ncorect</u></p>';
+			expect( serialize( pasteHandler( { HTML } ) ) ).toMatchSnapshot();
+			expect( console ).toHaveLogged();
+		} );
 	} );
 } );
 
@@ -328,6 +334,11 @@ describe( 'rawHandler', () => {
 
 	it( 'should convert a list with attributes', () => {
 		const HTML = readFile( path.join( __dirname, 'fixtures/list-with-attributes.html' ) );
+		expect( serialize( rawHandler( { HTML } ) ) ).toMatchSnapshot();
+	} );
+
+	it( 'should not strip any text-level elements', () => {
+		const HTML = '<p>This is <u>ncorect</u></p>';
 		expect( serialize( rawHandler( { HTML } ) ) ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
## Description

Attempt to expand phrasing content schema. This also prevents stripping of some content when transforming legacy content to blocks.
Partial fix for #17879.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
