### PR TITLE
Fix copy paste and delete error core paragraph with locking

### DIFF
--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -244,8 +244,8 @@ class ParagraphBlock extends Component {
 					} }
 					unstableOnSplit={ this.splitBlock }
 					onMerge={ mergeBlocks }
-					onReplace={ this.onReplace }
-					onRemove={ () => onReplace( [] ) }
+					onReplace={ this.props.onReplace && this.onReplace }
+					onRemove={ this.props.onReplace && ( () => onReplace( [] ) ) }
 					aria-label={ content ? __( 'Paragraph block' ) : __( 'Empty block; start writing or type forward slash to choose a block' ) }
 					placeholder={ placeholder || __( 'Start writing or type / to choose a block' ) }
 				/>

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -245,7 +245,7 @@ class ParagraphBlock extends Component {
 					unstableOnSplit={ this.splitBlock }
 					onMerge={ mergeBlocks }
 					onReplace={ this.props.onReplace && this.onReplace }
-					onRemove={ this.props.onReplace && ( () => onReplace( [] ) ) }
+					onRemove={ onReplace && ( () => onReplace( [] ) ) }
 					aria-label={ content ? __( 'Paragraph block' ) : __( 'Empty block; start writing or type forward slash to choose a block' ) }
 					placeholder={ placeholder || __( 'Start writing or type / to choose a block' ) }
 				/>

--- a/packages/e2e-tests/specs/plugins/__snapshots__/cpt-locking.test.js.snap
+++ b/packages/e2e-tests/specs/plugins/__snapshots__/cpt-locking.test.js.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`cpt locking template_lock all should not error when deleting the cotents of a paragraph 1`] = `
+"<!-- wp:image -->
+<figure class=\\"wp-block-image\\"><img alt=\\"\\"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {\\"placeholder\\":\\"Add a description\\"} -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p></p></blockquote>
+<!-- /wp:quote -->"
+`;
+
 exports[`cpt locking template_lock false should allow blocks to be inserted 1`] = `
 "<!-- wp:image -->
 <figure class=\\"wp-block-image\\"><img alt=\\"\\"/></figure>

--- a/packages/e2e-tests/specs/plugins/cpt-locking.test.js
+++ b/packages/e2e-tests/specs/plugins/cpt-locking.test.js
@@ -8,6 +8,7 @@ import {
 	deactivatePlugin,
 	getEditedPostContent,
 	insertBlock,
+	pressKeyTimes,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'cpt locking', () => {
@@ -57,6 +58,14 @@ describe( 'cpt locking', () => {
 			expect(
 				await page.$( 'button[aria-label="Move up"]' )
 			).toBeNull();
+		} );
+
+		it( 'should not error when deleting the cotents of a paragraph', async () => {
+			await page.click( '.block-editor-block-list__block[data-type="core/paragraph"] p' );
+			const textToType = 'Paragraph';
+			await page.keyboard.type( 'Paragraph' );
+			await pressKeyTimes( 'Backspace', textToType.length + 1 );
+			expect( await getEditedPostContent() ).toMatchSnapshot();
 		} );
 	} );
 


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/12774

Rich text is able to handle the situation of onReplace and onRemove not existing.
When locking exist onReplace prop is not passed to blocks.
Previously onReplace prop was passed directly passed from paragraph to rich text. Now that's not the case and we have a middle function that may call the onReplace prop. If the onReplace property is not set (e.g we have locking) we should not pass the onReplace to rich text.

## How has this been tested?
I added the following CPT with locking:
```
function gutenberg_test_cpt_locking() {
	register_post_type(
		'locked-all-post',
		array(
			'public'        => true,
			'label'         => 'Locked All Post',
			'show_in_rest'  => true,
			'template'      => $template,
			'template_lock' => 'all',
		)
	);
	register_post_type(
		'locked-insert-post',
		array(
			'public'        => true,
			'label'         => 'Locked Insert Post',
			'show_in_rest'  => true,
			'template'      => $template,
			'template_lock' => 'insert',
		)
	);
}

add_action( 'init', 'gutenberg_test_cpt_locking' );
```
I verified I can paste in the paragraph.
I verified I can type something and delete all the contents again, and when I press backspace when the paragraph is empty no errors happen.
I repeated the same tests for the paragraph inside the following block:
( function() {
	const { registerBlockType } = wp.blocks;
	const { createElement: el } = wp.element;
	const { InnerBlocks } = wp.editor;

	registerBlockType( 'acme/product', {
		title: 'Product',
		icon: 'carrot',
		category: 'common',

		edit() {
			return el( 'div', { className: 'product', style: { outline: '1px solid gray', padding: 5 } },
				// Only paragraphs, images, and products:
				el(
                    InnerBlocks,
                    { template: [
                        [ 'core/heading', { placeholder: 'Slide heading...', level: 2 } ],
                        [ 'core/paragraph', { placeholder: 'Slide content...' } ],
                        [ 'core/button', { text: 'Read More', className: 'btn-lg' } ],
                    ],
                    templateLock: 'all'
                    }
                )
				// Everything and products:
				//el( InnerBlocks )
			);
		},

		save() {
			return el( 'div', { className: 'product', style: { outline: '1px solid gray', padding: 5 } },
				el( InnerBlocks.Content )
			);
		},
	} );
} )();


I verified that If I revert the fix in the paragraph block the tests start failing.