### PR TITLE
Fix the webpack shortcode config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,6 +80,7 @@ module.exports = {
 			'dom-ready',
 			'redux-routine',
 			'token-list',
+			'shortcode',
 		].map( camelCaseDash ) ),
 		new CopyWebpackPlugin(
 			gutenbergPackages.map( ( packageName ) => ( {


### PR DESCRIPTION
closes #14436 

The shortcode script has a default export, which means it should be included in the `LibraryExportDefaultPlugin` webpack config.
