### PR TITLE
Format Library: Code => Inline Code

### DIFF
--- a/packages/format-library/src/bold/index.js
+++ b/packages/format-library/src/bold/index.js
@@ -7,10 +7,11 @@ import { toggleFormat } from '@wordpress/rich-text';
 import { RichTextToolbarButton, RichTextShortcut, UnstableRichTextInputEvent } from '@wordpress/block-editor';
 
 const name = 'core/bold';
+const title = __( 'Bold' );
 
 export const bold = {
 	name,
-	title: __( 'Bold' ),
+	title,
 	tagName: 'strong',
 	className: null,
 	edit( { isActive, value, onChange } ) {
@@ -26,7 +27,7 @@ export const bold = {
 				<RichTextToolbarButton
 					name="bold"
 					icon="editor-bold"
-					title={ __( 'Bold' ) }
+					title={ title }
 					onClick={ onToggle }
 					isActive={ isActive }
 					shortcutType="primary"

--- a/packages/format-library/src/code/index.js
+++ b/packages/format-library/src/code/index.js
@@ -7,10 +7,11 @@ import { toggleFormat } from '@wordpress/rich-text';
 import { RichTextShortcut, RichTextToolbarButton } from '@wordpress/block-editor';
 
 const name = 'core/code';
+const title = __( 'Inline Code' );
 
 export const code = {
 	name,
-	title: __( 'Code' ),
+	title,
 	tagName: 'code',
 	className: null,
 	edit( { value, onChange, isActive } ) {
@@ -25,7 +26,7 @@ export const code = {
 				/>
 				<RichTextToolbarButton
 					icon="editor-code"
-					title={ __( 'Code' ) }
+					title={ title }
 					onClick={ onToggle }
 					isActive={ isActive }
 					shortcutType="access"

--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -11,12 +11,13 @@ import { LEFT, RIGHT, UP, DOWN, BACKSPACE, ENTER } from '@wordpress/keycodes';
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 
 const name = 'core/image';
+const title = __( 'Inline Image' );
 
 const stopKeyPropagation = ( event ) => event.stopPropagation();
 
 export const image = {
 	name,
-	title: __( 'Image' ),
+	title,
 	keywords: [ __( 'photo' ), __( 'media' ) ],
 	object: true,
 	tagName: 'img',
@@ -89,7 +90,7 @@ export const image = {
 				<MediaUploadCheck>
 					<RichTextToolbarButton
 						icon={ <SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M4 16h10c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v9c0 1.1.9 2 2 2zM4 5h10v9H4V5zm14 9v2h4v-2h-4zM2 20h20v-2H2v2zm6.4-8.8L7 9.4 5 12h8l-2.6-3.4-2 2.6z" /></SVG> }
-						title={ __( 'Inline Image' ) }
+						title={ title }
 						onClick={ this.openModal }
 						isActive={ isObjectActive }
 					/>

--- a/packages/format-library/src/italic/index.js
+++ b/packages/format-library/src/italic/index.js
@@ -7,10 +7,11 @@ import { toggleFormat } from '@wordpress/rich-text';
 import { RichTextToolbarButton, RichTextShortcut, UnstableRichTextInputEvent } from '@wordpress/block-editor';
 
 const name = 'core/italic';
+const title = __( 'Italic' );
 
 export const italic = {
 	name,
-	title: __( 'Italic' ),
+	title,
 	tagName: 'em',
 	className: null,
 	edit( { isActive, value, onChange } ) {
@@ -26,7 +27,7 @@ export const italic = {
 				<RichTextToolbarButton
 					name="italic"
 					icon="editor-italic"
-					title={ __( 'Italic' ) }
+					title={ title }
 					onClick={ onToggle }
 					isActive={ isActive }
 					shortcutType="primary"

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -19,10 +19,11 @@ import { RichTextToolbarButton, RichTextShortcut } from '@wordpress/block-editor
 import InlineLinkUI from './inline';
 
 const name = 'core/link';
+const title = __( 'Link' );
 
 export const link = {
 	name,
-	title: __( 'Link' ),
+	title,
 	tagName: 'a',
 	className: null,
 	attributes: {
@@ -102,7 +103,7 @@ export const link = {
 					{ ! isActive && <RichTextToolbarButton
 						name="link"
 						icon="admin-links"
-						title={ __( 'Link' ) }
+						title={ title }
 						onClick={ this.addLink }
 						isActive={ isActive }
 						shortcutType="primary"

--- a/packages/format-library/src/strikethrough/index.js
+++ b/packages/format-library/src/strikethrough/index.js
@@ -7,10 +7,11 @@ import { toggleFormat } from '@wordpress/rich-text';
 import { RichTextToolbarButton, RichTextShortcut } from '@wordpress/block-editor';
 
 const name = 'core/strikethrough';
+const title = __( 'Strikethrough' );
 
 export const strikethrough = {
 	name,
-	title: __( 'Strikethrough' ),
+	title,
 	tagName: 's',
 	className: null,
 	edit( { isActive, value, onChange } ) {
@@ -25,7 +26,7 @@ export const strikethrough = {
 				/>
 				<RichTextToolbarButton
 					icon="editor-strikethrough"
-					title={ __( 'Strikethrough' ) }
+					title={ title }
 					onClick={ onToggle }
 					isActive={ isActive }
 					shortcutType="access"


### PR DESCRIPTION
## Description

This PR renames the "Code" format to "Inline Code" to avoid confusing with the block "Code". This is similar to how we named the image format "Inline Image", because there is also an "Image" block.

Also removes some duplicate translations.

## How has this been tested?

## Screenshots <!-- if applicable -->

<img width="328" alt="Schermafbeelding 2019-04-25 om 22 36 27" src="https://user-images.githubusercontent.com/4710635/56766821-9b5a5300-67aa-11e9-8247-4569f5eeecbc.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->