### PR TITLE
Block list appender cleanup: Add gray background and dark theme styles, fix hover state.

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -10,8 +10,25 @@
 	outline: $border-width dashed $dark-gray-150;
 	width: 100%;
 	color: $dark-gray-500;
+	background-color: $dark-opacity-light-100;
 
-	&:hover {
+	// Multiple :not() are necessary to override default button styles.
+	&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover {
 		outline: $border-width dashed $dark-gray-500;
+		background-color: $dark-opacity-light-100;
+		box-shadow: none;
+	}
+
+	// Use opacity to work in various editor styles
+	.is-dark-theme & {
+		background-color: $light-opacity-light-100;
+		color: $light-gray-100;
+
+		&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover,
+		&:focus {
+			outline: $border-width dashed $white;
+			background-color: $light-opacity-light-100;
+			color: $white;
+		}
 	}
 }


### PR DESCRIPTION
This PR cleans up the block list appender:

- It adds a gray background to align with the styles in [#14241](https://github.com/WordPress/gutenberg/pull/14241#issuecomment-476163977) and [#12367](https://github.com/WordPress/gutenberg/pull/12367#pullrequestreview-218304810).
- It adds proper styles for themes that declare support for `dark-editor-style`. 
- It corrects a bug where the hover state was being overridden by default button styles. 

The easiest way to test is to use the block manager: Set the "Paragraph" block to be hidden. Once you do that, the block list appender should appear: 

![front-end](https://user-images.githubusercontent.com/1202812/54922438-80ac6a00-4ede-11e9-878b-23e03bd46b9f.gif)

---

### Screenshots

_Before:_ 

![Screen Shot 2019-03-25 at 9 01 15 AM](https://user-images.githubusercontent.com/1202812/54922449-8c982c00-4ede-11e9-90fe-4db039f33034.png)

_Before (Hover):_

![Screen Shot 2019-03-25 at 9 01 07 AM](https://user-images.githubusercontent.com/1202812/54922466-9588fd80-4ede-11e9-8509-dc510ed6d2c5.png)

_After:_

![Screen Shot 2019-03-25 at 9 16 47 AM](https://user-images.githubusercontent.com/1202812/54922541-c6693280-4ede-11e9-91c2-ed121eb722ea.png)

_After (Hover):_

![Screen Shot 2019-03-25 at 9 16 53 AM](https://user-images.githubusercontent.com/1202812/54922555-cec16d80-4ede-11e9-9552-08af78b72bd3.png)

_After (Dark Theme):_

![Screen Shot 2019-03-25 at 9 17 55 AM](https://user-images.githubusercontent.com/1202812/54922667-00d2cf80-4edf-11e9-9252-9c8ac016982a.png)

_After (Dark Theme, Hover):_

![Screen Shot 2019-03-25 at 9 18 26 AM](https://user-images.githubusercontent.com/1202812/54922681-09c3a100-4edf-11e9-8c38-efdf6677ddb5.png)
