### PR TITLE
Adding design documentation to the Notice readme

### DIFF
--- a/packages/components/src/notice/README.md
+++ b/packages/components/src/notice/README.md
@@ -1,8 +1,79 @@
 # Notice
 
-This component is used to display notices in editor.
+A notice is used to communicate a prominent message to the user.
 
-## Usage
+![Notice component](https://make.wordpress.org/design/files/2019/03/Notice-Screenshot-alt.png)
+
+## Table of contents
+
+1. [Design guidelines](#design-guidelines)
+2. [Development guidelines](#development-guidelines)
+3. [Related components](#related-components)
+
+## Design guidelines
+
+A notice displays a succinct message, and offers actions the user can take, like viewing a published post or updating a setting. It requires a user action to be dismissed.
+
+Notices communicate messages that are important but don’t *require* user action — a user can keep using the product even if they don’t choose to act on the message. They are less interruptive than a Modal.
+
+### Anatomy
+
+![Diagram of a Notice component with numbered labels](https://make.wordpress.org/design/files/2019/03/Notice-Anatomy.png)
+
+1. Container (status indicated with color)
+2. Icon (optional)
+3. Message
+4. Dismiss icon (optional)
+
+### Usage
+
+Notices display at the top of the screen, below any toolbars anchored to the top of  the page. They’re persistent and non-modal. Since they don’t overlay the content, users can ignore them, dismiss them, or choose interact with them at any time.
+
+![](https://make.wordpress.org/design/files/2019/03/Notice-States.png)
+
+Notices are color-coded to indicate the type of message being communicated:
+
+- **Default** notices have **no background**.
+- **Informational** notices are **blue.**
+- **Success** notices are **green.**
+- **Warning** notices are **yellow****.**
+- **Error** notices are **red.**
+
+If an icon is included in the Notice, it should be color-coded to match the Notice state.
+
+![A success Notice for updating a post](https://make.wordpress.org/design/files/2019/03/Notice-Do-1-alt.png)
+
+**Do**
+Use a Notice when you want to communicate a message of medium importance. 
+
+![A Notice that requires an immediate action](https://make.wordpress.org/design/files/2019/03/Notice-Dont-1-alt.png)
+
+**Don’t**
+Don't use a Notice for a message that is important for the user to read and act upon immediately. Use a Modal instead.
+
+![A success Notice for publishing a post](https://make.wordpress.org/design/files/2019/03/Notice-Do-2-alt.png)
+
+**Do**
+Show a Notice at the top of the screen, below any toolbars.
+
+![A success Notice on top of the editor toolbar](https://make.wordpress.org/design/files/2019/03/Notice-Dont-2-alt.png)
+
+**Don’t**
+Don't show notices on top of toolbars.
+
+![An error Notice using red](https://make.wordpress.org/design/files/2019/03/Notice-Do-3-alt.png)
+
+**Do**
+Use color to indicate the type of message being communicated.
+
+![An error Notice using purple](https://make.wordpress.org/design/files/2019/03/Notice-Dont-3-alt.png)
+
+**Don’t**
+Don't apply colors other than those for Warnings, Success, or Errors.
+
+## Development guidelines
+
+### Usage
 
 To display a plain notice, pass `Notice` a string:
 
@@ -24,7 +95,7 @@ const MyNotice = () => (
 );
 ```
 
-### Props
+#### Props
 
 The following props are used to control the display of the component.
 
@@ -32,3 +103,7 @@ The following props are used to control the display of the component.
 * `onRemove`: function called when dismissing the notice
 * `isDismissible`: (boolean) defaults to true, whether the notice should be dismissible or not
 * `actions`: (array) an array of action objects. Each member object should contain a `label` and either a `url` link string or `onClick` callback function. A `className` property can be used to add custom classes to the button styles. By default, some classes are used (e.g: is-link or is-default) the default classes can be removed by setting property `noDefaultClasses` to `false`.
+
+## Related components
+
+- To create a more prominent message that requires action, use a Modal.

--- a/packages/components/src/notice/README.md
+++ b/packages/components/src/notice/README.md
@@ -1,6 +1,6 @@
 # Notice
 
-A notice is used to communicate a prominent message to the user.
+Use Notices to communicate prominent messages to the user.
 
 ![Notice component](https://make.wordpress.org/design/files/2019/03/Notice-Screenshot-alt.png)
 
@@ -12,9 +12,9 @@ A notice is used to communicate a prominent message to the user.
 
 ## Design guidelines
 
-A notice displays a succinct message, and offers actions the user can take, like viewing a published post or updating a setting. It requires a user action to be dismissed.
+A Notice displays a succinct message. It can also offer the user options, like viewing a published post or updating a setting, and requires a user action to be dismissed.
 
-Notices communicate messages that are important but don’t *require* user action — a user can keep using the product even if they don’t choose to act on the message. They are less interruptive than a Modal.
+Use Notices to communicate things that are important but don’t necessarily require action — a user can keep using the product even if they don’t choose to act on a Notice. They are less interruptive than a Modal.
 
 ### Anatomy
 
@@ -27,7 +27,7 @@ Notices communicate messages that are important but don’t *require* user actio
 
 ### Usage
 
-Notices display at the top of the screen, below any toolbars anchored to the top of  the page. They’re persistent and non-modal. Since they don’t overlay the content, users can ignore them, dismiss them, or choose interact with them at any time.
+Notices display at the top of the screen, below any toolbars anchored to the top of the page. They’re persistent and non-modal. Since they don’t overlay the content, users can ignore or dismiss them, and choose when to interact with them.
 
 ![](https://make.wordpress.org/design/files/2019/03/Notice-States.png)
 
@@ -44,32 +44,32 @@ If an icon is included in the Notice, it should be color-coded to match the Noti
 ![A success Notice for updating a post](https://make.wordpress.org/design/files/2019/03/Notice-Do-1-alt.png)
 
 **Do**
-Use a Notice when you want to communicate a message of medium importance. 
+Do use a Notice when you want to communicate a message of medium importance.
 
 ![A Notice that requires an immediate action](https://make.wordpress.org/design/files/2019/03/Notice-Dont-1-alt.png)
 
 **Don’t**
-Don't use a Notice for a message that is important for the user to read and act upon immediately. Use a Modal instead.
+Don't use a Notice for a message that requires immediate attention and action from the user. Use a Modal for this instead.
 
 ![A success Notice for publishing a post](https://make.wordpress.org/design/files/2019/03/Notice-Do-2-alt.png)
 
 **Do**
-Show a Notice at the top of the screen, below any toolbars.
+Do display Notices at the top of the screen, below any toolbars.
 
 ![A success Notice on top of the editor toolbar](https://make.wordpress.org/design/files/2019/03/Notice-Dont-2-alt.png)
 
 **Don’t**
-Don't show notices on top of toolbars.
+Don't show Notices on top of toolbars.
 
 ![An error Notice using red](https://make.wordpress.org/design/files/2019/03/Notice-Do-3-alt.png)
 
 **Do**
-Use color to indicate the type of message being communicated.
+Do use color to indicate the type of message being communicated.
 
 ![An error Notice using purple](https://make.wordpress.org/design/files/2019/03/Notice-Dont-3-alt.png)
 
 **Don’t**
-Don't apply colors other than those for Warnings, Success, or Errors.
+Don't apply any colors other than those for Warnings, Success, or Errors.
 
 ## Development guidelines
 


### PR DESCRIPTION
Initial commit to update Notice readme. These changes add design documentation.

![Screen Shot 2019-03-19 at 10 22 51 AM](https://user-images.githubusercontent.com/618551/54618408-f8871a00-4a30-11e9-8f1d-d61569203b0e.png)


## Description

This PR adds design guideline documentation in addition to the development documentation that existed previously. These guidelines are 'best practices' for the usage of the component, as well as describing the component in more detail.

## Screenshots

A preview can be seen here, although it doesn't represent what it will look like in the handbook:

[preview](https://github.com/WordPress/gutenberg/blob/8966f1a0df6db54dd9d062848d3efa960922fa64/packages/components/src/notice/README.md)

## Feedback

I'd appreciate feedback on:

- Whether my markdown syntax is correct
- Design guidelines
- Double-checking a11y of the document
- Seeing if the design guidelines align with the development documentation

Thank you!

cc @sarahmonster 