### PR TITLE
Input Interaction: fix buffer for the triggering of multi-select

### DIFF
--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -181,6 +181,11 @@ export function isVerticalEdge( container, isReverse ) {
 	}
 
 	const editableRect = container.getBoundingClientRect();
+
+	// Calculate a buffer that is half the line height. In some browsers, the
+	// selection rectangle may not fill the entire height of the line, so we add
+	// half the line height to the selection rectangle to ensure that it is well
+	// over its line boundary.
 	const { lineHeight } = window.getComputedStyle( container );
 	const buffer = parseInt( lineHeight, 10 ) / 2;
 

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -180,8 +180,9 @@ export function isVerticalEdge( container, isReverse ) {
 		return false;
 	}
 
-	const buffer = rangeRect.height / 2;
 	const editableRect = container.getBoundingClientRect();
+	const { lineHeight } = window.getComputedStyle( container );
+	const buffer = parseInt( lineHeight, 10 ) / 2;
 
 	// Too low.
 	if ( isReverse && rangeRect.top - buffer > editableRect.top ) {

--- a/packages/e2e-tests/specs/__snapshots__/multi-block-selection.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/multi-block-selection.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Multi-block selection should only trigger multi-selection when at the end 1`] = `
+"<!-- wp:paragraph -->
+<p>1.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->"
+`;

--- a/packages/e2e-tests/specs/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/multi-block-selection.test.js
@@ -6,6 +6,8 @@ import {
 	insertBlock,
 	createNewPost,
 	pressKeyWithModifier,
+	pressKeyTimes,
+	getEditedPostContent,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Multi-block selection', () => {
@@ -136,5 +138,31 @@ describe( 'Multi-block selection', () => {
 		// inserts text into.
 		const speakTextContent = await page.$eval( '#a11y-speak-assertive', ( element ) => element.textContent );
 		expect( speakTextContent.trim() ).toEqual( '3 blocks selected.' );
+	} );
+
+	// See #14448: an incorrect buffer may trigger multi-selection too soon.
+	it( 'should only trigger multi-selection when at the end', async () => {
+		// Create a paragraph with four lines.
+		await clickBlockAppender();
+		await page.keyboard.type( '1.' );
+		await pressKeyWithModifier( 'shift', 'Enter' );
+		await page.keyboard.type( '2.' );
+		await pressKeyWithModifier( 'shift', 'Enter' );
+		await page.keyboard.type( '3.' );
+		await pressKeyWithModifier( 'shift', 'Enter' );
+		await page.keyboard.type( '4.' );
+		// Create a second block.
+		await page.keyboard.press( 'Enter' );
+		// Move to the middle of the first line.
+		await pressKeyTimes( 'ArrowUp', 4 );
+		await page.keyboard.press( 'ArrowRight' );
+		// Select mid line one to mid line four.
+		await pressKeyWithModifier( 'shift', 'ArrowDown' );
+		await pressKeyWithModifier( 'shift', 'ArrowDown' );
+		await pressKeyWithModifier( 'shift', 'ArrowDown' );
+		// Delete the text to see if the selection was correct.
+		await page.keyboard.press( 'Backspace' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
## Description

Fixes #12322. 

Fixes the `buffer` for calculating whether, based on the text selection, multi-selection should be triggered or not. This buffer was originally added with only a collapsed selection in mind, so calculating the line height was a simple matter of taking the height of the selection rectangle.

Solution: use `getComputedStyle` to get the line height from the browser.

Why is this buffer needed in the first place? Depending on the browser, there may be a difference between the height of the selection rectangles and the line height. The selection rectangle may not reach all the way to the line edge. This is why we add a buffer that is the line height divided by two.

## How has this been tested?

See #12322. Put the caret at the start of a paragraph that is at least 4 lines long. Press `shift+arrowDown` and ensure multi-block selection only starts after the last line has been selected.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->