### PR TITLE
Compose: Documentation: Document withGlobalEvents

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -121,7 +121,20 @@ _Returns_
 
 <a name="withGlobalEvents" href="#withGlobalEvents">#</a> **withGlobalEvents**
 
-Undocumented declaration.
+Higher-order component creator which, given an object of DOM event types and
+values corresponding to a callback function name on the component, will
+create or update a window event handler to invoke the callback when an event
+occurs. On behalf of the consuming developer, the higher-order component
+manages unbinding when the component unmounts, and binding at most a single
+event handler for the entire application.
+
+_Parameters_
+
+-   _eventTypesToHandlers_ `Object<string,string>`: Object with keys of DOM event type, the value a name of the function on the original component's instance which handles the event.
+
+_Returns_
+
+-   `Function`: Higher-order component.
 
 <a name="withInstanceId" href="#withInstanceId">#</a> **withInstanceId**
 

--- a/packages/compose/src/with-global-events/index.js
+++ b/packages/compose/src/with-global-events/index.js
@@ -21,6 +21,23 @@ import Listener from './listener';
  */
 const listener = new Listener();
 
+/**
+ * Higher-order component creator which, given an object of DOM event types and
+ * values corresponding to a callback function name on the component, will
+ * create or update a window event handler to invoke the callback when an event
+ * occurs. On behalf of the consuming developer, the higher-order component
+ * manages unbinding when the component unmounts, and binding at most a single
+ * event handler for the entire application.
+ *
+ * @param {Object<string,string>} eventTypesToHandlers Object with keys of DOM
+ *                                                     event type, the value a
+ *                                                     name of the function on
+ *                                                     the original component's
+ *                                                     instance which handles
+ *                                                     the event.
+ *
+ * @return {Function} Higher-order component.
+ */
 function withGlobalEvents( eventTypesToHandlers ) {
 	return createHigherOrderComponent( ( WrappedComponent ) => {
 		class Wrapper extends Component {


### PR DESCRIPTION
This pull request seeks to add missing documentation for the `withGlobalEvents` higher-order component creator.

**Testing Instructions:**

Verify by rendered output of "Files changed" tab that produced documentation is sensible.

There are only documentation changes. Thus, there is no expected impact on application runtime.