### PR TITLE
Testing: Add ESLint restricted syntax for truthy length rendering

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -92,6 +92,10 @@ module.exports = {
 				selector: 'CallExpression[callee.name="withDispatch"] > :function > BlockStatement > :not(VariableDeclaration,ReturnStatement)',
 				message: 'withDispatch must return an object with consistent keys. Avoid performing logic in `mapDispatchToProps`.',
 			},
+			{
+				selector: 'LogicalExpression[operator="&&"][left.property.name="length"][right.type="JSXElement"]',
+				message: 'Avoid truthy checks on length property rendering, as zero length is rendered verbatim.',
+			},
 		],
 		'react/forbid-elements': [ 'error', {
 			forbid: [


### PR DESCRIPTION
This pull request seeks to add a new ESLint restricted syntax to prevent the use of a `length` property in a boolean expression for rendering.

The problem is that if `length` yields a value of `0`, it will be rendered verbatim, which is not intended. The presumed intended behavior is to render the right-hand expression only if `length` is non-zero, which should be expressed as either `length > 0` or as explicitly coercing to a boolean value `!! length`.

See CodePen example: https://codepen.io/aduth/pen/dWwzrL

See ASTExplorer demo: https://astexplorer.net/#/gist/9ec7cf3fb53e63775defbc0e532b4cc8/487ccade54ed4c02fc846d1211083a9eac79f23f

**Testing instructions:**

I'm not positive how to trigger the zero length here. I discovered as an otherwise buggy state of an in-progress branch which caused multiple toolbars to be rendered ([screenshot](https://user-images.githubusercontent.com/1779930/54831715-4306d180-4c91-11e9-8fa8-383af5758a81.png)).


Repeat testing instructions from #14233

Verify that if the changes to `FormatToolbar` are undone in your local copy of the branch, proceeding to run `npm run lint` should produce an error.