### PR TITLE
Testing: Update end-to-end tests to use Escape press to activate block toolbar

### DIFF
--- a/packages/e2e-tests/specs/block-deletion.test.js
+++ b/packages/e2e-tests/specs/block-deletion.test.js
@@ -34,8 +34,8 @@ describe( 'block deletion -', () => {
 			// The blocks can't be empty to trigger the toolbar
 			await page.keyboard.type( 'Paragraph to remove' );
 
-			// Move the mouse to show the block toolbar
-			await page.mouse.move( 200, 300, { steps: 10 } );
+			// Press Escape to show the block toolbar
+			await page.keyboard.press( 'Escape' );
 
 			await clickOnBlockSettingsMenuItem( 'Remove Block' );
 			expect( await getEditedPostContent() ).toMatchSnapshot();

--- a/packages/e2e-tests/specs/editor-modes.test.js
+++ b/packages/e2e-tests/specs/editor-modes.test.js
@@ -19,8 +19,8 @@ describe( 'Editing modes (visual/HTML)', () => {
 		let visualBlock = await page.$$( '.block-editor-block-list__layout .block-editor-block-list__block .block-editor-rich-text' );
 		expect( visualBlock ).toHaveLength( 1 );
 
-		// Move the mouse to show the block toolbar
-		await page.mouse.move( 200, 300, { steps: 10 } );
+		// Press Escape to show the block toolbar
+		await page.keyboard.press( 'Escape' );
 
 		// Change editing mode from "Visual" to "HTML".
 		await page.waitForSelector( 'button[aria-label="More options"]' );
@@ -32,8 +32,8 @@ describe( 'Editing modes (visual/HTML)', () => {
 		const htmlBlock = await page.$$( '.block-editor-block-list__layout .block-editor-block-list__block .block-editor-block-list__block-html-textarea' );
 		expect( htmlBlock ).toHaveLength( 1 );
 
-		// Move the mouse to show the block toolbar
-		await page.mouse.move( 200, 300, { steps: 10 } );
+		// Press Escape to show the block toolbar
+		await page.keyboard.press( 'Escape' );
 
 		// Change editing mode from "HTML" back to "Visual".
 		await page.waitForSelector( 'button[aria-label="More options"]' );
@@ -47,8 +47,8 @@ describe( 'Editing modes (visual/HTML)', () => {
 	} );
 
 	it( 'should display sidebar in HTML mode', async () => {
-		// Move the mouse to show the block toolbar
-		await page.mouse.move( 200, 300, { steps: 10 } );
+		// Press Escape to show the block toolbar
+		await page.keyboard.press( 'Escape' );
 
 		// Change editing mode from "Visual" to "HTML".
 		await page.waitForSelector( 'button[aria-label="More options"]' );
@@ -63,8 +63,8 @@ describe( 'Editing modes (visual/HTML)', () => {
 	} );
 
 	it( 'should update HTML in HTML mode when sidebar is used', async () => {
-		// Move the mouse to show the block toolbar
-		await page.mouse.move( 200, 300, { steps: 10 } );
+		// Press Escape to show the block toolbar
+		await page.keyboard.press( 'Escape' );
 
 		// Change editing mode from "Visual" to "HTML".
 		await page.waitForSelector( 'button[aria-label="More options"]' );


### PR DESCRIPTION
This pull request seeks to replace use of a "mouse wiggle" interaction in end-to-end tests with a simpler, direct keyboard interaction. There was originally no way to activate the block toolbar using a keyboard, so an arbitrary mouse move interaction was implemented in tests to activate the toolbar. This was later found to be generally unreliable without a `steps` property to slow the interaction across many distinct steps.

Since it's now possible to activate the toolbar using the keyboard, these changes are proposed as an improvement to:

- Signal that this interaction is not dependent on a cursor
- Avoid potential delays to test runtime which could occur by spreading across multiple steps
- Avoid the arbitrary nature of the interaction (arbitrary selection of mouse coordinates and step count)
- The implementation without these changes is potentially prone to bugginess, where if the cursor had already been at the selected mouse coordinates, the "typing mode" would not be cancelled ([source](https://github.com/WordPress/gutenberg/blob/5d25504e9616fe6d5ef76fab9f2493c42f41d6c6/packages/block-editor/src/components/observe-typing/index.js#L104-L106))

**Testing Instructions:**

Ensure end-to-end tests pass:

```
npm run build && npm run test-e2e
```