### PR TITLE
Native mobile: don't set caret when rich-text text will get trimmed

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -670,7 +670,7 @@ export class RichText extends Component {
 			if (! this.isIOS && this.willTrimSpaces( html )) {
 				// the html will get trimmed by the cleaning up functions in Aztec and caret position will get out-of-sync.
 				// So, skip forcing it, let Aztec just do its best and just log the fact.
-				console.warn("RichText value will be trimmed for spaces! Avoiding setting the caret position manually." + html);
+				console.warn( "RichText value will be trimmed for spaces! Avoiding setting the caret position manually." + html );
 			} else {
 				selection = { start: this.state.start, end: this.state.end };
 			}

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -631,7 +631,7 @@ export class RichText extends Component {
 		// regex for detecting spaces around html tags
 		const trailingSpaces = /(\s+)<.+?>|<.+?>(\s+)/g;
 		const matches = html.match(trailingSpaces);
-		if (matches && matches.length > 0) {
+		if ( matches && matches.length > 0 ) {
 			return true;
 		}
 
@@ -669,7 +669,7 @@ export class RichText extends Component {
 			// Aztec performs some html text cleanup while parsing it so, its internal representation gets out-of-sync with the
 			// representation of the format-lib on the RN side. We need to avoid trying to set the caret position because it may
 			// be outside the text bounds and crash Aztec, at least on Android.
-			if (! this.isIOS && this.willTrimSpaces( html )) {
+			if ( ! this.isIOS && this.willTrimSpaces( html ) ) {
 				// the html will get trimmed by the cleaning up functions in Aztec and caret position will get out-of-sync.
 				// So, skip forcing it, let Aztec just do its best and just log the fact.
 				console.warn( 'RichText value will be trimmed for spaces! Avoiding setting the caret position manually.' );

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -107,6 +107,7 @@ export class RichText extends Component {
 		// This prevents a bug in Aztec which triggers onSelectionChange twice on format change
 		this.onSelectionChange = this.onSelectionChange.bind( this );
 		this.valueToFormat = this.valueToFormat.bind( this );
+		this.willTrimSpaces = this.willTrimSpaces.bind( this );
 		this.state = {
 			start: 0,
 			end: 0,
@@ -624,6 +625,17 @@ export class RichText extends Component {
 		}
 	}
 
+	willTrimSpaces( html ) {
+		// regex for detecting spaces around html tags
+		const trailingSpaces = /(\s+)<.+?>|<.+?>(\s+)/g;
+		const matches = html.match(trailingSpaces);
+		if (matches && matches.length > 0) {
+			return true;
+		}
+
+		return false;
+	}
+
 	render() {
 		const {
 			tagName,
@@ -651,7 +663,17 @@ export class RichText extends Component {
 		let selection = null;
 		if ( this.needsSelectionUpdate ) {
 			this.needsSelectionUpdate = false;
-			selection = { start: this.state.start, end: this.state.end };
+
+			// Aztec performs some html text cleanup while parsing it so, its internal representation gets out-of-sync with the
+			// representation of the format-lib on the RN side. We need to avoid trying to set the caret position because it may
+			// be outside the text bounds and crash Aztec, at least on Android.
+			if (! this.isIOS && this.willTrimSpaces( html )) {
+				// the html will get trimmed by the cleaning up functions in Aztec and caret position will get out-of-sync.
+				// So, skip forcing it, let Aztec just do its best and just log the fact.
+				console.warn("RichText value will be trimmed for spaces! Avoiding setting the caret position manually." + html);
+			} else {
+				selection = { start: this.state.start, end: this.state.end };
+			}
 		}
 
 		return (

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -630,7 +630,7 @@ export class RichText extends Component {
 	willTrimSpaces( html ) {
 		// regex for detecting spaces around html tags
 		const trailingSpaces = /(\s+)<.+?>|<.+?>(\s+)/g;
-		const matches = html.match(trailingSpaces);
+		const matches = html.match( trailingSpaces );
 		if ( matches && matches.length > 0 ) {
 			return true;
 		}

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -672,7 +672,7 @@ export class RichText extends Component {
 			if (! this.isIOS && this.willTrimSpaces( html )) {
 				// the html will get trimmed by the cleaning up functions in Aztec and caret position will get out-of-sync.
 				// So, skip forcing it, let Aztec just do its best and just log the fact.
-				console.warn( "RichText value will be trimmed for spaces! Avoiding setting the caret position manually." + html );
+				console.warn( 'RichText value will be trimmed for spaces! Avoiding setting the caret position manually.' );
 			} else {
 				selection = { start: this.state.start, end: this.state.end };
 			}

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -1,3 +1,5 @@
+/*eslint no-console: ["error", { allow: ["warn"] }] */
+
 /**
  * External dependencies
  */


### PR DESCRIPTION
## Description
Addressing https://github.com/wordpress-mobile/gutenberg-mobile/issues/871 on the native mobile side. The internal representation of rich-text in Aztec and the format-lib are not fully compatible or in-sync and we also use html to establish the communication between the two. That can lead to cases like the issue linked, where Aztec will do some trimming to remove spaces that are unimportant for html rendering, but format-lib won't so, making the caret positioning logic to get out of sync.

This PR will try to detect when such spaces will be removed and avoid telling Aztec where to put the caret and hope for the best 🤞.

## How has this been tested?
Using the gutenberg-mobile side PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/885

## Types of changes
Try to detect when such spaces will be removed and avoid telling Aztec where to put the caret. Only affecting Android.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
