### PR TITLE
Fix: Legacy Widgets description of "callback widgets" is not shown.

### DIFF
--- a/lib/widgets.php
+++ b/lib/widgets.php
@@ -110,7 +110,7 @@ function gutenberg_legacy_widget_settings( $settings ) {
 		}
 		$available_legacy_widgets[ $widget_id ] = array(
 			'name'             => html_entity_decode( $widget_obj['name'] ),
-			'description'      => null,
+			'description'      => html_entity_decode( wp_widget_description( $widget_id ) ),
 			'isCallbackWidget' => true,
 		);
 	}


### PR DESCRIPTION
## Description
Currently, the callback widgets description is not being shown. Callback widgets can also have a description, by setting that property in the options array passed to wp_register_sidebar_widget.

## How has this been tested?
I pasted the following code in functions.php:
```

function my_marquee_widget_callback() {
	echo '<marquee>This is a legacy widget!<marquee>';
}
wp_register_sidebar_widget(
	'my-marquee-widget',
	'My marquee widget',
	'my_marquee_widget_callback',
	array(
		'description' => 'my marquee widget callback'
	)
);

function my_marquee_widget_callback2() {
	echo '<marquee>This is a legacy widget2!<marquee>';
}
wp_register_sidebar_widget(
	'my-marquee-widget2',
	'My marquee widget2',
	'my_marquee_widget_callback2'
);
```
I selected "My marquee widget" in the legacy widget block. I checked a description appears for this block. In master, it does not appear.
I selected "My marquee widget2" in the legacy widget block. I checked a description does not appears for this block.


