### PR TITLE
Typo fix in a documentation MD file

### DIFF
--- a/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-1-up-and-running.md
+++ b/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-1-up-and-running.md
@@ -1,6 +1,6 @@
 # Get a Sidebar up and Running
 
-The first step in the journey is to tell the editor that there is a new plugin that will have its own sidebar. You can do so by using the [registerPlugin](/packages/plugins/REAMDE.md), [PluginSidebar](/packages/edit-post/README.md#pluginsidebar), and [createElement](/packages/element/README.md) utilities provided by WordPress, to be found in the `@wordpress/plugins`, `@wordpress/edit-post`, and `@wordpress/element` [packages](/docs/designers-developers/developers/packages.md), respectively.
+The first step in the journey is to tell the editor that there is a new plugin that will have its own sidebar. You can do so by using the [registerPlugin](/packages/plugins/README.md), [PluginSidebar](/packages/edit-post/README.md#pluginsidebar), and [createElement](/packages/element/README.md) utilities provided by WordPress, to be found in the `@wordpress/plugins`, `@wordpress/edit-post`, and `@wordpress/element` [packages](/docs/designers-developers/developers/packages.md), respectively.
 
 Add the following code to a JavaScript file called `plugin-sidebar.js` and save it within your plugin's directory:
 


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

I've updated a simple typo replacing `REAMD.md` to `README.md`. The wp-org docs link to many 404 pages though, which I am not sure of the docs build process, but I believe wp-docs backend takes slugs and markdown sources from the [`docs/manifest.json`](/WordPress/gutenberg/blob/master/docs/manifest.json) file.

Here are the 404 links in this page:
https://wordpress.org/gutenberg/handbook/designers-developers/developers/tutorials/plugin-sidebar-0/plugin-sidebar-1-up-and-running/

- ```[registerPlugin](/packages/plugins/README.md)```
Correct link: https://wordpress.org/gutenberg/handbook/designers-developers/developers/packages/packages-plugins/

- ```[createElement](/packages/element/README.md)```
Correct link: https://wordpress.org/gutenberg/handbook/designers-developers/developers/packages/packages-element/

- ```[packages](/docs/designers-developers/developers/packages.md)```
Correct link: https://wordpress.org/gutenberg/handbook/designers-developers/developers/packages/

This link on the other hand is working:
```
[PluginSidebar](/packages/edit-post/README.md#pluginsidebar)
```

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

No.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
