### PR TITLE
Add playsInline option in Video block

### DIFF
--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -129,6 +129,7 @@ class VideoEdit extends Component {
 			poster,
 			preload,
 			src,
+			playsinline,
 		} = this.props.attributes;
 		const { setAttributes, isSelected, className, noticeOperations, noticeUI } = this.props;
 		const { editing } = this.state;
@@ -199,6 +200,11 @@ class VideoEdit extends Component {
 							label={ __( 'Playback Controls' ) }
 							onChange={ this.toggleAttribute( 'controls' ) }
 							checked={ controls }
+						/>
+						<ToggleControl
+							label={ __( 'Playsinline' ) }
+							onChange={ this.toggleAttribute( 'playsinline' ) }
+							checked={ playsinline }
 						/>
 						<SelectControl
 							label={ __( 'Preload' ) }

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -129,7 +129,7 @@ class VideoEdit extends Component {
 			poster,
 			preload,
 			src,
-			playsinline,
+			playsInline,
 		} = this.props.attributes;
 		const { setAttributes, isSelected, className, noticeOperations, noticeUI } = this.props;
 		const { editing } = this.state;
@@ -203,8 +203,8 @@ class VideoEdit extends Component {
 						/>
 						<ToggleControl
 							label={ __( 'Play inline' ) }
-							onChange={ this.toggleAttribute( 'playsinline' ) }
-							checked={ playsinline }
+							onChange={ this.toggleAttribute( 'playsInline' ) }
+							checked={ playsInline }
 						/>
 						<SelectControl
 							label={ __( 'Preload' ) }

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -202,7 +202,7 @@ class VideoEdit extends Component {
 							checked={ controls }
 						/>
 						<ToggleControl
-							label={ __( 'Playsinline' ) }
+							label={ __( 'Play inline' ) }
 							onChange={ this.toggleAttribute( 'playsinline' ) }
 							checked={ playsinline }
 						/>

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -150,7 +150,7 @@ export const settings = {
 	edit,
 
 	save( { attributes } ) {
-		const { autoplay, caption, controls, loop, muted, poster, preload, src } = attributes;
+		const { autoplay, caption, controls, loop, muted, poster, preload, src, playsinline } = attributes;
 		return (
 			<figure>
 				{ src && (
@@ -162,6 +162,7 @@ export const settings = {
 						poster={ poster }
 						preload={ preload !== 'metadata' ? preload : undefined }
 						src={ src }
+						playsInline={ playsinline }
 					/>
 				) }
 				{ ! RichText.isEmpty( caption ) && (

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -78,7 +78,7 @@ export const settings = {
 			selector: 'video',
 			attribute: 'src',
 		},
-		playsinline: {
+		playsInline: {
 			type: 'boolean',
 			source: 'attribute',
 			selector: 'video',
@@ -150,7 +150,7 @@ export const settings = {
 	edit,
 
 	save( { attributes } ) {
-		const { autoplay, caption, controls, loop, muted, poster, preload, src, playsinline } = attributes;
+		const { autoplay, caption, controls, loop, muted, poster, preload, src, playsInline } = attributes;
 		return (
 			<figure>
 				{ src && (
@@ -162,7 +162,7 @@ export const settings = {
 						poster={ poster }
 						preload={ preload !== 'metadata' ? preload : undefined }
 						src={ src }
-						playsInline={ playsinline }
+						playsInline={ playsInline }
 					/>
 				) }
 				{ ! RichText.isEmpty( caption ) && (

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -78,6 +78,12 @@ export const settings = {
 			selector: 'video',
 			attribute: 'src',
 		},
+		playsinline: {
+			type: 'boolean',
+			source: 'attribute',
+			selector: 'video',
+			attribute: 'playsinline',
+		},
 	},
 
 	transforms: {

--- a/packages/e2e-tests/fixtures/blocks/core__video.json
+++ b/packages/e2e-tests/fixtures/blocks/core__video.json
@@ -9,7 +9,7 @@
             "controls": true,
             "loop": false,
             "muted": false,
-            "playsinline": false,
+            "playsInline": false,
             "preload": "metadata",
             "src": "https://awesome-fake.video/file.mp4"
         },

--- a/packages/e2e-tests/fixtures/blocks/core__video.json
+++ b/packages/e2e-tests/fixtures/blocks/core__video.json
@@ -9,6 +9,7 @@
             "controls": true,
             "loop": false,
             "muted": false,
+            "playsinline": false,
             "preload": "metadata",
             "src": "https://awesome-fake.video/file.mp4"
         },


### PR DESCRIPTION
## Description
This PR closes #14422 which requests the addition of a `playsInline` option in the `video` block.

## How has this been tested?
This PR has been tested by going through the following steps:

1. Added a Video block to the Gutenberg editor.
2. Made sure the "Playsinline" option shows up in the `InspectorControls`.
3. Made sure turning it on adds the `playsinline` attribute to the `<video>` tag.

## Screenshots <!-- if applicable -->
![gutenberg-14422-min](https://user-images.githubusercontent.com/20284937/54552432-46246800-49da-11e9-8ad4-fed115aaf208.gif)

## Types of changes
This PR just mocks the other attributes in the block like "Autoplay", "Muted" and acts accordingly.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
