### PR TITLE
Fix: Contributors can not use drag & drop

### DIFF
--- a/packages/block-editor/src/components/block-drop-zone/index.js
+++ b/packages/block-editor/src/components/block-drop-zone/index.js
@@ -19,11 +19,6 @@ import { Component } from '@wordpress/element';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
-/**
- * Internal dependencies
- */
-import MediaUploadCheck from '../media-upload/check';
-
 const parseDropEvent = ( event ) => {
 	let result = {
 		srcRootClientId: null,
@@ -63,6 +58,9 @@ class BlockDropZone extends Component {
 	}
 
 	onFilesDrop( files, position ) {
+		if ( ! this.props.hasUploadPermissions ) {
+			return;
+		}
 		const transformation = findTransform(
 			getBlockTransforms( 'from' ),
 			( transform ) => transform.type === 'files' && transform.isMatch( files )
@@ -111,25 +109,21 @@ class BlockDropZone extends Component {
 	}
 
 	render() {
-		const { isLockedAll } = this.props;
+		const { hasUploadPermissions, isLockedAll } = this.props;
 		if ( isLockedAll ) {
 			return null;
 		}
-
 		const index = this.getInsertIndex();
 		const isAppender = index === undefined;
-
 		return (
-			<MediaUploadCheck>
-				<DropZone
-					className={ classnames( 'editor-block-drop-zone block-editor-block-drop-zone', {
-						'is-appender': isAppender,
-					} ) }
-					onFilesDrop={ this.onFilesDrop }
-					onHTMLDrop={ this.onHTMLDrop }
-					onDrop={ this.onDrop }
-				/>
-			</MediaUploadCheck>
+			<DropZone
+				className={ classnames( 'editor-block-drop-zone block-editor-block-drop-zone', {
+					'is-appender': isAppender,
+				} ) }
+				onHTMLDrop={ this.onHTMLDrop }
+				onDrop={ this.onDrop }
+				onFilesDrop={ hasUploadPermissions ? this.onFilesDrop : undefined }
+			/>
 		);
 	}
 }
@@ -158,11 +152,17 @@ export default compose(
 		};
 	} ),
 	withSelect( ( select, { rootClientId } ) => {
-		const { getClientIdsOfDescendants, getTemplateLock, getBlockIndex } = select( 'core/block-editor' );
-		return {
-			isLockedAll: getTemplateLock( rootClientId ) === 'all',
-			getClientIdsOfDescendants,
+		const {
 			getBlockIndex,
+			getClientIdsOfDescendants,
+			getSettings,
+			getTemplateLock,
+		} = select( 'core/block-editor' );
+		return {
+			getBlockIndex,
+			getClientIdsOfDescendants,
+			hasUploadPermissions: !! getSettings().mediaUpload,
+			isLockedAll: getTemplateLock( rootClientId ) === 'all',
 		};
 	} ),
 	withFilters( 'editor.BlockDropZone' )

--- a/packages/components/src/drop-zone/index.js
+++ b/packages/components/src/drop-zone/index.js
@@ -58,10 +58,14 @@ class DropZoneComponent extends Component {
 	}
 
 	render() {
-		const { className, label } = this.props;
+		const { className, label, onFilesDrop, onHTMLDrop, onDrop } = this.props;
 		const { isDraggingOverDocument, isDraggingOverElement, position, type } = this.state;
 		const classes = classnames( 'components-drop-zone', className, {
-			'is-active': isDraggingOverDocument || isDraggingOverElement,
+			'is-active': ( isDraggingOverDocument || isDraggingOverElement ) && (
+				( type === 'file' && onFilesDrop ) ||
+				( type === 'html' && onHTMLDrop ) ||
+				( type === 'default' && onDrop )
+			),
 			'is-dragging-over-document': isDraggingOverDocument,
 			'is-dragging-over-element': isDraggingOverElement,
 			'is-close-to-top': position && position.y === 'top',


### PR DESCRIPTION
Currently, if the user has no permission to upload files, the user is not able to use block drag & drop.
This PR fixes the problem.

## How has this been tested?
I added some paragraphs in Gutenberg playground.
I hovered with the mouse at the left side of the paragraph until the hand to grab the paragraph appeared. The reason why the block movers don't become visible on the playground is probably another bug that I will try to find the cause.
I changed the paragraph position by dropping it above the blue line in another position.

I tried to drag a file to the playground and verified it was not possible to do it and the blue line to drop never appeared -- in the playground the user is not able to upload files.
