### PR TITLE
Remove negative toolbar position rules from full-aligned blocks

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -904,6 +904,12 @@
 	.block-editor-block-contextual-toolbar > * {
 		pointer-events: auto;
 	}
+
+	// Full-aligned blocks have negative margins on the parent of the toolbar, so additional position adjustment is not required.
+	&[data-align="full"] .block-editor-block-contextual-toolbar {
+		left: 0;
+		right: 0;
+	}
 }
 
 .block-editor-block-list__block.is-focus-mode:not(.is-multi-selected) > .block-editor-block-contextual-toolbar {


### PR DESCRIPTION
Fixes #14588.

Full-aligned blocks on mobile appear appear to have overly-aggressive negative positioning, knocking some of the controls offscreen. This PR zeroes out the left and right position of the toolbar in that case. For full-aligned blocks, the negative position is already applied via [the parent `.block-editor-block-list__block-edit`'s margins](https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/block-list/style.scss#L470-L484). (Thanks @m-e-h for pinpointing that). 

Though this is only really necessary on small screens, this change persists on all breakpoints. It doesn't seem to cause any problems, but I'm happy to add an `inherit` rule above the `mobile` breakpoint if we'd prefer. 

---

**Before**
![gutenberg test_wp-admin_post php_post=1 action=edit(iPhone 6_7_8) (1)](https://user-images.githubusercontent.com/1202812/55101652-007f3380-509b-11e9-87e2-42a555b9251c.png)

**After**
![gutenberg test_wp-admin_post php_post=1 action=edit(iPhone 6_7_8) (2)](https://user-images.githubusercontent.com/1202812/55101752-33c1c280-509b-11e9-823a-e3db57d1a065.png)