### PR TITLE
Keep styling after spliting a block

### DIFF
--- a/packages/block-editor/src/store/effects.js
+++ b/packages/block-editor/src/store/effects.js
@@ -117,7 +117,6 @@ export default {
 					...blockA,
 					attributes: {
 						...blockA.attributes,
-						...blockB.attributes,
 						...updatedAttributes,
 					},
 				},

--- a/packages/block-editor/src/store/effects.js
+++ b/packages/block-editor/src/store/effects.js
@@ -116,7 +116,7 @@ export default {
 				{
 					...blockA,
 					attributes: {
-						...blockA.attributes,
+						...( blockA.attributes.content.length === 0 ? blockB.attributes : blockA.attributes ),
 						...updatedAttributes,
 					},
 				},

--- a/packages/block-editor/src/store/effects.js
+++ b/packages/block-editor/src/store/effects.js
@@ -116,7 +116,8 @@ export default {
 				{
 					...blockA,
 					attributes: {
-						...( blockA.attributes.content.length === 0 ? blockB.attributes : blockA.attributes ),
+						...blockA.attributes,
+						...blockB.attributes,
 						...updatedAttributes,
 					},
 				},

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -103,8 +103,16 @@ class ParagraphBlock extends Component {
 
 		if ( after !== null ) {
 			// Append "After" content as a new paragraph block to the end of
-			// any other blocks being inserted after the current paragraph.
-			blocks.push( createBlock( name, { content: after } ) );
+			// any other blocks being inserted after the current paragraph
+			if ( after.length ) {
+				// If "After" has content, keep the new block styling same as current one.
+				const newBlockAttributes = attributes;
+				newBlockAttributes.content = after;
+				blocks.push( createBlock( name, newBlockAttributes ) );
+			} else {
+				// Otherwise, add a default block
+				blocks.push( createBlock( name ) );
+			}
 		}
 
 		if ( blocks.length && insertBlocksAfter ) {

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -106,8 +106,10 @@ class ParagraphBlock extends Component {
 			// any other blocks being inserted after the current paragraph
 			if ( after.length ) {
 				// If after has content, keep the new block styling same as current one.
-				const newBlockAttributes = attributes;
-				newBlockAttributes.content = after;
+				const newBlockAttributes = {
+					...attributes,
+					content: after
+				};
 				blocks.push( createBlock( name, newBlockAttributes ) );
 			} else {
 				// Otherwise, add a default block

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -105,7 +105,7 @@ class ParagraphBlock extends Component {
 			// Append "After" content as a new paragraph block to the end of
 			// any other blocks being inserted after the current paragraph
 			if ( after.length ) {
-				// If "After" has content, keep the new block styling same as current one.
+				// If after has content, keep the new block styling same as current one.
 				const newBlockAttributes = attributes;
 				newBlockAttributes.content = after;
 				blocks.push( createBlock( name, newBlockAttributes ) );
@@ -123,6 +123,9 @@ class ParagraphBlock extends Component {
 		if ( before === null ) {
 			// If before content is omitted, treat as intent to delete block.
 			onReplace( [] );
+		} else if ( before.length === 0 ) {
+			// If before has not content, replace by a default block.
+			onReplace( [ createBlock( name ) ] );
 		} else if ( content !== before ) {
 			// Only update content if it has in-fact changed. In case that user
 			// has created a new paragraph at end of an existing one, the value

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -108,7 +108,7 @@ class ParagraphBlock extends Component {
 				// If after has content, keep the new block styling same as current one.
 				const newBlockAttributes = {
 					...attributes,
-					content: after
+					content: after,
 				};
 				blocks.push( createBlock( name, newBlockAttributes ) );
 			} else {

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -212,6 +212,9 @@ export const settings = {
 
 	merge( attributes, attributesToMerge ) {
 		return {
+			backgroundColor: attributes.content.length === 0 ? attributesToMerge.backgroundColor : attributes.backgroundColor,
+			textColor: attributes.content.length === 0 ? attributesToMerge.textColor : attributes.textColor,
+			fontSize: attributes.content.length === 0 ? attributesToMerge.fontSize : attributes.fontSize,
 			content: ( attributes.content || '' ) + ( attributesToMerge.content || '' ),
 		};
 	},


### PR DESCRIPTION
## Description
Fix #13740 

## How has this been tested?

- [X] Local
- [X] unit tests
- [X] Local e2e tests
- [X] Browser testing

## Screenshots <!-- if applicable -->
![yPyTTA3q7J](https://user-images.githubusercontent.com/24849874/54455992-6e3e6d80-4733-11e9-87e5-4f23cf325aa9.gif)

## Types of changes
Update the `splitBlock` function such that it will make the styling of the new block same as the current one.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
