### PR TITLE
Block API: Support nesting (InnerBlocks) in unknown block types

### DIFF
--- a/packages/block-library/src/missing/edit.js
+++ b/packages/block-library/src/missing/edit.js
@@ -1,49 +1,30 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { RawHTML } from '@wordpress/element';
 import { Button } from '@wordpress/components';
-import { getBlockType, createBlock, parse } from '@wordpress/blocks';
+import { getBlockType, createBlock } from '@wordpress/blocks';
 import { withDispatch } from '@wordpress/data';
 import { Warning } from '@wordpress/block-editor';
 
-function MissingBlockWarning( { attributes, convertToHTML, extractBlocks } ) {
+function MissingBlockWarning( { attributes, convertToHTML } ) {
 	const { originalName, originalUndelimitedContent } = attributes;
 	const hasContent = !! originalUndelimitedContent;
-	const parseTree = parse( attributes.originalContent );
-	const hasInnerBlocks = get( parseTree, [ 0, 'innerBlocks' ], [] ).length;
 	const hasHTMLBlock = getBlockType( 'core/html' );
 
 	const actions = [];
 	let messageHTML;
 	if ( hasContent && hasHTMLBlock ) {
-		messageHTML = hasInnerBlocks ?
-			sprintf(
-				__( 'Your site doesn’t include support for the "%s" block. You can leave this block intact, convert its content to a Custom HTML block, extract any blocks it may contain, or remove it entirely.' ),
-				originalName
-			) :
-			sprintf(
-				__( 'Your site doesn’t include support for the "%s" block. You can leave this block intact, convert its content to a Custom HTML block, or remove it entirely.' ),
-				originalName
-			);
+		messageHTML = sprintf(
+			__( 'Your site doesn’t include support for the "%s" block. You can leave this block intact, convert its content to a Custom HTML block, or remove it entirely.' ),
+			originalName
+		);
 		actions.push(
 			<Button key="convert" onClick={ convertToHTML } isLarge isPrimary>
 				{ __( 'Keep as HTML' ) }
 			</Button>
 		);
-		if ( hasInnerBlocks ) {
-			actions.push(
-				<Button key="extract" onClick={ extractBlocks } isLarge>
-					{ __( 'Keep inner blocks' ) }
-				</Button>
-			);
-		}
 	} else {
 		messageHTML = sprintf(
 			__( 'Your site doesn’t include support for the "%s" block. You can leave this block intact or remove it entirely.' ),
@@ -68,13 +49,6 @@ const MissingEdit = withDispatch( ( dispatch, { clientId, attributes } ) => {
 			replaceBlock( clientId, createBlock( 'core/html', {
 				content: attributes.originalUndelimitedContent,
 			} ) );
-		},
-		extractBlocks() {
-			replaceBlock( clientId, get(
-				parse( attributes.originalContent ),
-				[ 0, 'innerBlocks' ],
-				[]
-			) );
 		},
 	};
 } )( MissingBlockWarning );

--- a/packages/block-library/src/missing/edit.js
+++ b/packages/block-library/src/missing/edit.js
@@ -1,30 +1,49 @@
 /**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { RawHTML } from '@wordpress/element';
 import { Button } from '@wordpress/components';
-import { getBlockType, createBlock } from '@wordpress/blocks';
+import { getBlockType, createBlock, parse } from '@wordpress/blocks';
 import { withDispatch } from '@wordpress/data';
 import { Warning } from '@wordpress/block-editor';
 
-function MissingBlockWarning( { attributes, convertToHTML } ) {
+function MissingBlockWarning( { attributes, convertToHTML, extractBlocks } ) {
 	const { originalName, originalUndelimitedContent } = attributes;
 	const hasContent = !! originalUndelimitedContent;
+	const parseTree = parse( attributes.originalContent );
+	const hasInnerBlocks = get( parseTree, [ 0, 'innerBlocks' ], [] ).length;
 	const hasHTMLBlock = getBlockType( 'core/html' );
 
 	const actions = [];
 	let messageHTML;
 	if ( hasContent && hasHTMLBlock ) {
-		messageHTML = sprintf(
-			__( 'Your site doesn’t include support for the "%s" block. You can leave this block intact, convert its content to a Custom HTML block, or remove it entirely.' ),
-			originalName
-		);
+		messageHTML = hasInnerBlocks ?
+			sprintf(
+				__( 'Your site doesn’t include support for the "%s" block. You can leave this block intact, convert its content to a Custom HTML block, extract any blocks it may contain, or remove it entirely.' ),
+				originalName
+			) :
+			sprintf(
+				__( 'Your site doesn’t include support for the "%s" block. You can leave this block intact, convert its content to a Custom HTML block, or remove it entirely.' ),
+				originalName
+			);
 		actions.push(
 			<Button key="convert" onClick={ convertToHTML } isLarge isPrimary>
 				{ __( 'Keep as HTML' ) }
 			</Button>
 		);
+		if ( hasInnerBlocks ) {
+			actions.push(
+				<Button key="extract" onClick={ extractBlocks } isLarge>
+					{ __( 'Keep inner blocks' ) }
+				</Button>
+			);
+		}
 	} else {
 		messageHTML = sprintf(
 			__( 'Your site doesn’t include support for the "%s" block. You can leave this block intact or remove it entirely.' ),
@@ -49,6 +68,13 @@ const MissingEdit = withDispatch( ( dispatch, { clientId, attributes } ) => {
 			replaceBlock( clientId, createBlock( 'core/html', {
 				content: attributes.originalUndelimitedContent,
 			} ) );
+		},
+		extractBlocks() {
+			replaceBlock( clientId, get(
+				parse( attributes.originalContent ),
+				[ 0, 'innerBlocks' ],
+				[]
+			) );
 		},
 	};
 } )( MissingBlockWarning );

--- a/packages/blocks/src/api/test/parser.js
+++ b/packages/blocks/src/api/test/parser.js
@@ -761,23 +761,30 @@ describe( 'block parser', () => {
 	describe( 'serializeBlockNode', () => {
 		it( 'reserializes block nodes', () => {
 			const expected = `<!-- wp:columns -->
-<div class="wp-block-columns has-2-columns">
-<!-- wp:column -->
-<div class="wp-block-column">
-<!-- wp:paragraph -->
-<p>A</p>
-<!-- /wp:paragraph -->
-</div>
-<!-- /wp:column -->
-<!-- wp:column -->
-<div class="wp-block-column">
-<!-- wp:list -->
-<ul><li>B</li><li>C</li></ul>
-<!-- /wp:list -->
-</div>
-<!-- /wp:column -->
-</div>
-<!-- /wp:columns -->`;
+				<div class="wp-block-columns has-2-columns">
+					<!-- wp:column -->
+					<div class="wp-block-column">
+						<!-- wp:paragraph -->
+						<p>A</p>
+						<!-- /wp:paragraph -->
+					</div>
+					<!-- /wp:column -->
+					<!-- wp:column -->
+					<div class="wp-block-column">
+						<!-- wp:group -->
+						<div class="wp-block-group"><div class="wp-block-group__inner-container">
+							<!-- wp:list -->
+							<ul><li>B</li><li>C</li></ul>
+							<!-- /wp:list -->
+							<!-- wp:paragraph -->
+							<p>D</p>
+							<!-- /wp:paragraph -->
+						</div></div>
+						<!-- /wp:group -->
+					</div>
+					<!-- /wp:column -->
+				</div>
+				<!-- /wp:columns -->`.replace( /\t/g, '' );
 			const input = {
 				blockName: 'core/columns',
 				attrs: {},
@@ -806,11 +813,31 @@ describe( 'block parser', () => {
 						attrs: {},
 						innerBlocks: [
 							{
-								blockName: 'core/list',
+								blockName: 'core/group',
 								attrs: {},
-								innerBlocks: [],
-								innerHTML: '<ul><li>B</li><li>C</li></ul>',
-								innerContent: [ '<ul><li>B</li><li>C</li></ul>' ],
+								innerBlocks: [
+									{
+										blockName: 'core/list',
+										attrs: {},
+										innerBlocks: [],
+										innerHTML: '<ul><li>B</li><li>C</li></ul>',
+										innerContent: [ '<ul><li>B</li><li>C</li></ul>' ],
+									},
+									{
+										blockName: 'core/paragraph',
+										attrs: {},
+										innerBlocks: [],
+										innerHTML: '<p>D</p>',
+										innerContent: [ '<p>D</p>' ],
+									},
+								],
+								innerHTML: '<div class="wp-block-group"><div class="wp-block-group__inner-container"></div></div>',
+								innerContent: [
+									'<div class="wp-block-group"><div class="wp-block-group__inner-container">',
+									null,
+									'',
+									null,
+									'</div></div>' ],
 							},
 						],
 						innerHTML: '<div class="wp-block-column"></div>',

--- a/packages/blocks/src/api/test/parser.js
+++ b/packages/blocks/src/api/test/parser.js
@@ -19,6 +19,7 @@ import {
 	isOfTypes,
 	isValidByType,
 	isValidByEnum,
+	serializeBlockNode,
 } from '../parser';
 import {
 	registerBlockType,
@@ -754,6 +755,84 @@ describe( 'block parser', () => {
 			expect( block.isValid ).toBe( true );
 			expect( console ).toHaveErrored();
 			expect( console ).toHaveWarned();
+		} );
+	} );
+
+	describe( 'serializeBlockNode', () => {
+		it( 'reserializes block nodes', () => {
+			const expected = `<!-- wp:columns -->
+<div class="wp-block-columns has-2-columns">
+<!-- wp:column -->
+<div class="wp-block-column">
+<!-- wp:paragraph -->
+<p>A</p>
+<!-- /wp:paragraph -->
+</div>
+<!-- /wp:column -->
+<!-- wp:column -->
+<div class="wp-block-column">
+<!-- wp:list -->
+<ul><li>B</li><li>C</li></ul>
+<!-- /wp:list -->
+</div>
+<!-- /wp:column -->
+</div>
+<!-- /wp:columns -->`;
+			const input = {
+				blockName: 'core/columns',
+				attrs: {},
+				innerBlocks: [
+					{
+						blockName: 'core/column',
+						attrs: {},
+						innerBlocks: [
+							{
+								blockName: 'core/paragraph',
+								attrs: {},
+								innerBlocks: [],
+								innerHTML: '<p>A</p>',
+								innerContent: [ '<p>A</p>' ],
+							},
+						],
+						innerHTML: '<div class="wp-block-column"></div>',
+						innerContent: [
+							'<div class="wp-block-column">',
+							null,
+							'</div>',
+						],
+					},
+					{
+						blockName: 'core/column',
+						attrs: {},
+						innerBlocks: [
+							{
+								blockName: 'core/list',
+								attrs: {},
+								innerBlocks: [],
+								innerHTML: '<ul><li>B</li><li>C</li></ul>',
+								innerContent: [ '<ul><li>B</li><li>C</li></ul>' ],
+							},
+						],
+						innerHTML: '<div class="wp-block-column"></div>',
+						innerContent: [
+							'<div class="wp-block-column">',
+							null,
+							'</div>',
+						],
+					},
+				],
+				innerHTML: '<div class="wp-block-columns has-2-columns"></div>',
+				innerContent: [
+					'<div class="wp-block-columns has-2-columns">',
+					null,
+					'',
+					null,
+					'</div>',
+				],
+			};
+			const actual = serializeBlockNode( input );
+
+			expect( actual ).toEqual( expected );
 		} );
 	} );
 


### PR DESCRIPTION
Fixes #13391.
Fixes #15202.

## Description

When the block parser finds a block of unknown type, it wraps it in a special block (per `getUnregisteredTypeHandlerName`) — by default, this will be a block of type `core/missing`. This new outer block can then offer the user the possibility to extract the wrapped content.

This pull request updates the parsing logic so that the fallback block is fed the entire tree of content of the unknown block — if it has child blocks — and not just its own surface-level content.

## Example

When parsing the following unknown block:

```html
<!-- wp:my/unknown -->
  <p>Begin block that contains a list.</p>
  <!-- wp:list -->
  <ul><li>1</li><li>2</li></ul>
  <!-- /wp:list -->
  <p>End a block that contains a list.</p>
<!-- /wp:my/unknown -->
```

Before, the rescued `originalContent` would have been:

```html
<!-- wp:my/unknown -->
  <p>Begin block that contains a list.</p>
  <p>End block that contains a list.</p>
<!-- /wp:my/unknown -->
```

Now, it would be the entire markup for `my/unknown`.

## How has this been tested?

See parent issue for details. In addition, below are some concrete steps:

1. Start a new post.
1. Add a Columns block with two columns.
1. Add some basic content to each column.
1. Back in the source code, comment out the registration of the Columns block (see diff below).
1. Refresh the editor.

- The former Columns block should be singled out as an unknown block.
- Its in-editor preview should still reveal the former content, though greyed out.
- Actioning _Keep as HTML_ should replace it with an HTML block reflecting the original content.
- Not actioning _Keep as HTML_ and previewing the whole post should reflect the original content.
- Switching to the Code Editor should reveal the whole nested content.

```diff
diff --git a/packages/block-library/src/index.js b/packages/block-library/src/index.js
index 81a0e9bec..6a7c4569c 100644
--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -86,7 +86,7 @@ export const registerCoreBlocks = () => {
 		calendar,
 		categories,
 		code,
-		columns,
+		// columns,
 		column,
 		cover,
 		embed,
```

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->