### PR TITLE
Cover Block: Respect prefers-reduced-motion for fixed backgrounds

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -66,7 +66,7 @@
 
 		// Remove the appearance of scrolling based on OS-level animation preferences.
 		@media (prefers-reduced-motion: reduce) {
-			background-attachment: local;
+			background-attachment: scroll;
 		}
 	}
 

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -63,6 +63,11 @@
 		@supports (-webkit-overflow-scrolling: touch) {
 			background-attachment: scroll;
 		}
+
+		// Remove the appearance of scrolling based on OS-level animation preferences.
+		@media (prefers-reduced-motion: reduce) {
+			background-attachment: local;
+		}
 	}
 
 	&.has-background-dim::before {


### PR DESCRIPTION
This PR checks the `prefers-reduced-motion` media query, and disables the parallax effect on Cover blocks if the user has disabled animations.

I was reading this article earlier, [Accessibility for Vestibular Disorders,](https://alistapart.com/article/accessibility-for-vestibular) and the author mentions the following about parallax elements. I thought of the Cover block, and how we could make this experience better across WP sites by respecting the user setting.

> While most animations did not trigger my symptoms, parallax scrolling did. I’d never been a fan of parallax to begin with, as I found it confusing. And when you’re experiencing vertigo, the issues introduced by parallax scrolling compound.
>[…]
> Every time I encountered it, I would put the bucket beside me to good use and be forced to lie in bed for hours as I felt the room spinning around me, and no meds could get me out of it. It was THAT bad.

## How has this been tested?

I've personally tested with the Cover block + Mac/Safari. `prefers-reduced-motion` is also supported by Firefox (and will be [in the next Chrome](https://developers.google.com/web/updates/2019/03/prefers-reduced-motion)), so Windows users should be able to use this too. See #14021 for some existing reduced-motion support.

**To test** 

- add a cover block to a post, turn on "fixed background"
- view the post (in Safari or Firefox), the background is fixed
- turn on the setting on your operating system, in the accessibility settings.
- view the post, the background is not fixed
- turn off the OS setting
- view the post, the background is fixed again

## Checklist:

- ~[ ] My code is tested.~ it's just a css change
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
- ~[ ] I've included developer documentation if appropriate.~
