### PR TITLE
Ensure that insertUsage is always present in preferences

### DIFF
--- a/packages/editor/src/store/defaults.js
+++ b/packages/editor/src/store/defaults.js
@@ -4,6 +4,7 @@
 import { SETTINGS_DEFAULTS } from '@wordpress/block-editor';
 
 export const PREFERENCES_DEFAULTS = {
+	insertUsage: {}, // Should be kept for backward compatibility, see: https://github.com/WordPress/gutenberg/issues/14580.
 	isPublishSidebarEnabled: true,
 };
 

--- a/packages/editor/src/store/test/reducer.js
+++ b/packages/editor/src/store/test/reducer.js
@@ -481,6 +481,7 @@ describe( 'state', () => {
 		it( 'should apply all defaults', () => {
 			const state = preferences( undefined, {} );
 			expect( state ).toEqual( {
+				insertUsage: {},
 				isPublishSidebarEnabled: true,
 			} );
 		} );


### PR DESCRIPTION
## Description
Follow-up for #14691. Another fix for #14580 :)

I did some more testing with `master` branch and discover another case when an older version of Gutenberg explodes.

**Testing instructions:**

1. (Prerequisite) Update to WordPress v5.1.1
   - In other words, be running the latest version, or at least **not** WordPress v5.2.0-beta.1
2. Clear localStorage
   - `localStorage.clear()` in your Developer Tools Console
3. Navigate to Posts > Add New
   - Toggle Publish sidebar through Options modal. 
4. Deactivate Gutenberg from the Plugins screen
5. Navigate to Posts > Add New
6. Click on the Inserter
   - It uses `insertUsage` preference from `core/editor`.
7. Activate Gutenberg plugin from the Plugins screen
   - Make sure the plugin is a built version of this branch.
8. Navigate to Posts > Add New
   - You don't need to take any action, just visit. The preference migration takes place automatically.
9. Deactivate Gutenberg from the Plugins screen
10. Navigate to Posts > Add New
11. Click the Inserter
12. Verify that no error occurs