### PR TITLE
Fix typo on hooks package readme.

### DIFF
--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -27,10 +27,10 @@ In the WordPress context, API functions can be called via the global `wp.hooks` 
 ### API Usage
 
 * `createHooks()`
-* `addAction( 'hookName', 'namespace', 'functionName', callback, priority )`
-* `addFilter( 'hookName', 'namespace', 'functionName', callback, priority )`
-* `removeAction( 'hookName', 'namespace', 'functionName' )`
-* `removeFilter( 'hookName', 'namespace', 'functionName' )`
+* `addAction( 'hookName', 'namespace', callback, priority )`
+* `addFilter( 'hookName', 'namespace', callback, priority )`
+* `removeAction( 'hookName', 'namespace' )`
+* `removeFilter( 'hookName', 'namespace' )`
 * `removeAllActions( 'hookName' )`
 * `removeAllFilters( 'hookName' )`
 * `doAction( 'hookName', arg1, arg2, moreArgs, finalArg )`


### PR DESCRIPTION
## Description
Remove the "functionName" parameter on the documentation which not used in the actual code of hooks package.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
Documentation improvement.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
