### PR TITLE
Add WordPress Area CPT

### DIFF
--- a/lib/widgets.php
+++ b/lib/widgets.php
@@ -126,3 +126,57 @@ function gutenberg_legacy_widget_settings( $settings ) {
 	return $settings;
 }
 add_filter( 'block_editor_settings', 'gutenberg_legacy_widget_settings' );
+
+/**
+ * Registers a wp_area post type.
+ */
+function gutenberg_create_wp_area_post_type() {
+	register_post_type(
+		'wp_area',
+		array(
+			'labels'       => array(
+				'name'                     => _x( 'Block Area', 'post type general name', 'gutenberg' ),
+				'singular_name'            => _x( 'Block Area', 'post type singular name', 'gutenberg' ),
+				'menu_name'                => _x( 'Block Areas', 'admin menu', 'gutenberg' ),
+				'name_admin_bar'           => _x( 'Block Area', 'add new on admin bar', 'gutenberg' ),
+				'add_new'                  => _x( 'Add New', 'Block', 'gutenberg' ),
+				'add_new_item'             => __( 'Add New Block Area', 'gutenberg' ),
+				'new_item'                 => __( 'New Block Area', 'gutenberg' ),
+				'edit_item'                => __( 'Edit Block Area', 'gutenberg' ),
+				'view_item'                => __( 'View Block Area', 'gutenberg' ),
+				'all_items'                => __( 'All Block Areas', 'gutenberg' ),
+				'search_items'             => __( 'Search Block Areas', 'gutenberg' ),
+				'not_found'                => __( 'No block area found.', 'gutenberg' ),
+				'not_found_in_trash'       => __( 'No block areas found in Trash.', 'gutenberg' ),
+				'filter_items_list'        => __( 'Filter block areas list', 'gutenberg' ),
+				'items_list_navigation'    => __( 'Block areas list navigation', 'gutenberg' ),
+				'items_list'               => __( 'Block areas list', 'gutenberg' ),
+				'item_published'           => __( 'Block area published.', 'gutenberg' ),
+				'item_published_privately' => __( 'Block area published privately.', 'gutenberg' ),
+				'item_reverted_to_draft'   => __( 'Block area reverted to draft.', 'gutenberg' ),
+				'item_scheduled'           => __( 'Block area scheduled.', 'gutenberg' ),
+				'item_updated'             => __( 'Block area updated.', 'gutenberg' ),
+			),
+			'public'       => false,
+			'show_ui'      => false,
+			'show_in_menu' => false,
+			'show_in_rest' => true,
+			'rest_base'    => '__experimental/block-areas',
+			'capabilities' => array(
+				'read'                   => 'edit_posts',
+				'create_posts'           => 'edit_theme_options',
+				'edit_posts'             => 'edit_theme_options',
+				'edit_published_posts'   => 'edit_theme_options',
+				'delete_published_posts' => 'edit_theme_options',
+				'edit_others_posts'      => 'edit_theme_options',
+				'delete_others_posts'    => 'edit_theme_options',
+			),
+			'map_meta_cap' => true,
+			'supports'     => array(
+				'title',
+				'editor',
+			),
+		)
+	);
+}
+add_action( 'init', 'gutenberg_create_wp_area_post_type' );


### PR DESCRIPTION
## Description
This PR is straight to the point and just proposes an implementation for the wp_area CPT required to implement the widgets RFC described in https://github.com/WordPress/gutenberg/blob/add/blocks-in-widget-areas-rfc/docs/rfcs/blocks-in-widget-areas.md


## How has this been tested?
I verified the CPT works as expected by going to /edit.php?post_type=wp_area (this probably should be disabled but it is useful for testing).
I verified I can use the rest API with this CPT e.g:
```
wp.apiFetch({
    path: '/wp/v2/block-areas',
    method: 'GET',
}).then(console.log);
```
