### PR TITLE
Fix typo: parentColumsBlockClientId => parentColumnsBlockClientId

### DIFF
--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -37,10 +37,10 @@ export default compose(
 		const { getBlockRootClientId } = select( 'core/editor' );
 
 		return {
-			parentColumsBlockClientId: getBlockRootClientId( clientId ),
+			parentColumnsBlockClientId: getBlockRootClientId( clientId ),
 		};
 	} ),
-	withDispatch( ( dispatch, { clientId, parentColumsBlockClientId } ) => {
+	withDispatch( ( dispatch, { clientId, parentColumnsBlockClientId } ) => {
 		return {
 			updateAlignment( alignment ) {
 				// Update self...
@@ -49,7 +49,7 @@ export default compose(
 				} );
 
 				// Reset Parent Columns Block
-				dispatch( 'core/editor' ).updateBlockAttributes( parentColumsBlockClientId, {
+				dispatch( 'core/editor' ).updateBlockAttributes( parentColumnsBlockClientId, {
 					verticalAlignment: null,
 				} );
 			},


### PR DESCRIPTION
## Description

This PR fix a typo in the word column in the `column` component.

## How has this been tested?

The code was manually tested in a local environment. A global search in the project showed that `parentColumsBlockClientId` is only used in that file.