### PR TITLE
Docs: RichText: elaborate on use of pre-wrap

### DIFF
--- a/packages/block-editor/src/components/rich-text/style.scss
+++ b/packages/block-editor/src/components/rich-text/style.scss
@@ -6,6 +6,7 @@
 
 .block-editor-rich-text__editable {
 	position: relative;
+
 	// In HTML, leading and trailing spaces are not visible, and multiple spaces
 	// elsewhere are visually reduced to one space. This rule prevents spaces
 	// from collapsing so all space is visible in the editor and can be removed.
@@ -15,6 +16,15 @@
 	// breaking spaces in between words. If also prevent Firefox from inserting
 	// a trailing `br` node to visualise any trailing space, causing the element
 	// to be saved.
+	//
+	// > Authors are encouraged to set the 'white-space' property on editing
+	// > hosts and on markup that was originally created through these editing
+	// > mechanisms to the value 'pre-wrap'. Default HTML whitespace handling is
+	// > not well suited to WYSIWYG editing, and line wrapping will not work
+	// > correctly in some corner cases if 'white-space' is left at its default
+	// > value.
+	// >
+	// > https://html.spec.whatwg.org/multipage/interaction.html#best-practices-for-in-page-editors
 	white-space: pre-wrap !important;
 
 	> p:first-child {


### PR DESCRIPTION
While I originally discovered this myself, today I stumbled upon a recommendation to use the `white-space: pre-wrap;` rule on a `contenteditable` element: https://html.spec.whatwg.org/multipage/interaction.html#best-practices-for-in-page-editors.

I think this is worth including as it confirms that it's not just _my_ opinion. :)