### PR TITLE
Block Editor: Restore block movers to full-, wide-align blocks

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -413,7 +413,6 @@
 			min-height: 0;
 			height: auto;
 			width: auto;
-			z-index: inherit;
 
 			&::before {
 				content: none;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -427,6 +427,7 @@
 		// Position hover label on the right
 		> .block-editor-block-list__block-edit > .block-editor-block-list__breadcrumb {
 			right: -$border-width;
+			left: auto;
 		}
 
 		// Hide mover until wide breakpoints, or it might be covered by toolbar
@@ -459,11 +460,6 @@
 
 	// Full-wide
 	&[data-align="full"] {
-		// Position hover label on the left for the top level block.
-		> .block-editor-block-list__block-edit > .block-editor-block-list__breadcrumb {
-			left: 0;
-		}
-
 		// Compensate for main container padding and subtract border.
 		@include break-small() {
 			margin-left: -$block-side-ui-width - $block-padding - $block-side-ui-clearance - $border-width;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -423,11 +423,6 @@
 			float: left;
 		}
 
-		// Position hover label on the right
-		> .block-editor-block-list__block-edit > .block-editor-block-list__breadcrumb {
-			right: -$border-width;
-		}
-
 		// Hide mover until wide breakpoints, or it might be covered by toolbar
 		> .block-editor-block-list__block-edit > .block-editor-block-mover {
 			display: none;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -426,7 +426,6 @@
 		// Position hover label on the right
 		> .block-editor-block-list__block-edit > .block-editor-block-list__breadcrumb {
 			right: -$border-width;
-			left: auto;
 		}
 
 		// Hide mover until wide breakpoints, or it might be covered by toolbar
@@ -459,6 +458,11 @@
 
 	// Full-wide
 	&[data-align="full"] {
+		// Position hover label on the left for the top level block.
+		> .block-editor-block-list__block-edit > .block-editor-block-list__breadcrumb {
+			left: 0;
+		}
+
 		// Compensate for main container padding and subtract border.
 		@include break-small() {
 			margin-left: -$block-side-ui-width - $block-padding - $block-side-ui-clearance - $border-width;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -406,7 +406,7 @@
 		z-index: z-index(".block-editor-block-list__block {core/image aligned wide or fullwide}");
 
 		// Mover and settings above
-		> .block-editor-block-mover {
+		> .block-editor-block-list__block-edit > .block-editor-block-mover {
 			// This moves the menu up by the height of the button + border + padding.
 			top: -$block-side-ui-width - $block-padding - $block-side-ui-clearance;
 			bottom: auto;
@@ -420,22 +420,22 @@
 			}
 		}
 
-		> .block-editor-block-mover .block-editor-block-mover__control {
+		> .block-editor-block-list__block-edit > .block-editor-block-mover .block-editor-block-mover__control {
 			float: left;
 		}
 
 		// Position hover label on the right
-		> .block-editor-block-list__breadcrumb {
+		> .block-editor-block-list__block-edit > .block-editor-block-list__breadcrumb {
 			right: -$border-width;
 		}
 
 		// Hide mover until wide breakpoints, or it might be covered by toolbar
-		> .block-editor-block-mover {
+		> .block-editor-block-list__block-edit > .block-editor-block-mover {
 			display: none;
 		}
 
 		@include break-wide() {
-			> .block-editor-block-mover {
+			> .block-editor-block-list__block-edit > .block-editor-block-mover {
 				display: block;
 			}
 		}
@@ -452,7 +452,7 @@
 	// Wide
 	&[data-align="wide"] {
 		// Position mover
-		> .block-editor-block-mover {
+		> .block-editor-block-list__block-edit > .block-editor-block-mover {
 			left: -$block-padding + $border-width;
 		}
 	}
@@ -494,7 +494,7 @@
 		}
 
 		// Position mover
-		> .block-editor-block-mover {
+		> .block-editor-block-list__block-edit > .block-editor-block-mover {
 			left: $border-width;
 		}
 	}
@@ -904,7 +904,7 @@
 	}
 }
 
-.block-editor-block-list__block.is-focus-mode:not(.is-multi-selected) > .block-editor-block-contextual-toolbar {
+.block-editor-block-list__block.is-focus-mode:not(.is-multi-selected) > .block-editor-block-list__block-edit > .block-editor-block-contextual-toolbar {
 	margin-left: -$block-side-ui-width;
 }
 

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -406,6 +406,7 @@
 		z-index: z-index(".block-editor-block-list__block {core/image aligned wide or fullwide}");
 
 		// Mover and settings above
+		&.is-multi-selected > .block-editor-block-mover,
 		> .block-editor-block-list__block-edit > .block-editor-block-mover {
 			// This moves the menu up by the height of the button + border + padding.
 			top: -$block-side-ui-width - $block-padding - $block-side-ui-clearance;
@@ -419,16 +420,19 @@
 			}
 		}
 
+		&.is-multi-selected > .block-editor-block-mover .block-editor-block-mover__control,
 		> .block-editor-block-list__block-edit > .block-editor-block-mover .block-editor-block-mover__control {
 			float: left;
 		}
 
 		// Hide mover until wide breakpoints, or it might be covered by toolbar
+		&.is-multi-selected > .block-editor-block-mover,
 		> .block-editor-block-list__block-edit > .block-editor-block-mover {
 			display: none;
 		}
 
 		@include break-wide() {
+			&.is-multi-selected > .block-editor-block-mover,
 			> .block-editor-block-list__block-edit > .block-editor-block-mover {
 				display: block;
 			}
@@ -446,6 +450,7 @@
 	// Wide
 	&[data-align="wide"] {
 		// Position mover
+		&.is-multi-selected > .block-editor-block-mover,
 		> .block-editor-block-list__block-edit > .block-editor-block-mover {
 			left: -$block-padding + $border-width;
 		}
@@ -488,6 +493,7 @@
 		}
 
 		// Position mover
+		&.is-multi-selected > .block-editor-block-mover,
 		> .block-editor-block-list__block-edit > .block-editor-block-mover {
 			left: $border-width;
 		}

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -27,8 +27,9 @@
 			margin-right: -$block-side-ui-width;
 		}
 
-		// Center the block toolbar on full-wide blocks.
+		// Center the block toolbar on wide and full-wide blocks.
 		// Use specific selector to not affect nested block toolbars.
+		&[data-align="wide"] > .block-editor-block-list__block-edit > .block-editor-block-contextual-toolbar,
 		&[data-align="full"] > .block-editor-block-list__block-edit > .block-editor-block-contextual-toolbar {
 			height: 0; // This collapses the container to an invisible element without margin.
 			width: calc(100% - 1px); // -1px to account for inner element left: 1px value causing overflow-x scrollbars


### PR DESCRIPTION
Fixes #14817 
Related: #14145
Regression introduced in #12758

This pull request seeks to restore block movers for full- and wide-aligned blocks.

**Implementation notes:**

Reflected in the two commits, there were two necessary changes:

- #12758 had changed the markup structure to introduce a new `div` `block-editor-block-list__block-edit`. Many styles applied in `block-list/style.scss` used direct descendent selectors and were not updated to account for the new element.
- #14145 had made updates to the breadcrumb hover states which appeared to have assumed the absence of the block movers, and would otherwise conflict upon their reintroduction. I've proposed to reposition the hover label from the left to the right for wide/full-align blocks.

Note that this only updates the descendent selectors, but does not account for the fact that there are two possibilities for how a `.block-editor-block-mover` are rendered:

- For multi-selections, it is still a direct descendent of `.block-editor-block-list__block` ([source](https://github.com/WordPress/gutenberg/blob/e209cfb77469b0e022198f75ab1fd641f98b229a/packages/block-editor/src/components/block-list/block.js#L522-L524))
- For singular selections, it is a descendent of the intermediary `.block-editor-block-list__block-edit` ([source](https://github.com/WordPress/gutenberg/blob/e209cfb77469b0e022198f75ab1fd641f98b229a/packages/block-editor/src/components/block-list/block.js#L541-L548)).

This was a result of the changes in #12758. It is unclear whether it requires further update to apply styles to both the direct descendent and the intermediary descendent.

There appears to be some issue which makes the movers harder to use. The cause is not yet determined, and I would not consider quite as blocking as the complete absence of movers, given timeline of WordPress 5.2 RC **today**.

**Testing instructions:**

Repeat Steps to Reproduce from #14817, verifying expected result.