### PR TITLE
[Mobile] Fix omission of pasted image with some clipboard content

### DIFF
--- a/packages/blocks/src/api/raw-handling/figure-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/figure-content-reducer.js
@@ -73,7 +73,7 @@ export default function( node, doc, schema ) {
 	let wrapper = nodeToInsert;
 
 	while ( wrapper && wrapper.nodeName !== 'P' ) {
-		wrapper = wrapper.parentElement;
+		wrapper = wrapper.parentNode;
 	}
 
 	const figure = doc.createElement( 'figure' );


### PR DESCRIPTION
## Description
This PR aims to fix an issue on mobile (https://github.com/wordpress-mobile/gutenberg-mobile/issues/827) where pasted content from certain sources omits the images. Related comment: https://github.com/wordpress-mobile/gutenberg-mobile/pull/617#pullrequestreview-205427915, and a clipboard snippet of html that reproduces the issue on mobile here: https://github.com/wordpress-mobile/gutenberg-mobile/issues/827#issuecomment-483913821.

## How has this been tested?
Steps to test:
1. Select content from [this site](https://designsbytierney.com/2010/01/how-to-add-edit-format-text-in-a-wordpress-post-or-page/), including text above and below the image above "The Visual Editor.". Alternatively, if you are using an emulator with shared clipboard, it suffices to copy the html from the snippet referenced above.
2. Create an empty paragraph block.
3. Paste the contents.

## Screenshots (before: left, after: right) <!-- if applicable -->
<img src="https://user-images.githubusercontent.com/8507675/56285459-9ec25e80-615a-11e9-85b6-df957241c3e0.gif" width="300"><img src="https://user-images.githubusercontent.com/8507675/56285471-a5e96c80-615a-11e9-994c-c11f88b2efce.gif" width="300">

## Types of changes
This PR modifies `figure-content-reducer.js` to use `parentNode` instead of `parentElement` when finding the containing `<p>` element (ancestor) surrounding an image element. Because `parentElement` is not implemented in the DOM for the mobile environment, `<img>` elements contained within `<p>` elements are not properly unwrapped, and are thus removed in a subsequent call to `cleanNodeList`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
