### PR TITLE
Block library: Try to use Babel plugins to inline block.json metadata

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,5 +3,6 @@ module.exports = function( api ) {
 
 	return {
 		presets: [ '@wordpress/babel-preset-default' ],
+		plugins: [ 'babel-plugin-inline-json-import' ],
 	};
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4065,6 +4065,15 @@
 				}
 			}
 		},
+		"babel-plugin-inline-json-import": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-inline-json-import/-/babel-plugin-inline-json-import-0.3.2.tgz",
+			"integrity": "sha512-QNNJx08KjmMT25Cw7rAPQ6dlREDPiZGDyApHL8KQ9vrQHbrr4PTi7W8g1tMMZPz0jEMd39nx/eH7xjnDNxq5sA==",
+			"dev": true,
+			"requires": {
+				"decache": "^4.5.1"
+			}
+		},
 		"babel-runtime": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
@@ -4697,6 +4706,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
 			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+			"dev": true
+		},
+		"callsite": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+			"integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
 			"dev": true
 		},
 		"callsites": {
@@ -7210,6 +7225,15 @@
 			"resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
 			"integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
 			"dev": true
+		},
+		"decache": {
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/decache/-/decache-4.5.1.tgz",
+			"integrity": "sha512-5J37nATc6FmOTLbcsr9qx7Nm28qQyg1SK4xyEHqM0IBkNhWFp0Sm+vKoWYHD8wq+OUEb9jLyaKFfzzd1A9hcoA==",
+			"dev": true,
+			"requires": {
+				"callsite": "^1.0.0"
+			}
 		},
 		"decamelize": {
 			"version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
 		"@wordpress/npm-package-json-lint-config": "file:packages/npm-package-json-lint-config",
 		"@wordpress/postcss-themes": "file:packages/postcss-themes",
 		"@wordpress/scripts": "file:packages/scripts",
+		"babel-plugin-inline-json-import": "0.3.2",
 		"benchmark": "2.1.4",
 		"browserslist": "4.4.1",
 		"chalk": "2.4.1",

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -9,6 +9,7 @@ import {
 	setDefaultBlockName,
 	setFreeformContentHandlerName,
 	setUnregisteredTypeHandlerName,
+	unstable__setBlockMetadata, // eslint-disable-line camelcase
 } from '@wordpress/blocks';
 
 /**
@@ -120,7 +121,10 @@ export const registerCoreBlocks = () => {
 		if ( ! block ) {
 			return;
 		}
-		const { name, settings } = block;
+		const { metadata, settings, name = metadata.name } = block;
+		if ( metadata ) {
+			unstable__setBlockMetadata( metadata ); // eslint-disable-line camelcase
+		}
 		registerBlockType( name, settings );
 	} );
 

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -9,7 +9,7 @@ import {
 	setDefaultBlockName,
 	setFreeformContentHandlerName,
 	setUnregisteredTypeHandlerName,
-	unstable__setBlockMetadata, // eslint-disable-line camelcase
+	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase
 } from '@wordpress/blocks';
 
 /**
@@ -123,7 +123,7 @@ export const registerCoreBlocks = () => {
 		}
 		const { metadata, settings, name = metadata.name } = block;
 		if ( metadata ) {
-			unstable__setBlockMetadata( metadata ); // eslint-disable-line camelcase
+			unstable__bootstrapServerSideBlockDefinitions( { [ name ]: metadata } ); // eslint-disable-line camelcase
 		}
 		registerBlockType( name, settings );
 	} );

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -121,7 +121,7 @@ export const registerCoreBlocks = () => {
 		if ( ! block ) {
 			return;
 		}
-		const { metadata, settings, name = metadata.name } = block;
+		const { metadata, settings, name } = block;
 		if ( metadata ) {
 			unstable__bootstrapServerSideBlockDefinitions( { [ name ]: metadata } ); // eslint-disable-line camelcase
 		}

--- a/packages/block-library/src/text-columns/block.json
+++ b/packages/block-library/src/text-columns/block.json
@@ -22,8 +22,5 @@
 		"width": {
 			"type": "string"
 		}
-	},
-	"supports": {
-		"inserter": false
 	}
 }

--- a/packages/block-library/src/text-columns/block.json
+++ b/packages/block-library/src/text-columns/block.json
@@ -1,0 +1,29 @@
+{
+	"name": "core/text-columns",
+	"icon": "columns",
+	"category": "layout",
+	"attributes": {
+		"content": {
+			"type": "array",
+			"source": "query",
+			"selector": "p",
+			"query": {
+				"children": {
+					"type": "string",
+					"source": "html"
+				}
+			},
+			"default": [ { }, { } ]
+		},
+		"columns": {
+			"type": "number",
+			"default": 2
+		},
+		"width": {
+			"type": "string"
+		}
+	},
+	"supports": {
+		"inserter": false
+	}
+}

--- a/packages/block-library/src/text-columns/block.json
+++ b/packages/block-library/src/text-columns/block.json
@@ -13,7 +13,7 @@
 					"source": "html"
 				}
 			},
-			"default": [ { }, { } ]
+			"default": [ {}, {} ]
 		},
 		"columns": {
 			"type": "number",

--- a/packages/block-library/src/text-columns/index.js
+++ b/packages/block-library/src/text-columns/index.js
@@ -18,43 +18,17 @@ import {
 } from '@wordpress/block-editor';
 import deprecated from '@wordpress/deprecated';
 
-export const name = 'core/text-columns';
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+export { metadata };
 
 export const settings = {
-	// Disable insertion as this block is deprecated and ultimately replaced by the Columns block.
-	supports: {
-		inserter: false,
-	},
-
 	title: __( 'Text Columns (deprecated)' ),
 
 	description: __( 'This block is deprecated. Please use the Columns block instead.' ),
-
-	icon: 'columns',
-
-	category: 'layout',
-
-	attributes: {
-		content: {
-			type: 'array',
-			source: 'query',
-			selector: 'p',
-			query: {
-				children: {
-					type: 'string',
-					source: 'html',
-				},
-			},
-			default: [ {}, {} ],
-		},
-		columns: {
-			type: 'number',
-			default: 2,
-		},
-		width: {
-			type: 'string',
-		},
-	},
 
 	transforms: {
 		to: [

--- a/packages/block-library/src/text-columns/index.js
+++ b/packages/block-library/src/text-columns/index.js
@@ -23,7 +23,9 @@ import deprecated from '@wordpress/deprecated';
  */
 import metadata from './block.json';
 
-export { metadata };
+const { name } = metadata;
+
+export { metadata, name };
 
 export const settings = {
 	// Disable insertion as this block is deprecated and ultimately replaced by the Columns block.

--- a/packages/block-library/src/text-columns/index.js
+++ b/packages/block-library/src/text-columns/index.js
@@ -26,6 +26,11 @@ import metadata from './block.json';
 export { metadata };
 
 export const settings = {
+	// Disable insertion as this block is deprecated and ultimately replaced by the Columns block.
+	supports: {
+		inserter: false,
+	},
+
 	title: __( 'Text Columns (deprecated)' ),
 
 	description: __( 'This block is deprecated. Please use the Columns block instead.' ),

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -44,6 +44,7 @@ export {
 	hasChildBlocks,
 	hasChildBlocksWithInserterSupport,
 	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase
+	unstable__setBlockMetadata, // eslint-disable-line camelcase
 	registerBlockStyle,
 	unregisterBlockStyle,
 } from './registration';

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -44,7 +44,6 @@ export {
 	hasChildBlocks,
 	hasChildBlocksWithInserterSupport,
 	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase
-	unstable__setBlockMetadata, // eslint-disable-line camelcase
 	registerBlockStyle,
 	unregisterBlockStyle,
 } from './registration';

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -58,6 +58,15 @@ export function unstable__bootstrapServerSideBlockDefinitions( definitions ) { /
 }
 
 /**
+ * Sets the block's metadata.
+ *
+ * @param {Object} definitions Server-side block definitions
+ */
+export function unstable__setBlockMetadata( { name, ...settings } ) { // eslint-disable-line camelcase
+	serverSideBlockDefinitions[ name ] = settings;
+}
+
+/**
  * Registers a new block provided a unique name and an object defining its
  * behavior. Once registered, the block is made available as an option to any
  * editor interface where blocks are implemented.

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -49,21 +49,15 @@ import { isValidIcon, normalizeIconObject } from './utils';
 let serverSideBlockDefinitions = {};
 
 /**
- * Set the server side block definition of blocks.
+ * Sets the server side block definition of blocks.
  *
  * @param {Object} definitions Server-side block definitions
  */
 export function unstable__bootstrapServerSideBlockDefinitions( definitions ) { // eslint-disable-line camelcase
-	serverSideBlockDefinitions = definitions;
-}
-
-/**
- * Sets the block's metadata.
- *
- * @param {Object} definitions Server-side block definitions
- */
-export function unstable__setBlockMetadata( { name, ...settings } ) { // eslint-disable-line camelcase
-	serverSideBlockDefinitions[ name ] = settings;
+	serverSideBlockDefinitions = {
+		...serverSideBlockDefinitions,
+		...definitions,
+	};
 }
 
 /**

--- a/playground/.babelrc
+++ b/playground/.babelrc
@@ -3,6 +3,7 @@
 	"plugins": [
 		[ "@babel/plugin-transform-react-jsx", {
 			"pragma": "createElement"
-		} ]
+		} ],
+		"babel-plugin-inline-json-import"
 	]
 }


### PR DESCRIPTION
## Description

It's based on RFC: #13693.

We discussed it with @youknowriad  earlier today. I think it looks very promising, the idea is that we inline `block.json` on the client to keep everything backward compatible with Drupal, Calypso, mobile
it also allows us to completely remove the existing script which generated server-side rendered definitions:
https://github.com/WordPress/gutenberg/blob/master/test/integration/full-content/server-registered.json 

## Testing

`block.json` is used for deprecated Text Columns block. To ensure it still works you can paste the following HTML code in the code editor mode:

```html
<!-- wp:text-columns -->
<div class="wp-block-text-columns alignundefined columns-2"><div class="wp-block-column"><p>Column 1</p></div><div class="wp-block-column"><p>Column 2</p></div></div>
<!-- /wp:text-columns -->
```

## Future

Moving forward we can add a few improvements by creating our own plugin:
- make it aware of translations
- structure generate code in a way which allows dead code elimination for Gutenberg and WordPress
- to do the previous, only ship metadata on the client if server-side registration isn’t used

In Gutenberg, we want to register all blocks on the server with PHP and don’t repeat it on the client. For the mobile app, there is a need to have those definitions to be loaded in JS as of today and maybe through network-based API later. Standalone Gutenberg which Riad works on would benefit from purely client-side block definitions loading. I'm fully aware, it’s all confusing :sweat_smile: With the proposed trick we can continue shipping npm modules which work out of the box even when blocks are partially defined in the JSON file. At the same time, we can introduce an env variable like `process.env.BLOCK_METADATA_SOURCE` (similar to `process.env.GUTENBERG_PHASE`) and don’t include code behind this flag in JS bundle when its value is set to `server` through some webpack magic. To better illustrate this idea, I hand-crafted example output which custom Babel plugin could generate:

```js
// input
import metadata from './block.json';
```

```json
{
	"name": "core/text-columns",
	"icon": "columns",
	"category": "layout",
	"attributes": {
		"content": {
			"type": "array",
			"source": "query",
			"selector": "p",
			"query": {
				"children": {
					"type": "string",
					"source": "html"
				}
			},
			"default": [ { }, { } ]
		},
		"columns": {
			"type": "number",
			"default": 2
		},
		"width": {
			"type": "string"
		}
	},
	"supports": {
		"inserter": false
	}
}
```

```js
// output
var metadata = {
  name: "core/text-columns",
};
if (process.env.BLOCK_METADATA_SOURCE !== 'server') {
	metadata = Object.assign({}, {
		icon: "columns",
		category: "layout",
		attributes: {
			content: {
				type: "array",
				source: "query",
				selector: "p",
				query: {
					children: {
						type: "string",
						source: "html"
					}
				},
				"default": [{}, {}]
			},
			columns: {
				type: "number",
				"default": 2
			},
			width: {
				type: "string"
			}
		},
		supports: {
			inserter: false
		}
	}, metadata);
}
exports.metadata = metadata;
```