### PR TITLE
RichText/Input Interaction: use ZWNBSP as padding

### DIFF
--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -390,7 +390,7 @@ export function placeCaretAtVerticalEdge( container, isReverse, rect, mayUseScro
 	const x = rect.left;
 	const y = isReverse ? ( editableRect.bottom - buffer ) : ( editableRect.top + buffer );
 
-	let range = hiddenCaretRangeFromPoint( document, x, y, container );
+	const range = hiddenCaretRangeFromPoint( document, x, y, container );
 
 	if ( ! range || ! container.contains( range.startContainer ) ) {
 		if ( mayUseScroll && (
@@ -405,20 +405,6 @@ export function placeCaretAtVerticalEdge( container, isReverse, rect, mayUseScro
 
 		placeCaretAtHorizontalEdge( container, isReverse );
 		return;
-	}
-
-	// Check if the closest text node is actually further away.
-	// If so, attempt to get the range again with the y position adjusted to get the right offset.
-	if ( range.startContainer.nodeType === TEXT_NODE ) {
-		const parentNode = range.startContainer.parentNode;
-		const parentRect = parentNode.getBoundingClientRect();
-		const side = isReverse ? 'bottom' : 'top';
-		const padding = parseInt( getComputedStyle( parentNode ).getPropertyValue( `padding-${ side }` ), 10 ) || 0;
-		const actualY = isReverse ? ( parentRect.bottom - padding - buffer ) : ( parentRect.top + padding + buffer );
-
-		if ( y !== actualY ) {
-			range = hiddenCaretRangeFromPoint( document, x, actualY, container );
-		}
 	}
 
 	const selection = window.getSelection();

--- a/packages/e2e-tests/specs/__snapshots__/writing-flow.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/writing-flow.test.js.snap
@@ -142,6 +142,20 @@ exports[`adding blocks should navigate contenteditable with padding 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`adding blocks should navigate contenteditable with side padding 1`] = `
+"<!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`adding blocks should navigate empty paragraph 1`] = `
 "<!-- wp:paragraph -->
 <p>1</p>

--- a/packages/e2e-tests/specs/blocks/__snapshots__/list.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/list.test.js.snap
@@ -212,6 +212,12 @@ exports[`List should outdent with children 2`] = `
 <!-- /wp:list -->"
 `;
 
+exports[`List should place the caret in the right place with nested list 1`] = `
+"<!-- wp:list -->
+<ul><li>1</li><li>2<ul><li>a</li></ul></li></ul>
+<!-- /wp:list -->"
+`;
+
 exports[`List should split indented list item 1`] = `
 "<!-- wp:list -->
 <ul><li>one<ul><li>two</li><li>three</li></ul></li></ul>

--- a/packages/e2e-tests/specs/blocks/list.test.js
+++ b/packages/e2e-tests/specs/blocks/list.test.js
@@ -358,4 +358,17 @@ describe( 'List', () => {
 		// That's 9 key presses to create the list, and 9 key presses to remove
 		// the list. ;)
 	} );
+
+	it( 'should place the caret in the right place with nested list', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '* 1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( ' a' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'Enter' );
+		// The caret should land in the second item.
+		await page.keyboard.type( '2' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );

--- a/packages/e2e-tests/specs/plugins/__snapshots__/hooks-api.test.js.snap
+++ b/packages/e2e-tests/specs/plugins/__snapshots__/hooks-api.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Using Hooks API Pressing reset block button resets the block 1`] = `""`;

--- a/packages/e2e-tests/specs/plugins/hooks-api.test.js
+++ b/packages/e2e-tests/specs/plugins/hooks-api.test.js
@@ -6,6 +6,7 @@ import {
 	clickBlockAppender,
 	createNewPost,
 	deactivatePlugin,
+	getEditedPostContent,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Using Hooks API', () => {
@@ -33,7 +34,6 @@ describe( 'Using Hooks API', () => {
 		const paragraphContent = await page.$eval( 'div[data-type="core/paragraph"] p', ( element ) => element.textContent );
 		expect( paragraphContent ).toEqual( 'First paragraph' );
 		await page.click( '.edit-post-sidebar .e2e-reset-block-button' );
-		const newParagraphContent = await page.$eval( 'div[data-type="core/paragraph"] p', ( element ) => element.textContent );
-		expect( newParagraphContent ).toEqual( '' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 } );

--- a/packages/e2e-tests/specs/writing-flow.test.js
+++ b/packages/e2e-tests/specs/writing-flow.test.js
@@ -395,4 +395,18 @@ describe( 'adding blocks', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should navigate contenteditable with side padding', async () => {
+		await clickBlockAppender();
+		await page.keyboard.press( 'Enter' );
+		await page.evaluate( () => {
+			document.activeElement.style.paddingLeft = '100px';
+		} );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.type( '1' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -13,6 +13,7 @@ import { mergePair } from './concat';
 import {
 	LINE_SEPARATOR,
 	OBJECT_REPLACEMENT_CHARACTER,
+	ZWNBSP,
 } from './special-characters';
 
 /**
@@ -267,10 +268,14 @@ function filterRange( node, range, filter ) {
 	return { startContainer, startOffset, endContainer, endOffset };
 }
 
+const ZWNBSPRegExp = new RegExp( ZWNBSP, 'g' );
+
 function filterString( string ) {
 	// Reduce any whitespace used for HTML formatting to one space
 	// character, because it will also be displayed as such by the browser.
-	return string.replace( /[\n\r\t]+/g, ' ' );
+	return string.replace( /[\n\r\t]+/g, ' ' )
+		// Remove padding added by `toTree`.
+		.replace( ZWNBSPRegExp, '' );
 }
 
 /**
@@ -329,8 +334,9 @@ function createFromElement( {
 		}
 
 		if (
-			node.getAttribute( 'data-rich-text-padding' ) ||
-			( isEditableTree && type === 'br' && ! node.getAttribute( 'data-rich-text-line-break' ) )
+			isEditableTree &&
+			type === 'br' &&
+			! node.getAttribute( 'data-rich-text-line-break' )
 		) {
 			accumulateSelection( accumulator, node, range, createEmptyValue() );
 			continue;

--- a/packages/rich-text/src/special-characters.js
+++ b/packages/rich-text/src/special-characters.js
@@ -1,6 +1,15 @@
 /**
- * Line separator character.
+ * Line separator character, used for multiline text.
  */
 export const LINE_SEPARATOR = '\u2028';
+
+/**
+ * Object replacement character, used as a placeholder for objects.
+ */
 export const OBJECT_REPLACEMENT_CHARACTER = '\ufffc';
+
+/**
+ * Zero width non-breaking space, used as padding in the editable DOM tree when
+ * it is empty otherwise.
+ */
 export const ZWNBSP = '\ufeff';

--- a/packages/rich-text/src/special-characters.js
+++ b/packages/rich-text/src/special-characters.js
@@ -3,3 +3,4 @@
  */
 export const LINE_SEPARATOR = '\u2028';
 export const OBJECT_REPLACEMENT_CHARACTER = '\ufffc';
+export const ZWNBSP = '\ufeff';

--- a/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
+++ b/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
@@ -110,18 +110,14 @@ exports[`recordToDom should create a value without formatting 1`] = `
 exports[`recordToDom should create an empty value 1`] = `
 <body>
   
-  <br
-    data-rich-text-padding="true"
-  />
+  ﻿
 </body>
 `;
 
 exports[`recordToDom should create an empty value from empty tags 1`] = `
 <body>
   
-  <br
-    data-rich-text-padding="true"
-  />
+  ﻿
 </body>
 `;
 
@@ -143,9 +139,7 @@ exports[`recordToDom should handle br 1`] = `
     data-rich-text-line-break="true"
   />
   
-  <br
-    data-rich-text-padding="true"
-  />
+  ﻿
 </body>
 `;
 
@@ -161,9 +155,7 @@ exports[`recordToDom should handle br with formatting 1`] = `
     
   </em>
   
-  <br
-    data-rich-text-padding="true"
-  />
+  ﻿
 </body>
 `;
 
@@ -195,9 +187,7 @@ exports[`recordToDom should handle empty list value 1`] = `
 <body>
   <li>
     
-    <br
-      data-rich-text-padding="true"
-    />
+    ﻿
   </li>
 </body>
 `;
@@ -206,9 +196,7 @@ exports[`recordToDom should handle empty multiline value 1`] = `
 <body>
   <p>
     
-    <br
-      data-rich-text-padding="true"
-    />
+    ﻿
   </p>
 </body>
 `;
@@ -217,23 +205,15 @@ exports[`recordToDom should handle middle empty list value 1`] = `
 <body>
   <li>
     
-    <br
-      data-rich-text-padding="true"
-    />
-    
+    ﻿
   </li>
   <li>
     
-    <br
-      data-rich-text-padding="true"
-    />
-    
+    ﻿
   </li>
   <li>
     
-    <br
-      data-rich-text-padding="true"
-    />
+    ﻿
   </li>
 </body>
 `;
@@ -291,9 +271,7 @@ exports[`recordToDom should handle multiline value with empty 1`] = `
   </p>
   <p>
     
-    <br
-      data-rich-text-padding="true"
-    />
+    ﻿
   </p>
 </body>
 `;
@@ -302,15 +280,11 @@ exports[`recordToDom should handle nested empty list value 1`] = `
 <body>
   <li>
     
-    <br
-      data-rich-text-padding="true"
-    />
+    ﻿
     <ul>
       <li>
         
-        <br
-          data-rich-text-padding="true"
-        />
+        ﻿
       </li>
     </ul>
   </li>
@@ -373,9 +347,7 @@ exports[`recordToDom should preserve non breaking space 1`] = `
 exports[`recordToDom should remove padding 1`] = `
 <body>
   
-  <br
-    data-rich-text-padding="true"
-  />
+  ﻿
 </body>
 `;
 

--- a/packages/rich-text/src/test/helpers/index.js
+++ b/packages/rich-text/src/test/helpers/index.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import { ZWNBSP } from '../../special-characters';
+
 export function getSparseArrayLength( array ) {
 	return array.reduce( ( i ) => i + 1, 0 );
 }
@@ -504,8 +509,8 @@ export const spec = [
 			endOffset: 0,
 			endContainer: element.firstChild.nextSibling,
 		} ),
-		startPath: [ 1, 2, 0 ],
-		endPath: [ 1, 2, 0 ],
+		startPath: [ 1, 1, 1 ],
+		endPath: [ 1, 1, 1 ],
 		record: {
 			start: 1,
 			end: 1,
@@ -568,7 +573,7 @@ export const spec = [
 	},
 	{
 		description: 'should remove padding',
-		html: '<br data-rich-text-padding="true">',
+		html: ZWNBSP,
 		createRange: ( element ) => ( {
 			startOffset: 0,
 			startContainer: element,

--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -7,6 +7,7 @@ import { getFormatType } from './get-format-type';
 import {
 	LINE_SEPARATOR,
 	OBJECT_REPLACEMENT_CHARACTER,
+	ZWNBSP,
 } from './special-characters';
 
 /**
@@ -68,14 +69,6 @@ function fromFormat( { type, attributes, unregisteredAttributes, object, boundar
 		attributes: elementAttributes,
 	};
 }
-
-const padding = {
-	type: 'br',
-	attributes: {
-		'data-rich-text-padding': 'true',
-	},
-	object: true,
-};
 
 export function toTree( {
 	value,
@@ -145,8 +138,7 @@ export function toTree( {
 				node = getLastChild( node );
 			}
 
-			append( getParent( node ), padding );
-			append( getParent( node ), '' );
+			append( getParent( node ), ZWNBSP );
 		}
 
 		// Set selection for the start of line.
@@ -255,7 +247,7 @@ export function toTree( {
 		}
 
 		if ( shouldInsertPadding && i === text.length ) {
-			append( getParent( pointer ), padding );
+			append( getParent( pointer ), ZWNBSP );
 		}
 
 		lastCharacterFormats = characterFormats;


### PR DESCRIPTION
## Description

`<br>` elements as padding for rich text elements proved to be no good.

* List padding is broken in Firefox. See https://github.com/WordPress/gutenberg/pull/14765#issuecomment-490449099.

<img width="263" alt="Screenshot 2019-07-24 at 17 30 02" src="https://user-images.githubusercontent.com/4710635/61806972-f7c81f80-ae38-11e9-8dab-a5fde9657d56.png">

* Using line breaks as padding can cause some subtle range-to-rectangle bugs. See https://github.com/WordPress/gutenberg/pull/14804#issuecomment-480049068. The following code tries to account for that, but doesn't fully succeed in some cases.

https://github.com/WordPress/gutenberg/blob/6cb0b3268217020a101561d6f9b7d37ab08fa7da/packages/dom/src/dom.js#L176-L218

If we use zero width spaces as padding, the calculation is more reliable, and Firefox doesn't have any issues.

It also fixes an issue in the list block, where to browser moves the selection from an empty text element between a br and nested list to the start of the nested list.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->