### PR TITLE
Add wpDataSelect WordPress end 2 end test util

### DIFF
--- a/packages/e2e-test-utils/src/are-pre-publish-checks-enabled.js
+++ b/packages/e2e-test-utils/src/are-pre-publish-checks-enabled.js
@@ -1,9 +1,12 @@
 /**
+ * Internal dependencies
+ */
+import { wpDataSelect } from './wp-data-select';
+
+/**
  * Verifies if publish checks are enabled.
  * @return {boolean} Boolean which represents the state of prepublish checks.
  */
-export async function arePrePublishChecksEnabled() {
-	return page.evaluate( () =>
-		window.wp.data.select( 'core/editor' ).isPublishSidebarEnabled()
-	);
+export function arePrePublishChecksEnabled() {
+	return wpDataSelect( 'core/editor', 'isPublishSidebarEnabled' );
 }

--- a/packages/e2e-test-utils/src/get-all-blocks.js
+++ b/packages/e2e-test-utils/src/get-all-blocks.js
@@ -1,11 +1,13 @@
 /**
+ * Internal dependencies
+ */
+import { wpDataSelect } from './wp-data-select';
+
+/**
  * Returns an array with all blocks; Equivalent to calling wp.data.select( 'core/editor' ).getBlocks();
  *
  * @return {Promise} Promise resolving with an array containing all blocks in the document.
  */
-export async function getAllBlocks() {
-	return await page.evaluate( () => {
-		const { select } = window.wp.data;
-		return select( 'core/editor' ).getBlocks();
-	} );
+export function getAllBlocks() {
+	return wpDataSelect( 'core/editor', 'getBlocks' );
 }

--- a/packages/e2e-test-utils/src/get-edited-post-content.js
+++ b/packages/e2e-test-utils/src/get-edited-post-content.js
@@ -1,10 +1,13 @@
 /**
+ * Internal dependencies
+ */
+import { wpDataSelect } from './wp-data-select';
+
+/**
  * Returns a promise which resolves with the edited post content (HTML string).
  *
  * @return {Promise} Promise resolving with post content markup.
  */
 export async function getEditedPostContent() {
-	return await page.evaluate( () => {
-		return window.wp.data.select( 'core/editor' ).getEditedPostContent();
-	} );
+	return wpDataSelect( 'core/editor', 'getEditedPostContent' );
 }

--- a/packages/e2e-test-utils/src/wp-data-select.js
+++ b/packages/e2e-test-utils/src/wp-data-select.js
@@ -1,5 +1,5 @@
 /**
- * Queries the wordpress data module.
+ * Queries the WordPress data module.
  * @param {string}    store      Store to query e.g: core/editor, core/blocks...
  * @param {string}    selector   Selector to exectute e.g: getBlocks.
  * @param {...Object} parameters Parameters to pass to the selector.

--- a/packages/e2e-test-utils/src/wp-data-select.js
+++ b/packages/e2e-test-utils/src/wp-data-select.js
@@ -1,0 +1,18 @@
+/**
+ * Queries the wordpress data module.
+ * @param {string}    store      Store to query e.g: core/editor, core/blocks...
+ * @param {string}    selector   Selector to exectute e.g: getBlocks.
+ * @param {...Object} parameters Parameters to pass to the selector.
+ *
+ * @return {?Object} Result of querying.
+ */
+export function wpDataSelect( store, selector, ...parameters ) {
+	return page.evaluate(
+		( _store, _selector, ..._parameters ) => {
+			return window.wp.data.select( _store )[ _selector ]( ..._parameters );
+		},
+		store,
+		selector,
+		parameters
+	);
+}


### PR DESCRIPTION
## Description
This a follow up on a suggestion by @gziolo to have a simple utility that allows us to easily query the WordPress data module.

## How has this been tested?
Verify the end 2 end tests pass.