### PR TITLE
Babel plugin JSX: Implement Fragment handling

### DIFF
--- a/packages/babel-plugin-import-jsx-pragma/CHANGELOG.md
+++ b/packages/babel-plugin-import-jsx-pragma/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.0 (unreleased)
+
+### Enhancement
+
+- Add Fragment import handling ([#15120](https://github.com/WordPress/gutenberg/pull/15120)).
+
 ## 2.0.0 (2019-03-06)
 
 ### Breaking Change
@@ -6,7 +12,7 @@
 
 ### Enhancement
 
-- Plugin skips now adding import JSX pragma when the scope variable is defined for all JSX elements ([#13809](https://github.com/WordPress/gutenberg/pull/13809)). 
+- Plugin skips now adding import JSX pragma when the scope variable is defined for all JSX elements ([#13809](https://github.com/WordPress/gutenberg/pull/13809)).
 
 ## 1.1.0 (2018-09-05)
 

--- a/packages/babel-plugin-import-jsx-pragma/CHANGELOG.md
+++ b/packages/babel-plugin-import-jsx-pragma/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.1.0 (unreleased)
 
-### Enhancement
+### New Feature
 
 - Add Fragment import handling ([#15120](https://github.com/WordPress/gutenberg/pull/15120)).
 

--- a/packages/babel-plugin-import-jsx-pragma/README.md
+++ b/packages/babel-plugin-import-jsx-pragma/README.md
@@ -44,11 +44,13 @@ module.exports = {
 	plugins: [
 		[ '@wordpress/babel-plugin-import-jsx-pragma', {
 			scopeVariable: 'createElement',
+			scopeVariableFrag: 'Fragment',
 			source: '@wordpress/element',
 			isDefault: false,
 		} ],
 		[ '@babel/transform-react-jsx', {
 			pragma: 'createElement',
+			pragmaFrag: 'Fragment',
 		} ],
 	],
 };
@@ -60,6 +62,12 @@ _Type:_ String
 
 Name of variable required to be in scope for use by the JSX pragma. For the default pragma of React.createElement, the React variable must be within scope.
 
+### `scopeVariableFrag`
+
+_Type:_ String
+
+Name of variable required to be in scope for `Fragment` (`<></>` or `<Fragment />`) JSX.
+
 ### `source`
 
 _Type:_ String
@@ -70,6 +78,7 @@ The module from which the scope variable is to be imported when missing.
 
 _Type:_ Boolean
 
-Whether the scopeVariable is the default import of the source module.
+Whether the scopeVariable is the default import of the source module. Note that this has no impact
+on `scopeVariableFrag`.
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/babel-plugin-import-jsx-pragma/README.md
+++ b/packages/babel-plugin-import-jsx-pragma/README.md
@@ -66,7 +66,8 @@ Name of variable required to be in scope for use by the JSX pragma. For the defa
 
 _Type:_ String
 
-Name of variable required to be in scope for `Fragment` (`<></>` or `<Fragment />`) JSX.
+Name of variable required to be in scope for `<></>` `Fragment` JSX. Named `<Fragment />` elements
+expect Fragment to be in scope and will not add the import.
 
 ### `source`
 

--- a/packages/babel-plugin-import-jsx-pragma/index.js
+++ b/packages/babel-plugin-import-jsx-pragma/index.js
@@ -60,9 +60,7 @@ module.exports = function( babel ) {
 					return;
 				}
 
-				if ( path.type === 'JSXFragment' ) {
-					state.hasUndeclaredScopeVariableFrag = ! path.scope.hasBinding( scopeVariableFrag );
-				}
+				state.hasUndeclaredScopeVariableFrag = ! path.scope.hasBinding( scopeVariableFrag );
 			},
 			Program: {
 				exit( path, state ) {

--- a/packages/babel-plugin-import-jsx-pragma/index.js
+++ b/packages/babel-plugin-import-jsx-pragma/index.js
@@ -55,7 +55,7 @@ module.exports = function( babel ) {
 				const { scopeVariable } = getOptions( state );
 				state.hasUndeclaredScopeVariable = ! path.scope.hasBinding( scopeVariable );
 			},
-			'JSXElement|JSXFragment'( path, state ) {
+			JSXFragment( path, state ) {
 				if ( state.hasUndeclaredScopeVariableFrag ) {
 					return;
 				}
@@ -65,10 +65,7 @@ module.exports = function( babel ) {
 					return;
 				}
 
-				if (
-					path.type === 'JSXFragment' ||
-					( path.type === 'JSXElement' && path.node.openingElement.name.name === 'Fragment' )
-				) {
+				if ( path.type === 'JSXFragment' ) {
 					state.hasUndeclaredScopeVariableFrag = ! path.scope.hasBinding( scopeVariableFrag );
 				}
 			},

--- a/packages/babel-plugin-import-jsx-pragma/index.js
+++ b/packages/babel-plugin-import-jsx-pragma/index.js
@@ -35,11 +35,6 @@ module.exports = function( babel ) {
 	function getOptions( state ) {
 		if ( ! state._options ) {
 			state._options = Object.assign( {}, DEFAULT_OPTIONS, state.opts );
-			if ( state._options.isDefault && state._options.scopeVariableFrag ) {
-				// eslint-disable-next-line no-console
-				console.warn( 'scopeVariableFrag is only available when isDefault is false' );
-				state._options.scopeVariableFrag = null;
-			}
 		}
 
 		return state._options;

--- a/packages/babel-plugin-import-jsx-pragma/test/index.js
+++ b/packages/babel-plugin-import-jsx-pragma/test/index.js
@@ -135,7 +135,7 @@ describe( 'babel-plugin-import-jsx-pragma', () => {
 		);
 	} );
 
-	it( 'adds Fragment import for Fragment', () => {
+	it( 'does not add Fragment import for <Fragment />', () => {
 		const original = 'let foo = <Fragment><bar /><baz /></Fragment>;';
 		const string = getTransformedCode( original, {
 			scopeVariable: 'createElement',
@@ -145,7 +145,7 @@ describe( 'babel-plugin-import-jsx-pragma', () => {
 		} );
 
 		expect( string ).toBe(
-			'import { createElement, Fragment } from "@wordpress/element";\nlet foo = <Fragment><bar /><baz /></Fragment>;'
+			'import { createElement } from "@wordpress/element";\nlet foo = <Fragment><bar /><baz /></Fragment>;'
 		);
 	} );
 } );

--- a/packages/babel-plugin-import-jsx-pragma/test/index.js
+++ b/packages/babel-plugin-import-jsx-pragma/test/index.js
@@ -9,18 +9,6 @@ import { transformSync } from '@babel/core';
 import plugin from '../';
 
 describe( 'babel-plugin-import-jsx-pragma', () => {
-	function getTransformedCode( source, options = {} ) {
-		const { code } = transformSync( source, {
-			configFile: false,
-			plugins: [
-				[ plugin, options ],
-				'@babel/plugin-syntax-jsx',
-			],
-		} );
-
-		return code;
-	}
-
 	it( 'does nothing if there is no jsx', () => {
 		const original = 'let foo;';
 		const string = getTransformedCode( original );
@@ -49,6 +37,13 @@ describe( 'babel-plugin-import-jsx-pragma', () => {
 		expect( string ).toBe( 'import React from "react";\n' + original );
 	} );
 
+	it( 'adds import for scope variable for Fragments', () => {
+		const original = 'let foo = <></>;';
+		const string = getTransformedCode( original );
+
+		expect( string ).toBe( 'import React from "react";\nlet foo = <></>;' );
+	} );
+
 	it( 'allows options customization', () => {
 		const original = 'let foo = <bar />;';
 		const string = getTransformedCode( original, {
@@ -61,7 +56,8 @@ describe( 'babel-plugin-import-jsx-pragma', () => {
 	} );
 
 	it( 'adds import for scope variable even when defined inside the local scope', () => {
-		const original = 'let foo = <bar />;\n\nfunction local() {\n  const createElement = wp.element.createElement;\n}';
+		const original =
+			'let foo = <bar />;\n\nfunction local() {\n  const createElement = wp.element.createElement;\n}';
 		const string = getTransformedCode( original, {
 			scopeVariable: 'createElement',
 			source: '@wordpress/element',
@@ -72,20 +68,93 @@ describe( 'babel-plugin-import-jsx-pragma', () => {
 	} );
 
 	it( 'does nothing if the outer scope variable is already defined when using custom options', () => {
-		const original = 'const {\n  createElement\n} = wp.element;\nlet foo = <bar />;';
+		const original =
+			'const {\n  createElement,\n  Fragment\n} = wp.element;\nlet foo = <><bar /></>;';
 		const string = getTransformedCode( original, {
 			scopeVariable: 'createElement',
+			scopeVariableFrag: 'Fragment',
+			source: '@wordpress/element',
+			isDefault: false,
 		} );
 
 		expect( string ).toBe( original );
+	} );
+
+	it( 'adds only Fragment when required', () => {
+		const original = 'const {\n  createElement\n} = wp.element;\nlet foo = <><bar /></>;';
+		const string = getTransformedCode( original, {
+			scopeVariable: 'createElement',
+			scopeVariableFrag: 'Fragment',
+			source: '@wordpress/element',
+			isDefault: false,
+		} );
+
+		expect( string ).toBe(
+			'import { Fragment } from "@wordpress/element";\nconst {\n  createElement\n} = wp.element;\nlet foo = <><bar /></>;'
+		);
+	} );
+
+	it( 'adds only createElement when required', () => {
+		const original = 'const {\n  Fragment\n} = wp.element;\nlet foo = <><bar /></>;';
+		const string = getTransformedCode( original, {
+			scopeVariable: 'createElement',
+			scopeVariableFrag: 'Fragment',
+			source: '@wordpress/element',
+			isDefault: false,
+		} );
+
+		expect( string ).toBe(
+			'import { createElement } from "@wordpress/element";\nconst {\n  Fragment\n} = wp.element;\nlet foo = <><bar /></>;'
+		);
 	} );
 
 	it( 'does nothing if the inner scope variable is already defined when using custom options', () => {
-		const original = '(function () {\n  const {\n    createElement\n  } = wp.element;\n  let foo = <bar />;\n})();';
+		const original =
+			'(function () {\n  const {\n    createElement\n  } = wp.element;\n  let foo = <bar />;\n})();';
 		const string = getTransformedCode( original, {
 			scopeVariable: 'createElement',
+			scopeVariableFrag: 'Fragment',
+			source: '@wordpress/element',
+			isDefault: false,
 		} );
 
 		expect( string ).toBe( original );
 	} );
+
+	it( 'adds Fragment as for <></>', () => {
+		const original = 'let foo = <><bar /><baz /></>;';
+		const string = getTransformedCode( original, {
+			scopeVariable: 'createElement',
+			scopeVariableFrag: 'Fragment',
+			source: '@wordpress/element',
+			isDefault: false,
+		} );
+
+		expect( string ).toBe(
+			'import { createElement, Fragment } from "@wordpress/element";\nlet foo = <><bar /><baz /></>;'
+		);
+	} );
+
+	it( 'adds Fragment import for Fragment', () => {
+		const original = 'let foo = <Fragment><bar /><baz /></Fragment>;';
+		const string = getTransformedCode( original, {
+			scopeVariable: 'createElement',
+			scopeVariableFrag: 'Fragment',
+			source: '@wordpress/element',
+			isDefault: false,
+		} );
+
+		expect( string ).toBe(
+			'import { createElement, Fragment } from "@wordpress/element";\nlet foo = <Fragment><bar /><baz /></Fragment>;'
+		);
+	} );
 } );
+
+function getTransformedCode( source, options = {} ) {
+	const { code } = transformSync( source, {
+		configFile: false,
+		plugins: [ [ plugin, options ], '@babel/plugin-syntax-jsx' ],
+	} );
+
+	return code;
+}

--- a/packages/babel-preset-default/CHANGELOG.md
+++ b/packages/babel-preset-default/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.1.0 (unreleased)
+
+### New Feature
+
+- Handle `<></>` JSX Fragments with `@wordpress/element` `Fragment` ([#15120](https://github.com/WordPress/gutenberg/pull/15120)).
+
 ## 4.0.0 (2019-03-06)
 
 ### Breaking Change

--- a/packages/babel-preset-default/index.js
+++ b/packages/babel-preset-default/index.js
@@ -58,12 +58,14 @@ module.exports = function( api ) {
 				require.resolve( '@wordpress/babel-plugin-import-jsx-pragma' ),
 				{
 					scopeVariable: 'createElement',
+					scopeVariableFrag: 'Fragment',
 					source: '@wordpress/element',
 					isDefault: false,
 				},
 			],
 			[ require.resolve( '@babel/plugin-transform-react-jsx' ), {
 				pragma: 'createElement',
+				pragmaFrag: 'Fragment',
 			} ],
 			require.resolve( '@babel/plugin-proposal-async-generator-functions' ),
 			maybeGetPluginTransformRuntime(),


### PR DESCRIPTION
Closes #12207

## Description

As described in #12207, the Babel plugin package that adds imports for JSX now handles Fragments as well:

```jsx
function MyComponent( props ) {
  return <>
    <h1>Hello!</h1>
    <h2>👋</h2>
  </>;
}

/* ⬇️ After transform ⬇️ */

import { createElement, Fragment } from '@wordpress/element';
function MyComponent( props ) {
  return <>
    <h1>Hello!</h1>
    <h2>👋</h2>
  </>;
}
```

Replace `<Fragment />` usage with `<>` and remove the `Fragment` imports where possible in the codebase. This may be better suited as a follow up PR.

## How has this been tested?
Includes additional tests.

## Types of changes
New feature: Add Fragment handling to the Babel plugin import JSX pragma package as outlined in #12207.

`<></>` will add a `Fragment` import if `scopeVariableFrag` is set and the import doesn't exist.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
