### PR TITLE
ESLint Plugin: Add rule react-no-unsafe-timeout 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
 		'plugin:jest/recommended',
 	],
 	rules: {
+		'@wordpress/react-no-unsafe-timeout': 'error',
 		'no-restricted-syntax': [
 			'error',
 			// NOTE: We can't include the forward slash in our regex or

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -821,7 +821,7 @@ export class RichText extends Component {
 		}
 
 		// Wait for boundary class to be added.
-		setTimeout( () => this.recalculateBoundaryStyle() );
+		this.props.setTimeout( () => this.recalculateBoundaryStyle() );
 
 		if ( newSelectedFormat !== selectedFormat ) {
 			this.applyRecord( { ...value, selectedFormat: newSelectedFormat } );

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -12,7 +12,7 @@ import { __, sprintf, _n } from '@wordpress/i18n';
 import { Component, createRef } from '@wordpress/element';
 import { UP, DOWN, ENTER, TAB } from '@wordpress/keycodes';
 import { Spinner, withSpokenMessages, Popover } from '@wordpress/components';
-import { withInstanceId, compose } from '@wordpress/compose';
+import { withInstanceId, withSafeTimeout, compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 
 // Since URLInput is rendered in the context of other inputs, but should be
@@ -49,7 +49,7 @@ class URLInput extends Component {
 				onlyScrollIfNeeded: true,
 			} );
 
-			setTimeout( () => {
+			this.props.setTimeout( () => {
 				this.scrollingIntoView = false;
 			}, 100 );
 		}
@@ -283,6 +283,7 @@ class URLInput extends Component {
 }
 
 export default compose(
+	withSafeTimeout,
 	withSpokenMessages,
 	withInstanceId,
 	withSelect( ( select ) => {

--- a/packages/components/src/form-token-field/suggestions-list.js
+++ b/packages/components/src/form-token-field/suggestions-list.js
@@ -9,6 +9,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
+import { withSafeTimeout } from '@wordpress/compose';
 
 class SuggestionsList extends Component {
 	constructor() {
@@ -26,7 +27,7 @@ class SuggestionsList extends Component {
 				onlyScrollIfNeeded: true,
 			} );
 
-			setTimeout( () => {
+			this.props.setTimeout( () => {
 				this.scrollingIntoView = false;
 			}, 100 );
 		}
@@ -131,4 +132,4 @@ SuggestionsList.defaultProps = {
 	suggestions: Object.freeze( [] ),
 };
 
-export default SuggestionsList;
+export default withSafeTimeout( SuggestionsList );

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -47,12 +47,13 @@ The granular rulesets will not define any environment globals. As such, if they 
 
 ### Rules
 
-Rule|Description
----|---
-[dependency-group](/packages/eslint-plugin/docs/rules/dependency-group.md)|Enforce dependencies docblocks formatting
-[gutenberg-phase](docs/rules/gutenberg-phase.md)|Governs the use of the `process.env.GUTENBERG_PHASE` constant
-[no-unused-vars-before-return](/packages/eslint-plugin/docs/rules/no-unused-vars-before-return.md)|Disallow assigning variable values if unused before a return
-[valid-sprintf](/packages/eslint-plugin/docs/rules/valid-sprintf.md)|Disallow assigning variable values if unused before a return
+Rule|Description|Recommended
+---|---|---
+[dependency-group](/packages/eslint-plugin/docs/rules/dependency-group.md)|Enforce dependencies docblocks formatting|✓
+[gutenberg-phase](docs/rules/gutenberg-phase.md)|Governs the use of the `process.env.GUTENBERG_PHASE` constant|✓
+[no-unused-vars-before-return](/packages/eslint-plugin/docs/rules/no-unused-vars-before-return.md)|Disallow assigning variable values if unused before a return|✓
+[react-no-unsafe-timeout](/packages/eslint-plugin/docs/rules/react-no-unsafe-timeout.md)|Disallow unsafe `setTimeout` in component|
+[valid-sprintf](/packages/eslint-plugin/docs/rules/valid-sprintf.md)|Disallow assigning variable values if unused before a return|✓
 
 ### Legacy
 

--- a/packages/eslint-plugin/docs/rules/react-no-unsafe-timeout.md
+++ b/packages/eslint-plugin/docs/rules/react-no-unsafe-timeout.md
@@ -1,0 +1,76 @@
+# Disallow unsafe `setTimeout` in component (react-no-unsafe-timeout)
+
+`setTimeout` in a component must be cancelled when the component is unmounted. This rule disallows references to the `setTimeout` global which occur in a component, and which are not assigned to a variable. A variable assignment is considered an acceptable use on the assumption that the timeout ID will be later referenced for cancellation via `clearTimeout`.
+
+Consider using the [`withSafeTimeout` higher-order component](https://github.com/WordPress/gutenberg/tree/master/packages/compose/src/with-safe-timeout) from the [`@wordpress/compose` module](https://www.npmjs.com/package/@wordpress/compose).
+
+## Rule details
+
+Examples of **incorrect** code for this rule:
+
+```js
+function MyComponent() {
+	setTimeout( fn );
+}
+
+class MyComponent extends Component {
+	componentDidMount() {
+		setTimeout( fn );
+	}
+}
+
+class MyComponent extends wp.element.Component {
+	componentDidMount() {
+		setTimeout( fn );
+	}
+}
+```
+
+Examples of **correct** code for this rule:
+
+```js
+function getNotComponent() {
+	setTimeout( fn );
+}
+
+function MyComponent( props ) {
+	const { setTimeout } = props;
+	setTimeout( fn );
+}
+
+function MyComponent( props ) {
+	props.setTimeout( fn );
+}
+
+class MyNotComponent { 
+	doAction() {
+		setTimeout( fn );
+	}
+}
+
+class MyComponent extends wp.element.Component {
+	componentDidMount() {
+		const { setTimeout } = this.props;
+		setTimeout( fn );
+	}
+}
+
+class MyComponent extends Component {
+	componentDidMount() {
+		const { setTimeout } = this.props;
+		setTimeout( fn );
+	}
+}
+
+class MyComponent extends Component {
+	componentDidMount() {
+		this.props.setTimeout( fn );
+	}
+}
+
+class MyComponent extends Component {
+	componentDidMount() {
+		this.timeoutId = setTimeout( fn );
+	}
+}
+```

--- a/packages/eslint-plugin/rules/__tests__/react-no-unsafe-timeout.js
+++ b/packages/eslint-plugin/rules/__tests__/react-no-unsafe-timeout.js
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { RuleTester } from 'eslint';
+
+/**
+ * Internal dependencies
+ */
+import rule from '../react-no-unsafe-timeout';
+
+const ruleTester = new RuleTester( {
+	parserOptions: {
+		ecmaVersion: 6,
+	},
+} );
+
+ruleTester.run( 'react-no-unsafe-timeout', rule, {
+	valid: [
+		{
+			code: `function getNotComponent() { setTimeout(); }`,
+		},
+		{
+			code: `function MyComponent( props ) { const { setTimeout } = props; ( () => { setTimeout(); } )(); }`,
+		},
+		{
+			code: `function MyComponent( props ) { props.setTimeout(); }`,
+		},
+		{
+			code: `class MyNotComponent { doAction() { setTimeout(); } }`,
+		},
+		{
+			code: `class MyComponent extends wp.element.Component { componentDidMount() { const { setTimeout } = this.props; setTimeout(); } }`,
+		},
+		{
+			code: `class MyComponent extends Component { componentDidMount() { const { setTimeout } = this.props; setTimeout(); } }`,
+		},
+		{
+			code: `class MyComponent extends Component { componentDidMount() { this.props.setTimeout(); } }`,
+		},
+		{
+			code: `class MyComponent extends Component { componentDidMount() { this.timeoutId = setTimeout(); } }`,
+		},
+	],
+	invalid: [
+		{
+			code: `function MyComponent() { setTimeout(); }`,
+			errors: [ { message: 'setTimeout in a component must be cancelled on unmount' } ],
+		},
+		{
+			code: `class MyComponent extends Component { componentDidMount() { setTimeout(); } }`,
+			errors: [ { message: 'setTimeout in a component must be cancelled on unmount' } ],
+		},
+		{
+			code: `class MyComponent extends wp.element.Component { componentDidMount() { setTimeout(); } }`,
+			errors: [ { message: 'setTimeout in a component must be cancelled on unmount' } ],
+		},
+	],
+} );

--- a/packages/eslint-plugin/rules/react-no-unsafe-timeout.js
+++ b/packages/eslint-plugin/rules/react-no-unsafe-timeout.js
@@ -1,0 +1,91 @@
+/**
+ * Given an Espree Node, returns true if the node is a component.
+ *
+ * @param {espree.Node} node Node to check.
+ *
+ * @return {boolean} Whether node is a component.
+ */
+function isComponent( node ) {
+	// Assume function component by naming convention of UpperCamelCase.
+	if (
+		node.type === 'FunctionDeclaration' &&
+		node.id &&
+		/^[A-Z]/.test( node.id.name )
+	) {
+		return true;
+	}
+
+	// Assume class component by extends name `Component`.
+	if ( node.type === 'ClassDeclaration' && node.superClass ) {
+		let superClassName;
+		switch ( node.superClass.type ) {
+			case 'Identifier':
+				superClassName = node.superClass.name;
+				break;
+
+			case 'MemberExpression':
+				superClassName = node.superClass.property.name;
+				break;
+		}
+
+		if ( superClassName === 'Component' ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+module.exports = {
+	meta: {
+		type: 'problem',
+		schema: [],
+	},
+	create( context ) {
+		return {
+			'CallExpression[callee.name="setTimeout"]'( node ) {
+				const { references } = context.getScope();
+
+				// If the result of a `setTimeout` call is assigned to a
+				// variable, assume the timer ID is handled by a cancellation.
+				const hasAssignment = node.parent.type === 'AssignmentExpression';
+				if ( hasAssignment ) {
+					return;
+				}
+
+				let isInComponent = false;
+
+				let parent = node;
+				while ( ( parent = parent.parent ) ) {
+					if ( isComponent( parent ) ) {
+						isInComponent = true;
+						break;
+					}
+				}
+
+				// Only consider `setTimeout` which occur within a component.
+				if ( ! isInComponent ) {
+					return;
+				}
+
+				// Consider whether `setTimeout` is a reference to the global
+				// by checking references to see if `setTimeout` resolves to a
+				// variable in scope.
+				const hasResolvedReference = references.some( ( reference ) => (
+					reference.identifier.name === 'setTimeout' &&
+					!! reference.resolved &&
+					reference.resolved.scope.type !== 'global'
+				) );
+
+				if ( hasResolvedReference ) {
+					return;
+				}
+
+				context.report(
+					node,
+					'setTimeout in a component must be cancelled on unmount'
+				);
+			},
+		};
+	},
+};


### PR DESCRIPTION
This pull request seeks to introduce a new ESLint rule `@wordpress/react-no-unsafe-timeout`. In brief, it is meant to enforce the anti-pattern of `setTimeout` use in components which [`withSafeTimeout`](https://github.com/WordPress/gutenberg/tree/master/packages/compose/src/with-safe-timeout) exists to address.

From the included rule documentation:

>`setTimeout` in a component must be cancelled when the component is unmounted. This rule disallows references to the `setTimeout` global which occur in a component, and which are not assigned to a variable. A variable assignment is considered an acceptable use on the assumption that the timeout ID will be later referenced for cancellation via `clearTimeout`.
>
>Consider using the [`withSafeTimeout` higher-order component](https://github.com/WordPress/gutenberg/tree/master/packages/compose/src/with-safe-timeout) from the [`@wordpress/compose` module](https://www.npmjs.com/package/@wordpress/compose).

In introducing the rule, it also resolves a few existing offending occurrences in code:

- `packages/block-editor/src/components/rich-text/index.js`
- `packages/block-editor/src/components/url-input/index.js`
- `packages/components/src/form-token-field/suggestions-list.js`

**Testing Instructions:**

Verify there are no errors when running `npm run lint-js`.

Verify unit tests pass running `npm run test-unit`