### PR TITLE
Fix: HTML entities in Author name are not decoded

### DIFF
--- a/packages/editor/src/components/post-author/index.js
+++ b/packages/editor/src/components/post-author/index.js
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { withInstanceId, compose } from '@wordpress/compose';
 import { Component } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -41,7 +42,7 @@ export class PostAuthor extends Component {
 					className="editor-post-author__select"
 				>
 					{ authors.map( ( author ) => (
-						<option key={ author.id } value={ author.id }>{ author.name }</option>
+						<option key={ author.id } value={ author.id }>{ decodeEntities(author.name) }</option>
 					) ) }
 				</select>
 			</PostAuthorCheck>

--- a/packages/editor/src/components/post-author/index.js
+++ b/packages/editor/src/components/post-author/index.js
@@ -42,7 +42,7 @@ export class PostAuthor extends Component {
 					className="editor-post-author__select"
 				>
 					{ authors.map( ( author ) => (
-						<option key={ author.id } value={ author.id }>{ decodeEntities(author.name) }</option>
+						<option key={ author.id } value={ author.id }>{ decodeEntities( author.name ) }</option>
 					) ) }
 				</select>
 			</PostAuthorCheck>


### PR DESCRIPTION
## Description
- Imported **decodeEntities** from WordPress dependencies on **post-author** module in **packages > editor > src > components >post-author** directory
- Change `author.name` to `decodeEntities(author.name)` on same file

## How has this been tested?
Tested on WordPress 4.9 using the dev build of this repu on xampp local environment

## Types of changes
- Single JS file change
- No related or non-related code or functionality have no change to be broken. 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
