### PR TITLE
Reset embed mocks on every request, stop request to instagram

### DIFF
--- a/packages/e2e-tests/specs/embedding.test.js
+++ b/packages/e2e-tests/specs/embedding.test.js
@@ -5,6 +5,7 @@ import {
 	clickBlockAppender,
 	createNewPost,
 	createEmbeddingMatcher,
+	createURLMatcher,
 	setUpResponseMocking,
 	createJSONResponse,
 	getEditedPostContent,
@@ -122,6 +123,12 @@ const MOCK_RESPONSES = [
 	},
 	{
 		match: createEmbeddingMatcher( 'https://twitter.com/wooyaygutenberg123454312' ),
+		onRequestMatch: createJSONResponse( MOCK_CANT_EMBED_RESPONSE ),
+	},
+	// Respond to the instagram URL with a non-image response, doesn't matter what it is,
+	// just make sure the image errors.
+	{
+		match: createURLMatcher( 'https://www.instagram.com/p/Bvl97o2AK6x/' ),
 		onRequestMatch: createJSONResponse( MOCK_CANT_EMBED_RESPONSE ),
 	},
 ];

--- a/packages/e2e-tests/specs/embedding.test.js
+++ b/packages/e2e-tests/specs/embedding.test.js
@@ -178,8 +178,10 @@ const addAllEmbeds = async () => {
 };
 
 describe( 'Embedding content', () => {
-	beforeAll( async () => await setUpResponseMocking( MOCK_RESPONSES ) );
-	beforeEach( createNewPost );
+	beforeEach( async () => {
+		await setUpResponseMocking( MOCK_RESPONSES );
+		await createNewPost();
+	} );
 
 	it( 'should render embeds in the correct state', async () => {
 		await addAllEmbeds();


### PR DESCRIPTION
## Description

After the retry test, mocks were not reset and so actual network requests happened. This made the tests unreliable, so this PR makes sure the mocks are reset for every test, and the instagram request is also mocked.


## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
