### PR TITLE
API Fetch: Fix error on empty OPTIONS preload data

### DIFF
--- a/packages/api-fetch/src/middlewares/preloading.js
+++ b/packages/api-fetch/src/middlewares/preloading.js
@@ -34,7 +34,11 @@ const createPreloadingMiddleware = ( preloadedData ) => ( options, next ) => {
 
 		if ( parse && 'GET' === method && preloadedData[ path ] ) {
 			return Promise.resolve( preloadedData[ path ].body );
-		} else if ( 'OPTIONS' === method && preloadedData[ method ][ path ] ) {
+		} else if (
+			'OPTIONS' === method &&
+			preloadedData[ method ] &&
+			preloadedData[ method ][ path ]
+		) {
 			return Promise.resolve( preloadedData[ method ][ path ] );
 		}
 	}

--- a/packages/api-fetch/src/middlewares/test/preloading.js
+++ b/packages/api-fetch/src/middlewares/test/preloading.js
@@ -25,20 +25,29 @@ describe( 'Preloading Middleware', () => {
 		} );
 	} );
 
-	it( 'should move to the next middleware if no preloaded data', () => {
-		const preloadedData = {};
-		const prelooadingMiddleware = createPreloadingMiddleware( preloadedData );
-		const requestOptions = {
-			method: 'GET',
-			path: 'wp/v2/posts',
-		};
+	describe.each( [
+		[ 'GET' ],
+		[ 'OPTIONS' ],
+	] )( '%s', ( method ) => {
+		describe.each( [
+			[ 'all empty', {} ],
+			[ 'method empty', { [ method ]: {} } ],
+		] )( '%s', ( label, preloadedData ) => {
+			it( 'should move to the next middleware if no preloaded data', () => {
+				const prelooadingMiddleware = createPreloadingMiddleware( preloadedData );
+				const requestOptions = {
+					method,
+					path: 'wp/v2/posts',
+				};
 
-		const callback = ( options ) => {
-			expect( options ).toBe( requestOptions );
-			return true;
-		};
+				const callback = ( options ) => {
+					expect( options ).toBe( requestOptions );
+					return true;
+				};
 
-		const ret = prelooadingMiddleware( requestOptions, callback );
-		expect( ret ).toBe( true );
+				const ret = prelooadingMiddleware( requestOptions, callback );
+				expect( ret ).toBe( true );
+			} );
+		} );
 	} );
 } );


### PR DESCRIPTION
Previously: #4155 (cc @imath)

This pull request seeks to resolve an error which occurs when the API Fetch preloading middleware is initialized with an empty object. Notably, this impacts preload request tests against `OPTIONS` requests, which prior to these changes performed an unsafe object property access.

**Testing instructions:**

Ensure unit tests pass:

```
npm run test-unit
```

Verify that no errors occur when resetting preloaded data to an empty array, placing the following snippet in some PHP code (e.g. a custom mu-plugin or `gutenberg/gutenberg.php`).

```php
add_filter( 'block_editor_preload_paths', '__return_empty_array' );
```