### PR TITLE
Add end 2 end test dynamic allowed blocks

### DIFF
--- a/packages/e2e-tests/plugins/inner-blocks-allowed-blocks/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-allowed-blocks/index.js
@@ -11,7 +11,7 @@
 		[ 'core/quote' ]
 	];
 	const allowedBlocksWhenSingleChild = [ 'core/image', 'core/list' ];
-	const allowedBlocksLessGreaterThan2 = [ 'core/gallery', 'core/video' ];
+	const allowedBlocksWhenMultipleChildren = [ 'core/gallery', 'core/video' ];
 
 	const save = function() {
 		return el( 'div', divProps,

--- a/packages/e2e-tests/plugins/inner-blocks-allowed-blocks/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-allowed-blocks/index.js
@@ -1,4 +1,5 @@
 ( function() {
+	const { withSelect } = wp.data;
 	const { registerBlockType } = wp.blocks;
 	const { createElement: el } = wp.element;
 	const { InnerBlocks } = wp.editor;
@@ -9,6 +10,8 @@
 		[ 'core/paragraph', { placeholder: __( 'Add a description' ) } ],
 		[ 'core/quote' ]
 	];
+	const allowedBlocksLessThan2 = [ 'core/image', 'core/list' ];
+	const allowedBlocksLessGreaterThan2 = [ 'core/gallery', 'core/video' ];
 
 	const save = function() {
 		return el( 'div', divProps,
@@ -51,6 +54,32 @@
 				)
 			);
 		},
+
+		save,
+	} );
+
+	registerBlockType( 'test/allowed-blocks-dynamic', {
+		title: 'Allowed Blocks Dynamic',
+		icon: 'carrot',
+		category: 'common',
+
+		edit: withSelect( function( select, ownProps ) {
+			var getBlockOrder = select( 'core/editor' ).getBlockOrder;
+			return {
+				numberOfChildren: getBlockOrder( ownProps.clientId ).length,
+			};
+		} )( function( props ) {
+			return el( 'div', divProps,
+				el(
+					InnerBlocks,
+					{
+						allowedBlocks: props.numberOfChildren < 2 ?
+							allowedBlocksLessThan2 :
+							allowedBlocksLessGreaterThan2,
+					}
+				)
+			);
+		} ),
 
 		save,
 	} );

--- a/packages/e2e-tests/plugins/inner-blocks-allowed-blocks/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-allowed-blocks/index.js
@@ -10,7 +10,7 @@
 		[ 'core/paragraph', { placeholder: __( 'Add a description' ) } ],
 		[ 'core/quote' ]
 	];
-	const allowedBlocksWhenSingleChild = [ 'core/image', 'core/list' ];
+	const allowedBlocksWhenSingleEmptyChild = [ 'core/image', 'core/list' ];
 	const allowedBlocksWhenMultipleChildren = [ 'core/gallery', 'core/video' ];
 
 	const save = function() {
@@ -74,8 +74,8 @@
 					InnerBlocks,
 					{
 						allowedBlocks: props.numberOfChildren < 2 ?
-							allowedBlocksLessThan2 :
-							allowedBlocksLessGreaterThan2,
+							allowedBlocksWhenSingleEmptyChild :
+							allowedBlocksWhenMultipleChildren,
 					}
 				)
 			);

--- a/packages/e2e-tests/plugins/inner-blocks-allowed-blocks/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-allowed-blocks/index.js
@@ -10,7 +10,7 @@
 		[ 'core/paragraph', { placeholder: __( 'Add a description' ) } ],
 		[ 'core/quote' ]
 	];
-	const allowedBlocksLessThan2 = [ 'core/image', 'core/list' ];
+	const allowedBlocksWhenSingleChild = [ 'core/image', 'core/list' ];
 	const allowedBlocksLessGreaterThan2 = [ 'core/gallery', 'core/video' ];
 
 	const save = function() {

--- a/packages/e2e-tests/specs/plugins/inner-blocks-allowed-blocks.test.js
+++ b/packages/e2e-tests/specs/plugins/inner-blocks-allowed-blocks.test.js
@@ -56,4 +56,30 @@ describe( 'Allowed Blocks Setting on InnerBlocks ', () => {
 			'Quote',
 		] );
 	} );
+
+	it( 'correctly applies dynamic allowed blocks restrictions', async () => {
+		await insertBlock( 'Allowed Blocks Dynamic' );
+		const parentBlockSelector = '[data-type="test/allowed-blocks-dynamic"]';
+		const blockAppender = '.block-list-appender button';
+		const appenderSelector = `${ parentBlockSelector } ${ blockAppender }`;
+		await page.waitForSelector( appenderSelector );
+		await page.click( appenderSelector );
+		await openAllBlockInserterCategories();
+		expect(
+			await getAllBlockInserterItemTitles()
+		).toEqual( [
+			'Image',
+			'List',
+		] );
+		await page.click( `.block-editor-block-types-list__item[aria-label="List"]` );
+		await insertBlock( 'Image' );
+		await page.click( appenderSelector );
+		await openAllBlockInserterCategories();
+		expect(
+			await getAllBlockInserterItemTitles()
+		).toEqual( [
+			'Gallery',
+			'Video',
+		] );
+	} );
 } );


### PR DESCRIPTION
## Description
This PR adds a simple end 2 end test that makes sure allowed blocks inside a parent block can be changed dynamically depending on some condition e.g: the number of child's the parent contains.

## How has this been tested?
We just need to make sure the test cases pass.

Related: #14515