### PR TITLE
Automatically add `mailto:` to email addresses when linking

### DIFF
--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -20,6 +20,8 @@ import InlineLinkUI from './inline';
 
 const name = 'core/link';
 
+const isEmail = ( email ) => /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,4}$/.test( email );
+
 export const link = {
 	name,
 	title: __( 'Link' ),
@@ -47,6 +49,8 @@ export const link = {
 
 			if ( text && isURL( text ) ) {
 				onChange( applyFormat( value, { type: name, attributes: { url: text } } ) );
+			} else if ( text && isEmail( text ) ) {
+				onChange( applyFormat( value, { type: name, attributes: { url: `mailto:${ text }` } } ) );
 			} else {
 				this.setState( { addingLink: true } );
 			}

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -10,7 +10,7 @@ import {
 	removeFormat,
 	slice,
 } from '@wordpress/rich-text';
-import { isURL } from '@wordpress/url';
+import { isURL, isEmail } from '@wordpress/url';
 import { RichTextToolbarButton, RichTextShortcut } from '@wordpress/block-editor';
 
 /**
@@ -19,8 +19,6 @@ import { RichTextToolbarButton, RichTextShortcut } from '@wordpress/block-editor
 import InlineLinkUI from './inline';
 
 const name = 'core/link';
-
-const isEmail = ( email ) => /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,4}$/.test( email );
 
 export const link = {
 	name,

--- a/packages/url/README.md
+++ b/packages/url/README.md
@@ -188,6 +188,24 @@ _Returns_
 
 -   `boolean`: Whether or not the URL contains the query arg.
 
+<a name="isEmail" href="#isEmail">#</a> **isEmail**
+
+Determines whether the given string looks like an email.
+
+_Usage_
+
+```js
+const isEmail = isEmail( 'hello@wordpress.org' ); // true
+```
+
+_Parameters_
+
+-   _email_ `string`: The string to scrutinise.
+
+_Returns_
+
+-   `boolean`: Whether or not it looks like an email.
+
 <a name="isURL" href="#isURL">#</a> **isURL**
 
 Determines whether the given string looks like a URL.

--- a/packages/url/src/index.js
+++ b/packages/url/src/index.js
@@ -24,6 +24,22 @@ export function isURL( url ) {
 }
 
 /**
+ * Determines whether the given string looks like an email.
+ *
+ * @param {string} email The string to scrutinise.
+ *
+ * @example
+ * ```js
+ * const isEmail = isEmail( 'hello@wordpress.org' ); // true
+ * ```
+ *
+ * @return {boolean} Whether or not it looks like an email.
+ */
+export function isEmail( email ) {
+	return EMAIL_REGEXP.test( email );
+}
+
+/**
  * Returns the protocol part of the URL.
  *
  * @param {string} url The full URL.

--- a/packages/url/src/test/index.test.js
+++ b/packages/url/src/test/index.test.js
@@ -8,6 +8,7 @@ import { every } from 'lodash';
  */
 import {
 	isURL,
+	isEmail,
 	getProtocol,
 	isValidProtocol,
 	getAuthority,
@@ -50,6 +51,38 @@ describe( 'isURL', () => {
 		];
 
 		expect( every( urls, isURL ) ).toBe( false );
+	} );
+} );
+
+describe( 'isEmail', () => {
+	it( 'returns true when given things that look like an email', () => {
+		const emails = [
+			'simple@wordpress.org',
+			'very.common@wordpress.org',
+			'disposable.style.email.with+symbol@wordpress.org',
+			'other.email-with-hyphen@wordpress.org',
+			'fully-qualified-domain@wordpress.org',
+			'user.name+tag+sorting@wordpress.org',
+			'x@wordpress.org',
+			'wordpress-indeed@strange-wordpress.org',
+			'wordpress@s.wordpress',
+		];
+
+		expect( every( emails, isEmail ) ).toBe( true );
+	} );
+
+	it( 'returns false when given things that don\'t look like an email', () => {
+		const emails = [
+			'Abc.wordpress.org',
+			'A@b@c@wordpress.org',
+			'a"b(c)d,e:f;g<h>i[j\k]l@wordpress.org',
+			'just"not"right@wordpress.org',
+			'this is"not\allowed@wordpress.org',
+			'this\ still\"not\\allowed@wordpress.org',
+			'1234567890123456789012345678901234567890123456789012345678901234+x@wordpress.org',
+		];
+
+		expect( every( emails, isEmail ) ).toBe( false );
 	} );
 } );
 


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
The link field is automatically populated when the selected text is an email.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I've done manual tests of the editor and added unit tests for the `isEmail` validator.

## Screenshots <!-- if applicable -->
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/3305402/55684191-b3c41400-5948-11e9-8c72-cecf53f85550.gif)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested (only unit tests for `isEmail`).
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->

----

Fixes #9774 