### PR TITLE
Plugin: Backport bug fixes from Gutenberg 5.5.0 to `wp/trunk` (WordPress 5.2 RC) (Part 2)

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -435,7 +435,6 @@
 		// Position hover label on the right
 		> .block-editor-block-list__block-edit > .block-editor-block-list__breadcrumb {
 			right: -$border-width;
-			left: auto;
 		}
 
 		// Hide mover until wide breakpoints, or it might be covered by toolbar
@@ -468,6 +467,11 @@
 
 	// Full-wide
 	&[data-align="full"] {
+		// Position hover label on the left for the top level block.
+		> .block-editor-block-list__block-edit > .block-editor-block-list__breadcrumb {
+			left: 0;
+		}
+
 		// Compensate for main container padding and subtract border.
 		@include break-small() {
 			margin-left: -$block-side-ui-width - $block-padding - $block-side-ui-clearance - $border-width;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -415,7 +415,7 @@
 		z-index: z-index(".block-editor-block-list__block {core/image aligned wide or fullwide}");
 
 		// Mover and settings above
-		> .block-editor-block-mover {
+		> .block-editor-block-list__block-edit > .block-editor-block-mover {
 			// This moves the menu up by the height of the button + border + padding.
 			top: -$block-side-ui-width - $block-padding - $block-side-ui-clearance;
 			bottom: auto;
@@ -429,22 +429,22 @@
 			}
 		}
 
-		> .block-editor-block-mover .block-editor-block-mover__control {
+		> .block-editor-block-list__block-edit > .block-editor-block-mover .block-editor-block-mover__control {
 			float: left;
 		}
 
 		// Position hover label on the right
-		> .block-editor-block-list__breadcrumb {
+		> .block-editor-block-list__block-edit > .block-editor-block-list__breadcrumb {
 			right: -$border-width;
 		}
 
 		// Hide mover until wide breakpoints, or it might be covered by toolbar
-		> .block-editor-block-mover {
+		> .block-editor-block-list__block-edit > .block-editor-block-mover {
 			display: none;
 		}
 
 		@include break-wide() {
-			> .block-editor-block-mover {
+			> .block-editor-block-list__block-edit > .block-editor-block-mover {
 				display: block;
 			}
 		}
@@ -461,7 +461,7 @@
 	// Wide
 	&[data-align="wide"] {
 		// Position mover
-		> .block-editor-block-mover {
+		> .block-editor-block-list__block-edit > .block-editor-block-mover {
 			left: -$block-padding + $border-width;
 		}
 	}
@@ -503,7 +503,7 @@
 		}
 
 		// Position mover
-		> .block-editor-block-mover {
+		> .block-editor-block-list__block-edit > .block-editor-block-mover {
 			left: $border-width;
 		}
 	}
@@ -913,7 +913,7 @@
 	}
 }
 
-.block-editor-block-list__block.is-focus-mode:not(.is-multi-selected) > .block-editor-block-contextual-toolbar {
+.block-editor-block-list__block.is-focus-mode:not(.is-multi-selected) > .block-editor-block-list__block-edit > .block-editor-block-contextual-toolbar {
 	margin-left: -$block-side-ui-width;
 }
 

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -415,6 +415,7 @@
 		z-index: z-index(".block-editor-block-list__block {core/image aligned wide or fullwide}");
 
 		// Mover and settings above
+		&.is-multi-selected > .block-editor-block-mover,
 		> .block-editor-block-list__block-edit > .block-editor-block-mover {
 			// This moves the menu up by the height of the button + border + padding.
 			top: -$block-side-ui-width - $block-padding - $block-side-ui-clearance;
@@ -428,16 +429,19 @@
 			}
 		}
 
+		&.is-multi-selected > .block-editor-block-mover .block-editor-block-mover__control,
 		> .block-editor-block-list__block-edit > .block-editor-block-mover .block-editor-block-mover__control {
 			float: left;
 		}
 
 		// Hide mover until wide breakpoints, or it might be covered by toolbar
+		&.is-multi-selected > .block-editor-block-mover,
 		> .block-editor-block-list__block-edit > .block-editor-block-mover {
 			display: none;
 		}
 
 		@include break-wide() {
+			&.is-multi-selected > .block-editor-block-mover,
 			> .block-editor-block-list__block-edit > .block-editor-block-mover {
 				display: block;
 			}
@@ -455,6 +459,7 @@
 	// Wide
 	&[data-align="wide"] {
 		// Position mover
+		&.is-multi-selected > .block-editor-block-mover,
 		> .block-editor-block-list__block-edit > .block-editor-block-mover {
 			left: -$block-padding + $border-width;
 		}
@@ -497,6 +502,7 @@
 		}
 
 		// Position mover
+		&.is-multi-selected > .block-editor-block-mover,
 		> .block-editor-block-list__block-edit > .block-editor-block-mover {
 			left: $border-width;
 		}

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -422,7 +422,6 @@
 			min-height: 0;
 			height: auto;
 			width: auto;
-			z-index: inherit;
 
 			&::before {
 				content: none;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -432,11 +432,6 @@
 			float: left;
 		}
 
-		// Position hover label on the right
-		> .block-editor-block-list__block-edit > .block-editor-block-list__breadcrumb {
-			right: -$border-width;
-		}
-
 		// Hide mover until wide breakpoints, or it might be covered by toolbar
 		> .block-editor-block-list__block-edit > .block-editor-block-mover {
 			display: none;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -436,6 +436,7 @@
 		// Position hover label on the right
 		> .block-editor-block-list__block-edit > .block-editor-block-list__breadcrumb {
 			right: -$border-width;
+			left: auto;
 		}
 
 		// Hide mover until wide breakpoints, or it might be covered by toolbar
@@ -468,11 +469,6 @@
 
 	// Full-wide
 	&[data-align="full"] {
-		// Position hover label on the left for the top level block.
-		> .block-editor-block-list__block-edit > .block-editor-block-list__breadcrumb {
-			left: 0;
-		}
-
 		// Compensate for main container padding and subtract border.
 		@include break-small() {
 			margin-left: -$block-side-ui-width - $block-padding - $block-side-ui-clearance - $border-width;

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -93,7 +93,16 @@ function isEdge( container, isReverse, onlyVertical ) {
 		return false;
 	}
 
-	const rangeRect = getRectangleFromRange( selection.getRangeAt( 0 ) );
+	const range = selection.getRangeAt( 0 ).cloneRange();
+	const isForward = isSelectionForward( selection );
+	const isCollapsed = selection.isCollapsed;
+
+	// Collapse in direction of selection.
+	if ( ! isCollapsed ) {
+		range.collapse( ! isForward );
+	}
+
+	const rangeRect = getRectangleFromRange( range );
 
 	if ( ! rangeRect ) {
 		return false;
@@ -105,9 +114,9 @@ function isEdge( container, isReverse, onlyVertical ) {
 	// Only consider the multiline selection at the edge if the direction is
 	// towards the edge.
 	if (
-		! selection.isCollapsed &&
+		! isCollapsed &&
 		rangeRect.height > lineHeight &&
-		isSelectionForward( selection ) === isReverse
+		isForward === isReverse
 	) {
 		return false;
 	}
@@ -213,6 +222,8 @@ export function getRectangleFromRange( range ) {
 	// See: https://stackoverflow.com/a/6847328/995445
 	if ( ! rect ) {
 		const padNode = document.createTextNode( '\u200b' );
+		// Do not modify the live range.
+		range = range.cloneRange();
 		range.insertNode( padNode );
 		rect = range.getClientRects()[ 0 ];
 		padNode.parentNode.removeChild( padNode );

--- a/packages/e2e-tests/specs/__snapshots__/writing-flow.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/writing-flow.test.js.snap
@@ -187,3 +187,13 @@ exports[`adding blocks should not delete surrounding space when deleting a word 
 <p>1 2 3</p>
 <!-- /wp:paragraph -->"
 `;
+
+exports[`adding blocks should not prematurely multi-select 1`] = `
+"<!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>></p>
+<!-- /wp:paragraph -->"
+`;

--- a/packages/e2e-tests/specs/adding-blocks.test.js
+++ b/packages/e2e-tests/specs/adding-blocks.test.js
@@ -66,7 +66,6 @@ describe( 'adding blocks', () => {
 		await page.keyboard.type( 'Foo' );
 		await page.keyboard.press( 'ArrowUp' );
 		await page.keyboard.press( 'ArrowUp' );
-		await pressKeyTimes( 'ArrowRight', 3 );
 		await pressKeyTimes( 'Delete', 6 );
 		await page.keyboard.type( ' text' );
 

--- a/packages/e2e-tests/specs/writing-flow.test.js
+++ b/packages/e2e-tests/specs/writing-flow.test.js
@@ -327,4 +327,19 @@ describe( 'adding blocks', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should not prematurely multi-select', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '><<' );
+		await pressKeyWithModifier( 'shift', 'Enter' );
+		await page.keyboard.type( '<<<' );
+		await page.keyboard.down( 'Shift' );
+		await pressKeyTimes( 'ArrowLeft', '<<\n<<<'.length );
+		await page.keyboard.up( 'Shift' );
+		await page.keyboard.press( 'Backspace' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -27,8 +27,9 @@
 			margin-right: -$block-side-ui-width;
 		}
 
-		// Center the block toolbar on full-wide blocks.
+		// Center the block toolbar on wide and full-wide blocks.
 		// Use specific selector to not affect nested block toolbars.
+		&[data-align="wide"] > .block-editor-block-list__block-edit > .block-editor-block-contextual-toolbar,
 		&[data-align="full"] > .block-editor-block-list__block-edit > .block-editor-block-contextual-toolbar {
 			height: 0; // This collapses the container to an invisible element without margin.
 			width: 100%;


### PR DESCRIPTION
Previously: #14987 

This pull request seeks to backport the following bug-fix pull requests from Gutenberg 5.5.0 to the `wp/trunk` branch, to be published as part of a subsequent packages release and patched into core ahead of this Wednesday's WordPress 5.2 release candidate.

- #14906 (@ellatrix)
   - This should have been included in #14987, but was missed due to a mix-up in the release changelog
- #15022 (@aduth, @jasmussen)

**Testing Instructions:**

Verify fix of impacted pull requests.

Ensure tests pass.