### PR TITLE
Add aria-describedby in the featured image preview

### DIFF
--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -78,7 +78,7 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 						/>
 						<p
 							id={ `editor-post-featured-image__description-${ featuredImageId }` }
-							className="screen-reader-text"
+							hidden
 						>
 							{ mediaAltText ?
 								sprintf( __( 'Current image: %s' ), mediaAltText ) :

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -103,21 +103,19 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 					</MediaUploadCheck>
 				}
 				{ ! featuredImageId &&
-					<div>
-						<MediaUploadCheck fallback={ instructions }>
-							<MediaUpload
-								title={ postLabel.featured_image || DEFAULT_FEATURE_IMAGE_LABEL }
-								onSelect={ onUpdateImage }
-								allowedTypes={ ALLOWED_MEDIA_TYPES }
-								modalClass="editor-post-featured-image__media-modal"
-								render={ ( { open } ) => (
-									<Button className="editor-post-featured-image__toggle" onClick={ open }>
-										{ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
-									</Button>
-								) }
-							/>
-						</MediaUploadCheck>
-					</div>
+				<MediaUploadCheck fallback={ instructions }>
+					<MediaUpload
+						title={ postLabel.featured_image || DEFAULT_FEATURE_IMAGE_LABEL }
+						onSelect={ onUpdateImage }
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
+						modalClass="editor-post-featured-image__media-modal"
+						render={ ( { open } ) => (
+							<Button className="editor-post-featured-image__toggle" onClick={ open }>
+								{ postLabel.set_featured_image || DEFAULT_SET_FEATURE_IMAGE_LABEL }
+							</Button>
+						) }
+					/>
+				</MediaUploadCheck>
 				}
 				{ !! featuredImageId &&
 					<MediaUploadCheck>

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -24,22 +24,25 @@ const ALLOWED_MEDIA_TYPES = [ 'image' ];
 const DEFAULT_FEATURE_IMAGE_LABEL = __( 'Featured Image' );
 const DEFAULT_SET_FEATURE_IMAGE_LABEL = __( 'Set featured image' );
 const DEFAULT_REMOVE_FEATURE_IMAGE_LABEL = __( 'Remove image' );
+const path = require( 'path' );
 
 function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onRemoveImage, media, postType } ) {
 	const postLabel = get( postType, [ 'labels' ], {} );
 	const instructions = <p>{ __( 'To edit the featured image, you need permission to upload media.' ) }</p>;
 
-	let mediaWidth, mediaHeight, mediaSourceUrl;
+	let mediaWidth, mediaHeight, mediaSourceUrl, mediaAltText;
 	if ( media ) {
 		const mediaSize = applyFilters( 'editor.PostFeaturedImage.imageSize', 'post-thumbnail', media.id, currentPostId );
 		if ( has( media, [ 'media_details', 'sizes', mediaSize ] ) ) {
 			mediaWidth = media.media_details.sizes[ mediaSize ].width;
 			mediaHeight = media.media_details.sizes[ mediaSize ].height;
 			mediaSourceUrl = media.media_details.sizes[ mediaSize ].source_url;
+			mediaAltText = media.media_details.sizes[ mediaSize ].alt_text;
 		} else {
 			mediaWidth = media.media_details.width;
 			mediaHeight = media.media_details.height;
 			mediaSourceUrl = media.source_url;
+			mediaAltText = media.alt_text;
 		}
 	}
 
@@ -54,7 +57,7 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 							allowedTypes={ ALLOWED_MEDIA_TYPES }
 							modalClass="editor-post-featured-image__media-modal"
 							render={ ( { open } ) => (
-								<Button className="editor-post-featured-image__preview" onClick={ open } aria-label={ __( 'Edit or update the image' ) }>
+								<Button className="editor-post-featured-image__preview" onClick={ open } aria-label={ __( 'Edit or update the image' ) } aria-describedby={ !! mediaAltText ? 'Current image: ' + mediaAltText : 'The current image has no alternative text. The file name is: ' + path.basename( mediaSourceUrl ) }>
 									{ media &&
 										<ResponsiveWrapper
 											naturalWidth={ mediaWidth }


### PR DESCRIPTION
## Description
Fix #14416 

## How has this been tested?
- [X] Local
- [X] unit tests
- [X] Local e2e tests
- [X] Browser testing

## Types of changes
Add `aria-describedby` in the image button of the feature image preview.
- when the image has an alt text, the `aria-describedby` should be `Current image: altText`
- when the image doesn't have an alt text, the `aria-describedby` should be `The current image has no alternative text. The file name is: fileName`

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
