### PR TITLE
Annotations & Performance: remove use of Memize

### DIFF
--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -27,7 +27,6 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/rich-text": "file:../rich-text",
 		"lodash": "^4.17.11",
-		"memize": "^1.0.5",
 		"rememo": "^3.0.0",
 		"uuid": "^3.3.2"
 	},

--- a/packages/annotations/src/format/annotation.js
+++ b/packages/annotations/src/format/annotation.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import memize from 'memize';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -120,40 +115,6 @@ function updateAnnotationsWithPositions( annotations, positions, { removeAnnotat
 	} );
 }
 
-/**
- * Create prepareEditableTree memoized based on the annotation props.
- *
- * @param {Object} The props with annotations in them.
- *
- * @return {Function} The prepareEditableTree.
- */
-const createPrepareEditableTree = memize( ( props ) => {
-	const { annotations } = props;
-
-	return ( formats, text ) => {
-		if ( annotations.length === 0 ) {
-			return formats;
-		}
-
-		let record = { formats, text };
-		record = applyAnnotations( record, annotations );
-		return record.formats;
-	};
-} );
-
-/**
- * Returns the annotations as a props object. Memoized to prevent re-renders.
- *
- * @param {Array} The annotations to put in the object.
- *
- * @return {Object} The annotations props object.
- */
-const getAnnotationObject = memize( ( annotations ) => {
-	return {
-		annotations,
-	};
-} );
-
 export const annotation = {
 	name: FORMAT_NAME,
 	title: __( 'Annotation' ),
@@ -167,9 +128,21 @@ export const annotation = {
 		return null;
 	},
 	__experimentalGetPropsForEditableTreePreparation( select, { richTextIdentifier, blockClientId } ) {
-		return getAnnotationObject( select( STORE_KEY ).__experimentalGetAnnotationsForRichText( blockClientId, richTextIdentifier ) );
+		return {
+			annotations: select( STORE_KEY ).__experimentalGetAnnotationsForRichText( blockClientId, richTextIdentifier ),
+		};
 	},
-	__experimentalCreatePrepareEditableTree: createPrepareEditableTree,
+	__experimentalCreatePrepareEditableTree( { annotations } ) {
+		return ( formats, text ) => {
+			if ( annotations.length === 0 ) {
+				return formats;
+			}
+
+			let record = { formats, text };
+			record = applyAnnotations( record, annotations );
+			return record.formats;
+		};
+	},
 	__experimentalGetPropsForEditableTreeChangeHandler( dispatch ) {
 		return {
 			removeAnnotation: dispatch( STORE_KEY ).__experimentalRemoveAnnotation,

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -25,6 +25,7 @@
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",
 		"@wordpress/escape-html": "file:../escape-html",
+		"@wordpress/hooks": "file:../hooks",
 		"lodash": "^4.17.11",
 		"rememo": "^3.0.0"
 	},

--- a/packages/rich-text/src/register-format-type.js
+++ b/packages/rich-text/src/register-format-type.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { mapKeys } from 'lodash';
-import memize from 'memize';
 
 /**
  * WordPress dependencies
@@ -10,17 +9,6 @@ import memize from 'memize';
 import { select, dispatch, withSelect, withDispatch } from '@wordpress/data';
 import { addFilter } from '@wordpress/hooks';
 import { compose } from '@wordpress/compose';
-
-/**
- * Shared reference to an empty array for cases where it is important to avoid
- * returning a new array reference on every invocation, as in a connected or
- * other pure component which performs `shouldComponentUpdate` check on props.
- * This should be used as a last resort, since the normalized data should be
- * maintained by the reducer result in state.
- *
- * @type {Array}
- */
-const EMPTY_ARRAY = [];
 
 /**
  * Registers a new format provided a unique name and an object defining its
@@ -135,99 +123,73 @@ export function registerFormatType( name, settings ) {
 
 	dispatch( 'core/rich-text' ).addFormatTypes( settings );
 
-	const getFunctionStackMemoized = memize( ( previousStack = EMPTY_ARRAY, newFunction ) => {
-		return [
-			...previousStack,
-			newFunction,
-		];
-	} );
-
-	if (
-		settings.__experimentalCreatePrepareEditableTree
-	) {
+	if ( settings.__experimentalCreatePrepareEditableTree ) {
 		addFilter( 'experimentalRichText', name, ( OriginalComponent ) => {
-			let Component = OriginalComponent;
-			if (
-				settings.__experimentalCreatePrepareEditableTree ||
-				settings.__experimentalCreateFormatToValue ||
-				settings.__experimentalCreateValueToFormat
-			) {
-				Component = ( props ) => {
-					const additionalProps = {};
+			const selectPrefix = `format_prepare_props_(${ name })_`;
+			const dispatchPrefix = `format_on_change_props_(${ name })_`;
 
-					if ( settings.__experimentalCreatePrepareEditableTree ) {
-						additionalProps.prepareEditableTree = getFunctionStackMemoized(
-							props.prepareEditableTree,
-							settings.__experimentalCreatePrepareEditableTree( props[ `format_${ name }` ], {
-								richTextIdentifier: props.identifier,
-								blockClientId: props.clientId,
-							} )
-						);
+			const Component = ( props ) => {
+				const newProps = { ...props };
+				const propsByPrefix = Object.keys( props ).reduce( ( accumulator, key ) => {
+					if ( key.startsWith( selectPrefix ) ) {
+						accumulator[ key.slice( selectPrefix.length ) ] = props[ key ];
 					}
 
-					if ( settings.__experimentalCreateOnChangeEditableValue ) {
-						const dispatchProps = Object.keys( props ).reduce( ( accumulator, propKey ) => {
-							const propValue = props[ propKey ];
-							const keyPrefix = `format_${ name }_dispatch_`;
-							if ( propKey.startsWith( keyPrefix ) ) {
-								const realKey = propKey.replace( keyPrefix, '' );
-
-								accumulator[ realKey ] = propValue;
-							}
-
-							return accumulator;
-						}, {} );
-
-						additionalProps.onChangeEditableValue = getFunctionStackMemoized(
-							props.onChangeEditableValue,
-							settings.__experimentalCreateOnChangeEditableValue( {
-								...props[ `format_${ name }` ],
-								...dispatchProps,
-							}, {
-								richTextIdentifier: props.identifier,
-								blockClientId: props.clientId,
-							} )
-						);
+					if ( key.startsWith( dispatchPrefix ) ) {
+						accumulator[ key.slice( dispatchPrefix.length ) ] = props[ key ];
 					}
 
-					return <OriginalComponent
-						{ ...props }
-						{ ...additionalProps }
-					/>;
+					return accumulator;
+				}, {} );
+				const args = {
+					richTextIdentifier: props.identifier,
+					blockClientId: props.clientId,
 				};
-			}
+
+				newProps[ `format_prepare_functions_(${ name })` ] =
+					settings.__experimentalCreatePrepareEditableTree(
+						propsByPrefix,
+						args
+					);
+
+				if ( settings.__experimentalCreateOnChangeEditableValue ) {
+					newProps[ `format_on_change_functions_(${ name })` ] =
+						settings.__experimentalCreateOnChangeEditableValue(
+							propsByPrefix,
+							args
+						);
+				}
+
+				return <OriginalComponent { ...newProps } />;
+			};
 
 			const hocs = [];
 
 			if ( settings.__experimentalGetPropsForEditableTreePreparation ) {
-				hocs.push( withSelect( ( sel, { clientId, identifier } ) => ( {
-					[ `format_${ name }` ]: settings.__experimentalGetPropsForEditableTreePreparation(
-						sel,
-						{
+				hocs.push( withSelect( ( sel, { clientId, identifier } ) =>
+					mapKeys(
+						settings.__experimentalGetPropsForEditableTreePreparation( sel, {
 							richTextIdentifier: identifier,
 							blockClientId: clientId,
-						}
-					),
-				} ) ) );
+						} ),
+						( value, key ) => selectPrefix + key
+					)
+				) );
 			}
 
 			if ( settings.__experimentalGetPropsForEditableTreeChangeHandler ) {
-				hocs.push( withDispatch( ( disp, { clientId, identifier } ) => {
-					const dispatchProps = settings.__experimentalGetPropsForEditableTreeChangeHandler(
-						disp,
-						{
+				hocs.push( withDispatch( ( disp, { clientId, identifier } ) =>
+					mapKeys(
+						settings.__experimentalGetPropsForEditableTreeChangeHandler( disp, {
 							richTextIdentifier: identifier,
 							blockClientId: clientId,
-						}
-					);
-
-					return mapKeys( dispatchProps, ( value, key ) => {
-						return `format_${ name }_dispatch_${ key }`;
-					} );
-				} ) );
+						} ),
+						( value, key ) => dispatchPrefix + key
+					)
+				) );
 			}
 
-			return compose( hocs )( Component );
+			return hocs.length ? compose( hocs )( Component ) : Component;
 		} );
 	}
 

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -113,12 +113,6 @@ function remove( node ) {
 	return node.parentNode.removeChild( node );
 }
 
-function prepareFormats( prepareEditableTree = [], value ) {
-	return prepareEditableTree.reduce( ( accumlator, fn ) => {
-		return fn( accumlator, value.text );
-	}, value.formats );
-}
-
 export function toDom( {
 	value,
 	multilineTag,
@@ -128,11 +122,15 @@ export function toDom( {
 	let startPath = [];
 	let endPath = [];
 
-	const tree = toTree( {
-		value: {
+	if ( prepareEditableTree ) {
+		value = {
 			...value,
-			formats: prepareFormats( prepareEditableTree, value ),
-		},
+			formats: prepareEditableTree( value ),
+		};
+	}
+
+	const tree = toTree( {
+		value,
 		multilineTag,
 		createEmpty,
 		append,

--- a/packages/rich-text/src/unregister-format-type.js
+++ b/packages/rich-text/src/unregister-format-type.js
@@ -22,10 +22,7 @@ export function unregisterFormatType( name ) {
 		return;
 	}
 
-	if (
-		oldFormat.__experimentalCreatePrepareEditableTree &&
-		oldFormat.__experimentalGetPropsForEditableTreePreparation
-	) {
+	if ( oldFormat.__experimentalCreatePrepareEditableTree ) {
 		removeFilter( 'experimentalRichText', name );
 	}
 


### PR DESCRIPTION
## Description

Split out from #14641.

Some functions were memoized in #12161, because new array and objects are returned as props. We can avoid this by prefixing the prop keys (as is already done in one case).

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->