### PR TITLE
[RNMobile] Fix for Heading block on ENTER.key to create empty paragraph

### DIFF
--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -48,10 +48,13 @@ class HeadingEdit extends Component {
 			onReplace,
 		} = this.props;
 
-		if ( after !== null ) {
-			// Append "After" content as a new paragraph block to the end of
-			// any other blocks being inserted after the current paragraph.
+		if ( after ) {
+			// Append "After" content as a new heading block to the end of
+			// any other blocks being inserted after the current heading.
 			const newBlock = createBlock( name, { content: after } );
+			blocks.push( newBlock );
+		} else {
+			const newBlock = createBlock( 'core/paragraph', { content: after } );
 			blocks.push( newBlock );
 		}
 


### PR DESCRIPTION
This PR fixes the problem on mobile where pressing enter at the end of a Heading block, it does create another Heading block. Ref: https://github.com/wordpress-mobile/gutenberg-mobile/issues/734

Expectation: Pressing enter on a Heading block, should create a Paragraph block. Same as on any other "split-able block)

To test this PR, use the following gb-mobile branch here: https://github.com/wordpress-mobile/gutenberg-mobile/pull/787