### PR TITLE
Remove the inserter title from mobile inserters

### DIFF
--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -83,7 +83,7 @@ class Inserter extends Component {
 	}
 
 	render() {
-		const { position, title } = this.props;
+		const { position } = this.props;
 
 		return (
 			<Dropdown
@@ -92,7 +92,6 @@ class Inserter extends Component {
 				position={ position }
 				onToggle={ this.onToggle }
 				expandOnMobile
-				headerTitle={ title }
 				renderToggle={ this.renderToggle }
 				renderContent={ this.renderContent }
 			/>
@@ -102,18 +101,9 @@ class Inserter extends Component {
 
 export default compose( [
 	withSelect( ( select, { rootClientId } ) => {
-		const {
-			hasInserterItems,
-		} = select( 'core/block-editor' );
-
-		// The title should be removed from the inserter
-		// or replaced by a prop passed to the inserter.
-		const {
-			getEditedPostAttribute,
-		} = select( 'core/editor' );
+		const { hasInserterItems } = select( 'core/block-editor' );
 
 		return {
-			title: getEditedPostAttribute( 'title' ),
 			hasItems: hasInserterItems( rootClientId ),
 		};
 	} ),

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -92,6 +92,7 @@ class Inserter extends Component {
 				position={ position }
 				onToggle={ this.onToggle }
 				expandOnMobile
+				headerTitle={ __( 'Add a block' ) }
 				renderToggle={ this.renderToggle }
 				renderContent={ this.renderContent }
 			/>


### PR DESCRIPTION
Related #14043 

On mobile, we open the inserter (all inserters, globals, in-between...) we should the title of the current post at the top but in a generic block editor world, this title doesn't make sense as we could imagine multiple inserters (widgets areas) on the same page without a title to show...

While we can provide a "config" somehow to show a custom title for each block editor, I wonder if we could avoid this complexity and just remove the title or find a generic title to show there "Add Block" or something in that vein.

