### PR TITLE
Always show drag handle for nested blocks, even if single; fixes issue #12831

### DIFF
--- a/packages/block-editor/src/components/block-mover/index.js
+++ b/packages/block-editor/src/components/block-mover/index.js
@@ -44,10 +44,10 @@ export class BlockMover extends Component {
 	}
 
 	render() {
-		const { onMoveUp, onMoveDown, isFirst, isLast, isDraggable, onDragStart, onDragEnd, clientIds, blockElementId, blockType, firstIndex, isLocked, instanceId, isHidden } = this.props;
+		const { onMoveUp, onMoveDown, isFirst, isLast, isDraggable, onDragStart, onDragEnd, clientIds, blockElementId, blockType, firstIndex, isLocked, instanceId, isHidden, rootClientId } = this.props;
 		const { isFocused } = this.state;
 		const blocksCount = castArray( clientIds ).length;
-		if ( isLocked || ( isFirst && isLast ) ) {
+		if ( isLocked || ( isFirst && isLast && ! rootClientId ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
## Description
Updates block-mover component to always show the drag handle for blocks that are not top-level (i.e. for blocks that are children of a columns block, a group block, etc.). This allows them to be dragged outside of their parent.

Previously, no drag handle was shown if the block was the only child of its parent.

## How has this been tested?
I have only tested this on my local environment (the docker setup that is bundled with the gutenberg repo).
