### PR TITLE
Data: Documentation: Document undocumented declarations

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -473,7 +473,13 @@ _Parameters_
 
 <a name="use" href="#use">#</a> **use**
 
-Undocumented declaration.
+Extends a registry to inherit functionality provided by a given plugin. A
+plugin is an object with properties aligning to that of a registry, merged
+to extend the default registry behavior.
+
+_Parameters_
+
+-   _plugin_ `Object`: Plugin object.
 
 <a name="useRegistry" href="#useRegistry">#</a> **useRegistry**
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -353,7 +353,15 @@ _Returns_
 
 <a name="plugins" href="#plugins">#</a> **plugins**
 
-Undocumented declaration.
+Object of available plugins to use with a registry.
+
+_Related_
+
+-   [use](#use)
+
+_Type_
+
+-   `Object` 
 
 <a name="registerGenericStore" href="#registerGenericStore">#</a> **registerGenericStore**
 

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -22,8 +22,16 @@ export {
 	AsyncModeProvider as __experimentalAsyncModeProvider,
 } from './components/async-mode-provider';
 export { createRegistry } from './registry';
-export { plugins };
 export { createRegistrySelector, createRegistryControl } from './factory';
+
+/**
+ * Object of available plugins to use with a registry.
+ *
+ * @see [use](#use)
+ *
+ * @type {Object}
+ */
+export { plugins };
 
 /**
  * The combineReducers helper function turns an object whose values are different

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -148,4 +148,12 @@ export const registerGenericStore = defaultRegistry.registerGenericStore;
  * @return {Object} Registered store object.
  */
 export const registerStore = defaultRegistry.registerStore;
+
+/**
+ * Extends a registry to inherit functionality provided by a given plugin. A
+ * plugin is an object with properties aligning to that of a registry, merged
+ * to extend the default registry behavior.
+ *
+ * @param {Object} plugin Plugin object.
+ */
 export const use = defaultRegistry.use;


### PR DESCRIPTION
This pull request seeks to add missing documentation for data module exports:

- `plugins`
- `use`
- `RegistryConsumer`
- `RegistryProvider`

**Implementation notes:**

The `plugins` documentation here could be improved to better reference available options. However, it's not clear how to reference this without adding overhead to future updates to these plugins, which would likely be overlooked. Suggestions welcome.

**Testing Instructions:**

Verify by rendered output of "Files changed" tab that produced documentation is sensible.

There are only documentation changes. Thus, there is no expected impact on application runtime.