### PR TITLE
Add publish step to preview with custom fields test

### DIFF
--- a/packages/e2e-tests/specs/preview.test.js
+++ b/packages/e2e-tests/specs/preview.test.js
@@ -218,6 +218,11 @@ describe( 'Preview with Custom Fields enabled', async () => {
 		await editorPage.keyboard.press( 'Tab' );
 		await editorPage.keyboard.type( 'content 1' );
 
+		// Publish the post and then close the publish panel.
+		await publishPost();
+		await page.waitForSelector( '.editor-post-publish-panel' );
+		await page.click( '.editor-post-publish-panel__header button' );
+
 		// Open the preview page.
 		const previewPage = await openPreviewPage( editorPage );
 


### PR DESCRIPTION
## Description
As mentioned here - https://github.com/WordPress/gutenberg/pull/14877#issuecomment-481266976 - the new preview end to end test I added should've included a publish step to properly reproduce #12617. This PR adds that publish step.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
