### PR TITLE
Display heading levels dynamically in Heading Options when Heading block is selected

### DIFF
--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -36,13 +36,13 @@ function HeadingEdit( {
 } ) {
 	const { align, content, level, placeholder } = attributes;
 	const tagName = 'h' + level;
-	const BlockControlsLevelsRange = ( levelChoices.length <= 3 ) ?
+	const blockControlsLevelsRange = ( levelChoices.length <= 3 ) ?
 		levelChoices :
 		levelChoices.slice( 1, 4 );
 	return (
 		<Fragment>
 			<BlockControls>
-				<HeadingToolbar levelsRange={ BlockControlsLevelsRange } selectedLevel={ level } onChange={ ( newLevel ) => setAttributes( { level: newLevel } ) } />
+				<HeadingToolbar levelsRange={ blockControlsLevelsRange } selectedLevel={ level } onChange={ ( newLevel ) => setAttributes( { level: newLevel } ) } />
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Heading Settings' ) }>

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -23,6 +23,8 @@ import {
 	AlignmentToolbar,
 } from '@wordpress/block-editor';
 
+const DEFAULT_LEVEL_CHOICES = [ 1, 2, 3, 4, 5, 6 ];
+
 function HeadingEdit( {
 	attributes,
 	setAttributes,
@@ -34,13 +36,13 @@ function HeadingEdit( {
 } ) {
 	const { align, content, level, placeholder } = attributes;
 	const tagName = 'h' + level;
-	const blockControlsLevelsRange = ( levelChoices.length <= 3 ) ?
+	const BlockControlsLevelsRange = ( levelChoices.length <= 3 ) ?
 		levelChoices :
-		levelChoices.slice( 1, 4 ); //
+		levelChoices.slice( 1, 4 );
 	return (
 		<Fragment>
 			<BlockControls>
-				<HeadingToolbar levelsRange={ blockControlsLevelsRange } selectedLevel={ level } onChange={ ( newLevel ) => setAttributes( { level: newLevel } ) } />
+				<HeadingToolbar levelsRange={ BlockControlsLevelsRange } selectedLevel={ level } onChange={ ( newLevel ) => setAttributes( { level: newLevel } ) } />
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Heading Settings' ) }>
@@ -55,7 +57,6 @@ function HeadingEdit( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<h1>HDHEDHJHEJHF</h1>
 			<RichText
 				identifier="content"
 				wrapperClassName="wp-block-heading"
@@ -88,7 +89,7 @@ export default withSelect( ( select ) => {
 	const levelChoices = get(
 		select( 'core/blocks' ).getBlockType( 'core/heading' ),
 		[ 'attributes', 'level', 'enum' ],
-		[]
+		DEFAULT_LEVEL_CHOICES
 	);
 
 	return {

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -36,7 +36,7 @@ function HeadingEdit( {
 	const tagName = 'h' + level;
 	const BlockControlsLevelsRange = ( levelChoices.length <= 3 ) ?
 		levelChoices :
-		levelChoices.slice( 1, 4 );
+		levelChoices.slice( 1, 4 ); //
 	return (
 		<Fragment>
 			<BlockControls>
@@ -83,6 +83,7 @@ function HeadingEdit( {
 }
 
 export default withSelect( ( select ) => {
+	// Parse the h1,h2,h3... choices to level numbers and pass it as a prop.
 	const levelChoices = get(
 		select( 'core/blocks' ).getBlockType( 'core/heading' ),
 		[ 'attributes', 'content', 'selector' ],

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -34,13 +34,13 @@ function HeadingEdit( {
 } ) {
 	const { align, content, level, placeholder } = attributes;
 	const tagName = 'h' + level;
-	const BlockControlsLevelsRange = ( levelChoices.length <= 3 ) ?
+	const blockControlsLevelsRange = ( levelChoices.length <= 3 ) ?
 		levelChoices :
 		levelChoices.slice( 1, 4 ); //
 	return (
 		<Fragment>
 			<BlockControls>
-				<HeadingToolbar levelsRange={ BlockControlsLevelsRange } selectedLevel={ level } onChange={ ( newLevel ) => setAttributes( { level: newLevel } ) } />
+				<HeadingToolbar levelsRange={ blockControlsLevelsRange } selectedLevel={ level } onChange={ ( newLevel ) => setAttributes( { level: newLevel } ) } />
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Heading Settings' ) }>
@@ -55,6 +55,7 @@ function HeadingEdit( {
 					/>
 				</PanelBody>
 			</InspectorControls>
+			<h1>HDHEDHJHEJHF</h1>
 			<RichText
 				identifier="content"
 				wrapperClassName="wp-block-heading"

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import HeadingToolbar from './heading-toolbar';
@@ -10,6 +15,7 @@ import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { PanelBody } from '@wordpress/components';
 import { createBlock } from '@wordpress/blocks';
+import { withSelect } from '@wordpress/data';
 import {
 	RichText,
 	BlockControls,
@@ -17,26 +23,29 @@ import {
 	AlignmentToolbar,
 } from '@wordpress/block-editor';
 
-export default function HeadingEdit( {
+function HeadingEdit( {
 	attributes,
 	setAttributes,
 	mergeBlocks,
 	insertBlocksAfter,
 	onReplace,
 	className,
+	levelChoices,
 } ) {
 	const { align, content, level, placeholder } = attributes;
 	const tagName = 'h' + level;
-
+	const BlockControlsLevelsRange = ( levelChoices.length <= 3 ) ?
+		levelChoices :
+		levelChoices.slice( 1, 4 );
 	return (
 		<Fragment>
 			<BlockControls>
-				<HeadingToolbar minLevel={ 2 } maxLevel={ 5 } selectedLevel={ level } onChange={ ( newLevel ) => setAttributes( { level: newLevel } ) } />
+				<HeadingToolbar levelsRange={ BlockControlsLevelsRange } selectedLevel={ level } onChange={ ( newLevel ) => setAttributes( { level: newLevel } ) } />
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Heading Settings' ) }>
 					<p>{ __( 'Level' ) }</p>
-					<HeadingToolbar minLevel={ 1 } maxLevel={ 7 } selectedLevel={ level } onChange={ ( newLevel ) => setAttributes( { level: newLevel } ) } />
+					<HeadingToolbar levelsRange={ levelChoices } selectedLevel={ level } onChange={ ( newLevel ) => setAttributes( { level: newLevel } ) } />
 					<p>{ __( 'Text Alignment' ) }</p>
 					<AlignmentToolbar
 						value={ align }
@@ -72,3 +81,17 @@ export default function HeadingEdit( {
 		</Fragment>
 	);
 }
+
+export default withSelect( ( select ) => {
+	const levelChoices = get(
+		select( 'core/blocks' ).getBlockType( 'core/heading' ),
+		[ 'attributes', 'content', 'selector' ],
+		''
+	)
+		.split( ',' )
+		.map( ( choice ) => Number( choice.substring( 1 ) ) );
+
+	return {
+		levelChoices,
+	};
+} )( HeadingEdit );

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -86,13 +86,12 @@ export default withSelect( ( select ) => {
 	// Parse the h1,h2,h3... choices to level numbers and pass it as a prop.
 	const levelChoices = get(
 		select( 'core/blocks' ).getBlockType( 'core/heading' ),
-		[ 'attributes', 'content', 'selector' ],
-		''
-	)
-		.split( ',' )
-		.map( ( choice ) => Number( choice.substring( 1 ) ) );
+		[ 'attributes', 'level', 'enum' ],
+		[]
+	);
 
 	return {
 		levelChoices,
 	};
 } )( HeadingEdit );
+

--- a/packages/block-library/src/heading/heading-toolbar.js
+++ b/packages/block-library/src/heading/heading-toolbar.js
@@ -23,9 +23,10 @@ class HeadingToolbar extends Component {
 	}
 
 	render() {
-		const { minLevel, maxLevel, selectedLevel, onChange } = this.props;
+		const { minLevel, maxLevel, selectedLevel, onChange, levelsRange = [] } = this.props;
+		const controls = ( levelsRange.length > 0 ) ? levelsRange : range( minLevel, maxLevel );
 		return (
-			<Toolbar controls={ range( minLevel, maxLevel ).map( ( index ) => this.createLevelControl( index, selectedLevel, onChange ) ) } />
+			<Toolbar controls={ controls.map( ( index ) => this.createLevelControl( index, selectedLevel, onChange ) ) } />
 		);
 	}
 }

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -49,6 +49,7 @@ const schema = {
 	level: {
 		type: 'number',
 		default: 2,
+		enum: [ 1, 2, 3, 4, 5, 6 ],
 	},
 	align: {
 		type: 'string',


### PR DESCRIPTION
## Description
1. `public_html/wp-content/plugins/gutenberg/packages/block-library/src/heading/edit.js` now parses the heading selector choices into numbers and dynamically display them as selector options in sidebar and toolbar.
2. `public_html/wp-content/plugins/gutenberg/packages/block-library/src/heading/heading-toolbar.js` (`HeadingToolbar` component) now accepts another parameter, `levelsRange`, that allows passing a list of levels instead of min/max values. This would allow passing heading lists like H1, H3, H5... instead of the common H1, H2, H3, H4, H5.
3. If the `levelsRange` prop is preset, the `minLevel` and the `maxLevel` props will be ignored. I couldn't come up with another solution to keep backward compatibility for other developers that could be using this component in their own JS.

## How has this been tested?
- Create a new post and add a new heading block.
- Use the following code to change the heading selector options:

```js
wp.hooks.addFilter( 'blocks.registerBlockType', 'heading-blocks-settings', ( settings, blockName ) => {
	if ( blockName !== 'core/heading' ) {
		return settings;
	}

	const { attributes = {} } = settings;
	return {
		...settings,
		attributes: {
			...attributes,
			content: {
				...attributes.content,
				selector: 'h2,h3,h4',
			},
		},
	};
} );
```

And you should see just a subset of headings to choose:

![Captura de pantalla 2019-03-28 a las 18 28 37](https://user-images.githubusercontent.com/1516569/55179285-68ab4380-5187-11e9-90f3-9714e9d7381c.png)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
