### PR TITLE
[Mobile] Improving accessibility on Post title

### DIFF
--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -96,7 +96,6 @@ class PostTitle extends Component {
 					setRef={ ( ref ) => {
 						this.titleViewRef = ref;
 					} }
-					accessible={ false }
 				>
 				</RichText>
 			</View>

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -75,7 +75,7 @@ class PostTitle extends Component {
 			<View
 				style={ [ styles.titleContainer, borderStyle, { borderColor } ] }
 				accessible={ ! this.state.isSelected }
-				accessibilityLabel={ __( 'Post title' ) + '. ' + ( isEmpty( title ) ? __( 'Empty' ) : title ) }
+				accessibilityLabel={ sprintf( '%s %s%s', __( 'Post title' ), __( '.' ), ( isEmpty( title ) ? __( 'Empty' ) : title ) ) }
 			>
 				<RichText
 					tagName={ 'p' }
@@ -96,6 +96,7 @@ class PostTitle extends Component {
 					setRef={ ( ref ) => {
 						this.titleViewRef = ref;
 					} }
+					accessible={ false }
 				>
 				</RichText>
 			</View>

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -13,7 +13,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { withDispatch } from '@wordpress/data';
 import { withFocusOutside } from '@wordpress/components';
 import { withInstanceId, compose } from '@wordpress/compose';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -75,7 +75,7 @@ class PostTitle extends Component {
 			<View
 				style={ [ styles.titleContainer, borderStyle, { borderColor } ] }
 				accessible={ ! this.state.isSelected }
-				accessibilityLabel={ sprintf( '%s %s%s', __( 'Post title' ), __( '.' ), ( isEmpty( title ) ? __( 'Empty' ) : title ) ) }
+				accessibilityLabel={ sprintf( '%s%s %s', __( 'Post title' ), __( '.' ), ( isEmpty( title ) ? __( 'Empty' ) : title ) ) }
 			>
 				<RichText
 					tagName={ 'p' }

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { View } from 'react-native';
+import { isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -12,6 +13,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { withDispatch } from '@wordpress/data';
 import { withFocusOutside } from '@wordpress/components';
 import { withInstanceId, compose } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -70,7 +72,11 @@ class PostTitle extends Component {
 		const borderColor = this.state.isSelected ? focusedBorderColor : 'transparent';
 
 		return (
-			<View style={ [ styles.titleContainer, borderStyle, { borderColor } ] }>
+			<View
+				style={ [ styles.titleContainer, borderStyle, { borderColor } ] }
+				accessible={ ! this.state.isSelected }
+				accessibilityLabel={ __( 'Post title' ) + '. ' + ( isEmpty( title ) ? __( 'Empty' ) : title ) }
+			>
 				<RichText
 					tagName={ 'p' }
 					rootTagsToEliminate={ [ 'strong' ] }


### PR DESCRIPTION
## Description
This PR improves accessibility on the Post title.
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/912

To test:
Please refer to the [gutenberg-mobile side PR.](https://github.com/wordpress-mobile/gutenberg-mobile/pull/916)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->