### PR TITLE
Color palette settings button hover tootlip fix.

### DIFF
--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -47,6 +47,8 @@ $color-palette-circle-spacing: 14px;
 	&.is-active {
 		box-shadow: inset 0 0 0 4px;
 		border: $border-width solid $dark-gray-400;
+		position: relative;
+		z-index: 1;
 
 		& + .dashicons-saved {
 			position: absolute;


### PR DESCRIPTION
## Description
Fixes https://github.com/WordPress/gutenberg/issues/14685
Adding `z-index` fixes the issue.

## How has this been tested?
Has been tested locally, more details in gif from below

## Screenshots
![Peek 2019-03-28 23-12](https://user-images.githubusercontent.com/1477453/55193675-54c80780-51b0-11e9-9b47-912e09ba5691.gif)


## Types of changes
Had added few styles to color palette settings button in active state.

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
