### PR TITLE
Fix embedding Twitter URLs with a trailing slash (Closes #12664)

### DIFF
--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -62,10 +62,17 @@ export function getEmbedEditComponent( title, icon, responsive = true ) {
 			if ( switchedPreview || switchedURL ) {
 				if ( this.props.cannotEmbed ) {
 					// Can't embed this URL, and we've just received or switched the preview.
+					this.resubmitWithoutTrailingSlash();
 					return;
 				}
 				this.handleIncomingPreview();
 			}
+		}
+
+		resubmitWithoutTrailingSlash() {
+			this.setState( ( prevState ) => ( {
+				url: prevState.url.replace( /\/$/, '' ),
+			} ), this.setUrl );
 		}
 
 		setUrl( event ) {

--- a/packages/e2e-tests/specs/embedding.test.js
+++ b/packages/e2e-tests/specs/embedding.test.js
@@ -65,6 +65,10 @@ const MOCK_RESPONSES = [
 		onRequestMatch: createJSONResponse( MOCK_BAD_WORDPRESS_RESPONSE ),
 	},
 	{
+		match: createEmbeddingMatcher( 'https://wordpress.org/gutenberg/handbook' ),
+		onRequestMatch: createJSONResponse( MOCK_BAD_WORDPRESS_RESPONSE ),
+	},
+	{
 		match: createEmbeddingMatcher( 'https://wordpress.org/gutenberg/handbook/block-api/attributes/' ),
 		onRequestMatch: createJSONResponse( MOCK_EMBED_WORDPRESS_SUCCESS_RESPONSE ),
 	},


### PR DESCRIPTION
## Description
Fixes #12664.

Fixed embedding tweets with a URL containing a trailing slash.

![embedding-tweet-with-trailing-slash](https://user-images.githubusercontent.com/12969835/54881352-f3551100-4e1c-11e9-9e3b-f7b1124e1691.gif)
## How has this been tested?
Manually tested the following cases:
1. Embedding valid Twitter URLs containing a trailing slash
2. Embedding valid Twitter URLs NOT containing a trailing slash
3. Tested embedding multiple **Twitter** blocks with trailing and non-trailing slashes

I'm looking into including a e2e test as suggested by @notnownikki, and the failed tests in the TravisCI build.

However, I can't seem to run the e2e tests locally. I'm getting the following error:
```
Error: The constant 'SCRIPT_DEBUG' is not defined in the 'wp-config.php' file.
```

Any idea on what I'm doing wrong or how to fix? I'm using the built-in [local environment](https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTING.md#local-environment) as suggested in [End to End Testing](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/testing-overview.md#end-to-end-testing)

## Types of changes
Bug fix - If the `<EmbedEdit />` component can't embed the URL, then it resubmits the URL without a trailing slash.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->