### PR TITLE
Blocks API: Improve validation after block gets filters applied

### DIFF
--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 6.2.0 (Unreleased)
+## 6.3.0 (Unreleased)
 
 ### New Feature
 

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -1,12 +1,8 @@
-## 6.3.0 (Unreleased)
+## x.x.x (Unreleased)
 
 ### New Feature
 
 - Added a default implementation for `save` setting in `registerBlockType` which saves no markup in the post content.
-
-## 6.2.0 (2019-03-20)
-
-- Maintenance minor version increment.
 
 ## 6.1.0 (2019-03-06)
 

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.2.0 (Unreleased)
+
+### New Feature
+
+- Added a default implementation for `save` setting in `registerBlockType` which saves no markup in the post content.
+
 ## 6.1.0 (2019-03-06)
 
 ### New Feature

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Added a default implementation for `save` setting in `registerBlockType` which saves no markup in the post content.
 
+## 6.2.0 (2019-03-20)
+
+- Maintenance minor version increment.
+
 ## 6.1.0 (2019-03-06)
 
 ### New Feature

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -3,7 +3,12 @@
 /**
  * External dependencies
  */
-import { get, isFunction, some } from 'lodash';
+import {
+	get,
+	isFunction,
+	isPlainObject,
+	some,
+} from 'lodash';
 
 /**
  * WordPress dependencies
@@ -91,10 +96,16 @@ export function registerBlockType( name, settings ) {
 	}
 
 	settings = applyFilters( 'blocks.registerBlockType', settings, name );
-
-	if ( ! settings || ! isFunction( settings.save ) ) {
+	if ( ! isPlainObject( settings ) ) {
 		console.error(
-			'The "save" property must be specified and must be a valid function.'
+			'Block settings need to remain a plain object after all "blocks.registerBlockType" filters are applied.'
+		);
+		return;
+	}
+
+	if ( ! isFunction( settings.save ) ) {
+		console.error(
+			'The "save" property must be a valid function.'
 		);
 		return;
 	}

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -98,7 +98,7 @@ export function registerBlockType( name, settings ) {
 	settings = applyFilters( 'blocks.registerBlockType', settings, name );
 	if ( ! isPlainObject( settings ) ) {
 		console.error(
-			'Block settings need to remain a plain object after all "blocks.registerBlockType" filters are applied.'
+			'Block settings must be a valid object.'
 		);
 		return;
 	}

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { noop, omit } from 'lodash';
+import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -103,6 +103,15 @@ describe( 'blocks', () => {
 			registerBlockType( 'core/test-block', defaultBlockSettings );
 			const block = registerBlockType( 'core/test-block', defaultBlockSettings );
 			expect( console ).toHaveErroredWith( 'Block "core/test-block" is already registered.' );
+			expect( block ).toBeUndefined();
+		} );
+
+		it( 'should reject blocks with invalid save function', () => {
+			const block = registerBlockType( 'my-plugin/fancy-block-5', {
+				...defaultBlockSettings,
+				save: 'invalid',
+			} );
+			expect( console ).toHaveErroredWith( 'The "save" property must be a valid function.' );
 			expect( block ).toBeUndefined();
 		} );
 
@@ -318,12 +327,12 @@ describe( 'blocks', () => {
 				expect( block ).toBeUndefined();
 			} );
 
-			it( 'should reject valid blocks when they become invalid after executing filter which removes save property', () => {
+			it( 'should reject blocks which become invalid after executing filter which does not return a plain object', () => {
 				addFilter( 'blocks.registerBlockType', 'core/blocks/without-save', ( settings ) => {
-					return omit( settings, 'save' );
+					return [ settings ];
 				} );
 				const block = registerBlockType( 'my-plugin/fancy-block-13', defaultBlockSettings );
-				expect( console ).toHaveErroredWith( 'The "save" property must be specified and must be a valid function.' );
+				expect( console ).toHaveErroredWith( 'Block settings need to remain a plain object after all "blocks.registerBlockType" filters are applied.' );
 				expect( block ).toBeUndefined();
 			} );
 		} );

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -332,7 +332,7 @@ describe( 'blocks', () => {
 					return [ settings ];
 				} );
 				const block = registerBlockType( 'my-plugin/fancy-block-13', defaultBlockSettings );
-				expect( console ).toHaveErroredWith( 'Block settings need to remain a plain object after all "blocks.registerBlockType" filters are applied.' );
+				expect( console ).toHaveErroredWith( 'Block settings must be a valid object.' );
 				expect( block ).toBeUndefined();
 			} );
 		} );


### PR DESCRIPTION
## Description
Follow-up for #14510.

It does three things:
- addressed @aduth's suggestion to bring back removed unit test (https://github.com/WordPress/gutenberg/pull/14510#discussion_r267043511).
- adds a new error validation message which makes it clear that settings object got corrupted.
- adds CHANGELOG entry which I missed...

## How has this been tested?
`npm run test-unit`

## Types of changes
Refactoring.