### PR TITLE
Refactor the Settings button CSS.

### DIFF
--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -69,7 +69,8 @@
 	&.is-toggled {
 		color: $white;
 		background: $dark-gray-500;
-		box-shadow: inset 0 0 0 $border-width $white;
+		margin: 1px;
+		padding: 7px;
 	}
 
 	// The !important in this ruleset need to override the pile of :not() selectors used in the icon-button.

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -68,26 +68,16 @@
 	// Header toggle buttons.
 	&.is-toggled {
 		color: $white;
-	}
-
-	// Put the gray background on a separate layer, so as to match the size of the publish button (34px).
-	&.is-toggled::before {
-		content: "";
-		border-radius: $radius-round-rectangle;
-		position: absolute;
-		z-index: -1;
 		background: $dark-gray-500;
-		top: 1px;
-		right: 1px;
-		bottom: 1px;
-		left: 1px;
+		box-shadow: inset 0 0 0 $border-width $white;
 	}
 
+	// The !important in this ruleset need to override the pile of :not() selectors used in the icon-button.
 	&.is-toggled:hover,
 	&.is-toggled:focus {
-		box-shadow: 0 0 0 $border-width $dark-gray-500, inset 0 0 0 $border-width $white;
-		color: $white;
-		background: $dark-gray-500;
+		box-shadow: 0 0 0 $border-width $dark-gray-500, inset 0 0 0 $border-width $white !important;
+		color: $white !important;
+		background: $dark-gray-500 !important;
 	}
 
 	// Make editor header bar buttons bigger to match IconButtons.


### PR DESCRIPTION
Fixes #14474.

This PR seeks to solve a Firefox / NVDA bug where changes to the Settings button `aria-expanded` state are not announced because of the CSS pseudo-element used for styling. For more details, please see the related issue #14474.

I've opted to just remove the CSS pseudo element and re-implement the styling by other means.

Worth nothing the `.is-toggled:hover` state didn't work as intended, not even on master. I had to use `!important` to override a pile of `:not()` selectors used in the icon-button. Adding one more `:not()` there didn't seem to me the best option.

The CSS should replicate the current styling. Do feel free to change it if desired, but please don't use a CSS pseudo-element 🙂 

/Cc @jasmussen 

Screenshot (for comparison, see the GIF on the issue):

![Screenshot (190)](https://user-images.githubusercontent.com/1682452/54475074-75c24d00-47ed-11e9-80ee-88c1c1535ee6.png)
