### PR TITLE
Reusable Blocks: Preload user permissions

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -560,3 +560,32 @@ function gutenberg_extend_block_editor_styles( $settings ) {
 	return $settings;
 }
 add_filter( 'block_editor_settings', 'gutenberg_extend_block_editor_styles' );
+
+/**
+ * Extends block editor preload paths to preload additional data. Note that any
+ * additions here should be complemented with a corresponding core ticket to
+ * reconcile the change upstream for future removal from Gutenberg.
+ *
+ * @since 5.6.0
+ *
+ * @param array $preload_paths $preload_paths Array of paths to preload.
+ *
+ * @return array Filtered array of paths to preload.
+ */
+function gutenberg_extend_block_editor_preload_paths( $preload_paths ) {
+	/*
+	 * Used in considering user permissions for creating and updating blocks,
+	 * as condition for displaying relevant actions in the interface.
+	 *
+	 * Trac ticket: https://core.trac.wordpress.org/ticket/46429
+	 *
+	 * This is present in WordPress 5.2 and should be removed from Gutenberg
+	 * once WordPress 5.2 is the minimum supported version.
+	 */
+	if ( ! in_array( array( '/wp/v2/blocks', 'OPTIONS' ), $preload_paths ) ) {
+		$preload_paths[] = array( '/wp/v2/blocks', 'OPTIONS' );
+	}
+
+	return $preload_paths;
+}
+add_filter( 'block_editor_preload_paths', 'gutenberg_extend_block_editor_preload_paths' );

--- a/packages/e2e-tests/specs/block-deletion.test.js
+++ b/packages/e2e-tests/specs/block-deletion.test.js
@@ -30,7 +30,7 @@ describe( 'block deletion -', () => {
 	beforeEach( addThreeParagraphsToNewPost );
 
 	describe( 'deleting the third block using the Remove Block menu item', () => {
-		it.skip( 'results in two remaining blocks and positions the caret at the end of the second block', async () => {
+		it( 'results in two remaining blocks and positions the caret at the end of the second block', async () => {
 			// The blocks can't be empty to trigger the toolbar
 			await page.keyboard.type( 'Paragraph to remove' );
 

--- a/phpunit/class-extend-preload-paths-test.php
+++ b/phpunit/class-extend-preload-paths-test.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Test `gutenberg_extend_block_editor_preload_paths`.
+ *
+ * @package Gutenberg
+ */
+
+class Extend_Preload_Paths_Test extends WP_UnitTestCase {
+	/**
+	 * Tests '/wp/v2/blocks' added if missing.
+	 */
+	function test_localizes_script() {
+		$preload_paths = gutenberg_extend_block_editor_preload_paths( array() );
+
+		$this->assertEquals( array( array( '/wp/v2/blocks', 'OPTIONS' ) ), $preload_paths );
+	}
+
+	/**
+	 * Tests '/wp/v2/blocks' not added if present.
+	 */
+	function test_replaces_registered_properties() {
+		$preload_paths = gutenberg_extend_block_editor_preload_paths( array( array( '/wp/v2/blocks', 'OPTIONS' ) ) );
+
+		$this->assertEquals( array( array( '/wp/v2/blocks', 'OPTIONS' ) ), $preload_paths );
+	}
+}


### PR DESCRIPTION
Previously: #12378

This pull request seeks to add the blocks permissions REST API request as a preloaded path, for two reasons:

- We use preload data to avoid UI "flickering". Presently, without these changes, UI such as the "Add to Reusable Blocks" button in a block settings menu appears only after a brief delay, which is undesirable.
- As described at https://github.com/WordPress/gutenberg/pull/15059#issuecomment-484647474 , the immediate unavailability of permissions data may be a culprit in end-to-end test instability

It appears this was already added in #12378 and exists in WordPress 5.2 (https://github.com/WordPress/wordpress-develop/commit/79a3abcb2a357aecb67b5b48b00f42053f88a981), but should remain in the Gutenberg plugin until WordPress 5.2 is the minimum supported version. It could be considered as erroneously removed via #13569.

**Testing Instructions:**

Verify that when clicking the block settings menu for the first time in a page session, the "Add to Reusable Blocks" is shown immediately if the user has permissions to undertake this operation (i.e. there is no delay in its appearance).

Ensure unit tests pass:

```
npm run test-php
```