### PR TITLE
Add missing "step" property in the RangeControl documentation

### DIFF
--- a/packages/components/src/range-control/README.md
+++ b/packages/components/src/range-control/README.md
@@ -184,6 +184,14 @@ The maximum value accepted. If higher values are inserted onChange will not be c
 - Type: `Number`
 - Required: No
 
+#### step
+
+This property can be used to change the number by which the value increments or decrements when the slider is moved.
+
+- Type: `Number`
+- Required: No
+- Default: 1
+
 ## Related components
 
 - To collect a numerical input in a text field, use the `TextControl` component.


### PR DESCRIPTION
## Description
Added missing "step" property in the RangeControl documentation.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
Documentation

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
