### PR TITLE
[Mobile] Fix caret position after inline paste.

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -423,7 +423,7 @@ export class RichText extends Component {
 			this.lastEventCount = undefined;
 			this.lastContent = newContent;
 
-			// explicitly set selection after inline paste
+			// explicitly set selection after inline paste - wake up Travis
 			( ( { start, end } ) => this.setState( { start, end,
 				needsSelectionUpdate: true } ) )( insertedContent );
 

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -422,6 +422,11 @@ export class RichText extends Component {
 			const newContent = this.valueToFormat( insertedContent );
 			this.lastEventCount = undefined;
 			this.lastContent = newContent;
+
+			// explicitly set selection after inline paste
+			( ( { start, end } ) => this.setState( { start, end,
+				needsSelectionUpdate: true } ) )( insertedContent );
+
 			this.props.onChange( this.lastContent );
 		} else if ( onSplit ) {
 			if ( ! pastedContent.length ) {

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -423,7 +423,7 @@ export class RichText extends Component {
 			this.lastEventCount = undefined;
 			this.lastContent = newContent;
 
-			// explicitly set selection after inline paste - wake up Travis
+			// explicitly set selection after inline paste
 			( ( { start, end } ) => this.setState( { start, end,
 				needsSelectionUpdate: true } ) )( insertedContent );
 


### PR DESCRIPTION
## Description
This PR fixes _part_ of this issue: https://github.com/wordpress-mobile/gutenberg-mobile/issues/828 , specifically, when inline content is pasted.

## How has this been tested?
This has been tested using the steps here:
https://github.com/wordpress-mobile/gutenberg-mobile/issues/828#issuecomment-481546078

## Screenshots <!-- if applicable -->
<img src="https://user-images.githubusercontent.com/8507675/55856919-174f7b00-5baf-11e9-9c1d-48d80813a0f8.gif" width="360">

## Types of changes
This is a bug fix, but currently only resolves a _part_ of the original issue. I'm leaving this as a draft PR to gather more information. It currently serves as an incremental improvement, but I'd like to have some consensus on whether it makes sense to wait for a full fix (for both inline and multi-line content) before merging.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
