### PR TITLE
Restore block movers to focus mode

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -397,7 +397,6 @@ export class BlockListBlock extends Component {
 						! isEmptyDefaultBlock;
 					// We render block movers and block settings to keep them tabbale even if hidden
 					const shouldRenderMovers =
-						! isFocusMode &&
 						( isSelected || hoverArea === 'left' ) &&
 						! showEmptyBlockSideInserter &&
 						! isPartOfMultiSelection &&

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -904,10 +904,6 @@
 	}
 }
 
-.block-editor-block-list__block.is-focus-mode:not(.is-multi-selected) > .block-editor-block-list__block-edit > .block-editor-block-contextual-toolbar {
-	margin-left: -$block-side-ui-width;
-}
-
 // Enable toolbar footprint collapsing
 .block-editor-block-contextual-toolbar {
 	// Position the contextual toolbar above the block.


### PR DESCRIPTION
Closes #14670. 

Currently Focus mode does not include a way to rearrange blocks. This PR corrects that by re-adding block movers to that mode. Conceptually, these seem fine to re-introduce because the movers shouldn't necessarily break your focus anyway: they only appear when you hover on a specific part of a block, and they fade away when you type. 

**Before:** 

<img width="484" alt="Screen Shot 2019-04-22 at 12 26 40 PM" src="https://user-images.githubusercontent.com/1202812/56511158-e568dd80-64f9-11e9-83e5-93059e3fca3b.png">


**After:**

<img width="443" alt="Screen Shot 2019-04-22 at 12 26 32 PM" src="https://user-images.githubusercontent.com/1202812/56511162-e7cb3780-64f9-11e9-82f4-7c7157cb38ce.png">
