### PR TITLE
Fix spacer NaN warning

### DIFF
--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -39,9 +39,11 @@ const SpacerEdit = ( { attributes, isSelected, setAttributes, toggleSelection, i
 					topLeft: false,
 				} }
 				onResizeStop={ ( event, direction, elt, delta ) => {
+					const spacerHeight = parseInt( height + delta.height, 10 );
 					setAttributes( {
-						height: parseInt( height + delta.height, 10 ),
+						height: spacerHeight,
 					} );
+					setInputHeightValue( spacerHeight );
 					toggleSelection( true );
 				} }
 				onResizeStart={ () => {

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -58,7 +58,7 @@ const SpacerEdit = ( { attributes, isSelected, setAttributes, toggleSelection, i
 									height: parseInt( event.target.value, 10 ),
 								} );
 							} }
-							value={ height }
+							value={ isNaN( height ) ? '' : height }
 							min="20"
 							step="10"
 						/>

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -54,9 +54,16 @@ const SpacerEdit = ( { attributes, isSelected, setAttributes, toggleSelection, i
 							type="number"
 							id={ id }
 							onChange={ ( event ) => {
-								const customHeight = parseInt( event.target.value, 10 );
+								let customHeight = parseInt( event.target.value, 10 );
+								if ( isNaN( customHeight ) ) {
+									// Set to the default size
+									customHeight = 100;
+								} else if ( customHeight < 20 ) {
+									// Set to the minimum size
+									customHeight = 20;
+								}
 								setAttributes( {
-									height: ( isNaN( customHeight ) ) ? 20 : customHeight,
+									height: customHeight,
 								} );
 							} }
 							value={ height }

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -54,11 +54,12 @@ const SpacerEdit = ( { attributes, isSelected, setAttributes, toggleSelection, i
 							type="number"
 							id={ id }
 							onChange={ ( event ) => {
+								const customHeight = parseInt( event.target.value, 10 );
 								setAttributes( {
-									height: parseInt( event.target.value, 10 ),
+									height: ( isNaN( customHeight ) ) ? 20 : customHeight,
 								} );
 							} }
-							value={ isNaN( height ) ? '' : height }
+							value={ height }
 							min="20"
 							step="10"
 						/>

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Fragment } from '@wordpress/element';
+import { Fragment, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
 import { BaseControl, PanelBody, ResizableBox } from '@wordpress/components';
@@ -15,6 +15,7 @@ import { withInstanceId } from '@wordpress/compose';
 const SpacerEdit = ( { attributes, isSelected, setAttributes, toggleSelection, instanceId } ) => {
 	const { height } = attributes;
 	const id = `block-spacer-height-input-${ instanceId }`;
+	const [ inputHeightValue, setInputHeightValue ] = useState( height );
 
 	return (
 		<Fragment>
@@ -54,19 +55,21 @@ const SpacerEdit = ( { attributes, isSelected, setAttributes, toggleSelection, i
 							type="number"
 							id={ id }
 							onChange={ ( event ) => {
-								let customHeight = parseInt( event.target.value, 10 );
-								if ( isNaN( customHeight ) ) {
-									// Set to the default size
-									customHeight = 100;
-								} else if ( customHeight < 20 ) {
-									// Set to the minimum size
-									customHeight = 20;
+								let spacerHeight = parseInt( event.target.value, 10 );
+								setInputHeightValue( spacerHeight );
+								if ( isNaN( spacerHeight ) ) {
+									// Set spacer height to default size and input box to empty string
+									setInputHeightValue( '' );
+									spacerHeight = 100;
+								} else if ( spacerHeight < 20 ) {
+									// Set spacer height to minimum size
+									spacerHeight = 20;
 								}
 								setAttributes( {
-									height: customHeight,
+									height: spacerHeight,
 								} );
 							} }
-							value={ height }
+							value={ inputHeightValue }
 							min="20"
 							step="10"
 						/>


### PR DESCRIPTION
## Description
Fix #14426 

## How has this been tested?

- [x] local test
- [x] brower test

## Types of changes
Change the value in BaseControl of the spacer block

## Checklist:
- [ X ] My code is tested.
- [ X ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ X ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ X ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ X ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
