### PR TITLE
Change the textcolor passed to ContrastChecker

### DIFF
--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -123,6 +123,20 @@ class ParagraphBlock extends Component {
 		}
 	}
 
+	getDisplayedTextColor( backgroundColorClass, textColor ) {
+		// If backgroundColor class is primary, secondary, dark gray, light grary,
+		// then the displayed color of text is '#fff' (white), even if the textColor remains undefined.
+		// If backgroundColor class is white, then the displayed color of text is '#111' (black).
+		// This is a feature to improve accessibility.
+		if ( backgroundColorClass ) {
+			if ( backgroundColorClass === 'has-white-background-color' ) {
+				return '#111';
+			}
+			return '#fff';
+		}
+		return textColor;
+	}
+
 	render() {
 		const {
 			attributes,
@@ -209,7 +223,7 @@ class ParagraphBlock extends Component {
 					>
 						<ContrastChecker
 							{ ...{
-								textColor: textColor.color,
+								textColor: this.getDisplayedTextColor( backgroundColor.class, textColor.color ),
 								backgroundColor: backgroundColor.color,
 								fallbackTextColor,
 								fallbackBackgroundColor,


### PR DESCRIPTION
## Description
Fix #14687 

## How has this been tested?

- [X] Local
- [X] Browser testing

## Types of changes
Change the parameters passed to ContrastChecker so that the contrast warning works correctly. That is only when we see light text on light background or dark text on dark background, the warning will be displayed.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
