### PR TITLE
Fix FormTokenField rendering

### DIFF
--- a/packages/components/src/form-token-field/index.js
+++ b/packages/components/src/form-token-field/index.js
@@ -11,6 +11,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { withInstanceId } from '@wordpress/compose';
 import { BACKSPACE, ENTER, UP, DOWN, LEFT, RIGHT, SPACE, DELETE, ESCAPE } from '@wordpress/keycodes';
+import isShallowEqual from '@wordpress/is-shallow-equal';
 
 /**
  * Internal dependencies
@@ -58,7 +59,7 @@ class FormTokenField extends Component {
 		}
 
 		const { suggestions, value } = this.props;
-		const suggestionsDidUpdate = suggestions !== prevProps.suggestions;
+		const suggestionsDidUpdate = ! isShallowEqual( suggestions, prevProps.suggestions );
 		if ( suggestionsDidUpdate || value !== prevProps.value ) {
 			this.updateSuggestions( suggestionsDidUpdate );
 		}

--- a/packages/components/src/form-token-field/index.js
+++ b/packages/components/src/form-token-field/index.js
@@ -48,12 +48,19 @@ class FormTokenField extends Component {
 		this.onInputChange = this.onInputChange.bind( this );
 		this.bindInput = this.bindInput.bind( this );
 		this.bindTokensAndInput = this.bindTokensAndInput.bind( this );
+		this.updateSuggestions = this.updateSuggestions.bind( this );
 	}
 
-	componentDidUpdate() {
+	componentDidUpdate( prevProps ) {
 		// Make sure to focus the input when the isActive state is true.
 		if ( this.state.isActive && ! this.input.hasFocus() ) {
 			this.input.focus();
+		}
+
+		const { suggestions, value } = this.props;
+		const suggestionsDidUpdate = suggestions !== prevProps.suggestions;
+		if ( suggestionsDidUpdate || value !== prevProps.value ) {
+			this.updateSuggestions( suggestionsDidUpdate );
 		}
 	}
 
@@ -193,38 +200,14 @@ class FormTokenField extends Component {
 		const separator = this.props.tokenizeOnSpace ? /[ ,\t]+/ : /[,\t]+/;
 		const items = text.split( separator );
 		const tokenValue = last( items ) || '';
-		const inputHasMinimumChars = tokenValue.trim().length > 1;
-		const matchingSuggestions = this.getMatchingSuggestions( tokenValue );
-		const hasVisibleSuggestions = inputHasMinimumChars && !! matchingSuggestions.length;
 
 		if ( items.length > 1 ) {
 			this.addNewTokens( items.slice( 0, -1 ) );
 		}
 
-		this.setState( {
-			incompleteTokenValue: tokenValue,
-			selectedSuggestionIndex: -1,
-			selectedSuggestionScroll: false,
-			isExpanded: false,
-		} );
+		this.setState( { incompleteTokenValue: tokenValue }, this.updateSuggestions );
 
 		this.props.onInputChange( tokenValue );
-
-		if ( inputHasMinimumChars ) {
-			this.setState( {
-				isExpanded: hasVisibleSuggestions,
-			} );
-
-			if ( !! matchingSuggestions.length ) {
-				this.props.debouncedSpeak( sprintf( _n(
-					'%d result found, use up and down arrow keys to navigate.',
-					'%d results found, use up and down arrow keys to navigate.',
-					matchingSuggestions.length
-				), matchingSuggestions.length ), 'assertive' );
-			} else {
-				this.props.debouncedSpeak( __( 'No results.' ), 'assertive' );
-			}
-		}
 	}
 
 	handleDeleteKey( deleteToken ) {
@@ -465,6 +448,38 @@ class FormTokenField extends Component {
 
 	inputHasValidValue() {
 		return this.props.saveTransform( this.state.incompleteTokenValue ).length > 0;
+	}
+
+	updateSuggestions( resetSelectedSuggestion = true ) {
+		const { incompleteTokenValue } = this.state;
+
+		const inputHasMinimumChars = incompleteTokenValue.trim().length > 1;
+		const matchingSuggestions = this.getMatchingSuggestions( incompleteTokenValue );
+		const hasMatchingSuggestions = matchingSuggestions.length > 0;
+
+		const newState = {
+			isExpanded: inputHasMinimumChars && hasMatchingSuggestions,
+		};
+		if ( resetSelectedSuggestion ) {
+			newState.selectedSuggestionIndex = -1;
+			newState.selectedSuggestionScroll = false;
+		}
+
+		this.setState( newState );
+
+		if ( inputHasMinimumChars ) {
+			const { debouncedSpeak } = this.props;
+
+			const message = hasMatchingSuggestions ?
+				sprintf( _n(
+					'%d result found, use up and down arrow keys to navigate.',
+					'%d results found, use up and down arrow keys to navigate.',
+					matchingSuggestions.length
+				), matchingSuggestions.length ) :
+				__( 'No results.' );
+
+			debouncedSpeak( message, 'assertive' );
+		}
 	}
 
 	renderTokensAndInput() {

--- a/packages/components/src/form-token-field/test/index.js
+++ b/packages/components/src/form-token-field/test/index.js
@@ -237,6 +237,26 @@ describe( 'FormTokenField', function() {
 			expect( getSelectedSuggestion() ).toBe( null );
 			expect( getTokensHTML() ).toEqual( [ 'foo', 'bar', 'with' ] );
 		} );
+
+		it( 'should re-render when suggestions prop has changed', function() {
+			wrapper.setState( {
+				tokenSuggestions: [],
+				isExpanded: true,
+			} );
+			expect( getSuggestionsText() ).toEqual( [] );
+			setText( 'so' );
+			expect( getSuggestionsText() ).toEqual( [] );
+
+			wrapper.setState( {
+				tokenSuggestions: fixtures.specialSuggestions.default,
+			} );
+			expect( getSuggestionsText() ).toEqual( fixtures.matchingSuggestions.so );
+
+			wrapper.setState( {
+				tokenSuggestions: [],
+			} );
+			expect( getSuggestionsText() ).toEqual( [] );
+		} );
 	} );
 
 	describe( 'adding tokens', function() {

--- a/packages/components/src/form-token-field/test/lib/fixtures.js
+++ b/packages/components/src/form-token-field/test/lib/fixtures.js
@@ -6,6 +6,11 @@ export default {
 		htmlUnescaped: [ 'a&nbsp;&nbsp;&nbsp;b', 'i&nbsp;&lt;3&nbsp;tags', '1&amp;2&amp;3&amp;4' ],
 	},
 	specialSuggestions: {
+		default: [
+			'the', 'of', 'and', 'to', 'a', 'in', 'for', 'is', 'on', 'that', 'by', 'this', 'with', 'i', 'you', 'it',
+			'not', 'or', 'be', 'are', 'from', 'at', 'as', 'your', 'all', 'have', 'new', 'more', 'an', 'was', 'we',
+			'associate', 'snake', 'pipes', 'sound',
+		],
 		textEscaped: [ '&lt;3', 'Stuff &amp; Things', 'Tags &amp; Stuff', 'Tags &amp; Stuff 2' ],
 		textUnescaped: [ '<3', 'Stuff & Things', 'Tags & Stuff', 'Tags & Stuff 2' ],
 		matchAmpersandUnescaped: [

--- a/packages/components/src/form-token-field/test/lib/token-field-wrapper.js
+++ b/packages/components/src/form-token-field/test/lib/token-field-wrapper.js
@@ -11,13 +11,10 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import fixtures from './fixtures';
 import TokenField from '../../';
 
-const suggestions = [
-	'the', 'of', 'and', 'to', 'a', 'in', 'for', 'is', 'on', 'that', 'by', 'this', 'with', 'i', 'you', 'it',
-	'not', 'or', 'be', 'are', 'from', 'at', 'as', 'your', 'all', 'have', 'new', 'more', 'an', 'was', 'we',
-	'associate', 'snake', 'pipes', 'sound',
-];
+const { specialSuggestions: { default: suggestions } } = fixtures;
 
 function unescapeAndFormatSpaces( str ) {
 	const nbsp = String.fromCharCode( 160 );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

The `FormTokenField` component takes both the list of values to select from and the list of currently selected values as props.

However, updating and rendering the component only relies on user interaction (i.e., changing what is in the input). Any changes to either the selectable values or the selected values is ignored.

This results in bad UX in case the values are fetched (asynchronously). The behavior is that you would enter something, WordPress goes and fetches the results, passes them to the component, ... and nothing. Rendering will only happen on the next change in the input.

(By the way, this is the exact situation with any non-hierarchical taxonomy input, for example, Tags.)

This PR fixes that logic, and updates the selection if either of the selectable or selected values changes.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Steps to reproduce:

A real-life use case is the Tags panel input. Assuming you have a post tag "test". Typing te into the input will kick off an according API call, and you get your response back. But nothing happens. At least not visually. The component has received the updated prop, but only on a third keystroke, say typing "s" to have "tes", you see the result.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Fix logic in rendering/reselection.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
