### PR TITLE
Fix: Impossible to drag & drop blocks if locking is insert

### DIFF
--- a/packages/block-editor/src/components/block-drop-zone/index.js
+++ b/packages/block-editor/src/components/block-drop-zone/index.js
@@ -111,8 +111,8 @@ class BlockDropZone extends Component {
 	}
 
 	render() {
-		const { isLocked, index } = this.props;
-		if ( isLocked ) {
+		const { isLockedAll, index } = this.props;
+		if ( isLockedAll ) {
 			return null;
 		}
 		const isAppender = index === undefined;
@@ -158,7 +158,7 @@ export default compose(
 	withSelect( ( select, { rootClientId } ) => {
 		const { getClientIdsOfDescendants, getTemplateLock, getBlockIndex } = select( 'core/block-editor' );
 		return {
-			isLocked: !! getTemplateLock( rootClientId ),
+			isLockedAll: getTemplateLock( rootClientId ) === 'all',
 			getClientIdsOfDescendants,
 			getBlockIndex,
 		};

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -298,7 +298,7 @@ export const moveBlocksUp = createOnMove( 'MOVE_BLOCKS_UP' );
  *
  * @yields {Object} Action object.
  */
-export function* moveBlockToPosition( clientId, fromRootClientId, toRootClientId, index ) {
+export function* moveBlockToPosition( clientId, fromRootClientId = '', toRootClientId = '', index ) {
 	const templateLock = yield select(
 		'core/block-editor',
 		'getTemplateLock',


### PR DESCRIPTION
## Description
If the CPT locking is set to insert it should be possible to move the blocks. Currently, it is possible to move the blocks using the block move buttons but not possible using drag & drop.

This PR fixes the problem of being impossible to use drag & drop when locking equals insert.

## How has this been tested?
I pasted the contents of this gist https://gist.github.com/jorgefilipecosta/b50b090932b22bff1abe193fd0f5d649 in the functions.php file of the theme enable on my test website. I verified I can move the blocks using drag & drop while on master that is not possible.

