### PR TITLE
Fix WordPress embed block resolution

### DIFF
--- a/packages/block-library/src/embed/util.js
+++ b/packages/block-library/src/embed/util.js
@@ -46,7 +46,7 @@ export const findBlock = ( url ) => {
 };
 
 export const isFromWordPress = ( html ) => {
-	return includes( html, 'class="wp-embedded-content" data-secret' );
+	return includes( html, 'class="wp-embedded-content"' );
 };
 
 export const getPhotoHtml = ( photo ) => {

--- a/packages/e2e-tests/specs/embedding.test.js
+++ b/packages/e2e-tests/specs/embedding.test.js
@@ -9,6 +9,8 @@ import {
 	createJSONResponse,
 	getEditedPostContent,
 	clickButton,
+	insertBlock,
+	publishPost,
 } from '@wordpress/e2e-test-utils';
 
 const MOCK_EMBED_WORDPRESS_SUCCESS_RESPONSE = {
@@ -191,5 +193,28 @@ describe( 'Embedding content', () => {
 		);
 		await clickButton( 'Try again' );
 		await page.waitForSelector( 'figure.wp-block-embed-twitter' );
+	} );
+
+	it( 'should switch to the WordPress block correctly', async () => {
+		// This test is to make sure that WordPress embeds are detected correctly,
+		// because the HTML can vary, and the block is detected by looking for
+		// classes in the HTML, so we need to flag up if the HTML changes.
+
+		// Publish a post to embed.
+		await insertBlock( 'Paragraph' );
+		await page.keyboard.type( 'Hello there!' );
+		await publishPost();
+		const postUrl = await page.$eval( '#inspector-text-control-0', ( el ) => el.value );
+
+		// Start a new post, embed the previous post.
+		await createNewPost();
+		await clickBlockAppender();
+		await page.keyboard.type( '/embed' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( postUrl );
+		await page.keyboard.press( 'Enter' );
+
+		// Check the block has become a WordPress block.
+		await page.waitForSelector( '.wp-block-embed-wordpress' );
 	} );
 } );


### PR DESCRIPTION
## Description

Embedding WordPress posts has changed slightly, the HTML returned
when embedding with latest WP no longer matched the `isFromWordPress`
check, so this PR updates it and adds an e2e test that publishes a post
and then embeds it in a new post to check the WordPressyness is
detected.

## How has this been tested?

New e2e test.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
