### PR TITLE
Fix uncaught TypeError in Columns block

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Add vertical alignment controls to `columns` Block ([#13899](https://github.com/WordPress/gutenberg/pull/13899/)).
 
+### Bug Fixes
+
+- fix uncaught error in `columns` block due to accessing a property on an object that might be undefined [#14605](https://github.com/WordPress/gutenberg/pull/14605)
+
 ## 2.3.0 (2019-03-06)
 
 ### New Feature

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -82,15 +82,18 @@ export const ColumnsEdit = function( { attributes, setAttributes, className, upd
 	);
 };
 
+const DEFAULT_EMPTY_ARRAY = [];
+
 export default compose(
 	/**
 	 * Selects the child column Blocks for this parent Column
 	 */
 	withSelect( ( select, { clientId } ) => {
 		const { getBlocksByClientId } = select( 'core/editor' );
+		const blocks = getBlocksByClientId( clientId )[ 0 ];
 
 		return {
-			childColumns: getBlocksByClientId( clientId )[ 0 ].innerBlocks,
+			childColumns: blocks ? blocks.innerBlocks : DEFAULT_EMPTY_ARRAY,
 		};
 	} ),
 	withDispatch( ( dispatch, { clientId, childColumns } ) => {

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -90,10 +90,10 @@ export default compose(
 	 */
 	withSelect( ( select, { clientId } ) => {
 		const { getBlocksByClientId } = select( 'core/editor' );
-		const blocks = getBlocksByClientId( clientId )[ 0 ];
+		const block = getBlocksByClientId( clientId )[ 0 ];
 
 		return {
-			childColumns: blocks ? blocks.innerBlocks : DEFAULT_EMPTY_ARRAY,
+			childColumns: block ? block.innerBlocks : DEFAULT_EMPTY_ARRAY,
 		};
 	} ),
 	withDispatch( ( dispatch, { clientId, childColumns } ) => {


### PR DESCRIPTION
## Description

The following error was discovered for the columns block:

> Uncaught (in promise) TypeError:  Cannot read property 'innerBlocks' of null.

### To Reproduce:

1. Create a columns block with two columns with content.
2. Delete the block in each column.
3. Delete the column container (triggers the error in the console).

The fix is just to ensure we're accessing `innerBlocks`property on a valid block object.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

* [x] Ensure unit tests/e2e tests don't fail.
* [x] Ran through reproducible steps on this branch and ensure error doesn't appear again.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

This is a non-breaking bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
