### PR TITLE
Adjust paragraph block spacing to use standardised variables

### DIFF
--- a/assets/stylesheets/_variables.scss
+++ b/assets/stylesheets/_variables.scss
@@ -58,8 +58,8 @@ $block-spacing: 4px; // Vertical space between blocks.
 $block-side-ui-width: 28px; // Width of the movers/drag handle UI.
 $block-side-ui-clearance: 2px; // Space between movers/drag handle UI, and block.
 $block-container-side-padding: $block-side-ui-width + $block-padding + 2 * $block-side-ui-clearance; // Total space left and right of the block footprint.
-$block-with-background-v-padding: $block-padding + $block-spacing + $block-side-ui-clearance;
-$block-with-background-h-padding: $block-side-ui-width + $block-side-ui-clearance;
+$block-bg-padding--v: $block-padding + $block-spacing + $block-side-ui-clearance; // padding for Blocks with a background color (eg: paragraph or section)
+$block-bg-padding--h: $block-side-ui-width + $block-side-ui-clearance; // padding for Blocks with a background color (eg: paragraph or section)
 
 // Buttons & UI Widgets
 $radius-round-rectangle: 4px;

--- a/assets/stylesheets/_variables.scss
+++ b/assets/stylesheets/_variables.scss
@@ -58,6 +58,8 @@ $block-spacing: 4px; // Vertical space between blocks.
 $block-side-ui-width: 28px; // Width of the movers/drag handle UI.
 $block-side-ui-clearance: 2px; // Space between movers/drag handle UI, and block.
 $block-container-side-padding: $block-side-ui-width + $block-padding + 2 * $block-side-ui-clearance; // Total space left and right of the block footprint.
+$block-with-background-v-padding: $block-padding + $block-spacing + $block-side-ui-clearance;
+$block-with-background-h-padding: $block-side-ui-width + $block-side-ui-clearance;
 
 // Buttons & UI Widgets
 $radius-round-rectangle: 4px;

--- a/packages/block-library/src/paragraph/style.scss
+++ b/packages/block-library/src/paragraph/style.scss
@@ -36,7 +36,7 @@
 }
 
 p.has-background {
-	padding: 20px 30px;
+	padding: $block-with-background-v-padding $block-with-background-h-padding;
 }
 
 p.has-text-color a {

--- a/packages/block-library/src/paragraph/style.scss
+++ b/packages/block-library/src/paragraph/style.scss
@@ -36,7 +36,7 @@
 }
 
 p.has-background {
-	padding: $block-with-background-v-padding $block-with-background-h-padding;
+	padding: $block-bg-padding--v $block-bg-padding--h;
 }
 
 p.has-text-color a {


### PR DESCRIPTION
## Description
Please see [this discussion](https://github.com/WordPress/gutenberg/pull/13964#issuecomment-477527679) on the Section Block for context.

Essentially we need to ensure that all Blocks which apply padding when they have a background set have the same values set. To do this we need to create some new variables that match up with what is currently set on the paragraph Block.

Adjusting the paragraph Block values seems fraught with danger so we construct new vars to provide new vars which match the existing values.

## Testing

To test just confirm that the values for `padding` on the `<p class="wp-block-paragraph...` have the same values as on `master` (ie: `padding: 20px 30px`).
