### PR TITLE
Use MenuItem instead of IconButton for items added by plugins

### DIFF
--- a/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
+++ b/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
@@ -6,7 +6,7 @@ import { difference } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { IconButton } from '@wordpress/components';
+import { MenuItem } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 
 /**
@@ -89,7 +89,7 @@ const PluginBlockSettingsMenuItem = ( { allowedBlocks, icon, label, onClick, sma
 			if ( ! shouldRenderItem( selectedBlocks, allowedBlocks ) ) {
 				return null;
 			}
-			return ( <IconButton
+			return ( <MenuItem
 				className="editor-block-settings-menu__control"
 				onClick={ compose( onClick, onClose ) }
 				icon={ icon || 'admin-plugins' }
@@ -97,7 +97,7 @@ const PluginBlockSettingsMenuItem = ( { allowedBlocks, icon, label, onClick, sma
 				role={ role }
 			>
 				{ ! small && label }
-			</IconButton> );
+			</MenuItem> );
 		} }
 	</PluginBlockSettingsMenuGroup>
 );


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/14567

### Test

- Create a plugin that adds a new item to the block settings menu and make it available in your WordPress setup (you can reuse [this](https://github.com/nosolosw/understanding-gutenberg/tree/master/blocksettingsmenu-plugin))
- Activate the plugin.
- Check that the icon is aligned with the rest of core items.

![Screenshot from 2019-03-22 13-07-24](https://user-images.githubusercontent.com/583546/54821789-8702d200-4ca3-11e9-905c-5e77a381ec56.png)

