### PR TITLE
Allow spaces in file paths for package build process 

### DIFF
--- a/bin/packages/watch.js
+++ b/bin/packages/watch.js
@@ -12,7 +12,7 @@ const chalk = require( 'chalk' );
  */
 const getPackages = require( './get-packages' );
 
-const BUILD_CMD = `node ${ path.resolve( __dirname, './build.js' ) }`;
+const BUILD_CMD = `node \"${ path.resolve( __dirname, './build.js' ) }\"`;
 
 let filesToBuild = new Map();
 
@@ -69,7 +69,7 @@ setInterval( () => {
 	if ( files.length ) {
 		filesToBuild = new Map();
 		try {
-			execSync( `${ BUILD_CMD } ${ files.join( ' ' ) }`, { stdio: [ 0, 1, 2 ] } );
+			execSync( `${ BUILD_CMD } \"${ files.join( ' ' ) }\"`, { stdio: [ 0, 1, 2 ] } );
 		} catch ( e ) {}
 	}
 }, 100 );


### PR DESCRIPTION
## Description
Currently, the package build process fails when a path contains spaces, because the build script as well as the package location paths are not escaped in `bin/packages/watch.js`.

This PR escapes both paths, to support spaces.

### Additional information
The following error is thrown (Windows):

```
node 'C:\Users\[path with spaces]\wp-content\plugins\gutenberg\bin\packages\build.js'
internal/modules/cjs/loader.js:584
    throw err;
    ^

Error: Cannot find module 'C:\Users\[username]\'C:\Users\[path up until space]'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:582:15)
    at Function.Module._load (internal/modules/cjs/loader.js:508:25)
    at Function.Module.runMain (internal/modules/cjs/loader.js:754:12)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:622:3)
```

By adding double quotes to the `BUILD_CMD` variable in `bin/packages/watch.js` and also the argument provided to the command (the path to the package to build), spaces are now supported.

This is the only location in the code where a command gets constructed and executed "manually"; all other paths pass through node's `fs` which already supports spaces.

### Considerations
Since spaces in paths are usually escaped with a backslash on *nix, but with double quotes on Windows, I've opted for the latter since that works across all platforms. There are other approaches available to solve this problem, but this is the most unobtrusive.

## How has this been tested?
This branch was tested on Windows (build 1809) and MacOS Mojave 10.14.2, using paths with as well as without spaces in the build path.

Run `npm run dev:packages`, change a file and verify that the build process finishes without errors.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
