### PR TITLE
[Mobile] Fix caret position after inline paste - Update.

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -427,8 +427,7 @@ export class RichText extends Component {
 			this.lastContent = newContent;
 
 			// explicitly set selection after inline paste
-			( ( { start, end } ) => this.setState( { start, end,
-				needsSelectionUpdate: true } ) )( insertedContent );
+			this.forceSelectionUpdate( insertedContent.start, insertedContent.end );
 
 			this.props.onChange( this.lastContent );
 		} else if ( onSplit ) {


### PR DESCRIPTION
## Note
This is an addendum to https://github.com/WordPress/gutenberg/pull/14893 as "concurrent" changes in https://github.com/WordPress/gutenberg/pull/14820 made the previous patch inert.

Specifically, the flag `needsSelectionUpdate` was moved from `state` to `this` so that it could be toggled false in the `render` method without triggering an additional render. More details here: https://github.com/WordPress/gutenberg/pull/14820/files#r274915836 .

## Description
This PR fixes _part_ of this issue: https://github.com/wordpress-mobile/gutenberg-mobile/issues/828 , specifically, when inline content is pasted.

## How has this been tested?
This has been tested using the steps here:
https://github.com/wordpress-mobile/gutenberg-mobile/issues/828#issuecomment-481546078

## Screenshots <!-- if applicable -->
<img src="https://user-images.githubusercontent.com/8507675/55856919-174f7b00-5baf-11e9-9c1d-48d80813a0f8.gif" width="360">

## Types of changes
This is a bug fix, but currently only resolves a _part_ of the original issue. It serves as an incremental improvement.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
