### PR TITLE
[Mobile]Paragraph - Add accessibility label for unselected state

### DIFF
--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { View } from 'react-native';
+import { isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -22,6 +23,12 @@ class ParagraphEdit extends Component {
 		super( props );
 		this.splitBlock = this.splitBlock.bind( this );
 		this.onReplace = this.onReplace.bind( this );
+		this.onFocus = this.onFocus.bind( this );
+		this.onBlur = this.onBlur.bind( this );
+
+		this.state = {
+			isSelected: false,
+		};
 	}
 
 	/**
@@ -81,6 +88,20 @@ class ParagraphEdit extends Component {
 		) ) );
 	}
 
+	onFocus() {
+		this.setState( { isSelected: true } );
+		if ( this.props.onFocus ) {
+			this.props.onFocus();
+		}
+	}
+
+	onBlur() {
+		this.setState( { isSelected: false } );
+		if ( this.props.onBlur ) {
+			this.props.onBlur();
+		}
+	}
+
 	render() {
 		const {
 			attributes,
@@ -95,13 +116,16 @@ class ParagraphEdit extends Component {
 		} = attributes;
 
 		return (
-			<View>
+			<View
+				accessible={ ! this.state.isSelected }
+				accessibilityLabel={ __( 'Paragraph block' ) + __( '.' ) + ' ' + ( isEmpty( content ) ? __( 'Empty' ) : content ) }
+			>
 				<RichText
 					tagName="p"
 					value={ content }
 					isSelected={ this.props.isSelected }
-					onFocus={ this.props.onFocus } // always assign onFocus as a props
-					onBlur={ this.props.onBlur } // always assign onBlur as a props
+					onFocus={ this.onFocus }
+					onBlur={ this.onBlur }
 					onCaretVerticalPositionChange={ this.props.onCaretVerticalPositionChange }
 					style={ style }
 					onChange={ ( nextContent ) => {

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -11,6 +11,7 @@ import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { createBlock } from '@wordpress/blocks';
 import { RichText } from '@wordpress/block-editor';
+import { create } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
@@ -23,12 +24,6 @@ class ParagraphEdit extends Component {
 		super( props );
 		this.splitBlock = this.splitBlock.bind( this );
 		this.onReplace = this.onReplace.bind( this );
-		this.onFocus = this.onFocus.bind( this );
-		this.onBlur = this.onBlur.bind( this );
-
-		this.state = {
-			isSelected: false,
-		};
 	}
 
 	/**
@@ -88,18 +83,12 @@ class ParagraphEdit extends Component {
 		) ) );
 	}
 
-	onFocus() {
-		this.setState( { isSelected: true } );
-		if ( this.props.onFocus ) {
-			this.props.onFocus();
+	plainTextContent( html ) {
+		const result = create( { html } );
+		if ( result ) {
+			return result.text;
 		}
-	}
-
-	onBlur() {
-		this.setState( { isSelected: false } );
-		if ( this.props.onBlur ) {
-			this.props.onBlur();
-		}
+		return '';
 	}
 
 	render() {
@@ -117,15 +106,16 @@ class ParagraphEdit extends Component {
 
 		return (
 			<View
-				accessible={ ! this.state.isSelected }
-				accessibilityLabel={ __( 'Paragraph block' ) + __( '.' ) + ' ' + ( isEmpty( content ) ? __( 'Empty' ) : content ) }
+				accessible={ ! this.props.isSelected }
+				accessibilityLabel={ __( 'Paragraph block' ) + __( '.' ) + ' ' + ( isEmpty( content ) ? __( 'Empty' ) : this.plainTextContent( content ) ) }
+				onAccessibilityTap={ this.props.onFocus }
 			>
 				<RichText
 					tagName="p"
 					value={ content }
 					isSelected={ this.props.isSelected }
-					onFocus={ this.onFocus }
-					onBlur={ this.onBlur }
+					onFocus={ this.props.onFocus } // always assign onFocus as a props
+					onBlur={ this.props.onBlur } // always assign onBlur as a props
 					onCaretVerticalPositionChange={ this.props.onCaretVerticalPositionChange }
 					style={ style }
 					onChange={ ( nextContent ) => {


### PR DESCRIPTION
## Description
This PR improves accessibility on image block selected state.
Fixes part of https://github.com/wordpress-mobile/gutenberg-mobile/issues/907

To test:
Please refer to the [gutenberg-mobile side PR.](https://github.com/wordpress-mobile/gutenberg-mobile/pull/923)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->