### PR TITLE
Fix: Bug Affecting Widgets without description

### DIFF
--- a/lib/widgets.php
+++ b/lib/widgets.php
@@ -95,7 +95,12 @@ function gutenberg_legacy_widget_settings( $settings ) {
 		if ( ! in_array( $class, $core_widgets ) ) {
 			$available_legacy_widgets[ $class ] = array(
 				'name'             => html_entity_decode( $widget_obj->name ),
-				'description'      => html_entity_decode( $widget_obj->widget_options['description'] ),
+				// wp_widget_description is not being used because its input parameter is a Widget Id.
+				// Widgets id's reference to a specific widget instance.
+				// Here we are iterating on all the available widget classes even if no widget instance exists for them.
+				'description'      => isset( $widget_obj->widget_options['description'] ) ?
+					html_entity_decode( $widget_obj->widget_options['description'] ) :
+					null,
 				'isCallbackWidget' => false,
 			);
 		}


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/14552

We were not checking in the widget description was set and on widgets, without description, an undefined notice was being thrown.

## How has this been tested?
I installed the AnsPress Question Answer plugin: https://wordpress.org/plugins/anspress-question-answer.
I created a new page and verified and checked Undefined notice was not being thrown in the PHP code. In master, a notice should appear.

