### PR TITLE
[Mobile] Fix caret position after multi line paste

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -436,6 +436,12 @@ export class RichText extends Component {
 			} else {
 				this.splitContent( currentRecord, pastedContent, isPasted );
 			}
+
+			// select last pasted block
+			if ( this.props.selectBlock ) {
+				const lastPastedBlock = pastedContent[ pastedContent.length - 1 ];
+				this.props.selectBlock( lastPastedBlock );
+			}
 		}
 	}
 

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -102,6 +102,7 @@ class ParagraphEdit extends Component {
 					isSelected={ this.props.isSelected }
 					onFocus={ this.props.onFocus } // always assign onFocus as a props
 					onBlur={ this.props.onBlur } // always assign onBlur as a props
+					selectBlock={ this.props.selectBlock }
 					onCaretVerticalPositionChange={ this.props.onCaretVerticalPositionChange }
 					style={ style }
 					onChange={ ( nextContent ) => {


### PR DESCRIPTION
## Description
This PR is a draft with the intent to open a discussion about how best to handle pasting multi-line content. The code changes are early steps to addressing this issue: https://github.com/wordpress-mobile/gutenberg-mobile/issues/828. This comment in particular contains details about the multi-line case: https://github.com/wordpress-mobile/gutenberg-mobile/issues/828#issuecomment-481127008.

Related gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/870

### Note
This PR should not be merged, as the changes in https://github.com/wordpress-mobile/gutenberg-mobile/pull/789 and https://github.com/WordPress/gutenberg/pull/14662 will conflict.

Currently, when multi-line content is pasted into a paragraph block, the content is split into multiple blocks, splitting the current block if necessary (if the caret position is somewhere in the middle of the original block's text). After the paste event ends, the first pasted block is focused, with the caret at the start of that block's text.

These changes expose a `selectBlock` method from the `BlockHolder` object, and make it available to the RichText component. This is sufficient for the RichText component receiving the paste event to select the last pasted block after inserting multiple blocks. However, this is not sufficient to ensure the caret is in the correct position on selected block.

In order to ensure the caret is in the correct position after paste, it may be possible to expose a method to the RichText component to manipulate the selection in a sibling block, or alternatively, pass selection information to a block at creation. Neither of these approaches feel particularly elegant. In both of these cases, I suspect a race condition will exist, as the underlying native instantiation of sibling blocks will only occur asynchronously, after the paste method has terminated. This could _theoretically_ be resolved via a callback, but I'd like to explore some ideas to see if a better approach can be found.

One concern with implementing the required behavior is that `onSplit` is used by both `onPaste` and `onEnter`. When `onEnter` is called, it creates a new "sibling" block containing the text following the caret. In this case, the expected caret position after the event is at the start of the new block. This is currently satisfied by setting the selection to 0 in native code when the view is instantiated (e.g. in Android, this occurs via the method `forceCaretAtStartOnTakeFocus`).

With the refactor and "porting" of `BlockHolder` and `BlockManager` to Gutenberg as `BlockListBlock` and `BlockList` respectively, I wonder if a solution can be implemented that could resolve this issue across mobile and web platforms.

## How has this been tested?
This has been tested using the steps here:
https://github.com/wordpress-mobile/gutenberg-mobile/issues/828#issuecomment-481546078

## Screenshots <!-- if applicable -->
<img src="https://user-images.githubusercontent.com/8507675/56077419-5b48b700-5e1f-11e9-965e-c35fac84e907.gif" width="360">

## Types of changes
This is a _partial_ bug fix, but currently only resolves a _part_ of the original issue. It serves as an incremental improvement. This is not intended to be merged.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
