### PR TITLE
Edit Post: Remove menu toggling on checkbox, radio buttons

### DIFF
--- a/packages/e2e-tests/specs/editor-modes.test.js
+++ b/packages/e2e-tests/specs/editor-modes.test.js
@@ -98,8 +98,11 @@ describe( 'Editing modes (visual/HTML)', () => {
 		let blockInspectorTab = await page.$( '.edit-post-sidebar__panel-tab.is-active[data-label="Block"]' );
 		expect( blockInspectorTab ).not.toBeNull();
 
-		// Switch to Code Editor
+		// Switch to Code Editor and hide More Menu
 		await switchEditorModeTo( 'Code' );
+		await page.click(
+			'.edit-post-more-menu [aria-label="Hide more tools & options"]'
+		);
 
 		// The Block inspector should not be active anymore
 		blockInspectorTab = await page.$( '.edit-post-sidebar__panel-tab.is-active[data-label="Block"]' );

--- a/packages/edit-post/src/components/header/feature-toggle/index.js
+++ b/packages/edit-post/src/components/header/feature-toggle/index.js
@@ -40,7 +40,6 @@ export default compose( [
 	withDispatch( ( dispatch, ownProps ) => ( {
 		onToggle() {
 			dispatch( 'core/edit-post' ).toggleFeature( ownProps.feature );
-			ownProps.onToggle();
 		},
 	} ) ),
 	withSpokenMessages,

--- a/packages/edit-post/src/components/header/mode-switcher/index.js
+++ b/packages/edit-post/src/components/header/mode-switcher/index.js
@@ -53,10 +53,9 @@ export default compose( [
 		mode: select( 'core/edit-post' ).getEditorMode(),
 	} ) ),
 	ifCondition( ( { isRichEditingEnabled } ) => isRichEditingEnabled ),
-	withDispatch( ( dispatch, ownProps ) => ( {
+	withDispatch( ( dispatch ) => ( {
 		onSwitch( mode ) {
 			dispatch( 'core/edit-post' ).switchEditorMode( mode );
-			ownProps.onSelect( mode );
 		},
 	} ) ),
 ] )( ModeSwitcher );

--- a/packages/edit-post/src/components/header/more-menu/index.js
+++ b/packages/edit-post/src/components/header/more-menu/index.js
@@ -33,8 +33,8 @@ const MoreMenu = () => (
 		) }
 		renderContent={ ( { onClose } ) => (
 			<Fragment>
-				<WritingMenu onClose={ onClose } />
-				<ModeSwitcher onSelect={ onClose } />
+				<WritingMenu />
+				<ModeSwitcher />
 				<PluginMoreMenuGroup.Slot fillProps={ { onClose } } />
 				<ToolsMoreMenuGroup.Slot fillProps={ { onClose } } />
 				<MenuGroup>

--- a/packages/edit-post/src/components/header/writing-menu/index.js
+++ b/packages/edit-post/src/components/header/writing-menu/index.js
@@ -10,7 +10,7 @@ import { ifViewportMatches } from '@wordpress/viewport';
  */
 import FeatureToggle from '../feature-toggle';
 
-function WritingMenu( { onClose } ) {
+function WritingMenu() {
 	return (
 		<MenuGroup
 			label={ _x( 'View', 'noun' ) }
@@ -19,7 +19,6 @@ function WritingMenu( { onClose } ) {
 				feature="fixedToolbar"
 				label={ __( 'Top Toolbar' ) }
 				info={ __( 'Access all block and document tools in a single place' ) }
-				onToggle={ onClose }
 				messageActivated={ __( 'Top toolbar activated' ) }
 				messageDeactivated={ __( 'Top toolbar deactivated' ) }
 			/>
@@ -27,7 +26,6 @@ function WritingMenu( { onClose } ) {
 				feature="focusMode"
 				label={ __( 'Spotlight Mode' ) }
 				info={ __( 'Focus on one block at a time' ) }
-				onToggle={ onClose }
 				messageActivated={ __( 'Spotlight mode activated' ) }
 				messageDeactivated={ __( 'Spotlight mode deactivated' ) }
 			/>
@@ -35,7 +33,6 @@ function WritingMenu( { onClose } ) {
 				feature="fullscreenMode"
 				label={ __( 'Fullscreen Mode' ) }
 				info={ __( 'Work without distraction' ) }
-				onToggle={ onClose }
 				messageActivated={ __( 'Fullscreen mode activated' ) }
 				messageDeactivated={ __( 'Fullscreen mode deactivated' ) }
 			/>


### PR DESCRIPTION
This pull request seeks to avoid closing the More Options menu when selecting one of its checkbox or radio items (specifically, the options under "View" and "Editor" subheadings).

I could not find an associated issue, though one may exist.

Per WAI-ARIA Authoring Practices 1.1 3.15 Menu or Menu bar:

>- Space:
>   - (Optional): When focus is on a `menuitemcheckbox`, changes the state **without closing the menu**.
>   - (Optional): When focus is on a `menuitemradio` that is not checked, **without closing the menu**, checks the focused `menuitemradio` and unchecks any other checked `menuitemradio` element in the same group.

(Emphasis mine)

https://www.w3.org/TR/wai-aria-practices/#menu

**Testing Instructions:**

Note: The current behavior is still not ideal. Focus is lost due to rendering behavior of `MenuItem`, specifically in that it renders a new element of a different type (`Button` vs. `IconButton`) depending on whether the menu item is checked ([source](https://github.com/WordPress/gutenberg/blob/7723b06b34a9c9f2ebc72eae863724c2895b54bd/packages/components/src/menu-item/index.js#L69)). This needs to be addressed.

In the meantime: The menu should at least no longer close when pressing these buttons, if either by keyboard activation or a direct mouse click.