### PR TITLE
Scripts: Optimize default Webpack configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3135,483 +3135,6 @@
 				"webpack-bundle-analyzer": "^3.0.3",
 				"webpack-cli": "^3.1.2",
 				"webpack-livereload-plugin": "^2.2.0"
-			},
-			"dependencies": {
-				"ajv": {
-					"version": "6.10.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-					"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
-					"requires": {
-						"fast-deep-equal": "^2.0.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.2"
-					}
-				},
-				"bluebird": {
-					"version": "3.5.4",
-					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
-					"integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw=="
-				},
-				"cacache": {
-					"version": "11.3.2",
-					"resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
-					"integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
-					"requires": {
-						"bluebird": "^3.5.3",
-						"chownr": "^1.1.1",
-						"figgy-pudding": "^3.5.1",
-						"glob": "^7.1.3",
-						"graceful-fs": "^4.1.15",
-						"lru-cache": "^5.1.1",
-						"mississippi": "^3.0.0",
-						"mkdirp": "^0.5.1",
-						"move-concurrently": "^1.0.1",
-						"promise-inflight": "^1.0.1",
-						"rimraf": "^2.6.2",
-						"ssri": "^6.0.1",
-						"unique-filename": "^1.1.1",
-						"y18n": "^4.0.0"
-					}
-				},
-				"chownr": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-					"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
-				},
-				"commander": {
-					"version": "2.13.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-					"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
-					"dev": true
-				},
-				"fast-deep-equal": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-				},
-				"find-cache-dir": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-					"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
-					"requires": {
-						"commondir": "^1.0.1",
-						"make-dir": "^2.0.0",
-						"pkg-dir": "^3.0.0"
-					}
-				},
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"glob": {
-					"version": "7.1.3",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.1.15",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-					"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
-				},
-				"json-schema-traverse": {
-					"version": "0.4.1",
-					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"lru-cache": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-					"requires": {
-						"yallist": "^3.0.2"
-					}
-				},
-				"make-dir": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-					"requires": {
-						"pify": "^4.0.1",
-						"semver": "^5.6.0"
-					}
-				},
-				"mississippi": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
-					"integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
-					"requires": {
-						"concat-stream": "^1.5.0",
-						"duplexify": "^3.4.2",
-						"end-of-stream": "^1.1.0",
-						"flush-write-stream": "^1.0.0",
-						"from2": "^2.1.0",
-						"parallel-transform": "^1.1.0",
-						"pump": "^3.0.0",
-						"pumpify": "^1.3.3",
-						"stream-each": "^1.1.0",
-						"through2": "^2.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-				},
-				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
-				},
-				"pkg-dir": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-					"requires": {
-						"find-up": "^3.0.0"
-					}
-				},
-				"pump": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.1"
-					}
-				},
-				"schema-utils": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-					"requires": {
-						"ajv": "^6.1.0",
-						"ajv-keywords": "^3.1.0"
-					}
-				},
-				"semver": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				},
-				"ssri": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-					"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
-					"requires": {
-						"figgy-pudding": "^3.5.1"
-					}
-				},
-				"uglify-es": {
-					"version": "3.3.9",
-					"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-					"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-					"dev": true,
-					"requires": {
-						"commander": "~2.13.0",
-						"source-map": "~0.6.1"
-					}
-				},
-				"uglifyjs-webpack-plugin": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-2.1.2.tgz",
-					"integrity": "sha512-G1fJx2uOAAfvdZ77SVCzmFo6mv8uKaHoZBL9Qq/ciC8r6p0ANOL1uY85fIUiyWXKw5RzAaJYZfNSL58Or2hQ0A==",
-					"requires": {
-						"cacache": "^11.2.0",
-						"find-cache-dir": "^2.0.0",
-						"schema-utils": "^1.0.0",
-						"serialize-javascript": "^1.4.0",
-						"source-map": "^0.6.1",
-						"uglify-js": "^3.0.0",
-						"webpack-sources": "^1.1.0",
-						"worker-farm": "^1.5.2"
-					}
-				},
-				"unique-filename": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-					"integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
-					"requires": {
-						"unique-slug": "^2.0.0"
-					}
-				},
-				"webpack": {
-					"version": "4.8.3",
-					"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.8.3.tgz",
-					"integrity": "sha512-/hfAjBISycdK597lxONjKEFX7dSIU1PsYwC3XlXUXoykWBlv9QV5HnO+ql3HvrrgfBJ7WXdnjO9iGPR2aAc5sw==",
-					"dev": true,
-					"requires": {
-						"@webassemblyjs/ast": "1.4.3",
-						"@webassemblyjs/wasm-edit": "1.4.3",
-						"@webassemblyjs/wasm-parser": "1.4.3",
-						"acorn": "^5.0.0",
-						"acorn-dynamic-import": "^3.0.0",
-						"ajv": "^6.1.0",
-						"ajv-keywords": "^3.1.0",
-						"chrome-trace-event": "^0.1.1",
-						"enhanced-resolve": "^4.0.0",
-						"eslint-scope": "^3.7.1",
-						"loader-runner": "^2.3.0",
-						"loader-utils": "^1.1.0",
-						"memory-fs": "~0.4.1",
-						"micromatch": "^3.1.8",
-						"mkdirp": "~0.5.0",
-						"neo-async": "^2.5.0",
-						"node-libs-browser": "^2.0.0",
-						"schema-utils": "^0.4.4",
-						"tapable": "^1.0.0",
-						"uglifyjs-webpack-plugin": "^1.2.4",
-						"watchpack": "^1.5.0",
-						"webpack-sources": "^1.0.1"
-					},
-					"dependencies": {
-						"ajv-keywords": {
-							"version": "3.4.0",
-							"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
-							"integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
-							"dev": true
-						},
-						"cacache": {
-							"version": "10.0.4",
-							"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
-							"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
-							"dev": true,
-							"requires": {
-								"bluebird": "^3.5.1",
-								"chownr": "^1.0.1",
-								"glob": "^7.1.2",
-								"graceful-fs": "^4.1.11",
-								"lru-cache": "^4.1.1",
-								"mississippi": "^2.0.0",
-								"mkdirp": "^0.5.1",
-								"move-concurrently": "^1.0.1",
-								"promise-inflight": "^1.0.1",
-								"rimraf": "^2.6.2",
-								"ssri": "^5.2.4",
-								"unique-filename": "^1.1.0",
-								"y18n": "^4.0.0"
-							}
-						},
-						"find-cache-dir": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
-							"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
-							"dev": true,
-							"requires": {
-								"commondir": "^1.0.1",
-								"make-dir": "^1.0.0",
-								"pkg-dir": "^2.0.0"
-							}
-						},
-						"find-up": {
-							"version": "2.1.0",
-							"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-							"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-							"dev": true,
-							"requires": {
-								"locate-path": "^2.0.0"
-							}
-						},
-						"locate-path": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-							"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-							"dev": true,
-							"requires": {
-								"p-locate": "^2.0.0",
-								"path-exists": "^3.0.0"
-							}
-						},
-						"lru-cache": {
-							"version": "4.1.5",
-							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-							"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-							"dev": true,
-							"requires": {
-								"pseudomap": "^1.0.2",
-								"yallist": "^2.1.2"
-							}
-						},
-						"make-dir": {
-							"version": "1.3.0",
-							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-							"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-							"dev": true,
-							"requires": {
-								"pify": "^3.0.0"
-							}
-						},
-						"mississippi": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
-							"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
-							"dev": true,
-							"requires": {
-								"concat-stream": "^1.5.0",
-								"duplexify": "^3.4.2",
-								"end-of-stream": "^1.1.0",
-								"flush-write-stream": "^1.0.0",
-								"from2": "^2.1.0",
-								"parallel-transform": "^1.1.0",
-								"pump": "^2.0.1",
-								"pumpify": "^1.3.3",
-								"stream-each": "^1.1.0",
-								"through2": "^2.0.0"
-							}
-						},
-						"p-limit": {
-							"version": "1.3.0",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-							"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-							"dev": true,
-							"requires": {
-								"p-try": "^1.0.0"
-							}
-						},
-						"p-locate": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-							"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-							"dev": true,
-							"requires": {
-								"p-limit": "^1.1.0"
-							}
-						},
-						"p-try": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-							"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-							"dev": true
-						},
-						"pify": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-							"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-							"dev": true
-						},
-						"pkg-dir": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-							"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-							"dev": true,
-							"requires": {
-								"find-up": "^2.1.0"
-							}
-						},
-						"pump": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-							"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-							"dev": true,
-							"requires": {
-								"end-of-stream": "^1.1.0",
-								"once": "^1.3.1"
-							}
-						},
-						"schema-utils": {
-							"version": "0.4.7",
-							"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
-							"integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
-							"dev": true,
-							"requires": {
-								"ajv": "^6.1.0",
-								"ajv-keywords": "^3.1.0"
-							}
-						},
-						"ssri": {
-							"version": "5.3.0",
-							"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
-							"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
-							"dev": true,
-							"requires": {
-								"safe-buffer": "^5.1.1"
-							}
-						},
-						"uglifyjs-webpack-plugin": {
-							"version": "1.3.0",
-							"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz",
-							"integrity": "sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==",
-							"dev": true,
-							"requires": {
-								"cacache": "^10.0.4",
-								"find-cache-dir": "^1.0.0",
-								"schema-utils": "^0.4.5",
-								"serialize-javascript": "^1.4.0",
-								"source-map": "^0.6.1",
-								"uglify-es": "^3.3.4",
-								"webpack-sources": "^1.1.0",
-								"worker-farm": "^1.5.2"
-							}
-						},
-						"worker-farm": {
-							"version": "1.6.0",
-							"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
-							"integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
-							"dev": true,
-							"requires": {
-								"errno": "~0.1.7"
-							}
-						},
-						"yallist": {
-							"version": "2.1.2",
-							"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-							"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-							"dev": true
-						}
-					}
-				},
-				"y18n": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
-				},
-				"yallist": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
-				}
 			}
 		},
 		"@wordpress/shortcode": {
@@ -3775,7 +3298,8 @@
 		"ajv-keywords": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
-			"integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw=="
+			"integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
+			"dev": true
 		},
 		"alphanum-sort": {
 			"version": "1.0.2",
@@ -3846,7 +3370,8 @@
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+			"dev": true
 		},
 		"are-we-there-yet": {
 			"version": "1.1.5",
@@ -4611,7 +4136,8 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"base": {
 			"version": "0.11.2",
@@ -4858,6 +4384,7 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -5078,7 +4605,8 @@
 		"buffer-from": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
-			"integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
+			"integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
+			"dev": true
 		},
 		"buffer-xor": {
 			"version": "1.0.3",
@@ -6387,7 +5915,8 @@
 		"commondir": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+			"dev": true
 		},
 		"compare-func": {
 			"version": "1.3.2",
@@ -6430,12 +5959,14 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"concat-stream": {
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
 			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"inherits": "^2.0.3",
@@ -7002,6 +6533,7 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
 			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+			"dev": true,
 			"requires": {
 				"aproba": "^1.1.1",
 				"fs-write-stream-atomic": "^1.0.8",
@@ -7079,7 +6611,8 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"cosmiconfig": {
 			"version": "5.0.5",
@@ -7616,7 +7149,8 @@
 		"cyclist": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
+			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+			"dev": true
 		},
 		"damerau-levenshtein": {
 			"version": "1.0.4",
@@ -8049,6 +7583,7 @@
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
 			"integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
+			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.0.0",
 				"inherits": "^2.0.1",
@@ -8171,6 +7706,7 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
 			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -8303,6 +7839,7 @@
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
 			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+			"dev": true,
 			"requires": {
 				"prr": "~1.0.1"
 			}
@@ -9097,7 +8634,8 @@
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
@@ -9162,7 +8700,8 @@
 		"figgy-pudding": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-			"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
+			"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
+			"dev": true
 		},
 		"figures": {
 			"version": "2.0.0",
@@ -9422,6 +8961,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
 			"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.4"
@@ -9489,6 +9029,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
 			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.0"
@@ -9524,6 +9065,7 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
 			"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"iferr": "^0.1.5",
@@ -9534,7 +9076,8 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"fsevents": {
 			"version": "1.2.4",
@@ -10557,6 +10100,7 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -10661,7 +10205,8 @@
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+			"dev": true
 		},
 		"grapheme-breaker": {
 			"version": "0.3.2",
@@ -11501,7 +11046,8 @@
 		"iferr": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
+			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+			"dev": true
 		},
 		"ignore": {
 			"version": "3.3.10",
@@ -11555,7 +11101,8 @@
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
 		},
 		"in-publish": {
 			"version": "2.0.0",
@@ -11585,6 +11132,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -12126,7 +11674,8 @@
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -15606,6 +15155,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -15613,7 +15163,8 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"dev": true
 		},
 		"minimist-options": {
 			"version": "3.0.2",
@@ -15713,6 +15264,7 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
@@ -15751,6 +15303,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
 			"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+			"dev": true,
 			"requires": {
 				"aproba": "^1.1.1",
 				"copy-concurrently": "^1.0.0",
@@ -16679,6 +16232,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -17082,6 +16636,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
 			"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+			"dev": true,
 			"requires": {
 				"cyclist": "~0.2.2",
 				"inherits": "^2.0.3",
@@ -17339,7 +16894,8 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
@@ -19426,7 +18982,8 @@
 		"process-nextick-args": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+			"dev": true
 		},
 		"progress": {
 			"version": "2.0.0",
@@ -19445,7 +19002,8 @@
 		"promise-inflight": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
+			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+			"dev": true
 		},
 		"promise-retry": {
 			"version": "1.1.1",
@@ -19536,7 +19094,8 @@
 		"prr": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+			"dev": true
 		},
 		"pseudomap": {
 			"version": "1.0.2",
@@ -19567,6 +19126,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
 			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
@@ -19576,6 +19136,7 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
 			"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+			"dev": true,
 			"requires": {
 				"duplexify": "^3.6.0",
 				"inherits": "^2.0.3",
@@ -19585,7 +19146,8 @@
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"dev": true
 		},
 		"puppeteer": {
 			"version": "1.6.1",
@@ -19992,6 +19554,7 @@
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -20622,6 +20185,7 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"dev": true,
 			"requires": {
 				"glob": "^7.0.5"
 			}
@@ -20703,6 +20267,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
 			"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+			"dev": true,
 			"requires": {
 				"aproba": "^1.1.1"
 			}
@@ -21096,7 +20661,8 @@
 		"serialize-javascript": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
-			"integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ=="
+			"integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ==",
+			"dev": true
 		},
 		"serialize-to-js": {
 			"version": "1.2.2",
@@ -21444,7 +21010,8 @@
 		"source-list-map": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
-			"integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A=="
+			"integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
+			"dev": true
 		},
 		"source-map": {
 			"version": "0.5.7",
@@ -21760,6 +21327,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
 			"integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
+			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"stream-shift": "^1.0.0"
@@ -21781,7 +21349,8 @@
 		"stream-shift": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+			"dev": true
 		},
 		"strict-uri-encode": {
 			"version": "1.1.0",
@@ -21835,6 +21404,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -22604,6 +22174,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+			"dev": true,
 			"requires": {
 				"readable-stream": "^2.1.5",
 				"xtend": "~4.0.1"
@@ -22867,7 +22438,8 @@
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true
 		},
 		"ua-parser-js": {
 			"version": "0.7.18",
@@ -22878,6 +22450,8 @@
 			"version": "3.4.9",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
 			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+			"dev": true,
+			"optional": true,
 			"requires": {
 				"commander": "~2.17.1",
 				"source-map": "~0.6.1"
@@ -22886,12 +22460,16 @@
 				"commander": {
 					"version": "2.17.1",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-					"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+					"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+					"dev": true,
+					"optional": true
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -23132,6 +22710,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
 			"integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
+			"dev": true,
 			"requires": {
 				"imurmurhash": "^0.1.4"
 			}
@@ -23270,6 +22849,7 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			}
@@ -23320,7 +22900,8 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
 		},
 		"util.promisify": {
 			"version": "1.0.0",
@@ -24390,6 +23971,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
 			"integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
+			"dev": true,
 			"requires": {
 				"source-list-map": "^2.0.0",
 				"source-map": "~0.6.1"
@@ -24398,7 +23980,8 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				}
 			}
 		},
@@ -24534,6 +24117,7 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
 			"integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
+			"dev": true,
 			"requires": {
 				"errno": "~0.1.7"
 			}
@@ -24583,7 +24167,8 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"write": {
 			"version": "0.2.1",
@@ -24667,7 +24252,8 @@
 		"xtend": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+			"dev": true
 		},
 		"y18n": {
 			"version": "3.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3130,10 +3130,488 @@
 				"source-map-loader": "^0.2.4",
 				"stylelint": "^9.10.1",
 				"stylelint-config-wordpress": "^13.1.0",
+				"thread-loader": "^2.1.2",
 				"webpack": "4.8.3",
 				"webpack-bundle-analyzer": "^3.0.3",
 				"webpack-cli": "^3.1.2",
 				"webpack-livereload-plugin": "^2.2.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "6.10.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+					"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+					"requires": {
+						"fast-deep-equal": "^2.0.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"bluebird": {
+					"version": "3.5.4",
+					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
+					"integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw=="
+				},
+				"cacache": {
+					"version": "11.3.2",
+					"resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
+					"integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
+					"requires": {
+						"bluebird": "^3.5.3",
+						"chownr": "^1.1.1",
+						"figgy-pudding": "^3.5.1",
+						"glob": "^7.1.3",
+						"graceful-fs": "^4.1.15",
+						"lru-cache": "^5.1.1",
+						"mississippi": "^3.0.0",
+						"mkdirp": "^0.5.1",
+						"move-concurrently": "^1.0.1",
+						"promise-inflight": "^1.0.1",
+						"rimraf": "^2.6.2",
+						"ssri": "^6.0.1",
+						"unique-filename": "^1.1.1",
+						"y18n": "^4.0.0"
+					}
+				},
+				"chownr": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+					"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
+				},
+				"commander": {
+					"version": "2.13.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+					"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+					"dev": true
+				},
+				"fast-deep-equal": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+				},
+				"find-cache-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+					"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+					"requires": {
+						"commondir": "^1.0.1",
+						"make-dir": "^2.0.0",
+						"pkg-dir": "^3.0.0"
+					}
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.3",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.1.15",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+					"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"lru-cache": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+					"requires": {
+						"yallist": "^3.0.2"
+					}
+				},
+				"make-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+					"requires": {
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
+					}
+				},
+				"mississippi": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+					"integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+					"requires": {
+						"concat-stream": "^1.5.0",
+						"duplexify": "^3.4.2",
+						"end-of-stream": "^1.1.0",
+						"flush-write-stream": "^1.0.0",
+						"from2": "^2.1.0",
+						"parallel-transform": "^1.1.0",
+						"pump": "^3.0.0",
+						"pumpify": "^1.3.3",
+						"stream-each": "^1.1.0",
+						"through2": "^2.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+				},
+				"pify": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+				},
+				"pkg-dir": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+					"requires": {
+						"find-up": "^3.0.0"
+					}
+				},
+				"pump": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
+				},
+				"schema-utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+					"requires": {
+						"ajv": "^6.1.0",
+						"ajv-keywords": "^3.1.0"
+					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				},
+				"ssri": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+					"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+					"requires": {
+						"figgy-pudding": "^3.5.1"
+					}
+				},
+				"uglify-es": {
+					"version": "3.3.9",
+					"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+					"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+					"dev": true,
+					"requires": {
+						"commander": "~2.13.0",
+						"source-map": "~0.6.1"
+					}
+				},
+				"uglifyjs-webpack-plugin": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-2.1.2.tgz",
+					"integrity": "sha512-G1fJx2uOAAfvdZ77SVCzmFo6mv8uKaHoZBL9Qq/ciC8r6p0ANOL1uY85fIUiyWXKw5RzAaJYZfNSL58Or2hQ0A==",
+					"requires": {
+						"cacache": "^11.2.0",
+						"find-cache-dir": "^2.0.0",
+						"schema-utils": "^1.0.0",
+						"serialize-javascript": "^1.4.0",
+						"source-map": "^0.6.1",
+						"uglify-js": "^3.0.0",
+						"webpack-sources": "^1.1.0",
+						"worker-farm": "^1.5.2"
+					}
+				},
+				"unique-filename": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+					"integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+					"requires": {
+						"unique-slug": "^2.0.0"
+					}
+				},
+				"webpack": {
+					"version": "4.8.3",
+					"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.8.3.tgz",
+					"integrity": "sha512-/hfAjBISycdK597lxONjKEFX7dSIU1PsYwC3XlXUXoykWBlv9QV5HnO+ql3HvrrgfBJ7WXdnjO9iGPR2aAc5sw==",
+					"dev": true,
+					"requires": {
+						"@webassemblyjs/ast": "1.4.3",
+						"@webassemblyjs/wasm-edit": "1.4.3",
+						"@webassemblyjs/wasm-parser": "1.4.3",
+						"acorn": "^5.0.0",
+						"acorn-dynamic-import": "^3.0.0",
+						"ajv": "^6.1.0",
+						"ajv-keywords": "^3.1.0",
+						"chrome-trace-event": "^0.1.1",
+						"enhanced-resolve": "^4.0.0",
+						"eslint-scope": "^3.7.1",
+						"loader-runner": "^2.3.0",
+						"loader-utils": "^1.1.0",
+						"memory-fs": "~0.4.1",
+						"micromatch": "^3.1.8",
+						"mkdirp": "~0.5.0",
+						"neo-async": "^2.5.0",
+						"node-libs-browser": "^2.0.0",
+						"schema-utils": "^0.4.4",
+						"tapable": "^1.0.0",
+						"uglifyjs-webpack-plugin": "^1.2.4",
+						"watchpack": "^1.5.0",
+						"webpack-sources": "^1.0.1"
+					},
+					"dependencies": {
+						"ajv-keywords": {
+							"version": "3.4.0",
+							"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
+							"integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
+							"dev": true
+						},
+						"cacache": {
+							"version": "10.0.4",
+							"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+							"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
+							"dev": true,
+							"requires": {
+								"bluebird": "^3.5.1",
+								"chownr": "^1.0.1",
+								"glob": "^7.1.2",
+								"graceful-fs": "^4.1.11",
+								"lru-cache": "^4.1.1",
+								"mississippi": "^2.0.0",
+								"mkdirp": "^0.5.1",
+								"move-concurrently": "^1.0.1",
+								"promise-inflight": "^1.0.1",
+								"rimraf": "^2.6.2",
+								"ssri": "^5.2.4",
+								"unique-filename": "^1.1.0",
+								"y18n": "^4.0.0"
+							}
+						},
+						"find-cache-dir": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+							"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+							"dev": true,
+							"requires": {
+								"commondir": "^1.0.1",
+								"make-dir": "^1.0.0",
+								"pkg-dir": "^2.0.0"
+							}
+						},
+						"find-up": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+							"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+							"dev": true,
+							"requires": {
+								"locate-path": "^2.0.0"
+							}
+						},
+						"locate-path": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+							"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+							"dev": true,
+							"requires": {
+								"p-locate": "^2.0.0",
+								"path-exists": "^3.0.0"
+							}
+						},
+						"lru-cache": {
+							"version": "4.1.5",
+							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+							"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+							"dev": true,
+							"requires": {
+								"pseudomap": "^1.0.2",
+								"yallist": "^2.1.2"
+							}
+						},
+						"make-dir": {
+							"version": "1.3.0",
+							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+							"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+							"dev": true,
+							"requires": {
+								"pify": "^3.0.0"
+							}
+						},
+						"mississippi": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
+							"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
+							"dev": true,
+							"requires": {
+								"concat-stream": "^1.5.0",
+								"duplexify": "^3.4.2",
+								"end-of-stream": "^1.1.0",
+								"flush-write-stream": "^1.0.0",
+								"from2": "^2.1.0",
+								"parallel-transform": "^1.1.0",
+								"pump": "^2.0.1",
+								"pumpify": "^1.3.3",
+								"stream-each": "^1.1.0",
+								"through2": "^2.0.0"
+							}
+						},
+						"p-limit": {
+							"version": "1.3.0",
+							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+							"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+							"dev": true,
+							"requires": {
+								"p-try": "^1.0.0"
+							}
+						},
+						"p-locate": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+							"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+							"dev": true,
+							"requires": {
+								"p-limit": "^1.1.0"
+							}
+						},
+						"p-try": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+							"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+							"dev": true
+						},
+						"pify": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+							"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+							"dev": true
+						},
+						"pkg-dir": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+							"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+							"dev": true,
+							"requires": {
+								"find-up": "^2.1.0"
+							}
+						},
+						"pump": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+							"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+							"dev": true,
+							"requires": {
+								"end-of-stream": "^1.1.0",
+								"once": "^1.3.1"
+							}
+						},
+						"schema-utils": {
+							"version": "0.4.7",
+							"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
+							"integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+							"dev": true,
+							"requires": {
+								"ajv": "^6.1.0",
+								"ajv-keywords": "^3.1.0"
+							}
+						},
+						"ssri": {
+							"version": "5.3.0",
+							"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
+							"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
+							"dev": true,
+							"requires": {
+								"safe-buffer": "^5.1.1"
+							}
+						},
+						"uglifyjs-webpack-plugin": {
+							"version": "1.3.0",
+							"resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz",
+							"integrity": "sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==",
+							"dev": true,
+							"requires": {
+								"cacache": "^10.0.4",
+								"find-cache-dir": "^1.0.0",
+								"schema-utils": "^0.4.5",
+								"serialize-javascript": "^1.4.0",
+								"source-map": "^0.6.1",
+								"uglify-es": "^3.3.4",
+								"webpack-sources": "^1.1.0",
+								"worker-farm": "^1.5.2"
+							}
+						},
+						"worker-farm": {
+							"version": "1.6.0",
+							"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
+							"integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
+							"dev": true,
+							"requires": {
+								"errno": "~0.1.7"
+							}
+						},
+						"yallist": {
+							"version": "2.1.2",
+							"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+							"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+							"dev": true
+						}
+					}
+				},
+				"y18n": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+				},
+				"yallist": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+				}
 			}
 		},
 		"@wordpress/shortcode": {
@@ -3297,8 +3775,7 @@
 		"ajv-keywords": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
-			"integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
-			"dev": true
+			"integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw=="
 		},
 		"alphanum-sort": {
 			"version": "1.0.2",
@@ -3369,8 +3846,7 @@
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-			"dev": true
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
 		},
 		"are-we-there-yet": {
 			"version": "1.1.5",
@@ -4135,8 +4611,7 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"base": {
 			"version": "0.11.2",
@@ -4383,7 +4858,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -4604,8 +5078,7 @@
 		"buffer-from": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
-			"integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
-			"dev": true
+			"integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
 		},
 		"buffer-xor": {
 			"version": "1.0.3",
@@ -5914,8 +6387,7 @@
 		"commondir": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-			"dev": true
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
 		},
 		"compare-func": {
 			"version": "1.3.2",
@@ -5958,14 +6430,12 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concat-stream": {
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
 			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"inherits": "^2.0.3",
@@ -6532,7 +7002,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
 			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
-			"dev": true,
 			"requires": {
 				"aproba": "^1.1.1",
 				"fs-write-stream-atomic": "^1.0.8",
@@ -6610,8 +7079,7 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"cosmiconfig": {
 			"version": "5.0.5",
@@ -7148,8 +7616,7 @@
 		"cyclist": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
-			"dev": true
+			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
 		},
 		"damerau-levenshtein": {
 			"version": "1.0.4",
@@ -7582,7 +8049,6 @@
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
 			"integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
-			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.0.0",
 				"inherits": "^2.0.1",
@@ -7705,7 +8171,6 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
 			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -7838,7 +8303,6 @@
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
 			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-			"dev": true,
 			"requires": {
 				"prr": "~1.0.1"
 			}
@@ -8633,8 +9097,7 @@
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-			"dev": true
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
@@ -8699,8 +9162,7 @@
 		"figgy-pudding": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-			"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
-			"dev": true
+			"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
 		},
 		"figures": {
 			"version": "2.0.0",
@@ -8960,7 +9422,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
 			"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.4"
@@ -9028,7 +9489,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
 			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.0"
@@ -9064,7 +9524,6 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
 			"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"iferr": "^0.1.5",
@@ -9075,8 +9534,7 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
 			"version": "1.2.4",
@@ -10099,7 +10557,6 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -10204,8 +10661,7 @@
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-			"dev": true
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
 		},
 		"grapheme-breaker": {
 			"version": "0.3.2",
@@ -11045,8 +11501,7 @@
 		"iferr": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
-			"dev": true
+			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
 		},
 		"ignore": {
 			"version": "3.3.10",
@@ -11100,8 +11555,7 @@
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-			"dev": true
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
 		},
 		"in-publish": {
 			"version": "2.0.0",
@@ -11131,7 +11585,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -11673,8 +12126,7 @@
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -15154,7 +15606,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -15162,8 +15613,7 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-			"dev": true
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"minimist-options": {
 			"version": "3.0.2",
@@ -15263,7 +15713,6 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
@@ -15302,7 +15751,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
 			"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
-			"dev": true,
 			"requires": {
 				"aproba": "^1.1.1",
 				"copy-concurrently": "^1.0.0",
@@ -16231,7 +16679,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -16635,7 +17082,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
 			"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
-			"dev": true,
 			"requires": {
 				"cyclist": "~0.2.2",
 				"inherits": "^2.0.3",
@@ -16893,8 +17339,7 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
@@ -18981,8 +19426,7 @@
 		"process-nextick-args": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-			"dev": true
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
 		},
 		"progress": {
 			"version": "2.0.0",
@@ -19001,8 +19445,7 @@
 		"promise-inflight": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
-			"dev": true
+			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
 		},
 		"promise-retry": {
 			"version": "1.1.1",
@@ -19093,8 +19536,7 @@
 		"prr": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-			"dev": true
+			"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
 		},
 		"pseudomap": {
 			"version": "1.0.2",
@@ -19125,7 +19567,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
 			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
@@ -19135,7 +19576,6 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
 			"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
-			"dev": true,
 			"requires": {
 				"duplexify": "^3.6.0",
 				"inherits": "^2.0.3",
@@ -19145,8 +19585,7 @@
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-			"dev": true
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 		},
 		"puppeteer": {
 			"version": "1.6.1",
@@ -19553,7 +19992,6 @@
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -20184,7 +20622,6 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-			"dev": true,
 			"requires": {
 				"glob": "^7.0.5"
 			}
@@ -20266,7 +20703,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
 			"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
-			"dev": true,
 			"requires": {
 				"aproba": "^1.1.1"
 			}
@@ -20556,9 +20992,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "6.9.1",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
-					"integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
+					"version": "6.10.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+					"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^2.0.1",
@@ -20660,8 +21096,7 @@
 		"serialize-javascript": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
-			"integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ==",
-			"dev": true
+			"integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ=="
 		},
 		"serialize-to-js": {
 			"version": "1.2.2",
@@ -21009,8 +21444,7 @@
 		"source-list-map": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
-			"integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
-			"dev": true
+			"integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A=="
 		},
 		"source-map": {
 			"version": "0.5.7",
@@ -21326,7 +21760,6 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
 			"integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
-			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"stream-shift": "^1.0.0"
@@ -21348,8 +21781,7 @@
 		"stream-shift": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-			"dev": true
+			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
 		},
 		"strict-uri-encode": {
 			"version": "1.1.0",
@@ -21403,7 +21835,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -22138,6 +22569,25 @@
 			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
 			"dev": true
 		},
+		"thread-loader": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/thread-loader/-/thread-loader-2.1.2.tgz",
+			"integrity": "sha512-7xpuc9Ifg6WU+QYw/8uUqNdRwMD+N5gjwHKMqETrs96Qn+7BHwECpt2Brzr4HFlf4IAkZsayNhmGdbkBsTJ//w==",
+			"dev": true,
+			"requires": {
+				"loader-runner": "^2.3.1",
+				"loader-utils": "^1.1.0",
+				"neo-async": "^2.6.0"
+			},
+			"dependencies": {
+				"neo-async": {
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
+					"integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+					"dev": true
+				}
+			}
+		},
 		"throat": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
@@ -22154,7 +22604,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-			"dev": true,
 			"requires": {
 				"readable-stream": "^2.1.5",
 				"xtend": "~4.0.1"
@@ -22418,8 +22867,7 @@
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-			"dev": true
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 		},
 		"ua-parser-js": {
 			"version": "0.7.18",
@@ -22430,8 +22878,6 @@
 			"version": "3.4.9",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
 			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
-			"dev": true,
-			"optional": true,
 			"requires": {
 				"commander": "~2.17.1",
 				"source-map": "~0.6.1"
@@ -22440,16 +22886,12 @@
 				"commander": {
 					"version": "2.17.1",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-					"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-					"dev": true,
-					"optional": true
+					"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true,
-					"optional": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -22690,7 +23132,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
 			"integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
-			"dev": true,
 			"requires": {
 				"imurmurhash": "^0.1.4"
 			}
@@ -22829,7 +23270,6 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			}
@@ -22880,8 +23320,7 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"util.promisify": {
 			"version": "1.0.0",
@@ -23182,9 +23621,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "6.9.1",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
-					"integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
+					"version": "6.10.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+					"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^2.0.1",
@@ -23951,7 +24390,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
 			"integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
-			"dev": true,
 			"requires": {
 				"source-list-map": "^2.0.0",
 				"source-map": "~0.6.1"
@@ -23960,8 +24398,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -24097,7 +24534,6 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
 			"integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
-			"dev": true,
 			"requires": {
 				"errno": "~0.1.7"
 			}
@@ -24147,8 +24583,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write": {
 			"version": "0.2.1",
@@ -24232,8 +24667,7 @@
 		"xtend": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-			"dev": true
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
 		},
 		"y18n": {
 			"version": "3.2.1",

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -97,10 +97,13 @@ const config = {
 			{
 				test: /\.js$/,
 				exclude: /node_modules/,
-				use: {
-					loader: require.resolve( 'babel-loader' ),
-					options: getBabelLoaderOptions(),
-				},
+				use: [
+					'thread-loader',
+					{
+						loader: require.resolve( 'babel-loader' ),
+						options: getBabelLoaderOptions(),
+					},
+				],
 			},
 		],
 	},

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -87,7 +87,7 @@ const config = {
 				test: /\.js$/,
 				exclude: /node_modules/,
 				use: [
-					'thread-loader',
+					require.resolve( 'thread-loader' ),
 					{
 						loader: require.resolve( 'babel-loader' ),
 						options: {

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -83,13 +83,6 @@ const config = {
 	},
 	module: {
 		rules: [
-			// Sourcemap Loader is a complement to the `devtool` configuration,
-			// and thus is only necessary for development environments.
-			! isProduction && {
-				test: /\.js$/,
-				use: require.resolve( 'source-map-loader' ),
-				enforce: 'pre',
-			},
 			{
 				test: /\.js$/,
 				exclude: /node_modules/,
@@ -114,7 +107,7 @@ const config = {
 					},
 				],
 			},
-		].filter( Boolean ),
+		],
 	},
 	plugins: [
 		// WP_BUNDLE_ANALYZER global variable enables utility that represents bundle content
@@ -133,6 +126,11 @@ if ( ! isProduction ) {
 	// WP_DEVTOOL global variable controls how source maps are generated.
 	// See: https://webpack.js.org/configuration/devtool/#devtool.
 	config.devtool = process.env.WP_DEVTOOL || 'source-map';
+	config.module.rules.unshift( {
+		test: /\.js$/,
+		use: require.resolve( 'source-map-loader' ),
+		enforce: 'pre',
+	} );
 }
 
 module.exports = config;

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -89,7 +89,9 @@ const config = {
 	},
 	module: {
 		rules: [
-			{
+			// Sourcemap Loader is a complement to the `devtool` configuration,
+			// and thus is only necessary for development environments.
+			! isProduction && {
 				test: /\.js$/,
 				use: require.resolve( 'source-map-loader' ),
 				enforce: 'pre',
@@ -105,7 +107,7 @@ const config = {
 					},
 				],
 			},
-		],
+		].filter( Boolean ),
 	},
 	plugins: [
 		// WP_BUNDLE_ANALYZER global variable enables utility that represents bundle content

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -66,12 +66,6 @@ const externals = [
 const isProduction = process.env.NODE_ENV === 'production';
 const mode = isProduction ? 'production' : 'development';
 
-const getBabelLoaderOptions = () => hasBabelConfig() ? {} : {
-	babelrc: false,
-	configFile: false,
-	presets: [ require.resolve( '@wordpress/babel-preset-default' ) ],
-};
-
 const config = {
 	mode,
 	entry: {
@@ -103,7 +97,20 @@ const config = {
 					'thread-loader',
 					{
 						loader: require.resolve( 'babel-loader' ),
-						options: getBabelLoaderOptions(),
+						options: {
+							// Babel uses a directory within local node_modules
+							// by default. Use the environment variable option
+							// to enable more persistent caching.
+							cacheDirectory: process.env.BABEL_CACHE_DIRECTORY || true,
+
+							// Provide a fallback configuration if there's not
+							// one explicitly available in the project.
+							...( ! hasBabelConfig() && {
+								babelrc: false,
+								configFile: false,
+								presets: [ require.resolve( '@wordpress/babel-preset-default' ) ],
+							} ),
+						},
 					},
 				],
 			},

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -50,6 +50,7 @@
 		"source-map-loader": "^0.2.4",
 		"stylelint": "^9.10.1",
 		"stylelint-config-wordpress": "^13.1.0",
+		"thread-loader": "^2.1.2",
 		"webpack": "4.8.3",
 		"webpack-bundle-analyzer": "^3.0.3",
 		"webpack-cli": "^3.1.2",


### PR DESCRIPTION
This pull request seeks to try a few optimizations for the default Webpack configuration. In my testing using `time ./node_modules/.bin/wp-scripts build`, the approximate result in my environment is a net build time decrease of ~38% (18.5s to 11.5s) uncached to ~50% (18.5s to 9.3s) cached.

The optimizations are three:

- Use [`thread-loader`](https://github.com/webpack-contrib/thread-loader) to complement Babel compilation. On its own, with a default configuration, this seemed to reduce build time by approximately 2-3 seconds. The result may vary by machine depending on the number of cores available (default threading is `numCPU - 1` workers).
- Opt-in to [`babel-loader`'s `cacheDirectory` option](https://webpack.js.org/loaders/babel-loader/#options). This too appeared to reduce build time by approximately 2-3 seconds further. By default, this uses a cache directory local to the project's `node_modules`. Thus, it will not have an immediate benefit on a fresh clone, or if `node_modules` is removed for any reason. I've included an option to direct this to a more persistent cache directory, which is partly self-serving for one of my [own projects](https://github.com/aduth/gutenberg.run) where I'd like to use a more persistent cache.
- Exclude `source-map-loader` from production builds. This had a slightly more significant impact to reduce build time by a further 3-4 seconds. My reading of the [`source-map-loader` documentation](https://webpack.js.org/loaders/source-map-loader/) is that it is intended to complement the `devtool` option, which we already [configure only for non-production environments](https://github.com/WordPress/gutenberg/blob/a9f6a1e0eee428831a9482e0d3c36ee9e4004056/packages/scripts/config/webpack.config.js#L120-L124).
   - >All source map data is passed to webpack for processing as per a chosen source map style specified by the `devtool` option in webpack.config.js.

A few others I considered, but did not include:

- Updating Webpack to the latest version. Webpack 5.x promises performance improvements, but is currently in alpha, and thus I did not consider stable enough to explore here, or at least not as part of this pull request. The latest minor/patch version combination actually appeared to _increase_ build time.
- A few other tips from [Webpack's Build Performance guide](https://webpack.js.org/guides/build-performance) which did not appear to have much impact positive or negative (`output.pathinfo`).

**References:**

- https://slack.engineering/keep-webpack-fast-a-field-guide-for-better-build-performance-f56a5995e8f1
- https://webpack.js.org/guides/build-performance/
- https://blog.box.com/blog/how-we-improved-webpack-build-performance-95

**Testing instructions:**

You may consider to compare build times between master and this branch:

```
time ./node_modules/.bin/wp-scripts build
```

_(Note: Babel loader's `cacheDirectory` won't have an impact the first time it's run. You can look to see whether a cache exists as `node_modules/.cache/babel-loader`)_

Otherwise, verify there are no regressions in the expected output from build scripts (runs in browser, no sourcemap/devtool regression).