### PR TITLE
Remove extra bottom margin for nested lists.

### DIFF
--- a/packages/block-library/src/list/editor.scss
+++ b/packages/block-library/src/list/editor.scss
@@ -2,4 +2,9 @@
 .editor-styles-wrapper .block-library-list ol {
 	padding-left: 1.3em;
 	margin-left: 1.3em;
+
+	ul,
+	ol {
+		margin-bottom: 0;
+	}
 }

--- a/packages/block-library/src/list/editor.scss
+++ b/packages/block-library/src/list/editor.scss
@@ -2,9 +2,4 @@
 .editor-styles-wrapper .block-library-list ol {
 	padding-left: 1.3em;
 	margin-left: 1.3em;
-
-	ul,
-	ol {
-		margin-bottom: 0;
-	}
 }

--- a/packages/editor/src/editor-styles.scss
+++ b/packages/editor/src/editor-styles.scss
@@ -105,6 +105,12 @@ ol {
 	margin-bottom: $default-block-margin;
 	padding: inherit;
 
+	// Remove bottom margin from nested lists.
+	ul,
+	ol {
+		margin-bottom: 0;
+	}
+
 	li {
 		// This overrides a bottom margin globally applied to list items in wp-admin.
 		margin-bottom: initial;


### PR DESCRIPTION
Currently, lists that are two levels deep (or more) appear with some extra-tall bottom margins: 

<img width="626" alt="Screen Shot 2019-04-24 at 3 03 22 PM" src="https://user-images.githubusercontent.com/1202812/56686514-26035b00-66a2-11e9-87b0-7735588214ff.png">

In previous versions of Gutenberg, that extra margin did not exist (I checked against Version 5.5.0). I believe this was introduced via #14407. This PR adds a quick rule to clear out the bottom margin there: 

<img width="629" alt="Screen Shot 2019-04-24 at 3 03 32 PM" src="https://user-images.githubusercontent.com/1202812/56687216-c6a64a80-66a3-11e9-96c8-25668afdb999.png">