### PR TITLE
Automatically use a subregistry when using the block editor provider

### DIFF
--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -3,8 +3,13 @@
  */
 import { Component } from '@wordpress/element';
 import { DropZoneProvider, SlotFillProvider } from '@wordpress/components';
-import { withDispatch, withRegistry } from '@wordpress/data';
+import { withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import withRegistryProvider from './with-registry-provider';
 
 class BlockEditorProvider extends Component {
 	componentDidMount() {
@@ -115,6 +120,7 @@ class BlockEditorProvider extends Component {
 }
 
 export default compose( [
+	withRegistryProvider,
 	withDispatch( ( dispatch ) => {
 		const {
 			updateSettings,
@@ -126,5 +132,4 @@ export default compose( [
 			resetBlocks,
 		};
 	} ),
-	withRegistry,
 ] )( BlockEditorProvider );

--- a/packages/block-editor/src/components/provider/with-registry-provider.js
+++ b/packages/block-editor/src/components/provider/with-registry-provider.js
@@ -17,13 +17,13 @@ const withRegistryProvider = createHigherOrderComponent( ( WrappedComponent ) =>
 			return <WrappedComponent registry={ registry } { ...props } />;
 		}
 
-		const [ subRegistry, updateRegistry ] = useState( null );
+		const [ subRegistry, setSubRegistry ] = useState( null );
 		useEffect( () => {
 			const newRegistry = createRegistry( {}, registry );
 			const store = newRegistry.registerStore( 'core/block-editor', storeConfig );
 			// This should be removed after the refactoring of the effects to controls.
 			applyMiddlewares( store );
-			updateRegistry( newRegistry );
+			setSubRegistry( newRegistry );
 		}, [ registry ] );
 
 		if ( ! subRegistry ) {

--- a/packages/block-editor/src/components/provider/with-registry-provider.js
+++ b/packages/block-editor/src/components/provider/with-registry-provider.js
@@ -13,14 +13,11 @@ import applyMiddlewares from '../../store/middlewares';
 
 const withRegistryProvider = createHigherOrderComponent( ( WrappedComponent ) => {
 	return withRegistry( ( { useSubRegistry = true, registry, ...props } ) => {
-		// Disable reason, this rule conflicts with the React hooks rule (no conditionals)
-		// eslint-disable-next-line @wordpress/no-unused-vars-before-return
-		const [ subRegistry, updateRegistry ] = useState( null );
-
 		if ( ! useSubRegistry ) {
 			return <WrappedComponent registry={ registry } { ...props } />;
 		}
 
+		const [ subRegistry, updateRegistry ] = useState( null );
 		useEffect( () => {
 			const newRegistry = createRegistry( {}, registry );
 			const store = newRegistry.registerStore( 'core/block-editor', storeConfig );

--- a/packages/block-editor/src/components/provider/with-registry-provider.js
+++ b/packages/block-editor/src/components/provider/with-registry-provider.js
@@ -1,0 +1,44 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+import { withRegistry, createRegistry, RegistryProvider } from '@wordpress/data';
+import { createHigherOrderComponent } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { storeConfig } from '../../store';
+import applyMiddlewares from '../../store/middlewares';
+
+const withRegistryProvider = createHigherOrderComponent( ( WrappedComponent ) => {
+	return withRegistry( ( { useSubRegistry = true, registry, ...props } ) => {
+		// Disable reason, this rule conflicts with the React hooks rule (no conditionals)
+		// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+		const [ subRegistry, updateRegistry ] = useState( null );
+
+		if ( ! useSubRegistry ) {
+			return <WrappedComponent registry={ registry } { ...props } />;
+		}
+
+		useEffect( () => {
+			const newRegistry = createRegistry( {}, registry );
+			const store = newRegistry.registerStore( 'core/block-editor', storeConfig );
+			// This should be removed after the refactoring of the effects to controls.
+			applyMiddlewares( store );
+			updateRegistry( newRegistry );
+		}, [ registry ] );
+
+		if ( ! subRegistry ) {
+			return null;
+		}
+
+		return (
+			<RegistryProvider value={ subRegistry }>
+				<WrappedComponent registry={ subRegistry } { ...props } />
+			</RegistryProvider>
+		);
+	} );
+}, 'withRegistryProvider' );
+
+export default withRegistryProvider;

--- a/packages/block-editor/src/store/index.js
+++ b/packages/block-editor/src/store/index.js
@@ -17,11 +17,15 @@ import controls from './controls';
  */
 const MODULE_KEY = 'core/block-editor';
 
-const store = registerStore( MODULE_KEY, {
+export const storeConfig = {
 	reducer,
 	selectors,
 	actions,
 	controls,
+};
+
+const store = registerStore( MODULE_KEY, {
+	...storeConfig,
 	persist: [ 'preferences' ],
 } );
 applyMiddlewares( store );

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -154,6 +154,7 @@ class EditorProvider extends Component {
 				onInput={ resetEditorBlocksWithoutUndoLevel }
 				onChange={ resetEditorBlocks }
 				settings={ editorSettings }
+				useSubRegistry={ false }
 			>
 				{ children }
 				<ReusableBlocksButtons />


### PR DESCRIPTION
This PR automatically creates a subRegistry for each block editor provider making it more like "local state" and making the component more reusable.

We opt-out from this behavior using `useSubRegistry={ false }` in the edit-post module in order to allow access to the `core/block-editor` store from the global registry in the editor page. (BC)

**Testing instructions**

 - Check that you can still call selectors `wp.data.select( 'core/block-editor' ).getBlocks()`
 - Check that the playground work as expected.