### PR TITLE
Project management: Refinements to CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,7 @@
 # Editor
 /packages/annotations                           @youknowriad @aduth @atimmer
 /packages/autop                                 @youknowriad @aduth
+/packages/block-editor                          @youknowriad @gziolo @talldan @noisysocks
 /packages/block-serialization-spec-parser       @youknowriad @gziolo @aduth @dmsnell
 /packages/block-serialization-default-parser    @youknowriad @gziolo @aduth @dmsnell
 /packages/blocks                                @youknowriad @gziolo @aduth @noisysocks

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,8 @@
+# Documentation
+/docs                                           @youknowriad @chrisvanpatten @mkaz @ajitbohra @nosolosw @notnownikki
+/docs/designers-developers/developers           @youknowriad @gziolo @chrisvanpatten @mkaz @ajitbohra @nosolosw @notnownikki
+/docs/designers-developers/designers            @youknowriad @chrisvanpatten @mkaz @ajitbohra @nosolosw @notnownikki
+
 # Data
 /packages/api-fetch                             @youknowriad @aduth @nerrad @mmtr
 /packages/core-data                             @youknowriad @gziolo @aduth @nerrad @noisysocks
@@ -8,13 +13,13 @@
 /packages/block-library                         @youknowriad @gziolo @Soean @ajitbohra @jorgefilipecosta @talldan @noisysocks @notnownikki
 
 # Editor
-/packages/annotations                           @youknowriad @gziolo @aduth @atimmer
+/packages/annotations                           @youknowriad @aduth @atimmer
 /packages/autop                                 @youknowriad @aduth
 /packages/block-serialization-spec-parser       @youknowriad @gziolo @aduth @dmsnell
 /packages/block-serialization-default-parser    @youknowriad @gziolo @aduth @dmsnell
 /packages/blocks                                @youknowriad @gziolo @aduth @noisysocks
-/packages/edit-post                             @youknowriad @gziolo @talldan @noisysocks
-/packages/editor                                @youknowriad @gziolo @talldan @noisysocks
+/packages/edit-post                             @youknowriad @talldan @noisysocks
+/packages/editor                                @youknowriad @talldan @noisysocks
 /packages/list-reusable-blocks                  @youknowriad @aduth @noisysocks
 /packages/shortcode                             @youknowriad @aduth
 
@@ -23,12 +28,13 @@
 
 # Tooling
 /bin                                            @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
+/docs/tool                                      @youknowriad @gziolo @chrisvanpatten @mkaz @ajitbohra @nosolosw @notnownikki                      
 /packages/babel-plugin-import-jsx-pragma        @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra @nosolosw
 /packages/babel-plugin-makepot                  @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
 /packages/babel-preset-default                  @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra @nosolosw
 /packages/browserslist-config                   @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
 /packages/custom-templated-path-webpack-plugin  @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
-/packages/docgen                                @nosolosw @mkaz
+/packages/docgen                                @nosolosw @mkaz @gziolo
 /packages/e2e-test-utils                        @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
 /packages/e2e-tests                             @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra @talldan
 /packages/eslint-plugin                         @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra @nosolosw
@@ -70,15 +76,12 @@
 /packages/plugins                               @youknowriad @gziolo @aduth @adamsilverstein
 
 # Rich Text
-/packages/format-library                        @youknowriad @gziolo @aduth @iseulde @jorgefilipecosta
+/packages/format-library                        @youknowriad @aduth @iseulde @jorgefilipecosta
 /packages/rich-text                             @youknowriad @aduth @iseulde @jorgefilipecosta
-/packages/editor/src/components/rich-text       @youknowriad @aduth @iseulde @jorgefilipecosta
+/packages/block-editor/src/components/rich-text @youknowriad @aduth @iseulde @jorgefilipecosta
 
 # PHP
 /lib                                            @youknowriad @gziolo @aduth
-
-# Documentation
-/docs                                           @youknowriad @gziolo @chrisvanpatten @mkaz @ajitbohra @nosolosw @notnownikki
 
 # Styles
 *.scss                                          @chrisvanpatten


### PR DESCRIPTION
## Description
This PR does 4 things to the existing CODEOWNERS file:
- Divides `/docs` folder into smaller chunks to make it easier to opt-in for a specific type of documentation (designer, developer or tools).
- Fixes the path to `RichText` component.
- Updates my own assignments to better reflect what I'm able to review.
- Adds missing `block-editor` package.