### PR TITLE
Pin branch used to build handbook

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2,1297 +2,1297 @@
 	{
 		"title": "Gutenberg Handbook",
 		"slug": "handbook",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/readme.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/readme.md",
 		"parent": null
 	},
 	{
 		"title": "Designer & Developer Handbook",
 		"slug": "designers-developers",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/readme.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/readme.md",
 		"parent": null
 	},
 	{
 		"title": "Key Concepts",
 		"slug": "key-concepts",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/key-concepts.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/key-concepts.md",
 		"parent": "designers-developers"
 	},
 	{
 		"title": "Developer Documentation",
 		"slug": "developers",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/README.md",
 		"parent": "designers-developers"
 	},
 	{
 		"title": "Block API Reference",
 		"slug": "block-api",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/block-api/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/block-api/README.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Block Registration ",
 		"slug": "block-registration",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/block-api/block-registration.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/block-api/block-registration.md",
 		"parent": "block-api"
 	},
 	{
 		"title": "Edit and Save",
 		"slug": "block-edit-save",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/block-api/block-edit-save.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/block-api/block-edit-save.md",
 		"parent": "block-api"
 	},
 	{
 		"title": "Attributes",
 		"slug": "block-attributes",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/block-api/block-attributes.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/block-api/block-attributes.md",
 		"parent": "block-api"
 	},
 	{
 		"title": "Deprecated Blocks",
 		"slug": "block-deprecation",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/block-api/block-deprecation.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/block-api/block-deprecation.md",
 		"parent": "block-api"
 	},
 	{
 		"title": "Templates",
 		"slug": "block-templates",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/block-api/block-templates.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/block-api/block-templates.md",
 		"parent": "block-api"
 	},
 	{
 		"title": "Annotations",
 		"slug": "block-annotations",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/block-api/block-annotations.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/block-api/block-annotations.md",
 		"parent": "block-api"
 	},
 	{
 		"title": "Filter Reference",
 		"slug": "filters",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/filters/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/filters/README.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Block Filters",
 		"slug": "block-filters",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/filters/block-filters.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/filters/block-filters.md",
 		"parent": "filters"
 	},
 	{
 		"title": "Editor Filters (Experimental)",
 		"slug": "editor-filters",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/filters/editor-filters.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/filters/editor-filters.md",
 		"parent": "filters"
 	},
 	{
 		"title": "Parser Filters",
 		"slug": "parser-filters",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/filters/parser-filters.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/filters/parser-filters.md",
 		"parent": "filters"
 	},
 	{
 		"title": "Autocomplete",
 		"slug": "autocomplete-filters",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/filters/autocomplete-filters.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/filters/autocomplete-filters.md",
 		"parent": "filters"
 	},
 	{
 		"title": "Internationalization",
 		"slug": "internationalization",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/internationalization.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/internationalization.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Accessibility",
 		"slug": "accessibility",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/accessibility.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/accessibility.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Feature Flags",
 		"slug": "feature-flags",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/feature-flags.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/feature-flags.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Data Module Reference",
 		"slug": "data",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/data/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/data/README.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Packages",
 		"slug": "packages",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/packages.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/packages.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Components",
 		"slug": "components",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/README.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Theming for Gutenberg",
 		"slug": "themes",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/themes/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/themes/README.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Theme Support",
 		"slug": "theme-support",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/themes/theme-support.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/themes/theme-support.md",
 		"parent": "themes"
 	},
 	{
 		"title": "Backward Compatibility",
 		"slug": "backward-compatibility",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/backward-compatibility/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/backward-compatibility/README.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Deprecations",
 		"slug": "deprecations",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/backward-compatibility/deprecations.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/backward-compatibility/deprecations.md",
 		"parent": "backward-compatibility"
 	},
 	{
 		"title": "Meta Boxes",
 		"slug": "meta-box",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/backward-compatibility/meta-box.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/backward-compatibility/meta-box.md",
 		"parent": "backward-compatibility"
 	},
 	{
 		"title": "Tutorials",
 		"slug": "tutorials",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/readme.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/readme.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Getting Started with JavaScript",
 		"slug": "javascript",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/javascript/readme.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/javascript/readme.md",
 		"parent": "tutorials"
 	},
 	{
 		"title": "Plugins Background",
 		"slug": "plugins-background",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/javascript/plugins-background.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/javascript/plugins-background.md",
 		"parent": "javascript"
 	},
 	{
 		"title": "Loading JavaScript",
 		"slug": "loading-javascript",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/javascript/loading-javascript.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/javascript/loading-javascript.md",
 		"parent": "javascript"
 	},
 	{
 		"title": "Extending the Block Editor",
 		"slug": "extending-the-block-editor",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/javascript/extending-the-block-editor.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/javascript/extending-the-block-editor.md",
 		"parent": "javascript"
 	},
 	{
 		"title": "Troubleshooting",
 		"slug": "troubleshooting",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/javascript/troubleshooting.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/javascript/troubleshooting.md",
 		"parent": "javascript"
 	},
 	{
 		"title": "JavaScript Versions and Build Step",
 		"slug": "versions-and-building",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/javascript/versions-and-building.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/javascript/versions-and-building.md",
 		"parent": "javascript"
 	},
 	{
 		"title": "Scope Your Code",
 		"slug": "scope-your-code",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/javascript/scope-your-code.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/javascript/scope-your-code.md",
 		"parent": "javascript"
 	},
 	{
 		"title": "JavaScript Build Setup",
 		"slug": "js-build-setup",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md",
 		"parent": "javascript"
 	},
 	{
 		"title": "Blocks",
 		"slug": "block-tutorial",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/block-tutorial/readme.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/block-tutorial/readme.md",
 		"parent": "tutorials"
 	},
 	{
 		"title": "Writing Your First Block Type",
 		"slug": "writing-your-first-block-type",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md",
 		"parent": "block-tutorial"
 	},
 	{
 		"title": "Applying Styles From a Stylesheet",
 		"slug": "applying-styles-with-stylesheets",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/block-tutorial/applying-styles-with-stylesheets.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/block-tutorial/applying-styles-with-stylesheets.md",
 		"parent": "block-tutorial"
 	},
 	{
 		"title": "Introducing Attributes and Editable Fields",
 		"slug": "introducing-attributes-and-editable-fields",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md",
 		"parent": "block-tutorial"
 	},
 	{
 		"title": "Block Controls: Toolbars and Inspector",
 		"slug": "block-controls-toolbars-and-inspector",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/block-tutorial/block-controls-toolbars-and-inspector.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/block-tutorial/block-controls-toolbars-and-inspector.md",
 		"parent": "block-tutorial"
 	},
 	{
 		"title": "Creating dynamic blocks",
 		"slug": "creating-dynamic-blocks",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/block-tutorial/creating-dynamic-blocks.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/block-tutorial/creating-dynamic-blocks.md",
 		"parent": "block-tutorial"
 	},
 	{
 		"title": "Generate Blocks with WP-CLI",
 		"slug": "generate-blocks-with-wp-cli",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/block-tutorial/generate-blocks-with-wp-cli.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/block-tutorial/generate-blocks-with-wp-cli.md",
 		"parent": "block-tutorial"
 	},
 	{
 		"title": "Meta Boxes",
 		"slug": "metabox",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/metabox/readme.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/metabox/readme.md",
 		"parent": "tutorials"
 	},
 	{
 		"title": "Store Post Meta with a Block",
 		"slug": "meta-block-1-intro",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/metabox/meta-block-1-intro.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/metabox/meta-block-1-intro.md",
 		"parent": "metabox"
 	},
 	{
 		"title": "Register Meta Field",
 		"slug": "meta-block-2-register-meta",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/metabox/meta-block-2-register-meta.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/metabox/meta-block-2-register-meta.md",
 		"parent": "metabox"
 	},
 	{
 		"title": "Create Meta Block",
 		"slug": "meta-block-3-add",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md",
 		"parent": "metabox"
 	},
 	{
 		"title": "Use Post Meta Data",
 		"slug": "meta-block-4-use-data",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/metabox/meta-block-4-use-data.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/metabox/meta-block-4-use-data.md",
 		"parent": "metabox"
 	},
 	{
 		"title": "Finishing Touches",
 		"slug": "meta-block-5-finishing",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/metabox/meta-block-5-finishing.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/metabox/meta-block-5-finishing.md",
 		"parent": "metabox"
 	},
 	{
 		"title": "Displaying Notices from Your Plugin or Theme",
 		"slug": "notices",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/notices/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/notices/README.md",
 		"parent": "tutorials"
 	},
 	{
 		"title": "Creating a Sidebar for Your Plugin",
 		"slug": "plugin-sidebar-0",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-0.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-0.md",
 		"parent": "tutorials"
 	},
 	{
 		"title": "Get a Sidebar up and Running",
 		"slug": "plugin-sidebar-1-up-and-running",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-1-up-and-running.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-1-up-and-running.md",
 		"parent": "plugin-sidebar-0"
 	},
 	{
 		"title": "Tweak the sidebar style and add controls",
 		"slug": "plugin-sidebar-2-styles-and-controls",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-2-styles-and-controls.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-2-styles-and-controls.md",
 		"parent": "plugin-sidebar-0"
 	},
 	{
 		"title": "Register the Meta Field",
 		"slug": "plugin-sidebar-3-register-meta",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-3-register-meta.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-3-register-meta.md",
 		"parent": "plugin-sidebar-0"
 	},
 	{
 		"title": "Initialize the Input Control",
 		"slug": "plugin-sidebar-4-initialize-input",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-4-initialize-input.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-4-initialize-input.md",
 		"parent": "plugin-sidebar-0"
 	},
 	{
 		"title": "Update the Meta Field When the Input's Content Changes",
 		"slug": "plugin-sidebar-5-update-meta",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-5-update-meta.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-5-update-meta.md",
 		"parent": "plugin-sidebar-0"
 	},
 	{
 		"title": "Finishing Touches",
 		"slug": "plugin-sidebar-6-finishing-touches",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-6-finishing-touches.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-6-finishing-touches.md",
 		"parent": "plugin-sidebar-0"
 	},
 	{
 		"title": "Introduction to the Format API",
 		"slug": "format-api",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/format-api/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/format-api/README.md",
 		"parent": "tutorials"
 	},
 	{
 		"title": "Register a New Format",
 		"slug": "1-register-format",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/format-api/1-register-format.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/format-api/1-register-format.md",
 		"parent": "format-api"
 	},
 	{
 		"title": "Add a Button to the Toolbar",
 		"slug": "2-toolbar-button",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/format-api/2-toolbar-button.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/format-api/2-toolbar-button.md",
 		"parent": "format-api"
 	},
 	{
 		"title": "Apply the Format When the Button Is Clicked",
 		"slug": "3-apply-format",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/format-api/3-apply-format.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/tutorials/format-api/3-apply-format.md",
 		"parent": "format-api"
 	},
 	{
 		"title": "Designer Documentation",
 		"slug": "designers",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/designers/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/designers/README.md",
 		"parent": "designers-developers"
 	},
 	{
 		"title": "Block Design",
 		"slug": "block-design",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/designers/block-design.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/designers/block-design.md",
 		"parent": "designers"
 	},
 	{
 		"title": "Patterns",
 		"slug": "design-patterns",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/designers/design-patterns.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/designers/design-patterns.md",
 		"parent": "designers"
 	},
 	{
 		"title": "Resources",
 		"slug": "design-resources",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/designers/design-resources.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/designers/design-resources.md",
 		"parent": "designers"
 	},
 	{
 		"title": "Animation",
 		"slug": "animation",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/designers/animation.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/designers/animation.md",
 		"parent": "designers"
 	},
 	{
 		"title": "Contributors Guide",
 		"slug": "contributors",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/readme.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/contributors/readme.md",
 		"parent": null
 	},
 	{
 		"title": "Principles",
 		"slug": "principles",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/principles.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/contributors/principles.md",
 		"parent": "contributors"
 	},
 	{
 		"title": "Design Principles & Vision",
 		"slug": "design",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/design.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/contributors/design.md",
 		"parent": "contributors"
 	},
 	{
 		"title": "Blocks are the Interface",
 		"slug": "the-block",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/principles/the-block.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/contributors/principles/the-block.md",
 		"parent": "design"
 	},
 	{
 		"title": "Reference",
 		"slug": "reference",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/reference.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/contributors/reference.md",
 		"parent": "design"
 	},
 	{
 		"title": "Developer Contributions",
 		"slug": "develop",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/develop.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/contributors/develop.md",
 		"parent": "contributors"
 	},
 	{
 		"title": "Coding Guidelines",
 		"slug": "coding-guidelines",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/coding-guidelines.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/contributors/coding-guidelines.md",
 		"parent": "develop"
 	},
 	{
 		"title": "Testing Overview",
 		"slug": "testing-overview",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/testing-overview.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/contributors/testing-overview.md",
 		"parent": "develop"
 	},
 	{
 		"title": "Git Workflow",
 		"slug": "git-workflow",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/git-workflow.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/contributors/git-workflow.md",
 		"parent": "develop"
 	},
 	{
 		"title": "Block Grammar",
 		"slug": "grammar",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/grammar.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/contributors/grammar.md",
 		"parent": "develop"
 	},
 	{
 		"title": "Scripts",
 		"slug": "scripts",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/scripts.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/contributors/scripts.md",
 		"parent": "develop"
 	},
 	{
 		"title": "Gutenberg Release Process",
 		"slug": "release",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/release.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/contributors/release.md",
 		"parent": "develop"
 	},
 	{
 		"title": "Documentation Contributions",
 		"slug": "document",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/document.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/contributors/document.md",
 		"parent": "contributors"
 	},
 	{
 		"title": "Copy Guidelines",
 		"slug": "copy-guide",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/copy-guide.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/contributors/copy-guide.md",
 		"parent": "document"
 	},
 	{
 		"title": "History",
 		"slug": "history",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/history.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/contributors/history.md",
 		"parent": "contributors"
 	},
 	{
 		"title": "Glossary",
 		"slug": "glossary",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/glossary.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/glossary.md",
 		"parent": "contributors"
 	},
 	{
 		"title": "Frequently Asked Questions",
 		"slug": "faq",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/faq.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/faq.md",
 		"parent": "contributors"
 	},
 	{
 		"title": "Repository Management",
 		"slug": "repository-management",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/repository-management.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/contributors/repository-management.md",
 		"parent": "contributors"
 	},
 	{
 		"title": "Outreach",
 		"slug": "outreach",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/outreach.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/contributors/outreach.md",
 		"parent": "contributors"
 	},
 	{
 		"title": "@wordpress/a11y",
 		"slug": "packages-a11y",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/a11y/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/a11y/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/annotations",
 		"slug": "packages-annotations",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/annotations/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/annotations/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/api-fetch",
 		"slug": "packages-api-fetch",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/api-fetch/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/api-fetch/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/autop",
 		"slug": "packages-autop",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/autop/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/autop/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/babel-plugin-import-jsx-pragma",
 		"slug": "packages-babel-plugin-import-jsx-pragma",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/babel-plugin-import-jsx-pragma/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/babel-plugin-import-jsx-pragma/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/babel-plugin-makepot",
 		"slug": "packages-babel-plugin-makepot",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/babel-plugin-makepot/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/babel-plugin-makepot/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/babel-preset-default",
 		"slug": "packages-babel-preset-default",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/babel-preset-default/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/babel-preset-default/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/blob",
 		"slug": "packages-blob",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/blob/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/blob/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/block-editor",
 		"slug": "packages-block-editor",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/block-editor/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/block-editor/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/block-library",
 		"slug": "packages-block-library",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/block-library/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/block-library/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/block-serialization-default-parser",
 		"slug": "packages-block-serialization-default-parser",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/block-serialization-default-parser/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/block-serialization-default-parser/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/block-serialization-spec-parser",
 		"slug": "packages-block-serialization-spec-parser",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/block-serialization-spec-parser/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/block-serialization-spec-parser/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/blocks",
 		"slug": "packages-blocks",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/blocks/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/blocks/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/browserslist-config",
 		"slug": "packages-browserslist-config",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/browserslist-config/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/browserslist-config/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/components",
 		"slug": "packages-components",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/compose",
 		"slug": "packages-compose",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/compose/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/compose/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/core-data",
 		"slug": "packages-core-data",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/core-data/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/core-data/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/custom-templated-path-webpack-plugin",
 		"slug": "packages-custom-templated-path-webpack-plugin",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/custom-templated-path-webpack-plugin/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/custom-templated-path-webpack-plugin/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/data",
 		"slug": "packages-data",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/data/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/data/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/date",
 		"slug": "packages-date",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/date/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/date/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/deprecated",
 		"slug": "packages-deprecated",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/deprecated/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/deprecated/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/docgen",
 		"slug": "packages-docgen",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/docgen/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/docgen/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/dom-ready",
 		"slug": "packages-dom-ready",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/dom-ready/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/dom-ready/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/dom",
 		"slug": "packages-dom",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/dom/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/dom/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/e2e-test-utils",
 		"slug": "packages-e2e-test-utils",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/e2e-test-utils/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/e2e-test-utils/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/e2e-tests",
 		"slug": "packages-e2e-tests",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/e2e-tests/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/e2e-tests/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/edit-post",
 		"slug": "packages-edit-post",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/edit-post/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/edit-post/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/edit-widgets",
 		"slug": "packages-edit-widgets",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/edit-widgets/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/edit-widgets/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/editor",
 		"slug": "packages-editor",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/editor/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/editor/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/element",
 		"slug": "packages-element",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/element/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/element/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/escape-html",
 		"slug": "packages-escape-html",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/escape-html/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/escape-html/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/eslint-plugin",
 		"slug": "packages-eslint-plugin",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/eslint-plugin/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/eslint-plugin/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/format-library",
 		"slug": "packages-format-library",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/format-library/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/format-library/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/hooks",
 		"slug": "packages-hooks",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/hooks/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/hooks/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/html-entities",
 		"slug": "packages-html-entities",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/html-entities/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/html-entities/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/i18n",
 		"slug": "packages-i18n",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/i18n/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/i18n/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/is-shallow-equal",
 		"slug": "packages-is-shallow-equal",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/is-shallow-equal/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/is-shallow-equal/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/jest-console",
 		"slug": "packages-jest-console",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/jest-console/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/jest-console/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/jest-preset-default",
 		"slug": "packages-jest-preset-default",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/jest-preset-default/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/jest-preset-default/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/jest-puppeteer-axe",
 		"slug": "packages-jest-puppeteer-axe",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/jest-puppeteer-axe/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/jest-puppeteer-axe/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/keycodes",
 		"slug": "packages-keycodes",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/keycodes/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/keycodes/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/library-export-default-webpack-plugin",
 		"slug": "packages-library-export-default-webpack-plugin",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/library-export-default-webpack-plugin/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/library-export-default-webpack-plugin/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/list-reusable-blocks",
 		"slug": "packages-list-reusable-blocks",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/list-reusable-blocks/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/list-reusable-blocks/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/notices",
 		"slug": "packages-notices",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/notices/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/notices/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/npm-package-json-lint-config",
 		"slug": "packages-npm-package-json-lint-config",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/npm-package-json-lint-config/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/npm-package-json-lint-config/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/nux",
 		"slug": "packages-nux",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/nux/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/nux/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/plugins",
 		"slug": "packages-plugins",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/plugins/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/plugins/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/postcss-themes",
 		"slug": "packages-postcss-themes",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/postcss-themes/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/postcss-themes/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/priority-queue",
 		"slug": "packages-priority-queue",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/priority-queue/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/priority-queue/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/redux-routine",
 		"slug": "packages-redux-routine",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/redux-routine/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/redux-routine/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/rich-text",
 		"slug": "packages-rich-text",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/rich-text/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/rich-text/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/scripts",
 		"slug": "packages-scripts",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/scripts/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/scripts/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/shortcode",
 		"slug": "packages-shortcode",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/shortcode/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/shortcode/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/token-list",
 		"slug": "packages-token-list",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/token-list/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/token-list/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/url",
 		"slug": "packages-url",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/url/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/url/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/viewport",
 		"slug": "packages-viewport",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/viewport/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/viewport/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/wordcount",
 		"slug": "packages-wordcount",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/wordcount/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/wordcount/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "Animate",
 		"slug": "animate",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/animate/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/animate/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Autocomplete",
 		"slug": "autocomplete",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/autocomplete/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/autocomplete/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "BaseControl",
 		"slug": "base-control",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/base-control/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/base-control/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "ButtonGroup",
 		"slug": "button-group",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/button-group/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/button-group/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Button",
 		"slug": "button",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/button/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/button/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "CheckboxControl",
 		"slug": "checkbox-control",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/checkbox-control/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/checkbox-control/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "ClipboardButton",
 		"slug": "clipboard-button",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/clipboard-button/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/clipboard-button/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "ColorIndicator",
 		"slug": "color-indicator",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/color-indicator/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/color-indicator/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "ColorPalette",
 		"slug": "color-palette",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/color-palette/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/color-palette/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "ColorPicker",
 		"slug": "color-picker",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/color-picker/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/color-picker/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Dashicon",
 		"slug": "dashicon",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/dashicon/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/dashicon/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "DateTime",
 		"slug": "date-time",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/date-time/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/date-time/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Disabled",
 		"slug": "disabled",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/disabled/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/disabled/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Draggable",
 		"slug": "draggable",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/draggable/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/draggable/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "DropZone",
 		"slug": "drop-zone",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/drop-zone/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/drop-zone/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "DropdownMenu",
 		"slug": "dropdown-menu",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/dropdown-menu/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/dropdown-menu/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Dropdown",
 		"slug": "dropdown",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/dropdown/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/dropdown/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "ExternalLink",
 		"slug": "external-link",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/external-link/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/external-link/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "FocalPointPicker",
 		"slug": "focal-point-picker",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/focal-point-picker/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/focal-point-picker/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "FocusableIframe",
 		"slug": "focusable-iframe",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/focusable-iframe/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/focusable-iframe/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "FontSizePicker",
 		"slug": "font-size-picker",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/font-size-picker/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/font-size-picker/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "FormFileUpload",
 		"slug": "form-file-upload",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/form-file-upload/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/form-file-upload/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "FormToggle",
 		"slug": "form-toggle",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/form-toggle/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/form-toggle/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "FormTokenField",
 		"slug": "form-token-field",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/form-token-field/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/form-token-field/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "NavigateRegions",
 		"slug": "navigate-regions",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/higher-order/navigate-regions/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/higher-order/navigate-regions/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "HigherOrder",
 		"slug": "higher-order",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/higher-order/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/higher-order/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "WithConstrainedTabbing",
 		"slug": "with-constrained-tabbing",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/higher-order/with-constrained-tabbing/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/higher-order/with-constrained-tabbing/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "WithFallbackStyles",
 		"slug": "with-fallback-styles",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/higher-order/with-fallback-styles/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/higher-order/with-fallback-styles/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "WithFilters",
 		"slug": "with-filters",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/higher-order/with-filters/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/higher-order/with-filters/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "WithFocusOutside",
 		"slug": "with-focus-outside",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/higher-order/with-focus-outside/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/higher-order/with-focus-outside/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "WithFocusReturn",
 		"slug": "with-focus-return",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/higher-order/with-focus-return/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/higher-order/with-focus-return/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "WithNotices",
 		"slug": "with-notices",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/higher-order/with-notices/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/higher-order/with-notices/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "WithSpokenMessages",
 		"slug": "with-spoken-messages",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/higher-order/with-spoken-messages/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/higher-order/with-spoken-messages/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "IconButton",
 		"slug": "icon-button",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/icon-button/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/icon-button/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Icon",
 		"slug": "icon",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/icon/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/icon/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "IsolatedEventContainer",
 		"slug": "isolated-event-container",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/isolated-event-container/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/isolated-event-container/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "KeyboardShortcuts",
 		"slug": "keyboard-shortcuts",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/keyboard-shortcuts/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/keyboard-shortcuts/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "MenuGroup",
 		"slug": "menu-group",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/menu-group/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/menu-group/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "MenuItem",
 		"slug": "menu-item",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/menu-item/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/menu-item/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "MenuItemsChoice",
 		"slug": "menu-items-choice",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/menu-items-choice/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/menu-items-choice/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Modal",
 		"slug": "modal",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/modal/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/modal/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "NavigableContainer",
 		"slug": "navigable-container",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/navigable-container/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/navigable-container/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Notice",
 		"slug": "notice",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/notice/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/notice/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Panel",
 		"slug": "panel",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/panel/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/panel/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Placeholder",
 		"slug": "placeholder",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/placeholder/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/placeholder/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Popover",
 		"slug": "popover",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/popover/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/popover/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Svg",
 		"slug": "svg",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/primitives/svg/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/primitives/svg/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "QueryControls",
 		"slug": "query-controls",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/query-controls/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/query-controls/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "RadioControl",
 		"slug": "radio-control",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/radio-control/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/radio-control/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "RangeControl",
 		"slug": "range-control",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/range-control/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/range-control/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "ResizableBox",
 		"slug": "resizable-box",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/resizable-box/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/resizable-box/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "ResponsiveWrapper",
 		"slug": "responsive-wrapper",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/responsive-wrapper/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/responsive-wrapper/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Sandbox",
 		"slug": "sandbox",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/sandbox/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/sandbox/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "ScrollLock",
 		"slug": "scroll-lock",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/scroll-lock/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/scroll-lock/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "SelectControl",
 		"slug": "select-control",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/select-control/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/select-control/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "ServerSideRender",
 		"slug": "server-side-render",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/server-side-render/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/server-side-render/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "SlotFill",
 		"slug": "slot-fill",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/slot-fill/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/slot-fill/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Spinner",
 		"slug": "spinner",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/spinner/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/spinner/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "TabPanel",
 		"slug": "tab-panel",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/tab-panel/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/tab-panel/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "TextControl",
 		"slug": "text-control",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/text-control/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/text-control/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "TextareaControl",
 		"slug": "textarea-control",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/textarea-control/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/textarea-control/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "ToggleControl",
 		"slug": "toggle-control",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/toggle-control/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/toggle-control/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Toolbar",
 		"slug": "toolbar",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/toolbar/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/toolbar/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Tooltip",
 		"slug": "tooltip",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/tooltip/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/tooltip/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "TreeSelect",
 		"slug": "tree-select",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/tree-select/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/packages/components/src/tree-select/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "WordPress Core Data",
 		"slug": "data-core",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/data/data-core.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/data/data-core.md",
 		"parent": "data"
 	},
 	{
 		"title": "Annotations",
 		"slug": "data-core-annotations",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/data/data-core-annotations.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/data/data-core-annotations.md",
 		"parent": "data"
 	},
 	{
 		"title": "Block Types Data",
 		"slug": "data-core-blocks",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/data/data-core-blocks.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/data/data-core-blocks.md",
 		"parent": "data"
 	},
 	{
 		"title": "The Block Editor’s Data",
 		"slug": "data-core-block-editor",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/data/data-core-block-editor.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/data/data-core-block-editor.md",
 		"parent": "data"
 	},
 	{
 		"title": "The Post Editor’s Data",
 		"slug": "data-core-editor",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/data/data-core-editor.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/data/data-core-editor.md",
 		"parent": "data"
 	},
 	{
 		"title": "The Editor’s UI Data",
 		"slug": "data-core-edit-post",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/data/data-core-edit-post.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/data/data-core-edit-post.md",
 		"parent": "data"
 	},
 	{
 		"title": "Notices Data",
 		"slug": "data-core-notices",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/data/data-core-notices.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/data/data-core-notices.md",
 		"parent": "data"
 	},
 	{
 		"title": "The NUX (New User Experience) Data",
 		"slug": "data-core-nux",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/data/data-core-nux.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/data/data-core-nux.md",
 		"parent": "data"
 	},
 	{
 		"title": "The Viewport Data",
 		"slug": "data-core-viewport",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/data/data-core-viewport.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.2/docs/designers-developers/developers/data/data-core-viewport.md",
 		"parent": "data"
 	}
 ]

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2,1297 +2,1297 @@
 	{
 		"title": "Gutenberg Handbook",
 		"slug": "handbook",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/readme.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/readme.md",
 		"parent": null
 	},
 	{
 		"title": "Designer & Developer Handbook",
 		"slug": "designers-developers",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/readme.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/readme.md",
 		"parent": null
 	},
 	{
 		"title": "Key Concepts",
 		"slug": "key-concepts",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/key-concepts.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/key-concepts.md",
 		"parent": "designers-developers"
 	},
 	{
 		"title": "Developer Documentation",
 		"slug": "developers",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/README.md",
 		"parent": "designers-developers"
 	},
 	{
 		"title": "Block API Reference",
 		"slug": "block-api",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/block-api/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/block-api/README.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Block Registration ",
 		"slug": "block-registration",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/block-api/block-registration.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/block-api/block-registration.md",
 		"parent": "block-api"
 	},
 	{
 		"title": "Edit and Save",
 		"slug": "block-edit-save",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/block-api/block-edit-save.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/block-api/block-edit-save.md",
 		"parent": "block-api"
 	},
 	{
 		"title": "Attributes",
 		"slug": "block-attributes",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/block-api/block-attributes.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/block-api/block-attributes.md",
 		"parent": "block-api"
 	},
 	{
 		"title": "Deprecated Blocks",
 		"slug": "block-deprecation",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/block-api/block-deprecation.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/block-api/block-deprecation.md",
 		"parent": "block-api"
 	},
 	{
 		"title": "Templates",
 		"slug": "block-templates",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/block-api/block-templates.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/block-api/block-templates.md",
 		"parent": "block-api"
 	},
 	{
 		"title": "Annotations",
 		"slug": "block-annotations",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/block-api/block-annotations.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/block-api/block-annotations.md",
 		"parent": "block-api"
 	},
 	{
 		"title": "Filter Reference",
 		"slug": "filters",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/filters/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/filters/README.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Block Filters",
 		"slug": "block-filters",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/filters/block-filters.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/filters/block-filters.md",
 		"parent": "filters"
 	},
 	{
 		"title": "Editor Filters (Experimental)",
 		"slug": "editor-filters",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/filters/editor-filters.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/filters/editor-filters.md",
 		"parent": "filters"
 	},
 	{
 		"title": "Parser Filters",
 		"slug": "parser-filters",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/filters/parser-filters.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/filters/parser-filters.md",
 		"parent": "filters"
 	},
 	{
 		"title": "Autocomplete",
 		"slug": "autocomplete-filters",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/filters/autocomplete-filters.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/filters/autocomplete-filters.md",
 		"parent": "filters"
 	},
 	{
 		"title": "Internationalization",
 		"slug": "internationalization",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/internationalization.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/internationalization.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Accessibility",
 		"slug": "accessibility",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/accessibility.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/accessibility.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Feature Flags",
 		"slug": "feature-flags",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/feature-flags.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/feature-flags.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Data Module Reference",
 		"slug": "data",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/data/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/data/README.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Packages",
 		"slug": "packages",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/packages.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/packages.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Components",
 		"slug": "components",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/README.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Theming for Gutenberg",
 		"slug": "themes",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/themes/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/themes/README.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Theme Support",
 		"slug": "theme-support",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/themes/theme-support.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/themes/theme-support.md",
 		"parent": "themes"
 	},
 	{
 		"title": "Backward Compatibility",
 		"slug": "backward-compatibility",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/backward-compatibility/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/backward-compatibility/README.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Deprecations",
 		"slug": "deprecations",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/backward-compatibility/deprecations.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/backward-compatibility/deprecations.md",
 		"parent": "backward-compatibility"
 	},
 	{
 		"title": "Meta Boxes",
 		"slug": "meta-box",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/backward-compatibility/meta-box.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/backward-compatibility/meta-box.md",
 		"parent": "backward-compatibility"
 	},
 	{
 		"title": "Tutorials",
 		"slug": "tutorials",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/readme.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/readme.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Getting Started with JavaScript",
 		"slug": "javascript",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/javascript/readme.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/javascript/readme.md",
 		"parent": "tutorials"
 	},
 	{
 		"title": "Plugins Background",
 		"slug": "plugins-background",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/javascript/plugins-background.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/javascript/plugins-background.md",
 		"parent": "javascript"
 	},
 	{
 		"title": "Loading JavaScript",
 		"slug": "loading-javascript",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/javascript/loading-javascript.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/javascript/loading-javascript.md",
 		"parent": "javascript"
 	},
 	{
 		"title": "Extending the Block Editor",
 		"slug": "extending-the-block-editor",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/javascript/extending-the-block-editor.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/javascript/extending-the-block-editor.md",
 		"parent": "javascript"
 	},
 	{
 		"title": "Troubleshooting",
 		"slug": "troubleshooting",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/javascript/troubleshooting.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/javascript/troubleshooting.md",
 		"parent": "javascript"
 	},
 	{
 		"title": "JavaScript Versions and Build Step",
 		"slug": "versions-and-building",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/javascript/versions-and-building.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/javascript/versions-and-building.md",
 		"parent": "javascript"
 	},
 	{
 		"title": "Scope Your Code",
 		"slug": "scope-your-code",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/javascript/scope-your-code.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/javascript/scope-your-code.md",
 		"parent": "javascript"
 	},
 	{
 		"title": "JavaScript Build Setup",
 		"slug": "js-build-setup",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md",
 		"parent": "javascript"
 	},
 	{
 		"title": "Blocks",
 		"slug": "block-tutorial",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/block-tutorial/readme.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/block-tutorial/readme.md",
 		"parent": "tutorials"
 	},
 	{
 		"title": "Writing Your First Block Type",
 		"slug": "writing-your-first-block-type",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md",
 		"parent": "block-tutorial"
 	},
 	{
 		"title": "Applying Styles From a Stylesheet",
 		"slug": "applying-styles-with-stylesheets",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/block-tutorial/applying-styles-with-stylesheets.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/block-tutorial/applying-styles-with-stylesheets.md",
 		"parent": "block-tutorial"
 	},
 	{
 		"title": "Introducing Attributes and Editable Fields",
 		"slug": "introducing-attributes-and-editable-fields",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md",
 		"parent": "block-tutorial"
 	},
 	{
 		"title": "Block Controls: Toolbars and Inspector",
 		"slug": "block-controls-toolbars-and-inspector",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/block-tutorial/block-controls-toolbars-and-inspector.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/block-tutorial/block-controls-toolbars-and-inspector.md",
 		"parent": "block-tutorial"
 	},
 	{
 		"title": "Creating dynamic blocks",
 		"slug": "creating-dynamic-blocks",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/block-tutorial/creating-dynamic-blocks.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/block-tutorial/creating-dynamic-blocks.md",
 		"parent": "block-tutorial"
 	},
 	{
 		"title": "Generate Blocks with WP-CLI",
 		"slug": "generate-blocks-with-wp-cli",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/block-tutorial/generate-blocks-with-wp-cli.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/block-tutorial/generate-blocks-with-wp-cli.md",
 		"parent": "block-tutorial"
 	},
 	{
 		"title": "Meta Boxes",
 		"slug": "metabox",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/metabox/readme.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/metabox/readme.md",
 		"parent": "tutorials"
 	},
 	{
 		"title": "Store Post Meta with a Block",
 		"slug": "meta-block-1-intro",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/metabox/meta-block-1-intro.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/metabox/meta-block-1-intro.md",
 		"parent": "metabox"
 	},
 	{
 		"title": "Register Meta Field",
 		"slug": "meta-block-2-register-meta",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/metabox/meta-block-2-register-meta.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/metabox/meta-block-2-register-meta.md",
 		"parent": "metabox"
 	},
 	{
 		"title": "Create Meta Block",
 		"slug": "meta-block-3-add",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md",
 		"parent": "metabox"
 	},
 	{
 		"title": "Use Post Meta Data",
 		"slug": "meta-block-4-use-data",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/metabox/meta-block-4-use-data.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/metabox/meta-block-4-use-data.md",
 		"parent": "metabox"
 	},
 	{
 		"title": "Finishing Touches",
 		"slug": "meta-block-5-finishing",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/metabox/meta-block-5-finishing.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/metabox/meta-block-5-finishing.md",
 		"parent": "metabox"
 	},
 	{
 		"title": "Displaying Notices from Your Plugin or Theme",
 		"slug": "notices",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/notices/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/notices/README.md",
 		"parent": "tutorials"
 	},
 	{
 		"title": "Creating a Sidebar for Your Plugin",
 		"slug": "plugin-sidebar-0",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-0.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-0.md",
 		"parent": "tutorials"
 	},
 	{
 		"title": "Get a Sidebar up and Running",
 		"slug": "plugin-sidebar-1-up-and-running",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-1-up-and-running.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-1-up-and-running.md",
 		"parent": "plugin-sidebar-0"
 	},
 	{
 		"title": "Tweak the sidebar style and add controls",
 		"slug": "plugin-sidebar-2-styles-and-controls",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-2-styles-and-controls.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-2-styles-and-controls.md",
 		"parent": "plugin-sidebar-0"
 	},
 	{
 		"title": "Register the Meta Field",
 		"slug": "plugin-sidebar-3-register-meta",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-3-register-meta.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-3-register-meta.md",
 		"parent": "plugin-sidebar-0"
 	},
 	{
 		"title": "Initialize the Input Control",
 		"slug": "plugin-sidebar-4-initialize-input",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-4-initialize-input.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-4-initialize-input.md",
 		"parent": "plugin-sidebar-0"
 	},
 	{
 		"title": "Update the Meta Field When the Input's Content Changes",
 		"slug": "plugin-sidebar-5-update-meta",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-5-update-meta.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-5-update-meta.md",
 		"parent": "plugin-sidebar-0"
 	},
 	{
 		"title": "Finishing Touches",
 		"slug": "plugin-sidebar-6-finishing-touches",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-6-finishing-touches.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-6-finishing-touches.md",
 		"parent": "plugin-sidebar-0"
 	},
 	{
 		"title": "Introduction to the Format API",
 		"slug": "format-api",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/format-api/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/format-api/README.md",
 		"parent": "tutorials"
 	},
 	{
 		"title": "Register a New Format",
 		"slug": "1-register-format",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/format-api/1-register-format.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/format-api/1-register-format.md",
 		"parent": "format-api"
 	},
 	{
 		"title": "Add a Button to the Toolbar",
 		"slug": "2-toolbar-button",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/format-api/2-toolbar-button.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/format-api/2-toolbar-button.md",
 		"parent": "format-api"
 	},
 	{
 		"title": "Apply the Format When the Button Is Clicked",
 		"slug": "3-apply-format",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/format-api/3-apply-format.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/tutorials/format-api/3-apply-format.md",
 		"parent": "format-api"
 	},
 	{
 		"title": "Designer Documentation",
 		"slug": "designers",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/designers/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/designers/README.md",
 		"parent": "designers-developers"
 	},
 	{
 		"title": "Block Design",
 		"slug": "block-design",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/designers/block-design.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/designers/block-design.md",
 		"parent": "designers"
 	},
 	{
 		"title": "Patterns",
 		"slug": "design-patterns",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/designers/design-patterns.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/designers/design-patterns.md",
 		"parent": "designers"
 	},
 	{
 		"title": "Resources",
 		"slug": "design-resources",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/designers/design-resources.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/designers/design-resources.md",
 		"parent": "designers"
 	},
 	{
 		"title": "Animation",
 		"slug": "animation",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/designers/animation.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/designers/animation.md",
 		"parent": "designers"
 	},
 	{
 		"title": "Contributors Guide",
 		"slug": "contributors",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/readme.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/readme.md",
 		"parent": null
 	},
 	{
 		"title": "Principles",
 		"slug": "principles",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/principles.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/principles.md",
 		"parent": "contributors"
 	},
 	{
 		"title": "Design Principles & Vision",
 		"slug": "design",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/design.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/design.md",
 		"parent": "contributors"
 	},
 	{
 		"title": "Blocks are the Interface",
 		"slug": "the-block",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/principles/the-block.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/principles/the-block.md",
 		"parent": "design"
 	},
 	{
 		"title": "Reference",
 		"slug": "reference",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/reference.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/reference.md",
 		"parent": "design"
 	},
 	{
 		"title": "Developer Contributions",
 		"slug": "develop",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/develop.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/develop.md",
 		"parent": "contributors"
 	},
 	{
 		"title": "Coding Guidelines",
 		"slug": "coding-guidelines",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/coding-guidelines.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/coding-guidelines.md",
 		"parent": "develop"
 	},
 	{
 		"title": "Testing Overview",
 		"slug": "testing-overview",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/testing-overview.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/testing-overview.md",
 		"parent": "develop"
 	},
 	{
 		"title": "Git Workflow",
 		"slug": "git-workflow",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/git-workflow.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/git-workflow.md",
 		"parent": "develop"
 	},
 	{
 		"title": "Block Grammar",
 		"slug": "grammar",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/grammar.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/grammar.md",
 		"parent": "develop"
 	},
 	{
 		"title": "Scripts",
 		"slug": "scripts",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/scripts.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/scripts.md",
 		"parent": "develop"
 	},
 	{
 		"title": "Gutenberg Release Process",
 		"slug": "release",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/release.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/release.md",
 		"parent": "develop"
 	},
 	{
 		"title": "Documentation Contributions",
 		"slug": "document",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/document.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/document.md",
 		"parent": "contributors"
 	},
 	{
 		"title": "Copy Guidelines",
 		"slug": "copy-guide",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/copy-guide.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/copy-guide.md",
 		"parent": "document"
 	},
 	{
 		"title": "History",
 		"slug": "history",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/history.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/history.md",
 		"parent": "contributors"
 	},
 	{
 		"title": "Glossary",
 		"slug": "glossary",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/glossary.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/glossary.md",
 		"parent": "contributors"
 	},
 	{
 		"title": "Frequently Asked Questions",
 		"slug": "faq",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/faq.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/faq.md",
 		"parent": "contributors"
 	},
 	{
 		"title": "Repository Management",
 		"slug": "repository-management",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/repository-management.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/repository-management.md",
 		"parent": "contributors"
 	},
 	{
 		"title": "Outreach",
 		"slug": "outreach",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/outreach.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/contributors/outreach.md",
 		"parent": "contributors"
 	},
 	{
 		"title": "@wordpress/a11y",
 		"slug": "packages-a11y",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/a11y/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/a11y/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/annotations",
 		"slug": "packages-annotations",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/annotations/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/annotations/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/api-fetch",
 		"slug": "packages-api-fetch",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/api-fetch/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/api-fetch/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/autop",
 		"slug": "packages-autop",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/autop/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/autop/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/babel-plugin-import-jsx-pragma",
 		"slug": "packages-babel-plugin-import-jsx-pragma",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/babel-plugin-import-jsx-pragma/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/babel-plugin-import-jsx-pragma/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/babel-plugin-makepot",
 		"slug": "packages-babel-plugin-makepot",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/babel-plugin-makepot/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/babel-plugin-makepot/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/babel-preset-default",
 		"slug": "packages-babel-preset-default",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/babel-preset-default/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/babel-preset-default/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/blob",
 		"slug": "packages-blob",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/blob/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/blob/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/block-editor",
 		"slug": "packages-block-editor",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/block-editor/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/block-editor/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/block-library",
 		"slug": "packages-block-library",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/block-library/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/block-library/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/block-serialization-default-parser",
 		"slug": "packages-block-serialization-default-parser",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/block-serialization-default-parser/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/block-serialization-default-parser/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/block-serialization-spec-parser",
 		"slug": "packages-block-serialization-spec-parser",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/block-serialization-spec-parser/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/block-serialization-spec-parser/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/blocks",
 		"slug": "packages-blocks",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/blocks/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/blocks/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/browserslist-config",
 		"slug": "packages-browserslist-config",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/browserslist-config/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/browserslist-config/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/components",
 		"slug": "packages-components",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/compose",
 		"slug": "packages-compose",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/compose/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/compose/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/core-data",
 		"slug": "packages-core-data",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/core-data/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/core-data/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/custom-templated-path-webpack-plugin",
 		"slug": "packages-custom-templated-path-webpack-plugin",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/custom-templated-path-webpack-plugin/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/custom-templated-path-webpack-plugin/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/data",
 		"slug": "packages-data",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/data/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/data/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/date",
 		"slug": "packages-date",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/date/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/date/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/deprecated",
 		"slug": "packages-deprecated",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/deprecated/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/deprecated/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/docgen",
 		"slug": "packages-docgen",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/docgen/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/docgen/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/dom-ready",
 		"slug": "packages-dom-ready",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/dom-ready/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/dom-ready/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/dom",
 		"slug": "packages-dom",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/dom/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/dom/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/e2e-test-utils",
 		"slug": "packages-e2e-test-utils",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/e2e-test-utils/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/e2e-test-utils/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/e2e-tests",
 		"slug": "packages-e2e-tests",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/e2e-tests/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/e2e-tests/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/edit-post",
 		"slug": "packages-edit-post",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/edit-post/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/edit-post/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/edit-widgets",
 		"slug": "packages-edit-widgets",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/edit-widgets/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/edit-widgets/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/editor",
 		"slug": "packages-editor",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/editor/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/editor/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/element",
 		"slug": "packages-element",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/element/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/element/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/escape-html",
 		"slug": "packages-escape-html",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/escape-html/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/escape-html/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/eslint-plugin",
 		"slug": "packages-eslint-plugin",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/eslint-plugin/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/eslint-plugin/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/format-library",
 		"slug": "packages-format-library",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/format-library/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/format-library/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/hooks",
 		"slug": "packages-hooks",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/hooks/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/hooks/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/html-entities",
 		"slug": "packages-html-entities",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/html-entities/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/html-entities/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/i18n",
 		"slug": "packages-i18n",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/i18n/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/i18n/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/is-shallow-equal",
 		"slug": "packages-is-shallow-equal",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/is-shallow-equal/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/is-shallow-equal/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/jest-console",
 		"slug": "packages-jest-console",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/jest-console/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/jest-console/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/jest-preset-default",
 		"slug": "packages-jest-preset-default",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/jest-preset-default/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/jest-preset-default/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/jest-puppeteer-axe",
 		"slug": "packages-jest-puppeteer-axe",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/jest-puppeteer-axe/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/jest-puppeteer-axe/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/keycodes",
 		"slug": "packages-keycodes",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/keycodes/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/keycodes/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/library-export-default-webpack-plugin",
 		"slug": "packages-library-export-default-webpack-plugin",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/library-export-default-webpack-plugin/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/library-export-default-webpack-plugin/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/list-reusable-blocks",
 		"slug": "packages-list-reusable-blocks",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/list-reusable-blocks/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/list-reusable-blocks/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/notices",
 		"slug": "packages-notices",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/notices/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/notices/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/npm-package-json-lint-config",
 		"slug": "packages-npm-package-json-lint-config",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/npm-package-json-lint-config/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/npm-package-json-lint-config/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/nux",
 		"slug": "packages-nux",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/nux/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/nux/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/plugins",
 		"slug": "packages-plugins",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/plugins/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/plugins/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/postcss-themes",
 		"slug": "packages-postcss-themes",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/postcss-themes/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/postcss-themes/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/priority-queue",
 		"slug": "packages-priority-queue",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/priority-queue/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/priority-queue/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/redux-routine",
 		"slug": "packages-redux-routine",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/redux-routine/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/redux-routine/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/rich-text",
 		"slug": "packages-rich-text",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/rich-text/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/rich-text/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/scripts",
 		"slug": "packages-scripts",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/scripts/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/scripts/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/shortcode",
 		"slug": "packages-shortcode",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/shortcode/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/shortcode/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/token-list",
 		"slug": "packages-token-list",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/token-list/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/token-list/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/url",
 		"slug": "packages-url",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/url/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/url/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/viewport",
 		"slug": "packages-viewport",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/viewport/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/viewport/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "@wordpress/wordcount",
 		"slug": "packages-wordcount",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/wordcount/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/wordcount/README.md",
 		"parent": "packages"
 	},
 	{
 		"title": "Animate",
 		"slug": "animate",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/animate/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/animate/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Autocomplete",
 		"slug": "autocomplete",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/autocomplete/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/autocomplete/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "BaseControl",
 		"slug": "base-control",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/base-control/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/base-control/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "ButtonGroup",
 		"slug": "button-group",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/button-group/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/button-group/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Button",
 		"slug": "button",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/button/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/button/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "CheckboxControl",
 		"slug": "checkbox-control",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/checkbox-control/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/checkbox-control/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "ClipboardButton",
 		"slug": "clipboard-button",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/clipboard-button/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/clipboard-button/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "ColorIndicator",
 		"slug": "color-indicator",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/color-indicator/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/color-indicator/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "ColorPalette",
 		"slug": "color-palette",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/color-palette/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/color-palette/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "ColorPicker",
 		"slug": "color-picker",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/color-picker/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/color-picker/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Dashicon",
 		"slug": "dashicon",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/dashicon/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/dashicon/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "DateTime",
 		"slug": "date-time",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/date-time/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/date-time/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Disabled",
 		"slug": "disabled",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/disabled/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/disabled/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Draggable",
 		"slug": "draggable",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/draggable/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/draggable/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "DropZone",
 		"slug": "drop-zone",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/drop-zone/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/drop-zone/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "DropdownMenu",
 		"slug": "dropdown-menu",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/dropdown-menu/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/dropdown-menu/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Dropdown",
 		"slug": "dropdown",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/dropdown/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/dropdown/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "ExternalLink",
 		"slug": "external-link",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/external-link/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/external-link/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "FocalPointPicker",
 		"slug": "focal-point-picker",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/focal-point-picker/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/focal-point-picker/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "FocusableIframe",
 		"slug": "focusable-iframe",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/focusable-iframe/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/focusable-iframe/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "FontSizePicker",
 		"slug": "font-size-picker",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/font-size-picker/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/font-size-picker/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "FormFileUpload",
 		"slug": "form-file-upload",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/form-file-upload/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/form-file-upload/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "FormToggle",
 		"slug": "form-toggle",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/form-toggle/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/form-toggle/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "FormTokenField",
 		"slug": "form-token-field",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/form-token-field/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/form-token-field/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "NavigateRegions",
 		"slug": "navigate-regions",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/higher-order/navigate-regions/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/higher-order/navigate-regions/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "HigherOrder",
 		"slug": "higher-order",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/higher-order/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/higher-order/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "WithConstrainedTabbing",
 		"slug": "with-constrained-tabbing",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/higher-order/with-constrained-tabbing/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/higher-order/with-constrained-tabbing/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "WithFallbackStyles",
 		"slug": "with-fallback-styles",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/higher-order/with-fallback-styles/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/higher-order/with-fallback-styles/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "WithFilters",
 		"slug": "with-filters",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/higher-order/with-filters/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/higher-order/with-filters/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "WithFocusOutside",
 		"slug": "with-focus-outside",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/higher-order/with-focus-outside/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/higher-order/with-focus-outside/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "WithFocusReturn",
 		"slug": "with-focus-return",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/higher-order/with-focus-return/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/higher-order/with-focus-return/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "WithNotices",
 		"slug": "with-notices",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/higher-order/with-notices/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/higher-order/with-notices/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "WithSpokenMessages",
 		"slug": "with-spoken-messages",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/higher-order/with-spoken-messages/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/higher-order/with-spoken-messages/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "IconButton",
 		"slug": "icon-button",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/icon-button/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/icon-button/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Icon",
 		"slug": "icon",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/icon/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/icon/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "IsolatedEventContainer",
 		"slug": "isolated-event-container",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/isolated-event-container/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/isolated-event-container/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "KeyboardShortcuts",
 		"slug": "keyboard-shortcuts",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/keyboard-shortcuts/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/keyboard-shortcuts/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "MenuGroup",
 		"slug": "menu-group",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/menu-group/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/menu-group/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "MenuItem",
 		"slug": "menu-item",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/menu-item/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/menu-item/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "MenuItemsChoice",
 		"slug": "menu-items-choice",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/menu-items-choice/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/menu-items-choice/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Modal",
 		"slug": "modal",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/modal/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/modal/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "NavigableContainer",
 		"slug": "navigable-container",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/navigable-container/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/navigable-container/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Notice",
 		"slug": "notice",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/notice/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/notice/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Panel",
 		"slug": "panel",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/panel/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/panel/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Placeholder",
 		"slug": "placeholder",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/placeholder/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/placeholder/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Popover",
 		"slug": "popover",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/popover/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/popover/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Svg",
 		"slug": "svg",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/primitives/svg/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/primitives/svg/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "QueryControls",
 		"slug": "query-controls",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/query-controls/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/query-controls/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "RadioControl",
 		"slug": "radio-control",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/radio-control/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/radio-control/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "RangeControl",
 		"slug": "range-control",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/range-control/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/range-control/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "ResizableBox",
 		"slug": "resizable-box",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/resizable-box/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/resizable-box/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "ResponsiveWrapper",
 		"slug": "responsive-wrapper",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/responsive-wrapper/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/responsive-wrapper/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Sandbox",
 		"slug": "sandbox",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/sandbox/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/sandbox/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "ScrollLock",
 		"slug": "scroll-lock",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/scroll-lock/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/scroll-lock/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "SelectControl",
 		"slug": "select-control",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/select-control/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/select-control/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "ServerSideRender",
 		"slug": "server-side-render",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/server-side-render/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/server-side-render/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "SlotFill",
 		"slug": "slot-fill",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/slot-fill/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/slot-fill/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Spinner",
 		"slug": "spinner",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/spinner/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/spinner/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "TabPanel",
 		"slug": "tab-panel",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/tab-panel/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/tab-panel/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "TextControl",
 		"slug": "text-control",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/text-control/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/text-control/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "TextareaControl",
 		"slug": "textarea-control",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/textarea-control/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/textarea-control/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "ToggleControl",
 		"slug": "toggle-control",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/toggle-control/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/toggle-control/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Toolbar",
 		"slug": "toolbar",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/toolbar/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/toolbar/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "Tooltip",
 		"slug": "tooltip",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/tooltip/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/tooltip/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "TreeSelect",
 		"slug": "tree-select",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/tree-select/README.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/packages/components/src/tree-select/README.md",
 		"parent": "components"
 	},
 	{
 		"title": "WordPress Core Data",
 		"slug": "data-core",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/data/data-core.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/data/data-core.md",
 		"parent": "data"
 	},
 	{
 		"title": "Annotations",
 		"slug": "data-core-annotations",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/data/data-core-annotations.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/data/data-core-annotations.md",
 		"parent": "data"
 	},
 	{
 		"title": "Block Types Data",
 		"slug": "data-core-blocks",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/data/data-core-blocks.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/data/data-core-blocks.md",
 		"parent": "data"
 	},
 	{
 		"title": "The Block Editor’s Data",
 		"slug": "data-core-block-editor",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/data/data-core-block-editor.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/data/data-core-block-editor.md",
 		"parent": "data"
 	},
 	{
 		"title": "The Post Editor’s Data",
 		"slug": "data-core-editor",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/data/data-core-editor.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/data/data-core-editor.md",
 		"parent": "data"
 	},
 	{
 		"title": "The Editor’s UI Data",
 		"slug": "data-core-edit-post",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/data/data-core-edit-post.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/data/data-core-edit-post.md",
 		"parent": "data"
 	},
 	{
 		"title": "Notices Data",
 		"slug": "data-core-notices",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/data/data-core-notices.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/data/data-core-notices.md",
 		"parent": "data"
 	},
 	{
 		"title": "The NUX (New User Experience) Data",
 		"slug": "data-core-nux",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/data/data-core-nux.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/data/data-core-nux.md",
 		"parent": "data"
 	},
 	{
 		"title": "The Viewport Data",
 		"slug": "data-core-viewport",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/data/data-core-viewport.md",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.1/docs/designers-developers/developers/data/data-core-viewport.md",
 		"parent": "data"
 	}
 ]

--- a/docs/tool/manifest.js
+++ b/docs/tool/manifest.js
@@ -5,7 +5,7 @@ const { camelCase, kebabCase, nth, upperFirst } = require( 'lodash' );
 
 const fs = require( 'fs' );
 
-const BRANCH = 'wp/5.1';
+const BRANCH = 'wp/5.2';
 const baseRepoUrl = `https://raw.githubusercontent.com/WordPress/gutenberg/${ BRANCH }`;
 
 /**

--- a/docs/tool/manifest.js
+++ b/docs/tool/manifest.js
@@ -5,7 +5,8 @@ const { camelCase, kebabCase, nth, upperFirst } = require( 'lodash' );
 
 const fs = require( 'fs' );
 
-const baseRepoUrl = `https://raw.githubusercontent.com/WordPress/gutenberg/master`;
+const BRANCH = 'master';
+const baseRepoUrl = `https://raw.githubusercontent.com/WordPress/gutenberg/${ BRANCH }`;
 
 /**
  * Generates the package manifest.

--- a/docs/tool/manifest.js
+++ b/docs/tool/manifest.js
@@ -5,7 +5,7 @@ const { camelCase, kebabCase, nth, upperFirst } = require( 'lodash' );
 
 const fs = require( 'fs' );
 
-const BRANCH = 'master';
+const BRANCH = 'wp/5.1';
 const baseRepoUrl = `https://raw.githubusercontent.com/WordPress/gutenberg/${ BRANCH }`;
 
 /**


### PR DESCRIPTION
**NOT TO MERGE YET.**

Fixes https://github.com/WordPress/gutenberg/issues/14303

This will pin the branch contents that will be used to publish the Gutenberg handbook.

Note that current handbook includes contents that people depend on (published [posts](https://make.wordpress.org/core/2019/03/25/building-javascript/) that point to the handbook, etc.) so we can't pin the handbook to `wp/5.1` because that will unpublish the contents.

I'm proposing this to be merged during/after WordPress 5.2 release.
