### PR TITLE
Plugin: Account for null return of `get_current_screen`

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -93,7 +93,8 @@ function is_gutenberg_page() {
 	_deprecated_function( __FUNCTION__, '5.3.0', 'WP_Screen::is_block_editor' );
 
 	require_once ABSPATH . 'wp-admin/includes/screen.php';
-	return get_current_screen()->is_block_editor();
+	$screen = get_current_screen();
+	return ! is_null( $screen ) && get_current_screen()->is_block_editor();
 }
 
 /**
@@ -159,5 +160,6 @@ function gutenberg_init() {
 	_deprecated_function( __FUNCTION__, '5.3.0' );
 
 	require_once ABSPATH . 'wp-admin/includes/screen.php';
-	return get_current_screen()->is_block_editor();
+	$screen = get_current_screen();
+	return ! is_null( $screen ) && get_current_screen()->is_block_editor();
 }


### PR DESCRIPTION
Fixes #14547

This pull request seeks to resolve issues where calling the deprecated functions `is_gutenberg_page` or `gutenberg_init` in a non-WP-Admin context may produce fatal errors.

For additional context, see https://github.com/WordPress/gutenberg/issues/14547#issuecomment-475375258 .

Additional unguarded references to `get_current_screen` [exist in `lib/widgets.php`](https://github.com/WordPress/gutenberg/blob/master/lib/widgets.php). However, these functions are action handlers for `admin_print_styles`, at which point it's considered an assumed guarantee that `get_current_screen` would exist and return a non-`null` value (the [screen is set](https://github.com/WordPress/wordpress-develop/blob/49d8c2590c73c283576c9864cd69973f7f1421b8/src/wp-admin/admin-header.php#L29-L32) immediately prior to the [actions firing](https://github.com/WordPress/wordpress-develop/blob/49d8c2590c73c283576c9864cd69973f7f1421b8/src/wp-admin/admin-header.php#L108-L127)). This is still a loose guarantee, and it may be advisable to consider introducing guarded conditions all the same (e.g. for handling an unprompted plugin's `do_action( 'admin_print_styles' );`).

**Testing instructions:**

Place the following file as e.g. `is-gutenberg-page.php` within `wp-content/mu-plugins`. There should be no fatal error when visiting the front of the site.

```php
<?php

add_action( 'init', function() {
	is_gutenberg_page();
} );
```