### PR TITLE
Fix the post title focus style in the default mode

### DIFF
--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -52,14 +52,9 @@
 		}
 
 		&:focus {
-			// Stack borders on mobile.
 			border: $border-width solid transparent;
 			border-left-width: 0;
-			border-right-width: 0;
-
-			// Include transparent outline for Windows High Contrast mode.
 			outline: $border-width solid transparent;
-
 			box-shadow: none;
 		}
 	}


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/pull/14509#discussion_r268149163

This fixes the hover style of the post title input in the default mode.

**Testing instructions**

 - Check the post title focus style in both the default and spotlight modes.