### PR TITLE
Format Library: Assign Popover anchorRect to update selection position

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added the usage of `mediaPreview` for the `Placeholder` component to the `MediaPlaceholder` component.
 - Added a an `onDoubleClick` event handler to the `MediaPlaceholder` component.
 - Added a way to pass special `ref` property to the `PlainText` component.
+- The `URLPopover` component now passes through all unhandled props to the underlying Popover component.
 
 ### Breaking Changes
 

--- a/packages/block-editor/src/components/url-popover/README.md
+++ b/packages/block-editor/src/components/url-popover/README.md
@@ -85,7 +85,7 @@ class MyURLPopover extends Component {
 
 ## Props
 
-The component accepts the following props.
+The component accepts the following props. Any other props are passed through to the underlying `Popover` component ([refer to props documentation](/packages/components/src/popover/README.md)).
 
 ### position
 
@@ -103,14 +103,6 @@ an element.
 - Type: `String`
 - Required: No
 - Default: "firstElement"
-
-### onClose
-
-Callback that triggers when the user indicates the popover should close (e.g. they've used the escape key or clicked
-outside of the popover.)
-
-- Type: `Function`
-- Required: No
 
 ### renderSettings
 

--- a/packages/block-editor/src/components/url-popover/index.js
+++ b/packages/block-editor/src/components/url-popover/index.js
@@ -29,10 +29,9 @@ class URLPopover extends Component {
 		const {
 			children,
 			renderSettings,
-			onClose,
-			onClickOutside,
 			position = 'bottom center',
 			focusOnMount = 'firstElement',
+			...popoverProps
 		} = this.props;
 
 		const {
@@ -46,8 +45,7 @@ class URLPopover extends Component {
 				className="editor-url-popover block-editor-url-popover"
 				focusOnMount={ focusOnMount }
 				position={ position }
-				onClose={ onClose }
-				onClickOutside={ onClickOutside }
+				{ ...popoverProps }
 			>
 				<div className="editor-url-popover__row block-editor-url-popover__row">
 					{ children }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added a new `render` property to `FormFileUpload` component. Allowing users of the component to custom the UI for their needs.
 - Added a new `BaseControl.VisualLabel` component.
 - Added a new `preview` prop to the `Placeholder` component which allows to display a preview, for example a media preview when the Placeholder is used in media editing contexts.
+- Added a new `anchorRect` prop to `Popover` which enables a developer to provide a custom `DOMRect` object at which to position the popover.
 
 ### Bug fixes
 

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -43,7 +43,7 @@ export { default as PanelHeader } from './panel/header';
 export { default as PanelRow } from './panel/row';
 export { default as Placeholder } from './placeholder';
 export { default as Popover } from './popover';
-export { default as PositionedAtSelection } from './positioned-at-selection';
+export { default as __unstablePositionedAtSelection } from './positioned-at-selection';
 export { default as QueryControls } from './query-controls';
 export { default as RadioControl } from './radio-control';
 export { default as RangeControl } from './range-control';

--- a/packages/components/src/popover/README.md
+++ b/packages/components/src/popover/README.md
@@ -123,13 +123,6 @@ Opt-in prop to show popovers fullscreen on mobile, pass `false` in this prop to 
  - Required: No
  - Default: `false`
 
-### getAnchorRect
-
-A function called given the element to which the Popover is anchored, can return a custom `DOMRect` object at which to position the popover.
-
-- Type: `Function`
-- Required: No
-
 ### anchorRect
 
 A custom `DOMRect` object at which to position the popover.

--- a/packages/components/src/popover/README.md
+++ b/packages/components/src/popover/README.md
@@ -123,6 +123,20 @@ Opt-in prop to show popovers fullscreen on mobile, pass `false` in this prop to 
  - Required: No
  - Default: `false`
 
+### getAnchorRect
+
+A function called given the element to which the Popover is anchored, can return a custom `DOMRect` object at which to position the popover.
+
+- Type: `Function`
+- Required: No
+
+### anchorRect
+
+A custom `DOMRect` object at which to position the popover.
+
+- Type: `DOMRect`
+- Required: No
+
 ## Methods
 
 ### refresh

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -69,7 +69,7 @@ class Popover extends Component {
 	}
 
 	componentDidMount() {
-		this.toggleAutoRefresh( true );
+		this.toggleAutoRefresh( ! this.props.hasOwnProperty( 'anchorRect' ) );
 		this.refresh();
 
 		/*
@@ -86,6 +86,15 @@ class Popover extends Component {
 	componentDidUpdate( prevProps ) {
 		if ( prevProps.position !== this.props.position ) {
 			this.computePopoverPosition( this.state.popoverSize, this.anchorRect );
+		}
+
+		if ( prevProps.anchorRect !== this.props.anchorRect ) {
+			this.refreshOnAnchorMove();
+		}
+
+		const hasAnchorRect = this.props.hasOwnProperty( 'anchorRect' );
+		if ( hasAnchorRect !== prevProps.hasOwnProperty( 'anchorRect' ) ) {
+			this.toggleAutoRefresh( ! hasAnchorRect );
 		}
 	}
 
@@ -129,8 +138,7 @@ class Popover extends Component {
 	 * will only refresh the popover position if the anchor moves.
 	 */
 	refreshOnAnchorMove() {
-		const { getAnchorRect = this.getAnchorRect } = this.props;
-		const anchorRect = getAnchorRect( this.anchorNode.current );
+		const anchorRect = this.getAnchorRect( this.anchorNode.current );
 		const didAnchorRectChange = ! isShallowEqual( anchorRect, this.anchorRect );
 		if ( didAnchorRectChange ) {
 			this.anchorRect = anchorRect;
@@ -144,8 +152,7 @@ class Popover extends Component {
 	 * position.
 	 */
 	refresh() {
-		const { getAnchorRect = this.getAnchorRect } = this.props;
-		const anchorRect = getAnchorRect( this.anchorNode.current );
+		const anchorRect = this.getAnchorRect( this.anchorNode.current );
 		const contentRect = this.contentNode.current.getBoundingClientRect();
 		const popoverSize = {
 			width: contentRect.width,
@@ -191,6 +198,16 @@ class Popover extends Component {
 	}
 
 	getAnchorRect( anchor ) {
+		const { getAnchorRect, anchorRect } = this.props;
+
+		if ( anchorRect ) {
+			return anchorRect;
+		}
+
+		if ( getAnchorRect ) {
+			return getAnchorRect( anchor );
+		}
+
 		if ( ! anchor || ! anchor.parentNode ) {
 			return;
 		}

--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Path, SVG, TextControl, Popover, IconButton, PositionedAtSelection } from '@wordpress/components';
+import { Path, SVG, TextControl, Popover, IconButton, __unstablePositionedAtSelection } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { insertObject } from '@wordpress/rich-text';
@@ -113,7 +113,7 @@ export const image = {
 							return null;
 						} }
 					/> }
-					{ isObjectActive && <PositionedAtSelection key={ key }>
+					{ isObjectActive && <__unstablePositionedAtSelection key={ key }>
 						<Popover
 							position="bottom center"
 							focusOnMount={ false }
@@ -155,7 +155,7 @@ export const image = {
 							</form>
 							{ /* eslint-enable jsx-a11y/no-noninteractive-element-interactions */ }
 						</Popover>
-					</PositionedAtSelection> }
+					</__unstablePositionedAtSelection> }
 				</MediaUploadCheck>
 			);
 		}

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -103,7 +103,7 @@ const URLPopoverAtLink = ( { isActive, addingLink, value, ...props } ) => {
 		return null;
 	}
 
-	return <URLPopover getAnchorRect={ () => anchorRect } { ...props } />;
+	return <URLPopover anchorRect={ anchorRect } { ...props } />;
 };
 
 const LinkViewer = ( { url, editLink } ) => {

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -89,6 +89,10 @@ const URLPopoverAtLink = ( { isActive, addingLink, value, ...props } ) => {
 		}
 
 		let element = range.startContainer;
+
+		// If the caret is right before the element, select the next element.
+		element = element.nextElementSibling || element;
+
 		while ( element.nodeType !== window.Node.ELEMENT_NODE ) {
 			element = element.parentNode;
 		}


### PR DESCRIPTION
Fixes #14872 
Fixes #11092 
Alternative to #14921
Cherry-picks fc1fec7 from #14851

This pull request seeks to resolve an issue where repeated mounting of the link URLPopover component would cause excessive animations to occur in response to changes of selection or content within the formatted link. In doing so, it updates the behavior of link Popover to anchor to the link element itself, rather than follow the position of the caret.

**Implementation Notes:**

This reimplements the positioning to behave similar to `Autocomplete` in passing `getAnchorRect` to the rendered Popover, computed from the current selection. This replaces use of `PositionedAtSelection`.

#14872 is partly caused by the fact that to update `PositionedAtSelection`, we must assign a new `key` value, which would unmount and remount the component, causing the animation to restart.

It may be simpler to review using GitHub's ["Hide whitespace changes"](https://user-images.githubusercontent.com/1779930/55990506-cf475b80-5c75-11e9-8e8d-7265a8d1fe38.png) diff options, given the changes in `inline.js` are largely indentation changes.

**Testing instructions:**

Repeat Steps to Reproduce from #14872, verifying that the animation only occurs once when within the link formatting.