### PR TITLE
Add clarification around functions used

### DIFF
--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -1,10 +1,10 @@
-# Block Registration 
+# Block Registration
 
 ## `register_block_type`
 
 * **Type:** `Function`
 
-Every block starts by registering a new block type definition. The function `registerBlockType` takes two arguments, a block `name` and a block configuration object.
+Every block starts by registering a new block type definition. To register, you use the `registerBlockType` function from the [`wp-blocks` package](/packages/blocks/README.md#registerBlockType). The function takes two arguments, a block `name` and a block configuration object.
 
 ### Block Name
 
@@ -174,7 +174,7 @@ attributes: {
 
 Transforms provide rules for what a block can be transformed from and what it can be transformed to. A block can be transformed from another block, a shortcode, a regular expression, a file or a raw DOM node.
 
-For example, a paragraph block can be transformed into a heading block.
+For example, a paragraph block can be transformed into a heading block. This uses the `createBlock` function from the [`wp-blocks` package](/packages/blocks/README.md#createBlock)
 
 {% codetabs %}
 {% ES5 %}

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -30,7 +30,7 @@
 		"parent": "developers"
 	},
 	{
-		"title": "Block Registration ",
+		"title": "Block Registration",
 		"slug": "block-registration",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/block-api/block-registration.md",
 		"parent": "block-api"


### PR DESCRIPTION
## Description

Adds addition information specifying the registerBlockType, and createBlock functions come from wp-blocks package and links to the full documentation.

## How has this been tested?

See [updated documentation page live on branch](https://github.com/WordPress/gutenberg/blob/docs/clarify/block-reg/docs/designers-developers/developers/block-api/block-registration.md)

## Types of changes

Documentation
