### PR TITLE
No allignment gallery block className fix.

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -271,10 +271,12 @@ class GalleryEdit extends Component {
 					className={ classnames(
 						className,
 						{
-							[ `align${ align }` ]: align,
 							[ `columns-${ columns }` ]: columns,
 							'is-cropped': imageCrop,
-						}
+						},
+						align ? {
+							[ `align${ align }` ]: align,
+						} : null
 					) }
 				>
 					{ dropZone }


### PR DESCRIPTION
## Description
Steps for reproduction are described here:
https://github.com/WordPress/gutenberg/issues/13696

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/1477453/54883362-d85ebd00-4e6d-11e9-85d7-5f0469f42a9d.png)
![image](https://user-images.githubusercontent.com/1477453/54883364-e3195200-4e6d-11e9-81f9-be71dae345a7.png)
![image](https://user-images.githubusercontent.com/1477453/54883367-eb718d00-4e6d-11e9-8a4c-3cebee27b38d.png)

## Types of changes
If there is no alignment set than there should be no classes related alignment added to gallery.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
