### PR TITLE
Media & Text: Add width constraints

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -37,6 +37,7 @@ const ALLOWED_BLOCKS = [ 'core/button', 'core/paragraph', 'core/heading', 'core/
 const TEMPLATE = [
 	[ 'core/paragraph', { fontSize: 'large', placeholder: _x( 'Content…', 'content placeholder' ) } ],
 ];
+const applyWidthConstraints = ( width ) => Math.max( 15, Math.min( width, 85 ) );
 
 class MediaTextEdit extends Component {
 	constructor() {
@@ -85,7 +86,7 @@ class MediaTextEdit extends Component {
 
 	onWidthChange( width ) {
 		this.setState( {
-			mediaWidth: width,
+			mediaWidth: applyWidthConstraints( width ),
 		} );
 	}
 
@@ -93,7 +94,7 @@ class MediaTextEdit extends Component {
 		const { setAttributes } = this.props;
 
 		setAttributes( {
-			mediaWidth: width,
+			mediaWidth: applyWidthConstraints( width ),
 		} );
 		this.setState( {
 			mediaWidth: null,

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -37,7 +37,9 @@ const ALLOWED_BLOCKS = [ 'core/button', 'core/paragraph', 'core/heading', 'core/
 const TEMPLATE = [
 	[ 'core/paragraph', { fontSize: 'large', placeholder: _x( 'Content…', 'content placeholder' ) } ],
 ];
-const applyWidthConstraints = ( width ) => Math.max( 15, Math.min( width, 85 ) );
+// this limits the resize to a safe zone to avoid making broken layouts
+const WIDTH_CONSTRAINT_PERCENTAGE = 15;
+const applyWidthConstraints = ( width ) => Math.max( WIDTH_CONSTRAINT_PERCENTAGE, Math.min( width, 100 - WIDTH_CONSTRAINT_PERCENTAGE ) );
 
 class MediaTextEdit extends Component {
 	constructor() {

--- a/packages/block-library/src/media-text/editor.scss
+++ b/packages/block-library/src/media-text/editor.scss
@@ -3,6 +3,7 @@
 		"media-text-media media-text-content"
 		"resizer resizer";
 	align-items: center;
+	word-break: break-all;
 }
 
 .wp-block-media-text.has-media-on-the-right {


### PR DESCRIPTION
## Description
Fixes problem reported in #14901 by adding constraints for media width in UI manipulation. Changing the width now always falls between 15% and 85%.

Save and render functions are untouched.

## How has this been tested?

Before applying this branch, make a post with Media & Text blocks that have their widths outside of our new boundaries. Eg: extremely narrow media or extremely narrow content, all the way to the side.

Now apply the patch a try loading your post. It should correctly load and keep your widths as you've initially defined them. Save the post and reload. Make sure it still looks the same. This confirms we've not changed the behavior for already placed blocks and we won't be breaking existing layouts.

Now try resizing the Media & Text. With the first interaction, it should jump to 15% or 85% and only allow you to operate in that range from now on.

## Screenshots

![width-constraints](https://user-images.githubusercontent.com/156676/56038644-63481e80-5d6d-11e9-91da-1f505e33e20e.gif)

## Types of changes
Something between bug fix and breaking change? 🤔

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
