### PR TITLE
Fix: Fill Verse icon

### DIFF
--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -18,7 +18,7 @@ export const settings = {
 
 	description: __( 'Insert poetry. Use special spacing formats. Or quote song lyrics.' ),
 
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M21 11.01L3 11V13H21V11.01ZM3 16H17V18H3V16ZM15 6H3V8.01L15 8V6Z" /></SVG>,
+	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M21 11.01L3 11V13H21V11.01ZM3 16H17V18H3V16ZM15 6H3V8.01L15 8V6Z" /></SVG>,
 
 	category: 'formatting',
 


### PR DESCRIPTION
## Description
The new Verse icon needs to be filled.

Introduced in #14622
Before:
<img width="126" alt="Bildschirmfoto 2019-03-30 um 18 52 52" src="https://user-images.githubusercontent.com/695201/55279843-be195900-531d-11e9-81d9-e6daec4771da.png">
After:
<img width="126" alt="Bildschirmfoto 2019-03-30 um 18 55 10" src="https://user-images.githubusercontent.com/695201/55279842-bd80c280-531d-11e9-86c9-3b29d0d5fc3d.png">
