### PR TITLE
[Mobile]: Avoid block list auto-scroll when Links UI is present.

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -512,7 +512,7 @@ export class RichText extends Component {
 			html = '';
 			this.lastEventCount = undefined; // force a refresh on the native side
 		}
-		
+
 		let minHeight = styles[ 'editor-rich-text' ].minHeight;
 		if ( style && style.minHeight ) {
 			minHeight = style.minHeight;

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -490,7 +490,7 @@ export class RichText extends Component {
 	componentDidUpdate( prevProps ) {
 		if ( this.props.isSelected && ! prevProps.isSelected ) {
 			this._editor.focus();
-		} else if ( ! this.props.isSelected && prevProps.isSelected && this.isIOS ) {
+		} else if ( ! this.props.isSelected && prevProps.isSelected && this._editor.isFocused ) {
 			this._editor.blur();
 		}
 	}

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -490,7 +490,7 @@ export class RichText extends Component {
 	componentDidUpdate( prevProps ) {
 		if ( this.props.isSelected && ! prevProps.isSelected ) {
 			this._editor.focus();
-		} else if ( ! this.props.isSelected && prevProps.isSelected && this._editor.isFocused ) {
+		} else if ( ! this.props.isSelected && prevProps.isSelected && this.isIOS && this._editor.isFocused ) {
 			this._editor.blur();
 		}
 	}

--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -6,7 +6,7 @@ import HeadingToolbar from './heading-toolbar';
 /**
  * External dependencies
  */
-import { View, Platform } from 'react-native';
+import { View } from 'react-native';
 
 /**
  * WordPress dependencies
@@ -97,7 +97,7 @@ class HeadingEdit extends Component {
 					isSelected={ this.props.isSelected }
 					style={ {
 						...style,
-						minHeight: styles['wp-block-heading'].minHeight,
+						minHeight: styles[ 'wp-block-heading' ].minHeight,
 					} }
 					onFocus={ this.props.onFocus } // always assign onFocus as a props
 					onBlur={ this.props.onBlur } // always assign onBlur as a props

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -36,7 +36,6 @@ import { __ } from '@wordpress/i18n';
 import { isURL } from '@wordpress/url';
 import { doAction, hasAction } from '@wordpress/hooks';
 
-
 /**
  * Internal dependencies
  */
@@ -91,7 +90,7 @@ class ImageEdit extends React.Component {
 	componentWillUnmount() {
 		// this action will only exist if the user pressed the trash button on the block holder
 		if ( hasAction( 'blocks.onRemoveBlockCheckUpload' ) && this.state.isUploadInProgress ) {
-			doAction( 'blocks.onRemoveBlockCheckUpload', this.props.attributes.id )
+			doAction( 'blocks.onRemoveBlockCheckUpload', this.props.attributes.id );
 		}
 		this.removeMediaUploadListener();
 	}

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -51,7 +51,9 @@ class PostTitle extends Component {
 	onSelect() {
 		this.setState( { isSelected: true } );
 		this.props.clearSelectedBlock();
-		this.props.onFocus && this.props.onFocus();
+		if ( this.props.onFocus ) {
+			this.props.onFocus();
+		}
 	}
 
 	onUnselect() {

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -51,6 +51,7 @@ class PostTitle extends Component {
 	onSelect() {
 		this.setState( { isSelected: true } );
 		this.props.clearSelectedBlock();
+		this.props.onFocus && this.props.onFocus();
 	}
 
 	onUnselect() {


### PR DESCRIPTION
This PR implements some necessary changes for https://github.com/wordpress-mobile/gutenberg-mobile/pull/764

There are also a few lint issues fixed from a previous merged PR.

To test:
Please refer to https://github.com/wordpress-mobile/gutenberg-mobile/pull/764