### PR TITLE
ResizableBox: Make invisible resize handles bigger

### DIFF
--- a/assets/stylesheets/_z-index.scss
+++ b/assets/stylesheets/_z-index.scss
@@ -99,7 +99,11 @@ $z-layers: (
 	".nux-dot-tip": 1000001,
 
 	// Show tooltips above NUX tips, wp-admin menus, submenus, and sidebar:
-	".components-tooltip": 1000002
+	".components-tooltip": 1000002,
+
+	// Make sure corner handles are above side handles for ResizableBox component
+	".components-resizable-box__side-handle": 1,
+	".components-resizable-box__corner-handle": 2
 );
 
 @function z-index( $key ) {

--- a/packages/components/src/resizable-box/index.js
+++ b/packages/components/src/resizable-box/index.js
@@ -16,6 +16,8 @@ function ResizableBox( { className, ...props } ) {
 	};
 
 	const handleClassName = 'components-resizable-box__handle';
+	const sideHandleClassName = 'components-resizable-box__side-handle';
+	const cornerHandleClassName = 'components-resizable-box__corner-handle';
 
 	return (
 		<ReResizableBox
@@ -26,18 +28,46 @@ function ResizableBox( { className, ...props } ) {
 			handleClasses={ {
 				top: classnames(
 					handleClassName,
+					sideHandleClassName,
 					'components-resizable-box__handle-top',
 				),
 				right: classnames(
 					handleClassName,
+					sideHandleClassName,
 					'components-resizable-box__handle-right',
 				),
 				bottom: classnames(
 					handleClassName,
+					sideHandleClassName,
 					'components-resizable-box__handle-bottom',
 				),
 				left: classnames(
 					handleClassName,
+					sideHandleClassName,
+					'components-resizable-box__handle-left',
+				),
+				topLeft: classnames(
+					handleClassName,
+					cornerHandleClassName,
+					'components-resizable-box__handle-top',
+					'components-resizable-box__handle-left',
+				),
+				topRight: classnames(
+					handleClassName,
+					cornerHandleClassName,
+					'components-resizable-box__handle-top',
+					'components-resizable-box__handle-right',
+				),
+				bottomRight: classnames(
+					handleClassName,
+					cornerHandleClassName,
+					'components-resizable-box__handle-bottom',
+					'components-resizable-box__handle-right',
+				),
+				bottomLeft: classnames(
+					handleClassName,
+					cornerHandleClassName,
+					'components-resizable-box__handle-bottom',
 					'components-resizable-box__handle-left',
 				),
 			} }
@@ -46,6 +76,10 @@ function ResizableBox( { className, ...props } ) {
 				right: handleStylesOverrides,
 				bottom: handleStylesOverrides,
 				left: handleStylesOverrides,
+				topLeft: handleStylesOverrides,
+				topRight: handleStylesOverrides,
+				bottomRight: handleStylesOverrides,
+				bottomLeft: handleStylesOverrides,
 			} }
 			{ ...props }
 		/>

--- a/packages/components/src/resizable-box/style.scss
+++ b/packages/components/src/resizable-box/style.scss
@@ -1,5 +1,7 @@
 .components-resizable-box__handle {
 	display: none;
+	width: $resize-handler-container-size;
+	height: $resize-handler-container-size;
 
 	// Show the resize handle when selected.
 	.components-resizable-box__container.is-selected & {
@@ -22,14 +24,30 @@
 	right: calc(50% - #{$resize-handler-size / 2});
 }
 
-/*!rtl:begin:ignore*/
-.components-resizable-box__handle-right,
-.components-resizable-box__handle-left {
-	top: 0;
-	height: 100%;
-	width: $resize-handler-container-size;
+// Show corner handles on top of side handles so they can be used
+.components-resizable-box__side-handle {
+	z-index: z-index(".components-resizable-box__side-handle");
 }
 
+.components-resizable-box__corner-handle {
+	z-index: z-index(".components-resizable-box__corner-handle");
+}
+
+// Make horizontal side-handles full width
+.components-resizable-box__side-handle.components-resizable-box__handle-top,
+.components-resizable-box__side-handle.components-resizable-box__handle-bottom {
+	width: 100%;
+	left: 0;
+}
+
+// Make vertical side-handles full height
+.components-resizable-box__side-handle.components-resizable-box__handle-left,
+.components-resizable-box__side-handle.components-resizable-box__handle-right {
+	height: 100%;
+	top: 0;
+}
+
+/*!rtl:begin:ignore*/
 .components-resizable-box__handle-right {
 	right: calc(#{$resize-handler-container-size / 2} * -1);
 }
@@ -38,9 +56,11 @@
 	left: calc(#{$resize-handler-container-size / 2} * -1);
 }
 
+.components-resizable-box__handle-top {
+	top: calc(#{$resize-handler-container-size / 2} * -1);
+}
+
 .components-resizable-box__handle-bottom {
 	bottom: calc(#{$resize-handler-container-size / 2} * -1);
-	width: 100%;
-	height: $resize-handler-container-size;
 }
 /*!rtl:end:ignore*/

--- a/packages/components/src/resizable-box/style.scss
+++ b/packages/components/src/resizable-box/style.scss
@@ -1,3 +1,5 @@
+// This is a wrapper of the actual visible handle (pseudo element). It is styled
+// to be much bigger than the visual part so it's easier to click and use.
 .components-resizable-box__handle {
 	display: none;
 	width: $resize-handler-container-size;

--- a/packages/components/src/resizable-box/style.scss
+++ b/packages/components/src/resizable-box/style.scss
@@ -5,12 +5,6 @@
 	.components-resizable-box__container.is-selected & {
 		display: block;
 	}
-
-	// The handle is a pseudo-element and will sit inside this larger
-	// container size.
-	width: $resize-handler-container-size;
-	height: $resize-handler-container-size;
-	padding: $grid-size-small;
 }
 
 // This is the "visible" resize handle.
@@ -23,21 +17,30 @@
 	border-radius: 50%;
 	background: theme(primary);
 	cursor: inherit;
+	position: absolute;
+	top: calc(50% - #{$resize-handler-size / 2});
+	right: calc(50% - #{$resize-handler-size / 2});
 }
 
 /*!rtl:begin:ignore*/
+.components-resizable-box__handle-right,
+.components-resizable-box__handle-left {
+	top: 0;
+	height: 100%;
+	width: $resize-handler-container-size;
+}
+
 .components-resizable-box__handle-right {
-	top: calc(50% - #{$resize-handler-container-size / 2});
 	right: calc(#{$resize-handler-container-size / 2} * -1);
+}
+
+.components-resizable-box__handle-left {
+	left: calc(#{$resize-handler-container-size / 2} * -1);
 }
 
 .components-resizable-box__handle-bottom {
 	bottom: calc(#{$resize-handler-container-size / 2} * -1);
-	left: calc(50% - #{$resize-handler-container-size / 2});
-}
-
-.components-resizable-box__handle-left {
-	top: calc(50% - #{$resize-handler-container-size / 2});
-	left: calc(#{$resize-handler-container-size / 2} * -1);
+	width: 100%;
+	height: $resize-handler-container-size;
 }
 /*!rtl:end:ignore*/


### PR DESCRIPTION
## Description
I've suggested several resizing improvements in #14410 and this is one of them. It makes resize handles of `ResizableBox` much bigger - spanning across the whole side they control instead of just the small blue dot in the center. 

I've built this with Media & Text in mind but it seems it helps other blocks too, especially Spacer where the blue dot collides with "Add Block" button.

~Known limitation: This bigger handler is only implemented for Left, Right and Bottom resizers. Those are the only resizers that have been supported and used in our codebase so I've continued with the same limitation.~

All sides and corners are now supported. Additional testing instructions related to them are in my comments on this PR.

## How has this been tested?

Visually, all blocks should look the same and show the blue dot in the center of resizable areas. What should change is the area that you can initiate the resize action from.

`ResizableBox` component is used in Media & Text, Spacer and Image blocks. Test all of them and confirm their drag & drop resizing still works in all expected cases. Try resizing by dragging anywhere on a side but outside of the blue dot. Make sure the action is appropriately indicated with a resizing cursor.

## Screenshots <!-- if applicable -->

Green color is for demonstration purposes only to show where the active area is. For users, this should be pretty intuitive as the whole side of media acts as a handler.

![resizers-v2](https://user-images.githubusercontent.com/156676/54506502-10529580-4980-11e9-9a12-b0ab17f2ea3b.gif)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
