### PR TITLE
Block Editor: Consider received blocks state change as ignored

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -775,6 +775,20 @@ via its `onChange` callback, in addition to `onInput`.
 
 Whether the most recent block change was persistent.
 
+### __unstableIsLastBlockChangeIgnored
+
+Returns true if the most recent block change is be considered ignored, or
+false otherwise. An ignored change is one not to be committed by
+BlockEditorProvider, neither via `onChange` nor `onInput`.
+
+*Parameters*
+
+ * state: Block editor state.
+
+*Returns*
+
+Whether the most recent block change was ignored.
+
 ## Actions
 
 ### resetBlocks

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -15,6 +15,10 @@
 
 - `CopyHandler` will now only catch cut/copy events coming from its `props.children`, instead of from anywhere in the `document`.
 
+### Internal
+
+- Improved handling of blocks state references for unchanging states.
+
 ## 1.0.0 (2019-03-06)
 
 ### New Features

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Internal
 
 - Improved handling of blocks state references for unchanging states.
+- Updated handling of blocks state to effectively ignored programmatically-received blocks data (e.g. reusable blocks received from editor).
 
 ## 1.0.0 (2019-03-06)
 

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -69,6 +69,7 @@ class BlockEditorProvider extends Component {
 		const {
 			getBlocks,
 			isLastBlockChangePersistent,
+			__unstableIsLastBlockChangeIgnored,
 		} = registry.select( 'core/block-editor' );
 
 		let blocks = getBlocks();
@@ -81,7 +82,12 @@ class BlockEditorProvider extends Component {
 			} = this.props;
 			const newBlocks = getBlocks();
 			const newIsPersistent = isLastBlockChangePersistent();
-			if ( newBlocks !== blocks && this.isSyncingIncomingValue ) {
+			if (
+				newBlocks !== blocks && (
+					this.isSyncingIncomingValue ||
+					__unstableIsLastBlockChangeIgnored()
+				)
+			) {
 				this.isSyncingIncomingValue = false;
 				blocks = newBlocks;
 				isPersistent = newIsPersistent;

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -236,8 +236,7 @@ function withPersistentBlockChange( reducer ) {
  */
 function withIgnoredBlockChange( reducer ) {
 	/**
-	 * Set of action types for which a blocks state change should be considered
-	 * non-persistent.
+	 * Set of action types for which a blocks state change should be ignored.
 	 *
 	 * @type {Set}
 	 */

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -206,9 +206,14 @@ function withPersistentBlockChange( reducer ) {
 		// Defer to previous state value (or default) unless changing or
 		// explicitly marking as persistent.
 		if ( state === nextState && ! isExplicitPersistentChange ) {
+			const nextIsPersistentChange = get( state, [ 'isPersistentChange' ], true );
+			if ( state.isPersistentChange === nextIsPersistentChange ) {
+				return state;
+			}
+
 			return {
 				...nextState,
-				isPersistentChange: get( state, [ 'isPersistentChange' ], true ),
+				isPersistentChange: nextIsPersistentChange,
 			};
 		}
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1392,17 +1392,16 @@ export function isLastBlockChangePersistent( state ) {
  * false otherwise. An ignored change is one not to be committed by
  * BlockEditorProvider, neither via `onChange` nor `onInput`.
  *
- * TODO: Removal Plan: Changes incurred by RECEIVE_BLOCKS should not be ignored
- * if in-fact they result in a change in blocks state. The current need to
- * ignore changes incurred not as a result of user interaction should be
- * accounted for in the refactoring of reusable blocks as occurring within
- * their own separate block editor / state (#7119).
- *
  * @param {Object} state Block editor state.
  *
  * @return {boolean} Whether the most recent block change was ignored.
  */
 export function __unstableIsLastBlockChangeIgnored( state ) {
+	// TODO: Removal Plan: Changes incurred by RECEIVE_BLOCKS should not be
+	// ignored if in-fact they result in a change in blocks state. The current
+	// need to ignore changes not a result of user interaction should be
+	// accounted for in the refactoring of reusable blocks as occurring within
+	// their own separate block editor / state (#7119).
 	return state.blocks.isIgnoredChange;
 }
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1388,6 +1388,25 @@ export function isLastBlockChangePersistent( state ) {
 }
 
 /**
+ * Returns true if the most recent block change is be considered ignored, or
+ * false otherwise. An ignored change is one not to be committed by
+ * BlockEditorProvider, neither via `onChange` nor `onInput`.
+ *
+ * TODO: Removal Plan: Changes incurred by RECEIVE_BLOCKS should not be ignored
+ * if in-fact they result in a change in blocks state. The current need to
+ * ignore changes incurred not as a result of user interaction should be
+ * accounted for in the refactoring of reusable blocks as occurring within
+ * their own separate block editor / state (#7119).
+ *
+ * @param {Object} state Block editor state.
+ *
+ * @return {boolean} Whether the most recent block change was ignored.
+ */
+export function __unstableIsLastBlockChangeIgnored( state ) {
+	return state.blocks.isIgnoredChange;
+}
+
+/**
  * Returns the value of a post meta from the editor settings.
  *
  * @param {Object} state Global application state.

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -1500,6 +1500,19 @@ describe( 'state', () => {
 					expect( state.isPersistentChange ).toBe( true );
 				} );
 
+				it( 'should retain reference for same state, same persistence', () => {
+					const original = deepFreeze( blocks( undefined, {
+						type: 'RESET_BLOCKS',
+						blocks: [],
+					} ) );
+
+					const state = blocks( original, {
+						type: '__INERT__',
+					} );
+
+					expect( state ).toBe( original );
+				} );
+
 				it( 'should not consider received blocks as persistent change', () => {
 					const state = blocks( undefined, {
 						type: 'RECEIVE_BLOCKS',

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -233,7 +233,8 @@ describe( 'state', () => {
 				const state = blocks( existingState, action );
 
 				expect( state ).toEqual( {
-					isPersistentChange: expect.anything(),
+					isPersistentChange: true,
+					isIgnoredChange: false,
 					byClientId: {
 						clicken: {
 							clientId: 'chicken',
@@ -295,7 +296,8 @@ describe( 'state', () => {
 				const state = blocks( existingState, action );
 
 				expect( state ).toEqual( {
-					isPersistentChange: expect.anything(),
+					isPersistentChange: true,
+					isIgnoredChange: false,
 					byClientId: {
 						clicken: {
 							clientId: 'chicken',
@@ -386,7 +388,8 @@ describe( 'state', () => {
 				const state = blocks( existingState, action );
 
 				expect( state ).toEqual( {
-					isPersistentChange: expect.anything(),
+					isPersistentChange: true,
+					isIgnoredChange: false,
 					byClientId: {
 						clicken: {
 							clientId: 'chicken',
@@ -478,7 +481,8 @@ describe( 'state', () => {
 				const state = blocks( existingState, action );
 
 				expect( state ).toEqual( {
-					isPersistentChange: expect.anything(),
+					isPersistentChange: true,
+					isIgnoredChange: false,
 					byClientId: {
 						clicken: {
 							clientId: 'chicken',
@@ -512,6 +516,7 @@ describe( 'state', () => {
 				attributes: {},
 				order: {},
 				isPersistentChange: true,
+				isIgnoredChange: false,
 			} );
 		} );
 
@@ -1512,8 +1517,10 @@ describe( 'state', () => {
 
 					expect( state ).toBe( original );
 				} );
+			} );
 
-				it( 'should not consider received blocks as persistent change', () => {
+			describe( 'isIgnoredChange', () => {
+				it( 'should consider received blocks as ignored change', () => {
 					const state = blocks( undefined, {
 						type: 'RECEIVE_BLOCKS',
 						blocks: [ {
@@ -1523,7 +1530,7 @@ describe( 'state', () => {
 						} ],
 					} );
 
-					expect( state.isPersistentChange ).toBe( false );
+					expect( state.isIgnoredChange ).toBe( true );
 				} );
 			} );
 		} );

--- a/packages/e2e-tests/specs/change-detection.test.js
+++ b/packages/e2e-tests/specs/change-detection.test.js
@@ -288,4 +288,21 @@ describe( 'Change detection', () => {
 
 		await assertIsDirty( true );
 	} );
+
+	it( 'should not prompt when receiving reusable blocks', async () => {
+		// Regression Test: Verify that non-modifying behaviors does not incur
+		// dirtiness. Previously, this could occur as a result of either (a)
+		// selecting a block, (b) opening the inserter, or (c) editing a post
+		// which contained a reusable block. The root issue was changes in
+		// block editor state as a result of reusable blocks data having been
+		// received, reflected here in this test.
+		//
+		// TODO: This should be considered a temporary test, existing only so
+		// long as the experimental reusable blocks fetching data flow exists.
+		//
+		// See: https://github.com/WordPress/gutenberg/issues/14766
+		await page.evaluate( () => window.wp.data.dispatch( 'core/editor' ).__experimentalReceiveReusableBlocks( [] ) );
+
+		await assertIsDirty( false );
+	} );
 } );


### PR DESCRIPTION
Fixes #14910 
Fixes #14766

This pull request seeks to resolve an issue where any fetch of reusable blocks (selecting a paragraph, using inserter, editing a post containing reusable block) would cause the post to immediately become "dirty" (prompt the user about unsaved changes when navigating away) and would immediately add an undo history level.

The changes here effectively better align to behavior of `RECEIVE_BLOCKS` prior to #13088 . As of #13088, we considered `RECEIVE_BLOCKS` as "non-persistent" which helped for avoiding to create undo levels (except when it's the first action of a session), but did not consider that received blocks should be entirely ignored in consideration of change detection ([as it was implemented before #13088](https://github.com/WordPress/gutenberg/blob/4be0a36c703a45cdcac67807d30e2e4f26c92343/packages/editor/src/store/reducer.js#L415)).

**Testing Instructions:**

Repeat Steps to Reproduce from #14910 and #14766, verifying expected results.

Ensure unit tests pass:

```
npm run test-unit packages/e2e-tests/specs/change-detection.test.js
```

Ensure end-to-end tests pass:

```
npm run build && npm run test-e2e packages/e2e-tests/specs/change-detection.test.js
```