### PR TITLE
Edit Post: Update PluginBlockSettingsMenuItem to use block-editor class name

### DIFF
--- a/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-group.js
+++ b/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-group.js
@@ -18,7 +18,7 @@ const PluginBlockSettingsMenuGroupSlot = ( { fillProps, selectedBlocks } ) => {
 		<Slot fillProps={ { ...fillProps, selectedBlocks } } >
 			{ ( fills ) => ! isEmpty( fills ) && (
 				<Fragment>
-					<div className="editor-block-settings-menu__separator" />
+					<div className="editor-block-settings-menu__separator block-editor-block-settings-menu__separator" />
 					{ fills }
 				</Fragment>
 			) }

--- a/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
+++ b/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-item.js
@@ -90,7 +90,7 @@ const PluginBlockSettingsMenuItem = ( { allowedBlocks, icon, label, onClick, sma
 				return null;
 			}
 			return ( <MenuItem
-				className="editor-block-settings-menu__control"
+				className="editor-block-settings-menu__control block-editor-block-settings-menu__control"
 				onClick={ compose( onClick, onClose ) }
 				icon={ icon || 'admin-plugins' }
 				label={ small ? label : undefined }


### PR DESCRIPTION
Previously: #14420, #14112 

This pull request seeks to update a few remaining occurrences of class names which have since been updated from `editor-` to `block-editor-` prefix to align with the creation of a new block editor module in #14112.

_**Aside:** This serves as good reaffirmation of why there exists guidelines around [class naming specific to modules](https://github.com/WordPress/gutenberg/blob/72a27f97edbf9811432ca4004274b78778413447/docs/contributors/coding-guidelines.md#naming) and in how violations become sources of issue for future maintenance._

**Testing instructions:**

Verify that custom plugin menu items and groups receive appropriate styles. I tested using the ["TinyMCE Advanced" plugin](https://wordpress.org/plugins/tinymce-advanced/), which includes a custom menu item for "Convert to Blocks".

**Future Tasks:**

These components should not be applying the class name in the way they are. The changes here are the most conservative resolution to the bug, but I would suggest one of the following future enhancements:

1. Eliminate the `block-editor-block-settings-menu__control` class name altogether. If it's assumed to be of type `wp.components.MenuItem`, then `BlockSettingsMenu` can simply target that class name (`.components-menu-item__button`) directly [in its own styles](https://github.com/WordPress/gutenberg/blob/ad7d183b493177992b720b66506f1cc71dd95b0a/packages/block-editor/src/components/block-settings-menu/style.scss#L36).
2. Abstract components in `block-editor` which apply the necessary class names, to be used by `edit-post` and others.