### PR TITLE
Fix react warning for instanceId prop on a DOM element (<Button> component)

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/test/__snapshots__/reusable-block-delete-button.js.snap
+++ b/packages/block-editor/src/components/block-settings-menu/test/__snapshots__/reusable-block-delete-button.js.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ReusableBlockDeleteButton matches the snapshot 1`] = `
-<WithInstanceId(MenuItem)
+<MenuItem
   className="editor-block-settings-menu__control block-editor-block-settings-menu__control"
   disabled={false}
   icon="no"
   onClick={[Function]}
 >
   Remove from Reusable Blocks
-</WithInstanceId(MenuItem)>
+</MenuItem>
 `;

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,4 +1,4 @@
-7.2.1 (Unreleased)
+## 7.2.1 (Unreleased)
 
 ### Bug fixes
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug fixes
 
-- Fix `instanceId` prop passed through to `Button` component via `MenuItems` producing React console error. [#14599](https://github.com/WordPress/gutenberg/pull/14599)
+- Fix `instanceId` prop passed through to `Button` component via `MenuItems` producing React console error. Fixed by removing the unnecessary use of `withInstanceId` on the `MenuItems` component [#14599](https://github.com/WordPress/gutenberg/pull/14599)
 
 ## 7.2.0 (2019-03-20)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,3 +1,9 @@
+7.2.1 (Unreleased)
+
+### Bug fixes
+
+- Fix `instanceId` prop passed through to `Button` component via `MenuItems` producing React console error. [#14599](https://github.com/WordPress/gutenberg/pull/14599)
+
 ## 7.2.0 (2019-03-20)
 
 ### Improvements

--- a/packages/components/src/button/index.js
+++ b/packages/components/src/button/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -43,13 +42,9 @@ export function Button( props, ref ) {
 	const tag = href !== undefined && ! disabled ? 'a' : 'button';
 	const tagProps = tag === 'a' ? { href, target } : { type: 'button', disabled };
 
-	const passThruProps = additionalProps.instanceId ?
-		omit( additionalProps, [ 'instanceId' ] ) :
-		additionalProps;
-
 	return createElement( tag, {
 		...tagProps,
-		...passThruProps,
+		...additionalProps,
 		className: classes,
 		ref,
 	} );

--- a/packages/components/src/button/index.js
+++ b/packages/components/src/button/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -42,9 +43,13 @@ export function Button( props, ref ) {
 	const tag = href !== undefined && ! disabled ? 'a' : 'button';
 	const tagProps = tag === 'a' ? { href, target } : { type: 'button', disabled };
 
+	const passThruProps = additionalProps.instanceId ?
+		omit( additionalProps, [ 'instanceId' ] ) :
+		additionalProps;
+
 	return createElement( tag, {
 		...tagProps,
-		...additionalProps,
+		...passThruProps,
 		className: classes,
 		ref,
 	} );

--- a/packages/components/src/menu-item/index.js
+++ b/packages/components/src/menu-item/index.js
@@ -8,7 +8,6 @@ import { isString } from 'lodash';
  * WordPress dependencies
  */
 import { createElement, cloneElement } from '@wordpress/element';
-import { withInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -77,4 +76,4 @@ export function MenuItem( {
 	);
 }
 
-export default withInstanceId( MenuItem );
+export default MenuItem;

--- a/packages/edit-post/src/components/header/plugin-more-menu-item/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/header/plugin-more-menu-item/test/__snapshots__/index.js.snap
@@ -18,7 +18,6 @@ exports[`PluginMoreMenuItem renders menu item as button properly 1`] = `
   >
     <button
       className="components-button components-icon-button components-menu-item__button has-icon has-text"
-      instanceId={0}
       onClick={[Function]}
       role="menuitem"
       type="button"


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Was getting this warning appear whenever I clicked the menu toggle on a block:

> Warning: React does not recognize the `instanceId` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `instanceid` instead. If you accidentally passed it from a parent component, remove it from the DOM element.

This results from the `instanceId` prop getting passed through via `<MenuItem />`


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

* [x] Verify unit tests/ e2e tests pass
* [x] Ensure console error doesn't appear in this branch.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Non-breaking change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
