### PR TITLE
Change the filtervalue to lowercase

### DIFF
--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -302,7 +302,7 @@ class HierarchicalTermSelector extends Component {
 
 			// If the term's name contains the filterValue, or it has children
 			// (i.e. some child matched at some point in the tree) then return it.
-			if ( -1 !== term.name.toLowerCase().indexOf( filterValue ) || term.children.length > 0 ) {
+			if ( -1 !== term.name.toLowerCase().indexOf( filterValue.toLowerCase( ) ) || term.children.length > 0 ) {
 				return term;
 			}
 

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -302,7 +302,7 @@ class HierarchicalTermSelector extends Component {
 
 			// If the term's name contains the filterValue, or it has children
 			// (i.e. some child matched at some point in the tree) then return it.
-			if ( -1 !== term.name.toLowerCase().indexOf( filterValue.toLowerCase( ) ) || term.children.length > 0 ) {
+			if ( -1 !== term.name.toLowerCase().indexOf( filterValue.toLowerCase() ) || term.children.length > 0 ) {
 				return term;
 			}
 


### PR DESCRIPTION
## Description
Fix #13250 

## How has this been tested?
- [X] local test
- [X] browser test


## Types of changes
Change the filterValue to lower case

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
