### PR TITLE
Add legacy widget to calendar transform

### DIFF
--- a/packages/block-library/src/calendar/index.js
+++ b/packages/block-library/src/calendar/index.js
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
  */
 import metadata from './block.json';
 import edit from './edit';
+import transforms from './transforms';
 
 const { name } = metadata;
 
@@ -24,4 +25,5 @@ export const settings = {
 	},
 	example: {},
 	edit,
+	transforms,
 };

--- a/packages/block-library/src/calendar/transforms.js
+++ b/packages/block-library/src/calendar/transforms.js
@@ -1,0 +1,30 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+const transforms = {
+	from: [
+		{
+			type: 'block',
+			blocks: [ 'core/legacy-widget' ],
+			isMatch: ( { widgetClass } ) => {
+				return widgetClass === 'WP_Widget_Calendar';
+			},
+			transform: ( { instance } ) => {
+				const calendarBlock = createBlock( 'core/calendar' );
+				if ( ! instance || ! instance.title ) {
+					return calendarBlock;
+				}
+				return [
+					createBlock( 'core/heading', {
+						content: instance.title,
+					} ),
+					calendarBlock,
+				];
+			},
+		},
+	],
+};
+
+export default transforms;


### PR DESCRIPTION
Based on: https://github.com/WordPress/gutenberg/pull/15396
Should be merged after the other PR lands.

This PR makes use of the current transforms mechanism to allow transforming legacy widgets containing a calendar into a calendar block.

## Testing
I pasted the following block in the code editor:
```
<!-- wp:legacy-widget {"identifier":"WP_Widget_Calendar","instance":{"title":"My calendar"},"isCallbackWidget":false,"hasEditForm":true} /-->
````

I was able to transform the legacy widget into a calendar block and also got a heading block with the title.

When I pasted this block and transformed it I only got a calendar:
```
<!-- wp:legacy-widget {"identifier":"WP_Widget_Calendar","instance":{"title":"My calendar"},"isCallbackWidget":false,"hasEditForm":true} /-->
```

When I pasted this blocks:
```
<!-- wp:legacy-widget {"identifier":"WP_Widget_Tag_Cloud","instance":{"title":"Tags","count":0,"taxonomy":"post_tag"},"isCallbackWidget":false,"hasEditForm":true} /-->

<!-- wp:legacy-widget {"identifier":"WP_Widget_Archives","instance":{"title":"My archives","count":0,"dropdown":0},"isCallbackWidget":false,"hasEditForm":true} /-->
```
I checked there was no option to convert them into a calendar.