### PR TITLE
Add withSafeInterval HOC

### DIFF
--- a/packages/block-editor/src/components/url-popover/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/url-popover/test/__snapshots__/index.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`URLPopover matches the snapshot in its default state 1`] = `
-<Popover
+<WithSafeInterval(Popover)
   className="editor-url-popover block-editor-url-popover"
   focusOnMount="firstElement"
   noArrow={false}
@@ -21,11 +21,11 @@ exports[`URLPopover matches the snapshot in its default state 1`] = `
       onClick={[Function]}
     />
   </div>
-</Popover>
+</WithSafeInterval(Popover)>
 `;
 
 exports[`URLPopover matches the snapshot when the settings are toggled open 1`] = `
-<Popover
+<WithSafeInterval(Popover)
   className="editor-url-popover block-editor-url-popover"
   focusOnMount="firstElement"
   noArrow={false}
@@ -52,11 +52,11 @@ exports[`URLPopover matches the snapshot when the settings are toggled open 1`] 
       Settings
     </div>
   </div>
-</Popover>
+</WithSafeInterval(Popover)>
 `;
 
 exports[`URLPopover matches the snapshot when there are no settings 1`] = `
-<Popover
+<WithSafeInterval(Popover)
   className="editor-url-popover block-editor-url-popover"
   focusOnMount="firstElement"
   noArrow={false}
@@ -69,5 +69,5 @@ exports[`URLPopover matches the snapshot when there are no settings 1`] = `
       Editor
     </div>
   </div>
-</Popover>
+</WithSafeInterval(Popover)>
 `;

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Component, createRef } from '@wordpress/element';
+import { withSafeInterval } from '@wordpress/compose';
 import { focus } from '@wordpress/dom';
 import { ESCAPE } from '@wordpress/keycodes';
 import isShallowEqual from '@wordpress/is-shallow-equal';
@@ -95,6 +96,8 @@ class Popover extends Component {
 	}
 
 	toggleAutoRefresh( isActive ) {
+		const { clearInterval, setInterval } = this.props;
+
 		window.cancelAnimationFrame( this.rafHandle );
 
 		// Refresh the popover every time the window is resized or scrolled
@@ -386,4 +389,4 @@ const PopoverContainer = Popover;
 
 PopoverContainer.Slot = () => <Slot bubblesVirtually name={ SLOT_NAME } />;
 
-export default PopoverContainer;
+export default withSafeInterval( PopoverContainer );

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -389,4 +389,6 @@ const PopoverContainer = Popover;
 
 PopoverContainer.Slot = () => <Slot bubblesVirtually name={ SLOT_NAME } />;
 
+export { PopoverContainer as Popover };
+
 export default withSafeInterval( PopoverContainer );

--- a/packages/components/src/popover/test/index.js
+++ b/packages/components/src/popover/test/index.js
@@ -8,7 +8,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import Popover from '../';
+import { Popover } from '../';
 
 describe( 'Popover', () => {
 	describe( '#componentDidUpdate()', () => {

--- a/packages/compose/src/index.js
+++ b/packages/compose/src/index.js
@@ -8,6 +8,7 @@ export { default as ifCondition } from './if-condition';
 export { default as pure } from './pure';
 export { default as withGlobalEvents } from './with-global-events';
 export { default as withInstanceId } from './with-instance-id';
+export { default as withSafeInterval } from './with-safe-interval';
 export { default as withSafeTimeout } from './with-safe-timeout';
 export { default as withState } from './with-state';
 

--- a/packages/compose/src/with-safe-interval/README.md
+++ b/packages/compose/src/with-safe-interval/README.md
@@ -1,0 +1,25 @@
+withSafeInterval
+===============
+
+`withSafeInterval` is a React [higher-order component](https://facebook.github.io/react/docs/higher-order-components.html) which provides a special version of `window.setInterval` which respects the original component's lifecycle. Simply put, a function set to be called in the future via `setInterval` will never be called if the original component instance ceases to exist in the meantime.
+
+## Usage
+
+```jsx
+/**
+ * WordPress dependencies
+ */
+import { withSafeInterval } from '@wordpress/compose';
+
+function MyEffectfulComponent( { setInterval } ) {
+	return (
+		<Button
+			onClick={ () => {
+				setInterval( intervalAction, 1000 );
+			} }
+		/>
+	);
+}
+
+export default withSafeInterval( MyEffectfulComponent );
+```

--- a/packages/compose/src/with-safe-interval/index.js
+++ b/packages/compose/src/with-safe-interval/index.js
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import { without } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import createHigherOrderComponent from '../create-higher-order-component';
+
+/**
+ * A higher-order component used to provide and manage interval-based function
+ * calls that ought to be bound to a component's lifecycle.
+ *
+ * @param {Component} OriginalComponent Component requiring setInterval
+ *
+ * @return {Component}                  Wrapped component.
+ */
+const withSafeInterval = createHigherOrderComponent(
+	( OriginalComponent ) => {
+		return class WrappedComponent extends Component {
+			constructor() {
+				super( ...arguments );
+				this.intervals = [];
+				this.setInterval = this.setInterval.bind( this );
+				this.clearInterval = this.clearInterval.bind( this );
+			}
+
+			componentWillUnmount() {
+				this.intervals.forEach( clearInterval );
+			}
+
+			setInterval( fn, delay ) {
+				const id = setInterval( () => {
+					fn();
+					this.clearInterval( id );
+				}, delay );
+				this.intervals.push( id );
+				return id;
+			}
+
+			clearInterval( id ) {
+				clearInterval( id );
+				this.intervals = without( this.intervals, id );
+			}
+
+			render() {
+				return (
+					<OriginalComponent
+						{ ...this.props }
+						setInterval={ this.setInterval }
+						clearInterval={ this.clearInterval }
+					/>
+				);
+			}
+		};
+	},
+	'withSafeInterval'
+);
+
+export default withSafeInterval;

--- a/packages/compose/src/with-safe-interval/index.js
+++ b/packages/compose/src/with-safe-interval/index.js
@@ -36,10 +36,7 @@ const withSafeInterval = createHigherOrderComponent(
 			}
 
 			setInterval( fn, delay ) {
-				const id = setInterval( () => {
-					fn();
-					this.clearInterval( id );
-				}, delay );
+				const id = setInterval( fn, delay );
 				this.intervals.push( id );
 				return id;
 			}

--- a/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DotTip should render correctly 1`] = `
-<Popover
+<WithSafeInterval(Popover)
   aria-label="Editor tips"
   className="nux-dot-tip"
   focusOnMount="container"
@@ -26,5 +26,5 @@ exports[`DotTip should render correctly 1`] = `
     icon="no-alt"
     label="Disable tips"
   />
-</Popover>
+</WithSafeInterval(Popover)>
 `;


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This pull request adds and applies a new higher-order component (HOC), `withSafeInterval`, which works just along the lines of the existing `withSafeTimeout` HOC.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I ran `npm run test-unit`.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
* Add new HOC to wrap `window.setInterval`.
* Use new HOC where `window.setInterval` was used before.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
