### PR TITLE
Added missing reference to lodash

### DIFF
--- a/docs/designers-developers/developers/block-api/block-deprecation.md
+++ b/docs/designers-developers/developers/block-api/block-deprecation.md
@@ -194,7 +194,8 @@ E.g: a block wants to migrate a title attribute to a paragraph innerBlock.
 {% ES5 %}
 ```js
 var el = wp.element.createElement,
-	registerBlockType = wp.blocks.registerBlockType;
+	registerBlockType = wp.blocks.registerBlockType,
+	omit = lodash.omit;
 
 registerBlockType( 'gutenberg/block-with-deprecated-version', {
 
@@ -232,6 +233,7 @@ registerBlockType( 'gutenberg/block-with-deprecated-version', {
 {% ESNext %}
 ```js
 const { registerBlockType } = wp.blocks;
+const { omit } = lodash;
 
 registerBlockType( 'gutenberg/block-with-deprecated-version', {
 


### PR DESCRIPTION
A reference to the `omit` method of lodash is in the *Changing the innerBlocks* section, but the method is not defined in the code examples, causing confusion.

## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
