### PR TITLE
Avoid passing down isFirst and isLast props

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -363,8 +363,6 @@ export class BlockListBlock extends Component {
 						isFocusMode,
 						hasFixedToolbar,
 						isLocked,
-						isFirst,
-						isLast,
 						clientId,
 						rootClientId,
 						isSelected,
@@ -527,8 +525,6 @@ export class BlockListBlock extends Component {
 									<BlockMover
 										clientIds={ clientId }
 										blockElementId={ blockElementId }
-										isFirst={ isFirst }
-										isLast={ isLast }
 										isHidden={ ! ( isHovered || isSelected ) || hoverArea !== 'left' }
 										isDraggable={
 											isDraggable !== false &&

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -201,7 +201,7 @@ class BlockList extends Component {
 
 		return (
 			<div className="editor-block-list__layout block-editor-block-list__layout">
-				{ map( blockClientIds, ( clientId, blockIndex ) => {
+				{ map( blockClientIds, ( clientId ) => {
 					const isBlockInSelection = hasMultiSelection ?
 						multiSelectedBlockClientIds.includes( clientId ) :
 						selectedBlockClientId === clientId;
@@ -216,8 +216,6 @@ class BlockList extends Component {
 								blockRef={ this.setBlockRef }
 								onSelectionStart={ this.onSelectionStart }
 								rootClientId={ rootClientId }
-								isFirst={ blockIndex === 0 }
-								isLast={ blockIndex === blockClientIds.length - 1 }
 								isDraggable={ isDraggable }
 							/>
 						</AsyncModeProvider>

--- a/packages/block-editor/src/components/block-list/multi-controls.js
+++ b/packages/block-editor/src/components/block-list/multi-controls.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { first, last } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { withSelect } from '@wordpress/data';
@@ -15,10 +10,7 @@ import BlockMover from '../block-mover';
 
 function BlockListMultiControls( {
 	multiSelectedBlockClientIds,
-	clientId,
 	isSelecting,
-	isFirst,
-	isLast,
 } ) {
 	if ( isSelecting ) {
 		return null;
@@ -26,30 +18,20 @@ function BlockListMultiControls( {
 
 	return (
 		<BlockMover
-			key="mover"
-			clientId={ clientId }
 			clientIds={ multiSelectedBlockClientIds }
-			isFirst={ isFirst }
-			isLast={ isLast }
 		/>
 	);
 }
 
-export default withSelect( ( select, { clientId } ) => {
+export default withSelect( ( select ) => {
 	const {
 		getMultiSelectedBlockClientIds,
 		isMultiSelecting,
-		getBlockIndex,
-		getBlockCount,
 	} = select( 'core/block-editor' );
 	const clientIds = getMultiSelectedBlockClientIds();
-	const firstIndex = getBlockIndex( first( clientIds ), clientId );
-	const lastIndex = getBlockIndex( last( clientIds ), clientId );
 
 	return {
 		multiSelectedBlockClientIds: clientIds,
 		isSelecting: isMultiSelecting(),
-		isFirst: firstIndex === 0,
-		isLast: lastIndex + 1 === getBlockCount(),
 	};
 } )( BlockListMultiControls );

--- a/packages/block-editor/src/components/block-mover/index.js
+++ b/packages/block-editor/src/components/block-mover/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { first, partial, castArray } from 'lodash';
+import { first, last, partial, castArray } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -117,16 +117,22 @@ export class BlockMover extends Component {
 
 export default compose(
 	withSelect( ( select, { clientIds } ) => {
-		const { getBlock, getBlockIndex, getTemplateLock, getBlockRootClientId } = select( 'core/block-editor' );
-		const firstClientId = first( castArray( clientIds ) );
+		const { getBlock, getBlockIndex, getTemplateLock, getBlockRootClientId, getBlockOrder } = select( 'core/block-editor' );
+		const normalizedClientIds = castArray( clientIds );
+		const firstClientId = first( normalizedClientIds );
 		const block = getBlock( firstClientId );
-		const rootClientId = getBlockRootClientId( first( castArray( clientIds ) ) );
+		const rootClientId = getBlockRootClientId( first( normalizedClientIds ) );
+		const blockOrder = getBlockOrder( rootClientId );
+		const firstIndex = getBlockIndex( firstClientId, rootClientId );
+		const lastIndex = getBlockIndex( last( normalizedClientIds ), rootClientId );
 
 		return {
-			firstIndex: getBlockIndex( firstClientId, rootClientId ),
 			blockType: block ? getBlockType( block.name ) : null,
 			isLocked: getTemplateLock( rootClientId ) === 'all',
 			rootClientId,
+			firstIndex,
+			isFirst: firstIndex === 0,
+			isLast: lastIndex === blockOrder.length - 1,
 		};
 	} ),
 	withDispatch( ( dispatch, { clientIds, rootClientId } ) => {


### PR DESCRIPTION
This PR refactors the block list, block and block mover components to avoid computing isFirst and isLast props early in the process. The idea is that these are only needed in the movers.