### PR TITLE
Fix 13776: Format is already registered to handle class name

### DIFF
--- a/packages/rich-text/src/store/selectors.js
+++ b/packages/rich-text/src/store/selectors.js
@@ -40,8 +40,8 @@ export function getFormatType( state, name ) {
  * @return {?Object} Format type.
  */
 export function getFormatTypeForBareElement( state, bareElementTagName ) {
-	return find( getFormatTypes( state ), ( { tagName } ) => {
-		return bareElementTagName === tagName;
+	return find( getFormatTypes( state ), ( { className, tagName } ) => {
+		return className === null && bareElementTagName === tagName;
 	} );
 }
 

--- a/packages/rich-text/src/store/test/selectors.js
+++ b/packages/rich-text/src/store/test/selectors.js
@@ -6,33 +6,69 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { getFormatTypes, getFormatType } from '../selectors';
+import {
+	getFormatTypes,
+	getFormatType,
+	getFormatTypeForBareElement,
+	getFormatTypeForClassName,
+} from '../selectors';
 
 describe( 'selectors', () => {
+	const formatType = {
+		name: 'core/test-format',
+		className: null,
+		tagName: 'format',
+	};
+	const formatTypeBareTag = {
+		name: 'core/test-format-bare-tag',
+		className: null,
+		tagName: 'strong',
+	};
+	const formatTypeClassName = {
+		name: 'core/test-format-class-name',
+		className: 'class-name',
+		tagName: 'strong',
+	};
 	const defaultState = deepFreeze( {
 		formatTypes: {
-			'core/test-format': { name: 'core/test-format' },
-			'core/test-format-2': { name: 'core/test-format-2' },
+			'core/test-format': formatType,
+			'core/test-format-bare-tag': formatTypeBareTag,
+			'core/test-format-class-name': formatTypeClassName,
 		},
 	} );
 
 	describe( 'getFormatTypes', () => {
 		it( 'should get format types', () => {
 			const expected = [
-				{ name: 'core/test-format' },
-				{ name: 'core/test-format-2' },
+				formatType,
+				formatTypeBareTag,
+				formatTypeClassName,
 			];
-
 			expect( getFormatTypes( defaultState ) ).toEqual( expected );
 		} );
 	} );
 
 	describe( 'getFormatType', () => {
 		it( 'should get a format type', () => {
-			const expected = { name: 'core/test-format' };
 			const result = getFormatType( defaultState, 'core/test-format' );
 
-			expect( result ).toEqual( expected );
+			expect( result ).toEqual( formatType );
+		} );
+	} );
+
+	describe( 'getFormatTypeForBareElement', () => {
+		it( 'should get a format type', () => {
+			const result = getFormatTypeForBareElement( defaultState, 'strong' );
+
+			expect( result ).toEqual( formatTypeBareTag );
+		} );
+	} );
+
+	describe( 'getFormatTypeForClassName', () => {
+		it( 'should get a format type', () => {
+			const result = getFormatTypeForClassName( defaultState, 'class-name' );
+
+			expect( result ).toEqual( formatTypeClassName );
 		} );
 	} );
 } );

--- a/packages/rich-text/src/store/test/selectors.js
+++ b/packages/rich-text/src/store/test/selectors.js
@@ -19,21 +19,23 @@ describe( 'selectors', () => {
 		className: null,
 		tagName: 'format',
 	};
-	const formatTypeBareTag = {
-		name: 'core/test-format-bare-tag',
-		className: null,
-		tagName: 'strong',
-	};
 	const formatTypeClassName = {
 		name: 'core/test-format-class-name',
 		className: 'class-name',
 		tagName: 'strong',
 	};
+	const formatTypeBareTag = {
+		name: 'core/test-format-bare-tag',
+		className: null,
+		tagName: 'strong',
+	};
 	const defaultState = deepFreeze( {
 		formatTypes: {
 			'core/test-format': formatType,
-			'core/test-format-bare-tag': formatTypeBareTag,
 			'core/test-format-class-name': formatTypeClassName,
+			// Order matters: we need to ensure that
+			// `core/test-format-class-name` is not considered bare.
+			'core/test-format-bare-tag': formatTypeBareTag,
 		},
 	} );
 
@@ -41,8 +43,8 @@ describe( 'selectors', () => {
 		it( 'should get format types', () => {
 			const expected = [
 				formatType,
-				formatTypeBareTag,
 				formatTypeClassName,
+				formatTypeBareTag,
 			];
 			expect( getFormatTypes( defaultState ) ).toEqual( expected );
 		} );


### PR DESCRIPTION
## Description
Fixes #13776.

Custom formats are logging this error: https://github.com/WordPress/gutenberg/blob/01be7ac89b97b76c490d57a15c16466657240770/packages/rich-text/src/register-format-type.js#L95 even when classNames were defined.

**To Reproduce**
Steps to reproduce the behavior:

1. Format type with a class name A and tag name B gets registered.
1. Another format type without any class name but the same tag name B gets registered.

Example format type to test with:

```js
const { registerFormatType } = window.wp.richText;
const { RichTextToolbarButton } = window.wp.editor;

registerFormatType( 'wk/no-icon', {
	edit( { isActive } ) {
		return (
			<RichTextToolbarButton
				icon={ 'editor-link' }
				title={ 'Link ohne Icon' }
				isActive={ isActive }
				/>
		);
	},
  	tagName: 'a',
  	className: 'without-icon',
  	title: 'Link ohne Icon'
} );
```

Props to @pascalknecht for sharing.

**Expected behavior**
No error logs and all format types are properly registered. In the example provided core link should be there.

**Screenshots**
<img width="1274" alt="screen shot 2019-02-08 at 12 57 06 pm" src="https://user-images.githubusercontent.com/3365507/52482539-7e22d900-2bec-11e9-8541-009a2562c260.png">