### PR TITLE
Repair and refine embed block styles

### DIFF
--- a/packages/block-library/src/embed/editor.scss
+++ b/packages/block-library/src/embed/editor.scss
@@ -1,3 +1,11 @@
+// Apply max-width to floated items that have no intrinsic width
+.block-editor-block-list__block[data-type^="core-embed"][data-align="left"] .block-editor-block-list__block-edit,
+.block-editor-block-list__block[data-type^="core-embed"][data-align="right"] .block-editor-block-list__block-edit {
+	// Instagram widgets have a min-width of 326px, so go a bit beyond that.
+	max-width: 360px;
+	width: 100%;
+}
+
 .wp-block-embed {
 	// Remove the left and right margin the figure is born with.
 	margin-left: 0;

--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -3,17 +3,17 @@
 	// This rule explicitly sets it, to ensure at least some bottom-margin in the flow.
 	margin-bottom: 1em;
 
+	// don't allow iframe to overflow it's container.
+	iframe {
+		max-width: 100%;
+	}
+
 	// Apply max-width to floated items that have no intrinsic width.
 	&.alignleft,
 	&.alignright {
 		// Instagram widgets have a min-width of 326px, so go a bit beyond that.
 		max-width: 360px;
 		width: 100%;
-
-		// override the iframe's static width.
-		iframe {
-			width: 100%;
-		}
 	}
 }
 

--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -1,74 +1,71 @@
-// Apply max-width to floated items that have no intrinsic width
-.block-editor-block-list__block[data-type="core/embed"][data-align="left"] .block-editor-block-list__block-edit,
-.block-editor-block-list__block[data-type="core/embed"][data-align="right"] .block-editor-block-list__block-edit,
-.wp-block-embed.alignleft,
-.wp-block-embed.alignright {
-	// Instagram widgets have a min-width of 326px, so go a bit beyond that.
-	max-width: 360px;
-	width: 100%;
-}
-
 .wp-block-embed {
 	// The embed block is in a `figure` element, and many themes zero this out.
 	// This rule explicitly sets it, to ensure at least some bottom-margin in the flow.
 	margin-bottom: 1em;
+
+	// Apply max-width to floated items that have no intrinsic width.
+	&.alignleft,
+	&.alignright {
+		// Instagram widgets have a min-width of 326px, so go a bit beyond that.
+		max-width: 360px;
+		width: 100%;
+
+		// override the iframe's static width.
+		iframe {
+			width: 100%;
+		}
+	}
+}
+
+.wp-block-embed__wrapper {
+	position: relative;
+}
+
+// Add responsiveness to embeds with aspect ratios.
+.wp-embed-responsive .wp-has-aspect-ratio {
+	.wp-block-embed__wrapper::before {
+		content: "";
+		display: block;
+		padding-top: 50%; // Default to 2:1 aspect ratio.
+	}
+
+	iframe {
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		height: 100%;
+		width: 100%;
+	}
 }
 
 .wp-embed-responsive {
-	.wp-block-embed {
-		// Add responsiveness to common aspect ratios.
-		&.wp-embed-aspect-21-9 .wp-block-embed__wrapper,
-		&.wp-embed-aspect-18-9 .wp-block-embed__wrapper,
-		&.wp-embed-aspect-16-9 .wp-block-embed__wrapper,
-		&.wp-embed-aspect-4-3 .wp-block-embed__wrapper,
-		&.wp-embed-aspect-1-1 .wp-block-embed__wrapper,
-		&.wp-embed-aspect-9-16 .wp-block-embed__wrapper,
-		&.wp-embed-aspect-1-2 .wp-block-embed__wrapper {
-			position: relative;
+	.wp-embed-aspect-21-9 .wp-block-embed__wrapper::before {
+		padding-top: 42.85%; // 9 / 21 * 100
+	}
 
-			&::before {
-				content: "";
-				display: block;
-				padding-top: 50%; // Default to 2:1 aspect ratio.
-			}
+	.wp-embed-aspect-18-9 .wp-block-embed__wrapper::before {
+		padding-top: 50%; // 9 / 18 * 100
+	}
 
-			iframe {
-				position: absolute;
-				top: 0;
-				right: 0;
-				bottom: 0;
-				left: 0;
-				width: 100%;
-				height: 100%;
-			}
-		}
+	.wp-embed-aspect-16-9 .wp-block-embed__wrapper::before {
+		padding-top: 56.25%; // 9 / 16 * 100
+	}
 
-		&.wp-embed-aspect-21-9 .wp-block-embed__wrapper::before {
-			padding-top: 42.85%; // 9 / 21 * 100
-		}
+	.wp-embed-aspect-4-3 .wp-block-embed__wrapper::before {
+		padding-top: 75%; // 3 / 4 * 100
+	}
 
-		&.wp-embed-aspect-18-9 .wp-block-embed__wrapper::before {
-			padding-top: 50%; // 9 / 18 * 100
-		}
+	.wp-embed-aspect-1-1 .wp-block-embed__wrapper::before {
+		padding-top: 100%; // 1 / 1 * 100
+	}
 
-		&.wp-embed-aspect-16-9 .wp-block-embed__wrapper::before {
-			padding-top: 56.25%; // 9 / 16 * 100
-		}
+	.wp-embed-aspect-9-6 .wp-block-embed__wrapper::before {
+		padding-top: 66.66%; // 6 / 9 * 100
+	}
 
-		&.wp-embed-aspect-4-3 .wp-block-embed__wrapper::before {
-			padding-top: 75%; // 3 / 4 * 100
-		}
-
-		&.wp-embed-aspect-1-1 .wp-block-embed__wrapper::before {
-			padding-top: 100%; // 1 / 1 * 100
-		}
-
-		&.wp-embed-aspect-9-6 .wp-block-embed__wrapper::before {
-			padding-top: 66.66%; // 6 / 9 * 100
-		}
-
-		&.wp-embed-aspect-1-2 .wp-block-embed__wrapper::before {
-			padding-top: 200%; // 2 / 1 * 100
-		}
+	.wp-embed-aspect-1-2 .wp-block-embed__wrapper::before {
+		padding-top: 200%; // 2 / 1 * 100
 	}
 }


### PR DESCRIPTION
## Description
#### editor.scss
- corrected the attribute selector from `[data-type="core/embed"]` to `[data-type^="core-embed"]` and move these style rules from `style.scss` the more appropriate `editor.scss`.

#### style.scss
- Reduced specificity by un-nesting and removing unnecessary selectors.
- Added 100% width to the `iframe` for `alignright` and `alignleft`. Previously, on embeds without an aspect-ratio, floats weren't responsive and the `iframe` would overflow it's container. (If using normalize.css this wouldn't be noticed)

## How has this been tested?
Tested visually with several themes including TwentyNineteen.

## Types of changes
Bug fix


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
