### PR TITLE
'string' misspelled as 'srting'

### DIFF
--- a/packages/block-library/src/audio/transforms.js
+++ b/packages/block-library/src/audio/transforms.js
@@ -40,7 +40,7 @@ const transforms = {
 					},
 				},
 				autoplay: {
-					type: 'srting',
+					type: 'string',
 					shortcode: ( { named: { autoplay } } ) => {
 						return autoplay;
 					},


### PR DESCRIPTION
The `type` attribute for `autoplay` is misspelled as 'srting' instead of 'string'