### PR TITLE
Updated text in tooltip on block transformations to include style

### DIFF
--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -95,7 +95,7 @@ export class BlockSwitcher extends Component {
 					};
 					const label = (
 						1 === blocks.length ?
-							__( 'Change block type' ) :
+							__( 'Change block type or style' ) :
 							sprintf(
 								_n(
 									'Change type of %d block',

--- a/packages/e2e-tests/specs/style-variation.test.js
+++ b/packages/e2e-tests/specs/style-variation.test.js
@@ -18,7 +18,7 @@ describe( 'adding blocks', () => {
 		await insertBlock( 'Quote' );
 		await page.keyboard.type( 'Quote content' );
 
-		await clickBlockToolbarButton( 'Change block type' );
+		await clickBlockToolbarButton( 'Change block type or style' );
 
 		const styleVariations = await page.$$( '.block-editor-block-styles__item' );
 		await styleVariations[ 1 ].click();


### PR DESCRIPTION
## Description
Fixes #10852. Editing tooltip for the Change Block icon. 

## How has this been tested?
Tested locally.

![toolbar-tooltip](https://user-images.githubusercontent.com/617986/54470143-37328100-4760-11e9-87ef-215fba3c74ac.gif)


## Types of changes
Updates the text from "Change block type" to "Change block type or style".

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
