### PR TITLE
Popover Component: Allow tabbable index to focusOnMount

### DIFF
--- a/packages/components/src/dropdown/README.md
+++ b/packages/components/src/dropdown/README.md
@@ -95,8 +95,10 @@ Opt-in prop to show popovers fullscreen on mobile, pass `false` in this prop to 
  
  By default, the *first tabblable element* in the popover will receive focus when it mounts. This is the same as setting `focusOnMount` to `"firstElement"`. If you want to focus the container instead, you can set `focusOnMount` to `"container"`.
  
+ Alternatively, if you'd like to specify the index of the tabbable element to focus, supply number value.
+ 
  Set this prop to `false` to disable focus changing entirely. This should only be set when an appropriately accessible substitute behavior exists.
  
- - Type: `String` or `Boolean`
+ - Type: `String` or `Boolean` or `Number`
  - Required: No
  - Default: `"firstElement"`

--- a/packages/components/src/popover/README.md
+++ b/packages/components/src/popover/README.md
@@ -58,9 +58,11 @@ The component accepts the following props. Props not included in this set will b
 
 By default, the *first tabblable element* in the popover will receive focus when it mounts. This is the same as setting `focusOnMount` to `"firstElement"`. If you want to focus the container instead, you can set `focusOnMount` to `"container"`.
 
+Alternatively, if you'd like to specify the index of the tabbable element to focus, supply number value.
+
 Set this prop to `false` to disable focus changing entirely. This should only be set when an appropriately accessible substitute behavior exists.
 
-- Type: `String` or `Boolean`
+- Type: `String` or `Boolean` on `Number`
 - Required: No
 - Default: `"firstElement"`
 

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -169,23 +169,22 @@ class Popover extends Component {
 			return;
 		}
 
-		if ( focusOnMount === 'firstElement' ) {
-			// Find first tabbable node within content and shift focus, falling
-			// back to the popover panel itself.
-			const firstTabbable = focus.tabbable.find( this.contentNode.current )[ 0 ];
-
-			if ( firstTabbable ) {
-				firstTabbable.focus();
-			} else {
-				this.contentNode.current.focus();
-			}
+		if ( focusOnMount === 'container' ) {
+			// Focus the popover panel itself so items in the popover are easily
+			// accessed via keyboard navigation.
+			this.contentNode.current.focus();
 
 			return;
 		}
 
-		if ( focusOnMount === 'container' ) {
-			// Focus the popover panel itself so items in the popover are easily
-			// accessed via keyboard navigation.
+		// Find the specified tabbable node within content and shift focus, falling
+		// back to the popover panel itself.
+		const tabbableIndex = 'firstElement' === focusOnMount ? 0 : focusOnMount;
+		const tabbable = focus.tabbable.find( this.contentNode.current )[ tabbableIndex ];
+
+		if ( tabbable ) {
+			tabbable.focus();
+		} else {
 			this.contentNode.current.focus();
 		}
 	}

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -165,7 +165,7 @@ class Popover extends Component {
 	focus() {
 		const { focusOnMount } = this.props;
 
-		if ( ! focusOnMount || ! this.contentNode.current ) {
+		if ( false === focusOnMount || ! this.contentNode.current ) {
 			return;
 		}
 
@@ -349,9 +349,9 @@ class Popover extends Component {
 		);
 		/* eslint-enable jsx-a11y/no-static-element-interactions */
 
-		// Apply focus to element as long as focusOnMount is truthy; false is
+		// Apply focus to element as long as focusOnMount is not false; false is
 		// the only "disabled" value.
-		if ( focusOnMount ) {
+		if ( false !== focusOnMount ) {
 			content = <FocusManaged>{ content }</FocusManaged>;
 		}
 

--- a/packages/components/src/popover/test/index.js
+++ b/packages/components/src/popover/test/index.js
@@ -11,7 +11,11 @@ import { noop } from 'lodash';
 import Popover from '../';
 
 /**
- * Explain why here.
+ * The @wordpress/dom focusable's find function needs to be mocked because
+ * `TestUtils.renderIntoDocument` does not actually render into a document.
+ * This causes problems with a check for an element's offset width and height to
+ * determine if the element is visible. So here we simply return all found
+ * elements.
  */
 const { SELECTOR: mockSELECTOR } = require.requireActual( '../../../../dom/src/focusable' );
 jest.mock( '../../../../dom/src/focusable', () => ( {

--- a/packages/components/src/popover/test/index.js
+++ b/packages/components/src/popover/test/index.js
@@ -141,6 +141,27 @@ describe( 'Popover', () => {
 
 			jest.runAllTimers();
 		} );
+
+		it( 'should allow an index value of zero to be passed to focusOnMount to focus the first element', ( done ) => {
+			wrapper = TestUtils.renderIntoDocument(
+				<Popover focusOnMount={ 0 } >
+					<div>
+						<button>One</button>
+						<button>Two</button>
+						<button>Three</button>
+						<button>Four</button>
+						<button>Five</button>
+					</div>
+				</Popover>
+			);
+
+			setTimeout( () => {
+				expect( 'One' ).toBe( document.activeElement.textContent );
+				done();
+			} );
+
+			jest.runAllTimers();
+		} );
 	} );
 
 	describe( '#render()', () => {

--- a/packages/components/src/popover/test/index.js
+++ b/packages/components/src/popover/test/index.js
@@ -10,6 +10,14 @@ import { noop } from 'lodash';
  */
 import Popover from '../';
 
+/**
+ * Explain why here.
+ */
+const { SELECTOR: mockSELECTOR } = require.requireActual( '../../../../dom/src/focusable' );
+jest.mock( '../../../../dom/src/focusable', () => ( {
+	find: ( context ) => [ ...context.querySelectorAll( mockSELECTOR ) ],
+} ) );
+
 describe( 'Popover', () => {
 	describe( '#componentDidUpdate()', () => {
 		let wrapper;
@@ -86,6 +94,48 @@ describe( 'Popover', () => {
 
 			setTimeout( () => {
 				expect( document.activeElement ).toBe( activeElement );
+				done();
+			} );
+
+			jest.runAllTimers();
+		} );
+
+		it( 'should focus the first focusable element by default', ( done ) => {
+			wrapper = TestUtils.renderIntoDocument(
+				<Popover>
+					<div>
+						<button>One</button>
+						<button>Two</button>
+						<button>Three</button>
+						<button>Four</button>
+						<button>Five</button>
+					</div>
+				</Popover>
+			);
+
+			setTimeout( () => {
+				expect( 'One' ).toBe( document.activeElement.textContent );
+				done();
+			} );
+
+			jest.runAllTimers();
+		} );
+
+		it( 'should allow an index to be passed to focusOnMount to select the focused element', ( done ) => {
+			wrapper = TestUtils.renderIntoDocument(
+				<Popover focusOnMount={ 2 } >
+					<div>
+						<button>One</button>
+						<button>Two</button>
+						<button>Three</button>
+						<button>Four</button>
+						<button>Five</button>
+					</div>
+				</Popover>
+			);
+
+			setTimeout( () => {
+				expect( 'Three' ).toBe( document.activeElement.textContent );
 				done();
 			} );
 

--- a/packages/dom/src/focusable.js
+++ b/packages/dom/src/focusable.js
@@ -17,7 +17,7 @@
  *  - https://w3c.github.io/html/editing.html#data-model
  */
 
-const SELECTOR = [
+export const SELECTOR = [
 	'[tabindex]',
 	'a[href]',
 	'button:not([disabled])',


### PR DESCRIPTION
## Description

Allow an index to be specified to determine which focusable element receives focus upon mounting.

Here is a use case. The dropdown's popover contains a button and an input. Upon opening the dropdown, I'd like to be able to choose which tabbable element receives focus by supplying an index.

<img width="436" alt="Screen Shot 2019-03-19 at 8 43 52 AM" src="https://user-images.githubusercontent.com/1922453/54558879-a095e680-4a23-11e9-89e7-40b022b959c1.png">


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
