### PR TITLE
Fix move block to position bug; Add test cases;

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -331,6 +331,12 @@ export function* moveBlockToPosition( clientId, fromRootClientId = '', toRootCli
 		return;
 	}
 
+	// If templateLock is insert we can not remove the block from the parent.
+	// Given that here we know that we are moving the block to a different parent, the move should not be possible if the condition is true.
+	if ( templateLock === 'insert' ) {
+		return;
+	}
+
 	const blockName = yield select(
 		'core/block-editor',
 		'getBlockName',

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -9,6 +9,7 @@ import {
 	insertBlock,
 	insertBlocks,
 	mergeBlocks,
+	moveBlockToPosition,
 	multiSelect,
 	removeBlock,
 	removeBlocks,
@@ -465,6 +466,184 @@ describe( 'actions', () => {
 					'getBlockCount',
 				),
 			] );
+		} );
+	} );
+
+	describe( 'moveBlockToPosition', () => {
+		it( 'should yield MOVE_BLOCK_TO_POSITION action if locking is insert and move is not changing the root block', () => {
+			const moveBlockToPositionGenerator = moveBlockToPosition(
+				'chicken',
+				'ribs',
+				'ribs',
+				5
+			);
+
+			expect(
+				moveBlockToPositionGenerator.next().value
+			).toEqual( {
+				args: [ 'ribs' ],
+				selectorName: 'getTemplateLock',
+				storeName: 'core/block-editor',
+				type: 'SELECT',
+			} );
+
+			expect(
+				moveBlockToPositionGenerator.next( 'insert' ).value
+			).toEqual( {
+				type: 'MOVE_BLOCK_TO_POSITION',
+				fromRootClientId: 'ribs',
+				toRootClientId: 'ribs',
+				clientId: 'chicken',
+				index: 5,
+			} );
+
+			expect(
+				moveBlockToPositionGenerator.next().done
+			).toBe( true );
+		} );
+
+		it( 'should not yield MOVE_BLOCK_TO_POSITION action if locking is all', () => {
+			const moveBlockToPositionGenerator = moveBlockToPosition(
+				'chicken',
+				'ribs',
+				'ribs',
+				5
+			);
+
+			expect(
+				moveBlockToPositionGenerator.next().value
+			).toEqual( {
+				args: [ 'ribs' ],
+				selectorName: 'getTemplateLock',
+				storeName: 'core/block-editor',
+				type: 'SELECT',
+			} );
+
+			expect(
+				moveBlockToPositionGenerator.next( 'all' )
+			).toEqual( {
+				done: true,
+				value: undefined,
+			} );
+		} );
+
+		it( 'should not yield MOVE_BLOCK_TO_POSITION action if locking is insert and move is changing the root block', () => {
+			const moveBlockToPositionGenerator = moveBlockToPosition(
+				'chicken',
+				'ribs',
+				'chicken-ribs',
+				5
+			);
+
+			expect(
+				moveBlockToPositionGenerator.next().value
+			).toEqual( {
+				args: [ 'ribs' ],
+				selectorName: 'getTemplateLock',
+				storeName: 'core/block-editor',
+				type: 'SELECT',
+			} );
+
+			expect(
+				moveBlockToPositionGenerator.next( 'insert' )
+			).toEqual( {
+				done: true,
+				value: undefined,
+			} );
+		} );
+
+		it( 'should yield MOVE_BLOCK_TO_POSITION action if there is not locking in the original root block and block can be inserted in the destination', () => {
+			const moveBlockToPositionGenerator = moveBlockToPosition( 'chicken',
+				'ribs',
+				'chicken-ribs',
+				5
+			);
+
+			expect(
+				moveBlockToPositionGenerator.next().value
+			).toEqual( {
+				args: [ 'ribs' ],
+				selectorName: 'getTemplateLock',
+				storeName: 'core/block-editor',
+				type: 'SELECT',
+			} );
+
+			expect(
+				moveBlockToPositionGenerator.next().value
+			).toEqual( {
+				args: [ 'chicken' ],
+				selectorName: 'getBlockName',
+				storeName: 'core/block-editor',
+				type: 'SELECT',
+			} );
+
+			expect(
+				moveBlockToPositionGenerator.next( 'myblock/chicken-block' ).value
+			).toEqual( {
+				args: [ 'myblock/chicken-block', 'chicken-ribs' ],
+				selectorName: 'canInsertBlockType',
+				storeName: 'core/block-editor',
+				type: 'SELECT',
+			} );
+
+			expect(
+				moveBlockToPositionGenerator.next( true ).value
+			).toEqual( {
+				type: 'MOVE_BLOCK_TO_POSITION',
+				fromRootClientId: 'ribs',
+				toRootClientId: 'chicken-ribs',
+				clientId: 'chicken',
+				index: 5,
+			} );
+
+			expect(
+				moveBlockToPositionGenerator.next()
+			).toEqual( {
+				done: true,
+				value: undefined,
+			} );
+		} );
+
+		it( 'should not yield MOVE_BLOCK_TO_POSITION action if there is not locking in the original root block and block can be inserted in the destination', () => {
+			const moveBlockToPositionGenerator = moveBlockToPosition( 'chicken',
+				'ribs',
+				'chicken-ribs',
+				5
+			);
+
+			expect(
+				moveBlockToPositionGenerator.next().value
+			).toEqual( {
+				args: [ 'ribs' ],
+				selectorName: 'getTemplateLock',
+				storeName: 'core/block-editor',
+				type: 'SELECT',
+			} );
+
+			expect(
+				moveBlockToPositionGenerator.next().value
+			).toEqual( {
+				args: [ 'chicken' ],
+				selectorName: 'getBlockName',
+				storeName: 'core/block-editor',
+				type: 'SELECT',
+			} );
+
+			expect(
+				moveBlockToPositionGenerator.next( 'myblock/chicken-block' ).value
+			).toEqual( {
+				args: [ 'myblock/chicken-block', 'chicken-ribs' ],
+				selectorName: 'canInsertBlockType',
+				storeName: 'core/block-editor',
+				type: 'SELECT',
+			} );
+
+			expect(
+				moveBlockToPositionGenerator.next( false )
+			).toEqual( {
+				done: true,
+				value: undefined,
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
## Description
On https://github.com/WordPress/gutenberg/pull/14003 I missed a case where a restriction was still not being applied and the moving blocks were possible when it should not be.

Basically, if an InnerBlocks are contained templateLock insert we should be able to move inside the area but not move an InnerBlock to another root block, that move was still possible.

I also add test cases to the moveBlockToPosition action.


## How has this been tested?
Add the blocks available in https://gist.github.com/jorgefilipecosta/c9a9cc1c5199aca6786413492c302ccd.
Add the product block.
Verify none of its nested blocks can be moved outside. (before they could).