### PR TITLE
Testing: Skip unreliable end-to-end tests

### DIFF
--- a/packages/e2e-tests/specs/block-deletion.test.js
+++ b/packages/e2e-tests/specs/block-deletion.test.js
@@ -30,7 +30,7 @@ describe( 'block deletion -', () => {
 	beforeEach( addThreeParagraphsToNewPost );
 
 	describe( 'deleting the third block using the Remove Block menu item', () => {
-		it( 'results in two remaining blocks and positions the caret at the end of the second block', async () => {
+		it.skip( 'results in two remaining blocks and positions the caret at the end of the second block', async () => {
 			// The blocks can't be empty to trigger the toolbar
 			await page.keyboard.type( 'Paragraph to remove' );
 

--- a/packages/e2e-tests/specs/embedding.test.js
+++ b/packages/e2e-tests/specs/embedding.test.js
@@ -272,7 +272,7 @@ describe( 'Embedding content', () => {
 		await page.waitForSelector( '.wp-block-embed-wordpress' );
 	} );
 
-	it( 'should transform from video to embed block when YouTube URL is pasted', async () => {
+	it.skip( 'should transform from video to embed block when YouTube URL is pasted', async () => {
 		await clickBlockAppender();
 		await insertBlock( 'Video' );
 		await page.click( '.editor-media-placeholder__url-input-container button' );
@@ -281,7 +281,7 @@ describe( 'Embedding content', () => {
 		await page.waitForSelector( '.wp-block-embed-youtube' );
 	} );
 
-	it( 'should transform from image to embed block when Instagram URL is pasted', async () => {
+	it.skip( 'should transform from image to embed block when Instagram URL is pasted', async () => {
 		await clickBlockAppender();
 		await page.keyboard.type( '/image' );
 		await page.keyboard.press( 'Enter' );
@@ -291,7 +291,7 @@ describe( 'Embedding content', () => {
 		await page.waitForSelector( '.wp-block-embed-instagram' );
 	} );
 
-	it( 'should transform from audio to embed block when Soundcloud URL is pasted', async () => {
+	it.skip( 'should transform from audio to embed block when Soundcloud URL is pasted', async () => {
 		await clickBlockAppender();
 		await page.keyboard.type( '/audio' );
 		await page.keyboard.press( 'Enter' );

--- a/packages/e2e-tests/specs/links.test.js
+++ b/packages/e2e-tests/specs/links.test.js
@@ -266,8 +266,7 @@ describe( 'Links', () => {
 	};
 
 	// Test for regressions of https://github.com/WordPress/gutenberg/issues/10496.
-	// Disabled until improved as it wasn't reliable enough.
-	it( 'allows autocomplete suggestions to be selected with the mouse', async () => {
+	it.skip( 'allows autocomplete suggestions to be selected with the mouse', async () => {
 		// First create a post that we can search for using the link autocompletion.
 		const titleText = 'Test post mouse';
 		const postURL = await createPostWithTitle( titleText );


### PR DESCRIPTION
This pull request seeks to disable unreliable end-to-end test cases until their reliability can be improved. They have been shown to cause intermittent build failures.

- https://travis-ci.com/WordPress/gutenberg/jobs/193889133
- https://travis-ci.com/WordPress/gutenberg/jobs/192907647
- https://travis-ci.com/WordPress/gutenberg/jobs/193911229

**Testing Instructions:**

Ensure end-to-end tests pass:

```
npm run build && npm run test-e2e
```

**Follow-up Actions:**

Create issue(s) for re-enabling skipped tests.