### PR TITLE
Block gallery: add support for image reordering

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -285,6 +285,8 @@ class GalleryEdit extends Component {
 									url={ img.url }
 									alt={ img.alt }
 									id={ img.id }
+									isFirstItem={ index === 0 }
+									isLastItem={ ( index + 1 ) === images.length }
 									isSelected={ isSelected && this.state.selectedImage === index }
 									onMoveBackward={ this.onMoveBackward( index ) }
 									onMoveForward={ this.onMoveForward( index ) }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -91,6 +91,7 @@ class GalleryEdit extends Component {
 		const images = [ ...this.props.attributes.images ];
 		images.splice( newIndex, 1, this.props.attributes.images[ oldIndex ] );
 		images.splice( oldIndex, 1, this.props.attributes.images[ newIndex ] );
+		this.setState( { selectedImage: newIndex } );
 		this.setAttributes( { images } );
 	}
 

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -50,6 +50,9 @@ class GalleryEdit extends Component {
 		this.setLinkTo = this.setLinkTo.bind( this );
 		this.setColumnsNumber = this.setColumnsNumber.bind( this );
 		this.toggleImageCrop = this.toggleImageCrop.bind( this );
+		this.onMove = this.onMove.bind( this );
+		this.onMoveForward = this.onMoveForward.bind( this );
+		this.onMoveBackward = this.onMoveBackward.bind( this );
 		this.onRemoveImage = this.onRemoveImage.bind( this );
 		this.setImageAttributes = this.setImageAttributes.bind( this );
 		this.setAttributes = this.setAttributes.bind( this );
@@ -81,6 +84,31 @@ class GalleryEdit extends Component {
 					selectedImage: index,
 				} );
 			}
+		};
+	}
+
+	onMove( oldIndex, newIndex ) {
+		const images = [ ...this.props.attributes.images ];
+		images.splice( newIndex, 1, this.props.attributes.images[ oldIndex ] );
+		images.splice( oldIndex, 1, this.props.attributes.images[ newIndex ] );
+		this.setAttributes( { images } );
+	}
+
+	onMoveForward( oldIndex ) {
+		return () => {
+			if ( oldIndex === this.props.attributes.images.length - 1 ) {
+				return;
+			}
+			this.onMove( oldIndex, oldIndex + 1 );
+		};
+	}
+
+	onMoveBackward( oldIndex ) {
+		return () => {
+			if ( oldIndex === 0 ) {
+				return;
+			}
+			this.onMove( oldIndex, oldIndex - 1 );
 		};
 	}
 
@@ -257,6 +285,8 @@ class GalleryEdit extends Component {
 									alt={ img.alt }
 									id={ img.id }
 									isSelected={ isSelected && this.state.selectedImage === index }
+									onMoveBackward={ this.onMoveBackward( index ) }
+									onMoveForward={ this.onMoveForward( index ) }
 									onRemove={ this.onRemoveImage( index ) }
 									onSelect={ this.onSelectImage( index ) }
 									setAttributes={ ( attrs ) => this.setImageAttributes( index, attrs ) }

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -79,6 +79,7 @@ ul.wp-block-gallery {
 	}
 }
 
+.block-library-gallery-item__move-menu,
 .block-library-gallery-item__inline-menu {
 	padding: 2px;
 	position: absolute;
@@ -92,13 +93,20 @@ ul.wp-block-gallery {
 	}
 }
 
-.blocks-gallery-item__move-backward,
-.blocks-gallery-item__move-forward {
-	&.components-button:focus {
-		color: inherit;
-	}
+.block-library-gallery-item__inline-menu {
+	position: absolute;
+	top: -2px;
+	right: -2px;
 }
 
+.block-library-gallery-item__move-menu {
+	position: absolute;
+	top: -2px;
+	left: -2px;
+}
+
+.blocks-gallery-item__move-backward,
+.blocks-gallery-item__move-forward,
 .blocks-gallery-item__remove {
 	padding: 0;
 }

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -92,6 +92,13 @@ ul.wp-block-gallery {
 	}
 }
 
+.blocks-gallery-item__move-backward,
+.blocks-gallery-item__move-forward {
+	&.components-button:focus {
+		color: inherit;
+	}
+}
+
 .blocks-gallery-item__remove {
 	padding: 0;
 }

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -59,6 +59,7 @@ ul.wp-block-gallery {
 		}
 	}
 
+	.is-selected .block-library-gallery-item__move-menu,
 	.is-selected .block-library-gallery-item__inline-menu {
 		background-color: theme(primary);
 
@@ -93,15 +94,7 @@ ul.wp-block-gallery {
 	}
 }
 
-.block-library-gallery-item__inline-menu {
-	position: absolute;
-	top: -2px;
-	right: -2px;
-}
-
 .block-library-gallery-item__move-menu {
-	position: absolute;
-	top: -2px;
 	left: -2px;
 }
 

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -83,9 +83,6 @@ ul.wp-block-gallery {
 .block-library-gallery-item__move-menu,
 .block-library-gallery-item__inline-menu {
 	padding: 2px;
-	position: absolute;
-	top: -2px;
-	right: -2px;
 	display: inline-flex;
 	z-index: z-index(".block-library-gallery-item__inline-menu");
 
@@ -94,7 +91,15 @@ ul.wp-block-gallery {
 	}
 }
 
+.block-library-gallery-item__inline-menu {
+	position: absolute;
+	top: -2px;
+	right: -2px;
+}
+
 .block-library-gallery-item__move-menu {
+	position: absolute;
+	top: -2px;
 	left: -2px;
 }
 

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -129,27 +129,31 @@ class GalleryImage extends Component {
 			<figure className={ className }>
 				{ href ? <a href={ href }>{ img }</a> : img }
 				<div className="block-library-gallery-item__inline-menu">
-					<IconButton
-						icon="controls-back"
-						onClick={ onMoveBackward }
-						className="blocks-gallery-item__move-backward"
-						label={ __( 'Move Image Backward' ) }
-					/>
-					<IconButton
-						icon="no-alt"
-						onClick={ onRemove }
-						onFocus={ this.onSelectImage }
-						className="blocks-gallery-item__remove"
-						label={ __( 'Remove Image' ) }
-						disabled={ ! isSelected }
-					/>
-					<IconButton
-						icon="controls-forward"
-						onClick={ onMoveForward }
-						className="blocks-gallery-item__move-forward"
-						label={ __( 'Move Image Forward' ) }
-					/>
-				</div>
+						{ process.env.GUTENBERG_PHASE === 2 ?
+							<IconButton
+								icon="controls-back"
+								onClick={ onMoveBackward }
+								className="blocks-gallery-item__move-backward"
+								label={ __( 'Move Image Backward' ) }
+							/> :
+							null
+						}
+						<IconButton
+							icon="no-alt"
+							onClick={ onRemove }
+							className="blocks-gallery-item__remove"
+							label={ __( 'Remove Image' ) }
+						/>
+						{ process.env.GUTENBERG_PHASE === 2 ?
+							<IconButton
+								icon="controls-forward"
+								onClick={ onMoveForward }
+								className="blocks-gallery-item__move-forward"
+								label={ __( 'Move Image Forward' ) }
+							/> :
+							null
+						}
+					</div>
 				<RichText
 					tagName="figcaption"
 					placeholder={ isSelected ? __( 'Write caption…' ) : null }

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -148,8 +148,10 @@ class GalleryImage extends Component {
 					<IconButton
 						icon="no-alt"
 						onClick={ onRemove }
+						onFocus={ this.onSelectImage }
 						className="blocks-gallery-item__remove"
 						label={ __( 'Remove Image' ) }
+						disabled={ ! isSelected }
 					/>
 				</div>
 				<RichText

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -127,23 +127,23 @@ class GalleryImage extends Component {
 
 		return (
 			<figure className={ className }>
+				{ href ? <a href={ href }>{ img }</a> : img }
 				<div className="block-library-gallery-item__move-menu">
 					<IconButton
 						icon="arrow-left"
-						onClick={ onMoveBackward }
+						onClick={ isFirstItem ? undefined : onMoveBackward }
 						className="blocks-gallery-item__move-backward"
 						label={ __( 'Move Image Backward' ) }
 						aria-disabled={ isFirstItem }
 					/>
 					<IconButton
 						icon="arrow-right"
-						onClick={ onMoveForward }
+						onClick={ isLastItem ? undefined : onMoveForward }
 						className="blocks-gallery-item__move-forward"
 						label={ __( 'Move Image Forward' ) }
 						aria-disabled={ isLastItem }
 					/>
 				</div>
-
 				<div className="block-library-gallery-item__inline-menu">
 					<IconButton
 						icon="no-alt"

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -127,33 +127,32 @@ class GalleryImage extends Component {
 
 		return (
 			<figure className={ className }>
-				{ href ? <a href={ href }>{ img }</a> : img }
-				<div className="block-library-gallery-item__inline-menu">
-						{ process.env.GUTENBERG_PHASE === 2 ?
-							<IconButton
-								icon="controls-back"
-								onClick={ onMoveBackward }
-								className="blocks-gallery-item__move-backward"
-								label={ __( 'Move Image Backward' ) }
-							/> :
-							null
-						}
+				{ process.env.GUTENBERG_PHASE === 2 ?
+					<div className="block-library-gallery-item__move-menu">
 						<IconButton
-							icon="no-alt"
-							onClick={ onRemove }
-							className="blocks-gallery-item__remove"
-							label={ __( 'Remove Image' ) }
+							icon="arrow-left"
+							onClick={ onMoveBackward }
+							className="blocks-gallery-item__move-backward"
+							label={ __( 'Move Image Backward' ) }
 						/>
-						{ process.env.GUTENBERG_PHASE === 2 ?
-							<IconButton
-								icon="controls-forward"
-								onClick={ onMoveForward }
-								className="blocks-gallery-item__move-forward"
-								label={ __( 'Move Image Forward' ) }
-							/> :
-							null
-						}
-					</div>
+						<IconButton
+							icon="arrow-right"
+							onClick={ onMoveForward }
+							className="blocks-gallery-item__move-forward"
+							label={ __( 'Move Image Forward' ) }
+						/>
+					</div> :
+					null
+				}
+
+				<div className="block-library-gallery-item__inline-menu">
+					<IconButton
+						icon="no-alt"
+						onClick={ onRemove }
+						className="blocks-gallery-item__remove"
+						label={ __( 'Remove Image' ) }
+					/>
+				</div>
 				<RichText
 					tagName="figcaption"
 					placeholder={ isSelected ? __( 'Write caption…' ) : null }

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -150,7 +150,6 @@ class GalleryImage extends Component {
 					<IconButton
 						icon="no-alt"
 						onClick={ onRemove }
-						onFocus={ this.onSelectImage }
 						className="blocks-gallery-item__remove"
 						label={ __( 'Remove Image' ) }
 						disabled={ ! isSelected }

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -127,25 +127,22 @@ class GalleryImage extends Component {
 
 		return (
 			<figure className={ className }>
-				{ process.env.GUTENBERG_PHASE === 2 ?
-					<div className="block-library-gallery-item__move-menu">
-						<IconButton
-							icon="arrow-left"
-							onClick={ onMoveBackward }
-							className="blocks-gallery-item__move-backward"
-							label={ __( 'Move Image Backward' ) }
-							aria-disabled={ isFirstItem }
-						/>
-						<IconButton
-							icon="arrow-right"
-							onClick={ onMoveForward }
-							className="blocks-gallery-item__move-forward"
-							label={ __( 'Move Image Forward' ) }
-							aria-disabled={ isLastItem }
-						/>
-					</div> :
-					null
-				}
+				<div className="block-library-gallery-item__move-menu">
+					<IconButton
+						icon="arrow-left"
+						onClick={ onMoveBackward }
+						className="blocks-gallery-item__move-backward"
+						label={ __( 'Move Image Backward' ) }
+						aria-disabled={ isFirstItem }
+					/>
+					<IconButton
+						icon="arrow-right"
+						onClick={ onMoveForward }
+						className="blocks-gallery-item__move-forward"
+						label={ __( 'Move Image Forward' ) }
+						aria-disabled={ isLastItem }
+					/>
+				</div>
 
 				<div className="block-library-gallery-item__inline-menu">
 					<IconButton

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -86,7 +86,7 @@ class GalleryImage extends Component {
 	}
 
 	render() {
-		const { url, alt, id, linkTo, link, isSelected, caption, onRemove, setAttributes, 'aria-label': ariaLabel } = this.props;
+		const { url, alt, id, linkTo, link, isSelected, caption, onRemove, onMoveForward, onMoveBackward, setAttributes, 'aria-label': ariaLabel } = this.props;
 
 		let href;
 
@@ -130,12 +130,22 @@ class GalleryImage extends Component {
 				{ href ? <a href={ href }>{ img }</a> : img }
 				<div className="block-library-gallery-item__inline-menu">
 					<IconButton
+						icon="controls-back"
+						onClick={ onMoveBackward }
+						label={ __( 'Move Image Backward' ) }
+					/>
+					<IconButton
 						icon="no-alt"
 						onClick={ onRemove }
 						onFocus={ this.onSelectImage }
 						className="blocks-gallery-item__remove"
 						label={ __( 'Remove Image' ) }
 						disabled={ ! isSelected }
+					/>
+					<IconButton
+						icon="controls-forward"
+						onClick={ onMoveForward }
+						label={ __( 'Move Image Forward' ) }
 					/>
 				</div>
 				<RichText

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -86,7 +86,7 @@ class GalleryImage extends Component {
 	}
 
 	render() {
-		const { url, alt, id, linkTo, link, isSelected, caption, onRemove, onMoveForward, onMoveBackward, setAttributes, 'aria-label': ariaLabel } = this.props;
+		const { url, alt, id, linkTo, link, isFirstItem, isLastItem, isSelected, caption, onRemove, onMoveForward, onMoveBackward, setAttributes, 'aria-label': ariaLabel } = this.props;
 
 		let href;
 
@@ -134,12 +134,14 @@ class GalleryImage extends Component {
 							onClick={ onMoveBackward }
 							className="blocks-gallery-item__move-backward"
 							label={ __( 'Move Image Backward' ) }
+							disabled={ isFirstItem }
 						/>
 						<IconButton
 							icon="arrow-right"
 							onClick={ onMoveForward }
 							className="blocks-gallery-item__move-forward"
 							label={ __( 'Move Image Forward' ) }
+							disabled={ isLastItem }
 						/>
 					</div> :
 					null

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -134,14 +134,14 @@ class GalleryImage extends Component {
 							onClick={ onMoveBackward }
 							className="blocks-gallery-item__move-backward"
 							label={ __( 'Move Image Backward' ) }
-							disabled={ isFirstItem }
+							aria-disabled={ isFirstItem }
 						/>
 						<IconButton
 							icon="arrow-right"
 							onClick={ onMoveForward }
 							className="blocks-gallery-item__move-forward"
 							label={ __( 'Move Image Forward' ) }
-							disabled={ isLastItem }
+							aria-disabled={ isLastItem }
 						/>
 					</div> :
 					null

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -135,6 +135,7 @@ class GalleryImage extends Component {
 						className="blocks-gallery-item__move-backward"
 						label={ __( 'Move Image Backward' ) }
 						aria-disabled={ isFirstItem }
+						disabled={ ! isSelected }
 					/>
 					<IconButton
 						icon="arrow-right"
@@ -142,6 +143,7 @@ class GalleryImage extends Component {
 						className="blocks-gallery-item__move-forward"
 						label={ __( 'Move Image Forward' ) }
 						aria-disabled={ isLastItem }
+						disabled={ ! isSelected }
 					/>
 				</div>
 				<div className="block-library-gallery-item__inline-menu">

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -132,6 +132,7 @@ class GalleryImage extends Component {
 					<IconButton
 						icon="controls-back"
 						onClick={ onMoveBackward }
+						className="blocks-gallery-item__move-backward"
 						label={ __( 'Move Image Backward' ) }
 					/>
 					<IconButton
@@ -145,6 +146,7 @@ class GalleryImage extends Component {
 					<IconButton
 						icon="controls-forward"
 						onClick={ onMoveForward }
+						className="blocks-gallery-item__move-forward"
 						label={ __( 'Move Image Forward' ) }
 					/>
 				</div>


### PR DESCRIPTION
This PR implements the basic mechanics to move the selected image forward/backward within a gallery. Also adds the corresponding visual controls.

![Peek 2019-05-10 14-46](https://user-images.githubusercontent.com/583546/57528460-ab3d6f80-7332-11e9-8d41-7daff4ed0647.gif)
