### PR TITLE
Remove dead / unreachable code in `core/calendar` block renderer.

### DIFF
--- a/packages/block-library/src/calendar/index.php
+++ b/packages/block-library/src/calendar/index.php
@@ -34,7 +34,7 @@ function render_block_core_calendar( $attributes ) {
 	$custom_class_name = empty( $attributes['className'] ) ? '' : ' ' . $attributes['className'];
 	$align_class_name  = empty( $attributes['align'] ) ? '' : ' ' . "align{$attributes['align']}";
 
-	return sprintf(
+	$output = sprintf(
 		'<div class="%1$s">%2$s</div>',
 		esc_attr( 'wp-block-calendar' . $custom_class_name . $align_class_name ),
 		get_calendar( true, false )
@@ -44,6 +44,8 @@ function render_block_core_calendar( $attributes ) {
 	$monthnum = $previous_monthnum;
 	// phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
 	$year = $previous_year;
+
+	return $output;
 }
 
 /**


### PR DESCRIPTION
## Description
The `core/calendar` block registration file contains variable assignments after a `return` statement (hence dead code). After removing this code, I discovered that the variables in question (`$previous_monthnum` and `$previous_year`) are never used anyway (not in this function, not in `get_calendar` and never in the entire codebase for that matter).

This PR removes dead code and unused variables to prevent any future ambiguities or bugs.

## How has this been tested?
Tests pass, not sure how to test server side rendering well
This change seems safe / harmless, however

## Types of changes
Refactor, non-breaking
