### PR TITLE
Paste: check plain text for Gutenberg content

### DIFF
--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -127,9 +127,14 @@ export function pasteHandler( { HTML = '', plainText = '', mode = 'AUTO', tagNam
 	// First of all, strip any meta tags.
 	HTML = HTML.replace( /<meta[^>]+>/, '' );
 
-	// If we detect block delimiters, parse entirely as blocks.
-	if ( mode !== 'INLINE' && HTML.indexOf( '<!-- wp:' ) !== -1 ) {
-		return parseWithGrammar( HTML );
+	// If we detect block delimiters in HTML, parse entirely as blocks.
+	if ( mode !== 'INLINE' ) {
+		// Check plain text if there is no HTML.
+		const content = HTML ? HTML : plainText;
+
+		if ( content.indexOf( '<!-- wp:' ) !== -1 ) {
+			return parseWithGrammar( content );
+		}
 	}
 
 	// Normalize unicode to use composed characters.

--- a/test/integration/blocks-raw-handling.spec.js
+++ b/test/integration/blocks-raw-handling.spec.js
@@ -221,6 +221,14 @@ describe( 'Blocks raw handling', () => {
 		expect( console ).toHaveLogged();
 	} );
 
+	it( 'should paste gutenberg content from plain text', () => {
+		const block = '<!-- wp:latest-posts /-->';
+		expect( serialize( pasteHandler( {
+			plainText: block,
+			mode: 'AUTO',
+		} ) ) ).toBe( block );
+	} );
+
 	describe( 'pasteHandler', () => {
 		[
 			'plain',


### PR DESCRIPTION
## Description

Fixes #14534.

We should also check the plain text, if no HTML is present (pure plain text paste), for Gutenberg content.

## How has this been tested?

See #14534.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->