### PR TITLE
RichText: stabilize onSplit

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -1008,6 +1008,7 @@ _Parameters_
 
 -   _clientIds_ `(string|Array<string>)`: Block client ID(s) to replace.
 -   _blocks_ `(Object|Array<Object>)`: Replacement block(s).
+-   _indexToSelect_ `number`: Index of replacement block to select.
 
 <a name="replaceInnerBlocks" href="#replaceInnerBlocks">#</a> **replaceInnerBlocks**
 

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -708,8 +708,8 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 				}
 			}
 		},
-		onReplace( blocks ) {
-			replaceBlocks( [ ownProps.clientId ], blocks );
+		onReplace( blocks, indexToSelect ) {
+			replaceBlocks( [ ownProps.clientId ], blocks, indexToSelect );
 		},
 		onShiftSelection() {
 			if ( ! ownProps.isSelectionEnabled ) {

--- a/packages/block-editor/src/components/rich-text/README.md
+++ b/packages/block-editor/src/components/rich-text/README.md
@@ -25,9 +25,13 @@ Render a rich [`contenteditable` input](https://developer.mozilla.org/en-US/docs
 
 *Optional.* By default, a line break will be inserted on <kbd>Enter</kbd>. If the editable field can contain multiple paragraphs, this property can be set to create new paragraphs on <kbd>Enter</kbd>.
 
+### `onSplit( value: String ): Function`
+
+*Optional.* Called when the content can be split, where `value` is a piece of content being split off. Here you should create a new block with that content and return it. Note that you also need to provide `onReplace` in order for this to take any effect.
+
 ### `onReplace( blocks: Array ): Function`
 
-*Optional.* Called when the `RichText` instance is empty and it can be replaced with the given blocks.
+*Optional.* Called when the `RichText` instance can be replaced with the given blocks.
 
 ### `onMerge( forward: Boolean ): Function`
 

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -820,8 +820,21 @@ export class RichText extends Component {
 		} );
 	}
 
+	/**
+	 * Signals to the RichText owner that the block can be replaced with two
+	 * blocks as a result of splitting the block by pressing enter, more with
+	 * blocks as a result of splitting the block by pasting block content in the
+	 * instance.
+	 *
+	 * @param  {Object} record       The rich text value to split.
+	 * @param  {Array}  pastedBlocks The pasted blocks to insert, if any.
+	 */
 	onSplit( record, pastedBlocks = [] ) {
-		const { onReplace, onSplit, onSplitMiddle } = this.props;
+		const {
+			onReplace,
+			onSplit,
+			__unstableOnSplitMiddle: onSplitMiddle,
+		} = this.props;
 
 		if ( ! onReplace || ! onSplit ) {
 			return;

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -853,7 +853,11 @@ export class RichText extends Component {
 			blocks.push( onSplit( this.valueToFormat( after ) ) );
 		}
 
-		onReplace( blocks );
+		// If there are pasted blocks, set the selection to the last one.
+		// Otherwise, set the selection to the second block.
+		const indexToSelect = hasPastedBlocks ? blocks.length - 1 : 1;
+
+		onReplace( blocks, indexToSelect );
 	}
 
 	/**

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -822,7 +822,7 @@ export class RichText extends Component {
 
 	/**
 	 * Signals to the RichText owner that the block can be replaced with two
-	 * blocks as a result of splitting the block by pressing enter, more with
+	 * blocks as a result of splitting the block by pressing enter, or with
 	 * blocks as a result of splitting the block by pasting block content in the
 	 * instance.
 	 *

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -218,12 +218,14 @@ export function toggleSelection( isSelectionEnabled = true ) {
  * Returns an action object signalling that a blocks should be replaced with
  * one or more replacement blocks.
  *
- * @param {(string|string[])} clientIds Block client ID(s) to replace.
- * @param {(Object|Object[])} blocks    Replacement block(s).
+ * @param {(string|string[])} clientIds     Block client ID(s) to replace.
+ * @param {(Object|Object[])} blocks        Replacement block(s).
+ * @param {number}            indexToSelect Index of replacement block to
+ *                                          select.
  *
  * @yields {Object} Action object.
  */
-export function* replaceBlocks( clientIds, blocks ) {
+export function* replaceBlocks( clientIds, blocks, indexToSelect ) {
 	clientIds = castArray( clientIds );
 	blocks = castArray( blocks );
 	const rootClientId = yield select(
@@ -249,6 +251,7 @@ export function* replaceBlocks( clientIds, blocks ) {
 		clientIds,
 		blocks,
 		time: Date.now(),
+		indexToSelect,
 	};
 	yield* ensureDefaultBlock();
 }

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -787,25 +787,24 @@ export function blockSelection( state = BLOCK_SELECTION_INITIAL_STATE, action ) 
 				return state;
 			}
 
-			// If there are replacement blocks, assign last block as the next
-			// selected block, otherwise set to null.
-			const lastBlock = last( action.blocks );
+			const indexToSelect = action.indexToSelect || action.blocks.length - 1;
+			const blockToSelect = action.blocks[ indexToSelect ];
 
-			if ( ! lastBlock ) {
+			if ( ! blockToSelect ) {
 				return BLOCK_SELECTION_INITIAL_STATE;
 			}
 
 			if (
-				lastBlock.clientId === state.start.clientId &&
-				lastBlock.clientId === state.end.clientId
+				blockToSelect.clientId === state.start.clientId &&
+				blockToSelect.clientId === state.end.clientId
 			) {
 				return state;
 			}
 
 			return {
 				...BLOCK_SELECTION_INITIAL_STATE,
-				start: { clientId: lastBlock.clientId },
-				end: { clientId: lastBlock.clientId },
+				start: { clientId: blockToSelect.clientId },
+				end: { clientId: blockToSelect.clientId },
 			};
 		}
 		case 'TOGGLE_SELECTION':

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -20,7 +20,6 @@ export default function HeadingEdit( {
 	attributes,
 	setAttributes,
 	mergeBlocks,
-	insertBlocksAfter,
 	onReplace,
 	className,
 } ) {
@@ -52,17 +51,17 @@ export default function HeadingEdit( {
 				value={ content }
 				onChange={ ( value ) => setAttributes( { content: value } ) }
 				onMerge={ mergeBlocks }
-				unstableOnSplit={
-					insertBlocksAfter ?
-						( before, after, ...blocks ) => {
-							setAttributes( { content: before } );
-							insertBlocksAfter( [
-								...blocks,
-								createBlock( 'core/paragraph', { content: after } ),
-							] );
-						} :
-						undefined
-				}
+				onSplit={ ( value ) => {
+					if ( ! value ) {
+						return createBlock( 'core/paragraph' );
+					}
+
+					return createBlock( 'core/heading', {
+						...attributes,
+						content: value,
+					} );
+				} }
+				onReplace={ onReplace }
 				onRemove={ () => onReplace( [] ) }
 				style={ { textAlign: align } }
 				className={ className }

--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -31,7 +31,7 @@ export default function ListEdit( {
 			placeholder={ __( 'Write list…' ) }
 			onMerge={ mergeBlocks }
 			onSplit={ ( value ) => createBlock( name, { ordered, values: value } ) }
-			onSplitMiddle={ () => createBlock( 'core/paragraph' ) }
+			__unstableOnSplitMiddle={ () => createBlock( 'core/paragraph' ) }
 			onReplace={ onReplace }
 			onRemove={ () => onReplace( [] ) }
 			onTagNameChange={ ( tag ) => setAttributes( { ordered: tag === 'ol' } ) }

--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -5,9 +5,13 @@ import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 import { RichText } from '@wordpress/block-editor';
 
+/**
+ * Internal dependencies
+ */
+import { name } from './';
+
 export default function ListEdit( {
 	attributes,
-	insertBlocksAfter,
 	setAttributes,
 	mergeBlocks,
 	onReplace,
@@ -26,25 +30,9 @@ export default function ListEdit( {
 			className={ className }
 			placeholder={ __( 'Write list…' ) }
 			onMerge={ mergeBlocks }
-			unstableOnSplit={
-				insertBlocksAfter ?
-					( before, after, ...blocks ) => {
-						if ( ! blocks.length ) {
-							blocks.push( createBlock( 'core/paragraph' ) );
-						}
-
-						if ( after !== '<li></li>' ) {
-							blocks.push( createBlock( 'core/list', {
-								ordered,
-								values: after,
-							} ) );
-						}
-
-						setAttributes( { values: before } );
-						insertBlocksAfter( blocks );
-					} :
-					undefined
-			}
+			onSplit={ ( value ) => createBlock( name, { values: value } ) }
+			onSplitMiddle={ () => createBlock( 'core/paragraph' ) }
+			onReplace={ onReplace }
 			onRemove={ () => onReplace( [] ) }
 			onTagNameChange={ ( tag ) => setAttributes( { ordered: tag === 'ol' } ) }
 		/>

--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -30,7 +30,7 @@ export default function ListEdit( {
 			className={ className }
 			placeholder={ __( 'Write list…' ) }
 			onMerge={ mergeBlocks }
-			onSplit={ ( value ) => createBlock( name, { values: value } ) }
+			onSplit={ ( value ) => createBlock( name, { ordered, values: value } ) }
 			onSplitMiddle={ () => createBlock( 'core/paragraph' ) }
 			onReplace={ onReplace }
 			onRemove={ () => onReplace( [] ) }

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -53,7 +53,7 @@ class ParagraphBlock extends Component {
 		this.toggleDropCap = this.toggleDropCap.bind( this );
 	}
 
-	onReplace( blocks ) {
+	onReplace( blocks, indexToSelect ) {
 		const { attributes, onReplace } = this.props;
 		onReplace( blocks.map( ( block, index ) => (
 			index === 0 && block.name === name ?
@@ -64,7 +64,7 @@ class ParagraphBlock extends Component {
 					},
 				} :
 				block
-		) ) );
+		) ), indexToSelect );
 	}
 
 	toggleDropCap() {

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -49,22 +49,7 @@ class ParagraphBlock extends Component {
 	constructor() {
 		super( ...arguments );
 
-		this.onReplace = this.onReplace.bind( this );
 		this.toggleDropCap = this.toggleDropCap.bind( this );
-	}
-
-	onReplace( blocks, indexToSelect ) {
-		const { attributes, onReplace } = this.props;
-		onReplace( blocks.map( ( block, index ) => (
-			index === 0 && block.name === name ?
-				{ ...block,
-					attributes: {
-						...attributes,
-						...block.attributes,
-					},
-				} :
-				block
-		) ), indexToSelect );
 	}
 
 	toggleDropCap() {
@@ -206,8 +191,8 @@ class ParagraphBlock extends Component {
 						} );
 					} }
 					onMerge={ mergeBlocks }
-					onReplace={ this.props.onReplace && this.onReplace }
-					onRemove={ onReplace && ( () => onReplace( [] ) ) }
+					onReplace={ onReplace }
+					onRemove={ onReplace ? () => onReplace( [] ) : undefined }
 					aria-label={ content ? __( 'Paragraph block' ) : __( 'Empty block; start writing or type forward slash to choose a block' ) }
 					placeholder={ placeholder || __( 'Start writing or type / to choose a block' ) }
 				/>

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -51,7 +51,6 @@ class ParagraphBlock extends Component {
 
 		this.onReplace = this.onReplace.bind( this );
 		this.toggleDropCap = this.toggleDropCap.bind( this );
-		this.splitBlock = this.splitBlock.bind( this );
 	}
 
 	onReplace( blocks ) {
@@ -75,49 +74,6 @@ class ParagraphBlock extends Component {
 
 	getDropCapHelp( checked ) {
 		return checked ? __( 'Showing large initial letter.' ) : __( 'Toggle to show a large initial letter.' );
-	}
-
-	/**
-	 * Split handler for RichText value, namely when content is pasted or the
-	 * user presses the Enter key.
-	 *
-	 * @param {?Array}     before Optional before value, to be used as content
-	 *                            in place of what exists currently for the
-	 *                            block. If undefined, the block is deleted.
-	 * @param {?Array}     after  Optional after value, to be appended in a new
-	 *                            paragraph block to the set of blocks passed
-	 *                            as spread.
-	 * @param {...WPBlock} blocks Optional blocks inserted between the before
-	 *                            and after value blocks.
-	 */
-	splitBlock( before, after, ...blocks ) {
-		const {
-			attributes,
-			insertBlocksAfter,
-			setAttributes,
-			onReplace,
-		} = this.props;
-
-		if ( after !== null ) {
-			// Append "After" content as a new paragraph block to the end of
-			// any other blocks being inserted after the current paragraph.
-			blocks.push( createBlock( name, { content: after } ) );
-		}
-
-		if ( blocks.length && insertBlocksAfter ) {
-			insertBlocksAfter( blocks );
-		}
-
-		const { content } = attributes;
-		if ( before === null ) {
-			// If before content is omitted, treat as intent to delete block.
-			onReplace( [] );
-		} else if ( content !== before ) {
-			// Only update content if it has in-fact changed. In case that user
-			// has created a new paragraph at end of an existing one, the value
-			// of before will be strictly equal to the current content.
-			setAttributes( { content: before } );
-		}
 	}
 
 	render() {
@@ -239,7 +195,7 @@ class ParagraphBlock extends Component {
 							content: nextContent,
 						} );
 					} }
-					unstableOnSplit={ this.splitBlock }
+					onSplit={ ( value ) => createBlock( name, { content: value } ) }
 					onMerge={ mergeBlocks }
 					onReplace={ this.props.onReplace && this.onReplace }
 					onRemove={ onReplace && ( () => onReplace( [] ) ) }

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -195,7 +195,16 @@ class ParagraphBlock extends Component {
 							content: nextContent,
 						} );
 					} }
-					onSplit={ ( value ) => createBlock( name, { content: value } ) }
+					onSplit={ ( value ) => {
+						if ( ! value ) {
+							return createBlock( name );
+						}
+
+						return createBlock( name, {
+							...attributes,
+							content: value,
+						} );
+					} }
 					onMerge={ mergeBlocks }
 					onReplace={ this.props.onReplace && this.onReplace }
 					onRemove={ onReplace && ( () => onReplace( [] ) ) }

--- a/packages/e2e-tests/specs/__snapshots__/splitting-merging.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/splitting-merging.test.js.snap
@@ -83,3 +83,9 @@ exports[`splitting and merging blocks should split and merge paragraph blocks us
 <p>BeforeSecond:Second</p>
 <!-- /wp:paragraph -->"
 `;
+
+exports[`splitting and merging blocks should undo split in one go 1`] = `
+"<!-- wp:paragraph -->
+<p>12</p>
+<!-- /wp:paragraph -->"
+`;

--- a/packages/e2e-tests/specs/blocks/__snapshots__/heading.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/heading.test.js.snap
@@ -1,13 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Separator can be created by prefixing existing content with number signs and a space 1`] = `
+exports[`Heading can be created by prefixing existing content with number signs and a space 1`] = `
 "<!-- wp:heading {\\"level\\":4} -->
 <h4>4</h4>
 <!-- /wp:heading -->"
 `;
 
-exports[`Separator can be created by prefixing number sign and a space 1`] = `
+exports[`Heading can be created by prefixing number sign and a space 1`] = `
 "<!-- wp:heading {\\"level\\":3} -->
 <h3>3</h3>
 <!-- /wp:heading -->"
+`;
+
+exports[`Heading should create a paragraph block above when pressing enter at the start 1`] = `
+"<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2>a</h2>
+<!-- /wp:heading -->"
+`;
+
+exports[`Heading should create a paragraph block below when pressing enter at the end 1`] = `
+"<!-- wp:heading -->
+<h2>a</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->"
 `;

--- a/packages/e2e-tests/specs/blocks/heading.test.js
+++ b/packages/e2e-tests/specs/blocks/heading.test.js
@@ -7,7 +7,7 @@ import {
 	createNewPost,
 } from '@wordpress/e2e-test-utils';
 
-describe( 'Separator', () => {
+describe( 'Heading', () => {
 	beforeEach( async () => {
 		await createNewPost();
 	} );
@@ -24,6 +24,23 @@ describe( 'Separator', () => {
 		await page.keyboard.type( '4' );
 		await page.keyboard.press( 'ArrowLeft' );
 		await page.keyboard.type( '#### ' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should create a paragraph block above when pressing enter at the start', async () => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '## a' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'Enter' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should create a paragraph block below when pressing enter at the end', async () => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '## a' );
+		await page.keyboard.press( 'Enter' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );

--- a/packages/e2e-tests/specs/splitting-merging.test.js
+++ b/packages/e2e-tests/specs/splitting-merging.test.js
@@ -202,4 +202,14 @@ describe( 'splitting and merging blocks', () => {
 		// And focus is retained:
 		expect( await isInDefaultBlock() ).toBe( true );
 	} );
+
+	it( 'should undo split in one go', async () => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '12' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'Enter' );
+		await pressKeyWithModifier( 'primary', 'z' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );


### PR DESCRIPTION
## Description

Stablizes the `RichText` onSplit prop.

* Fixes #10761, see the issue for more information.
* Fixes #8882: Using Enter to split a paragraph block requires two Ctrl-Z's to undo.
* Fixes #10326. Pressing enter at the start of a heading block should push it down and create a paragraph above.
* Fixes #13740. Keep paragraph styling on split at the start.
* Fixes pasting a list inside a list.
* It also fixes an issue with lists instances where pasted content would split the block. Since these two are now separate handlers, pasted content can now appear as list items inside lists.

Additionally it fixes issues where core blocks (heading and list) do not take into account any null values passed to `unstableOnSplit`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->