### PR TITLE
Blocks: Add enum validation to browser block parser

### DIFF
--- a/packages/blocks/src/api/parser.js
+++ b/packages/blocks/src/api/parser.js
@@ -137,8 +137,8 @@ export function isValidByType( value, type ) {
  *
  * @link https://json-schema.org/latest/json-schema-validation.html#rfc.section.6.1.2
  *
- * @param {*}              value   Value to test.
- * @param {?Array<string>} enumSet Block attribute schema enum.
+ * @param {*}      value   Value to test.
+ * @param {?Array} enumSet Block attribute schema enum.
  *
  * @return {boolean} Whether value is valid.
  */

--- a/packages/blocks/src/api/parser.js
+++ b/packages/blocks/src/api/parser.js
@@ -117,6 +117,36 @@ export function isOfTypes( value, types ) {
 }
 
 /**
+ * Returns true if value is valid per the given block attribute schema type
+ * definition, or false otherwise.
+ *
+ * @link https://json-schema.org/latest/json-schema-validation.html#rfc.section.6.1.1
+ *
+ * @param {*}                       value Value to test.
+ * @param {?(Array<string>|string)} type  Block attribute schema type.
+ *
+ * @return {boolean} Whether value is valid.
+ */
+export function isValidByType( value, type ) {
+	return type === undefined || isOfTypes( value, castArray( type ) );
+}
+
+/**
+ * Returns true if value is valid per the given block attribute schema enum
+ * definition, or false otherwise.
+ *
+ * @link https://json-schema.org/latest/json-schema-validation.html#rfc.section.6.1.2
+ *
+ * @param {*}              value   Value to test.
+ * @param {?Array<string>} enumSet Block attribute schema enum.
+ *
+ * @return {boolean} Whether value is valid.
+ */
+export function isValidByEnum( value, enumSet ) {
+	return ! Array.isArray( enumSet ) || enumSet.includes( value );
+}
+
+/**
  * Returns true if the given attribute schema describes a value which may be
  * an ambiguous string.
  *
@@ -242,7 +272,7 @@ export function parseWithAttributeSchema( innerHTML, attributeSchema ) {
  * @return {*} Attribute value.
  */
 export function getBlockAttribute( attributeKey, attributeSchema, innerHTML, commentAttributes ) {
-	const { type } = attributeSchema;
+	const { type, enum: enumSet } = attributeSchema;
 	let value;
 
 	switch ( attributeSchema.source ) {
@@ -262,9 +292,9 @@ export function getBlockAttribute( attributeKey, attributeSchema, innerHTML, com
 			break;
 	}
 
-	if ( type !== undefined && ! isOfTypes( value, castArray( type ) ) ) {
-		// Reject the value if it is not valid of type. Reverting to the
-		// undefined value ensures the default is restored, if applicable.
+	if ( ! isValidByType( value, type ) || ! isValidByEnum( value, enumSet ) ) {
+		// Reject the value if it is not valid. Reverting to the undefined
+		// value ensures the default is respected, if applicable.
 		value = undefined;
 	}
 

--- a/packages/blocks/src/api/test/parser.js
+++ b/packages/blocks/src/api/test/parser.js
@@ -18,6 +18,8 @@ import {
 	toBooleanAttributeMatcher,
 	isOfType,
 	isOfTypes,
+	isValidByType,
+	isValidByEnum,
 } from '../parser';
 import {
 	registerBlockType,
@@ -180,6 +182,42 @@ describe( 'block parser', () => {
 		} );
 	} );
 
+	describe( 'isValidByType', () => {
+		it( 'returns true if type undefined', () => {
+			expect( isValidByType( null ) ).toBe( true );
+		} );
+
+		it( 'returns false if value is not one of types array', () => {
+			expect( isValidByType( null, [ 'string' ] ) ).toBe( false );
+		} );
+
+		it( 'returns false if value is one of types array', () => {
+			expect( isValidByType( null, [ 'string', 'null' ] ) ).toBe( true );
+		} );
+
+		it( 'returns false if value is not of type string', () => {
+			expect( isValidByType( null, 'string' ) ).toBe( false );
+		} );
+
+		it( 'returns true if value is type string', () => {
+			expect( isValidByType( null, 'null' ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'isValidByEnum', () => {
+		it( 'returns true if enum set undefined', () => {
+			expect( isValidByEnum( 2 ) ).toBe( true );
+		} );
+
+		it( 'returns false if value is not of enum set', () => {
+			expect( isValidByEnum( 2, [ 1, 3 ] ) ).toBe( false );
+		} );
+
+		it( 'returns true if value is of enum set', () => {
+			expect( isValidByEnum( 2, [ 1, 2, 3 ] ) ).toBe( true );
+		} );
+	} );
+
 	describe( 'parseWithAttributeSchema', () => {
 		it( 'should return the matcher’s attribute value', () => {
 			const value = parseWithAttributeSchema(
@@ -258,6 +296,62 @@ describe( 'block parser', () => {
 			);
 
 			expect( value ).toBe( 10 );
+		} );
+
+		it( 'should reject type-invalid value, with default', () => {
+			const value = getBlockAttribute(
+				'number',
+				{
+					type: 'string',
+					default: 5,
+				},
+				'',
+				{ number: 10 }
+			);
+
+			expect( value ).toBe( 5 );
+		} );
+
+		it( 'should reject type-invalid value, without default', () => {
+			const value = getBlockAttribute(
+				'number',
+				{
+					type: 'string',
+				},
+				'',
+				{ number: 10 }
+			);
+
+			expect( value ).toBe( undefined );
+		} );
+
+		it( 'should reject enum-invalid value, with default', () => {
+			const value = getBlockAttribute(
+				'number',
+				{
+					type: 'number',
+					enum: [ 4, 5, 6 ],
+					default: 5,
+				},
+				'',
+				{ number: 10 }
+			);
+
+			expect( value ).toBe( 5 );
+		} );
+
+		it( 'should reject enum-invalid value, without default', () => {
+			const value = getBlockAttribute(
+				'number',
+				{
+					type: 'number',
+					enum: [ 4, 5, 6 ],
+				},
+				'',
+				{ number: 10 }
+			);
+
+			expect( value ).toBe( undefined );
 		} );
 
 		it( "should return the matcher's attribute value", () => {

--- a/packages/blocks/src/api/test/parser.js
+++ b/packages/blocks/src/api/test/parser.js
@@ -191,7 +191,7 @@ describe( 'block parser', () => {
 			expect( isValidByType( null, [ 'string' ] ) ).toBe( false );
 		} );
 
-		it( 'returns false if value is one of types array', () => {
+		it( 'returns true if value is one of types array', () => {
 			expect( isValidByType( null, [ 'string', 'null' ] ) ).toBe( true );
 		} );
 


### PR DESCRIPTION
Related: #14689, #10338

This pull request seeks to implement missing [JSON schema `enum` validation](https://json-schema.org/latest/json-schema-validation.html#rfc.section.6.1.2) for block attributes parsing. A value will be rejected if it is not one of the `enum` set, if an `enum` is provided with the block attributes schema. This results in either the value being reset to `undefined`, or the `default` provided for the attribute if specified. This is identical behavior to both `type` parsing validation implemented in #10338, and existing `enum` server-side parsing validation ([reference](https://github.com/WordPress/gutenberg/pull/14689#issuecomment-479555660)). 

**Testing instructions:**

Verify unit tests pass:

```
npm run test-unit
```

Verify by explicitly assigning a `direction` comment attribute in a paragraph block (optionally [via UI](https://github.com/WordPress/gutenberg/pull/10663)) to a value other than `ltr` or `rtl`, the value will be removed during parse stage. The paragraph block includes an `enum`-specified value, despite not having been previous enforced ([see previous discussion](https://github.com/WordPress/gutenberg/pull/10663#discussion_r225685965)).

cc @igmoweb