### PR TITLE
Media & Text: Easier resizing

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { get } from 'lodash';
+import { get, values } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -17,10 +17,13 @@ import {
 } from '@wordpress/block-editor';
 import { Component, Fragment } from '@wordpress/element';
 import {
+	BaseControl,
 	Button,
+	ButtonGroup,
 	PanelBody,
-	RangeControl,
+	RadioControl,
 	TextareaControl,
+	TextControl,
 	ToggleControl,
 	Toolbar,
 } from '@wordpress/components';
@@ -36,6 +39,11 @@ const ALLOWED_BLOCKS = [ 'core/button', 'core/paragraph', 'core/heading', 'core/
 const TEMPLATE = [
 	[ 'core/paragraph', { fontSize: 'large', placeholder: _x( 'Content…', 'content placeholder' ) } ],
 ];
+const WIDTH_PRESETS = {
+	38: { label: _x( 'Small', 'small media size' ), value: '38' },
+	50: { label: _x( 'Half', 'media size filling 50%' ), value: '50' },
+	62: { label: _x( 'Large', 'large media size' ), value: '62' },
+};
 
 class MediaTextEdit extends Component {
 	constructor() {
@@ -90,7 +98,7 @@ class MediaTextEdit extends Component {
 		const { setAttributes } = this.props;
 
 		setAttributes( {
-			mediaWidth: width,
+			mediaWidth: parseInt( width, 10 ),
 		} );
 		this.setState( {
 			mediaWidth: null,
@@ -180,15 +188,43 @@ class MediaTextEdit extends Component {
 			<Fragment>
 				<InspectorControls>
 					{ mediaTextGeneralSettings }
-					<PanelBody title={ __( 'Layout' ) }>
-						<RangeControl
+					<PanelBody title={ __( 'Layout 1' ) }>
+						<TextControl
+							type="number"
 							label={ __( 'Media width' ) }
 							value={ temporaryMediaWidth || mediaWidth }
 							onChange={ this.commitWidthChange }
 						/>
-						<Button isSmall onClick={ () => setAttributes( { mediaWidth: 38 } ) }>Golden ratio small</Button>
-						<Button isSmall onClick={ () => setAttributes( { mediaWidth: 50 } ) }>Half and half</Button>
-						<Button isSmall onClick={ () => setAttributes( { mediaWidth: 62 } ) }>Golden ratio big</Button>
+						<ButtonGroup>
+							<Button isSmall isPrimary={ ( temporaryMediaWidth || mediaWidth ) === 38 } onClick={ () => setAttributes( { mediaWidth: 38 } ) }>Small</Button>
+							<Button isSmall isPrimary={ ( temporaryMediaWidth || mediaWidth ) === 50 } onClick={ () => setAttributes( { mediaWidth: 50 } ) }>Half</Button>
+							<Button isSmall isPrimary={ ( temporaryMediaWidth || mediaWidth ) === 62 } onClick={ () => setAttributes( { mediaWidth: 62 } ) }>Large</Button>
+						</ButtonGroup>
+					</PanelBody>
+					<PanelBody title={ __( 'Layout 2' ) }>
+						<RadioControl
+							label="Media Width"
+							selected={ this.state.enableCustomWidth ? 'custom' : String( mediaWidth ) }
+							options={ values( WIDTH_PRESETS ).concat( { label: 'Custom', value: 'custom' } ) }
+							onChange={ ( newMediaWidth ) => setAttributes( { mediaWidth: newMediaWidth } ) }
+						/>
+					</PanelBody>
+					<PanelBody title={ __( 'Layout 3' ) }>
+						<BaseControl
+							label="Media Width"
+						>
+							<ButtonGroup>
+								<Button isLarge isPrimary={ ( temporaryMediaWidth || mediaWidth ) === 38 } onClick={ () => setAttributes( { mediaWidth: 38 } ) }>Small</Button>
+								<Button isLarge isPrimary={ ( temporaryMediaWidth || mediaWidth ) === 50 } onClick={ () => setAttributes( { mediaWidth: 50 } ) }>Half</Button>
+								<Button isLarge isPrimary={ ( temporaryMediaWidth || mediaWidth ) === 62 } onClick={ () => setAttributes( { mediaWidth: 62 } ) }>Large</Button>
+							</ButtonGroup>
+						</BaseControl>
+						<TextControl
+							type="number"
+							label={ __( 'Custom width' ) }
+							value={ temporaryMediaWidth || mediaWidth }
+							onChange={ this.commitWidthChange }
+						/>
 					</PanelBody>
 					<PanelColorSettings
 						title={ __( 'Color Settings' ) }

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -17,7 +17,9 @@ import {
 } from '@wordpress/block-editor';
 import { Component, Fragment } from '@wordpress/element';
 import {
+	Button,
 	PanelBody,
+	RangeControl,
 	TextareaControl,
 	ToggleControl,
 	Toolbar,
@@ -178,6 +180,16 @@ class MediaTextEdit extends Component {
 			<Fragment>
 				<InspectorControls>
 					{ mediaTextGeneralSettings }
+					<PanelBody title={ __( 'Layout' ) }>
+						<RangeControl
+							label={ __( 'Media width' ) }
+							value={ temporaryMediaWidth || mediaWidth }
+							onChange={ this.commitWidthChange }
+						/>
+						<Button isSmall onClick={ () => setAttributes( { mediaWidth: 38 } ) }>Golden ratio small</Button>
+						<Button isSmall onClick={ () => setAttributes( { mediaWidth: 50 } ) }>Half and half</Button>
+						<Button isSmall onClick={ () => setAttributes( { mediaWidth: 62 } ) }>Golden ratio big</Button>
+					</PanelBody>
 					<PanelColorSettings
 						title={ __( 'Color Settings' ) }
 						initialOpen={ false }


### PR DESCRIPTION
## Description
This PR aims to make it easier to resize Media & Text (part of #14410). It adds a new panel to inspector controls called "Layout" which offers a slider to control the Media & Width. 

For some users, this might be useful because they can enter specific number manually (currently they can only do that in the code editor). As an alternative to drag & drop in the block itself, this might also help users that have trouble using drag & drop interactions — the slider in sidebar is accessible from keyboard, can be edited using arrow keys and the number input next to it accepts direct number input.

I have also played with an idea to provide several "presets" for widths. They are currently buttons under the range input, which is not their intended style. For now, they are just a first iteration of the idea.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

<img width="279" alt="Screenshot 2019-03-18 at 17 22 46" src="https://user-images.githubusercontent.com/156676/54516516-78b26e80-49a2-11e9-91f5-4464f6a1175e.png">

![resize-presets](https://user-images.githubusercontent.com/156676/54516838-6be24a80-49a3-11e9-8e0c-899c1ec89d10.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
