### PR TITLE
Fix regression with color swatch focus style

### DIFF
--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -46,7 +46,6 @@ $color-palette-circle-spacing: 14px;
 
 	&.is-active {
 		box-shadow: inset 0 0 0 4px;
-		border: $border-width solid $dark-gray-400;
 		position: relative;
 		z-index: 1;
 


### PR DESCRIPTION
When you focus a color swatch, the circle around the check is offset.

Removing the border that this PR removes, fixes that, and appears to not have any side-effects.

I'm not sure how it regressed.

Before:

![before](https://user-images.githubusercontent.com/1204802/56027905-44b73880-5d17-11e9-96dd-01c1d857a854.gif)

After:

![after](https://user-images.githubusercontent.com/1204802/56027911-47199280-5d17-11e9-8404-3405c41228f7.gif)
