### PR TITLE
RichText: completely controlled

### DIFF
--- a/packages/annotations/src/format/annotation.js
+++ b/packages/annotations/src/format/annotation.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import memize from 'memize';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -120,27 +115,6 @@ function updateAnnotationsWithPositions( annotations, positions, { removeAnnotat
 	} );
 }
 
-/**
- * Create prepareEditableTree memoized based on the annotation props.
- *
- * @param {Object} The props with annotations in them.
- *
- * @return {Function} The prepareEditableTree.
- */
-const createPrepareEditableTree = memize( ( props ) => {
-	const { annotations } = props;
-
-	return ( formats, text ) => {
-		if ( annotations.length === 0 ) {
-			return formats;
-		}
-
-		let record = { formats, text };
-		record = applyAnnotations( record, annotations );
-		return record.formats;
-	};
-} );
-
 export const annotation = {
 	name: FORMAT_NAME,
 	title: __( 'Annotation' ),
@@ -158,7 +132,17 @@ export const annotation = {
 			annotations: select( STORE_KEY ).__experimentalGetAnnotationsForRichText( blockClientId, richTextIdentifier ),
 		};
 	},
-	__experimentalCreatePrepareEditableTree: createPrepareEditableTree,
+	__experimentalCreatePrepareEditableTree( { annotations } ) {
+		return ( formats, text ) => {
+			if ( annotations.length === 0 ) {
+				return formats;
+			}
+
+			let record = { formats, text };
+			record = applyAnnotations( record, annotations );
+			return record.formats;
+		};
+	},
 	__experimentalGetPropsForEditableTreeChangeHandler( dispatch ) {
 		return {
 			removeAnnotation: dispatch( STORE_KEY ).__experimentalRemoveAnnotation,

--- a/packages/annotations/src/format/annotation.js
+++ b/packages/annotations/src/format/annotation.js
@@ -141,19 +141,6 @@ const createPrepareEditableTree = memize( ( props ) => {
 	};
 } );
 
-/**
- * Returns the annotations as a props object. Memoized to prevent re-renders.
- *
- * @param {Array} The annotations to put in the object.
- *
- * @return {Object} The annotations props object.
- */
-const getAnnotationObject = memize( ( annotations ) => {
-	return {
-		annotations,
-	};
-} );
-
 export const annotation = {
 	name: FORMAT_NAME,
 	title: __( 'Annotation' ),
@@ -167,7 +154,9 @@ export const annotation = {
 		return null;
 	},
 	__experimentalGetPropsForEditableTreePreparation( select, { richTextIdentifier, blockClientId } ) {
-		return getAnnotationObject( select( STORE_KEY ).__experimentalGetAnnotationsForRichText( blockClientId, richTextIdentifier ) );
+		return {
+			annotations: select( STORE_KEY ).__experimentalGetAnnotationsForRichText( blockClientId, richTextIdentifier ),
+		};
 	},
 	__experimentalCreatePrepareEditableTree: createPrepareEditableTree,
 	__experimentalGetPropsForEditableTreeChangeHandler( dispatch ) {

--- a/packages/block-editor/src/components/rich-text/editable.js
+++ b/packages/block-editor/src/components/rich-text/editable.js
@@ -108,6 +108,8 @@ export default class Editable extends Component {
 	// update the attributes on the wrapper nodes here. `componentDidUpdate`
 	// will never be called.
 	shouldComponentUpdate( nextProps ) {
+		this.props.reconcileInnerDom();
+
 		this.configureIsPlaceholderVisible( nextProps.isPlaceholderVisible );
 
 		if ( ! isEqual( this.props.style, nextProps.style ) ) {

--- a/packages/block-editor/src/components/rich-text/editable.js
+++ b/packages/block-editor/src/components/rich-text/editable.js
@@ -108,8 +108,6 @@ export default class Editable extends Component {
 	// update the attributes on the wrapper nodes here. `componentDidUpdate`
 	// will never be called.
 	shouldComponentUpdate( nextProps ) {
-		this.props.reconcileInnerDom();
-
 		this.configureIsPlaceholderVisible( nextProps.isPlaceholderVisible );
 
 		if ( ! isEqual( this.props.style, nextProps.style ) ) {

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -943,6 +943,20 @@ export class RichText extends Component {
 			record = this.getLingeringRecord();
 		}
 
+		// To do: find a better way to move the caret to the end after merge.
+		// If the value's been changed from the outside and the instance is
+		// selected, set the caret at the end on focus (which sets
+		// this.lastState).
+		if ( this.props.isSelected && this.props.value !== this.savedContent ) {
+			const prevRecord = this.formatToValue( prevProps.value );
+			const length = getTextContent( prevRecord ).length;
+
+			this.lastState = {
+				start: length,
+				end: length,
+			};
+		}
+
 		this.applyRecord( record );
 	}
 


### PR DESCRIPTION
## Description

Splitting this out from #14640.

This makes RichText a completely controlled component: changes in props or state are always reconciled with the DOM.

This eliminates a lot of logic trying to figure out of the DOM should be reconciled or not. It's easier to just do it: the DOM won't be touched if no changes need to be made.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->