### PR TITLE
Modal Component: rename to Dialog

### DIFF
--- a/packages/components/src/modal/README.md
+++ b/packages/components/src/modal/README.md
@@ -1,30 +1,30 @@
-# Modal
+# Dialog
 
-The modal is used to create an accessible modal over an application.
+The dialog is used to create an accessible dialog over an application.
 
-**Note:** The API for this modal has been mimicked to resemble [`react-modal`](https://github.com/reactjs/react-modal).
+**Note:** The API for this dialog has been mimicked to resemble [`react-dialog`](https://github.com/reactjs/react-dialog).
 
 ## Usage
 
-The following example shows you how to properly implement a modal. For the modal to properly work it's important you implement the close logic for the modal properly.
+The following example shows you how to properly implement a dialog. For the dialog to properly work it's important you implement the close logic for the dialog properly.
 
 ```jsx
-import { Button, Modal } from '@wordpress/components';
+import { Button, Dialog } from '@wordpress/components';
 import { withState } from '@wordpress/compose';
 
-const MyModal = withState( {
+const MyDialog = withState( {
 	isOpen: false,
 } )( ( { isOpen, setState } ) => (
 	<div>
-		<Button isDefault onClick={ () => setState( { isOpen: true } ) }>Open Modal</Button>
+		<Button isDefault onClick={ () => setState( { isOpen: true } ) }>Open Dialog</Button>
 		{ isOpen && (
-			<Modal
-				title="This is my modal"
+			<Dialog
+				title="This is my dialog"
 				onRequestClose={ () => setState( { isOpen: false } ) }>
 				<Button isDefault onClick={ () => setState( { isOpen: false } ) }>
 					My custom close button
 				</Button>
-			</Modal>
+			</Dialog>
 		) }
 	</div>
 ) );
@@ -37,21 +37,21 @@ Props not included in this set will be applied to the input elements.
 
 ### title
 
-This property is used as the modal header's title. It is required for accessibility reasons.
+This property is used as the dialog header's title. It is required for accessibility reasons.
 
 - Type: `String`
 - Required: Yes
 
 ### onRequestClose
 
-This function is called to indicate that the modal should be closed.
+This function is called to indicate that the dialog should be closed.
 
 - Type: `function`
 - Required: Yes
 
 ### contentLabel
 
-If this property is added, it will be added to the modal content `div` as `aria-label`.
+If this property is added, it will be added to the dialog content `div` as `aria-label`.
 You are encouraged to use this if `aria.labelledby` is not provided.
 
 - Type: `String`
@@ -59,23 +59,23 @@ You are encouraged to use this if `aria.labelledby` is not provided.
 
 ### aria.labelledby
 
-If this property is added, it will be added to the modal content `div` as `aria-labelledby`.
-You are encouraged to use this when the modal is visually labelled.
+If this property is added, it will be added to the dialog content `div` as `aria-labelledby`.
+You are encouraged to use this when the dialog is visually labelled.
 
 - Type: `String`
 - Required: No
-- Default: `modal-heading`
+- Default: `dialog-heading`
 
 ### aria.describedby
 
-If this property is added, it will be added to the modal content `div` as `aria-describedby`.
+If this property is added, it will be added to the dialog content `div` as `aria-describedby`.
 
 - Type: `String`
 - Required: No
 
 ### focusOnMount
 
-If this property is true, it will focus the first tabbable element rendered in the modal.
+If this property is true, it will focus the first tabbable element rendered in the dialog.
 
 - Type: `boolean`
 - Required: No
@@ -83,7 +83,7 @@ If this property is true, it will focus the first tabbable element rendered in t
 
 ### shouldCloseOnEsc
 
-If this property is added, it will determine whether the modal requests to close when the escape key is pressed.
+If this property is added, it will determine whether the dialog requests to close when the escape key is pressed.
 
 - Type: `boolean`
 - Required: No
@@ -91,7 +91,7 @@ If this property is added, it will determine whether the modal requests to close
 
 ### shouldCloseOnClickOutside
 
-If this property is added, it will determine whether the modal requests to close when a mouse click occurs outside of the modal content.
+If this property is added, it will determine whether the dialog requests to close when a mouse click occurs outside of the dialog content.
 
 - Type: `boolean`
 - Required: No
@@ -99,7 +99,7 @@ If this property is added, it will determine whether the modal requests to close
 
 ### isDismissable
 
-If this property is set to false, the modal will not display a close icon and cannot be dismissed.
+If this property is set to false, the dialog will not display a close icon and cannot be dismissed.
 
 - Type: `boolean`
 - Required: No
@@ -107,14 +107,14 @@ If this property is set to false, the modal will not display a close icon and ca
 
 ### className
 
-If this property is added, it will an additional class name to the modal content `div`.
+If this property is added, it will an additional class name to the dialog content `div`.
 
 - Type: `String`
 - Required: No
 
 ### role
 
-If this property is added, it will override the default role of the modal.
+If this property is added, it will override the default role of the dialog.
 
 - Type: `String`
 - Required: No
@@ -122,7 +122,7 @@ If this property is added, it will override the default role of the modal.
 
 ### overlayClassName
 
-If this property is added, it will an additional class name to the modal overlay `div`.
+If this property is added, it will an additional class name to the dialog overlay `div`.
 
 - Type: `String`
 - Required: No

--- a/packages/components/src/modal/frame.js
+++ b/packages/components/src/modal/frame.js
@@ -17,7 +17,7 @@ import clickOutside from 'react-click-outside';
 import withFocusReturn from '../higher-order/with-focus-return';
 import withConstrainedTabbing from '../higher-order/with-constrained-tabbing';
 
-class ModalFrame extends Component {
+class DialogFrame extends Component {
 	constructor() {
 		super( ...arguments );
 
@@ -48,7 +48,7 @@ class ModalFrame extends Component {
 	}
 
 	/**
-	 * Callback function called when clicked outside the modal.
+	 * Callback function called when clicked outside the dialog.
 	 *
 	 * @param {Object} event Mouse click event.
 	 */
@@ -96,9 +96,9 @@ class ModalFrame extends Component {
 	}
 
 	/**
-	 * Renders the modal frame element.
+	 * Renders the dialog frame element.
 	 *
-	 * @return {WPElement} The modal frame element.
+	 * @return {WPElement} The dialog frame element.
 	 */
 	render() {
 		const {
@@ -137,4 +137,4 @@ export default compose( [
 	withGlobalEvents( {
 		keydown: 'handleKeyDown',
 	} ),
-] )( ModalFrame );
+] )( DialogFrame );

--- a/packages/components/src/modal/header.js
+++ b/packages/components/src/modal/header.js
@@ -8,22 +8,22 @@ import { __ } from '@wordpress/i18n';
  */
 import IconButton from '../icon-button';
 
-const ModalHeader = ( { icon, title, onClose, closeLabel, headingId, isDismissable } ) => {
+const DialogHeader = ( { icon, title, onClose, closeLabel, headingId, isDismissable } ) => {
 	const label = closeLabel ? closeLabel : __( 'Close dialog' );
 
 	return (
 		<div
-			className="components-modal__header"
+			className="components-dialog__header"
 		>
-			<div className="components-modal__header-heading-container">
+			<div className="components-dialog__header-heading-container">
 				{ icon &&
-					<span className="components-modal__icon-container" aria-hidden>
+					<span className="components-dialog__icon-container" aria-hidden>
 						{ icon }
 					</span>
 				}
 				{ title &&
 					<h1 id={ headingId }
-						className="components-modal__header-heading">
+						className="components-dialog__header-heading">
 						{ title }
 					</h1>
 				}
@@ -39,4 +39,4 @@ const ModalHeader = ( { icon, title, onClose, closeLabel, headingId, isDismissab
 	);
 };
 
-export default ModalHeader;
+export default DialogHeader;

--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -13,16 +13,16 @@ import { withInstanceId } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import ModalFrame from './frame';
-import ModalHeader from './header';
+import DialogFrame from './frame';
+import DialogHeader from './header';
 import * as ariaHelper from './aria-helper';
 import IsolatedEventContainer from '../isolated-event-container';
 
-// Used to count the number of open modals.
+// Used to count the number of open dialogs.
 let parentElement,
-	openModalCount = 0;
+	openDialogCount = 0;
 
-class Modal extends Component {
+class Dialog extends Component {
 	constructor( props ) {
 		super( props );
 
@@ -30,40 +30,40 @@ class Modal extends Component {
 	}
 
 	/**
-	 * Appends the modal's node to the DOM, so the portal can render the
-	 * modal in it. Also calls the openFirstModal when this is the first modal to be
+	 * Appends the dialog's node to the DOM, so the portal can render the
+	 * dialog in it. Also calls the openFirstDialog when this is the first dialog to be
 	 * opened.
 	 */
 	componentDidMount() {
-		openModalCount++;
+		openDialogCount++;
 
-		if ( openModalCount === 1 ) {
-			this.openFirstModal();
+		if ( openDialogCount === 1 ) {
+			this.openFirstDialog();
 		}
 	}
 
 	/**
-	 * Removes the modal's node from the DOM. Also calls closeLastModal when this is
-	 * the last modal to be closed.
+	 * Removes the dialog's node from the DOM. Also calls closeLastDialog when this is
+	 * the last dialog to be closed.
 	 */
 	componentWillUnmount() {
-		openModalCount--;
+		openDialogCount--;
 
-		if ( openModalCount === 0 ) {
-			this.closeLastModal();
+		if ( openDialogCount === 0 ) {
+			this.closeLastDialog();
 		}
 
 		this.cleanDOM();
 	}
 
 	/**
-	 * Prepares the DOM for the modals to be rendered.
+	 * Prepares the DOM for the dialogs to be rendered.
 	 *
-	 * Every modal is mounted in a separate div appended to a parent div
+	 * Every dialog is mounted in a separate div appended to a parent div
 	 * that is appended to the document body.
 	 *
 	 * The parent div will be created if it does not yet exist, and the
-	 * separate div for this specific modal will be appended to that.
+	 * separate div for this specific dialog will be appended to that.
 	 */
 	prepareDOM() {
 		if ( ! parentElement ) {
@@ -75,37 +75,37 @@ class Modal extends Component {
 	}
 
 	/**
-	 * Removes the specific mounting point for this modal from the DOM.
+	 * Removes the specific mounting point for this dialog from the DOM.
 	 */
 	cleanDOM() {
 		parentElement.removeChild( this.node );
 	}
 
 	/**
-	 * Prepares the DOM for this modal and any additional modal to be mounted.
+	 * Prepares the DOM for this dialog and any additional dialog to be mounted.
 	 *
-	 * It appends an additional div to the body for the modals to be rendered in,
+	 * It appends an additional div to the body for the dialogs to be rendered in,
 	 * it hides any other elements from screen-readers and adds an additional class
-	 * to the body to prevent scrolling while the modal is open.
+	 * to the body to prevent scrolling while the dialog is open.
 	 */
-	openFirstModal() {
+	openFirstDialog() {
 		ariaHelper.hideApp( parentElement );
 		document.body.classList.add( this.props.bodyOpenClassName );
 	}
 
 	/**
-	 * Cleans up the DOM after the last modal is closed and makes the app available
+	 * Cleans up the DOM after the last dialog is closed and makes the app available
 	 * for screen-readers again.
 	 */
-	closeLastModal() {
+	closeLastDialog() {
 		document.body.classList.remove( this.props.bodyOpenClassName );
 		ariaHelper.showApp();
 	}
 
 	/**
-	 * Renders the modal.
+	 * Renders the dialog.
 	 *
-	 * @return {WPElement} The modal element.
+	 * @return {WPElement} The dialog element.
 	 */
 	render() {
 		const {
@@ -122,18 +122,18 @@ class Modal extends Component {
 			...otherProps
 		} = this.props;
 
-		const headingId = aria.labelledby || `components-modal-header-${ instanceId }`;
+		const headingId = aria.labelledby || `components-dialog-header-${ instanceId }`;
 
 		// Disable reason: this stops mouse events from triggering tooltips and
-		// other elements underneath the modal overlay.
+		// other elements underneath the dialog overlay.
 		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		return createPortal(
 			<IsolatedEventContainer
-				className={ classnames( 'components-modal__screen-overlay', overlayClassName ) }
+				className={ classnames( 'components-dialog__screen-overlay', overlayClassName ) }
 			>
-				<ModalFrame
+				<DialogFrame
 					className={ classnames(
-						'components-modal__frame',
+						'components-dialog__frame',
 						className
 					) }
 					onRequestClose={ onRequestClose }
@@ -143,8 +143,8 @@ class Modal extends Component {
 					} }
 					{ ...otherProps }
 				>
-					<div className={ 'components-modal__content' } tabIndex="0">
-						<ModalHeader
+					<div className={ 'components-dialog__content' } tabIndex="0">
+						<DialogHeader
 							closeLabel={ closeButtonLabel }
 							headingId={ headingId }
 							icon={ icon }
@@ -154,7 +154,7 @@ class Modal extends Component {
 						/>
 						{ children }
 					</div>
-				</ModalFrame>
+				</DialogFrame>
 			</IsolatedEventContainer>,
 			this.node
 		);
@@ -162,8 +162,8 @@ class Modal extends Component {
 	}
 }
 
-Modal.defaultProps = {
-	bodyOpenClassName: 'modal-open',
+Dialog.defaultProps = {
+	bodyOpenClassName: 'dialog-open',
 	role: 'dialog',
 	title: null,
 	onRequestClose: noop,
@@ -178,4 +178,4 @@ Modal.defaultProps = {
 	},
 };
 
-export default withInstanceId( Modal );
+export default withInstanceId( Dialog );

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -1,19 +1,19 @@
-// The scrim behind the modal window.
-.components-modal__screen-overlay {
+// The scrim behind the dialog window.
+.components-dialog__screen-overlay {
 	position: fixed;
 	top: 0;
 	right: 0;
 	bottom: 0;
 	left: 0;
 	background-color: rgba($white, 0.4);
-	z-index: z-index(".components-modal__screen-overlay");
+	z-index: z-index(".components-dialog__screen-overlay");
 
 	// This animates the appearance of the white background.
 	@include edit-post__fade-in-animation();
 }
 
-// The modal window element.
-.components-modal__frame {
+// The dialog window element.
+.components-dialog__frame {
 	// On small screens the content needs to be full width because of limited
 	// space.
 	position: absolute;
@@ -25,27 +25,27 @@
 	margin: 0;
 	border: $border-width solid $light-gray-500;
 	background: $white;
-	box-shadow: $shadow-modal;
+	box-shadow: $shadow-dialog;
 	overflow: auto;
 
-	// Show a centered modal on bigger screens.
+	// Show a centered dialog on bigger screens.
 	@include break-small() {
 		top: 50%;
 		right: auto;
 		bottom: auto;
 		left: 50%;
-		min-width: $modal-min-width;
+		min-width: $dialog-min-width;
 		max-width: calc(100% - #{ $grid-size-large } - #{ $grid-size-large });
 		max-height: calc(100% - #{ $header-height } - #{ $header-height });
 		transform: translate(-50%, -50%);
 
-		// Animate the modal frame/contents appearing on the page.
-		animation: components-modal__appear-animation 0.1s ease-out;
+		// Animate the dialog frame/contents appearing on the page.
+		animation: components-dialog__appear-animation 0.1s ease-out;
 		animation-fill-mode: forwards;
 	}
 }
 
-@keyframes components-modal__appear-animation {
+@keyframes components-dialog__appear-animation {
 	from {
 		margin-top: $grid-size * 4;
 	}
@@ -54,10 +54,10 @@
 	}
 }
 
-// Fix header to the top so it is always there to provide context to the modal
+// Fix header to the top so it is always there to provide context to the dialog
 // if the content needs to be scrolled (for example, on the keyboard shortcuts
-// modal screen).
-.components-modal__header {
+// dialog screen).
+.components-dialog__header {
 	box-sizing: border-box;
 	border-bottom: $border-width solid $light-gray-500;
 	padding: 0 $grid-size-large;
@@ -69,7 +69,7 @@
 	height: $header-height;
 	position: sticky;
 	top: 0;
-	z-index: z-index(".components-modal__header");
+	z-index: z-index(".components-dialog__header");
 	margin: 0 -#{ $grid-size-large } $grid-size-large;
 
 	// Rules inside this query are only run by Microsoft Edge.
@@ -80,7 +80,7 @@
 		width: 100%;
 	}
 
-	.components-modal__header-heading {
+	.components-dialog__header-heading {
 		font-size: 1rem;
 		font-weight: 600;
 	}
@@ -91,7 +91,7 @@
 	}
 }
 
-.components-modal__header-heading-container {
+.components-dialog__header-heading-container {
 	align-items: center;
 	flex-grow: 1;
 	display: flex;
@@ -99,7 +99,7 @@
 	justify-content: left;
 }
 
-.components-modal__header-icon-container {
+.components-dialog__header-icon-container {
 	display: inline-block;
 
 	svg {
@@ -109,8 +109,8 @@
 	}
 }
 
-// Modal contents.
-.components-modal__content {
+// Dialog contents.
+.components-dialog__content {
 	box-sizing: border-box;
 	height: 100%;
 	padding: 0 $grid-size-large $grid-size-large;


### PR DESCRIPTION
## Description
I have renamed everything from `modal` to `dialog` in the components package folder.

I'm not sure what all needs to be done. This PR is to get the conversation going.

See #14195 for discussion and context

## How has this been tested?
This PR has not been tested.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
