### PR TITLE
Make a11y string properly localizable

### DIFF
--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -103,12 +103,12 @@ class HeadingEdit extends Component {
 				accessible={ ! this.props.isSelected }
 				accessibilityLabel={
 					isEmpty( content ) ?
-						/* translators: %s: heading level. */
+						/* translators: accessibility text. %s: heading level. */
 						sprintf(
 							__( 'Heading block. Level %s. Empty.' ),
 							level
 						) :
-						/* translators: 1: heading level. 2: heading content. */
+						/* translators: accessibility text. 1: heading level. 2: heading content. */
 						sprintf(
 							__( 'Heading block. Level %s1$s. %2$s' ),
 							level,

--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -13,7 +13,7 @@ import { isEmpty } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { RichText, BlockControls } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
@@ -98,13 +98,23 @@ class HeadingEdit extends Component {
 
 		const tagName = 'h' + level;
 
-		const accessibilityLabelLevel = __( 'level' ) + ' ' + level + __( '.' );
-		const accessibilityLabelContent = isEmpty( content ) ? __( 'Empty' ) : this.plainTextContent( content );
-
 		return (
 			<View
 				accessible={ ! this.props.isSelected }
-				accessibilityLabel={ __( 'Heading block' ) + __( '.' ) + ' ' + accessibilityLabelLevel + ' ' + accessibilityLabelContent }
+				accessibilityLabel={
+					isEmpty( content ) ?
+						/* translators: %s: heading level. */
+						sprintf(
+							__( 'Heading block. Level %s. Empty.' ),
+							level
+						) :
+						/* translators: 1: heading level. 2: heading content. */
+						sprintf(
+							__( 'Heading block. Level %s1$s. %2$s.' ),
+							level,
+							this.plainTextContent( content )
+						)
+				}
 				onAccessibilityTap={ this.props.onFocus }
 			>
 				<BlockControls>

--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -103,13 +103,13 @@ class HeadingEdit extends Component {
 				accessible={ ! this.props.isSelected }
 				accessibilityLabel={
 					isEmpty( content ) ?
-						/* translators: accessibility text. %s: heading level. */
 						sprintf(
+							/* translators: accessibility text. %s: heading level. */
 							__( 'Heading block. Level %s. Empty.' ),
 							level
 						) :
-						/* translators: accessibility text. 1: heading level. 2: heading content. */
 						sprintf(
+							/* translators: accessibility text. 1: heading level. 2: heading content. */
 							__( 'Heading block. Level %1$s. %2$s' ),
 							level,
 							this.plainTextContent( content )

--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -110,7 +110,7 @@ class HeadingEdit extends Component {
 						) :
 						/* translators: accessibility text. 1: heading level. 2: heading content. */
 						sprintf(
-							__( 'Heading block. Level %s1$s. %2$s' ),
+							__( 'Heading block. Level %1$s. %2$s' ),
 							level,
 							this.plainTextContent( content )
 						)

--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -110,7 +110,7 @@ class HeadingEdit extends Component {
 						) :
 						/* translators: 1: heading level. 2: heading content. */
 						sprintf(
-							__( 'Heading block. Level %s1$s. %2$s.' ),
+							__( 'Heading block. Level %s1$s. %2$s' ),
 							level,
 							this.plainTextContent( content )
 						)


### PR DESCRIPTION
## Description
Fixes the non-localizable code introduced by #15144.

This is a friendly reminder to think about internationalization best practices :-)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
