### PR TITLE
RNMobile: Fix autoscroll on ListBlock

### DIFF
--- a/packages/block-editor/src/components/block-controls/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/block-controls/test/__snapshots__/index.js.snap
@@ -7,6 +7,7 @@ exports[`BlockControls should render a dynamic toolbar of controls 1`] = `
       "clientId": undefined,
       "isSelected": true,
       "name": undefined,
+      "onCaretVerticalPositionChange": undefined,
       "onFocus": undefined,
     }
   }

--- a/packages/block-editor/src/components/block-edit/index.js
+++ b/packages/block-editor/src/components/block-edit/index.js
@@ -27,13 +27,13 @@ class BlockEdit extends Component {
 		);
 	}
 
-	propsToContext( name, isSelected, clientId, onFocus ) {
-		return { name, isSelected, clientId, onFocus };
+	propsToContext( name, isSelected, clientId, onFocus, onCaretVerticalPositionChange ) {
+		return { name, isSelected, clientId, onFocus, onCaretVerticalPositionChange };
 	}
 
 	render() {
-		const { name, isSelected, clientId, onFocus } = this.props;
-		const value = this.propsToContext( name, isSelected, clientId, onFocus );
+		const { name, isSelected, clientId, onFocus, onCaretVerticalPositionChange } = this.props;
+		const value = this.propsToContext( name, isSelected, clientId, onFocus, onCaretVerticalPositionChange );
 
 		return (
 			<BlockEditContextProvider value={ value }>

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -769,6 +769,7 @@ const RichTextContainer = compose( [
 			clientId: context.clientId,
 			isSelected: context.isSelected,
 			onFocus: context.onFocus || ownProps.onFocus,
+			onCaretVerticalPositionChange: context.onCaretVerticalPositionChange,
 		};
 	} ),
 ] )( RichText );

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -761,6 +761,7 @@ const RichTextContainer = compose( [
 			return {
 				isSelected: context.isSelected,
 				clientId: context.clientId,
+				onCaretVerticalPositionChange: context.onCaretVerticalPositionChange,
 			};
 		}
 

--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -104,7 +104,6 @@ class HeadingEdit extends Component {
 					} }
 					onFocus={ this.props.onFocus } // always assign onFocus as a props
 					onBlur={ this.props.onBlur } // always assign onBlur as a props
-					onCaretVerticalPositionChange={ this.props.onCaretVerticalPositionChange }
 					onChange={ ( value ) => setAttributes( { content: value } ) }
 					onMerge={ mergeBlocks }
 					onSplit={ this.splitBlock }

--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -12,7 +12,6 @@ export default function ListEdit( {
 	mergeBlocks,
 	onReplace,
 	className,
-	...props
 } ) {
 	const { ordered, values } = attributes;
 
@@ -48,7 +47,6 @@ export default function ListEdit( {
 			}
 			onRemove={ () => onReplace( [] ) }
 			onTagNameChange={ ( tag ) => setAttributes( { ordered: tag === 'ol' } ) }
-			{ ...props }
 		/>
 	);
 }

--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -12,6 +12,7 @@ export default function ListEdit( {
 	mergeBlocks,
 	onReplace,
 	className,
+	...props
 } ) {
 	const { ordered, values } = attributes;
 
@@ -47,6 +48,7 @@ export default function ListEdit( {
 			}
 			onRemove={ () => onReplace( [] ) }
 			onTagNameChange={ ( tag ) => setAttributes( { ordered: tag === 'ol' } ) }
+			{ ...props }
 		/>
 	);
 }

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -102,7 +102,6 @@ class ParagraphEdit extends Component {
 					isSelected={ this.props.isSelected }
 					onFocus={ this.props.onFocus } // always assign onFocus as a props
 					onBlur={ this.props.onBlur } // always assign onBlur as a props
-					onCaretVerticalPositionChange={ this.props.onCaretVerticalPositionChange }
 					style={ style }
 					onChange={ ( nextContent ) => {
 						setAttributes( {


### PR DESCRIPTION
This is necessary to send an iOS only prop `onCaretVerticalPositionChange` to activate autoscroll when the caret is out of the viewport.

![lists-autoscroll](https://user-images.githubusercontent.com/9772967/56373032-683f1f00-6200-11e9-846d-3faeb8b82ecb.gif)

To test:
- Follow the instructions in the [`gutenberg-mobile` side PR.](https://github.com/wordpress-mobile/gutenberg-mobile/pull/890)
