### PR TITLE
Docs: Update link for Inner Blocks

### DIFF
--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -1,4 +1,4 @@
-# Block Registration 
+# Block Registration
 
 ## `register_block_type`
 
@@ -486,7 +486,7 @@ transforms: {
 
 * **Type:** `Array`
 
-Blocks are able to be inserted into blocks that use [`InnerBlocks`](/packages/editor/src/components/inner-blocks/README.md) as nested content. Sometimes it is useful to restrict a block so that it is only available as a nested block. For example, you might want to allow an 'Add to Cart' block to only be available within a 'Product' block.
+Blocks are able to be inserted into blocks that use [`InnerBlocks`](/packages/block-editor/src/components/inner-blocks/README.md) as nested content. Sometimes it is useful to restrict a block so that it is only available as a nested block. For example, you might want to allow an 'Add to Cart' block to only be available within a 'Product' block.
 
 Setting `parent` lets a block require that it is only available when nested within the specified blocks.
 

--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -1,4 +1,4 @@
-# Block Registration
+# Block Registration 
 
 ## `register_block_type`
 

--- a/docs/designers-developers/developers/block-api/block-templates.md
+++ b/docs/designers-developers/developers/block-api/block-templates.md
@@ -32,7 +32,7 @@ function myplugin_register_template() {
 add_action( 'init', 'myplugin_register_template' );
 ```
 
-The following example in JavaScript creates a new block using [InnerBlocks](/packages/editor/src/components/inner-blocks) and templates, when inserted creates a set of blocks based off the template.
+The following example in JavaScript creates a new block using [InnerBlocks](/packages/block-editor/src/components/inner-blocks/README.md) and templates, when inserted creates a set of blocks based off the template.
 
 ```js
 const el = wp.element.createElement;


### PR DESCRIPTION
## Description

The Inner Blocks component is linked to the wrong spot, the old link is going to `/packages/editor/src/components/inner-block/README.md` the new location should be `block-editor` package.

This PR updates the link on block-registration, and block-templtes page.

However, I don't think the actually Inner Block documentation is being published anywhere.

@nosolosw if I look in the source repo on Github, the readme file is there for Inner Blocks.
See: https://github.com/WordPress/gutenberg/tree/master/packages/block-editor/src/components/inner-blocks

However, if I look at the Gutenberg Handbook, it looks empty here
https://wordpress.org/gutenberg/handbook/designers-developers/developers/packages/packages-block-editor/#InnerBlocks


## Types of changes

Documentation
