### PR TITLE
Avoid synchronous xhr by using window.sendBeacon when available

### DIFF
--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -121,9 +121,13 @@ class PostLockedModal extends Component {
 		data.append( 'post_ID', postId );
 		data.append( 'active_post_lock', activePostLock );
 
-		const xhr = new window.XMLHttpRequest();
-		xhr.open( 'POST', postLockUtils.ajaxUrl, false );
-		xhr.send( data );
+		if ( window.navigator.sendBeacon ) {
+			window.navigator.sendBeacon( postLockUtils.ajaxUrl, data );
+		} else {
+			const xhr = new window.XMLHttpRequest();
+			xhr.open( 'POST', postLockUtils.ajaxUrl, false );
+			xhr.send( data );
+		}
 	}
 
 	render() {


### PR DESCRIPTION
## Description
While looking at https://github.com/WordPress/gutenberg/pull/14986 I noticed an error occurring with one of the preview tests:

```
DOMException: Failed to execute 'send' on 'XMLHttpRequest': 
Failed to load 'http://localhost:8889/wp-admin/admin-ajax.php': Synchronous XHR in page dismissal.

      at PostLockedModal.releasePostLock (../../http:/localhost:8889/wp-content/plugins/gutenberg/build/editor/index.js?ver=1555400628:8006:11)
```

Upon some investigation, it looks like this is a change in newer versions of chrome/chromium. Use of synchronous xhr requests have been disallowed in `beforeunload`. Not a great deal of evidence for this change, I found the stack overflow question first and then the thread on the chromium group after that:
- https://stackoverflow.com/questions/55676319/ajax-synchronous-request-failing-in-chrome
- https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/LnqwTCiT9Gs

We're using synchronous xhr requests in `beforeunload` to unlock a post when the page is closed. This fix detects whether the `navigator.sendBeacon` is available, and uses that instead to make the request.

## How has this been tested?
**Use browser dev tool network tab**
1. Load up a post
2. Open chrome dev tools network tab
3. Filter to 'admin-ajax'.
4. Enabled the 'Preserve Logs' option.
5. Refresh the page
6. Check that a request to `/wp-admin/admin-ajax.php` was made. The request should have an action of 'wp-remove-post-lock' in its form data.

**Tail logs**
1. Tail server access logs (for the docker dev env I used `docker logs -f <container_id>`
2. Load up a post in your browser
3. Close the browser tab
4. Check that there's a request to `/wp-admin/admin-ajax.php` in the logs when closing the tab (when I tested I added a temporary query string to the url to verify that it was the right request in the logs).

**Other ways of testing.**
- Trigger the `beforeUnload` event from the browser console (`window.dispatchEvent(new Event('beforeunload'));`) and monitor the network requests
- Use a network sniffer like Charles to catch the requests.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
