### PR TITLE
NPM Package JSON Lint Config: Remove is-plain-obj dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
 		"glob": "7.1.2",
 		"husky": "0.14.3",
 		"is-equal-shallow": "0.1.3",
-		"is-plain-obj": "1.1.0",
 		"jsdom": "11.12.0",
 		"lerna": "3.11.1",
 		"lint-staged": "7.3.0",

--- a/packages/npm-package-json-lint-config/test/index.test.js
+++ b/packages/npm-package-json-lint-config/test/index.test.js
@@ -10,10 +10,10 @@ import config from '../';
 
 describe( 'npm-package-json-lint config tests', () => {
 	it( 'should be an object', () => {
-		expect( { isPlainObject }( config ) ).toBeTruthy();
+		expect( isPlainObject( config ) ).toBeTruthy();
 	} );
 
 	it( 'should have rules property as an object', () => {
-		expect( { isPlainObject }( config.rules ) ).toBeTruthy();
+		expect( isPlainObject( config.rules ) ).toBeTruthy();
 	} );
 } );

--- a/packages/npm-package-json-lint-config/test/index.test.js
+++ b/packages/npm-package-json-lint-config/test/index.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import isPlainObj from 'is-plain-obj';
+import { isPlainObject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -10,10 +10,10 @@ import config from '../';
 
 describe( 'npm-package-json-lint config tests', () => {
 	it( 'should be an object', () => {
-		expect( isPlainObj( config ) ).toBeTruthy();
+		expect( { isPlainObject }( config ) ).toBeTruthy();
 	} );
 
 	it( 'should have rules property as an object', () => {
-		expect( isPlainObj( config.rules ) ).toBeTruthy();
+		expect( { isPlainObject }( config.rules ) ).toBeTruthy();
 	} );
 } );


### PR DESCRIPTION
Previously: #7556

This pull request seeks to use Lodash's `isPlainObject` instead of the standalone `is-plain-obj` package. This is intended to consolidate to reduce the overall number of packages we depend upon for the project.

**Testing Instructions:**

Verify unit tests pass:

```
npm run test-unit
```