### PR TITLE
Add preload paths for autosaves

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -608,11 +608,14 @@ function gutenberg_extend_block_editor_preload_paths( $preload_paths, $post ) {
 	 * the minimum supported version.
 	 */
 	$post_type_object = get_post_type_object( $post->post_type );
-	$rest_base        = ! empty( $post_type_object->rest_base ) ? $post_type_object->rest_base : $post_type_object->name;
-	$autosaves_path   = sprintf( '/wp/v2/%s/%d/autosaves?context=edit', $rest_base, $post->ID );
 
-	if ( ! in_array( $autosaves_path, $preload_paths ) ) {
-		$preload_paths[] = $autosaves_path;
+	if ( isset( $post_type_object ) ) {
+		$rest_base      = ! empty( $post_type_object->rest_base ) ? $post_type_object->rest_base : $post_type_object->name;
+		$autosaves_path = sprintf( '/wp/v2/%s/%d/autosaves?context=edit', $rest_base, $post->ID );
+
+		if ( ! in_array( $autosaves_path, $preload_paths ) ) {
+			$preload_paths[] = $autosaves_path;
+		}
 	}
 
 	/*

--- a/phpunit/class-extend-preload-paths-test.php
+++ b/phpunit/class-extend-preload-paths-test.php
@@ -7,20 +7,48 @@
 
 class Extend_Preload_Paths_Test extends WP_UnitTestCase {
 	/**
-	 * Tests '/wp/v2/blocks' added if missing.
+	 * Post object.
+	 *
+	 * @var WP_Post
 	 */
-	function test_localizes_script() {
-		$preload_paths = gutenberg_extend_block_editor_preload_paths( array() );
+	protected static $post;
 
-		$this->assertEquals( array( array( '/wp/v2/blocks', 'OPTIONS' ) ), $preload_paths );
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$post = $factory->post->create_and_get();
 	}
 
 	/**
-	 * Tests '/wp/v2/blocks' not added if present.
+	 * Tests paths added if missing.
+	 */
+	function test_localizes_script() {
+		$post = (object) array(
+			'ID'        => 12,
+			'post_type' => 'post',
+		);
+
+		$preload_paths = gutenberg_extend_block_editor_preload_paths( array(), self::$post );
+
+		$expected_blocks_path    = array( '/wp/v2/blocks', 'OPTIONS' );
+		$expected_autosaves_path = sprintf( '/wp/v2/%s/%d/autosaves?context=edit', 'posts', self::$post->ID );
+
+		$this->assertEquals( array( $expected_autosaves_path, $expected_blocks_path ), $preload_paths );
+	}
+
+	/**
+	 * Tests paths not added if present.
 	 */
 	function test_replaces_registered_properties() {
-		$preload_paths = gutenberg_extend_block_editor_preload_paths( array( array( '/wp/v2/blocks', 'OPTIONS' ) ) );
+		$post = (object) array(
+			'ID'        => 12,
+			'post_type' => 'post',
+		);
 
-		$this->assertEquals( array( array( '/wp/v2/blocks', 'OPTIONS' ) ), $preload_paths );
+		$existing_blocks_path    = array( '/wp/v2/blocks', 'OPTIONS' );
+		$existing_autosaves_path = sprintf( '/wp/v2/%s/%d/autosaves?context=edit', 'posts', self::$post->ID );
+		$existing_preload_paths  = array( $existing_blocks_path, $existing_autosaves_path );
+
+		$preload_paths = gutenberg_extend_block_editor_preload_paths( $existing_preload_paths, self::$post );
+
+		$this->assertEquals( $existing_preload_paths, $preload_paths );
 	}
 }

--- a/phpunit/class-extend-preload-paths-test.php
+++ b/phpunit/class-extend-preload-paths-test.php
@@ -21,11 +21,6 @@ class Extend_Preload_Paths_Test extends WP_UnitTestCase {
 	 * Tests paths added if missing.
 	 */
 	function test_localizes_script() {
-		$post = (object) array(
-			'ID'        => 12,
-			'post_type' => 'post',
-		);
-
 		$preload_paths = gutenberg_extend_block_editor_preload_paths( array(), self::$post );
 
 		$expected_blocks_path    = array( '/wp/v2/blocks', 'OPTIONS' );
@@ -38,11 +33,6 @@ class Extend_Preload_Paths_Test extends WP_UnitTestCase {
 	 * Tests paths not added if present.
 	 */
 	function test_replaces_registered_properties() {
-		$post = (object) array(
-			'ID'        => 12,
-			'post_type' => 'post',
-		);
-
 		$existing_blocks_path    = array( '/wp/v2/blocks', 'OPTIONS' );
 		$existing_autosaves_path = sprintf( '/wp/v2/%s/%d/autosaves?context=edit', 'posts', self::$post->ID );
 		$existing_preload_paths  = array( $existing_blocks_path, $existing_autosaves_path );


### PR DESCRIPTION
## Description
Adds a preload path for autosaves to help optimize the changes made in #7945.

Note there is a trac ticket that replicates this functionality in core (https://core.trac.wordpress.org/ticket/46974). In the meantime this should bring the same optimization to the plugin.

## How has this been tested?
1. Create a new post and publish it
2. Open the browser dev tool and monitor the network requests
2. Reload the editor

**With this change:** no requests to the autosaves endpoint are made when reloading the editor.
**Without this change:** a request is made to the autosaves endpoint when reloading the editor.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
