### PR TITLE
Block Editor: Assign Provider isSyncingOutcomingValue only when blocks changing

### DIFF
--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -99,10 +99,15 @@ class BlockEditorProvider extends Component {
 				// This happens when a previous input is explicitely marked as persistent.
 				( newIsPersistent && ! isPersistent )
 			) {
+				// When knowing the blocks value is changing, assign instance
+				// value to skip reset in subsequent `componentDidUpdate`.
+				if ( newBlocks !== blocks ) {
+					this.isSyncingOutcomingValue = true;
+				}
+
 				blocks = newBlocks;
 				isPersistent = newIsPersistent;
 
-				this.isSyncingOutcomingValue = true;
 				if ( isPersistent ) {
 					onChange( blocks );
 				} else {


### PR DESCRIPTION
Fixes #14950 

This pull request seeks to resolve an issue where Undo may not behave as expected in response to creation of explicit undo levels. Additional debugging is available at https://github.com/WordPress/gutenberg/issues/14950#issuecomment-482566900 and https://github.com/WordPress/gutenberg/issues/14950#issuecomment-482573283 .

**Implementation Notes:**

As a controlled input, the `BlockEditorProvider` component assigns an instance variable to avoid resetting its own state when it knows blocks values are changing (when **_it_** is the source of those changes). However, because this was also assigned in response to the creation of an explicit persistence level, even when blocks did not change, it wasn't always correctly unset. The reason for this is that while normally the `componentDidUpdate` is called immediately after the value is assigned, because the blocks value doesn't actually change, it is not unassigned until the next change occurs. For this reason, by the time the user presses Undo, the instance value is still assigned and it (wrongly) skips resetting the blocks state with value reflecting the Undo.

The changes here simply assign the instance value only if blocks are actually changing, to better represent its intention to account for an expected `componentDidUpdate` in response to its own changed blocks state.

**Testing Instructions:**

Repeat Steps to Reproduce from #14950, verifying the Undo result is correct.

Ensure end-to-end tests pass:

```
npm run build && npm run test-e2e packages/e2e-tests/specs/undo.test.js
```