### PR TITLE
Removes unwanted theme specific Column bottom margin

### DIFF
--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -10,6 +10,8 @@
 }
 
 .wp-block-column {
+	margin-bottom: 1em;
+
 	flex-grow: 1;
 
 	// Responsiveness: Show at most one columns on mobile.
@@ -42,14 +44,6 @@
 			margin-left: $grid-size-large * 2;
 		}
 	}
-}
-
-// Specificity overide to ensure margin is applied
-// and preserved on last child to ensure that when columns
-// are aligned to bottom they are are flush with each other
-.wp-block-column,
-.entry-content > .wp-block-columns .wp-block-column:last-child {
-	margin-bottom: 1em;
 }
 
 /**

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -11,7 +11,6 @@
 
 .wp-block-column {
 	margin-bottom: 1em;
-
 	flex-grow: 1;
 
 	// Responsiveness: Show at most one columns on mobile.


### PR DESCRIPTION
Restores margin to original spacing value. Removes unwanted additional margin on last child.

## Description
Addresses https://github.com/WordPress/gutenberg/issues/14596
