### PR TITLE
WIP using reference to access selected Block

### DIFF
--- a/packages/block-editor/src/components/block-navigation/index.js
+++ b/packages/block-editor/src/components/block-navigation/index.js
@@ -12,6 +12,7 @@ import { Button, NavigableMenu } from '@wordpress/components';
 import { getBlockType } from '@wordpress/blocks';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
+import { useRef, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -35,10 +36,25 @@ function BlockNavigationList( {
 				const blockType = getBlockType( block.name );
 				const isSelected = block.clientId === selectedBlockClientId;
 
+				/* HTML equivalent code
+				 * document.getElementsByClassName("editor-block-navigation__container")[0].closest(".components-popover__content").scrollTop
+				 *		= document.getElementsByClassName("components-button is-selected")[0].offsetTop
+				 */
+
+				const blockEl = useRef( null );
+
+				// similar to componentDidMount and componentDidUpdate
+				useEffect( () => {
+					if ( isSelected ) {
+						blockEl.current.closest( '.components-popover__content' ).scrollTop = block.offsetTop;
+					}
+				} );
+
 				return (
 					<li key={ block.clientId }>
 						<div className="editor-block-navigation__item block-editor-block-navigation__item">
 							<Button
+								ref={ blockEl }
 								className={ classnames( 'editor-block-navigation__item-button block-editor-block-navigation__item-button', {
 									'is-selected': isSelected,
 								} ) }


### PR DESCRIPTION
## Description
Closes #14311. 

Ensures selected block is in view in the Block Navigation List. However, this is still a WIP as I am unable to access DOM object to call `.scrollTop`.

I am contributing as part of a University course and have been using react for ~1 week. Have been reading up and receiving guidance form @youknowriad, @gziolo, @ashwin-pc on implementing this with `useRef(...)`, but still stuck on how/ when to update the DOM.

Would appreciate any guidance.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Ran it in local environment setup.
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
Goal
![gutenberg-2](https://user-images.githubusercontent.com/12999836/56215934-7b01fa00-602e-11e9-9b14-a61e04192156.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
New feature. Closes out #14311. 
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
