### PR TITLE
Remove box shadow from the default appender inserter button hover state

### DIFF
--- a/packages/block-editor/src/components/default-block-appender/style.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.scss
@@ -74,6 +74,12 @@
 
 	.block-editor-inserter__toggle {
 		margin-right: 0;
+
+		// Hide the box shadow that appears on hover.
+		// All the :not() rules are needed to override default iconButton styles.
+		&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover {
+			box-shadow: none;
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #14853.

This removes the box shadow on the inserter button that appears to the left of the default block appender (or to the right on mobile).

This brings the hover state in line with the hover state for the sibling inserter. 

**Before:** 
![before](https://user-images.githubusercontent.com/1202812/55988617-5b578400-5c72-11e9-99c8-ddacd233e825.gif)

**After:**
![after](https://user-images.githubusercontent.com/1202812/55988624-5e527480-5c72-11e9-9c10-820df42e2748.gif)
