### PR TITLE
Fix last mobile merge into master

### DIFF
--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -16,20 +16,58 @@ import { Component } from '@wordpress/element';
 import { RichText, BlockControls } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 
-/**
- * Internal dependencies
- */
-import './editor.scss';
+import styles from './editor.scss';
 
-const minHeight = 24;
+const name = 'core/heading';
 
 class HeadingEdit extends Component {
 	constructor( props ) {
 		super( props );
 
-		this.state = {
-			aztecHeight: 0,
-		};
+		this.splitBlock = this.splitBlock.bind( this );
+	}
+
+	/**
+	 * Split handler for RichText value, namely when content is pasted or the
+	 * user presses the Enter key.
+	 *
+	 * @param {?Array}     before Optional before value, to be used as content
+	 *                            in place of what exists currently for the
+	 *                            block. If undefined, the block is deleted.
+	 * @param {?Array}     after  Optional after value, to be appended in a new
+	 *                            paragraph block to the set of blocks passed
+	 *                            as spread.
+	 * @param {...WPBlock} blocks Optional blocks inserted between the before
+	 *                            and after value blocks.
+	 */
+	splitBlock( before, after, ...blocks ) {
+		const {
+			attributes,
+			insertBlocksAfter,
+			setAttributes,
+			onReplace,
+		} = this.props;
+
+		if ( after !== null ) {
+			// Append "After" content as a new paragraph block to the end of
+			// any other blocks being inserted after the current paragraph.
+			const newBlock = createBlock( name, { content: after } );
+			blocks.push( newBlock );
+		}
+
+		if ( blocks.length && insertBlocksAfter ) {
+			insertBlocksAfter( blocks );
+		}
+
+		const { content } = attributes;
+		if ( before === null ) {
+			onReplace( [] );
+		} else if ( content !== before ) {
+			// Only update content if it has in-fact changed. In case that user
+			// has created a new paragraph at end of an existing one, the value
+			// of before will be strictly equal to the current content.
+			setAttributes( { content: before } );
+		}
 	}
 
 	render() {
@@ -37,7 +75,7 @@ class HeadingEdit extends Component {
 			attributes,
 			setAttributes,
 			mergeBlocks,
-			insertBlocksAfter,
+			style,
 		} = this.props;
 
 		const {
@@ -47,6 +85,7 @@ class HeadingEdit extends Component {
 		} = attributes;
 
 		const tagName = 'h' + level;
+
 		return (
 			<View>
 				<BlockControls>
@@ -56,28 +95,16 @@ class HeadingEdit extends Component {
 					tagName={ tagName }
 					value={ content }
 					isSelected={ this.props.isSelected }
+					style={ {
+						...style,
+						minHeight: styles[ 'wp-block-heading' ].minHeight,
+					} }
 					onFocus={ this.props.onFocus } // always assign onFocus as a props
 					onBlur={ this.props.onBlur } // always assign onBlur as a props
 					onCaretVerticalPositionChange={ this.props.onCaretVerticalPositionChange }
-					style={ {
-						minHeight: Math.max( minHeight, this.state.aztecHeight ),
-					} }
 					onChange={ ( value ) => setAttributes( { content: value } ) }
 					onMerge={ mergeBlocks }
-					onSplit={
-						insertBlocksAfter ?
-							( before, after, ...blocks ) => {
-								setAttributes( { content: before } );
-								insertBlocksAfter( [
-									...blocks,
-									createBlock( 'core/paragraph', { content: after } ),
-								] );
-							} :
-							undefined
-					}
-					onContentSizeChange={ ( event ) => {
-						this.setState( { aztecHeight: event.aztecHeight } );
-					} }
+					onSplit={ this.splitBlock }
 					placeholder={ placeholder || __( 'Write heading…' ) }
 				/>
 			</View>

--- a/packages/block-library/src/heading/style.native.scss
+++ b/packages/block-library/src/heading/style.native.scss
@@ -1,4 +1,3 @@
-@import "variables.scss";
 
 .blockText {
 	min-height: $min-height-heading;

--- a/packages/block-library/src/heading/style.native.scss
+++ b/packages/block-library/src/heading/style.native.scss
@@ -1,5 +1,5 @@
 @import "variables.scss";
 
 .blockText {
-	min-height: $min-height-paragraph;
+	min-height: $min-height-heading;
 }

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -347,14 +347,6 @@ class ImageEdit extends React.Component {
 								imageHeightWithinContainer,
 							} = sizes;
 
-							if ( imageWidthWithinContainer === undefined ) {
-								return (
-									<View style={ styles.imageContainer } >
-										<Dashicon icon={ 'format-image' } size={ 300 } />
-									</View>
-								);
-							}
-
 							let finalHeight = imageHeightWithinContainer;
 							if ( height > 0 && height < imageHeightWithinContainer ) {
 								finalHeight = height;
@@ -369,6 +361,9 @@ class ImageEdit extends React.Component {
 								<View style={ { flex: 1 } } >
 									{ getInspectorControls() }
 									{ getMediaOptions() }
+									{ ! imageWidthWithinContainer && <View style={ styles.imageContainer } >
+										<Dashicon icon={ 'format-image' } size={ 300 } />
+									</View> }
 									<ImageBackground
 										style={ { width: finalWidth, height: finalHeight, opacity } }
 										resizeMethod="scale"

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -14,7 +14,6 @@ import { RichText } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
-import styles from './style.scss';
 
 const name = 'core/paragraph';
 
@@ -23,10 +22,6 @@ class ParagraphEdit extends Component {
 		super( props );
 		this.splitBlock = this.splitBlock.bind( this );
 		this.onReplace = this.onReplace.bind( this );
-
-		this.state = {
-			aztecHeight: 0,
-		};
 	}
 
 	/**
@@ -99,8 +94,6 @@ class ParagraphEdit extends Component {
 			content,
 		} = attributes;
 
-		const minHeight = styles.blockText.minHeight;
-
 		return (
 			<View>
 				<RichText
@@ -110,10 +103,7 @@ class ParagraphEdit extends Component {
 					onFocus={ this.props.onFocus } // always assign onFocus as a props
 					onBlur={ this.props.onBlur } // always assign onBlur as a props
 					onCaretVerticalPositionChange={ this.props.onCaretVerticalPositionChange }
-					style={ {
-						...style,
-						minHeight: Math.max( minHeight, this.state.aztecHeight ),
-					} }
+					style={ style }
 					onChange={ ( nextContent ) => {
 						setAttributes( {
 							content: nextContent,
@@ -122,9 +112,6 @@ class ParagraphEdit extends Component {
 					onSplit={ this.splitBlock }
 					onMerge={ mergeBlocks }
 					onReplace={ this.onReplace }
-					onContentSizeChange={ ( event ) => {
-						this.setState( { aztecHeight: event.aztecHeight } );
-					} }
 					placeholder={ placeholder || __( 'Start writing…' ) }
 				/>
 			</View>

--- a/packages/block-library/src/paragraph/style.native.scss
+++ b/packages/block-library/src/paragraph/style.native.scss
@@ -1,4 +1,3 @@
-@import "variables.scss";
 
 .blockText {
 	min-height: $min-height-paragraph;


### PR DESCRIPTION
## Description
Last PR https://github.com/WordPress/gutenberg/pull/14503 was supposed to merge all the changes from `rnmobile/develop` (the development branch for mobile) to master. It seems I made some mistakes when resolving conflicts as a couple of changes from `rnmobile/develop` were omitted. This PR aims to fix this and have `rnmobile/develop` fully merged into `master`.

## How has this been tested?
I checked manually by looking at the PRs merged into `rnmobile/develop` and what we have in `master`.
I also used the following command to find diff between `master` and `rnmobile/develop`:
```
git diff -M origin/master...origin/rnmobile/develop --name-only --diff-filter=M | grep .native. | xargs git diff -M origin/master...origin/rnmobile/develop --
```
Note that I'm excluding all non `.native.*` file here.

