### PR TITLE
Testing: Add Undo test for explicit persistence undo regression

### DIFF
--- a/packages/e2e-tests/specs/undo.test.js
+++ b/packages/e2e-tests/specs/undo.test.js
@@ -6,6 +6,9 @@ import {
 	getEditedPostContent,
 	createNewPost,
 	pressKeyWithModifier,
+	selectBlockByClientId,
+	getAllBlocks,
+	saveDraft,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'undo', () => {
@@ -62,5 +65,37 @@ describe( 'undo', () => {
 		expect( await getEditedPostContent() ).toBe( '' );
 		// After undoing every action, there should be no more undo history.
 		expect( await page.$( '.editor-history__undo[aria-disabled="true"]' ) ).not.toBeNull();
+	} );
+
+	it( 'should undo for explicit persistence editing post', async () => {
+		// Regression test: An issue had occurred where the creation of an
+		// explicit undo level would interfere with blocks values being synced
+		// correctly to the block editor.
+		//
+		// See: https://github.com/WordPress/gutenberg/issues/14950
+
+		// Issue is demonstrated from an edited post: create, save, and reload.
+		await clickBlockAppender();
+		await page.keyboard.type( 'original' );
+		await saveDraft();
+		await page.reload();
+
+		// Issue is demonstrated by forcing state merges (multiple inputs) on
+		// an existing text after a fresh reload.
+		await selectBlockByClientId( ( await getAllBlocks() )[ 0 ].clientId );
+		await page.keyboard.type( 'modified' );
+
+		// The issue is demonstrated after the one second delay to trigger the
+		// creation of an explicit undo persistence level.
+		await new Promise( ( resolve ) => setTimeout( resolve, 1000 ) );
+
+		await pressKeyWithModifier( 'primary', 'z' );
+
+		// Assert against the _visible_ content. Since editor state with the
+		// regression present was accurate, it would produce the correct
+		// content. The issue had manifested in the form of what was shown to
+		// the user since the blocks state failed to sync to block editor.
+		const visibleContent = await page.evaluate( () => document.activeElement.textContent );
+		expect( visibleContent ).toBe( 'original' );
 	} );
 } );


### PR DESCRIPTION
Previously: #14955

This pull request seeks to add an end-to-end test to verify the expected behavior introduced in #14955. It was originally included with #14955, but due to general test instability in the Undo suite, it was reverted as blocked by #14915. #14915 has since been merged, so it should be safe and stable to introduce this test now.

**Testing instructions:**

Ensure end-to-end tests pass:

```
npm run build && npm run test-e2e packages/e2e-tests/specs/undo.test.js
```