### PR TITLE
ESLint Plugin: Add missing react-no-unsafe-timeout CHANGELOG

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.2.0 (Unreleased)
+## x.x.x (Unreleased)
 
 ### New Features
 

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.0 (Unreleased)
+
+### New Features
+
+- New Rule: [`@wordpress/react-no-unsafe-timeout`](https://github.com/WordPress/gutenberg/blob/master/packages/eslint-plugin/docs/rules/react-no-unsafe-timeout.md)
+
 ## 2.1.0 (2019-03-20)
 
 ### New Features


### PR DESCRIPTION
Previously: #14650

This pull request seeks to add a CHANGELOG entry for the new rule added in #14650

