### PR TITLE
[RNMobile] fixed this.onChange reference and added checks for nativeEvent before eval

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -241,7 +241,7 @@ export class RichText extends Component {
 			this.lastEventCount = event.nativeEvent.eventCount;
 			const contentWithoutRootTag = this.removeRootTagsProduceByAztec( unescapeSpaces( event.nativeEvent.text ) );
 			this.lastContent = contentWithoutRootTag;
-			this.onChange( this.lastContent );
+			this.props.onChange( this.lastContent );
 		}
 	}
 

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -196,7 +196,7 @@ export class RichText extends Component {
 			formatPlaceholder: record.formatPlaceholder,
 		} );
 		if ( newContent && newContent !== this.props.value ) {
-			this.props.onChange( newContent );
+			this.onChange( newContent );
 			if ( record.needsSelectionUpdate && record.start && record.end ) {
 				this.setState( { start: record.start, end: record.end } );
 			}
@@ -237,10 +237,12 @@ export class RichText extends Component {
 	 * Handles any case where the content of the AztecRN instance has changed
 	 */
 	onChange( event ) {
-		this.lastEventCount = event.nativeEvent.eventCount;
-		const contentWithoutRootTag = this.removeRootTagsProduceByAztec( unescapeSpaces( event.nativeEvent.text ) );
-		this.lastContent = contentWithoutRootTag;
-		this.props.onChange( this.lastContent );
+		if ( event.nativeEvent ) {
+			this.lastEventCount = event.nativeEvent.eventCount;
+			const contentWithoutRootTag = this.removeRootTagsProduceByAztec( unescapeSpaces( event.nativeEvent.text ) );
+			this.lastContent = contentWithoutRootTag;
+			this.onChange( this.lastContent );
+		}
 	}
 
 	/**
@@ -322,7 +324,7 @@ export class RichText extends Component {
 				} );
 				this.lastContent = this.valueToFormat( linkedRecord );
 				this.lastEventCount = undefined;
-				this.props.onChange( this.lastContent );
+				this.onChange( this.lastContent );
 
 				// Allows us to ask for this information when we get a report.
 				window.console.log( 'Created link:\n\n', trimmedText );
@@ -355,7 +357,7 @@ export class RichText extends Component {
 			const newContent = this.valueToFormat( insertedContent );
 			this.lastEventCount = undefined;
 			this.lastContent = newContent;
-			this.props.onChange( this.lastContent );
+			this.onChange( this.lastContent );
 		} else if ( onSplit ) {
 			if ( ! pastedContent.length ) {
 				return;
@@ -388,11 +390,14 @@ export class RichText extends Component {
 			end: realEnd,
 			formatPlaceholder,
 		} );
-		this.lastEventCount = event.nativeEvent.eventCount;
+
+		if ( event.nativeEvent ) {
+			this.lastEventCount = event.nativeEvent.eventCount;
+		}
 		// we don't want to refresh aztec as no content can have changed from this event
 		// let's update lastContent to prevent that in shouldComponentUpdate
 		this.lastContent = this.removeRootTagsProduceByAztec( unescapeSpaces( text ) );
-		this.props.onChange( this.lastContent );
+		this.onChange( this.lastContent );
 	}
 
 	isEmpty() {


### PR DESCRIPTION
## Description
Fixes rotation problems on Android when RichText is empty and `eventCount` is tried to be evaluated

## How has this been tested?
Use WPAndroid PR https://github.com/wordpress-mobile/WordPress-Android/pull/9457
Gutenberg mobile PR https://github.com/wordpress-mobile/gutenberg-mobile/pull/770

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
