### PR TITLE
Docs: Clarify usage of @wordpress/babel-plugin-import-jsx-pragma with WordPress Babel preset

### DIFF
--- a/packages/babel-plugin-import-jsx-pragma/README.md
+++ b/packages/babel-plugin-import-jsx-pragma/README.md
@@ -30,7 +30,7 @@ module.exports = {
 };
 ```
 
-_Note:_ `@wordpress/babel-plugin-import-jsx-pragma` is now included in `@wordpress/babel-preset-default` (default preset for WordPress development). If you are using it, you shouldn't need to include this plugin anymore in your Babel config. 
+_Note:_ `@wordpress/babel-plugin-import-jsx-pragma` is included in `@wordpress/babel-preset-default` (default preset for WordPress development) starting from `v4.0.0`. If you are using this preset, you shouldn't include this plugin in your Babel config. 
 
 ## Options
 


### PR DESCRIPTION
## Description
Follow-up for #14482.

It's another try to clarify the usage of @wordpress/babel-plugin-import-jsx-pragma with WordPress Babel preset. This time it is reworded to age well according to the recommendation from @aduth shared in https://github.com/WordPress/gutenberg/pull/14482#discussion_r266888700 and this part in particular:

> To me, the perfect scenario would be that the plugin gracefully handles the case that it's included twice. The next best thing would be a clear note that the preset and plugin cannot be used in combination. Re-reading this text, I think it's fairly clear. It may have just been that the phrases "now" and "anymore" caught my attention as sounding temporary and not associated with any sense of when "now" actually occurred. "As of vX.X.X" might have served as an alternative pinned to a specific point in time.
