### PR TITLE
Add documentation for FormFileUpload props

### DIFF
--- a/packages/components/src/form-file-upload/README.md
+++ b/packages/components/src/form-file-upload/README.md
@@ -14,3 +14,55 @@ const MyFormFileUpload = () => (
 	</FormFileUpload>
 );
 ```
+
+## Props
+
+The component accepts the following props. Props not included in this set will be passed to the `IconButton` component.
+
+### accept
+
+A string passed to `input` element that tells the browser which file types can be upload to the upload by the user use. e.g: `image/*,video/*`.
+More information about this string is available in https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#Unique_file_type_specifiers.
+
+- Type: `String`
+- Required: No
+
+
+### children
+
+Children are passed as children of `IconButton`.
+
+- Type: `Boolean`
+- Required: No
+
+### icon
+
+The icon to render. Supported values are: Dashicons (specified as strings), functions, WPComponent instances and `null`.
+
+- Type: `String|Function|WPComponent|null`
+- Required: No
+- Default: `null`
+
+
+### multiple
+
+Whether to allow multiple selection of files or not.
+
+- Type: `Boolean`
+- Required: No
+- Default: `false`
+
+### onChange
+
+Callback function passed directly to the `input` file element.
+
+- Type: `Function`
+- Required: Yes
+
+### render
+
+Optional callback function used to render the UI. If passed the component does not render any UI and calls this function to render it.
+This function receives an object with the property `openFileDialog`. The property is a function that when called opens the browser window to upload files.
+
+- Type: `Function`
+- Required: No

--- a/packages/components/src/form-file-upload/index.js
+++ b/packages/components/src/form-file-upload/index.js
@@ -24,7 +24,15 @@ class FormFileUpload extends Component {
 	}
 
 	render() {
-		const { children, multiple = false, accept, onChange, icon = 'upload', render, ...props } = this.props;
+		const {
+			accept,
+			children,
+			icon = 'upload',
+			multiple = false,
+			onChange,
+			render,
+			...props
+		} = this.props;
 
 		const ui = render ?
 			render( { openFileDialog: this.openFileDialog } ) : (


### PR DESCRIPTION
## Description
This PR just adds documentation for the FormFileUpload props.
I noticed during a recent change that the props were not documented.

## How has this been tested?
This PR just affects the documentation.
