### PR TITLE
Update to Babel 7.4 and core-js 3

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,35 +38,6 @@ module.exports = {
 				message: 'Deprecated functions must be removed before releasing this version.',
 			},
 			{
-				// Builds a selector which handles CallExpression with path
-				// argument at varied position by function.
-				//
-				// See: https://github.com/WordPress/gutenberg/pull/9615
-				selector: map( {
-					1: [
-						'property',
-						'matchesProperty',
-						'path',
-					],
-					2: [
-						'invokeMap',
-						'get',
-						'has',
-						'hasIn',
-						'invoke',
-						'result',
-						'set',
-						'setWith',
-						'unset',
-						'update',
-						'updateWith',
-					],
-				}, ( functionNames, argPosition ) => (
-					`CallExpression[callee.name=/^(${ functionNames.join( '|' ) })$/] > Literal:nth-child(${ argPosition })`
-				) ).join( ',' ),
-				message: 'Always pass an array as the path argument',
-			},
-			{
 				selector: 'CallExpression[callee.name=/^(__|_x|_n|_nx)$/] Literal[value=/\\.{3}/]',
 				message: 'Use ellipsis character (…) in place of three dots',
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,47 +35,6 @@
 				"source-map": "^0.5.0"
 			},
 			"dependencies": {
-				"@babel/generator": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
-					"integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.4.0",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.17.11",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.4.3",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
-					"integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
-					"dev": true
-				},
-				"@babel/template": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
-					"integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/parser": "^7.4.0",
-						"@babel/types": "^7.4.0"
-					}
-				},
-				"@babel/types": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
-					"integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.11",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
 				"debug": {
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -109,14 +68,14 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.3.2",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.2.tgz",
-			"integrity": "sha512-f3QCuPppXxtZOEm5GWPra/uYUjmNQlu9pbAD8D/9jze4pTY83rTtB1igTBSwvkeNlC5gR24zFFkz+2WHLFQhqQ==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+			"integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.3.2",
+				"@babel/types": "^7.4.0",
 				"jsesc": "^2.5.1",
-				"lodash": "^4.17.10",
+				"lodash": "^4.17.11",
 				"source-map": "^0.5.0",
 				"trim-right": "^1.0.1"
 			}
@@ -151,25 +110,25 @@
 			}
 		},
 		"@babel/helper-call-delegate": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.1.0.tgz",
-			"integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.0.tgz",
+			"integrity": "sha512-SdqDfbVdNQCBp3WhK2mNdDvHd3BD6qbmIc43CAyjnsfCmgHMeqgDcM3BzY2lchi7HBJGJ2CVdynLWbezaE4mmQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.0.0",
-				"@babel/traverse": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/helper-hoist-variables": "^7.4.0",
+				"@babel/traverse": "^7.4.0",
+				"@babel/types": "^7.4.0"
 			}
 		},
 		"@babel/helper-define-map": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz",
-			"integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.0.tgz",
+			"integrity": "sha512-wAhQ9HdnLIywERVcSvX40CEJwKdAa1ID4neI9NXQPDOHwwA+57DqwLiPEVy2AIyWzAk0CQ8qx4awO0VUURwLtA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
-				"@babel/types": "^7.0.0",
-				"lodash": "^4.17.10"
+				"@babel/types": "^7.4.0",
+				"lodash": "^4.17.11"
 			}
 		},
 		"@babel/helper-explode-assignable-expression": {
@@ -203,12 +162,12 @@
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz",
-			"integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.0.tgz",
+			"integrity": "sha512-/NErCuoe/et17IlAQFKWM24qtyYYie7sFIrW/tIQXpck6vAu2hhtYYsKLBWQV+BQZMbcIYPU/QMYuTufrY4aQw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/types": "^7.4.0"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
@@ -230,9 +189,9 @@
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.2.2.tgz",
-			"integrity": "sha512-YRD7I6Wsv+IHuTPkAmAS4HhY0dkPobgLftHp0cRGZSdrRvmZY8rFvae/GVu3bD00qscuvK3WPHB3YdNpBXUqrA==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.3.tgz",
+			"integrity": "sha512-H88T9IySZW25anu5uqyaC1DaQre7ofM+joZtAaO2F8NBdFfupH0SZ4gKjgSFVcvtx/aAirqA9L9Clio2heYbZA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
@@ -240,7 +199,7 @@
 				"@babel/helper-split-export-declaration": "^7.0.0",
 				"@babel/template": "^7.2.2",
 				"@babel/types": "^7.2.2",
-				"lodash": "^4.17.10"
+				"lodash": "^4.17.11"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
@@ -259,12 +218,12 @@
 			"dev": true
 		},
 		"@babel/helper-regex": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
-			"integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.3.tgz",
+			"integrity": "sha512-hnoq5u96pLCfgjXuj8ZLX3QQ+6nAulS+zSgi6HulUwFbEruRAKwbGLU5OvXkE14L8XW6XsQEKsIDfgthKLRAyA==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.10"
+				"lodash": "^4.17.11"
 			}
 		},
 		"@babel/helper-remap-async-to-generator": {
@@ -281,15 +240,15 @@
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.2.3.tgz",
-			"integrity": "sha512-GyieIznGUfPXPWu0yLS6U55Mz67AZD9cUk0BfirOWlPrXlBcan9Gz+vHGz+cPfuoweZSnPzPIm67VtQM0OWZbA==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.0.tgz",
+			"integrity": "sha512-PVwCVnWWAgnal+kJ+ZSAphzyl58XrFeSKSAJRiqg5QToTsjL+Xu1f9+RJ+d+Q0aPhPfBGaYfkox66k86thxNSg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-member-expression-to-functions": "^7.0.0",
 				"@babel/helper-optimise-call-expression": "^7.0.0",
-				"@babel/traverse": "^7.2.3",
-				"@babel/types": "^7.0.0"
+				"@babel/traverse": "^7.4.0",
+				"@babel/types": "^7.4.0"
 			}
 		},
 		"@babel/helper-simple-access": {
@@ -303,12 +262,12 @@
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
-			"integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+			"integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/types": "^7.4.0"
 			}
 		},
 		"@babel/helper-wrap-function": {
@@ -332,36 +291,6 @@
 				"@babel/template": "^7.4.0",
 				"@babel/traverse": "^7.4.3",
 				"@babel/types": "^7.4.0"
-			},
-			"dependencies": {
-				"@babel/parser": {
-					"version": "7.4.3",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
-					"integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
-					"dev": true
-				},
-				"@babel/template": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
-					"integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/parser": "^7.4.0",
-						"@babel/types": "^7.4.0"
-					}
-				},
-				"@babel/types": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
-					"integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.11",
-						"to-fast-properties": "^2.0.0"
-					}
-				}
 			}
 		},
 		"@babel/highlight": {
@@ -376,9 +305,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.3.2",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.2.tgz",
-			"integrity": "sha512-QzNUC2RO1gadg+fs21fi0Uu0OuGNzRKEmgCxoLNzbCdoprLwjfmZwzUrpUNfJPaVRwBpDY47A17yYEGWyRelnQ==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
+			"integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
 			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
@@ -403,9 +332,9 @@
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.3.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.2.tgz",
-			"integrity": "sha512-DjeMS+J2+lpANkYLLO+m6GjoTMygYglKmRe6cDTbFv3L9i6mmiE8fe6B8MtCSLZpVXscD5kn7s6SgtHrDoBWoA==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.3.tgz",
+			"integrity": "sha512-xC//6DNSSHVjq8O2ge0dyYlhshsH4T7XdCVoxbi5HzLYWfsC5ooFlJjrXk8RcAT+hjHAK9UjBXdylzSoDK3t4g==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -423,14 +352,14 @@
 			}
 		},
 		"@babel/plugin-proposal-unicode-property-regex": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.2.0.tgz",
-			"integrity": "sha512-LvRVYb7kikuOtIoUeWTkOxQEV1kYvL5B6U3iWEGCzPNRus1MzJweFqORTj+0jkxozkTSYNJozPOddxmqdqsRpw==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.0.tgz",
+			"integrity": "sha512-h/KjEZ3nK9wv1P1FSNb9G079jXrNYR0Ko+7XkOx85+gM24iZbPn0rh4vCftk+5QKY7y1uByFataBTmX7irEF1w==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.0.0",
-				"regexpu-core": "^4.2.0"
+				"regexpu-core": "^4.5.4"
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
@@ -497,9 +426,9 @@
 			}
 		},
 		"@babel/plugin-transform-async-to-generator": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.2.0.tgz",
-			"integrity": "sha512-CEHzg4g5UraReozI9D4fblBYABs7IM6UerAVG7EJVrTLC5keh00aEuLUT+O40+mJCEzaXkYfTCUKIyeDfMOFFQ==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.0.tgz",
+			"integrity": "sha512-EeaFdCeUULM+GPFEsf7pFcNSxM7hYjoj5fiYbyuiXobW4JhFnjAv9OWzNwHyHcKoPNpAfeRDuW6VyaXEDUBa7g==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
@@ -517,28 +446,28 @@
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.2.0.tgz",
-			"integrity": "sha512-vDTgf19ZEV6mx35yiPJe4fS02mPQUUcBNwWQSZFXSzTSbsJFQvHt7DqyS3LK8oOWALFOsJ+8bbqBgkirZteD5Q==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.0.tgz",
+			"integrity": "sha512-AWyt3k+fBXQqt2qb9r97tn3iBwFpiv9xdAiG+Gr2HpAZpuayvbL55yWrsV3MyHvXk/4vmSiedhDRl1YI2Iy5nQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"lodash": "^4.17.10"
+				"lodash": "^4.17.11"
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.2.2.tgz",
-			"integrity": "sha512-gEZvgTy1VtcDOaQty1l10T3jQmJKlNVxLDCs+3rCVPr6nMkODLELxViq5X9l+rfxbie3XrfrMCYYY6eX3aOcOQ==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.3.tgz",
+			"integrity": "sha512-PUaIKyFUDtG6jF5DUJOfkBdwAS/kFFV3XFk7Nn0a6vR7ZT8jYw5cGtIlat77wcnd0C6ViGqo/wyNf4ZHytF/nQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.0.0",
-				"@babel/helper-define-map": "^7.1.0",
+				"@babel/helper-define-map": "^7.4.0",
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/helper-optimise-call-expression": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.1.0",
-				"@babel/helper-split-export-declaration": "^7.0.0",
+				"@babel/helper-replace-supers": "^7.4.0",
+				"@babel/helper-split-export-declaration": "^7.4.0",
 				"globals": "^11.1.0"
 			}
 		},
@@ -552,23 +481,23 @@
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.3.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.3.2.tgz",
-			"integrity": "sha512-Lrj/u53Ufqxl/sGxyjsJ2XNtNuEjDyjpqdhMNh5aZ+XFOdThL46KBj27Uem4ggoezSYBxKWAil6Hu8HtwqesYw==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.3.tgz",
+			"integrity": "sha512-rVTLLZpydDFDyN4qnXdzwoVpk1oaXHIvPEOkOLyr88o7oHxVc/LyrnDx+amuBWGOwUb7D1s/uLsKBNTx08htZg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.2.0.tgz",
-			"integrity": "sha512-sKxnyHfizweTgKZf7XsXu/CNupKhzijptfTM+bozonIuyVrLWVUvYjE2bhuSBML8VQeMxq4Mm63Q9qvcvUcciQ==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.3.tgz",
+			"integrity": "sha512-9Arc2I0AGynzXRR/oPdSALv3k0rM38IMFyto7kOCwb5F9sLUt2Ykdo3V9yUPR+Bgr4kb6bVEyLkPEiBhzcTeoA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.0.0",
-				"regexpu-core": "^4.1.3"
+				"@babel/helper-regex": "^7.4.3",
+				"regexpu-core": "^4.5.4"
 			}
 		},
 		"@babel/plugin-transform-duplicate-keys": {
@@ -601,18 +530,18 @@
 			}
 		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.2.0.tgz",
-			"integrity": "sha512-Kz7Mt0SsV2tQk6jG5bBv5phVbkd0gd27SgYD4hH1aLMJRchM0dzHaXvrWhVZ+WxAlDoAKZ7Uy3jVTW2mKXQ1WQ==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.3.tgz",
+			"integrity": "sha512-UselcZPwVWNSURnqcfpnxtMehrb8wjXYOimlYQPBnup/Zld426YzIhNEvuRsEWVHfESIECGrxoI6L5QqzuLH5Q==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-function-name": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.2.0.tgz",
-			"integrity": "sha512-kWgksow9lHdvBC2Z4mxTsvc7YdY7w/V6B2vy9cTIPtLEE9NhwoWivaxdNM/S37elu5bqlLP/qOY906LukO9lkQ==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.3.tgz",
+			"integrity": "sha512-uT5J/3qI/8vACBR9I1GlAuU/JqBtWdfCrynuOkrWG6nCDieZd5przB1vfP59FRHBZQ9DC2IUfqr/xKqzOD5x0A==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
@@ -659,12 +588,12 @@
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.2.0.tgz",
-			"integrity": "sha512-aYJwpAhoK9a+1+O625WIjvMY11wkB/ok0WClVwmeo3mCjcNRjt+/8gHWrB5i+00mUju0gWsBkQnPpdvQ7PImmQ==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.0.tgz",
+			"integrity": "sha512-gjPdHmqiNhVoBqus5qK60mWPp1CmYWp/tkh11mvb0rrys01HycEGD7NvvSoKXlWEfSM9TcL36CpsK8ElsADptQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.0.0",
+				"@babel/helper-hoist-variables": "^7.4.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
@@ -679,18 +608,18 @@
 			}
 		},
 		"@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.3.0.tgz",
-			"integrity": "sha512-NxIoNVhk9ZxS+9lSoAQ/LM0V2UEvARLttEHUrRDGKFaAxOYQcrkN/nLRE+BbbicCAvZPl7wMP0X60HsHE5DtQw==",
+			"version": "7.4.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.2.tgz",
+			"integrity": "sha512-NsAuliSwkL3WO2dzWTOL1oZJHm0TM8ZY8ZSxk2ANyKkt5SQlToGA4pzctmq1BEjoacurdwZ3xp2dCQWJkME0gQ==",
 			"dev": true,
 			"requires": {
 				"regexp-tree": "^0.1.0"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0.tgz",
-			"integrity": "sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.0.tgz",
+			"integrity": "sha512-6ZKNgMQmQmrEX/ncuCwnnw1yVGoaOW5KpxNhoWI7pCQdA0uZ0HqHGqenCUIENAnxRjy2WwNQ30gfGdIgqJXXqw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -707,12 +636,12 @@
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.2.0.tgz",
-			"integrity": "sha512-kB9+hhUidIgUoBQ0MsxMewhzr8i60nMa2KgeJKQWYrqQpqcBYtnpR+JgkadZVZoaEZ/eKu9mclFaVwhRpLNSzA==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.3.tgz",
+			"integrity": "sha512-ULJYC2Vnw96/zdotCZkMGr2QVfKpIT/4/K+xWWY0MbOJyMZuk660BGkr3bEKWQrrciwz6xpmft39nA4BF7hJuA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-call-delegate": "^7.1.0",
+				"@babel/helper-call-delegate": "^7.4.0",
 				"@babel/helper-get-function-arity": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -738,12 +667,12 @@
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz",
-			"integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.3.tgz",
+			"integrity": "sha512-kEzotPuOpv6/iSlHroCDydPkKYw7tiJGKlmYp6iJn4a6C/+b2FdttlJsLKYxolYHgotTJ5G5UY5h0qey5ka3+A==",
 			"dev": true,
 			"requires": {
-				"regenerator-transform": "^0.13.3"
+				"regenerator-transform": "^0.13.4"
 			}
 		},
 		"@babel/plugin-transform-reserved-words": {
@@ -756,9 +685,9 @@
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.2.0.tgz",
-			"integrity": "sha512-jIgkljDdq4RYDnJyQsiWbdvGeei/0MOTtSHKO/rfbd/mXBxNpdlulMx49L0HQ4pug1fXannxoqCI+fYSle9eSw==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.3.tgz",
+			"integrity": "sha512-7Q61bU+uEI7bCUFReT1NKn7/X6sDQsZ7wL1sJ9IYMAO7cI+eg6x9re1cEw2fCRMbbTVyoeUKWSV1M6azEfKCfg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
@@ -768,9 +697,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-					"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 					"dev": true
 				}
 			}
@@ -823,73 +752,121 @@
 			}
 		},
 		"@babel/plugin-transform-unicode-regex": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.2.0.tgz",
-			"integrity": "sha512-m48Y0lMhrbXEJnVUaYly29jRXbQ3ksxPrS1Tg8t+MHqzXhtBYAvI51euOBaoAlZLPHsieY9XPVMf80a5x0cPcA==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.3.tgz",
+			"integrity": "sha512-lnSNgkVjL8EMtnE8eSS7t2ku8qvKH3eqNf/IwIfnSPUqzgqYmRwzdsQWv4mNQAN9Nuo6Gz1Y0a4CSmdpu1Pp6g==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.0.0",
-				"regexpu-core": "^4.1.3"
+				"@babel/helper-regex": "^7.4.3",
+				"regexpu-core": "^4.5.4"
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.3.1.tgz",
-			"integrity": "sha512-FHKrD6Dxf30e8xgHQO0zJZpUPfVZg+Xwgz5/RdSWCbza9QLNk4Qbp40ctRoqDxml3O8RMzB1DU55SXeDG6PqHQ==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.3.tgz",
+			"integrity": "sha512-FYbZdV12yHdJU5Z70cEg0f6lvtpZ8jFSDakTm7WXeJbLXh4R0ztGEu/SW7G1nJ2ZvKwDhz8YrbA84eYyprmGqw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
 				"@babel/plugin-proposal-json-strings": "^7.2.0",
-				"@babel/plugin-proposal-object-rest-spread": "^7.3.1",
+				"@babel/plugin-proposal-object-rest-spread": "^7.4.3",
 				"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-				"@babel/plugin-proposal-unicode-property-regex": "^7.2.0",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.4.0",
 				"@babel/plugin-syntax-async-generators": "^7.2.0",
 				"@babel/plugin-syntax-json-strings": "^7.2.0",
 				"@babel/plugin-syntax-object-rest-spread": "^7.2.0",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
 				"@babel/plugin-transform-arrow-functions": "^7.2.0",
-				"@babel/plugin-transform-async-to-generator": "^7.2.0",
+				"@babel/plugin-transform-async-to-generator": "^7.4.0",
 				"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-				"@babel/plugin-transform-block-scoping": "^7.2.0",
-				"@babel/plugin-transform-classes": "^7.2.0",
+				"@babel/plugin-transform-block-scoping": "^7.4.0",
+				"@babel/plugin-transform-classes": "^7.4.3",
 				"@babel/plugin-transform-computed-properties": "^7.2.0",
-				"@babel/plugin-transform-destructuring": "^7.2.0",
-				"@babel/plugin-transform-dotall-regex": "^7.2.0",
+				"@babel/plugin-transform-destructuring": "^7.4.3",
+				"@babel/plugin-transform-dotall-regex": "^7.4.3",
 				"@babel/plugin-transform-duplicate-keys": "^7.2.0",
 				"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
-				"@babel/plugin-transform-for-of": "^7.2.0",
-				"@babel/plugin-transform-function-name": "^7.2.0",
+				"@babel/plugin-transform-for-of": "^7.4.3",
+				"@babel/plugin-transform-function-name": "^7.4.3",
 				"@babel/plugin-transform-literals": "^7.2.0",
+				"@babel/plugin-transform-member-expression-literals": "^7.2.0",
 				"@babel/plugin-transform-modules-amd": "^7.2.0",
-				"@babel/plugin-transform-modules-commonjs": "^7.2.0",
-				"@babel/plugin-transform-modules-systemjs": "^7.2.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.4.3",
+				"@babel/plugin-transform-modules-systemjs": "^7.4.0",
 				"@babel/plugin-transform-modules-umd": "^7.2.0",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.3.0",
-				"@babel/plugin-transform-new-target": "^7.0.0",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.4.2",
+				"@babel/plugin-transform-new-target": "^7.4.0",
 				"@babel/plugin-transform-object-super": "^7.2.0",
-				"@babel/plugin-transform-parameters": "^7.2.0",
-				"@babel/plugin-transform-regenerator": "^7.0.0",
+				"@babel/plugin-transform-parameters": "^7.4.3",
+				"@babel/plugin-transform-property-literals": "^7.2.0",
+				"@babel/plugin-transform-regenerator": "^7.4.3",
+				"@babel/plugin-transform-reserved-words": "^7.2.0",
 				"@babel/plugin-transform-shorthand-properties": "^7.2.0",
 				"@babel/plugin-transform-spread": "^7.2.0",
 				"@babel/plugin-transform-sticky-regex": "^7.2.0",
 				"@babel/plugin-transform-template-literals": "^7.2.0",
 				"@babel/plugin-transform-typeof-symbol": "^7.2.0",
-				"@babel/plugin-transform-unicode-regex": "^7.2.0",
-				"browserslist": "^4.3.4",
+				"@babel/plugin-transform-unicode-regex": "^7.4.3",
+				"@babel/types": "^7.4.0",
+				"browserslist": "^4.5.2",
+				"core-js-compat": "^3.0.0",
 				"invariant": "^2.2.2",
 				"js-levenshtein": "^1.1.3",
-				"semver": "^5.3.0"
+				"semver": "^5.5.0"
+			},
+			"dependencies": {
+				"@babel/plugin-transform-modules-commonjs": {
+					"version": "7.4.3",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.3.tgz",
+					"integrity": "sha512-sMP4JqOTbMJMimqsSZwYWsMjppD+KRyDIUVW91pd7td0dZKAvPmhCaxhOzkzLParKwgQc7bdL9UNv+rpJB0HfA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-transforms": "^7.4.3",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-simple-access": "^7.1.0"
+					}
+				},
+				"browserslist": {
+					"version": "4.5.5",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.5.tgz",
+					"integrity": "sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "^1.0.30000960",
+						"electron-to-chromium": "^1.3.124",
+						"node-releases": "^1.1.14"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30000963",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000963.tgz",
+					"integrity": "sha512-n4HUiullc7Lw0LyzpeLa2ffP8KxFBGdxqD/8G3bSL6oB758hZ2UE2CVK+tQN958tJIi0/tfpjAc67aAtoHgnrQ==",
+					"dev": true
+				},
+				"electron-to-chromium": {
+					"version": "1.3.125",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.125.tgz",
+					"integrity": "sha512-XxowpqQxJ4nDwUXHtVtmEhRqBpm2OnjBomZmZtHD0d2Eo0244+Ojezhk3sD/MBSSe2nxCdGQFRXHIsf/LUTL9A==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
-			"integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
+			"integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
 			"requires": {
-				"regenerator-runtime": "^0.12.0"
+				"regenerator-runtime": "^0.13.2"
+			},
+			"dependencies": {
+				"regenerator-runtime": {
+					"version": "0.13.2",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+					"integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+				}
 			}
 		},
 		"@babel/runtime-corejs3": {
@@ -911,14 +888,14 @@
 			}
 		},
 		"@babel/template": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
-			"integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
+			"integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.2.2",
-				"@babel/types": "^7.2.2"
+				"@babel/parser": "^7.4.0",
+				"@babel/types": "^7.4.0"
 			}
 		},
 		"@babel/traverse": {
@@ -938,45 +915,6 @@
 				"lodash": "^4.17.11"
 			},
 			"dependencies": {
-				"@babel/generator": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
-					"integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.4.0",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.17.11",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
-					"integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.4.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.4.3",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
-					"integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
-					"dev": true
-				},
-				"@babel/types": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
-					"integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.11",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
 				"debug": {
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -995,13 +933,13 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.3.2",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.2.tgz",
-			"integrity": "sha512-3Y6H8xlUlpbGR+XvawiH0UXehqydTmNmEpozWcXymqwcrwYAl5KMvKtQ+TF6f6E08V6Jur7v/ykdDSF+WDEIXQ==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+			"integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
 			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
-				"lodash": "^4.17.10",
+				"lodash": "^4.17.11",
 				"to-fast-properties": "^2.0.0"
 			}
 		},
@@ -3093,414 +3031,6 @@
 				"@babel/runtime": "^7.4.3",
 				"@wordpress/babel-plugin-import-jsx-pragma": "file:packages/babel-plugin-import-jsx-pragma",
 				"@wordpress/browserslist-config": "file:packages/browserslist-config"
-			},
-			"dependencies": {
-				"@babel/helper-call-delegate": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.0.tgz",
-					"integrity": "sha512-SdqDfbVdNQCBp3WhK2mNdDvHd3BD6qbmIc43CAyjnsfCmgHMeqgDcM3BzY2lchi7HBJGJ2CVdynLWbezaE4mmQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-hoist-variables": "^7.4.0",
-						"@babel/traverse": "^7.4.0",
-						"@babel/types": "^7.4.0"
-					}
-				},
-				"@babel/helper-define-map": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.0.tgz",
-					"integrity": "sha512-wAhQ9HdnLIywERVcSvX40CEJwKdAa1ID4neI9NXQPDOHwwA+57DqwLiPEVy2AIyWzAk0CQ8qx4awO0VUURwLtA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/types": "^7.4.0",
-						"lodash": "^4.17.11"
-					}
-				},
-				"@babel/helper-hoist-variables": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.0.tgz",
-					"integrity": "sha512-/NErCuoe/et17IlAQFKWM24qtyYYie7sFIrW/tIQXpck6vAu2hhtYYsKLBWQV+BQZMbcIYPU/QMYuTufrY4aQw==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.4.0"
-					}
-				},
-				"@babel/helper-module-transforms": {
-					"version": "7.4.3",
-					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.3.tgz",
-					"integrity": "sha512-H88T9IySZW25anu5uqyaC1DaQre7ofM+joZtAaO2F8NBdFfupH0SZ4gKjgSFVcvtx/aAirqA9L9Clio2heYbZA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-module-imports": "^7.0.0",
-						"@babel/helper-simple-access": "^7.1.0",
-						"@babel/helper-split-export-declaration": "^7.0.0",
-						"@babel/template": "^7.2.2",
-						"@babel/types": "^7.2.2",
-						"lodash": "^4.17.11"
-					}
-				},
-				"@babel/helper-replace-supers": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.0.tgz",
-					"integrity": "sha512-PVwCVnWWAgnal+kJ+ZSAphzyl58XrFeSKSAJRiqg5QToTsjL+Xu1f9+RJ+d+Q0aPhPfBGaYfkox66k86thxNSg==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.0.0",
-						"@babel/helper-optimise-call-expression": "^7.0.0",
-						"@babel/traverse": "^7.4.0",
-						"@babel/types": "^7.4.0"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
-					"integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.4.0"
-					}
-				},
-				"@babel/plugin-proposal-unicode-property-regex": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.0.tgz",
-					"integrity": "sha512-h/KjEZ3nK9wv1P1FSNb9G079jXrNYR0Ko+7XkOx85+gM24iZbPn0rh4vCftk+5QKY7y1uByFataBTmX7irEF1w==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"@babel/helper-regex": "^7.0.0",
-						"regexpu-core": "^4.5.4"
-					}
-				},
-				"@babel/plugin-transform-async-to-generator": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.0.tgz",
-					"integrity": "sha512-EeaFdCeUULM+GPFEsf7pFcNSxM7hYjoj5fiYbyuiXobW4JhFnjAv9OWzNwHyHcKoPNpAfeRDuW6VyaXEDUBa7g==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-module-imports": "^7.0.0",
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"@babel/helper-remap-async-to-generator": "^7.1.0"
-					}
-				},
-				"@babel/plugin-transform-block-scoping": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.0.tgz",
-					"integrity": "sha512-AWyt3k+fBXQqt2qb9r97tn3iBwFpiv9xdAiG+Gr2HpAZpuayvbL55yWrsV3MyHvXk/4vmSiedhDRl1YI2Iy5nQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"lodash": "^4.17.11"
-					}
-				},
-				"@babel/plugin-transform-classes": {
-					"version": "7.4.3",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.3.tgz",
-					"integrity": "sha512-PUaIKyFUDtG6jF5DUJOfkBdwAS/kFFV3XFk7Nn0a6vR7ZT8jYw5cGtIlat77wcnd0C6ViGqo/wyNf4ZHytF/nQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-annotate-as-pure": "^7.0.0",
-						"@babel/helper-define-map": "^7.4.0",
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-optimise-call-expression": "^7.0.0",
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"@babel/helper-replace-supers": "^7.4.0",
-						"@babel/helper-split-export-declaration": "^7.4.0",
-						"globals": "^11.1.0"
-					}
-				},
-				"@babel/plugin-transform-destructuring": {
-					"version": "7.4.3",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.3.tgz",
-					"integrity": "sha512-rVTLLZpydDFDyN4qnXdzwoVpk1oaXHIvPEOkOLyr88o7oHxVc/LyrnDx+amuBWGOwUb7D1s/uLsKBNTx08htZg==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.0.0"
-					}
-				},
-				"@babel/plugin-transform-dotall-regex": {
-					"version": "7.4.3",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.3.tgz",
-					"integrity": "sha512-9Arc2I0AGynzXRR/oPdSALv3k0rM38IMFyto7kOCwb5F9sLUt2Ykdo3V9yUPR+Bgr4kb6bVEyLkPEiBhzcTeoA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"@babel/helper-regex": "^7.4.3",
-						"regexpu-core": "^4.5.4"
-					},
-					"dependencies": {
-						"@babel/helper-regex": {
-							"version": "7.4.3",
-							"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.3.tgz",
-							"integrity": "sha512-hnoq5u96pLCfgjXuj8ZLX3QQ+6nAulS+zSgi6HulUwFbEruRAKwbGLU5OvXkE14L8XW6XsQEKsIDfgthKLRAyA==",
-							"dev": true,
-							"requires": {
-								"lodash": "^4.17.11"
-							}
-						}
-					}
-				},
-				"@babel/plugin-transform-for-of": {
-					"version": "7.4.3",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.3.tgz",
-					"integrity": "sha512-UselcZPwVWNSURnqcfpnxtMehrb8wjXYOimlYQPBnup/Zld426YzIhNEvuRsEWVHfESIECGrxoI6L5QqzuLH5Q==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.0.0"
-					}
-				},
-				"@babel/plugin-transform-function-name": {
-					"version": "7.4.3",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.3.tgz",
-					"integrity": "sha512-uT5J/3qI/8vACBR9I1GlAuU/JqBtWdfCrynuOkrWG6nCDieZd5przB1vfP59FRHBZQ9DC2IUfqr/xKqzOD5x0A==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-plugin-utils": "^7.0.0"
-					}
-				},
-				"@babel/plugin-transform-modules-commonjs": {
-					"version": "7.4.3",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.3.tgz",
-					"integrity": "sha512-sMP4JqOTbMJMimqsSZwYWsMjppD+KRyDIUVW91pd7td0dZKAvPmhCaxhOzkzLParKwgQc7bdL9UNv+rpJB0HfA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-module-transforms": "^7.4.3",
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"@babel/helper-simple-access": "^7.1.0"
-					}
-				},
-				"@babel/plugin-transform-modules-systemjs": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.0.tgz",
-					"integrity": "sha512-gjPdHmqiNhVoBqus5qK60mWPp1CmYWp/tkh11mvb0rrys01HycEGD7NvvSoKXlWEfSM9TcL36CpsK8ElsADptQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-hoist-variables": "^7.4.0",
-						"@babel/helper-plugin-utils": "^7.0.0"
-					}
-				},
-				"@babel/plugin-transform-named-capturing-groups-regex": {
-					"version": "7.4.2",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.2.tgz",
-					"integrity": "sha512-NsAuliSwkL3WO2dzWTOL1oZJHm0TM8ZY8ZSxk2ANyKkt5SQlToGA4pzctmq1BEjoacurdwZ3xp2dCQWJkME0gQ==",
-					"dev": true,
-					"requires": {
-						"regexp-tree": "^0.1.0"
-					}
-				},
-				"@babel/plugin-transform-new-target": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.0.tgz",
-					"integrity": "sha512-6ZKNgMQmQmrEX/ncuCwnnw1yVGoaOW5KpxNhoWI7pCQdA0uZ0HqHGqenCUIENAnxRjy2WwNQ30gfGdIgqJXXqw==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.0.0"
-					}
-				},
-				"@babel/plugin-transform-parameters": {
-					"version": "7.4.3",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.3.tgz",
-					"integrity": "sha512-ULJYC2Vnw96/zdotCZkMGr2QVfKpIT/4/K+xWWY0MbOJyMZuk660BGkr3bEKWQrrciwz6xpmft39nA4BF7hJuA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-call-delegate": "^7.4.0",
-						"@babel/helper-get-function-arity": "^7.0.0",
-						"@babel/helper-plugin-utils": "^7.0.0"
-					}
-				},
-				"@babel/plugin-transform-regenerator": {
-					"version": "7.4.3",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.3.tgz",
-					"integrity": "sha512-kEzotPuOpv6/iSlHroCDydPkKYw7tiJGKlmYp6iJn4a6C/+b2FdttlJsLKYxolYHgotTJ5G5UY5h0qey5ka3+A==",
-					"dev": true,
-					"requires": {
-						"regenerator-transform": "^0.13.4"
-					}
-				},
-				"@babel/plugin-transform-unicode-regex": {
-					"version": "7.4.3",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.3.tgz",
-					"integrity": "sha512-lnSNgkVjL8EMtnE8eSS7t2ku8qvKH3eqNf/IwIfnSPUqzgqYmRwzdsQWv4mNQAN9Nuo6Gz1Y0a4CSmdpu1Pp6g==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"@babel/helper-regex": "^7.4.3",
-						"regexpu-core": "^4.5.4"
-					},
-					"dependencies": {
-						"@babel/helper-regex": {
-							"version": "7.4.3",
-							"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.3.tgz",
-							"integrity": "sha512-hnoq5u96pLCfgjXuj8ZLX3QQ+6nAulS+zSgi6HulUwFbEruRAKwbGLU5OvXkE14L8XW6XsQEKsIDfgthKLRAyA==",
-							"dev": true,
-							"requires": {
-								"lodash": "^4.17.11"
-							}
-						}
-					}
-				},
-				"@babel/preset-env": {
-					"version": "7.4.3",
-					"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.3.tgz",
-					"integrity": "sha512-FYbZdV12yHdJU5Z70cEg0f6lvtpZ8jFSDakTm7WXeJbLXh4R0ztGEu/SW7G1nJ2ZvKwDhz8YrbA84eYyprmGqw==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-module-imports": "^7.0.0",
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
-						"@babel/plugin-proposal-json-strings": "^7.2.0",
-						"@babel/plugin-proposal-object-rest-spread": "^7.4.3",
-						"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-						"@babel/plugin-proposal-unicode-property-regex": "^7.4.0",
-						"@babel/plugin-syntax-async-generators": "^7.2.0",
-						"@babel/plugin-syntax-json-strings": "^7.2.0",
-						"@babel/plugin-syntax-object-rest-spread": "^7.2.0",
-						"@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
-						"@babel/plugin-transform-arrow-functions": "^7.2.0",
-						"@babel/plugin-transform-async-to-generator": "^7.4.0",
-						"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-						"@babel/plugin-transform-block-scoping": "^7.4.0",
-						"@babel/plugin-transform-classes": "^7.4.3",
-						"@babel/plugin-transform-computed-properties": "^7.2.0",
-						"@babel/plugin-transform-destructuring": "^7.4.3",
-						"@babel/plugin-transform-dotall-regex": "^7.4.3",
-						"@babel/plugin-transform-duplicate-keys": "^7.2.0",
-						"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
-						"@babel/plugin-transform-for-of": "^7.4.3",
-						"@babel/plugin-transform-function-name": "^7.4.3",
-						"@babel/plugin-transform-literals": "^7.2.0",
-						"@babel/plugin-transform-member-expression-literals": "^7.2.0",
-						"@babel/plugin-transform-modules-amd": "^7.2.0",
-						"@babel/plugin-transform-modules-commonjs": "^7.4.3",
-						"@babel/plugin-transform-modules-systemjs": "^7.4.0",
-						"@babel/plugin-transform-modules-umd": "^7.2.0",
-						"@babel/plugin-transform-named-capturing-groups-regex": "^7.4.2",
-						"@babel/plugin-transform-new-target": "^7.4.0",
-						"@babel/plugin-transform-object-super": "^7.2.0",
-						"@babel/plugin-transform-parameters": "^7.4.3",
-						"@babel/plugin-transform-property-literals": "^7.2.0",
-						"@babel/plugin-transform-regenerator": "^7.4.3",
-						"@babel/plugin-transform-reserved-words": "^7.2.0",
-						"@babel/plugin-transform-shorthand-properties": "^7.2.0",
-						"@babel/plugin-transform-spread": "^7.2.0",
-						"@babel/plugin-transform-sticky-regex": "^7.2.0",
-						"@babel/plugin-transform-template-literals": "^7.2.0",
-						"@babel/plugin-transform-typeof-symbol": "^7.2.0",
-						"@babel/plugin-transform-unicode-regex": "^7.4.3",
-						"@babel/types": "^7.4.0",
-						"browserslist": "^4.5.2",
-						"core-js-compat": "^3.0.0",
-						"invariant": "^2.2.2",
-						"js-levenshtein": "^1.1.3",
-						"semver": "^5.5.0"
-					},
-					"dependencies": {
-						"@babel/plugin-proposal-object-rest-spread": {
-							"version": "7.4.3",
-							"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.3.tgz",
-							"integrity": "sha512-xC//6DNSSHVjq8O2ge0dyYlhshsH4T7XdCVoxbi5HzLYWfsC5ooFlJjrXk8RcAT+hjHAK9UjBXdylzSoDK3t4g==",
-							"dev": true,
-							"requires": {
-								"@babel/helper-plugin-utils": "^7.0.0",
-								"@babel/plugin-syntax-object-rest-spread": "^7.2.0"
-							}
-						}
-					}
-				},
-				"@babel/types": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
-					"integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.11",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"browserslist": {
-					"version": "4.5.5",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.5.tgz",
-					"integrity": "sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==",
-					"dev": true,
-					"requires": {
-						"caniuse-lite": "^1.0.30000960",
-						"electron-to-chromium": "^1.3.124",
-						"node-releases": "^1.1.14"
-					}
-				},
-				"caniuse-lite": {
-					"version": "1.0.30000963",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000963.tgz",
-					"integrity": "sha512-n4HUiullc7Lw0LyzpeLa2ffP8KxFBGdxqD/8G3bSL6oB758hZ2UE2CVK+tQN958tJIi0/tfpjAc67aAtoHgnrQ==",
-					"dev": true
-				},
-				"electron-to-chromium": {
-					"version": "1.3.125",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.125.tgz",
-					"integrity": "sha512-XxowpqQxJ4nDwUXHtVtmEhRqBpm2OnjBomZmZtHD0d2Eo0244+Ojezhk3sD/MBSSe2nxCdGQFRXHIsf/LUTL9A==",
-					"dev": true
-				},
-				"jsesc": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-					"dev": true
-				},
-				"regenerate-unicode-properties": {
-					"version": "8.0.2",
-					"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.0.2.tgz",
-					"integrity": "sha512-SbA/iNrBUf6Pv2zU8Ekv1Qbhv92yxL4hiDa2siuxs4KKn4oOoMDHXjAf7+Nz9qinUQ46B1LcWEi/PhJfPWpZWQ==",
-					"dev": true,
-					"requires": {
-						"regenerate": "^1.4.0"
-					}
-				},
-				"regenerator-transform": {
-					"version": "0.13.4",
-					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.4.tgz",
-					"integrity": "sha512-T0QMBjK3J0MtxjPmdIMXm72Wvj2Abb0Bd4HADdfijwMdoIsyQZ6fWC7kDFhk2YinBBEMZDL7Y7wh0J1sGx3S4A==",
-					"dev": true,
-					"requires": {
-						"private": "^0.1.6"
-					}
-				},
-				"regexpu-core": {
-					"version": "4.5.4",
-					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
-					"integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
-					"dev": true,
-					"requires": {
-						"regenerate": "^1.4.0",
-						"regenerate-unicode-properties": "^8.0.2",
-						"regjsgen": "^0.5.0",
-						"regjsparser": "^0.6.0",
-						"unicode-match-property-ecmascript": "^1.0.4",
-						"unicode-match-property-value-ecmascript": "^1.1.0"
-					}
-				},
-				"regjsgen": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
-					"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
-					"dev": true
-				},
-				"regjsparser": {
-					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
-					"integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
-					"dev": true,
-					"requires": {
-						"jsesc": "~0.5.0"
-					}
-				},
-				"unicode-match-property-value-ecmascript": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
-					"integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
-					"dev": true
-				}
 			}
 		},
 		"@wordpress/blob": {
@@ -4648,21 +4178,74 @@
 			}
 		},
 		"babel-eslint": {
-			"version": "8.0.3",
-			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.0.3.tgz",
-			"integrity": "sha512-7D4iUpylEiKJPGbeSAlNddGcmA41PadgZ6UAb6JVyh003h3d0EbZusYFBR/+nBgqtaVJM2J2zUVa3N0hrpMH6g==",
+			"version": "8.2.6",
+			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.6.tgz",
+			"integrity": "sha512-aCdHjhzcILdP8c9lej7hvXKvQieyRt20SF102SIGyY4cUIiw6UaAtK4j2o3dXX74jEmy0TJ0CEhv4fTIM3SzcA==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.31",
-				"@babel/traverse": "7.0.0-beta.31",
-				"@babel/types": "7.0.0-beta.31",
-				"babylon": "7.0.0-beta.31"
+				"@babel/code-frame": "7.0.0-beta.44",
+				"@babel/traverse": "7.0.0-beta.44",
+				"@babel/types": "7.0.0-beta.44",
+				"babylon": "7.0.0-beta.44",
+				"eslint-scope": "3.7.1",
+				"eslint-visitor-keys": "^1.0.0"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.0.0-beta.31",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.31.tgz",
-					"integrity": "sha512-yd7CkUughvHQoEahQqcMdrZw6o/6PwUxiRkfZuVDVHCDe77mysD/suoNyk5mK6phTnRW1kyIbPHyCJgxw++LXg==",
+					"version": "7.0.0-beta.44",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
+					"integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "7.0.0-beta.44"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.0.0-beta.44",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
+					"integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "7.0.0-beta.44",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.2.0",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.0.0-beta.44",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
+					"integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "7.0.0-beta.44",
+						"@babel/template": "7.0.0-beta.44",
+						"@babel/types": "7.0.0-beta.44"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.0.0-beta.44",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
+					"integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "7.0.0-beta.44"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.0.0-beta.44",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
+					"integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "7.0.0-beta.44"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0-beta.44",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
+					"integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.0.0",
@@ -4670,59 +4253,40 @@
 						"js-tokens": "^3.0.0"
 					}
 				},
-				"@babel/helper-function-name": {
-					"version": "7.0.0-beta.31",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.31.tgz",
-					"integrity": "sha512-c+DAyp8LMm2nzSs2uXEuxp4LYGSUYEyHtU3fU57avFChjsnTmmpWmXj2dv0yUxHTEydgVAv5fIzA+4KJwoqWDA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-get-function-arity": "7.0.0-beta.31",
-						"@babel/template": "7.0.0-beta.31",
-						"@babel/traverse": "7.0.0-beta.31",
-						"@babel/types": "7.0.0-beta.31"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.0.0-beta.31",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.31.tgz",
-					"integrity": "sha512-m7rVVX/dMLbbB9NCzKYRrrFb0qZxgpmQ4Wv6y7zEsB6skoJHRuXVeb/hAFze79vXBbuD63ci7AVHXzAdZSk9KQ==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.31"
-					}
-				},
 				"@babel/template": {
-					"version": "7.0.0-beta.31",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.31.tgz",
-					"integrity": "sha512-97IRmLvoDhIDSQkqklVt3UCxJsv0LUEVb/0DzXWtc8Lgiyxj567qZkmTG9aR21CmcJVVIvq2Y/moZj4oEpl5AA==",
+					"version": "7.0.0-beta.44",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
+					"integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "7.0.0-beta.31",
-						"@babel/types": "7.0.0-beta.31",
-						"babylon": "7.0.0-beta.31",
+						"@babel/code-frame": "7.0.0-beta.44",
+						"@babel/types": "7.0.0-beta.44",
+						"babylon": "7.0.0-beta.44",
 						"lodash": "^4.2.0"
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.0.0-beta.31",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.31.tgz",
-					"integrity": "sha512-3N+VJW+KlezEjFBG7WSYeMyC5kIqVLPb/PGSzCDPFcJrnArluD1GIl7Y3xC7cjKiTq2/JohaLWHVPjJWHlo9Gg==",
+					"version": "7.0.0-beta.44",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
+					"integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "7.0.0-beta.31",
-						"@babel/helper-function-name": "7.0.0-beta.31",
-						"@babel/types": "7.0.0-beta.31",
-						"babylon": "7.0.0-beta.31",
-						"debug": "^3.0.1",
-						"globals": "^10.0.0",
+						"@babel/code-frame": "7.0.0-beta.44",
+						"@babel/generator": "7.0.0-beta.44",
+						"@babel/helper-function-name": "7.0.0-beta.44",
+						"@babel/helper-split-export-declaration": "7.0.0-beta.44",
+						"@babel/types": "7.0.0-beta.44",
+						"babylon": "7.0.0-beta.44",
+						"debug": "^3.1.0",
+						"globals": "^11.1.0",
 						"invariant": "^2.2.0",
 						"lodash": "^4.2.0"
 					}
 				},
 				"@babel/types": {
-					"version": "7.0.0-beta.31",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.31.tgz",
-					"integrity": "sha512-exAHB+NeFGxkfQ5dSUD03xl3zYGneeSk2Mw2ldTt/nTvYxuDiuSp3DlxgUBgzbdTFG4fbwPk0WtKWOoTXCmNGg==",
+					"version": "7.0.0-beta.44",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
+					"integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
 					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
@@ -4730,17 +4294,15 @@
 						"to-fast-properties": "^2.0.0"
 					}
 				},
-				"babylon": {
-					"version": "7.0.0-beta.31",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.31.tgz",
-					"integrity": "sha512-6lm2mV3S51yEnKmQQNnswoABL1U1H1KHoCCVwdwI3hvIv+W7ya4ki7Aw4o4KxtUHjNKkK5WpZb22rrMMOcJXJQ==",
-					"dev": true
-				},
-				"globals": {
-					"version": "10.4.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
-					"integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA==",
-					"dev": true
+				"eslint-scope": {
+					"version": "3.7.1",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+					"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+					"dev": true,
+					"requires": {
+						"esrecurse": "^4.1.0",
+						"estraverse": "^4.1.1"
+					}
 				},
 				"js-tokens": {
 					"version": "3.0.2",
@@ -4893,14 +4455,14 @@
 			}
 		},
 		"babel-plugin-istanbul": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.1.tgz",
-			"integrity": "sha512-RNNVv2lsHAXJQsEJ5jonQwrJVWK8AcZpG1oxhnjCUaAjL7xahYLANhPUZbzEQHjKy1NMYUwn+0NPKQc8iSY4xQ==",
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.3.tgz",
+			"integrity": "sha512-IFyehbvRRwdBlI1lDp+FaMsWNnEndEk7065IB8NhzBX+ZKLPwPodgk4I5Gobw/8SNUUzso2Dv3hbqRh88eiSCQ==",
 			"dev": true,
 			"requires": {
 				"find-up": "^3.0.0",
-				"istanbul-lib-instrument": "^3.0.0",
-				"test-exclude": "^5.0.0"
+				"istanbul-lib-instrument": "^3.2.0",
+				"test-exclude": "^5.2.2"
 			},
 			"dependencies": {
 				"find-up": {
@@ -4910,6 +4472,53 @@
 					"dev": true,
 					"requires": {
 						"locate-path": "^3.0.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.3",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"istanbul-lib-coverage": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
+					"integrity": "sha512-LXTBICkMARVgo579kWDm8SqfB6nvSDKNqIOBEjmJRnL04JvoMHCYGWaMddQnseJYtkEuEvO/sIcOxPLk9gERug==",
+					"dev": true
+				},
+				"istanbul-lib-instrument": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.2.0.tgz",
+					"integrity": "sha512-06IM3xShbNW4NgZv5AP4QH0oHqf1/ivFo8eFys0ZjPXHGldHJQWb3riYOKXqmOqfxXBfxu4B+g/iuhOPZH0RJg==",
+					"dev": true,
+					"requires": {
+						"@babel/generator": "^7.0.0",
+						"@babel/parser": "^7.0.0",
+						"@babel/template": "^7.0.0",
+						"@babel/traverse": "^7.0.0",
+						"@babel/types": "^7.0.0",
+						"istanbul-lib-coverage": "^2.0.4",
+						"semver": "^6.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
 					}
 				},
 				"locate-path": {
@@ -4945,6 +4554,73 @@
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
+				},
+				"parse-json": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+					"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+					"dev": true,
+					"requires": {
+						"find-up": "^3.0.0",
+						"read-pkg": "^3.0.0"
+					}
+				},
+				"require-main-filename": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+					"dev": true
+				},
+				"semver": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+					"integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==",
+					"dev": true
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+					"dev": true
+				},
+				"test-exclude": {
+					"version": "5.2.2",
+					"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.2.tgz",
+					"integrity": "sha512-N2pvaLpT8guUpb5Fe1GJlmvmzH3x+DAKmmyEQmFP792QcLYoGE1syxztSvPD1V8yPe6VrcCt6YGQVjSRjCASsA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3",
+						"minimatch": "^3.0.4",
+						"read-pkg-up": "^4.0.0",
+						"require-main-filename": "^2.0.0"
+					}
 				}
 			}
 		},
@@ -5010,6 +4686,12 @@
 					"dev": true
 				}
 			}
+		},
+		"babylon": {
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+			"integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+			"dev": true
 		},
 		"babylon-walk": {
 			"version": "1.0.2",
@@ -16570,6 +16252,104 @@
 						}
 					}
 				},
+				"@babel/generator": {
+					"version": "7.3.4",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.4.tgz",
+					"integrity": "sha512-8EXhHRFqlVVWXPezBW5keTiQi/rJMQTg/Y9uVCEZ0CAF3PKtCCaVRnp64Ii1ujhkoDhhF1fVsImoN4yJ2uz4Wg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.3.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.11",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+							"dev": true
+						}
+					}
+				},
+				"@babel/parser": {
+					"version": "7.3.4",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.4.tgz",
+					"integrity": "sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ==",
+					"dev": true
+				},
+				"@babel/preset-env": {
+					"version": "7.3.4",
+					"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.3.4.tgz",
+					"integrity": "sha512-2mwqfYMK8weA0g0uBKOt4FE3iEodiHy9/CW0b+nWXcbL+pGzLx8ESYc+j9IIxr6LTDHWKgPm71i9smo02bw+gA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.0.0",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+						"@babel/plugin-proposal-json-strings": "^7.2.0",
+						"@babel/plugin-proposal-object-rest-spread": "^7.3.4",
+						"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
+						"@babel/plugin-proposal-unicode-property-regex": "^7.2.0",
+						"@babel/plugin-syntax-async-generators": "^7.2.0",
+						"@babel/plugin-syntax-json-strings": "^7.2.0",
+						"@babel/plugin-syntax-object-rest-spread": "^7.2.0",
+						"@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+						"@babel/plugin-transform-arrow-functions": "^7.2.0",
+						"@babel/plugin-transform-async-to-generator": "^7.3.4",
+						"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
+						"@babel/plugin-transform-block-scoping": "^7.3.4",
+						"@babel/plugin-transform-classes": "^7.3.4",
+						"@babel/plugin-transform-computed-properties": "^7.2.0",
+						"@babel/plugin-transform-destructuring": "^7.2.0",
+						"@babel/plugin-transform-dotall-regex": "^7.2.0",
+						"@babel/plugin-transform-duplicate-keys": "^7.2.0",
+						"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
+						"@babel/plugin-transform-for-of": "^7.2.0",
+						"@babel/plugin-transform-function-name": "^7.2.0",
+						"@babel/plugin-transform-literals": "^7.2.0",
+						"@babel/plugin-transform-modules-amd": "^7.2.0",
+						"@babel/plugin-transform-modules-commonjs": "^7.2.0",
+						"@babel/plugin-transform-modules-systemjs": "^7.3.4",
+						"@babel/plugin-transform-modules-umd": "^7.2.0",
+						"@babel/plugin-transform-named-capturing-groups-regex": "^7.3.0",
+						"@babel/plugin-transform-new-target": "^7.0.0",
+						"@babel/plugin-transform-object-super": "^7.2.0",
+						"@babel/plugin-transform-parameters": "^7.2.0",
+						"@babel/plugin-transform-regenerator": "^7.3.4",
+						"@babel/plugin-transform-shorthand-properties": "^7.2.0",
+						"@babel/plugin-transform-spread": "^7.2.0",
+						"@babel/plugin-transform-sticky-regex": "^7.2.0",
+						"@babel/plugin-transform-template-literals": "^7.2.0",
+						"@babel/plugin-transform-typeof-symbol": "^7.2.0",
+						"@babel/plugin-transform-unicode-regex": "^7.2.0",
+						"browserslist": "^4.3.4",
+						"invariant": "^2.2.2",
+						"js-levenshtein": "^1.1.3",
+						"semver": "^5.3.0"
+					}
+				},
+				"@babel/runtime": {
+					"version": "7.3.4",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.4.tgz",
+					"integrity": "sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.12.0"
+					}
+				},
+				"@babel/template": {
+					"version": "7.2.2",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
+					"integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.2.2",
+						"@babel/types": "^7.2.2"
+					}
+				},
 				"@babel/traverse": {
 					"version": "7.3.4",
 					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.3.4.tgz",
@@ -16623,6 +16403,17 @@
 							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
 							"dev": true
 						}
+					}
+				},
+				"@babel/types": {
+					"version": "7.3.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz",
+					"integrity": "sha512-WEkp8MsLftM7O/ty580wAmZzN1nDmCACc5+jFzUt+GUFNNIi3LdRlueYz0YIlmJhlZx1QYDMZL5vdWCL0fNjFQ==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
 					}
 				},
 				"clone": {
@@ -19119,9 +18910,9 @@
 			"dev": true
 		},
 		"regenerate-unicode-properties": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
-			"integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.0.2.tgz",
+			"integrity": "sha512-SbA/iNrBUf6Pv2zU8Ekv1Qbhv92yxL4hiDa2siuxs4KKn4oOoMDHXjAf7+Nz9qinUQ46B1LcWEi/PhJfPWpZWQ==",
 			"dev": true,
 			"requires": {
 				"regenerate": "^1.4.0"
@@ -19130,12 +18921,13 @@
 		"regenerator-runtime": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.0.tgz",
-			"integrity": "sha512-SpV2LhF5Dm9UYMEprB3WwsBnWwqTrmjrm2UZb42cl2G02WVGgx7Mg8aa9pdLEKp6hZ+/abcMc2NxKA8f02EG2w=="
+			"integrity": "sha512-SpV2LhF5Dm9UYMEprB3WwsBnWwqTrmjrm2UZb42cl2G02WVGgx7Mg8aa9pdLEKp6hZ+/abcMc2NxKA8f02EG2w==",
+			"dev": true
 		},
 		"regenerator-transform": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",
-			"integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
+			"version": "0.13.4",
+			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.4.tgz",
+			"integrity": "sha512-T0QMBjK3J0MtxjPmdIMXm72Wvj2Abb0Bd4HADdfijwMdoIsyQZ6fWC7kDFhk2YinBBEMZDL7Y7wh0J1sGx3S4A==",
 			"dev": true,
 			"requires": {
 				"private": "^0.1.6"
@@ -19346,29 +19138,29 @@
 			"dev": true
 		},
 		"regexpu-core": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
-			"integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
+			"integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
 			"dev": true,
 			"requires": {
 				"regenerate": "^1.4.0",
-				"regenerate-unicode-properties": "^7.0.0",
-				"regjsgen": "^0.4.0",
-				"regjsparser": "^0.3.0",
+				"regenerate-unicode-properties": "^8.0.2",
+				"regjsgen": "^0.5.0",
+				"regjsparser": "^0.6.0",
 				"unicode-match-property-ecmascript": "^1.0.4",
-				"unicode-match-property-value-ecmascript": "^1.0.2"
+				"unicode-match-property-value-ecmascript": "^1.1.0"
 			}
 		},
 		"regjsgen": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
-			"integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
+			"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
 			"dev": true
 		},
 		"regjsparser": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
-			"integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+			"integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
 			"dev": true,
 			"requires": {
 				"jsesc": "~0.5.0"
@@ -21620,118 +21412,6 @@
 				}
 			}
 		},
-		"test-exclude": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.1.0.tgz",
-			"integrity": "sha512-gwf0S2fFsANC55fSeSqpb8BYk6w3FDvwZxfNjeF6FRgvFa43r+7wRiA/Q0IxoRU37wB/LE8IQ4221BsNucTaCA==",
-			"dev": true,
-			"requires": {
-				"arrify": "^1.0.1",
-				"minimatch": "^3.0.4",
-				"read-pkg-up": "^4.0.0",
-				"require-main-filename": "^1.0.1"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"load-json-file": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^4.0.0",
-						"pify": "^3.0.0",
-						"strip-bom": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
-				},
-				"parse-json": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
-					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
-					}
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
-				},
-				"read-pkg": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
-					"requires": {
-						"load-json-file": "^4.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^3.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-					"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
-					"dev": true,
-					"requires": {
-						"find-up": "^3.0.0",
-						"read-pkg": "^3.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-					"dev": true
-				}
-			}
-		},
 		"text-extensions": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
@@ -22216,9 +21896,9 @@
 			}
 		},
 		"unicode-match-property-value-ecmascript": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
-			"integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+			"integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
 			"dev": true
 		},
 		"unicode-property-aliases-ecmascript": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,27 +14,68 @@
 			}
 		},
 		"@babel/core": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.2.2.tgz",
-			"integrity": "sha512-59vB0RWt09cAct5EIe58+NzGP4TFSD3Bz//2/ELy3ZeTeKF6VTD1AXlH8BGGbCX0PuobZBsIzO7IAI9PH67eKw==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.3.tgz",
+			"integrity": "sha512-oDpASqKFlbspQfzAE7yaeTmdljSH2ADIvBlb0RwbStltTuWa0+7CCI1fYVINNv9saHPa1W7oaKeuNuKj+RQCvA==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/generator": "^7.2.2",
-				"@babel/helpers": "^7.2.0",
-				"@babel/parser": "^7.2.2",
-				"@babel/template": "^7.2.2",
-				"@babel/traverse": "^7.2.2",
-				"@babel/types": "^7.2.2",
+				"@babel/generator": "^7.4.0",
+				"@babel/helpers": "^7.4.3",
+				"@babel/parser": "^7.4.3",
+				"@babel/template": "^7.4.0",
+				"@babel/traverse": "^7.4.3",
+				"@babel/types": "^7.4.0",
 				"convert-source-map": "^1.1.0",
 				"debug": "^4.1.0",
 				"json5": "^2.1.0",
-				"lodash": "^4.17.10",
+				"lodash": "^4.17.11",
 				"resolve": "^1.3.2",
 				"semver": "^5.4.1",
 				"source-map": "^0.5.0"
 			},
 			"dependencies": {
+				"@babel/generator": {
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+					"integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.0",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.11",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.4.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
+					"integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
+					"integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.4.0",
+						"@babel/types": "^7.4.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+					"integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
 				"debug": {
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -283,14 +324,44 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.3.1.tgz",
-			"integrity": "sha512-Q82R3jKsVpUV99mgX50gOPCWwco9Ec5Iln/8Vyu4osNIOQgSrd9RFrQeUvmvddFNoLwMyOUWU+5ckioEKpDoGA==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.3.tgz",
+			"integrity": "sha512-BMh7X0oZqb36CfyhvtbSmcWc3GXocfxv3yNsAEuM0l+fAqSO22rQrUpijr3oE/10jCTrB6/0b9kzmG4VetCj8Q==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.1.2",
-				"@babel/traverse": "^7.1.5",
-				"@babel/types": "^7.3.0"
+				"@babel/template": "^7.4.0",
+				"@babel/traverse": "^7.4.3",
+				"@babel/types": "^7.4.0"
+			},
+			"dependencies": {
+				"@babel/parser": {
+					"version": "7.4.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
+					"integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
+					"integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.4.0",
+						"@babel/types": "^7.4.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+					"integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/highlight": {
@@ -794,14 +865,22 @@
 				"regenerator-runtime": "^0.12.0"
 			}
 		},
-		"@babel/runtime-corejs2": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.3.1.tgz",
-			"integrity": "sha512-YpO13776h3e6Wy8dl2J8T9Qwlvopr+b4trCEhHE+yek6yIqV8sx6g3KozdHMbXeBpjosbPi+Ii5Z7X9oXFHUKA==",
+		"@babel/runtime-corejs3": {
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.4.3.tgz",
+			"integrity": "sha512-12jcdiSTZu6bLXyjCqD4E8/rFoctaLjR/MvIiI4I4kvqFEnifeDbaChDpYHrt9meOXbkDpykXdqhXfRJCJYHxQ==",
 			"dev": true,
 			"requires": {
-				"core-js": "^2.5.7",
-				"regenerator-runtime": "^0.12.0"
+				"core-js-pure": "^3.0.0",
+				"regenerator-runtime": "^0.13.2"
+			},
+			"dependencies": {
+				"regenerator-runtime": {
+					"version": "0.13.2",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+					"integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/template": {
@@ -816,22 +895,61 @@
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
-			"integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
+			"integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/generator": "^7.2.2",
+				"@babel/generator": "^7.4.0",
 				"@babel/helper-function-name": "^7.1.0",
-				"@babel/helper-split-export-declaration": "^7.0.0",
-				"@babel/parser": "^7.2.3",
-				"@babel/types": "^7.2.2",
+				"@babel/helper-split-export-declaration": "^7.4.0",
+				"@babel/parser": "^7.4.3",
+				"@babel/types": "^7.4.0",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
-				"lodash": "^4.17.10"
+				"lodash": "^4.17.11"
 			},
 			"dependencies": {
+				"@babel/generator": {
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+					"integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.0",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.11",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+					"integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.4.3",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
+					"integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+					"integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
 				"debug": {
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -4424,6 +4542,12 @@
 				"regenerator-runtime": "^0.11.0"
 			},
 			"dependencies": {
+				"core-js": {
+					"version": "2.6.5",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+					"integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+					"dev": true
+				},
 				"regenerator-runtime": {
 					"version": "0.11.1",
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
@@ -7005,9 +7129,15 @@
 			}
 		},
 		"core-js": {
-			"version": "2.5.7",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.1.tgz",
+			"integrity": "sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew==",
+			"dev": true
+		},
+		"core-js-pure": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.0.1.tgz",
+			"integrity": "sha512-mSxeQ6IghKW3MoyF4cz19GJ1cMm7761ON+WObSyLfTu/Jn3x7w4NwNFnrZxgl4MTSvYYepVLNuRtlB4loMwJ5g==",
 			"dev": true
 		},
 		"core-util-is": {
@@ -15884,6 +16014,130 @@
 				"ws": "^5.1.1"
 			},
 			"dependencies": {
+				"@babel/core": {
+					"version": "7.3.4",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.3.4.tgz",
+					"integrity": "sha512-jRsuseXBo9pN197KnDwhhaaBzyZr2oIcLHHTt2oDdQrej5Qp57dCCJafWx5ivU8/alEYDpssYqv1MUqcxwQlrA==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/generator": "^7.3.4",
+						"@babel/helpers": "^7.2.0",
+						"@babel/parser": "^7.3.4",
+						"@babel/template": "^7.2.2",
+						"@babel/traverse": "^7.3.4",
+						"@babel/types": "^7.3.4",
+						"convert-source-map": "^1.1.0",
+						"debug": "^4.1.0",
+						"json5": "^2.1.0",
+						"lodash": "^4.17.11",
+						"resolve": "^1.3.2",
+						"semver": "^5.4.1",
+						"source-map": "^0.5.0"
+					},
+					"dependencies": {
+						"@babel/generator": {
+							"version": "7.4.0",
+							"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+							"integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+							"dev": true,
+							"requires": {
+								"@babel/types": "^7.4.0",
+								"jsesc": "^2.5.1",
+								"lodash": "^4.17.11",
+								"source-map": "^0.5.0",
+								"trim-right": "^1.0.1"
+							}
+						},
+						"@babel/parser": {
+							"version": "7.4.3",
+							"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
+							"integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
+							"dev": true
+						},
+						"@babel/types": {
+							"version": "7.4.0",
+							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+							"integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+							"dev": true,
+							"requires": {
+								"esutils": "^2.0.2",
+								"lodash": "^4.17.11",
+								"to-fast-properties": "^2.0.0"
+							}
+						},
+						"json5": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+							"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+							"dev": true,
+							"requires": {
+								"minimist": "^1.2.0"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+							"dev": true
+						}
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.3.4",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.3.4.tgz",
+					"integrity": "sha512-TvTHKp6471OYEcE/91uWmhR6PrrYywQntCHSaZ8CM8Vmp+pjAusal4nGB2WCCQd0rvI7nOMKn9GnbcvTUz3/ZQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/generator": "^7.3.4",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.0.0",
+						"@babel/parser": "^7.3.4",
+						"@babel/types": "^7.3.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.11"
+					},
+					"dependencies": {
+						"@babel/generator": {
+							"version": "7.4.0",
+							"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+							"integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+							"dev": true,
+							"requires": {
+								"@babel/types": "^7.4.0",
+								"jsesc": "^2.5.1",
+								"lodash": "^4.17.11",
+								"source-map": "^0.5.0",
+								"trim-right": "^1.0.1"
+							}
+						},
+						"@babel/parser": {
+							"version": "7.4.3",
+							"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
+							"integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
+							"dev": true
+						},
+						"@babel/types": {
+							"version": "7.4.0",
+							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+							"integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+							"dev": true,
+							"requires": {
+								"esutils": "^2.0.2",
+								"lodash": "^4.17.11",
+								"to-fast-properties": "^2.0.0"
+							}
+						},
+						"source-map": {
+							"version": "0.5.7",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+							"dev": true
+						}
+					}
+				},
 				"clone": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -15903,6 +16157,15 @@
 						"which": "^1.2.9"
 					}
 				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
 				"json5": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
@@ -15916,6 +16179,12 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
 					"dev": true
 				},
 				"postcss-value-parser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3395,7 +3395,7 @@
 			"version": "file:packages/eslint-plugin",
 			"dev": true,
 			"requires": {
-				"babel-eslint": "^8.0.3",
+				"babel-eslint": "^10.0.1",
 				"eslint-plugin-jsx-a11y": "^6.2.1",
 				"eslint-plugin-react": "^7.12.4",
 				"eslint-plugin-react-hooks": "^1.6.0",
@@ -3585,7 +3585,7 @@
 				"chalk": "^2.4.1",
 				"check-node-version": "^3.1.1",
 				"cross-spawn": "^5.1.0",
-				"eslint": "^5.12.1",
+				"eslint": "^5.16.0",
 				"jest": "^24.7.1",
 				"jest-puppeteer": "^4.0.0",
 				"npm-package-json-lint": "^3.6.0",
@@ -4178,122 +4178,19 @@
 			}
 		},
 		"babel-eslint": {
-			"version": "8.2.6",
-			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.6.tgz",
-			"integrity": "sha512-aCdHjhzcILdP8c9lej7hvXKvQieyRt20SF102SIGyY4cUIiw6UaAtK4j2o3dXX74jEmy0TJ0CEhv4fTIM3SzcA==",
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.1.tgz",
+			"integrity": "sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.44",
-				"@babel/traverse": "7.0.0-beta.44",
-				"@babel/types": "7.0.0-beta.44",
-				"babylon": "7.0.0-beta.44",
+				"@babel/code-frame": "^7.0.0",
+				"@babel/parser": "^7.0.0",
+				"@babel/traverse": "^7.0.0",
+				"@babel/types": "^7.0.0",
 				"eslint-scope": "3.7.1",
 				"eslint-visitor-keys": "^1.0.0"
 			},
 			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0-beta.44",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
-					"integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "7.0.0-beta.44"
-					}
-				},
-				"@babel/generator": {
-					"version": "7.0.0-beta.44",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
-					"integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.44",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.2.0",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
-					}
-				},
-				"@babel/helper-function-name": {
-					"version": "7.0.0-beta.44",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
-					"integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-get-function-arity": "7.0.0-beta.44",
-						"@babel/template": "7.0.0-beta.44",
-						"@babel/types": "7.0.0-beta.44"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.0.0-beta.44",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
-					"integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.44"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.0.0-beta.44",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
-					"integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "7.0.0-beta.44"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0-beta.44",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
-					"integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.0"
-					}
-				},
-				"@babel/template": {
-					"version": "7.0.0-beta.44",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
-					"integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "7.0.0-beta.44",
-						"@babel/types": "7.0.0-beta.44",
-						"babylon": "7.0.0-beta.44",
-						"lodash": "^4.2.0"
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.0.0-beta.44",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
-					"integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "7.0.0-beta.44",
-						"@babel/generator": "7.0.0-beta.44",
-						"@babel/helper-function-name": "7.0.0-beta.44",
-						"@babel/helper-split-export-declaration": "7.0.0-beta.44",
-						"@babel/types": "7.0.0-beta.44",
-						"babylon": "7.0.0-beta.44",
-						"debug": "^3.1.0",
-						"globals": "^11.1.0",
-						"invariant": "^2.2.0",
-						"lodash": "^4.2.0"
-					}
-				},
-				"@babel/types": {
-					"version": "7.0.0-beta.44",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-					"integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.2.0",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
 				"eslint-scope": {
 					"version": "3.7.1",
 					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
@@ -4303,12 +4200,6 @@
 						"esrecurse": "^4.1.0",
 						"estraverse": "^4.1.1"
 					}
-				},
-				"js-tokens": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-					"dev": true
 				}
 			}
 		},
@@ -4686,12 +4577,6 @@
 					"dev": true
 				}
 			}
-		},
-		"babylon": {
-			"version": "7.0.0-beta.44",
-			"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
-			"integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
-			"dev": true
 		},
 		"babylon-walk": {
 			"version": "1.0.2",
@@ -6111,12 +5996,6 @@
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
 			}
-		},
-		"circular-json": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-			"dev": true
 		},
 		"clap": {
 			"version": "1.2.3",
@@ -8606,54 +8485,53 @@
 			}
 		},
 		"eslint": {
-			"version": "5.12.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.12.1.tgz",
-			"integrity": "sha512-54NV+JkTpTu0d8+UYSA8mMKAG4XAsaOrozA9rCW7tgneg1mevcL7wIotPC+fZ0SkWwdhNqoXoxnQCTBp7UvTsg==",
+			"version": "5.16.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
+			"integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"ajv": "^6.5.3",
+				"ajv": "^6.9.1",
 				"chalk": "^2.1.0",
 				"cross-spawn": "^6.0.5",
 				"debug": "^4.0.1",
-				"doctrine": "^2.1.0",
-				"eslint-scope": "^4.0.0",
+				"doctrine": "^3.0.0",
+				"eslint-scope": "^4.0.3",
 				"eslint-utils": "^1.3.1",
 				"eslint-visitor-keys": "^1.0.0",
-				"espree": "^5.0.0",
+				"espree": "^5.0.1",
 				"esquery": "^1.0.1",
 				"esutils": "^2.0.2",
-				"file-entry-cache": "^2.0.0",
+				"file-entry-cache": "^5.0.1",
 				"functional-red-black-tree": "^1.0.1",
 				"glob": "^7.1.2",
 				"globals": "^11.7.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
-				"inquirer": "^6.1.0",
-				"js-yaml": "^3.12.0",
+				"inquirer": "^6.2.2",
+				"js-yaml": "^3.13.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.3.0",
-				"lodash": "^4.17.5",
+				"lodash": "^4.17.11",
 				"minimatch": "^3.0.4",
 				"mkdirp": "^0.5.1",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.8.2",
 				"path-is-inside": "^1.0.2",
-				"pluralize": "^7.0.0",
 				"progress": "^2.0.0",
 				"regexpp": "^2.0.1",
 				"semver": "^5.5.1",
 				"strip-ansi": "^4.0.0",
 				"strip-json-comments": "^2.0.1",
-				"table": "^5.0.2",
+				"table": "^5.2.3",
 				"text-table": "^0.2.0"
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "6.0.5",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz",
-					"integrity": "sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg==",
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+					"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
 					"dev": true
 				},
 				"acorn-jsx": {
@@ -8663,9 +8541,9 @@
 					"dev": true
 				},
 				"ajv": {
-					"version": "6.7.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
-					"integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
+					"version": "6.10.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+					"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^2.0.1",
@@ -8673,6 +8551,18 @@
 						"json-schema-traverse": "^0.4.1",
 						"uri-js": "^4.2.2"
 					}
+				},
+				"ansi-escapes": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+					"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+					"dev": true
+				},
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
 				},
 				"cross-spawn": {
 					"version": "6.0.5",
@@ -8696,10 +8586,19 @@
 						"ms": "^2.1.1"
 					}
 				},
+				"doctrine": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+					"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2"
+					}
+				},
 				"eslint-scope": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
-					"integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+					"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
 					"dev": true,
 					"requires": {
 						"esrecurse": "^4.1.0",
@@ -8707,12 +8606,12 @@
 					}
 				},
 				"espree": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/espree/-/espree-5.0.0.tgz",
-					"integrity": "sha512-1MpUfwsdS9MMoN7ZXqAr9e9UKdVHDcvrJpyx7mm1WuQlx/ygErEQBzgi5Nh5qBHIoYweprhtMkTCb9GhcAIcsA==",
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
+					"integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
 					"dev": true,
 					"requires": {
-						"acorn": "^6.0.2",
+						"acorn": "^6.0.7",
 						"acorn-jsx": "^5.0.0",
 						"eslint-visitor-keys": "^1.0.0"
 					}
@@ -8723,11 +8622,74 @@
 					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
 					"dev": true
 				},
+				"file-entry-cache": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+					"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+					"dev": true,
+					"requires": {
+						"flat-cache": "^2.0.1"
+					}
+				},
+				"flat-cache": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+					"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+					"dev": true,
+					"requires": {
+						"flatted": "^2.0.0",
+						"rimraf": "2.6.3",
+						"write": "1.0.3"
+					}
+				},
 				"ignore": {
 					"version": "4.0.6",
 					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
 					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
 					"dev": true
+				},
+				"inquirer": {
+					"version": "6.3.1",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.3.1.tgz",
+					"integrity": "sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==",
+					"dev": true,
+					"requires": {
+						"ansi-escapes": "^3.2.0",
+						"chalk": "^2.4.2",
+						"cli-cursor": "^2.1.0",
+						"cli-width": "^2.0.0",
+						"external-editor": "^3.0.3",
+						"figures": "^2.0.0",
+						"lodash": "^4.17.11",
+						"mute-stream": "0.0.7",
+						"run-async": "^2.2.0",
+						"rxjs": "^6.4.0",
+						"string-width": "^2.1.0",
+						"strip-ansi": "^5.1.0",
+						"through": "^2.3.6"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "2.4.2",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^4.1.0"
+							}
+						}
+					}
 				},
 				"json-schema-traverse": {
 					"version": "0.4.1",
@@ -8741,11 +8703,99 @@
 					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
 					"dev": true
 				},
+				"rimraf": {
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					},
+					"dependencies": {
+						"glob": {
+							"version": "7.1.3",
+							"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+							"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+							"dev": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						}
+					}
+				},
+				"rxjs": {
+					"version": "6.5.1",
+					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.1.tgz",
+					"integrity": "sha512-y0j31WJc83wPu31vS1VlAFW5JGrnGC+j+TtGAa1fRQphy48+fDYiDmX8tjGloToEsMkxnouOg/1IzXGKkJnZMg==",
+					"dev": true,
+					"requires": {
+						"tslib": "^1.9.0"
+					}
+				},
 				"semver": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-					"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 					"dev": true
+				},
+				"slice-ansi": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+					"integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"astral-regex": "^1.0.0",
+						"is-fullwidth-code-point": "^2.0.0"
+					}
+				},
+				"table": {
+					"version": "5.2.3",
+					"resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
+					"integrity": "sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==",
+					"dev": true,
+					"requires": {
+						"ajv": "^6.9.1",
+						"lodash": "^4.17.11",
+						"slice-ansi": "^2.1.0",
+						"string-width": "^3.0.0"
+					},
+					"dependencies": {
+						"string-width": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+							"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+							"dev": true,
+							"requires": {
+								"emoji-regex": "^7.0.1",
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^4.1.0"
+							}
+						}
+					}
+				},
+				"write": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+					"integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+					"dev": true,
+					"requires": {
+						"mkdirp": "^0.5.1"
+					}
 				}
 			}
 		},
@@ -9328,16 +9378,6 @@
 				"escape-string-regexp": "^1.0.5"
 			}
 		},
-		"file-entry-cache": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-			"dev": true,
-			"requires": {
-				"flat-cache": "^1.2.1",
-				"object-assign": "^4.0.1"
-			}
-		},
 		"fileset": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
@@ -9547,18 +9587,6 @@
 					"integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
 					"dev": true
 				}
-			}
-		},
-		"flat-cache": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
-			"integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
-			"dev": true,
-			"requires": {
-				"circular-json": "^0.3.1",
-				"graceful-fs": "^4.1.2",
-				"rimraf": "~2.6.2",
-				"write": "^0.2.1"
 			}
 		},
 		"flatted": {
@@ -16765,12 +16793,6 @@
 				"irregular-plurals": "^2.0.0"
 			}
 		},
-		"pluralize": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-			"dev": true
-		},
 		"pn": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
@@ -23434,15 +23456,6 @@
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 			"dev": true
-		},
-		"write": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-			"dev": true,
-			"requires": {
-				"mkdirp": "^0.5.1"
-			}
 		},
 		"write-file-atomic": {
 			"version": "2.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -628,6 +628,15 @@
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
+		"@babel/plugin-transform-member-expression-literals": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz",
+			"integrity": "sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
 		"@babel/plugin-transform-modules-amd": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz",
@@ -708,6 +717,15 @@
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
+		"@babel/plugin-transform-property-literals": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz",
+			"integrity": "sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
 		"@babel/plugin-transform-react-jsx": {
 			"version": "7.3.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.3.0.tgz",
@@ -726,6 +744,15 @@
 			"dev": true,
 			"requires": {
 				"regenerator-transform": "^0.13.3"
+			}
+		},
+		"@babel/plugin-transform-reserved-words": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz",
+			"integrity": "sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-runtime": {
@@ -3057,15 +3084,423 @@
 			"version": "file:packages/babel-preset-default",
 			"dev": true,
 			"requires": {
-				"@babel/core": "^7.2.2",
+				"@babel/core": "^7.4.3",
 				"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
-				"@babel/plugin-proposal-object-rest-spread": "^7.3.2",
+				"@babel/plugin-proposal-object-rest-spread": "^7.4.3",
 				"@babel/plugin-transform-react-jsx": "^7.3.0",
-				"@babel/plugin-transform-runtime": "^7.2.0",
-				"@babel/preset-env": "^7.3.1",
-				"@babel/runtime": "^7.3.1",
+				"@babel/plugin-transform-runtime": "^7.4.3",
+				"@babel/preset-env": "^7.4.3",
+				"@babel/runtime": "^7.4.3",
 				"@wordpress/babel-plugin-import-jsx-pragma": "file:packages/babel-plugin-import-jsx-pragma",
 				"@wordpress/browserslist-config": "file:packages/browserslist-config"
+			},
+			"dependencies": {
+				"@babel/helper-call-delegate": {
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.0.tgz",
+					"integrity": "sha512-SdqDfbVdNQCBp3WhK2mNdDvHd3BD6qbmIc43CAyjnsfCmgHMeqgDcM3BzY2lchi7HBJGJ2CVdynLWbezaE4mmQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-hoist-variables": "^7.4.0",
+						"@babel/traverse": "^7.4.0",
+						"@babel/types": "^7.4.0"
+					}
+				},
+				"@babel/helper-define-map": {
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.0.tgz",
+					"integrity": "sha512-wAhQ9HdnLIywERVcSvX40CEJwKdAa1ID4neI9NXQPDOHwwA+57DqwLiPEVy2AIyWzAk0CQ8qx4awO0VUURwLtA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/types": "^7.4.0",
+						"lodash": "^4.17.11"
+					}
+				},
+				"@babel/helper-hoist-variables": {
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.0.tgz",
+					"integrity": "sha512-/NErCuoe/et17IlAQFKWM24qtyYYie7sFIrW/tIQXpck6vAu2hhtYYsKLBWQV+BQZMbcIYPU/QMYuTufrY4aQw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.0"
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.4.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.3.tgz",
+					"integrity": "sha512-H88T9IySZW25anu5uqyaC1DaQre7ofM+joZtAaO2F8NBdFfupH0SZ4gKjgSFVcvtx/aAirqA9L9Clio2heYbZA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.0.0",
+						"@babel/helper-simple-access": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.0.0",
+						"@babel/template": "^7.2.2",
+						"@babel/types": "^7.2.2",
+						"lodash": "^4.17.11"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.0.tgz",
+					"integrity": "sha512-PVwCVnWWAgnal+kJ+ZSAphzyl58XrFeSKSAJRiqg5QToTsjL+Xu1f9+RJ+d+Q0aPhPfBGaYfkox66k86thxNSg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.0.0",
+						"@babel/helper-optimise-call-expression": "^7.0.0",
+						"@babel/traverse": "^7.4.0",
+						"@babel/types": "^7.4.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+					"integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.4.0"
+					}
+				},
+				"@babel/plugin-proposal-unicode-property-regex": {
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.0.tgz",
+					"integrity": "sha512-h/KjEZ3nK9wv1P1FSNb9G079jXrNYR0Ko+7XkOx85+gM24iZbPn0rh4vCftk+5QKY7y1uByFataBTmX7irEF1w==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-regex": "^7.0.0",
+						"regexpu-core": "^4.5.4"
+					}
+				},
+				"@babel/plugin-transform-async-to-generator": {
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.0.tgz",
+					"integrity": "sha512-EeaFdCeUULM+GPFEsf7pFcNSxM7hYjoj5fiYbyuiXobW4JhFnjAv9OWzNwHyHcKoPNpAfeRDuW6VyaXEDUBa7g==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.0.0",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-remap-async-to-generator": "^7.1.0"
+					}
+				},
+				"@babel/plugin-transform-block-scoping": {
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.0.tgz",
+					"integrity": "sha512-AWyt3k+fBXQqt2qb9r97tn3iBwFpiv9xdAiG+Gr2HpAZpuayvbL55yWrsV3MyHvXk/4vmSiedhDRl1YI2Iy5nQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"lodash": "^4.17.11"
+					}
+				},
+				"@babel/plugin-transform-classes": {
+					"version": "7.4.3",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.3.tgz",
+					"integrity": "sha512-PUaIKyFUDtG6jF5DUJOfkBdwAS/kFFV3XFk7Nn0a6vR7ZT8jYw5cGtIlat77wcnd0C6ViGqo/wyNf4ZHytF/nQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.0.0",
+						"@babel/helper-define-map": "^7.4.0",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-optimise-call-expression": "^7.0.0",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-replace-supers": "^7.4.0",
+						"@babel/helper-split-export-declaration": "^7.4.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/plugin-transform-destructuring": {
+					"version": "7.4.3",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.3.tgz",
+					"integrity": "sha512-rVTLLZpydDFDyN4qnXdzwoVpk1oaXHIvPEOkOLyr88o7oHxVc/LyrnDx+amuBWGOwUb7D1s/uLsKBNTx08htZg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-dotall-regex": {
+					"version": "7.4.3",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.3.tgz",
+					"integrity": "sha512-9Arc2I0AGynzXRR/oPdSALv3k0rM38IMFyto7kOCwb5F9sLUt2Ykdo3V9yUPR+Bgr4kb6bVEyLkPEiBhzcTeoA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-regex": "^7.4.3",
+						"regexpu-core": "^4.5.4"
+					},
+					"dependencies": {
+						"@babel/helper-regex": {
+							"version": "7.4.3",
+							"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.3.tgz",
+							"integrity": "sha512-hnoq5u96pLCfgjXuj8ZLX3QQ+6nAulS+zSgi6HulUwFbEruRAKwbGLU5OvXkE14L8XW6XsQEKsIDfgthKLRAyA==",
+							"dev": true,
+							"requires": {
+								"lodash": "^4.17.11"
+							}
+						}
+					}
+				},
+				"@babel/plugin-transform-for-of": {
+					"version": "7.4.3",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.3.tgz",
+					"integrity": "sha512-UselcZPwVWNSURnqcfpnxtMehrb8wjXYOimlYQPBnup/Zld426YzIhNEvuRsEWVHfESIECGrxoI6L5QqzuLH5Q==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-function-name": {
+					"version": "7.4.3",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.3.tgz",
+					"integrity": "sha512-uT5J/3qI/8vACBR9I1GlAuU/JqBtWdfCrynuOkrWG6nCDieZd5przB1vfP59FRHBZQ9DC2IUfqr/xKqzOD5x0A==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-modules-commonjs": {
+					"version": "7.4.3",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.3.tgz",
+					"integrity": "sha512-sMP4JqOTbMJMimqsSZwYWsMjppD+KRyDIUVW91pd7td0dZKAvPmhCaxhOzkzLParKwgQc7bdL9UNv+rpJB0HfA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-transforms": "^7.4.3",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-simple-access": "^7.1.0"
+					}
+				},
+				"@babel/plugin-transform-modules-systemjs": {
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.0.tgz",
+					"integrity": "sha512-gjPdHmqiNhVoBqus5qK60mWPp1CmYWp/tkh11mvb0rrys01HycEGD7NvvSoKXlWEfSM9TcL36CpsK8ElsADptQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-hoist-variables": "^7.4.0",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-named-capturing-groups-regex": {
+					"version": "7.4.2",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.2.tgz",
+					"integrity": "sha512-NsAuliSwkL3WO2dzWTOL1oZJHm0TM8ZY8ZSxk2ANyKkt5SQlToGA4pzctmq1BEjoacurdwZ3xp2dCQWJkME0gQ==",
+					"dev": true,
+					"requires": {
+						"regexp-tree": "^0.1.0"
+					}
+				},
+				"@babel/plugin-transform-new-target": {
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.0.tgz",
+					"integrity": "sha512-6ZKNgMQmQmrEX/ncuCwnnw1yVGoaOW5KpxNhoWI7pCQdA0uZ0HqHGqenCUIENAnxRjy2WwNQ30gfGdIgqJXXqw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-parameters": {
+					"version": "7.4.3",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.3.tgz",
+					"integrity": "sha512-ULJYC2Vnw96/zdotCZkMGr2QVfKpIT/4/K+xWWY0MbOJyMZuk660BGkr3bEKWQrrciwz6xpmft39nA4BF7hJuA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-call-delegate": "^7.4.0",
+						"@babel/helper-get-function-arity": "^7.0.0",
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-regenerator": {
+					"version": "7.4.3",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.3.tgz",
+					"integrity": "sha512-kEzotPuOpv6/iSlHroCDydPkKYw7tiJGKlmYp6iJn4a6C/+b2FdttlJsLKYxolYHgotTJ5G5UY5h0qey5ka3+A==",
+					"dev": true,
+					"requires": {
+						"regenerator-transform": "^0.13.4"
+					}
+				},
+				"@babel/plugin-transform-unicode-regex": {
+					"version": "7.4.3",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.3.tgz",
+					"integrity": "sha512-lnSNgkVjL8EMtnE8eSS7t2ku8qvKH3eqNf/IwIfnSPUqzgqYmRwzdsQWv4mNQAN9Nuo6Gz1Y0a4CSmdpu1Pp6g==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-regex": "^7.4.3",
+						"regexpu-core": "^4.5.4"
+					},
+					"dependencies": {
+						"@babel/helper-regex": {
+							"version": "7.4.3",
+							"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.3.tgz",
+							"integrity": "sha512-hnoq5u96pLCfgjXuj8ZLX3QQ+6nAulS+zSgi6HulUwFbEruRAKwbGLU5OvXkE14L8XW6XsQEKsIDfgthKLRAyA==",
+							"dev": true,
+							"requires": {
+								"lodash": "^4.17.11"
+							}
+						}
+					}
+				},
+				"@babel/preset-env": {
+					"version": "7.4.3",
+					"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.3.tgz",
+					"integrity": "sha512-FYbZdV12yHdJU5Z70cEg0f6lvtpZ8jFSDakTm7WXeJbLXh4R0ztGEu/SW7G1nJ2ZvKwDhz8YrbA84eYyprmGqw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.0.0",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+						"@babel/plugin-proposal-json-strings": "^7.2.0",
+						"@babel/plugin-proposal-object-rest-spread": "^7.4.3",
+						"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
+						"@babel/plugin-proposal-unicode-property-regex": "^7.4.0",
+						"@babel/plugin-syntax-async-generators": "^7.2.0",
+						"@babel/plugin-syntax-json-strings": "^7.2.0",
+						"@babel/plugin-syntax-object-rest-spread": "^7.2.0",
+						"@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+						"@babel/plugin-transform-arrow-functions": "^7.2.0",
+						"@babel/plugin-transform-async-to-generator": "^7.4.0",
+						"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
+						"@babel/plugin-transform-block-scoping": "^7.4.0",
+						"@babel/plugin-transform-classes": "^7.4.3",
+						"@babel/plugin-transform-computed-properties": "^7.2.0",
+						"@babel/plugin-transform-destructuring": "^7.4.3",
+						"@babel/plugin-transform-dotall-regex": "^7.4.3",
+						"@babel/plugin-transform-duplicate-keys": "^7.2.0",
+						"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
+						"@babel/plugin-transform-for-of": "^7.4.3",
+						"@babel/plugin-transform-function-name": "^7.4.3",
+						"@babel/plugin-transform-literals": "^7.2.0",
+						"@babel/plugin-transform-member-expression-literals": "^7.2.0",
+						"@babel/plugin-transform-modules-amd": "^7.2.0",
+						"@babel/plugin-transform-modules-commonjs": "^7.4.3",
+						"@babel/plugin-transform-modules-systemjs": "^7.4.0",
+						"@babel/plugin-transform-modules-umd": "^7.2.0",
+						"@babel/plugin-transform-named-capturing-groups-regex": "^7.4.2",
+						"@babel/plugin-transform-new-target": "^7.4.0",
+						"@babel/plugin-transform-object-super": "^7.2.0",
+						"@babel/plugin-transform-parameters": "^7.4.3",
+						"@babel/plugin-transform-property-literals": "^7.2.0",
+						"@babel/plugin-transform-regenerator": "^7.4.3",
+						"@babel/plugin-transform-reserved-words": "^7.2.0",
+						"@babel/plugin-transform-shorthand-properties": "^7.2.0",
+						"@babel/plugin-transform-spread": "^7.2.0",
+						"@babel/plugin-transform-sticky-regex": "^7.2.0",
+						"@babel/plugin-transform-template-literals": "^7.2.0",
+						"@babel/plugin-transform-typeof-symbol": "^7.2.0",
+						"@babel/plugin-transform-unicode-regex": "^7.4.3",
+						"@babel/types": "^7.4.0",
+						"browserslist": "^4.5.2",
+						"core-js-compat": "^3.0.0",
+						"invariant": "^2.2.2",
+						"js-levenshtein": "^1.1.3",
+						"semver": "^5.5.0"
+					},
+					"dependencies": {
+						"@babel/plugin-proposal-object-rest-spread": {
+							"version": "7.4.3",
+							"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.3.tgz",
+							"integrity": "sha512-xC//6DNSSHVjq8O2ge0dyYlhshsH4T7XdCVoxbi5HzLYWfsC5ooFlJjrXk8RcAT+hjHAK9UjBXdylzSoDK3t4g==",
+							"dev": true,
+							"requires": {
+								"@babel/helper-plugin-utils": "^7.0.0",
+								"@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+							}
+						}
+					}
+				},
+				"@babel/types": {
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+					"integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.11",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"browserslist": {
+					"version": "4.5.5",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.5.tgz",
+					"integrity": "sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "^1.0.30000960",
+						"electron-to-chromium": "^1.3.124",
+						"node-releases": "^1.1.14"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30000963",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000963.tgz",
+					"integrity": "sha512-n4HUiullc7Lw0LyzpeLa2ffP8KxFBGdxqD/8G3bSL6oB758hZ2UE2CVK+tQN958tJIi0/tfpjAc67aAtoHgnrQ==",
+					"dev": true
+				},
+				"electron-to-chromium": {
+					"version": "1.3.125",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.125.tgz",
+					"integrity": "sha512-XxowpqQxJ4nDwUXHtVtmEhRqBpm2OnjBomZmZtHD0d2Eo0244+Ojezhk3sD/MBSSe2nxCdGQFRXHIsf/LUTL9A==",
+					"dev": true
+				},
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
+				},
+				"regenerate-unicode-properties": {
+					"version": "8.0.2",
+					"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.0.2.tgz",
+					"integrity": "sha512-SbA/iNrBUf6Pv2zU8Ekv1Qbhv92yxL4hiDa2siuxs4KKn4oOoMDHXjAf7+Nz9qinUQ46B1LcWEi/PhJfPWpZWQ==",
+					"dev": true,
+					"requires": {
+						"regenerate": "^1.4.0"
+					}
+				},
+				"regenerator-transform": {
+					"version": "0.13.4",
+					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.4.tgz",
+					"integrity": "sha512-T0QMBjK3J0MtxjPmdIMXm72Wvj2Abb0Bd4HADdfijwMdoIsyQZ6fWC7kDFhk2YinBBEMZDL7Y7wh0J1sGx3S4A==",
+					"dev": true,
+					"requires": {
+						"private": "^0.1.6"
+					}
+				},
+				"regexpu-core": {
+					"version": "4.5.4",
+					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
+					"integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
+					"dev": true,
+					"requires": {
+						"regenerate": "^1.4.0",
+						"regenerate-unicode-properties": "^8.0.2",
+						"regjsgen": "^0.5.0",
+						"regjsparser": "^0.6.0",
+						"unicode-match-property-ecmascript": "^1.0.4",
+						"unicode-match-property-value-ecmascript": "^1.1.0"
+					}
+				},
+				"regjsgen": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
+					"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
+					"dev": true
+				},
+				"regjsparser": {
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+					"integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+					"dev": true,
+					"requires": {
+						"jsesc": "~0.5.0"
+					}
+				},
+				"unicode-match-property-value-ecmascript": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+					"integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
+					"dev": true
+				}
 			}
 		},
 		"@wordpress/blob": {
@@ -7133,6 +7568,49 @@
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.1.tgz",
 			"integrity": "sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew==",
 			"dev": true
+		},
+		"core-js-compat": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.0.1.tgz",
+			"integrity": "sha512-2pC3e+Ht/1/gD7Sim/sqzvRplMiRnFQVlPpDVaHtY9l7zZP7knamr3VRD6NyGfHd84MrDC0tAM9ulNxYMW0T3g==",
+			"dev": true,
+			"requires": {
+				"browserslist": "^4.5.4",
+				"core-js": "3.0.1",
+				"core-js-pure": "3.0.1",
+				"semver": "^6.0.0"
+			},
+			"dependencies": {
+				"browserslist": {
+					"version": "4.5.5",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.5.tgz",
+					"integrity": "sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "^1.0.30000960",
+						"electron-to-chromium": "^1.3.124",
+						"node-releases": "^1.1.14"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30000963",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000963.tgz",
+					"integrity": "sha512-n4HUiullc7Lw0LyzpeLa2ffP8KxFBGdxqD/8G3bSL6oB758hZ2UE2CVK+tQN958tJIi0/tfpjAc67aAtoHgnrQ==",
+					"dev": true
+				},
+				"electron-to-chromium": {
+					"version": "1.3.125",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.125.tgz",
+					"integrity": "sha512-XxowpqQxJ4nDwUXHtVtmEhRqBpm2OnjBomZmZtHD0d2Eo0244+Ojezhk3sD/MBSSe2nxCdGQFRXHIsf/LUTL9A==",
+					"dev": true
+				},
+				"semver": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+					"integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==",
+					"dev": true
+				}
+			}
 		},
 		"core-js-pure": {
 			"version": "3.0.1",
@@ -14835,6 +15313,15 @@
 				"semver": "^5.5.0",
 				"shellwords": "^0.1.1",
 				"which": "^1.3.0"
+			}
+		},
+		"node-releases": {
+			"version": "1.1.17",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.17.tgz",
+			"integrity": "sha512-/SCjetyta1m7YXLgtACZGDYJdCSIBAWorDWkGCGZlydP2Ll7J48l7j/JxNYZ+xsgSPbWfdulVS/aY+GdjUsQ7Q==",
+			"dev": true,
+			"requires": {
+				"semver": "^5.3.0"
 			}
 		},
 		"node-sass": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,18 +14,18 @@
 			}
 		},
 		"@babel/core": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.3.tgz",
-			"integrity": "sha512-oDpASqKFlbspQfzAE7yaeTmdljSH2ADIvBlb0RwbStltTuWa0+7CCI1fYVINNv9saHPa1W7oaKeuNuKj+RQCvA==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.4.tgz",
+			"integrity": "sha512-lQgGX3FPRgbz2SKmhMtYgJvVzGZrmjaF4apZ2bLwofAKiSjxU0drPh4S/VasyYXwaTs+A1gvQ45BN8SQJzHsQQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/generator": "^7.4.0",
-				"@babel/helpers": "^7.4.3",
-				"@babel/parser": "^7.4.3",
-				"@babel/template": "^7.4.0",
-				"@babel/traverse": "^7.4.3",
-				"@babel/types": "^7.4.0",
+				"@babel/generator": "^7.4.4",
+				"@babel/helpers": "^7.4.4",
+				"@babel/parser": "^7.4.4",
+				"@babel/template": "^7.4.4",
+				"@babel/traverse": "^7.4.4",
+				"@babel/types": "^7.4.4",
 				"convert-source-map": "^1.1.0",
 				"debug": "^4.1.0",
 				"json5": "^2.1.0",
@@ -68,12 +68,12 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
-			"integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+			"integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.4.0",
+				"@babel/types": "^7.4.4",
 				"jsesc": "^2.5.1",
 				"lodash": "^4.17.11",
 				"source-map": "^0.5.0",
@@ -110,24 +110,24 @@
 			}
 		},
 		"@babel/helper-call-delegate": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.0.tgz",
-			"integrity": "sha512-SdqDfbVdNQCBp3WhK2mNdDvHd3BD6qbmIc43CAyjnsfCmgHMeqgDcM3BzY2lchi7HBJGJ2CVdynLWbezaE4mmQ==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
+			"integrity": "sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.4.0",
-				"@babel/traverse": "^7.4.0",
-				"@babel/types": "^7.4.0"
+				"@babel/helper-hoist-variables": "^7.4.4",
+				"@babel/traverse": "^7.4.4",
+				"@babel/types": "^7.4.4"
 			}
 		},
 		"@babel/helper-define-map": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.0.tgz",
-			"integrity": "sha512-wAhQ9HdnLIywERVcSvX40CEJwKdAa1ID4neI9NXQPDOHwwA+57DqwLiPEVy2AIyWzAk0CQ8qx4awO0VUURwLtA==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.4.tgz",
+			"integrity": "sha512-IX3Ln8gLhZpSuqHJSnTNBWGDE9kdkTEWl21A/K7PQ00tseBwbqCHTvNLHSBd9M0R5rER4h5Rsvj9vw0R5SieBg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
-				"@babel/types": "^7.4.0",
+				"@babel/types": "^7.4.4",
 				"lodash": "^4.17.11"
 			}
 		},
@@ -162,12 +162,12 @@
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.0.tgz",
-			"integrity": "sha512-/NErCuoe/et17IlAQFKWM24qtyYYie7sFIrW/tIQXpck6vAu2hhtYYsKLBWQV+BQZMbcIYPU/QMYuTufrY4aQw==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
+			"integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.4.0"
+				"@babel/types": "^7.4.4"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
@@ -189,16 +189,16 @@
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.3.tgz",
-			"integrity": "sha512-H88T9IySZW25anu5uqyaC1DaQre7ofM+joZtAaO2F8NBdFfupH0SZ4gKjgSFVcvtx/aAirqA9L9Clio2heYbZA==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.4.tgz",
+			"integrity": "sha512-3Z1yp8TVQf+B4ynN7WoHPKS8EkdTbgAEy0nU0rs/1Kw4pDgmvYH3rz3aI11KgxKCba2cn7N+tqzV1mY2HMN96w==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
 				"@babel/helper-simple-access": "^7.1.0",
-				"@babel/helper-split-export-declaration": "^7.0.0",
-				"@babel/template": "^7.2.2",
-				"@babel/types": "^7.2.2",
+				"@babel/helper-split-export-declaration": "^7.4.4",
+				"@babel/template": "^7.4.4",
+				"@babel/types": "^7.4.4",
 				"lodash": "^4.17.11"
 			}
 		},
@@ -218,9 +218,9 @@
 			"dev": true
 		},
 		"@babel/helper-regex": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.3.tgz",
-			"integrity": "sha512-hnoq5u96pLCfgjXuj8ZLX3QQ+6nAulS+zSgi6HulUwFbEruRAKwbGLU5OvXkE14L8XW6XsQEKsIDfgthKLRAyA==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.4.tgz",
+			"integrity": "sha512-Y5nuB/kESmR3tKjU8Nkn1wMGEx1tjJX076HBMeL3XLQCu6vA/YRzuTW0bbb+qRnXvQGn+d6Rx953yffl8vEy7Q==",
 			"dev": true,
 			"requires": {
 				"lodash": "^4.17.11"
@@ -240,15 +240,15 @@
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.0.tgz",
-			"integrity": "sha512-PVwCVnWWAgnal+kJ+ZSAphzyl58XrFeSKSAJRiqg5QToTsjL+Xu1f9+RJ+d+Q0aPhPfBGaYfkox66k86thxNSg==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.4.tgz",
+			"integrity": "sha512-04xGEnd+s01nY1l15EuMS1rfKktNF+1CkKmHoErDppjAAZL+IUBZpzT748x262HF7fibaQPhbvWUl5HeSt1EXg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-member-expression-to-functions": "^7.0.0",
 				"@babel/helper-optimise-call-expression": "^7.0.0",
-				"@babel/traverse": "^7.4.0",
-				"@babel/types": "^7.4.0"
+				"@babel/traverse": "^7.4.4",
+				"@babel/types": "^7.4.4"
 			}
 		},
 		"@babel/helper-simple-access": {
@@ -262,12 +262,12 @@
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
-			"integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+			"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.4.0"
+				"@babel/types": "^7.4.4"
 			}
 		},
 		"@babel/helper-wrap-function": {
@@ -283,14 +283,14 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.3.tgz",
-			"integrity": "sha512-BMh7X0oZqb36CfyhvtbSmcWc3GXocfxv3yNsAEuM0l+fAqSO22rQrUpijr3oE/10jCTrB6/0b9kzmG4VetCj8Q==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.4.tgz",
+			"integrity": "sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.4.0",
-				"@babel/traverse": "^7.4.3",
-				"@babel/types": "^7.4.0"
+				"@babel/template": "^7.4.4",
+				"@babel/traverse": "^7.4.4",
+				"@babel/types": "^7.4.4"
 			}
 		},
 		"@babel/highlight": {
@@ -305,9 +305,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
-			"integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.4.tgz",
+			"integrity": "sha512-5pCS4mOsL+ANsFZGdvNLybx4wtqAZJ0MJjMHxvzI3bvIsz6sQvzW8XX92EYIkiPtIvcfG3Aj+Ir5VNyjnZhP7w==",
 			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
@@ -332,9 +332,9 @@
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.3.tgz",
-			"integrity": "sha512-xC//6DNSSHVjq8O2ge0dyYlhshsH4T7XdCVoxbi5HzLYWfsC5ooFlJjrXk8RcAT+hjHAK9UjBXdylzSoDK3t4g==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.4.tgz",
+			"integrity": "sha512-dMBG6cSPBbHeEBdFXeQ2QLc5gUpg4Vkaz8octD4aoW/ISO+jBOcsuxYL7bsb5WSu8RLP6boxrBIALEHgoHtO9g==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -352,13 +352,13 @@
 			}
 		},
 		"@babel/plugin-proposal-unicode-property-regex": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.0.tgz",
-			"integrity": "sha512-h/KjEZ3nK9wv1P1FSNb9G079jXrNYR0Ko+7XkOx85+gM24iZbPn0rh4vCftk+5QKY7y1uByFataBTmX7irEF1w==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
+			"integrity": "sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.0.0",
+				"@babel/helper-regex": "^7.4.4",
 				"regexpu-core": "^4.5.4"
 			}
 		},
@@ -426,9 +426,9 @@
 			}
 		},
 		"@babel/plugin-transform-async-to-generator": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.0.tgz",
-			"integrity": "sha512-EeaFdCeUULM+GPFEsf7pFcNSxM7hYjoj5fiYbyuiXobW4JhFnjAv9OWzNwHyHcKoPNpAfeRDuW6VyaXEDUBa7g==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.4.tgz",
+			"integrity": "sha512-YiqW2Li8TXmzgbXw+STsSqPBPFnGviiaSp6CYOq55X8GQ2SGVLrXB6pNid8HkqkZAzOH6knbai3snhP7v0fNwA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
@@ -446,9 +446,9 @@
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.0.tgz",
-			"integrity": "sha512-AWyt3k+fBXQqt2qb9r97tn3iBwFpiv9xdAiG+Gr2HpAZpuayvbL55yWrsV3MyHvXk/4vmSiedhDRl1YI2Iy5nQ==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.4.tgz",
+			"integrity": "sha512-jkTUyWZcTrwxu5DD4rWz6rDB5Cjdmgz6z7M7RLXOJyCUkFBawssDGcGh8M/0FTSB87avyJI1HsTwUXp9nKA1PA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -456,18 +456,18 @@
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.3.tgz",
-			"integrity": "sha512-PUaIKyFUDtG6jF5DUJOfkBdwAS/kFFV3XFk7Nn0a6vR7ZT8jYw5cGtIlat77wcnd0C6ViGqo/wyNf4ZHytF/nQ==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.4.tgz",
+			"integrity": "sha512-/e44eFLImEGIpL9qPxSRat13I5QNRgBLu2hOQJCF7VLy/otSM/sypV1+XaIw5+502RX/+6YaSAPmldk+nhHDPw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.0.0",
-				"@babel/helper-define-map": "^7.4.0",
+				"@babel/helper-define-map": "^7.4.4",
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/helper-optimise-call-expression": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.4.0",
-				"@babel/helper-split-export-declaration": "^7.4.0",
+				"@babel/helper-replace-supers": "^7.4.4",
+				"@babel/helper-split-export-declaration": "^7.4.4",
 				"globals": "^11.1.0"
 			}
 		},
@@ -481,22 +481,22 @@
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.3.tgz",
-			"integrity": "sha512-rVTLLZpydDFDyN4qnXdzwoVpk1oaXHIvPEOkOLyr88o7oHxVc/LyrnDx+amuBWGOwUb7D1s/uLsKBNTx08htZg==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.4.tgz",
+			"integrity": "sha512-/aOx+nW0w8eHiEHm+BTERB2oJn5D127iye/SUQl7NjHy0lf+j7h4MKMMSOwdazGq9OxgiNADncE+SRJkCxjZpQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.3.tgz",
-			"integrity": "sha512-9Arc2I0AGynzXRR/oPdSALv3k0rM38IMFyto7kOCwb5F9sLUt2Ykdo3V9yUPR+Bgr4kb6bVEyLkPEiBhzcTeoA==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
+			"integrity": "sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.4.3",
+				"@babel/helper-regex": "^7.4.4",
 				"regexpu-core": "^4.5.4"
 			}
 		},
@@ -530,18 +530,18 @@
 			}
 		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.3.tgz",
-			"integrity": "sha512-UselcZPwVWNSURnqcfpnxtMehrb8wjXYOimlYQPBnup/Zld426YzIhNEvuRsEWVHfESIECGrxoI6L5QqzuLH5Q==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
+			"integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-function-name": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.3.tgz",
-			"integrity": "sha512-uT5J/3qI/8vACBR9I1GlAuU/JqBtWdfCrynuOkrWG6nCDieZd5przB1vfP59FRHBZQ9DC2IUfqr/xKqzOD5x0A==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
+			"integrity": "sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
@@ -577,23 +577,23 @@
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.2.0.tgz",
-			"integrity": "sha512-V6y0uaUQrQPXUrmj+hgnks8va2L0zcZymeU7TtWEgdRLNkceafKXEduv7QzgQAE4lT+suwooG9dC7LFhdRAbVQ==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.4.tgz",
+			"integrity": "sha512-4sfBOJt58sEo9a2BQXnZq+Q3ZTSAUXyK3E30o36BOGnJ+tvJ6YSxF0PG6kERvbeISgProodWuI9UVG3/FMY6iw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.1.0",
+				"@babel/helper-module-transforms": "^7.4.4",
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-simple-access": "^7.1.0"
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.0.tgz",
-			"integrity": "sha512-gjPdHmqiNhVoBqus5qK60mWPp1CmYWp/tkh11mvb0rrys01HycEGD7NvvSoKXlWEfSM9TcL36CpsK8ElsADptQ==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.4.tgz",
+			"integrity": "sha512-MSiModfILQc3/oqnG7NrP1jHaSPryO6tA2kOMmAQApz5dayPxWiHqmq4sWH2xF5LcQK56LlbKByCd8Aah/OIkQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.4.0",
+				"@babel/helper-hoist-variables": "^7.4.4",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
@@ -608,18 +608,18 @@
 			}
 		},
 		"@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.4.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.2.tgz",
-			"integrity": "sha512-NsAuliSwkL3WO2dzWTOL1oZJHm0TM8ZY8ZSxk2ANyKkt5SQlToGA4pzctmq1BEjoacurdwZ3xp2dCQWJkME0gQ==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.4.tgz",
+			"integrity": "sha512-Ki+Y9nXBlKfhD+LXaRS7v95TtTGYRAf9Y1rTDiE75zf8YQz4GDaWRXosMfJBXxnk88mGFjWdCRIeqDbon7spYA==",
 			"dev": true,
 			"requires": {
 				"regexp-tree": "^0.1.0"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.0.tgz",
-			"integrity": "sha512-6ZKNgMQmQmrEX/ncuCwnnw1yVGoaOW5KpxNhoWI7pCQdA0uZ0HqHGqenCUIENAnxRjy2WwNQ30gfGdIgqJXXqw==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
+			"integrity": "sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -636,12 +636,12 @@
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.3.tgz",
-			"integrity": "sha512-ULJYC2Vnw96/zdotCZkMGr2QVfKpIT/4/K+xWWY0MbOJyMZuk660BGkr3bEKWQrrciwz6xpmft39nA4BF7hJuA==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
+			"integrity": "sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-call-delegate": "^7.4.0",
+				"@babel/helper-call-delegate": "^7.4.4",
 				"@babel/helper-get-function-arity": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -667,9 +667,9 @@
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.3.tgz",
-			"integrity": "sha512-kEzotPuOpv6/iSlHroCDydPkKYw7tiJGKlmYp6iJn4a6C/+b2FdttlJsLKYxolYHgotTJ5G5UY5h0qey5ka3+A==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.4.tgz",
+			"integrity": "sha512-Zz3w+pX1SI0KMIiqshFZkwnVGUhDZzpX2vtPzfJBKQQq8WsP/Xy9DNdELWivxcKOCX/Pywge4SiEaPaLtoDT4g==",
 			"dev": true,
 			"requires": {
 				"regenerator-transform": "^0.13.4"
@@ -685,9 +685,9 @@
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.3.tgz",
-			"integrity": "sha512-7Q61bU+uEI7bCUFReT1NKn7/X6sDQsZ7wL1sJ9IYMAO7cI+eg6x9re1cEw2fCRMbbTVyoeUKWSV1M6azEfKCfg==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.4.tgz",
+			"integrity": "sha512-aMVojEjPszvau3NRg+TIH14ynZLvPewH4xhlCW1w6A3rkxTS1m4uwzRclYR9oS+rl/dr+kT+pzbfHuAWP/lc7Q==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
@@ -733,9 +733,9 @@
 			}
 		},
 		"@babel/plugin-transform-template-literals": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.2.0.tgz",
-			"integrity": "sha512-FkPix00J9A/XWXv4VoKJBMeSkyY9x/TqIh76wzcdfl57RJJcf8CehQ08uwfhCDNtRQYtHQKBTwKZDEyjE13Lwg==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
+			"integrity": "sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.0.0",
@@ -752,65 +752,65 @@
 			}
 		},
 		"@babel/plugin-transform-unicode-regex": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.3.tgz",
-			"integrity": "sha512-lnSNgkVjL8EMtnE8eSS7t2ku8qvKH3eqNf/IwIfnSPUqzgqYmRwzdsQWv4mNQAN9Nuo6Gz1Y0a4CSmdpu1Pp6g==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
+			"integrity": "sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.4.3",
+				"@babel/helper-regex": "^7.4.4",
 				"regexpu-core": "^4.5.4"
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.3.tgz",
-			"integrity": "sha512-FYbZdV12yHdJU5Z70cEg0f6lvtpZ8jFSDakTm7WXeJbLXh4R0ztGEu/SW7G1nJ2ZvKwDhz8YrbA84eYyprmGqw==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.4.tgz",
+			"integrity": "sha512-FU1H+ACWqZZqfw1x2G1tgtSSYSfxJLkpaUQL37CenULFARDo+h4xJoVHzRoHbK+85ViLciuI7ME4WTIhFRBBlw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
 				"@babel/plugin-proposal-json-strings": "^7.2.0",
-				"@babel/plugin-proposal-object-rest-spread": "^7.4.3",
+				"@babel/plugin-proposal-object-rest-spread": "^7.4.4",
 				"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-				"@babel/plugin-proposal-unicode-property-regex": "^7.4.0",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
 				"@babel/plugin-syntax-async-generators": "^7.2.0",
 				"@babel/plugin-syntax-json-strings": "^7.2.0",
 				"@babel/plugin-syntax-object-rest-spread": "^7.2.0",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
 				"@babel/plugin-transform-arrow-functions": "^7.2.0",
-				"@babel/plugin-transform-async-to-generator": "^7.4.0",
+				"@babel/plugin-transform-async-to-generator": "^7.4.4",
 				"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-				"@babel/plugin-transform-block-scoping": "^7.4.0",
-				"@babel/plugin-transform-classes": "^7.4.3",
+				"@babel/plugin-transform-block-scoping": "^7.4.4",
+				"@babel/plugin-transform-classes": "^7.4.4",
 				"@babel/plugin-transform-computed-properties": "^7.2.0",
-				"@babel/plugin-transform-destructuring": "^7.4.3",
-				"@babel/plugin-transform-dotall-regex": "^7.4.3",
+				"@babel/plugin-transform-destructuring": "^7.4.4",
+				"@babel/plugin-transform-dotall-regex": "^7.4.4",
 				"@babel/plugin-transform-duplicate-keys": "^7.2.0",
 				"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
-				"@babel/plugin-transform-for-of": "^7.4.3",
-				"@babel/plugin-transform-function-name": "^7.4.3",
+				"@babel/plugin-transform-for-of": "^7.4.4",
+				"@babel/plugin-transform-function-name": "^7.4.4",
 				"@babel/plugin-transform-literals": "^7.2.0",
 				"@babel/plugin-transform-member-expression-literals": "^7.2.0",
 				"@babel/plugin-transform-modules-amd": "^7.2.0",
-				"@babel/plugin-transform-modules-commonjs": "^7.4.3",
-				"@babel/plugin-transform-modules-systemjs": "^7.4.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.4.4",
+				"@babel/plugin-transform-modules-systemjs": "^7.4.4",
 				"@babel/plugin-transform-modules-umd": "^7.2.0",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.4.2",
-				"@babel/plugin-transform-new-target": "^7.4.0",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.4.4",
+				"@babel/plugin-transform-new-target": "^7.4.4",
 				"@babel/plugin-transform-object-super": "^7.2.0",
-				"@babel/plugin-transform-parameters": "^7.4.3",
+				"@babel/plugin-transform-parameters": "^7.4.4",
 				"@babel/plugin-transform-property-literals": "^7.2.0",
-				"@babel/plugin-transform-regenerator": "^7.4.3",
+				"@babel/plugin-transform-regenerator": "^7.4.4",
 				"@babel/plugin-transform-reserved-words": "^7.2.0",
 				"@babel/plugin-transform-shorthand-properties": "^7.2.0",
 				"@babel/plugin-transform-spread": "^7.2.0",
 				"@babel/plugin-transform-sticky-regex": "^7.2.0",
-				"@babel/plugin-transform-template-literals": "^7.2.0",
+				"@babel/plugin-transform-template-literals": "^7.4.4",
 				"@babel/plugin-transform-typeof-symbol": "^7.2.0",
-				"@babel/plugin-transform-unicode-regex": "^7.4.3",
-				"@babel/types": "^7.4.0",
+				"@babel/plugin-transform-unicode-regex": "^7.4.4",
+				"@babel/types": "^7.4.4",
 				"browserslist": "^4.5.2",
 				"core-js-compat": "^3.0.0",
 				"invariant": "^2.2.2",
@@ -818,17 +818,6 @@
 				"semver": "^5.5.0"
 			},
 			"dependencies": {
-				"@babel/plugin-transform-modules-commonjs": {
-					"version": "7.4.3",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.3.tgz",
-					"integrity": "sha512-sMP4JqOTbMJMimqsSZwYWsMjppD+KRyDIUVW91pd7td0dZKAvPmhCaxhOzkzLParKwgQc7bdL9UNv+rpJB0HfA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-module-transforms": "^7.4.3",
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"@babel/helper-simple-access": "^7.1.0"
-					}
-				},
 				"browserslist": {
 					"version": "4.5.5",
 					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.5.tgz",
@@ -847,69 +836,54 @@
 					"dev": true
 				},
 				"electron-to-chromium": {
-					"version": "1.3.125",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.125.tgz",
-					"integrity": "sha512-XxowpqQxJ4nDwUXHtVtmEhRqBpm2OnjBomZmZtHD0d2Eo0244+Ojezhk3sD/MBSSe2nxCdGQFRXHIsf/LUTL9A==",
+					"version": "1.3.127",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.127.tgz",
+					"integrity": "sha512-1o25iFRf/dbgauTWalEzmD1EmRN3a2CzP/K7UVpYLEBduk96LF0FyUdCcf4Ry2mAWJ1VxyblFjC93q6qlLwA2A==",
 					"dev": true
 				}
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
-			"integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
+			"integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
 			"requires": {
 				"regenerator-runtime": "^0.13.2"
-			},
-			"dependencies": {
-				"regenerator-runtime": {
-					"version": "0.13.2",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-					"integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
-				}
 			}
 		},
 		"@babel/runtime-corejs3": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.4.3.tgz",
-			"integrity": "sha512-12jcdiSTZu6bLXyjCqD4E8/rFoctaLjR/MvIiI4I4kvqFEnifeDbaChDpYHrt9meOXbkDpykXdqhXfRJCJYHxQ==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.4.4.tgz",
+			"integrity": "sha512-9uYCgQvCVw4Jl5vVyTt6ZYIAgsLyAKx0CvBqOJW0D/bRx/jSOQS1A+31GiisgKhgyTt3/CWnbdGzFxxw8NOtlw==",
 			"dev": true,
 			"requires": {
 				"core-js-pure": "^3.0.0",
 				"regenerator-runtime": "^0.13.2"
-			},
-			"dependencies": {
-				"regenerator-runtime": {
-					"version": "0.13.2",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-					"integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/template": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
-			"integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+			"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.4.0",
-				"@babel/types": "^7.4.0"
+				"@babel/parser": "^7.4.4",
+				"@babel/types": "^7.4.4"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
-			"integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.4.tgz",
+			"integrity": "sha512-Gw6qqkw/e6AGzlyj9KnkabJX7VcubqPtkUQVAwkc0wUMldr3A/hezNB3Rc5eIvId95iSGkGIOe5hh1kMKf951A==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/generator": "^7.4.0",
+				"@babel/generator": "^7.4.4",
 				"@babel/helper-function-name": "^7.1.0",
-				"@babel/helper-split-export-declaration": "^7.4.0",
-				"@babel/parser": "^7.4.3",
-				"@babel/types": "^7.4.0",
+				"@babel/helper-split-export-declaration": "^7.4.4",
+				"@babel/parser": "^7.4.4",
+				"@babel/types": "^7.4.4",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.11"
@@ -933,9 +907,9 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
-			"integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+			"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
 			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
@@ -2974,14 +2948,14 @@
 		"@wordpress/a11y": {
 			"version": "file:packages/a11y",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"@wordpress/dom-ready": "file:packages/dom-ready"
 			}
 		},
 		"@wordpress/annotations": {
 			"version": "file:packages/annotations",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/i18n": "file:packages/i18n",
@@ -2994,7 +2968,7 @@
 		"@wordpress/api-fetch": {
 			"version": "file:packages/api-fetch",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/url": "file:packages/url"
 			}
@@ -3002,7 +2976,7 @@
 		"@wordpress/autop": {
 			"version": "file:packages/autop",
 			"requires": {
-				"@babel/runtime": "^7.3.1"
+				"@babel/runtime": "^7.4.4"
 			}
 		},
 		"@wordpress/babel-plugin-import-jsx-pragma": {
@@ -3013,7 +2987,7 @@
 			"version": "file:packages/babel-plugin-makepot",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"gettext-parser": "^1.3.1",
 				"lodash": "^4.17.11"
 			}
@@ -3022,13 +2996,13 @@
 			"version": "file:packages/babel-preset-default",
 			"dev": true,
 			"requires": {
-				"@babel/core": "^7.4.3",
+				"@babel/core": "^7.4.4",
 				"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
-				"@babel/plugin-proposal-object-rest-spread": "^7.4.3",
+				"@babel/plugin-proposal-object-rest-spread": "^7.4.4",
 				"@babel/plugin-transform-react-jsx": "^7.3.0",
-				"@babel/plugin-transform-runtime": "^7.4.3",
-				"@babel/preset-env": "^7.4.3",
-				"@babel/runtime": "^7.4.3",
+				"@babel/plugin-transform-runtime": "^7.4.4",
+				"@babel/preset-env": "^7.4.4",
+				"@babel/runtime": "^7.4.4",
 				"@wordpress/babel-plugin-import-jsx-pragma": "file:packages/babel-plugin-import-jsx-pragma",
 				"@wordpress/browserslist-config": "file:packages/browserslist-config"
 			}
@@ -3036,13 +3010,13 @@
 		"@wordpress/blob": {
 			"version": "file:packages/blob",
 			"requires": {
-				"@babel/runtime": "^7.3.1"
+				"@babel/runtime": "^7.4.4"
 			}
 		},
 		"@wordpress/block-editor": {
 			"version": "file:packages/block-editor",
 			"requires": {
-				"@babel/runtime": "^7.0.0",
+				"@babel/runtime": "^7.4.4",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/blob": "file:packages/blob",
 				"@wordpress/blocks": "file:packages/blocks",
@@ -3073,7 +3047,7 @@
 		"@wordpress/block-library": {
 			"version": "file:packages/block-library",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"@wordpress/autop": "file:packages/autop",
 				"@wordpress/blob": "file:packages/blob",
 				"@wordpress/block-editor": "file:packages/block-editor",
@@ -3099,7 +3073,7 @@
 		"@wordpress/block-serialization-default-parser": {
 			"version": "file:packages/block-serialization-default-parser",
 			"requires": {
-				"@babel/runtime": "^7.3.1"
+				"@babel/runtime": "^7.4.4"
 			}
 		},
 		"@wordpress/block-serialization-spec-parser": {
@@ -3111,7 +3085,7 @@
 		"@wordpress/blocks": {
 			"version": "file:packages/blocks",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"@wordpress/autop": "file:packages/autop",
 				"@wordpress/blob": "file:packages/blob",
 				"@wordpress/block-serialization-default-parser": "file:packages/block-serialization-default-parser",
@@ -3140,7 +3114,7 @@
 		"@wordpress/components": {
 			"version": "file:packages/components",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/compose": "file:packages/compose",
@@ -3171,7 +3145,7 @@
 		"@wordpress/compose": {
 			"version": "file:packages/compose",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"lodash": "^4.17.11"
@@ -3180,7 +3154,7 @@
 		"@wordpress/core-data": {
 			"version": "file:packages/core-data",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/deprecated": "file:packages/deprecated",
@@ -3194,14 +3168,14 @@
 			"version": "file:packages/custom-templated-path-webpack-plugin",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"escape-string-regexp": "^1.0.5"
 			}
 		},
 		"@wordpress/data": {
 			"version": "file:packages/data",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/element": "file:packages/element",
@@ -3218,7 +3192,7 @@
 		"@wordpress/date": {
 			"version": "file:packages/date",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"moment": "^2.22.1",
 				"moment-timezone": "^0.5.16"
 			}
@@ -3252,7 +3226,7 @@
 		"@wordpress/deprecated": {
 			"version": "file:packages/deprecated",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"@wordpress/hooks": "file:packages/hooks"
 			}
 		},
@@ -3270,21 +3244,21 @@
 		"@wordpress/dom": {
 			"version": "file:packages/dom",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"lodash": "^4.17.11"
 			}
 		},
 		"@wordpress/dom-ready": {
 			"version": "file:packages/dom-ready",
 			"requires": {
-				"@babel/runtime": "^7.3.1"
+				"@babel/runtime": "^7.4.4"
 			}
 		},
 		"@wordpress/e2e-test-utils": {
 			"version": "file:packages/e2e-test-utils",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"@wordpress/url": "file:packages/url",
 				"lodash": "^4.17.11",
@@ -3305,7 +3279,7 @@
 		"@wordpress/edit-post": {
 			"version": "file:packages/edit-post",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/block-editor": "file:packages/block-editor",
@@ -3333,7 +3307,7 @@
 		"@wordpress/edit-widgets": {
 			"version": "file:packages/edit-widgets",
 			"requires": {
-				"@babel/runtime": "^7.0.0",
+				"@babel/runtime": "^7.4.4",
 				"@wordpress/block-editor": "file:packages/block-editor",
 				"@wordpress/components": "file:packages/components",
 				"@wordpress/element": "file:packages/element",
@@ -3343,7 +3317,7 @@
 		"@wordpress/editor": {
 			"version": "file:packages/editor",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/blob": "file:packages/blob",
 				"@wordpress/block-editor": "file:packages/block-editor",
@@ -3378,7 +3352,7 @@
 		"@wordpress/element": {
 			"version": "file:packages/element",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"@wordpress/escape-html": "file:packages/escape-html",
 				"lodash": "^4.17.11",
 				"react": "^16.8.4",
@@ -3388,7 +3362,7 @@
 		"@wordpress/escape-html": {
 			"version": "file:packages/escape-html",
 			"requires": {
-				"@babel/runtime": "^7.3.1"
+				"@babel/runtime": "^7.4.4"
 			}
 		},
 		"@wordpress/eslint-plugin": {
@@ -3405,7 +3379,7 @@
 		"@wordpress/format-library": {
 			"version": "file:packages/format-library",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"@wordpress/block-editor": "file:packages/block-editor",
 				"@wordpress/components": "file:packages/components",
 				"@wordpress/editor": "file:packages/editor",
@@ -3419,19 +3393,19 @@
 		"@wordpress/hooks": {
 			"version": "file:packages/hooks",
 			"requires": {
-				"@babel/runtime": "^7.3.1"
+				"@babel/runtime": "^7.4.4"
 			}
 		},
 		"@wordpress/html-entities": {
 			"version": "file:packages/html-entities",
 			"requires": {
-				"@babel/runtime": "^7.3.1"
+				"@babel/runtime": "^7.4.4"
 			}
 		},
 		"@wordpress/i18n": {
 			"version": "file:packages/i18n",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"gettext-parser": "^1.3.1",
 				"lodash": "^4.17.11",
 				"memize": "^1.0.5",
@@ -3442,14 +3416,14 @@
 		"@wordpress/is-shallow-equal": {
 			"version": "file:packages/is-shallow-equal",
 			"requires": {
-				"@babel/runtime": "^7.3.1"
+				"@babel/runtime": "^7.4.4"
 			}
 		},
 		"@wordpress/jest-console": {
 			"version": "file:packages/jest-console",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"jest-matcher-utils": "^24.7.0",
 				"lodash": "^4.17.11"
 			}
@@ -3475,7 +3449,7 @@
 		"@wordpress/keycodes": {
 			"version": "file:packages/keycodes",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"@wordpress/i18n": "file:packages/i18n",
 				"lodash": "^4.17.11"
 			}
@@ -3484,7 +3458,7 @@
 			"version": "file:packages/library-export-default-webpack-plugin",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"lodash": "^4.17.11",
 				"webpack-sources": "^1.1.0"
 			}
@@ -3492,7 +3466,7 @@
 		"@wordpress/list-reusable-blocks": {
 			"version": "file:packages/list-reusable-blocks",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/components": "file:packages/components",
 				"@wordpress/compose": "file:packages/compose",
@@ -3504,7 +3478,7 @@
 		"@wordpress/notices": {
 			"version": "file:packages/notices",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/data": "file:packages/data",
 				"lodash": "^4.17.11"
@@ -3517,7 +3491,7 @@
 		"@wordpress/nux": {
 			"version": "file:packages/nux",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"@wordpress/components": "file:packages/components",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/data": "file:packages/data",
@@ -3530,7 +3504,7 @@
 		"@wordpress/plugins": {
 			"version": "file:packages/plugins",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",
@@ -3549,13 +3523,13 @@
 		"@wordpress/priority-queue": {
 			"version": "file:packages/priority-queue",
 			"requires": {
-				"@babel/runtime": "^7.3.1"
+				"@babel/runtime": "^7.4.4"
 			}
 		},
 		"@wordpress/redux-routine": {
 			"version": "file:packages/redux-routine",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"is-promise": "^2.1.0",
 				"rungen": "^0.3.2"
 			}
@@ -3563,7 +3537,7 @@
 		"@wordpress/rich-text": {
 			"version": "file:packages/rich-text",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/escape-html": "file:packages/escape-html",
@@ -3605,7 +3579,7 @@
 		"@wordpress/shortcode": {
 			"version": "file:packages/shortcode",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"lodash": "^4.17.11",
 				"memize": "^1.0.5"
 			}
@@ -3613,21 +3587,21 @@
 		"@wordpress/token-list": {
 			"version": "file:packages/token-list",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"lodash": "^4.17.11"
 			}
 		},
 		"@wordpress/url": {
 			"version": "file:packages/url",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"qs": "^6.5.2"
 			}
 		},
 		"@wordpress/viewport": {
 			"version": "file:packages/viewport",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/element": "file:packages/element",
@@ -3637,7 +3611,7 @@
 		"@wordpress/wordcount": {
 			"version": "file:packages/wordcount",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
+				"@babel/runtime": "^7.4.4",
 				"lodash": "^4.17.11"
 			}
 		},
@@ -4365,20 +4339,6 @@
 						"locate-path": "^3.0.0"
 					}
 				},
-				"glob": {
-					"version": "7.1.3",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
 				"istanbul-lib-coverage": {
 					"version": "2.0.4",
 					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -4398,18 +4358,6 @@
 						"@babel/types": "^7.0.0",
 						"istanbul-lib-coverage": "^2.0.4",
 						"semver": "^6.0.0"
-					}
-				},
-				"load-json-file": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^4.0.0",
-						"pify": "^3.0.0",
-						"strip-bom": "^3.0.0"
 					}
 				},
 				"locate-path": {
@@ -4446,72 +4394,11 @@
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
-				"parse-json": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
-					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
-					}
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
-				},
-				"read-pkg": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
-					"requires": {
-						"load-json-file": "^4.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^3.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-					"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
-					"dev": true,
-					"requires": {
-						"find-up": "^3.0.0",
-						"read-pkg": "^3.0.0"
-					}
-				},
-				"require-main-filename": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-					"dev": true
-				},
 				"semver": {
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
 					"integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==",
 					"dev": true
-				},
-				"strip-bom": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-					"dev": true
-				},
-				"test-exclude": {
-					"version": "5.2.2",
-					"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.2.tgz",
-					"integrity": "sha512-N2pvaLpT8guUpb5Fe1GJlmvmzH3x+DAKmmyEQmFP792QcLYoGE1syxztSvPD1V8yPe6VrcCt6YGQVjSRjCASsA==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3",
-						"minimatch": "^3.0.4",
-						"read-pkg-up": "^4.0.0",
-						"require-main-filename": "^2.0.0"
-					}
 				}
 			}
 		},
@@ -16277,6 +16164,17 @@
 					"integrity": "sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ==",
 					"dev": true
 				},
+				"@babel/plugin-transform-modules-commonjs": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.2.0.tgz",
+					"integrity": "sha512-V6y0uaUQrQPXUrmj+hgnks8va2L0zcZymeU7TtWEgdRLNkceafKXEduv7QzgQAE4lT+suwooG9dC7LFhdRAbVQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-transforms": "^7.1.0",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/helper-simple-access": "^7.1.0"
+					}
+				},
 				"@babel/preset-env": {
 					"version": "7.3.4",
 					"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.3.4.tgz",
@@ -16429,6 +16327,12 @@
 					"version": "3.3.1",
 					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
 					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				},
+				"regenerator-runtime": {
+					"version": "0.12.1",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+					"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
 					"dev": true
 				},
 				"source-map": {
@@ -18873,10 +18777,9 @@
 			}
 		},
 		"regenerator-runtime": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.0.tgz",
-			"integrity": "sha512-SpV2LhF5Dm9UYMEprB3WwsBnWwqTrmjrm2UZb42cl2G02WVGgx7Mg8aa9pdLEKp6hZ+/abcMc2NxKA8f02EG2w==",
-			"dev": true
+			"version": "0.13.2",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+			"integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
 		},
 		"regenerator-transform": {
 			"version": "0.13.4",
@@ -21366,6 +21269,138 @@
 				}
 			}
 		},
+		"test-exclude": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.2.tgz",
+			"integrity": "sha512-N2pvaLpT8guUpb5Fe1GJlmvmzH3x+DAKmmyEQmFP792QcLYoGE1syxztSvPD1V8yPe6VrcCt6YGQVjSRjCASsA==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3",
+				"minimatch": "^3.0.4",
+				"read-pkg-up": "^4.0.0",
+				"require-main-filename": "^2.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.3",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"parse-json": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+					"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+					"dev": true,
+					"requires": {
+						"find-up": "^3.0.0",
+						"read-pkg": "^3.0.0"
+					}
+				},
+				"require-main-filename": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+					"dev": true
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+					"dev": true
+				}
+			}
+		},
 		"text-extensions": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
@@ -23527,6 +23562,12 @@
 					"requires": {
 						"regenerator-runtime": "^0.12.0"
 					}
+				},
+				"regenerator-runtime": {
+					"version": "0.12.1",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+					"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+					"dev": true
 				}
 			}
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16233,36 +16233,6 @@
 						"source-map": "^0.5.0"
 					},
 					"dependencies": {
-						"@babel/generator": {
-							"version": "7.4.0",
-							"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
-							"integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
-							"dev": true,
-							"requires": {
-								"@babel/types": "^7.4.0",
-								"jsesc": "^2.5.1",
-								"lodash": "^4.17.11",
-								"source-map": "^0.5.0",
-								"trim-right": "^1.0.1"
-							}
-						},
-						"@babel/parser": {
-							"version": "7.4.3",
-							"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
-							"integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
-							"dev": true
-						},
-						"@babel/types": {
-							"version": "7.4.0",
-							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
-							"integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
-							"dev": true,
-							"requires": {
-								"esutils": "^2.0.2",
-								"lodash": "^4.17.11",
-								"to-fast-properties": "^2.0.0"
-							}
-						},
 						"json5": {
 							"version": "2.1.0",
 							"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
@@ -16393,44 +16363,6 @@
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
 						"lodash": "^4.17.11"
-					},
-					"dependencies": {
-						"@babel/generator": {
-							"version": "7.4.0",
-							"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
-							"integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
-							"dev": true,
-							"requires": {
-								"@babel/types": "^7.4.0",
-								"jsesc": "^2.5.1",
-								"lodash": "^4.17.11",
-								"source-map": "^0.5.0",
-								"trim-right": "^1.0.1"
-							}
-						},
-						"@babel/parser": {
-							"version": "7.4.3",
-							"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
-							"integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
-							"dev": true
-						},
-						"@babel/types": {
-							"version": "7.4.0",
-							"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
-							"integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
-							"dev": true,
-							"requires": {
-								"esutils": "^2.0.2",
-								"lodash": "^4.17.11",
-								"to-fast-properties": "^2.0.0"
-							}
-						},
-						"source-map": {
-							"version": "0.5.7",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-							"dev": true
-						}
 					}
 				},
 				"@babel/types": {

--- a/package.json
+++ b/package.json
@@ -57,10 +57,10 @@
 		"@wordpress/wordcount": "file:packages/wordcount"
 	},
 	"devDependencies": {
-		"@babel/core": "7.4.3",
+		"@babel/core": "7.4.4",
 		"@babel/plugin-syntax-jsx": "7.2.0",
-		"@babel/runtime-corejs3": "7.4.3",
-		"@babel/traverse": "7.4.3",
+		"@babel/runtime-corejs3": "7.4.4",
+		"@babel/traverse": "7.4.4",
 		"@wordpress/babel-plugin-import-jsx-pragma": "file:packages/babel-plugin-import-jsx-pragma",
 		"@wordpress/babel-plugin-makepot": "file:packages/babel-plugin-makepot",
 		"@wordpress/babel-preset-default": "file:packages/babel-preset-default",

--- a/package.json
+++ b/package.json
@@ -57,10 +57,10 @@
 		"@wordpress/wordcount": "file:packages/wordcount"
 	},
 	"devDependencies": {
-		"@babel/core": "7.2.2",
+		"@babel/core": "7.4.3",
 		"@babel/plugin-syntax-jsx": "7.2.0",
-		"@babel/runtime-corejs2": "7.3.1",
-		"@babel/traverse": "7.2.3",
+		"@babel/runtime-corejs3": "7.4.3",
+		"@babel/traverse": "7.4.3",
 		"@wordpress/babel-plugin-import-jsx-pragma": "file:packages/babel-plugin-import-jsx-pragma",
 		"@wordpress/babel-plugin-makepot": "file:packages/babel-plugin-makepot",
 		"@wordpress/babel-preset-default": "file:packages/babel-preset-default",
@@ -84,7 +84,7 @@
 		"chalk": "2.4.1",
 		"concurrently": "3.5.0",
 		"copy-webpack-plugin": "4.5.2",
-		"core-js": "2.5.7",
+		"core-js": "3.0.1",
 		"cross-env": "3.2.4",
 		"cssnano": "4.1.10",
 		"deasync": "0.1.14",

--- a/packages/README.md
+++ b/packages/README.md
@@ -29,7 +29,7 @@ When creating a new package, you need to provide at least the following:
 		"module": "build-module/index.js",
 		"react-native": "src/index",
 		"dependencies": {
-			"@babel/runtime": "^7.0.0"
+			"@babel/runtime": "^7.4.4"
 		},
 		"publishConfig": {
 			"access": "public"

--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -22,7 +22,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"@wordpress/dom-ready": "file:../dom-ready"
 	},
 	"publishConfig": {

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"@wordpress/data": "file:../data",
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/i18n": "file:../i18n",

--- a/packages/api-fetch/package.json
+++ b/packages/api-fetch/package.json
@@ -22,7 +22,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/url": "file:../url"
 	},

--- a/packages/autop/package.json
+++ b/packages/autop/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1"
+		"@babel/runtime": "^7.4.4"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/babel-plugin-makepot/package.json
+++ b/packages/babel-plugin-makepot/package.json
@@ -29,7 +29,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"gettext-parser": "^1.3.1",
 		"lodash": "^4.17.11"
 	},

--- a/packages/babel-preset-default/CHANGELOG.md
+++ b/packages/babel-preset-default/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 4.1.0 (unreleased)
+## Unreleased
 
-### New Feature
+### New Features
 
 - Handle `<></>` JSX Fragments with `@wordpress/element` `Fragment` ([#15120](https://github.com/WordPress/gutenberg/pull/15120)).
+- The bundled `@babel/core` dependency has been updated from requiring `^7.2.2` to requiring `^7.4.4`. Babel preset is now using `core-js@3` instead of `core-js@2` (see [Migration Guide](https://babeljs.io/blog/2019/03/19/7.4.0#migration-from-core-js-2)).
 
 ## 4.0.0 (2019-03-06)
 

--- a/packages/babel-preset-default/index.js
+++ b/packages/babel-preset-default/index.js
@@ -19,7 +19,7 @@ module.exports = function( api ) {
 
 		if ( isTestEnv ) {
 			opts.useBuiltIns = 'usage';
-			opts.corejs = 2;
+			opts.corejs = 3;
 		} else {
 			opts.modules = false;
 			opts.targets = {

--- a/packages/babel-preset-default/index.js
+++ b/packages/babel-preset-default/index.js
@@ -19,6 +19,7 @@ module.exports = function( api ) {
 
 		if ( isTestEnv ) {
 			opts.useBuiltIns = 'usage';
+			opts.corejs = 2;
 		} else {
 			opts.modules = false;
 			opts.targets = {

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -27,13 +27,13 @@
 	],
 	"main": "index.js",
 	"dependencies": {
-		"@babel/core": "^7.2.2",
+		"@babel/core": "^7.4.3",
 		"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
-		"@babel/plugin-proposal-object-rest-spread": "^7.3.2",
+		"@babel/plugin-proposal-object-rest-spread": "^7.4.3",
 		"@babel/plugin-transform-react-jsx": "^7.3.0",
-		"@babel/plugin-transform-runtime": "^7.2.0",
-		"@babel/preset-env": "^7.3.1",
-		"@babel/runtime": "^7.3.1",
+		"@babel/plugin-transform-runtime": "^7.4.3",
+		"@babel/preset-env": "^7.4.3",
+		"@babel/runtime": "^7.4.3",
 		"@wordpress/babel-plugin-import-jsx-pragma": "file:../babel-plugin-import-jsx-pragma",
 		"@wordpress/browserslist-config": "file:../browserslist-config"
 	},

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -27,13 +27,13 @@
 	],
 	"main": "index.js",
 	"dependencies": {
-		"@babel/core": "^7.4.3",
+		"@babel/core": "^7.4.4",
 		"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
-		"@babel/plugin-proposal-object-rest-spread": "^7.4.3",
+		"@babel/plugin-proposal-object-rest-spread": "^7.4.4",
 		"@babel/plugin-transform-react-jsx": "^7.3.0",
-		"@babel/plugin-transform-runtime": "^7.4.3",
-		"@babel/preset-env": "^7.4.3",
-		"@babel/runtime": "^7.4.3",
+		"@babel/plugin-transform-runtime": "^7.4.4",
+		"@babel/preset-env": "^7.4.4",
+		"@babel/runtime": "^7.4.4",
 		"@wordpress/babel-plugin-import-jsx-pragma": "file:../babel-plugin-import-jsx-pragma",
 		"@wordpress/browserslist-config": "file:../browserslist-config"
 	},

--- a/packages/babel-preset-default/test/__snapshots__/index.js.snap
+++ b/packages/babel-preset-default/test/__snapshots__/index.js.snap
@@ -30,7 +30,7 @@ describe('Babel preset default', function () {
               return _context.stop();
           }
         }
-      }, _callee, this);
+      }, _callee);
     }));
     return _foo.apply(this, arguments);
   }
@@ -63,7 +63,7 @@ describe('Babel preset default', function () {
             return _context2.stop();
         }
       }
-    }, _callee2, this);
+    }, _callee2);
   })));
 });"
 `;

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1"
+		"@babel/runtime": "^7.4.4"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -22,7 +22,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0",
+		"@babel/runtime": "^7.4.4",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/blob": "file:../blob",
 		"@wordpress/blocks": "file:../blocks",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"@wordpress/autop": "file:../autop",
 		"@wordpress/blob": "file:../blob",
 		"@wordpress/block-editor": "file:../block-editor",

--- a/packages/block-serialization-default-parser/package.json
+++ b/packages/block-serialization-default-parser/package.json
@@ -22,7 +22,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1"
+		"@babel/runtime": "^7.4.4"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"@wordpress/autop": "file:../autop",
 		"@wordpress/blob": "file:../blob",
 		"@wordpress/block-serialization-default-parser": "file:../block-serialization-default-parser",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/compose": "file:../compose",

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -22,7 +22,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"@wordpress/element": "file:../element",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"lodash": "^4.17.11"

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -22,7 +22,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/data": "file:../data",
 		"@wordpress/deprecated": "file:../deprecated",

--- a/packages/custom-templated-path-webpack-plugin/package.json
+++ b/packages/custom-templated-path-webpack-plugin/package.json
@@ -28,7 +28,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"escape-string-regexp": "^1.0.5"
 	},
 	"peerDependencies": {

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -22,7 +22,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/element": "file:../element",

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"moment": "^2.22.1",
 		"moment-timezone": "^0.5.16"
 	},

--- a/packages/deprecated/package.json
+++ b/packages/deprecated/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"@wordpress/hooks": "file:../hooks"
 	},
 	"publishConfig": {

--- a/packages/dom-ready/package.json
+++ b/packages/dom-ready/package.json
@@ -20,7 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1"
+		"@babel/runtime": "^7.4.4"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -22,7 +22,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"lodash": "^4.17.11"
 	},
 	"publishConfig": {

--- a/packages/e2e-test-utils/package.json
+++ b/packages/e2e-test-utils/package.json
@@ -28,7 +28,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/url": "file:../url",
 		"lodash": "^4.17.11",

--- a/packages/e2e-tests/jest.config.js
+++ b/packages/e2e-tests/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
 	...require( '@wordpress/scripts/config/jest-e2e.config' ),
 	setupFiles: [
+		'core-js/modules/web.dom.iterable',
 		'<rootDir>/config/gutenberg-phase.js',
 	],
 	setupFilesAfterEnv: [

--- a/packages/e2e-tests/jest.config.js
+++ b/packages/e2e-tests/jest.config.js
@@ -1,7 +1,6 @@
 module.exports = {
 	...require( '@wordpress/scripts/config/jest-e2e.config' ),
 	setupFiles: [
-		'core-js/modules/web.dom.iterable',
 		'<rootDir>/config/gutenberg-phase.js',
 	],
 	setupFilesAfterEnv: [

--- a/packages/e2e-tests/jest.config.js
+++ b/packages/e2e-tests/jest.config.js
@@ -7,8 +7,4 @@ module.exports = {
 		'<rootDir>/config/setup-test-framework.js',
 		'expect-puppeteer',
 	],
-	transformIgnorePatterns: [
-		'node_modules',
-		'scripts/config/puppeteer.config.js',
-	],
 };

--- a/packages/e2e-tests/specs/preview.test.js
+++ b/packages/e2e-tests/specs/preview.test.js
@@ -100,7 +100,7 @@ describe( 'Preview', () => {
 
 		// When autosave completes for a new post, the URL of the editor should
 		// update to include the ID. Use this to assert on preview URL.
-		const [ , postId ] = await( await editorPage.waitForFunction( () => {
+		const [ , postId ] = await ( await editorPage.waitForFunction( () => {
 			return window.location.search.match( /[\?&]post=(\d+)/ );
 		} ) ).jsonValue();
 

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/block-editor": "file:../block-editor",

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.0.0",
+		"@babel/runtime": "^7.4.4",
 		"@wordpress/block-editor": "file:../block-editor",
 		"@wordpress/components": "file:../components",
 		"@wordpress/element": "file:../element",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/blob": "file:../blob",
 		"@wordpress/block-editor": "file:../block-editor",

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -22,7 +22,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"@wordpress/escape-html": "file:../escape-html",
 		"lodash": "^4.17.11",
 		"react": "^16.8.4",

--- a/packages/escape-html/package.json
+++ b/packages/escape-html/package.json
@@ -20,7 +20,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1"
+		"@babel/runtime": "^7.4.4"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -18,7 +18,7 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"dependencies": {
-		"babel-eslint": "^8.0.3",
+		"babel-eslint": "^10.0.1",
 		"eslint-plugin-jsx-a11y": "^6.2.1",
 		"eslint-plugin-react": "^7.12.4",
 		"eslint-plugin-react-hooks": "^1.6.0",

--- a/packages/format-library/package.json
+++ b/packages/format-library/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"@wordpress/block-editor": "file:../block-editor",
 		"@wordpress/components": "file:../components",
 		"@wordpress/editor": "file:../editor",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1"
+		"@babel/runtime": "^7.4.4"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/html-entities/package.json
+++ b/packages/html-entities/package.json
@@ -22,7 +22,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1"
+		"@babel/runtime": "^7.4.4"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -24,7 +24,7 @@
 		"pot-to-php": "./tools/pot-to-php.js"
 	},
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"gettext-parser": "^1.3.1",
 		"lodash": "^4.17.11",
 		"memize": "^1.0.5",

--- a/packages/is-shallow-equal/package.json
+++ b/packages/is-shallow-equal/package.json
@@ -25,7 +25,7 @@
 	],
 	"main": "index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1"
+		"@babel/runtime": "^7.4.4"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -29,7 +29,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"jest-matcher-utils": "^24.7.0",
 		"lodash": "^4.17.11"
 	},

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"@wordpress/i18n": "file:../i18n",
 		"lodash": "^4.17.11"
 	},

--- a/packages/library-export-default-webpack-plugin/package.json
+++ b/packages/library-export-default-webpack-plugin/package.json
@@ -27,7 +27,7 @@
 	],
 	"main": "build/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"lodash": "^4.17.11",
 		"webpack-sources": "^1.1.0"
 	},

--- a/packages/list-reusable-blocks/package.json
+++ b/packages/list-reusable-blocks/package.json
@@ -20,7 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",

--- a/packages/notices/package.json
+++ b/packages/notices/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/data": "file:../data",
 		"lodash": "^4.17.11"

--- a/packages/nux/package.json
+++ b/packages/nux/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -20,7 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",

--- a/packages/priority-queue/package.json
+++ b/packages/priority-queue/package.json
@@ -22,7 +22,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1"
+		"@babel/runtime": "^7.4.4"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/redux-routine/package.json
+++ b/packages/redux-routine/package.json
@@ -23,7 +23,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"is-promise": "^2.1.0",
 		"rungen": "^0.3.2"
 	},

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",
 		"@wordpress/escape-html": "file:../escape-html",

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Leverage `@wordpress/dependency-extraction-webpack-plugin` plugin to extract WordPress
   dependencies.
+- The bundled `eslint` dependency has been updated from requiring `^5.12.1` to requiring `^5.16.0`.
 
 ### Enhancements
 

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -41,7 +41,7 @@
 		"chalk": "^2.4.1",
 		"check-node-version": "^3.1.1",
 		"cross-spawn": "^5.1.0",
-		"eslint": "^5.12.1",
+		"eslint": "^5.16.0",
 		"jest": "^24.7.1",
 		"jest-puppeteer": "^4.0.0",
 		"npm-package-json-lint": "^3.6.0",

--- a/packages/shortcode/package.json
+++ b/packages/shortcode/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"lodash": "^4.17.11",
 		"memize": "^1.0.5"
 	},

--- a/packages/token-list/package.json
+++ b/packages/token-list/package.json
@@ -19,7 +19,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"lodash": "^4.17.11"
 	},
 	"publishConfig": {

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"qs": "^6.5.2"
 	},
 	"publishConfig": {

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -21,7 +21,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",

--- a/packages/wordcount/package.json
+++ b/packages/wordcount/package.json
@@ -20,7 +20,7 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"dependencies": {
-		"@babel/runtime": "^7.3.1",
+		"@babel/runtime": "^7.4.4",
 		"lodash": "^4.17.11"
 	},
 	"publishConfig": {

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -14,7 +14,7 @@ module.exports = {
 	},
 	preset: '@wordpress/jest-preset-default',
 	setupFiles: [
-		'core-js/fn/symbol/async-iterator',
+		'core-js/es/symbol/async-iterator',
 		'<rootDir>/test/unit/config/gutenberg-phase.js',
 	],
 	testURL: 'http://localhost',

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -14,8 +14,6 @@ module.exports = {
 	},
 	preset: '@wordpress/jest-preset-default',
 	setupFiles: [
-		'core-js/es/symbol/async-iterator',
-		'core-js/modules/web.dom-collections.iterator',
 		'<rootDir>/test/unit/config/gutenberg-phase.js',
 	],
 	testURL: 'http://localhost',

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -15,6 +15,7 @@ module.exports = {
 	preset: '@wordpress/jest-preset-default',
 	setupFiles: [
 		'core-js/es/symbol/async-iterator',
+		'core-js/modules/web.dom-collections.iterator',
 		'<rootDir>/test/unit/config/gutenberg-phase.js',
 	],
 	testURL: 'http://localhost',


### PR DESCRIPTION
## Description

Specifies the version of `core-js` used in the package (Gutenberg uses 2.x at the moment) to prevent warnings.

## How has this been tested?

1. Install `wp-scripts` in your project.
2. Try to run some tests
3. Notice that there's no error anymore.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->

Fixes #15138.