### PR TITLE
Updated the "Move to Trash" button 

### DIFF
--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -22,8 +22,8 @@ const ALLOWED_MEDIA_TYPES = [ 'image' ];
 
 // Used when labels from post type were not yet loaded or when they are not present.
 const DEFAULT_FEATURE_IMAGE_LABEL = __( 'Featured Image' );
-const DEFAULT_SET_FEATURE_IMAGE_LABEL = __( 'Set featured image' );
-const DEFAULT_REMOVE_FEATURE_IMAGE_LABEL = __( 'Remove image' );
+const DEFAULT_SET_FEATURE_IMAGE_LABEL = __( 'Set Featured Image' );
+const DEFAULT_REMOVE_FEATURE_IMAGE_LABEL = __( 'Remove Image' );
 
 function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onRemoveImage, media, postType } ) {
 	const postLabel = get( postType, [ 'labels' ], {} );
@@ -81,7 +81,7 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 							modalClass="editor-post-featured-image__media-modal"
 							render={ ( { open } ) => (
 								<Button onClick={ open } isDefault isLarge>
-									{ __( 'Replace image' ) }
+									{ __( 'Replace Image' ) }
 								</Button>
 							) }
 						/>

--- a/packages/editor/src/components/post-trash/index.js
+++ b/packages/editor/src/components/post-trash/index.js
@@ -15,7 +15,7 @@ function PostTrash( { isNew, postId, postType, ...props } ) {
 
 	return (
 		<Button className="editor-post-trash button-link-delete" onClick={ onClick } isDefault isLarge>
-			{ __( 'Move to trash' ) }
+			{ __( 'Move to Trash' ) }
 		</Button>
 	);
 }


### PR DESCRIPTION
## Description
The "Move to trash" button in the document inspector wasn't title case. This PR makes the text match the title case of other buttons. Closes #12366.

## How has this been tested?
Tested locally.

![Screen Shot 2019-03-22 at 9 37 29 PM](https://user-images.githubusercontent.com/617986/54861728-4a5ac900-4ceb-11e9-9052-ac49408b11fd.png)


## Types of changes
Simple text change.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
