### PR TITLE
Writing Flow: allow undo of patterns with BACKSPACE and ESC

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -20,6 +20,18 @@ _Returns_
 
 -   `boolean`: Whether the given block type is allowed to be inserted.
 
+<a name="didAutomaticChange" href="#didAutomaticChange">#</a> **didAutomaticChange**
+
+Returns true if the last change was an automatic change, false otherwise.
+
+_Parameters_
+
+-   _state_ `Object`: Global application state.
+
+_Returns_
+
+-   `boolean`: Whether the last change was automatic.
+
 <a name="getAdjacentBlockClientId" href="#getAdjacentBlockClientId">#</a> **getAdjacentBlockClientId**
 
 Returns the client ID of the block adjacent one at the given reference

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -712,6 +712,20 @@ export function __unstableMarkLastChangeAsPersistent() {
 }
 
 /**
+ * Returns an action object used in signalling that the last block change is
+ * an automatic change, meaning it was not performed by the user, and can be
+ * undone using the `Escape` and `Backspace` keys. This action must be called
+ * after the change was made, and any actions that are a consequence of it, so
+ * it is recommended to be called at the next idle period to ensure all
+ * selection changes have been recorded.
+ *
+ * @return {Object} Action object.
+ */
+export function __unstableMarkAutomaticChange() {
+	return { type: 'MARK_AUTOMATIC_CHANGE' };
+}
+
+/**
  * Returns an action object used to enable or disable the navigation mode.
  *
  * @param {string} isNavigationMode Enable/Disable navigation mode.

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1260,7 +1260,7 @@ export function lastBlockAttributesChange( state, action ) {
  * @return {boolean} Updated state.
  */
 export function didAutomaticChange( state, action ) {
-	return action.type === 'MARK_AUTOMATIC_CHANGE' ? true : false;
+	return action.type === 'MARK_AUTOMATIC_CHANGE';
 }
 
 export default combineReducers( {

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1251,6 +1251,18 @@ export function lastBlockAttributesChange( state, action ) {
 	return null;
 }
 
+/**
+ * Reducer returning automatic change state.
+ *
+ * @param {boolean} state  Current state.
+ * @param {Object}  action Dispatched action.
+ *
+ * @return {boolean} Updated state.
+ */
+export function didAutomaticChange( state, action ) {
+	return action.type === 'MARK_AUTOMATIC_CHANGE' ? true : false;
+}
+
 export default combineReducers( {
 	blocks,
 	isTyping,
@@ -1264,4 +1276,5 @@ export default combineReducers( {
 	preferences,
 	lastBlockAttributesChange,
 	isNavigationMode,
+	didAutomaticChange,
 } );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1415,3 +1415,14 @@ function getReusableBlocks( state ) {
 export function isNavigationMode( state ) {
 	return state.isNavigationMode;
 }
+
+/**
+ * Returns true if the last change was an automatic change, false otherwise.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {boolean} Whether the last change was automatic.
+ */
+export function didAutomaticChange( state ) {
+	return state.didAutomaticChange;
+}

--- a/packages/e2e-tests/specs/__snapshots__/rich-text.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/rich-text.test.js.snap
@@ -48,6 +48,10 @@ exports[`RichText should not lose selection direction 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`RichText should not undo backtick transform with backspace after selection change 1`] = `""`;
+
+exports[`RichText should not undo backtick transform with backspace after typing 1`] = `""`;
+
 exports[`RichText should only mutate text data on input 1`] = `
 "<!-- wp:paragraph -->
 <p>1<strong>2</strong>34</p>
@@ -75,5 +79,11 @@ exports[`RichText should transform backtick to code 2`] = `
 exports[`RichText should update internal selection after fresh focus 1`] = `
 "<!-- wp:paragraph -->
 <p>1<strong>2</strong></p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`RichText should undo backtick transform with backspace 1`] = `
+"<!-- wp:paragraph -->
+<p>\`a\`</p>
 <!-- /wp:paragraph -->"
 `;

--- a/packages/e2e-tests/specs/blocks/__snapshots__/list.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/list.test.js.snap
@@ -200,6 +200,8 @@ exports[`List should not transform lines in block when transforming multiple blo
 <!-- /wp:list -->"
 `;
 
+exports[`List should not undo asterisk transform with backspace after typing 1`] = `""`;
+
 exports[`List should outdent with children 1`] = `
 "<!-- wp:list -->
 <ul><li>a<ul><li>b<ul><li>c</li></ul></li></ul></li></ul>
@@ -266,4 +268,18 @@ exports[`List should split into two with paragraph and merge lists 3`] = `
 <!-- wp:list -->
 <ul><li>two</li></ul>
 <!-- /wp:list -->"
+`;
+
+exports[`List should undo asterisk transform with backspace 1`] = `
+"<!-- wp:paragraph -->
+<p>* </p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`List should undo asterisk transform with backspace after selection change 1`] = `""`;
+
+exports[`List should undo asterisk transform with escape 1`] = `
+"<!-- wp:paragraph -->
+<p>* </p>
+<!-- /wp:paragraph -->"
 `;

--- a/packages/e2e-tests/specs/blocks/__snapshots__/list.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/list.test.js.snap
@@ -200,6 +200,8 @@ exports[`List should not transform lines in block when transforming multiple blo
 <!-- /wp:list -->"
 `;
 
+exports[`List should not undo asterisk transform with backspace after selection change 1`] = `""`;
+
 exports[`List should not undo asterisk transform with backspace after typing 1`] = `""`;
 
 exports[`List should outdent with children 1`] = `
@@ -275,8 +277,6 @@ exports[`List should undo asterisk transform with backspace 1`] = `
 <p>* </p>
 <!-- /wp:paragraph -->"
 `;
-
-exports[`List should undo asterisk transform with backspace after selection change 1`] = `""`;
 
 exports[`List should undo asterisk transform with escape 1`] = `
 "<!-- wp:paragraph -->

--- a/packages/e2e-tests/specs/blocks/list.test.js
+++ b/packages/e2e-tests/specs/blocks/list.test.js
@@ -83,7 +83,7 @@ describe( 'List', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
-	it( 'should undo asterisk transform with backspace after selection change', async () => {
+	it( 'should not undo asterisk transform with backspace after selection change', async () => {
 		await clickBlockAppender();
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '* ' );

--- a/packages/e2e-tests/specs/blocks/list.test.js
+++ b/packages/e2e-tests/specs/blocks/list.test.js
@@ -55,6 +55,47 @@ describe( 'List', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
+	it( 'should undo asterisk transform with backspace', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '* ' );
+		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
+		await page.keyboard.press( 'Backspace' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should undo asterisk transform with escape', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '* ' );
+		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
+		await page.keyboard.press( 'Escape' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should not undo asterisk transform with backspace after typing', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '* a' );
+		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.press( 'Backspace' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should undo asterisk transform with backspace after selection change', async () => {
+		await clickBlockAppender();
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '* ' );
+		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'Backspace' );
+
+		// Expect list to be deleted
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
 	it( 'can be created by typing "/list"', async () => {
 		// Create a list with the slash block shortcut.
 		await clickBlockAppender();

--- a/packages/e2e-tests/specs/rich-text.test.js
+++ b/packages/e2e-tests/specs/rich-text.test.js
@@ -103,6 +103,42 @@ describe( 'RichText', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
+	it( 'should undo backtick transform with backspace', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '`a`' );
+		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
+		await page.keyboard.press( 'Backspace' );
+
+		// Expect "`a`" to be restored.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should not undo backtick transform with backspace after typing', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '`a`' );
+		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
+		await page.keyboard.type( 'b' );
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.press( 'Backspace' );
+
+		// Expect "a" to be deleted.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should not undo backtick transform with backspace after selection change', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '`a`' );
+		await page.evaluate( () => new Promise( window.requestIdleCallback ) );
+		// Move inside format boundary.
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.press( 'Backspace' );
+
+		// Expect "a" to be deleted.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
 	it( 'should not format text after code backtick', async () => {
 		await clickBlockAppender();
 		await page.keyboard.type( 'A `backtick` and more.' );

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -12,7 +12,7 @@ import {
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { BACKSPACE, DELETE, ENTER, LEFT, RIGHT, SPACE } from '@wordpress/keycodes';
+import { BACKSPACE, DELETE, ENTER, LEFT, RIGHT, SPACE, ESCAPE } from '@wordpress/keycodes';
 import { withSelect } from '@wordpress/data';
 import { withSafeTimeout, compose } from '@wordpress/compose';
 import isShallowEqual from '@wordpress/is-shallow-equal';
@@ -365,6 +365,7 @@ class RichText extends Component {
 		if ( transformed !== change ) {
 			this.onCreateUndoLevel();
 			this.onChange( { ...transformed, activeFormats } );
+			this.props.__unstableMarkAutomaticChange();
 		}
 
 		// Create an undo level when input stops for over a second.
@@ -518,7 +519,17 @@ class RichText extends Component {
 	handleDelete( event ) {
 		const { keyCode } = event;
 
-		if ( keyCode !== DELETE && keyCode !== BACKSPACE ) {
+		if ( keyCode !== DELETE && keyCode !== BACKSPACE && keyCode !== ESCAPE ) {
+			return;
+		}
+
+		if ( this.props.__unstableDidAutomaticChange ) {
+			event.preventDefault();
+			this.props.__unstableUndo();
+			return;
+		}
+
+		if ( keyCode === ESCAPE ) {
 			return;
 		}
 


### PR DESCRIPTION
## Description

Fixes #8942.
Fixes #16649.
Fixes #17038.

Sets a flag when an automatic change (input rule) happened, so it can be used to undo when `Backspace`, `Delete` or `Escape` is pressed. The flag is removed as soon any action follows.

This will hopefully alleviate the frustration when something automatically changes based on an input rule. It doesn't restore the selection though, only the content. For that, we'll need #16428.

## How has this been tested?

See e2e tests.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->