### PR TITLE
Docs: Clarify deprecation policy for Gutenberg plugin

### DIFF
--- a/docs/designers-developers/developers/backward-compatibility/deprecations.md
+++ b/docs/designers-developers/developers/backward-compatibility/deprecations.md
@@ -1,6 +1,6 @@
 # Deprecations
 
-The Gutenberg project's deprecation policy is intended to support backward compatibility for releases, when possible. The current deprecations are listed below and are grouped by _the version at which they will be removed completely_. If your plugin depends on these behaviors, you must update to the recommended alternative before the noted version.
+For features included in the Gutenberg plugin, the deprecation policy is intended to support backward compatibility for two minor plugin releases, when possible. Features and code included in a stable release of WordPress are not included in this deprecation timeline, and are instead subject to the [versioning policies of the WordPress project](https://make.wordpress.org/core/handbook/about/release-cycle/version-numbering/). The current deprecations are listed below and are grouped by _the version at which they will be removed completely_. If your plugin depends on these behaviors, you must update to the recommended alternative before the noted version.
 
 ## 5.5.0
 


### PR DESCRIPTION
Previously: #9925 

This pull request seeks to reinstate the prescribed backwards-compatibility support commitment for the plugin, and to clarify the distinction from features which land in a stable release of WordPress.

The current text reads as though it is missing the specific details of support:

>The Gutenberg project's deprecation policy is intended to support backward compatibility **for releases**, when possible.

[Emphasis mine]

**Testing Instructions:**

Documentation updates only. 