### PR TITLE
Add the default eslint react hooks config to the wordpress eslint package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3289,6 +3289,7 @@
 				"babel-eslint": "^8.0.3",
 				"eslint-plugin-jsx-a11y": "^6.2.1",
 				"eslint-plugin-react": "^7.12.4",
+				"eslint-plugin-react-hooks": "^1.6.0",
 				"requireindex": "^1.2.0"
 			}
 		},
@@ -8484,6 +8485,12 @@
 					}
 				}
 			}
+		},
+		"eslint-plugin-react-hooks": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.0.tgz",
+			"integrity": "sha512-lHBVRIaz5ibnIgNG07JNiAuBUeKhEf8l4etNx5vfAEwqQ5tcuK3jV9yjmopPgQDagQb7HwIuQVsE3IVcGrRnag==",
+			"dev": true
 		},
 		"eslint-scope": {
 			"version": "3.7.3",

--- a/packages/block-editor/src/components/contrast-checker/index.js
+++ b/packages/block-editor/src/components/contrast-checker/index.js
@@ -11,6 +11,22 @@ import { __ } from '@wordpress/i18n';
 import { Notice } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
 
+function ContrastCheckerMessage( { tinyBackgroundColor, tinyTextColor, backgroundColor, textColor } ) {
+	const msg = tinyBackgroundColor.getBrightness() < tinyTextColor.getBrightness() ?
+		__( 'This color combination may be hard for people to read. Try using a darker background color and/or a brighter text color.' ) :
+		__( 'This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.' );
+	useEffect( () => {
+		speak( __( 'This color combination may be hard for people to read.' ) );
+	}, [ backgroundColor, textColor ] );
+	return (
+		<div className="editor-contrast-checker block-editor-contrast-checker">
+			<Notice status="warning" isDismissible={ false }>
+				{ msg }
+			</Notice>
+		</div>
+	);
+}
+
 function ContrastChecker( {
 	backgroundColor,
 	fallbackBackgroundColor,
@@ -33,18 +49,14 @@ function ContrastChecker( {
 	) ) {
 		return null;
 	}
-	const msg = tinyBackgroundColor.getBrightness() < tinyTextColor.getBrightness() ?
-		__( 'This color combination may be hard for people to read. Try using a darker background color and/or a brighter text color.' ) :
-		__( 'This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.' );
-	useEffect( () => {
-		speak( __( 'This color combination may be hard for people to read.' ) );
-	}, [ backgroundColor, textColor ] );
+
 	return (
-		<div className="editor-contrast-checker block-editor-contrast-checker">
-			<Notice status="warning" isDismissible={ false }>
-				{ msg }
-			</Notice>
-		</div>
+		<ContrastCheckerMessage
+			backgroundColor={ backgroundColor }
+			textColor={ textColor }
+			tinyBackgroundColor={ tinyBackgroundColor }
+			tinyTextColor={ tinyTextColor }
+		/>
 	);
 }
 

--- a/packages/block-editor/src/components/contrast-checker/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/contrast-checker/test/__snapshots__/index.js.snap
@@ -8,24 +8,57 @@ exports[`ContrastChecker should render component when the colors do not meet AA 
   isLargeText={true}
   textColor="#666"
 >
-  <div
-    className="editor-contrast-checker block-editor-contrast-checker"
+  <ContrastCheckerMessage
+    backgroundColor="#666"
+    textColor="#666"
+    tinyBackgroundColor={
+      Object {
+        "_a": 1,
+        "_b": 102,
+        "_format": "hex",
+        "_g": 102,
+        "_gradientType": undefined,
+        "_ok": true,
+        "_originalInput": "#666",
+        "_r": 102,
+        "_roundA": 1,
+        "_tc_id": 2,
+      }
+    }
+    tinyTextColor={
+      Object {
+        "_a": 1,
+        "_b": 102,
+        "_format": "hex",
+        "_g": 102,
+        "_gradientType": undefined,
+        "_ok": true,
+        "_originalInput": "#666",
+        "_r": 102,
+        "_roundA": 1,
+        "_tc_id": 3,
+      }
+    }
   >
-    <Notice
-      isDismissible={false}
-      status="warning"
+    <div
+      className="editor-contrast-checker block-editor-contrast-checker"
     >
-      <div
-        className="components-notice is-warning"
+      <Notice
+        isDismissible={false}
+        status="warning"
       >
         <div
-          className="components-notice__content"
+          className="components-notice is-warning"
         >
-          This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
+          <div
+            className="components-notice__content"
+          >
+            This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
+          </div>
         </div>
-      </div>
-    </Notice>
-  </div>
+      </Notice>
+    </div>
+  </ContrastCheckerMessage>
 </ContrastChecker>
 `;
 
@@ -37,24 +70,57 @@ exports[`ContrastChecker should render different message matching snapshot when 
   isLargeText={false}
   textColor="#666"
 >
-  <div
-    className="editor-contrast-checker block-editor-contrast-checker"
+  <ContrastCheckerMessage
+    backgroundColor="#555"
+    textColor="#666"
+    tinyBackgroundColor={
+      Object {
+        "_a": 1,
+        "_b": 85,
+        "_format": "hex",
+        "_g": 85,
+        "_gradientType": undefined,
+        "_ok": true,
+        "_originalInput": "#555",
+        "_r": 85,
+        "_roundA": 1,
+        "_tc_id": 8,
+      }
+    }
+    tinyTextColor={
+      Object {
+        "_a": 1,
+        "_b": 102,
+        "_format": "hex",
+        "_g": 102,
+        "_gradientType": undefined,
+        "_ok": true,
+        "_originalInput": "#666",
+        "_r": 102,
+        "_roundA": 1,
+        "_tc_id": 9,
+      }
+    }
   >
-    <Notice
-      isDismissible={false}
-      status="warning"
+    <div
+      className="editor-contrast-checker block-editor-contrast-checker"
     >
-      <div
-        className="components-notice is-warning"
+      <Notice
+        isDismissible={false}
+        status="warning"
       >
         <div
-          className="components-notice__content"
+          className="components-notice is-warning"
         >
-          This color combination may be hard for people to read. Try using a darker background color and/or a brighter text color.
+          <div
+            className="components-notice__content"
+          >
+            This color combination may be hard for people to read. Try using a darker background color and/or a brighter text color.
+          </div>
         </div>
-      </div>
-    </Notice>
-  </div>
+      </Notice>
+    </div>
+  </ContrastCheckerMessage>
 </ContrastChecker>
 `;
 
@@ -63,24 +129,56 @@ exports[`ContrastChecker should render messages when the textColor is valid, but
   fallbackBackgroundColor="#000000"
   textColor="#000000"
 >
-  <div
-    className="editor-contrast-checker block-editor-contrast-checker"
+  <ContrastCheckerMessage
+    textColor="#000000"
+    tinyBackgroundColor={
+      Object {
+        "_a": 1,
+        "_b": 0,
+        "_format": "hex",
+        "_g": 0,
+        "_gradientType": undefined,
+        "_ok": true,
+        "_originalInput": "#000000",
+        "_r": 0,
+        "_roundA": 1,
+        "_tc_id": 24,
+      }
+    }
+    tinyTextColor={
+      Object {
+        "_a": 1,
+        "_b": 0,
+        "_format": "hex",
+        "_g": 0,
+        "_gradientType": undefined,
+        "_ok": true,
+        "_originalInput": "#000000",
+        "_r": 0,
+        "_roundA": 1,
+        "_tc_id": 25,
+      }
+    }
   >
-    <Notice
-      isDismissible={false}
-      status="warning"
+    <div
+      className="editor-contrast-checker block-editor-contrast-checker"
     >
-      <div
-        className="components-notice is-warning"
+      <Notice
+        isDismissible={false}
+        status="warning"
       >
         <div
-          className="components-notice__content"
+          className="components-notice is-warning"
         >
-          This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
+          <div
+            className="components-notice__content"
+          >
+            This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
+          </div>
         </div>
-      </div>
-    </Notice>
-  </div>
+      </Notice>
+    </div>
+  </ContrastCheckerMessage>
 </ContrastChecker>
 `;
 
@@ -90,24 +188,57 @@ exports[`ContrastChecker should take into consideration the font size passed 1`]
   fontSize={23}
   textColor="#000000"
 >
-  <div
-    className="editor-contrast-checker block-editor-contrast-checker"
+  <ContrastCheckerMessage
+    backgroundColor="#C44B4B"
+    textColor="#000000"
+    tinyBackgroundColor={
+      Object {
+        "_a": 1,
+        "_b": 75,
+        "_format": "hex",
+        "_g": 75,
+        "_gradientType": undefined,
+        "_ok": true,
+        "_originalInput": "#C44B4B",
+        "_r": 196,
+        "_roundA": 1,
+        "_tc_id": 14,
+      }
+    }
+    tinyTextColor={
+      Object {
+        "_a": 1,
+        "_b": 0,
+        "_format": "hex",
+        "_g": 0,
+        "_gradientType": undefined,
+        "_ok": true,
+        "_originalInput": "#000000",
+        "_r": 0,
+        "_roundA": 1,
+        "_tc_id": 15,
+      }
+    }
   >
-    <Notice
-      isDismissible={false}
-      status="warning"
+    <div
+      className="editor-contrast-checker block-editor-contrast-checker"
     >
-      <div
-        className="components-notice is-warning"
+      <Notice
+        isDismissible={false}
+        status="warning"
       >
         <div
-          className="components-notice__content"
+          className="components-notice is-warning"
         >
-          This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
+          <div
+            className="components-notice__content"
+          >
+            This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
+          </div>
         </div>
-      </div>
-    </Notice>
-  </div>
+      </Notice>
+    </div>
+  </ContrastCheckerMessage>
 </ContrastChecker>
 `;
 
@@ -117,24 +248,57 @@ exports[`ContrastChecker should take into consideration wherever text is large o
   isLargeText={false}
   textColor="#000000"
 >
-  <div
-    className="editor-contrast-checker block-editor-contrast-checker"
+  <ContrastCheckerMessage
+    backgroundColor="#C44B4B"
+    textColor="#000000"
+    tinyBackgroundColor={
+      Object {
+        "_a": 1,
+        "_b": 75,
+        "_format": "hex",
+        "_g": 75,
+        "_gradientType": undefined,
+        "_ok": true,
+        "_originalInput": "#C44B4B",
+        "_r": 196,
+        "_roundA": 1,
+        "_tc_id": 10,
+      }
+    }
+    tinyTextColor={
+      Object {
+        "_a": 1,
+        "_b": 0,
+        "_format": "hex",
+        "_g": 0,
+        "_gradientType": undefined,
+        "_ok": true,
+        "_originalInput": "#000000",
+        "_r": 0,
+        "_roundA": 1,
+        "_tc_id": 11,
+      }
+    }
   >
-    <Notice
-      isDismissible={false}
-      status="warning"
+    <div
+      className="editor-contrast-checker block-editor-contrast-checker"
     >
-      <div
-        className="components-notice is-warning"
+      <Notice
+        isDismissible={false}
+        status="warning"
       >
         <div
-          className="components-notice__content"
+          className="components-notice is-warning"
         >
-          This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
+          <div
+            className="components-notice__content"
+          >
+            This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
+          </div>
         </div>
-      </div>
-    </Notice>
-  </div>
+      </Notice>
+    </div>
+  </ContrastCheckerMessage>
 </ContrastChecker>
 `;
 
@@ -145,23 +309,56 @@ exports[`ContrastChecker should use isLargeText to make decisions if both isLarg
   isLargeText={false}
   textColor="#000000"
 >
-  <div
-    className="editor-contrast-checker block-editor-contrast-checker"
+  <ContrastCheckerMessage
+    backgroundColor="#C44B4B"
+    textColor="#000000"
+    tinyBackgroundColor={
+      Object {
+        "_a": 1,
+        "_b": 75,
+        "_format": "hex",
+        "_g": 75,
+        "_gradientType": undefined,
+        "_ok": true,
+        "_originalInput": "#C44B4B",
+        "_r": 196,
+        "_roundA": 1,
+        "_tc_id": 20,
+      }
+    }
+    tinyTextColor={
+      Object {
+        "_a": 1,
+        "_b": 0,
+        "_format": "hex",
+        "_g": 0,
+        "_gradientType": undefined,
+        "_ok": true,
+        "_originalInput": "#000000",
+        "_r": 0,
+        "_roundA": 1,
+        "_tc_id": 21,
+      }
+    }
   >
-    <Notice
-      isDismissible={false}
-      status="warning"
+    <div
+      className="editor-contrast-checker block-editor-contrast-checker"
     >
-      <div
-        className="components-notice is-warning"
+      <Notice
+        isDismissible={false}
+        status="warning"
       >
         <div
-          className="components-notice__content"
+          className="components-notice is-warning"
         >
-          This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
+          <div
+            className="components-notice__content"
+          >
+            This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.
+          </div>
         </div>
-      </div>
-    </Notice>
-  </div>
+      </Notice>
+    </div>
+  </ContrastCheckerMessage>
 </ContrastChecker>
 `;

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### New Features
 
 - New Rule: [`@wordpress/react-no-unsafe-timeout`](https://github.com/WordPress/gutenberg/blob/master/packages/eslint-plugin/docs/rules/react-no-unsafe-timeout.md)
+- Add [React Hooks Rules](https://reactjs.org/docs/hooks-rules.html) config.
 
 ## 2.1.0 (2019-03-20)
 

--- a/packages/eslint-plugin/configs/react.js
+++ b/packages/eslint-plugin/configs/react.js
@@ -9,6 +9,7 @@ module.exports = {
 	},
 	plugins: [
 		'react',
+		'react-hooks',
 	],
 	rules: {
 		'react/display-name': 'off',
@@ -24,5 +25,7 @@ module.exports = {
 		'react/no-children-prop': 'off',
 		'react/prop-types': 'off',
 		'react/react-in-jsx-scope': 'off',
+		'react-hooks/rules-of-hooks': 'error',
+		'react-hooks/exhaustive-deps': 'warn',
 	},
 };

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -21,6 +21,7 @@
 		"babel-eslint": "^8.0.3",
 		"eslint-plugin-jsx-a11y": "^6.2.1",
 		"eslint-plugin-react": "^7.12.4",
+		"eslint-plugin-react-hooks": "^1.6.0",
 		"requireindex": "^1.2.0"
 	},
 	"publishConfig": {


### PR DESCRIPTION
closes #14676

This PR adds the default eslint config for react hooks (See https://reactjs.org/docs/hooks-rules.html) to the WordPress eslint config.

 - We were already violating our rules in the contrast checker component.
 - It's also interesting to note that we are currently violating a "recommendation" in the `URLPopoverAtLink` component. It's our use-case is legitimate though so I was wondering if we should remove the second rule (the warning) added here. cc @aduth 

