### PR TITLE
[Mobile] Accessibility Mark I - Button

### DIFF
--- a/packages/components/src/button/index.native.js
+++ b/packages/components/src/button/index.native.js
@@ -55,6 +55,7 @@ export default function Button( props ) {
 		children,
 		onClick,
 		disabled,
+		hint,
 		'aria-disabled': ariaDisabled,
 		'aria-label': ariaLabel,
 		'aria-pressed': ariaPressed,
@@ -66,12 +67,18 @@ export default function Button( props ) {
 		opacity: isDisabled ? 0.2 : 1,
 		...( ariaPressed ? styles.buttonActive : styles.buttonInactive ),
 	};
+	let states = [];
+	ariaPressed && states.push( 'selected' );
+	isDisabled && states.push( 'disabled' );
 
 	return (
 		<TouchableOpacity
 			activeOpacity={ 0.7 }
 			accessible={ true }
 			accessibilityLabel={ ariaLabel }
+			accessibilityStates={ states }
+			accessibilityRole={ 'button' }
+			accessibilityHint={ hint }
 			onPress={ onClick }
 			style={ styles.container }
 			disabled={ isDisabled }

--- a/packages/components/src/button/index.native.js
+++ b/packages/components/src/button/index.native.js
@@ -67,9 +67,15 @@ export default function Button( props ) {
 		opacity: isDisabled ? 0.2 : 1,
 		...( ariaPressed ? styles.buttonActive : styles.buttonInactive ),
 	};
-	let states = [];
-	ariaPressed && states.push( 'selected' );
-	isDisabled && states.push( 'disabled' );
+
+	const states = [];
+	if ( ariaPressed ) {
+		states.push( 'selected' );
+	}
+
+	if ( isDisabled ) {
+		states.push( 'disabled' );
+	}
 
 	return (
 		<TouchableOpacity


### PR DESCRIPTION
This PR improves the Accessibility features of the `Button` component.

To test:
- Refer to the [`gutenberg-mobile` side PR.](https://github.com/wordpress-mobile/gutenberg-mobile/pull/793)