### PR TITLE
autop: Use placeholders to protect script, style tags

### DIFF
--- a/packages/autop/CHANGELOG.md
+++ b/packages/autop/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug Fix
 
-- `autop` will correctly avoid adding `br` and `p` elements within `script` and `style` tags.
+- `autop` will correctly avoid adding `br` and `p` elements within `script`, `style`, and `svg` tags.
 
 ## 2.3.0 (2019-05-21)
 

--- a/packages/autop/CHANGELOG.md
+++ b/packages/autop/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### Bug Fix
+
+- `autop` will correctly avoid adding `br` and `p` elements within `script` and `style` tags.
+
 ## 2.3.0 (2019-05-21)
 
 ### Bug Fix

--- a/packages/autop/src/index.js
+++ b/packages/autop/src/index.js
@@ -192,7 +192,8 @@ export function autop( text, br = true ) {
 	// Change multiple <br>s into two line breaks, which will turn into paragraphs.
 	text = text.replace( /<br\s*\/?>\s*<br\s*\/?>/g, '\n\n' );
 
-	const allBlocks = '(?:table|thead|tfoot|caption|col|colgroup|tbody|tr|td|th|div|dl|dd|dt|ul|ol|li|pre|form|map|area|blockquote|address|math|style|script|p|h[1-6]|hr|fieldset|legend|section|article|aside|hgroup|header|footer|nav|figure|figcaption|details|menu|summary)';
+	const allBlocks = '(?:table|thead|tfoot|caption|col|colgroup|tbody|tr|td|th|div|dl|dd|dt|ul|ol|li|pre|form|map|area|blockquote|address|math|p|h[1-6]|hr|fieldset|legend|section|article|aside|hgroup|header|footer|nav|figure|figcaption|details|menu|summary)';
+	const unwrapTags = '(?:' + allBlocks + '|script|style)';
 
 	// Add a double line break above block-level opening tags.
 	text = text.replace( new RegExp( '(<' + allBlocks + '[\\s\/>])', 'g' ), '\n\n$1' );
@@ -259,7 +260,7 @@ export function autop( text, br = true ) {
 	text = text.replace( /<p>([^<]+)<\/(div|address|form)>/g, '<p>$1</p></$2>' );
 
 	// If an opening or closing block element tag is wrapped in a <p>, unwrap it.
-	text = text.replace( new RegExp( '<p>\\s*(<\/?' + allBlocks + '[^>]*>)\\s*<\/p>', 'g' ), '$1' );
+	text = text.replace( new RegExp( '<p>\\s*(<\/?' + unwrapTags + '[^>]*>)\\s*<\/p>', 'g' ), '$1' );
 
 	// In some cases <li> may get wrapped in <p>, fix them.
 	text = text.replace( /<p>(<li.+?)<\/p>/g, '$1' );
@@ -269,10 +270,10 @@ export function autop( text, br = true ) {
 	text = text.replace( /<\/blockquote><\/p>/g, '</p></blockquote>' );
 
 	// If an opening or closing block element tag is preceded by an opening <p> tag, remove it.
-	text = text.replace( new RegExp( '<p>\\s*(<\/?' + allBlocks + '[^>]*>)', 'g' ), '$1' );
+	text = text.replace( new RegExp( '<p>\\s*(<\/?' + unwrapTags + '[^>]*>)', 'g' ), '$1' );
 
 	// If an opening or closing block element tag is followed by a closing <p> tag, remove it.
-	text = text.replace( new RegExp( '(<\/?' + allBlocks + '[^>]*>)\\s*<\/p>', 'g' ), '$1' );
+	text = text.replace( new RegExp( '(<\/?' + unwrapTags + '[^>]*>)\\s*<\/p>', 'g' ), '$1' );
 
 	// Optionally insert line breaks.
 	if ( br ) {
@@ -284,7 +285,7 @@ export function autop( text, br = true ) {
 	}
 
 	// If a <br /> tag is after an opening or closing block tag, remove it.
-	text = text.replace( new RegExp( '(<\/?' + allBlocks + '[^>]*>)\\s*<br \/>', 'g' ), '$1' );
+	text = text.replace( new RegExp( '(<\/?' + unwrapTags + '[^>]*>)\\s*<br \/>', 'g' ), '$1' );
 
 	// If a <br /> tag is before a subset of opening or closing block tags, remove it.
 	text = text.replace( /<br \/>(\s*<\/?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)[^>]*>)/g, '$1' );

--- a/packages/autop/src/index.js
+++ b/packages/autop/src/index.js
@@ -187,13 +187,13 @@ export function autop( text, br = true ) {
 	text = text + '\n';
 
 	let tags;
-	( { text, tags } = addTagPlaceholders( text, [ 'pre', 'script', 'style' ] ) );
+	( { text, tags } = addTagPlaceholders( text, [ 'pre', 'script', 'style', 'svg' ] ) );
 
 	// Change multiple <br>s into two line breaks, which will turn into paragraphs.
 	text = text.replace( /<br\s*\/?>\s*<br\s*\/?>/g, '\n\n' );
 
 	const allBlocks = '(?:table|thead|tfoot|caption|col|colgroup|tbody|tr|td|th|div|dl|dd|dt|ul|ol|li|pre|form|map|area|blockquote|address|math|p|h[1-6]|hr|fieldset|legend|section|article|aside|hgroup|header|footer|nav|figure|figcaption|details|menu|summary)';
-	const unwrapTags = '(?:' + allBlocks + '|script|style)';
+	const unwrapTags = '(?:' + allBlocks + '|script|style|svg)';
 
 	// Add a double line break above block-level opening tags.
 	text = text.replace( new RegExp( '(<' + allBlocks + '[\\s\/>])', 'g' ), '\n\n$1' );

--- a/packages/autop/src/test/index.test.js
+++ b/packages/autop/src/test/index.test.js
@@ -86,6 +86,23 @@ done = 0;
 	expect( autop( str ).trim() ).toBe( expected );
 } );
 
+test( 'skip script/style elements', () => {
+	// Not wrapped in <p> tags
+	const str = `<script>
+(function(){
+
+done = 0;
+});</script>
+<style>
+.example {
+
+	color: red;
+}
+</style>`;
+
+	expect( autop( str ).trim() ).toBe( str );
+} );
+
 test( 'skip input elements', () => {
 	const str = 'Username: <input type="text" id="username" name="username" /><br />Password: <input type="password" id="password1" name="password1" />';
 	expect( autop( str ).trim() ).toBe( '<p>' + str + '</p>' );

--- a/packages/autop/src/test/index.test.js
+++ b/packages/autop/src/test/index.test.js
@@ -103,6 +103,12 @@ done = 0;
 	expect( autop( str ).trim() ).toBe( str );
 } );
 
+test( 'avoid pulling out inline script', () => {
+	const str = '<p>This is <script>console.log();</script> some text.</p>';
+
+	expect( autop( str ).trim() ).toBe( str );
+} );
+
 test( 'skip input elements', () => {
 	const str = 'Username: <input type="text" id="username" name="username" /><br />Password: <input type="password" id="password1" name="password1" />';
 	expect( autop( str ).trim() ).toBe( '<p>' + str + '</p>' );
@@ -298,7 +304,6 @@ test( 'that_autop_treats_block_level_elements_as_blocks', () => {
 		'area',
 		'address',
 		'math',
-		'style',
 		'p',
 		'h1',
 		'h2',

--- a/packages/autop/src/test/index.test.js
+++ b/packages/autop/src/test/index.test.js
@@ -86,21 +86,44 @@ done = 0;
 	expect( autop( str ).trim() ).toBe( expected );
 } );
 
-test( 'skip script/style elements', () => {
-	// Not wrapped in <p> tags
-	const str = `<script>
+describe( 'exempt tags', () => {
+	it.each( [
+		[
+			'script',
+			`<script>
 (function(){
 
 done = 0;
-});</script>
-<style>
+});</script>`,
+		],
+		[
+			'style',
+			`<style>
 .example {
 
 	color: red;
 }
-</style>`;
-
-	expect( autop( str ).trim() ).toBe( str );
+</style>`,
+		],
+		[
+			'pre',
+			`<pre>
+body {
+	background-color: blue;
+}
+</pre>`,
+		],
+		[
+			'svg',
+			`<svg xmlns="http://www.w3.org/2000/svg">
+<circle cx="50" cy="50" r="30" fill="blue">
+<animateTransform attributeName="transform" type="scale" to="1.5" dur="2s" fill="freeze"/>
+</circle>
+</svg>`,
+		],
+	] )( '%s', ( _tagName, str ) => {
+		expect( autop( str ).trim() ).toBe( str );
+	} );
 } );
 
 test( 'avoid pulling out inline script', () => {


### PR DESCRIPTION
Fixes #9056
Related: https://core.trac.wordpress.org/ticket/2833#comment:19

This pull request seeks to resolve an issue with the `autop` implementation where `br` and `p` elements are added within the contents of a `script` or `style` tag. It also avoids adding a wrapping `p` to `script` tags (already present for `style`).

The underlying issue is described at https://github.com/WordPress/gutenberg/issues/9056#issuecomment-485885555 . While one possible solution would have been to fix the incorrectly-ported regular expression backreference, it would have left the remaining issue of paragraphs being added within the elements. For that reason, and inspired by prior art by @cmmarslender at [Trac#2833](https://core.trac.wordpress.org/ticket/2833#comment:19), the solution here extends the approach used for `pre` tag placeholder substitution to apply to `style` and `script` tags as well.

**Testing Instructions:**

Repeat steps to reproduce from #9056, verifying that neither `br` nor `p` tags are inserted within the contents of a post consisting only of this content (i.e. no blocks content, equivalent to a pre-WordPress 5.0 post).

Ensure unit tests pass:

```
npm run test-unit packages/autop
```