### PR TITLE
Add popoverProps property to DropDown component

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Next release
+
+### New Features
+
+- Added a new `popoverProps` prop to the `Dropdown` component which allows users of the `Dropdown` component to pass props directly to the `PopOver` component.
+
+
 ## 8.0.0 (2019-06-12)
 
 ### New Feature

--- a/packages/components/src/dropdown/README.md
+++ b/packages/components/src/dropdown/README.md
@@ -100,3 +100,11 @@ Opt-in prop to show popovers fullscreen on mobile, pass `false` in this prop to 
  - Type: `String` or `Boolean`
  - Required: No
  - Default: `"firstElement"`
+
+ ### popoverProps
+ 
+Properties of popoverProps object will be passed as props to the `Popover` component.
+Use this o object to access properties/feature if the `Popover` component that are not already exposed in the `Dropdown`component, e.g.: the hability to have the popover without an arrow. 
+ 
+ - Type: `Object`
+ - Required: No

--- a/packages/components/src/dropdown/index.js
+++ b/packages/components/src/dropdown/index.js
@@ -74,6 +74,7 @@ class Dropdown extends Component {
 			expandOnMobile,
 			headerTitle,
 			focusOnMount,
+			popoverProps,
 		} = this.props;
 
 		const args = { isOpen, onToggle: this.toggle, onClose: this.close };
@@ -90,6 +91,7 @@ class Dropdown extends Component {
 						expandOnMobile={ expandOnMobile }
 						headerTitle={ headerTitle }
 						focusOnMount={ focusOnMount }
+						{ ...popoverProps }
 					>
 						{ renderContent( args ) }
 					</Popover>


### PR DESCRIPTION
## Description
The PopOver component had a property that allows disabling the arrow that appears with it. The DropDown component did not pass that property to the popover, this PR makes sure the DropDown component forwards this property.

## How has this been tested?
I changed the DropDown component in packages/block-editor/src/components/block-switcher/index.js and verified the transforms menu did not contain the arrow.