### PR TITLE
Editor: Trigger reusable blocks autocomplete when options generated

### DIFF
--- a/packages/editor/src/components/autocompleters/block.js
+++ b/packages/editor/src/components/autocompleters/block.js
@@ -1,7 +1,12 @@
 /**
+ * External dependencies
+ */
+import { once } from 'lodash';
+
+/**
  * WordPress dependencies
  */
-import { select } from '@wordpress/data';
+import { select, dispatch } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 import { BlockIcon } from '@wordpress/block-editor';
 
@@ -42,6 +47,25 @@ function defaultGetSelectedBlockName() {
 }
 
 /**
+ * Triggers a fetch of reusable blocks, once.
+ *
+ * TODO: Reusable blocks fetching should be reimplemented as a core-data entity
+ * resolver, not relying on `core/editor` (see #7119). The implementation here
+ * is imperfect in that the options result will not await the completion of the
+ * fetch request and thus will not include any reusable blocks. This has always
+ * been true, but relied upon the fact the user would be delayed in typing an
+ * autocompleter search query. Once implemented using resolvers, the status of
+ * this request could be subscribed to as part of a promised return value using
+ * the result of `hasFinishedResolution`. There is currently reliable way to
+ * determine that a reusable blocks fetch request has completed.
+ *
+ * @return {Promise} Promise resolving once reusable blocks fetched.
+ */
+const fetchReusableBlocks = once( () => {
+	dispatch( 'core/editor' ).__experimentalFetchReusableBlocks();
+} );
+
+/**
  * Creates a blocks repeater for replacing the current block with a selected block type.
  *
  * @return {Completer} A blocks completer.
@@ -57,6 +81,8 @@ export function createBlockCompleter( {
 		className: 'editor-autocompleters__block',
 		triggerPrefix: '/',
 		options() {
+			fetchReusableBlocks();
+
 			const selectedBlockName = getSelectedBlockName();
 			return getInserterItems( getBlockInsertionParentClientId() ).filter(
 				// Avoid offering to replace the current block with a block of the same type.

--- a/packages/editor/src/components/autocompleters/test/block.js
+++ b/packages/editor/src/components/autocompleters/test/block.js
@@ -7,9 +7,29 @@ import { shallow } from 'enzyme';
  * Internal dependencies
  */
 import blockCompleter, { createBlockCompleter } from '../block';
+import '../../../';
 
 describe( 'block', () => {
-	it( 'should retrieve block options for current insertion point', () => {
+	let originalFetch;
+	beforeEach( () => {
+		originalFetch = window.fetch;
+		window.fetch = ( url ) => {
+			if ( ! /\/wp\/v2\/types\/wp_block(\?|$)/.test( url ) ) {
+				throw new Error( 'Unhandled fetch ' + url );
+			}
+
+			return Promise.resolve( {
+				status: 200,
+				json: () => Promise.resolve( [] ),
+			} );
+		};
+	} );
+
+	afterEach( () => {
+		window.fetch = originalFetch;
+	} );
+
+	it( 'should retrieve block options for current insertion point', async () => {
 		const expectedOptions = [ {}, {}, {} ];
 		const mockGetBlockInsertionParentClientId = jest.fn( () => 'expected-insertion-point' );
 		const mockGetInserterItems = jest.fn( () => expectedOptions );

--- a/packages/editor/src/hooks/default-autocompleters.js
+++ b/packages/editor/src/hooks/default-autocompleters.js
@@ -1,14 +1,13 @@
 /**
  * External dependencies
  */
-import { clone, once } from 'lodash';
+import { clone } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
 import { getDefaultBlockName } from '@wordpress/blocks';
-import { dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -17,8 +16,6 @@ import { blockAutocompleter, userAutocompleter } from '../components';
 
 const defaultAutocompleters = [ userAutocompleter ];
 
-const fetchReusableBlocks = once( () => dispatch( 'core/editor' ).__experimentalFetchReusableBlocks() );
-
 function setDefaultCompleters( completers, blockName ) {
 	if ( ! completers ) {
 		// Provide copies so filters may directly modify them.
@@ -26,14 +23,6 @@ function setDefaultCompleters( completers, blockName ) {
 		// Add blocks autocompleter for Paragraph block
 		if ( blockName === getDefaultBlockName() ) {
 			completers.push( clone( blockAutocompleter ) );
-
-			/*
-			 * NOTE: This is a hack to help ensure reusable blocks are loaded
-			 * so they may be included in the block completer. It can be removed
-			 * once we have a way for completers to Promise options while
-			 * store-based data dependencies are being resolved.
-			 */
-			fetchReusableBlocks();
 		}
 	}
 	return completers;


### PR DESCRIPTION
Fixes #14766 

This pull request changes the behavior of the default block autocompleter to avoid triggering a fetch of reusable blocks until the time at which the user begins entering a search query which would prompt the block autocompleter to generate its own options set. Prior to this change, a fetch would occur immediately upon selecting a paragraph block. While this had the benefit of preloading data for improved likelihood could be reflected in the search query, it had the downsides of (a) not guaranteeing this likelihood, (b) incurring the overhead of a network request, and (c) causing changes in state. The last of these manifests itself in the bug report described in #14766.

For transparency's sake, I should be clear that the implementation here does not solve the underlying issue that receiving reusable blocks into editor state has the dual effect of creating an undo level and marking the post as having unsaved changes. This is tracked more thoroughly at #14910, with a separate improvement planned. Thus, it is still expected that unexpected undo history will accumulate in response to reusable blocks fetching (e.g. clicking the Inserter when on a new post will add an Undo level). Technically speaking, the full fix considered for #14910 at https://github.com/WordPress/gutenberg/issues/14910#issuecomment-481808021 would resolve both #14910 and #14766, at which point this pull request could be considered an optional enhancement / change in behavior to defer fetching of reusable blocks.

Separately, I anticipate that we should explore further refactoring of autocompleters to avoid "fetches" as explicit actions, and consider what solutions might exist for being able to express autocompleter options via subscribed selectors (or `withSelect`-bound components) and complementing resolvers.

**Testing Instructions:**

Repeat Steps to Reproduce from #14766, observing that no undo level is created.