### PR TITLE
Docs: Try to clarify loading editor styles

### DIFF
--- a/docs/designers-developers/developers/themes/theme-support.md
+++ b/docs/designers-developers/developers/themes/theme-support.md
@@ -223,13 +223,13 @@ Note you don't need to add `add_theme_support( 'editor-styles' );` twice, but th
 
 ### Enqueuing the editor style
 
-The `add_editor_style` function enqueues and loads the CSS on the editor screen. For the classic editor, this was the only function needed to add style to the editor. For the new block editor, you first need to `add_theme_support( 'editor-styles');` mentioned above.
+Use the `add_editor_style` function to enqueue and load CSS on the editor screen. For the classic editor, this was the only function needed to add style to the editor. For the new block editor, you first need to `add_theme_support( 'editor-styles');` mentioned above.
 
 ```php
 add_editor_style( 'style-editor.css' );
 ```
 
-Adding that to your `functions.php` file will load the stylesheet `style-editor.css` found in your theme directory.
+Adding that to your `functions.php` file will add the stylesheet `style-editor.css` to the queue of stylesheets to be loaded in the editor.
 
 ### Basic colors
 

--- a/docs/designers-developers/developers/themes/theme-support.md
+++ b/docs/designers-developers/developers/themes/theme-support.md
@@ -223,13 +223,13 @@ Note you don't need to add `add_theme_support( 'editor-styles' );` twice, but th
 
 ### Enqueuing the editor style
 
-To make sure your editor style is loaded and parsed correctly, enqueue it using the following method:
+The `add_editor_style` function enqueues and loads the CSS on the editor screen. For the classic editor, this was the only function needed to add style to the editor. For the new block editor, you first need to `add_theme_support( 'editor-styles');` mentioned above.
 
 ```php
 add_editor_style( 'style-editor.css' );
 ```
 
-It is enough to paste that in your `functions.php` file, for the style to be loaded and parsed.
+Adding that to your `functions.php` file will load the stylesheet `style-editor.css` found in your theme directory.
 
 ### Basic colors
 


### PR DESCRIPTION
## Description

Attempt to add clarification to the loading of editor styles for themes

Clarify that the `add_theme_support()` is required in new editor which is new, and remove the wording around parsing for the `add_editor_style`

## Types of changes

Documentation
