### PR TITLE
Feature: Add webpack plugin to externalize and extract script dependencies

### DIFF
--- a/docs/contributors/scripts.md
+++ b/docs/contributors/scripts.md
@@ -65,3 +65,15 @@ It is recommended to use the main `wp-polyfill` script handle which takes care o
 | [Formdata Polyfill](https://www.npmjs.com/package/formdata-polyfill) | wp-polyfill-formdata| Polyfill conditionally replaces the native implementation |
 | [Node Contains Polyfill](https://polyfill.io) | wp-polyfill-node-contains |Polyfill for Node.contains |
 | [Element Closest Polyfill](https://www.npmjs.com/package/element-closest) | wp-polyfill-element-closest| Return the closest element matching a selector up the DOM tree |
+
+## Bundling and code sharing
+
+When using a JavaScript bundler like [webpack](https://webpack.js.org/), the scripts mentioned here
+can be excluded from the bundle and provided by WordPress in the form of script dependencies [(see
+`wp_enqueue_script`)][https://developer.wordpress.org/reference/functions/wp_enqueue_script/#default-scripts-included-and-registered-by-wordpress].
+
+The
+[`@wordpress/dependency-extraction-webpack-plugin`](https://github.com/WordPress/gutenberg/tree/master/packages/dependency-extraction-webpack-plugin)
+provides a webpack plugin to help extract WordPress dependencies from bundles. `@wordpress/scripts`
+[`build`](https://github.com/WordPress/gutenberg/tree/master/packages/scripts#build) script includes
+the plugin by default.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -630,6 +630,12 @@
 		"parent": "packages"
 	},
 	{
+		"title": "@wordpress/dependency-extraction-webpack-plugin",
+		"slug": "packages-dependency-extraction-webpack-plugin",
+		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/dependency-extraction-webpack-plugin/README.md",
+		"parent": "packages"
+	},
+	{
 		"title": "@wordpress/deprecated",
 		"slug": "packages-deprecated",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/deprecated/README.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3140,6 +3140,32 @@
 				"moment-timezone": "^0.5.16"
 			}
 		},
+		"@wordpress/dependency-extraction-webpack-plugin": {
+			"version": "file:packages/dependency-extraction-webpack-plugin",
+			"dev": true,
+			"requires": {
+				"webpack": "^4.8.3",
+				"webpack-sources": "^1.3.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"webpack-sources": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
+					"integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
+					"dev": true,
+					"requires": {
+						"source-list-map": "^2.0.0",
+						"source-map": "~0.6.1"
+					}
+				}
+			}
+		},
 		"@wordpress/deprecated": {
 			"version": "file:packages/deprecated",
 			"requires": {
@@ -3467,6 +3493,7 @@
 			"dev": true,
 			"requires": {
 				"@wordpress/babel-preset-default": "file:packages/babel-preset-default",
+				"@wordpress/dependency-extraction-webpack-plugin": "file:packages/dependency-extraction-webpack-plugin",
 				"@wordpress/eslint-plugin": "file:packages/eslint-plugin",
 				"@wordpress/jest-preset-default": "file:packages/jest-preset-default",
 				"@wordpress/npm-package-json-lint-config": "file:packages/npm-package-json-lint-config",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
 		"@wordpress/babel-preset-default": "file:packages/babel-preset-default",
 		"@wordpress/browserslist-config": "file:packages/browserslist-config",
 		"@wordpress/custom-templated-path-webpack-plugin": "file:packages/custom-templated-path-webpack-plugin",
+		"@wordpress/dependency-extraction-webpack-plugin": "file:packages/dependency-extraction-webpack-plugin",
 		"@wordpress/docgen": "file:packages/docgen",
 		"@wordpress/e2e-test-utils": "file:packages/e2e-test-utils",
 		"@wordpress/e2e-tests": "file:packages/e2e-tests",

--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 1.0.0 (tbd)
+
+### New Feature
+
+- Introduce the `@wordpress/dependency-extraction-webpack-plugin` package.

--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0 (tbd)
+## Unreleased
 
 ### New Feature
 

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -1,4 +1,4 @@
-# @wordpress/dependency-extraction-webpack-plugin
+# Dependency Extraction Webpack Plugin
 
 This webpack plugin serves two purposes:
 

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -16,7 +16,7 @@ Consult the [webpack website](https://webpack.js.org) for additional information
 Install the module
 
 ```bash
-npm install @wordpress/dependency-extraction-webpack-plugin --save
+npm install @wordpress/dependency-extraction-webpack-plugin --save-dev
 ```
 
 ## Usage

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -58,6 +58,10 @@ script handles from bundle compilation so that a list of script dependencies doe
 manually maintained. If you don't need to extract a list of script dependencies, use the `externals`
 option directly.
 
+This plugin is compatible with `externals`, but they may conflict. For example, adding
+`{ externals: { '@wordpress/blob': 'wp.blob' } }` to webpack configuration will effectively hide the
+`@wordpress/blob` module from the plugin and it will not be included in dependency lists.
+
 #### Options
 
 An object can be passed to the constructor to customize the behavior, for example:

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -52,6 +52,20 @@ import { Component } from '@wordpress/element';
 ['wp-element']
 ```
 
+By default, the following module requests are handled:
+
+| Request | Global | Script handle |
+| --- | --- | --- |
+| `@babel/runtime/regenerator` | `regeneratorRuntime` | `wp-polyfill` |
+| `@wordpress/*` | `wp.*` | `wp-*` |
+| `jquery` | `jQuery` | `jquery` |
+| `jquery` | `jQuery` | `jquery` |
+| `lodash-es` | `lodash` | `lodash` |
+| `lodash` | `lodash` | `lodash` |
+| `moment` | `moment` | `moment` |
+| `react-dom` | `ReactDOM` | `react-dom` |
+| `react` | `React` | `react` |
+
 **Note:** This plugin overlaps with the functionality provided by [webpack
 `externals`](https://webpack.js.org/configuration/externals). This plugin is intended to extract
 script handles from bundle compilation so that a list of script dependencies does not need to be
@@ -79,8 +93,7 @@ module.exports = {
 - Type: boolean
 - Default: `true`
 
-Pass `useDefaults: false` to disable the default plugin behavior. This will disable the handling of
-modules like `@wordpress/i18n`, `lodash`, and `jquery`.
+Pass `useDefaults: false` to disable the default request handling.
 
 ##### `injectPolyfill`
 

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -57,8 +57,8 @@ import { Component } from '@wordpress/element';
 Enqueue your script as usual and read the script dependencies dynamically:
 
 ```php
-$script_path      = 'path/to/script.js';
-$script_deps_path = 'path/to/script.deps.json';
+$script_path         = 'path/to/script.js';
+$script_deps_path    = 'path/to/script.deps.json';
 $script_dependencies = file_exists( $script_deps_path )
 	? json_decode( file_get_contents( $script_deps_path ) )
 	: array();

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -1,0 +1,67 @@
+# @wordpress/dependency-extraction-webpack-plugin
+
+This webpack plugin serves two purposes:
+
+- Externalize dependencies that are available as script dependencies on modern WordPress sites.
+- Add a JSON file for each entrypoint that declares the WordPress script dependencies for the
+  entrypoint.
+
+This allows JavaScript bundles produced by webpack to leverage WordPress style dependency sharing
+without an error-prone process of manually maintaining a dependency list.
+
+Consult the [webpack website](https://webpack.js.org) for additional information on webpack concepts.
+
+## Installation
+
+Install the module
+
+```bash
+npm install @wordpress/dependency-extraction-webpack-plugin --save
+```
+
+## Usage
+
+### Webpack
+
+Use this plugin as you would other webpack plugins:
+
+```js
+// webpack.config.js
+const WordPressExternalDependenciesPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+
+module.exports = {
+  // …snip
+  plugins: [
+    new WordPressExternalDependenciesPlugin(),
+  ]
+}
+```
+
+Each entrypoint in the webpack bundle will include JSON file that declares the WordPress script dependencies that should be enqueued.
+
+For example:
+
+```
+// Source file entrypoint.js
+import { Component } from '@wordpress/element';
+
+// Webpack will produce the output output/entrypoint.js
+/* bundled JS output */
+
+// Webpack will also produce output/entrypoint.deps.json declaring script dependencies
+['wp-element']
+```
+
+### WordPress
+
+Enqueue your script as usual and read the script dependencies dynamically:
+
+```php
+$script_path      = 'path/to/script.js';
+$script_deps_path = 'path/to/script.deps.json';
+$script_dependencies = file_exists( $script_deps_path )
+	? json_decode( file_get_contents( $script_deps_path ) )
+	: array();
+$script_url = plugins_url( $script_path, __FILE__ );
+wp_enqueue_script( 'script', $script_url, $script_dependencies );
+```

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -57,7 +57,7 @@ By default, the following module requests are handled:
 | Request | Global | Script handle |
 | --- | --- | --- |
 | `@babel/runtime/regenerator` | `regeneratorRuntime` | `wp-polyfill` |
-| `@wordpress/*` | `wp.*` | `wp-*` |
+| `@wordpress/*` | `wp['*']` | `wp-*` |
 | `jquery` | `jQuery` | `jquery` |
 | `jquery` | `jQuery` | `jquery` |
 | `lodash-es` | `lodash` | `lodash` |
@@ -108,7 +108,9 @@ adding `import '@wordpress/polyfill';` to each entrypoint.
 - Type: function
 
 `requestToExternal` allows the module handling to be customized. The function should accept a
-module request string and may return a string representing the global variable to use.
+module request string and may return a string representing the global variable to use. An array of
+strings may be used to access globals via an object path, e.g. `wp.i18n` may be represented as `[
+'wp', 'i18n' ]`.
 
 `requestToExternal` provided via configuration has precedence over default external handling.
 Unhandled requests will be handled by the default unless `useDefaults` is set to `false`.

--- a/packages/dependency-extraction-webpack-plugin/index.js
+++ b/packages/dependency-extraction-webpack-plugin/index.js
@@ -28,7 +28,13 @@ class DependencyExtractionWebpackPlugin {
 	externalizeWpDeps( context, request, callback ) {
 		let externRootRequest;
 
-		if ( this.options.useDefaults ) {
+		// Handle via options.requestToExternal first
+		if ( 'function' === typeof this.options.requestToExternal ) {
+			externRootRequest = this.options.requestToExternal( request );
+		}
+
+		// Cascade to default if unhandled and enabled
+		if ( 'undefined' === typeof externRootRequest && this.options.useDefaults !== false ) {
 			externRootRequest = defaultRequestToExternal( request );
 		}
 

--- a/packages/dependency-extraction-webpack-plugin/index.js
+++ b/packages/dependency-extraction-webpack-plugin/index.js
@@ -34,7 +34,7 @@ class DependencyExtractionWebpackPlugin {
 		}
 
 		// Cascade to default if unhandled and enabled
-		if ( typeof externRootRequest === 'undefined' && this.options.useDefaults !== false ) {
+		if ( typeof externRootRequest === 'undefined' && this.options.useDefaults ) {
 			externRootRequest = defaultRequestToExternal( request );
 		}
 

--- a/packages/dependency-extraction-webpack-plugin/index.js
+++ b/packages/dependency-extraction-webpack-plugin/index.js
@@ -13,7 +13,14 @@ const { RawSource } = require( 'webpack-sources' );
 const WORDPRESS_NAMESPACE = '@wordpress/';
 
 class DependencyExtractionWebpackPlugin {
-	constructor() {
+	constructor( options ) {
+		this.options = Object.assign(
+			{
+				injectPolyfill: false,
+				useDefaults: true,
+			},
+			options
+		);
 		this.externalizedDeps = new Set();
 		this.externalsPlugin = new ExternalsPlugin( 'global', [ this.externalizeWpDeps.bind( this ) ] );
 	}

--- a/packages/dependency-extraction-webpack-plugin/index.js
+++ b/packages/dependency-extraction-webpack-plugin/index.js
@@ -77,6 +77,9 @@ class DependencyExtractionWebpackPlugin {
 			// Each entrypoint will get a .deps.json file
 			for ( const [ entrypointName, entrypoint ] of compilation.entrypoints.entries() ) {
 				const entrypointExternalizedWpDeps = new Set();
+				if ( this.options.injectPolyfill ) {
+					entrypointExternalizedWpDeps.add( 'wp-polyfill' );
+				}
 
 				// Search for externalized dependencies in all modules in all entrypoint chunks
 				for ( const c of entrypoint.chunks ) {

--- a/packages/dependency-extraction-webpack-plugin/index.js
+++ b/packages/dependency-extraction-webpack-plugin/index.js
@@ -28,25 +28,26 @@ class DependencyExtractionWebpackPlugin {
 		this.externalizedDeps = new Set();
 
 		// Offload externalization work to the ExternalsPlugin.
-		this.externalsPlugin = new ExternalsPlugin( 'global', [ this.externalizeWpDeps.bind( this ) ] );
+		this.externalsPlugin = new ExternalsPlugin( 'this', this.externalizeWpDeps.bind( this ) );
 	}
 
 	externalizeWpDeps( context, request, callback ) {
-		let externRootRequest;
+		let externalRequest;
 
 		// Handle via options.requestToExternal first
 		if ( typeof this.options.requestToExternal === 'function' ) {
-			externRootRequest = this.options.requestToExternal( request );
+			externalRequest = this.options.requestToExternal( request );
 		}
 
 		// Cascade to default if unhandled and enabled
-		if ( typeof externRootRequest === 'undefined' && this.options.useDefaults ) {
-			externRootRequest = defaultRequestToExternal( request );
+		if ( typeof externalRequest === 'undefined' && this.options.useDefaults ) {
+			externalRequest = defaultRequestToExternal( request );
 		}
 
-		if ( externRootRequest ) {
+		if ( externalRequest ) {
 			this.externalizedDeps.add( request );
-			return callback( null, `root ${ externRootRequest }` );
+
+			return callback( null, { this: externalRequest } );
 		}
 
 		return callback();

--- a/packages/dependency-extraction-webpack-plugin/index.js
+++ b/packages/dependency-extraction-webpack-plugin/index.js
@@ -26,7 +26,11 @@ class DependencyExtractionWebpackPlugin {
 	}
 
 	externalizeWpDeps( context, request, callback ) {
-		const externRootRequest = defaultRequestToExternal( request );
+		let externRootRequest;
+
+		if ( this.options.useDefaults ) {
+			externRootRequest = defaultRequestToExternal( request );
+		}
 
 		if ( externRootRequest ) {
 			this.externalizedDeps.add( request );
@@ -81,6 +85,17 @@ class DependencyExtractionWebpackPlugin {
 	}
 }
 
+/**
+ * Handle default dependency to WordPress global transformation
+ *
+ * Transform @wordpress dependencies:
+ *   @wordpress/api-fetch -> wp.apiFetch
+ *   @wordpress/i18n -> wp.i18n
+ *
+ * @param {string} request Requested module
+ *
+ * @return {(string|undefined)} Script dependency slug
+ */
 function defaultRequestToExternal( request ) {
 	switch ( request ) {
 		case 'lodash':
@@ -92,15 +107,13 @@ function defaultRequestToExternal( request ) {
 
 		case 'react':
 			return 'React';
+
 		case 'react-dom':
 			return 'ReactDOM';
+	}
 
-		default:
-			if ( request.startsWith( WORDPRESS_NAMESPACE ) ) {
-				// @wordpress/api-fetch -> wp.apiFetch
-				// @wordpress/i18n -> wp.i18n
-				return `wp.${ camelCaseDash( request.substring( WORDPRESS_NAMESPACE.length ) ) }`;
-			}
+	if ( request.startsWith( WORDPRESS_NAMESPACE ) ) {
+		return `wp.${ camelCaseDash( request.substring( WORDPRESS_NAMESPACE.length ) ) }`;
 	}
 }
 

--- a/packages/dependency-extraction-webpack-plugin/index.js
+++ b/packages/dependency-extraction-webpack-plugin/index.js
@@ -121,7 +121,7 @@ class DependencyExtractionWebpackPlugin {
  *
  * @param {string} request Requested module
  *
- * @return {(string|undefined)} Script dependency slug
+ * @return {(string|undefined)} Script global
  */
 function defaultRequestToExternal( request ) {
 	switch ( request ) {

--- a/packages/dependency-extraction-webpack-plugin/index.js
+++ b/packages/dependency-extraction-webpack-plugin/index.js
@@ -129,6 +129,7 @@ class DependencyExtractionWebpackPlugin {
 function defaultRequestToExternal( request ) {
 	switch ( request ) {
 		case 'lodash':
+		case 'lodash-es':
 		case 'moment':
 			return request;
 

--- a/packages/dependency-extraction-webpack-plugin/index.js
+++ b/packages/dependency-extraction-webpack-plugin/index.js
@@ -29,12 +29,12 @@ class DependencyExtractionWebpackPlugin {
 		let externRootRequest;
 
 		// Handle via options.requestToExternal first
-		if ( 'function' === typeof this.options.requestToExternal ) {
+		if ( typeof this.options.requestToExternal === 'function' ) {
 			externRootRequest = this.options.requestToExternal( request );
 		}
 
 		// Cascade to default if unhandled and enabled
-		if ( 'undefined' === typeof externRootRequest && this.options.useDefaults !== false ) {
+		if ( typeof externRootRequest === 'undefined' && this.options.useDefaults !== false ) {
 			externRootRequest = defaultRequestToExternal( request );
 		}
 
@@ -48,7 +48,7 @@ class DependencyExtractionWebpackPlugin {
 
 	mapRequestToDependency( request ) {
 		// Handle via options.requestToDependency first
-		if ( 'function' === typeof this.options.requestToDependency ) {
+		if ( typeof this.options.requestToDependency === 'function' ) {
 			const scriptDependency = this.options.requestToDependency( request );
 			if ( scriptDependency ) {
 				return scriptDependency;

--- a/packages/dependency-extraction-webpack-plugin/index.js
+++ b/packages/dependency-extraction-webpack-plugin/index.js
@@ -139,6 +139,9 @@ class DependencyExtractionWebpackPlugin {
  */
 function defaultRequestToExternal( request ) {
 	switch ( request ) {
+		case '@babel/runtime/regenerator':
+			return 'regeneratorRuntime';
+
 		case 'lodash':
 		case 'lodash-es':
 		case 'moment':
@@ -171,6 +174,10 @@ function defaultRequestToExternal( request ) {
  * @return {(string|undefined)} Script dependency slug
  */
 function defaultRequestToDependency( request ) {
+	if ( request === '@babel/runtime/regenerator' ) {
+		return 'wp-polyfill';
+	}
+
 	if ( request.startsWith( WORDPRESS_NAMESPACE ) ) {
 		return 'wp-' + request.substring( WORDPRESS_NAMESPACE.length );
 	}

--- a/packages/dependency-extraction-webpack-plugin/index.js
+++ b/packages/dependency-extraction-webpack-plugin/index.js
@@ -1,0 +1,119 @@
+/**
+ * WordPress dependencies
+ */
+const { camelCaseDash } = require( '@wordpress/scripts/utils' );
+
+/**
+ * External dependencies
+ */
+const { createHash } = require( 'crypto' );
+const { ExternalsPlugin } = require( 'webpack' );
+const { RawSource } = require( 'webpack-sources' );
+
+const WORDPRESS_NAMESPACE = '@wordpress/';
+
+class DependencyExtractionWebpackPlugin {
+	constructor() {
+		this.externalizedDeps = new Set();
+		this.externalsPlugin = new ExternalsPlugin( 'global', [ this.externalizeWpDeps.bind( this ) ] );
+	}
+
+	externalizeWpDeps( context, request, callback ) {
+		let externRootRequest;
+
+		switch ( request ) {
+			case 'lodash':
+			case 'moment':
+				externRootRequest = request;
+				break;
+
+			case 'jquery':
+				externRootRequest = 'jQuery';
+				break;
+
+			case 'react':
+				externRootRequest = 'React';
+				break;
+			case 'react-dom':
+				externRootRequest = 'ReactDOM';
+				break;
+
+			default:
+				if ( request.startsWith( WORDPRESS_NAMESPACE ) ) {
+					// @wordpress/api-fetch -> wp.apiFetch
+					// @wordpress/i18n -> wp.i18n
+					externRootRequest = `wp.${ camelCaseDash(
+						request.substring( WORDPRESS_NAMESPACE.length )
+					) }`;
+				}
+				break;
+		}
+
+		if ( externRootRequest ) {
+			this.externalizedDeps.add( request );
+			return callback( null, `root ${ externRootRequest }` );
+		}
+
+		return callback();
+	}
+
+	apply( compiler ) {
+		this.externalsPlugin.apply( compiler );
+
+		const { output } = compiler.options;
+		const { filename: outputFilename } = output;
+
+		compiler.hooks.emit.tap( this.constructor.name, ( compilation ) => {
+			// Each entrypoint will get a .deps.json file
+			for ( const [ entrypointName, entrypoint ] of compilation.entrypoints.entries() ) {
+				const entrypointExternalizedWpDeps = new Set();
+
+				// Search for externalized dependencies in all modules in all entrypoint chunks
+				for ( const c of entrypoint.chunks ) {
+					for ( const { userRequest } of c.modulesIterable ) {
+						if ( this.externalizedDeps.has( userRequest ) ) {
+							// Transform @wordpress dependencies:
+							//   @wordpress/i18n -> wp-i18n
+							//   @wordpress/escape-html -> wp-escape-html
+							// Pass other externalized deps as they are
+							entrypointExternalizedWpDeps.add(
+								userRequest.startsWith( WORDPRESS_NAMESPACE ) ?
+									'wp-' + userRequest.substring( WORDPRESS_NAMESPACE.length ) :
+									userRequest
+							);
+						}
+					}
+				}
+
+				// Build a stable JSON string that declares the WordPress script dependencies.
+				const sortedDepsArray = Array.from( entrypointExternalizedWpDeps ).sort();
+				const depsString = JSON.stringify( sortedDepsArray );
+
+				// Determine a name for the `[entrypoint].deps.json` file.
+				const [ filename, query ] = entrypointName.split( '?', 2 );
+				const depsFile = compilation.getPath( outputFilename.replace( /\.js$/i, '.deps.json' ), {
+					chunk: entrypoint.getRuntimeChunk(),
+					filename,
+					query,
+					basename: basename( filename ),
+					contentHash: createHash( 'md4' )
+						.update( depsString )
+						.digest( 'hex' ),
+				} );
+
+				// Inject source/file into the compilation for webpack to output.
+				compilation.assets[ depsFile ] = new RawSource( depsString );
+				entrypoint.getRuntimeChunk().files.push( depsFile );
+			}
+		} );
+	}
+}
+
+function basename( name ) {
+	if ( ! name.includes( '/' ) ) {
+		return name;
+	}
+	return name.substr( name.lastIndexOf( '/' ) + 1 );
+}
+
+module.exports = DependencyExtractionWebpackPlugin;

--- a/packages/dependency-extraction-webpack-plugin/index.js
+++ b/packages/dependency-extraction-webpack-plugin/index.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-const { camelCaseDash } = require( '@wordpress/scripts/utils' );
-
-/**
  * External dependencies
  */
 const { createHash } = require( 'crypto' );
@@ -188,6 +183,22 @@ function basename( name ) {
 		return name;
 	}
 	return name.substr( name.lastIndexOf( '/' ) + 1 );
+}
+
+/**
+ * Given a string, returns a new string with dash separators converted to
+ * camelCase equivalent. This is not as aggressive as `_.camelCase` in
+ * converting to uppercase, where Lodash will also capitalize letters
+ * following numbers.
+ *
+ * Temporarily duplicated from @wordpress/scripts/utils.
+ *
+ * @param {string} string Input dash-delimited string.
+ *
+ * @return {string} Camel-cased string.
+ */
+function camelCaseDash( string ) {
+	return string.replace( /-([a-z])/g, ( match, letter ) => letter.toUpperCase() );
 }
 
 module.exports = DependencyExtractionWebpackPlugin;

--- a/packages/dependency-extraction-webpack-plugin/package.json
+++ b/packages/dependency-extraction-webpack-plugin/package.json
@@ -23,7 +23,6 @@
 	],
 	"main": "index.js",
 	"dependencies": {
-		"@wordpress/scripts": "file:../scripts",
 		"webpack": "^4.8.3",
 		"webpack-sources": "^1.3.0"
 	},

--- a/packages/dependency-extraction-webpack-plugin/package.json
+++ b/packages/dependency-extraction-webpack-plugin/package.json
@@ -24,8 +24,8 @@
 	"main": "index.js",
 	"dependencies": {
 		"@wordpress/scripts": "file:../scripts",
-		"webpack": "4.8.3",
-		"webpack-sources": "1.3.0"
+		"webpack": "^4.8.3",
+		"webpack-sources": "^1.3.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/dependency-extraction-webpack-plugin/package.json
+++ b/packages/dependency-extraction-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/dependency-extraction-webpack-plugin",
-	"version": "1.0.0",
+	"version": "1.0.0-alpha.0",
 	"description": "Extract WordPress script dependencies from webpack bundles.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/dependency-extraction-webpack-plugin/package.json
+++ b/packages/dependency-extraction-webpack-plugin/package.json
@@ -1,0 +1,33 @@
+{
+	"name": "@wordpress/dependency-extraction-webpack-plugin",
+	"version": "1.0.0",
+	"description": "Extract WordPress script dependencies from webpack bundles.",
+	"author": "The WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress",
+		"webpack",
+		"dependency"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/dependency-extraction-webpack-plugin/README.md",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/dependency-extraction-webpack-plugin"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"files": [
+		"index.js"
+	],
+	"main": "index.js",
+	"dependencies": {
+		"@wordpress/scripts": "file:../scripts",
+		"webpack": "4.8.3",
+		"webpack-sources": "1.3.0"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Build tests no-default no-default should produce expected output 1`] = `Array []`;
+
+exports[`Build tests no-deps no-deps should produce expected output 1`] = `Array []`;
+
+exports[`Build tests overrides overrides should produce expected output 1`] = `
+Array [
+  "wp-blob",
+  "wp-script-handle-for-rxjs",
+  "wp-url",
+]
+`;
+
+exports[`Build tests with-externs with-externs should produce expected output 1`] = `
+Array [
+  "wp-blob",
+  "wp-url",
+]
+`;
+
+exports[`Build tests wordpress wordpress should produce expected output 1`] = `
+Array [
+  "lodash",
+  "wp-blob",
+]
+`;

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -1,10 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Build tests no-default no-default should produce expected output 1`] = `Array []`;
+exports[`Build tests no-default no-default should produce expected output: Dependencies JSON should match snapshot 1`] = `Array []`;
 
-exports[`Build tests no-deps no-deps should produce expected output 1`] = `Array []`;
+exports[`Build tests no-default no-default should produce expected output: External modules should match snapshot 1`] = `Array []`;
 
-exports[`Build tests overrides overrides should produce expected output 1`] = `
+exports[`Build tests no-deps no-deps should produce expected output: Dependencies JSON should match snapshot 1`] = `Array []`;
+
+exports[`Build tests no-deps no-deps should produce expected output: External modules should match snapshot 1`] = `Array []`;
+
+exports[`Build tests overrides overrides should produce expected output: Dependencies JSON should match snapshot 1`] = `
 Array [
   "wp-blob",
   "wp-script-handle-for-rxjs",
@@ -12,16 +16,81 @@ Array [
 ]
 `;
 
-exports[`Build tests with-externs with-externs should produce expected output 1`] = `
+exports[`Build tests overrides overrides should produce expected output: External modules should match snapshot 1`] = `
+Array [
+  Object {
+    "externalType": "root",
+    "request": "wp.blob",
+    "userRequest": "@wordpress/blob",
+  },
+  Object {
+    "externalType": "root",
+    "request": "wp.url",
+    "userRequest": "@wordpress/url",
+  },
+  Object {
+    "externalType": "root",
+    "request": "rxjs.operators",
+    "userRequest": "rxjs/operators",
+  },
+  Object {
+    "externalType": "root",
+    "request": "rxjs",
+    "userRequest": "rxjs",
+  },
+]
+`;
+
+exports[`Build tests with-externs with-externs should produce expected output: Dependencies JSON should match snapshot 1`] = `
 Array [
   "wp-blob",
   "wp-url",
 ]
 `;
 
-exports[`Build tests wordpress wordpress should produce expected output 1`] = `
+exports[`Build tests with-externs with-externs should produce expected output: External modules should match snapshot 1`] = `
+Array [
+  Object {
+    "externalType": "root",
+    "request": "wp.blob",
+    "userRequest": "@wordpress/blob",
+  },
+  Object {
+    "externalType": "root",
+    "request": "wp.url",
+    "userRequest": "@wordpress/url",
+  },
+  Object {
+    "externalType": "var",
+    "request": "rxjs.operators",
+    "userRequest": "rxjs/operators",
+  },
+  Object {
+    "externalType": "var",
+    "request": "rxjs",
+    "userRequest": "rxjs",
+  },
+]
+`;
+
+exports[`Build tests wordpress wordpress should produce expected output: Dependencies JSON should match snapshot 1`] = `
 Array [
   "lodash",
   "wp-blob",
+]
+`;
+
+exports[`Build tests wordpress wordpress should produce expected output: External modules should match snapshot 1`] = `
+Array [
+  Object {
+    "externalType": "root",
+    "request": "wp.blob",
+    "userRequest": "@wordpress/blob",
+  },
+  Object {
+    "externalType": "root",
+    "request": "lodash",
+    "userRequest": "lodash",
+  },
 ]
 `;

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -1,5 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Webpack \`dynamic-import\` should produce expected output: Dependencies JSON should match snapshot 1`] = `
+Array [
+  "lodash",
+  "wp-blob",
+]
+`;
+
+exports[`Webpack \`dynamic-import\` should produce expected output: External modules should match snapshot 1`] = `
+Array [
+  Object {
+    "externalType": "this",
+    "request": Object {
+      "this": Array [
+        "wp",
+        "blob",
+      ],
+    },
+    "userRequest": "@wordpress/blob",
+  },
+  Object {
+    "externalType": "this",
+    "request": Object {
+      "this": "lodash",
+    },
+    "userRequest": "lodash",
+  },
+]
+`;
+
 exports[`Webpack \`no-default\` should produce expected output: Dependencies JSON should match snapshot 1`] = `Array []`;
 
 exports[`Webpack \`no-default\` should produce expected output: External modules should match snapshot 1`] = `Array []`;

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -93,3 +93,25 @@ Array [
   },
 ]
 `;
+
+exports[`Build tests wordpress-require wordpress-require should produce expected output: Dependencies JSON should match snapshot 1`] = `
+Array [
+  "lodash",
+  "wp-blob",
+]
+`;
+
+exports[`Build tests wordpress-require wordpress-require should produce expected output: External modules should match snapshot 1`] = `
+Array [
+  Object {
+    "externalType": "root",
+    "request": "wp.blob",
+    "userRequest": "@wordpress/blob",
+  },
+  Object {
+    "externalType": "root",
+    "request": "lodash",
+    "userRequest": "lodash",
+  },
+]
+`;

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -41,7 +41,10 @@ Array [
   Object {
     "externalType": "this",
     "request": Object {
-      "this": "rxjs.operators",
+      "this": Array [
+        "rxjs",
+        "operators",
+      ],
     },
     "userRequest": "rxjs/operators",
   },

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Webpack no-default should produce expected output: Dependencies JSON should match snapshot 1`] = `Array []`;
+exports[`Webpack \`no-default\` should produce expected output: Dependencies JSON should match snapshot 1`] = `Array []`;
 
-exports[`Webpack no-default should produce expected output: External modules should match snapshot 1`] = `Array []`;
+exports[`Webpack \`no-default\` should produce expected output: External modules should match snapshot 1`] = `Array []`;
 
-exports[`Webpack no-deps should produce expected output: Dependencies JSON should match snapshot 1`] = `Array []`;
+exports[`Webpack \`no-deps\` should produce expected output: Dependencies JSON should match snapshot 1`] = `Array []`;
 
-exports[`Webpack no-deps should produce expected output: External modules should match snapshot 1`] = `Array []`;
+exports[`Webpack \`no-deps\` should produce expected output: External modules should match snapshot 1`] = `Array []`;
 
-exports[`Webpack overrides should produce expected output: Dependencies JSON should match snapshot 1`] = `
+exports[`Webpack \`overrides\` should produce expected output: Dependencies JSON should match snapshot 1`] = `
 Array [
   "wp-blob",
   "wp-script-handle-for-rxjs",
@@ -16,7 +16,7 @@ Array [
 ]
 `;
 
-exports[`Webpack overrides should produce expected output: External modules should match snapshot 1`] = `
+exports[`Webpack \`overrides\` should produce expected output: External modules should match snapshot 1`] = `
 Array [
   Object {
     "externalType": "root",
@@ -41,13 +41,13 @@ Array [
 ]
 `;
 
-exports[`Webpack with-externs should produce expected output: Dependencies JSON should match snapshot 1`] = `
+exports[`Webpack \`with-externs\` should produce expected output: Dependencies JSON should match snapshot 1`] = `
 Array [
   "wp-url",
 ]
 `;
 
-exports[`Webpack with-externs should produce expected output: External modules should match snapshot 1`] = `
+exports[`Webpack \`with-externs\` should produce expected output: External modules should match snapshot 1`] = `
 Array [
   Object {
     "externalType": "var",
@@ -72,14 +72,14 @@ Array [
 ]
 `;
 
-exports[`Webpack wordpress should produce expected output: Dependencies JSON should match snapshot 1`] = `
+exports[`Webpack \`wordpress\` should produce expected output: Dependencies JSON should match snapshot 1`] = `
 Array [
   "lodash",
   "wp-blob",
 ]
 `;
 
-exports[`Webpack wordpress should produce expected output: External modules should match snapshot 1`] = `
+exports[`Webpack \`wordpress\` should produce expected output: External modules should match snapshot 1`] = `
 Array [
   Object {
     "externalType": "root",
@@ -94,14 +94,14 @@ Array [
 ]
 `;
 
-exports[`Webpack wordpress-require should produce expected output: Dependencies JSON should match snapshot 1`] = `
+exports[`Webpack \`wordpress-require\` should produce expected output: Dependencies JSON should match snapshot 1`] = `
 Array [
   "lodash",
   "wp-blob",
 ]
 `;
 
-exports[`Webpack wordpress-require should produce expected output: External modules should match snapshot 1`] = `
+exports[`Webpack \`wordpress-require\` should produce expected output: External modules should match snapshot 1`] = `
 Array [
   Object {
     "externalType": "root",

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -19,23 +19,37 @@ Array [
 exports[`Webpack \`overrides\` should produce expected output: External modules should match snapshot 1`] = `
 Array [
   Object {
-    "externalType": "root",
-    "request": "wp.blob",
+    "externalType": "this",
+    "request": Object {
+      "this": Array [
+        "wp",
+        "blob",
+      ],
+    },
     "userRequest": "@wordpress/blob",
   },
   Object {
-    "externalType": "root",
-    "request": "wp.url",
+    "externalType": "this",
+    "request": Object {
+      "this": Array [
+        "wp",
+        "url",
+      ],
+    },
     "userRequest": "@wordpress/url",
   },
   Object {
-    "externalType": "root",
-    "request": "rxjs.operators",
+    "externalType": "this",
+    "request": Object {
+      "this": "rxjs.operators",
+    },
     "userRequest": "rxjs/operators",
   },
   Object {
-    "externalType": "root",
-    "request": "rxjs",
+    "externalType": "this",
+    "request": Object {
+      "this": "rxjs",
+    },
     "userRequest": "rxjs",
   },
 ]
@@ -55,8 +69,13 @@ Array [
     "userRequest": "@wordpress/blob",
   },
   Object {
-    "externalType": "root",
-    "request": "wp.url",
+    "externalType": "this",
+    "request": Object {
+      "this": Array [
+        "wp",
+        "url",
+      ],
+    },
     "userRequest": "@wordpress/url",
   },
   Object {
@@ -82,13 +101,20 @@ Array [
 exports[`Webpack \`wordpress\` should produce expected output: External modules should match snapshot 1`] = `
 Array [
   Object {
-    "externalType": "root",
-    "request": "wp.blob",
+    "externalType": "this",
+    "request": Object {
+      "this": Array [
+        "wp",
+        "blob",
+      ],
+    },
     "userRequest": "@wordpress/blob",
   },
   Object {
-    "externalType": "root",
-    "request": "lodash",
+    "externalType": "this",
+    "request": Object {
+      "this": "lodash",
+    },
     "userRequest": "lodash",
   },
 ]
@@ -104,13 +130,20 @@ Array [
 exports[`Webpack \`wordpress-require\` should produce expected output: External modules should match snapshot 1`] = `
 Array [
   Object {
-    "externalType": "root",
-    "request": "wp.blob",
+    "externalType": "this",
+    "request": Object {
+      "this": Array [
+        "wp",
+        "blob",
+      ],
+    },
     "userRequest": "@wordpress/blob",
   },
   Object {
-    "externalType": "root",
-    "request": "lodash",
+    "externalType": "this",
+    "request": Object {
+      "this": "lodash",
+    },
     "userRequest": "lodash",
   },
 ]

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Build tests no-default no-default should produce expected output: Dependencies JSON should match snapshot 1`] = `Array []`;
+exports[`Webpack no-default should produce expected output: Dependencies JSON should match snapshot 1`] = `Array []`;
 
-exports[`Build tests no-default no-default should produce expected output: External modules should match snapshot 1`] = `Array []`;
+exports[`Webpack no-default should produce expected output: External modules should match snapshot 1`] = `Array []`;
 
-exports[`Build tests no-deps no-deps should produce expected output: Dependencies JSON should match snapshot 1`] = `Array []`;
+exports[`Webpack no-deps should produce expected output: Dependencies JSON should match snapshot 1`] = `Array []`;
 
-exports[`Build tests no-deps no-deps should produce expected output: External modules should match snapshot 1`] = `Array []`;
+exports[`Webpack no-deps should produce expected output: External modules should match snapshot 1`] = `Array []`;
 
-exports[`Build tests overrides overrides should produce expected output: Dependencies JSON should match snapshot 1`] = `
+exports[`Webpack overrides should produce expected output: Dependencies JSON should match snapshot 1`] = `
 Array [
   "wp-blob",
   "wp-script-handle-for-rxjs",
@@ -16,7 +16,7 @@ Array [
 ]
 `;
 
-exports[`Build tests overrides overrides should produce expected output: External modules should match snapshot 1`] = `
+exports[`Webpack overrides should produce expected output: External modules should match snapshot 1`] = `
 Array [
   Object {
     "externalType": "root",
@@ -41,13 +41,13 @@ Array [
 ]
 `;
 
-exports[`Build tests with-externs with-externs should produce expected output: Dependencies JSON should match snapshot 1`] = `
+exports[`Webpack with-externs should produce expected output: Dependencies JSON should match snapshot 1`] = `
 Array [
   "wp-url",
 ]
 `;
 
-exports[`Build tests with-externs with-externs should produce expected output: External modules should match snapshot 1`] = `
+exports[`Webpack with-externs should produce expected output: External modules should match snapshot 1`] = `
 Array [
   Object {
     "externalType": "var",
@@ -72,14 +72,14 @@ Array [
 ]
 `;
 
-exports[`Build tests wordpress wordpress should produce expected output: Dependencies JSON should match snapshot 1`] = `
+exports[`Webpack wordpress should produce expected output: Dependencies JSON should match snapshot 1`] = `
 Array [
   "lodash",
   "wp-blob",
 ]
 `;
 
-exports[`Build tests wordpress wordpress should produce expected output: External modules should match snapshot 1`] = `
+exports[`Webpack wordpress should produce expected output: External modules should match snapshot 1`] = `
 Array [
   Object {
     "externalType": "root",
@@ -94,14 +94,14 @@ Array [
 ]
 `;
 
-exports[`Build tests wordpress-require wordpress-require should produce expected output: Dependencies JSON should match snapshot 1`] = `
+exports[`Webpack wordpress-require should produce expected output: Dependencies JSON should match snapshot 1`] = `
 Array [
   "lodash",
   "wp-blob",
 ]
 `;
 
-exports[`Build tests wordpress-require wordpress-require should produce expected output: External modules should match snapshot 1`] = `
+exports[`Webpack wordpress-require should produce expected output: External modules should match snapshot 1`] = `
 Array [
   Object {
     "externalType": "root",

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -43,7 +43,6 @@ Array [
 
 exports[`Build tests with-externs with-externs should produce expected output: Dependencies JSON should match snapshot 1`] = `
 Array [
-  "wp-blob",
   "wp-url",
 ]
 `;
@@ -51,7 +50,7 @@ Array [
 exports[`Build tests with-externs with-externs should produce expected output: External modules should match snapshot 1`] = `
 Array [
   Object {
-    "externalType": "root",
+    "externalType": "var",
     "request": "wp.blob",
     "userRequest": "@wordpress/blob",
   },

--- a/packages/dependency-extraction-webpack-plugin/test/build.js
+++ b/packages/dependency-extraction-webpack-plugin/test/build.js
@@ -23,7 +23,10 @@ configFixtures.forEach( ( configCase ) => {
 		const testDirectory = path.join( fixturesPath, configCase );
 		const outputDirectory = path.join( __dirname, 'build', configCase );
 
-		beforeAll( () => mkdirp( outputDirectory ) );
+		beforeAll( () => {
+			rimraf( outputDirectory );
+			mkdirp( outputDirectory );
+		} );
 		afterAll( () => rimraf( outputDirectory ) );
 
 		test( 'should produce expected output', () =>

--- a/packages/dependency-extraction-webpack-plugin/test/build.js
+++ b/packages/dependency-extraction-webpack-plugin/test/build.js
@@ -13,63 +13,60 @@ const configFixtures = fs.readdirSync( fixturesPath ).sort();
 
 afterAll( () => rimraf( path.join( __dirname, 'build' ) ) );
 
-configFixtures.forEach( ( configCase ) => {
-	describe( `Webpack ${ configCase }`, () => {
-		const testDirectory = path.join( fixturesPath, configCase );
-		const outputDirectory = path.join( __dirname, 'build', configCase );
+describe.each( configFixtures )( 'Webpack `%s`', ( configCase ) => {
+	const testDirectory = path.join( fixturesPath, configCase );
+	const outputDirectory = path.join( __dirname, 'build', configCase );
 
-		beforeAll( () => {
-			rimraf( outputDirectory );
-			mkdirp( outputDirectory );
-		} );
-		afterAll( () => rimraf( outputDirectory ) );
-
-		test( 'should produce expected output', () =>
-			new Promise( ( resolve ) => {
-				const options = Object.assign(
-					{
-						context: testDirectory,
-						entry: './index.js',
-						mode: 'production',
-						optimization: {
-							minimize: false,
-							namedChunks: true,
-							namedModules: true,
-						},
-						output: {},
-					},
-					require( path.join( testDirectory, 'webpack.config.js' ) )
-				);
-				options.output.path = outputDirectory;
-
-				webpack( options, ( err, stats ) => {
-					expect( err ).toBeNull();
-
-					const depsFiles = glob( `${ outputDirectory }/*.deps.json` );
-					const expectedLength =
-						typeof options.entry === 'object' ? Object.keys( options.entry ).length : 1;
-					expect( depsFiles ).toHaveLength( expectedLength );
-
-					// Deps files should match
-					depsFiles.forEach( ( depsFile ) => {
-						expect( require( depsFile ) ).toMatchSnapshot(
-							'Dependencies JSON should match snapshot'
-						);
-					} );
-
-					// Webpack stats external modules should match
-					const externalModules = stats.compilation.modules
-						.filter( ( { external } ) => external )
-						.sort()
-						.map( ( module ) => ( {
-							externalType: module.externalType,
-							request: module.request,
-							userRequest: module.userRequest,
-						} ) );
-					expect( externalModules ).toMatchSnapshot( 'External modules should match snapshot' );
-
-					resolve();
-				} );
-			} ) );
+	beforeAll( () => {
+		rimraf( outputDirectory );
+		mkdirp( outputDirectory );
 	} );
+
+	test( 'should produce expected output', () =>
+		new Promise( ( resolve ) => {
+			const options = Object.assign(
+				{
+					context: testDirectory,
+					entry: './index.js',
+					mode: 'production',
+					optimization: {
+						minimize: false,
+						namedChunks: true,
+						namedModules: true,
+					},
+					output: {},
+				},
+				require( path.join( testDirectory, 'webpack.config.js' ) )
+			);
+			options.output.path = outputDirectory;
+
+			webpack( options, ( err, stats ) => {
+				expect( err ).toBeNull();
+
+				const depsFiles = glob( `${ outputDirectory }/*.deps.json` );
+				const expectedLength =
+					typeof options.entry === 'object' ? Object.keys( options.entry ).length : 1;
+				expect( depsFiles ).toHaveLength( expectedLength );
+
+				// Deps files should match
+				depsFiles.forEach( ( depsFile ) => {
+					expect( require( depsFile ) ).toMatchSnapshot(
+						'Dependencies JSON should match snapshot'
+					);
+				} );
+
+				// Webpack stats external modules should match
+				const externalModules = stats.compilation.modules
+					.filter( ( { external } ) => external )
+					.sort()
+					.map( ( module ) => ( {
+						externalType: module.externalType,
+						request: module.request,
+						userRequest: module.userRequest,
+					} ) );
+				expect( externalModules ).toMatchSnapshot( 'External modules should match snapshot' );
+
+				resolve();
+			} );
+		} ) );
 } );

--- a/packages/dependency-extraction-webpack-plugin/test/build.js
+++ b/packages/dependency-extraction-webpack-plugin/test/build.js
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+const fs = require( 'fs' );
+const glob = require( 'glob' ).sync;
+const mkdirp = require( 'mkdirp' ).sync;
+const path = require( 'path' );
+const rimraf = require( 'rimraf' ).sync;
+const webpack = require( 'webpack' );
+
+/**
+ * Internal dependencies
+ */
+const DependencyExtractionWebpackPlugin = require( '..' );
+
+describe( 'Build tests', () => {
+	afterAll( () => rimraf( path.join( __dirname, 'build' ) ) );
+
+	// jest.setTimeout( 20000 );
+
+	const fixturesPath = path.join( __dirname, 'fixtures' );
+	const configFixtures = fs.readdirSync( fixturesPath ).sort();
+
+	configFixtures.forEach( ( configCase ) => {
+		describe( configCase, () => {
+			const testDirectory = path.join( fixturesPath, configCase );
+			const outputDirectory = path.join( __dirname, 'build', configCase );
+
+			beforeAll( () => mkdirp( outputDirectory ) );
+			afterAll( () => rimraf( outputDirectory ) );
+
+			test( `${ configCase } should produce expected output`, () =>
+				new Promise( ( resolve ) => {
+					const options = Object.assign(
+						{
+							context: testDirectory,
+							entry: './index.js',
+							mode: 'production',
+							optimization: { minimize: false },
+							output: {},
+						},
+						require( path.join( testDirectory, 'webpack.config.js' ) )
+					);
+					options.output.path = outputDirectory;
+					if ( ! options.plugins ) {
+						options.plugins = [ new DependencyExtractionWebpackPlugin() ];
+					}
+
+					webpack( options, ( err ) => {
+						expect( err ).toBeNull();
+
+						const depsFiles = glob( `${ outputDirectory }/*.deps.json` );
+						const expectedLength =
+							typeof options.entry === 'object' ? Object.keys( options.entry ).length : 1;
+						expect( depsFiles ).toHaveLength( expectedLength );
+
+						depsFiles.forEach( ( depsFile ) => {
+							expect( require( depsFile ) ).toMatchSnapshot();
+						} );
+						resolve();
+					} );
+				} ) );
+		} );
+	} );
+} );

--- a/packages/dependency-extraction-webpack-plugin/test/build.js
+++ b/packages/dependency-extraction-webpack-plugin/test/build.js
@@ -8,11 +8,6 @@ const path = require( 'path' );
 const rimraf = require( 'rimraf' ).sync;
 const webpack = require( 'webpack' );
 
-/**
- * Internal dependencies
- */
-const DependencyExtractionWebpackPlugin = require( '..' );
-
 const fixturesPath = path.join( __dirname, 'fixtures' );
 const configFixtures = fs.readdirSync( fixturesPath ).sort();
 
@@ -46,9 +41,6 @@ configFixtures.forEach( ( configCase ) => {
 					require( path.join( testDirectory, 'webpack.config.js' ) )
 				);
 				options.output.path = outputDirectory;
-				if ( ! options.plugins ) {
-					options.plugins = [ new DependencyExtractionWebpackPlugin() ];
-				}
 
 				webpack( options, ( err, stats ) => {
 					expect( err ).toBeNull();

--- a/packages/dependency-extraction-webpack-plugin/test/build.js
+++ b/packages/dependency-extraction-webpack-plugin/test/build.js
@@ -17,10 +17,13 @@ describe.each( configFixtures )( 'Webpack `%s`', ( configCase ) => {
 	const testDirectory = path.join( fixturesPath, configCase );
 	const outputDirectory = path.join( __dirname, 'build', configCase );
 
-	beforeAll( () => {
+	beforeEach( () => {
 		rimraf( outputDirectory );
 		mkdirp( outputDirectory );
 	} );
+
+	// This afterEach is necessary to prevent watched tests from retriggering on every run.
+	afterEach( () => rimraf( outputDirectory ) );
 
 	test( 'should produce expected output', () =>
 		new Promise( ( resolve ) => {

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/dynamic-import/index.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/dynamic-import/index.js
@@ -1,0 +1,6 @@
+/**
+ * External dependencies
+ */
+import _ from 'lodash';
+
+import( './util' ).then( _.noop );

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/dynamic-import/util.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/dynamic-import/util.js
@@ -1,0 +1,6 @@
+/**
+ * WordPress dependencies
+ */
+import { isBlobURL } from '@wordpress/blob';
+
+isBlobURL();

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/dynamic-import/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/dynamic-import/webpack.config.js
@@ -1,0 +1,5 @@
+const DependencyExtractionWebpackPlugin = require( '../../..' );
+
+module.exports = {
+	plugins: [ new DependencyExtractionWebpackPlugin() ],
+};

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/no-default/index.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/no-default/index.js
@@ -1,0 +1,6 @@
+/**
+ * External dependencies
+ */
+import _ from 'lodash';
+
+_.map( [], _.identity );

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/no-default/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/no-default/webpack.config.js
@@ -1,0 +1,5 @@
+const DependencyExtractionWebpackPlugin = require( '../../..' );
+
+module.exports = {
+	plugins: [ new DependencyExtractionWebpackPlugin( { useDefaults: false } ) ],
+};

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/no-deps/index.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/no-deps/index.js
@@ -1,0 +1,1 @@
+/* Silence is golden */

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/no-deps/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/no-deps/webpack.config.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/no-deps/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/no-deps/webpack.config.js
@@ -1,1 +1,5 @@
-module.exports = {};
+const DependencyExtractionWebpackPlugin = require( '../../..' );
+
+module.exports = {
+	plugins: [ new DependencyExtractionWebpackPlugin() ],
+};

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/overrides/index.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/overrides/index.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { isBlobURL } from '@wordpress/blob';
+import { isURL } from '@wordpress/url';
+
+/**
+ * External dependencies
+ */
+import { range } from 'rxjs';
+import { map, filter } from 'rxjs/operators';
+
+range( 1, 200 )
+	.pipe(
+		filter( isBlobURL ),
+		map( ( x ) => x + x )
+	)
+	.subscribe( ( x ) => isURL( x ) );

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/overrides/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/overrides/webpack.config.js
@@ -1,0 +1,22 @@
+const DependencyExtractionWebpackPlugin = require( '../../..' );
+
+module.exports = {
+	plugins: [
+		new DependencyExtractionWebpackPlugin( {
+			requestToExternal( request ) {
+				if ( request === 'rxjs' ) {
+					return 'rxjs';
+				}
+
+				if ( request === 'rxjs/operators' ) {
+					return 'rxjs.operators';
+				}
+			},
+			requestToDependency( request ) {
+				if ( request === 'rxjs' || request === 'rxjs/operators' ) {
+					return 'wp-script-handle-for-rxjs';
+				}
+			},
+		} ),
+	],
+};

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/overrides/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/overrides/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
 				}
 
 				if ( request === 'rxjs/operators' ) {
-					return 'rxjs.operators';
+					return [ 'rxjs', 'operators' ];
 				}
 			},
 			requestToDependency( request ) {

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/with-externs/index.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/with-externs/index.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { isBlobURL } from '@wordpress/blob';
+import { isURL } from '@wordpress/url';
+
+/**
+ * External dependencies
+ */
+import { range } from 'rxjs';
+import { map, filter } from 'rxjs/operators';
+
+range( 1, 200 )
+	.pipe(
+		filter( isBlobURL ),
+		map( ( x ) => x + x )
+	)
+	.subscribe( ( x ) => isURL( x ) );

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/with-externs/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/with-externs/webpack.config.js
@@ -1,6 +1,7 @@
 module.exports = {
 	externals: {
-		rxjs: true,
+		'@wordpress/blob': 'wp.blob',
 		'rxjs/operators': 'rxjs.operators',
+		rxjs: true,
 	},
 };

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/with-externs/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/with-externs/webpack.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	externals: {
+		rxjs: true,
+		'rxjs/operators': 'rxjs.operators',
+	},
+};

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/with-externs/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/with-externs/webpack.config.js
@@ -1,7 +1,10 @@
+const DependencyExtractionWebpackPlugin = require( '../../..' );
+
 module.exports = {
 	externals: {
 		'@wordpress/blob': 'wp.blob',
 		'rxjs/operators': 'rxjs.operators',
 		rxjs: true,
 	},
+	plugins: [ new DependencyExtractionWebpackPlugin() ],
 };

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress-require/index.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress-require/index.js
@@ -1,0 +1,11 @@
+/**
+ * WordPress dependencies
+ */
+const { isBlobURL } = require( '@wordpress/blob' );
+
+/**
+ * External dependencies
+ */
+const _ = require( 'lodash' );
+
+_.isEmpty( isBlobURL( '' ) );

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress-require/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress-require/webpack.config.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress-require/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress-require/webpack.config.js
@@ -1,1 +1,5 @@
-module.exports = {};
+const DependencyExtractionWebpackPlugin = require( '../../..' );
+
+module.exports = {
+	plugins: [ new DependencyExtractionWebpackPlugin() ],
+};

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress/index.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress/index.js
@@ -1,0 +1,11 @@
+/**
+ * WordPress dependencies
+ */
+import { isBlobURL } from '@wordpress/blob';
+
+/**
+ * External dependencies
+ */
+import _ from 'lodash';
+
+_.isEmpty( isBlobURL( '' ) );

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress/webpack.config.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/wordpress/webpack.config.js
@@ -1,1 +1,5 @@
-module.exports = {};
+const DependencyExtractionWebpackPlugin = require( '../../..' );
+
+module.exports = {
+	plugins: [ new DependencyExtractionWebpackPlugin() ],
+};

--- a/packages/dependency-extraction-webpack-plugin/test/util.js
+++ b/packages/dependency-extraction-webpack-plugin/test/util.js
@@ -13,13 +13,14 @@ describe( 'defaultRequestToExternal', () => {
 	} );
 
 	test( 'Handles known @wordpress request', () => {
-		expect( defaultRequestToExternal( '@wordpress/i18n' ) ).toBe( 'wp.i18n' );
+		expect( defaultRequestToExternal( '@wordpress/i18n' ) ).toEqual( [ 'wp', 'i18n' ] );
 	} );
 
 	test( 'Handles future @wordpress namespace packages', () => {
-		expect( defaultRequestToExternal( '@wordpress/some-future-package' ) ).toBe(
-			'wp.someFuturePackage'
-		);
+		expect( defaultRequestToExternal( '@wordpress/some-future-package' ) ).toEqual( [
+			'wp',
+			'someFuturePackage',
+		] );
 	} );
 } );
 

--- a/packages/dependency-extraction-webpack-plugin/test/util.js
+++ b/packages/dependency-extraction-webpack-plugin/test/util.js
@@ -1,0 +1,40 @@
+/**
+ * Internal dependencies
+ */
+const { defaultRequestToExternal, defaultRequestToHandle } = require( '../util' );
+
+describe( 'defaultRequestToExternal', () => {
+	test( 'Returns undefined on unrecognized request', () => {
+		expect( defaultRequestToExternal( 'unknown-request' ) ).toBeUndefined();
+	} );
+
+	test( 'Handles known lodash-es request', () => {
+		expect( defaultRequestToExternal( 'lodash-es' ) ).toBe( 'lodash' );
+	} );
+
+	test( 'Handles known @wordpress request', () => {
+		expect( defaultRequestToExternal( '@wordpress/i18n' ) ).toBe( 'wp.i18n' );
+	} );
+
+	test( 'Handles future @wordpress namespace packages', () => {
+		expect( defaultRequestToExternal( '@wordpress/some-future-package' ) ).toBe(
+			'wp.someFuturePackage'
+		);
+	} );
+} );
+
+describe( 'defaultRequestToHandle', () => {
+	test( 'Handles known lodash-es request', () => {
+		expect( defaultRequestToHandle( 'lodash-es' ) ).toBe( 'lodash' );
+	} );
+
+	test( 'Handles known @wordpress request', () => {
+		expect( defaultRequestToHandle( '@wordpress/i18n' ) ).toBe( 'wp-i18n' );
+	} );
+
+	test( 'Handles  @wordpress request', () => {
+		expect( defaultRequestToHandle( '@wordpress/some-future-package' ) ).toBe(
+			'wp-some-future-package'
+		);
+	} );
+} );

--- a/packages/dependency-extraction-webpack-plugin/util.js
+++ b/packages/dependency-extraction-webpack-plugin/util.js
@@ -47,7 +47,7 @@ function defaultRequestToExternal( request ) {
  *
  * @param {string} request Requested module
  *
- * @return {(string|undefined)} Script dependency slug
+ * @return {(string|undefined)} Script handle
  */
 function defaultRequestToHandle( request ) {
 	switch ( request ) {

--- a/packages/dependency-extraction-webpack-plugin/util.js
+++ b/packages/dependency-extraction-webpack-plugin/util.js
@@ -1,0 +1,85 @@
+const WORDPRESS_NAMESPACE = '@wordpress/';
+
+/**
+ * Default request to global transformation
+ *
+ * Transform @wordpress dependencies:
+ *   @wordpress/api-fetch -> wp.apiFetch
+ *   @wordpress/i18n -> wp.i18n
+ *
+ * @param {string} request Requested module
+ *
+ * @return {(string|undefined)} Script global
+ */
+function defaultRequestToExternal( request ) {
+	switch ( request ) {
+		case 'moment':
+			return request;
+
+		case '@babel/runtime/regenerator':
+			return 'regeneratorRuntime';
+
+		case 'lodash':
+		case 'lodash-es':
+			return 'lodash';
+
+		case 'jquery':
+			return 'jQuery';
+
+		case 'react':
+			return 'React';
+
+		case 'react-dom':
+			return 'ReactDOM';
+	}
+
+	if ( request.startsWith( WORDPRESS_NAMESPACE ) ) {
+		return `wp.${ camelCaseDash( request.substring( WORDPRESS_NAMESPACE.length ) ) }`;
+	}
+}
+
+/**
+ * Default request to WordPress script handle transformation
+ *
+ * Transform @wordpress dependencies:
+ *   @wordpress/i18n -> wp-i18n
+ *   @wordpress/escape-html -> wp-escape-html
+ *
+ * @param {string} request Requested module
+ *
+ * @return {(string|undefined)} Script dependency slug
+ */
+function defaultRequestToHandle( request ) {
+	switch ( request ) {
+		case '@babel/runtime/regenerator':
+			return 'wp-polyfill';
+
+		case 'lodash-es':
+			return 'lodash';
+	}
+
+	if ( request.startsWith( WORDPRESS_NAMESPACE ) ) {
+		return 'wp-' + request.substring( WORDPRESS_NAMESPACE.length );
+	}
+}
+
+/**
+ * Given a string, returns a new string with dash separators converted to
+ * camelCase equivalent. This is not as aggressive as `_.camelCase` in
+ * converting to uppercase, where Lodash will also capitalize letters
+ * following numbers.
+ *
+ * Temporarily duplicated from @wordpress/scripts/utils.
+ *
+ * @param {string} string Input dash-delimited string.
+ *
+ * @return {string} Camel-cased string.
+ */
+function camelCaseDash( string ) {
+	return string.replace( /-([a-z])/g, ( match, letter ) => letter.toUpperCase() );
+}
+
+module.exports = {
+	defaultRequestToExternal,
+	defaultRequestToHandle,
+};

--- a/packages/dependency-extraction-webpack-plugin/util.js
+++ b/packages/dependency-extraction-webpack-plugin/util.js
@@ -9,7 +9,7 @@ const WORDPRESS_NAMESPACE = '@wordpress/';
  *
  * @param {string} request Requested module
  *
- * @return {(string|undefined)} Script global
+ * @return {(string|string[]|undefined)} Script global
  */
 function defaultRequestToExternal( request ) {
 	switch ( request ) {
@@ -34,7 +34,7 @@ function defaultRequestToExternal( request ) {
 	}
 
 	if ( request.startsWith( WORDPRESS_NAMESPACE ) ) {
-		return `wp.${ camelCaseDash( request.substring( WORDPRESS_NAMESPACE.length ) ) }`;
+		return [ 'wp', camelCaseDash( request.substring( WORDPRESS_NAMESPACE.length ) ) ];
 	}
 }
 

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.2.0 (tbd)
+## Unreleased
 
 ### New Feature
 

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.2.0 (tbd)
+
+### New Feature
+
+- Leverage `@wordpress/dependency-extraction-webpack-plugin` plugin to extract WordPress
+  dependencies.
+
 ## 3.1.0 (2019-03-20)
 
 ## New features

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -272,7 +272,7 @@ The `build` and `start` commands use [webpack](https://webpack.js.org/) behind t
 * [Entry](https://webpack.js.org/configuration/entry-context/#entry): `src/index.js`
 * [Output](https://webpack.js.org/configuration/output): `build/index.js`
 * [Plugins](https://webpack.js.org/configuration/plugins): The webpack plugin provided by
-[`@wordpress/dependency-extraction-webpack-plugin`](../dependency-extraction-webpack-plugin) is used
+[`@wordpress/dependency-extraction-webpack-plugin`](/packages/dependency-extraction-webpack-plugin/README.md) is used
 with the default configuration.
 
 #### Provide your own webpack config

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -273,7 +273,8 @@ The `build` and `start` commands use [webpack](https://webpack.js.org/) behind t
 * [Output](https://webpack.js.org/configuration/output): `build/index.js`
 * [Plugins](https://webpack.js.org/configuration/plugins): The webpack plugin provided by
 [`@wordpress/dependency-extraction-webpack-plugin`](/packages/dependency-extraction-webpack-plugin/README.md) is used
-with the default configuration.
+with the default configuration to ensure that WordPress provided scripts are not included in the
+built bundle.
 
 #### Provide your own webpack config
 

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -271,17 +271,9 @@ The `build` and `start` commands use [webpack](https://webpack.js.org/) behind t
 
 * [Entry](https://webpack.js.org/configuration/entry-context/#entry): `src/index.js`
 * [Output](https://webpack.js.org/configuration/output): `build/index.js`
-* [Externals](https://webpack.js.org/configuration/externals). These are libraries that are to be found in the global scope:
-
-Package | Input syntax | Output
---- | --- | ---
-React | `import x from 'react';` | `var x = window.React.x;`
-ReactDOM | `import x from 'react-dom';` | `var x = window.ReactDOM.x;`
-moment | `import x from 'moment';` | `var x = window.moment.x;`
-jQuery | `import x from 'jquery';` | `var x = window.jQuery.x;`
-lodash | `import x from 'lodash';` | `var x = window.lodash.x;`
-lodash-es | `import x from 'lodash-es';` | `var x = window.lodash.x;`
-WordPress packages | `import x from '@wordpress/package-name'` | `var x = window.wp.packageName.x`
+* [Plugins](https://webpack.js.org/configuration/plugins): The webpack plugin provided by
+[`@wordpress/dependency-extraction-webpack-plugin`](../dependency-extraction-webpack-plugin) is used
+with the default configuration.
 
 #### Provide your own webpack config
 

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -27,6 +27,17 @@ const config = {
 		filename: '[name].js',
 		path: path.resolve( process.cwd(), 'build' ),
 	},
+	externals: [
+		{
+			// Distributed NPM packages may depend on Babel's runtime regenerator.
+			// In a WordPress context, the regenerator is assigned to the global
+			// scope via the `wp-polyfill` script. It is reassigned here as an
+			// externals to reduce the size of generated bundles.
+			//
+			// See: https://github.com/WordPress/gutenberg/issues/13890
+			'@babel/runtime/regenerator': 'regeneratorRuntime',
+		},
+	],
 	resolve: {
 		alias: {
 			'lodash-es': 'lodash',

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -27,17 +27,6 @@ const config = {
 		filename: '[name].js',
 		path: path.resolve( process.cwd(), 'build' ),
 	},
-	externals: [
-		{
-			// Distributed NPM packages may depend on Babel's runtime regenerator.
-			// In a WordPress context, the regenerator is assigned to the global
-			// scope via the `wp-polyfill` script. It is reassigned here as an
-			// externals to reduce the size of generated bundles.
-			//
-			// See: https://github.com/WordPress/gutenberg/issues/13890
-			'@babel/runtime/regenerator': 'regeneratorRuntime',
-		},
-	],
 	resolve: {
 		alias: {
 			'lodash-es': 'lodash',

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/scripts",
-	"version": "3.2.0",
+	"version": "3.1.0",
 	"description": "Collection of reusable scripts for WordPress development.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -33,6 +33,7 @@
 	},
 	"dependencies": {
 		"@wordpress/babel-preset-default": "file:../babel-preset-default",
+		"@wordpress/dependency-extraction-webpack-plugin": "file:../dependency-extraction-webpack-plugin",
 		"@wordpress/eslint-plugin": "file:../eslint-plugin",
 		"@wordpress/jest-preset-default": "file:../jest-preset-default",
 		"@wordpress/npm-package-json-lint-config": "file:../npm-package-json-lint-config",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/scripts",
-	"version": "3.1.0",
+	"version": "3.2.0",
 	"description": "Collection of reusable scripts for WordPress development.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## Description

Add a webpack plugin that externalizes WordPress script dependencies and adds a dependency manifest per entrypoint. The goal is to eliminate error-prone process of manually creating and maintaining script dependencies.

A JSON file is output alongside each entrypoint. That looks like (webpack output):

```
             ./build/annotations/index.js    9.17 KiB      39  [emitted]         annotations
                    ./build/a11y/index.js    1.78 KiB      40  [emitted]         a11y
             ./build/a11y/index.deps.json    16 bytes      40  [emitted]         a11y
      ./build/annotations/index.deps.json    56 bytes      39  [emitted]         annotations
```

More detail in the README.

~Closes~ Part of #14837 

## To do
- [x] Add tests
- [x] Update README. Document options with examples.
- [x] CHANGELOG - this package and `scripts`
- [x] Fix CI test failures
- [x] Document in handbook: [#](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/coding-guidelines.md#external-dependencies) [#](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/scripts.md)

## How has this been tested?

The plugin is put to use in the Gutenberg webpack config. It can be tested using `npm run build`.

<details>

<summary>Plugin output results</summary>

<!--

Produced via:

for f in $(ls build ); do echo '**'$(basename $f)'**'; echo '```js'; cat "build/$f/index.deps.json" ; echo ; echo '```'; echo; done

-->

**a11y**
```js
["wp-dom-ready"]
```

**annotations**
```js
["lodash","wp-data","wp-hooks","wp-i18n","wp-rich-text"]
```

**api-fetch**
```js
["wp-i18n","wp-url"]
```

**autop**
```js
[]
```

**blob**
```js
[]
```

**block-editor**
```js
["lodash","react","wp-a11y","wp-blob","wp-blocks","wp-components","wp-compose","wp-core-data","wp-data","wp-deprecated","wp-dom","wp-element","wp-hooks","wp-html-entities","wp-i18n","wp-is-shallow-equal","wp-keycodes","wp-rich-text","wp-token-list","wp-url","wp-viewport","wp-wordcount"]
```

**block-library**
```js
["lodash","moment","wp-a11y","wp-api-fetch","wp-autop","wp-blob","wp-block-editor","wp-blocks","wp-components","wp-compose","wp-core-data","wp-data","wp-date","wp-deprecated","wp-editor","wp-element","wp-i18n","wp-is-shallow-equal","wp-keycodes","wp-rich-text","wp-url","wp-viewport"]
```

**block-serialization-default-parser**
```js
[]
```

**block-serialization-spec-parser**
```js
[]
```

**blocks**
```js
["lodash","wp-autop","wp-blob","wp-block-serialization-default-parser","wp-compose","wp-data","wp-dom","wp-element","wp-hooks","wp-html-entities","wp-i18n","wp-is-shallow-equal","wp-shortcode"]
```

**components**
```js
["lodash","moment","react","react-dom","wp-a11y","wp-api-fetch","wp-compose","wp-dom","wp-element","wp-hooks","wp-i18n","wp-is-shallow-equal","wp-keycodes","wp-rich-text","wp-url"]
```

**compose**
```js
["lodash","wp-element","wp-is-shallow-equal"]
```

**core-data**
```js
["lodash","wp-api-fetch","wp-data","wp-deprecated","wp-url"]
```

**data**
```js
["lodash","wp-compose","wp-deprecated","wp-element","wp-is-shallow-equal","wp-priority-queue","wp-redux-routine"]
```

**date**
```js
["moment"]
```

**deprecated**
```js
["wp-hooks"]
```

**dom**
```js
["lodash"]
```

**dom-ready**
```js
[]
```

**edit-post**
```js
["lodash","wp-a11y","wp-api-fetch","wp-block-editor","wp-block-library","wp-blocks","wp-components","wp-compose","wp-core-data","wp-data","wp-editor","wp-element","wp-hooks","wp-i18n","wp-keycodes","wp-notices","wp-nux","wp-plugins","wp-url","wp-viewport"]
```

**edit-widgets**
```js
["wp-element"]
```

**editor**
```js
["lodash","react","wp-api-fetch","wp-autop","wp-blob","wp-block-editor","wp-blocks","wp-components","wp-compose","wp-core-data","wp-data","wp-date","wp-deprecated","wp-element","wp-hooks","wp-html-entities","wp-i18n","wp-keycodes","wp-notices","wp-nux","wp-rich-text","wp-url","wp-viewport","wp-wordcount"]
```

**element**
```js
["lodash","react","react-dom","wp-escape-html"]
```

**escape-html**
```js
[]
```

**format-library**
```js
["lodash","wp-block-editor","wp-components","wp-element","wp-i18n","wp-keycodes","wp-rich-text","wp-url"]
```

**hooks**
```js
[]
```

**html-entities**
```js
[]
```

**i18n**
```js
[]
```

**is-shallow-equal**
```js
[]
```

**keycodes**
```js
["lodash","wp-i18n"]
```

**list-reusable-blocks**
```js
["lodash","wp-api-fetch","wp-components","wp-compose","wp-element","wp-i18n"]
```

**notices**
```js
["lodash","wp-a11y","wp-data"]
```

**nux**
```js
["lodash","wp-components","wp-compose","wp-data","wp-element","wp-i18n"]
```

**plugins**
```js
["lodash","wp-compose","wp-element","wp-hooks"]
```

**priority-queue**
```js
[]
```

**redux-routine**
```js
["lodash"]
```

**rich-text**
```js
["lodash","wp-compose","wp-data","wp-element","wp-escape-html","wp-hooks"]
```

**shortcode**
```js
["lodash"]
```

**token-list**
```js
["lodash"]
```

**url**
```js
[]
```

**viewport**
```js
["lodash","wp-compose","wp-data"]
```

**wordcount**
```js
["lodash"]
```



</details>

## Types of changes
New feature:
Adds a new package `@wordpress/dependency-extraction-webpack-plugin`.

New feature:
Uses the plugin in `@wordpress/scripts` (will require version bump, not included initially). This can be part of another PR but is useful for testing.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
