### PR TITLE
Exculde test files when rebuilding packages

### DIFF
--- a/bin/packages/watch.js
+++ b/bin/packages/watch.js
@@ -23,9 +23,11 @@ const exists = ( filename ) => {
 	return false;
 };
 
-// Exclude deceitful source-like files, such as editor swap files.
+// Exclude test files including .js files inside of __tests__ or test folders
+// and files with a suffix of .test or .spec (e.g. blocks.test.js),
+// and deceitful source-like files, such as editor swap files.
 const isSourceFile = ( filename ) => {
-	return /.\.(js|scss)$/.test( filename );
+	return ! [ /\/(__tests__|test)\/.+.js$/, /.\.(spec|test)\.js$/ ].some( ( regex ) => regex.test( filename ) ) && /.\.(js|scss)$/.test( filename );
 };
 
 const rebuild = ( filename ) => filesToBuild.set( filename, true );


### PR DESCRIPTION
## Description
Fix #11799  

## How has this been tested?

- [X] Local
- [X] unit tests
- [X] Local e2e tests
- [X] Browser testing

## Types of changes
Use regular expressions to exclude test files including .js files inside of __tests__ or test folders and files with a suffix of .test or .spec (e.g. blocks.test.js) such webpack will not rebuild these files when watching some changes.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
