### PR TITLE
fix gap in figcaption backround gradient

### DIFF
--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -150,5 +150,4 @@
 // By providing a minimum of margin styles, we ensure it doesn't look broken or unstyled in those themes.
 figcaption {
 	margin-top: 0.5em;
-	margin-bottom: 1em;
 }


### PR DESCRIPTION
## Description
In https://github.com/WordPress/gutenberg/pull/14366 a bottom margin was added to all figcaptions.

This broke figcaptions on gallery-items.
This PR fixes that by removing the `margin-bottom` declaration.

Not having a bottom margin was discussed on the original PR but I think was forgotten about.
https://github.com/WordPress/gutenberg/pull/14366#issuecomment-473325030
> I'm also wondering if the margin-bottom: 1em on figcaption is necessary.
If the block has a margin-bottom, the figcaption's margin-bottom does nothing. Even without a specific margin on the block, figure gets a margin-bottom: 1em from the browser.

I first discovered this regression while investigating https://github.com/WordPress/gutenberg/issues/14674
This does not resolve that issue.

## How has this been tested?
Visually all blocks look the same after this change. Except of course the gallery block.

## Screenshots <!-- if applicable -->
![Screenshot_2019-03-29 Gut Check – one wordpress test](https://user-images.githubusercontent.com/3585901/55205953-3a3f5f80-51ab-11e9-9759-6edb675c02e4.jpg)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
