### PR TITLE
Data: Return result of middleware chain in resolvers cache middleware

### DIFF
--- a/packages/data/src/namespace-store/index.js
+++ b/packages/data/src/namespace-store/index.js
@@ -187,7 +187,10 @@ function mapSelectors( selectors, store, registry ) {
  * @return {Object}           Actions mapped to the redux store provided.
  */
 function mapActions( actions, store ) {
-	const createBoundAction = ( action ) => ( ...args ) => store.dispatch( action( ...args ) );
+	const createBoundAction = ( action ) => ( ...args ) => {
+		store.dispatch( action( ...args ) );
+	};
+
 	return mapValues( actions, createBoundAction );
 }
 

--- a/packages/data/src/resolvers-cache-middleware.js
+++ b/packages/data/src/resolvers-cache-middleware.js
@@ -30,7 +30,7 @@ const createResolversCacheMiddleware = ( registry, reducerKey ) => () => ( next 
 			registry.dispatch( 'core/data' ).invalidateResolution( reducerKey, selectorName, args );
 		} );
 	} );
-	next( action );
+	return next( action );
 };
 
 export default createResolversCacheMiddleware;

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -555,7 +555,8 @@ describe( 'createRegistry', () => {
 				},
 			} );
 
-			registry.dispatch( 'counter' ).increment(); // state = 1
+			const dispatchResult = registry.dispatch( 'counter' ).increment(); // state = 1
+			expect( dispatchResult ).toBe( undefined ); // Actions are implementation detail.
 			registry.dispatch( 'counter' ).increment( 4 ); // state = 5
 			expect( store.getState() ).toBe( 5 );
 		} );


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/14634#discussion_r270477472

This pull request seeks to resolve an issue with resolver behavior where resolution is marked as finished before the results of a generator control have finished. This is due to the fact that we await the result of `store.dispatch` as if it would return an action, but the order of the middleware chain is such that the promise resolvers cache middleware runs first, and it previously would always return `undefined` (ignoring the fact that the result of `next` was the promise returned by `redux-routine`), causing the resolution to be marked as finished immediately.

https://github.com/WordPress/gutenberg/blob/edf6b37fd887d2eb31c5427a42625ce54092f23c/packages/data/src/namespace-store/index.js#L260

https://github.com/WordPress/gutenberg/blob/edf6b37fd887d2eb31c5427a42625ce54092f23c/packages/data/src/resolvers-cache-middleware.js#L33

https://github.com/WordPress/gutenberg/blob/edf6b37fd887d2eb31c5427a42625ce54092f23c/packages/redux-routine/src/runtime.js#L48

**Testing instructions:**

Verify that unit tests pass:

```
npm run test-unit
```

As I was only able to reproduce in a local working branch, I am not certain steps to verify the behavior in the application. As an alternative, it should be sufficient to verify that other resolved behaviors work as expected (e.g. saving a post).