### PR TITLE
Fix: Insert Before and Insert After appear even when default block can't be inserted

### DIFF
--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -11,48 +11,57 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import { cloneBlock, hasBlockSupport, switchToBlockType } from '@wordpress/blocks';
 
 function BlockActions( {
-	onDuplicate,
-	onRemove,
-	onInsertBefore,
-	onInsertAfter,
-	onGroup,
-	onUngroup,
-	isLocked,
 	canDuplicate,
+	canInsertDefaultBlock,
 	children,
+	isLocked,
+	onDuplicate,
+	onGroup,
+	onInsertAfter,
+	onInsertBefore,
+	onRemove,
+	onUngroup,
 } ) {
 	return children( {
+		canDuplicate,
+		canInsertDefaultBlock,
+		isLocked,
 		onDuplicate,
-		onRemove,
+		onGroup,
 		onInsertAfter,
 		onInsertBefore,
-		onGroup,
+		onRemove,
 		onUngroup,
-		isLocked,
-		canDuplicate,
 	} );
 }
 
 export default compose( [
 	withSelect( ( select, props ) => {
 		const {
+			canInsertBlockType,
+			getBlockRootClientId,
 			getBlocksByClientId,
 			getTemplateLock,
-			getBlockRootClientId,
 		} = select( 'core/block-editor' );
+		const { getDefaultBlockName } = select( 'core/blocks' );
 
 		const blocks = getBlocksByClientId( props.clientIds );
 		const canDuplicate = every( blocks, ( block ) => {
 			return !! block && hasBlockSupport( block.name, 'multiple', true );
 		} );
 		const rootClientId = getBlockRootClientId( props.clientIds[ 0 ] );
+		const canInsertDefaultBlock = canInsertBlockType(
+			getDefaultBlockName(),
+			rootClientId
+		);
 
 		return {
-			isLocked: !! getTemplateLock( rootClientId ),
 			blocks,
 			canDuplicate,
-			rootClientId,
+			canInsertDefaultBlock,
 			extraProps: props,
+			isLocked: !! getTemplateLock( rootClientId ),
+			rootClientId,
 		};
 	} ),
 	withDispatch( ( dispatch, props, { select } ) => {

--- a/packages/block-editor/src/components/block-settings-menu/index.js
+++ b/packages/block-editor/src/components/block-settings-menu/index.js
@@ -32,7 +32,15 @@ export function BlockSettingsMenu( { clientIds } ) {
 
 	return (
 		<BlockActions clientIds={ clientIds }>
-			{ ( { onDuplicate, onRemove, onInsertAfter, onInsertBefore, canDuplicate, isLocked } ) => (
+			{ ( {
+				canDuplicate,
+				canInsertDefaultBlock,
+				isLocked,
+				onDuplicate,
+				onInsertAfter,
+				onInsertBefore,
+				onRemove,
+			} ) => (
 				<Toolbar>
 					<DropdownMenu
 						icon="ellipsis"
@@ -69,7 +77,7 @@ export function BlockSettingsMenu( { clientIds } ) {
 											{ __( 'Duplicate' ) }
 										</MenuItem>
 									) }
-									{ ! isLocked && (
+									{ canInsertDefaultBlock && (
 										<>
 											<MenuItem
 												className="editor-block-settings-menu__control block-editor-block-settings-menu__control"


### PR DESCRIPTION
Insert Before and Insert after just insert the default block. After the merge of the inserter restrictions PR if a block cannot be inserted the insert action does nothing.
We had a bug if the default block could not be inserted we still allowed the user to click Insert After and Before while the actions did nothing.

This PR does not render an insert before/after button if the default block cannot be inserted.


## How has this been tested?
I  disabled the default block using:
```

function my_plugin_allowed_block_types( $allowed_block_types, $post ) {
	if ( 'post' !== $post->post_type ) {
		return $allowed_block_types;
	}
	return array( 'core/video', 'core/image' );
}


add_filter( 'allowed_block_types', 'my_plugin_allowed_block_types', 10, 2 );
```

I created a new post; I inserted an image; I pressed the button to open the "Elipsis menu" and verified "Insert Before/After" buttons don't appear.

I inserted the block "Allowed Blocks Set" available at https://gist.github.com/jorgefilipecosta/ee7969d72e13e9e8e3ab58efdd1fd03b.
I verified that when I open the ellipsis menu of a block inside "Allowed Blocks Set" the insert before/after buttons don't appear.
