### PR TITLE
Fix regression with column block being selected.

### DIFF
--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -148,26 +148,30 @@ div.block-core-columns.is-vertically-aligned-bottom {
 	right: 0;
 }
 
+// The empty state of a columns block has the default appenders.
+// Since those appenders are not blocks, the parent, actual block, appears "hovered" when hovering the appenders.
+// Because the column shouldn't be hovered as part of this temporary passthrough, we unset the hover style.
+.wp-block-columns [data-type="core/column"].is-hovered {
+	> .block-editor-block-list__block-edit::before {
+		content: none;
+	}
+
+	.block-editor-block-list__breadcrumb {
+		display: none;
+	}
+}
+
 // In absence of making the individual columns resizable, we prevent them from being clickable.
 // This makes them less fiddly. @todo: This should be revisited as the interface is refined.
 .wp-block-columns [data-type="core/column"] {
 	pointer-events: none;
 
-	// The empty state of a columns block has the default appenders.
-	// Since those appenders are not blocks, the parent, actual block, appears "hovered" when hovering the appenders.
-	// Because the column shouldn't be hovered as part of this temporary passthrough, we unset the hover style.
-	&.is-hovered {
-		> .block-editor-block-list__block-edit::before {
-			content: none;
-		}
-
-		.block-editor-block-list__breadcrumb {
-			display: none;
-		}
+	// This selector re-enables clicking on any child of a column block.
+	.block-core-columns .block-editor-block-list__layout {
+		pointer-events: all;
 	}
 }
 
-// This selector re-enables clicking on any child of a column block.
 :not(.components-disabled) > .wp-block-columns > .editor-inner-blocks > .editor-block-list__layout > [data-type="core/column"] > .editor-block-list__block-edit > * {
-	pointer-events: all;
+	//pointer-events: all;
 }

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -171,7 +171,3 @@ div.block-core-columns.is-vertically-aligned-bottom {
 		pointer-events: all;
 	}
 }
-
-:not(.components-disabled) > .wp-block-columns > .editor-inner-blocks > .editor-block-list__layout > [data-type="core/column"] > .editor-block-list__block-edit > * {
-	//pointer-events: all;
-}


### PR DESCRIPTION
The columns block is currently slightly fiddly, due to the nesting nature of Columns > Column > Blocks structure. All three levels are "Blocks" in the block editor sense, and all can be selected. This is pending enhancements in #9628.

However in the mean time, we have a hack in place, this uses `pointer-events` to prevent the _mouse_ selection of the individual column blocks. This makes it drastically simpler to select the Columns block, which is where you can adjust the number of columns in the block. The individual column blocks, on the other hand, is currently largely inactionable. You can set alignments on them, which is why #9628 is urgent, but until we have a better system for selecting parent blocks, this pointer-events hack is arguably the better stopgap solution.

That hack regressed in master. This PR restores it, and makes it slightly better.

Things to test:

- Insert a columns block with content, and verify you can select both child and parent block.
- Insert an "Archives" block inside a column, and verify that the block itself is clickable, but the links inside are not (it's using component-disabled to make archive links unfollowable)

This branch:

![this branch](https://user-images.githubusercontent.com/1204802/55780684-d66d3e80-5aa8-11e9-957e-4e3a8c62db30.gif)

Master:

![master](https://user-images.githubusercontent.com/1204802/55780765-fef53880-5aa8-11e9-8e77-7a8bb8f6f7a5.gif)
