### PR TITLE
Improve e2e testing docs and add cli args.

### DIFF
--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -216,6 +216,9 @@ This is how you execute those scripts using the presented setup:
 
 * `npm run test:e2e` - runs all unit tests.
 * `npm run test:e2e:help` - prints all available options to configure unit tests runner.
+* `npm run test-e2e -- --puppeteer-interactive` - runs all unit tests interactively.
+* `npm run test-e2e FILE_NAME -- --puppeteer-interactive ` - runs one test file interactively.
+* `npm run test-e2e:watch -- --puppeteer-interactive` - runs all tests interactively and watch for changes.
 
 This script automatically detects the best config to start Puppeteer but sometimes you may need to specify custom options:
  - You can add a `jest-puppeteer.config.js` at the root of the project or define a custom path using `JEST_PUPPETEER_CONFIG` environment variable. Check [jest-puppeteer](https://github.com/smooth-code/jest-puppeteer#jest-puppeteerconfigjs) for more details.

--- a/packages/scripts/scripts/test-e2e.js
+++ b/packages/scripts/scripts/test-e2e.js
@@ -56,9 +56,9 @@ const configsMapping = {
 	WP_PASSWORD: '--wordpress-password',
 };
 
-Object.entries( configsMapping ).forEach( ( [ key, value ] ) => {
-	if ( hasCliArg( value ) ) {
-		process.env[ key ] = getCliArg( value );
+Object.entries( configsMapping ).forEach( ( [ envKey, argName ] ) => {
+	if ( hasCliArg( argName ) ) {
+		process.env[ envKey ] = getCliArg( argName );
 	}
 } );
 

--- a/packages/scripts/scripts/test-e2e.js
+++ b/packages/scripts/scripts/test-e2e.js
@@ -49,7 +49,7 @@ if ( hasCliArg( '--puppeteer-interactive' ) ) {
 }
 
 const configsMapping = {
-	WP_BASE_URL: '--wordpress-host',
+	WP_BASE_URL: '--wordpress-base-url',
 	WP_USERNAME: '--wordpress-username',
 	WP_PASSWORD: '--wordpress-password',
 };

--- a/packages/scripts/scripts/test-e2e.js
+++ b/packages/scripts/scripts/test-e2e.js
@@ -51,15 +51,15 @@ if ( hasCliArg( '--puppeteer-interactive' ) ) {
 }
 
 const configsMapping = {
-	WP_BASE_URL: "--wordpress-host",
-	WP_USERNAME: "--wordpress-username",
-	WP_PASSWORD: "--wordpress-password"
+	WP_BASE_URL: '--wordpress-host',
+	WP_USERNAME: '--wordpress-username',
+	WP_PASSWORD: '--wordpress-password',
 };
 
-Object.entries(configsMapping).forEach(([key, value]) => {
-	if (hasCliArg(value)) {
-		process.env[key] = getCliArg(value);
+Object.entries( configsMapping ).forEach( ( [ key, value ] ) => {
+	if ( hasCliArg( value ) ) {
+		process.env[ key ] = getCliArg( value );
 	}
-});
+} );
 
 jest.run( [ ...config, ...runInBand, ...getCliArgs( cleanUpPrefixes ) ] );

--- a/packages/scripts/scripts/test-e2e.js
+++ b/packages/scripts/scripts/test-e2e.js
@@ -50,4 +50,16 @@ if ( hasCliArg( '--puppeteer-interactive' ) ) {
 	process.env.PUPPETEER_SLOWMO = getCliArg( '--puppeteer-slowmo' ) || 80;
 }
 
+const configsMapping = {
+	WP_BASE_URL: "--wordpress-host",
+	WP_USERNAME: "--wordpress-username",
+	WP_PASSWORD: "--wordpress-password"
+};
+
+Object.entries(configsMapping).forEach(([key, value]) => {
+	if (hasCliArg(value)) {
+		process.env[key] = getCliArg(value);
+	}
+});
+
 jest.run( [ ...config, ...runInBand, ...getCliArgs( cleanUpPrefixes ) ] );

--- a/packages/scripts/scripts/test-e2e.js
+++ b/packages/scripts/scripts/test-e2e.js
@@ -43,8 +43,6 @@ const runInBand = ! hasRunInBand ?
 	[ '--runInBand' ] :
 	[];
 
-const cleanUpPrefixes = [ '--puppeteer-' ];
-
 if ( hasCliArg( '--puppeteer-interactive' ) ) {
 	process.env.PUPPETEER_HEADLESS = 'false';
 	process.env.PUPPETEER_SLOWMO = getCliArg( '--puppeteer-slowmo' ) || 80;
@@ -61,5 +59,7 @@ Object.entries( configsMapping ).forEach( ( [ envKey, argName ] ) => {
 		process.env[ envKey ] = getCliArg( argName );
 	}
 } );
+
+const cleanUpPrefixes = [ '--puppeteer-', '--wordpress-' ];
 
 jest.run( [ ...config, ...runInBand, ...getCliArgs( cleanUpPrefixes ) ] );


### PR DESCRIPTION
## Description
Fixes to: https://github.com/WordPress/gutenberg/issues/14494
I added `local` arg to `npm run test-e2e` command.

## How has this been tested?
It was tested locally.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
