### PR TITLE
Block Library: Reimplement Reusable Block using EditorProvider for embedded post editor

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -197,6 +197,10 @@ Undocumented declaration.
 
 Undocumented declaration.
 
+<a name="FormatToolbar" href="#FormatToolbar">#</a> **FormatToolbar**
+
+Undocumented declaration.
+
 <a name="getColorClassName" href="#getColorClassName">#</a> **getColorClassName**
 
 Returns a class based on the context a color is being used and its slug.

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -29,6 +29,7 @@ export {
 	RichTextShortcut,
 	RichTextToolbarButton,
 	__unstableRichTextInputEvent,
+	FormatToolbar,
 } from './rich-text';
 export { default as URLInput } from './url-input';
 export { default as URLInputButton } from './url-input/button';

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { DropZoneProvider, SlotFillProvider } from '@wordpress/components';
+import { DropZoneProvider } from '@wordpress/components';
 import { withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
@@ -121,11 +121,9 @@ class BlockEditorProvider extends Component {
 		const { children } = this.props;
 
 		return (
-			<SlotFillProvider>
-				<DropZoneProvider>
-					{ children }
-				</DropZoneProvider>
-			</SlotFillProvider>
+			<DropZoneProvider>
+				{ children }
+			</DropZoneProvider>
 		);
 	}
 }

--- a/packages/block-editor/src/components/rich-text/format-toolbar/index.js
+++ b/packages/block-editor/src/components/rich-text/format-toolbar/index.js
@@ -9,7 +9,9 @@ import { orderBy } from 'lodash';
  */
 
 import { __ } from '@wordpress/i18n';
-import { Toolbar, Slot, DropdownMenu } from '@wordpress/components';
+import { Toolbar, Slot, DropdownMenu, createSlotFill } from '@wordpress/components';
+
+const { Slot: ToolbarControlsSlot } = createSlotFill( 'RichText.ToolbarControls' );
 
 const FormatToolbar = ( { controls } ) => {
 	return (
@@ -18,7 +20,7 @@ const FormatToolbar = ( { controls } ) => {
 				{ controls.map( ( format ) =>
 					<Slot name={ `RichText.ToolbarControls.${ format }` } key={ format } />
 				) }
-				<Slot name="RichText.ToolbarControls">
+				<ToolbarControlsSlot>
 					{ ( fills ) => fills.length !== 0 &&
 						<DropdownMenu
 							icon={ false }
@@ -27,10 +29,12 @@ const FormatToolbar = ( { controls } ) => {
 							controls={ orderBy( fills.map( ( [ { props } ] ) => props ), 'title' ) }
 						/>
 					}
-				</Slot>
+				</ToolbarControlsSlot>
 			</Toolbar>
 		</div>
 	);
 };
+
+FormatToolbar.Slot = ToolbarControlsSlot;
 
 export default FormatToolbar;

--- a/packages/block-editor/src/components/rich-text/format-toolbar/index.native.js
+++ b/packages/block-editor/src/components/rich-text/format-toolbar/index.native.js
@@ -2,7 +2,9 @@
  * WordPress dependencies
  */
 
-import { Toolbar, Slot } from '@wordpress/components';
+import { Toolbar, Slot, createSlotFill } from '@wordpress/components';
+
+const { Slot: ToolbarControlsSlot } = createSlotFill( 'RichText.ToolbarControls' );
 
 const FormatToolbar = ( { controls } ) => {
 	return (
@@ -10,9 +12,11 @@ const FormatToolbar = ( { controls } ) => {
 			{ controls.map( ( format ) =>
 				<Slot name={ `RichText.ToolbarControls.${ format }` } key={ format } />
 			) }
-			<Slot name="RichText.ToolbarControls" />
+			<ToolbarControlsSlot />
 		</Toolbar>
 	);
 };
+
+FormatToolbar.Slot = ToolbarControlsSlot;
 
 export default FormatToolbar;

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -1217,3 +1217,4 @@ export default RichTextContainer;
 export { RichTextShortcut } from './shortcut';
 export { RichTextToolbarButton } from './toolbar-button';
 export { __unstableRichTextInputEvent } from './input-event';
+export { FormatToolbar };

--- a/packages/block-library/src/block/edit-panel/index.js
+++ b/packages/block-library/src/block/edit-panel/index.js
@@ -5,7 +5,8 @@ import { Button } from '@wordpress/components';
 import { Component, createRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ESCAPE } from '@wordpress/keycodes';
-import { withInstanceId } from '@wordpress/compose';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { withInstanceId, compose } from '@wordpress/compose';
 
 class ReusableBlockEditPanel extends Component {
 	constructor() {
@@ -107,4 +108,36 @@ class ReusableBlockEditPanel extends Component {
 	}
 }
 
-export default withInstanceId( ReusableBlockEditPanel );
+export default compose( [
+	withInstanceId,
+	withSelect( ( select ) => {
+		const { getEditedPostAttribute, isSavingPost } = select( 'core/editor' );
+
+		return {
+			title: getEditedPostAttribute( 'title' ),
+			isSaving: isSavingPost(),
+		};
+	} ),
+	withDispatch( ( dispatch, ownProps ) => {
+		const {
+			editPost,
+			savePost,
+			clearSelectedBlock,
+		} = dispatch( 'core/editor' );
+
+		return {
+			onChangeTitle( title ) {
+				editPost( { title } );
+			},
+			onSave() {
+				clearSelectedBlock();
+				savePost();
+				ownProps.onSave();
+			},
+			onCancel() {
+				clearSelectedBlock();
+				ownProps.onCancel();
+			},
+		};
+	} ),
+] )( ReusableBlockEditPanel );

--- a/packages/block-library/src/block/editor.scss
+++ b/packages/block-library/src/block/editor.scss
@@ -1,0 +1,9 @@
+.block-editor-block-list__block[data-type="core/block"] {
+	.block-editor-block-list__layout > .block-editor-block-list__block:first-child > .block-editor-block-list__block-edit {
+		margin-top: 0;
+	}
+
+	.block-editor-block-list__layout > .block-editor-block-list__block:last-child > .block-editor-block-list__block-edit {
+		margin-bottom: 0;
+	}
+}

--- a/packages/block-library/src/block/selection-observer/index.js
+++ b/packages/block-library/src/block/selection-observer/index.js
@@ -1,0 +1,54 @@
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
+import { withSelect, withDispatch } from '@wordpress/data';
+
+/**
+ * Component which calls onBlockSelected prop when a block becomes selected. It
+ * is assumed to be used in a separate registry context from the reusable block
+ * in which it is rendered, ensuring that only one block appears as selected
+ * between the editor in which the reusable resides and block's own editor.
+ *
+ * @type {WPComponent}
+ */
+class SelectionObserver extends Component {
+	componentDidUpdate( prevProps ) {
+		const {
+			hasSelectedBlock,
+			onBlockSelected,
+			isParentSelected,
+			clearSelectedBlock,
+		} = this.props;
+
+		if ( hasSelectedBlock && ! prevProps.hasSelectedBlock ) {
+			onBlockSelected();
+		}
+
+		if ( ! isParentSelected && prevProps.isParentSelected ) {
+			clearSelectedBlock();
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default compose( [
+	withSelect( ( select ) => {
+		const { hasSelectedBlock } = select( 'core/block-editor' );
+
+		return {
+			hasSelectedBlock: hasSelectedBlock(),
+		};
+	} ),
+	withDispatch( ( dispatch ) => {
+		const { clearSelectedBlock } = dispatch( 'core/block-editor' );
+
+		return {
+			clearSelectedBlock,
+		};
+	} ),
+] )( SelectionObserver );

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -1,4 +1,5 @@
 @import "./audio/style.scss";
+@import "./block/editor.scss";
 @import "./button/style.scss";
 @import "./calendar/style.scss";
 @import "./categories/style.scss";

--- a/packages/components/src/slot-fill/fill.js
+++ b/packages/components/src/slot-fill/fill.js
@@ -11,11 +11,11 @@ import { createPortal, useLayoutEffect, useRef, useState } from '@wordpress/elem
 /**
  * Internal dependencies
  */
-import { Consumer } from './context';
+import { withConsumerContext } from './context';
 
 let occurrences = 0;
 
-function FillComponent( { name, getSlot, children, registerFill, unregisterFill } ) {
+function Fill( { name, getSlot, children, registerFill, unregisterFill } ) {
 	// Random state used to rerender the component if needed, ideally we don't need this
 	const [ , updateRerenderState ] = useState( {} );
 	const rerender = () => updateRerenderState( {} );
@@ -67,17 +67,4 @@ function FillComponent( { name, getSlot, children, registerFill, unregisterFill 
 	return createPortal( children, slot.node );
 }
 
-const Fill = ( props ) => (
-	<Consumer>
-		{ ( { getSlot, registerFill, unregisterFill } ) => (
-			<FillComponent
-				{ ...props }
-				getSlot={ getSlot }
-				registerFill={ registerFill }
-				unregisterFill={ unregisterFill }
-			/>
-		) }
-	</Consumer>
-);
-
-export default Fill;
+export default withConsumerContext( Fill );

--- a/packages/components/src/slot-fill/index.js
+++ b/packages/components/src/slot-fill/index.js
@@ -15,6 +15,7 @@ export function createSlotFill( name ) {
 
 	const SlotComponent = ( props ) => <Slot name={ name } { ...props } />;
 	SlotComponent.displayName = name + 'Slot';
+	SlotComponent.slotName = name;
 
 	return {
 		Fill: FillComponent,

--- a/packages/components/src/slot-fill/slot.js
+++ b/packages/components/src/slot-fill/slot.js
@@ -21,9 +21,9 @@ import {
 /**
  * Internal dependencies
  */
-import { Consumer } from './context';
+import { withConsumerContext } from './context';
 
-class SlotComponent extends Component {
+class Slot extends Component {
 	constructor() {
 		super( ...arguments );
 
@@ -89,17 +89,4 @@ class SlotComponent extends Component {
 	}
 }
 
-const Slot = ( props ) => (
-	<Consumer>
-		{ ( { registerSlot, unregisterSlot, getFills } ) => (
-			<SlotComponent
-				{ ...props }
-				registerSlot={ registerSlot }
-				unregisterSlot={ unregisterSlot }
-				getFills={ getFills }
-			/>
-		) }
-	</Consumer>
-);
-
-export default Slot;
+export default withConsumerContext( Slot );

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -10,7 +10,7 @@ import { size, map, without } from 'lodash';
 import { withSelect } from '@wordpress/data';
 import { EditorProvider, ErrorBoundary, PostLockedModal } from '@wordpress/editor';
 import { StrictMode, Component } from '@wordpress/element';
-import { KeyboardShortcuts } from '@wordpress/components';
+import { KeyboardShortcuts, SlotFillProvider } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -87,19 +87,21 @@ class Editor extends Component {
 
 		return (
 			<StrictMode>
-				<EditorProvider
-					settings={ editorSettings }
-					post={ post }
-					initialEdits={ initialEdits }
-					useSubRegistry={ false }
-					{ ...props }
-				>
-					<ErrorBoundary onError={ onError }>
-						<Layout />
-						<KeyboardShortcuts shortcuts={ preventEventDiscovery } />
-					</ErrorBoundary>
-					<PostLockedModal />
-				</EditorProvider>
+				<SlotFillProvider>
+					<EditorProvider
+						settings={ editorSettings }
+						post={ post }
+						initialEdits={ initialEdits }
+						useSubRegistry={ false }
+						{ ...props }
+					>
+						<ErrorBoundary onError={ onError }>
+							<Layout />
+							<KeyboardShortcuts shortcuts={ preventEventDiscovery } />
+						</ErrorBoundary>
+						<PostLockedModal />
+					</EditorProvider>
+				</SlotFillProvider>
 			</StrictMode>
 		);
 	}


### PR DESCRIPTION
Closes #7119 
Previously: #7453

This pull request seeks to reimplement the reusable block as an embedded post editor, using `EditorProvider`.

**Work in Progress:**

This pull request currently cherry-picks a few related fixes (#14711), and includes changes which are likely more appropriate to be proposed in their own pull requests. It also lacks sufficient test coverage and documentation for newly proposed features.

Functionally, it largely works as expected.

I'm still trying to find the right balance of the extent to which this should be refactored. Currently, I'm considering to not remove any actions around fetching or saving reusable blocks as it impacts the inserter and block static/reusable conversion features. To that end, it would largely be a refactor primarily only impacting the block itself, but leaving all other behaviors intact.