### PR TITLE
[Mobile] Accessibility mark III

### DIFF
--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -90,11 +90,11 @@ class HeadingEdit extends Component {
 
 		const tagName = 'h' + level;
 
-		let accessibilityLabel = __( "Heading block" );
+		let accessibilityLabel = __( 'Heading block' );
 		if ( ! content ) {
-			accessibilityLabel += ". " + __( "Empty" );
+			accessibilityLabel += '. ' + __( 'Empty' );
 		} else {
-			accessibilityLabel += ". " + content;
+			accessibilityLabel += '. ' + content;
 		}
 
 		return (

--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -79,6 +79,7 @@ class HeadingEdit extends Component {
 			setAttributes,
 			mergeBlocks,
 			style,
+			isSelected,
 		} = this.props;
 
 		const {
@@ -89,8 +90,19 @@ class HeadingEdit extends Component {
 
 		const tagName = 'h' + level;
 
+		let accessibilityLabel = __( "Heading block" );
+		if ( ! content ) {
+			accessibilityLabel += ". " + __( "Empty" );
+		} else {
+			accessibilityLabel += ". " + content;
+		}
+
 		return (
-			<View>
+			<View
+				accessible={ ! isSelected }
+				accessibilityLabel={ accessibilityLabel }
+				onAccessibilityTap={ this.props.onFocus }
+			>
 				<BlockControls>
 					<HeadingToolbar minLevel={ 2 } maxLevel={ 5 } selectedLevel={ level } onChange={ ( newLevel ) => setAttributes( { level: newLevel } ) } />
 				</BlockControls>

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -110,7 +110,6 @@ export const registerCoreBlocks = () => {
 		more,
 		image,
 		nextpage,
-		list,
 	].forEach( ( { name, settings } ) => {
 		registerBlockType( name, settings );
 	} );

--- a/packages/block-library/src/missing/edit.native.js
+++ b/packages/block-library/src/missing/edit.native.js
@@ -23,9 +23,14 @@ export default class UnsupportedBlockEdit extends Component {
 		const blockType = coreBlocks[ originalName ];
 		const title = blockType ? blockType.settings.title : __( 'Unsupported' );
 		const icon = blockType ? normalizeIconObject( blockType.settings.icon ) : 'admin-plugins';
-
+		const accessibilityTitle = blockType ? blockType.settings.title : __( 'Unknown' );
 		return (
-			<View style={ styles.unsupportedBlock }>
+			<View
+				accessible
+				accessibilityLabel={ __( "Block not supported" ) + ". " + accessibilityTitle }
+				accessibilityStates={ this.props.isSelected && [ "selected" ] }
+				style={ styles.unsupportedBlock }
+			>
 				<Icon className="unsupported-icon" icon={ icon && icon.src ? icon.src : icon } />
 				<Text style={ styles.unsupportedBlockMessage }>{ title }</Text>
 			</View>

--- a/packages/block-library/src/missing/edit.native.js
+++ b/packages/block-library/src/missing/edit.native.js
@@ -24,11 +24,12 @@ export default class UnsupportedBlockEdit extends Component {
 		const title = blockType ? blockType.settings.title : __( 'Unsupported' );
 		const icon = blockType ? normalizeIconObject( blockType.settings.icon ) : 'admin-plugins';
 		const accessibilityTitle = blockType ? blockType.settings.title : __( 'Unknown' );
+		const accessibilityState = this.props.isSelected ? [ 'selected' ] : [];
 		return (
 			<View
 				accessible
 				accessibilityLabel={ __( 'Block not supported' ) + '. ' + accessibilityTitle }
-				accessibilityStates={ this.props.isSelected && [ 'selected' ] }
+				accessibilityStates={ accessibilityState }
 				style={ styles.unsupportedBlock }
 			>
 				<Icon className="unsupported-icon" icon={ icon && icon.src ? icon.src : icon } />

--- a/packages/block-library/src/missing/edit.native.js
+++ b/packages/block-library/src/missing/edit.native.js
@@ -27,8 +27,8 @@ export default class UnsupportedBlockEdit extends Component {
 		return (
 			<View
 				accessible
-				accessibilityLabel={ __( "Block not supported" ) + ". " + accessibilityTitle }
-				accessibilityStates={ this.props.isSelected && [ "selected" ] }
+				accessibilityLabel={ __( 'Block not supported' ) + '. ' + accessibilityTitle }
+				accessibilityStates={ this.props.isSelected && [ 'selected' ] }
 				style={ styles.unsupportedBlock }
 			>
 				<Icon className="unsupported-icon" icon={ icon && icon.src ? icon.src : icon } />

--- a/packages/block-library/src/nextpage/edit.native.js
+++ b/packages/block-library/src/nextpage/edit.native.js
@@ -17,12 +17,6 @@ import styles from './editor.scss';
 export default function NextPageEdit( { attributes, isSelected, onFocus } ) {
 	const { customText = __( 'Page break' ) } = attributes;
 	const accessibilityTitle = attributes.customText || '';
-	// Setting the font here to keep the CSS linter happy, it was demanding a syntax
-	// that React Native wasn't able to handle (adding a fallback generic font family).
-	const textStyle = {
-		...styles[ 'block-library-nextpage__text' ],
-		fontFamily: 'System',
-	};
 
 	return (
 		<View
@@ -30,10 +24,9 @@ export default function NextPageEdit( { attributes, isSelected, onFocus } ) {
 			accessibilityLabel={ __( 'Page break block' ) + '. ' + accessibilityTitle }
 			accessibilityStates={ isSelected && [ 'selected' ] }
 			onAccessibilityTap={ onFocus }
-			style={ styles[ 'block-library-nextpage__container' ] }
 		>
 			<Hr text={ customText }
-				textStyle={ textStyle }
+				textStyle={ styles[ 'block-library-nextpage__text' ] }
 				lineStyle={ styles[ 'block-library-nextpage__line' ] } />
 		</View>
 	);

--- a/packages/block-library/src/nextpage/edit.native.js
+++ b/packages/block-library/src/nextpage/edit.native.js
@@ -17,12 +17,13 @@ import styles from './editor.scss';
 export default function NextPageEdit( { attributes, isSelected, onFocus } ) {
 	const { customText = __( 'Page break' ) } = attributes;
 	const accessibilityTitle = attributes.customText || '';
+	const accessibilityState = isSelected ? [ 'selected' ] : [];
 
 	return (
 		<View
 			accessible
 			accessibilityLabel={ __( 'Page break block' ) + '. ' + accessibilityTitle }
-			accessibilityStates={ isSelected && [ 'selected' ] }
+			accessibilityStates={ accessibilityState }
 			onAccessibilityTap={ onFocus }
 		>
 			<Hr text={ customText }

--- a/packages/block-library/src/nextpage/edit.native.js
+++ b/packages/block-library/src/nextpage/edit.native.js
@@ -16,12 +16,12 @@ import styles from './editor.scss';
 
 export default function NextPageEdit( { attributes, isSelected, onFocus } ) {
 	const { customText = __( 'Page break' ) } = attributes;
-	const accessibilityTitle = attributes.customText || "";
+	const accessibilityTitle = attributes.customText || '';
 	return (
-		<View 
+		<View
 			accessible
-			accessibilityLabel={ __( 'Page break block' ) + ". " + accessibilityTitle }
-			accessibilityStates={ isSelected && [ "selected" ] }
+			accessibilityLabel={ __( 'Page break block' ) + '. ' + accessibilityTitle }
+			accessibilityStates={ isSelected && [ 'selected' ] }
 			onAccessibilityTap={ onFocus }
 			style={ styles[ 'block-library-nextpage__container' ] }
 		>

--- a/packages/block-library/src/nextpage/edit.native.js
+++ b/packages/block-library/src/nextpage/edit.native.js
@@ -14,11 +14,17 @@ import { __ } from '@wordpress/i18n';
  */
 import styles from './editor.scss';
 
-export default function NextPageEdit( { attributes } ) {
+export default function NextPageEdit( { attributes, isSelected, onFocus } ) {
 	const { customText = __( 'Page break' ) } = attributes;
-
+	const accessibilityTitle = attributes.customText || "";
 	return (
-		<View style={ styles[ 'block-library-nextpage__container' ] }>
+		<View 
+			accessible
+			accessibilityLabel={ __( 'Page break block' ) + ". " + accessibilityTitle }
+			accessibilityStates={ isSelected && [ "selected" ] }
+			onAccessibilityTap={ onFocus }
+			style={ styles[ 'block-library-nextpage__container' ] }
+		>
 			<Hr text={ customText }
 				textStyle={ styles[ 'block-library-nextpage__text' ] }
 				lineStyle={ styles[ 'block-library-nextpage__line' ] } />

--- a/packages/block-library/src/nextpage/editor.native.scss
+++ b/packages/block-library/src/nextpage/editor.native.scss
@@ -7,6 +7,7 @@
 
 .block-library-nextpage__text {
 	color: $gray;
+	font-family: $default-regular-font;
 	text-decoration-style: solid;
 	text-transform: uppercase;
 }

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -96,11 +96,11 @@ class ParagraphEdit extends Component {
 		} = attributes;
 
 
-		let accessibilityLabel = __( "Paragraph block." );
+		let accessibilityLabel = __( "Paragraph block" );
 		if ( ! content ) {
-			accessibilityLabel += " " + __( "Empty" );
+			accessibilityLabel += ". " + __( "Empty" );
 		} else {
-			accessibilityLabel += " " + content;
+			accessibilityLabel += ". " + content;
 		}
 
 		return (

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { createBlock } from '@wordpress/blocks';
 import { RichText } from '@wordpress/block-editor';
+import { create } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -81,6 +82,10 @@ class ParagraphEdit extends Component {
 		) ) );
 	}
 
+	removeHtmlTags( html ) {
+		return create( { html } ).text;
+	}
+
 	render() {
 		const {
 			attributes,
@@ -95,12 +100,11 @@ class ParagraphEdit extends Component {
 			content,
 		} = attributes;
 
-
 		let accessibilityLabel = __( "Paragraph block" );
 		if ( ! content ) {
 			accessibilityLabel += ". " + __( "Empty" );
 		} else {
-			accessibilityLabel += ". " + content;
+			accessibilityLabel += ". " + this.removeHtmlTags( content );
 		}
 
 		return (

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -100,11 +100,11 @@ class ParagraphEdit extends Component {
 			content,
 		} = attributes;
 
-		let accessibilityLabel = __( "Paragraph block" );
+		let accessibilityLabel = __( 'Paragraph block' );
 		if ( ! content ) {
-			accessibilityLabel += ". " + __( "Empty" );
+			accessibilityLabel += '. ' + __( 'Empty' );
 		} else {
-			accessibilityLabel += ". " + this.removeHtmlTags( content );
+			accessibilityLabel += '. ' + this.removeHtmlTags( content );
 		}
 
 		return (

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -87,6 +87,7 @@ class ParagraphEdit extends Component {
 			setAttributes,
 			mergeBlocks,
 			style,
+			isSelected,
 		} = this.props;
 
 		const {
@@ -94,8 +95,20 @@ class ParagraphEdit extends Component {
 			content,
 		} = attributes;
 
+
+		let accessibilityLabel = __( "Paragraph block." );
+		if ( ! content ) {
+			accessibilityLabel += " " + __( "Empty" );
+		} else {
+			accessibilityLabel += " " + content;
+		}
+
 		return (
-			<View>
+			<View
+				accessible={ ! isSelected }
+				accessibilityLabel={ accessibilityLabel }
+				onAccessibilityTap={ this.props.onFocus }
+			>
 				<RichText
 					tagName="p"
 					value={ content }


### PR DESCRIPTION
This PR improves support for Screen readers on the following blocks:

- Paragraph
- heading
- Missing (Unsupported)
- NextPage (Page Break)

**Note:**
There was a problem after the last merge from master, where the example content wasn't scrolling with VoiceOver ON. This started happening after the merge of this PR: https://github.com/WordPress/gutenberg/pull/14826. In particular because of the deletion of `font-family: $default-regular-font;`, so I rolled back that change.

**Note 2:**
A similar problem happens when there are just paragraph blocks. The block list becomes un-scrollable by VoiceOver. This issue seems to have been there for sometime now, so I decided to 