### PR TITLE
Fixed background grey of the Shortcode block placeholder screen

### DIFF
--- a/packages/block-library/src/shortcode/edit.js
+++ b/packages/block-library/src/shortcode/edit.js
@@ -10,8 +10,8 @@ const ShortcodeEdit = ( { attributes, setAttributes, instanceId } ) => {
 	const inputId = `blocks-shortcode-input-${ instanceId }`;
 
 	return (
-		<div className="wp-block-shortcode">
-			<label htmlFor={ inputId }>
+		<div className="wp-block-shortcode  components-placeholder">
+			<label htmlFor={ inputId } className="components-placeholder__label">
 				<Dashicon icon="shortcode" />
 				{ __( 'Shortcode' ) }
 			</label>

--- a/packages/block-library/src/shortcode/editor.scss
+++ b/packages/block-library/src/shortcode/editor.scss
@@ -2,7 +2,7 @@
 	display: flex;
 	flex-direction: row;
 	padding: $block-padding;
-	background-color: $light-gray-100;
+	background-color: $dark-opacity-light-200;
 	font-size: $default-font-size;
 	font-family: $default-font;
 

--- a/packages/block-library/src/shortcode/editor.scss
+++ b/packages/block-library/src/shortcode/editor.scss
@@ -1,6 +1,6 @@
 .wp-block-shortcode {
 	display: flex;
-	flex-direction: row;
+	flex-direction: column;
 	padding: $block-padding;
 	background-color: $dark-opacity-light-200;
 	font-size: $default-font-size;
@@ -9,7 +9,6 @@
 	label {
 		display: flex;
 		align-items: center;
-		margin-right: $grid-size;
 		white-space: nowrap;
 		font-weight: 600;
 		flex-shrink: 0;
@@ -17,6 +16,9 @@
 
 	.block-editor-plain-text {
 		flex-grow: 1;
+		line-height: 1;
+		max-height: 30px;
+		width: 80%;
 	}
 
 	.dashicon {


### PR DESCRIPTION
## Description
Changed the background grey of the shortcode block to match all the other placeholder setup screens on other blocks. Fixes #14718

## How has this been tested?
Tested locally.

## Before

![shortcode](https://user-images.githubusercontent.com/617986/55270908-260a6980-5262-11e9-8584-09c51d265a10.png)

## After

![Screen Shot 2019-03-29 at 8 34 52 PM](https://user-images.githubusercontent.com/617986/55270910-2c004a80-5262-11e9-97ea-f02b1099895c.png)


## Types of changes
Changed the variable used for the background grey.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
