### PR TITLE
Refactor core blocks to have save and transforms in their own files (part 4)

### DIFF
--- a/packages/block-library/src/subhead/index.js
+++ b/packages/block-library/src/subhead/index.js
@@ -2,8 +2,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { createBlock } from '@wordpress/blocks';
-import { RichText } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -11,6 +9,8 @@ import { RichText } from '@wordpress/block-editor';
 import edit from './edit';
 import icon from './icon';
 import metadata from './block.json';
+import save from './save';
+import transforms from './tranforms';
 
 const { name } = metadata;
 
@@ -18,39 +18,14 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Subheading (deprecated)' ),
-
 	description: __( 'This block is deprecated. Please use the Paragraph block instead.' ),
-
 	icon,
-
 	supports: {
 		// Hide from inserter as this block is deprecated.
 		inserter: false,
 		multiple: false,
 	},
-
-	transforms: {
-		to: [
-			{
-				type: 'block',
-				blocks: [ 'core/paragraph' ],
-				transform: ( attributes ) =>
-					createBlock( 'core/paragraph', attributes ),
-			},
-		],
-	},
-
+	transforms,
 	edit,
-
-	save( { attributes } ) {
-		const { align, content } = attributes;
-
-		return (
-			<RichText.Content
-				tagName="p"
-				style={ { textAlign: align } }
-				value={ content }
-			/>
-		);
-	},
+	save,
 };

--- a/packages/block-library/src/subhead/save.js
+++ b/packages/block-library/src/subhead/save.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+
+export default function save( { attributes } ) {
+	const { align, content } = attributes;
+
+	return (
+		<RichText.Content
+			tagName="p"
+			style={ { textAlign: align } }
+			value={ content }
+		/>
+	);
+}

--- a/packages/block-library/src/subhead/tranforms.js
+++ b/packages/block-library/src/subhead/tranforms.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+const transforms = {
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/paragraph' ],
+			transform: ( attributes ) =>
+				createBlock( 'core/paragraph', attributes ),
+		},
+	],
+};
+
+export default transforms;

--- a/packages/block-library/src/tag-cloud/index.js
+++ b/packages/block-library/src/tag-cloud/index.js
@@ -12,17 +12,12 @@ export const name = 'core/tag-cloud';
 
 export const settings = {
 	title: __( 'Tag Cloud' ),
-
 	description: __( 'A cloud of your most used tags.' ),
-
 	icon: 'tag',
-
 	category: 'widgets',
-
 	supports: {
 		html: false,
 		align: true,
 	},
-
 	edit,
 };

--- a/packages/block-library/src/template/edit.js
+++ b/packages/block-library/src/template/edit.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+
+export default function TemplateEdit() {
+	return <InnerBlocks />;
+}

--- a/packages/block-library/src/template/index.js
+++ b/packages/block-library/src/template/index.js
@@ -2,13 +2,14 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { InnerBlocks } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
+import edit from './edit';
 import icon from './icon';
 import metadata from './block.json';
+import save from './save';
 
 const { name } = metadata;
 
@@ -16,22 +17,13 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Reusable Template' ),
-
 	description: __( 'Template block used as a container.' ),
-
 	icon,
-
 	supports: {
 		customClassName: false,
 		html: false,
 		inserter: false,
 	},
-
-	edit() {
-		return <InnerBlocks />;
-	},
-
-	save() {
-		return <InnerBlocks.Content />;
-	},
+	edit,
+	save,
 };

--- a/packages/block-library/src/template/save.js
+++ b/packages/block-library/src/template/save.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+
+export default function save() {
+	return <InnerBlocks.Content />;
+}

--- a/packages/block-library/src/text-columns/index.js
+++ b/packages/block-library/src/text-columns/index.js
@@ -1,20 +1,15 @@
 /**
- * External dependencies
- */
-import { get, times } from 'lodash';
-
-/**
  * WordPress dependencies
  */
-import { createBlock } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-import { RichText } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import edit from './edit';
 import metadata from './block.json';
+import save from './save';
+import transforms from './tranforms';
 
 const { name } = metadata;
 
@@ -25,56 +20,15 @@ export const settings = {
 	supports: {
 		inserter: false,
 	},
-
 	title: __( 'Text Columns (deprecated)' ),
-
 	description: __( 'This block is deprecated. Please use the Columns block instead.' ),
-
-	transforms: {
-		to: [
-			{
-				type: 'block',
-				blocks: [ 'core/columns' ],
-				transform: ( { className, columns, content, width } ) => (
-					createBlock(
-						'core/columns',
-						{
-							align: ( 'wide' === width || 'full' === width ) ? width : undefined,
-							className,
-							columns,
-						},
-						content.map( ( { children } ) =>
-							createBlock(
-								'core/column',
-								{},
-								[ createBlock( 'core/paragraph', { content: children } ) ]
-							)
-						)
-					)
-				),
-			},
-		],
-	},
-
+	transforms,
 	getEditWrapperProps( attributes ) {
 		const { width } = attributes;
 		if ( 'wide' === width || 'full' === width ) {
 			return { 'data-align': width };
 		}
 	},
-
 	edit,
-
-	save( { attributes } ) {
-		const { width, content, columns } = attributes;
-		return (
-			<div className={ `align${ width } columns-${ columns }` }>
-				{ times( columns, ( index ) =>
-					<div className="wp-block-column" key={ `column-${ index }` }>
-						<RichText.Content tagName="p" value={ get( content, [ index, 'children' ] ) } />
-					</div>
-				) }
-			</div>
-		);
-	},
+	save,
 };

--- a/packages/block-library/src/text-columns/save.js
+++ b/packages/block-library/src/text-columns/save.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { get, times } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+
+export default function save( { attributes } ) {
+	const { width, content, columns } = attributes;
+	return (
+		<div className={ `align${ width } columns-${ columns }` }>
+			{ times( columns, ( index ) =>
+				<div className="wp-block-column" key={ `column-${ index }` }>
+					<RichText.Content tagName="p" value={ get( content, [ index, 'children' ] ) } />
+				</div>
+			) }
+		</div>
+	);
+}

--- a/packages/block-library/src/text-columns/tranforms.js
+++ b/packages/block-library/src/text-columns/tranforms.js
@@ -1,0 +1,32 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+const transforms = {
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/columns' ],
+			transform: ( { className, columns, content, width } ) => (
+				createBlock(
+					'core/columns',
+					{
+						align: ( 'wide' === width || 'full' === width ) ? width : undefined,
+						className,
+						columns,
+					},
+					content.map( ( { children } ) =>
+						createBlock(
+							'core/column',
+							{},
+							[ createBlock( 'core/paragraph', { content: children } ) ]
+						)
+					)
+				)
+			),
+		},
+	],
+};
+
+export default transforms;

--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -2,8 +2,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { createBlock } from '@wordpress/blocks';
-import { RichText } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -11,6 +9,8 @@ import { RichText } from '@wordpress/block-editor';
 import edit from './edit';
 import icon from './icon';
 import metadata from './block.json';
+import save from './save';
+import transforms from './tranforms';
 
 const { name } = metadata;
 
@@ -18,46 +18,12 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Verse' ),
-
 	description: __( 'Insert poetry. Use special spacing formats. Or quote song lyrics.' ),
-
 	icon,
-
 	keywords: [ __( 'poetry' ) ],
-
-	transforms: {
-		from: [
-			{
-				type: 'block',
-				blocks: [ 'core/paragraph' ],
-				transform: ( attributes ) =>
-					createBlock( 'core/verse', attributes ),
-			},
-		],
-		to: [
-			{
-				type: 'block',
-				blocks: [ 'core/paragraph' ],
-				transform: ( attributes ) =>
-					createBlock( 'core/paragraph', attributes ),
-			},
-		],
-	},
-
+	transforms,
 	edit,
-
-	save( { attributes } ) {
-		const { textAlign, content } = attributes;
-
-		return (
-			<RichText.Content
-				tagName="pre"
-				style={ { textAlign } }
-				value={ content }
-			/>
-		);
-	},
-
+	save,
 	merge( attributes, attributesToMerge ) {
 		return {
 			content: attributes.content + attributesToMerge.content,

--- a/packages/block-library/src/verse/save.js
+++ b/packages/block-library/src/verse/save.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+
+export default function save( { attributes } ) {
+	const { textAlign, content } = attributes;
+
+	return (
+		<RichText.Content
+			tagName="pre"
+			style={ { textAlign } }
+			value={ content }
+		/>
+	);
+}

--- a/packages/block-library/src/verse/tranforms.js
+++ b/packages/block-library/src/verse/tranforms.js
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+const transforms = {
+	from: [
+		{
+			type: 'block',
+			blocks: [ 'core/paragraph' ],
+			transform: ( attributes ) =>
+				createBlock( 'core/verse', attributes ),
+		},
+	],
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/paragraph' ],
+			transform: ( attributes ) =>
+				createBlock( 'core/paragraph', attributes ),
+		},
+	],
+};
+
+export default transforms;

--- a/packages/block-library/src/video/index.js
+++ b/packages/block-library/src/video/index.js
@@ -1,9 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { createBlobURL } from '@wordpress/blob';
-import { createBlock } from '@wordpress/blocks';
-import { RichText } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -12,6 +9,8 @@ import { __ } from '@wordpress/i18n';
 import edit from './edit';
 import icon from './icon';
 import metadata from './block.json';
+import save from './save';
+import transforms from './tranforms';
 
 const { name } = metadata;
 
@@ -19,96 +18,13 @@ export { metadata, name };
 
 export const settings = {
 	title: __( 'Video' ),
-
 	description: __( 'Embed a video from your media library or upload a new one.' ),
-
 	icon,
-
 	keywords: [ __( 'movie' ) ],
-
-	transforms: {
-		from: [
-			{
-				type: 'files',
-				isMatch( files ) {
-					return files.length === 1 && files[ 0 ].type.indexOf( 'video/' ) === 0;
-				},
-				transform( files ) {
-					const file = files[ 0 ];
-					// We don't need to upload the media directly here
-					// It's already done as part of the `componentDidMount`
-					// in the video block
-					const block = createBlock( 'core/video', {
-						src: createBlobURL( file ),
-					} );
-					return block;
-				},
-			},
-			{
-				type: 'shortcode',
-				tag: 'video',
-				attributes: {
-					src: {
-						type: 'string',
-						shortcode: ( { named: { src } } ) => {
-							return src;
-						},
-					},
-					poster: {
-						type: 'string',
-						shortcode: ( { named: { poster } } ) => {
-							return poster;
-						},
-					},
-					loop: {
-						type: 'string',
-						shortcode: ( { named: { loop } } ) => {
-							return loop;
-						},
-					},
-					autoplay: {
-						type: 'string',
-						shortcode: ( { named: { autoplay } } ) => {
-							return autoplay;
-						},
-					},
-					preload: {
-						type: 'string',
-						shortcode: ( { named: { preload } } ) => {
-							return preload;
-						},
-					},
-				},
-			},
-		],
-	},
-
+	transforms,
 	supports: {
 		align: true,
 	},
-
 	edit,
-
-	save( { attributes } ) {
-		const { autoplay, caption, controls, loop, muted, poster, preload, src, playsInline } = attributes;
-		return (
-			<figure>
-				{ src && (
-					<video
-						autoPlay={ autoplay }
-						controls={ controls }
-						loop={ loop }
-						muted={ muted }
-						poster={ poster }
-						preload={ preload !== 'metadata' ? preload : undefined }
-						src={ src }
-						playsInline={ playsInline }
-					/>
-				) }
-				{ ! RichText.isEmpty( caption ) && (
-					<RichText.Content tagName="figcaption" value={ caption } />
-				) }
-			</figure>
-		);
-	},
+	save,
 };

--- a/packages/block-library/src/video/save.js
+++ b/packages/block-library/src/video/save.js
@@ -1,0 +1,27 @@
+/**
+ * WordPress dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+
+export default function save( { attributes } ) {
+	const { autoplay, caption, controls, loop, muted, poster, preload, src, playsInline } = attributes;
+	return (
+		<figure>
+			{ src && (
+				<video
+					autoPlay={ autoplay }
+					controls={ controls }
+					loop={ loop }
+					muted={ muted }
+					poster={ poster }
+					preload={ preload !== 'metadata' ? preload : undefined }
+					src={ src }
+					playsInline={ playsInline }
+				/>
+			) }
+			{ ! RichText.isEmpty( caption ) && (
+				<RichText.Content tagName="figcaption" value={ caption } />
+			) }
+		</figure>
+	);
+}

--- a/packages/block-library/src/video/tranforms.js
+++ b/packages/block-library/src/video/tranforms.js
@@ -1,0 +1,64 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlobURL } from '@wordpress/blob';
+import { createBlock } from '@wordpress/blocks';
+
+const transforms = {
+	from: [
+		{
+			type: 'files',
+			isMatch( files ) {
+				return files.length === 1 && files[ 0 ].type.indexOf( 'video/' ) === 0;
+			},
+			transform( files ) {
+				const file = files[ 0 ];
+				// We don't need to upload the media directly here
+				// It's already done as part of the `componentDidMount`
+				// in the video block
+				const block = createBlock( 'core/video', {
+					src: createBlobURL( file ),
+				} );
+				return block;
+			},
+		},
+		{
+			type: 'shortcode',
+			tag: 'video',
+			attributes: {
+				src: {
+					type: 'string',
+					shortcode: ( { named: { src } } ) => {
+						return src;
+					},
+				},
+				poster: {
+					type: 'string',
+					shortcode: ( { named: { poster } } ) => {
+						return poster;
+					},
+				},
+				loop: {
+					type: 'string',
+					shortcode: ( { named: { loop } } ) => {
+						return loop;
+					},
+				},
+				autoplay: {
+					type: 'string',
+					shortcode: ( { named: { autoplay } } ) => {
+						return autoplay;
+					},
+				},
+				preload: {
+					type: 'string',
+					shortcode: ( { named: { preload } } ) => {
+						return preload;
+					},
+				},
+			},
+		},
+	],
+};
+
+export default transforms;


### PR DESCRIPTION
## Description
Part of aligning block library to Block Registration API RFC #13693.

It's all about moving `save` and `transforms` to their own file to follow the proposal drafted in RFC. There might be some additional fields moved to their own files if I noticed that they were missed or introduced recently.

Updated blocks:
- Subhead
- Tag Cloud
- Template
- Verse
- Video

## How has this been tested?

`npm test`
`npm run test-e2e`

Manually tested whether all blocks load as before.