### PR TITLE
Fix property name in PluginBlockSettingsMenuItem

### DIFF
--- a/packages/edit-post/README.md
+++ b/packages/edit-post/README.md
@@ -61,7 +61,7 @@ function MyPluginBlockSettingsMenuItem() {
 	return wp.element.createElement(
 		PluginBlockSettingsMenuItem,
 		{
-			allowedBlockNames: [ 'core/paragraph' ],
+			allowedBlocks: [ 'core/paragraph' ],
 			icon: 'dashicon-name',
 			label: __( 'Menu item text' ),
 			onClick: doOnClick,
@@ -81,7 +81,7 @@ const doOnClick = ( ) => {
 
 const MyPluginBlockSettingsMenuItem = () => (
     <PluginBlockSettingsMenuItem
-		allowedBlockNames=[ 'core/paragraph' ]
+		allowedBlocks=[ 'core/paragraph' ]
 		icon='dashicon-name'
 		label=__( 'Menu item text' )
 		onClick={ doOnClick } />
@@ -91,7 +91,7 @@ const MyPluginBlockSettingsMenuItem = () => (
 _Parameters_
 
 -   _props_ `Object`: Component props.
--   _props.allowedBlockNames_ `[Array]`: An array containing a list of block names for which the item should be shown. If not present, it'll be rendered for any block. If multiple blocks are selected, it'll be shown if and only if all of them are in the whitelist.
+-   _props.allowedBlocks_ `[Array]`: An array containing a list of block names for which the item should be shown. If not present, it'll be rendered for any block. If multiple blocks are selected, it'll be shown if and only if all of them are in the whitelist.
 -   _props.icon_ `[(string|Element)]`: The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element.
 -   _props.label_ `string`: The menu item text.
 -   _props.onClick_ `Function`: Callback function to be executed when the user click the menu item.

--- a/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
+++ b/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
@@ -34,7 +34,7 @@ const shouldRenderItem = ( selectedBlockNames, allowedBlockNames ) => ! Array.is
  * Renders a new item in the block settings menu.
  *
  * @param {Object} props Component props.
- * @param {Array} [props.allowedBlockNames] An array containing a list of block names for which the item should be shown. If not present, it'll be rendered for any block. If multiple blocks are selected, it'll be shown if and only if all of them are in the whitelist.
+ * @param {Array} [props.allowedBlocks] An array containing a list of block names for which the item should be shown. If not present, it'll be rendered for any block. If multiple blocks are selected, it'll be shown if and only if all of them are in the whitelist.
  * @param {string|Element} [props.icon] The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element.
  * @param {string} props.label The menu item text.
  * @param {Function} props.onClick Callback function to be executed when the user click the menu item.
@@ -53,7 +53,7 @@ const shouldRenderItem = ( selectedBlockNames, allowedBlockNames ) => ! Array.is
  * 	return wp.element.createElement(
  * 		PluginBlockSettingsMenuItem,
  * 		{
- * 			allowedBlockNames: [ 'core/paragraph' ],
+ * 			allowedBlocks: [ 'core/paragraph' ],
  * 			icon: 'dashicon-name',
  * 			label: __( 'Menu item text' ),
  * 			onClick: doOnClick,
@@ -74,7 +74,7 @@ const shouldRenderItem = ( selectedBlockNames, allowedBlockNames ) => ! Array.is
  *
  * const MyPluginBlockSettingsMenuItem = () => (
  *     <PluginBlockSettingsMenuItem
- * 		allowedBlockNames=[ 'core/paragraph' ]
+ * 		allowedBlocks=[ 'core/paragraph' ]
  * 		icon='dashicon-name'
  * 		label=__( 'Menu item text' )
  * 		onClick={ doOnClick } />
@@ -83,10 +83,10 @@ const shouldRenderItem = ( selectedBlockNames, allowedBlockNames ) => ! Array.is
  *
  * @return {WPElement} The WPElement to be rendered.
  */
-const PluginBlockSettingsMenuItem = ( { allowedBlockNames, icon, label, onClick, small, role } ) => (
+const PluginBlockSettingsMenuItem = ( { allowedBlocks, icon, label, onClick, small, role } ) => (
 	<PluginBlockSettingsMenuGroup>
 		{ ( { selectedBlocks, onClose } ) => {
-			if ( ! shouldRenderItem( selectedBlocks, allowedBlockNames ) ) {
+			if ( ! shouldRenderItem( selectedBlocks, allowedBlocks ) ) {
 				return null;
 			}
 			return ( <MenuItem

--- a/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
+++ b/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
@@ -18,7 +18,7 @@ const isEverySelectedBlockAllowed = ( selected, allowed ) => difference( selecte
 
 /**
  * Plugins may want to add an item to the menu either for every block
- * or only for the specific ones provided in the `allowedBlockNames` component property.
+ * or only for the specific ones provided in the `allowedBlocks` component property.
  *
  * If there are multiple blocks selected the item will be rendered if every block
  * is of one allowed type (not necessarily the same).

--- a/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
+++ b/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
@@ -23,12 +23,12 @@ const isEverySelectedBlockAllowed = ( selected, allowed ) => difference( selecte
  * If there are multiple blocks selected the item will be rendered if every block
  * is of one allowed type (not necessarily the same).
  *
- * @param {string[]} selectedBlockNames Array containing the names of the blocks selected
- * @param {string[]} allowedBlockNames Array containing the names of the blocks allowed
+ * @param {string[]} selectedBlocks Array containing the names of the blocks selected
+ * @param {string[]} allowedBlocks Array containing the names of the blocks allowed
  * @return {boolean} Whether the item will be rendered or not.
  */
-const shouldRenderItem = ( selectedBlockNames, allowedBlockNames ) => ! Array.isArray( allowedBlockNames ) ||
-	isEverySelectedBlockAllowed( selectedBlockNames, allowedBlockNames );
+const shouldRenderItem = ( selectedBlocks, allowedBlocks ) => ! Array.isArray( allowedBlocks ) ||
+	isEverySelectedBlockAllowed( selectedBlocks, allowedBlocks );
 
 /**
  * Renders a new item in the block settings menu.

--- a/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
+++ b/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
@@ -18,7 +18,7 @@ const isEverySelectedBlockAllowed = ( selected, allowed ) => difference( selecte
 
 /**
  * Plugins may want to add an item to the menu either for every block
- * or only for the specific ones provided in the `allowedBlocks` component property.
+ * or only for the specific ones provided in the `allowedBlockNames` component property.
  *
  * If there are multiple blocks selected the item will be rendered if every block
  * is of one allowed type (not necessarily the same).
@@ -83,10 +83,10 @@ const shouldRenderItem = ( selectedBlockNames, allowedBlockNames ) => ! Array.is
  *
  * @return {WPElement} The WPElement to be rendered.
  */
-const PluginBlockSettingsMenuItem = ( { allowedBlocks, icon, label, onClick, small, role } ) => (
+const PluginBlockSettingsMenuItem = ( { allowedBlockNames, icon, label, onClick, small, role } ) => (
 	<PluginBlockSettingsMenuGroup>
 		{ ( { selectedBlocks, onClose } ) => {
-			if ( ! shouldRenderItem( selectedBlocks, allowedBlocks ) ) {
+			if ( ! shouldRenderItem( selectedBlocks, allowedBlockNames ) ) {
 				return null;
 			}
 			return ( <MenuItem


### PR DESCRIPTION
## Description
In #7895, `PluginBlockSettingsMenuItem` was made extensible for plugin developers.

There was a slight oversight though regarding the `allowedBlockNames` prop. While the documentation was referring to `allowedBlockNames`, the code was actually checking for `allowedBlocks`,

## How has this been tested?

I extended the settings menu by using the examples from the documentation and verified that `allowedBlocks` now is properly documented as such.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
