### PR TITLE
Fix Blocker Picker autocompleter icon spacing

### DIFF
--- a/packages/editor/src/components/autocompleters/block.js
+++ b/packages/editor/src/components/autocompleters/block.js
@@ -54,7 +54,7 @@ export function createBlockCompleter( {
 } = {} ) {
 	return {
 		name: 'blocks',
-		className: 'block-editor-autocompleters__block',
+		className: 'editor-autocompleters__block',
 		triggerPrefix: '/',
 		options() {
 			const selectedBlockName = getSelectedBlockName();

--- a/packages/editor/src/components/autocompleters/block.js
+++ b/packages/editor/src/components/autocompleters/block.js
@@ -54,7 +54,7 @@ export function createBlockCompleter( {
 } = {} ) {
 	return {
 		name: 'blocks',
-		className: 'editor-autocompleters__block',
+		className: 'block-editor-autocompleters__block',
 		triggerPrefix: '/',
 		options() {
 			const selectedBlockName = getSelectedBlockName();

--- a/packages/editor/src/components/autocompleters/style.scss
+++ b/packages/editor/src/components/autocompleters/style.scss
@@ -1,12 +1,11 @@
-
-.block-editor-autocompleters__block {
-	.block-editor-block-icon {
+.editor-autocompleters__block {
+	.editor-block-icon {
 		margin-right: 8px;
 	}
 }
 
-.block-editor-autocompleters__user {
-	.block-editor-autocompleters__user-avatar {
+.editor-autocompleters__user {
+	.editor-autocompleters__user-avatar {
 		margin-right: 8px;
 		flex-grow: 0;
 		flex-shrink: 0;
@@ -14,7 +13,7 @@
 		width: 24px; // avoid jarring resize by seting the size upfront
 		height: 24px;
 	}
-	.block-editor-autocompleters__user-name {
+	.editor-autocompleters__user-name {
 		white-space: nowrap;
 		text-overflow: ellipsis;
 		overflow: hidden;
@@ -22,7 +21,7 @@
 		flex-shrink: 0;
 		flex-grow: 1;
 	}
-	.block-editor-autocompleters__user-slug {
+	.editor-autocompleters__user-slug {
 		margin-left: 8px;
 		color: $dark-gray-100;
 		white-space: nowrap;
@@ -32,7 +31,7 @@
 		flex-grow: 0;
 		flex-shrink: 0;
 	}
-	&:hover .block-editor-autocompleters__user-slug {
+	&:hover .editor-autocompleters__user-slug {
 		color: $blue-medium-300;
 	}
 }


### PR DESCRIPTION
During the creation of the `block-editor` package the `className` in the JSX on the autocompleter wasn’t updated. However the CSS rule _was_ updated. This inconsistency meant that a number to CSS rules were **no longer being applied**. 

The main result was that the Block autocompeleter lost its right hand margin thereby making the icon too close to the text.

![Screen Shot 2019-04-02 at 14 30 13](https://user-images.githubusercontent.com/444434/55410543-ec847780-555b-11e9-9ad7-b4eb814c31a1.png)

## What was fixed?
This PR updates the `className` in the JSX to use the `block-editor-` prefix. This causes the CSS to apply again thereby correcting the margin that was missing.

**Fixed version** - note the space between icon and text has been restored:
![Screen Shot 2019-04-02 at 15 28 35](https://user-images.githubusercontent.com/444434/55410583-04f49200-555c-11e9-81b6-5bd3a082a4b0.png)


## Types of changes
Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
