### PR TITLE
Fix the text editor styles after the mixins reset

### DIFF
--- a/packages/edit-post/src/components/text-editor/style.scss
+++ b/packages/edit-post/src/components/text-editor/style.scss
@@ -32,6 +32,10 @@
 			border: $border-width solid $light-gray-500;
 			margin-bottom: 4px;
 			padding: $block-padding;
+
+			&:focus {
+				border: $border-width solid $light-gray-500;
+			}
 		}
 
 		textarea:hover,

--- a/packages/editor/src/components/post-text-editor/style.scss
+++ b/packages/editor/src/components/post-text-editor/style.scss
@@ -18,10 +18,9 @@
 
 	&:hover,
 	&:focus {
-		border: $border-width solid $light-gray-500 !important;
+		border: $border-width solid $light-gray-800 !important;
 		box-shadow: none !important;
 		// Emulate the effect used on the post title.
-		outline: $border-width solid $light-gray-500 !important;
 		outline-offset: -2px !important;
 	}
 }

--- a/packages/editor/src/components/post-text-editor/style.scss
+++ b/packages/editor/src/components/post-text-editor/style.scss
@@ -6,14 +6,14 @@
 	box-shadow: none;
 	resize: none;
 	overflow: hidden;
-	font-family: $editor-html-font;
+	font-family: $editor-html-font !important;
 	line-height: 150%;
 	border-radius: 0 !important;
 
 	/* Fonts smaller than 16px causes mobile safari to zoom. */
-	font-size: $mobile-text-min-font-size;
+	font-size: $mobile-text-min-font-size !important;
 	@include break-small {
-		font-size: $text-editor-font-size;
+		font-size: $text-editor-font-size !important;
 	}
 
 	&:hover,

--- a/packages/editor/src/components/post-text-editor/style.scss
+++ b/packages/editor/src/components/post-text-editor/style.scss
@@ -1,5 +1,5 @@
 .editor-post-text-editor {
-	border: $border-width solid $light-gray-500;
+	border: $border-width solid $light-gray-500 !important;
 	display: block;
 	margin: 0 0 2em;
 	width: 100%;
@@ -8,6 +8,7 @@
 	overflow: hidden;
 	font-family: $editor-html-font;
 	line-height: 150%;
+	border-radius: 0 !important;
 
 	/* Fonts smaller than 16px causes mobile safari to zoom. */
 	font-size: $mobile-text-min-font-size;
@@ -17,11 +18,11 @@
 
 	&:hover,
 	&:focus {
-		border: $border-width solid $light-gray-500;
-		box-shadow: none;
+		border: $border-width solid $light-gray-500 !important;
+		box-shadow: none !important;
 		// Emulate the effect used on the post title.
-		outline: $border-width solid $light-gray-500;
-		outline-offset: -2px;
+		outline: $border-width solid $light-gray-500 !important;
+		outline-offset: -2px !important;
 	}
 }
 


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/pull/14509#discussion_r271027196

This turns out to be a little bit more complex that I originally thought.
I think it just surfaces the point I raised in #14509 saying that we should try to kill all "resets" in the future in favor of styles per components.

The problem is that the refactoring in #14509 applied the textarea and input resets more globally which means we need to reset these styles in the textarea of the text editor. The problem is that the specificity is higher for the reset because we can't apply it globally to the page (admin menus...), this uses `!important` to override these styles.