### PR TITLE
Block Editor: Docs: Add DocBlock `see` references to component READMEs

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -74,7 +74,9 @@ Undocumented declaration.
 
 <a name="Autocomplete" href="#Autocomplete">#</a> **Autocomplete**
 
-Undocumented declaration.
+_Related_
+
+-   <https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/autocomplete/README.md>
 
 <a name="BlockAlignmentToolbar" href="#BlockAlignmentToolbar">#</a> **BlockAlignmentToolbar**
 
@@ -138,11 +140,15 @@ Undocumented declaration.
 
 <a name="BlockVerticalAlignmentToolbar" href="#BlockVerticalAlignmentToolbar">#</a> **BlockVerticalAlignmentToolbar**
 
-Undocumented declaration.
+_Related_
+
+-   <https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/block-vertical-alignment-toolbar/README.md>
 
 <a name="ButtonBlockerAppender" href="#ButtonBlockerAppender">#</a> **ButtonBlockerAppender**
 
-Undocumented declaration.
+_Related_
+
+-   <https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/button-block-appender/README.md>
 
 <a name="ColorPalette" href="#ColorPalette">#</a> **ColorPalette**
 
@@ -261,7 +267,9 @@ _Returns_
 
 <a name="InnerBlocks" href="#InnerBlocks">#</a> **InnerBlocks**
 
-Undocumented declaration.
+_Related_
+
+-   <https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/inner-blocks/README.md>
 
 <a name="Inserter" href="#Inserter">#</a> **Inserter**
 
@@ -273,19 +281,27 @@ Undocumented declaration.
 
 <a name="InspectorControls" href="#InspectorControls">#</a> **InspectorControls**
 
-Undocumented declaration.
+_Related_
+
+-   <https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/inspector-controls/README.md>
 
 <a name="MediaPlaceholder" href="#MediaPlaceholder">#</a> **MediaPlaceholder**
 
-Undocumented declaration.
+_Related_
+
+-   <https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/media-placeholder/README.md>
 
 <a name="MediaUpload" href="#MediaUpload">#</a> **MediaUpload**
 
-Undocumented declaration.
+_Related_
+
+-   <https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/media-upload/README.md>
 
 <a name="MediaUploadCheck" href="#MediaUploadCheck">#</a> **MediaUploadCheck**
 
-Undocumented declaration.
+_Related_
+
+-   <https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/media-upload/README.md>
 
 <a name="MultiBlocksSwitcher" href="#MultiBlocksSwitcher">#</a> **MultiBlocksSwitcher**
 
@@ -301,7 +317,9 @@ Undocumented declaration.
 
 <a name="ObserveTyping" href="#ObserveTyping">#</a> **ObserveTyping**
 
-Undocumented declaration.
+_Related_
+
+-   <https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/observe-typing/README.md>
 
 <a name="PanelColorSettings" href="#PanelColorSettings">#</a> **PanelColorSettings**
 
@@ -309,7 +327,9 @@ Undocumented declaration.
 
 <a name="PlainText" href="#PlainText">#</a> **PlainText**
 
-Undocumented declaration.
+_Related_
+
+-   <https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/plain-text/README.md>
 
 <a name="PreserveScrollInReorder" href="#PreserveScrollInReorder">#</a> **PreserveScrollInReorder**
 
@@ -317,7 +337,9 @@ Undocumented declaration.
 
 <a name="RichText" href="#RichText">#</a> **RichText**
 
-Undocumented declaration.
+_Related_
+
+-   <https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/rich-text/README.md>
 
 <a name="RichTextShortcut" href="#RichTextShortcut">#</a> **RichTextShortcut**
 
@@ -354,15 +376,21 @@ Undocumented declaration.
 
 <a name="URLInput" href="#URLInput">#</a> **URLInput**
 
-Undocumented declaration.
+_Related_
+
+-   <https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/url-input/README.md>
 
 <a name="URLInputButton" href="#URLInputButton">#</a> **URLInputButton**
 
-Undocumented declaration.
+_Related_
+
+-   <https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/url-input/README.md>
 
 <a name="URLPopover" href="#URLPopover">#</a> **URLPopover**
 
-Undocumented declaration.
+_Related_
+
+-   <https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/url-popover/README.md>
 
 <a name="Warning" href="#Warning">#</a> **Warning**
 

--- a/packages/block-editor/src/components/autocomplete/index.js
+++ b/packages/block-editor/src/components/autocomplete/index.js
@@ -114,6 +114,9 @@ export function withFilteredAutocompleters( Autocomplete ) {
 	};
 }
 
+/**
+ * @see https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/autocomplete/README.md
+ */
 export default compose( [
 	withBlockEditContext( ( { name } ) => {
 		return {

--- a/packages/block-editor/src/components/block-vertical-alignment-toolbar/index.js
+++ b/packages/block-editor/src/components/block-vertical-alignment-toolbar/index.js
@@ -57,6 +57,9 @@ export function BlockVerticalAlignmentToolbar( { isCollapsed, value, onChange, c
 	);
 }
 
+/**
+ * @see https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/block-vertical-alignment-toolbar/README.md
+ */
 export default compose(
 	withBlockEditContext( ( { clientId } ) => {
 		return {

--- a/packages/block-editor/src/components/button-block-appender/index.js
+++ b/packages/block-editor/src/components/button-block-appender/index.js
@@ -14,7 +14,7 @@ import { __ } from '@wordpress/i18n';
  */
 import Inserter from '../inserter';
 
-export default function ButtonBlockAppender( { rootClientId, className } ) {
+function ButtonBlockAppender( { rootClientId, className } ) {
 	return (
 		<Inserter
 			rootClientId={ rootClientId }
@@ -33,3 +33,8 @@ export default function ButtonBlockAppender( { rootClientId, className } ) {
 		/>
 	);
 }
+
+/**
+ * @see https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/button-block-appender/README.md
+ */
+export default ButtonBlockAppender;

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -177,4 +177,7 @@ InnerBlocks.Content = withBlockContentContext(
 	( { BlockContent } ) => <BlockContent />
 );
 
+/**
+ * @see https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/inner-blocks/README.md
+ */
 export default InnerBlocks;

--- a/packages/block-editor/src/components/inspector-controls/index.js
+++ b/packages/block-editor/src/components/inspector-controls/index.js
@@ -14,4 +14,7 @@ const InspectorControls = ifBlockEditSelected( Fill );
 
 InspectorControls.Slot = Slot;
 
+/**
+ * @see https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/inspector-controls/README.md
+ */
 export default InspectorControls;

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -416,6 +416,9 @@ const applyWithSelect = withSelect( ( select ) => {
 	};
 } );
 
+/**
+ * @see https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/media-placeholder/README.md
+ */
 export default compose(
 	applyWithSelect,
 	withFilters( 'editor.MediaPlaceholder' ),

--- a/packages/block-editor/src/components/media-upload/check.js
+++ b/packages/block-editor/src/components/media-upload/check.js
@@ -7,6 +7,9 @@ export function MediaUploadCheck( { hasUploadPermissions, fallback = null, child
 	return hasUploadPermissions ? children : fallback;
 }
 
+/**
+ * @see https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/media-upload/README.md
+ */
 export default withSelect( ( select ) => {
 	const { getSettings } = select( 'core/block-editor' );
 

--- a/packages/block-editor/src/components/media-upload/index.js
+++ b/packages/block-editor/src/components/media-upload/index.js
@@ -12,5 +12,7 @@ import { withFilters } from '@wordpress/components';
  */
 const MediaUpload = () => null;
 
-// Todo: rename the filter
+/**
+ * @see https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/media-upload/README.md
+ */
 export default withFilters( 'editor.MediaUpload' )( MediaUpload );

--- a/packages/block-editor/src/components/observe-typing/index.js
+++ b/packages/block-editor/src/components/observe-typing/index.js
@@ -199,6 +199,9 @@ class ObserveTyping extends Component {
 	}
 }
 
+/**
+ * @see https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/observe-typing/README.md
+ */
 export default compose( [
 	withSelect( ( select ) => {
 		const { isTyping } = select( 'core/block-editor' );

--- a/packages/block-editor/src/components/plain-text/index.js
+++ b/packages/block-editor/src/components/plain-text/index.js
@@ -10,6 +10,9 @@ import { forwardRef } from '@wordpress/element';
 import TextareaAutosize from 'react-autosize-textarea';
 import classnames from 'classnames';
 
+/**
+ * @see https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/plain-text/README.md
+ */
 const PlainText = forwardRef( ( { onChange, className, ...props }, ref ) => {
 	return (
 		<TextareaAutosize

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -1230,6 +1230,9 @@ RichTextContainer.Content.defaultProps = {
 	value: '',
 };
 
+/**
+ * @see https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/rich-text/README.md
+ */
 export default RichTextContainer;
 export { RichTextShortcut } from './shortcut';
 export { RichTextToolbarButton } from './toolbar-button';

--- a/packages/block-editor/src/components/url-input/button.js
+++ b/packages/block-editor/src/components/url-input/button.js
@@ -75,4 +75,7 @@ class URLInputButton extends Component {
 	}
 }
 
+/**
+ * @see https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/url-input/README.md
+ */
 export default URLInputButton;

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -282,6 +282,9 @@ class URLInput extends Component {
 	}
 }
 
+/**
+ * @see https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/url-input/README.md
+ */
 export default compose(
 	withSafeTimeout,
 	withSpokenMessages,

--- a/packages/block-editor/src/components/url-popover/index.js
+++ b/packages/block-editor/src/components/url-popover/index.js
@@ -69,4 +69,7 @@ class URLPopover extends Component {
 	}
 }
 
+/**
+ * @see https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/url-popover/README.md
+ */
 export default URLPopover;


### PR DESCRIPTION
Previously: https://github.com/WordPress/gutenberg/issues/14227#issuecomment-486716222
Partially addresses: #15107 

This pull request seeks to add a minimal JSDoc for the autogenerated documentation of block editor components where there is a corresponding `README.md` file which could provide additional usage information.

**Implementation notes:**

Discovered relevant README files to include via:

```
find packages/block-editor -name 'README.md'
```

**Testing instructions:**

Verify there are no changes after running `npm run docs:build`.

Verify all links are valid.