### PR TITLE
Check if onFocus is not undefined before calling it

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -445,7 +445,10 @@ export class RichText extends Component {
 
 	onFocus( event ) {
 		this.isTouched = true;
-		this.props.onFocus( event );
+
+		if ( this.props.onFocus ) {
+			this.props.onFocus( event );
+		}
 	}
 
 	onBlur( event ) {

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -745,7 +745,7 @@ const RichTextContainer = compose( [
 		return {
 			clientId: context.clientId,
 			isSelected: context.isSelected,
-			onFocus: context.onFocus,
+			onFocus: context.onFocus ? context.onFocus : ownProps.onFocus,
 		};
 	} ),
 ] )( RichText );

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -745,7 +745,7 @@ const RichTextContainer = compose( [
 		return {
 			clientId: context.clientId,
 			isSelected: context.isSelected,
-			onFocus: context.onFocus ? context.onFocus : ownProps.onFocus,
+			onFocus: context.onFocus,
 		};
 	} ),
 ] )( RichText );


### PR DESCRIPTION
Fixes : https://github.com/wordpress-mobile/gutenberg-mobile/issues/865

Corresponding gutenberg-mobile PR : https://github.com/wordpress-mobile/gutenberg-mobile/pull/866

