### PR TITLE
Reduce memory footprint of rich text values

### DIFF
--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -386,12 +386,25 @@ function createFromElement( {
 				} );
 			}
 		} else {
-			mergePair( accumulator, {
-				...value,
-				formats: Array.from( value.formats, ( formats ) =>
-					formats ? [ format, ...formats ] : [ format ]
-				),
-			} );
+			// Use same reference for equal vertical format list.
+			const newRef = [ format ];
+			const oldRefs = new Set;
+
+			let i = value.formats.length;
+
+			while ( i-- ) {
+				const formatsAtIndex = value.formats[ i ];
+
+				if ( formatsAtIndex ) {
+					oldRefs.add( formatsAtIndex );
+				} else {
+					value.formats[ i ] = newRef;
+				}
+			}
+
+			oldRefs.forEach( ( ref ) => ref.unshift( format ) );
+
+			mergePair( accumulator, value );
 		}
 	}
 

--- a/packages/rich-text/src/normalise-formats.js
+++ b/packages/rich-text/src/normalise-formats.js
@@ -13,28 +13,28 @@ import { isFormatEqual } from './is-format-equal';
  * @return {Object} New value with normalised formats.
  */
 export function normaliseFormats( value ) {
-	const newFormats = value.formats.slice();
-
-	newFormats.forEach( ( formatsAtIndex, index ) => {
-		const formatsAtPreviousIndex = newFormats[ index - 1 ];
-
-		if ( formatsAtPreviousIndex ) {
-			const newFormatsAtIndex = formatsAtIndex.slice();
-
-			newFormatsAtIndex.forEach( ( format, formatIndex ) => {
-				const previousFormat = formatsAtPreviousIndex[ formatIndex ];
-
-				if ( isFormatEqual( format, previousFormat ) ) {
-					newFormatsAtIndex[ formatIndex ] = previousFormat;
-				}
-			} );
-
-			newFormats[ index ] = newFormatsAtIndex;
-		}
-	} );
-
 	return {
 		...value,
-		formats: newFormats,
+		formats: value.formats.reduce( ( accumulator, charFormats, charIndex ) => {
+			const prevCharFormats = accumulator[ charIndex - 1 ];
+
+			// Only if there are formats at the previous character, the same
+			// reference can be used.
+			if ( prevCharFormats ) {
+				accumulator[ charIndex ] = charFormats.map( ( format, formatIndex ) => {
+					const ref = prevCharFormats[ formatIndex ];
+
+					if ( isFormatEqual( format, ref ) ) {
+						return ref;
+					}
+
+					return format;
+				} );
+			} else {
+				accumulator[ charIndex ] = charFormats;
+			}
+
+			return accumulator;
+		}, Array( value.formats.length ) ),
 	};
 }

--- a/packages/rich-text/src/normalise-formats.js
+++ b/packages/rich-text/src/normalise-formats.js
@@ -13,28 +13,39 @@ import { isFormatEqual } from './is-format-equal';
  * @return {Object} New value with normalised formats.
  */
 export function normaliseFormats( value ) {
+	const newFormats = value.formats.reduce( ( accumulator, charFormats, charIndex ) => {
+		const prevCharFormats = accumulator[ charIndex - 1 ];
+
+		// Only if there are formats at the previous character, the same
+		// reference can be used.
+		if ( prevCharFormats ) {
+			const newCharFormats = charFormats.map( ( format, formatIndex ) => {
+				const ref = prevCharFormats[ formatIndex ];
+
+				if ( isFormatEqual( format, ref ) ) {
+					return ref;
+				}
+
+				return format;
+			} );
+
+			if (
+				newCharFormats.length === prevCharFormats.length &&
+				newCharFormats.every( ( ref, index ) => ref === prevCharFormats[ index ] )
+			) {
+				accumulator[ charIndex ] = prevCharFormats;
+			} else {
+				accumulator[ charIndex ] = newCharFormats;
+			}
+		} else {
+			accumulator[ charIndex ] = charFormats;
+		}
+
+		return accumulator;
+	}, Array( value.formats.length ) );
+
 	return {
 		...value,
-		formats: value.formats.reduce( ( accumulator, charFormats, charIndex ) => {
-			const prevCharFormats = accumulator[ charIndex - 1 ];
-
-			// Only if there are formats at the previous character, the same
-			// reference can be used.
-			if ( prevCharFormats ) {
-				accumulator[ charIndex ] = charFormats.map( ( format, formatIndex ) => {
-					const ref = prevCharFormats[ formatIndex ];
-
-					if ( isFormatEqual( format, ref ) ) {
-						return ref;
-					}
-
-					return format;
-				} );
-			} else {
-				accumulator[ charIndex ] = charFormats;
-			}
-
-			return accumulator;
-		}, Array( value.formats.length ) ),
+		formats: newFormats,
 	};
 }

--- a/packages/rich-text/src/normalise-formats.js
+++ b/packages/rich-text/src/normalise-formats.js
@@ -19,6 +19,11 @@ export function normaliseFormats( value ) {
 		// Only if there are formats at the previous character, the same
 		// reference can be used.
 		if ( prevCharFormats ) {
+			// Early return if the format list was already normalised.
+			if ( prevCharFormats === charFormats ) {
+				return accumulator;
+			}
+
 			const newCharFormats = charFormats.map( ( format, formatIndex ) => {
 				const ref = prevCharFormats[ formatIndex ];
 


### PR DESCRIPTION
## Description

[Still needs unit tests.]

This change ensures that format arrays are reused for multiple characters in a row. We already reuse the format objects themselves, but not the array containing them, if the contents are the same.

Before:

```
1234 (references)
↑↑↑↑
  BB
AAAA
test
```

```
1122 (references)
↑↑↑↑
  BB
AAAA
test
```

It also makes `normaliseFormats` faster for already normalised values, because it can now use the array reference to check equality.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->