### PR TITLE
adds virtual space at the bottom of the editor

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "editor.fontFamily": "Hasklig",
-    "editor.fontSize": 14,
-    "workbench.quickOpen.closeOnFocusLost": false
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "editor.fontFamily": "Hasklig",
+    "editor.fontSize": 14,
+    "workbench.quickOpen.closeOnFocusLost": false
+}

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -341,7 +341,7 @@ class WritingFlow extends Component {
 		const focusableNodes = focus.focusable.find( this.container );
 		const target = findLast( focusableNodes, isTabbableTextField );
 		if ( target ) {
-			placeCaretAtHorizontalEdge( target, true );
+			placeCaretAtHorizontalEdge( target, true, { preventScroll: false } );
 		}
 	}
 

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -341,7 +341,7 @@ class WritingFlow extends Component {
 		const focusableNodes = focus.focusable.find( this.container );
 		const target = findLast( focusableNodes, isTabbableTextField );
 		if ( target ) {
-			placeCaretAtHorizontalEdge( target, true, { preventScroll: false } );
+			placeCaretAtHorizontalEdge( target, true, { preventScroll: true } );
 		}
 	}
 

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -341,7 +341,11 @@ class WritingFlow extends Component {
 		const focusableNodes = focus.focusable.find( this.container );
 		const target = findLast( focusableNodes, isTabbableTextField );
 		if ( target ) {
-			placeCaretAtHorizontalEdge( target, true, { preventScroll: true } );
+			placeCaretAtHorizontalEdge(
+				target,
+				true,
+				{ focusOptions: { preventScroll: true } }
+			);
 		}
 	}
 

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -154,6 +154,7 @@ _Parameters_
 
 -   _container_ `Element`: Focusable element.
 -   _isReverse_ `boolean`: True for end, false for start.
+-   _focusOptions_ `Object`: options that get passed to the focus() call.
 
 <a name="placeCaretAtVerticalEdge" href="#placeCaretAtVerticalEdge">#</a> **placeCaretAtVerticalEdge**
 

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -154,7 +154,10 @@ _Parameters_
 
 -   _container_ `Element`: Focusable element.
 -   _isReverse_ `boolean`: True for end, false for start.
--   _focusOptions_ `Object`: options that get passed to the focus() call.
+-   _options_ `Object`: options for configuring this behavior. 
+ 
+ Current options:
+ -`{ focusOptions: { preventScroll: true } }` - prevents the browser to scroll the element into view at focus.
 
 <a name="placeCaretAtVerticalEdge" href="#placeCaretAtVerticalEdge">#</a> **placeCaretAtVerticalEdge**
 

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -154,10 +154,7 @@ _Parameters_
 
 -   _container_ `Element`: Focusable element.
 -   _isReverse_ `boolean`: True for end, false for start.
--   _options_ `Object`: options for configuring this behavior. 
- 
- Current options:
- -`{ focusOptions: { preventScroll: true } }` - prevents the browser to scroll the element into view at focus.
+-   _options_ `Object`: options for configuring this behavior.
 
 <a name="placeCaretAtVerticalEdge" href="#placeCaretAtVerticalEdge">#</a> **placeCaretAtVerticalEdge**
 

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -264,7 +264,8 @@ export function placeCaretAtHorizontalEdge( container, isReverse ) {
 	}
 
 	if ( includes( [ 'INPUT', 'TEXTAREA' ], container.tagName ) ) {
-		container.focus();
+		container.focus( { preventScroll: true } );
+
 		if ( isReverse ) {
 			container.selectionStart = container.value.length;
 			container.selectionEnd = container.value.length;
@@ -275,7 +276,7 @@ export function placeCaretAtHorizontalEdge( container, isReverse ) {
 		return;
 	}
 
-	container.focus();
+	container.focus( { preventScroll: true } );
 
 	if ( ! container.isContentEditable ) {
 		return;

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -259,7 +259,7 @@ export function computeCaretRect() {
  * @param {boolean} isReverse True for end, false for start.
  * @param {Object} focusOptions options that get passed to the focus() call.
  */
-export function placeCaretAtHorizontalEdge( container, isReverse, focusOptions = {} ) {
+export function placeCaretAtHorizontalEdge( container, isReverse, focusOptions = { preventScroll: false } ) {
 	if ( ! container ) {
 		return;
 	}

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -257,14 +257,15 @@ export function computeCaretRect() {
  *
  * @param {Element} container Focusable element.
  * @param {boolean} isReverse True for end, false for start.
+ * @param {Object} focusOptions options that get passed to the focus() call.
  */
-export function placeCaretAtHorizontalEdge( container, isReverse ) {
+export function placeCaretAtHorizontalEdge( container, isReverse, focusOptions = {} ) {
 	if ( ! container ) {
 		return;
 	}
 
 	if ( includes( [ 'INPUT', 'TEXTAREA' ], container.tagName ) ) {
-		container.focus( { preventScroll: true } );
+		container.focus( focusOptions );
 
 		if ( isReverse ) {
 			container.selectionStart = container.value.length;

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -259,7 +259,7 @@ export function computeCaretRect() {
  * @param {boolean} isReverse True for end, false for start.
  * @param {Object} focusOptions options that get passed to the focus() call.
  */
-export function placeCaretAtHorizontalEdge( container, isReverse, focusOptions = { preventScroll: false } ) {
+export function placeCaretAtHorizontalEdge( container, isReverse, focusOptions = {} ) {
 	if ( ! container ) {
 		return;
 	}
@@ -277,7 +277,7 @@ export function placeCaretAtHorizontalEdge( container, isReverse, focusOptions =
 		return;
 	}
 
-	container.focus( { preventScroll: true } );
+	container.focus( focusOptions );
 
 	if ( ! container.isContentEditable ) {
 		return;

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -255,14 +255,16 @@ export function computeCaretRect() {
 /**
  * Places the caret at start or end of a given element.
  *
- * @param {Element} container Focusable element.
- * @param {boolean} isReverse True for end, false for start.
- * @param {Object} focusOptions options that get passed to the focus() call.
+ * @param {Element} container    Focusable element.
+ * @param {boolean} isReverse    True for end, false for start.
+ * @param {Object}  options      options for configuring this behavior.
  */
-export function placeCaretAtHorizontalEdge( container, isReverse, focusOptions = {} ) {
+export function placeCaretAtHorizontalEdge( container, isReverse, options = {} ) {
 	if ( ! container ) {
 		return;
 	}
+
+	const { focusOptions } = options;
 
 	if ( includes( [ 'INPUT', 'TEXTAREA' ], container.tagName ) ) {
 		container.focus( focusOptions );

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -9,7 +9,7 @@
 
 .edit-post-visual-editor .block-editor-writing-flow__click-redirect {
 	// Collapse to minimum height of 50px, to fully occupy editor bottom pad.
-	height: 240px;
+	min-height: 240px;
 	width: 100%;
 	// Offset for: Visual editor padding, block (default appender) margin.
 	margin: #{ -1 * $block-spacing } auto -50px;

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -13,6 +13,7 @@
 	width: 100%;
 	// Offset for: Visual editor padding, block (default appender) margin.
 	margin: #{ -1 * $block-spacing } auto -50px;
+	min-height: 60vh;
 }
 
 // The base width of blocks

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -12,7 +12,7 @@
 	height: 240px;
 	width: 100%;
 	// Offset for: Visual editor padding, block (default appender) margin.
-	margin: #{ -1 * $block-spacing } auto -50px;
+	margin: #{ -1 * $block-spacing } auto -240px;
 }
 
 // The base width of blocks

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -9,11 +9,10 @@
 
 .edit-post-visual-editor .block-editor-writing-flow__click-redirect {
 	// Collapse to minimum height of 50px, to fully occupy editor bottom pad.
-	height: 50px;
+	height: 240px;
 	width: 100%;
 	// Offset for: Visual editor padding, block (default appender) margin.
 	margin: #{ -1 * $block-spacing } auto -50px;
-	min-height: 60vh;
 }
 
 // The base width of blocks

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -9,8 +9,12 @@
 
 .edit-post-visual-editor .block-editor-writing-flow__click-redirect {
 	// Collapse to minimum height of 50px, to fully occupy editor bottom pad.
-	min-height: 240px;
+	height: 50px;
 	width: 100%;
+
+	// Provide a bottom margin for some minimum scroll space.
+	min-height: 160px;
+
 	// Offset for: Visual editor padding, block (default appender) margin.
 	margin: #{ -1 * $block-spacing } auto -50px;
 }

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -12,7 +12,7 @@
 	height: 240px;
 	width: 100%;
 	// Offset for: Visual editor padding, block (default appender) margin.
-	margin: #{ -1 * $block-spacing } auto -240px;
+	margin: #{ -1 * $block-spacing } auto -50px;
 }
 
 // The base width of blocks


### PR DESCRIPTION
## Description
Moves #14852 forward by adding a simple clickable space at the bottom of the editor. For me it feels amazing already! :)

## How has this been tested?
It is a very small change, I tested locally only.

## Screenshots <!-- if applicable -->

## Types of changes
CSS update to the min height of the click redirect element.

## Checklist:
- [x] My code is tested.