### PR TITLE
[Mobile]: Fix broken imports on native rich-text.

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -20,7 +20,6 @@ import {
 	toHTMLString,
 	insert,
 	__unstableInsertLineSeparator as insertLineSeparator,
-	insertLineBreak,
 	__unstableIsEmptyLine as isEmptyLine,
 	isCollapsed,
 	getTextContent,
@@ -295,7 +294,7 @@ export class RichText extends Component {
 
 		if ( this.multilineTag ) {
 			if ( event.shiftKey ) {
-				const insertedLineBreak = { needsSelectionUpdate: true, ...insertLineBreak( currentRecord ) };
+				const insertedLineBreak = { needsSelectionUpdate: true, ...insert( currentRecord, '\n' ) };
 				this.onFormatChangeForceChild( insertedLineBreak );
 			} else if ( this.onSplit && isEmptyLine( currentRecord ) ) {
 				this.setState( {
@@ -307,7 +306,7 @@ export class RichText extends Component {
 				this.onFormatChangeForceChild( insertedLineSeparator );
 			}
 		} else if ( event.shiftKey || ! this.onSplit ) {
-			const insertedLineBreak = { needsSelectionUpdate: true, ...insertLineBreak( currentRecord ) };
+			const insertedLineBreak = { needsSelectionUpdate: true, ...insert( currentRecord, '\n' ) };
 			this.onFormatChangeForceChild( insertedLineBreak );
 		} else {
 			this.splitContent( currentRecord );

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -19,9 +19,9 @@ import {
 	split,
 	toHTMLString,
 	insert,
-	insertLineSeparator,
+	__unstableInsertLineSeparator as insertLineSeparator,
 	insertLineBreak,
-	isEmptyLine,
+	__unstableIsEmptyLine as isEmptyLine,
 	isCollapsed,
 	getTextContent,
 } from '@wordpress/rich-text';


### PR DESCRIPTION
This is a small PR to fix broken imports due to the addition of `__unstable` prefix.

To test:
- Check out the related [`gutenberg-mobile` PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/863).
- Check that lists doesn't crash when adding a new list item (pressing Enter).