### PR TITLE
Prevent block breadcrumb overlap with block movers for full/wide blocks

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -445,6 +445,11 @@
 				display: inline-flex;
 			}
 		}
+
+		// If the block movers are visible, push the breadcrumb down to make room for them.
+		.block-editor-block-mover.is-visible + .block-editor-block-list__breadcrumb {
+			top: (-$block-padding - $block-left-border-width - ($grid-size-small / 2));
+		}
 	}
 
 	// Wide


### PR DESCRIPTION
#14145 introduced a new left-side placement for the block breadcrumb. This worked great at first, but when #15022 reintroduced the block movers for wide and full blocks, we realized that the new breadcrumb location overlapped with the block movers. 

This PR is a potential fix for the overlap: it moves the block breadcrumb down slightly for full/wide blocks when the block movers are visible. It bumps right up against the block content itself, but I don't think this should actually cause any issues. 

**Before:** 

<img width="276" alt="Screen Shot 2019-04-22 at 2 14 53 PM" src="https://user-images.githubusercontent.com/1202812/56516653-0553cd80-6509-11e9-97df-6b9570e36f4c.png">


**After:**

<img width="277" alt="Screen Shot 2019-04-22 at 2 15 40 PM" src="https://user-images.githubusercontent.com/1202812/56516689-24eaf600-6509-11e9-9eb9-6b524e7fd77f.png">

![movers-after](https://user-images.githubusercontent.com/1202812/56516853-890dba00-6509-11e9-895f-cc4babf98d5c.gif)