### PR TITLE
Add LGPL as an OSS license

### DIFF
--- a/packages/scripts/scripts/check-licenses.js
+++ b/packages/scripts/scripts/check-licenses.js
@@ -79,6 +79,7 @@ const otherOssLicenses = [
 	'Apache License, Version 2.0',
 	'Apache version 2.0',
 	'CC-BY-3.0',
+	'LGPL',
 ];
 
 const licenses = [


### PR DESCRIPTION
## Description

[LGPLv2.1 is GPLv2 compatible](https://www.gnu.org/licenses/license-list.en.html#LGPLv2.1), but [LGPLv3 is not](https://www.gnu.org/licenses/license-list.en.html#LGPLv3).

When a package declares its license as LGPL (as it `xmldom` does, for example), we can't assume which LGPL license is intended, so have to assume it's not going to be GPLv2 compatible.

This PR addresses pento/testpress#137.
