### PR TITLE
Editor: Display trash button only if user has delete capability

### DIFF
--- a/packages/editor/src/components/post-trash/check.js
+++ b/packages/editor/src/components/post-trash/check.js
@@ -3,8 +3,8 @@
  */
 import { withSelect } from '@wordpress/data';
 
-function PostTrashCheck( { isNew, postId, children } ) {
-	if ( isNew || ! postId ) {
+function PostTrashCheck( { canUserTrash, isNew, postId, children } ) {
+	if ( ! canUserTrash || isNew || ! postId ) {
 		return null;
 	}
 
@@ -13,8 +13,12 @@ function PostTrashCheck( { isNew, postId, children } ) {
 
 export default withSelect( ( select ) => {
 	const { isEditedPostNew, getCurrentPostId } = select( 'core/editor' );
+	const { canUser } = select( 'core' );
+	const postId = getCurrentPostId();
+
 	return {
 		isNew: isEditedPostNew(),
-		postId: getCurrentPostId(),
+		canUserTrash: !! postId && canUser( 'delete', 'posts', postId ),
+		postId,
 	};
 } )( PostTrashCheck );

--- a/packages/editor/src/components/post-trash/index.js
+++ b/packages/editor/src/components/post-trash/index.js
@@ -3,37 +3,37 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { withDispatch } from '@wordpress/data';
 
-function PostTrash( { isNew, postId, postType, ...props } ) {
-	if ( isNew || ! postId ) {
-		return null;
-	}
+/**
+ * Internal dependencies
+ */
+import PostTrashCheck from './check';
 
-	const onClick = () => props.trashPost( postId, postType );
-
+function PostTrash( { trashPost } ) {
 	return (
-		<Button className="editor-post-trash button-link-delete" onClick={ onClick } isDefault isLarge>
-			{ __( 'Move to Trash' ) }
-		</Button>
+		<PostTrashCheck>
+			<Button
+				onClick={ trashPost }
+				isDefault
+				isLarge
+				className="editor-post-trash button-link-delete"
+			>
+				{ __( 'Move to Trash' ) }
+			</Button>
+		</PostTrashCheck>
 	);
 }
 
-export default compose( [
-	withSelect( ( select ) => {
-		const {
-			isEditedPostNew,
-			getCurrentPostId,
-			getCurrentPostType,
-		} = select( 'core/editor' );
-		return {
-			isNew: isEditedPostNew(),
-			postId: getCurrentPostId(),
-			postType: getCurrentPostType(),
-		};
-	} ),
-	withDispatch( ( dispatch ) => ( {
-		trashPost: dispatch( 'core/editor' ).trashPost,
-	} ) ),
-] )( PostTrash );
+export default withDispatch( ( dispatch, ownProps, registry ) => {
+	const { trashPost } = dispatch( 'core/editor' );
+
+	return {
+		trashPost() {
+			const { postId } = ownProps;
+			const { getCurrentPostType } = registry.select( 'core/editor' );
+			const postType = getCurrentPostType();
+			trashPost( postId, postType );
+		},
+	};
+} )( PostTrash );


### PR DESCRIPTION
Fixes #14828 

This pull request seeks to resolve an issue where the "Move to Trash" button is shown even if the user does not have the correct capabilities to be able to trash the post.

**Implementation notes:**

I followed the suggested implementation from @talldan at https://github.com/wordPress/gutenberg/issues/14828#issuecomment-480149595 . I could not encounter the same issued described from the comment there with respect to a 403 (Forbidden) response. @talldan could you check to see if the issue is present here, and if so, elaborate on the instructions to reproduce it?

**Testing Instructions:**

Repeat Steps to Reproduce from #14828, verifying that the Move to Trash button is only shown when the user has capabilities to delete the post.