### PR TITLE
Block Library: Display ButtonBlockAppender only if selected or empty

### DIFF
--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -7,6 +7,8 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Fragment } from '@wordpress/element';
+import { withSelect } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import {
 	InspectorControls,
@@ -15,7 +17,14 @@ import {
 	withColors,
 } from '@wordpress/block-editor';
 
-function GroupEdit( { className, setBackgroundColor, backgroundColor } ) {
+function GroupEdit( {
+	className,
+	setBackgroundColor,
+	backgroundColor,
+	isSelected,
+	hasInnerBlocks,
+	isInnerBlockSelected,
+} ) {
 	const styles = {
 		backgroundColor: backgroundColor.color,
 	};
@@ -23,6 +32,12 @@ function GroupEdit( { className, setBackgroundColor, backgroundColor } ) {
 	const classes = classnames( className, backgroundColor.class, {
 		'has-background': !! backgroundColor.color,
 	} );
+
+	const isAppenderVisible = (
+		isSelected ||
+		isInnerBlockSelected ||
+		! hasInnerBlocks
+	);
 
 	return (
 		<Fragment>
@@ -39,10 +54,29 @@ function GroupEdit( { className, setBackgroundColor, backgroundColor } ) {
 				/>
 			</InspectorControls>
 			<div className={ classes } style={ styles }>
-				<InnerBlocks renderAppender={ () => <InnerBlocks.ButtonBlockAppender /> } />
+				<InnerBlocks
+					renderAppender={ () => (
+						isAppenderVisible && <InnerBlocks.ButtonBlockAppender />
+					) }
+				/>
 			</div>
 		</Fragment>
 	);
 }
 
-export default withColors( 'backgroundColor' )( GroupEdit );
+export default compose( [
+	withColors( 'backgroundColor' ),
+	withSelect( ( select, { clientId } ) => {
+		const {
+			getBlock,
+			hasSelectedInnerBlock,
+		} = select( 'core/block-editor' );
+
+		const block = getBlock( clientId );
+
+		return {
+			hasInnerBlocks: !! ( block && block.innerBlocks.length ),
+			isInnerBlockSelected: hasSelectedInnerBlock( clientId, true ),
+		};
+	} ),
+] )( GroupEdit );


### PR DESCRIPTION
Merges to #14943 as base branch.

WIP: Experimenting to conditionally render ButtonBlockAppender only if selected or empty.