### PR TITLE
Block Editor: Alphabetize block editor components exports

### DIFF
--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -1,22 +1,27 @@
-// Block Creation Components
-export { default as Autocomplete } from './autocomplete';
+/*
+ * Block Creation Components
+ */
+
+export * from './colors';
+export * from './font-sizes';
 export { default as AlignmentToolbar } from './alignment-toolbar';
+export { default as Autocomplete } from './autocomplete';
 export { default as BlockAlignmentToolbar } from './block-alignment-toolbar';
 export { default as BlockControls } from './block-controls';
 export { default as BlockEdit } from './block-edit';
 export { default as BlockFormatControls } from './block-format-controls';
-export { default as BlockNavigationDropdown } from './block-navigation/dropdown';
 export { default as BlockIcon } from './block-icon';
+export { default as BlockNavigationDropdown } from './block-navigation/dropdown';
 export { default as BlockVerticalAlignmentToolbar } from './block-vertical-alignment-toolbar';
 export { default as ButtonBlockerAppender } from './button-block-appender';
 export { default as ColorPalette } from './color-palette';
-export { default as withColorContext } from './color-palette/with-color-context';
-export * from './colors';
 export { default as ContrastChecker } from './contrast-checker';
-export * from './font-sizes';
 export { default as InnerBlocks } from './inner-blocks';
 export { default as InspectorAdvancedControls } from './inspector-advanced-controls';
 export { default as InspectorControls } from './inspector-controls';
+export { default as MediaPlaceholder } from './media-placeholder';
+export { default as MediaUpload } from './media-upload';
+export { default as MediaUploadCheck } from './media-upload/check';
 export { default as PanelColorSettings } from './panel-color-settings';
 export { default as PlainText } from './plain-text';
 export {
@@ -25,22 +30,23 @@ export {
 	RichTextToolbarButton,
 	UnstableRichTextInputEvent,
 } from './rich-text';
-export { default as MediaPlaceholder } from './media-placeholder';
-export { default as MediaUpload } from './media-upload';
-export { default as MediaUploadCheck } from './media-upload/check';
 export { default as URLInput } from './url-input';
 export { default as URLInputButton } from './url-input/button';
 export { default as URLPopover } from './url-popover';
+export { default as withColorContext } from './color-palette/with-color-context';
 
-// Content Related Components
+/*
+ * Content Related Components
+ */
+
+export { default as __experimentalBlockSettingsMenuFirstItem } from './block-settings-menu/block-settings-menu-first-item';
+export { default as __experimentalBlockSettingsMenuPluginsExtension } from './block-settings-menu/block-settings-menu-plugins-extension';
 export { default as BlockEditorKeyboardShortcuts } from './block-editor-keyboard-shortcuts';
 export { default as BlockInspector } from './block-inspector';
 export { default as BlockList } from './block-list';
 export { default as BlockMover } from './block-mover';
 export { default as BlockSelectionClearer } from './block-selection-clearer';
 export { default as BlockSettingsMenu } from './block-settings-menu';
-export { default as __experimentalBlockSettingsMenuFirstItem } from './block-settings-menu/block-settings-menu-first-item';
-export { default as __experimentalBlockSettingsMenuPluginsExtension } from './block-settings-menu/block-settings-menu-plugins-extension';
 export { default as BlockTitle } from './block-title';
 export { default as BlockToolbar } from './block-toolbar';
 export { default as CopyHandler } from './copy-handler';
@@ -55,5 +61,8 @@ export { default as SkipToSelectedBlock } from './skip-to-selected-block';
 export { default as Warning } from './warning';
 export { default as WritingFlow } from './writing-flow';
 
-// State Related Components
+/*
+ * State Related Components
+ */
+
 export { default as BlockEditorProvider } from './provider';


### PR DESCRIPTION
Extracted from #15194 

This pull request seeks to correct inconsistent alphabetization of exported entries from the `packages/block-editor/src/components/index.js` file.

**Testing instructions:**

The included changes are simply a reordering. There should be no impact on the behavior of the application. Verify that this is true.