### PR TITLE
[Enhancement] Making the focus state of button text in Button block more visible

### DIFF
--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -36,6 +36,11 @@
 		opacity: 0;
 	}
 
+	// Align cursor to left when text input is focused and placeholder is active.
+	.block-editor-rich-text__editable[data-is-placeholder-visible="true"]:focus {
+		text-align: left;
+	}
+
 	// Don't let the placeholder text wrap in the variation preview.
 	.block-editor-block-preview__content & {
 		max-width: 100%;

--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -36,8 +36,8 @@
 		opacity: 0;
 	}
 
-	// Align cursor to left when text input is focused and placeholder is active.
-	.block-editor-rich-text__editable[data-is-placeholder-visible="true"]:focus {
+	// Align cursor to left when placeholder is active.
+	.block-editor-rich-text__editable[data-is-placeholder-visible="true"] {
 		text-align: left;
 	}
 

--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -31,6 +31,11 @@
 		opacity: 0.8;
 	}
 
+	// Reduce placeholder opacity on focus to make cursor visible.
+	.block-editor-rich-text__editable[data-is-placeholder-visible="true"]:focus + .block-editor-rich-text__editable {
+		opacity: 0.4;
+	}
+
 	// Don't let the placeholder text wrap in the variation preview.
 	.block-editor-block-preview__content & {
 		max-width: 100%;

--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -31,9 +31,9 @@
 		opacity: 0.8;
 	}
 
-	// Reduce placeholder opacity on focus to make cursor visible.
+	// Make placeholder disappear on focus to make focus-state visible.
 	.block-editor-rich-text__editable[data-is-placeholder-visible="true"]:focus + .block-editor-rich-text__editable {
-		opacity: 0.4;
+		opacity: 0;
 	}
 
 	// Don't let the placeholder text wrap in the variation preview.

--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -26,6 +26,15 @@
 		color: $white;
 	}
 
+	// Add outline to button on focus to indicate focus-state
+	.block-editor-rich-text__editable:focus {
+		box-shadow: 0 0 0 1px $white, 0 0 0 3px $blue-medium-500;
+
+		// Windows' High Contrast mode will show this outline, but not the box-shadow.
+		outline: 2px solid transparent;
+		outline-offset: -2px;
+	}
+
 	// Increase placeholder opacity to meet contrast ratios.
 	.block-editor-rich-text__editable[data-is-placeholder-visible="true"] + .block-editor-rich-text__editable {
 		opacity: 0.8;
@@ -75,6 +84,9 @@
 	// The width of input box plus padding plus two icon buttons.
 	$blocks-button__link-input-width: 300px + 2px + 2 * $icon-button-size;
 	width: $blocks-button__link-input-width;
+
+	// Move it down by 2px so that it doesn't overlap the button focus outline.
+	margin-top: 2px;
 
 	.block-editor-url-input {
 		width: auto;


### PR DESCRIPTION
## Description
This PR tries to close #15051 which reports the focus style of the button text within the button block not being clear.

The placeholder on this text input is essentially an overlay. It has a reduced opacity set so that the cursor shows up. But naturally, it barely does. This PR just reduces the opacity further only when the input is focused so that the cursor, i.e. the focus state, is more visible.

I don't think it is the most ideal approach to this, but at least it's a start. I'd request some feedback and suggestions on how we could improve it. Thanks ❤️ 

## How has this been tested?
This PR has been tested by going through the following steps:

1. Started a new post using the Gutenberg editor.
2. Added the "Button" block.
3. Focused on the button text input.
4. Made sure the opacity of the placeholder reduces making the cursor more visible.

## Screenshots <!-- if applicable -->
![15051](https://user-images.githubusercontent.com/20284937/56381919-fe426c00-6237-11e9-9f50-dd8664127524.gif)

## Types of changes
This PR just simply reduces the opacity of the placeholder on `:focus` state of the text input.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
