### PR TITLE
Docs: Update JavaScript build and setup with wp-scripts updates

### DIFF
--- a/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md
+++ b/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md
@@ -8,9 +8,11 @@ Most browsers can not interpret or run ESNext and JSX syntaxes, so we use a tran
 
 There are a few reasons to use ESNext and the extra step. First, it makes for simpler code that is easier to read and write. Using a transformation step allows for tools to optimize the code to work on the widest variety of browsers. Also, by using a build step you can organize your code into smaller modules and files that can be bundled together into a single download.
 
-There are many tools that can perform this transformation or build step, but in this tutorial we will focus on Webpack and Babel.
+There are different tools that can perform this transformation or build step, but WordPress uses Webpack and Babel.
 
 [Webpack](https://webpack.js.org/) is a pluggable tool that processes JavaScript creating a compiled bundle that runs in a browser. [Babel](https://babeljs.io/) transforms JavaScript from one format to another. You use Babel as a plugin to Webpack to transform both ESNext and JSX to JavaScript.
+
+The @wordpress/scripts package abstracts these libraries away to standardize and simplify development, so you won't need to handle the details for configuring those libraries.
 
 ## Quick Start
 
@@ -76,9 +78,9 @@ Is this OK? (yes) yes
 
 The next step is to install the packages required. You can install packages using the npm command `npm install`. If you pass the `--save-dev` parameter, npm will write the package as a dev dependency in the package.json file. The `--save-exact` parameter instructs npm to save an exact version of a dependency, not a range of valid versions. See [npm install documentation](https://docs.npmjs.com/cli/install) for more details.
 
-Run `npm install --save-dev --save-exact webpack webpack-cli`
+Run `npm install --save-dev --save-exact @wordpress/scripts`
 
-After installing, a `node_modules` directory is created with the webpack module and its dependencies.
+After installing, a `node_modules` directory is created with the modules and its dependencies.
 
 Also, if you look at package.json file it will include a new section:
 

--- a/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md
+++ b/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md
@@ -12,7 +12,7 @@ There are different tools that can perform this transformation or build step, bu
 
 [Webpack](https://webpack.js.org/) is a pluggable tool that processes JavaScript creating a compiled bundle that runs in a browser. [Babel](https://babeljs.io/) transforms JavaScript from one format to another. You use Babel as a plugin to Webpack to transform both ESNext and JSX to JavaScript.
 
-The `@wordpress/scripts` package abstracts these libraries away to standardize and simplify development, so you won't need to handle the details for configuring those libraries.
+The [@wordpress/scripts](https://www.npmjs.com/package/@wordpress/scripts) package abstracts these libraries away to standardize and simplify development, so you won't need to handle the details for configuring those libraries.
 
 ## Quick Start
 

--- a/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md
+++ b/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md
@@ -50,7 +50,7 @@ npm init
 package name: (myguten-block) myguten-block
 version: (1.0.0)
 description: Test block
-entry point: (index.js) block.js
+entry point: (index.js) build/index.js
 test command:
 git repository:
 keywords:

--- a/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md
+++ b/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md
@@ -104,12 +104,8 @@ registerBlockType( 'myguten/test-block', {
 	title: 'Basic Example',
 	icon: 'smiley',
 	category: 'layout',
-	edit() {
-		return <div>Hola, mundo!</div>;
-	},
-	save() {
-		return <div>Hola, mundo!</div>;
-	},
+	edit: () => <div>Hola, mundo!</div>,
+	save: () => <div>Hola, mundo!</div>,
 } );
 ```
 

--- a/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md
+++ b/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md
@@ -92,13 +92,7 @@ Also, if you look at package.json file it will include a new section:
 
 ## Webpack & Babel
 
-The `@wordpress/scripts` package handles the default configuration for Webpack and Babel. You need to add the following packages:
-
-```
-npm install --save-dev webpack webpack-cli @wordpress/babel-preset-default babel-plugin-transform-react-jsx
-```
-
-The scripts package expects the source file to compile to be found at `src/index.js`, and will save the compiled output to `build/index.js`.
+The `@wordpress/scripts` package handles the dependencies and default configuration for Webpack and Babel. The scripts package expects the source file to compile to be found at `src/index.js`, and will save the compiled output to `build/index.js`.
 
 With that in mind, let's set up a basic block. Create a file at `src/index.js` with the following content:
 

--- a/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md
+++ b/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md
@@ -40,6 +40,7 @@ To start a new node project, first create a directory to work in.
 
 ```
 mkdir myguten-block
+cd myguten-block
 ```
 
 You create a new package.json running `npm init` in your terminal.  This will walk you through creating your package.json file:

--- a/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md
+++ b/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md
@@ -12,7 +12,7 @@ There are different tools that can perform this transformation or build step, bu
 
 [Webpack](https://webpack.js.org/) is a pluggable tool that processes JavaScript creating a compiled bundle that runs in a browser. [Babel](https://babeljs.io/) transforms JavaScript from one format to another. You use Babel as a plugin to Webpack to transform both ESNext and JSX to JavaScript.
 
-The @wordpress/scripts package abstracts these libraries away to standardize and simplify development, so you won't need to handle the details for configuring those libraries.
+The `@wordpress/scripts` package abstracts these libraries away to standardize and simplify development, so you won't need to handle the details for configuring those libraries.
 
 ## Quick Start
 
@@ -80,7 +80,7 @@ The next step is to install the packages required. You can install packages usin
 
 Run `npm install --save-dev --save-exact @wordpress/scripts`
 
-After installing, a `node_modules` directory is created with the modules and its dependencies.
+After installing, a `node_modules` directory is created with the modules and their dependencies.
 
 Also, if you look at package.json file it will include a new section:
 
@@ -92,13 +92,15 @@ Also, if you look at package.json file it will include a new section:
 
 ## Webpack & Babel
 
-The @wordpress/scripts package handles the default configuration for Webpack and Babel. You need to add the following packages
+The `@wordpress/scripts` package handles the default configuration for Webpack and Babel. You need to add the following packages:
 
 ```
 npm install --save-dev webpack webpack-cli @wordpress/babel-preset-default babel-plugin-transform-react-jsx
 ```
 
-The scripts package expects the source file to compile to be found at `src/index.js` and will output to `build/index.js`. So create a basic block to build. Create a file at `src/index.js` with the following content:
+The scripts package expects the source file to compile to be found at `src/index.js`, and will save the compiled output to `build/index.js`.
+
+With that in mind, let's set up a basic block. Create a file at `src/index.js` with the following content:
 
 ```js
 const { registerBlockType } = wp.blocks;
@@ -132,9 +134,9 @@ After the build finishes, you will see the built file created at `build/index.js
 
 ### Development Mode
 
-The **build** command in @wordpress/scripts runs in a production mode which shrinks the code down so it downloads faster, but makes it difficult to read. You can use the **start** command which runs a development mode that does not shrink the code, and additionally continues a running process to watch the source file for more changes and rebuilt as you develop.
+The **build** command in `@wordpress/scripts` runs in a "production" mode. This shrinks the code down so it downloads faster, but makes it difficult to read in the process. You can use the **start** command which runs a development mode that does not shrink the code, and additionally continues a running process to watch the source file for more changes and rebuild as you develop.
 
-The start command can be added to the same scripts section of `package.json`.
+The start command can be added to the same scripts section of `package.json`:
 
 ```json
   "scripts": {
@@ -156,7 +158,7 @@ Likewise, you do not need to include `node_modules` or any of the above configur
 
 ## Summary
 
-Yes, the initial setup is a bit more involved, but once in place adds additional features which are usually worth the trade off.
+Yes, the initial setup is a bit more involved, but the additional features and benefits are usually worth the trade off in setup time.
 
 With a setup in place, the standard workflow is:
 


### PR DESCRIPTION
## Description

Closes #13712.

Updates the build and setup section of the JavaScript tutorial with the new simplified commands included in wp-scripts. Removes webpack and babel configs and replaces recommending to use the default configs using `wp-scripts build|start` 

## How has this been tested?

Follow the instructions, in the tutorial which includes a simple block you can create to test.
Until the wp-scripts gets published you will need to add a local reference to `@wordpress/scripts` package. 

For me Gutenberg is one directory up from my sample plugin so my package.json entry looks like:
```
    "@wordpress/scripts": "file:../gutenberg/packages/scripts",
```

View [documentation live on branch here](https://github.com/WordPress/gutenberg/blob/update/js-build-docs/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md)

Depends on #14168 