### PR TITLE
Input Interaction: fix cmd+arrow

### DIFF
--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -220,9 +220,14 @@ class WritingFlow extends Component {
 	}
 
 	onKeyDown( event ) {
-		const { hasMultiSelection, onMultiSelect, blocks } = this.props;
+		const {
+			hasMultiSelection,
+			onMultiSelect,
+			blocks,
+			onSelectBlock,
+		} = this.props;
 
-		const { keyCode, target } = event;
+		const { keyCode, target, shiftKey, ctrlKey, altKey, metaKey } = event;
 		const isUp = keyCode === UP;
 		const isDown = keyCode === DOWN;
 		const isLeft = keyCode === LEFT;
@@ -231,8 +236,7 @@ class WritingFlow extends Component {
 		const isHorizontal = isLeft || isRight;
 		const isVertical = isUp || isDown;
 		const isNav = isHorizontal || isVertical;
-		const isShift = event.shiftKey;
-		const hasModifier = isShift || event.ctrlKey || event.altKey || event.metaKey;
+		const hasModifier = shiftKey || ctrlKey || altKey || metaKey;
 		const isNavEdge = isVertical ? isVerticalEdge : isHorizontalEdge;
 
 		// This logic inside this condition needs to be checked before
@@ -269,6 +273,18 @@ class WritingFlow extends Component {
 			return;
 		}
 
+		if ( metaKey ) {
+			if ( isUp ) {
+				onSelectBlock( blocks[ 0 ] );
+				event.preventDefault();
+			} else if ( isDown ) {
+				onSelectBlock( blocks[ blocks.length - 1 ], -1 );
+				event.preventDefault();
+			}
+
+			return;
+		}
+
 		// Abort if our current target is not a candidate for navigation (e.g.
 		// preserve native input behaviors).
 		if ( ! isNavigationCandidate( target, keyCode, hasModifier ) ) {
@@ -281,7 +297,7 @@ class WritingFlow extends Component {
 			this.verticalRect = computeCaretRect( target );
 		}
 
-		if ( isShift && ( hasMultiSelection || (
+		if ( shiftKey && ( hasMultiSelection || (
 			this.isTabbableEdge( target, isReverse ) &&
 			isNavEdge( target, isReverse )
 		) ) ) {

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -17,7 +17,7 @@ import {
 	placeCaretAtVerticalEdge,
 	isEntirelySelected,
 } from '@wordpress/dom';
-import { UP, DOWN, LEFT, RIGHT, isKeyboardEvent } from '@wordpress/keycodes';
+import { UP, DOWN, LEFT, RIGHT, HOME, END, isKeyboardEvent } from '@wordpress/keycodes';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
@@ -273,11 +273,11 @@ class WritingFlow extends Component {
 			return;
 		}
 
-		if ( metaKey ) {
-			if ( isUp ) {
+		if ( metaKey || ctrlKey ) {
+			if ( ( metaKey && isUp ) || ( ctrlKey && keyCode === HOME ) ) {
 				onSelectBlock( blocks[ 0 ] );
 				event.preventDefault();
-			} else if ( isDown ) {
+			} else if ( ( metaKey && isDown ) || ( ctrlKey && keyCode === END ) ) {
 				onSelectBlock( blocks[ blocks.length - 1 ], -1 );
 				event.preventDefault();
 			}

--- a/packages/keycodes/CHANGELOG.md
+++ b/packages/keycodes/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0 (Unreleased)
+
+- Added keycodes for HOME and END keys.
+
 ## 2.0.5 (2018-11-21)
 
 ## 2.0.4 (2018-11-20)

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -45,6 +45,14 @@ export const ESCAPE = 27;
  */
 export const SPACE = 32;
 /**
+ * Keycode for END key.
+ */
+export const END = 35;
+/**
+ * Keycode for HOME key.
+ */
+export const HOME = 36;
+/**
  * Keycode for LEFT key.
  */
 export const LEFT = 37;


### PR DESCRIPTION
## Description

Fixes #5805 and #8353.

* For cmd + horizontal arrow: always fall back to browser behaviour.
* For cmd + arrow up: select the first block.
* For cmd + arrow down: select the last block.
* For ctrl + home: select the first block.
* For ctrl + end: select the last block.

Question: does ctrl + arrow work the same outside macOS?

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->