### PR TITLE
Replace verse block icon.

### DIFF
--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -18,7 +18,7 @@ export const settings = {
 
 	description: __( 'Insert poetry. Use special spacing formats. Or quote song lyrics.' ),
 
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><Path d="M3 17v4h4l11-11-4-4L3 17zm3 2H5v-1l9-9 1 1-9 9zM21 6l-3-3h-1l-2 2 4 4 2-2V6z" /></SVG>,
+	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M21 11.01L3 11V13H21V11.01ZM3 16H17V18H3V16ZM15 6H3V8.01L15 8V6Z" /></SVG>,
 
 	category: 'formatting',
 


### PR DESCRIPTION
This PR replaces the verse block icon, as proposed in #14131. The new icon is a slightly tweaked version of the [Material "Notes" icon](https://material.io/tools/icons/?icon=notes&style=outline).

**Before:** 
![Screen Shot 2019-03-25 at 2 40 58 PM](https://user-images.githubusercontent.com/1202812/54945385-05fa4380-4f0c-11e9-9364-cab33ff1b7bc.png)


**After:** 
![Screen Shot 2019-03-25 at 2 35 16 PM](https://user-images.githubusercontent.com/1202812/54945274-d21f1e00-4f0b-11e9-87f3-ec69137f69bd.png)