### PR TITLE
Refactor core blocks to have deprecated extracted to their own files (p.1)

### DIFF
--- a/packages/block-library/src/button/deprecated.js
+++ b/packages/block-library/src/button/deprecated.js
@@ -1,0 +1,112 @@
+/**
+ * External dependencies
+ */
+import { omit } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+
+const colorsMigration = ( attributes ) => {
+	return omit( {
+		...attributes,
+		customTextColor: attributes.textColor && '#' === attributes.textColor[ 0 ] ? attributes.textColor : undefined,
+		customBackgroundColor: attributes.color && '#' === attributes.color[ 0 ] ? attributes.color : undefined,
+	}, [ 'color', 'textColor' ] );
+};
+
+const blockAttributes = {
+	url: {
+		type: 'string',
+		source: 'attribute',
+		selector: 'a',
+		attribute: 'href',
+	},
+	title: {
+		type: 'string',
+		source: 'attribute',
+		selector: 'a',
+		attribute: 'title',
+	},
+	text: {
+		type: 'string',
+		source: 'html',
+		selector: 'a',
+	},
+};
+
+const deprecated = [
+	{
+		attributes: {
+			...blockAttributes,
+			color: {
+				type: 'string',
+			},
+			textColor: {
+				type: 'string',
+			},
+			align: {
+				type: 'string',
+				default: 'none',
+			},
+		},
+		save( { attributes } ) {
+			const { url, text, title, align, color, textColor } = attributes;
+
+			const buttonStyle = {
+				backgroundColor: color,
+				color: textColor,
+			};
+
+			const linkClass = 'wp-block-button__link';
+
+			return (
+				<div className={ `align${ align }` }>
+					<RichText.Content
+						tagName="a"
+						className={ linkClass }
+						href={ url }
+						title={ title }
+						style={ buttonStyle }
+						value={ text }
+					/>
+				</div>
+			);
+		},
+		migrate: colorsMigration,
+	},
+	{
+		attributes: {
+			...blockAttributes,
+			color: {
+				type: 'string',
+			},
+			textColor: {
+				type: 'string',
+			},
+			align: {
+				type: 'string',
+				default: 'none',
+			},
+		},
+		save( { attributes } ) {
+			const { url, text, title, align, color, textColor } = attributes;
+
+			return (
+				<div className={ `align${ align }` } style={ { backgroundColor: color } }>
+					<RichText.Content
+						tagName="a"
+						href={ url }
+						title={ title }
+						style={ { color: textColor } }
+						value={ text }
+					/>
+				</div>
+			);
+		},
+		migrate: colorsMigration,
+	},
+];
+
+export default deprecated;

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -1,33 +1,20 @@
 /**
- * External dependencies
- */
-import { omit, pick } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
-import { RichText } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
+import deprecated from './deprecated';
 import edit from './edit';
 import icon from './icon';
 import metadata from './block.json';
 import save from './save';
 
-const { name, attributes: blockAttributes } = metadata;
+const { name } = metadata;
 
 export { metadata, name };
-
-const colorsMigration = ( attributes ) => {
-	return omit( {
-		...attributes,
-		customTextColor: attributes.textColor && '#' === attributes.textColor[ 0 ] ? attributes.textColor : undefined,
-		customBackgroundColor: attributes.color && '#' === attributes.color[ 0 ] ? attributes.color : undefined,
-	}, [ 'color', 'textColor' ] );
-};
 
 export const settings = {
 	title: __( 'Button' ),
@@ -45,77 +32,5 @@ export const settings = {
 	],
 	edit,
 	save,
-	deprecated: [ {
-		attributes: {
-			...pick( blockAttributes, [ 'url', 'title', 'text' ] ),
-			color: {
-				type: 'string',
-			},
-			textColor: {
-				type: 'string',
-			},
-			align: {
-				type: 'string',
-				default: 'none',
-			},
-		},
-
-		save( { attributes } ) {
-			const { url, text, title, align, color, textColor } = attributes;
-
-			const buttonStyle = {
-				backgroundColor: color,
-				color: textColor,
-			};
-
-			const linkClass = 'wp-block-button__link';
-
-			return (
-				<div className={ `align${ align }` }>
-					<RichText.Content
-						tagName="a"
-						className={ linkClass }
-						href={ url }
-						title={ title }
-						style={ buttonStyle }
-						value={ text }
-					/>
-				</div>
-			);
-		},
-		migrate: colorsMigration,
-	},
-	{
-		attributes: {
-			...pick( blockAttributes, [ 'url', 'title', 'text' ] ),
-			color: {
-				type: 'string',
-			},
-			textColor: {
-				type: 'string',
-			},
-			align: {
-				type: 'string',
-				default: 'none',
-			},
-		},
-
-		save( { attributes } ) {
-			const { url, text, title, align, color, textColor } = attributes;
-
-			return (
-				<div className={ `align${ align }` } style={ { backgroundColor: color } }>
-					<RichText.Content
-						tagName="a"
-						href={ url }
-						title={ title }
-						style={ { color: textColor } }
-						value={ text }
-					/>
-				</div>
-			);
-		},
-		migrate: colorsMigration,
-	},
-	],
+	deprecated,
 };

--- a/packages/block-library/src/cover/deprecated.js
+++ b/packages/block-library/src/cover/deprecated.js
@@ -1,0 +1,224 @@
+/**
+ * External dependencies
+ */
+import { omit } from 'lodash';
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+import {
+	RichText,
+	getColorClassName,
+} from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import {
+	IMAGE_BACKGROUND_TYPE,
+	VIDEO_BACKGROUND_TYPE,
+	backgroundImageStyles,
+	dimRatioToClass,
+} from './shared';
+
+const blockAttributes = {
+	url: {
+		type: 'string',
+		source: 'attribute',
+		selector: 'a',
+		attribute: 'href',
+	},
+	title: {
+		type: 'string',
+		source: 'attribute',
+		selector: 'a',
+		attribute: 'title',
+	},
+	text: {
+		type: 'string',
+		source: 'html',
+		selector: 'a',
+	},
+	backgroundColor: {
+		type: 'string',
+	},
+	textColor: {
+		type: 'string',
+	},
+	customBackgroundColor: {
+		type: 'string',
+	},
+	customTextColor: {
+		type: 'string',
+	},
+};
+
+const deprecated = [
+	{
+		attributes: {
+			...blockAttributes,
+			title: {
+				type: 'string',
+				source: 'html',
+				selector: 'p',
+			},
+			contentAlign: {
+				type: 'string',
+				default: 'center',
+			},
+		},
+		supports: {
+			align: true,
+		},
+		save( { attributes } ) {
+			const {
+				backgroundType,
+				contentAlign,
+				customOverlayColor,
+				dimRatio,
+				focalPoint,
+				hasParallax,
+				overlayColor,
+				title,
+				url,
+			} = attributes;
+			const overlayColorClass = getColorClassName( 'background-color', overlayColor );
+			const style = backgroundType === IMAGE_BACKGROUND_TYPE ?
+				backgroundImageStyles( url ) :
+				{};
+			if ( ! overlayColorClass ) {
+				style.backgroundColor = customOverlayColor;
+			}
+			if ( focalPoint && ! hasParallax ) {
+				style.backgroundPosition = `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`;
+			}
+
+			const classes = classnames(
+				dimRatioToClass( dimRatio ),
+				overlayColorClass,
+				{
+					'has-background-dim': dimRatio !== 0,
+					'has-parallax': hasParallax,
+					[ `has-${ contentAlign }-content` ]: contentAlign !== 'center',
+				},
+			);
+
+			return (
+				<div className={ classes } style={ style }>
+					{ VIDEO_BACKGROUND_TYPE === backgroundType && url && ( <video
+						className="wp-block-cover__video-background"
+						autoPlay
+						muted
+						loop
+						src={ url }
+					/> ) }
+					{ ! RichText.isEmpty( title ) && (
+						<RichText.Content tagName="p" className="wp-block-cover-text" value={ title } />
+					) }
+				</div>
+			);
+		},
+		migrate( attributes ) {
+			return [
+				omit( attributes, [ 'title', 'contentAlign' ] ),
+				[
+					createBlock(
+						'core/paragraph',
+						{
+							content: attributes.title,
+							align: attributes.contentAlign,
+							fontSize: 'large',
+							placeholder: __( 'Write title…' ),
+						}
+					),
+				],
+			];
+		},
+	}, {
+		attributes: {
+			...blockAttributes,
+			title: {
+				type: 'string',
+				source: 'html',
+				selector: 'p',
+			},
+			contentAlign: {
+				type: 'string',
+				default: 'center',
+			},
+			align: {
+				type: 'string',
+			},
+		},
+		supports: {
+			className: false,
+		},
+		save( { attributes } ) {
+			const { url, title, hasParallax, dimRatio, align, contentAlign, overlayColor, customOverlayColor } = attributes;
+			const overlayColorClass = getColorClassName( 'background-color', overlayColor );
+			const style = backgroundImageStyles( url );
+			if ( ! overlayColorClass ) {
+				style.backgroundColor = customOverlayColor;
+			}
+
+			const classes = classnames(
+				'wp-block-cover-image',
+				dimRatioToClass( dimRatio ),
+				overlayColorClass,
+				{
+					'has-background-dim': dimRatio !== 0,
+					'has-parallax': hasParallax,
+					[ `has-${ contentAlign }-content` ]: contentAlign !== 'center',
+				},
+				align ? `align${ align }` : null,
+			);
+
+			return (
+				<div className={ classes } style={ style }>
+					{ ! RichText.isEmpty( title ) && (
+						<RichText.Content tagName="p" className="wp-block-cover-image-text" value={ title } />
+					) }
+				</div>
+			);
+		},
+	}, {
+		attributes: {
+			...blockAttributes,
+			align: {
+				type: 'string',
+			},
+			title: {
+				type: 'string',
+				source: 'html',
+				selector: 'h2',
+			},
+			contentAlign: {
+				type: 'string',
+				default: 'center',
+			},
+		},
+		save( { attributes } ) {
+			const { url, title, hasParallax, dimRatio, align } = attributes;
+			const style = backgroundImageStyles( url );
+			const classes = classnames(
+				dimRatioToClass( dimRatio ),
+				{
+					'has-background-dim': dimRatio !== 0,
+					'has-parallax': hasParallax,
+				},
+				align ? `align${ align }` : null,
+			);
+
+			return (
+				<section className={ classes } style={ style }>
+					<RichText.Content tagName="h2" value={ title } />
+				</section>
+			);
+		},
+	},
+];
+
+export default deprecated;

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -1,35 +1,19 @@
 /**
- * External dependencies
- */
-import { omit } from 'lodash';
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
-import { createBlock } from '@wordpress/blocks';
-import {
-	RichText,
-	getColorClassName,
-} from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import deprecated from './deprecated';
 import edit from './edit';
 import icon from './icon';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
-import {
-	IMAGE_BACKGROUND_TYPE,
-	VIDEO_BACKGROUND_TYPE,
-	backgroundImageStyles,
-	dimRatioToClass,
-} from './shared';
 
-const { name, attributes: blockAttributes } = metadata;
+const { name } = metadata;
 
 export { metadata, name };
 
@@ -43,172 +27,5 @@ export const settings = {
 	transforms,
 	save,
 	edit,
-	deprecated: [ {
-		attributes: {
-			...blockAttributes,
-			title: {
-				type: 'string',
-				source: 'html',
-				selector: 'p',
-			},
-			contentAlign: {
-				type: 'string',
-				default: 'center',
-			},
-		},
-
-		supports: {
-			align: true,
-		},
-
-		save( { attributes } ) {
-			const {
-				backgroundType,
-				contentAlign,
-				customOverlayColor,
-				dimRatio,
-				focalPoint,
-				hasParallax,
-				overlayColor,
-				title,
-				url,
-			} = attributes;
-			const overlayColorClass = getColorClassName( 'background-color', overlayColor );
-			const style = backgroundType === IMAGE_BACKGROUND_TYPE ?
-				backgroundImageStyles( url ) :
-				{};
-			if ( ! overlayColorClass ) {
-				style.backgroundColor = customOverlayColor;
-			}
-			if ( focalPoint && ! hasParallax ) {
-				style.backgroundPosition = `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`;
-			}
-
-			const classes = classnames(
-				dimRatioToClass( dimRatio ),
-				overlayColorClass,
-				{
-					'has-background-dim': dimRatio !== 0,
-					'has-parallax': hasParallax,
-					[ `has-${ contentAlign }-content` ]: contentAlign !== 'center',
-				},
-			);
-
-			return (
-				<div className={ classes } style={ style }>
-					{ VIDEO_BACKGROUND_TYPE === backgroundType && url && ( <video
-						className="wp-block-cover__video-background"
-						autoPlay
-						muted
-						loop
-						src={ url }
-					/> ) }
-					{ ! RichText.isEmpty( title ) && (
-						<RichText.Content tagName="p" className="wp-block-cover-text" value={ title } />
-					) }
-				</div>
-			);
-		},
-
-		migrate( attributes ) {
-			return [
-				omit( attributes, [ 'title', 'contentAlign' ] ),
-				[
-					createBlock(
-						'core/paragraph',
-						{
-							content: attributes.title,
-							align: attributes.contentAlign,
-							fontSize: 'large',
-							placeholder: __( 'Write title…' ),
-						}
-					),
-				],
-			];
-		},
-	}, {
-		attributes: {
-			...blockAttributes,
-			title: {
-				type: 'string',
-				source: 'html',
-				selector: 'p',
-			},
-			contentAlign: {
-				type: 'string',
-				default: 'center',
-			},
-			align: {
-				type: 'string',
-			},
-		},
-
-		supports: {
-			className: false,
-		},
-
-		save( { attributes } ) {
-			const { url, title, hasParallax, dimRatio, align, contentAlign, overlayColor, customOverlayColor } = attributes;
-			const overlayColorClass = getColorClassName( 'background-color', overlayColor );
-			const style = backgroundImageStyles( url );
-			if ( ! overlayColorClass ) {
-				style.backgroundColor = customOverlayColor;
-			}
-
-			const classes = classnames(
-				'wp-block-cover-image',
-				dimRatioToClass( dimRatio ),
-				overlayColorClass,
-				{
-					'has-background-dim': dimRatio !== 0,
-					'has-parallax': hasParallax,
-					[ `has-${ contentAlign }-content` ]: contentAlign !== 'center',
-				},
-				align ? `align${ align }` : null,
-			);
-
-			return (
-				<div className={ classes } style={ style }>
-					{ ! RichText.isEmpty( title ) && (
-						<RichText.Content tagName="p" className="wp-block-cover-image-text" value={ title } />
-					) }
-				</div>
-			);
-		},
-	}, {
-		attributes: {
-			...blockAttributes,
-			align: {
-				type: 'string',
-			},
-			title: {
-				type: 'string',
-				source: 'html',
-				selector: 'h2',
-			},
-			contentAlign: {
-				type: 'string',
-				default: 'center',
-			},
-		},
-
-		save( { attributes } ) {
-			const { url, title, hasParallax, dimRatio, align } = attributes;
-			const style = backgroundImageStyles( url );
-			const classes = classnames(
-				dimRatioToClass( dimRatio ),
-				{
-					'has-background-dim': dimRatio !== 0,
-					'has-parallax': hasParallax,
-				},
-				align ? `align${ align }` : null,
-			);
-
-			return (
-				<section className={ classes } style={ style }>
-					<RichText.Content tagName="h2" value={ title } />
-				</section>
-			);
-		},
-	} ],
+	deprecated,
 };


### PR DESCRIPTION
## Description
Part of aligning block library to Block Registration API RFC #13693.

It's all about moving `deprecated` fields to their own file to follow the proposal drafted in RFC.

Updated blocks:
- `Button`
- `Cover`

## How has this been tested?

`npm test`
`npm run test-e2e`

Manually tested whether all blocks load as before.