### PR TITLE
Fix: Setting a contrast color, triggers a contrast warning.

### DIFF
--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -33,17 +33,23 @@ const { getComputedStyle } = window;
 
 const name = 'core/paragraph';
 
-const applyFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
-	const { textColor, backgroundColor, fontSize, customFontSize } = ownProps.attributes;
-	const editableNode = node.querySelector( '[contenteditable="true"]' );
-	//verify if editableNode is available, before using getComputedStyle.
-	const computedStyles = editableNode ? getComputedStyle( editableNode ) : null;
-	return {
-		fallbackBackgroundColor: backgroundColor || ! computedStyles ? undefined : computedStyles.backgroundColor,
-		fallbackTextColor: textColor || ! computedStyles ? undefined : computedStyles.color,
-		fallbackFontSize: fontSize || customFontSize || ! computedStyles ? undefined : parseInt( computedStyles.fontSize ) || undefined,
-	};
-} );
+const applyFallbackStyles = withFallbackStyles(
+	( node, ownProps ) => {
+		const { textColor, backgroundColor, fontSize } = ownProps;
+		const editableNode = node.querySelector( '[contenteditable="true"]' );
+		//verify if editableNode is available, before using getComputedStyle.
+		const computedStyles = editableNode ? getComputedStyle( editableNode ) : null;
+		return {
+			fallbackBackgroundColor: ( backgroundColor.color || ! computedStyles ) ? undefined : computedStyles.backgroundColor,
+			fallbackTextColor: ( textColor.color || ! computedStyles ) ? undefined : computedStyles.color,
+			fallbackFontSize: ( fontSize.size || ! computedStyles ) ? undefined : parseInt( computedStyles.fontSize ) || undefined,
+		};
+	},
+	( ownProps ) => {
+		const { textColor, backgroundColor, fontSize } = ownProps;
+		return [ textColor.color, backgroundColor.color, fontSize.size ];
+	}
+);
 
 class ParagraphBlock extends Component {
 	constructor() {

--- a/packages/components/src/higher-order/with-fallback-styles/index.js
+++ b/packages/components/src/higher-order/with-fallback-styles/index.js
@@ -8,8 +8,9 @@ import { every, isEqual } from 'lodash';
  */
 import { Component } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import isShallowEqual from '@wordpress/is-shallow-equal';
 
-export default ( mapNodeToProps ) => createHigherOrderComponent(
+export default ( mapNodeToProps, computeWhenChange ) => createHigherOrderComponent(
 	( WrappedComponent ) => {
 		return class extends Component {
 			constructor() {
@@ -19,6 +20,7 @@ export default ( mapNodeToProps ) => createHigherOrderComponent(
 					fallbackStyles: undefined,
 					grabStylesCompleted: false,
 				};
+				this.shouldRecomputeValues = this.shouldRecomputeValues().bind( this );
 
 				this.bindRef = this.bindRef.bind( this );
 			}
@@ -38,9 +40,24 @@ export default ( mapNodeToProps ) => createHigherOrderComponent(
 				this.grabFallbackStyles();
 			}
 
+			shouldRecomputeValues() {
+				let lastRecomputeValues = [];
+				return () => {
+					if ( ! computeWhenChange ) {
+						return ! this.state.grabStylesCompleted;
+					}
+					const newRecomputeValues = computeWhenChange( this.props );
+					if ( isShallowEqual( lastRecomputeValues, newRecomputeValues ) ) {
+						return false;
+					}
+					lastRecomputeValues = newRecomputeValues;
+					return true;
+				};
+			}
+
 			grabFallbackStyles() {
-				const { grabStylesCompleted, fallbackStyles } = this.state;
-				if ( this.nodeRef && ! grabStylesCompleted ) {
+				const { fallbackStyles } = this.state;
+				if ( this.nodeRef && this.shouldRecomputeValues() ) {
 					const newFallbackStyles = mapNodeToProps( this.nodeRef, this.props );
 					if ( ! isEqual( newFallbackStyles, fallbackStyles ) ) {
 						this.setState( {


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/14687
Alternative to: https://github.com/WordPress/gutenberg/pull/14716

withFallbackStyles is a HOC that allows components to query styles from the dom. This allows retrieving colors used in contrast checking when explicit colors are not set.
To avoid querying the dom on each prop change, this component had an optimization as soon as all the fallback colors are known it never computed them again.
This assumed that fallBack colors of specific block instance (colors set with CSS) never changed during the editor execution.  This assumption was wrong.
When we set a background color dark in twenty nineteen the CSS class also sets a text color (the text color attribute is not changed), so in this case setting a background color changes the fallback text color.

This PR adds a second parameter to withFallbackStyles, a function that receives the props and should return an array with values that may be relevant to the fallback styles. When a change happens to these values the fallback styles are recomputed.

Remaining task: document the new functionality

## How has this been tested?
I repeated the steps described in https://github.com/WordPress/gutenberg/issues/14687 and verified the bug is not happening anymore.