### PR TITLE
Try lowering the color classname specificity

### DIFF
--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -25,94 +25,91 @@
 @import "./verse/style.scss";
 @import "./video/style.scss";
 
-// Class names are doubled to increase specificity to assure colors take effect
-// over another base class color.
-
-.has-pale-pink-background-color.has-pale-pink-background-color {
+.has-pale-pink-background-color {
 	background-color: #f78da7;
 }
 
-.has-vivid-red-background-color.has-vivid-red-background-color {
+.has-vivid-red-background-color {
 	background-color: #cf2e2e;
 }
 
-.has-luminous-vivid-orange-background-color.has-luminous-vivid-orange-background-color {
+.has-luminous-vivid-orange-background-color {
 	background-color: #ff6900;
 }
 
-.has-luminous-vivid-amber-background-color.has-luminous-vivid-amber-background-color {
+.has-luminous-vivid-amber-background-color {
 	background-color: #fcb900;
 }
 
-.has-light-green-cyan-background-color.has-light-green-cyan-background-color {
+.has-light-green-cyan-background-color {
 	background-color: #7bdcb5;
 }
 
-.has-vivid-green-cyan-background-color.has-vivid-green-cyan-background-color {
+.has-vivid-green-cyan-background-color {
 	background-color: #00d084;
 }
 
-.has-pale-cyan-blue-background-color.has-pale-cyan-blue-background-color {
+.has-pale-cyan-blue-background-color {
 	background-color: #8ed1fc;
 }
 
-.has-vivid-cyan-blue-background-color.has-vivid-cyan-blue-background-color {
+.has-vivid-cyan-blue-background-color {
 	background-color: #0693e3;
 }
 
-.has-very-light-gray-background-color.has-very-light-gray-background-color {
+.has-very-light-gray-background-color {
 	background-color: #eee;
 }
 
-.has-cyan-bluish-gray-background-color.has-cyan-bluish-gray-background-color {
+.has-cyan-bluish-gray-background-color {
 	background-color: #abb8c3;
 }
 
-.has-very-dark-gray-background-color.has-very-dark-gray-background-color {
+.has-very-dark-gray-background-color {
 	background-color: #313131;
 }
 
-.has-pale-pink-color.has-pale-pink-color {
+.has-pale-pink-color {
 	color: #f78da7;
 }
 
-.has-vivid-red-color.has-vivid-red-color {
+.has-vivid-red-color {
 	color: #cf2e2e;
 }
 
-.has-luminous-vivid-orange-color.has-luminous-vivid-orange-color {
+.has-luminous-vivid-orange-color {
 	color: #ff6900;
 }
 
-.has-luminous-vivid-amber-color.has-luminous-vivid-amber-color {
+.has-luminous-vivid-amber-color {
 	color: #fcb900;
 }
 
-.has-light-green-cyan-color.has-light-green-cyan-color {
+.has-light-green-cyan-color {
 	color: #7bdcb5;
 }
 
-.has-vivid-green-cyan-color.has-vivid-green-cyan-color {
+.has-vivid-green-cyan-color {
 	color: #00d084;
 }
 
-.has-pale-cyan-blue-color.has-pale-cyan-blue-color {
+.has-pale-cyan-blue-color {
 	color: #8ed1fc;
 }
 
-.has-vivid-cyan-blue-color.has-vivid-cyan-blue-color {
+.has-vivid-cyan-blue-color {
 	color: #0693e3;
 }
 
-.has-very-light-gray-color.has-very-light-gray-color {
+.has-very-light-gray-color {
 	color: #eee;
 }
 
-.has-cyan-bluish-gray-color.has-cyan-bluish-gray-color {
+.has-cyan-bluish-gray-color {
 	color: #abb8c3;
 }
 
-.has-very-dark-gray-color.has-very-dark-gray-color {
+.has-very-dark-gray-color {
 	color: #313131;
 }
 


### PR DESCRIPTION
With recent changes to reduce the specificity of editor styles, it appears we no longer need the class doubling hack. Please test all the custom colors with a theme that does not specify its own color palette, i.e. you can't test with TwentyNineteen. Verify that colors look correct in the editing canvas, in the frontend. Try both button background colors, paragraph background colors, and any other blocks that uses these colors.

![Screenshot 2019-04-22 at 13 14 47](https://user-images.githubusercontent.com/1204802/56498195-f537f000-6500-11e9-8e46-0b227a179210.png)

![Screenshot 2019-04-22 at 13 14 51](https://user-images.githubusercontent.com/1204802/56498197-f6691d00-6500-11e9-9304-36b5776b6baf.png)

Fixes #12986.