### PR TITLE
Fix issue with top bar menu having unique ARIA roles (2)

### DIFF
--- a/packages/components/src/menu-group/index.js
+++ b/packages/components/src/menu-group/index.js
@@ -38,7 +38,9 @@ export function MenuGroup( {
 		<div className={ classNames }>
 			{ label &&
 				<div
-					className={ `components-menu-group__label ${ ( isScreenReaderLabel ) ? 'screen-reader-text' : '' }` }
+					className={ classnames( 'components-menu-group__label', {
+						'screen-reader-text': isScreenReaderLabel,
+					} ) }
 					{ ...labelRole }
 					id={ labelId }>
 					{ label }

--- a/packages/components/src/menu-group/index.js
+++ b/packages/components/src/menu-group/index.js
@@ -19,6 +19,10 @@ export function MenuGroup( {
 	className = '',
 	instanceId,
 	label,
+	role = 'menu',
+	labelRole = ( role === 'group' ) ? { role: 'presentation' } : {},
+	useEventToOffset = true,
+	isScreenReaderLabel = false,
 } ) {
 	if ( ! Children.count( children ) ) {
 		return null;
@@ -33,9 +37,14 @@ export function MenuGroup( {
 	return (
 		<div className={ classNames }>
 			{ label &&
-				<div className="components-menu-group__label" id={ labelId }>{ label }</div>
+				<div
+					className={ `components-menu-group__label ${ ( isScreenReaderLabel ) ? 'screen-reader-text' : '' }` }
+					{ ...labelRole }
+					id={ labelId }>
+					{ label }
+				</div>
 			}
-			<NavigableMenu orientation="vertical" aria-labelledby={ label ? labelId : null }>
+			<NavigableMenu orientation="vertical" aria-labelledby={ label ? labelId : null } role={ role } useEventToOffset={ useEventToOffset }>
 				{ children }
 			</NavigableMenu>
 		</div>

--- a/packages/components/src/menu-group/test/__snapshots__/index.js.snap
+++ b/packages/components/src/menu-group/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`MenuGroup should match snapshot 1`] = `
   className="components-menu-group"
 >
   <div
-    className="components-menu-group__label"
+    className="components-menu-group__label "
     id="components-menu-group-label-1"
   >
     My group
@@ -13,6 +13,8 @@ exports[`MenuGroup should match snapshot 1`] = `
   <ForwardRef(NavigableMenu)
     aria-labelledby="components-menu-group-label-1"
     orientation="vertical"
+    role="menu"
+    useEventToOffset={true}
   >
     <p>
       My item

--- a/packages/components/src/menu-group/test/__snapshots__/index.js.snap
+++ b/packages/components/src/menu-group/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`MenuGroup should match snapshot 1`] = `
   className="components-menu-group"
 >
   <div
-    className="components-menu-group__label "
+    className="components-menu-group__label"
     id="components-menu-group-label-1"
   >
     My group

--- a/packages/components/src/navigable-container/container.js
+++ b/packages/components/src/navigable-container/container.js
@@ -67,8 +67,12 @@ class NavigableContainer extends Component {
 
 		const { getFocusableContext } = this;
 		const { cycle = true, eventToOffset, onNavigate = noop, stopNavigationEvents } = this.props;
+		let offset;
 
-		const offset = eventToOffset( event );
+		// Prevent an error if eventToOffset is null or not a function.
+		if ( typeof eventToOffset === 'function' ) {
+			offset = eventToOffset( event );
+		}
 
 		// eventToOffset returns undefined if the event is not handled by the component
 		if ( offset !== undefined && stopNavigationEvents ) {

--- a/packages/components/src/navigable-container/container.js
+++ b/packages/components/src/navigable-container/container.js
@@ -67,12 +67,13 @@ class NavigableContainer extends Component {
 
 		const { getFocusableContext } = this;
 		const { cycle = true, eventToOffset, onNavigate = noop, stopNavigationEvents } = this.props;
-		let offset;
 
-		// Prevent an error if eventToOffset is null or not a function.
-		if ( typeof eventToOffset === 'function' ) {
-			offset = eventToOffset( event );
+		// This avoids a console error when eventToOffset is null
+		if ( ! eventToOffset ) {
+			return;
 		}
+
+		const offset = eventToOffset( event );
 
 		// eventToOffset returns undefined if the event is not handled by the component
 		if ( offset !== undefined && stopNavigationEvents ) {

--- a/packages/components/src/navigable-container/menu.js
+++ b/packages/components/src/navigable-container/menu.js
@@ -17,6 +17,7 @@ import NavigableContainer from './container';
 export function NavigableMenu( {
 	role = 'menu',
 	orientation = 'vertical',
+	useEventToOffset = true,
 	...rest
 }, ref ) {
 	const eventToOffset = ( evt ) => {
@@ -49,7 +50,7 @@ export function NavigableMenu( {
 			onlyBrowserTabstops={ false }
 			role={ role }
 			aria-orientation={ role === 'presentation' ? null : orientation }
-			eventToOffset={ eventToOffset }
+			eventToOffset={ useEventToOffset ? eventToOffset : null }
 			{ ...rest }
 		/>
 	);

--- a/packages/e2e-tests/specs/__snapshots__/block-hierarchy-navigation.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/block-hierarchy-navigation.test.js.snap
@@ -24,7 +24,7 @@ exports[`Navigating the block hierarchy should navigate block hierarchy using on
 
 <!-- wp:column -->
 <div class=\\"wp-block-column\\"><!-- wp:paragraph -->
-<p>Third column</p>
+<p></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->"

--- a/packages/e2e-tests/specs/__snapshots__/block-hierarchy-navigation.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/block-hierarchy-navigation.test.js.snap
@@ -24,7 +24,7 @@ exports[`Navigating the block hierarchy should navigate block hierarchy using on
 
 <!-- wp:column -->
 <div class=\\"wp-block-column\\"><!-- wp:paragraph -->
-<p></p>
+<p>Third column</p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->"

--- a/packages/edit-post/src/components/header/mode-switcher/index.js
+++ b/packages/edit-post/src/components/header/mode-switcher/index.js
@@ -36,6 +36,8 @@ function ModeSwitcher( { onSwitch, mode } ) {
 
 	return (
 		<MenuGroup
+			role={ 'group' }
+			useEventToOffset={ false }
 			label={ __( 'Editor' ) }
 		>
 			<MenuItemsChoice

--- a/packages/edit-post/src/components/header/more-menu/index.js
+++ b/packages/edit-post/src/components/header/more-menu/index.js
@@ -16,6 +16,7 @@ import WritingMenu from '../writing-menu';
 
 const ariaClosed = __( 'Show more tools & options' );
 const ariaOpen = __( 'Hide more tools & options' );
+const menuLabel = __( 'Tools & Options' );
 
 const MoreMenu = () => (
 	<Dropdown
@@ -33,7 +34,7 @@ const MoreMenu = () => (
 		) }
 		renderContent={ ( { onClose } ) => (
 			<Fragment>
-				<MenuGroup>
+				<MenuGroup label={ menuLabel } isScreenReaderLabel={ true }>
 					<WritingMenu onClose={ onClose } />
 					<ModeSwitcher onSelect={ onClose } />
 					<PluginMoreMenuGroup.Slot fillProps={ { onClose } } />

--- a/packages/edit-post/src/components/header/more-menu/index.js
+++ b/packages/edit-post/src/components/header/more-menu/index.js
@@ -33,11 +33,12 @@ const MoreMenu = () => (
 		) }
 		renderContent={ ( { onClose } ) => (
 			<Fragment>
-				<WritingMenu onClose={ onClose } />
-				<ModeSwitcher onSelect={ onClose } />
-				<PluginMoreMenuGroup.Slot fillProps={ { onClose } } />
-				<ToolsMoreMenuGroup.Slot fillProps={ { onClose } } />
 				<MenuGroup>
+					<WritingMenu onClose={ onClose } />
+					<ModeSwitcher onSelect={ onClose } />
+					<PluginMoreMenuGroup.Slot fillProps={ { onClose } } />
+					<ToolsMoreMenuGroup.Slot fillProps={ { onClose } } />
+
 					<OptionsMenuItem onSelect={ onClose } />
 				</MenuGroup>
 			</Fragment>

--- a/packages/edit-post/src/components/header/options-menu-item/index.js
+++ b/packages/edit-post/src/components/header/options-menu-item/index.js
@@ -3,18 +3,25 @@
  */
 import { withDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { MenuItem } from '@wordpress/components';
+import { MenuItem, MenuGroup } from '@wordpress/components';
 
 export function OptionsMenuItem( { openModal, onSelect } ) {
 	return (
-		<MenuItem
-			onClick={ () => {
-				onSelect();
-				openModal( 'edit-post/options' );
-			} }
-		>
-			{ __( 'Options' ) }
-		</MenuItem>
+		<MenuGroup
+			role={ 'group' }
+			useEventToOffset={ false }
+			label={ __( 'Options' ) }
+			isScreenReaderLabel={ true }
+			>
+			<MenuItem
+				onClick={ () => {
+					onSelect();
+					openModal( 'edit-post/options' );
+				} }
+			>
+				{ __( 'Options' ) }
+			</MenuItem>
+		</MenuGroup>
 	);
 }
 

--- a/packages/edit-post/src/components/header/options-menu-item/index.js
+++ b/packages/edit-post/src/components/header/options-menu-item/index.js
@@ -11,8 +11,7 @@ export function OptionsMenuItem( { openModal, onSelect } ) {
 			role={ 'group' }
 			useEventToOffset={ false }
 			label={ __( 'Options' ) }
-			isScreenReaderLabel={ true }
-			>
+			isScreenReaderLabel={ true }>
 			<MenuItem
 				onClick={ () => {
 					onSelect();

--- a/packages/edit-post/src/components/header/plugin-more-menu-item/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/header/plugin-more-menu-item/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`PluginMoreMenuItem renders menu item as button properly 1`] = `
   className="components-menu-group"
 >
   <div
-    className="components-menu-group__label "
+    className="components-menu-group__label"
     id="components-menu-group-label-0"
     role="presentation"
   >

--- a/packages/edit-post/src/components/header/plugin-more-menu-item/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/header/plugin-more-menu-item/test/__snapshots__/index.js.snap
@@ -5,8 +5,9 @@ exports[`PluginMoreMenuItem renders menu item as button properly 1`] = `
   className="components-menu-group"
 >
   <div
-    className="components-menu-group__label"
+    className="components-menu-group__label "
     id="components-menu-group-label-0"
+    role="presentation"
   >
     Plugins
   </div>
@@ -14,7 +15,7 @@ exports[`PluginMoreMenuItem renders menu item as button properly 1`] = `
     aria-labelledby="components-menu-group-label-0"
     aria-orientation="vertical"
     onKeyDown={[Function]}
-    role="menu"
+    role="group"
   >
     <button
       className="components-button components-icon-button components-menu-item__button has-icon has-text"

--- a/packages/edit-post/src/components/header/plugins-more-menu-group/index.js
+++ b/packages/edit-post/src/components/header/plugins-more-menu-group/index.js
@@ -17,8 +17,7 @@ PluginsMoreMenuGroup.Slot = ( { fillProps } ) => (
 			<MenuGroup
 				role={ 'group' }
 				useEventToOffset={ false }
-				label={ __( 'Plugins' ) }
-				>
+				label={ __( 'Plugins' ) }>
 				{ fills }
 			</MenuGroup>
 		) }

--- a/packages/edit-post/src/components/header/plugins-more-menu-group/index.js
+++ b/packages/edit-post/src/components/header/plugins-more-menu-group/index.js
@@ -14,7 +14,11 @@ const { Fill: PluginsMoreMenuGroup, Slot } = createSlotFill( 'PluginsMoreMenuGro
 PluginsMoreMenuGroup.Slot = ( { fillProps } ) => (
 	<Slot fillProps={ fillProps }>
 		{ ( fills ) => ! isEmpty( fills ) && (
-			<MenuGroup label={ __( 'Plugins' ) }>
+			<MenuGroup
+				role={ 'group' }
+				useEventToOffset={ false }
+				label={ __( 'Plugins' ) }
+				>
 				{ fills }
 			</MenuGroup>
 		) }

--- a/packages/edit-post/src/components/header/tools-more-menu-group/index.js
+++ b/packages/edit-post/src/components/header/tools-more-menu-group/index.js
@@ -14,7 +14,11 @@ const { Fill: ToolsMoreMenuGroup, Slot } = createSlotFill( 'ToolsMoreMenuGroup' 
 ToolsMoreMenuGroup.Slot = ( { fillProps } ) => (
 	<Slot fillProps={ fillProps }>
 		{ ( fills ) => ! isEmpty( fills ) && (
-			<MenuGroup label={ __( 'Tools' ) }>
+			<MenuGroup
+				role={ 'group' }
+				useEventToOffset={ false }
+				label={ __( 'Tools' ) }
+				>
 				{ fills }
 			</MenuGroup>
 		) }

--- a/packages/edit-post/src/components/header/tools-more-menu-group/index.js
+++ b/packages/edit-post/src/components/header/tools-more-menu-group/index.js
@@ -17,8 +17,7 @@ ToolsMoreMenuGroup.Slot = ( { fillProps } ) => (
 			<MenuGroup
 				role={ 'group' }
 				useEventToOffset={ false }
-				label={ __( 'Tools' ) }
-				>
+				label={ __( 'Tools' ) }>
 				{ fills }
 			</MenuGroup>
 		) }

--- a/packages/edit-post/src/components/header/writing-menu/index.js
+++ b/packages/edit-post/src/components/header/writing-menu/index.js
@@ -13,6 +13,8 @@ import FeatureToggle from '../feature-toggle';
 function WritingMenu( { onClose } ) {
 	return (
 		<MenuGroup
+			role={ 'group' }
+			useEventToOffset={ false }
 			label={ _x( 'View', 'noun' ) }
 		>
 			<FeatureToggle


### PR DESCRIPTION
## Description
Opened in place of #13059. Continues work started by @Firestorm980.

Closes https://github.com/WordPress/gutenberg/issues/12505. Adds role options to menus so that the items within the main more menu can now be groups within the menu. Should fix issues with keyboard navigation as well as roles. The menu options/props default to what they used to be, so if it isn't specified and these menus are used elsewhere, it should fallback to the old functionality.

## How has this been tested?

- Manual keyboard navigation testing in the admin with VoiceOver.
- Ran `test-e2e` within Gutenberg docker.

## Types of changes

- Updates menu group component to have a default role, label, and keyboard event control
- Changes menus used in the top nav to use `group` instead of `menu` and wraps within a parent `menu`
- Changes menus used in the top nav to let the parent menu handle overall keyboard event navigation

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
