### PR TITLE
Restore proper radio button appearance on desktop screens.

### DIFF
--- a/assets/stylesheets/_mixins.scss
+++ b/assets/stylesheets/_mixins.scss
@@ -484,7 +484,7 @@
 			background-color: $white;
 
 			@include break-medium() {
-				margin: -3px 0 0 -3px;
+				margin: 3px 0 0 3px;
 			}
 		}
 	}


### PR DESCRIPTION
#14624 mistakenly used negative pixel values for the position of the dot inside of radio buttons. This PR restores the correct values.

**Before**
<img width="306" alt="Screen Shot 2019-03-28 at 8 52 56 AM" src="https://user-images.githubusercontent.com/1202812/55159405-50133d00-5137-11e9-8cd8-c221c5e43b5e.png">

**After**
<img width="299" alt="Screen Shot 2019-03-28 at 8 52 34 AM" src="https://user-images.githubusercontent.com/1202812/55159410-530e2d80-5137-11e9-877e-52bdb6e09985.png">
