### PR TITLE
Fix selecting separator block

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -741,7 +741,7 @@
 
 	// Show a clickable plus.
 	.block-editor-inserter__toggle {
-		margin-top: -4px;
+		margin-top: -8px;
 		border-radius: 50%;
 		color: $blue-medium-focus;
 		background: $white;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -737,6 +737,7 @@
 	left: 0;
 	right: 0;
 	justify-content: center;
+	height: $block-padding + 8px;
 
 	// Show a clickable plus.
 	.block-editor-inserter__toggle {


### PR DESCRIPTION
## Description
Stopgap fix to the issue #12080. It's is an alternate solution to the fix mentioned in #13695. It fixes the inability to select the separator by reducing the insertion point elements height so that the area is still large enough to hover over but not large enough to make selecting the separator impossible. 

No visual change will be seen in the editor due to this change.

## How has this been tested?

- Passed all unit tests by running `npm test`
- Passed all E2E tests by running `npm run test-e2e`
- Manually verified on both desktop and mobile chrome and desktop firefox browsers 

## Screenshots 

Before Change:
![image](https://user-images.githubusercontent.com/20453492/55666229-7ad95180-5819-11e9-9c97-f2c9464c93dd.png)

After change:
![image](https://user-images.githubusercontent.com/20453492/55666220-5ed5b000-5819-11e9-8a0a-3f6dc227a544.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
