### PR TITLE
Update the block component to use react hooks instead

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -7,7 +7,7 @@ import { get, reduce, size, first, last } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { useRef, useEffect, useState } from '@wordpress/element';
 import {
 	focus,
 	isTextField,
@@ -48,100 +48,172 @@ import Inserter from '../inserter';
 import HoverArea from './hover-area';
 import { isInsideRootBlock } from '../../utils/dom';
 
-export class BlockListBlock extends Component {
-	constructor() {
-		super( ...arguments );
+/**
+ * Prevents default dragging behavior within a block to allow for multi-
+ * selection to take effect unhampered.
+ *
+ * @param {DragEvent} event Drag event.
+ *
+ * @return {void}
+ */
+const preventDrag = ( event ) => {
+	event.preventDefault();
+};
 
-		this.setBlockListRef = this.setBlockListRef.bind( this );
-		this.bindBlockNode = this.bindBlockNode.bind( this );
-		this.setAttributes = this.setAttributes.bind( this );
-		this.maybeHover = this.maybeHover.bind( this );
-		this.forceFocusedContextualToolbar = this.forceFocusedContextualToolbar.bind( this );
-		this.hideHoverEffects = this.hideHoverEffects.bind( this );
-		this.onFocus = this.onFocus.bind( this );
-		this.preventDrag = this.preventDrag.bind( this );
-		this.onPointerDown = this.onPointerDown.bind( this );
-		this.deleteOrInsertAfterWrapper = this.deleteOrInsertAfterWrapper.bind( this );
-		this.onBlockError = this.onBlockError.bind( this );
-		this.onTouchStart = this.onTouchStart.bind( this );
-		this.onClick = this.onClick.bind( this );
-		this.onDragStart = this.onDragStart.bind( this );
-		this.onDragEnd = this.onDragEnd.bind( this );
-		this.selectOnOpen = this.selectOnOpen.bind( this );
-		this.hadTouchStart = false;
+function BlockListBlock( {
+	blockRef,
+	mode,
+	isFocusMode,
+	hasFixedToolbar,
+	isLocked,
+	clientId,
+	rootClientId,
+	isSelected,
+	isPartOfMultiSelection,
+	isFirstMultiSelected,
+	isTypingWithinBlock,
+	isCaretWithinFormattedText,
+	isEmptyDefaultBlock,
+	isMovable,
+	isParentOfSelectedBlock,
+	isDraggable,
+	isSelectionEnabled,
+	className,
+	name,
+	isValid,
+	attributes,
+	initialPosition,
+	wrapperProps,
+	onMetaChange,
+	onReplace,
+	onChange,
+	onInsertBlocksAfter,
+	onMerge,
+	onSelect,
+	onRemove,
+	onInsertDefaultBlockAfter,
+	toggleSelection,
+	onShiftSelection,
+	onSelectionStart,
+} ) {
+	// Random state used to rerender the component if needed, ideally we don't need this
+	const [ , updateRerenderState ] = useState( {} );
+	const rerender = () => updateRerenderState( {} );
 
-		this.state = {
-			error: null,
-			dragging: false,
-			isHovered: false,
-		};
-		this.isForcingContextualToolbar = false;
-	}
+	// Reference of the wrapper -------------------------------------------------
+	const wrapper = useRef( null );
+	useEffect( () => {
+		blockRef( wrapper.current, clientId );
+		// We need to rerender to trigger a rerendering of HoverArea.
+		rerender();
+	}, [ blockRef, clientId ] );
 
-	componentDidMount() {
-		if ( this.props.isSelected ) {
-			this.focusTabbable();
+	// Reference to the block edit node -----------------------------------------
+	const blockNodeRef = useRef();
+
+	// Keep track of touchstart to disable hover on iOS -------------------------
+	const hadTouchStart = useRef( false );
+	const onTouchStart = () => {
+		hadTouchStart.current = true;
+	};
+	const onTouchStop = () => {
+		// Clear touchstart detection
+		// Browser will try to emulate mouse events also see https://www.html5rocks.com/en/mobile/touchandmouse/
+		hadTouchStart.current = false;
+	};
+
+	// Handling isHovered -------------------------------------------------------
+	const [ isBlockHovered, setBlockHoveredState ] = useState( false );
+
+	/**
+	 * Sets the block state as unhovered if currently hovering. There are cases
+	 * where mouseleave may occur but the block is not hovered (multi-select),
+	 * so to avoid unnecesary renders, the state is only set if hovered.
+	 */
+	const hideHoverEffects = () => {
+		if ( isBlockHovered ) {
+			setBlockHoveredState( false );
 		}
-	}
+	};
+	/**
+	 * A mouseover event handler to apply hover effect when a pointer device is
+	 * placed within the bounds of the block. The mouseover event is preferred
+	 * over mouseenter because it may be the case that a previous mouseenter
+	 * event was blocked from being handled by a IgnoreNestedEvents component,
+	 * therefore transitioning out of a nested block to the bounds of the block
+	 * would otherwise not trigger a hover effect.
+	 *
+	 * @see https://developer.mozilla.org/en-US/docs/Web/Events/mouseenter
+	 */
+	const maybeHover = () => {
+		if (
+			isBlockHovered ||
+			isPartOfMultiSelection ||
+			isSelected ||
+			hadTouchStart.current
+		) {
+			return;
+		}
+		setBlockHoveredState( true );
+	};
 
-	componentDidUpdate( prevProps ) {
-		if ( this.isForcingContextualToolbar ) {
+	// Set hover to false once we start typing or select the block.
+	useEffect( () => {
+		if ( isTypingWithinBlock || isSelected ) {
+			hideHoverEffects();
+		}
+	} );
+
+	// Handling the dragging state ----------------------------------------------
+	const [ isDragging, setBlockDraggingState ] = useState( false );
+	const onDragStart = () => {
+		setBlockDraggingState( true );
+	};
+	const onDragEnd = () => {
+		setBlockDraggingState( false );
+	};
+
+	// Handling the error state -------------------------------------------------
+	const [ hasError, setErrorState ] = useState( false );
+	const onBlockError = () => setErrorState( false );
+
+	// Handling of forceContextualToolbarFocus ----------------------------------
+	const isForcingContextualToolbar = useRef( false );
+	useEffect( () => {
+		if ( isForcingContextualToolbar.current ) {
 			// The forcing of contextual toolbar should only be true during one update,
 			// after the first update normal conditions should apply.
-			this.isForcingContextualToolbar = false;
+			isForcingContextualToolbar.current = false;
 		}
-		if ( this.props.isTypingWithinBlock || this.props.isSelected ) {
-			this.hideHoverEffects();
-		}
+	} );
+	const forceFocusedContextualToolbar = () => {
+		isForcingContextualToolbar.current = true;
+		// trigger a re-render
+		rerender();
+	};
 
-		if ( this.props.isSelected && ! prevProps.isSelected ) {
-			this.focusTabbable( true );
-		}
-
-		// When triggering a multi-selection, move the focus to the wrapper of the first selected block.
-		// This ensures that it is not possible to continue editing the initially selected block
-		// when a multi-selection is triggered.
-		if ( this.props.isFirstMultiSelected && ! prevProps.isFirstMultiSelected ) {
-			this.wrapperNode.focus();
-		}
-	}
-
-	setBlockListRef( node ) {
-		this.wrapperNode = node;
-		this.props.blockRef( node, this.props.clientId );
-
-		// We need to rerender to trigger a rerendering of HoverArea
-		// it depents on this.wrapperNode but we can't keep this.wrapperNode in state
-		// Because we need it to be immediately availeble for `focusableTabbable` to work.
-		this.forceUpdate();
-	}
-
-	bindBlockNode( node ) {
-		this.node = node;
-	}
+	// Handing the focus of the block on creation and update --------------------
 
 	/**
 	 * When a block becomes selected, transition focus to an inner tabbable.
 	 *
 	 * @param {boolean} ignoreInnerBlocks Should not focus inner blocks.
 	 */
-	focusTabbable( ignoreInnerBlocks ) {
-		const { initialPosition } = this.props;
-
+	const focusTabbable = ( ignoreInnerBlocks ) => {
 		// Focus is captured by the wrapper node, so while focus transition
 		// should only consider tabbables within editable display, since it
 		// may be the wrapper itself or a side control which triggered the
 		// focus event, don't unnecessary transition to an inner tabbable.
-		if ( this.wrapperNode.contains( document.activeElement ) ) {
+		if ( wrapper.current.contains( document.activeElement ) ) {
 			return;
 		}
 
 		// Find all tabbables within node.
 		const textInputs = focus.tabbable
-			.find( this.node )
+			.find( blockNodeRef.current )
 			.filter( isTextField )
 			// Exclude inner blocks
-			.filter( ( node ) => ! ignoreInnerBlocks || isInsideRootBlock( this.node, node ) );
+			.filter( ( node ) => ! ignoreInnerBlocks || isInsideRootBlock( blockNodeRef.current, node ) );
 
 		// If reversed (e.g. merge via backspace), use the last in the set of
 		// tabbables.
@@ -149,20 +221,35 @@ export class BlockListBlock extends Component {
 		const target = ( isReverse ? last : first )( textInputs );
 
 		if ( ! target ) {
-			this.wrapperNode.focus();
+			wrapper.current.focus();
 			return;
 		}
 
 		placeCaretAtHorizontalEdge( target, isReverse );
-	}
+	};
 
-	setAttributes( attributes ) {
-		const { clientId, name, onChange } = this.props;
+	// Focus the selected block's wrapper or inner input on mount and update
+	const isMounting = useRef( true );
+	useEffect( () => {
+		if ( isSelected ) {
+			focusTabbable( ! isMounting.current );
+		}
+		isMounting.current = false;
+	}, [ focusTabbable, isSelected ] );
+
+	// Focus the first multi selected block
+	useEffect( () => {
+		if ( isFirstMultiSelected ) {
+			wrapper.current.focus();
+		}
+	}, [ isFirstMultiSelected ] );
+
+	// Other event handlers -----------------------------------------------------
+	const setAttributes = ( newAttributes ) => {
 		const type = getBlockType( name );
-		onChange( clientId, attributes );
-
+		onChange( clientId, newAttributes );
 		const metaAttributes = reduce(
-			attributes,
+			newAttributes,
 			( result, value, key ) => {
 				if ( get( type, [ 'attributes', key, 'source' ] ) === 'meta' ) {
 					result[ type.attributes[ key ].meta ] = value;
@@ -174,57 +261,9 @@ export class BlockListBlock extends Component {
 		);
 
 		if ( size( metaAttributes ) ) {
-			this.props.onMetaChange( metaAttributes );
+			onMetaChange( metaAttributes );
 		}
-	}
-
-	onTouchStart() {
-		// Detect touchstart to disable hover on iOS
-		this.hadTouchStart = true;
-	}
-
-	onClick() {
-		// Clear touchstart detection
-		// Browser will try to emulate mouse events also see https://www.html5rocks.com/en/mobile/touchandmouse/
-		this.hadTouchStart = false;
-	}
-
-	/**
-	 * A mouseover event handler to apply hover effect when a pointer device is
-	 * placed within the bounds of the block. The mouseover event is preferred
-	 * over mouseenter because it may be the case that a previous mouseenter
-	 * event was blocked from being handled by a IgnoreNestedEvents component,
-	 * therefore transitioning out of a nested block to the bounds of the block
-	 * would otherwise not trigger a hover effect.
-	 *
-	 * @see https://developer.mozilla.org/en-US/docs/Web/Events/mouseenter
-	 */
-	maybeHover() {
-		const { isPartOfMultiSelection, isSelected } = this.props;
-		const { isHovered } = this.state;
-
-		if (
-			isHovered ||
-			isPartOfMultiSelection ||
-			isSelected ||
-			this.hadTouchStart
-		) {
-			return;
-		}
-
-		this.setState( { isHovered: true } );
-	}
-
-	/**
-	 * Sets the block state as unhovered if currently hovering. There are cases
-	 * where mouseleave may occur but the block is not hovered (multi-select),
-	 * so to avoid unnecesary renders, the state is only set if hovered.
-	 */
-	hideHoverEffects() {
-		if ( this.state.isHovered ) {
-			this.setState( { isHovered: false } );
-		}
-	}
+	};
 
 	/**
 	 * Marks the block as selected when focused and not already selected. This
@@ -233,56 +272,11 @@ export class BlockListBlock extends Component {
 	 *
 	 * @return {void}
 	 */
-	onFocus() {
-		if ( ! this.props.isSelected && ! this.props.isPartOfMultiSelection ) {
-			this.props.onSelect();
+	const onFocus = () => {
+		if ( ! isSelected && ! isPartOfMultiSelection ) {
+			onSelect();
 		}
-	}
-
-	/**
-	 * Prevents default dragging behavior within a block to allow for multi-
-	 * selection to take effect unhampered.
-	 *
-	 * @param {DragEvent} event Drag event.
-	 *
-	 * @return {void}
-	 */
-	preventDrag( event ) {
-		event.preventDefault();
-	}
-
-	/**
-	 * Begins tracking cursor multi-selection when clicking down within block.
-	 *
-	 * @param {MouseEvent} event A mousedown event.
-	 *
-	 * @return {void}
-	 */
-	onPointerDown( event ) {
-		// Not the main button.
-		// https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
-		if ( event.button !== 0 ) {
-			return;
-		}
-
-		if ( event.shiftKey ) {
-			if ( ! this.props.isSelected ) {
-				this.props.onShiftSelection();
-				event.preventDefault();
-			}
-		} else {
-			this.props.onSelectionStart( this.props.clientId );
-
-			// Allow user to escape out of a multi-selection to a singular
-			// selection of a block via click. This is handled here since
-			// onFocus excludes blocks involved in a multiselection, as
-			// focus can be incurred by starting a multiselection (focus
-			// moved to first block's multi-controls).
-			if ( this.props.isPartOfMultiSelection ) {
-				this.props.onSelect();
-			}
-		}
-	}
+	};
 
 	/**
 	 * Interprets keydown event intent to remove or insert after block if key
@@ -292,15 +286,15 @@ export class BlockListBlock extends Component {
 	 *
 	 * @param {KeyboardEvent} event Keydown event.
 	 */
-	deleteOrInsertAfterWrapper( event ) {
+	const deleteOrInsertAfterWrapper = ( event ) => {
 		const { keyCode, target } = event;
 
 		// These block shortcuts should only trigger if the wrapper of the block is selected
 		// And when it's not a multi-selection to avoid conflicting with RichText/Inputs and multiselection.
 		if (
-			! this.props.isSelected ||
-			target !== this.wrapperNode ||
-			this.props.isLocked
+			! isSelected ||
+			target !== wrapper.current ||
+			isLocked
 		) {
 			return;
 		}
@@ -309,304 +303,292 @@ export class BlockListBlock extends Component {
 			case ENTER:
 				// Insert default block after current block if enter and event
 				// not already handled by descendant.
-				this.props.onInsertDefaultBlockAfter();
+				onInsertDefaultBlockAfter();
 				event.preventDefault();
 				break;
 
 			case BACKSPACE:
 			case DELETE:
 				// Remove block on backspace.
-				const { clientId, onRemove } = this.props;
 				onRemove( clientId );
 				event.preventDefault();
 				break;
 		}
-	}
+	};
 
-	onBlockError( error ) {
-		this.setState( { error } );
-	}
-
-	onDragStart() {
-		this.setState( { dragging: true } );
-	}
-
-	onDragEnd() {
-		this.setState( { dragging: false } );
-	}
-
-	selectOnOpen( open ) {
-		if ( open && ! this.props.isSelected ) {
-			this.props.onSelect();
+	/**
+	 * Begins tracking cursor multi-selection when clicking down within block.
+	 *
+	 * @param {MouseEvent} event A mousedown event.
+	 *
+	 * @return {void}
+	 */
+	const onPointerDown = ( event ) => {
+		// Not the main button.
+		// https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
+		if ( event.button !== 0 ) {
+			return;
 		}
-	}
 
-	forceFocusedContextualToolbar() {
-		this.isForcingContextualToolbar = true;
-		// trigger a re-render
-		this.setState( () => ( {} ) );
-	}
+		if ( event.shiftKey ) {
+			if ( ! isSelected ) {
+				onShiftSelection();
+				event.preventDefault();
+			}
+		} else {
+			onSelectionStart( clientId );
 
-	render() {
-		return (
-			<HoverArea container={ this.wrapperNode }>
-				{ ( { hoverArea } ) => {
-					const {
-						mode,
-						isFocusMode,
-						hasFixedToolbar,
-						isLocked,
-						clientId,
-						rootClientId,
-						isSelected,
-						isPartOfMultiSelection,
-						isFirstMultiSelected,
-						isTypingWithinBlock,
-						isCaretWithinFormattedText,
-						isEmptyDefaultBlock,
-						isMovable,
-						isParentOfSelectedBlock,
-						isDraggable,
-						className,
-						name,
-						isValid,
-						attributes,
-					} = this.props;
-					const isHovered = this.state.isHovered && ! isPartOfMultiSelection;
-					const blockType = getBlockType( name );
-					// translators: %s: Type of block (i.e. Text, Image etc)
-					const blockLabel = sprintf( __( 'Block: %s' ), blockType.title );
-					// The block as rendered in the editor is composed of general block UI
-					// (mover, toolbar, wrapper) and the display of the block content.
+			// Allow user to escape out of a multi-selection to a singular
+			// selection of a block via click. This is handled here since
+			// onFocus excludes blocks involved in a multiselection, as
+			// focus can be incurred by starting a multiselection (focus
+			// moved to first block's multi-controls).
+			if ( isPartOfMultiSelection ) {
+				onSelect();
+			}
+		}
+	};
 
-					const isUnregisteredBlock = name === getUnregisteredTypeHandlerName();
+	const selectOnOpen = ( open ) => {
+		if ( open && ! isSelected ) {
+			onSelect();
+		}
+	};
 
-					// If the block is selected and we're typing the block should not appear.
-					// Empty paragraph blocks should always show up as unselected.
-					const showEmptyBlockSideInserter =
-						( isSelected || isHovered ) && isEmptyDefaultBlock && isValid;
-					const shouldAppearSelected =
-						! isFocusMode &&
-						! showEmptyBlockSideInserter &&
-						isSelected &&
-						! isTypingWithinBlock;
-					const shouldAppearHovered =
-						! isFocusMode &&
-						! hasFixedToolbar &&
-						isHovered &&
-						! isEmptyDefaultBlock;
-					// We render block movers and block settings to keep them tabbale even if hidden
-					const shouldRenderMovers =
-						( isSelected || hoverArea === 'left' ) &&
-						! showEmptyBlockSideInserter &&
-						! isPartOfMultiSelection &&
-						! isTypingWithinBlock;
-					const shouldShowBreadcrumb =
-						! isFocusMode && isHovered && ! isEmptyDefaultBlock;
-					const shouldShowContextualToolbar =
-						! hasFixedToolbar &&
-						! showEmptyBlockSideInserter &&
-						( ( isSelected &&
-							( ! isTypingWithinBlock || isCaretWithinFormattedText ) ) ||
-							isFirstMultiSelected );
-					const shouldShowMobileToolbar = shouldAppearSelected;
-					const { error, dragging } = this.state;
+	return (
+		<HoverArea container={ wrapper.current }>
+			{ ( { hoverArea } ) => {
+				const isHovered = isBlockHovered && ! isPartOfMultiSelection;
+				const blockType = getBlockType( name );
+				// translators: %s: Type of block (i.e. Text, Image etc)
+				const blockLabel = sprintf( __( 'Block: %s' ), blockType.title );
+				// The block as rendered in the editor is composed of general block UI
+				// (mover, toolbar, wrapper) and the display of the block content.
 
-					// Insertion point can only be made visible if the block is at the
-					// the extent of a multi-selection, or not in a multi-selection.
-					const shouldShowInsertionPoint =
-						( isPartOfMultiSelection && isFirstMultiSelected ) ||
-						! isPartOfMultiSelection;
+				const isUnregisteredBlock = name === getUnregisteredTypeHandlerName();
 
-					// The wp-block className is important for editor styles.
-					// Generate the wrapper class names handling the different states of the block.
-					const wrapperClassName = classnames(
-						'wp-block editor-block-list__block block-editor-block-list__block',
-						{
-							'has-warning': ! isValid || !! error || isUnregisteredBlock,
-							'is-selected': shouldAppearSelected,
-							'is-multi-selected': isPartOfMultiSelection,
-							'is-hovered': shouldAppearHovered,
-							'is-reusable': isReusableBlock( blockType ),
-							'is-dragging': dragging,
-							'is-typing': isTypingWithinBlock,
-							'is-focused':
-								isFocusMode && ( isSelected || isParentOfSelectedBlock ),
-							'is-focus-mode': isFocusMode,
-						},
-						className
-					);
+				// If the block is selected and we're typing the block should not appear.
+				// Empty paragraph blocks should always show up as unselected.
+				const showEmptyBlockSideInserter =
+					( isSelected || isHovered ) && isEmptyDefaultBlock && isValid;
+				const shouldAppearSelected =
+					! isFocusMode &&
+					! showEmptyBlockSideInserter &&
+					isSelected &&
+					! isTypingWithinBlock;
+				const shouldAppearHovered =
+					! isFocusMode &&
+					! hasFixedToolbar &&
+					isHovered &&
+					! isEmptyDefaultBlock;
+				// We render block movers and block settings to keep them tabbale even if hidden
+				const shouldRenderMovers =
+					( isSelected || hoverArea === 'left' ) &&
+					! showEmptyBlockSideInserter &&
+					! isPartOfMultiSelection &&
+					! isTypingWithinBlock;
+				const shouldShowBreadcrumb =
+					! isFocusMode && isHovered && ! isEmptyDefaultBlock;
+				const shouldShowContextualToolbar =
+					! hasFixedToolbar &&
+					! showEmptyBlockSideInserter &&
+					( ( isSelected &&
+						( ! isTypingWithinBlock || isCaretWithinFormattedText ) ) ||
+						isFirstMultiSelected );
+				const shouldShowMobileToolbar = shouldAppearSelected;
 
-					const { onReplace } = this.props;
+				// Insertion point can only be made visible if the block is at the
+				// the extent of a multi-selection, or not in a multi-selection.
+				const shouldShowInsertionPoint =
+					( isPartOfMultiSelection && isFirstMultiSelected ) ||
+					! isPartOfMultiSelection;
 
-					// Determine whether the block has props to apply to the wrapper.
-					let wrapperProps = this.props.wrapperProps;
-					if ( blockType.getEditWrapperProps ) {
-						wrapperProps = {
-							...wrapperProps,
-							...blockType.getEditWrapperProps( attributes ),
-						};
-					}
-					const blockElementId = `block-${ clientId }`;
+				// The wp-block className is important for editor styles.
+				// Generate the wrapper class names handling the different states of the block.
+				const wrapperClassName = classnames(
+					'wp-block editor-block-list__block block-editor-block-list__block',
+					{
+						'has-warning': ! isValid || !! hasError || isUnregisteredBlock,
+						'is-selected': shouldAppearSelected,
+						'is-multi-selected': isPartOfMultiSelection,
+						'is-hovered': shouldAppearHovered,
+						'is-reusable': isReusableBlock( blockType ),
+						'is-dragging': isDragging,
+						'is-typing': isTypingWithinBlock,
+						'is-focused':
+							isFocusMode && ( isSelected || isParentOfSelectedBlock ),
+						'is-focus-mode': isFocusMode,
+					},
+					className
+				);
 
-					// We wrap the BlockEdit component in a div that hides it when editing in
-					// HTML mode. This allows us to render all of the ancillary pieces
-					// (InspectorControls, etc.) which are inside `BlockEdit` but not
-					// `BlockHTML`, even in HTML mode.
-					let blockEdit = (
-						<BlockEdit
-							name={ name }
-							isSelected={ isSelected }
-							attributes={ attributes }
-							setAttributes={ this.setAttributes }
-							insertBlocksAfter={ isLocked ? undefined : this.props.onInsertBlocksAfter }
-							onReplace={ isLocked ? undefined : onReplace }
-							mergeBlocks={ isLocked ? undefined : this.props.onMerge }
-							clientId={ clientId }
-							isSelectionEnabled={ this.props.isSelectionEnabled }
-							toggleSelection={ this.props.toggleSelection }
-						/>
-					);
-					if ( mode !== 'visual' ) {
-						blockEdit = <div style={ { display: 'none' } }>{ blockEdit }</div>;
-					}
+				// Determine whether the block has props to apply to the wrapper.
+				let blockWrapperProps = wrapperProps;
+				if ( blockType.getEditWrapperProps ) {
+					blockWrapperProps = {
+						...blockWrapperProps,
+						...blockType.getEditWrapperProps( attributes ),
+					};
+				}
+				const blockElementId = `block-${ clientId }`;
 
-					// Disable reasons:
-					//
-					//  jsx-a11y/mouse-events-have-key-events:
-					//   - onMouseOver is explicitly handling hover effects
-					//
-					//  jsx-a11y/no-static-element-interactions:
-					//   - Each block can be selected by clicking on it
+				// We wrap the BlockEdit component in a div that hides it when editing in
+				// HTML mode. This allows us to render all of the ancillary pieces
+				// (InspectorControls, etc.) which are inside `BlockEdit` but not
+				// `BlockHTML`, even in HTML mode.
+				let blockEdit = (
+					<BlockEdit
+						name={ name }
+						isSelected={ isSelected }
+						attributes={ attributes }
+						setAttributes={ setAttributes }
+						insertBlocksAfter={ isLocked ? undefined : onInsertBlocksAfter }
+						onReplace={ isLocked ? undefined : onReplace }
+						mergeBlocks={ isLocked ? undefined : onMerge }
+						clientId={ clientId }
+						isSelectionEnabled={ isSelectionEnabled }
+						toggleSelection={ toggleSelection }
+					/>
+				);
+				if ( mode !== 'visual' ) {
+					blockEdit = <div style={ { display: 'none' } }>{ blockEdit }</div>;
+				}
 
-					/* eslint-disable jsx-a11y/mouse-events-have-key-events, jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
+				// Disable reasons:
+				//
+				//  jsx-a11y/mouse-events-have-key-events:
+				//   - onMouseOver is explicitly handling hover effects
+				//
+				//  jsx-a11y/no-static-element-interactions:
+				//   - Each block can be selected by clicking on it
 
-					return (
-						<IgnoreNestedEvents
-							id={ blockElementId }
-							ref={ this.setBlockListRef }
-							onMouseOver={ this.maybeHover }
-							onMouseOverHandled={ this.hideHoverEffects }
-							onMouseLeave={ this.hideHoverEffects }
-							className={ wrapperClassName }
-							data-type={ name }
-							onTouchStart={ this.onTouchStart }
-							onFocus={ this.onFocus }
-							onClick={ this.onClick }
-							onKeyDown={ this.deleteOrInsertAfterWrapper }
-							tabIndex="0"
-							aria-label={ blockLabel }
-							childHandledEvents={ [ 'onDragStart', 'onMouseDown' ] }
-							{ ...wrapperProps }
-						>
-							{ shouldShowInsertionPoint && (
-								<BlockInsertionPoint
-									clientId={ clientId }
-									rootClientId={ rootClientId }
-								/>
-							) }
-							<BlockDropZone
+				/* eslint-disable jsx-a11y/mouse-events-have-key-events, jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
+
+				return (
+					<IgnoreNestedEvents
+						id={ blockElementId }
+						ref={ wrapper }
+						onMouseOver={ maybeHover }
+						onMouseOverHandled={ hideHoverEffects }
+						onMouseLeave={ hideHoverEffects }
+						className={ wrapperClassName }
+						data-type={ name }
+						onTouchStart={ onTouchStart }
+						onFocus={ onFocus }
+						onClick={ onTouchStop }
+						onKeyDown={ deleteOrInsertAfterWrapper }
+						tabIndex="0"
+						aria-label={ blockLabel }
+						childHandledEvents={ [ 'onDragStart', 'onMouseDown' ] }
+						{ ...blockWrapperProps }
+					>
+						{ shouldShowInsertionPoint && (
+							<BlockInsertionPoint
 								clientId={ clientId }
 								rootClientId={ rootClientId }
 							/>
-							{ isFirstMultiSelected && (
-								<BlockMultiControls rootClientId={ rootClientId } />
+						) }
+						<BlockDropZone
+							clientId={ clientId }
+							rootClientId={ rootClientId }
+						/>
+						{ isFirstMultiSelected && (
+							<BlockMultiControls rootClientId={ rootClientId } />
+						) }
+						<div className="editor-block-list__block-edit block-editor-block-list__block-edit">
+							{ shouldRenderMovers && (
+								<BlockMover
+									clientIds={ clientId }
+									blockElementId={ blockElementId }
+									isHidden={ ! ( isHovered || isSelected ) || hoverArea !== 'left' }
+									isDraggable={
+										isDraggable !== false &&
+										( ! isPartOfMultiSelection && isMovable )
+									}
+									onDragStart={ onDragStart }
+									onDragEnd={ onDragEnd }
+								/>
 							) }
-							<div className="editor-block-list__block-edit block-editor-block-list__block-edit">
-								{ shouldRenderMovers && (
-									<BlockMover
-										clientIds={ clientId }
-										blockElementId={ blockElementId }
-										isHidden={ ! ( isHovered || isSelected ) || hoverArea !== 'left' }
-										isDraggable={
-											isDraggable !== false &&
-											( ! isPartOfMultiSelection && isMovable )
-										}
-										onDragStart={ this.onDragStart }
-										onDragEnd={ this.onDragEnd }
-									/>
-								) }
-								{ shouldShowBreadcrumb && (
-									<BlockBreadcrumb
-										clientId={ clientId }
-										isHidden={
-											! ( isHovered || isSelected ) || hoverArea !== 'left'
-										}
-									/>
-								) }
-								{ ( shouldShowContextualToolbar ||
-									this.isForcingContextualToolbar ) && (
-									<BlockContextualToolbar
-										// If the toolbar is being shown because of being forced
-										// it should focus the toolbar right after the mount.
-										focusOnMount={ this.isForcingContextualToolbar }
-									/>
-								) }
-								{ ! shouldShowContextualToolbar &&
-									isSelected &&
-									! hasFixedToolbar &&
-									! isEmptyDefaultBlock && (
-									<KeyboardShortcuts
-										bindGlobal
-										eventName="keydown"
-										shortcuts={ {
-											'alt+f10': this.forceFocusedContextualToolbar,
-										} }
-									/>
-								) }
-								<IgnoreNestedEvents
-									ref={ this.bindBlockNode }
-									onDragStart={ this.preventDrag }
-									onMouseDown={ this.onPointerDown }
-									data-block={ clientId }
-								>
-									<BlockCrashBoundary onError={ this.onBlockError }>
-										{ isValid && blockEdit }
-										{ isValid && mode === 'html' && (
-											<BlockHtml clientId={ clientId } />
-										) }
-										{ ! isValid && [
-											<BlockInvalidWarning
-												key="invalid-warning"
-												clientId={ clientId }
-											/>,
-											<div key="invalid-preview">
-												{ getSaveElement( blockType, attributes ) }
-											</div>,
-										] }
-									</BlockCrashBoundary>
-									{ shouldShowMobileToolbar && (
-										<BlockMobileToolbar clientId={ clientId } />
+							{ shouldShowBreadcrumb && (
+								<BlockBreadcrumb
+									clientId={ clientId }
+									isHidden={
+										! ( isHovered || isSelected ) || hoverArea !== 'left'
+									}
+								/>
+							) }
+							{ ( shouldShowContextualToolbar ||
+								isForcingContextualToolbar.current ) && (
+								<BlockContextualToolbar
+									// If the toolbar is being shown because of being forced
+									// it should focus the toolbar right after the mount.
+									focusOnMount={ isForcingContextualToolbar.current }
+								/>
+							) }
+							{ ! shouldShowContextualToolbar &&
+								isSelected &&
+								! hasFixedToolbar &&
+								! isEmptyDefaultBlock && (
+								<KeyboardShortcuts
+									bindGlobal
+									eventName="keydown"
+									shortcuts={ {
+										'alt+f10': forceFocusedContextualToolbar,
+									} }
+								/>
+							) }
+							<IgnoreNestedEvents
+								ref={ blockNodeRef }
+								onDragStart={ preventDrag }
+								onMouseDown={ onPointerDown }
+								data-block={ clientId }
+							>
+								<BlockCrashBoundary onError={ onBlockError }>
+									{ isValid && blockEdit }
+									{ isValid && mode === 'html' && (
+										<BlockHtml clientId={ clientId } />
 									) }
-									{ !! error && <BlockCrashWarning /> }
-								</IgnoreNestedEvents>
-							</div>
-							{ showEmptyBlockSideInserter && (
-								<>
-									<div className="editor-block-list__side-inserter block-editor-block-list__side-inserter">
-										<InserterWithShortcuts
+									{ ! isValid && [
+										<BlockInvalidWarning
+											key="invalid-warning"
 											clientId={ clientId }
-											rootClientId={ rootClientId }
-											onToggle={ this.selectOnOpen }
-										/>
-									</div>
-									<div className="editor-block-list__empty-block-inserter block-editor-block-list__empty-block-inserter">
-										<Inserter
-											position="top right"
-											onToggle={ this.selectOnOpen }
-											rootClientId={ rootClientId }
-											clientId={ clientId }
-										/>
-									</div>
-								</>
-							) }
-						</IgnoreNestedEvents>
-					);
-					/* eslint-enable jsx-a11y/mouse-events-have-key-events, jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
-				} }
-			</HoverArea>
-		);
-	}
+										/>,
+										<div key="invalid-preview">
+											{ getSaveElement( blockType, attributes ) }
+										</div>,
+									] }
+								</BlockCrashBoundary>
+								{ shouldShowMobileToolbar && (
+									<BlockMobileToolbar clientId={ clientId } />
+								) }
+								{ !! hasError && <BlockCrashWarning /> }
+							</IgnoreNestedEvents>
+						</div>
+						{ showEmptyBlockSideInserter && (
+							<>
+								<div className="editor-block-list__side-inserter block-editor-block-list__side-inserter">
+									<InserterWithShortcuts
+										clientId={ clientId }
+										rootClientId={ rootClientId }
+										onToggle={ selectOnOpen }
+									/>
+								</div>
+								<div className="editor-block-list__empty-block-inserter block-editor-block-list__empty-block-inserter">
+									<Inserter
+										position="top right"
+										onToggle={ selectOnOpen }
+										rootClientId={ rootClientId }
+										clientId={ clientId }
+									/>
+								</div>
+							</>
+						) }
+					</IgnoreNestedEvents>
+				);
+				/* eslint-enable jsx-a11y/mouse-events-have-key-events, jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
+			} }
+		</HoverArea>
+	);
 }
 
 const applyWithSelect = withSelect(

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -99,7 +99,7 @@ function BlockListBlock( {
 	const [ , updateRerenderState ] = useState( {} );
 	const rerender = () => updateRerenderState( {} );
 
-	// Reference of the wrapper -------------------------------------------------
+	// Reference of the wrapper
 	const wrapper = useRef( null );
 	useEffect( () => {
 		blockRef( wrapper.current, clientId );
@@ -107,10 +107,10 @@ function BlockListBlock( {
 		rerender();
 	}, [ blockRef, clientId ] );
 
-	// Reference to the block edit node -----------------------------------------
+	// Reference to the block edit node
 	const blockNodeRef = useRef();
 
-	// Keep track of touchstart to disable hover on iOS -------------------------
+	// Keep track of touchstart to disable hover on iOS
 	const hadTouchStart = useRef( false );
 	const onTouchStart = () => {
 		hadTouchStart.current = true;
@@ -121,7 +121,7 @@ function BlockListBlock( {
 		hadTouchStart.current = false;
 	};
 
-	// Handling isHovered -------------------------------------------------------
+	// Handling isHovered
 	const [ isBlockHovered, setBlockHoveredState ] = useState( false );
 
 	/**
@@ -163,7 +163,7 @@ function BlockListBlock( {
 		}
 	} );
 
-	// Handling the dragging state ----------------------------------------------
+	// Handling the dragging state
 	const [ isDragging, setBlockDraggingState ] = useState( false );
 	const onDragStart = () => {
 		setBlockDraggingState( true );
@@ -172,11 +172,11 @@ function BlockListBlock( {
 		setBlockDraggingState( false );
 	};
 
-	// Handling the error state -------------------------------------------------
+	// Handling the error state
 	const [ hasError, setErrorState ] = useState( false );
 	const onBlockError = () => setErrorState( false );
 
-	// Handling of forceContextualToolbarFocus ----------------------------------
+	// Handling of forceContextualToolbarFocus
 	const isForcingContextualToolbar = useRef( false );
 	useEffect( () => {
 		if ( isForcingContextualToolbar.current ) {
@@ -191,7 +191,7 @@ function BlockListBlock( {
 		rerender();
 	};
 
-	// Handing the focus of the block on creation and update --------------------
+	// Handing the focus of the block on creation and update
 
 	/**
 	 * When a block becomes selected, transition focus to an inner tabbable.
@@ -243,7 +243,7 @@ function BlockListBlock( {
 		}
 	}, [ isFirstMultiSelected ] );
 
-	// Other event handlers -----------------------------------------------------
+	// Other event handlers
 
 	/**
 	 * Marks the block as selected when focused and not already selected. This

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -53,8 +53,6 @@ import { isInsideRootBlock } from '../../utils/dom';
  * selection to take effect unhampered.
  *
  * @param {DragEvent} event Drag event.
- *
- * @return {void}
  */
 const preventDrag = ( event ) => {
 	event.preventDefault();
@@ -249,8 +247,6 @@ function BlockListBlock( {
 	 * Marks the block as selected when focused and not already selected. This
 	 * specifically handles the case where block does not set focus on its own
 	 * (via `setFocus`), typically if there is no focusable input in the block.
-	 *
-	 * @return {void}
 	 */
 	const onFocus = () => {
 		if ( ! isSelected && ! isPartOfMultiSelection ) {
@@ -300,8 +296,6 @@ function BlockListBlock( {
 	 * Begins tracking cursor multi-selection when clicking down within block.
 	 *
 	 * @param {MouseEvent} event A mousedown event.
-	 *
-	 * @return {void}
 	 */
 	const onPointerDown = ( event ) => {
 		// Not the main button.

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -105,7 +105,7 @@ function BlockListBlock( {
 		blockRef( wrapper.current, clientId );
 		// We need to rerender to trigger a rerendering of HoverArea.
 		rerender();
-	}, [ blockRef, clientId ] );
+	}, [] );
 
 	// Reference to the block edit node
 	const blockNodeRef = useRef();
@@ -234,7 +234,7 @@ function BlockListBlock( {
 			focusTabbable( ! isMounting.current );
 		}
 		isMounting.current = false;
-	}, [ focusTabbable, isSelected ] );
+	}, [ isSelected ] );
 
 	// Focus the first multi selected block
 	useEffect( () => {

--- a/packages/eslint-plugin/configs/react.js
+++ b/packages/eslint-plugin/configs/react.js
@@ -26,6 +26,5 @@ module.exports = {
 		'react/prop-types': 'off',
 		'react/react-in-jsx-scope': 'off',
 		'react-hooks/rules-of-hooks': 'error',
-		'react-hooks/exhaustive-deps': 'warn',
 	},
 };


### PR DESCRIPTION
I said previously that we're not going to refactor our components to use hooks just to use hooks. But in this PR, I'm trying to refactor the `BlockListBlock` component. 

The main reasons are:

 - The component is one of the most complex one in the repository and using hooks clarifies its code as related behaviors/functions/state are grouped.
 - This is one of the bottleneck components in terms of performance, and I'd like to explore whether we can make improvements using hooks or not.
 - I have some plans to bring new features to this component and I don't want to just continue growing without some "organization".

At the moment, I kept the refactoring as minimal as I can, which means I kept, in theory, the same flows, states... There's something different though which can be impactful. A lot of the callbacks are not bound the instance object which means some child components might rerender more often. There are options and solutions but I want to measure the differences before making changes.

 - I can use `useCallback` to memoize these callbacks
 - I want to be mindful of the memory impact of memoizing all of these callbacks, maybe these are rerendered regardless of the callback change which means the memoization can be more costly than anticipated. 
 - Another option could be to move some of these callbacks to the `withDispatch` HoC instead.