### PR TITLE
[Mobile]: Avoid crash rotating Android devices.

### DIFF
--- a/packages/block-editor/src/components/default-block-appender/index.native.js
+++ b/packages/block-editor/src/components/default-block-appender/index.native.js
@@ -37,6 +37,7 @@ export function DefaultBlockAppender( {
 			<View style={ [ styles.blockHolder, containerStyle ] } pointerEvents="box-only">
 				<RichText
 					placeholder={ value }
+					onChange={ ()=>{} }
 				/>
 			</View>
 		</TouchableWithoutFeedback>

--- a/packages/block-editor/src/components/default-block-appender/index.native.js
+++ b/packages/block-editor/src/components/default-block-appender/index.native.js
@@ -37,7 +37,7 @@ export function DefaultBlockAppender( {
 			<View style={ [ styles.blockHolder, containerStyle ] } pointerEvents="box-only">
 				<RichText
 					placeholder={ value }
-					onChange={ ()=>{} }
+					onChange={ () => {} }
 				/>
 			</View>
 		</TouchableWithoutFeedback>


### PR DESCRIPTION
This PR implement dummy onChange on DefaultBlockAppender's RichText to avoid crash rotating Android devices.

To test: 
- Please follow the steps on https://github.com/wordpress-mobile/gutenberg-mobile/pull/774