### PR TITLE
Suppress the List block on Android

### DIFF
--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { Platform } from 'react-native';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -113,6 +118,11 @@ export const registerCoreBlocks = () => {
 		separator,
 		list,
 	].forEach( ( { metadata, name, settings } ) => {
+		// Don't register the List block on Android for now.
+		if (name == 'core/list' && Platform.OS === 'android') {
+			return;
+		}
+
 		registerBlockType( name, {
 			...metadata,
 			...settings,

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -119,7 +119,7 @@ export const registerCoreBlocks = () => {
 		list,
 	].forEach( ( { metadata, name, settings } ) => {
 		// Don't register the List block on Android for now.
-		if (name == 'core/list' && Platform.OS === 'android') {
+		if ( name === 'core/list' && Platform.OS === 'android' ) {
 			return;
 		}
 


### PR DESCRIPTION
## Description
This PR is open to track the `gbmobile/disable-list-block-on-android` branch, which disables the List block for Android only. We'll use this branch for the v1.3 release of gutenberg-mobile but we may choose not to merge it to master since we'll want to continue working/fixing the list block support on Android.

This PR is based on 0883192c5, which it the commit last used in the v1.3 release process for gutenberg-mobile.

## How has this been tested?
Using this gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/906

## Types of changes
Disable the registration of the List block but only for Android

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
