### PR TITLE
RichText: improve format boundary style

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -505,7 +505,9 @@ export class RichText extends Component {
 
 		if ( element ) {
 			const computedStyle = getComputedStyle( element );
-			const newColor = computedStyle.color.replace( ')', ', 0.2)' );
+			const newColor = computedStyle.color
+				.replace( ')', ', 0.2)' )
+				.replace( 'rgb', 'rgba' );
 
 			globalStyle.innerHTML =
 				`${ boundarySelector }{background-color: ${ newColor }}`;

--- a/packages/block-editor/src/components/rich-text/style.scss
+++ b/packages/block-editor/src/components/rich-text/style.scss
@@ -45,27 +45,6 @@
 
 		*[data-rich-text-format-boundary] {
 			border-radius: 2px;
-			box-shadow: 0 0 0 1px $light-gray-400;
-			background: $light-gray-400;
-
-			// Enforce a dark text color so active inline boundaries
-			// are always readable.
-			// See https://github.com/WordPress/gutenberg/issues/9508
-			color: $dark-gray-900;
-		}
-
-		// Link inline boundaries get special colors.
-		a[data-rich-text-format-boundary] {
-			box-shadow: 0 0 0 1px $blue-medium-100;
-			background: $blue-medium-100;
-			color: $blue-medium-900;
-		}
-
-		// <code> inline boundaries need special treatment because their
-		// un-selected style is already padded.
-		code[data-rich-text-format-boundary] {
-			background: $light-gray-400;
-			box-shadow: 0 0 0 1px $light-gray-400;
 		}
 	}
 

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -1,10 +1,5 @@
 .wp-block-cover-image,
 .wp-block-cover {
-	.block-editor-rich-text__editable:focus a[data-rich-text-format-boundary] {
-		box-shadow: none;
-		background: rgba(255, 255, 255, 0.3);
-	}
-
 	&.components-placeholder h2 {
 		color: inherit;
 	}

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -82,10 +82,6 @@ ul.wp-block-gallery li {
 		a {
 			color: $white;
 		}
-
-		&:focus a[data-rich-text-format-boundary] {
-			color: rgba(0, 0, 0, 0.2);
-		}
 	}
 }
 


### PR DESCRIPTION
## Description

Fixes #14023. As discussed in #14023, the boundary style should be updated to inherit the current colour with opacity applied, so the style works in all contexts. This can be done in JS (unfortunately not CSS) but calculating the current colour and applying opacity, then setting it is a global stylesheet.

## How has this been tested?

Format | Before | After
--- | --- | ---
Link in Cover Image | <img width="335" alt="screenshot 2019-02-22 at 11 47 07" src="https://user-images.githubusercontent.com/4710635/53237980-63df0580-3698-11e9-93ce-63c4092afc47.png"> | <img width="340" alt="screenshot 2019-02-22 at 11 45 19" src="https://user-images.githubusercontent.com/4710635/53238001-6e010400-3698-11e9-8fbb-8841c302df7d.png">
Bold in Cover Image | <img width="255" alt="screenshot 2019-02-22 at 11 47 14" src="https://user-images.githubusercontent.com/4710635/53238013-7b1df300-3698-11e9-9f43-16c054022564.png"> | <img width="321" alt="screenshot 2019-02-22 at 11 45 27" src="https://user-images.githubusercontent.com/4710635/53238032-896c0f00-3698-11e9-9e93-9efa0287b394.png">
Bold in Button | <img width="186" alt="screenshot 2019-02-22 at 11 48 00" src="https://user-images.githubusercontent.com/4710635/53238053-9852c180-3698-11e9-8322-96467d86e428.png"> | <img width="165" alt="screenshot 2019-02-22 at 11 46 21" src="https://user-images.githubusercontent.com/4710635/53238063-9f79cf80-3698-11e9-9a83-10d877bd2eb8.png">
Link | <img width="346" alt="screenshot 2019-02-22 at 11 47 46" src="https://user-images.githubusercontent.com/4710635/53238079-ab659180-3698-11e9-8e6f-6ebce96fd5e5.png"> | <img width="336" alt="screenshot 2019-02-22 at 11 45 54" src="https://user-images.githubusercontent.com/4710635/53238091-b1f40900-3698-11e9-8204-09ffda8f9ed9.png">
Colour | <img width="136" alt="screenshot 2019-02-22 at 11 47 21" src="https://user-images.githubusercontent.com/4710635/53238102-bddfcb00-3698-11e9-96d1-50e2d0d93f40.png"> | <img width="122" alt="screenshot 2019-02-22 at 11 25 00" src="https://user-images.githubusercontent.com/4710635/53238107-c3d5ac00-3698-11e9-9ee9-1b56817328e4.png">
Bold | <img width="176" alt="screenshot 2019-02-22 at 11 47 29" src="https://user-images.githubusercontent.com/4710635/53238140-d2bc5e80-3698-11e9-8af9-4fce7f5c4ce1.png"> | <img width="164" alt="screenshot 2019-02-22 at 11 45 41" src="https://user-images.githubusercontent.com/4710635/53238159-d9e36c80-3698-11e9-9567-ec37993d5499.png">

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->