### PR TITLE
WIP for IE11 bug in Media and Text block

### DIFF
--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -53,9 +53,15 @@
 @media (max-width: #{ ($break-small) }) {
 	.wp-block-media-text.is-stacked-on-mobile {
 		grid-template-columns: 100% !important;
+		-ms-grid-columns: 100% !important;
 		grid-template-areas:
 			"media-text-media"
 			"media-text-content";
+
+		.wp-block-media-text__media,
+		.wp-block-media-text__content {
+			-ms-grid-column: 1;
+		}
 	}
 
 	.wp-block-media-text.is-stacked-on-mobile.has-media-on-the-right {

--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -1,5 +1,6 @@
 .wp-block-media-text {
 	display: grid;
+	display: -ms-grid;
 }
 
 .wp-block-media-text {
@@ -7,21 +8,32 @@
 	align-items: center;
 	grid-template-areas: "media-text-media media-text-content";
 	grid-template-columns: 50% auto;
+	-ms-grid-columns: 50% auto;
 	&.has-media-on-the-right {
 		grid-template-areas: "media-text-content media-text-media";
 		grid-template-columns: auto 50%;
+
+		.wp-block-media-text__media {
+			-ms-grid-column: 2;
+		}
+
+		.wp-block-media-text__content {
+			-ms-grid-column: 1;
+		}
 	}
 }
 
 .wp-block-media-text .wp-block-media-text__media {
 	grid-area: media-text-media;
 	margin: 0;
+	-ms-grid-column: 1;
 }
 
 .wp-block-media-text .wp-block-media-text__content {
 	word-break: break-word;
 	grid-area: media-text-content;
 	padding: 0 8% 0 8%;
+	-ms-grid-column: 2;
 }
 
 .wp-block-media-text > figure > img,


### PR DESCRIPTION
Added styles to allow `display: grid;` to work in IE11 for the Media and Text block. Not perfect though because the text does not vertically center within the block. Problem reported in #11577 

## How has this been tested?
Tested in IE11

## Screenshots
![media-text-ie11-fix](https://user-images.githubusercontent.com/34601694/54938497-d5f77400-4efc-11e9-9623-bd4c07703423.PNG)

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style.
- [X] My code follows the accessibility standards.
