### PR TITLE
Wrapped anchor tag around the image and caption for gallery block

### DIFF
--- a/packages/block-library/src/gallery/index.js
+++ b/packages/block-library/src/gallery/index.js
@@ -207,16 +207,18 @@ export const settings = {
 							break;
 					}
 
-					const img = <img src={ image.url } alt={ image.alt } data-id={ image.id } data-link={ image.link } className={ image.id ? `wp-image-${ image.id }` : null } />;
+					const figure = (
+						<figure>
+							<img src={ image.url } alt={ image.alt } data-id={ image.id } data-link={ image.link } className={ image.id ? `wp-image-${ image.id }` : null } />
+							{ ( image.caption && image.caption.length > 0 ) ? (
+								<RichText.Content tagName="figcaption" value={ image.caption } />
+							) : null }
+						</figure>
+					);
 
 					return (
 						<li key={ image.id || image.url } className="blocks-gallery-item">
-							<figure>
-								{ href ? <a href={ href }>{ img }</a> : img }
-								{ image.caption && image.caption.length > 0 && (
-									<RichText.Content tagName="figcaption" value={ image.caption } />
-								) }
-							</figure>
+							{ href ? <a href={ href }>{ figure }</a> : figure }
 						</li>
 					);
 				} ) }


### PR DESCRIPTION
## Description
Fixes #14304. In the saved version of the post the anchor tag is now wrapped around the whole figure and not just the image. This is done only in the saved post to maintain interaction with the caption editor in the edit mode.

## How has this been tested?
- Passed all unit test cases using `npm test`
- Manually tested by clicking on the gallery image with and without the `Link To` property being set. When `Link To` is not `None` the entire image can be clicked. When it is set to `None`, clicking the image does nothing.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
