### PR TITLE
Docs: Clarify requirements for e2e-test-utils package

### DIFF
--- a/packages/e2e-test-utils/CHANGELOG.md
+++ b/packages/e2e-test-utils/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Requirements
+
+- The minimum version of Gutenberg `5.6.0` or the minimum version of WordPress `5.2.0`.
+
 ## 1.1.0 (2019-03-20)
 
 ### New Features
@@ -6,7 +12,16 @@
 - New Function: `openAllBlockInserterCategories` - Opens all block inserter categories.
 - New Function: `getAllBlockInserterItemTitles` - Opens the global block inserter.
 
+### Requirements
+
+- The minimum version of Gutenberg `5.3.0` or the minimum version of WordPress `5.2.0`.
 
 ## 1.0.0 (2019-03-06)
 
+### New Features 
+
 -   Initial release.
+
+### Requirements
+
+- The minimum version of Gutenberg `5.2.0` or the minimum version of WordPress `5.2.0`.

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -2,6 +2,8 @@
 
 End-To-End (E2E) test utils for WordPress.
 
+_It works properly with the minimum version of Gutenberg `5.6.0` or the minimum version of WordPress `5.2.0`._
+
 ## Installation
 
 Install the module


### PR DESCRIPTION
## Description
Fixes #14834.

In #14834 @kamataryo shared the following expectations:

> Tests with `@wordpress/e2e-test-utils` should work with Gutenberg which is bundled with WordPress <= 5.1.1.

However, I did some investigation and it looks like the version `1.0` of `@wordpress/e2e-test-utils` which was published to npm can work only with 
> The minimum version of Gutenberg `5.2.0` or the minimum version of WordPress `5.2.0`.

For the current 1.1 version it is:
> The minimum version of Gutenberg `5.3.0` or the minimum version of WordPress `5.2.0`.

This PR adds this clarification to the changelog file, and to README file as well.