### PR TITLE
Adjust clashing shortcuts used for character input

### DIFF
--- a/docs/designers-developers/faq.md
+++ b/docs/designers-developers/faq.md
@@ -102,13 +102,13 @@ This is the canonical list of keyboard shortcuts:
 		</tr>
 		<tr>
 			<td>Navigate to a the next part of the editor (alternative).</td>
-			<td><kbd>Shift</kbd>+<kbd>Alt</kbd>+<kbd>N</kbd></td>
-			<td><kbd>⇧</kbd><kbd>⌥</kbd><kbd>N</kbd></td>
+			<td><kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>N</kbd></td>
+			<td><kbd>⌃</kbd><kbd>⌥</kbd><kbd>N</kbd></td>
 		</tr>
 		<tr>
 			<td>Navigate to the previous part of the editor (alternative).</td>
-			<td><kbd>Shift</kbd>+<kbd>Alt</kbd>+<kbd>P</kbd></td>
-			<td><kbd>⇧</kbd><kbd>⌥</kbd><kbd>P</kbd></td>
+			<td><kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>P</kbd></td>
+			<td><kbd>⌃</kbd><kbd>⌥</kbd><kbd>P</kbd></td>
 		</tr>
 		<tr>
 			<td>Navigate to the nearest toolbar.</td>

--- a/packages/components/src/higher-order/navigate-regions/index.js
+++ b/packages/components/src/higher-order/navigate-regions/index.js
@@ -8,6 +8,7 @@ import classnames from 'classnames';
  */
 import { Component } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import { rawShortcut } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -67,9 +68,9 @@ export default createHigherOrderComponent(
 							bindGlobal
 							shortcuts={ {
 								'ctrl+`': this.focusNextRegion,
-								'shift+alt+n': this.focusNextRegion,
+								[ rawShortcut.access( 'n' ) ]: this.focusNextRegion,
 								'ctrl+shift+`': this.focusPreviousRegion,
-								'shift+alt+p': this.focusPreviousRegion,
+								[ rawShortcut.access( 'p' ) ]: this.focusPreviousRegion,
 							} }
 						/>
 						<WrappedComponent { ...this.props } />

--- a/packages/components/src/keyboard-shortcuts/index.js
+++ b/packages/components/src/keyboard-shortcuts/index.js
@@ -10,20 +10,6 @@ import { forEach } from 'lodash';
  */
 import { Component, Children } from '@wordpress/element';
 
-function throwForInvalidCombination( combination ) {
-	const keys = combination.split( '+' );
-	const modifiers = new Set( keys.filter( ( value ) => value.length > 1 ) );
-	const hasAlt = modifiers.has( 'alt' );
-	const hasShift = modifiers.has( 'shift' );
-
-	if (
-		( modifiers.size === 1 && hasAlt ) ||
-		( modifiers.size === 2 && hasAlt && hasShift )
-	) {
-		throw new Error( `Cannot bind ${ combination }. Alt and Shift+Alt modifiers are reserved for character input.` );
-	}
-}
-
 class KeyboardShortcuts extends Component {
 	constructor() {
 		super( ...arguments );
@@ -38,7 +24,17 @@ class KeyboardShortcuts extends Component {
 
 		forEach( this.props.shortcuts, ( callback, key ) => {
 			if ( process.env.NODE_ENV === 'development' ) {
-				throwForInvalidCombination( key );
+				const keys = key.split( '+' );
+				const modifiers = new Set( keys.filter( ( value ) => value.length > 1 ) );
+				const hasAlt = modifiers.has( 'alt' );
+				const hasShift = modifiers.has( 'shift' );
+
+				if (
+					( modifiers.size === 1 && hasAlt ) ||
+					( modifiers.size === 2 && hasAlt && hasShift )
+				) {
+					throw new Error( `Cannot bind ${ key }. Alt and Shift+Alt modifiers are reserved for character input.` );
+				}
 			}
 
 			const { bindGlobal, eventName } = this.props;

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/config.js
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/config.js
@@ -18,7 +18,6 @@ const {
 	ctrl,
 	alt,
 	ctrlShift,
-	shiftAlt,
 } = displayShortcutList;
 
 const globalShortcuts = {
@@ -60,11 +59,11 @@ const globalShortcuts = {
 			ariaLabel: shortcutAriaLabel.ctrlShift( '`' ),
 		},
 		{
-			keyCombination: shiftAlt( 'n' ),
+			keyCombination: access( 'n' ),
 			description: __( 'Navigate to the next part of the editor (alternative).' ),
 		},
 		{
-			keyCombination: shiftAlt( 'p' ),
+			keyCombination: access( 'p' ),
 			description: __( 'Navigate to the previous part of the editor (alternative).' ),
 		},
 		{


### PR DESCRIPTION
## Description

Fixes #13118. Replaces the `shift+alt` combination with the "standard" WordPress `access` combination.

Also adds a check to `KeyboardShortcuts` to prevent this mistake from happening in the future.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->