### PR TITLE
Adds a new option to core/editor to disable code editing

### DIFF
--- a/docs/designers-developers/developers/filters/editor-filters.md
+++ b/docs/designers-developers/developers/filters/editor-filters.md
@@ -32,7 +32,7 @@ wp.hooks.addFilter( 'editor.PostPreview.interstitialMarkup', 'my-plugin/custom-p
 ## Editor settings
 
 ### `block_editor_settings`
-This is a PHP filter which is applied before sending settings to the Editor in `wp-admin/edit-form-blocks.php`.
+This is a PHP filter which is applied before sending settings to the WordPress block editor.
 
 You may find details about this filter [on its WordPress Code Reference page](wp-admin/edit-form-blocks.php).
 

--- a/docs/designers-developers/developers/filters/editor-filters.md
+++ b/docs/designers-developers/developers/filters/editor-filters.md
@@ -47,6 +47,6 @@ It is set by default by the WordPress function [`user_can_richedit`](https://dev
 
 
 #### `codeEditingEnabled`
-Default `true`. Sets if the user can access the code editor **in adition** to the visual editor.
+Default `true`. Indicates whether the user can access the Code Editor **in addition** to the Visual Editor.
 
 If set to false the user will not be able to switch between Visual and Code editor. The option in the settings menu will not be available and the keyboard shortcut for switching editor types will not fire.  

--- a/docs/designers-developers/developers/filters/editor-filters.md
+++ b/docs/designers-developers/developers/filters/editor-filters.md
@@ -41,7 +41,7 @@ The filter will send any setting to the initialized Editor, which means any edit
 ### Available default editor settings
 
 #### `richEditingEnabled`
-If it is true the user can edit the content using the visual editor.
+If it is `true` the user can edit the content using the Visual Editor.
 
 It is set by default by the WordPress function [`user_can_richedit`](https://developer.wordpress.org/reference/functions/user_can_richedit/). This function checks if the user can access the visual editor and that it’s supported by the user’s browser.
 

--- a/docs/designers-developers/developers/filters/editor-filters.md
+++ b/docs/designers-developers/developers/filters/editor-filters.md
@@ -34,7 +34,7 @@ wp.hooks.addFilter( 'editor.PostPreview.interstitialMarkup', 'my-plugin/custom-p
 ### `block_editor_settings`
 This is a PHP filter which is applied before sending settings to the WordPress block editor.
 
-You may find details about this filter [on its WordPress Code Reference page](wp-admin/edit-form-blocks.php).
+You may find details about this filter [on its WordPress Code Reference page](https://developer.wordpress.org/reference/hooks/block_editor_settings/).
 
 The filter will send any setting to the initialized Editor, which means any editor setting that is used to configure the editor at initialisation can be filtered by a PHP WordPress plugin before being sent. 
 

--- a/docs/designers-developers/developers/filters/editor-filters.md
+++ b/docs/designers-developers/developers/filters/editor-filters.md
@@ -1,5 +1,4 @@
 # Editor Filters (Experimental)
-
 To modify the behavior of the editor experience, the following Filters are exposed:
 
 ### `editor.PostFeaturedImage.imageSize`
@@ -30,3 +29,24 @@ var customPreviewMessage = function() {
 wp.hooks.addFilter( 'editor.PostPreview.interstitialMarkup', 'my-plugin/custom-preview-message', customPreviewMessage );
 ```
 
+## Editor settings
+
+### `block_editor_settings`
+This is a PHP filter which is applied before sending settings to the Editor in `wp-admin/edit-form-blocks.php`.
+
+You may find details about this filter [on its WordPress Code Reference page](wp-admin/edit-form-blocks.php).
+
+The filter will send any setting to the initialized Editor, which means any editor setting that is used to configure the editor at initialisation can be filtered by a PHP WordPress plugin before being sent. 
+
+### Available default editor settings
+
+#### `richEditingEnabled`
+If it is true the user can edit the content using the visual editor.
+
+It is set by default by the WordPress function [`user_can_richedit`](https://developer.wordpress.org/reference/functions/user_can_richedit/). This function checks if the user can access the visual editor and that it’s supported by the user’s browser.
+
+
+#### `codeEditingEnabled`
+Default `true`. Sets if the user can access the code editor **in adition** to the visual editor.
+
+If set to false the user will not be able to switch between Visual and Code editor. The option in the settings menu will not be available and the keyboard shortcut for switching editor types will not fire.  

--- a/docs/designers-developers/developers/filters/editor-filters.md
+++ b/docs/designers-developers/developers/filters/editor-filters.md
@@ -43,7 +43,7 @@ The filter will send any setting to the initialized Editor, which means any edit
 #### `richEditingEnabled`
 If it is `true` the user can edit the content using the Visual Editor.
 
-It is set by default by the WordPress function [`user_can_richedit`](https://developer.wordpress.org/reference/functions/user_can_richedit/). This function checks if the user can access the visual editor and that it’s supported by the user’s browser.
+It is set by default to the return value of the [`user_can_richedit`](https://developer.wordpress.org/reference/functions/user_can_richedit/) function. It checks if the user can access the Visual Editor and whether it’s supported by the user’s browser.
 
 
 #### `codeEditingEnabled`

--- a/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
@@ -12,12 +12,8 @@ import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
-export function BlockModeToggle( { blockType, mode, onToggleMode, small = false, isCodeEditingEnabled } ) {
-	if ( ! hasBlockSupport( blockType, 'html', true ) ) {
-		return null;
-	}
-
-	if ( ! isCodeEditingEnabled ) {
+export function BlockModeToggle( { blockType, mode, onToggleMode, small = false, isCodeEditingEnabled = true } ) {
+	if ( ! hasBlockSupport( blockType, 'html', true ) || ! isCodeEditingEnabled ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
@@ -12,8 +12,12 @@ import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
-export function BlockModeToggle( { blockType, mode, onToggleMode, small = false } ) {
+export function BlockModeToggle( { blockType, mode, onToggleMode, small = false, isCodeEditingEnabled } ) {
 	if ( ! hasBlockSupport( blockType, 'html', true ) ) {
+		return null;
+	}
+
+	if ( ! isCodeEditingEnabled ) {
 		return null;
 	}
 
@@ -36,10 +40,12 @@ export default compose( [
 	withSelect( ( select, { clientId } ) => {
 		const { getBlock, getBlockMode } = select( 'core/block-editor' );
 		const block = getBlock( clientId );
+		const isCodeEditingEnabled = select( 'core/editor' ).getEditorSettings().codeEditingEnabled;
 
 		return {
 			mode: getBlockMode( clientId ),
 			blockType: block ? getBlockType( block.name ) : null,
+			isCodeEditingEnabled,
 		};
 	} ),
 	withDispatch( ( dispatch, { onToggle = noop, clientId } ) => ( {

--- a/packages/block-editor/src/components/block-settings-menu/test/block-mode-toggle.js
+++ b/packages/block-editor/src/components/block-settings-menu/test/block-mode-toggle.js
@@ -28,6 +28,7 @@ describe( 'BlockModeToggle', () => {
 			<BlockModeToggle
 				blockType={ { supports: { html: true } } }
 				mode="visual"
+				isCodeEditingEnabled={ true }
 			/>
 		);
 		const text = wrapper.props.children;
@@ -40,6 +41,7 @@ describe( 'BlockModeToggle', () => {
 			<BlockModeToggle
 				blockType={ { supports: { html: true } } }
 				mode="html"
+				isCodeEditingEnabled={ true }
 			/>
 		);
 		const text = wrapper.props.children;

--- a/packages/block-editor/src/components/block-settings-menu/test/block-mode-toggle.js
+++ b/packages/block-editor/src/components/block-settings-menu/test/block-mode-toggle.js
@@ -28,7 +28,6 @@ describe( 'BlockModeToggle', () => {
 			<BlockModeToggle
 				blockType={ { supports: { html: true } } }
 				mode="visual"
-				isCodeEditingEnabled={ true }
 			/>
 		);
 		const text = wrapper.props.children;
@@ -41,11 +40,22 @@ describe( 'BlockModeToggle', () => {
 			<BlockModeToggle
 				blockType={ { supports: { html: true } } }
 				mode="html"
-				isCodeEditingEnabled={ true }
 			/>
 		);
 		const text = wrapper.props.children;
 
 		expect( text ).toEqual( 'Edit visually' );
+	} );
+
+	it( 'should not render the Visual mode button if code editing is disabled', () => {
+		const wrapper = getShallowRenderOutput(
+			<BlockModeToggle
+				blockType={ { supports: { html: true } } }
+				mode="html"
+				isCodeEditingEnabled={ false }
+			/>
+		);
+
+		expect( wrapper ).toBe( null );
 	} );
 } );

--- a/packages/edit-post/src/components/header/mode-switcher/index.js
+++ b/packages/edit-post/src/components/header/mode-switcher/index.js
@@ -53,8 +53,7 @@ export default compose( [
 		isCodeEditingEnabled: select( 'core/editor' ).getEditorSettings().codeEditingEnabled,
 		mode: select( 'core/edit-post' ).getEditorMode(),
 	} ) ),
-	ifCondition( ( { isRichEditingEnabled } ) => isRichEditingEnabled ),
-	ifCondition( ( { isCodeEditingEnabled } ) => isCodeEditingEnabled ),
+	ifCondition( ( { isRichEditingEnabled, isCodeEditingEnabled } ) => isRichEditingEnabled && isCodeEditingEnabled ),
 	withDispatch( ( dispatch ) => ( {
 		onSwitch( mode ) {
 			dispatch( 'core/edit-post' ).switchEditorMode( mode );

--- a/packages/edit-post/src/components/header/mode-switcher/index.js
+++ b/packages/edit-post/src/components/header/mode-switcher/index.js
@@ -50,9 +50,11 @@ function ModeSwitcher( { onSwitch, mode } ) {
 export default compose( [
 	withSelect( ( select ) => ( {
 		isRichEditingEnabled: select( 'core/editor' ).getEditorSettings().richEditingEnabled,
+		isCodeEditingEnabled: select( 'core/editor' ).getEditorSettings().codeEditingEnabled,
 		mode: select( 'core/edit-post' ).getEditorMode(),
 	} ) ),
 	ifCondition( ( { isRichEditingEnabled } ) => isRichEditingEnabled ),
+	ifCondition( ( { isCodeEditingEnabled } ) => isCodeEditingEnabled ),
 	withDispatch( ( dispatch ) => ( {
 		onSwitch( mode ) {
 			dispatch( 'core/edit-post' ).switchEditorMode( mode );

--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -20,8 +20,8 @@ class EditorModeKeyboardShortcuts extends Component {
 	}
 
 	toggleMode() {
-		const { mode, switchMode, isRichEditingEnabled, isCodeEditingEnabled } = this.props;
-		if ( ! isRichEditingEnabled || ! isCodeEditingEnabled ) {
+		const { mode, switchMode, isModeSwitchEnabled } = this.props;
+		if ( ! isModeSwitchEnabled ) {
 			return;
 		}
 		switchMode( mode === 'visual' ? 'text' : 'visual' );
@@ -54,12 +54,15 @@ class EditorModeKeyboardShortcuts extends Component {
 }
 
 export default compose( [
-	withSelect( ( select ) => ( {
-		isRichEditingEnabled: select( 'core/editor' ).getEditorSettings().richEditingEnabled,
-		isCodeEditingEnabled: select( 'core/editor' ).getEditorSettings().codeEditingEnabled,
-		mode: select( 'core/edit-post' ).getEditorMode(),
-		isEditorSidebarOpen: select( 'core/edit-post' ).isEditorSidebarOpened(),
-	} ) ),
+	withSelect( ( select ) => {
+		const { richEditingEnabled, codeEditingEnabled } = select( 'core/editor' ).getEditorSettings();
+
+		return {
+			isModeSwitchEnabled: richEditingEnabled && codeEditingEnabled,
+			mode: select( 'core/edit-post' ).getEditorMode(),
+			isEditorSidebarOpen: select( 'core/edit-post' ).isEditorSidebarOpened(),
+		};
+	} ),
 	withDispatch( ( dispatch, ownProps, { select } ) => ( {
 		switchMode( mode ) {
 			dispatch( 'core/edit-post' ).switchEditorMode( mode );

--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -20,8 +20,8 @@ class EditorModeKeyboardShortcuts extends Component {
 	}
 
 	toggleMode() {
-		const { mode, switchMode, isRichEditingEnabled } = this.props;
-		if ( ! isRichEditingEnabled ) {
+		const { mode, switchMode, isRichEditingEnabled, isCodeEditingEnabled } = this.props;
+		if ( ! isRichEditingEnabled || ! isCodeEditingEnabled ) {
 			return;
 		}
 		switchMode( mode === 'visual' ? 'text' : 'visual' );
@@ -56,6 +56,7 @@ class EditorModeKeyboardShortcuts extends Component {
 export default compose( [
 	withSelect( ( select ) => ( {
 		isRichEditingEnabled: select( 'core/editor' ).getEditorSettings().richEditingEnabled,
+		isCodeEditingEnabled: select( 'core/editor' ).getEditorSettings().codeEditingEnabled,
 		mode: select( 'core/edit-post' ).getEditorMode(),
 		isEditorSidebarOpen: select( 'core/edit-post' ).isEditorSidebarOpened(),
 	} ) ),

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -56,6 +56,7 @@ function Layout( {
 	isSaving,
 	isMobileViewport,
 	isRichEditingEnabled,
+	isCodeEditingEnabled,
 } ) {
 	const sidebarIsOpened = editorSidebarOpened || pluginSidebarOpened || publishSidebarOpened;
 
@@ -92,7 +93,7 @@ function Layout( {
 				<ManageBlocksModal />
 				<OptionsModal />
 				{ ( mode === 'text' || ! isRichEditingEnabled ) && <TextEditor /> }
-				{ isRichEditingEnabled && mode === 'visual' && <VisualEditor /> }
+				{ ( ( isRichEditingEnabled && mode === 'visual' ) || ! isCodeEditingEnabled ) && <VisualEditor /> }
 				<div className="edit-post-layout__metaboxes">
 					<MetaBoxes location="normal" />
 				</div>
@@ -145,6 +146,7 @@ export default compose(
 		hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
 		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
 		isRichEditingEnabled: select( 'core/editor' ).getEditorSettings().richEditingEnabled,
+		isCodeEditingEnabled: select( 'core/editor' ).getEditorSettings().codeEditingEnabled,
 	} ) ),
 	withDispatch( ( dispatch ) => {
 		const { closePublishSidebar, togglePublishSidebar } = dispatch( 'core/edit-post' );

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -136,20 +136,16 @@ function Layout( {
 }
 
 export default compose(
-	withSelect( ( select ) => {
-		const isCodeEditingEnabled = select( 'core/editor' ).getEditorSettings().codeEditingEnabled;
-		return {
-			editorSidebarOpened: select( 'core/edit-post' ).isEditorSidebarOpened(),
-			pluginSidebarOpened: select( 'core/edit-post' ).isPluginSidebarOpened(),
-			publishSidebarOpened: select( 'core/edit-post' ).isPublishSidebarOpened(),
-			hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' ),
-			hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
-			isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
-			isRichEditingEnabled: select( 'core/editor' ).getEditorSettings().richEditingEnabled,
-			isCodeEditingEnabled,
-			mode: isCodeEditingEnabled ? select( 'core/edit-post' ).getEditorMode() : 'visual',
-		};
-	} ),
+	withSelect( ( select ) => ( {
+		mode: select( 'core/edit-post' ).getEditorMode(),
+		editorSidebarOpened: select( 'core/edit-post' ).isEditorSidebarOpened(),
+		pluginSidebarOpened: select( 'core/edit-post' ).isPluginSidebarOpened(),
+		publishSidebarOpened: select( 'core/edit-post' ).isPublishSidebarOpened(),
+		hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' ),
+		hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
+		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
+		isRichEditingEnabled: select( 'core/editor' ).getEditorSettings().richEditingEnabled,
+	} ) ),
 	withDispatch( ( dispatch ) => {
 		const { closePublishSidebar, togglePublishSidebar } = dispatch( 'core/edit-post' );
 		return {

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -136,16 +136,20 @@ function Layout( {
 }
 
 export default compose(
-	withSelect( ( select ) => ( {
-		mode: select( 'core/edit-post' ).getEditorMode(),
-		editorSidebarOpened: select( 'core/edit-post' ).isEditorSidebarOpened(),
-		pluginSidebarOpened: select( 'core/edit-post' ).isPluginSidebarOpened(),
-		publishSidebarOpened: select( 'core/edit-post' ).isPublishSidebarOpened(),
-		hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' ),
-		hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
-		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
-		isRichEditingEnabled: select( 'core/editor' ).getEditorSettings().richEditingEnabled,
-	} ) ),
+	withSelect( ( select ) => {
+		const isCodeEditingEnabled = select( 'core/editor' ).getEditorSettings().codeEditingEnabled;
+		return {
+			editorSidebarOpened: select( 'core/edit-post' ).isEditorSidebarOpened(),
+			pluginSidebarOpened: select( 'core/edit-post' ).isPluginSidebarOpened(),
+			publishSidebarOpened: select( 'core/edit-post' ).isPublishSidebarOpened(),
+			hasFixedToolbar: select( 'core/edit-post' ).isFeatureActive( 'fixedToolbar' ),
+			hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
+			isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
+			isRichEditingEnabled: select( 'core/editor' ).getEditorSettings().richEditingEnabled,
+			isCodeEditingEnabled,
+			mode: isCodeEditingEnabled ? select( 'core/edit-post' ).getEditorMode() : 'visual',
+		};
+	} ),
 	withDispatch( ( dispatch ) => {
 		const { closePublishSidebar, togglePublishSidebar } = dispatch( 'core/edit-post' );
 		return {

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -56,7 +56,6 @@ function Layout( {
 	isSaving,
 	isMobileViewport,
 	isRichEditingEnabled,
-	isCodeEditingEnabled,
 } ) {
 	const sidebarIsOpened = editorSidebarOpened || pluginSidebarOpened || publishSidebarOpened;
 
@@ -93,7 +92,7 @@ function Layout( {
 				<ManageBlocksModal />
 				<OptionsModal />
 				{ ( mode === 'text' || ! isRichEditingEnabled ) && <TextEditor /> }
-				{ ( ( isRichEditingEnabled && mode === 'visual' ) || ! isCodeEditingEnabled ) && <VisualEditor /> }
+				{ isRichEditingEnabled && mode === 'visual' && <VisualEditor /> }
 				<div className="edit-post-layout__metaboxes">
 					<MetaBoxes location="normal" />
 				</div>
@@ -146,7 +145,6 @@ export default compose(
 		hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
 		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
 		isRichEditingEnabled: select( 'core/editor' ).getEditorSettings().richEditingEnabled,
-		isCodeEditingEnabled: select( 'core/editor' ).getEditorSettings().codeEditingEnabled,
 	} ) ),
 	withDispatch( ( dispatch ) => {
 		const { closePublishSidebar, togglePublishSidebar } = dispatch( 'core/edit-post' );

--- a/packages/editor/src/store/defaults.js
+++ b/packages/editor/src/store/defaults.js
@@ -20,6 +20,7 @@ export const INITIAL_EDITS_DEFAULTS = {};
  *
  *  allowedBlockTypes  boolean|Array Allowed block types
  *  richEditingEnabled boolean       Whether rich editing is enabled or not
+ *  codeEditingEnabled boolean       Whether code editing is enabled or not
  *  enableCustomFields boolean       Whether the WordPress custom fields are enabled or not
  *  autosaveInterval   number        Autosave Interval
  *  availableTemplates array?        The available post templates
@@ -31,6 +32,7 @@ export const EDITOR_SETTINGS_DEFAULTS = {
 	...SETTINGS_DEFAULTS,
 
 	richEditingEnabled: true,
+	codeEditingEnabled: true,
 	enableCustomFields: false,
 };
 


### PR DESCRIPTION
## Description
Closes #14647. This adds a new option codeEditingEnabled which the block_editor_settings filter in WP Core can set to false (default is true), case in which the post editor will have two changes reflected:

- the more tools and options menu (vertical dots menu top right) will not show the option to switch between code and visual
- the blocks themselves will not have the option for HTML editing @myleshyson I thought that'd be a good idea, as no code editing means _no code editing_ :)

## How has this been tested?

1. Set the codeEditingEnabled editor setting to false with a plugin (or hack it in edit-form-blocks.php)
2. Observe the block editor while editing a post, you cannot edit the code anymore.


## Screenshots
<img width="400" alt="Screenshot 2019-04-11 at 19 10 23" src="https://user-images.githubusercontent.com/107534/55973407-2e18cf00-5c8e-11e9-8940-96b31df7142e.png">


## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
