### PR TITLE
Block library: Standardize file structure of core blocks

### DIFF
--- a/packages/block-library/src/archives/icon.js
+++ b/packages/block-library/src/archives/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { G, Path, SVG } from '@wordpress/components';
+
+export default (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M7 11h2v2H7v-2zm14-5v14c0 1.1-.9 2-2 2H5c-1.11 0-2-.9-2-2l.01-14c0-1.1.88-2 1.99-2h1V2h2v2h8V2h2v2h1c1.1 0 2 .9 2 2zM5 8h14V6H5v2zm14 12V10H5v10h14zm-4-7h2v-2h-2v2zm-4 0h2v-2h-2v2z" /></G></SVG>
+);

--- a/packages/block-library/src/archives/index.js
+++ b/packages/block-library/src/archives/index.js
@@ -2,12 +2,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { G, Path, SVG } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import edit from './edit';
+import icon from './icon';
 
 export const name = 'core/archives';
 
@@ -16,7 +16,7 @@ export const settings = {
 
 	description: __( 'Display a monthly archive of your posts.' ),
 
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M7 11h2v2H7v-2zm14-5v14c0 1.1-.9 2-2 2H5c-1.11 0-2-.9-2-2l.01-14c0-1.1.88-2 1.99-2h1V2h2v2h8V2h2v2h1c1.1 0 2 .9 2 2zM5 8h14V6H5v2zm14 12V10H5v10h14zm-4-7h2v-2h-2v2zm-4 0h2v-2h-2v2z" /></G></SVG>,
+	icon,
 
 	category: 'widgets',
 

--- a/packages/block-library/src/button/icon.js
+++ b/packages/block-library/src/button/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { G, Path, SVG } from '@wordpress/components';
+
+export default (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M19 6H5c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm0 10H5V8h14v8z" /></G></SVG>
+);

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -7,7 +7,6 @@ import { omit, pick } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { G, Path, SVG } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import {
 	RichText,
@@ -18,6 +17,7 @@ import {
  * Internal dependencies
  */
 import edit from './edit';
+import icon from './icon';
 
 const blockAttributes = {
 	url: {
@@ -66,7 +66,7 @@ export const settings = {
 
 	description: __( 'Prompt visitors to take action with a button-style link.' ),
 
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M19 6H5c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm0 10H5V8h14v8z" /></G></SVG>,
+	icon,
 
 	category: 'layout',
 

--- a/packages/block-library/src/categories/icon.js
+++ b/packages/block-library/src/categories/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/components';
+
+export default (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Path d="M12,2l-5.5,9h11L12,2z M12,5.84L13.93,9h-3.87L12,5.84z" /><Path d="m17.5 13c-2.49 0-4.5 2.01-4.5 4.5s2.01 4.5 4.5 4.5 4.5-2.01 4.5-4.5-2.01-4.5-4.5-4.5zm0 7c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z" /><Path d="m3 21.5h8v-8h-8v8zm2-6h4v4h-4v-4z" /></SVG>
+);

--- a/packages/block-library/src/categories/index.js
+++ b/packages/block-library/src/categories/index.js
@@ -2,12 +2,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { SVG, Path } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import edit from './edit';
+import icon from './icon';
 
 export const name = 'core/categories';
 
@@ -16,7 +16,7 @@ export const settings = {
 
 	description: __( 'Display a list of all categories.' ),
 
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Path d="M12,2l-5.5,9h11L12,2z M12,5.84L13.93,9h-3.87L12,5.84z" /><Path d="m17.5 13c-2.49 0-4.5 2.01-4.5 4.5s2.01 4.5 4.5 4.5 4.5-2.01 4.5-4.5-2.01-4.5-4.5-4.5zm0 7c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z" /><Path d="m3 21.5h8v-8h-8v8zm2-6h4v4h-4v-4z" /></SVG>,
+	icon,
 
 	category: 'widgets',
 

--- a/packages/block-library/src/classic/icon.js
+++ b/packages/block-library/src/classic/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, Rect, SVG } from '@wordpress/components';
+
+export default (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z M0,0h24v24H0V0z" fill="none" /><Path d="m20 7v10h-16v-10h16m0-2h-16c-1.1 0-1.99 0.9-1.99 2l-0.01 10c0 1.1 0.9 2 2 2h16c1.1 0 2-0.9 2-2v-10c0-1.1-0.9-2-2-2z" /><Rect x="11" y="8" width="2" height="2" /><Rect x="11" y="11" width="2" height="2" /><Rect x="8" y="8" width="2" height="2" /><Rect x="8" y="11" width="2" height="2" /><Rect x="5" y="11" width="2" height="2" /><Rect x="5" y="8" width="2" height="2" /><Rect x="8" y="14" width="8" height="2" /><Rect x="14" y="11" width="2" height="2" /><Rect x="14" y="8" width="2" height="2" /><Rect x="17" y="11" width="2" height="2" /><Rect x="17" y="8" width="2" height="2" /></SVG>
+);

--- a/packages/block-library/src/classic/index.js
+++ b/packages/block-library/src/classic/index.js
@@ -3,12 +3,12 @@
  */
 import { RawHTML } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
-import { Path, Rect, SVG } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import edit from './edit';
+import icon from './icon';
 
 export const name = 'core/freeform';
 
@@ -17,7 +17,7 @@ export const settings = {
 
 	description: __( 'Use the classic WordPress editor.' ),
 
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z M0,0h24v24H0V0z" fill="none" /><Path d="m20 7v10h-16v-10h16m0-2h-16c-1.1 0-1.99 0.9-1.99 2l-0.01 10c0 1.1 0.9 2 2 2h16c1.1 0 2-0.9 2-2v-10c0-1.1-0.9-2-2-2z" /><Rect x="11" y="8" width="2" height="2" /><Rect x="11" y="11" width="2" height="2" /><Rect x="8" y="8" width="2" height="2" /><Rect x="8" y="11" width="2" height="2" /><Rect x="5" y="11" width="2" height="2" /><Rect x="5" y="8" width="2" height="2" /><Rect x="8" y="14" width="8" height="2" /><Rect x="14" y="11" width="2" height="2" /><Rect x="14" y="8" width="2" height="2" /><Rect x="17" y="11" width="2" height="2" /><Rect x="17" y="8" width="2" height="2" /></SVG>,
+	icon,
 
 	category: 'formatting',
 

--- a/packages/block-library/src/code/icon.js
+++ b/packages/block-library/src/code/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+export default (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Path d="M9.4,16.6L4.8,12l4.6-4.6L8,6l-6,6l6,6L9.4,16.6z M14.6,16.6l4.6-4.6l-4.6-4.6L16,6l6,6l-6,6L14.6,16.6z" /></SVG>
+);

--- a/packages/block-library/src/code/index.js
+++ b/packages/block-library/src/code/index.js
@@ -3,15 +3,12 @@
  */
 import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
-import {
-	Path,
-	SVG,
-} from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import edit from './edit';
+import icon from './icon';
 
 export const name = 'core/code';
 
@@ -20,7 +17,7 @@ export const settings = {
 
 	description: __( 'Display code snippets that respect your spacing and tabs.' ),
 
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Path d="M9.4,16.6L4.8,12l4.6-4.6L8,6l-6,6l6,6L9.4,16.6z M14.6,16.6l4.6-4.6l-4.6-4.6L16,6l6,6l-6,6L14.6,16.6z" /></SVG>,
+	icon,
 
 	category: 'formatting',
 

--- a/packages/block-library/src/columns/icon.js
+++ b/packages/block-library/src/columns/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { G, Path, SVG } from '@wordpress/components';
+
+export default (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M4,4H20a2,2,0,0,1,2,2V18a2,2,0,0,1-2,2H4a2,2,0,0,1-2-2V6A2,2,0,0,1,4,4ZM4 6V18H8V6Zm6 0V18h4V6Zm6 0V18h4V6Z" /></G></SVG>
+);

--- a/packages/block-library/src/columns/index.js
+++ b/packages/block-library/src/columns/index.js
@@ -7,11 +7,6 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	G,
-	SVG,
-	Path,
-} from '@wordpress/components';
 
 import {
 	InnerBlocks,
@@ -22,13 +17,14 @@ import {
  */
 import deprecated from './deprecated';
 import edit from './edit';
+import icon from './icon';
 
 export const name = 'core/columns';
 
 export const settings = {
 	title: __( 'Columns' ),
 
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M4,4H20a2,2,0,0,1,2,2V18a2,2,0,0,1-2,2H4a2,2,0,0,1-2-2V6A2,2,0,0,1,4,4ZM4 6V18H8V6Zm6 0V18h4V6Zm6 0V18h4V6Z" /></G></SVG>,
+	icon,
 
 	category: 'layout',
 

--- a/packages/block-library/src/heading/icon.js
+++ b/packages/block-library/src/heading/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+export default (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M5 4v3h5.5v12h3V7H19V4z" /><Path fill="none" d="M0 0h24v24H0V0z" /></SVG>
+);

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -13,15 +13,12 @@ import {
 	getBlockAttributes,
 } from '@wordpress/blocks';
 import { RichText } from '@wordpress/block-editor';
-import {
-	Path,
-	SVG,
-} from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import edit from './edit';
+import icon from './icon';
 
 /**
  * Given a node name string for a heading node, returns its numeric level.
@@ -65,7 +62,7 @@ export const settings = {
 
 	description: __( 'Introduce new sections and organize content to help visitors (and search engines) understand the structure of your content.' ),
 
-	icon: <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M5 4v3h5.5v12h3V7H19V4z" /><Path fill="none" d="M0 0h24v24H0V0z" /></SVG>,
+	icon,
 
 	category: 'common',
 

--- a/packages/block-library/src/html/icon.js
+++ b/packages/block-library/src/html/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/components';
+
+export default (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M4.5,11h-2V9H1v6h1.5v-2.5h2V15H6V9H4.5V11z M7,10.5h1.5V15H10v-4.5h1.5V9H7V10.5z M14.5,10l-1-1H12v6h1.5v-3.9  l1,1l1-1V15H17V9h-1.5L14.5,10z M19.5,13.5V9H18v6h5v-1.5H19.5z" /></SVG>
+);

--- a/packages/block-library/src/html/index.js
+++ b/packages/block-library/src/html/index.js
@@ -3,13 +3,13 @@
  */
 import { RawHTML } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { SVG, Path } from '@wordpress/components';
 import { getPhrasingContentSchema } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import edit from './edit';
+import icon from './icon';
 
 export const name = 'core/html';
 
@@ -18,7 +18,7 @@ export const settings = {
 
 	description: __( 'Add custom HTML code and preview it as you edit.' ),
 
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M4.5,11h-2V9H1v6h1.5v-2.5h2V15H6V9H4.5V11z M7,10.5h1.5V15H10v-4.5h1.5V9H7V10.5z M14.5,10l-1-1H12v6h1.5v-3.9  l1,1l1-1V15H17V9h-1.5L14.5,10z M19.5,13.5V9H18v6h5v-1.5H19.5z" /></SVG>,
+	icon,
 
 	category: 'formatting',
 

--- a/packages/block-library/src/latest-comments/icon.js
+++ b/packages/block-library/src/latest-comments/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { G, Path, SVG } from '@wordpress/components';
+
+export default (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M21.99 4c0-1.1-.89-2-1.99-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h14l4 4-.01-18zM20 4v13.17L18.83 16H4V4h16zM6 12h12v2H6zm0-3h12v2H6zm0-3h12v2H6z" /></G></SVG>
+);

--- a/packages/block-library/src/latest-comments/index.js
+++ b/packages/block-library/src/latest-comments/index.js
@@ -1,13 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { G, Path, SVG } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import edit from './edit';
+import icon from './icon';
 
 export const name = 'core/latest-comments';
 
@@ -16,7 +16,7 @@ export const settings = {
 
 	description: __( 'Display a list of your most recent comments.' ),
 
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M21.99 4c0-1.1-.89-2-1.99-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h14l4 4-.01-18zM20 4v13.17L18.83 16H4V4h16zM6 12h12v2H6zm0-3h12v2H6zm0-3h12v2H6z" /></G></SVG>,
+	icon,
 
 	category: 'widgets',
 

--- a/packages/block-library/src/latest-posts/icon.js
+++ b/packages/block-library/src/latest-posts/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, Rect, SVG } from '@wordpress/components';
+
+export default (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Rect x="11" y="7" width="6" height="2" /><Rect x="11" y="11" width="6" height="2" /><Rect x="11" y="15" width="6" height="2" /><Rect x="7" y="7" width="2" height="2" /><Rect x="7" y="11" width="2" height="2" /><Rect x="7" y="15" width="2" height="2" /><Path d="M20.1,3H3.9C3.4,3,3,3.4,3,3.9v16.2C3,20.5,3.4,21,3.9,21h16.2c0.4,0,0.9-0.5,0.9-0.9V3.9C21,3.4,20.5,3,20.1,3z M19,19H5V5h14V19z" /></SVG>
+);

--- a/packages/block-library/src/latest-posts/index.js
+++ b/packages/block-library/src/latest-posts/index.js
@@ -2,12 +2,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Path, Rect, SVG } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import edit from './edit';
+import icon from './icon';
 
 export const name = 'core/latest-posts';
 
@@ -16,7 +16,7 @@ export const settings = {
 
 	description: __( 'Display a list of your most recent posts.' ),
 
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Rect x="11" y="7" width="6" height="2" /><Rect x="11" y="11" width="6" height="2" /><Rect x="11" y="15" width="6" height="2" /><Rect x="7" y="7" width="2" height="2" /><Rect x="7" y="11" width="2" height="2" /><Rect x="7" y="15" width="2" height="2" /><Path d="M20.1,3H3.9C3.4,3,3,3.4,3,3.9v16.2C3,20.5,3.4,21,3.9,21h16.2c0.4,0,0.9-0.5,0.9-0.9V3.9C21,3.4,20.5,3,20.1,3z M19,19H5V5h14V19z" /></SVG>,
+	icon,
 
 	category: 'widgets',
 

--- a/packages/block-library/src/legacy-widget/icon.js
+++ b/packages/block-library/src/legacy-widget/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { G, Path, SVG } from '@wordpress/components';
+
+export default (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M7 11h2v2H7v-2zm14-5v14l-2 2H5l-2-2V6l2-2h1V2h2v2h8V2h2v2h1l2 2zM5 8h14V6H5v2zm14 12V10H5v10h14zm-4-7h2v-2h-2v2zm-4 0h2v-2h-2v2z" /></G></SVG>
+);

--- a/packages/block-library/src/legacy-widget/index.js
+++ b/packages/block-library/src/legacy-widget/index.js
@@ -2,12 +2,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { G, Path, SVG } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import edit from './edit';
+import icon from './icon';
 
 export const name = 'core/legacy-widget';
 
@@ -16,7 +16,7 @@ export const settings = {
 
 	description: __( 'Display a legacy widget.' ),
 
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M7 11h2v2H7v-2zm14-5v14l-2 2H5l-2-2V6l2-2h1V2h2v2h8V2h2v2h1l2 2zM5 8h14V6H5v2zm14 12V10H5v10h14zm-4-7h2v-2h-2v2zm-4 0h2v-2h-2v2z" /></G></SVG>,
+	icon,
 
 	category: 'widgets',
 

--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -1,0 +1,52 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createBlock } from '@wordpress/blocks';
+import { RichText } from '@wordpress/block-editor';
+
+export default function ListEdit( {
+	attributes,
+	insertBlocksAfter,
+	setAttributes,
+	mergeBlocks,
+	onReplace,
+	className,
+} ) {
+	const { ordered, values } = attributes;
+
+	return (
+		<RichText
+			identifier="values"
+			multiline="li"
+			tagName={ ordered ? 'ol' : 'ul' }
+			onChange={ ( nextValues ) => setAttributes( { values: nextValues } ) }
+			value={ values }
+			wrapperClassName="block-library-list"
+			className={ className }
+			placeholder={ __( 'Write list…' ) }
+			onMerge={ mergeBlocks }
+			unstableOnSplit={
+				insertBlocksAfter ?
+					( before, after, ...blocks ) => {
+						if ( ! blocks.length ) {
+							blocks.push( createBlock( 'core/paragraph' ) );
+						}
+
+						if ( after !== '<li></li>' ) {
+							blocks.push( createBlock( 'core/list', {
+								ordered,
+								values: after,
+							} ) );
+						}
+
+						setAttributes( { values: before } );
+						insertBlocksAfter( blocks );
+					} :
+					undefined
+			}
+			onRemove={ () => onReplace( [] ) }
+			onTagNameChange={ ( tag ) => setAttributes( { ordered: tag === 'ol' } ) }
+		/>
+	);
+}

--- a/packages/block-library/src/list/icon.js
+++ b/packages/block-library/src/list/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { G, Path, SVG } from '@wordpress/components';
+
+export default (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><G><Path d="M9 19h12v-2H9v2zm0-6h12v-2H9v2zm0-8v2h12V5H9zm-4-.5c-.828 0-1.5.672-1.5 1.5S4.172 7.5 5 7.5 6.5 6.828 6.5 6 5.828 4.5 5 4.5zm0 6c-.828 0-1.5.672-1.5 1.5s.672 1.5 1.5 1.5 1.5-.672 1.5-1.5-.672-1.5-1.5-1.5zm0 6c-.828 0-1.5.672-1.5 1.5s.672 1.5 1.5 1.5 1.5-.672 1.5-1.5-.672-1.5-1.5-1.5z" /></G></SVG>
+);

--- a/packages/block-library/src/list/index.js
+++ b/packages/block-library/src/list/index.js
@@ -14,7 +14,12 @@ import {
 } from '@wordpress/blocks';
 import { RichText } from '@wordpress/block-editor';
 import { replace, join, split, create, toHTMLString, LINE_SEPARATOR } from '@wordpress/rich-text';
-import { G, Path, SVG } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import icon from './icon';
 
 const listContentSchema = {
 	...getPhrasingContentSchema(),
@@ -56,7 +61,7 @@ export const name = 'core/list';
 export const settings = {
 	title: __( 'List' ),
 	description: __( 'Create a bulleted or numbered list.' ),
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><G><Path d="M9 19h12v-2H9v2zm0-6h12v-2H9v2zm0-8v2h12V5H9zm-4-.5c-.828 0-1.5.672-1.5 1.5S4.172 7.5 5 7.5 6.5 6.828 6.5 6 5.828 4.5 5 4.5zm0 6c-.828 0-1.5.672-1.5 1.5s.672 1.5 1.5 1.5 1.5-.672 1.5-1.5-.672-1.5-1.5-1.5zm0 6c-.828 0-1.5.672-1.5 1.5s.672 1.5 1.5 1.5 1.5-.672 1.5-1.5-.672-1.5-1.5-1.5z" /></G></SVG>,
+	icon,
 	category: 'common',
 	keywords: [ __( 'bullet list' ), __( 'ordered list' ), __( 'numbered list' ) ],
 
@@ -220,51 +225,7 @@ export const settings = {
 		};
 	},
 
-	edit( {
-		attributes,
-		insertBlocksAfter,
-		setAttributes,
-		mergeBlocks,
-		onReplace,
-		className,
-	} ) {
-		const { ordered, values } = attributes;
-
-		return (
-			<RichText
-				identifier="values"
-				multiline="li"
-				tagName={ ordered ? 'ol' : 'ul' }
-				onChange={ ( nextValues ) => setAttributes( { values: nextValues } ) }
-				value={ values }
-				wrapperClassName="block-library-list"
-				className={ className }
-				placeholder={ __( 'Write list…' ) }
-				onMerge={ mergeBlocks }
-				unstableOnSplit={
-					insertBlocksAfter ?
-						( before, after, ...blocks ) => {
-							if ( ! blocks.length ) {
-								blocks.push( createBlock( 'core/paragraph' ) );
-							}
-
-							if ( after !== '<li></li>' ) {
-								blocks.push( createBlock( 'core/list', {
-									ordered,
-									values: after,
-								} ) );
-							}
-
-							setAttributes( { values: before } );
-							insertBlocksAfter( blocks );
-						} :
-						undefined
-				}
-				onRemove={ () => onReplace( [] ) }
-				onTagNameChange={ ( tag ) => setAttributes( { ordered: tag === 'ol' } ) }
-			/>
-		);
-	},
+	edit,
 
 	save( { attributes } ) {
 		const { ordered, values } = attributes;

--- a/packages/block-library/src/missing/edit.js
+++ b/packages/block-library/src/missing/edit.js
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { RawHTML, Fragment } from '@wordpress/element';
+import { Button } from '@wordpress/components';
+import { getBlockType, createBlock } from '@wordpress/blocks';
+import { withDispatch } from '@wordpress/data';
+import { Warning } from '@wordpress/block-editor';
+
+function MissingBlockWarning( { attributes, convertToHTML } ) {
+	const { originalName, originalUndelimitedContent } = attributes;
+	const hasContent = !! originalUndelimitedContent;
+	const hasHTMLBlock = getBlockType( 'core/html' );
+
+	const actions = [];
+	let messageHTML;
+	if ( hasContent && hasHTMLBlock ) {
+		messageHTML = sprintf(
+			__( 'Your site doesn’t include support for the "%s" block. You can leave this block intact, convert its content to a Custom HTML block, or remove it entirely.' ),
+			originalName
+		);
+		actions.push(
+			<Button key="convert" onClick={ convertToHTML } isLarge isPrimary>
+				{ __( 'Keep as HTML' ) }
+			</Button>
+		);
+	} else {
+		messageHTML = sprintf(
+			__( 'Your site doesn’t include support for the "%s" block. You can leave this block intact or remove it entirely.' ),
+			originalName
+		);
+	}
+
+	return (
+		<Fragment>
+			<Warning actions={ actions }>
+				{ messageHTML }
+			</Warning>
+			<RawHTML>{ originalUndelimitedContent }</RawHTML>
+		</Fragment>
+	);
+}
+
+const MissingEdit = withDispatch( ( dispatch, { clientId, attributes } ) => {
+	const { replaceBlock } = dispatch( 'core/block-editor' );
+	return {
+		convertToHTML() {
+			replaceBlock( clientId, createBlock( 'core/html', {
+				content: attributes.originalUndelimitedContent,
+			} ) );
+		},
+	};
+} )( MissingBlockWarning );
+
+export default MissingEdit;

--- a/packages/block-library/src/missing/index.js
+++ b/packages/block-library/src/missing/index.js
@@ -1,57 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
-import { RawHTML, Fragment } from '@wordpress/element';
-import { Button } from '@wordpress/components';
-import { getBlockType, createBlock } from '@wordpress/blocks';
-import { withDispatch } from '@wordpress/data';
-import { Warning } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import { RawHTML } from '@wordpress/element';
 
-function MissingBlockWarning( { attributes, convertToHTML } ) {
-	const { originalName, originalUndelimitedContent } = attributes;
-	const hasContent = !! originalUndelimitedContent;
-	const hasHTMLBlock = getBlockType( 'core/html' );
-
-	const actions = [];
-	let messageHTML;
-	if ( hasContent && hasHTMLBlock ) {
-		messageHTML = sprintf(
-			__( 'Your site doesn’t include support for the "%s" block. You can leave this block intact, convert its content to a Custom HTML block, or remove it entirely.' ),
-			originalName
-		);
-		actions.push(
-			<Button key="convert" onClick={ convertToHTML } isLarge isPrimary>
-				{ __( 'Keep as HTML' ) }
-			</Button>
-		);
-	} else {
-		messageHTML = sprintf(
-			__( 'Your site doesn’t include support for the "%s" block. You can leave this block intact or remove it entirely.' ),
-			originalName
-		);
-	}
-
-	return (
-		<Fragment>
-			<Warning actions={ actions }>
-				{ messageHTML }
-			</Warning>
-			<RawHTML>{ originalUndelimitedContent }</RawHTML>
-		</Fragment>
-	);
-}
-
-const edit = withDispatch( ( dispatch, { clientId, attributes } ) => {
-	const { replaceBlock } = dispatch( 'core/block-editor' );
-	return {
-		convertToHTML() {
-			replaceBlock( clientId, createBlock( 'core/html', {
-				content: attributes.originalUndelimitedContent,
-			} ) );
-		},
-	};
-} )( MissingBlockWarning );
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
 
 export const name = 'core/missing';
 

--- a/packages/block-library/src/more/icon.js
+++ b/packages/block-library/src/more/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { G, Path, SVG } from '@wordpress/components';
+
+export default (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M2 9v2h19V9H2zm0 6h5v-2H2v2zm7 0h5v-2H9v2zm7 0h5v-2h-5v2z" /></G></SVG>
+);

--- a/packages/block-library/src/more/index.js
+++ b/packages/block-library/src/more/index.js
@@ -9,16 +9,12 @@ import { compact } from 'lodash';
 import { __, _x } from '@wordpress/i18n';
 import { RawHTML } from '@wordpress/element';
 import { createBlock } from '@wordpress/blocks';
-import {
-	Path,
-	G,
-	SVG,
-} from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import edit from './edit';
+import icon from './icon';
 
 export const name = 'core/more';
 
@@ -27,7 +23,7 @@ export const settings = {
 
 	description: __( 'Content before this block will be shown in the excerpt on your archives page.' ),
 
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M2 9v2h19V9H2zm0 6h5v-2H2v2zm7 0h5v-2H9v2zm7 0h5v-2h-5v2z" /></G></SVG>,
+	icon,
 
 	category: 'layout',
 

--- a/packages/block-library/src/nextpage/icon.js
+++ b/packages/block-library/src/nextpage/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { G, Path, SVG } from '@wordpress/components';
+
+export default (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><G><Path d="M9 12h6v-2H9zm-7 0h5v-2H2zm15 0h5v-2h-5zm3 2v2l-6 6H6a2 2 0 0 1-2-2v-6h2v6h6v-4a2 2 0 0 1 2-2h6zM4 8V4a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v4h-2V4H6v4z" /></G></SVG>
+);

--- a/packages/block-library/src/nextpage/index.js
+++ b/packages/block-library/src/nextpage/index.js
@@ -4,12 +4,12 @@
 import { __ } from '@wordpress/i18n';
 import { RawHTML } from '@wordpress/element';
 import { createBlock } from '@wordpress/blocks';
-import { G, Path, SVG } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import edit from './edit';
+import icon from './icon';
 
 export const name = 'core/nextpage';
 
@@ -18,7 +18,7 @@ export const settings = {
 
 	description: __( 'Separate your content into a multi-page experience.' ),
 
-	icon: <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><G><Path d="M9 12h6v-2H9zm-7 0h5v-2H2zm15 0h5v-2h-5zm3 2v2l-6 6H6a2 2 0 0 1-2-2v-6h2v6h6v-4a2 2 0 0 1 2-2h6zM4 8V4a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v4h-2V4H6v4z" /></G></SVG>,
+	icon,
 
 	category: 'layout',
 

--- a/packages/block-library/src/paragraph/icon.js
+++ b/packages/block-library/src/paragraph/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+export default (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M11 5v7H9.5C7.6 12 6 10.4 6 8.5S7.6 5 9.5 5H11m8-2H9.5C6.5 3 4 5.5 4 8.5S6.5 14 9.5 14H11v7h2V5h2v16h2V5h2V3z" /></SVG>
+);

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -17,15 +17,12 @@ import {
 	RichText,
 } from '@wordpress/block-editor';
 import { getPhrasingContentSchema } from '@wordpress/blocks';
-import {
-	Path,
-	SVG,
-} from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import edit from './edit';
+import icon from './icon';
 
 const supports = {
 	className: false,
@@ -79,7 +76,7 @@ export const settings = {
 
 	description: __( 'Start with the building block of all narrative.' ),
 
-	icon: <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M11 5v7H9.5C7.6 12 6 10.4 6 8.5S7.6 5 9.5 5H11m8-2H9.5C6.5 3 4 5.5 4 8.5S6.5 14 9.5 14H11v7h2V5h2v16h2V5h2V3z" /></SVG>,
+	icon,
 
 	category: 'common',
 

--- a/packages/block-library/src/preformatted/edit.js
+++ b/packages/block-library/src/preformatted/edit.js
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { RichText } from '@wordpress/block-editor';
+
+export default function PreformattedEdit( { attributes, mergeBlocks, setAttributes, className } ) {
+	const { content } = attributes;
+
+	return (
+		<RichText
+			tagName="pre"
+			// Ensure line breaks are normalised to HTML.
+			value={ content.replace( /\n/g, '<br>' ) }
+			onChange={ ( nextContent ) => {
+				setAttributes( {
+					// Ensure line breaks are normalised to characters. This
+					// saves space, is easier to read, and ensures display
+					// filters work correctly.
+					content: nextContent.replace( /<br ?\/?>/g, '\n' ),
+				} );
+			} }
+			placeholder={ __( 'Write preformatted text…' ) }
+			wrapperClassName={ className }
+			onMerge={ mergeBlocks }
+		/>
+	);
+}

--- a/packages/block-library/src/preformatted/icon.js
+++ b/packages/block-library/src/preformatted/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, Rect, SVG } from '@wordpress/components';
+
+export default (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Path d="M20,4H4C2.9,4,2,4.9,2,6v12c0,1.1,0.9,2,2,2h16c1.1,0,2-0.9,2-2V6C22,4.9,21.1,4,20,4z M20,18H4V6h16V18z" /><Rect x="6" y="10" width="2" height="2" /><Rect x="6" y="14" width="8" height="2" /><Rect x="16" y="14" width="2" height="2" /><Rect x="10" y="10" width="8" height="2" /></SVG>
+);

--- a/packages/block-library/src/preformatted/index.js
+++ b/packages/block-library/src/preformatted/index.js
@@ -4,7 +4,12 @@
 import { __ } from '@wordpress/i18n';
 import { createBlock, getPhrasingContentSchema } from '@wordpress/blocks';
 import { RichText } from '@wordpress/block-editor';
-import { Path, Rect, SVG } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import icon from './icon';
 
 export const name = 'core/preformatted';
 
@@ -13,7 +18,7 @@ export const settings = {
 
 	description: __( 'Add text that respects your spacing and tabs, and also allows styling.' ),
 
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Path d="M20,4H4C2.9,4,2,4.9,2,6v12c0,1.1,0.9,2,2,2h16c1.1,0,2-0.9,2-2V6C22,4.9,21.1,4,20,4z M20,18H4V6h16V18z" /><Rect x="6" y="10" width="2" height="2" /><Rect x="6" y="14" width="8" height="2" /><Rect x="16" y="14" width="2" height="2" /><Rect x="10" y="10" width="8" height="2" /></SVG>,
+	icon,
 
 	category: 'formatting',
 
@@ -62,28 +67,7 @@ export const settings = {
 		],
 	},
 
-	edit( { attributes, mergeBlocks, setAttributes, className } ) {
-		const { content } = attributes;
-
-		return (
-			<RichText
-				tagName="pre"
-				// Ensure line breaks are normalised to HTML.
-				value={ content.replace( /\n/g, '<br>' ) }
-				onChange={ ( nextContent ) => {
-					setAttributes( {
-						// Ensure line breaks are normalised to characters. This
-						// saves space, is easier to read, and ensures display
-						// filters work correctly.
-						content: nextContent.replace( /<br ?\/?>/g, '\n' ),
-					} );
-				} }
-				placeholder={ __( 'Write preformatted text…' ) }
-				wrapperClassName={ className }
-				onMerge={ mergeBlocks }
-			/>
-		);
-	},
+	edit,
 
 	save( { attributes } ) {
 		const { content } = attributes;

--- a/packages/block-library/src/pullquote/icon.js
+++ b/packages/block-library/src/pullquote/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, Polygon, SVG } from '@wordpress/components';
+
+export default (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Polygon points="21 18 2 18 2 20 21 20" /><Path d="m19 10v4h-15v-4h15m1-2h-17c-0.55 0-1 0.45-1 1v6c0 0.55 0.45 1 1 1h17c0.55 0 1-0.45 1-1v-6c0-0.55-0.45-1-1-1z" /><Polygon points="21 4 2 4 2 6 21 6" /></SVG>
+);

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -16,7 +16,6 @@ import {
 import {
 	select,
 } from '@wordpress/data';
-import { Path, Polygon, SVG } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -26,6 +25,7 @@ import {
 	SOLID_COLOR_STYLE_NAME,
 	SOLID_COLOR_CLASS,
 } from './edit';
+import icon from './icon';
 
 const blockAttributes = {
 	value: {
@@ -62,7 +62,7 @@ export const settings = {
 
 	description: __( 'Give special visual emphasis to a quote from your text.' ),
 
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M0,0h24v24H0V0z" fill="none" /><Polygon points="21 18 2 18 2 20 21 20" /><Path d="m19 10v4h-15v-4h15m1-2h-17c-0.55 0-1 0.45-1 1v6c0 0.55 0.45 1 1 1h17c0.55 0 1-0.45 1-1v-6c0-0.55-0.45-1-1-1z" /><Polygon points="21 4 2 4 2 6 21 6" /></SVG>,
+	icon,
 
 	category: 'formatting',
 

--- a/packages/block-library/src/quote/contants.js
+++ b/packages/block-library/src/quote/contants.js
@@ -1,0 +1,2 @@
+export const ATTRIBUTE_QUOTE = 'value';
+export const ATTRIBUTE_CITATION = 'citation';

--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -1,0 +1,70 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Fragment } from '@wordpress/element';
+import {
+	BlockControls,
+	AlignmentToolbar,
+	RichText,
+} from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { ATTRIBUTE_QUOTE, ATTRIBUTE_CITATION } from './contants';
+
+export default function QuoteEdit( { attributes, setAttributes, isSelected, mergeBlocks, onReplace, className } ) {
+	const { align, value, citation } = attributes;
+	return (
+		<Fragment>
+			<BlockControls>
+				<AlignmentToolbar
+					value={ align }
+					onChange={ ( nextAlign ) => {
+						setAttributes( { align: nextAlign } );
+					} }
+				/>
+			</BlockControls>
+			<blockquote className={ className } style={ { textAlign: align } }>
+				<RichText
+					identifier={ ATTRIBUTE_QUOTE }
+					multiline
+					value={ value }
+					onChange={
+						( nextValue ) => setAttributes( {
+							value: nextValue,
+						} )
+					}
+					onMerge={ mergeBlocks }
+					onRemove={ ( forward ) => {
+						const hasEmptyCitation = ! citation || citation.length === 0;
+						if ( ! forward && hasEmptyCitation ) {
+							onReplace( [] );
+						}
+					} }
+					placeholder={
+						// translators: placeholder text used for the quote
+						__( 'Write quote…' )
+					}
+				/>
+				{ ( ! RichText.isEmpty( citation ) || isSelected ) && (
+					<RichText
+						identifier={ ATTRIBUTE_CITATION }
+						value={ citation }
+						onChange={
+							( nextCitation ) => setAttributes( {
+								citation: nextCitation,
+							} )
+						}
+						placeholder={
+							// translators: placeholder text used for the citation
+							__( 'Write citation…' )
+						}
+						className="wp-block-quote__citation"
+					/>
+				) }
+			</blockquote>
+		</Fragment>
+	);
+}

--- a/packages/block-library/src/quote/icon.js
+++ b/packages/block-library/src/quote/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+export default (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><Path d="M18.62 18h-5.24l2-4H13V6h8v7.24L18.62 18zm-2-2h.76L19 12.76V8h-4v4h3.62l-2 4zm-8 2H3.38l2-4H3V6h8v7.24L8.62 18zm-2-2h.76L9 12.76V8H5v4h3.62l-2 4z" /></SVG>
+);

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -7,18 +7,16 @@ import { omit } from 'lodash';
  * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { createBlock, getPhrasingContentSchema } from '@wordpress/blocks';
-import {
-	BlockControls,
-	AlignmentToolbar,
-	RichText,
-} from '@wordpress/block-editor';
+import { RichText } from '@wordpress/block-editor';
 import { join, split, create, toHTMLString } from '@wordpress/rich-text';
-import { Path, SVG } from '@wordpress/components';
 
-const ATTRIBUTE_QUOTE = 'value';
-const ATTRIBUTE_CITATION = 'citation';
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import icon from './icon';
+import { ATTRIBUTE_QUOTE, ATTRIBUTE_CITATION } from './contants';
 
 const blockAttributes = {
 	[ ATTRIBUTE_QUOTE ]: {
@@ -44,7 +42,7 @@ export const name = 'core/quote';
 export const settings = {
 	title: __( 'Quote' ),
 	description: __( 'Give quoted text visual emphasis. "In quoting others, we cite ourselves." — Julio Cortázar' ),
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><Path d="M18.62 18h-5.24l2-4H13V6h8v7.24L18.62 18zm-2-2h.76L19 12.76V8h-4v4h3.62l-2 4zm-8 2H3.38l2-4H3V6h8v7.24L8.62 18zm-2-2h.76L9 12.76V8H5v4h3.62l-2 4z" /></SVG>,
+	icon,
 	category: 'common',
 	keywords: [ __( 'blockquote' ) ],
 
@@ -223,60 +221,7 @@ export const settings = {
 		],
 	},
 
-	edit( { attributes, setAttributes, isSelected, mergeBlocks, onReplace, className } ) {
-		const { align, value, citation } = attributes;
-		return (
-			<Fragment>
-				<BlockControls>
-					<AlignmentToolbar
-						value={ align }
-						onChange={ ( nextAlign ) => {
-							setAttributes( { align: nextAlign } );
-						} }
-					/>
-				</BlockControls>
-				<blockquote className={ className } style={ { textAlign: align } }>
-					<RichText
-						identifier={ ATTRIBUTE_QUOTE }
-						multiline
-						value={ value }
-						onChange={
-							( nextValue ) => setAttributes( {
-								value: nextValue,
-							} )
-						}
-						onMerge={ mergeBlocks }
-						onRemove={ ( forward ) => {
-							const hasEmptyCitation = ! citation || citation.length === 0;
-							if ( ! forward && hasEmptyCitation ) {
-								onReplace( [] );
-							}
-						} }
-						placeholder={
-							// translators: placeholder text used for the quote
-							__( 'Write quote…' )
-						}
-					/>
-					{ ( ! RichText.isEmpty( citation ) || isSelected ) && (
-						<RichText
-							identifier={ ATTRIBUTE_CITATION }
-							value={ citation }
-							onChange={
-								( nextCitation ) => setAttributes( {
-									citation: nextCitation,
-								} )
-							}
-							placeholder={
-								// translators: placeholder text used for the citation
-								__( 'Write citation…' )
-							}
-							className="wp-block-quote__citation"
-						/>
-					) }
-				</blockquote>
-			</Fragment>
-		);
-	},
+	edit,
 
 	save( { attributes } ) {
 		const { align, value, citation } = attributes;

--- a/packages/block-library/src/separator/edit.js
+++ b/packages/block-library/src/separator/edit.js
@@ -1,0 +1,3 @@
+export default function SeparatorEdit( { className } ) {
+	return <hr className={ className } />;
+}

--- a/packages/block-library/src/separator/icon.js
+++ b/packages/block-library/src/separator/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+export default (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><Path d="M19 13H5v-2h14v2z" /></SVG>
+);

--- a/packages/block-library/src/separator/index.js
+++ b/packages/block-library/src/separator/index.js
@@ -3,7 +3,12 @@
  */
 import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
-import { SVG, Path } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import icon from './icon';
 
 export const name = 'core/separator';
 
@@ -12,7 +17,7 @@ export const settings = {
 
 	description: __( 'Create a break between ideas or sections with a horizontal separator.' ),
 
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><Path d="M19 13H5v-2h14v2z" /></SVG>,
+	icon,
 
 	category: 'layout',
 
@@ -41,9 +46,7 @@ export const settings = {
 		],
 	},
 
-	edit( { className } ) {
-		return <hr className={ className } />;
-	},
+	edit,
 
 	save() {
 		return <hr />;

--- a/packages/block-library/src/shortcode/edit.js
+++ b/packages/block-library/src/shortcode/edit.js
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Dashicon } from '@wordpress/components';
+import { PlainText } from '@wordpress/block-editor';
+import { withInstanceId } from '@wordpress/compose';
+
+const ShortcodeEdit = ( { attributes, setAttributes, instanceId } ) => {
+	const inputId = `blocks-shortcode-input-${ instanceId }`;
+
+	return (
+		<div className="wp-block-shortcode">
+			<label htmlFor={ inputId }>
+				<Dashicon icon="shortcode" />
+				{ __( 'Shortcode' ) }
+			</label>
+			<PlainText
+				className="input-control"
+				id={ inputId }
+				value={ attributes.text }
+				placeholder={ __( 'Write shortcode here…' ) }
+				onChange={ ( text ) => setAttributes( { text } ) }
+			/>
+		</div>
+	);
+};
+
+export default withInstanceId( ShortcodeEdit );

--- a/packages/block-library/src/shortcode/icon.js
+++ b/packages/block-library/src/shortcode/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+export default (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M8.5,21.4l1.9,0.5l5.2-19.3l-1.9-0.5L8.5,21.4z M3,19h4v-2H5V7h2V5H3V19z M17,5v2h2v10h-2v2h4V5H17z" /></SVG>
+);

--- a/packages/block-library/src/shortcode/index.js
+++ b/packages/block-library/src/shortcode/index.js
@@ -4,9 +4,12 @@
 import { removep, autop } from '@wordpress/autop';
 import { RawHTML } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Dashicon, SVG, Path } from '@wordpress/components';
-import { PlainText } from '@wordpress/block-editor';
-import { withInstanceId } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import icon from './icon';
 
 export const name = 'core/shortcode';
 
@@ -15,7 +18,7 @@ export const settings = {
 
 	description: __( 'Insert additional custom elements with a WordPress shortcode.' ),
 
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M8.5,21.4l1.9,0.5l5.2-19.3l-1.9-0.5L8.5,21.4z M3,19h4v-2H5V7h2V5H3V19z M17,5v2h2v10h-2v2h4V5H17z" /></SVG>,
+	icon,
 
 	category: 'widgets',
 
@@ -50,27 +53,7 @@ export const settings = {
 		html: false,
 	},
 
-	edit: withInstanceId(
-		( { attributes, setAttributes, instanceId } ) => {
-			const inputId = `blocks-shortcode-input-${ instanceId }`;
-
-			return (
-				<div className="wp-block-shortcode">
-					<label htmlFor={ inputId }>
-						<Dashicon icon="shortcode" />
-						{ __( 'Shortcode' ) }
-					</label>
-					<PlainText
-						className="input-control"
-						id={ inputId }
-						value={ attributes.text }
-						placeholder={ __( 'Write shortcode here…' ) }
-						onChange={ ( text ) => setAttributes( { text } ) }
-					/>
-				</div>
-			);
-		}
-	),
+	edit,
 
 	save( { attributes } ) {
 		return <RawHTML>{ attributes.text }</RawHTML>;

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { InspectorControls } from '@wordpress/block-editor';
+import { BaseControl, PanelBody, ResizableBox } from '@wordpress/components';
+import { withInstanceId } from '@wordpress/compose';
+
+const SpacerEdit = ( { attributes, isSelected, setAttributes, toggleSelection, instanceId } ) => {
+	const { height } = attributes;
+	const id = `block-spacer-height-input-${ instanceId }`;
+
+	return (
+		<Fragment>
+			<ResizableBox
+				className={ classnames(
+					'block-library-spacer__resize-container',
+					{ 'is-selected': isSelected },
+				) }
+				size={ {
+					height,
+				} }
+				minHeight="20"
+				enable={ {
+					top: false,
+					right: false,
+					bottom: true,
+					left: false,
+					topRight: false,
+					bottomRight: false,
+					bottomLeft: false,
+					topLeft: false,
+				} }
+				onResizeStop={ ( event, direction, elt, delta ) => {
+					setAttributes( {
+						height: parseInt( height + delta.height, 10 ),
+					} );
+					toggleSelection( true );
+				} }
+				onResizeStart={ () => {
+					toggleSelection( false );
+				} }
+			/>
+			<InspectorControls>
+				<PanelBody title={ __( 'Spacer Settings' ) }>
+					<BaseControl label={ __( 'Height in pixels' ) } id={ id }>
+						<input
+							type="number"
+							id={ id }
+							onChange={ ( event ) => {
+								setAttributes( {
+									height: parseInt( event.target.value, 10 ),
+								} );
+							} }
+							value={ height }
+							min="20"
+							step="10"
+						/>
+					</BaseControl>
+				</PanelBody>
+			</InspectorControls>
+		</Fragment>
+	);
+};
+
+export default withInstanceId( SpacerEdit );

--- a/packages/block-library/src/spacer/icon.js
+++ b/packages/block-library/src/spacer/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { G, Path, SVG } from '@wordpress/components';
+
+export default (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><G><Path d="M13 4v2h3.59L6 16.59V13H4v7h7v-2H7.41L18 7.41V11h2V4h-7" /></G></SVG>
+);

--- a/packages/block-library/src/spacer/index.js
+++ b/packages/block-library/src/spacer/index.js
@@ -1,16 +1,13 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
-import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { InspectorControls } from '@wordpress/block-editor';
-import { BaseControl, PanelBody, ResizableBox, G, SVG, Path } from '@wordpress/components';
-import { withInstanceId } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import icon from './icon';
 
 export const name = 'core/spacer';
 
@@ -19,7 +16,7 @@ export const settings = {
 
 	description: __( 'Add white space between blocks and customize its height.' ),
 
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><G><Path d="M13 4v2h3.59L6 16.59V13H4v7h7v-2H7.41L18 7.41V11h2V4h-7" /></G></SVG>,
+	icon,
 
 	category: 'layout',
 
@@ -30,64 +27,7 @@ export const settings = {
 		},
 	},
 
-	edit: withInstanceId(
-		( { attributes, isSelected, setAttributes, toggleSelection, instanceId } ) => {
-			const { height } = attributes;
-			const id = `block-spacer-height-input-${ instanceId }`;
-
-			return (
-				<Fragment>
-					<ResizableBox
-						className={ classnames(
-							'block-library-spacer__resize-container',
-							{ 'is-selected': isSelected }
-						) }
-						size={ {
-							height,
-						} }
-						minHeight="20"
-						enable={ {
-							top: false,
-							right: false,
-							bottom: true,
-							left: false,
-							topRight: false,
-							bottomRight: false,
-							bottomLeft: false,
-							topLeft: false,
-						} }
-						onResizeStop={ ( event, direction, elt, delta ) => {
-							setAttributes( {
-								height: parseInt( height + delta.height, 10 ),
-							} );
-							toggleSelection( true );
-						} }
-						onResizeStart={ () => {
-							toggleSelection( false );
-						} }
-					/>
-					<InspectorControls>
-						<PanelBody title={ __( 'Spacer Settings' ) }>
-							<BaseControl label={ __( 'Height in pixels' ) } id={ id }>
-								<input
-									type="number"
-									id={ id }
-									onChange={ ( event ) => {
-										setAttributes( {
-											height: parseInt( event.target.value, 10 ),
-										} );
-									} }
-									value={ height }
-									min="20"
-									step="10"
-								/>
-							</BaseControl>
-						</PanelBody>
-					</InspectorControls>
-				</Fragment>
-			);
-		}
-	),
+	edit,
 
 	save( { attributes } ) {
 		return <div style={ { height: attributes.height } } aria-hidden />;

--- a/packages/block-library/src/subhead/edit.js
+++ b/packages/block-library/src/subhead/edit.js
@@ -1,0 +1,45 @@
+/**
+ * WordPress dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+import { __ } from '@wordpress/i18n';
+import { Fragment } from '@wordpress/element';
+import {
+	RichText,
+	BlockControls,
+	AlignmentToolbar,
+} from '@wordpress/block-editor';
+
+export default function SubheadEdit( { attributes, setAttributes, className } ) {
+	const { align, content, placeholder } = attributes;
+
+	deprecated( 'The Subheading block', {
+		alternative: 'the Paragraph block',
+		plugin: 'Gutenberg',
+	} );
+
+	return (
+		<Fragment>
+			<BlockControls>
+				<AlignmentToolbar
+					value={ align }
+					onChange={ ( nextAlign ) => {
+						setAttributes( { align: nextAlign } );
+					} }
+				/>
+			</BlockControls>
+			<RichText
+				tagName="p"
+				value={ content }
+				onChange={ ( nextContent ) => {
+					setAttributes( {
+						content: nextContent,
+					} );
+				} }
+				style={ { textAlign: align } }
+				className={ className }
+				placeholder={ placeholder || __( 'Write subheading…' ) }
+			/>
+		</Fragment>
+	);
+}

--- a/packages/block-library/src/subhead/icon.js
+++ b/packages/block-library/src/subhead/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+export default (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M7.1 6l-.5 3h4.5L9.4 19h3l1.8-10h4.5l.5-3H7.1z" /></SVG>
+);

--- a/packages/block-library/src/subhead/index.js
+++ b/packages/block-library/src/subhead/index.js
@@ -1,16 +1,15 @@
 /**
  * WordPress dependencies
  */
-import deprecated from '@wordpress/deprecated';
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { createBlock } from '@wordpress/blocks';
-import {
-	RichText,
-	BlockControls,
-	AlignmentToolbar,
-} from '@wordpress/block-editor';
-import { SVG, Path } from '@wordpress/components';
+import { RichText } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import icon from './icon';
 
 export const name = 'core/subhead';
 
@@ -19,7 +18,7 @@ export const settings = {
 
 	description: __( 'This block is deprecated. Please use the Paragraph block instead.' ),
 
-	icon: <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M7.1 6l-.5 3h4.5L9.4 19h3l1.8-10h4.5l.5-3H7.1z" /></SVG>,
+	icon,
 
 	category: 'common',
 
@@ -51,39 +50,7 @@ export const settings = {
 		],
 	},
 
-	edit( { attributes, setAttributes, className } ) {
-		const { align, content, placeholder } = attributes;
-
-		deprecated( 'The Subheading block', {
-			alternative: 'the Paragraph block',
-			plugin: 'Gutenberg',
-		} );
-
-		return (
-			<Fragment>
-				<BlockControls>
-					<AlignmentToolbar
-						value={ align }
-						onChange={ ( nextAlign ) => {
-							setAttributes( { align: nextAlign } );
-						} }
-					/>
-				</BlockControls>
-				<RichText
-					tagName="p"
-					value={ content }
-					onChange={ ( nextContent ) => {
-						setAttributes( {
-							content: nextContent,
-						} );
-					} }
-					style={ { textAlign: align } }
-					className={ className }
-					placeholder={ placeholder || __( 'Write subheading…' ) }
-				/>
-			</Fragment>
-		);
-	},
+	edit,
 
 	save( { attributes } ) {
 		const { align, content } = attributes;

--- a/packages/block-library/src/table/icon.js
+++ b/packages/block-library/src/table/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { G, Path, SVG } from '@wordpress/components';
+
+export default (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M20 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h15c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 2v3H5V5h15zm-5 14h-5v-9h5v9zM5 10h3v9H5v-9zm12 9v-9h3v9h-3z" /></G></SVG>
+);

--- a/packages/block-library/src/table/index.js
+++ b/packages/block-library/src/table/index.js
@@ -8,13 +8,13 @@ import classnames from 'classnames';
  */
 import { __, _x } from '@wordpress/i18n';
 import { getPhrasingContentSchema } from '@wordpress/blocks';
-import { G, Path, SVG } from '@wordpress/components';
 import { RichText, getColorClassName } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import edit from './edit';
+import icon from './icon';
 
 const tableContentPasteSchema = {
 	tr: {
@@ -84,7 +84,7 @@ export const name = 'core/table';
 export const settings = {
 	title: __( 'Table' ),
 	description: __( 'Insert a table — perfect for sharing charts and data.' ),
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M20 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h15c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 2v3H5V5h15zm-5 14h-5v-9h5v9zM5 10h3v9H5v-9zm12 9v-9h3v9h-3z" /></G></SVG>,
+	icon,
 	category: 'formatting',
 
 	attributes: {

--- a/packages/block-library/src/template/icon.js
+++ b/packages/block-library/src/template/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { G, Path, Rect, SVG } from '@wordpress/components';
+
+export default (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Rect x="0" fill="none" width="24" height="24" /><G><Path d="M19 3H5c-1.105 0-2 .895-2 2v14c0 1.105.895 2 2 2h14c1.105 0 2-.895 2-2V5c0-1.105-.895-2-2-2zM6 6h5v5H6V6zm4.5 13C9.12 19 8 17.88 8 16.5S9.12 14 10.5 14s2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5zm3-6l3-5 3 5h-6z" /></G></SVG>
+);

--- a/packages/block-library/src/template/index.js
+++ b/packages/block-library/src/template/index.js
@@ -3,7 +3,11 @@
  */
 import { __ } from '@wordpress/i18n';
 import { InnerBlocks } from '@wordpress/block-editor';
-import { G, Path, Rect, SVG } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import icon from './icon';
 
 export const name = 'core/template';
 
@@ -14,7 +18,7 @@ export const settings = {
 
 	description: __( 'Template block used as a container.' ),
 
-	icon: <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Rect x="0" fill="none" width="24" height="24" /><G><Path d="M19 3H5c-1.105 0-2 .895-2 2v14c0 1.105.895 2 2 2h14c1.105 0 2-.895 2-2V5c0-1.105-.895-2-2-2zM6 6h5v5H6V6zm4.5 13C9.12 19 8 17.88 8 16.5S9.12 14 10.5 14s2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5zm3-6l3-5 3 5h-6z" /></G></SVG>,
+	icon,
 
 	supports: {
 		customClassName: false,

--- a/packages/block-library/src/text-columns/edit.js
+++ b/packages/block-library/src/text-columns/edit.js
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+import { get, times } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { PanelBody, RangeControl } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
+import {
+	BlockControls,
+	BlockAlignmentToolbar,
+	InspectorControls,
+	RichText,
+} from '@wordpress/block-editor';
+import deprecated from '@wordpress/deprecated';
+
+export default function TextColumnsEdit( { attributes, setAttributes, className } ) {
+	const { width, content, columns } = attributes;
+
+	deprecated( 'The Text Columns block', {
+		alternative: 'the Columns block',
+		plugin: 'Gutenberg',
+	} );
+
+	return (
+		<Fragment>
+			<BlockControls>
+				<BlockAlignmentToolbar
+					value={ width }
+					onChange={ ( nextWidth ) => setAttributes( { width: nextWidth } ) }
+					controls={ [ 'center', 'wide', 'full' ] }
+				/>
+			</BlockControls>
+			<InspectorControls>
+				<PanelBody>
+					<RangeControl
+						label={ __( 'Columns' ) }
+						value={ columns }
+						onChange={ ( value ) => setAttributes( { columns: value } ) }
+						min={ 2 }
+						max={ 4 }
+						required
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div className={ `${ className } align${ width } columns-${ columns }` }>
+				{ times( columns, ( index ) => {
+					return (
+						<div className="wp-block-column" key={ `column-${ index }` }>
+							<RichText
+								tagName="p"
+								value={ get( content, [ index, 'children' ] ) }
+								onChange={ ( nextContent ) => {
+									setAttributes( {
+										content: [
+											...content.slice( 0, index ),
+											{ children: nextContent },
+											...content.slice( index + 1 ),
+										],
+									} );
+								} }
+								placeholder={ __( 'New Column' ) }
+							/>
+						</div>
+					);
+				} ) }
+			</div>
+		</Fragment>
+	);
+}

--- a/packages/block-library/src/text-columns/index.js
+++ b/packages/block-library/src/text-columns/index.js
@@ -8,15 +8,12 @@ import { get, times } from 'lodash';
  */
 import { createBlock } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-import { PanelBody, RangeControl } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
-import {
-	BlockControls,
-	BlockAlignmentToolbar,
-	InspectorControls,
-	RichText,
-} from '@wordpress/block-editor';
-import deprecated from '@wordpress/deprecated';
+import { RichText } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
 
 export const name = 'core/text-columns';
 
@@ -89,60 +86,7 @@ export const settings = {
 		}
 	},
 
-	edit: ( ( { attributes, setAttributes, className } ) => {
-		const { width, content, columns } = attributes;
-
-		deprecated( 'The Text Columns block', {
-			alternative: 'the Columns block',
-			plugin: 'Gutenberg',
-		} );
-
-		return (
-			<Fragment>
-				<BlockControls>
-					<BlockAlignmentToolbar
-						value={ width }
-						onChange={ ( nextWidth ) => setAttributes( { width: nextWidth } ) }
-						controls={ [ 'center', 'wide', 'full' ] }
-					/>
-				</BlockControls>
-				<InspectorControls>
-					<PanelBody>
-						<RangeControl
-							label={ __( 'Columns' ) }
-							value={ columns }
-							onChange={ ( value ) => setAttributes( { columns: value } ) }
-							min={ 2 }
-							max={ 4 }
-							required
-						/>
-					</PanelBody>
-				</InspectorControls>
-				<div className={ `${ className } align${ width } columns-${ columns }` }>
-					{ times( columns, ( index ) => {
-						return (
-							<div className="wp-block-column" key={ `column-${ index }` }>
-								<RichText
-									tagName="p"
-									value={ get( content, [ index, 'children' ] ) }
-									onChange={ ( nextContent ) => {
-										setAttributes( {
-											content: [
-												...content.slice( 0, index ),
-												{ children: nextContent },
-												...content.slice( index + 1 ),
-											],
-										} );
-									} }
-									placeholder={ __( 'New Column' ) }
-								/>
-							</div>
-						);
-					} ) }
-				</div>
-			</Fragment>
-		);
-	} ),
+	edit,
 
 	save( { attributes } ) {
 		const { width, content, columns } = attributes;

--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Fragment } from '@wordpress/element';
+import {
+	RichText,
+	BlockControls,
+	AlignmentToolbar,
+} from '@wordpress/block-editor';
+
+export default function VerseEdit( { attributes, setAttributes, className, mergeBlocks } ) {
+	const { textAlign, content } = attributes;
+
+	return (
+		<Fragment>
+			<BlockControls>
+				<AlignmentToolbar
+					value={ textAlign }
+					onChange={ ( nextAlign ) => {
+						setAttributes( { textAlign: nextAlign } );
+					} }
+				/>
+			</BlockControls>
+			<RichText
+				tagName="pre"
+				value={ content }
+				onChange={ ( nextContent ) => {
+					setAttributes( {
+						content: nextContent,
+					} );
+				} }
+				style={ { textAlign } }
+				placeholder={ __( 'Write…' ) }
+				wrapperClassName={ className }
+				onMerge={ mergeBlocks }
+			/>
+		</Fragment>
+	);
+}

--- a/packages/block-library/src/verse/icon.js
+++ b/packages/block-library/src/verse/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+export default (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M21 11.01L3 11V13H21V11.01ZM3 16H17V18H3V16ZM15 6H3V8.01L15 8V6Z" /></SVG>
+);

--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -2,14 +2,14 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { createBlock } from '@wordpress/blocks';
-import {
-	RichText,
-	BlockControls,
-	AlignmentToolbar,
-} from '@wordpress/block-editor';
-import { SVG, Path } from '@wordpress/components';
+import { RichText } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import icon from './icon';
 
 export const name = 'core/verse';
 
@@ -18,7 +18,7 @@ export const settings = {
 
 	description: __( 'Insert poetry. Use special spacing formats. Or quote song lyrics.' ),
 
-	icon: <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M21 11.01L3 11V13H21V11.01ZM3 16H17V18H3V16ZM15 6H3V8.01L15 8V6Z" /></SVG>,
+	icon,
 
 	category: 'formatting',
 
@@ -55,35 +55,7 @@ export const settings = {
 		],
 	},
 
-	edit( { attributes, setAttributes, className, mergeBlocks } ) {
-		const { textAlign, content } = attributes;
-
-		return (
-			<Fragment>
-				<BlockControls>
-					<AlignmentToolbar
-						value={ textAlign }
-						onChange={ ( nextAlign ) => {
-							setAttributes( { textAlign: nextAlign } );
-						} }
-					/>
-				</BlockControls>
-				<RichText
-					tagName="pre"
-					value={ content }
-					onChange={ ( nextContent ) => {
-						setAttributes( {
-							content: nextContent,
-						} );
-					} }
-					style={ { textAlign } }
-					placeholder={ __( 'Write…' ) }
-					wrapperClassName={ className }
-					onMerge={ mergeBlocks }
-				/>
-			</Fragment>
-		);
-	},
+	edit,
 
 	save( { attributes } ) {
 		const { textAlign, content } = attributes;


### PR DESCRIPTION
## Description
This is trying to bring the structure of core blocks closer to what is proposed in block registration RFC #13693. In particular, it ensures that:
- all `edit` methods are moved to their own file
- all SVG based icons are moved to their own files

Extracting SVG icons is going to be a good step towards exploring how #14628 could be achieved as all SVG based icons would be located in their own files making it easier to reason how to convert them to the current form from the commonly known file format.

## Testing

Ensure all block icons in the inserter display as before for core blocks.

## Follow-up task

- Perform the same refactoring for `save` methods as well.
- Investigate what to do about all other client-side properties like `transforms` or `merge`.