### PR TITLE
[Mobile]Improve accessibility on image block selected state

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -13,6 +13,7 @@ import {
 	requestImageFailedRetryDialog,
 	requestImageUploadCancelDialog,
 } from 'react-native-gutenberg-bridge';
+import { isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -394,7 +395,13 @@ class ImageEdit extends React.Component {
 						} }
 					</ImageSize>
 					{ ( ! RichText.isEmpty( caption ) > 0 || isSelected ) && (
-						<View style={ { padding: 12, flex: 1 } }>
+						<View
+							style={ { padding: 12, flex: 1 } }
+							accessible={ true }
+							accessibilityLabel={ __( 'Image caption' ) + __( '.' ) + ' ' + ( isEmpty( caption ) ? __( 'Empty' ) : caption ) }
+							accessibilityHint={ __( 'Double tap to edit caption' ) }
+							accessibilityRole={ 'button' }
+						>
 							<TextInput
 								style={ { textAlign: 'center' } }
 								fontFamily={ this.props.fontFamily || ( styles[ 'caption-text' ].fontFamily ) }

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -254,9 +254,10 @@ class ImageEdit extends React.Component {
 		const toolbarEditButton = (
 			<Toolbar>
 				<ToolbarButton
-					label={ __( 'Edit image' ) }
+					title={ __( 'Edit image' ) }
 					icon="edit"
 					onClick={ onMediaOptionsButtonPressed }
+					extraProps={ { hint: __( 'Double tap to edit image' ) } }
 				/>
 			</Toolbar>
 		);
@@ -343,9 +344,10 @@ class ImageEdit extends React.Component {
 					</BlockControls>
 					<InspectorControls>
 						<ToolbarButton
-							label={ __( 'Image Settings' ) }
+							title={ __( 'Image Settings' ) }
 							icon="admin-generic"
 							onClick={ onImageSettingsButtonPressed }
+							extraProps={ { hint: __( 'Double tap to open image settings' ) } }
 						/>
 					</InspectorControls>
 					<ImageSize src={ url } >

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -32,7 +32,7 @@ import {
 	BottomSheet,
 	Picker,
 } from '@wordpress/block-editor';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { isURL } from '@wordpress/url';
 import { doAction, hasAction } from '@wordpress/hooks';
 
@@ -331,7 +331,7 @@ class ImageEdit extends React.Component {
 		return (
 			<TouchableWithoutFeedback
 				accessible={ ! isSelected }
-				accessibilityLabel={ sprintf( '%s%s %s', __( 'Image block' ), __( '.' ), alt ) }
+				accessibilityLabel={ __( 'Image block' ) + __( '.' ) + ' ' + alt + __( '.' ) + ' ' + caption }
 				accessibilityRole={ 'button' }
 				onPress={ this.onImagePressed }
 				disabled={ ! isSelected }
@@ -378,7 +378,7 @@ class ImageEdit extends React.Component {
 										source={ { uri: url } }
 										key={ url }
 										accessible={ true }
-										accessibilityLabel={ __( 'Image' ) + __( '.' ) + ' ' + alt }
+										accessibilityLabel={ alt }
 									>
 										{ this.state.isUploadFailed &&
 											<View style={ styles.imageContainer } >

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -379,6 +379,8 @@ class ImageEdit extends React.Component {
 										resizeMethod="scale"
 										source={ { uri: url } }
 										key={ url }
+										accessible={ true }
+										accessibilityLabel={ __( 'Image' ) + __( '.' ) + ' ' + alt }
 									>
 										{ this.state.isUploadFailed &&
 											<View style={ styles.imageContainer } >

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -396,7 +396,6 @@ class ImageEdit extends React.Component {
 							style={ { padding: 12, flex: 1 } }
 							accessible={ true }
 							accessibilityLabel={ __( 'Image caption' ) + __( '.' ) + ' ' + ( isEmpty( caption ) ? __( 'Empty' ) : caption ) }
-							accessibilityHint={ __( 'Double tap to edit caption' ) }
 							accessibilityRole={ 'button' }
 						>
 							<TextInput

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -258,7 +258,6 @@ class ImageEdit extends React.Component {
 					title={ __( 'Edit image' ) }
 					icon="edit"
 					onClick={ onMediaOptionsButtonPressed }
-					extraProps={ { hint: __( 'Double tap to edit image' ) } }
 				/>
 			</Toolbar>
 		);
@@ -334,7 +333,6 @@ class ImageEdit extends React.Component {
 				accessible={ ! isSelected }
 				accessibilityLabel={ sprintf( '%s%s %s', __( 'Image block' ), __( '.' ), alt ) }
 				accessibilityRole={ 'button' }
-				accessibilityHint={ __( 'Double tap to edit the image' ) }
 				onPress={ this.onImagePressed }
 				disabled={ ! isSelected }
 			>
@@ -348,7 +346,6 @@ class ImageEdit extends React.Component {
 							title={ __( 'Image Settings' ) }
 							icon="admin-generic"
 							onClick={ onImageSettingsButtonPressed }
-							extraProps={ { hint: __( 'Double tap to open image settings' ) } }
 						/>
 					</InspectorControls>
 					<ImageSize src={ url } >


### PR DESCRIPTION
## Description
This PR improves accessibility on image block selected state.
Fixes part of: https://github.com/wordpress-mobile/gutenberg-mobile/issues/909

To test:
Please refer to the [gutenberg-mobile side PR.](https://github.com/wordpress-mobile/gutenberg-mobile/pull/920)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->