### PR TITLE
ESLint Plugin: Fix description for valid-sprintf rule

### DIFF
--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -53,7 +53,7 @@ Rule|Description|Recommended
 [gutenberg-phase](docs/rules/gutenberg-phase.md)|Governs the use of the `process.env.GUTENBERG_PHASE` constant|✓
 [no-unused-vars-before-return](/packages/eslint-plugin/docs/rules/no-unused-vars-before-return.md)|Disallow assigning variable values if unused before a return|✓
 [react-no-unsafe-timeout](/packages/eslint-plugin/docs/rules/react-no-unsafe-timeout.md)|Disallow unsafe `setTimeout` in component|
-[valid-sprintf](/packages/eslint-plugin/docs/rules/valid-sprintf.md)|Disallow assigning variable values if unused before a return|✓
+[valid-sprintf](/packages/eslint-plugin/docs/rules/valid-sprintf.md)|Enforce valid sprintf usage|✓
 
 ### Legacy
 


### PR DESCRIPTION
Previously: #13756

This pull request seeks to correct an inaccurate description for the `valid-sprintf` custom ESLint rule, which was wrongly using the description text from the `no-unused-vars-before-return` rule.

**Testing Instructions:**

Only includes documentation updates. Verify previewed results.