### PR TITLE
Block gallery: fix tab order

### DIFF
--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -127,6 +127,7 @@ class GalleryImage extends Component {
 
 		return (
 			<figure className={ className }>
+				{ href ? <a href={ href }>{ img }</a> : img }
 				{ isSelected &&
 					<div className="block-library-gallery-item__inline-menu">
 						<IconButton
@@ -137,7 +138,6 @@ class GalleryImage extends Component {
 						/>
 					</div>
 				}
-				{ href ? <a href={ href }>{ img }</a> : img }
 				{ ( ! RichText.isEmpty( caption ) || isSelected ) ? (
 					<RichText
 						tagName="figcaption"


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/14814

Before | After
--- | ---
![Peek 2019-04-04 16-08-before](https://user-images.githubusercontent.com/583546/55562985-5a17db80-56f5-11e9-8635-27e98644dec9.gif) | ![Peek 2019-04-04 16-16-after](https://user-images.githubusercontent.com/583546/55562995-5dab6280-56f5-11e9-9180-fb4a7360b79d.gif)
