### PR TITLE
Add left padding to the categories list inside of the categories panel

### DIFF
--- a/packages/editor/src/components/post-taxonomies/style.scss
+++ b/packages/editor/src/components/post-taxonomies/style.scss
@@ -1,6 +1,9 @@
 .editor-post-taxonomies__hierarchical-terms-list {
 	max-height: 14em;
 	overflow: auto;
+
+	// Extra left padding prevents checkbox focus borders from being cut off.
+	padding-left: 2px;
 }
 
 .editor-post-taxonomies__hierarchical-terms-choice {


### PR DESCRIPTION
Fixes #15045. This extra padding prevents the focus state for checkboxes from being trimmed off.

**Before:** 
![Screen Shot 2019-04-19 at 10 39 42 AM](https://user-images.githubusercontent.com/1202812/56429191-0cbc7200-6290-11e9-9bff-13cf18ac6a05.png)

**After:**
![Screen Shot 2019-04-19 at 10 40 08 AM](https://user-images.githubusercontent.com/1202812/56429193-0fb76280-6290-11e9-8f14-ca47f6767498.png)
