### PR TITLE
Input Interaction: only consider selection at edge if directed towards it

### DIFF
--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -169,7 +169,18 @@ export function isVerticalEdge( container, isReverse ) {
 	}
 
 	const selection = window.getSelection();
+
+	// Only consider the selection at the edge if the direction is towards the
+	// edge.
+	if (
+		! selection.isCollapsed &&
+		isSelectionForward( selection ) === isReverse
+	) {
+		return false;
+	}
+
 	const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
+
 	if ( ! range ) {
 		return false;
 	}

--- a/packages/e2e-tests/specs/__snapshots__/multi-block-selection.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/multi-block-selection.test.js.snap
@@ -9,3 +9,9 @@ exports[`Multi-block selection should only trigger multi-selection when at the e
 <p></p>
 <!-- /wp:paragraph -->"
 `;
+
+exports[`Multi-block selection should use selection direction to determine vertical edge 1`] = `
+"<!-- wp:paragraph -->
+<p>1<br>2.</p>
+<!-- /wp:paragraph -->"
+`;

--- a/packages/e2e-tests/specs/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/multi-block-selection.test.js
@@ -165,4 +165,19 @@ describe( 'Multi-block selection', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should use selection direction to determine vertical edge', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '1' );
+		await pressKeyWithModifier( 'shift', 'Enter' );
+		await page.keyboard.type( '2' );
+
+		await pressKeyWithModifier( 'shift', 'ArrowUp' );
+		await pressKeyWithModifier( 'shift', 'ArrowDown' );
+
+		// Should type at the end of the paragraph.
+		await page.keyboard.type( '.' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );


### PR DESCRIPTION
Closes #12322

## Description

An alternative to #13638. I chose to make the selection direction check inside `isVerticalEdge`, as we do the same for `isHorizontalEdge`. ~~Still needs tests.~~

## How has this been tested?



## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->