### PR TITLE
Rich Text: Treat ctrl+d as delete

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -17,7 +17,7 @@ import memize from 'memize';
 import { Component, Fragment, RawHTML } from '@wordpress/element';
 import { isHorizontalEdge } from '@wordpress/dom';
 import { createBlobURL } from '@wordpress/blob';
-import { BACKSPACE, ENTER, LEFT, RIGHT, SPACE, isDeleteKeyboardEvent } from '@wordpress/keycodes';
+import { BACKSPACE, ENTER, LEFT, RIGHT, SPACE, isDeleteKeyboardEvent, isReverseDeleteKeyboardEvent } from '@wordpress/keycodes';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { pasteHandler, children, getBlockTransforms, findTransform } from '@wordpress/blocks';
 import { withInstanceId, withSafeTimeout, compose } from '@wordpress/compose';
@@ -551,15 +551,13 @@ export class RichText extends Component {
 			return;
 		}
 
-		const { keyCode } = event;
-		const isReverse = keyCode === BACKSPACE;
-
 		// Only process delete if the key press occurs at uncollapsed edge.
 		if ( ! isCollapsed( this.createRecord() ) ) {
 			return;
 		}
 
 		const empty = this.isEmpty();
+		const isReverse = isReverseDeleteKeyboardEvent( event );
 
 		// It is important to consider emptiness because an empty container
 		// will include a padding BR node _after_ the caret, so in a forward

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -17,7 +17,7 @@ import memize from 'memize';
 import { Component, Fragment, RawHTML } from '@wordpress/element';
 import { isHorizontalEdge } from '@wordpress/dom';
 import { createBlobURL } from '@wordpress/blob';
-import { BACKSPACE, DELETE, ENTER, LEFT, RIGHT, SPACE } from '@wordpress/keycodes';
+import { BACKSPACE, ENTER, LEFT, RIGHT, SPACE, isDeleteKeyboardEvent } from '@wordpress/keycodes';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { pasteHandler, children, getBlockTransforms, findTransform } from '@wordpress/blocks';
 import { withInstanceId, withSafeTimeout, compose } from '@wordpress/compose';
@@ -619,7 +619,7 @@ export class RichText extends Component {
 			}
 		}
 
-		if ( keyCode === DELETE || keyCode === BACKSPACE || ( ctrlKey && keyCode === 68 ) ) {
+		if ( isDeleteKeyboardEvent( event ) ) {
 			const value = this.createRecord();
 			const { replacements, text, start, end } = value;
 

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -619,7 +619,7 @@ export class RichText extends Component {
 			}
 		}
 
-		if ( keyCode === DELETE || keyCode === BACKSPACE ) {
+		if ( keyCode === DELETE || keyCode === BACKSPACE || ( ctrlKey && keyCode === 68 ) ) {
 			const value = this.createRecord();
 			const { replacements, text, start, end } = value;
 

--- a/packages/keycodes/README.md
+++ b/packages/keycodes/README.md
@@ -92,6 +92,18 @@ Keycode for ESCAPE key.
 
 Keycode for F10 key.
 
+<a name="isDeleteKeyboardEvent" href="#isDeleteKeyboardEvent">#</a> **isDeleteKeyboardEvent**
+
+Determine if an event is a "delete" keyboard event.
+
+_Parameters_
+
+-   _event_ `SyntheticEvent`: A synthetic keyboard event.
+
+_Returns_
+
+-   `boolean`: True if the event is a keyboard event, otherwise false.
+
 <a name="isKeyboardEvent" href="#isKeyboardEvent">#</a> **isKeyboardEvent**
 
 An object that contains functions to check if a keyboard event matches a

--- a/packages/keycodes/README.md
+++ b/packages/keycodes/README.md
@@ -54,6 +54,10 @@ Keycode for COMMAND/META key.
 
 Keycode for CTRL key.
 
+<a name="D" href="#D">#</a> **D**
+
+Keycode for the D key
+
 <a name="DELETE" href="#DELETE">#</a> **DELETE**
 
 Keycode for DELETE key.
@@ -92,9 +96,14 @@ Keycode for ESCAPE key.
 
 Keycode for F10 key.
 
+<a name="H" href="#H">#</a> **H**
+
+Keycode for the H key
+
 <a name="isDeleteKeyboardEvent" href="#isDeleteKeyboardEvent">#</a> **isDeleteKeyboardEvent**
 
 Determine if an event is a "delete" keyboard event.
+This includes keypresses to `delete`, `backspace`, `ctrl+d`, `ctrl+h`, etc.
 
 _Parameters_
 
@@ -102,7 +111,7 @@ _Parameters_
 
 _Returns_
 
--   `boolean`: True if the event is a keyboard event, otherwise false.
+-   `boolean`: True if the event is a "delete" keyboard event, otherwise false.
 
 <a name="isKeyboardEvent" href="#isKeyboardEvent">#</a> **isKeyboardEvent**
 
@@ -114,6 +123,19 @@ signals pressing ⌘M.
 _Type_
 
 -   `Object` Keyed map of functions to match events.
+
+<a name="isReverseDeleteKeyboardEvent" href="#isReverseDeleteKeyboardEvent">#</a> **isReverseDeleteKeyboardEvent**
+
+Determine if an event is a "reverse delete" keyboard event.
+This includes keypresses to `backspace`, `ctrl+h`, etc.
+
+_Parameters_
+
+-   _event_ `SyntheticEvent`: A synthetic keyboard event.
+
+_Returns_
+
+-   `boolean`: True if the event is a "reverse delete" keyboard event, otherwise false.
 
 <a name="LEFT" href="#LEFT">#</a> **LEFT**
 

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -234,8 +234,8 @@ export const isKeyboardEvent = mapValues( modifiers, ( getModifiers ) => {
 export const isDeleteKeyboardEvent = ( { keyCode, ctrlKey } ) => (
 	keyCode === DELETE ||
 	keyCode === BACKSPACE ||
-	// On Apple devices, treat control + d & control + h as delete events
-	( isAppleOS && ctrlKey && [ D, H ].includes( keyCode ) )
+	// Treat control + d & control + h as delete events
+	( ctrlKey && [ D, H ].includes( keyCode ) )
 );
 
 /**
@@ -246,5 +246,6 @@ export const isDeleteKeyboardEvent = ( { keyCode, ctrlKey } ) => (
  */
 export const isReverseDeleteKeyboardEvent = ( { keyCode, ctrlKey } ) => (
 	keyCode === BACKSPACE ||
+	// Treat control + h as a reverse delete event
 	( ctrlKey && keyCode === H )
 );

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -216,3 +216,15 @@ export const isKeyboardEvent = mapValues( modifiers, ( getModifiers ) => {
 		return event.key === character;
 	};
 } );
+
+/**
+ * Determine if an event is a "delete" keyboard event.
+ * @param {SyntheticEvent} event A synthetic keyboard event.
+ * @return {boolean} True if the event is a keyboard event, otherwise false.
+ */
+export const isDeleteKeyboardEvent = ( { keyCode, ctrlKey } ) => (
+	keyCode === DELETE ||
+	keyCode === BACKSPACE ||
+	// On Apple devices, treat control + d as a delete event
+	( isAppleOS && ctrlKey && keyCode === 68 )
+);

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -84,6 +84,14 @@ export const COMMAND = 'meta';
  * Keycode for SHIFT key.
  */
 export const SHIFT = 'shift';
+/**
+ * Keycode for the D key
+ */
+export const D = 'D'.charCodeAt( 0 );
+/**
+ * Keycode for the H key
+ */
+export const H = 'H'.charCodeAt( 0 );
 
 /**
  * Object that contains functions that return the available modifier
@@ -219,12 +227,24 @@ export const isKeyboardEvent = mapValues( modifiers, ( getModifiers ) => {
 
 /**
  * Determine if an event is a "delete" keyboard event.
+ * This includes keypresses to `delete`, `backspace`, `ctrl+d`, `ctrl+h`, etc.
  * @param {SyntheticEvent} event A synthetic keyboard event.
- * @return {boolean} True if the event is a keyboard event, otherwise false.
+ * @return {boolean} True if the event is a "delete" keyboard event, otherwise false.
  */
 export const isDeleteKeyboardEvent = ( { keyCode, ctrlKey } ) => (
 	keyCode === DELETE ||
 	keyCode === BACKSPACE ||
-	// On Apple devices, treat control + d as a delete event
-	( isAppleOS && ctrlKey && keyCode === 68 )
+	// On Apple devices, treat control + d & control + h as delete events
+	( isAppleOS && ctrlKey && [ D, H ].includes( keyCode ) )
+);
+
+/**
+ * Determine if an event is a "reverse delete" keyboard event.
+ * This includes keypresses to `backspace`, `ctrl+h`, etc.
+ * @param {SyntheticEvent} event A synthetic keyboard event.
+ * @return {boolean} True if the event is a "reverse delete" keyboard event, otherwise false.
+ */
+export const isReverseDeleteKeyboardEvent = ( { keyCode, ctrlKey } ) => (
+	keyCode === BACKSPACE ||
+	( ctrlKey && keyCode === H )
 );


### PR DESCRIPTION
## Description
Currently, pressing the `delete` button (<kbd>fn</kbd>+<kbd>delete</kbd> on the MacBook keyboard) at the end of a Paragraph / Rich-Text block results in a subsequent block merging with the selected one as shown in this screencap:

![gutenberg-delete-end-of-rich-text](https://user-images.githubusercontent.com/1587282/56289707-8d903800-60ef-11e9-8902-538f7c558656.gif)

On the Mac (& in some other environments), pressing <kbd>ctrl</kbd>+<kbd>d</kbd> in a text-editor is functionally the same as pressing `delete`.  Inside a block, this works appropriately (presumably by the OS control the browser is using): content to the right of the cursor is deleted.

However, the gutenberg [conditional](https://github.com/WordPress/gutenberg/blob/d32993c61d9e72785b6b81871438c84c77b7058c/packages/block-editor/src/components/rich-text/index.js#L648) which handles deletions is not currently returning true, so [`onDeleteKeyDown`](https://github.com/WordPress/gutenberg/blob/d32993c61d9e72785b6b81871438c84c77b7058c/packages/block-editor/src/components/rich-text/index.js#L565-L574) does not get called.

This change adds <kbd>ctrl</kbd>+<kbd>d</kbd> to the list of key combinations which result in `onDeleteKeyDown` being called.
It also adds <kbd>ctrl</kbd>+<kbd>h</kbd> to achieve the opposite on the starting boundary of the text box (which merges in the other direction as per the "backspace" functionality (now called <kbd>delete</kbd> on the Apple keyboard)

## How has this been tested?
* Run locally in Docker
* Create some Paragraph blocks
* Place the cursor in the middle of the block
  * Press <kbd>ctrl</kbd>+<kbd>d</kbd>
  * The text following the cursor is deleted
* Place the cursor at the end of a block with a subsequent Paragraph block
  * Press <kbd>ctrl</kbd>+<kbd>d</kbd>
  * The two paragraphs are merged and the text following the cursor is the start of the next block (behavior should be the same as pressing the "proper" delete key)
* Repeat the above with a non-text block (like an image block) following the Paragraph under test
  * Nothing should happen -- the non-text block should stay where it is

## Types of changes
New feature

## Checklist:
- [x] My code is tested (manually, but it could use a unit test!)
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
