### PR TITLE
Use inline-block to limit label width to content

### DIFF
--- a/packages/block-library/src/video/editor.scss
+++ b/packages/block-library/src/video/editor.scss
@@ -3,6 +3,7 @@
 }
 
 .editor-video-poster-control .components-button {
+	display: block;
 	margin-right: 8px;
 }
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -53,6 +53,10 @@
 - Added a new `preview` prop to the `Placeholder` component which allows to display a preview, for example a media preview when the Placeholder is used in media editing contexts.
 - Added a new `anchorRect` prop to `Popover` which enables a developer to provide a custom `DOMRect` object at which to position the popover.
 
+### Improvements
+
+- Limit `Base Control Label` to the width of its content. 
+
 ### Bug fixes
 
 - Fix `instanceId` prop passed through to `Button` component via `MenuItems` producing React console error. Fixed by removing the unnecessary use of `withInstanceId` on the `MenuItems` component [#14599](https://github.com/WordPress/gutenberg/pull/14599)

--- a/packages/components/src/base-control/style.scss
+++ b/packages/components/src/base-control/style.scss
@@ -11,7 +11,7 @@
 	}
 
 	.components-base-control__label {
-		display: block;
+		display: inline-block;
 		margin-bottom: $grid-size-small;
 	}
 


### PR DESCRIPTION
## Description
Closes #9612.  Use `display: inline-block` instead of `display: block` to limit `BaseControl label` to width of the content of the label.  

## How has this been tested?
- `npm run test` all tests successful.  
- manually looked at different blocks with labels. Obviously not an exhaustive test, and will be willing to look at anything else to confirm this change. 

## Screenshots
before:
![image](https://user-images.githubusercontent.com/6384100/54484383-51856100-482b-11e9-9973-cfd3d128859e.png)

after:
![image](https://user-images.githubusercontent.com/6384100/54484374-2864d080-482b-11e9-87fe-aaeb8e0dbcea.png)

before: 
![image](https://user-images.githubusercontent.com/6384100/54484393-6bbf3f00-482b-11e9-8b0a-95e9b7b63fe2.png)

after: 
![image](https://user-images.githubusercontent.com/6384100/54484397-7ed20f00-482b-11e9-80a5-302f784028bd.png)


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. 
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation. 
- [x] I've included developer documentation if appropriate. 
