### PR TITLE
RichText: remove selection change listener during composition

### DIFF
--- a/packages/block-editor/src/components/rich-text/editable.js
+++ b/packages/block-editor/src/components/rich-text/editable.js
@@ -13,7 +13,7 @@ import { BACKSPACE, DELETE } from '@wordpress/keycodes';
 /**
  * Internal dependencies
  */
-import { diffAriaProps, pickAriaProps } from './aria';
+import { diffAriaProps } from './aria';
 
 /**
  * Browser dependencies
@@ -137,10 +137,7 @@ export default class Editable extends Component {
 
 	bindEditorNode( editorNode ) {
 		this.editorNode = editorNode;
-
-		if ( this.props.setRef ) {
-			this.props.setRef( editorNode );
-		}
+		this.props.setRef( editorNode );
 
 		if ( IS_IE ) {
 			if ( editorNode ) {
@@ -154,7 +151,6 @@ export default class Editable extends Component {
 	}
 
 	render() {
-		const ariaProps = pickAriaProps( this.props );
 		const {
 			tagName = 'div',
 			style,
@@ -162,21 +158,14 @@ export default class Editable extends Component {
 			valueToEditableHTML,
 			className,
 			isPlaceholderVisible,
-			onPaste,
-			onInput,
-			onKeyDown,
-			onCompositionEnd,
-			onFocus,
-			onBlur,
-			onMouseDown,
-			onTouchStart,
+			...remainingProps
 		} = this.props;
 
-		ariaProps.role = 'textbox';
-		ariaProps[ 'aria-multiline' ] = true;
+		delete remainingProps.setRef;
 
 		return createElement( tagName, {
-			...ariaProps,
+			role: 'textbox',
+			'aria-multiline': true,
 			className: classnames( className, CLASS_NAME ),
 			contentEditable: true,
 			[ IS_PLACEHOLDER_VISIBLE_ATTR_NAME ]: isPlaceholderVisible,
@@ -184,14 +173,7 @@ export default class Editable extends Component {
 			style,
 			suppressContentEditableWarning: true,
 			dangerouslySetInnerHTML: { __html: valueToEditableHTML( record ) },
-			onPaste,
-			onInput,
-			onFocus,
-			onBlur,
-			onKeyDown,
-			onCompositionEnd,
-			onMouseDown,
-			onTouchStart,
+			...remainingProps,
 		} );
 	}
 }

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -373,6 +373,8 @@ export class RichText extends Component {
 		// Browsers setting `isComposing` to `true` will usually emit a final
 		// `input` event when the characters are composed.
 		if ( event && event.nativeEvent.isComposing ) {
+			// Also don't update any selection.
+			document.removeEventListener( 'selectionchange', this.onSelectionChange );
 			return;
 		}
 
@@ -444,6 +446,8 @@ export class RichText extends Component {
 		// Ensure the value is up-to-date for browsers that don't emit a final
 		// input event after composition.
 		this.onInput();
+		// Tracking selection changes can be resumed.
+		document.addEventListener( 'selectionchange', this.onSelectionChange );
 	}
 
 	/**
@@ -1114,8 +1118,6 @@ export class RichText extends Component {
 								onBlur={ this.onBlur }
 								onMouseDown={ this.onPointerDown }
 								onTouchStart={ this.onPointerDown }
-								multilineTag={ this.multilineTag }
-								multilineWrapperTags={ this.multilineWrapperTags }
 								setRef={ this.setRef }
 							/>
 							{ isPlaceholderVisible &&


### PR DESCRIPTION
## Description

This should be included in WP 5.2. It worked fine in WP 5.1.

Fixes #14434.

This bug can also be reproduced with other keyboards, including an American keyboard.

1. Create a new post and paragraph.
2. Press `` option+` ``. You started composing a character.
3. Press any vowel, e.g. `a`.

Expected: `à`. Actual: `` `à ``. 

Cause: the selection change event listener is called after input, which overwrites the DOM if the selection state is different (and it is different, but shouldn't be recorded). The overwrite happens for the format boundaries.

Solution: remove the selection change listener during composition.

Includes a minor clean up, as I was experimenting with different events bound to `Editable`.

## How has this been tested?

See above.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->