### PR TITLE
Fix: reducer tested properties not related  to replaceInnerBlocks action while testing that action 

### DIFF
--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -232,9 +232,7 @@ describe( 'state', () => {
 
 				const state = blocks( existingState, action );
 
-				expect( state ).toEqual( {
-					isPersistentChange: true,
-					isIgnoredChange: false,
+				expect( state ).toMatchObject( {
 					byClientId: {
 						clicken: {
 							clientId: 'chicken',
@@ -295,9 +293,7 @@ describe( 'state', () => {
 
 				const state = blocks( existingState, action );
 
-				expect( state ).toEqual( {
-					isPersistentChange: true,
-					isIgnoredChange: false,
+				expect( state ).toMatchObject( {
 					byClientId: {
 						clicken: {
 							clientId: 'chicken',
@@ -387,9 +383,7 @@ describe( 'state', () => {
 
 				const state = blocks( existingState, action );
 
-				expect( state ).toEqual( {
-					isPersistentChange: true,
-					isIgnoredChange: false,
+				expect( state ).toMatchObject( {
 					byClientId: {
 						clicken: {
 							clientId: 'chicken',
@@ -480,9 +474,7 @@ describe( 'state', () => {
 
 				const state = blocks( existingState, action );
 
-				expect( state ).toEqual( {
-					isPersistentChange: true,
-					isIgnoredChange: false,
+				expect( state ).toMatchObject( {
 					byClientId: {
 						clicken: {
 							clientId: 'chicken',


### PR DESCRIPTION
Initially, during https://github.com/WordPress/gutenberg/pull/14291, I noticed that in the reducer that tests for the replaceInnerBlocks action there has a property that was not relevant to this tests and so I did not check it ( used isPersistentChange: expect.anything())
Meanwhile, in https://github.com/WordPress/gutenberg/pull/14916 the expect anything was removed and the tests were updated to take into account a new property.

I think these tests should use toMatchObject to make sure new properties added in the future not related to the action we are testing don't have an impact on the tests.


cc: @aduth 

## How has this been tested?
I verified the unit tests pass.