### PR TITLE
Ensure correct attributes are always used for embed preview

### DIFF
--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -41,11 +41,10 @@ export function getEmbedEditComponent( title, icon, responsive = true ) {
 		}
 
 		handleIncomingPreview() {
-			const { allowResponsive } = this.props.attributes;
 			this.setAttributesFromPreview();
 			const upgradedBlock = createUpgradedEmbedBlock(
 				this.props,
-				getAttributesFromPreview( this.props.preview, this.props.attributes.className, responsive, allowResponsive )
+				this.getAttributesFromPreview()
 			);
 			if ( upgradedBlock ) {
 				this.props.onReplace( upgradedBlock );

--- a/packages/block-library/src/embed/util.js
+++ b/packages/block-library/src/embed/util.js
@@ -184,6 +184,7 @@ export function fallback( url, onReplace ) {
  * Gets block attributes based on the preview and responsive state.
  *
  * @param {Object} preview The preview data.
+ * @param {string} title The block's title, e.g. Twitter.
  * @param {Object} currentClassNames The block's current class names.
  * @param {boolean} isResponsive Boolean indicating if the block supports responsive content.
  * @param {boolean} allowResponsive Apply responsive classes to fixed size content.


### PR DESCRIPTION
## Description

When pasting a YouTube URL multiple times, the responsive styles are not applied on the first render, and so the second render is incorrect and either has scrollbars or whitespace.

This change make sure we are always rendering using the correct attributes, generated from the preview.

## How has this been tested?

Paste a YouTube URL, e.g. https://www.youtube.com/watch?v=wSaoXwQzHnY multiple times into a new post. Each video should be responsive with no large amounts of whitespace or scrollbars.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
