### PR TITLE
Refactor core blocks to have save and transforms in their own files (part 1)

### DIFF
--- a/packages/block-library/src/archives/index.js
+++ b/packages/block-library/src/archives/index.js
@@ -13,17 +13,12 @@ export const name = 'core/archives';
 
 export const settings = {
 	title: __( 'Archives' ),
-
 	description: __( 'Display a monthly archive of your posts.' ),
-
 	icon,
-
 	category: 'widgets',
-
 	supports: {
 		align: true,
 		html: false,
 	},
-
 	edit,
 };

--- a/packages/block-library/src/audio/index.js
+++ b/packages/block-library/src/audio/index.js
@@ -1,9 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { createBlobURL } from '@wordpress/blob';
-import { createBlock } from '@wordpress/blocks';
-import { RichText } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -12,6 +9,8 @@ import { __ } from '@wordpress/i18n';
 import edit from './edit';
 import icon from './icon';
 import metadata from './block.json';
+import save from './save';
+import transforms from './transforms';
 
 const { name } = metadata;
 
@@ -19,76 +18,12 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Audio' ),
-
 	description: __( 'Embed a simple audio player.' ),
-
 	icon,
-
-	transforms: {
-		from: [
-			{
-				type: 'files',
-				isMatch( files ) {
-					return files.length === 1 && files[ 0 ].type.indexOf( 'audio/' ) === 0;
-				},
-				transform( files ) {
-					const file = files[ 0 ];
-					// We don't need to upload the media directly here
-					// It's already done as part of the `componentDidMount`
-					// in the audio block
-					const block = createBlock( 'core/audio', {
-						src: createBlobURL( file ),
-					} );
-
-					return block;
-				},
-			},
-			{
-				type: 'shortcode',
-				tag: 'audio',
-				attributes: {
-					src: {
-						type: 'string',
-						shortcode: ( { named: { src } } ) => {
-							return src;
-						},
-					},
-					loop: {
-						type: 'string',
-						shortcode: ( { named: { loop } } ) => {
-							return loop;
-						},
-					},
-					autoplay: {
-						type: 'srting',
-						shortcode: ( { named: { autoplay } } ) => {
-							return autoplay;
-						},
-					},
-					preload: {
-						type: 'string',
-						shortcode: ( { named: { preload } } ) => {
-							return preload;
-						},
-					},
-				},
-			},
-		],
-	},
-
+	transforms,
 	supports: {
 		align: true,
 	},
-
 	edit,
-
-	save( { attributes } ) {
-		const { autoplay, caption, loop, preload, src } = attributes;
-		return (
-			<figure>
-				<audio controls="controls" src={ src } autoPlay={ autoplay } loop={ loop } preload={ preload } />
-				{ ! RichText.isEmpty( caption ) && <RichText.Content tagName="figcaption" value={ caption } /> }
-			</figure>
-		);
-	},
+	save,
 };

--- a/packages/block-library/src/audio/save.js
+++ b/packages/block-library/src/audio/save.js
@@ -1,0 +1,15 @@
+/**
+ * WordPress dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+
+export default function save( { attributes } ) {
+	const { autoplay, caption, loop, preload, src } = attributes;
+
+	return (
+		<figure>
+			<audio controls="controls" src={ src } autoPlay={ autoplay } loop={ loop } preload={ preload } />
+			{ ! RichText.isEmpty( caption ) && <RichText.Content tagName="figcaption" value={ caption } /> }
+		</figure>
+	);
+}

--- a/packages/block-library/src/audio/transforms.js
+++ b/packages/block-library/src/audio/transforms.js
@@ -1,0 +1,59 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlobURL } from '@wordpress/blob';
+import { createBlock } from '@wordpress/blocks';
+
+const transforms = {
+	from: [
+		{
+			type: 'files',
+			isMatch( files ) {
+				return files.length === 1 && files[ 0 ].type.indexOf( 'audio/' ) === 0;
+			},
+			transform( files ) {
+				const file = files[ 0 ];
+				// We don't need to upload the media directly here
+				// It's already done as part of the `componentDidMount`
+				// in the audio block
+				const block = createBlock( 'core/audio', {
+					src: createBlobURL( file ),
+				} );
+
+				return block;
+			},
+		},
+		{
+			type: 'shortcode',
+			tag: 'audio',
+			attributes: {
+				src: {
+					type: 'string',
+					shortcode: ( { named: { src } } ) => {
+						return src;
+					},
+				},
+				loop: {
+					type: 'string',
+					shortcode: ( { named: { loop } } ) => {
+						return loop;
+					},
+				},
+				autoplay: {
+					type: 'srting',
+					shortcode: ( { named: { autoplay } } ) => {
+						return autoplay;
+					},
+				},
+				preload: {
+					type: 'string',
+					shortcode: ( { named: { preload } } ) => {
+						return preload;
+					},
+				},
+			},
+		},
+	],
+};
+
+export default transforms;

--- a/packages/block-library/src/block/index.js
+++ b/packages/block-library/src/block/index.js
@@ -12,16 +12,12 @@ export const name = 'core/block';
 
 export const settings = {
 	title: __( 'Reusable Block' ),
-
 	category: 'reusable',
-
 	description: __( 'Create content, and save it for you and other contributors to reuse across your site. Update the block, and the changes apply everywhere it’s used.' ),
-
 	supports: {
 		customClassName: false,
 		html: false,
 		inserter: false,
 	},
-
 	edit,
 };

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -1,17 +1,13 @@
 /**
  * External dependencies
  */
-import classnames from 'classnames';
 import { omit, pick } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
-import {
-	RichText,
-	getColorClassName,
-} from '@wordpress/block-editor';
+import { RichText } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -19,6 +15,7 @@ import {
 import edit from './edit';
 import icon from './icon';
 import metadata from './block.json';
+import save from './save';
 
 const { name, attributes: blockAttributes } = metadata;
 
@@ -34,66 +31,20 @@ const colorsMigration = ( attributes ) => {
 
 export const settings = {
 	title: __( 'Button' ),
-
 	description: __( 'Prompt visitors to take action with a button-style link.' ),
-
 	icon,
-
 	keywords: [ __( 'link' ) ],
-
 	supports: {
 		align: true,
 		alignWide: false,
 	},
-
 	styles: [
 		{ name: 'default', label: _x( 'Default', 'block style' ), isDefault: true },
 		{ name: 'outline', label: __( 'Outline' ) },
 		{ name: 'squared', label: _x( 'Squared', 'block style' ) },
 	],
-
 	edit,
-
-	save( { attributes } ) {
-		const {
-			url,
-			text,
-			title,
-			backgroundColor,
-			textColor,
-			customBackgroundColor,
-			customTextColor,
-		} = attributes;
-
-		const textClass = getColorClassName( 'color', textColor );
-		const backgroundClass = getColorClassName( 'background-color', backgroundColor );
-
-		const buttonClasses = classnames( 'wp-block-button__link', {
-			'has-text-color': textColor || customTextColor,
-			[ textClass ]: textClass,
-			'has-background': backgroundColor || customBackgroundColor,
-			[ backgroundClass ]: backgroundClass,
-		} );
-
-		const buttonStyle = {
-			backgroundColor: backgroundClass ? undefined : customBackgroundColor,
-			color: textClass ? undefined : customTextColor,
-		};
-
-		return (
-			<div>
-				<RichText.Content
-					tagName="a"
-					className={ buttonClasses }
-					href={ url }
-					title={ title }
-					style={ buttonStyle }
-					value={ text }
-				/>
-			</div>
-		);
-	},
-
+	save,
 	deprecated: [ {
 		attributes: {
 			...pick( blockAttributes, [ 'url', 'title', 'text' ] ),

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	RichText,
+	getColorClassName,
+} from '@wordpress/block-editor';
+
+export default function save( { attributes } ) {
+	const {
+		url,
+		text,
+		title,
+		backgroundColor,
+		textColor,
+		customBackgroundColor,
+		customTextColor,
+	} = attributes;
+
+	const textClass = getColorClassName( 'color', textColor );
+	const backgroundClass = getColorClassName( 'background-color', backgroundColor );
+
+	const buttonClasses = classnames( 'wp-block-button__link', {
+		'has-text-color': textColor || customTextColor,
+		[ textClass ]: textClass,
+		'has-background': backgroundColor || customBackgroundColor,
+		[ backgroundClass ]: backgroundClass,
+	} );
+
+	const buttonStyle = {
+		backgroundColor: backgroundClass ? undefined : customBackgroundColor,
+		color: textClass ? undefined : customTextColor,
+	};
+
+	return (
+		<div>
+			<RichText.Content
+				tagName="a"
+				className={ buttonClasses }
+				href={ url }
+				title={ title }
+				style={ buttonStyle }
+				value={ text }
+			/>
+		</div>
+	);
+}

--- a/packages/block-library/src/calendar/index.js
+++ b/packages/block-library/src/calendar/index.js
@@ -12,18 +12,12 @@ export const name = 'core/calendar';
 
 export const settings = {
 	title: __( 'Calendar' ),
-
 	description: __( 'A calendar of your site’s posts.' ),
-
 	icon: 'calendar',
-
 	category: 'widgets',
-
 	keywords: [ __( 'posts' ), __( 'archive' ) ],
-
 	supports: {
 		align: true,
 	},
-
 	edit,
 };

--- a/packages/block-library/src/categories/index.js
+++ b/packages/block-library/src/categories/index.js
@@ -13,17 +13,12 @@ export const name = 'core/categories';
 
 export const settings = {
 	title: __( 'Categories' ),
-
 	description: __( 'Display a list of all categories.' ),
-
 	icon,
-
 	category: 'widgets',
-
 	supports: {
 		align: true,
 		html: false,
 	},
-
 	edit,
 };

--- a/packages/block-library/src/classic/index.js
+++ b/packages/block-library/src/classic/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { RawHTML } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 
 /**
@@ -10,6 +9,7 @@ import { __, _x } from '@wordpress/i18n';
 import edit from './edit';
 import icon from './icon';
 import metadata from './block.json';
+import save from './save';
 
 const { name } = metadata;
 
@@ -17,11 +17,8 @@ export { metadata, name };
 
 export const settings = {
 	title: _x( 'Classic', 'block title' ),
-
 	description: __( 'Use the classic WordPress editor.' ),
-
 	icon,
-
 	supports: {
 		className: false,
 		customClassName: false,
@@ -29,12 +26,6 @@ export const settings = {
 		// confusing UX, because of its similarity to the 'Convert to Blocks' button.
 		reusable: false,
 	},
-
 	edit,
-
-	save( { attributes } ) {
-		const { content } = attributes;
-
-		return <RawHTML>{ content }</RawHTML>;
-	},
+	save,
 };

--- a/packages/block-library/src/classic/save.js
+++ b/packages/block-library/src/classic/save.js
@@ -1,0 +1,10 @@
+/**
+ * WordPress dependencies
+ */
+import { RawHTML } from '@wordpress/element';
+
+export default function save( { attributes } ) {
+	const { content } = attributes;
+
+	return <RawHTML>{ content }</RawHTML>;
+}

--- a/packages/block-library/src/code/index.js
+++ b/packages/block-library/src/code/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -10,6 +9,8 @@ import { createBlock } from '@wordpress/blocks';
 import edit from './edit';
 import icon from './icon';
 import metadata from './block.json';
+import save from './save';
+import transforms from './transforms';
 
 const { name } = metadata;
 
@@ -17,47 +18,12 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Code' ),
-
 	description: __( 'Display code snippets that respect your spacing and tabs.' ),
-
 	icon,
-
 	supports: {
 		html: false,
 	},
-
-	transforms: {
-		from: [
-			{
-				type: 'enter',
-				regExp: /^```$/,
-				transform: () => createBlock( 'core/code' ),
-			},
-			{
-				type: 'raw',
-				isMatch: ( node ) => (
-					node.nodeName === 'PRE' &&
-					node.children.length === 1 &&
-					node.firstChild.nodeName === 'CODE'
-				),
-				schema: {
-					pre: {
-						children: {
-							code: {
-								children: {
-									'#text': {},
-								},
-							},
-						},
-					},
-				},
-			},
-		],
-	},
-
+	transforms,
 	edit,
-
-	save( { attributes } ) {
-		return <pre><code>{ attributes.content }</code></pre>;
-	},
+	save,
 };

--- a/packages/block-library/src/code/save.js
+++ b/packages/block-library/src/code/save.js
@@ -1,0 +1,3 @@
+export default function save( { attributes } ) {
+	return <pre><code>{ attributes.content }</code></pre>;
+}

--- a/packages/block-library/src/code/transforms.js
+++ b/packages/block-library/src/code/transforms.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+const transforms = {
+	from: [
+		{
+			type: 'enter',
+			regExp: /^```$/,
+			transform: () => createBlock( 'core/code' ),
+		},
+		{
+			type: 'raw',
+			isMatch: ( node ) => (
+				node.nodeName === 'PRE' &&
+				node.children.length === 1 &&
+				node.firstChild.nodeName === 'CODE'
+			),
+			schema: {
+				pre: {
+					children: {
+						code: {
+							children: {
+								'#text': {},
+							},
+						},
+					},
+				},
+			},
+		},
+	],
+};
+
+export default transforms;

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks, BlockControls, BlockVerticalAlignmentToolbar } from '@wordpress/block-editor';
+import { withDispatch, withSelect } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+
+const ColumnEdit = ( { attributes, updateAlignment } ) => {
+	const { verticalAlignment } = attributes;
+
+	const classes = classnames( 'block-core-columns', {
+		[ `is-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
+	} );
+
+	const onChange = ( alignment ) => updateAlignment( alignment );
+
+	return (
+		<div className={ classes }>
+			<BlockControls>
+				<BlockVerticalAlignmentToolbar
+					onChange={ onChange }
+					value={ verticalAlignment }
+				/>
+			</BlockControls>
+			<InnerBlocks templateLock={ false } />
+		</div>
+	);
+};
+
+export default compose(
+	withSelect( ( select, { clientId } ) => {
+		const { getBlockRootClientId } = select( 'core/editor' );
+
+		return {
+			parentColumsBlockClientId: getBlockRootClientId( clientId ),
+		};
+	} ),
+	withDispatch( ( dispatch, { clientId, parentColumsBlockClientId } ) => {
+		return {
+			updateAlignment( alignment ) {
+				// Update self...
+				dispatch( 'core/editor' ).updateBlockAttributes( clientId, {
+					verticalAlignment: alignment,
+				} );
+
+				// Reset Parent Columns Block
+				dispatch( 'core/editor' ).updateBlockAttributes( parentColumsBlockClientId, {
+					verticalAlignment: null,
+				} );
+			},
+		};
+	} )
+)( ColumnEdit );

--- a/packages/block-library/src/column/icon.js
+++ b/packages/block-library/src/column/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+export default (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path fill="none" d="M0 0h24v24H0V0z" /><Path d="M11.99 18.54l-7.37-5.73L3 14.07l9 7 9-7-1.63-1.27zM12 16l7.36-5.73L21 9l-9-7-9 7 1.63 1.27L12 16zm0-11.47L17.74 9 12 13.47 6.26 9 12 4.53z" /></SVG>
+);

--- a/packages/block-library/src/column/index.js
+++ b/packages/block-library/src/column/index.js
@@ -1,101 +1,31 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
-import { Path, SVG } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { InnerBlocks, BlockControls, BlockVerticalAlignmentToolbar } from '@wordpress/block-editor';
-import { withDispatch, withSelect } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
+import edit from './edit';
+import icon from './icon';
 import metadata from './block.json';
+import save from './save';
 
 const { name } = metadata;
 
 export { metadata, name };
 
-const ColumnEdit = ( { attributes, updateAlignment } ) => {
-	const { verticalAlignment } = attributes;
-
-	const classes = classnames( 'block-core-columns', {
-		[ `is-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
-	} );
-
-	const onChange = ( alignment ) => updateAlignment( alignment );
-
-	return (
-		<div className={ classes }>
-			<BlockControls>
-				<BlockVerticalAlignmentToolbar
-					onChange={ onChange }
-					value={ verticalAlignment }
-				/>
-			</BlockControls>
-			<InnerBlocks templateLock={ false } />
-		</div>
-	);
-};
-
-const edit = compose(
-	withSelect( ( select, { clientId } ) => {
-		const { getBlockRootClientId } = select( 'core/editor' );
-
-		return {
-			parentColumsBlockClientId: getBlockRootClientId( clientId ),
-		};
-	} ),
-	withDispatch( ( dispatch, { clientId, parentColumsBlockClientId } ) => {
-		return {
-			updateAlignment( alignment ) {
-				// Update self...
-				dispatch( 'core/editor' ).updateBlockAttributes( clientId, {
-					verticalAlignment: alignment,
-				} );
-
-				// Reset Parent Columns Block
-				dispatch( 'core/editor' ).updateBlockAttributes( parentColumsBlockClientId, {
-					verticalAlignment: null,
-				} );
-			},
-		};
-	} )
-)( ColumnEdit );
-
 export const settings = {
 	title: __( 'Column' ),
-
 	parent: [ 'core/columns' ],
-
-	icon: <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path fill="none" d="M0 0h24v24H0V0z" /><Path d="M11.99 18.54l-7.37-5.73L3 14.07l9 7 9-7-1.63-1.27zM12 16l7.36-5.73L21 9l-9-7-9 7 1.63 1.27L12 16zm0-11.47L17.74 9 12 13.47 6.26 9 12 4.53z" /></SVG>,
-
+	icon,
 	description: __( 'A single column within a columns block.' ),
-
 	supports: {
 		inserter: false,
 		reusable: false,
 		html: false,
 	},
-
 	edit,
-
-	save( { attributes } ) {
-		const { verticalAlignment } = attributes;
-		const wrapperClasses = classnames( {
-			[ `is-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
-		} );
-
-		return (
-			<div className={ wrapperClasses }>
-				<InnerBlocks.Content />
-			</div>
-		);
-	},
+	save,
 };
 

--- a/packages/block-library/src/column/save.js
+++ b/packages/block-library/src/column/save.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+
+export default function save( { attributes } ) {
+	const { verticalAlignment } = attributes;
+	const wrapperClasses = classnames( {
+		[ `is-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
+	} );
+
+	return (
+		<div className={ wrapperClasses }>
+			<InnerBlocks.Content />
+		</div>
+	);
+}

--- a/packages/block-library/src/columns/index.js
+++ b/packages/block-library/src/columns/index.js
@@ -1,16 +1,7 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-
-import {
-	InnerBlocks,
-} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -19,6 +10,7 @@ import deprecated from './deprecated';
 import edit from './edit';
 import icon from './icon';
 import metadata from './block.json';
+import save from './save';
 
 const { name } = metadata;
 
@@ -26,32 +18,14 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Columns' ),
-
 	icon,
-
 	description: __( 'Add a block that displays content in multiple columns, then add whatever content blocks you’d like.' ),
-
 	supports: {
 		align: [ 'wide', 'full' ],
 		html: false,
 	},
-
 	deprecated,
-
 	edit,
-
-	save( { attributes } ) {
-		const { columns, verticalAlignment } = attributes;
-
-		const wrapperClasses = classnames( `has-${ columns }-columns`, {
-			[ `are-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
-		} );
-
-		return (
-			<div className={ wrapperClasses }>
-				<InnerBlocks.Content />
-			</div>
-		);
-	},
+	save,
 };
 

--- a/packages/block-library/src/columns/save.js
+++ b/packages/block-library/src/columns/save.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+
+export default function save( { attributes } ) {
+	const { columns, verticalAlignment } = attributes;
+
+	const wrapperClasses = classnames( `has-${ columns }-columns`, {
+		[ `are-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
+	} );
+
+	return (
+		<div className={ wrapperClasses }>
+			<InnerBlocks.Content />
+		</div>
+	);
+}

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -36,12 +36,16 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import icon from './icon';
+import {
+	IMAGE_BACKGROUND_TYPE,
+	VIDEO_BACKGROUND_TYPE,
+	backgroundImageStyles,
+	dimRatioToClass,
+} from './shared';
 
 /**
  * Module Constants
  */
-export const IMAGE_BACKGROUND_TYPE = 'image';
-export const VIDEO_BACKGROUND_TYPE = 'video';
 const ALLOWED_MEDIA_TYPES = [ 'image', 'video' ];
 const INNER_BLOCKS_TEMPLATE = [
 	[ 'core/paragraph', {
@@ -57,18 +61,6 @@ function retrieveFastAverageColor() {
 		retrieveFastAverageColor.fastAverageColor = new FastAverageColor();
 	}
 	return retrieveFastAverageColor.fastAverageColor;
-}
-
-export function backgroundImageStyles( url ) {
-	return url ?
-		{ backgroundImage: `url(${ url })` } :
-		{};
-}
-
-export function dimRatioToClass( ratio ) {
-	return ( ratio === 0 || ratio === 50 ) ?
-		null :
-		'has-background-dim-' + ( 10 * Math.round( ratio / 10 ) );
 }
 
 class CoverEdit extends Component {

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -9,7 +9,6 @@ import classnames from 'classnames';
  */
 import { createBlock } from '@wordpress/blocks';
 import {
-	InnerBlocks,
 	RichText,
 	getColorClassName,
 } from '@wordpress/block-editor';
@@ -18,15 +17,17 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import edit from './edit';
 import icon from './icon';
+import metadata from './block.json';
+import save from './save';
+import transforms from './transforms';
 import {
-	default as CoverEdit,
 	IMAGE_BACKGROUND_TYPE,
 	VIDEO_BACKGROUND_TYPE,
 	backgroundImageStyles,
 	dimRatioToClass,
-} from './edit';
-import metadata from './block.json';
+} from './shared';
 
 const { name, attributes: blockAttributes } = metadata;
 
@@ -34,124 +35,14 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Cover' ),
-
 	description: __( 'Add an image or video with a text overlay — great for headers.' ),
-
 	icon,
-
 	supports: {
 		align: true,
 	},
-
-	transforms: {
-		from: [
-			{
-				type: 'block',
-				blocks: [ 'core/image' ],
-				transform: ( { caption, url, align, id } ) => (
-					createBlock( 'core/cover', {
-						title: caption,
-						url,
-						align,
-						id,
-					} )
-				),
-			},
-			{
-				type: 'block',
-				blocks: [ 'core/video' ],
-				transform: ( { caption, src, align, id } ) => (
-					createBlock( 'core/cover', {
-						title: caption,
-						url: src,
-						align,
-						id,
-						backgroundType: VIDEO_BACKGROUND_TYPE,
-					} )
-				),
-			},
-		],
-		to: [
-			{
-				type: 'block',
-				blocks: [ 'core/image' ],
-				isMatch: ( { backgroundType, url } ) => {
-					return ! url || backgroundType === IMAGE_BACKGROUND_TYPE;
-				},
-				transform: ( { title, url, align, id } ) => (
-					createBlock( 'core/image', {
-						caption: title,
-						url,
-						align,
-						id,
-					} )
-				),
-			},
-			{
-				type: 'block',
-				blocks: [ 'core/video' ],
-				isMatch: ( { backgroundType, url } ) => {
-					return ! url || backgroundType === VIDEO_BACKGROUND_TYPE;
-				},
-				transform: ( { title, url, align, id } ) => (
-					createBlock( 'core/video', {
-						caption: title,
-						src: url,
-						id,
-						align,
-					} )
-				),
-			},
-		],
-	},
-
-	save( { attributes } ) {
-		const {
-			backgroundType,
-			customOverlayColor,
-			dimRatio,
-			focalPoint,
-			hasParallax,
-			overlayColor,
-			url,
-		} = attributes;
-		const overlayColorClass = getColorClassName( 'background-color', overlayColor );
-		const style = backgroundType === IMAGE_BACKGROUND_TYPE ?
-			backgroundImageStyles( url ) :
-			{};
-		if ( ! overlayColorClass ) {
-			style.backgroundColor = customOverlayColor;
-		}
-		if ( focalPoint && ! hasParallax ) {
-			style.backgroundPosition = `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`;
-		}
-
-		const classes = classnames(
-			dimRatioToClass( dimRatio ),
-			overlayColorClass,
-			{
-				'has-background-dim': dimRatio !== 0,
-				'has-parallax': hasParallax,
-			},
-		);
-
-		return (
-			<div className={ classes } style={ style }>
-				{ VIDEO_BACKGROUND_TYPE === backgroundType && url && ( <video
-					className="wp-block-cover__video-background"
-					autoPlay
-					muted
-					loop
-					src={ url }
-				/> ) }
-				<div className="wp-block-cover__inner-container">
-					<InnerBlocks.Content />
-				</div>
-			</div>
-		);
-	},
-
-	edit: CoverEdit,
+	transforms,
+	save,
+	edit,
 	deprecated: [ {
 		attributes: {
 			...blockAttributes,

--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	InnerBlocks,
+	getColorClassName,
+} from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import {
+	IMAGE_BACKGROUND_TYPE,
+	VIDEO_BACKGROUND_TYPE,
+	backgroundImageStyles,
+	dimRatioToClass,
+} from './shared';
+
+export default function save( { attributes } ) {
+	const {
+		backgroundType,
+		customOverlayColor,
+		dimRatio,
+		focalPoint,
+		hasParallax,
+		overlayColor,
+		url,
+	} = attributes;
+	const overlayColorClass = getColorClassName( 'background-color', overlayColor );
+	const style = backgroundType === IMAGE_BACKGROUND_TYPE ?
+		backgroundImageStyles( url ) :
+		{};
+	if ( ! overlayColorClass ) {
+		style.backgroundColor = customOverlayColor;
+	}
+	if ( focalPoint && ! hasParallax ) {
+		style.backgroundPosition = `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`;
+	}
+
+	const classes = classnames(
+		dimRatioToClass( dimRatio ),
+		overlayColorClass,
+		{
+			'has-background-dim': dimRatio !== 0,
+			'has-parallax': hasParallax,
+		},
+	);
+
+	return (
+		<div className={ classes } style={ style }>
+			{ VIDEO_BACKGROUND_TYPE === backgroundType && url && ( <video
+				className="wp-block-cover__video-background"
+				autoPlay
+				muted
+				loop
+				src={ url }
+			/> ) }
+			<div className="wp-block-cover__inner-container">
+				<InnerBlocks.Content />
+			</div>
+		</div>
+	);
+}

--- a/packages/block-library/src/cover/shared.js
+++ b/packages/block-library/src/cover/shared.js
@@ -1,0 +1,14 @@
+export const IMAGE_BACKGROUND_TYPE = 'image';
+export const VIDEO_BACKGROUND_TYPE = 'video';
+
+export function backgroundImageStyles( url ) {
+	return url ?
+		{ backgroundImage: `url(${ url })` } :
+		{};
+}
+
+export function dimRatioToClass( ratio ) {
+	return ( ratio === 0 || ratio === 50 ) ?
+		null :
+		'has-background-dim-' + ( 10 * Math.round( ratio / 10 ) );
+}

--- a/packages/block-library/src/cover/transforms.js
+++ b/packages/block-library/src/cover/transforms.js
@@ -1,0 +1,73 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { IMAGE_BACKGROUND_TYPE, VIDEO_BACKGROUND_TYPE } from './shared';
+
+const transforms = {
+	from: [
+		{
+			type: 'block',
+			blocks: [ 'core/image' ],
+			transform: ( { caption, url, align, id } ) => (
+				createBlock( 'core/cover', {
+					title: caption,
+					url,
+					align,
+					id,
+				} )
+			),
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/video' ],
+			transform: ( { caption, src, align, id } ) => (
+				createBlock( 'core/cover', {
+					title: caption,
+					url: src,
+					align,
+					id,
+					backgroundType: VIDEO_BACKGROUND_TYPE,
+				} )
+			),
+		},
+	],
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/image' ],
+			isMatch: ( { backgroundType, url } ) => {
+				return ! url || backgroundType === IMAGE_BACKGROUND_TYPE;
+			},
+			transform: ( { title, url, align, id } ) => (
+				createBlock( 'core/image', {
+					caption: title,
+					url,
+					align,
+					id,
+				} )
+			),
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/video' ],
+			isMatch: ( { backgroundType, url } ) => {
+				return ! url || backgroundType === VIDEO_BACKGROUND_TYPE;
+			},
+			transform: ( { title, url, align, id } ) => (
+				createBlock( 'core/video', {
+					caption: title,
+					src: url,
+					id,
+					align,
+				} )
+			),
+		},
+	],
+};
+
+export default transforms;


### PR DESCRIPTION
## Description
Part of aligning block library to Block Registration API RFC #13693.

It's all about moving `save` and `transforms` to their own file to follow the proposal drafted in RFC. There might be some additional fields moved to their own files if I noticed that they were missed or introduced recently.

Updated blocks:
- Archives
- Audio
- Block
- Button
- Calendar
- Categories
- Classic
- Code
- Column
- Columns
- Cover

## How has this been tested?

`npm test`
`npm run test-e2e`

Manually tested whether all blocks load as before.