### PR TITLE
[RNMobile] Fix for history stack that's is not empty on a fresh start of the editor

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -483,10 +483,11 @@ export class RichText extends Component {
 		this.lastEventCount = event.nativeEvent.eventCount;
 		
 		// Make sure there are changes made to the content before upgrading it upward
-		if ( this.lastContent !== this.removeRootTagsProduceByAztec( unescapeSpaces( text ) ) ) {
-			// we don't want to refresh aztec as no content can have changed from this event
+		const newContent = this.removeRootTagsProduceByAztec( unescapeSpaces( text ) );
+		if ( this.lastContent !== newContent ) {
+			// we don't want to refresh aztec native as no content can have changed from this event
 			// let's update lastContent to prevent that in shouldComponentUpdate
-			this.lastContent = this.removeRootTagsProduceByAztec( unescapeSpaces( text ) );
+			this.lastContent = newContent;
 			this.props.onChange( this.lastContent );
 		}
 	}

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -481,7 +481,7 @@ export class RichText extends Component {
 			formatPlaceholder,
 		} );
 		this.lastEventCount = event.nativeEvent.eventCount;
-		
+
 		// Make sure there are changes made to the content before upgrading it upward
 		const newContent = this.removeRootTagsProduceByAztec( unescapeSpaces( text ) );
 		if ( this.lastContent !== newContent ) {

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -481,9 +481,14 @@ export class RichText extends Component {
 			formatPlaceholder,
 		} );
 		this.lastEventCount = event.nativeEvent.eventCount;
-		// we don't want to refresh aztec as no content can have changed from this event
-		// let's update lastContent to prevent that in shouldComponentUpdate
-		this.lastContent = this.removeRootTagsProduceByAztec( unescapeSpaces( text ) );
+		
+		// Make sure there are changes made to the content before upgrading it upward
+		if ( this.lastContent !== this.removeRootTagsProduceByAztec( unescapeSpaces( text ) ) ) {
+			// we don't want to refresh aztec as no content can have changed from this event
+			// let's update lastContent to prevent that in shouldComponentUpdate
+			this.lastContent = this.removeRootTagsProduceByAztec( unescapeSpaces( text ) );
+			this.props.onChange( this.lastContent );
+		}
 	}
 
 	isEmpty() {

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -484,7 +484,6 @@ export class RichText extends Component {
 		// we don't want to refresh aztec as no content can have changed from this event
 		// let's update lastContent to prevent that in shouldComponentUpdate
 		this.lastContent = this.removeRootTagsProduceByAztec( unescapeSpaces( text ) );
-		this.props.onChange( this.lastContent );
 	}
 
 	isEmpty() {


### PR DESCRIPTION
This PR does fix a [problem](https://github.com/wordpress-mobile/gutenberg-mobile/issues/887) where opening a post in GB mobile (without modify it) does result on having the `Undo` button already available/enabled in the toolbar.
It also fixes the other problem where removing a new block with Undo/Redo was not possible without fast clicking on the the Undo button. 

In this PR i've just removed the call that refreshes the content into the store in `onSelectChange`. Not quite sure why we're sending back the content if it was not modified. In fact `this.lastContent` was set with the actual content to avoid a refresh of the component.

**Testing steps in the GB Mobile PR here: https://github.com/wordpress-mobile/gutenberg-mobile/pull/892**