### PR TITLE
Ignore .git folder in unit test execution

### DIFF
--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -19,7 +19,7 @@ module.exports = {
 	],
 	testURL: 'http://localhost',
 	testPathIgnorePatterns: [
-		'/.git/',
+		'/\.git/',
 		'/node_modules/',
 		'/packages/e2e-tests',
 		'<rootDir>/.*/build/',

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -19,6 +19,7 @@ module.exports = {
 	],
 	testURL: 'http://localhost',
 	testPathIgnorePatterns: [
+		'/.git/',
 		'/node_modules/',
 		'/packages/e2e-tests',
 		'<rootDir>/.*/build/',


### PR DESCRIPTION
## Description
Currently, test unit mechanism tried to find unit tests in the git folder. This PR fixes that problem.

## How has this been tested?
Created a file randomstring.test.js in .git folder executed npm run test-unit and verified unit tests still pass.
Created a git branch update/myrandombranch.test.js executed npm run test-unit and verified unit tests still pass.