### PR TITLE
autop: Correctly preserve attributed multi-line paragraphs in removep

### DIFF
--- a/packages/autop/CHANGELOG.md
+++ b/packages/autop/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### Bug Fix
+
+- `removep` will correctly preserve multi-line paragraph tags where attributes are present.
+
 ## 2.1.0 (2019-03-06)
 
 ### Bug Fix

--- a/packages/autop/src/index.js
+++ b/packages/autop/src/index.js
@@ -343,7 +343,7 @@ export function removep( html ) {
 	html = html.replace( new RegExp( '\\s*<((?:' + blocklist1 + ')(?: [^>]*)?)>', 'g' ), '\n<$1>' );
 
 	// Mark </p> if it has any attributes.
-	html = html.replace( /(<p [^>]+>.*?)<\/p>/g, '$1</p#>' );
+	html = html.replace( /(<p [^>]+>[\s\S]*?)<\/p>/g, '$1</p#>' );
 
 	// Preserve the first <p> inside a <div>.
 	html = html.replace( /<div( [^>]*)?>\s*<p>/gi, '<div$1>\n\n' );

--- a/packages/autop/src/test/index.test.js
+++ b/packages/autop/src/test/index.test.js
@@ -3,6 +3,7 @@
  */
 import {
 	autop,
+	removep,
 } from '../';
 
 test( 'empty string', () => {
@@ -501,4 +502,13 @@ test( 'that autop correctly adds a start and end tag when followed by a div', ()
 	const expected = '<p>Testing autop with a div</p>\n<div class="wp-some-class">content</div>';
 
 	expect( autop( content ).trim() ).toBe( expected );
+} );
+
+describe( 'removep', () => {
+	test( 'preserves paragraphs with attributes', () => {
+		const content = '<p style="text-align: center">\nHello World\n</p>';
+		const expected = '<p style="text-align: center">\nHello World</p>';
+
+		expect( removep( content ) ).toBe( expected );
+	} );
 } );


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/issues/9056#issuecomment-485885555

This pull request seeks to resolve an issue where `removep` will wrongly remove a paragraph tag when it has attributes, if the paragraph spans multiple lines. As described in https://github.com/WordPress/gutenberg/issues/9056#issuecomment-485885555, this occurs because the default behavior of `.` in JavaScript regular expressions will not match newline characters.

_Before:_

```js
removep( '<p style="text-align: center">\nHello World\n</p>' );
// '<p style="text-align: center">\nHello World'
```

_After:_

```js
removep( '<p style="text-align: center">\nHello World\n</p>' );
// '<p style="text-align: center">\nHello World</p>'
```

**Testing Instructions:**

Ensure unit tests pass.

Verify that content is not mangled when multi-line paragraph in a classic block (i.e. in non-block-demarcated content).

1. Navigate to Posts > Add New
2. Switch to Code Editor
3. In the text field, paste:

```html
<p style="text-align: center">
Hello World
</p>
```

4. Blur the text field
5. Observe that text is not mangled
   - The trailing newline preceding the closing tag will be omitted. This had existed in the source implementation, and could likely be preserved, though it seemed incidental to the primary bug.