### PR TITLE
Better center tooltip content

### DIFF
--- a/packages/components/src/tooltip/style.scss
+++ b/packages/components/src/tooltip/style.scss
@@ -20,6 +20,7 @@
 	border-width: 0;
 	color: $white;
 	white-space: nowrap;
+	text-align: center;
 }
 
 .components-tooltip:not(.is-mobile) .components-popover__content {
@@ -28,6 +29,5 @@
 
 .components-tooltip__shortcut {
 	display: block;
-	text-align: center;
 	color: $dark-gray-200;
 }


### PR DESCRIPTION
Fixes #14472.

On Windows, keyboard shortcuts within tooltips are longer than on macOS, thus the text is not centered:

![chrome windows](https://user-images.githubusercontent.com/1682452/54473937-e150ee00-47de-11e9-8ae1-a70e92a075d2.png)

This PR moves `text-align: center;` from the shortcut text to the tooltip content container.

If you can't test on Windows, you can try:
- use Chrome and open the dev tools > Sources tab
- hover on the Redo button
- press F8: you're now in "paused in debugger" mode
- switch to the dev tools Elements tab
- search for the keyboard shortcut text and replace it with a longer text:

<img width="209" alt="Screenshot 2019-03-16 at 10 49 41" src="https://user-images.githubusercontent.com/1682452/54473964-3d1b7700-47df-11e9-9d2b-ff6e8c8f6e2f.png">

- verify the text is centered