### PR TITLE
[Mobile] Fix title not focusing

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -768,7 +768,7 @@ const RichTextContainer = compose( [
 		return {
 			clientId: context.clientId,
 			isSelected: context.isSelected,
-			onFocus: context.onFocus,
+			onFocus: context.onFocus || ownProps.onFocus,
 		};
 	} ),
 ] )( RichText );


### PR DESCRIPTION
This PR fixes an issue where the post title is not being focused when the user tap on it.
Related `gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/893

I noticed that the:
```javascript
return {
    clientId: context.clientId,
    isSelected: context.isSelected,
    onFocus: context.onFocus,
};
```

Is necessary for the ListBlock to get focus properly, but the addition of it broke the PostTitle, since context.onFocus is undefined when setting up the PostTitle's RichText component.

To solve it, we pass the `onFocus` from ownProps directly if `context.onFocus` is undefined.

I'd prefer to give `context.onFocus` preference, since it's how it is supposed to be set up for blocks, being the PostTitle the special case (the one that needs `ownProps.onFocus`).

The difference with Web is that they don't use `RichText` for the PostTitle.

To test:
- Run the project.
- Focus any block.
- Focus on the PostTitle.
- Check that it is focused with highlighted borders.
- Create a ListBlock.
- Focus other block and focus back the ListBlock.
- Check that block selection works properly.