### PR TITLE
Data: Restore dispatch actions returning actions that are a Promise

### DIFF
--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### Bug Fix
+
+- Restore functionality of action-generators returning a Promise.  Clarify intent and behaviour for `wp.data.dispatch` behaviour ([#14830](https://github.com/WordPress/gutenberg/pull/14830)
+
 ## 4.3.0 (2019-03-06)
 
 ### Enhancements

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Bug Fix
 
-- Restore functionality of action-generators returning a Promise.  Clarify intent and behaviour for `wp.data.dispatch` behaviour ([#14830](https://github.com/WordPress/gutenberg/pull/14830)
+- Restore functionality of action-generators returning a Promise.  Clarify intent and behaviour for `wp.data.dispatch` behaviour. Dispatch actions now always
+ return a promise ([#14830](https://github.com/WordPress/gutenberg/pull/14830)
 
 ## 4.3.0 (2019-03-06)
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -332,6 +332,9 @@ _Returns_
 Given the name of a registered store, returns an object of the store's action creators.
 Calling an action creator will cause it to be dispatched, updating the state value accordingly.
 
+Note: If the action creator is a generator then a promise is returned.
+Otherwise, the dispatch will return `undefined`.
+
 _Usage_
 
 ```js

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -332,8 +332,8 @@ _Returns_
 Given the name of a registered store, returns an object of the store's action creators.
 Calling an action creator will cause it to be dispatched, updating the state value accordingly.
 
-Note: If the action creator is a generator then a promise is returned.
-Otherwise, the dispatch will return `undefined`.
+Note: If the action creator is a generator or returns a promise, a promise is
+returned. Otherwise, the dispatch will return `undefined`.
 
 _Usage_
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -332,7 +332,8 @@ _Returns_
 Given the name of a registered store, returns an object of the store's action creators.
 Calling an action creator will cause it to be dispatched, updating the state value accordingly.
 
-Note: This will return a promise.
+Note: Action creators returned by the dispatch will return a promise when
+they are called.
 
 _Usage_
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -332,8 +332,7 @@ _Returns_
 Given the name of a registered store, returns an object of the store's action creators.
 Calling an action creator will cause it to be dispatched, updating the state value accordingly.
 
-Note: If the action creator is a generator or returns a promise, a promise is
-returned. Otherwise, the dispatch will return `undefined`.
+Note: This will return a promise.
 
 _Usage_
 

--- a/packages/data/src/components/with-dispatch/test/index.js
+++ b/packages/data/src/components/with-dispatch/test/index.js
@@ -34,8 +34,13 @@ describe( 'withDispatch', () => {
 
 			return {
 				increment: () => {
-					const actionReturnedFromDispatch = _dispatch( 'counter' ).increment( count );
-					expect( actionReturnedFromDispatch ).toBe( undefined );
+					const actionReturnedFromDispatch = Promise.resolve( _dispatch( 'counter' ).increment( count ) );
+					expect( actionReturnedFromDispatch ).resolves.toEqual(
+						{
+							type: 'increment',
+							count,
+						}
+					);
 				},
 			};
 		} )( ( props ) => <button onClick={ props.increment } /> );
@@ -120,7 +125,8 @@ describe( 'withDispatch', () => {
 		expect( secondRegistryAction ).toHaveBeenCalledTimes( 2 );
 	} );
 
-	it( 'always calls select with the latest state in the handler passed to the component', () => {
+	it( 'always calls select with the latest state in the handler passed to ' +
+		'the component', () => {
 		const store = registry.registerStore( 'counter', {
 			reducer: ( state = 0, action ) => {
 				if ( action.type === 'update' ) {
@@ -142,8 +148,13 @@ describe( 'withDispatch', () => {
 				update: () => {
 					const innerCount = _select( 'counter' ).getCount();
 					expect( innerCount ).toBe( outerCount );
-					const actionReturnedFromDispatch = _dispatch( 'counter' ).update( innerCount + 1 );
-					expect( actionReturnedFromDispatch ).toBe( undefined );
+					const actionReturnedFromDispatch = Promise.resolve(
+						_dispatch( 'counter' ).update( innerCount + 1 )
+					);
+					expect( actionReturnedFromDispatch ).resolves.toEqual( {
+						type: 'update',
+						count: innerCount + 1,
+					} );
 				},
 			};
 		} )( ( props ) => <button onClick={ props.update } /> );

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -79,6 +79,9 @@ export const select = defaultRegistry.select;
  * Given the name of a registered store, returns an object of the store's action creators.
  * Calling an action creator will cause it to be dispatched, updating the state value accordingly.
  *
+ * Note: If the action creator is a generator then a promise is returned.
+ * Otherwise, the dispatch will return `undefined`.
+ *
  * @param {string} name Store name
  *
  * @example

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -79,8 +79,8 @@ export const select = defaultRegistry.select;
  * Given the name of a registered store, returns an object of the store's action creators.
  * Calling an action creator will cause it to be dispatched, updating the state value accordingly.
  *
- * Note: If the action creator is a generator then a promise is returned.
- * Otherwise, the dispatch will return `undefined`.
+ * Note: If the action creator is a generator or returns a promise, a promise is
+ * returned. Otherwise, the dispatch will return `undefined`.
  *
  * @param {string} name Store name
  *

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -79,8 +79,8 @@ export const select = defaultRegistry.select;
  * Given the name of a registered store, returns an object of the store's action creators.
  * Calling an action creator will cause it to be dispatched, updating the state value accordingly.
  *
- * Note: If the action creator is a generator or returns a promise, a promise is
- * returned. Otherwise, the dispatch will return `undefined`.
+ * Note: Action creators returned by the dispatch will return a promise when
+ * they are called.
  *
  * @param {string} name Store name
  *

--- a/packages/data/src/namespace-store/index.js
+++ b/packages/data/src/namespace-store/index.js
@@ -8,6 +8,7 @@ import {
 	mapValues,
 } from 'lodash';
 import combineReducers from 'turbo-combine-reducers';
+import isPromise from 'is-promise';
 
 /**
  * WordPress dependencies
@@ -188,7 +189,10 @@ function mapSelectors( selectors, store, registry ) {
  */
 function mapActions( actions, store ) {
 	const createBoundAction = ( action ) => ( ...args ) => {
-		store.dispatch( action( ...args ) );
+		const result = store.dispatch( action( ...args ) );
+		if ( isPromise( result ) ) {
+			return result;
+		}
 	};
 
 	return mapValues( actions, createBoundAction );

--- a/packages/data/src/namespace-store/index.js
+++ b/packages/data/src/namespace-store/index.js
@@ -8,7 +8,6 @@ import {
 	mapValues,
 } from 'lodash';
 import combineReducers from 'turbo-combine-reducers';
-import isPromise from 'is-promise';
 
 /**
  * WordPress dependencies
@@ -189,10 +188,7 @@ function mapSelectors( selectors, store, registry ) {
  */
 function mapActions( actions, store ) {
 	const createBoundAction = ( action ) => ( ...args ) => {
-		const result = store.dispatch( action( ...args ) );
-		if ( isPromise( result ) ) {
-			return result;
-		}
+		return Promise.resolve( store.dispatch( action( ...args ) ) );
 	};
 
 	return mapValues( actions, createBoundAction );

--- a/packages/data/src/namespace-store/test/index.js
+++ b/packages/data/src/namespace-store/test/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import isPromise from 'is-promise';
+
+/**
  * Internal dependencies
  */
 import { createRegistry } from '../../registry';
@@ -79,5 +84,19 @@ describe( 'controls', () => {
 		} );
 
 		registry.select( 'store' ).getItems();
+	} );
+	it( 'returns undefined when action is dispatched unless it is a ' +
+		'promise', () => {
+		const actions = {
+			withPromise: () => new Promise( ( resolve ) => resolve( {} ) ),
+			normal: () => ( { type: 'NORMAL' } ),
+		};
+		registry.registerStore( 'store', {
+			reducer: () => {},
+			actions,
+		} );
+		expect( isPromise( registry.dispatch( 'store' ).withPromise() ) )
+			.toBe( true );
+		expect( registry.dispatch( 'store' ).normal() ).toBeUndefined();
 	} );
 } );

--- a/packages/data/src/namespace-store/test/index.js
+++ b/packages/data/src/namespace-store/test/index.js
@@ -81,7 +81,7 @@ describe( 'controls', () => {
 		registry.select( 'store' ).getItems();
 	} );
 	describe( 'various action types have expected response and resolve as ' +
-		'expected', () => {
+		'expected with controls middleware', () => {
 		const actions = {
 			*withPromise() {
 				yield { type: 'SOME_ACTION' };
@@ -133,6 +133,37 @@ describe( 'controls', () => {
 		} );
 		it( 'returns undefined for normal dispatch action', () => {
 			expect( registry.dispatch( 'store' ).normal() ).toBeUndefined();
+		} );
+	} );
+	describe( 'action type resolves as expected with just promise ' +
+		'middleware', () => {
+		const actions = {
+			normal: () => ( { type: 'NORMAL' } ),
+			withPromiseAndAction: () => new Promise(
+				( resolve ) => resolve( { type: 'WITH_PROMISE' } )
+			),
+			withPromiseAndNonAction: () => new Promise(
+				( resolve ) => resolve( 10 )
+			),
+		};
+		beforeEach( () => {
+			registry.registerStore( 'store', {
+				reducer: () => {},
+				actions,
+			} );
+		} );
+		it( 'normal action returns undefined', () => {
+			expect( registry.dispatch( 'store' ).normal() ).toBeUndefined();
+		} );
+		it( 'action with promise resolving to action returning undefined', () => {
+			expect( registry.dispatch( 'store' ).withPromiseAndAction() )
+				.resolves
+				.toBeUndefined();
+		} );
+		it( 'action with promise returning non action throws error', () => {
+			const dispatchedAction = registry.dispatch( 'store' )
+				.withPromiseAndNonAction();
+			expect( dispatchedAction ).resolves.toBe( 10 );
 		} );
 	} );
 } );

--- a/packages/data/src/namespace-store/test/index.js
+++ b/packages/data/src/namespace-store/test/index.js
@@ -110,19 +110,19 @@ describe( 'controls', () => {
 			} );
 		} );
 		it( 'action generator returning a yielded promise control descriptor ' +
-			'resolves as expected', () => {
+			'resolves as expected', async () => {
 			const withPromise = registry.dispatch( 'store' ).withPromise();
-			expect( withPromise ).resolves.toEqual( 10 );
+			await expect( withPromise ).resolves.toEqual( 10 );
 		} );
 		it( 'action generator yielding normal action objects resolves as ' +
-			'expected', () => {
+			'expected', async () => {
 			const withNormal = registry.dispatch( 'store' ).withNormal();
-			expect( withNormal ).resolves.toBeUndefined();
+			await expect( withNormal ).resolves.toBeUndefined();
 		} );
-		it( 'action generator returning a non action like value', () => {
+		it( 'action generator returning a non action like value', async () => {
 			const withNonActionLikeValue = registry.dispatch( 'store' )
 				.withNonActionLikeValue();
-			expect( withNonActionLikeValue ).resolves.toEqual( 10 );
+			await expect( withNonActionLikeValue ).resolves.toEqual( 10 );
 		} );
 		it( 'normal dispatch action throwing error because no action ' +
 			'returned', () => {
@@ -131,8 +131,10 @@ describe( 'controls', () => {
 				'Actions must be plain objects. Use custom middleware for async actions.'
 			);
 		} );
-		it( 'returns undefined for normal dispatch action', () => {
-			expect( registry.dispatch( 'store' ).normal() ).toBeUndefined();
+		it( 'returns action object for normal dispatch action', async () => {
+			await expect( registry.dispatch( 'store' ).normal() )
+				.resolves
+				.toEqual( { type: 'NORMAL' } );
 		} );
 	} );
 	describe( 'action type resolves as expected with just promise ' +
@@ -152,18 +154,23 @@ describe( 'controls', () => {
 				actions,
 			} );
 		} );
-		it( 'normal action returns undefined', () => {
-			expect( registry.dispatch( 'store' ).normal() ).toBeUndefined();
-		} );
-		it( 'action with promise resolving to action returning undefined', () => {
-			expect( registry.dispatch( 'store' ).withPromiseAndAction() )
+		it( 'normal action returns action object', async () => {
+			await expect( registry.dispatch( 'store' ).normal() )
 				.resolves
-				.toBeUndefined();
+				.toEqual( { type: 'NORMAL' } );
 		} );
-		it( 'action with promise returning non action throws error', () => {
+		it( 'action with promise resolving to action returning ' +
+			'action object', async () => {
+			await expect( registry.dispatch( 'store' ).withPromiseAndAction() )
+				.resolves
+				.toEqual( { type: 'WITH_PROMISE' } );
+		} );
+		it( 'action with promise returning non action throws error', async () => {
 			const dispatchedAction = registry.dispatch( 'store' )
 				.withPromiseAndNonAction();
-			expect( dispatchedAction ).resolves.toBe( 10 );
+			await expect( dispatchedAction ).rejects.toThrow(
+				'Actions must be plain objects. Use custom middleware for async actions.'
+			);
 		} );
 	} );
 } );

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -541,7 +541,7 @@ describe( 'createRegistry', () => {
 	} );
 
 	describe( 'dispatch', () => {
-		it( 'registers actions to the public API', () => {
+		it( 'registers actions to the public API', async () => {
 			const increment = ( count = 1 ) => ( { type: 'increment', count } );
 			const store = registry.registerStore( 'counter', {
 				reducer: ( state = 0, action ) => {
@@ -554,9 +554,14 @@ describe( 'createRegistry', () => {
 					increment,
 				},
 			} );
-
-			const dispatchResult = registry.dispatch( 'counter' ).increment(); // state = 1
-			expect( dispatchResult ).toBe( undefined ); // Actions are implementation detail.
+			// state = 1
+			const dispatchResult = await registry.dispatch( 'counter' ).increment();
+			await expect( dispatchResult ).toEqual(
+				{
+					type: 'increment',
+					count: 1,
+				}
+			);
 			registry.dispatch( 'counter' ).increment( 4 ); // state = 5
 			expect( store.getState() ).toBe( 5 );
 		} );


### PR DESCRIPTION
## Description

This pull is prompted by some discussion beginning [here](https://github.com/WordPress/gutenberg/pull/14711#pullrequestreview-220758889) around what dispatch actions return.  Prior to [this pull](https://github.com/WordPress/gutenberg/pull/14634) dispatching a generator action would return a promise and after that pull it returned undefined. While #14711 fixed a related issue with returning the result of middleware chains, it _removed_ the behaviour that existed prior to #14634 for dispatch action returns.

In a plugin I'm developing, we came to rely on that behaviour because it was useful for complex dispatch chains via action-generators where the response of one dispatch could inform the shape of the next dispatch.  So I was able to have something like this as a control which allowed for awaiting the result of the action generator promise:

```js
async RESOLVE_DISPATCH( { reducerKey, dispatchName, args } ) {
		return await dispatchData( reducerKey )[ dispatchName ]( ...args );
	},
```

This pull seeks to be more specific on what `wp.data.dispatch( 'storeName' ).action()` can return and _only_ return if the action is a promise.  This also adds appropriate tests.

## How has this been tested?

* [x] Verify this fixes issues I was seeing in third party work I'm doing.
* [x] Verify existing/new unit tests pass.
* [x] Verify there is no breakage in e2e tests.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
This is a non-breaking change (and in fact restores regression incurred that _was_ breaking).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
