### PR TITLE
Update the version of lint-staged

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5666,12 +5666,6 @@
 						"number-is-nan": "^1.0.0"
 					}
 				},
-				"slice-ansi": {
-					"version": "0.0.4",
-					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-					"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-					"dev": true
-				},
 				"string-width": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -7372,6 +7366,49 @@
 			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
 			"dev": true
 		},
+		"del": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+			"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
+			"dev": true,
+			"requires": {
+				"globby": "^6.1.0",
+				"is-path-cwd": "^1.0.0",
+				"is-path-in-cwd": "^1.0.0",
+				"p-map": "^1.1.1",
+				"pify": "^3.0.0",
+				"rimraf": "^2.2.8"
+			},
+			"dependencies": {
+				"globby": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+					"dev": true,
+					"requires": {
+						"array-union": "^1.0.1",
+						"glob": "^7.0.3",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					},
+					"dependencies": {
+						"pify": {
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+							"dev": true
+						}
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				}
+			}
+		},
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -8966,6 +9003,12 @@
 				"readable-stream": "^2.0.4"
 			}
 		},
+		"fn-name": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
+			"integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
+			"dev": true
+		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -9658,6 +9701,17 @@
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
 			"dev": true
+		},
+		"g-status": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/g-status/-/g-status-2.0.2.tgz",
+			"integrity": "sha512-kQoE9qH+T1AHKgSSD0Hkv98bobE90ILQcXAF4wvGgsr7uFqNvwmh8j+Lq3l0RVt3E3HjSbv2B9biEGcEtpHLCA==",
+			"dev": true,
+			"requires": {
+				"arrify": "^1.0.1",
+				"matcher": "^1.0.0",
+				"simple-git": "^1.85.0"
+			}
 		},
 		"gauge": {
 			"version": "2.7.4",
@@ -11512,6 +11566,41 @@
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
 			"dev": true
+		},
+		"is-observable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
+			"integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+			"dev": true,
+			"requires": {
+				"symbol-observable": "^1.1.0"
+			}
+		},
+		"is-path-cwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+			"dev": true
+		},
+		"is-path-in-cwd": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+			"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+			"dev": true,
+			"requires": {
+				"is-path-inside": "^1.0.0"
+			},
+			"dependencies": {
+				"is-path-inside": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+					"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+					"dev": true,
+					"requires": {
+						"path-is-inside": "^1.0.1"
+					}
+				}
+			}
 		},
 		"is-path-inside": {
 			"version": "2.0.0",
@@ -14105,9 +14194,9 @@
 			}
 		},
 		"lint-staged": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-7.3.0.tgz",
-			"integrity": "sha512-AXk40M9DAiPi7f4tdJggwuKIViUplYtVj1os1MVEteW7qOkU50EOehayCfO9TsoGK24o/EsWb41yrEgfJDDjCw==",
+			"version": "8.1.5",
+			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-8.1.5.tgz",
+			"integrity": "sha512-e5ZavfnSLcBJE1BTzRTqw6ly8OkqVyO3GL2M6teSmTBYQ/2BuueD5GIt2RPsP31u/vjKdexUyDCxSyK75q4BDA==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.3.1",
@@ -14115,13 +14204,15 @@
 				"cosmiconfig": "^5.0.2",
 				"debug": "^3.1.0",
 				"dedent": "^0.7.0",
-				"execa": "^0.9.0",
+				"del": "^3.0.0",
+				"execa": "^1.0.0",
 				"find-parent-dir": "^0.3.0",
+				"g-status": "^2.0.2",
 				"is-glob": "^4.0.0",
 				"is-windows": "^1.0.2",
-				"jest-validate": "^23.5.0",
-				"listr": "^0.14.1",
-				"lodash": "^4.17.5",
+				"listr": "^0.14.2",
+				"listr-update-renderer": "^0.5.0",
+				"lodash": "^4.17.11",
 				"log-symbols": "^2.2.0",
 				"micromatch": "^3.1.8",
 				"npm-which": "^3.0.1",
@@ -14129,9 +14220,112 @@
 				"path-is-inside": "^1.0.2",
 				"pify": "^3.0.0",
 				"please-upgrade-node": "^3.0.2",
-				"staged-git-files": "1.1.1",
+				"staged-git-files": "1.1.2",
 				"string-argv": "^0.0.2",
-				"stringify-object": "^3.2.2"
+				"stringify-object": "^3.2.2",
+				"yup": "^0.26.10"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"execa": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^6.0.0",
+						"get-stream": "^4.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				},
+				"pump": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+					"dev": true,
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
+				}
+			}
+		},
+		"listr": {
+			"version": "0.14.3",
+			"resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
+			"integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
+			"dev": true,
+			"requires": {
+				"@samverschueren/stream-to-observable": "^0.3.0",
+				"is-observable": "^1.1.0",
+				"is-promise": "^2.1.0",
+				"is-stream": "^1.1.0",
+				"listr-silent-renderer": "^1.1.1",
+				"listr-update-renderer": "^0.5.0",
+				"listr-verbose-renderer": "^0.5.0",
+				"p-map": "^2.0.0",
+				"rxjs": "^6.3.3"
+			},
+			"dependencies": {
+				"p-map": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+					"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+					"dev": true
+				}
+			}
+		},
+		"listr-silent-renderer": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+			"integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+			"dev": true
+		},
+		"listr-update-renderer": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
+			"integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
+			"dev": true,
+			"requires": {
+				"chalk": "^1.1.3",
+				"cli-truncate": "^0.2.1",
+				"elegant-spinner": "^1.0.1",
+				"figures": "^1.7.0",
+				"indent-string": "^3.0.0",
+				"log-symbols": "^1.0.2",
+				"log-update": "^2.3.0",
+				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -14146,19 +14340,17 @@
 					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
 					"dev": true
 				},
-				"execa": {
-					"version": "0.9.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz",
-					"integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "^5.0.1",
-						"get-stream": "^3.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"figures": {
@@ -14171,152 +14363,14 @@
 						"object-assign": "^4.1.0"
 					}
 				},
-				"is-extglob": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-					"dev": true
-				},
-				"is-glob": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+				"log-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^2.1.1"
+						"chalk": "^1.0.0"
 					}
-				},
-				"is-observable": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
-					"integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
-					"dev": true,
-					"requires": {
-						"symbol-observable": "^1.1.0"
-					}
-				},
-				"jest-get-type": {
-					"version": "22.4.3",
-					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
-					"integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
-					"dev": true
-				},
-				"jest-validate": {
-					"version": "23.6.0",
-					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.6.0.tgz",
-					"integrity": "sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.1",
-						"jest-get-type": "^22.1.0",
-						"leven": "^2.1.0",
-						"pretty-format": "^23.6.0"
-					}
-				},
-				"listr": {
-					"version": "0.14.3",
-					"resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
-					"integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
-					"dev": true,
-					"requires": {
-						"@samverschueren/stream-to-observable": "^0.3.0",
-						"is-observable": "^1.1.0",
-						"is-promise": "^2.1.0",
-						"is-stream": "^1.1.0",
-						"listr-silent-renderer": "^1.1.1",
-						"listr-update-renderer": "^0.5.0",
-						"listr-verbose-renderer": "^0.5.0",
-						"p-map": "^2.0.0",
-						"rxjs": "^6.3.3"
-					},
-					"dependencies": {
-						"p-map": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.0.0.tgz",
-							"integrity": "sha512-GO107XdrSUmtHxVoi60qc9tUl/KkNKm+X2CF4P9amalpGxv5YqVPJNfSb0wcA+syCopkZvYYIzW8OVTQW59x/w==",
-							"dev": true
-						}
-					}
-				},
-				"listr-update-renderer": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
-					"integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
-					"dev": true,
-					"requires": {
-						"chalk": "^1.1.3",
-						"cli-truncate": "^0.2.1",
-						"elegant-spinner": "^1.0.1",
-						"figures": "^1.7.0",
-						"indent-string": "^3.0.0",
-						"log-symbols": "^1.0.2",
-						"log-update": "^2.3.0",
-						"strip-ansi": "^3.0.1"
-					},
-					"dependencies": {
-						"chalk": {
-							"version": "1.1.3",
-							"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-							"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^2.2.1",
-								"escape-string-regexp": "^1.0.2",
-								"has-ansi": "^2.0.0",
-								"strip-ansi": "^3.0.0",
-								"supports-color": "^2.0.0"
-							}
-						},
-						"log-symbols": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-							"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-							"dev": true,
-							"requires": {
-								"chalk": "^1.0.0"
-							}
-						}
-					}
-				},
-				"listr-verbose-renderer": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
-					"integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.1",
-						"cli-cursor": "^2.1.0",
-						"date-fns": "^1.27.2",
-						"figures": "^2.0.0"
-					},
-					"dependencies": {
-						"figures": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-							"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-							"dev": true,
-							"requires": {
-								"escape-string-regexp": "^1.0.5"
-							}
-						}
-					}
-				},
-				"log-update": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
-					"integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
-					"dev": true,
-					"requires": {
-						"ansi-escapes": "^3.0.0",
-						"cli-cursor": "^2.0.0",
-						"wrap-ansi": "^3.0.1"
-					}
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
@@ -14332,41 +14386,20 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
 					"dev": true
-				},
-				"wrap-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
-					"integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
-					"dev": true,
-					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-							"dev": true
-						},
-						"strip-ansi": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^3.0.0"
-							}
-						}
-					}
 				}
 			}
 		},
-		"listr-silent-renderer": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
-			"integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
-			"dev": true
+		"listr-verbose-renderer": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
+			"integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.4.1",
+				"cli-cursor": "^2.1.0",
+				"date-fns": "^1.27.2",
+				"figures": "^2.0.0"
+			}
 		},
 		"livereload-js": {
 			"version": "2.3.0",
@@ -14534,6 +14567,29 @@
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1"
+			}
+		},
+		"log-update": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
+			"integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "^3.0.0",
+				"cli-cursor": "^2.0.0",
+				"wrap-ansi": "^3.0.1"
+			},
+			"dependencies": {
+				"wrap-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+					"integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+					"dev": true,
+					"requires": {
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0"
+					}
+				}
 			}
 		},
 		"long": {
@@ -14808,6 +14864,15 @@
 			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.2.tgz",
 			"integrity": "sha512-NcWuJFHDA8V3wkDgR/j4+gZx+YQwstPgfQDV8ndUeWWzta3dnDTBxpVzqS9lkmJAuV5YX35lmyojl6HO5JXAgw==",
 			"dev": true
+		},
+		"matcher": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/matcher/-/matcher-1.1.1.tgz",
+			"integrity": "sha512-+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^1.0.4"
+			}
 		},
 		"math-expression-evaluator": {
 			"version": "1.2.17",
@@ -18956,16 +19021,6 @@
 			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
 			"dev": true
 		},
-		"pretty-format": {
-			"version": "23.6.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
-			"integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
-			"dev": true,
-			"requires": {
-				"ansi-regex": "^3.0.0",
-				"ansi-styles": "^3.2.0"
-			}
-		},
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -19052,6 +19107,12 @@
 				"object.assign": "^4.1.0",
 				"reflect.ownkeys": "^0.2.0"
 			}
+		},
+		"property-expr": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/property-expr/-/property-expr-1.5.1.tgz",
+			"integrity": "sha512-CGuc0VUTGthpJXL36ydB6jnbyOf/rAHFvmVrJlH+Rg0DqqLFQGAP6hIaxD/G0OAmBJPhXDHuEJigrp0e0wFV6g==",
+			"dev": true
 		},
 		"proto-list": {
 			"version": "1.2.4",
@@ -20815,6 +20876,32 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
+		"simple-git": {
+			"version": "1.110.0",
+			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.110.0.tgz",
+			"integrity": "sha512-UYY0rQkknk0P5eb+KW+03F4TevZ9ou0H+LoGaj7iiVgpnZH4wdj/HTViy/1tNNkmIPcmtxuBqXWiYt2YwlRKOQ==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.0.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				}
+			}
+		},
 		"simple-html-tokenizer": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.4.1.tgz",
@@ -20847,6 +20934,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
 			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+			"dev": true
+		},
+		"slice-ansi": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+			"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
 			"dev": true
 		},
 		"slide": {
@@ -21200,9 +21293,9 @@
 			"dev": true
 		},
 		"staged-git-files": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-1.1.1.tgz",
-			"integrity": "sha512-H89UNKr1rQJvI1c/PIR3kiAMBV23yvR7LItZiV74HWZwzt7f3YHuujJ9nJZlt58WlFox7XQsOahexwk7nTe69A==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-1.1.2.tgz",
+			"integrity": "sha512-0Eyrk6uXW6tg9PYkhi/V/J4zHp33aNyi2hOCmhFLqLTIhbgqWn5jlSzI+IU0VqrZq6+DbHcabQl/WP6P3BG0QA==",
 			"dev": true
 		},
 		"state-toggle": {
@@ -21993,6 +22086,12 @@
 			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
 			"dev": true
 		},
+		"synchronous-promise": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.7.tgz",
+			"integrity": "sha512-16GbgwTmFMYFyQMLvtQjvNWh30dsFe1cAW5Fg1wm5+dg84L9Pe36mftsIRU95/W2YsISxsz/xq4VB23sqpgb/A==",
+			"dev": true
+		},
 		"table": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/table/-/table-5.2.1.tgz",
@@ -22273,6 +22372,12 @@
 				"is-number": "^3.0.0",
 				"repeat-string": "^1.6.1"
 			}
+		},
+		"toposort": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+			"integrity": "sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=",
+			"dev": true
 		},
 		"tough-cookie": {
 			"version": "2.4.3",
@@ -24279,6 +24384,31 @@
 			"dev": true,
 			"requires": {
 				"fd-slicer": "~1.0.1"
+			}
+		},
+		"yup": {
+			"version": "0.26.10",
+			"resolved": "https://registry.npmjs.org/yup/-/yup-0.26.10.tgz",
+			"integrity": "sha512-keuNEbNSnsOTOuGCt3UJW69jDE3O4P+UHAakO7vSeFMnjaitcmlbij/a3oNb9g1Y1KvSKH/7O1R2PQ4m4TRylw==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "7.0.0",
+				"fn-name": "~2.0.1",
+				"lodash": "^4.17.10",
+				"property-expr": "^1.5.0",
+				"synchronous-promise": "^2.0.5",
+				"toposort": "^2.0.2"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
+					"integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.12.0"
+					}
+				}
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
 		"is-equal-shallow": "0.1.3",
 		"jsdom": "11.12.0",
 		"lerna": "3.11.1",
-		"lint-staged": "7.3.0",
+		"lint-staged": "8.1.5",
 		"lodash": "4.17.11",
 		"mkdirp": "0.5.1",
 		"node-sass": "4.11.0",


### PR DESCRIPTION
## Description
Fix #14784 

## How has this been tested?
1. `git add modified-files`, call the files VersionA
2. `git commit -m "some messages"`, then the program will run `npm run -s precommit` to check lint styles and some other things.
3. Encounter some errors like "Multiple spaces found", so you change the code again and save, call the files VersionB. But do not `git add` again.
4. `git commit` again, failed. Because now the `lint-staged` only check staged changes (i.e, VersionA).
You should `git add` again and then `git commit`

## Screenshots <!-- if applicable -->
The screenshot of running `git commit` with old version of `lint-staged`
![image](https://user-images.githubusercontent.com/24849874/56072453-06486a80-5d65-11e9-990a-9447b14abd9a.png)
The screenshot of running `git commit` with latest version of `lint-staged`. The blue boxes highlight the difference
![image](https://user-images.githubusercontent.com/24849874/56072493-84a50c80-5d65-11e9-8373-77353c8601ac.png)


## Types of changes
Upgrade lint-staged

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
