### PR TITLE
Fix: Passing async functions to describe

### DIFF
--- a/packages/api-fetch/src/middlewares/test/fetch-all-middleware.js
+++ b/packages/api-fetch/src/middlewares/test/fetch-all-middleware.js
@@ -3,7 +3,7 @@
  */
 import fetchAllMiddleware from '../fetch-all-middleware';
 
-describe( 'Fetch All Middleware', async () => {
+describe( 'Fetch All Middleware', () => {
 	it( 'should defer with the same options to the next middleware', async () => {
 		expect.hasAssertions();
 		const originalOptions = { path: '/posts' };

--- a/packages/e2e-tests/specs/blocks/quote.test.js
+++ b/packages/e2e-tests/specs/blocks/quote.test.js
@@ -68,7 +68,7 @@ describe( 'Quote', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
-	describe( 'can be converted to paragraphs', async () => {
+	describe( 'can be converted to paragraphs', () => {
 		it( 'and renders one paragraph block per <p> within quote', async () => {
 			await insertBlock( 'Quote' );
 			await page.keyboard.type( 'one' );

--- a/packages/e2e-tests/specs/preview.test.js
+++ b/packages/e2e-tests/specs/preview.test.js
@@ -199,7 +199,7 @@ describe( 'Preview', () => {
 	} );
 } );
 
-describe( 'Preview with Custom Fields enabled', async () => {
+describe( 'Preview with Custom Fields enabled', () => {
 	beforeEach( async () => {
 		await createNewPost();
 		await toggleCustomFieldsOption( true );


### PR DESCRIPTION
## Description
I'm getting the following errors on end 2 end test execution:
```
Returning a Promise from "describe" is not supported. Tests must be defined synchronously.
Returning a value from "describe" will fail the test in a future version of Jest.
```
Watching the test cases there seems to be no reason for passing an async function to describe.

## How has this been tested?
Checked the end 2 end tests execute without a warning related to passing async functions to describe.
