### PR TITLE
Fix: Block movers don't appear on the playground and on the widgets page

### DIFF
--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -40,3 +40,31 @@ body.gutenberg_page_gutenberg-widgets {
 		height: 100%;
 	}
 }
+
+/**
+ * Animations
+ */
+
+// These keyframes should not be part of the _animations.scss mixins file.
+// Because keyframe animations can't be defined as mixins properly, they are duplicated.
+// Since hey are intended only for the editor, we add them here instead.
+@keyframes edit-post__loading-fade-animation {
+	0% {
+		opacity: 0.5;
+	}
+	50% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0.5;
+	}
+}
+
+@keyframes edit-post__fade-in-animation {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}

--- a/playground/src/style.scss
+++ b/playground/src/style.scss
@@ -35,3 +35,31 @@
 		height: 100%;
 	}
 }
+
+/**
+ * Animations
+ */
+
+// These keyframes should not be part of the _animations.scss mixins file.
+// Because keyframe animations can't be defined as mixins properly, they are duplicated.
+// Since hey are intended only for the editor, we add them here instead.
+@keyframes edit-post__loading-fade-animation {
+	0% {
+		opacity: 0.5;
+	}
+	50% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0.5;
+	}
+}
+
+@keyframes edit-post__fade-in-animation {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}


### PR DESCRIPTION
The keyframe animations contained a comment saying they need to be duplicated, but they were not being duplicated in widgets and playground styles this made the block movers invisible.
This PR fixes the problem by duplicating the animation styles that needed to be duplicated.

## How has this been tested?
I went to Gutenberg playground `npm run playground:start`. I added multiple blocks and verified the block movers appear when I hover a block.
I went to the Gutenberg widgets page /wp-admin/admin.php?page=gutenberg-widgets and repeated the test described above.
