### PR TITLE
Improve openAllBlockInserterCategories function; 

### DIFF
--- a/packages/e2e-test-utils/src/open-all-block-inserter-categories.js
+++ b/packages/e2e-test-utils/src/open-all-block-inserter-categories.js
@@ -2,10 +2,10 @@
  * Opens all block inserter categories.
  */
 export async function openAllBlockInserterCategories() {
-	const notOpenCategoryPanels = await page.$$(
-		'.block-editor-inserter__results .components-panel__body:not(.is-opened)'
-	);
-	for ( const categoryPanel of notOpenCategoryPanels ) {
+	const notOppenedCategorySelector = '.block-editor-inserter__results .components-panel__body:not(.is-opened)';
+	let categoryPanel = await page.$( notOppenedCategorySelector );
+	while ( categoryPanel !== null ) {
 		await categoryPanel.click();
+		categoryPanel = await page.$( notOppenedCategorySelector );
 	}
 }

--- a/packages/e2e-tests/specs/plugins/inner-blocks-allowed-blocks.test.js
+++ b/packages/e2e-tests/specs/plugins/inner-blocks-allowed-blocks.test.js
@@ -11,12 +11,7 @@ import {
 	openGlobalBlockInserter,
 } from '@wordpress/e2e-test-utils';
 
-// Todo: Understand why this test causing intermitent fails on travis.
-// Error:   ● Allowed Blocks Setting on InnerBlocks  › allows all blocks if the allowed blocks setting was not set
-// Node is detached from document
-// at ElementHandle._scrollIntoViewIfNeeded (../../node_modules/puppeteer/lib/ElementHandle.js:75:13)
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip( 'Allowed Blocks Setting on InnerBlocks ', () => {
+describe( 'Allowed Blocks Setting on InnerBlocks ', () => {
 	const paragraphSelector = '.block-editor-rich-text__editable.wp-block-paragraph';
 	beforeAll( async () => {
 		await activatePlugin( 'gutenberg-test-innerblocks-allowed-blocks' );


### PR DESCRIPTION
Fix intermittent failures in inner-blocks-allowed-blocks.test.js.


## How has this been tested?
The best method seems to be executing this test in Travis CI multiple times and check that the tests don't fail.
