### PR TITLE
Input Interaction: take into account container padding

### DIFF
--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -113,7 +113,7 @@ function isEdge( container, isReverse, onlyVertical ) {
 	}
 
 	const padding = parseInt( computedStyle[
-		`padding${ isReverse ? 'Bottom' : 'Top' }`
+		`padding${ isReverse ? 'Top' : 'Bottom' }`
 	], 10 ) || 0;
 
 	// Calculate a buffer that is half the line height. In some browsers, the

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -100,7 +100,7 @@ function isEdge( container, isReverse, onlyVertical ) {
 	}
 
 	const computedStyle = window.getComputedStyle( container );
-	const lineHeight = parseInt( computedStyle.lineHeight, 10 );
+	const lineHeight = parseInt( computedStyle.lineHeight, 10 ) || 0;
 
 	// Only consider the multiline selection at the edge if the direction is
 	// towards the edge.
@@ -112,6 +112,10 @@ function isEdge( container, isReverse, onlyVertical ) {
 		return false;
 	}
 
+	const padding = parseInt( computedStyle[
+		`padding${ isReverse ? 'Bottom' : 'Top' }`
+	], 10 ) || 0;
+
 	// Calculate a buffer that is half the line height. In some browsers, the
 	// selection rectangle may not fill the entire height of the line, so we add
 	// 3/4 the line height to the selection rectangle to ensure that it is well
@@ -119,8 +123,8 @@ function isEdge( container, isReverse, onlyVertical ) {
 	const buffer = 3 * parseInt( lineHeight, 10 ) / 4;
 	const containerRect = container.getBoundingClientRect();
 	const verticalEdge = isReverse ?
-		containerRect.top > rangeRect.top - buffer :
-		containerRect.bottom < rangeRect.bottom + buffer;
+		containerRect.top + padding > rangeRect.top - buffer :
+		containerRect.bottom - padding < rangeRect.bottom + buffer;
 
 	if ( ! verticalEdge ) {
 		return false;

--- a/packages/e2e-tests/specs/__snapshots__/writing-flow.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/writing-flow.test.js.snap
@@ -126,6 +126,16 @@ exports[`adding blocks should navigate around nested inline boundaries 2`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`adding blocks should navigate contenteditable with padding 1`] = `
+"<!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>2</p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`adding blocks should navigate empty paragraph 1`] = `
 "<!-- wp:paragraph -->
 <p>1</p>

--- a/packages/e2e-tests/specs/writing-flow.test.js
+++ b/packages/e2e-tests/specs/writing-flow.test.js
@@ -310,4 +310,21 @@ describe( 'adding blocks', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should navigate contenteditable with padding', async () => {
+		await clickBlockAppender();
+		await page.keyboard.press( 'Enter' );
+		await page.evaluate( () => {
+			document.activeElement.style.paddingTop = '100px';
+		} );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.type( '1' );
+		await page.evaluate( () => {
+			document.activeElement.style.paddingBottom = '100px';
+		} );
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.type( '2' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );


### PR DESCRIPTION
## Description

Fixes #14702. We need to take into account container padding to see if the caret is at the vertical edge of the container. This is relevant for e.g. paragraphs with a background color.

Why does it work in some themes? In some cases the padding may be small enough to get ignored with the buffer we have added.

## How has this been tested?

Ensure cross block navigation works with a paragraph with a background color in e.g. Twenty Fifteen.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
