### PR TITLE
Fix pullquote import

### DIFF
--- a/packages/block-library/src/pullquote/save.js
+++ b/packages/block-library/src/pullquote/save.js
@@ -19,7 +19,7 @@ import {
 /**
  * Internal dependencies
  */
-import { SOLID_COLOR_CLASS } from './edit';
+import { SOLID_COLOR_CLASS } from './shared';
 
 export default function save( { attributes } ) {
 	const { mainColor, customMainColor, textColor, customTextColor, value, citation, className } = attributes;


### PR DESCRIPTION
## Description
Spotted this ouput in master when running `npm run dev`:
```
[0] WARNING in ./packages/block-library/build-module/pullquote/save.js
[0] 29:46-63 "export 'SOLID_COLOR_CLASS' was not found in './edit'
```

Appears to be a require a small update to that import, which this PR fixes.