### PR TITLE
Retry failing embeds with trailing slash

### DIFF
--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -61,8 +61,12 @@ export function getEmbedEditComponent( title, icon, responsive = true ) {
 
 			if ( switchedPreview || switchedURL ) {
 				if ( this.props.cannotEmbed ) {
-					// Can't embed this URL, and we've just received or switched the preview.
-					this.resubmitWithoutTrailingSlash();
+					// We either have a new preview or a new URL, but we can't embed it.
+					if ( ! this.props.fetching ) {
+						// If we're not fetching the preview, then we know it can't be embedded, so try
+						// removing any trailing slash, and resubmit.
+						this.resubmitWithoutTrailingSlash();
+					}
 					return;
 				}
 				this.handleIncomingPreview();

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -62,10 +62,17 @@ export function getEmbedEditComponent( title, icon, responsive = true ) {
 			if ( switchedPreview || switchedURL ) {
 				if ( this.props.cannotEmbed ) {
 					// Can't embed this URL, and we've just received or switched the preview.
+					this.resubmitWithoutTrailingSlash();
 					return;
 				}
 				this.handleIncomingPreview();
 			}
+		}
+
+		resubmitWithoutTrailingSlash() {
+			this.setState( ( prevState ) => ( {
+				url: prevState.url.replace( /\/$/, '' ),
+			} ), this.setUrl );
 		}
 
 		setUrl( event ) {

--- a/packages/e2e-tests/specs/embedding.test.js
+++ b/packages/e2e-tests/specs/embedding.test.js
@@ -63,6 +63,10 @@ const MOCK_BAD_WORDPRESS_RESPONSE = {
 
 const MOCK_RESPONSES = [
 	{
+		match: createEmbeddingMatcher( 'https://wordpress.org/gutenberg/handbook' ),
+		onRequestMatch: createJSONResponse( MOCK_BAD_WORDPRESS_RESPONSE ),
+	},
+	{
 		match: createEmbeddingMatcher( 'https://wordpress.org/gutenberg/handbook/' ),
 		onRequestMatch: createJSONResponse( MOCK_BAD_WORDPRESS_RESPONSE ),
 	},
@@ -81,6 +85,10 @@ const MOCK_RESPONSES = [
 	{
 		match: createEmbeddingMatcher( 'https://twitter.com/notnownikki' ),
 		onRequestMatch: createJSONResponse( MOCK_EMBED_RICH_SUCCESS_RESPONSE ),
+	},
+	{
+		match: createEmbeddingMatcher( 'https://twitter.com/notnownikki/' ),
+		onRequestMatch: createJSONResponse( MOCK_CANT_EMBED_RESPONSE ),
 	},
 	{
 		match: createEmbeddingMatcher( 'https://twitter.com/thatbunty' ),
@@ -173,6 +181,17 @@ describe( 'Embedding content', () => {
 
 		await clickButton( 'Convert to link' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should retry embeds that could not be embedded with trailing slashes, without the trailing slashes', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '/embed' );
+		await page.keyboard.press( 'Enter' );
+		// This URL can't be embedded, but without the trailing slash, it can.
+		await page.keyboard.type( 'https://twitter.com/notnownikki/' );
+		await page.keyboard.press( 'Enter' );
+		// The twitter block should appear correctly.
+		await page.waitForSelector( 'figure.wp-block-embed-twitter' );
 	} );
 
 	it( 'should allow the user to try embedding a failed URL again', async () => {


### PR DESCRIPTION
## Description

Fixes #12664.

Based on #14600.

When a URL can't be embedded, and it has a trailing slash, this resubmits without the trailing slash, so catch cases where people put trailing slashes at the end of twitter URLs, for example.

## How has this been tested?

1. Embed a valid Twitter URLs containing a trailing slash
2. Embed valid Twitter URLs NOT containing a trailing slash
3. Embed a Twitter URL with a trailing slash that WOULD be valid without it.
4. Embed a valid WordPress URL that has a trailing slash.

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
