### PR TITLE
Format Library: Remove secondary (access) shortcuts

### DIFF
--- a/packages/e2e-tests/specs/__snapshots__/rich-text.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/rich-text.test.js.snap
@@ -6,12 +6,6 @@ exports[`RichText should apply formatting when selection is collapsed 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
-exports[`RichText should apply formatting with access shortcut 1`] = `
-"<!-- wp:paragraph -->
-<p><s>test</s></p>
-<!-- /wp:paragraph -->"
-`;
-
 exports[`RichText should apply formatting with primary shortcut 1`] = `
 "<!-- wp:paragraph -->
 <p><strong>test</strong></p>

--- a/packages/e2e-tests/specs/rich-text.test.js
+++ b/packages/e2e-tests/specs/rich-text.test.js
@@ -27,15 +27,6 @@ describe( 'RichText', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
-	it( 'should apply formatting with access shortcut', async () => {
-		await clickBlockAppender();
-		await page.keyboard.type( 'test' );
-		await pressKeyWithModifier( 'primary', 'a' );
-		await pressKeyWithModifier( 'access', 'd' );
-
-		expect( await getEditedPostContent() ).toMatchSnapshot();
-	} );
-
 	it( 'should apply formatting with primary shortcut', async () => {
 		await clickBlockAppender();
 		await page.keyboard.type( 'test' );

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/config.js
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/config.js
@@ -133,10 +133,6 @@ const textFormattingShortcuts = {
 			description: __( 'Make the selected text italic.' ),
 		},
 		{
-			keyCombination: primary( 'u' ),
-			description: __( 'Underline the selected text.' ),
-		},
-		{
 			keyCombination: primary( 'k' ),
 			description: __( 'Convert the selected text into a link.' ),
 		},
@@ -145,12 +141,8 @@ const textFormattingShortcuts = {
 			description: __( 'Remove a link.' ),
 		},
 		{
-			keyCombination: access( 'd' ),
-			description: __( 'Add a strikethrough to the selected text.' ),
-		},
-		{
-			keyCombination: access( 'x' ),
-			description: __( 'Display the selected text in a monospaced font.' ),
+			keyCombination: primary( 'u' ),
+			description: __( 'Underline the selected text.' ),
 		},
 	],
 };

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
@@ -236,14 +236,6 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
             ],
           },
           Object {
-            "description": "Underline the selected text.",
-            "keyCombination": Array [
-              "Ctrl",
-              "+",
-              "U",
-            ],
-          },
-          Object {
             "description": "Convert the selected text into a link.",
             "keyCombination": Array [
               "Ctrl",
@@ -262,23 +254,11 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
             ],
           },
           Object {
-            "description": "Add a strikethrough to the selected text.",
+            "description": "Underline the selected text.",
             "keyCombination": Array [
-              "Shift",
+              "Ctrl",
               "+",
-              "Alt",
-              "+",
-              "D",
-            ],
-          },
-          Object {
-            "description": "Display the selected text in a monospaced font.",
-            "keyCombination": Array [
-              "Shift",
-              "+",
-              "Alt",
-              "+",
-              "X",
+              "U",
             ],
           },
         ]

--- a/packages/format-library/src/code/index.js
+++ b/packages/format-library/src/code/index.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { toggleFormat } from '@wordpress/rich-text';
-import { RichTextShortcut, RichTextToolbarButton } from '@wordpress/block-editor';
+import { RichTextToolbarButton } from '@wordpress/block-editor';
 
 const name = 'core/code';
 const title = __( 'Inline Code' );
@@ -17,21 +17,12 @@ export const code = {
 		const onToggle = () => onChange( toggleFormat( value, { type: name } ) );
 
 		return (
-			<>
-				<RichTextShortcut
-					type="access"
-					character="x"
-					onUse={ onToggle }
-				/>
-				<RichTextToolbarButton
-					icon="editor-code"
-					title={ title }
-					onClick={ onToggle }
-					isActive={ isActive }
-					shortcutType="access"
-					shortcutCharacter="x"
-				/>
-			</>
+			<RichTextToolbarButton
+				icon="editor-code"
+				title={ title }
+				onClick={ onToggle }
+				isActive={ isActive }
+			/>
 		);
 	},
 };

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -72,16 +72,6 @@ export const link = {
 			return (
 				<>
 					<RichTextShortcut
-						type="access"
-						character="a"
-						onUse={ this.addLink }
-					/>
-					<RichTextShortcut
-						type="access"
-						character="s"
-						onUse={ this.onRemoveFormat }
-					/>
-					<RichTextShortcut
 						type="primary"
 						character="k"
 						onUse={ this.addLink }

--- a/packages/format-library/src/strikethrough/index.js
+++ b/packages/format-library/src/strikethrough/index.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { toggleFormat } from '@wordpress/rich-text';
-import { RichTextToolbarButton, RichTextShortcut } from '@wordpress/block-editor';
+import { RichTextToolbarButton } from '@wordpress/block-editor';
 
 const name = 'core/strikethrough';
 const title = __( 'Strikethrough' );
@@ -17,21 +17,12 @@ export const strikethrough = {
 		const onToggle = () => onChange( toggleFormat( value, { type: name } ) );
 
 		return (
-			<>
-				<RichTextShortcut
-					type="access"
-					character="d"
-					onUse={ onToggle }
-				/>
-				<RichTextToolbarButton
-					icon="editor-strikethrough"
-					title={ title }
-					onClick={ onToggle }
-					isActive={ isActive }
-					shortcutType="access"
-					shortcutCharacter="d"
-				/>
-			</>
+			<RichTextToolbarButton
+				icon="editor-strikethrough"
+				title={ title }
+				onClick={ onToggle }
+				isActive={ isActive }
+			/>
 		);
 	},
 };


### PR DESCRIPTION
## Description

See #11154 (partial fix). Removes all `access` shortcuts from the format library.

It is worth noting that:

* All primary (most used) formats (bold, italic, and link) still have primary shortcuts.
* Strikethrough and code are present in the UI, so they can both be accessed with the keyboard and pointer device.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->