### PR TITLE
Fixes column import on native

### DIFF
--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -22,7 +22,7 @@ import * as calendar from './calendar';
 import * as categories from './categories';
 import * as code from './code';
 import * as columns from './columns';
-import * as column from './columns/column';
+import * as column from './column';
 import * as cover from './cover';
 import * as embed from './embed';
 import * as file from './file';


### PR DESCRIPTION
The changes in #14770 moved the column block from `columns/column` to `column`. This fixes the import on the native file.

To test:

- Launch gutenberg-mobile (https://github.com/wordpress-mobile/gutenberg-mobile/pull/844) and verify it doesn't crash
- Check that tests pass