### PR TITLE
Fix issue with double scrollbar in Fullscreen Mode

### DIFF
--- a/packages/edit-post/src/components/sidebar/style.scss
+++ b/packages/edit-post/src/components/sidebar/style.scss
@@ -40,16 +40,9 @@
 		z-index: z-index(".edit-post-sidebar .components-panel");
 
 		@include break-small() {
-			overflow: inherit;
+			overflow: hidden;
 			height: auto;
 			max-height: none;
-		}
-
-		@include break-medium() {
-
-			body.is-fullscreen-mode & {
-				max-height: calc(100vh - #{ $panel-header-height });
-			}
 		}
 	}
 


### PR DESCRIPTION
This PR fixes an issue where the sidebar would have two scrollbars when in fullscreen mode.

Before:

<img width="1698" alt="Screenshot 2019-03-28 at 10 18 43" src="https://user-images.githubusercontent.com/1204802/55145364-e1d47780-5142-11e9-853f-520293180d56.png">

After:

<img width="1695" alt="Screenshot 2019-03-28 at 10 17 13" src="https://user-images.githubusercontent.com/1204802/55145315-cf5a3e00-5142-11e9-98e4-363b5670f569.png">
