### PR TITLE
Data: Avoid assuming persisted preferences shape

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1115,7 +1115,7 @@ export const canInsertBlockType = createSelector(
  *                                            the number of inserts that have occurred.
  */
 function getInsertUsage( state, id ) {
-	return state.preferences.insertUsage[ id ] || null;
+	return get( state.preferences.insertUsage, [ id ], null );
 }
 
 /**

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -1927,9 +1927,11 @@ describe( 'selectors', () => {
 						{ id: 1, isTemporary: false, clientId: 'block1', title: 'Reusable Block 1' },
 					],
 				},
-				preferences: {
-					insertUsage: {},
-				},
+				// Intentionally include a test case which considers
+				// `insertUsage` as not present within preferences.
+				//
+				// See: https://github.com/WordPress/gutenberg/issues/14580
+				preferences: {},
 				blockListSettings: {},
 			};
 			const items = getInserterItems( state );

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -139,7 +139,10 @@ export function isEditorPanelEnabled( state, panelName ) {
  */
 export function isEditorPanelOpened( state, panelName ) {
 	const panels = getPreference( state, 'panels' );
-	return panels[ panelName ] === true || get( panels, [ panelName, 'opened' ], false );
+	return (
+		get( panels, [ panelName ] ) === true ||
+		get( panels, [ panelName, 'opened' ] ) === true
+	);
 }
 
 /**
@@ -163,7 +166,7 @@ export function isModalActive( state, modalName ) {
  * @return {boolean} Is active.
  */
 export function isFeatureActive( state, feature ) {
-	return !! state.preferences.features[ feature ];
+	return get( state.preferences.features, [ feature ], false );
 }
 
 /**

--- a/packages/edit-post/src/store/test/selectors.js
+++ b/packages/edit-post/src/store/test/selectors.js
@@ -273,6 +273,15 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'isEditorPanelOpened', () => {
+		it( 'is tolerant to an undefined panels preference', () => {
+			// See: https://github.com/WordPress/gutenberg/issues/14580
+			const state = {
+				preferences: {},
+			};
+
+			expect( isEditorPanelOpened( state, 'post-status' ) ).toBe( false );
+		} );
+
 		it( 'should return false by default', () => {
 			const state = {
 				preferences: {
@@ -333,6 +342,15 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'isFeatureActive', () => {
+		it( 'is tolerant to an undefined features preference', () => {
+			// See: https://github.com/WordPress/gutenberg/issues/14580
+			const state = {
+				preferences: {},
+			};
+
+			expect( isFeatureActive( state, 'chicken' ) ).toBe( false );
+		} );
+
 		it( 'should return true if feature is active', () => {
 			const state = {
 				preferences: {

--- a/packages/nux/src/store/selectors.js
+++ b/packages/nux/src/store/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import createSelector from 'rememo';
-import { includes, difference, keys } from 'lodash';
+import { includes, difference, keys, has } from 'lodash';
 
 /**
  * An object containing information about a guide.
@@ -55,7 +55,7 @@ export function isTipVisible( state, tipId ) {
 		return false;
 	}
 
-	if ( state.preferences.dismissedTips[ tipId ] ) {
+	if ( has( state.preferences.dismissedTips, [ tipId ] ) ) {
 		return false;
 	}
 

--- a/packages/nux/src/store/test/selectors.js
+++ b/packages/nux/src/store/test/selectors.js
@@ -53,6 +53,26 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'isTipVisible', () => {
+		it( 'is tolerant to individual preferences being undefined', () => {
+			// See: https://github.com/WordPress/gutenberg/issues/14580
+			const state = {
+				guides: [],
+				preferences: {},
+			};
+			expect( isTipVisible( state, 'test/tip' ) ).toBe( false );
+		} );
+
+		it( 'is tolerant to undefined dismissedTips', () => {
+			// See: https://github.com/WordPress/gutenberg/issues/14580
+			const state = {
+				guides: [],
+				preferences: {
+					areTipsEnabled: true,
+				},
+			};
+			expect( isTipVisible( state, 'test/tip' ) ).toBe( true );
+		} );
+
 		it( 'should return true by default', () => {
 			const state = {
 				guides: [],


### PR DESCRIPTION
Related: #14580, #14691 

This pull request seeks to update references to persisted preferences objects to avoid assumed shape of individual property values within preferences. See #14580 for additional context.

**Testing instructions:**

Verify unit tests pass:

```
npm run test-unit
```

Extra credit: Verify no regressions in affected behavior (insert usage, feature activation, active sidebar, NUX dismissed tips).