### PR TITLE
Add footers "Code is Poetry" are missing

### DIFF
--- a/packages/custom-templated-path-webpack-plugin/README.md
+++ b/packages/custom-templated-path-webpack-plugin/README.md
@@ -51,3 +51,5 @@ module.exports = {
 ```
 
 For more examples, refer to Webpack's own [`TemplatedPathPlugin.js`](https://github.com/webpack/webpack/blob/v4.1.1/lib/TemplatedPathPlugin.js), which implements the base set of template tags.
+
+<br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -194,3 +194,5 @@ $script_dependencies = file_exists( $script_deps_path )
 $script_url = plugins_url( $script_path, __FILE__ );
 wp_enqueue_script( 'script', $script_url, $script_dependencies );
 ```
+
+<br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>


### PR DESCRIPTION
## Description
Add footer "Code is Poetry" inside 2 README files where it missed in packages subfolders

Closes https://github.com/WordPress/gutenberg/issues/15047
