### PR TITLE
RichText: add withoutInteractiveFormatting prop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3270,6 +3270,7 @@
 				"@wordpress/components": "file:packages/components",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/data": "file:packages/data",
+				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/dom": "file:packages/dom",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Master
 
+### New Features
+
+- Added a new `allowedFormats` prop to `RichText` to fine tune allowed formats. Deprecated the `formattingControls` prop in favour of this. Also added a `withoutInteractiveFormatting` to specifically disable format types that would insert interactive elements, which can not be nested.
+
 ### Breaking Changes
 
 - `BlockEditorProvider` no longer renders a wrapping `SlotFillProvider` or `DropZoneProvider` (from `@wordpress/components`). For custom block editors, you should render your own as wrapping the `BlockEditorProvider`. A future release will include a new `BlockEditor` component for simple, standard usage. `BlockEditorProvider` will serve the simple purpose of establishing its own context for block editors.

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -29,6 +29,7 @@
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",
+		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/dom": "file:../dom",
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",

--- a/packages/block-editor/src/components/rich-text/README.md
+++ b/packages/block-editor/src/components/rich-text/README.md
@@ -41,9 +41,9 @@ Render a rich [`contenteditable` input](https://developer.mozilla.org/en-US/docs
 
 *Optional.* Called when the block can be removed. `forward` is true when the selection is expected to move to the next block, false to the previous block.
 
-### `formattingControls: Array`
+### `withoutInteractiveFormatting: Boolean`
 
-*Optional.* By default, all formatting controls are present. This setting can be used to fine-tune formatting controls. Possible items: `[ 'bold', 'italic', 'strikethrough', 'link' ]`.
+*Optional.* By default, all formatting controls are present. This setting can be used to remove formatting controls that would make content [interactive](https://html.spec.whatwg.org/multipage/dom.html#interactive-content). This is useful if you want to make content that is already interactive editable.
 
 ### `isSelected: Boolean`
 

--- a/packages/block-editor/src/components/rich-text/README.md
+++ b/packages/block-editor/src/components/rich-text/README.md
@@ -41,6 +41,10 @@ Render a rich [`contenteditable` input](https://developer.mozilla.org/en-US/docs
 
 *Optional.* Called when the block can be removed. `forward` is true when the selection is expected to move to the next block, false to the previous block.
 
+### `allowedFormats: Array`
+
+*Optional.* By default, all registered formats are allowed. This setting can be used to fine-tune the allowed formats. Example: `[ 'core/bold', 'core/link' ]`.
+
 ### `withoutInteractiveFormatting: Boolean`
 
 *Optional.* By default, all formatting controls are present. This setting can be used to remove formatting controls that would make content [interactive](https://html.spec.whatwg.org/multipage/dom.html#interactive-content). This is useful if you want to make content that is already interactive editable.

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -275,6 +275,7 @@ class RichTextWraper extends Component {
 			onCreateUndoLevel,
 			placeholder,
 			keepPlaceholderOnFocus,
+			withoutInteractiveFormatting,
 			// eslint-disable-next-line no-unused-vars
 			onRemove,
 			// eslint-disable-next-line no-unused-vars
@@ -317,6 +318,7 @@ class RichTextWraper extends Component {
 				className={ classnames( classes, className ) }
 				placeholder={ placeholder }
 				keepPlaceholderOnFocus={ keepPlaceholderOnFocus }
+				withoutInteractiveFormatting={ withoutInteractiveFormatting }
 				onEnter={ this.onEnter }
 				onDelete={ this.onDelete }
 				onPaste={ this.onPaste }

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -275,6 +275,7 @@ class RichTextWraper extends Component {
 			onCreateUndoLevel,
 			placeholder,
 			keepPlaceholderOnFocus,
+			allowedFormats,
 			withoutInteractiveFormatting,
 			// eslint-disable-next-line no-unused-vars
 			onRemove,
@@ -318,6 +319,7 @@ class RichTextWraper extends Component {
 				className={ classnames( classes, className ) }
 				placeholder={ placeholder }
 				keepPlaceholderOnFocus={ keepPlaceholderOnFocus }
+				allowedFormats={ allowedFormats }
 				withoutInteractiveFormatting={ withoutInteractiveFormatting }
 				onEnter={ this.onEnter }
 				onDelete={ this.onDelete }
@@ -343,12 +345,12 @@ class RichTextWraper extends Component {
 								onChange={ onChange }
 							/>
 						) }
-						{ isSelected && ! inlineToolbar && (
+						{ isSelected && ! inlineToolbar && allowedFormats.length > 0 && (
 							<BlockFormatControls>
 								<FormatToolbar />
 							</BlockFormatControls>
 						) }
-						{ isSelected && inlineToolbar && (
+						{ isSelected && inlineToolbar && allowedFormats.length > 0 && (
 							<IsolatedEventContainer
 								className="editor-rich-text__inline-toolbar block-editor-rich-text__inline-toolbar"
 							>

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -319,6 +319,7 @@ class RichTextWraper extends Component {
 		} = this.props;
 
 		const adjustedAllowedFormats = this.getAllowedFormats();
+		const showToolbar = ! adjustedAllowedFormats || adjustedAllowedFormats.length > 0;
 		let adjustedValue = originalValue;
 		let adjustedOnChange = originalOnChange;
 
@@ -369,12 +370,12 @@ class RichTextWraper extends Component {
 								onChange={ onChange }
 							/>
 						) }
-						{ isSelected && ! inlineToolbar && adjustedAllowedFormats.length > 0 && (
+						{ isSelected && ! inlineToolbar && showToolbar && (
 							<BlockFormatControls>
 								<FormatToolbar />
 							</BlockFormatControls>
 						) }
-						{ isSelected && inlineToolbar && adjustedAllowedFormats.length > 0 && (
+						{ isSelected && inlineToolbar && showToolbar && (
 							<IsolatedEventContainer
 								className="editor-rich-text__inline-toolbar block-editor-rich-text__inline-toolbar"
 							>

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -261,16 +261,13 @@ class RichTextWraper extends Component {
 			return;
 		}
 
-		if ( formattingControls ) {
-			deprecated( 'wp.blockEditor.RichText formattingControls prop', {
-				version: 'the future',
-				alternative: 'allowedFormats',
-			} );
-		}
-
 		if ( allowedFormats ) {
 			return allowedFormats;
 		}
+
+		deprecated( 'wp.blockEditor.RichText formattingControls prop', {
+			alternative: 'allowedFormats',
+		} );
 
 		return formattingControls.map( ( name ) => `core/${ name }` );
 	}
@@ -319,7 +316,7 @@ class RichTextWraper extends Component {
 		} = this.props;
 
 		const adjustedAllowedFormats = this.getAllowedFormats();
-		const showToolbar = ! adjustedAllowedFormats || adjustedAllowedFormats.length > 0;
+		const hasFormats = ! adjustedAllowedFormats || adjustedAllowedFormats.length > 0;
 		let adjustedValue = originalValue;
 		let adjustedOnChange = originalOnChange;
 
@@ -370,12 +367,12 @@ class RichTextWraper extends Component {
 								onChange={ onChange }
 							/>
 						) }
-						{ isSelected && ! inlineToolbar && showToolbar && (
+						{ isSelected && ! inlineToolbar && hasFormats && (
 							<BlockFormatControls>
 								<FormatToolbar />
 							</BlockFormatControls>
 						) }
-						{ isSelected && inlineToolbar && showToolbar && (
+						{ isSelected && inlineToolbar && hasFormats && (
 							<IsolatedEventContainer
 								className="editor-rich-text__inline-toolbar block-editor-rich-text__inline-toolbar"
 							>

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -27,6 +27,7 @@ import {
 } from '@wordpress/rich-text';
 import { withFilters, IsolatedEventContainer } from '@wordpress/components';
 import { createBlobURL } from '@wordpress/blob';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -253,6 +254,27 @@ class RichTextWraper extends Component {
 		onReplace( [ block ] );
 	}
 
+	getAllowedFormats() {
+		const { allowedFormats, formattingControls } = this.props;
+
+		if ( ! allowedFormats && ! formattingControls ) {
+			return;
+		}
+
+		if ( formattingControls ) {
+			deprecated( 'wp.blockEditor.RichText formattingControls prop', {
+				version: 'the future',
+				alternative: 'allowedFormats',
+			} );
+		}
+
+		if ( allowedFormats ) {
+			return allowedFormats;
+		}
+
+		return formattingControls.map( ( name ) => `core/${ name }` );
+	}
+
 	render() {
 		const {
 			tagName,
@@ -275,6 +297,7 @@ class RichTextWraper extends Component {
 			onCreateUndoLevel,
 			placeholder,
 			keepPlaceholderOnFocus,
+			// eslint-disable-next-line no-unused-vars
 			allowedFormats,
 			withoutInteractiveFormatting,
 			// eslint-disable-next-line no-unused-vars
@@ -295,6 +318,7 @@ class RichTextWraper extends Component {
 			...experimentalProps
 		} = this.props;
 
+		const adjustedAllowedFormats = this.getAllowedFormats();
 		let adjustedValue = originalValue;
 		let adjustedOnChange = originalOnChange;
 
@@ -319,7 +343,7 @@ class RichTextWraper extends Component {
 				className={ classnames( classes, className ) }
 				placeholder={ placeholder }
 				keepPlaceholderOnFocus={ keepPlaceholderOnFocus }
-				allowedFormats={ allowedFormats }
+				allowedFormats={ adjustedAllowedFormats }
 				withoutInteractiveFormatting={ withoutInteractiveFormatting }
 				onEnter={ this.onEnter }
 				onDelete={ this.onDelete }
@@ -345,12 +369,12 @@ class RichTextWraper extends Component {
 								onChange={ onChange }
 							/>
 						) }
-						{ isSelected && ! inlineToolbar && allowedFormats.length > 0 && (
+						{ isSelected && ! inlineToolbar && adjustedAllowedFormats.length > 0 && (
 							<BlockFormatControls>
 								<FormatToolbar />
 							</BlockFormatControls>
 						) }
-						{ isSelected && inlineToolbar && allowedFormats.length > 0 && (
+						{ isSelected && inlineToolbar && adjustedAllowedFormats.length > 0 && (
 							<IsolatedEventContainer
 								className="editor-rich-text__inline-toolbar block-editor-rich-text__inline-toolbar"
 							>

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -114,7 +114,7 @@ class ButtonEdit extends Component {
 					placeholder={ __( 'Add text…' ) }
 					value={ text }
 					onChange={ ( value ) => setAttributes( { text: value } ) }
-					formattingControls={ [ 'bold', 'italic', 'strikethrough' ] }
+					withoutInteractiveFormatting
 					className={ classnames(
 						'wp-block-button__link', {
 							'has-background': backgroundColor.color,

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -213,7 +213,7 @@ class FileEdit extends Component {
 							value={ fileName }
 							placeholder={ __( 'Write file name…' ) }
 							keepPlaceholderOnFocus
-							formattingControls={ [] } // disable controls
+							withoutInteractiveFormatting
 							onChange={ ( text ) => setAttributes( { fileName: text } ) }
 						/>
 						{ showDownloadButton &&
@@ -223,7 +223,7 @@ class FileEdit extends Component {
 									tagName="div" // must be block-level or else cursor disappears
 									className={ 'wp-block-file__button' }
 									value={ downloadButtonText }
-									formattingControls={ [] } // disable controls
+									withoutInteractiveFormatting
 									placeholder={ __( 'Add text…' ) }
 									keepPlaceholderOnFocus
 									onChange={ ( text ) => setAttributes( { downloadButtonText: text } ) }

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -14,7 +14,7 @@ export default function SearchEdit( { className, attributes, setAttributes } ) {
 				aria-label={ __( 'Label text' ) }
 				placeholder={ __( 'Add label…' ) }
 				keepPlaceholderOnFocus
-				formattingControls={ [] }
+				withoutInteractiveFormatting
 				value={ label }
 				onChange={ ( html ) => setAttributes( { label: html } ) }
 			/>
@@ -34,7 +34,7 @@ export default function SearchEdit( { className, attributes, setAttributes } ) {
 				aria-label={ __( 'Button text' ) }
 				placeholder={ __( 'Add button text…' ) }
 				keepPlaceholderOnFocus
-				formattingControls={ [] }
+				withoutInteractiveFormatting
 				value={ buttonText }
 				onChange={ ( html ) => setAttributes( { buttonText: html } ) }
 			/>

--- a/packages/rich-text/src/component/format-edit.js
+++ b/packages/rich-text/src/component/format-edit.js
@@ -9,11 +9,41 @@ import { withSelect } from '@wordpress/data';
 import { getActiveFormat } from '../get-active-format';
 import { getActiveObject } from '../get-active-object';
 
-const FormatEdit = ( { formatTypes, onChange, value } ) => {
+/**
+ * Set of all interactive content tags.
+ *
+ * @see https://html.spec.whatwg.org/multipage/dom.html#interactive-content
+ */
+const interactiveContentTags = new Set( [
+	'a',
+	'audio',
+	'button',
+	'details',
+	'embed',
+	'iframe',
+	'input',
+	'label',
+	'select',
+	'textarea',
+	'video',
+] );
+
+const FormatEdit = ( { formatTypes, onChange, value, withoutInteractiveFormatting } ) => {
 	return (
 		<>
-			{ formatTypes.map( ( { name, edit: Edit } ) => {
+			{ formatTypes.map( ( {
+				name,
+				edit: Edit,
+				tagName,
+			} ) => {
 				if ( ! Edit ) {
+					return null;
+				}
+
+				if (
+					withoutInteractiveFormatting &&
+					interactiveContentTags.has( tagName )
+				) {
 					return null;
 				}
 

--- a/packages/rich-text/src/component/format-edit.js
+++ b/packages/rich-text/src/component/format-edit.js
@@ -28,56 +28,55 @@ const interactiveContentTags = new Set( [
 	'video',
 ] );
 
-const FormatEdit = ( { formatTypes, onChange, value, withoutInteractiveFormatting } ) => {
-	return (
-		<>
-			{ formatTypes.map( ( {
-				name,
-				edit: Edit,
-				tagName,
-			} ) => {
-				if ( ! Edit ) {
-					return null;
+const FormatEdit = ( {
+	formatTypes,
+	onChange,
+	value,
+	allowedFormats,
+	withoutInteractiveFormatting,
+} ) =>
+	formatTypes.map( ( {
+		name,
+		edit: Edit,
+		tagName,
+	} ) => {
+		if ( ! Edit ) {
+			return null;
+		}
+
+		if ( allowedFormats && allowedFormats.indexOf( name ) === -1 ) {
+			return null;
+		}
+
+		if (
+			withoutInteractiveFormatting &&
+			interactiveContentTags.has( tagName )
+		) {
+			return null;
+		}
+
+		const activeFormat = getActiveFormat( value, name );
+		const isActive = activeFormat !== undefined;
+		const activeObject = getActiveObject( value );
+		const isObjectActive = activeObject !== undefined;
+
+		return (
+			<Edit
+				key={ name }
+				isActive={ isActive }
+				activeAttributes={
+					isActive ? activeFormat.attributes || {} : {}
 				}
-
-				if (
-					withoutInteractiveFormatting &&
-					interactiveContentTags.has( tagName )
-				) {
-					return null;
+				isObjectActive={ isObjectActive }
+				activeObjectAttributes={
+					isObjectActive ? activeObject.attributes || {} : {}
 				}
+				value={ value }
+				onChange={ onChange }
+			/>
+		);
+	} );
 
-				const activeFormat = getActiveFormat( value, name );
-				const isActive = activeFormat !== undefined;
-				const activeObject = getActiveObject( value );
-				const isObjectActive = activeObject !== undefined;
-
-				return (
-					<Edit
-						key={ name }
-						isActive={ isActive }
-						activeAttributes={
-							isActive ? activeFormat.attributes || {} : {}
-						}
-						isObjectActive={ isObjectActive }
-						activeObjectAttributes={
-							isObjectActive ? activeObject.attributes || {} : {}
-						}
-						value={ value }
-						onChange={ onChange }
-					/>
-				);
-			} ) }
-		</>
-	);
-};
-
-export default withSelect(
-	( select ) => {
-		const { getFormatTypes } = select( 'core/rich-text' );
-
-		return {
-			formatTypes: getFormatTypes(),
-		};
-	}
-)( FormatEdit );
+export default withSelect( ( select ) => ( {
+	formatTypes: select( 'core/rich-text' ).getFormatTypes(),
+} ) )( FormatEdit );

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -864,6 +864,7 @@ class RichText extends Component {
 			__unstableAutocompleters: autocompleters,
 			__unstableAutocomplete: Autocomplete = ( { children: ch } ) => ch( {} ),
 			__unstableOnReplace: onReplace,
+			withoutInteractiveFormatting,
 		} = this.props;
 
 		// Generating a key that includes `tagName` ensures that if the tag
@@ -908,7 +909,11 @@ class RichText extends Component {
 						{ MultilineTag ? <MultilineTag>{ placeholder }</MultilineTag> : placeholder }
 					</Tagname>
 				}
-				{ isSelected && <FormatEdit value={ record } onChange={ this.onChange } /> }
+				{ isSelected && <FormatEdit
+					withoutInteractiveFormatting={ withoutInteractiveFormatting }
+					value={ record }
+					onChange={ this.onChange }
+				/> }
 			</>
 		);
 

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -864,6 +864,7 @@ class RichText extends Component {
 			__unstableAutocompleters: autocompleters,
 			__unstableAutocomplete: Autocomplete = ( { children: ch } ) => ch( {} ),
 			__unstableOnReplace: onReplace,
+			allowedFormats,
 			withoutInteractiveFormatting,
 		} = this.props;
 
@@ -910,6 +911,7 @@ class RichText extends Component {
 					</Tagname>
 				}
 				{ isSelected && <FormatEdit
+					allowedFormats={ allowedFormats }
 					withoutInteractiveFormatting={ withoutInteractiveFormatting }
 					value={ record }
 					onChange={ this.onChange }


### PR DESCRIPTION
## Description

Fixes https://github.com/WordPress/gutenberg/pull/15212#discussion_r297522724.
Fixes #14528.
Fixes #15858.

Adds a `withoutInteractiveFormatting` prop to `RichText`. We currently have a use case where we'd like to remove the link button (and any other interactive elements) from blocks such as button, file, and search, as it would create invalid HTML.

Also deprecates `formattingControls` and introduces `allowedFormats` (similar to `allowedBlocks`). Example: `[ 'core/bold' ]`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->