### PR TITLE
RichText: fix tree output after applying format

### DIFF
--- a/packages/rich-text/src/apply-format.js
+++ b/packages/rich-text/src/apply-format.js
@@ -68,19 +68,24 @@ export function applyFormat(
 			};
 		}
 	} else {
+		// Determine the highest position the new format can be inserted at.
+		let position = +Infinity;
+
 		for ( let index = startIndex; index < endIndex; index++ ) {
 			if ( newFormats[ index ] ) {
 				newFormats[ index ] = newFormats[ index ]
 					.filter( ( { type } ) => type !== format.type );
+
+				const length = newFormats[ index ].length;
+
+				if ( length < position ) {
+					position = length;
+				}
 			} else {
 				newFormats[ index ] = [];
+				position = 0;
 			}
 		}
-
-		const position = Math.min(
-			newFormats[ startIndex ].length,
-			newFormats[ endIndex - 1 ].length
-		);
 
 		for ( let index = startIndex; index < endIndex; index++ ) {
 			newFormats[ index ].splice( position, 0, format );

--- a/packages/rich-text/src/apply-format.js
+++ b/packages/rich-text/src/apply-format.js
@@ -10,6 +10,12 @@ import { find } from 'lodash';
 
 import { normaliseFormats } from './normalise-formats';
 
+function replace( array, index, value ) {
+	array = array.slice();
+	array[ index ] = value;
+	return array;
+}
+
 /**
  * Apply a format object to a Rich Text value from the given `startIndex` to the
  * given `endIndex`. Indices are retrieved from the selection if none are
@@ -38,15 +44,19 @@ export function applyFormat(
 		// If the caret is at a format of the same type, expand start and end to
 		// the edges of the format. This is useful to apply new attributes.
 		if ( startFormat ) {
-			while ( find( newFormats[ startIndex ], startFormat ) ) {
-				applyFormats( newFormats, startIndex, format );
+			const index = newFormats[ startIndex ].indexOf( startFormat );
+
+			while ( newFormats[ startIndex ] && newFormats[ startIndex ][ index ] === startFormat ) {
+				newFormats[ startIndex ] =
+					replace( newFormats[ startIndex ], index, format );
 				startIndex--;
 			}
 
 			endIndex++;
 
-			while ( find( newFormats[ endIndex ], startFormat ) ) {
-				applyFormats( newFormats, endIndex, format );
+			while ( newFormats[ endIndex ] && newFormats[ endIndex ][ index ] === startFormat ) {
+				newFormats[ endIndex ] =
+					replace( newFormats[ endIndex ], index, format );
 				endIndex++;
 			}
 		// Otherwise, insert a placeholder with the format so new input appears
@@ -59,19 +69,23 @@ export function applyFormat(
 		}
 	} else {
 		for ( let index = startIndex; index < endIndex; index++ ) {
-			applyFormats( newFormats, index, format );
+			if ( newFormats[ index ] ) {
+				newFormats[ index ] = newFormats[ index ]
+					.filter( ( { type } ) => type !== format.type );
+			} else {
+				newFormats[ index ] = [];
+			}
+		}
+
+		const position = Math.min(
+			newFormats[ startIndex ].length,
+			newFormats[ endIndex - 1 ].length
+		);
+
+		for ( let index = startIndex; index < endIndex; index++ ) {
+			newFormats[ index ].splice( position, 0, format );
 		}
 	}
 
 	return normaliseFormats( { ...value, formats: newFormats } );
-}
-
-function applyFormats( formats, index, format ) {
-	if ( formats[ index ] ) {
-		const newFormatsAtIndex = formats[ index ].filter( ( { type } ) => type !== format.type );
-		newFormatsAtIndex.push( format );
-		formats[ index ] = newFormatsAtIndex;
-	} else {
-		formats[ index ] = [ format ];
-	}
 }

--- a/packages/rich-text/src/test/apply-format.js
+++ b/packages/rich-text/src/test/apply-format.js
@@ -112,6 +112,22 @@ describe( 'applyFormat', () => {
 		expect( getSparseArrayLength( result.formats ) ).toBe( 3 );
 	} );
 
+	it( 'should apply format around existing format with break', () => {
+		const record = {
+			formats: [ , [ em ], , [ em ] ],
+			text: 'test',
+		};
+		const expected = {
+			...record,
+			formats: [ , [ strong, em ], [ strong ], [ strong, em ] ],
+		};
+		const result = applyFormat( deepFreeze( record ), strong, 1, 4 );
+
+		expect( result ).toEqual( expected );
+		expect( result ).not.toBe( record );
+		expect( getSparseArrayLength( result.formats ) ).toBe( 3 );
+	} );
+
 	it( 'should apply format crossing existing format', () => {
 		const record = {
 			formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],

--- a/packages/rich-text/src/test/apply-format.js
+++ b/packages/rich-text/src/test/apply-format.js
@@ -18,6 +18,102 @@ describe( 'applyFormat', () => {
 
 	it( 'should apply format', () => {
 		const record = {
+			formats: [ , , , , ],
+			text: 'test',
+		};
+		const expected = {
+			...record,
+			formats: [ [ em ], [ em ], [ em ], [ em ] ],
+		};
+		const result = applyFormat( deepFreeze( record ), em, 0, 4 );
+
+		expect( result ).toEqual( expected );
+		expect( result ).not.toBe( record );
+		expect( getSparseArrayLength( result.formats ) ).toBe( 4 );
+	} );
+
+	it( 'should apply format on top of existing format', () => {
+		const record = {
+			formats: [ [ strong ], [ strong ], [ strong ], [ strong ] ],
+			text: 'test',
+		};
+		const expected = {
+			...record,
+			formats: [ [ strong, em ], [ strong, em ], [ strong, em ], [ strong, em ] ],
+		};
+		const result = applyFormat( deepFreeze( record ), em, 0, 4 );
+
+		expect( result ).toEqual( expected );
+		expect( result ).not.toBe( record );
+		expect( getSparseArrayLength( result.formats ) ).toBe( 4 );
+	} );
+
+	it( 'should apply format and remove same format type', () => {
+		const record = {
+			formats: [ [ strong ], [ em, strong ], [ em, strong ], [ strong ] ],
+			text: 'test',
+		};
+		const expected = {
+			...record,
+			formats: [ [ strong, em ], [ strong, em ], [ strong, em ], [ strong, em ] ],
+		};
+		const result = applyFormat( deepFreeze( record ), em, 0, 4 );
+
+		expect( result ).toEqual( expected );
+		expect( result ).not.toBe( record );
+		expect( getSparseArrayLength( result.formats ) ).toBe( 4 );
+	} );
+
+	it( 'should apply format around existing format', () => {
+		const record = {
+			formats: [ , [ em ], [ em ], , ],
+			text: 'test',
+		};
+		const expected = {
+			...record,
+			formats: [ [ strong ], [ strong, em ], [ strong, em ], [ strong ] ],
+		};
+		const result = applyFormat( deepFreeze( record ), strong, 0, 4 );
+
+		expect( result ).toEqual( expected );
+		expect( result ).not.toBe( record );
+		expect( getSparseArrayLength( result.formats ) ).toBe( 4 );
+	} );
+
+	it( 'should apply format around existing format with edge right', () => {
+		const record = {
+			formats: [ , [ em ], [ em ], , ],
+			text: 'test',
+		};
+		const expected = {
+			...record,
+			formats: [ [ strong ], [ strong, em ], [ strong, em ], , ],
+		};
+		const result = applyFormat( deepFreeze( record ), strong, 0, 3 );
+
+		expect( result ).toEqual( expected );
+		expect( result ).not.toBe( record );
+		expect( getSparseArrayLength( result.formats ) ).toBe( 3 );
+	} );
+
+	it( 'should apply format around existing format with edge left', () => {
+		const record = {
+			formats: [ , [ em ], [ em ], , ],
+			text: 'test',
+		};
+		const expected = {
+			...record,
+			formats: [ , [ strong, em ], [ strong, em ], [ strong ] ],
+		};
+		const result = applyFormat( deepFreeze( record ), strong, 1, 4 );
+
+		expect( result ).toEqual( expected );
+		expect( result ).not.toBe( record );
+		expect( getSparseArrayLength( result.formats ) ).toBe( 3 );
+	} );
+
+	it( 'should apply format crossing existing format', () => {
+		const record = {
 			formats: [ , , , , [ em ], [ em ], [ em ], , , , , , , ],
 			text: 'one two three',
 		};

--- a/packages/rich-text/src/test/apply-format.js
+++ b/packages/rich-text/src/test/apply-format.js
@@ -22,7 +22,7 @@ describe( 'applyFormat', () => {
 			text: 'one two three',
 		};
 		const expected = {
-			formats: [ , , , [ strong ], [ em, strong ], [ em, strong ], [ em ], , , , , , , ],
+			formats: [ , , , [ strong ], [ strong, em ], [ strong, em ], [ em ], , , , , , , ],
 			text: 'one two three',
 		};
 		const result = applyFormat( deepFreeze( record ), strong, 3, 6 );
@@ -40,7 +40,7 @@ describe( 'applyFormat', () => {
 			end: 6,
 		};
 		const expected = {
-			formats: [ , , , [ strong ], [ em, strong ], [ em, strong ], [ em ], , , , , , , ],
+			formats: [ , , , [ strong ], [ strong, em ], [ strong, em ], [ em ], , , , , , , ],
 			text: 'one two three',
 			start: 3,
 			end: 6,

--- a/packages/rich-text/src/test/toggle-format.js
+++ b/packages/rich-text/src/test/toggle-format.js
@@ -42,7 +42,7 @@ describe( 'toggleFormat', () => {
 			end: 6,
 		};
 		const expected = {
-			formats: [ , , , [ strong ], [ em, strong ], [ em, strong ], [ em ], , , , , , , ],
+			formats: [ , , , [ strong ], [ strong, em ], [ strong, em ], [ em ], , , , , , , ],
 			text: 'one two three',
 			start: 3,
 			end: 6,


### PR DESCRIPTION
## Description

Fixes #12314. Still needs some additional tests.

Problem: Applying a format around an existing format (greater selection), will chop the applied format into 2-3 pieces. Why? Because the format is just added at the end of each format array at every index:

```
     1111
111110000
link bold
     link
```

Instead, this should be:

```
     0000
111111111
link bold
     link
```

Solution: check the position at which to insert first. This should be the lowest value between the start and end indices.

## How has this been tested?

Make something bold. Select the bolded text, including something more. Now link it. The link should not be split into two elements.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->