### PR TITLE
Fix styling regression to autocompleters

### DIFF
--- a/packages/editor/src/components/autocompleters/block.js
+++ b/packages/editor/src/components/autocompleters/block.js
@@ -54,7 +54,7 @@ export function createBlockCompleter( {
 } = {} ) {
 	return {
 		name: 'blocks',
-		className: 'editor-autocompleters__block',
+		className: 'block-editor-autocompleters__block',
 		triggerPrefix: '/',
 		options() {
 			const selectedBlockName = getSelectedBlockName();

--- a/packages/editor/src/components/autocompleters/user.js
+++ b/packages/editor/src/components/autocompleters/user.js
@@ -10,7 +10,7 @@ import apiFetch from '@wordpress/api-fetch';
 */
 export default {
 	name: 'users',
-	className: 'editor-autocompleters__user',
+	className: 'block-editor-autocompleters__user',
 	triggerPrefix: '@',
 	options( search ) {
 		let payload = '';
@@ -25,9 +25,9 @@ export default {
 	},
 	getOptionLabel( user ) {
 		return [
-			<img key="avatar" className="editor-autocompleters__user-avatar" alt="" src={ user.avatar_urls[ 24 ] } />,
-			<span key="name" className="editor-autocompleters__user-name">{ user.name }</span>,
-			<span key="slug" className="editor-autocompleters__user-slug">{ user.slug }</span>,
+			<img key="avatar" className="block-editor-autocompleters__user-avatar" alt="" src={ user.avatar_urls[ 24 ] } />,
+			<span key="name" className="block-editor-autocompleters__user-name">{ user.name }</span>,
+			<span key="slug" className="block-editor-autocompleters__user-slug">{ user.slug }</span>,
 		];
 	},
 	getOptionCompletion( user ) {


### PR DESCRIPTION
## Description
The styles of the autocompleters (slash inserter autocompleter and `@` user autocompleter) regressed recently, and it looks like it was caused by the block-editor refactor. Some classnames were updated to `block-editor` in SCSS, but not in JS. I've updated them to use the `block-editor` prefix. However, as these components are still in the `editor` package, maybe I should have gone with the `editor` prefix instead?

## How has this been tested?
- Type `/` in a new paragraph. Observe that block icons in the autocompletion menu have correct padding.
- Type `@` in a new paragraph. Observe that icons and text in the autocompletion menu have correct padding/spacing.

## Screenshots <!-- if applicable -->
**Slash inserter before regression**
![Screen Shot 2019-04-03 at 5 53 00 pm](https://user-images.githubusercontent.com/677833/55472034-b7e8ec80-563d-11e9-9712-67142c45d104.png)

**Slash inserter after regression**
![Screen Shot 2019-04-03 at 6 24 58 pm](https://user-images.githubusercontent.com/677833/55472094-d3ec8e00-563d-11e9-9802-736edcc88f4f.png)

**Slash inserter after fix**
![Screen Shot 2019-04-03 at 6 25 49 pm](https://user-images.githubusercontent.com/677833/55472144-eebf0280-563d-11e9-9abc-63b1eb021f3a.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
