### PR TITLE
Allow failures on php versions below 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,3 +99,15 @@ jobs:
         - $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --listTests > ~/.jest-e2e-tests
         - npm run build
         - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 2 == 1' < ~/.jest-e2e-tests )
+  allow_failures:
+    - name: PHP unit tests (PHP 5.3)
+      env: WP_VERSION=latest SWITCH_TO_PHP=5.3
+      script:
+        - ./bin/run-wp-unit-tests.sh
+      if: branch = master and type != "pull_request"
+
+    - name: PHP unit tests (PHP 5.2)
+      env: WP_VERSION=latest SWITCH_TO_PHP=5.2
+      script:
+        - ./bin/run-wp-unit-tests.sh
+


### PR DESCRIPTION
This is a follow up to https://core.trac.wordpress.org/changeset/44950

Based on the docs - https://docs.travis-ci.com/user/build-matrix/#rows-that-are-allowed-to-fail - The allow_failures entry needs to exactly match the jobs. 