### PR TITLE
Catch nested blocks preview errors

### DIFF
--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -9,6 +9,7 @@ import { noop } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 import { Disabled } from '@wordpress/components';
+import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -31,18 +32,37 @@ function BlockPreview( props ) {
 	);
 }
 
-export function BlockPreviewContent( { name, attributes } ) {
-	const block = createBlock( name, attributes );
-	return (
-		<Disabled className="editor-block-preview__content block-editor-block-preview__content editor-styles-wrapper" aria-hidden>
-			<BlockEdit
-				name={ name }
-				focus={ false }
-				attributes={ block.attributes }
-				setAttributes={ noop }
-			/>
-		</Disabled>
-	);
+export class BlockPreviewContent extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			hasError: false,
+		};
+	}
+
+	componentDidCatch() {
+		this.setState( {
+			hasError: true,
+		} );
+	}
+
+	render() {
+		if ( this.state.hasError ) {
+			return null;
+		}
+		const { name, attributes } = this.props;
+		const block = createBlock( name, attributes );
+		return (
+			<Disabled className="editor-block-preview__content block-editor-block-preview__content editor-styles-wrapper" aria-hidden>
+				<BlockEdit
+					name={ name }
+					focus={ false }
+					attributes={ block.attributes }
+					setAttributes={ noop }
+				/>
+			</Disabled>
+		);
+	}
 }
 
 export default BlockPreview;


### PR DESCRIPTION
closes #9897

This is a stopgap solution for block style variations for blocks using InnerBlocks. At the moment, rendering innerBlocks in a preview doesn't work. Details here https://github.com/WordPress/gutenberg/issues/9897#issuecomment-422044067 

The solution for the root issue is a little bit complex and might require using a nested editor.

In the meantime, this is a stop-gap solution that avoid rendering the preview if it triggers an error.

**Testing instructions**

 - Add a style variations for the columns block
 - Check that you can switch style variations.