### PR TITLE
Try: Improve appearance of hover on colored backgrounds.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -158,7 +158,7 @@
 
 	// Hover style.
 	&.is-hovered > .block-editor-block-list__block-edit::before {
-		box-shadow: -$block-left-border-width 0 0 0  $dark-opacity-light-500;
+		box-shadow: -$block-left-border-width 0 0 0 $dark-opacity-light-500;
 
 		.is-dark-theme & {
 			box-shadow: -$block-left-border-width 0 0 0 $light-opacity-light-400;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -158,10 +158,10 @@
 
 	// Hover style.
 	&.is-hovered > .block-editor-block-list__block-edit::before {
-		box-shadow: -$block-left-border-width 0 0 0 $light-gray-500;
+		box-shadow: -$block-left-border-width 0 0 0  $dark-opacity-light-500;
 
 		.is-dark-theme & {
-			box-shadow: -$block-left-border-width 0 0 0 $dark-gray-600;
+			box-shadow: -$block-left-border-width 0 0 0 $light-opacity-light-400;
 		}
 	}
 

--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -75,7 +75,11 @@
 
 	&:not(.is-focus-mode):not(.has-fixed-toolbar):not(.is-selected) {
 		.editor-post-title__input:hover {
-			box-shadow: -$block-left-border-width 0 0 0 $light-gray-500;
+			box-shadow: -$block-left-border-width 0 0 0 $dark-opacity-light-500;
+
+			.is-dark-theme & {
+				box-shadow: -$block-left-border-width 0 0 0 $light-opacity-light-400;
+			}
 		}
 	}
 


### PR DESCRIPTION
The current hover state uses solid colors. These work nicely in many cases, but can also end up clashing with the document background if the theme uses a non white/black background color. As initially discussed in https://github.com/WordPress/gutenberg/pull/14145#issuecomment-471679245, switching to a color value that uses opacity could positively impact the appearance in these cases. 

This PR switches the following color values to their closest opacity equivalents: 
- Light backgrounds: `$light-gray-500` to `$dark-opacity-light-500`
- Dark backgrounds: `$dark-gray-600` to `$light-opacity-light-400`

The main design issue to note is that the breadcrumb background colors are unchanged in this PR. This is required to ensure proper text contrast of the breadcrumb text. This eliminates a bit of the visual connection between the left border and the breadcrumb. It feels a little clumsy to me, and I'm not totally sold on this solution for that reason. 

**Screenshots (Light Backgrounds)**

<img width="665" alt="Light-01" src="https://user-images.githubusercontent.com/1202812/54555710-a04b0c00-498d-11e9-8d80-3760981120f8.png">
<img width="665" alt="Light-02" src="https://user-images.githubusercontent.com/1202812/54555713-a04b0c00-498d-11e9-885f-bf1b51897df3.png">
<img width="665" alt="Light-03" src="https://user-images.githubusercontent.com/1202812/54555714-a04b0c00-498d-11e9-84ad-11a6a2ff7776.png">
<img width="665" alt="Light-04" src="https://user-images.githubusercontent.com/1202812/54555716-a04b0c00-498d-11e9-8ec7-3f20d4ed6a27.png">

**Screenshots (Dark Backgrounds)**
<img width="665" alt="Dark-01" src="https://user-images.githubusercontent.com/1202812/54555730-a80ab080-498d-11e9-8ee1-c4a600a1b5ce.png">
<img width="665" alt="Dark-02" src="https://user-images.githubusercontent.com/1202812/54555731-a80ab080-498d-11e9-99cc-f4278041f492.png">
<img width="665" alt="Dark-03" src="https://user-images.githubusercontent.com/1202812/54555732-a80ab080-498d-11e9-87f6-151b56fe1b27.png">
<img width="665" alt="Dark-04" src="https://user-images.githubusercontent.com/1202812/54555733-a80ab080-498d-11e9-8dc8-bd19bddef416.png">
