### PR TITLE
Update/edit flow for blocks which have a media placeholder

### DIFF
--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { getBlobByURL, isBlobURL } from '@wordpress/blob';
@@ -29,10 +34,6 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import icon from './icon';
-
-/**
- * Internal dependencies
- */
 import { createUpgradedEmbedBlock } from '../embed/util';
 
 const ALLOWED_MEDIA_TYPES = [ 'audio' ];
@@ -106,7 +107,7 @@ class AudioEdit extends Component {
 		const { setAttributes, isSelected, className, noticeOperations, noticeUI } = this.props;
 		const { editing } = this.state;
 		const switchToEditing = () => {
-			this.setState( { editing: true } );
+			this.setState( { editing: ! this.state.editing } );
 		};
 		const onSelectAudio = ( media ) => {
 			if ( ! media || ! media.url ) {
@@ -121,23 +122,35 @@ class AudioEdit extends Component {
 			setAttributes( { src: media.url, id: media.id } );
 			this.setState( { src: media.url, editing: false } );
 		};
+		const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
 		if ( editing ) {
 			return (
-				<MediaPlaceholder
-					icon={ <BlockIcon icon={ icon } /> }
-					className={ className }
-					onSelect={ onSelectAudio }
-					onSelectURL={ this.onSelectURL }
-					accept="audio/*"
-					allowedTypes={ ALLOWED_MEDIA_TYPES }
-					value={ this.props.attributes }
-					notices={ noticeUI }
-					onError={ noticeOperations.createErrorNotice }
-				/>
+				<Fragment>
+					<BlockControls>
+						<Toolbar>
+							<IconButton
+								className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': this.state.editing } ) }
+								label={ __( 'Edit audio' ) }
+								onClick={ switchToEditing }
+								icon={ editImageIcon }
+							/>
+						</Toolbar>
+					</BlockControls>
+					<MediaPlaceholder
+						icon={ <BlockIcon icon={ icon } /> }
+						className={ className }
+						onCancel={ switchToEditing }
+						onSelect={ onSelectAudio }
+						onSelectURL={ this.onSelectURL }
+						accept="audio/*"
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
+						value={ this.props.attributes }
+						notices={ noticeUI }
+						onError={ noticeOperations.createErrorNotice }
+					/>
+				</Fragment>
 			);
 		}
-
-		const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
 		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 		return (
 			<Fragment>

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -6,7 +6,10 @@ import {
 	Disabled,
 	IconButton,
 	PanelBody,
+	Path,
+	Rect,
 	SelectControl,
+	SVG,
 	ToggleControl,
 	Toolbar,
 	withNotices,
@@ -134,6 +137,7 @@ class AudioEdit extends Component {
 			);
 		}
 
+		const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
 		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 		return (
 			<Fragment>
@@ -143,7 +147,7 @@ class AudioEdit extends Component {
 							className="components-icon-button components-toolbar__control"
 							label={ __( 'Edit audio' ) }
 							onClick={ switchToEditing }
-							icon="edit"
+							icon={ editImageIcon }
 						/>
 					</Toolbar>
 				</BlockControls>

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -127,19 +127,19 @@ class AudioEdit extends Component {
 			return (
 				<Fragment>
 					<BlockControls>
-						<Toolbar>
+						{ !! src && ( <Toolbar>
 							<IconButton
 								className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': this.state.editing } ) }
 								label={ __( 'Edit audio' ) }
 								onClick={ switchToEditing }
 								icon={ editImageIcon }
 							/>
-						</Toolbar>
+						</Toolbar> ) }
 					</BlockControls>
 					<MediaPlaceholder
 						icon={ <BlockIcon icon={ icon } /> }
 						className={ className }
-						onCancel={ switchToEditing }
+						onCancel={ !! src && switchToEditing }
 						onSelect={ onSelectAudio }
 						onSelectURL={ this.onSelectURL }
 						accept="audio/*"

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -12,7 +12,10 @@ import {
 	FocalPointPicker,
 	IconButton,
 	PanelBody,
+	Path,
 	RangeControl,
+	Rect,
+	SVG,
 	ToggleControl,
 	Toolbar,
 	withNotices,
@@ -157,6 +160,7 @@ class CoverEdit extends Component {
 			style.backgroundPosition = `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`;
 		}
 
+		const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
 		const controls = (
 			<Fragment>
 				<BlockControls>
@@ -172,7 +176,7 @@ class CoverEdit extends Component {
 											<IconButton
 												className="components-toolbar__control"
 												label={ __( 'Edit media' ) }
-												icon="edit"
+												icon={ editImageIcon }
 												onClick={ open }
 											/>
 										) }

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -200,7 +200,7 @@ class CoverEdit extends Component {
 							<MediaUploadCheck>
 								<Toolbar>
 									<IconButton
-										className="components-toolbar__control"
+										className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': this.state.isEditing } ) }
 										label={ __( 'Edit media' ) }
 										icon={ editImageIcon }
 										onClick={ this.toggleIsEditing }

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -201,6 +201,7 @@ class CoverEdit extends Component {
 								<Toolbar>
 									<IconButton
 										className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': this.state.isEditing } ) }
+										aria-pressed={ this.state.isEditing }
 										label={ __( 'Edit media' ) }
 										icon={ editImageIcon }
 										onClick={ this.toggleIsEditing }

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -129,7 +129,7 @@ export function getEmbedEditComponent( title, icon, responsive = true ) {
 		}
 
 		switchBackToURLInput() {
-			this.setState( { editingURL: true } );
+			this.setState( { editingURL: ! this.state.editingURL } );
 		}
 
 		getResponsiveHelp( checked ) {
@@ -166,16 +166,32 @@ export function getEmbedEditComponent( title, icon, responsive = true ) {
 			// No preview, or we can't embed the current URL, or we've clicked the edit button.
 			if ( ! preview || cannotEmbed || editingURL ) {
 				return (
-					<EmbedPlaceholder
-						icon={ icon }
-						label={ label }
-						onSubmit={ this.setUrl }
-						value={ url }
-						cannotEmbed={ cannotEmbed }
-						onChange={ ( event ) => this.setState( { url: event.target.value } ) }
-						fallback={ () => fallback( url, this.props.onReplace ) }
-						tryAgain={ tryAgain }
-					/>
+					<Fragment>
+						<EmbedControls
+							showEditButton={ preview && ! cannotEmbed }
+							editingURL={ this.state.editingURL }
+							url={ this.state.url }
+							themeSupportsResponsive={ themeSupportsResponsive }
+							blockSupportsResponsive={ responsive }
+							allowResponsive={ allowResponsive }
+							getResponsiveHelp={ this.getResponsiveHelp }
+							toggleResponsive={ this.toggleResponsive }
+							switchBackToURLInput={ this.switchBackToURLInput }
+						/>
+						<EmbedPlaceholder
+							icon={ icon }
+							label={ label }
+							onSubmit={ this.setUrl }
+							value={ url }
+							cannotEmbed={ cannotEmbed }
+							onChange={ ( event ) => this.setState( { url: event.target.value } ) }
+							fallback={ () => fallback( url, this.props.onReplace ) }
+							tryAgain={ tryAgain }
+							switchBackToURLInput={ this.switchBackToURLInput }
+							editingURL={ this.state.editingURL }
+							url={ this.state.url }
+						/>
+					</Fragment>
 				);
 			}
 
@@ -183,6 +199,8 @@ export function getEmbedEditComponent( title, icon, responsive = true ) {
 				<Fragment>
 					<EmbedControls
 						showEditButton={ preview && ! cannotEmbed }
+						editingURL={ this.state.editingURL }
+						url={ this.state.url }
 						themeSupportsResponsive={ themeSupportsResponsive }
 						blockSupportsResponsive={ responsive }
 						allowResponsive={ allowResponsive }

--- a/packages/block-library/src/embed/editor.scss
+++ b/packages/block-library/src/embed/editor.scss
@@ -37,6 +37,12 @@
 	.components-placeholder__error {
 		word-break: break-word;
 	}
+	.components-placeholder__cancel {
+		padding-top: 10px;
+		width: 100%;
+		float: none;
+		text-align: center;
+	}
 }
 
 .block-library-embed__interactive-overlay {

--- a/packages/block-library/src/embed/embed-controls.js
+++ b/packages/block-library/src/embed/embed-controls.js
@@ -1,34 +1,40 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
-import { IconButton, Toolbar, PanelBody, ToggleControl } from '@wordpress/components';
+import { IconButton, Toolbar, PanelBody, ToggleControl, SVG, Rect, Path } from '@wordpress/components';
 import { BlockControls, InspectorControls } from '@wordpress/block-editor';
 
 const EmbedControls = ( props ) => {
 	const {
 		blockSupportsResponsive,
-		showEditButton,
 		themeSupportsResponsive,
 		allowResponsive,
 		getResponsiveHelp,
 		toggleResponsive,
 		switchBackToURLInput,
+		editingURL,
+		url,
 	} = props;
+	const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
 	return (
 		<Fragment>
 			<BlockControls>
-				<Toolbar>
-					{ showEditButton && (
-						<IconButton
-							className="components-toolbar__control"
-							label={ __( 'Edit URL' ) }
-							icon="edit"
-							onClick={ switchBackToURLInput }
-						/>
-					) }
-				</Toolbar>
+				{ !! url && ( <Toolbar>
+					<IconButton
+						className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': editingURL } ) }
+						aria-pressed={ editingURL }
+						label={ __( 'Edit URL' ) }
+						icon={ editImageIcon }
+						onClick={ switchBackToURLInput }
+					/>
+				</Toolbar> ) }
 			</BlockControls>
 			{ themeSupportsResponsive && blockSupportsResponsive && (
 				<InspectorControls>

--- a/packages/block-library/src/embed/embed-placeholder.js
+++ b/packages/block-library/src/embed/embed-placeholder.js
@@ -4,31 +4,44 @@
 import { __, _x } from '@wordpress/i18n';
 import { Button, Placeholder } from '@wordpress/components';
 import { BlockIcon } from '@wordpress/block-editor';
+import { Fragment } from '@wordpress/element';
 
 const EmbedPlaceholder = ( props ) => {
-	const { icon, label, value, onSubmit, onChange, cannotEmbed, fallback, tryAgain } = props;
+	const { icon, label, value, onSubmit, onChange, switchBackToURLInput, cannotEmbed, fallback, tryAgain } = props;
 	return (
 		<Placeholder icon={ <BlockIcon icon={ icon } showColors /> } label={ label } className="wp-block-embed">
-			<form onSubmit={ onSubmit }>
-				<input
-					type="url"
-					value={ value || '' }
-					className="components-placeholder__input"
-					aria-label={ label }
-					placeholder={ __( 'Enter URL to embed here…' ) }
-					onChange={ onChange } />
-				<Button
-					isLarge
-					type="submit">
-					{ _x( 'Embed', 'button label' ) }
-				</Button>
-				{ cannotEmbed &&
-					<p className="components-placeholder__error">
-						{ __( 'Sorry, this content could not be embedded.' ) }<br />
-						<Button isLarge onClick={ tryAgain }>{ _x( 'Try again', 'button label' ) }</Button> <Button isLarge onClick={ fallback }>{ _x( 'Convert to link', 'button label' ) }</Button>
-					</p>
-				}
-			</form>
+			<Fragment>
+				<form onSubmit={ onSubmit }>
+					<input
+						type="url"
+						value={ value || '' }
+						className="components-placeholder__input"
+						aria-label={ label }
+						placeholder={ __( 'Enter URL to embed here…' ) }
+						onChange={ onChange } />
+					<Button
+						isLarge
+						type="submit">
+						{ _x( 'Embed', 'button label' ) }
+					</Button>
+					{ cannotEmbed &&
+						<p className="components-placeholder__error">
+							{ __( 'Sorry, this content could not be embedded.' ) }<br />
+							<Button isLarge onClick={ tryAgain }>{ _x( 'Try again', 'button label' ) }</Button> <Button isLarge onClick={ fallback }>{ _x( 'Convert to link', 'button label' ) }</Button>
+						</p>
+					}
+				</form>
+				<div className="components-placeholder__cancel">
+					<Button
+						className="block-editor-embed-placeholder__cancel-button"
+						title={ __( 'Cancel' ) }
+						isLink
+						onClick={ switchBackToURLInput }
+					>
+						{ __( 'Cancel' ) }
+					</Button>
+				</div>
+			</Fragment>
 		</Placeholder>
 	);
 };

--- a/packages/block-library/src/embed/embed-placeholder.js
+++ b/packages/block-library/src/embed/embed-placeholder.js
@@ -31,7 +31,7 @@ const EmbedPlaceholder = ( props ) => {
 						</p>
 					}
 				</form>
-				<div className="components-placeholder__cancel">
+				{ value && <div className="components-placeholder__cancel">
 					<Button
 						className="block-editor-embed-placeholder__cancel-button"
 						title={ __( 'Cancel' ) }
@@ -40,7 +40,7 @@ const EmbedPlaceholder = ( props ) => {
 					>
 						{ __( 'Cancel' ) }
 					</Button>
-				</div>
+				</div> }
 			</Fragment>
 		</Placeholder>
 	);

--- a/packages/block-library/src/embed/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/embed/test/__snapshots__/index.js.snap
@@ -45,6 +45,17 @@ exports[`core/embed block edit matches snapshot 1`] = `
         Embed
       </button>
     </form>
+    <div
+      class="components-placeholder__cancel"
+    >
+      <button
+        class="components-button block-editor-embed-placeholder__cancel-button is-link"
+        title="Cancel"
+        type="button"
+      >
+        Cancel
+      </button>
+    </div>
   </div>
 </div>
 `;

--- a/packages/block-library/src/embed/test/__snapshots__/index.js.snap
+++ b/packages/block-library/src/embed/test/__snapshots__/index.js.snap
@@ -45,17 +45,6 @@ exports[`core/embed block edit matches snapshot 1`] = `
         Embed
       </button>
     </form>
-    <div
-      class="components-placeholder__cancel"
-    >
-      <button
-        class="components-button block-editor-embed-placeholder__cancel-button is-link"
-        title="Cancel"
-        type="button"
-      >
-        Cancel
-      </button>
-    </div>
   </div>
 </div>
 `;

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -14,6 +14,9 @@ import {
 import {
 	ClipboardButton,
 	IconButton,
+	Path,
+	Rect,
+	SVG,
 	Toolbar,
 	withNotices,
 } from '@wordpress/components';
@@ -158,7 +161,7 @@ class FileEdit extends Component {
 		const classes = classnames( className, {
 			'is-transient': isBlobURL( href ),
 		} );
-
+		const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
 		return (
 			<Fragment>
 				<FileBlockInspector
@@ -182,7 +185,7 @@ class FileEdit extends Component {
 										className="components-toolbar__control"
 										label={ __( 'Edit file' ) }
 										onClick={ open }
-										icon="edit"
+										icon={ editImageIcon }
 									/>
 								) }
 							/>

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -25,8 +25,6 @@ import { withSelect } from '@wordpress/data';
 import {
 	BlockControls,
 	BlockIcon,
-	MediaUpload,
-	MediaUploadCheck,
 	MediaPlaceholder,
 	RichText,
 } from '@wordpress/block-editor';
@@ -39,12 +37,15 @@ import { __ } from '@wordpress/i18n';
  */
 import icon from './icon';
 import FileBlockInspector from './inspector';
+import { speak } from '@wordpress/a11y';
 
 class FileEdit extends Component {
-	constructor() {
+	constructor( { attributes } ) {
 		super( ...arguments );
 
 		this.onSelectFile = this.onSelectFile.bind( this );
+		this.onSelectURL = this.onSelectURL.bind( this );
+		this.toggleIsEditing = this.toggleIsEditing.bind( this );
 		this.confirmCopyURL = this.confirmCopyURL.bind( this );
 		this.resetCopyConfirmation = this.resetCopyConfirmation.bind( this );
 		this.changeLinkDestinationOption = this.changeLinkDestinationOption.bind( this );
@@ -54,6 +55,7 @@ class FileEdit extends Component {
 		this.state = {
 			hasError: false,
 			showCopyConfirmation: false,
+			isEditing: ! attributes.href,
 		};
 	}
 
@@ -94,6 +96,33 @@ class FileEdit extends Component {
 				textLinkHref: media.url,
 				id: media.id,
 			} );
+		}
+		this.toggleIsEditing();
+	}
+
+	onSelectURL( newURL ) {
+		const { href } = this.props.attributes;
+
+		if ( newURL !== href ) {
+			this.props.setAttributes( {
+				href: newURL,
+				id: undefined,
+			} );
+		}
+
+		this.setState( {
+			isEditing: false,
+		} );
+	}
+
+	toggleIsEditing() {
+		this.setState( {
+			isEditing: ! this.state.isEditing,
+		} );
+		if ( this.state.isEditing ) {
+			speak( __( 'You are now viewing the image in the image block.' ) );
+		} else {
+			speak( __( 'You are now editing the image in the image block.' ) );
 		}
 	}
 
@@ -137,33 +166,58 @@ class FileEdit extends Component {
 			textLinkTarget,
 			showDownloadButton,
 			downloadButtonText,
-			id,
 		} = attributes;
-		const { hasError, showCopyConfirmation } = this.state;
+		const { hasError, showCopyConfirmation, isEditing } = this.state;
 		const attachmentPage = media && media.link;
+		const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
 
-		if ( ! href || hasError ) {
+		if ( ! href || isEditing || hasError ) {
 			return (
-				<MediaPlaceholder
-					icon={ <BlockIcon icon={ icon } /> }
-					labels={ {
-						title: __( 'File' ),
-						instructions: __( 'Drag a file, upload a new one or select a file from your library.' ),
-					} }
-					onSelect={ this.onSelectFile }
-					notices={ noticeUI }
-					onError={ noticeOperations.createErrorNotice }
-					accept="*"
-				/>
+				<Fragment>
+					<BlockControls>
+						<Toolbar>
+							{ !! href && ( <IconButton
+								className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': this.state.isEditing } ) }
+								aria-pressed={ this.state.isEditing }
+								label={ __( 'Edit file' ) }
+								onClick={ this.toggleIsEditing }
+								icon={ editImageIcon }
+							/> ) }
+						</Toolbar>
+					</BlockControls>
+					<MediaPlaceholder
+						icon={ <BlockIcon icon={ icon } /> }
+						labels={ {
+							title: __( 'File' ),
+							instructions: __( 'Drag a file, upload a new one or select a file from your library.' ),
+						} }
+						onSelect={ this.onSelectFile }
+						onSelectURL={ this.onSelectURL }
+						onCancel={ !! href && this.toggleIsEditing }
+						notices={ noticeUI }
+						onError={ noticeOperations.createErrorNotice }
+						accept="*"
+					/>
+				</Fragment>
 			);
 		}
 
 		const classes = classnames( className, {
 			'is-transient': isBlobURL( href ),
 		} );
-		const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
 		return (
 			<Fragment>
+				<BlockControls>
+					<Toolbar>
+						<IconButton
+							className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': this.state.isEditing } ) }
+							aria-pressed={ this.state.isEditing }
+							label={ __( 'Edit file' ) }
+							onClick={ this.toggleIsEditing }
+							icon={ editImageIcon }
+						/>
+					</Toolbar>
+				</BlockControls>
 				<FileBlockInspector
 					hrefs={ { href, textLinkHref, attachmentPage } }
 					{ ...{
@@ -174,24 +228,6 @@ class FileEdit extends Component {
 						changeShowDownloadButton: this.changeShowDownloadButton,
 					} }
 				/>
-				<BlockControls>
-					<MediaUploadCheck>
-						<Toolbar>
-							<MediaUpload
-								onSelect={ this.onSelectFile }
-								value={ id }
-								render={ ( { open } ) => (
-									<IconButton
-										className="components-toolbar__control"
-										label={ __( 'Edit file' ) }
-										onClick={ open }
-										icon={ editImageIcon }
-									/>
-								) }
-							/>
-						</Toolbar>
-					</MediaUploadCheck>
-				</BlockControls>
 				<div className={ classes }>
 					<div className={ 'wp-block-file__content-wrapper' }>
 						<RichText

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -273,7 +273,8 @@ class MediaTextEdit extends Component {
 				<BlockControls>
 					<Toolbar
 						controls={ toolbarControls }
-					>
+					/>
+					<Toolbar>
 						{ mediaUrl && <IconButton
 							className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': this.state.isEditing } ) }
 							label={ __( 'Edit Media' ) }

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -24,11 +24,16 @@ import {
 	Toolbar,
 	ExternalLink,
 	FocalPointPicker,
+	IconButton,
+	Path,
+	Rect,
+	SVG,
 } from '@wordpress/components';
 /**
  * Internal dependencies
  */
 import MediaContainer from './media-container';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Constants
@@ -39,15 +44,45 @@ const TEMPLATE = [
 ];
 
 class MediaTextEdit extends Component {
-	constructor() {
+	constructor( { attributes } ) {
 		super( ...arguments );
 
 		this.onSelectMedia = this.onSelectMedia.bind( this );
 		this.onWidthChange = this.onWidthChange.bind( this );
 		this.commitWidthChange = this.commitWidthChange.bind( this );
+		this.toggleIsEditing = this.toggleIsEditing.bind( this );
+		this.onSelectUrl = this.onSelectUrl.bind( this );
+		this.renderMediaArea = this.renderMediaArea.bind( this );
 		this.state = {
 			mediaWidth: null,
+			isEditing: ! attributes.mediaUrl,
 		};
+	}
+
+	toggleIsEditing() {
+		this.setState( {
+			isEditing: ! this.state.isEditing,
+		} );
+		if ( this.state.isEditing ) {
+			speak( __( 'You are now viewing the image in the image block.' ) );
+		} else {
+			speak( __( 'You are now editing the image in the image block.' ) );
+		}
+	}
+
+	onSelectUrl( newURL ) {
+		const { mediaUrl } = this.props.attributes;
+
+		if ( newURL !== mediaUrl ) {
+			this.props.setAttributes( {
+				mediaUrl: newURL,
+				mediaId: undefined,
+			} );
+		}
+
+		this.setState( {
+			isEditing: false,
+		} );
 	}
 
 	onSelectMedia( media ) {
@@ -72,6 +107,10 @@ class MediaTextEdit extends Component {
 			// Try the "large" size URL, falling back to the "full" size URL below.
 			src = get( media, [ 'sizes', 'large', 'url' ] ) || get( media, [ 'media_details', 'sizes', 'large', 'source_url' ] );
 		}
+
+		this.setState( {
+			isEditing: false,
+		} );
 
 		setAttributes( {
 			mediaAlt: media.alt,
@@ -102,7 +141,16 @@ class MediaTextEdit extends Component {
 
 	renderMediaArea() {
 		const { attributes } = this.props;
-		const { mediaAlt, mediaId, mediaPosition, mediaType, mediaUrl, mediaWidth, imageFill, focalPoint } = attributes;
+		const {
+			mediaAlt,
+			mediaId,
+			mediaPosition,
+			mediaType,
+			mediaUrl,
+			mediaWidth,
+			imageFill,
+			focalPoint,
+		} = attributes;
 
 		return (
 			<MediaContainer
@@ -110,6 +158,9 @@ class MediaTextEdit extends Component {
 				onSelectMedia={ this.onSelectMedia }
 				onWidthChange={ this.onWidthChange }
 				commitWidthChange={ this.commitWidthChange }
+				isEditing={ this.state.isEditing }
+				toggleIsEditing={ this.toggleIsEditing }
+				onSelectUrl={ this.onSelectUrl }
 				{ ...{ mediaAlt, mediaId, mediaType, mediaUrl, mediaPosition, mediaWidth, imageFill, focalPoint } }
 			/>
 		);
@@ -208,6 +259,7 @@ class MediaTextEdit extends Component {
 				/> ) }
 			</PanelBody>
 		);
+		const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
 		return (
 			<Fragment>
 				<InspectorControls>
@@ -221,7 +273,15 @@ class MediaTextEdit extends Component {
 				<BlockControls>
 					<Toolbar
 						controls={ toolbarControls }
-					/>
+					>
+						{ mediaUrl && <IconButton
+							className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': this.state.isEditing } ) }
+							label={ __( 'Edit Media' ) }
+							aria-pressed={ this.state.isEditing }
+							onClick={ this.toggleIsEditing }
+							icon={ editImageIcon }
+						/> }
+					</Toolbar>
 					<BlockVerticalAlignmentToolbar
 						onChange={ onVerticalAlignmentChange }
 						value={ verticalAlignment }

--- a/packages/block-library/src/media-text/editor.scss
+++ b/packages/block-library/src/media-text/editor.scss
@@ -50,6 +50,10 @@ figure.block-library-media-text__media-container {
 	width: 100%;
 }
 
+.wp-block-media-text .block-library-media-text__media-container .components-placeholder__preview img {
+	width: 80%;
+}
+
 .editor-media-container__resizer .components-resizable-box__handle {
 	display: none;
 }

--- a/packages/block-library/src/media-text/media-container.js
+++ b/packages/block-library/src/media-text/media-container.js
@@ -1,7 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { IconButton, ResizableBox, Toolbar } from '@wordpress/components';
+import {
+	IconButton,
+	ResizableBox,
+	Toolbar,
+	Path,
+	Rect,
+	SVG,
+} from '@wordpress/components';
 import {
 	BlockControls,
 	BlockIcon,
@@ -33,6 +40,7 @@ export function imageFillStyles( url, focalPoint ) {
 class MediaContainer extends Component {
 	renderToolbarEditButton() {
 		const { mediaId, onSelectMedia } = this.props;
+		const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
 		return (
 			<BlockControls>
 				<Toolbar>
@@ -44,7 +52,7 @@ class MediaContainer extends Component {
 							<IconButton
 								className="components-toolbar__control"
 								label={ __( 'Edit media' ) }
-								icon="edit"
+								icon={ editImageIcon }
 								onClick={ open }
 							/>
 						) }

--- a/packages/block-library/src/media-text/media-container.js
+++ b/packages/block-library/src/media-text/media-container.js
@@ -2,18 +2,11 @@
  * WordPress dependencies
  */
 import {
-	IconButton,
 	ResizableBox,
-	Toolbar,
-	Path,
-	Rect,
-	SVG,
 } from '@wordpress/components';
 import {
-	BlockControls,
 	BlockIcon,
 	MediaPlaceholder,
-	MediaUpload,
 } from '@wordpress/block-editor';
 import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -38,36 +31,11 @@ export function imageFillStyles( url, focalPoint ) {
 }
 
 class MediaContainer extends Component {
-	renderToolbarEditButton() {
-		const { mediaId, onSelectMedia } = this.props;
-		const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
-		return (
-			<BlockControls>
-				<Toolbar>
-					<MediaUpload
-						onSelect={ onSelectMedia }
-						allowedTypes={ ALLOWED_MEDIA_TYPES }
-						value={ mediaId }
-						render={ ( { open } ) => (
-							<IconButton
-								className="components-toolbar__control"
-								label={ __( 'Edit media' ) }
-								icon={ editImageIcon }
-								onClick={ open }
-							/>
-						) }
-					/>
-				</Toolbar>
-			</BlockControls>
-		);
-	}
-
 	renderImage() {
 		const { mediaAlt, mediaUrl, className, imageFill, focalPoint } = this.props;
 		const backgroundStyles = imageFill ? imageFillStyles( mediaUrl, focalPoint ) : {};
 		return (
 			<Fragment>
-				{ this.renderToolbarEditButton() }
 				<figure className={ className } style={ backgroundStyles }>
 					<img src={ mediaUrl } alt={ mediaAlt } />
 				</figure>
@@ -79,7 +47,6 @@ class MediaContainer extends Component {
 		const { mediaUrl, className } = this.props;
 		return (
 			<Fragment>
-				{ this.renderToolbarEditButton() }
 				<figure className={ className }>
 					<video controls src={ mediaUrl } />
 				</figure>
@@ -88,60 +55,84 @@ class MediaContainer extends Component {
 	}
 
 	renderPlaceholder() {
-		const { onSelectMedia, className } = this.props;
+		const {
+			mediaUrl,
+			mediaId,
+			toggleIsEditing,
+			onSelectMedia,
+			onSelectUrl,
+			className,
+		} = this.props;
+
+		const labels = {
+			title: ! mediaUrl ? __( 'Media' ) : __( 'Edit media' ),
+		};
+
+		const mediaPreview = ( !! mediaUrl && <img
+			alt={ __( 'Edit media' ) }
+			title={ __( 'Edit media' ) }
+			className={ 'edit-image-preview' }
+			src={ mediaUrl }
+		/> );
+
 		return (
+
 			<MediaPlaceholder
 				icon={ <BlockIcon icon={ icon } /> }
-				labels={ {
-					title: __( 'Media area' ),
-				} }
 				className={ className }
+				labels={ labels }
 				onSelect={ onSelectMedia }
+				onSelectURL={ onSelectUrl }
+				onDoubleClick={ toggleIsEditing }
+				onCancel={ !! mediaUrl && toggleIsEditing }
+				onError={ this.onUploadError }
 				accept="image/*,video/*"
 				allowedTypes={ ALLOWED_MEDIA_TYPES }
+				value={ { mediaId, mediaUrl } }
+				mediaPreview={ mediaPreview }
 			/>
 		);
 	}
 
 	render() {
-		const { mediaPosition, mediaUrl, mediaType, mediaWidth, commitWidthChange, onWidthChange } = this.props;
-		if ( mediaType && mediaUrl ) {
-			const onResize = ( event, direction, elt ) => {
-				onWidthChange( parseInt( elt.style.width ) );
-			};
-			const onResizeStop = ( event, direction, elt ) => {
-				commitWidthChange( parseInt( elt.style.width ) );
-			};
-			const enablePositions = {
-				right: mediaPosition === 'left',
-				left: mediaPosition === 'right',
-			};
-
-			let mediaElement = null;
-			switch ( mediaType ) {
-				case 'image':
-					mediaElement = this.renderImage();
-					break;
-				case 'video':
-					mediaElement = this.renderVideo();
-					break;
-			}
-			return (
-				<ResizableBox
-					className="editor-media-container__resizer"
-					size={ { width: mediaWidth + '%' } }
-					minWidth="10%"
-					maxWidth="100%"
-					enable={ enablePositions }
-					onResize={ onResize }
-					onResizeStop={ onResizeStop }
-					axis="x"
-				>
-					{ mediaElement }
-				</ResizableBox>
-			);
+		const { isEditing, mediaPosition, mediaType, mediaWidth, commitWidthChange, onWidthChange } = this.props;
+		if ( isEditing ) {
+			return this.renderPlaceholder();
 		}
-		return this.renderPlaceholder();
+		const onResize = ( event, direction, elt ) => {
+			onWidthChange( parseInt( elt.style.width ) );
+		};
+		const onResizeStop = ( event, direction, elt ) => {
+			commitWidthChange( parseInt( elt.style.width ) );
+		};
+		const enablePositions = {
+			right: mediaPosition === 'left',
+			left: mediaPosition === 'right',
+		};
+
+		let mediaElement = null;
+		switch ( mediaType ) {
+			case 'image':
+				mediaElement = this.renderImage();
+				break;
+			case 'video':
+				mediaElement = this.renderVideo();
+				break;
+		}
+		return (
+			<ResizableBox
+				className="editor-media-container__resizer"
+				size={ { width: mediaWidth + '%' } }
+				minWidth="10%"
+				maxWidth="100%"
+				enable={ enablePositions }
+				onResize={ onResize }
+				onResizeStop={ onResizeStop }
+				axis="x"
+			>
+				{ mediaElement }
+			</ResizableBox>
+		);
 	}
 }
 

--- a/packages/block-library/src/media-text/media-container.js
+++ b/packages/block-library/src/media-text/media-container.js
@@ -58,6 +58,7 @@ class MediaContainer extends Component {
 		const {
 			mediaUrl,
 			mediaId,
+			mediaType,
 			toggleIsEditing,
 			onSelectMedia,
 			onSelectUrl,
@@ -89,7 +90,7 @@ class MediaContainer extends Component {
 				accept="image/*,video/*"
 				allowedTypes={ ALLOWED_MEDIA_TYPES }
 				value={ { mediaId, mediaUrl } }
-				mediaPreview={ mediaPreview }
+				mediaPreview={ mediaType === 'image' && mediaPreview }
 			/>
 		);
 	}

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -8,7 +8,10 @@ import {
 	Disabled,
 	IconButton,
 	PanelBody,
+	Path,
+	Rect,
 	SelectControl,
+	SVG,
 	ToggleControl,
 	Toolbar,
 	withNotices,
@@ -181,6 +184,7 @@ class VideoEdit extends Component {
 		}
 		const videoPosterDescription = `video-block__poster-image-description-${ instanceId }`;
 
+		const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
 		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 		return (
 			<Fragment>
@@ -190,7 +194,7 @@ class VideoEdit extends Component {
 							className="components-icon-button components-toolbar__control"
 							label={ __( 'Edit video' ) }
 							onClick={ switchToEditing }
-							icon="edit"
+							icon={ editImageIcon }
 						/>
 					</Toolbar>
 				</BlockControls>

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -205,8 +205,6 @@ class VideoEdit extends Component {
 		}
 		const videoPosterDescription = `video-block__poster-image-description-${ instanceId }`;
 
-		const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
-
 		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 		return (
 			<Fragment>

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { getBlobByURL, isBlobURL } from '@wordpress/blob';
@@ -151,7 +156,7 @@ class VideoEdit extends Component {
 		} = this.props;
 		const { editing } = this.state;
 		const switchToEditing = () => {
-			this.setState( { editing: true } );
+			this.setState( { editing: ! this.state.editing } );
 		};
 		const onSelectVideo = ( media ) => {
 			if ( ! media || ! media.url ) {
@@ -167,24 +172,41 @@ class VideoEdit extends Component {
 			this.setState( { src: media.url, editing: false } );
 		};
 
+		const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
+
 		if ( editing ) {
 			return (
-				<MediaPlaceholder
-					icon={ <BlockIcon icon={ icon } /> }
-					className={ className }
-					onSelect={ onSelectVideo }
-					onSelectURL={ this.onSelectURL }
-					accept="video/*"
-					allowedTypes={ ALLOWED_MEDIA_TYPES }
-					value={ this.props.attributes }
-					notices={ noticeUI }
-					onError={ noticeOperations.createErrorNotice }
-				/>
+				<Fragment>
+					<BlockControls>
+						{ !! src && ( <Toolbar>
+							<IconButton
+								className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': this.state.editing } ) }
+								aria-pressed={ this.state.editing }
+								label={ __( 'Edit video' ) }
+								onClick={ switchToEditing }
+								icon={ editImageIcon }
+							/>
+						</Toolbar> ) }
+					</BlockControls>
+					<MediaPlaceholder
+						icon={ <BlockIcon icon={ icon } /> }
+						className={ className }
+						onSelect={ onSelectVideo }
+						onSelectURL={ this.onSelectURL }
+						onCancel={ !! src && switchToEditing }
+						accept="video/*"
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
+						value={ this.props.attributes }
+						notices={ noticeUI }
+						onError={ noticeOperations.createErrorNotice }
+					/>
+				</Fragment>
 			);
 		}
 		const videoPosterDescription = `video-block__poster-image-description-${ instanceId }`;
 
 		const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
+
 		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 		return (
 			<Fragment>

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -30,6 +30,7 @@
 	justify-content: center;
 	font-weight: 600;
 	margin-bottom: 1em;
+	margin-top: 1em;
 
 	.dashicon,
 	.block-editor-block-icon {


### PR DESCRIPTION
## Description
Closes #14795 

This is a follow up to the image block edit flow update which ports the new flow to all the blocks which have media with an edit state. The blocks affected are:

- media+text
- cover
- audio
- video
- file

## How has this been tested?
For now I've only tested locally.

## Types of change
New feature (non-breaking change which adds functionality)

## Screenshots

### Media + text
![media+text](https://user-images.githubusercontent.com/107534/55975613-0bd58000-5c93-11e9-9cd2-0dfca34fc26f.gif)

### Cover
![cover](https://user-images.githubusercontent.com/107534/55975900-a33ad300-5c93-11e9-92f5-71f86914cf64.gif)

### Audio
![audio](https://user-images.githubusercontent.com/107534/55976121-16444980-5c94-11e9-8858-a3d80ac636ef.gif)

### File
![file](https://user-images.githubusercontent.com/107534/55976214-53a8d700-5c94-11e9-98ee-a41235cc8466.gif)

### Video
![video](https://user-images.githubusercontent.com/107534/55976311-8783fc80-5c94-11e9-9262-1ac1cb55d890.gif)

### Embed
![embed](https://user-images.githubusercontent.com/107534/55976429-daf64a80-5c94-11e9-8ebc-e95a552e8f8f.gif)


