### PR TITLE
Refactor Tabel block to use block.json metadata

### DIFF
--- a/packages/block-library/src/table/block.json
+++ b/packages/block-library/src/table/block.json
@@ -1,0 +1,88 @@
+{
+	"name": "core/table",
+	"category": "formatting",
+	"attributes": {
+		"hasFixedLayout": {
+			"type": "boolean",
+			"default": false
+		},
+		"backgroundColor": {
+			"type": "string"
+		},
+		"head": {
+			"type": "array",
+			"default": [],
+			"source": "query",
+			"selector": "thead tr",
+			"query": {
+				"cells": {
+					"type": "array",
+					"default": [],
+					"source": "query",
+					"selector": "td,th",
+					"query": {
+						"content": {
+							"type": "string",
+							"source": "html"
+						},
+						"tag": {
+							"type": "string",
+							"default": "td",
+							"source": "tag"
+						}
+					}
+				}
+			}
+		},
+		"body": {
+			"type": "array",
+			"default": [],
+			"source": "query",
+			"selector": "tbody tr",
+			"query": {
+				"cells": {
+					"type": "array",
+					"default": [],
+					"source": "query",
+					"selector": "td,th",
+					"query": {
+						"content": {
+							"type": "string",
+							"source": "html"
+						},
+						"tag": {
+							"type": "string",
+							"default": "td",
+							"source": "tag"
+						}
+					}
+				}
+			}
+		},
+		"foot": {
+			"type": "array",
+			"default": [],
+			"source": "query",
+			"selector": "tfoot tr",
+			"query": {
+				"cells": {
+					"type": "array",
+					"default": [],
+					"source": "query",
+					"selector": "td,th",
+					"query": {
+						"content": {
+							"type": "string",
+							"source": "html"
+						},
+						"tag": {
+							"type": "string",
+							"default": "td",
+							"source": "tag"
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/packages/block-library/src/table/index.js
+++ b/packages/block-library/src/table/index.js
@@ -1,177 +1,33 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
-import { getPhrasingContentSchema } from '@wordpress/blocks';
-import { RichText, getColorClassName } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import edit from './edit';
 import icon from './icon';
+import metadata from './block.json';
+import save from './save';
+import transforms from './transforms';
 
-const tableContentPasteSchema = {
-	tr: {
-		allowEmpty: true,
-		children: {
-			th: {
-				allowEmpty: true,
-				children: getPhrasingContentSchema(),
-			},
-			td: {
-				allowEmpty: true,
-				children: getPhrasingContentSchema(),
-			},
-		},
-	},
-};
+const { name } = metadata;
 
-const tablePasteSchema = {
-	table: {
-		children: {
-			thead: {
-				allowEmpty: true,
-				children: tableContentPasteSchema,
-			},
-			tfoot: {
-				allowEmpty: true,
-				children: tableContentPasteSchema,
-			},
-			tbody: {
-				allowEmpty: true,
-				children: tableContentPasteSchema,
-			},
-		},
-	},
-};
-
-function getTableSectionAttributeSchema( section ) {
-	return {
-		type: 'array',
-		default: [],
-		source: 'query',
-		selector: `t${ section } tr`,
-		query: {
-			cells: {
-				type: 'array',
-				default: [],
-				source: 'query',
-				selector: 'td,th',
-				query: {
-					content: {
-						type: 'string',
-						source: 'html',
-					},
-					tag: {
-						type: 'string',
-						default: 'td',
-						source: 'tag',
-					},
-				},
-			},
-		},
-	};
-}
-
-export const name = 'core/table';
+export { metadata, name };
 
 export const settings = {
 	title: __( 'Table' ),
 	description: __( 'Insert a table — perfect for sharing charts and data.' ),
 	icon,
-	category: 'formatting',
-
-	attributes: {
-		hasFixedLayout: {
-			type: 'boolean',
-			default: false,
-		},
-		backgroundColor: {
-			type: 'string',
-		},
-		head: getTableSectionAttributeSchema( 'head' ),
-		body: getTableSectionAttributeSchema( 'body' ),
-		foot: getTableSectionAttributeSchema( 'foot' ),
-	},
-
 	styles: [
 		{ name: 'regular', label: _x( 'Default', 'block style' ), isDefault: true },
 		{ name: 'stripes', label: __( 'Stripes' ) },
 	],
-
 	supports: {
 		align: true,
 	},
-
-	transforms: {
-		from: [
-			{
-				type: 'raw',
-				selector: 'table',
-				schema: tablePasteSchema,
-			},
-		],
-	},
-
+	transforms,
 	edit,
-
-	save( { attributes } ) {
-		const {
-			hasFixedLayout,
-			head,
-			body,
-			foot,
-			backgroundColor,
-		} = attributes;
-		const isEmpty = ! head.length && ! body.length && ! foot.length;
-
-		if ( isEmpty ) {
-			return null;
-		}
-
-		const backgroundClass = getColorClassName( 'background-color', backgroundColor );
-
-		const classes = classnames( backgroundClass, {
-			'has-fixed-layout': hasFixedLayout,
-			'has-background': !! backgroundClass,
-		} );
-
-		const Section = ( { type, rows } ) => {
-			if ( ! rows.length ) {
-				return null;
-			}
-
-			const Tag = `t${ type }`;
-
-			return (
-				<Tag>
-					{ rows.map( ( { cells }, rowIndex ) => (
-						<tr key={ rowIndex }>
-							{ cells.map( ( { content, tag }, cellIndex ) =>
-								<RichText.Content
-									tagName={ tag }
-									value={ content }
-									key={ cellIndex }
-								/>
-							) }
-						</tr>
-					) ) }
-				</Tag>
-			);
-		};
-
-		return (
-			<table className={ classes }>
-				<Section type="head" rows={ head } />
-				<Section type="body" rows={ body } />
-				<Section type="foot" rows={ foot } />
-			</table>
-		);
-	},
+	save,
 };

--- a/packages/block-library/src/table/save.js
+++ b/packages/block-library/src/table/save.js
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { RichText, getColorClassName } from '@wordpress/block-editor';
+
+export default function save( { attributes } ) {
+	const {
+		hasFixedLayout,
+		head,
+		body,
+		foot,
+		backgroundColor,
+	} = attributes;
+	const isEmpty = ! head.length && ! body.length && ! foot.length;
+
+	if ( isEmpty ) {
+		return null;
+	}
+
+	const backgroundClass = getColorClassName( 'background-color', backgroundColor );
+
+	const classes = classnames( backgroundClass, {
+		'has-fixed-layout': hasFixedLayout,
+		'has-background': !! backgroundClass,
+	} );
+
+	const Section = ( { type, rows } ) => {
+		if ( ! rows.length ) {
+			return null;
+		}
+
+		const Tag = `t${ type }`;
+
+		return (
+			<Tag>
+				{ rows.map( ( { cells }, rowIndex ) => (
+					<tr key={ rowIndex }>
+						{ cells.map( ( { content, tag }, cellIndex ) =>
+							<RichText.Content
+								tagName={ tag }
+								value={ content }
+								key={ cellIndex }
+							/>
+						) }
+					</tr>
+				) ) }
+			</Tag>
+		);
+	};
+
+	return (
+		<table className={ classes }>
+			<Section type="head" rows={ head } />
+			<Section type="body" rows={ body } />
+			<Section type="foot" rows={ foot } />
+		</table>
+	);
+}

--- a/packages/block-library/src/table/transforms.js
+++ b/packages/block-library/src/table/transforms.js
@@ -1,0 +1,51 @@
+/**
+ * WordPress dependencies
+ */
+import { getPhrasingContentSchema } from '@wordpress/blocks';
+
+const tableContentPasteSchema = {
+	tr: {
+		allowEmpty: true,
+		children: {
+			th: {
+				allowEmpty: true,
+				children: getPhrasingContentSchema(),
+			},
+			td: {
+				allowEmpty: true,
+				children: getPhrasingContentSchema(),
+			},
+		},
+	},
+};
+
+const tablePasteSchema = {
+	table: {
+		children: {
+			thead: {
+				allowEmpty: true,
+				children: tableContentPasteSchema,
+			},
+			tfoot: {
+				allowEmpty: true,
+				children: tableContentPasteSchema,
+			},
+			tbody: {
+				allowEmpty: true,
+				children: tableContentPasteSchema,
+			},
+		},
+	},
+};
+
+const transforms = {
+	from: [
+		{
+			type: 'raw',
+			selector: 'table',
+			schema: tablePasteSchema,
+		},
+	],
+};
+
+export default transforms;


### PR DESCRIPTION
## Description
Partially implements #13693:
- Refactors Table block to define `name`, `category` and `attributes` in `block.json`
- Moves all fields defined on the client like `transforms` or `save` to their own files

## How has this been tested?
Ensure that File block still works as before.
