### PR TITLE
Data: Avoid unsetting insertUsage preference in block editor migration

### DIFF
--- a/packages/data/src/plugins/persistence/index.js
+++ b/packages/data/src/plugins/persistence/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { merge, isPlainObject, omit } from 'lodash';
+import { merge, isPlainObject, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -209,20 +209,18 @@ persistencePlugin.__unstableMigrate = ( pluginOptions ) => {
 	const persistence = createPersistenceInterface( pluginOptions );
 
 	// Preferences migration to introduce the block editor module
-	const persistedState = persistence.get();
-	const coreEditorState = persistedState[ 'core/editor' ];
-	if ( coreEditorState && coreEditorState.preferences && coreEditorState.preferences.insertUsage ) {
-		const blockEditorState = {
-			preferences: {
-				insertUsage: coreEditorState.preferences.insertUsage,
-			},
-		};
+	const insertUsage = get( persistence.get(), [
+		'core/editor',
+		'preferences',
+		'insertUsage',
+	] );
 
-		persistence.set( 'core/editor', {
-			...coreEditorState,
-			preferences: omit( coreEditorState.preferences, [ 'insertUsage' ] ),
+	if ( insertUsage ) {
+		persistence.set( 'core/block-editor', {
+			preferences: {
+				insertUsage,
+			},
 		} );
-		persistence.set( 'core/block-editor', blockEditorState );
 	}
 };
 

--- a/packages/data/src/plugins/persistence/index.js
+++ b/packages/data/src/plugins/persistence/index.js
@@ -72,7 +72,7 @@ export function createPersistenceInterface( options ) {
 	 *
 	 * @return {Object} Persisted data.
 	 */
-	function get() {
+	function getData() {
 		if ( data === undefined ) {
 			// If unset, getItem is expected to return null. Fall back to
 			// empty object.
@@ -99,12 +99,15 @@ export function createPersistenceInterface( options ) {
 	 * @param {string} key   Key to update.
 	 * @param {*}      value Updated value.
 	 */
-	function set( key, value ) {
+	function setData( key, value ) {
 		data = { ...data, [ key ]: value };
 		storage.setItem( storageKey, JSON.stringify( data ) );
 	}
 
-	return { get, set };
+	return {
+		get: getData,
+		set: setData,
+	};
 }
 
 /**


### PR DESCRIPTION
Fixes #14580 

This pull request seeks to remove logic which would unset the `insertUsage` preference when migrating preferences to the `block-editor` module introduced in #13088 . This intends to resolve an issue where downgrading to an earlier version or deactivating the plugin could result in an editor crash due to the missing property.

**Testing instructions:**

1. (Prerequisite) Update to WordPress v5.1.1
   - In other words, be running the latest version, or at least **not** WordPress v5.2.0-beta.1
2. Deactivate Gutenberg from the Plugins screen
3. Navigate to Posts > Add New
4. Clear localStorage
   - `localStorage.clear()` in your Developer Tools Console
5. Reload
6. Click on the writing prompt
   - This initializes the `insertUsage` preference in `core/editor`.
7. Activate Gutenberg plugin from the Plugins screen
   - Make sure the plugin is a built version of this branch.
8. Navigate to Posts > Add New
   - You don't need to take any action, just visit. The preference migration takes place automatically.
9. Deactivate Gutenberg from the Plugins screen
10. Navigate to Posts > Add New
11. Click the Inserter
12. Verify that no error occurs