### PR TITLE
RichText: improve toDom performance

### DIFF
--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -142,11 +142,11 @@ export function toDom( {
 		getText,
 		remove,
 		appendText,
-		onStartIndex( body, pointer ) {
-			startPath = createPathToNode( pointer, body, [ pointer.nodeValue.length ] );
+		onStartIndex( body, pointer, length ) {
+			startPath = createPathToNode( pointer, body, [ length ] );
 		},
-		onEndIndex( body, pointer ) {
-			endPath = createPathToNode( pointer, body, [ pointer.nodeValue.length ] );
+		onEndIndex( body, pointer, length ) {
+			endPath = createPathToNode( pointer, body, [ length ] );
 		},
 		isEditableTree,
 	} );


### PR DESCRIPTION
## Description

Tested with 100.000 characters: `toDom` takes about 150-160ms to complete in `master`, and about 23ms to complete in this branch.

Cause: `appendData` is called on a text node for every character in the string. I've reduced these calls to only once per created text node.

## How has this been tested?

All rich text unit tests should pass.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
