### PR TITLE
Block library: Introduce block.json metadata for all client side blocks

### DIFF
--- a/packages/block-library/src/audio/block.json
+++ b/packages/block-library/src/audio/block.json
@@ -1,0 +1,38 @@
+{
+	"name": "core/audio",
+	"category": "common",
+	"attributes": {
+		"src": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "audio",
+			"attribute": "src"
+		},
+		"caption": {
+			"type": "string",
+			"source": "html",
+			"selector": "figcaption"
+		},
+		"id": {
+			"type": "number"
+		},
+		"autoplay": {
+			"type": "boolean",
+			"source": "attribute",
+			"selector": "audio",
+			"attribute": "autoplay"
+		},
+		"loop": {
+			"type": "boolean",
+			"source": "attribute",
+			"selector": "audio",
+			"attribute": "loop"
+		},
+		"preload": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "audio",
+			"attribute": "preload"
+		}
+	}
+}

--- a/packages/block-library/src/audio/index.js
+++ b/packages/block-library/src/audio/index.js
@@ -11,8 +11,11 @@ import { __ } from '@wordpress/i18n';
  */
 import edit from './edit';
 import icon from './icon';
+import metadata from './block.json';
 
-export const name = 'core/audio';
+const { name } = metadata;
+
+export { metadata, name };
 
 export const settings = {
 	title: __( 'Audio' ),
@@ -20,43 +23,6 @@ export const settings = {
 	description: __( 'Embed a simple audio player.' ),
 
 	icon,
-
-	category: 'common',
-
-	attributes: {
-		src: {
-			type: 'string',
-			source: 'attribute',
-			selector: 'audio',
-			attribute: 'src',
-		},
-		caption: {
-			type: 'string',
-			source: 'html',
-			selector: 'figcaption',
-		},
-		id: {
-			type: 'number',
-		},
-		autoplay: {
-			type: 'boolean',
-			source: 'attribute',
-			selector: 'audio',
-			attribute: 'autoplay',
-		},
-		loop: {
-			type: 'boolean',
-			source: 'attribute',
-			selector: 'audio',
-			attribute: 'loop',
-		},
-		preload: {
-			type: 'string',
-			source: 'attribute',
-			selector: 'audio',
-			attribute: 'preload',
-		},
-	},
 
 	transforms: {
 		from: [

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -1,0 +1,35 @@
+{
+	"name": "core/button",
+	"category": "layout",
+	"attributes": {
+		"url": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "a",
+			"attribute": "href"
+		},
+		"title": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "a",
+			"attribute": "title"
+		},
+		"text": {
+			"type": "string",
+			"source": "html",
+			"selector": "a"
+		},
+		"backgroundColor": {
+			"type": "string"
+		},
+		"textColor": {
+			"type": "string"
+		},
+		"customBackgroundColor": {
+			"type": "string"
+		},
+		"customTextColor": {
+			"type": "string"
+		}
+	}
+}

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -18,40 +18,11 @@ import {
  */
 import edit from './edit';
 import icon from './icon';
+import metadata from './block.json';
 
-const blockAttributes = {
-	url: {
-		type: 'string',
-		source: 'attribute',
-		selector: 'a',
-		attribute: 'href',
-	},
-	title: {
-		type: 'string',
-		source: 'attribute',
-		selector: 'a',
-		attribute: 'title',
-	},
-	text: {
-		type: 'string',
-		source: 'html',
-		selector: 'a',
-	},
-	backgroundColor: {
-		type: 'string',
-	},
-	textColor: {
-		type: 'string',
-	},
-	customBackgroundColor: {
-		type: 'string',
-	},
-	customTextColor: {
-		type: 'string',
-	},
-};
+const { name, attributes: blockAttributes } = metadata;
 
-export const name = 'core/button';
+export { metadata, name };
 
 const colorsMigration = ( attributes ) => {
 	return omit( {
@@ -68,11 +39,7 @@ export const settings = {
 
 	icon,
 
-	category: 'layout',
-
 	keywords: [ __( 'link' ) ],
-
-	attributes: blockAttributes,
 
 	supports: {
 		align: true,

--- a/packages/block-library/src/classic/block.json
+++ b/packages/block-library/src/classic/block.json
@@ -1,0 +1,10 @@
+{
+	"name": "core/freeform",
+	"category": "formatting",
+	"attributes": {
+		"content": {
+			"type": "string",
+			"source": "html"
+		}
+	}
+}

--- a/packages/block-library/src/classic/index.js
+++ b/packages/block-library/src/classic/index.js
@@ -9,8 +9,11 @@ import { __, _x } from '@wordpress/i18n';
  */
 import edit from './edit';
 import icon from './icon';
+import metadata from './block.json';
 
-export const name = 'core/freeform';
+const { name } = metadata;
+
+export { metadata, name };
 
 export const settings = {
 	title: _x( 'Classic', 'block title' ),
@@ -18,15 +21,6 @@ export const settings = {
 	description: __( 'Use the classic WordPress editor.' ),
 
 	icon,
-
-	category: 'formatting',
-
-	attributes: {
-		content: {
-			type: 'string',
-			source: 'html',
-		},
-	},
 
 	supports: {
 		className: false,

--- a/packages/block-library/src/code/block.json
+++ b/packages/block-library/src/code/block.json
@@ -1,0 +1,11 @@
+{
+	"name": "core/code",
+	"category": "formatting",
+	"attributes": {
+		"content": {
+			"type": "string",
+			"source": "text",
+			"selector": "code"
+		}
+	}
+}

--- a/packages/block-library/src/code/index.js
+++ b/packages/block-library/src/code/index.js
@@ -9,8 +9,11 @@ import { createBlock } from '@wordpress/blocks';
  */
 import edit from './edit';
 import icon from './icon';
+import metadata from './block.json';
 
-export const name = 'core/code';
+const { name } = metadata;
+
+export { metadata, name };
 
 export const settings = {
 	title: __( 'Code' ),
@@ -18,16 +21,6 @@ export const settings = {
 	description: __( 'Display code snippets that respect your spacing and tabs.' ),
 
 	icon,
-
-	category: 'formatting',
-
-	attributes: {
-		content: {
-			type: 'string',
-			source: 'text',
-			selector: 'code',
-		},
-	},
 
 	supports: {
 		html: false,

--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -1,0 +1,9 @@
+{
+	"name": "core/column",
+	"category": "common",
+	"attributes": {
+		"verticalAlignment": {
+			"type": "string"
+		}
+	}
+}

--- a/packages/block-library/src/column/index.js
+++ b/packages/block-library/src/column/index.js
@@ -12,7 +12,14 @@ import { InnerBlocks, BlockControls, BlockVerticalAlignmentToolbar } from '@word
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
-export const name = 'core/column';
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+const { name } = metadata;
+
+export { metadata, name };
 
 const ColumnEdit = ( { attributes, updateAlignment } ) => {
 	const { verticalAlignment } = attributes;
@@ -69,14 +76,6 @@ export const settings = {
 	icon: <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path fill="none" d="M0 0h24v24H0V0z" /><Path d="M11.99 18.54l-7.37-5.73L3 14.07l9 7 9-7-1.63-1.27zM12 16l7.36-5.73L21 9l-9-7-9 7 1.63 1.27L12 16zm0-11.47L17.74 9 12 13.47 6.26 9 12 4.53z" /></SVG>,
 
 	description: __( 'A single column within a columns block.' ),
-
-	category: 'common',
-
-	attributes: {
-		verticalAlignment: {
-			type: 'string',
-		},
-	},
 
 	supports: {
 		inserter: false,

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -1,0 +1,13 @@
+{
+	"name": "core/columns",
+	"category": "layout",
+	"attributes": {
+		"columns": {
+			"type": "number",
+			"default": 2
+		},
+		"verticalAlignment": {
+			"type": "string"
+		}
+	}
+}

--- a/packages/block-library/src/columns/index.js
+++ b/packages/block-library/src/columns/index.js
@@ -18,25 +18,16 @@ import {
 import deprecated from './deprecated';
 import edit from './edit';
 import icon from './icon';
+import metadata from './block.json';
 
-export const name = 'core/columns';
+const { name } = metadata;
+
+export { metadata, name };
 
 export const settings = {
 	title: __( 'Columns' ),
 
 	icon,
-
-	category: 'layout',
-
-	attributes: {
-		columns: {
-			type: 'number',
-			default: 2,
-		},
-		verticalAlignment: {
-			type: 'string',
-		},
-	},
 
 	description: __( 'Add a block that displays content in multiple columns, then add whatever content blocks you’d like.' ),
 

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -1,0 +1,33 @@
+{
+	"name": "core/cover",
+	"category": "common",
+	"attributes": {
+		"url": {
+			"type": "string"
+		},
+		"id": {
+			"type": "number"
+		},
+		"hasParallax": {
+			"type": "boolean",
+			"default": false
+		},
+		"dimRatio": {
+			"type": "number",
+			"default": 50
+		},
+		"overlayColor": {
+			"type": "string"
+		},
+		"customOverlayColor": {
+			"type": "string"
+		},
+		"backgroundType": {
+			"type": "string",
+			"default": "image"
+		},
+		"focalPoint": {
+			"type": "object"
+		}
+	}
+}

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -26,38 +26,11 @@ import {
 	backgroundImageStyles,
 	dimRatioToClass,
 } from './edit';
+import metadata from './block.json';
 
-const blockAttributes = {
-	url: {
-		type: 'string',
-	},
-	id: {
-		type: 'number',
-	},
-	hasParallax: {
-		type: 'boolean',
-		default: false,
-	},
-	dimRatio: {
-		type: 'number',
-		default: 50,
-	},
-	overlayColor: {
-		type: 'string',
-	},
-	customOverlayColor: {
-		type: 'string',
-	},
-	backgroundType: {
-		type: 'string',
-		default: 'image',
-	},
-	focalPoint: {
-		type: 'object',
-	},
-};
+const { name, attributes: blockAttributes } = metadata;
 
-export const name = 'core/cover';
+export { metadata, name };
 
 export const settings = {
 	title: __( 'Cover' ),
@@ -65,10 +38,6 @@ export const settings = {
 	description: __( 'Add an image or video with a text overlay — great for headers.' ),
 
 	icon,
-
-	category: 'common',
-
-	attributes: blockAttributes,
 
 	supports: {
 		align: true,

--- a/packages/block-library/src/file/block.json
+++ b/packages/block-library/src/file/block.json
@@ -1,0 +1,4 @@
+{
+	"name": "core/file",
+	"category": "common"
+}

--- a/packages/block-library/src/file/index.js
+++ b/packages/block-library/src/file/index.js
@@ -17,8 +17,11 @@ import { RichText } from '@wordpress/block-editor';
  */
 import edit from './edit';
 import icon from './icon';
+import metadata from './block.json';
 
-export const name = 'core/file';
+const { name } = metadata;
+
+export { metadata, name };
 
 export const settings = {
 	title: __( 'File' ),
@@ -26,8 +29,6 @@ export const settings = {
 	description: __( 'Add a link to a downloadable file.' ),
 
 	icon,
-
-	category: 'common',
 
 	keywords: [ __( 'document' ), __( 'pdf' ) ],
 

--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -1,0 +1,55 @@
+{
+	"name": "core/gallery",
+	"category": "common",
+	"attributes": {
+		"images": {
+			"type": "array",
+			"default": [ ],
+			"source": "query",
+			"selector": "ul.wp-block-gallery .blocks-gallery-item",
+			"query": {
+				"url": {
+					"source": "attribute",
+					"selector": "img",
+					"attribute": "src"
+				},
+				"link": {
+					"source": "attribute",
+					"selector": "img",
+					"attribute": "data-link"
+				},
+				"alt": {
+					"source": "attribute",
+					"selector": "img",
+					"attribute": "alt",
+					"default": ""
+				},
+				"id": {
+					"source": "attribute",
+					"selector": "img",
+					"attribute": "data-id"
+				},
+				"caption": {
+					"type": "string",
+					"source": "html",
+					"selector": "figcaption"
+				}
+			}
+		},
+		"ids": {
+			"type": "array",
+			"default": [ ]
+		},
+		"columns": {
+			"type": "number"
+		},
+		"imageCrop": {
+			"type": "boolean",
+			"default": true
+		},
+		"linkTo": {
+			"type": "string",
+			"default": "none"
+		}
+	}
+}

--- a/packages/block-library/src/gallery/index.js
+++ b/packages/block-library/src/gallery/index.js
@@ -17,60 +17,11 @@ import { createBlobURL } from '@wordpress/blob';
  */
 import { default as edit, defaultColumnsNumber, pickRelevantMediaFiles } from './edit';
 import icon from './icon';
+import metadata from './block.json';
 
-const blockAttributes = {
-	images: {
-		type: 'array',
-		default: [],
-		source: 'query',
-		selector: 'ul.wp-block-gallery .blocks-gallery-item',
-		query: {
-			url: {
-				source: 'attribute',
-				selector: 'img',
-				attribute: 'src',
-			},
-			link: {
-				source: 'attribute',
-				selector: 'img',
-				attribute: 'data-link',
-			},
-			alt: {
-				source: 'attribute',
-				selector: 'img',
-				attribute: 'alt',
-				default: '',
-			},
-			id: {
-				source: 'attribute',
-				selector: 'img',
-				attribute: 'data-id',
-			},
-			caption: {
-				type: 'string',
-				source: 'html',
-				selector: 'figcaption',
-			},
-		},
-	},
-	ids: {
-		type: 'array',
-		default: [],
-	},
-	columns: {
-		type: 'number',
-	},
-	imageCrop: {
-		type: 'boolean',
-		default: true,
-	},
-	linkTo: {
-		type: 'string',
-		default: 'none',
-	},
-};
+const { name, attributes: blockAttributes } = metadata;
 
-export const name = 'core/gallery';
+export { metadata, name };
 
 const parseShortcodeIds = ( ids ) => {
 	if ( ! ids ) {
@@ -86,9 +37,7 @@ export const settings = {
 	title: __( 'Gallery' ),
 	description: __( 'Display multiple images in a rich gallery.' ),
 	icon,
-	category: 'common',
 	keywords: [ __( 'images' ), __( 'photos' ) ],
-	attributes: blockAttributes,
 	supports: {
 		align: true,
 	},

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -1,0 +1,22 @@
+{
+	"name": "core/heading",
+	"category": "common",
+	"attributes": {
+		"align": {
+			"type": "string"
+		},
+		"content": {
+			"type": "string",
+			"source": "html",
+			"selector": "h1,h2,h3,h4,h5,h6",
+			"default": ""
+		},
+		"level": {
+			"type": "number",
+			"default": 2
+		},
+		"placeholder": {
+			"type": "string"
+		}
+	}
+}

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -19,6 +19,11 @@ import { RichText } from '@wordpress/block-editor';
  */
 import edit from './edit';
 import icon from './icon';
+import metadata from './block.json';
+
+const { name, attributes: schema } = metadata;
+
+export { metadata, name };
 
 /**
  * Given a node name string for a heading node, returns its numeric level.
@@ -36,27 +41,6 @@ const supports = {
 	anchor: true,
 };
 
-const schema = {
-	content: {
-		type: 'string',
-		source: 'html',
-		selector: 'h1,h2,h3,h4,h5,h6',
-		default: '',
-	},
-	level: {
-		type: 'number',
-		default: 2,
-	},
-	align: {
-		type: 'string',
-	},
-	placeholder: {
-		type: 'string',
-	},
-};
-
-export const name = 'core/heading';
-
 export const settings = {
 	title: __( 'Heading' ),
 
@@ -64,13 +48,9 @@ export const settings = {
 
 	icon,
 
-	category: 'common',
-
 	keywords: [ __( 'title' ), __( 'subtitle' ) ],
 
 	supports,
-
-	attributes: schema,
 
 	transforms: {
 		from: [

--- a/packages/block-library/src/html/block.json
+++ b/packages/block-library/src/html/block.json
@@ -1,0 +1,10 @@
+{
+	"name": "core/html",
+	"category": "formatting",
+	"attributes": {
+		"content": {
+			"type": "string",
+			"source": "html"
+		}
+	}
+}

--- a/packages/block-library/src/html/index.js
+++ b/packages/block-library/src/html/index.js
@@ -10,8 +10,11 @@ import { getPhrasingContentSchema } from '@wordpress/blocks';
  */
 import edit from './edit';
 import icon from './icon';
+import metadata from './block.json';
 
-export const name = 'core/html';
+const { name } = metadata;
+
+export { metadata, name };
 
 export const settings = {
 	title: __( 'Custom HTML' ),
@@ -20,21 +23,12 @@ export const settings = {
 
 	icon,
 
-	category: 'formatting',
-
 	keywords: [ __( 'embed' ) ],
 
 	supports: {
 		customClassName: false,
 		className: false,
 		html: false,
-	},
-
-	attributes: {
-		content: {
-			type: 'string',
-			source: 'html',
-		},
 	},
 
 	transforms: {

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -1,0 +1,64 @@
+{
+	"name": "core/image",
+	"category": "common",
+	"attributes": {
+		"align": {
+			"type": "string"
+		},
+		"url": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "img",
+			"attribute": "src"
+		},
+		"alt": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "img",
+			"attribute": "alt",
+			"default": ""
+		},
+		"caption": {
+			"type": "string",
+			"source": "html",
+			"selector": "figcaption"
+		},
+		"href": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "figure > a",
+			"attribute": "href"
+		},
+		"rel": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "figure > a",
+			"attribute": "rel"
+		},
+		"linkClass": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "figure > a",
+			"attribute": "class"
+		},
+		"id": {
+			"type": "number"
+		},
+		"width": {
+			"type": "number"
+		},
+		"height": {
+			"type": "number"
+		},
+		"linkDestination": {
+			"type": "string",
+			"default": "none"
+		},
+		"linkTarget": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "figure > a",
+			"attribute": "target"
+		}
+	}
+}

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -21,69 +21,11 @@ import { __ } from '@wordpress/i18n';
  */
 import edit from './edit';
 import icon from './icon';
+import metadata from './block.json';
 
-export const name = 'core/image';
+const { name, attributes: blockAttributes } = metadata;
 
-const blockAttributes = {
-	url: {
-		type: 'string',
-		source: 'attribute',
-		selector: 'img',
-		attribute: 'src',
-	},
-	alt: {
-		type: 'string',
-		source: 'attribute',
-		selector: 'img',
-		attribute: 'alt',
-		default: '',
-	},
-	caption: {
-		type: 'string',
-		source: 'html',
-		selector: 'figcaption',
-	},
-	href: {
-		type: 'string',
-		source: 'attribute',
-		selector: 'figure > a',
-		attribute: 'href',
-	},
-	rel: {
-		type: 'string',
-		source: 'attribute',
-		selector: 'figure > a',
-		attribute: 'rel',
-	},
-	linkClass: {
-		type: 'string',
-		source: 'attribute',
-		selector: 'figure > a',
-		attribute: 'class',
-	},
-	id: {
-		type: 'number',
-	},
-	align: {
-		type: 'string',
-	},
-	width: {
-		type: 'number',
-	},
-	height: {
-		type: 'number',
-	},
-	linkDestination: {
-		type: 'string',
-		default: 'none',
-	},
-	linkTarget: {
-		type: 'string',
-		source: 'attribute',
-		selector: 'figure > a',
-		attribute: 'target',
-	},
-};
+export { metadata, name };
 
 const imageSchema = {
 	img: {
@@ -149,14 +91,10 @@ export const settings = {
 
 	icon,
 
-	category: 'common',
-
 	keywords: [
 		'img', // "img" is not translated as it is intended to reflect the HTML <img> tag.
 		__( 'photo' ),
 	],
-
-	attributes: blockAttributes,
 
 	transforms: {
 		from: [

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -9,7 +9,6 @@ import {
 	setDefaultBlockName,
 	setFreeformContentHandlerName,
 	setUnregisteredTypeHandlerName,
-	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase
 } from '@wordpress/blocks';
 
 /**
@@ -27,7 +26,7 @@ import * as calendar from './calendar';
 import * as categories from './categories';
 import * as code from './code';
 import * as columns from './columns';
-import * as column from './columns/column';
+import * as column from './column';
 import * as cover from './cover';
 import * as embed from './embed';
 import * as file from './file';
@@ -124,10 +123,10 @@ export const registerCoreBlocks = () => {
 			return;
 		}
 		const { metadata, settings, name } = block;
-		if ( metadata ) {
-			unstable__bootstrapServerSideBlockDefinitions( { [ name ]: metadata } ); // eslint-disable-line camelcase
-		}
-		registerBlockType( name, settings );
+		registerBlockType( name, {
+			...metadata,
+			...settings,
+		} );
 	} );
 
 	setDefaultBlockName( paragraph.name );

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -9,6 +9,7 @@ import {
 	setDefaultBlockName,
 	setFreeformContentHandlerName,
 	setUnregisteredTypeHandlerName,
+	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase
 } from '@wordpress/blocks';
 
 /**
@@ -123,10 +124,10 @@ export const registerCoreBlocks = () => {
 			return;
 		}
 		const { metadata, settings, name } = block;
-		registerBlockType( name, {
-			...metadata,
-			...settings,
-		} );
+		if ( metadata ) {
+			unstable__bootstrapServerSideBlockDefinitions( { [ name ]: metadata } ); // eslint-disable-line camelcase
+		}
+		registerBlockType( name, settings );
 	} );
 
 	setDefaultBlockName( paragraph.name );

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -111,8 +111,11 @@ export const registerCoreBlocks = () => {
 		image,
 		nextpage,
 		list,
-	].forEach( ( { name, settings } ) => {
-		registerBlockType( name, settings );
+	].forEach( ( { metadata, name, settings } ) => {
+		registerBlockType( name, {
+			...metadata,
+			...settings,
+		} );
 	} );
 };
 

--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -1,0 +1,17 @@
+{
+	"name": "core/list",
+	"category": "common",
+	"attributes": {
+		"ordered": {
+			"type": "boolean",
+			"default": false
+		},
+		"values": {
+			"type": "string",
+			"source": "html",
+			"selector": "ol,ul",
+			"multiline": "li",
+			"default": ""
+		}
+	}
+}

--- a/packages/block-library/src/list/index.js
+++ b/packages/block-library/src/list/index.js
@@ -20,6 +20,11 @@ import { replace, join, split, create, toHTMLString, LINE_SEPARATOR } from '@wor
  */
 import edit from './edit';
 import icon from './icon';
+import metadata from './block.json';
+
+const { name, attributes: schema } = metadata;
+
+export { metadata, name };
 
 const listContentSchema = {
 	...getPhrasingContentSchema(),
@@ -42,30 +47,11 @@ const supports = {
 	className: false,
 };
 
-const schema = {
-	ordered: {
-		type: 'boolean',
-		default: false,
-	},
-	values: {
-		type: 'string',
-		source: 'html',
-		selector: 'ol,ul',
-		multiline: 'li',
-		default: '',
-	},
-};
-
-export const name = 'core/list';
-
 export const settings = {
 	title: __( 'List' ),
 	description: __( 'Create a bulleted or numbered list.' ),
 	icon,
-	category: 'common',
 	keywords: [ __( 'bullet list' ), __( 'ordered list' ), __( 'numbered list' ) ],
-
-	attributes: schema,
 
 	supports,
 

--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -1,0 +1,56 @@
+{
+	"name": "core/media-text",
+	"category": "layout",
+	"attributes": {
+		"align": {
+			"type": "string",
+			"default": "wide"
+		},
+		"backgroundColor": {
+			"type": "string"
+		},
+		"customBackgroundColor": {
+			"type": "string"
+		},
+		"mediaAlt": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "figure img",
+			"attribute": "alt",
+			"default": ""
+		},
+		"mediaPosition": {
+			"type": "string",
+			"default": "left"
+		},
+		"mediaId": {
+			"type": "number"
+		},
+		"mediaUrl": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "figure video,figure img",
+			"attribute": "src"
+		},
+		"mediaType": {
+			"type": "string"
+		},
+		"mediaWidth": {
+			"type": "number",
+			"default": 50
+		},
+		"isStackedOnMobile": {
+			"type": "boolean",
+			"default": false
+		},
+		"verticalAlignment": {
+			"type": "string"
+		},
+		"imageFill": {
+			"type": "boolean"
+		},
+		"focalPoint": {
+			"type": "object"
+		}
+	}
+}

--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -21,63 +21,13 @@ import edit from './edit';
 import icon from './icon';
 import deprecated from './deprecated';
 import { imageFillStyles } from './media-container';
+import metadata from './block.json';
 
 export const DEFAULT_MEDIA_WIDTH = 50;
 
-export const name = 'core/media-text';
+const { name } = metadata;
 
-const blockAttributes = {
-	align: {
-		type: 'string',
-		default: 'wide',
-	},
-	backgroundColor: {
-		type: 'string',
-	},
-	customBackgroundColor: {
-		type: 'string',
-	},
-	mediaAlt: {
-		type: 'string',
-		source: 'attribute',
-		selector: 'figure img',
-		attribute: 'alt',
-		default: '',
-	},
-	mediaPosition: {
-		type: 'string',
-		default: 'left',
-	},
-	mediaId: {
-		type: 'number',
-	},
-	mediaUrl: {
-		type: 'string',
-		source: 'attribute',
-		selector: 'figure video,figure img',
-		attribute: 'src',
-	},
-	mediaType: {
-		type: 'string',
-	},
-	mediaWidth: {
-		type: 'number',
-		default: 50,
-	},
-	isStackedOnMobile: {
-		type: 'boolean',
-		default: false,
-	},
-	verticalAlignment: {
-		type: 'string',
-	},
-	imageFill: {
-		type: 'boolean',
-	},
-	focalPoint: {
-		type: 'object',
-	},
-};
+export { metadata, name };
 
 export const settings = {
 	title: __( 'Media & Text' ),
@@ -86,11 +36,7 @@ export const settings = {
 
 	icon,
 
-	category: 'layout',
-
 	keywords: [ __( 'image' ), __( 'video' ) ],
-
-	attributes: blockAttributes,
 
 	supports: {
 		align: [ 'wide', 'full' ],

--- a/packages/block-library/src/missing/block.json
+++ b/packages/block-library/src/missing/block.json
@@ -1,0 +1,16 @@
+{
+	"name": "core/missing",
+	"category": "common",
+	"attributes": {
+		"originalName": {
+			"type": "string"
+		},
+		"originalUndelimitedContent": {
+			"type": "string"
+		},
+		"originalContent": {
+			"type": "string",
+			"source": "html"
+		}
+	}
+}

--- a/packages/block-library/src/missing/index.js
+++ b/packages/block-library/src/missing/index.js
@@ -8,12 +8,14 @@ import { RawHTML } from '@wordpress/element';
  * Internal dependencies
  */
 import edit from './edit';
+import metadata from './block.json';
 
-export const name = 'core/missing';
+const { name } = metadata;
+
+export { metadata, name };
 
 export const settings = {
 	name,
-	category: 'common',
 	title: __( 'Unrecognized Block' ),
 	description: __( 'Your site doesn’t include support for this block.' ),
 
@@ -23,19 +25,6 @@ export const settings = {
 		inserter: false,
 		html: false,
 		reusable: false,
-	},
-
-	attributes: {
-		originalName: {
-			type: 'string',
-		},
-		originalUndelimitedContent: {
-			type: 'string',
-		},
-		originalContent: {
-			type: 'string',
-			source: 'html',
-		},
 	},
 
 	edit,

--- a/packages/block-library/src/more/block.json
+++ b/packages/block-library/src/more/block.json
@@ -1,0 +1,13 @@
+{
+	"name": "core/more",
+	"category": "layout",
+	"attributes": {
+		"customText": {
+			"type": "string"
+		},
+		"noTeaser": {
+			"type": "boolean",
+			"default": false
+		}
+	}
+}

--- a/packages/block-library/src/more/index.js
+++ b/packages/block-library/src/more/index.js
@@ -15,8 +15,11 @@ import { createBlock } from '@wordpress/blocks';
  */
 import edit from './edit';
 import icon from './icon';
+import metadata from './block.json';
 
-export const name = 'core/more';
+const { name } = metadata;
+
+export { metadata, name };
 
 export const settings = {
 	title: _x( 'More', 'block name' ),
@@ -25,23 +28,11 @@ export const settings = {
 
 	icon,
 
-	category: 'layout',
-
 	supports: {
 		customClassName: false,
 		className: false,
 		html: false,
 		multiple: false,
-	},
-
-	attributes: {
-		customText: {
-			type: 'string',
-		},
-		noTeaser: {
-			type: 'boolean',
-			default: false,
-		},
 	},
 
 	transforms: {

--- a/packages/block-library/src/nextpage/block.json
+++ b/packages/block-library/src/nextpage/block.json
@@ -1,0 +1,4 @@
+{
+	"name": "core/nextpage",
+	"category": "layout"
+}

--- a/packages/block-library/src/nextpage/index.js
+++ b/packages/block-library/src/nextpage/index.js
@@ -10,8 +10,11 @@ import { createBlock } from '@wordpress/blocks';
  */
 import edit from './edit';
 import icon from './icon';
+import metadata from './block.json';
 
-export const name = 'core/nextpage';
+const { name } = metadata;
+
+export { metadata, name };
 
 export const settings = {
 	title: __( 'Page Break' ),
@@ -20,8 +23,6 @@ export const settings = {
 
 	icon,
 
-	category: 'layout',
-
 	keywords: [ __( 'next page' ), __( 'pagination' ) ],
 
 	supports: {
@@ -29,8 +30,6 @@ export const settings = {
 		className: false,
 		html: false,
 	},
-
-	attributes: {},
 
 	transforms: {
 		from: [

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -1,0 +1,44 @@
+{
+	"name": "core/paragraph",
+	"category": "common",
+	"attributes": {
+		"align": {
+			"type": "string"
+		},
+		"content": {
+			"type": "string",
+			"source": "html",
+			"selector": "p",
+			"default": ""
+		},
+		"dropCap": {
+			"type": "boolean",
+			"default": false
+		},
+		"placeholder": {
+			"type": "string"
+		},
+		"textColor": {
+			"type": "string"
+		},
+		"customTextColor": {
+			"type": "string"
+		},
+		"backgroundColor": {
+			"type": "string"
+		},
+		"customBackgroundColor": {
+			"type": "string"
+		},
+		"fontSize": {
+			"type": "string"
+		},
+		"customFontSize": {
+			"type": "number"
+		},
+		"direction": {
+			"type": "string",
+			"enum": [ "ltr", "rtl" ]
+		}
+	}
+}

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -23,53 +23,15 @@ import { getPhrasingContentSchema } from '@wordpress/blocks';
  */
 import edit from './edit';
 import icon from './icon';
+import metadata from './block.json';
+
+const { name, attributes: schema } = metadata;
+
+export { metadata, name };
 
 const supports = {
 	className: false,
 };
-
-const schema = {
-	content: {
-		type: 'string',
-		source: 'html',
-		selector: 'p',
-		default: '',
-	},
-	align: {
-		type: 'string',
-	},
-	dropCap: {
-		type: 'boolean',
-		default: false,
-	},
-	placeholder: {
-		type: 'string',
-	},
-	textColor: {
-		type: 'string',
-	},
-	customTextColor: {
-		type: 'string',
-	},
-	backgroundColor: {
-		type: 'string',
-	},
-	customBackgroundColor: {
-		type: 'string',
-	},
-	fontSize: {
-		type: 'string',
-	},
-	customFontSize: {
-		type: 'number',
-	},
-	direction: {
-		type: 'string',
-		enum: [ 'ltr', 'rtl' ],
-	},
-};
-
-export const name = 'core/paragraph';
 
 export const settings = {
 	title: __( 'Paragraph' ),
@@ -78,13 +40,9 @@ export const settings = {
 
 	icon,
 
-	category: 'common',
-
 	keywords: [ __( 'text' ) ],
 
 	supports,
-
-	attributes: schema,
 
 	transforms: {
 		from: [

--- a/packages/block-library/src/preformatted/block.json
+++ b/packages/block-library/src/preformatted/block.json
@@ -1,0 +1,12 @@
+{
+	"name": "core/preformatted",
+	"category": "formatting",
+	"attributes": {
+		"content": {
+			"type": "string",
+			"source": "html",
+			"selector": "pre",
+			"default": ""
+		}
+	}
+}

--- a/packages/block-library/src/preformatted/index.js
+++ b/packages/block-library/src/preformatted/index.js
@@ -10,8 +10,11 @@ import { RichText } from '@wordpress/block-editor';
  */
 import edit from './edit';
 import icon from './icon';
+import metadata from './block.json';
 
-export const name = 'core/preformatted';
+const { name } = metadata;
+
+export { metadata, name };
 
 export const settings = {
 	title: __( 'Preformatted' ),
@@ -19,17 +22,6 @@ export const settings = {
 	description: __( 'Add text that respects your spacing and tabs, and also allows styling.' ),
 
 	icon,
-
-	category: 'formatting',
-
-	attributes: {
-		content: {
-			type: 'string',
-			source: 'html',
-			selector: 'pre',
-			default: '',
-		},
-	},
 
 	transforms: {
 		from: [

--- a/packages/block-library/src/pullquote/block.json
+++ b/packages/block-library/src/pullquote/block.json
@@ -1,0 +1,30 @@
+{
+	"name": "core/pullquote",
+	"category": "formatting",
+	"attributes": {
+		"value": {
+			"type": "string",
+			"source": "html",
+			"selector": "blockquote",
+			"multiline": "p"
+		},
+		"citation": {
+			"type": "string",
+			"source": "html",
+			"selector": "cite",
+			"default": ""
+		},
+		"mainColor": {
+			"type": "string"
+		},
+		"customMainColor": {
+			"type": "string"
+		},
+		"textColor": {
+			"type": "string"
+		},
+		"customTextColor": {
+			"type": "string"
+		}
+	}
+}

--- a/packages/block-library/src/pullquote/index.js
+++ b/packages/block-library/src/pullquote/index.js
@@ -26,35 +26,11 @@ import {
 	SOLID_COLOR_CLASS,
 } from './edit';
 import icon from './icon';
+import metadata from './block.json';
 
-const blockAttributes = {
-	value: {
-		type: 'string',
-		source: 'html',
-		selector: 'blockquote',
-		multiline: 'p',
-	},
-	citation: {
-		type: 'string',
-		source: 'html',
-		selector: 'cite',
-		default: '',
-	},
-	mainColor: {
-		type: 'string',
-	},
-	customMainColor: {
-		type: 'string',
-	},
-	textColor: {
-		type: 'string',
-	},
-	customTextColor: {
-		type: 'string',
-	},
-};
+const { name, attributes: blockAttributes } = metadata;
 
-export const name = 'core/pullquote';
+export { metadata, name };
 
 export const settings = {
 
@@ -63,10 +39,6 @@ export const settings = {
 	description: __( 'Give special visual emphasis to a quote from your text.' ),
 
 	icon,
-
-	category: 'formatting',
-
-	attributes: blockAttributes,
 
 	styles: [
 		{ name: 'default', label: _x( 'Default', 'block style' ), isDefault: true },

--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -1,4 +1,22 @@
 {
 	"name": "core/quote",
-	"category": "common"
+	"category": "common",
+	"attributes": {
+		"value": {
+			"type": "string",
+			"source": "html",
+			"selector": "blockquote",
+			"multiline": "p",
+			"default": ""
+		},
+		"citation": {
+			"type": "string",
+			"source": "html",
+			"selector": "cite",
+			"default": ""
+		},
+		"align": {
+			"type": "string"
+		}
+	}
 }

--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -1,0 +1,4 @@
+{
+	"name": "core/quote",
+	"category": "common"
+}

--- a/packages/block-library/src/quote/contants.js
+++ b/packages/block-library/src/quote/contants.js
@@ -1,2 +1,0 @@
-export const ATTRIBUTE_QUOTE = 'value';
-export const ATTRIBUTE_CITATION = 'citation';

--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -3,16 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
-import {
-	BlockControls,
-	AlignmentToolbar,
-	RichText,
-} from '@wordpress/block-editor';
-
-/**
- * Internal dependencies
- */
-import { ATTRIBUTE_QUOTE, ATTRIBUTE_CITATION } from './contants';
+import { AlignmentToolbar, BlockControls, RichText } from '@wordpress/block-editor';
 
 export default function QuoteEdit( { attributes, setAttributes, isSelected, mergeBlocks, onReplace, className } ) {
 	const { align, value, citation } = attributes;
@@ -28,7 +19,7 @@ export default function QuoteEdit( { attributes, setAttributes, isSelected, merg
 			</BlockControls>
 			<blockquote className={ className } style={ { textAlign: align } }>
 				<RichText
-					identifier={ ATTRIBUTE_QUOTE }
+					identifier="value"
 					multiline
 					value={ value }
 					onChange={
@@ -50,7 +41,7 @@ export default function QuoteEdit( { attributes, setAttributes, isSelected, merg
 				/>
 				{ ( ! RichText.isEmpty( citation ) || isSelected ) && (
 					<RichText
-						identifier={ ATTRIBUTE_CITATION }
+						identifier="citation"
 						value={ citation }
 						onChange={
 							( nextCitation ) => setAttributes( {

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -9,38 +9,18 @@ import { omit } from 'lodash';
 import { __, _x } from '@wordpress/i18n';
 import { createBlock, getPhrasingContentSchema } from '@wordpress/blocks';
 import { RichText } from '@wordpress/block-editor';
-import { join, split, create, toHTMLString } from '@wordpress/rich-text';
+import { create, join, split, toHTMLString } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
  */
 import edit from './edit';
 import icon from './icon';
-import { ATTRIBUTE_QUOTE, ATTRIBUTE_CITATION } from './contants';
 import metadata from './block.json';
 
-const { name } = metadata;
+const { name, attributes: blockAttributes } = metadata;
 
 export { metadata, name };
-
-const blockAttributes = {
-	[ ATTRIBUTE_QUOTE ]: {
-		type: 'string',
-		source: 'html',
-		selector: 'blockquote',
-		multiline: 'p',
-		default: '',
-	},
-	[ ATTRIBUTE_CITATION ]: {
-		type: 'string',
-		source: 'html',
-		selector: 'cite',
-		default: '',
-	},
-	align: {
-		type: 'string',
-	},
-};
 
 export const settings = {
 	title: __( 'Quote' ),

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -17,6 +17,11 @@ import { join, split, create, toHTMLString } from '@wordpress/rich-text';
 import edit from './edit';
 import icon from './icon';
 import { ATTRIBUTE_QUOTE, ATTRIBUTE_CITATION } from './contants';
+import metadata from './block.json';
+
+const { name } = metadata;
+
+export { metadata, name };
 
 const blockAttributes = {
 	[ ATTRIBUTE_QUOTE ]: {
@@ -37,13 +42,10 @@ const blockAttributes = {
 	},
 };
 
-export const name = 'core/quote';
-
 export const settings = {
 	title: __( 'Quote' ),
 	description: __( 'Give quoted text visual emphasis. "In quoting others, we cite ourselves." — Julio Cortázar' ),
 	icon,
-	category: 'common',
 	keywords: [ __( 'blockquote' ) ],
 
 	attributes: blockAttributes,

--- a/packages/block-library/src/section/block.json
+++ b/packages/block-library/src/section/block.json
@@ -1,0 +1,12 @@
+{
+	"name": "core/section",
+	"category": "layout",
+	"attributes": {
+		"backgroundColor": {
+			"type": "string"
+		},
+		"customBackgroundColor": {
+			"type": "string"
+		}
+	}
+}

--- a/packages/block-library/src/section/index.js
+++ b/packages/block-library/src/section/index.js
@@ -14,15 +14,16 @@ import { InnerBlocks, getColorClassName } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import edit from './edit';
+import metadata from './block.json';
 
-export const name = 'core/section';
+const { name } = metadata;
+
+export { metadata, name };
 
 export const settings = {
 	title: __( 'Section' ),
 
 	icon: <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M19 12h-2v3h-3v2h5v-5zM7 9h3V7H5v5h2V9zm14-6H3c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16.01H3V4.99h18v14.02z" /><Path d="M0 0h24v24H0z" fill="none" /></SVG>,
-
-	category: 'layout',
 
 	description: __( 'A wrapping section acting as a container for other blocks.' ),
 
@@ -32,15 +33,6 @@ export const settings = {
 		align: [ 'wide', 'full' ],
 		anchor: true,
 		html: false,
-	},
-
-	attributes: {
-		backgroundColor: {
-			type: 'string',
-		},
-		customBackgroundColor: {
-			type: 'string',
-		},
 	},
 
 	edit,

--- a/packages/block-library/src/separator/block.json
+++ b/packages/block-library/src/separator/block.json
@@ -1,0 +1,4 @@
+{
+	"name": "core/separator",
+	"category": "layout"
+}

--- a/packages/block-library/src/separator/index.js
+++ b/packages/block-library/src/separator/index.js
@@ -9,8 +9,11 @@ import { createBlock } from '@wordpress/blocks';
  */
 import edit from './edit';
 import icon from './icon';
+import metadata from './block.json';
 
-export const name = 'core/separator';
+const { name } = metadata;
+
+export { metadata, name };
 
 export const settings = {
 	title: __( 'Separator' ),
@@ -18,8 +21,6 @@ export const settings = {
 	description: __( 'Create a break between ideas or sections with a horizontal separator.' ),
 
 	icon,
-
-	category: 'layout',
 
 	keywords: [ __( 'horizontal-line' ), 'hr', __( 'divider' ) ],
 

--- a/packages/block-library/src/spacer/block.json
+++ b/packages/block-library/src/spacer/block.json
@@ -1,0 +1,10 @@
+{
+	"name": "core/spacer",
+	"category": "layout",
+	"attributes": {
+		"height": {
+			"type": "number",
+			"default": 100
+		}
+	}
+}

--- a/packages/block-library/src/spacer/index.js
+++ b/packages/block-library/src/spacer/index.js
@@ -8,8 +8,11 @@ import { __ } from '@wordpress/i18n';
  */
 import edit from './edit';
 import icon from './icon';
+import metadata from './block.json';
 
-export const name = 'core/spacer';
+const { name } = metadata;
+
+export { metadata, name };
 
 export const settings = {
 	title: __( 'Spacer' ),
@@ -17,15 +20,6 @@ export const settings = {
 	description: __( 'Add white space between blocks and customize its height.' ),
 
 	icon,
-
-	category: 'layout',
-
-	attributes: {
-		height: {
-			type: 'number',
-			default: 100,
-		},
-	},
 
 	edit,
 

--- a/packages/block-library/src/subhead/block.json
+++ b/packages/block-library/src/subhead/block.json
@@ -1,0 +1,14 @@
+{
+	"name": "core/subhead",
+	"category": "common",
+	"attributes": {
+		"align": {
+			"type": "string"
+		},
+		"content": {
+			"type": "string",
+			"source": "html",
+			"selector": "p"
+		}
+	}
+}

--- a/packages/block-library/src/subhead/index.js
+++ b/packages/block-library/src/subhead/index.js
@@ -10,8 +10,11 @@ import { RichText } from '@wordpress/block-editor';
  */
 import edit from './edit';
 import icon from './icon';
+import metadata from './block.json';
 
-export const name = 'core/subhead';
+const { name } = metadata;
+
+export { metadata, name };
 
 export const settings = {
 	title: __( 'Subheading (deprecated)' ),
@@ -20,23 +23,10 @@ export const settings = {
 
 	icon,
 
-	category: 'common',
-
 	supports: {
 		// Hide from inserter as this block is deprecated.
 		inserter: false,
 		multiple: false,
-	},
-
-	attributes: {
-		content: {
-			type: 'string',
-			source: 'html',
-			selector: 'p',
-		},
-		align: {
-			type: 'string',
-		},
 	},
 
 	transforms: {

--- a/packages/block-library/src/template/block.json
+++ b/packages/block-library/src/template/block.json
@@ -1,0 +1,4 @@
+{
+	"name": "core/template",
+	"category": "reusable"
+}

--- a/packages/block-library/src/template/index.js
+++ b/packages/block-library/src/template/index.js
@@ -8,13 +8,14 @@ import { InnerBlocks } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import icon from './icon';
+import metadata from './block.json';
 
-export const name = 'core/template';
+const { name } = metadata;
+
+export { metadata, name };
 
 export const settings = {
 	title: __( 'Reusable Template' ),
-
-	category: 'reusable',
 
 	description: __( 'Template block used as a container.' ),
 

--- a/packages/block-library/src/text-columns/index.js
+++ b/packages/block-library/src/text-columns/index.js
@@ -14,10 +14,6 @@ import { RichText } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import edit from './edit';
-
-/**
- * Internal dependencies
- */
 import metadata from './block.json';
 
 const { name } = metadata;

--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -1,0 +1,15 @@
+{
+	"name": "core/verse",
+	"category": "formatting",
+	"attributes": {
+		"content": {
+			"type": "string",
+			"source": "html",
+			"selector": "pre",
+			"default": ""
+		},
+		"textAlign": {
+			"type": "string"
+		}
+	}
+}

--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -10,8 +10,11 @@ import { RichText } from '@wordpress/block-editor';
  */
 import edit from './edit';
 import icon from './icon';
+import metadata from './block.json';
 
-export const name = 'core/verse';
+const { name } = metadata;
+
+export { metadata, name };
 
 export const settings = {
 	title: __( 'Verse' ),
@@ -20,21 +23,7 @@ export const settings = {
 
 	icon,
 
-	category: 'formatting',
-
 	keywords: [ __( 'poetry' ) ],
-
-	attributes: {
-		content: {
-			type: 'string',
-			source: 'html',
-			selector: 'pre',
-			default: '',
-		},
-		textAlign: {
-			type: 'string',
-		},
-	},
 
 	transforms: {
 		from: [

--- a/packages/block-library/src/video/block.json
+++ b/packages/block-library/src/video/block.json
@@ -1,0 +1,64 @@
+{
+	"name": "core/video",
+	"category": "common",
+	"attributes": {
+		"autoplay": {
+			"type": "boolean",
+			"source": "attribute",
+			"selector": "video",
+			"attribute": "autoplay"
+		},
+		"caption": {
+			"type": "string",
+			"source": "html",
+			"selector": "figcaption"
+		},
+		"controls": {
+			"type": "boolean",
+			"source": "attribute",
+			"selector": "video",
+			"attribute": "controls",
+			"default": true
+		},
+		"id": {
+			"type": "number"
+		},
+		"loop": {
+			"type": "boolean",
+			"source": "attribute",
+			"selector": "video",
+			"attribute": "loop"
+		},
+		"muted": {
+			"type": "boolean",
+			"source": "attribute",
+			"selector": "video",
+			"attribute": "muted"
+		},
+		"poster": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "video",
+			"attribute": "poster"
+		},
+		"preload": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "video",
+			"attribute": "preload",
+			"default": "metadata"
+		},
+		"src": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "video",
+			"attribute": "src"
+		},
+		"playsInline": {
+			"type": "boolean",
+			"source": "attribute",
+			"selector": "video",
+			"attribute": "playsinline"
+		}
+	}
+}

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -11,8 +11,11 @@ import { __ } from '@wordpress/i18n';
  */
 import edit from './edit';
 import icon from './icon';
+import metadata from './block.json';
 
-export const name = 'core/video';
+const { name } = metadata;
+
+export { metadata, name };
 
 export const settings = {
 	title: __( 'Video' ),
@@ -22,69 +25,6 @@ export const settings = {
 	icon,
 
 	keywords: [ __( 'movie' ) ],
-
-	category: 'common',
-
-	attributes: {
-		autoplay: {
-			type: 'boolean',
-			source: 'attribute',
-			selector: 'video',
-			attribute: 'autoplay',
-		},
-		caption: {
-			type: 'string',
-			source: 'html',
-			selector: 'figcaption',
-		},
-		controls: {
-			type: 'boolean',
-			source: 'attribute',
-			selector: 'video',
-			attribute: 'controls',
-			default: true,
-		},
-		id: {
-			type: 'number',
-		},
-		loop: {
-			type: 'boolean',
-			source: 'attribute',
-			selector: 'video',
-			attribute: 'loop',
-		},
-		muted: {
-			type: 'boolean',
-			source: 'attribute',
-			selector: 'video',
-			attribute: 'muted',
-		},
-		poster: {
-			type: 'string',
-			source: 'attribute',
-			selector: 'video',
-			attribute: 'poster',
-		},
-		preload: {
-			type: 'string',
-			source: 'attribute',
-			selector: 'video',
-			attribute: 'preload',
-			default: 'metadata',
-		},
-		src: {
-			type: 'string',
-			source: 'attribute',
-			selector: 'video',
-			attribute: 'src',
-		},
-		playsInline: {
-			type: 'boolean',
-			source: 'attribute',
-			selector: 'video',
-			attribute: 'playsinline',
-		},
-	},
 
 	transforms: {
 		from: [

--- a/packages/e2e-tests/fixtures/blocks/core__cover.json
+++ b/packages/e2e-tests/fixtures/blocks/core__cover.json
@@ -15,8 +15,8 @@
                 "name": "core/paragraph",
                 "isValid": true,
                 "attributes": {
-                    "content": "\n\t\t\tGuten Berg!\n\t\t",
                     "align": "center",
+                    "content": "\n\t\t\tGuten Berg!\n\t\t",
                     "dropCap": false,
                     "placeholder": "Write title…",
                     "fontSize": "large"

--- a/packages/e2e-tests/fixtures/blocks/core__cover__video-overlay.json
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__video-overlay.json
@@ -16,8 +16,8 @@
                 "name": "core/paragraph",
                 "isValid": true,
                 "attributes": {
-                    "content": "\n\t\t\tGuten Berg!\n\t\t",
                     "align": "center",
+                    "content": "\n\t\t\tGuten Berg!\n\t\t",
                     "dropCap": false,
                     "placeholder": "Write title…",
                     "fontSize": "large"

--- a/packages/e2e-tests/fixtures/blocks/core__cover__video.json
+++ b/packages/e2e-tests/fixtures/blocks/core__cover__video.json
@@ -15,8 +15,8 @@
                 "name": "core/paragraph",
                 "isValid": true,
                 "attributes": {
-                    "content": "\n\t\t\tGuten Berg!\n\t\t",
                     "align": "center",
+                    "content": "\n\t\t\tGuten Berg!\n\t\t",
                     "dropCap": false,
                     "placeholder": "Write title…",
                     "fontSize": "large"

--- a/packages/e2e-tests/fixtures/blocks/core__image__center-caption.json
+++ b/packages/e2e-tests/fixtures/blocks/core__image__center-caption.json
@@ -4,10 +4,10 @@
         "name": "core/image",
         "isValid": true,
         "attributes": {
-            "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==",
+            "align": "center",
+	        "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==",
             "alt": "",
             "caption": "Give it a try. Press the \"really wide\" button on the image toolbar.",
-            "align": "center",
             "linkDestination": "none"
         },
         "innerBlocks": [],

--- a/packages/e2e-tests/fixtures/blocks/core__image__center-caption.json
+++ b/packages/e2e-tests/fixtures/blocks/core__image__center-caption.json
@@ -5,7 +5,7 @@
         "isValid": true,
         "attributes": {
             "align": "center",
-	        "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==",
+            "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==",
             "alt": "",
             "caption": "Give it a try. Press the \"really wide\" button on the image toolbar.",
             "linkDestination": "none"

--- a/packages/e2e-tests/fixtures/blocks/core__media-text__media-right-custom-width.json
+++ b/packages/e2e-tests/fixtures/blocks/core__media-text__media-right-custom-width.json
@@ -18,8 +18,8 @@
                 "name": "core/paragraph",
                 "isValid": true,
                 "attributes": {
-                    "content": "My video",
                     "align": "right",
+                    "content": "My video",
                     "dropCap": false,
                     "placeholder": "Content…",
                     "fontSize": "large"

--- a/packages/e2e-tests/fixtures/blocks/core__paragraph__align-right.json
+++ b/packages/e2e-tests/fixtures/blocks/core__paragraph__align-right.json
@@ -4,8 +4,8 @@
         "name": "core/paragraph",
         "isValid": true,
         "attributes": {
-            "content": "... like this one, which is separate from the above and right aligned.",
             "align": "right",
+            "content": "... like this one, which is separate from the above and right aligned.",
             "dropCap": false
         },
         "innerBlocks": [],

--- a/test/integration/__snapshots__/blocks-raw-handling.spec.js.snap
+++ b/test/integration/__snapshots__/blocks-raw-handling.spec.js.snap
@@ -56,19 +56,19 @@ exports[`rawHandler should convert HTML post to blocks with minimal content chan
 `;
 
 exports[`rawHandler should convert a caption shortcode 1`] = `
-"<!-- wp:image {\\"id\\":122,\\"align\\":\\"none\\",\\"className\\":\\"size-medium wp-image-122\\"} -->
+"<!-- wp:image {\\"align\\":\\"none\\",\\"id\\":122,\\"className\\":\\"size-medium wp-image-122\\"} -->
 <figure class=\\"wp-block-image alignnone size-medium wp-image-122\\"><img src=\\"image.png\\" alt=\\"\\" class=\\"wp-image-122\\"/><figcaption>test</figcaption></figure>
 <!-- /wp:image -->"
 `;
 
 exports[`rawHandler should convert a caption shortcode with caption 1`] = `
-"<!-- wp:image {\\"id\\":122,\\"align\\":\\"none\\",\\"className\\":\\"size-medium wp-image-122\\"} -->
+"<!-- wp:image {\\"align\\":\\"none\\",\\"id\\":122,\\"className\\":\\"size-medium wp-image-122\\"} -->
 <figure class=\\"wp-block-image alignnone size-medium wp-image-122\\"><img src=\\"image.png\\" alt=\\"\\" class=\\"wp-image-122\\"/><figcaption><a href=\\"https://w.org\\">test</a></figcaption></figure>
 <!-- /wp:image -->"
 `;
 
 exports[`rawHandler should convert a caption shortcode with link 1`] = `
-"<!-- wp:image {\\"id\\":754,\\"align\\":\\"none\\"} -->
+"<!-- wp:image {\\"align\\":\\"none\\",\\"id\\":754} -->
 <figure class=\\"wp-block-image alignnone\\"><a href=\\"http://build.wordpress-develop.test/wp-content/uploads/2011/07/100_5478.jpg\\"><img src=\\"http://build.wordpress-develop.test/wp-content/uploads/2011/07/100_5478.jpg?w=604\\" alt=\\"Bell on Wharf\\" class=\\"wp-image-754\\"/></a><figcaption>Bell on wharf in San Francisco</figcaption></figure>
 <!-- /wp:image -->"
 `;


### PR DESCRIPTION
## Description
This PR is a follow-up for #14551 which introduced a way to inline `block.json` metadata.

Scope covered by this PR:
- all static blocks (no PHP files) use `block.json` files for the following fields:
    - `name`
    - `category`
    - `attributes`

There were 2 exceptions where I couldn't easily move `attributes` to JSON file:
 - in File block, where there is used translated `default` value for an attribute (https://github.com/WordPress/gutenberg/blob/master/packages/block-library/src/file/index.js#L64-L69)
- in Table block, where attributes are generated with JavaScript callback

I opened separate PRs for them: #14862 and #14863.

## How has this been tested?
`npm run test`

`npm run dev` and ensure all blocks work as before.