### PR TITLE
Latest Post Block (Post Content Support) iteration 

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -195,9 +195,9 @@ class LatestPostsEdit extends Component {
 						if ( post.excerpt.raw === '' ) {
 							excerpt = post.content.raw;
 						}
-						const temp = document.createElement( 'div' );
-						temp.innerHTML = excerpt;
-						excerpt = temp.textContent || temp.innerText || '';
+						const excerptElement = document.createElement( 'div' );
+						excerptElement.innerHTML = excerpt;
+						excerpt = excerptElement.textContent || excerptElement.innerText || '';
 						return (
 							<li key={ i }>
 								<a href={ post.link } target="_blank" rel="noreferrer noopener">

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -181,8 +181,9 @@ class LatestPostsEdit extends Component {
 				<BlockControls>
 					<Toolbar controls={ layoutControls } />
 				</BlockControls>
-				<div
+				<ul
 					className={ classnames( this.props.className, {
+						'wp-block-latest-posts__list': true,
 						'is-grid': postLayout === 'grid',
 						'has-dates': displayPostDate,
 						[ `columns-${ columns }` ]: postLayout === 'grid',
@@ -191,7 +192,7 @@ class LatestPostsEdit extends Component {
 					{ displayPosts.map( ( post, i ) => {
 						const titleTrimmed = post.title.rendered.trim();
 						return (
-							<p key={ i }>
+							<li key={ i }>
 								<a href={ post.link } target="_blank" rel="noreferrer noopener">
 									{ titleTrimmed ? (
 										<RawHTML>
@@ -226,10 +227,10 @@ class LatestPostsEdit extends Component {
 									</RawHTML>
 								</div>
 								}
-							</p>
+							</li>
 						);
 					} ) }
-				</div>
+				</ul>
 			</Fragment>
 		);
 	}

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -32,7 +32,7 @@ import {
 import { withSelect } from '@wordpress/data';
 
 /**
- * Module Constants
+ *  Module Constants
  */
 const CATEGORIES_LIST_QUERY = {
 	per_page: -1,

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -32,7 +32,7 @@ import {
 import { withSelect } from '@wordpress/data';
 
 /**
- *  Module Constants
+ * Module Constants
  */
 const CATEGORIES_LIST_QUERY = {
 	per_page: -1,

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -193,8 +193,11 @@ class LatestPostsEdit extends Component {
 						const titleTrimmed = post.title.rendered.trim();
 						let excerpt = post.excerpt.rendered;
 						if ( post.excerpt.raw === '' ) {
-							excerpt = post.content.rendered;
+							excerpt = post.content.raw;
 						}
+						const temp = document.createElement( 'div' );
+						temp.innerHTML = excerpt;
+						excerpt = temp.textContent || temp.innerText || '';
 						return (
 							<li key={ i }>
 								<a href={ post.link } target="_blank" rel="noreferrer noopener">

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -196,13 +196,13 @@ class LatestPostsEdit extends Component {
 }
 
 export default withSelect( ( select, props ) => {
-	const { postsToShow, order, orderBy, categories } = props.attributes;
+	const { postCount, order, orderBy, categories } = props.attributes;
 	const { getEntityRecords } = select( 'core' );
 	const latestPostsQuery = pickBy( {
 		categories,
 		order,
 		orderby: orderBy,
-		per_page: postsToShow,
+		per_page: postCount,
 	}, ( value ) => ! isUndefined( value ) );
 	return {
 		latestPosts: getEntityRecords( 'postType', 'post', latestPostsQuery ),

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -191,6 +191,10 @@ class LatestPostsEdit extends Component {
 				>
 					{ displayPosts.map( ( post, i ) => {
 						const titleTrimmed = post.title.rendered.trim();
+						let excerpt = post.excerpt.rendered;
+						if ( post.excerpt.raw === '' ) {
+							excerpt = post.content.rendered;
+						}
 						return (
 							<li key={ i }>
 								<a href={ post.link } target="_blank" rel="noreferrer noopener">
@@ -212,9 +216,9 @@ class LatestPostsEdit extends Component {
 									<RawHTML
 										key="html"
 									>
-										{ excerptLength < post.excerpt.rendered.trim().split( ' ' ).length ?
-											post.excerpt.rendered.trim().split( ' ', excerptLength ).join( ' ' ) + ' ... <a href=' + post.link + 'target="_blank" rel="noopener noreferrer">Read More</a>' :
-											post.excerpt.rendered.trim().split( ' ', excerptLength ).join( ' ' ) }
+										{ excerptLength < excerpt.trim().split( ' ' ).length ?
+											excerpt.trim().split( ' ', excerptLength ).join( ' ' ) + ' ... <a href=' + post.link + 'target="_blank" rel="noopener noreferrer">Read More</a>' :
+											excerpt.trim().split( ' ', excerptLength ).join( ' ' ) }
 									</RawHTML>
 								</div>
 								}

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -42,7 +42,6 @@ class LatestPostsEdit extends Component {
 		this.state = {
 			categoriesList: [],
 		};
-		this.updateAttribute = this.updateAttribute.bind( this );
 	}
 
 	componentDidMount() {
@@ -68,12 +67,6 @@ class LatestPostsEdit extends Component {
 		this.isStillMounted = false;
 	}
 
-	updateAttribute( name, value ) {
-		const { setAttributes } = this.props;
-
-		setAttributes( { [ name ]: value } );
-	}
-
 	render() {
 		const { attributes, setAttributes, latestPosts } = this.props;
 		const { categoriesList } = this.state;
@@ -85,7 +78,7 @@ class LatestPostsEdit extends Component {
 					<ToggleControl
 						label={ __( 'Post Content' ) }
 						checked={ displayPostContent }
-						onChange={ ( value ) => this.updateAttribute( 'displayPostContent', value ) }
+						onChange={ ( value ) => setAttributes( { displayPostContent: value } ) }
 					/>
 					{ displayPostContent &&
 					<RadioControl
@@ -95,7 +88,7 @@ class LatestPostsEdit extends Component {
 							{ label: 'Excerpt', value: 'excerpt' },
 							{ label: 'Full Post', value: 'full_post' },
 						] }
-						onChange={ ( value ) => this.updateAttribute( 'displayPostContentRadio', value ) }
+						onChange={ ( value ) => setAttributes( { displayPostContentRadio: value } ) }
 					/>
 					}
 					{ displayPostContent && displayPostContentRadio === 'excerpt' &&
@@ -113,7 +106,7 @@ class LatestPostsEdit extends Component {
 					<ToggleControl
 						label={ __( 'Display post date' ) }
 						checked={ displayPostDate }
-						onChange={ ( value ) => this.updateAttribute( 'displayPostDate', value ) }
+						onChange={ ( value ) => setAttributes( { displayPostDate: value } ) }
 					/>
 				</PanelBody>
 

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -14,7 +14,7 @@
  */
 function render_block_core_latest_posts( $attributes ) {
 	$args = array(
-		'posts_per_page'   => $attributes['postsToShow'],
+		'posts_per_page'   => $attributes['postCount'],
 		'post_status'      => 'publish',
 		'order'            => $attributes['order'],
 		'orderby'          => $attributes['orderBy'],
@@ -29,13 +29,15 @@ function render_block_core_latest_posts( $attributes ) {
 
 	$list_items_markup = '';
 
+	$excerpt_length = $attributes['excerptLength'];
+
 	foreach ( $recent_posts as $post ) {
 		$title = get_the_title( $post );
 		if ( ! $title ) {
 			$title = __( '(Untitled)' );
 		}
 		$list_items_markup .= sprintf(
-			'<li><a href="%1$s">%2$s</a>',
+			'<p><a href="%1$s">%2$s</a>',
 			esc_url( get_permalink( $post ) ),
 			$title
 		);
@@ -48,7 +50,41 @@ function render_block_core_latest_posts( $attributes ) {
 			);
 		}
 
-		$list_items_markup .= "</li>\n";
+		if ( isset( $attributes['displayPostContent'] ) && $attributes['displayPostContent']
+			&& isset( $attributes['displayPostContentRadio'] ) && 'excerpt' == $attributes['displayPostContentRadio'] ) {
+			$post_excerpt = $post->post_excerpt;
+			if ( ! ( $post_excerpt ) ) {
+				$post_excerpt = $post->post_content;
+			}
+			$trimmed_excerpt = esc_html( wp_trim_words( $post_excerpt, $excerpt_length, ' &hellip; ' ) );
+
+			$list_items_markup .= sprintf(
+				'<div class="wp-block-latest-posts____post-excerpt">%1$s',
+				$trimmed_excerpt
+			);
+
+			if ( strpos( $trimmed_excerpt, ' &hellip; ' ) !== false ) {
+				$list_items_markup .= sprintf(
+					'<a href="%1$s">%2$s</a></div>',
+					esc_url( get_permalink( $post ) ),
+					__( 'Read More' )
+				);
+			} else {
+				$list_items_markup .= sprintf(
+					'</div>'
+				);
+			}
+		}
+
+		if ( isset( $attributes['displayPostContent'] ) && $attributes['displayPostContent']
+			&& isset( $attributes['displayPostContentRadio'] ) && 'full_post' == $attributes['displayPostContentRadio'] ) {
+			$list_items_markup .= sprintf(
+				'<div class="wp-block-latest-posts__post-full-content">%1$s</div>',
+				wp_kses_post( html_entity_decode( $post->post_content, ENT_QUOTES, get_option( 'blog_charset' ) ) )
+			);
+		}
+
+		$list_items_markup .= "</p>\n";
 	}
 
 	$class = 'wp-block-latest-posts';
@@ -73,7 +109,7 @@ function render_block_core_latest_posts( $attributes ) {
 	}
 
 	$block_content = sprintf(
-		'<ul class="%1$s">%2$s</ul>',
+		'<div class="%1$s">%2$s</div>',
 		esc_attr( $class ),
 		$list_items_markup
 	);
@@ -89,37 +125,49 @@ function register_block_core_latest_posts() {
 		'core/latest-posts',
 		array(
 			'attributes'      => array(
-				'align'           => array(
+				'align'                   => array(
 					'type' => 'string',
 					'enum' => array( 'left', 'center', 'right', 'wide', 'full' ),
 				),
-				'className'       => array(
+				'className'               => array(
 					'type' => 'string',
 				),
-				'categories'      => array(
+				'categories'              => array(
 					'type' => 'string',
 				),
-				'postsToShow'     => array(
+				'postCount'               => array(
 					'type'    => 'number',
 					'default' => 5,
 				),
-				'displayPostDate' => array(
+				'displayPostContent'      => array(
 					'type'    => 'boolean',
 					'default' => false,
 				),
-				'postLayout'      => array(
+				'displayPostContentRadio' => array(
+					'type'    => 'string',
+					'default' => 'excerpt',
+				),
+				'excerptLength'           => array(
+					'type'    => 'number',
+					'default' => 55,
+				),
+				'displayPostDate'         => array(
+					'type'    => 'boolean',
+					'default' => false,
+				),
+				'postLayout'              => array(
 					'type'    => 'string',
 					'default' => 'list',
 				),
-				'columns'         => array(
+				'columns'                 => array(
 					'type'    => 'number',
 					'default' => 3,
 				),
-				'order'           => array(
+				'order'                   => array(
 					'type'    => 'string',
 					'default' => 'desc',
 				),
-				'orderBy'         => array(
+				'orderBy'                 => array(
 					'type'    => 'string',
 					'default' => 'date',
 				),

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -37,7 +37,7 @@ function render_block_core_latest_posts( $attributes ) {
 			$title = __( '(Untitled)' );
 		}
 		$list_items_markup .= sprintf(
-			'<p><a href="%1$s">%2$s</a>',
+			'<li><a href="%1$s">%2$s</a>',
 			esc_url( get_permalink( $post ) ),
 			$title
 		);
@@ -84,10 +84,10 @@ function render_block_core_latest_posts( $attributes ) {
 			);
 		}
 
-		$list_items_markup .= "</p>\n";
+		$list_items_markup .= "</li>\n";
 	}
 
-	$class = 'wp-block-latest-posts';
+	$class = 'wp-block-latest-posts wp-block-latest-posts__list';
 	if ( isset( $attributes['align'] ) ) {
 		$class .= ' align' . $attributes['align'];
 	}
@@ -109,7 +109,7 @@ function render_block_core_latest_posts( $attributes ) {
 	}
 
 	$block_content = sprintf(
-		'<div class="%1$s">%2$s</div>',
+		'<ul class="%1$s">%2$s</ul>',
 		esc_attr( $class ),
 		$list_items_markup
 	);

--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -7,11 +7,13 @@
 		/*rtl:ignore*/
 		margin-left: 2em;
 	}
+	&.wp-block-latest-posts__list {
+		list-style: none;
+	}
 	&.is-grid {
 		display: flex;
 		flex-wrap: wrap;
 		padding: 0;
-		list-style: none;
 
 		li {
 			margin: 0 16px 16px 0;
@@ -33,4 +35,3 @@
 	color: $dark-gray-300;
 	font-size: $default-font-size;
 }
-


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Adds Post content support in #1594. @ajitbohra is working on all the other parts of the issue (#13698).

Work In Progress

### Screenshots

<img width="965" alt="Screen Shot 2019-03-30 at 10 51 01 PM" src="https://user-images.githubusercontent.com/44530193/55284122-4c9dd280-533e-11e9-9da9-eb0e9c8cc45c.png">

**Editor Side Display Excerpt**

<img width="1006" alt="Screen Shot 2019-03-30 at 10 45 33 PM" src="https://user-images.githubusercontent.com/44530193/55284098-ced9c700-533d-11e9-9768-c633a390b3fb.png">

**Rendered Display Excerpt**

<img width="881" alt="Screen Shot 2019-03-30 at 10 45 53 PM" src="https://user-images.githubusercontent.com/44530193/55284099-ced9c700-533d-11e9-8742-489d34bc34ae.png">

**Editor Side Display Full Post**

<img width="1000" alt="Screen Shot 2019-03-30 at 10 46 25 PM" src="https://user-images.githubusercontent.com/44530193/55284100-ced9c700-533d-11e9-8b5d-0bbe8bf42065.png">

**Rendered Display Full Post**

<img width="794" alt="Screen Shot 2019-03-30 at 10 46 46 PM" src="https://user-images.githubusercontent.com/44530193/55284101-ced9c700-533d-11e9-80fa-566e9720a7c7.png">


@gziolo @melchoyce You can track the progress on the issue here!