### PR TITLE
Load some components README files in the playground

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13992,6 +13992,12 @@
 			"integrity": "sha512-NcWuJFHDA8V3wkDgR/j4+gZx+YQwstPgfQDV8ndUeWWzta3dnDTBxpVzqS9lkmJAuV5YX35lmyojl6HO5JXAgw==",
 			"dev": true
 		},
+		"marked": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-0.6.1.tgz",
+			"integrity": "sha512-+H0L3ibcWhAZE02SKMqmvYsErLo4EAVJxu5h3bHBBDvvjeWXtl92rGUSBYHL2++5Y+RSNgl8dYOAXcYe7lp1fA==",
+			"dev": true
+		},
 		"matcher": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/matcher/-/matcher-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
 		"lerna": "3.13.2",
 		"lint-staged": "8.1.5",
 		"lodash": "4.17.11",
+		"marked": "0.6.1",
 		"mkdirp": "0.5.1",
 		"node-sass": "4.11.0",
 		"node-watch": "0.6.0",

--- a/playground/src/components/editor/editor-styles.scss
+++ b/playground/src/components/editor/editor-styles.scss
@@ -1,3 +1,20 @@
+.editor {
+	padding-top: 20px;
+
+	img {
+		max-width: 100%;
+		height: auto;
+	}
+
+	iframe {
+		width: 100%;
+	}
+
+	.components-navigate-regions {
+		height: 100%;
+	}
+}
+
 .editor-styles-wrapper {
 	font-family: $editor-font;
 	font-size: $editor-font-size;

--- a/playground/src/components/editor/index.js
+++ b/playground/src/components/editor/index.js
@@ -1,0 +1,53 @@
+
+/**
+ * WordPress dependencies
+ */
+import '@wordpress/editor'; // This shouldn't be necessary
+
+import { useEffect, useState } from '@wordpress/element';
+import {
+	BlockEditorProvider,
+	BlockList,
+	WritingFlow,
+	ObserveTyping,
+} from '@wordpress/block-editor';
+import { Popover } from '@wordpress/components';
+import { registerCoreBlocks } from '@wordpress/block-library';
+import '@wordpress/format-library';
+
+/* eslint-disable no-restricted-syntax */
+import '@wordpress/components/build-style/style.css';
+import '@wordpress/block-editor/build-style/style.css';
+import '@wordpress/block-library/build-style/style.css';
+import '@wordpress/block-library/build-style/editor.css';
+import '@wordpress/block-library/build-style/theme.css';
+import '@wordpress/format-library/build-style/style.css';
+/* eslint-enable no-restricted-syntax */
+
+function Editor() {
+	const [ blocks, updateBlocks ] = useState( [] );
+	useEffect( () => {
+		registerCoreBlocks();
+	}, [] );
+
+	return (
+		<div className="editor">
+			<BlockEditorProvider
+				value={ blocks }
+				onInput={ updateBlocks }
+				onChange={ updateBlocks }
+			>
+				<div className="editor-styles-wrapper">
+					<WritingFlow>
+						<ObserveTyping>
+							<BlockList />
+						</ObserveTyping>
+					</WritingFlow>
+				</div>
+				<Popover.Slot />
+			</BlockEditorProvider>
+		</div>
+	);
+}
+
+export default Editor;

--- a/playground/src/components/menu/index.js
+++ b/playground/src/components/menu/index.js
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+
+function Menu( { page, onNavigate } ) {
+	return (
+		<div className="menu">
+			<Button
+				isToggled={ page === 'editor' }
+				onClick={ () => onNavigate( 'editor' ) }
+			>
+				Editor
+			</Button>
+			<Button
+				isToggled={ page === 'components' }
+				onClick={ () => onNavigate( 'components' ) }
+			>
+				Components
+			</Button>
+		</div>
+	);
+}
+
+export default Menu;

--- a/playground/src/components/menu/style.scss
+++ b/playground/src/components/menu/style.scss
@@ -1,0 +1,24 @@
+.menu {
+	padding: 0 20px;
+
+	.components-button {
+		margin-right: 10px;
+		padding: 8px;
+		border-radius: 4px;
+		font-size: 14px;
+
+		&:hover {
+			color: $blue-wordpress-700;
+		}
+
+		&.is-toggled {
+			background: $blue-wordpress-700;
+			color: $white;
+
+			&:focus {
+				background: $blue-wordpress-700;
+				color: $white;
+			}
+		}
+	}
+}

--- a/playground/src/components/storybook/index.js
+++ b/playground/src/components/storybook/index.js
@@ -1,0 +1,49 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import buttonReadme from '../../../../packages/components/src/button/README.md';
+import buttonGroupReadme from '../../../../packages/components/src/button-group/README.md';
+
+const components = [
+	{ name: 'button', label: 'Button', readme: buttonReadme },
+	{ name: 'button-group', label: 'Button Group', readme: buttonGroupReadme },
+];
+
+function Storybook() {
+	const [ component, updateComponent ] = useState( 'button' );
+	const activeComponent = components.find( ( comp ) => comp.name === component );
+
+	return (
+		<div className="storybook">
+			<div className="storybook__sidebar">
+				<div className="storybook_menu">
+					{ components.map( ( { name, label } ) => (
+						<div key={ name }>
+							<Button
+								isToggled={ component === name }
+								onClick={ () => updateComponent( name ) }
+							>
+								{ label }
+							</Button>
+						</div>
+					) ) }
+				</div>
+			</div>
+			<div className="storybook__body">
+				<div dangerouslySetInnerHTML={ { __html: activeComponent.readme } } />
+			</div>
+		</div>
+	);
+}
+
+export default Storybook;

--- a/playground/src/components/storybook/index.js
+++ b/playground/src/components/storybook/index.js
@@ -25,7 +25,7 @@ import dropdownReadme from '../../../../packages/components/src/dropdown/README.
 import dropdownMenuReadme from '../../../../packages/components/src/dropdown-menu/README.md';
 
 import menuGroupReadme from '../../../../packages/components/src/menu-group/README.md';
-import menuItemReadme from '../../../../packages/components/src/menu-item/README.md';
+// import menuItemReadme from '../../../../packages/components/src/menu-item/README.md';
 import menuItemsChoiceReadme from '../../../../packages/components/src/menu-items-choice/README.md';
 
 const components = [
@@ -43,7 +43,7 @@ const components = [
 	{ name: 'dropdown-menu', label: 'Dropdown Menu', readme: dropdownMenuReadme },
 
 	{ name: 'menu-group', label: 'Menu Group', readme: menuGroupReadme },
-	{ name: 'menu-item', label: 'Menu Item', readme: menuItemReadme },
+	//	{ name: 'menu-item', label: 'Menu Item', readme: menuItemReadme },
 	{ name: 'menu-items-choice', label: 'Menu Items Choice', readme: menuItemsChoiceReadme },
 ];
 

--- a/playground/src/components/storybook/index.js
+++ b/playground/src/components/storybook/index.js
@@ -14,9 +14,37 @@ import { Button } from '@wordpress/components';
 import buttonReadme from '../../../../packages/components/src/button/README.md';
 import buttonGroupReadme from '../../../../packages/components/src/button-group/README.md';
 
+import checkboxControlReadme from '../../../../packages/components/src/checkbox-control/README.md';
+import radioControlReadme from '../../../../packages/components/src/radio-control/README.md';
+import rangeControlReadme from '../../../../packages/components/src/range-control/README.md';
+import selectControlReadme from '../../../../packages/components/src/select-control/README.md';
+import textControlReadme from '../../../../packages/components/src/text-control/README.md';
+import toggleControlReadme from '../../../../packages/components/src/toggle-control/README.md';
+
+import dropdownReadme from '../../../../packages/components/src/dropdown/README.md';
+import dropdownMenuReadme from '../../../../packages/components/src/dropdown-menu/README.md';
+
+import menuGroupReadme from '../../../../packages/components/src/menu-group/README.md';
+import menuItemReadme from '../../../../packages/components/src/menu-item/README.md';
+import menuItemsChoiceReadme from '../../../../packages/components/src/menu-items-choice/README.md';
+
 const components = [
 	{ name: 'button', label: 'Button', readme: buttonReadme },
 	{ name: 'button-group', label: 'Button Group', readme: buttonGroupReadme },
+
+	{ name: 'checkbox-control', label: 'Checkbox Control', readme: checkboxControlReadme },
+	{ name: 'radio-control', label: 'Radio Control', readme: radioControlReadme },
+	{ name: 'range-control', label: 'Range Control', readme: rangeControlReadme },
+	{ name: 'select-control', label: 'Select Control', readme: selectControlReadme },
+	{ name: 'text-control', label: 'Text Control', readme: textControlReadme },
+	{ name: 'toggle-control', label: 'Toggle Control', readme: toggleControlReadme },
+
+	{ name: 'dropdown', label: 'Dropdown', readme: dropdownReadme },
+	{ name: 'dropdown-menu', label: 'Dropdown Menu', readme: dropdownMenuReadme },
+
+	{ name: 'menu-group', label: 'Menu Group', readme: menuGroupReadme },
+	{ name: 'menu-item', label: 'Menu Item', readme: menuItemReadme },
+	{ name: 'menu-items-choice', label: 'Menu Items Choice', readme: menuItemsChoiceReadme },
 ];
 
 function Storybook() {

--- a/playground/src/components/storybook/style.scss
+++ b/playground/src/components/storybook/style.scss
@@ -1,0 +1,192 @@
+.storybook {
+	display: grid;
+	height: calc(100vh - 70px);
+	grid-template-columns: 300px 1fr;
+}
+
+.storybook__sidebar {
+	border-right: 1px solid #eee;
+	padding: 20px;
+}
+
+.storybook_menu {
+	text-align: right;
+
+	.components-button {
+		padding: 8px;
+		border-radius: 4px;
+		font-size: 14px;
+		margin-bottom: 4px;
+
+		&:hover {
+			color: $blue-wordpress-700;
+		}
+
+		&.is-toggled {
+			color: $blue-wordpress-700;
+			font-weight: 600;
+		}
+	}
+}
+
+.storybook__body {
+	padding: 20px;
+	max-width: 600px;
+	padding-left: 50px;
+
+	a {
+		text-decoration: none;
+		color: #34495e;
+	}
+
+	img {
+		border: none;
+	}
+
+	h1,
+	h2,
+	h3,
+	h4,
+	strong {
+		font-weight: 600;
+		color: #2c3e50;
+	}
+
+	code,
+	pre {
+		font-family: "Roboto Mono", Monaco, courier, monospace;
+		font-size: 0.8em;
+		background-color: #f8f8f8;
+		-webkit-font-smoothing: initial;
+		-moz-osx-font-smoothing: initial;
+	}
+
+	code {
+		color: #e96900;
+		padding: 3px 5px;
+		margin: 0 2px;
+		border-radius: 2px;
+		white-space: nowrap;
+	}
+
+	em {
+		color: #7f8c8d;
+	}
+
+	p {
+		word-spacing: 0.05em;
+	}
+
+	img {
+		max-width: 100%;
+	}
+
+	h1 {
+		margin: 0 0 1em;
+	}
+
+	h2 {
+		margin: 45px 0 0.8em;
+		padding-bottom: 0.7em;
+		border-bottom: 1px solid #ddd;
+	}
+
+	h3 {
+		margin: 52px 0 1.2em;
+		line-height: 1.2;
+		position: relative;
+	}
+
+	h3 > a::before {
+		content: "#";
+		color: $blue-medium-500;
+		position: absolute;
+		left: -0.7em;
+		margin-top: -0.05em;
+		padding-right: 0.5em;
+		font-size: 1.2em;
+		line-height: 1;
+		font-weight: bold;
+	}
+
+	figure {
+		margin: 1.2em 0;
+	}
+
+	p,
+	ul,
+	ol {
+		line-height: 1.6em;
+		margin: 1.2em 0 -1.2em;
+		padding-bottom: 1.2em;
+		position: relative;
+		z-index: 1;
+	}
+
+	ul,
+	ol {
+		padding-left: 1.5em;
+		position: inherit;
+	}
+
+	ul ul,
+	ol ul,
+	ul ol,
+	ol ol {
+		margin: 0;
+	}
+
+	a {
+		color: $blue-medium-600;
+		font-weight: 600;
+	}
+
+	blockquote {
+		margin: 2em 0;
+		padding-left: 20px;
+		border-left: 4px solid $blue-medium-600;
+	}
+
+	blockquote p {
+		font-weight: 600;
+		margin-left: 0;
+		margin-bottom: 0;
+		padding-bottom: 0;
+	}
+
+	iframe {
+		margin: 1em 0;
+	}
+
+	> table {
+		border-spacing: 0;
+		border-collapse: collapse;
+		margin: 1.2em auto;
+		padding: 0;
+		display: block;
+		overflow-x: auto;
+	}
+
+	> table td,
+	> table th {
+		line-height: 1.5em;
+		padding: 0.4em 0.8em;
+		border: none;
+		border: 1px solid #ddd;
+	}
+
+	> table th {
+		font-weight: bold;
+		text-align: left;
+	}
+
+	> table th,
+	> table tr:nth-child(2n) {
+		background-color: #f8f8f8;
+	}
+
+	> table th code,
+	> table tr:nth-child(2n) code {
+		background-color: #efefef;
+	}
+}

--- a/playground/src/components/storybook/style.scss
+++ b/playground/src/components/storybook/style.scss
@@ -15,7 +15,7 @@
 	.components-button {
 		padding: 8px;
 		border-radius: 4px;
-		font-size: 14px;
+		font-size: 13px;
 		margin-bottom: 4px;
 
 		&:hover {

--- a/playground/src/index.html
+++ b/playground/src/index.html
@@ -4,8 +4,8 @@
 	<meta charset="utf-8">
 	<title>The Gutenberg Playground</title>
 	<link href="https://fonts.googleapis.com/css?family=Noto+Serif:400,700" rel="stylesheet">
+	<link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600" rel="stylesheet">
 </head>
-
 <body>
 	<div id="app"></div>
 	<script src="./index.js"></script>

--- a/playground/src/index.js
+++ b/playground/src/index.js
@@ -6,63 +6,35 @@ import '@babel/polyfill';
 /**
  * WordPress dependencies
  */
-import '@wordpress/editor'; // This shouldn't be necessary
-
-import { render, useState, Fragment } from '@wordpress/element';
-import {
-	BlockEditorProvider,
-	BlockList,
-	WritingFlow,
-	ObserveTyping,
-} from '@wordpress/block-editor';
-import { Popover } from '@wordpress/components';
-import { registerCoreBlocks } from '@wordpress/block-library';
-import '@wordpress/format-library';
+import { render, Fragment, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
+import Menu from './components/menu';
+import Editor from './components/editor';
+import Storybook from './components/storybook';
 
-/* eslint-disable no-restricted-syntax */
-import '@wordpress/components/build-style/style.css';
-import '@wordpress/block-editor/build-style/style.css';
-import '@wordpress/block-library/build-style/style.css';
-import '@wordpress/block-library/build-style/editor.css';
-import '@wordpress/block-library/build-style/theme.css';
-import '@wordpress/format-library/build-style/style.css';
-/* eslint-enable no-restricted-syntax */
-
-function App() {
-	const [ blocks, updateBlocks ] = useState( [] );
-
+function Playground() {
+	const [ page, updatePage ] = useState( 'editor' );
 	return (
 		<Fragment>
 			<div className="playground__header">
 				<h1 className="playground__logo">Gutenberg Playground</h1>
+				<div className="playground__menu">
+					<Menu page={ page } onNavigate={ updatePage } />
+				</div>
 			</div>
 			<div className="playground__body">
-				<BlockEditorProvider
-					value={ blocks }
-					onInput={ updateBlocks }
-					onChange={ updateBlocks }
-				>
-					<div className="editor-styles-wrapper">
-						<WritingFlow>
-							<ObserveTyping>
-								<BlockList />
-							</ObserveTyping>
-						</WritingFlow>
-					</div>
-					<Popover.Slot />
-				</BlockEditorProvider>
+				{ page === 'editor' && <Editor /> }
+				{ page === 'components' && <Storybook /> }
 			</div>
 		</Fragment>
 	);
 }
 
-registerCoreBlocks();
 render(
-	<App />,
+	<Playground />,
 	document.querySelector( '#app' )
 );

--- a/playground/src/reset.scss
+++ b/playground/src/reset.scss
@@ -22,8 +22,11 @@ html,
 body {
 	margin: 0;
 	padding: 0;
-	font-family: $default-font;
-	font-size: $default-font-size;
+	font-family: "Source Sans Pro", "Helvetica Neue", Arial, sans-serif;
+	font-size: 16px;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	color: #34495e;
 }
 
 a,

--- a/playground/src/style.scss
+++ b/playground/src/style.scss
@@ -6,32 +6,20 @@
 @import "../../assets/stylesheets/z-index";
 
 @import "./reset";
-@import "./editor-styles";
+@import "./components/editor/editor-styles";
+@import "./components/menu/style";
+@import "./components/storybook/style";
 
 
 .playground__header {
-	padding: 20px;
-	border-bottom: 1px solid #ddd;
+	padding: 10px 20px;
+	display: flex;
+	align-items: center;
+	background: #f1f1f1;
 }
 
 .playground__logo {
 	font-size: 20px;
-	font-weight: 300;
-}
-
-.playground__body {
-	padding-top: 20px;
-
-	img {
-		max-width: 100%;
-		height: auto;
-	}
-
-	iframe {
-		width: 100%;
-	}
-
-	.components-navigate-regions {
-		height: 100%;
-	}
+	font-weight: 400;
+	margin-right: 20px;
 }


### PR DESCRIPTION
This PR adds a storybook like UI to the Gutenberg playground. For now, I just added "Button" and "Button Group" but if you think this is a good thing to have, there's no reason not to add all the components with good READMEs. Right now I'm not using any routing which means the current page is not persisted in the URL but this can be added later.

Also, right now these components pages are just loaded the README files but they can be tweaked to also include live running examples of the components.

<img width="942" alt="Capture d’écran 2019-03-27 à 10 54 46 AM" src="https://user-images.githubusercontent.com/272444/55066781-c2741680-507e-11e9-8227-ad480f9fb98c.png">

**Testing instructions**

`npm run playground:start && open http://localhost:1234`