### PR TITLE
Avoid running hasMetaBoxes on each subscribe

### DIFF
--- a/packages/edit-post/src/store/effects.js
+++ b/packages/edit-post/src/store/effects.js
@@ -45,6 +45,11 @@ const effects = {
 
 		let wasSavingPost = select( 'core/editor' ).isSavingPost();
 		let wasAutosavingPost = select( 'core/editor' ).isAutosavingPost();
+		
+		// Meta boxes are initialized once at page load. It is not necessary to
+		// account for updates on each state change.
+		//
+		// See: https://github.com/WordPress/WordPress/blob/5.1.1/wp-admin/includes/post.php#L2307-L2309
 		const hasActiveMetaBoxes = select( 'core/edit-post' ).hasMetaBoxes();
 		// Save metaboxes when performing a full save on the post.
 		subscribe( () => {

--- a/packages/edit-post/src/store/effects.js
+++ b/packages/edit-post/src/store/effects.js
@@ -45,11 +45,11 @@ const effects = {
 
 		let wasSavingPost = select( 'core/editor' ).isSavingPost();
 		let wasAutosavingPost = select( 'core/editor' ).isAutosavingPost();
+		const hasActiveMetaBoxes = select( 'core/edit-post' ).hasMetaBoxes();
 		// Save metaboxes when performing a full save on the post.
 		subscribe( () => {
 			const isSavingPost = select( 'core/editor' ).isSavingPost();
 			const isAutosavingPost = select( 'core/editor' ).isAutosavingPost();
-			const hasActiveMetaBoxes = select( 'core/edit-post' ).hasMetaBoxes();
 
 			// Save metaboxes on save completion, except for autosaves that are not a post preview.
 			const shouldTriggerMetaboxesSave = (


### PR DESCRIPTION
While monitoring the typing performance, I noticed that in the duraction of the key press event (53ms), 2 or 3ms is spent on calling `hasMetaboxes` selector. In this PR, I'm managing to tweak the side effect a little bit to avoid calling this selector on each subscribe.

While if we're trying to be pure, we should call the selector on each subscribe, in this particular use-cases where this is a legacy API that is only initialized at rendering, I think it's fine to optimize this way.