### PR TITLE
Input Interaction: better horizontal edge detection

### DIFF
--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -148,7 +148,7 @@ _Parameters_
 
 _Returns_
 
--   `boolean`: True if at the edge, false if not.
+-   `boolean`: True if at the vertical edge, false if not.
 
 <a name="placeCaretAtHorizontalEdge" href="#placeCaretAtHorizontalEdge">#</a> **placeCaretAtHorizontalEdge**
 

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -101,7 +101,7 @@ export function isHorizontalEdge( container, isReverse ) {
 		return false;
 	}
 
-	const rangeRect = getRectangleFromRange( range.cloneRange() );
+	const rangeRect = getRectangleFromRange( range );
 
 	if ( ! rangeRect ) {
 		return false;
@@ -114,7 +114,7 @@ export function isHorizontalEdge( container, isReverse ) {
 	// half the line height to the selection rectangle to ensure that it is well
 	// over its line boundary.
 	const { lineHeight, paddingLeft } = window.getComputedStyle( container );
-	const buffer = parseInt( lineHeight, 10 ) / 2;
+	const buffer = 3 * parseInt( lineHeight, 10 ) / 4;
 	const padding = parseInt( paddingLeft, 10 );
 
 	if ( isReverse ) {

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -113,30 +113,31 @@ export function isHorizontalEdge( container, isReverse ) {
 	// selection rectangle may not fill the entire height of the line, so we add
 	// half the line height to the selection rectangle to ensure that it is well
 	// over its line boundary.
-	const { lineHeight, paddingLeft } = window.getComputedStyle( container );
+	const { lineHeight } = window.getComputedStyle( container );
 	const buffer = 3 * parseInt( lineHeight, 10 ) / 4;
-	const padding = parseInt( paddingLeft, 10 );
 
-	if ( isReverse ) {
-		return (
-			Math.round( containerRect.left + padding ) === Math.round( rangeRect.left ) &&
-			containerRect.top > rangeRect.top - buffer
-		);
+	const verticalEdge = isReverse ?
+		containerRect.top > rangeRect.top - buffer :
+		containerRect.bottom < rangeRect.bottom + buffer;
+
+	if ( ! verticalEdge ) {
+		return false;
 	}
 
-	if ( containerRect.bottom < rangeRect.bottom + buffer ) {
-		const testRange = hiddenCaretRangeFromPoint(
-			document,
-			containerRect.right - 1,
-			containerRect.bottom - buffer,
-			container
-		);
-		const testRect = getRectangleFromRange( testRange );
+	const x = isReverse ? containerRect.left + 1 : containerRect.right - 1;
+	const y = isReverse ?
+		containerRect.top + buffer :
+		containerRect.bottom - buffer;
+	const testRange = hiddenCaretRangeFromPoint( document, x, y, container );
 
-		return Math.round( testRect.right ) === Math.round( rangeRect.right );
+	if ( ! testRange ) {
+		return false;
 	}
 
-	return false;
+	const side = isReverse ? 'left' : 'right';
+	const testRect = getRectangleFromRange( testRange );
+
+	return Math.round( testRect[ side ] ) === Math.round( rangeRect[ side ] );
 }
 
 /**

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -217,6 +217,18 @@ export function getRectangleFromRange( range ) {
 		return range.getBoundingClientRect();
 	}
 
+	const { startContainer } = range;
+
+	// Correct invalid "BR" ranges. The cannot contain any children.
+	if ( startContainer.nodeName === 'BR' ) {
+		const { parentNode } = startContainer;
+		const index = Array.from( parentNode.childNodes ).indexOf( startContainer );
+
+		range = document.createRange();
+		range.setStart( parentNode, index );
+		range.setEnd( parentNode, index );
+	}
+
 	let rect = range.getClientRects()[ 0 ];
 
 	// If the collapsed range starts (and therefore ends) at an element node,

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -90,7 +90,7 @@ function isEdge( container, { isReverse, isVertical } ) {
 	const selection = window.getSelection();
 
 	if ( ! selection.rangeCount ) {
-		return;
+		return false;
 	}
 
 	const rangeRect = getRectangleFromRange( selection.getRangeAt( 0 ) );

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -61,16 +61,16 @@ function isSelectionForward( selection ) {
 
 /**
  * Check whether the selection is at the edge of the container. Checks for
- * horizontal position by default. Set `isVertical` to true to check only
+ * horizontal position by default. Set `onlyVertical` to true to check only
  * vertically.
  *
- * @param {Element} container  Focusable element.
- * @param {boolean} isReverse  Set to true to check left, false to check right.
- * @param {boolean} isVertical Set to true to check only vertical position.
+ * @param {Element} container    Focusable element.
+ * @param {boolean} isReverse    Set to true to check left, false to check right.
+ * @param {boolean} onlyVertical Set to true to check only vertical position.
  *
- * @return {boolean} True if at the horizontal edge, false if not.
+ * @return {boolean} True if at the edge, false if not.
  */
-function isEdge( container, { isReverse, isVertical } ) {
+function isEdge( container, isReverse, onlyVertical ) {
 	if ( includes( [ 'INPUT', 'TEXTAREA' ], container.tagName ) ) {
 		if ( container.selectionStart !== container.selectionEnd ) {
 			return false;
@@ -126,10 +126,15 @@ function isEdge( container, { isReverse, isVertical } ) {
 		return false;
 	}
 
-	if ( isVertical ) {
+	if ( onlyVertical ) {
 		return true;
 	}
 
+	// To calculate the horizontal position, we insert a test range and see if
+	// this test range has the same horizontal position. This method proves to
+	// be better than a DOM-based calculation, because it ignores empty text
+	// nodes and a trailing line break element. In other words, we need to check
+	// visual positioning, not DOM positioning.
 	const x = isReverse ? containerRect.left + 1 : containerRect.right - 1;
 	const y = isReverse ? containerRect.top + buffer : containerRect.bottom - buffer;
 	const testRange = hiddenCaretRangeFromPoint( document, x, y, container );
@@ -153,7 +158,7 @@ function isEdge( container, { isReverse, isVertical } ) {
  * @return {boolean} True if at the horizontal edge, false if not.
  */
 export function isHorizontalEdge( container, isReverse ) {
-	return isEdge( container, { isReverse } );
+	return isEdge( container, isReverse );
 }
 
 /**
@@ -162,10 +167,10 @@ export function isHorizontalEdge( container, isReverse ) {
  * @param {Element} container Focusable element.
  * @param {boolean} isReverse Set to true to check top, false for bottom.
  *
- * @return {boolean} True if at the edge, false if not.
+ * @return {boolean} True if at the vertical edge, false if not.
  */
 export function isVerticalEdge( container, isReverse ) {
-	return isEdge( container, { isReverse, isVertical: true } );
+	return isEdge( container, isReverse, true );
 }
 
 /**

--- a/packages/e2e-tests/specs/__snapshots__/writing-flow.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/writing-flow.test.js.snap
@@ -126,6 +126,16 @@ exports[`adding blocks should navigate around nested inline boundaries 2`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`adding blocks should navigate empty paragraph 1`] = `
+"<!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`adding blocks should not create extra line breaks in multiline value 1`] = `
 "<!-- wp:quote -->
 <blockquote class=\\"wp-block-quote\\"><p></p></blockquote>

--- a/packages/e2e-tests/specs/writing-flow.test.js
+++ b/packages/e2e-tests/specs/writing-flow.test.js
@@ -298,4 +298,16 @@ describe( 'adding blocks', () => {
 		// Check that none of the paragraph blocks have <br> in them.
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should navigate empty paragraph', async () => {
+		await clickBlockAppender();
+		await page.keyboard.press( 'Enter' );
+		await page.waitForFunction( () => document.activeElement.isContentEditable );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.type( '1' );
+		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.type( '2' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );


### PR DESCRIPTION
## Description

Fixes #12114.

Fixes horizontal arrow navigation in empty containers. To reproduce, create an empty paragraph block and try to use the left/right arrow keys.

This completely rewrites `isHorizontalEdge` to check visual position instead of DOM position, just like `isVerticalEdge`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->