### PR TITLE
Correct name of `date_i18n()` PHP function.

### DIFF
--- a/packages/date/README.md
+++ b/packages/date/README.md
@@ -31,7 +31,7 @@ _Returns_
 
 <a name="dateI18n" href="#dateI18n">#</a> **dateI18n**
 
-Formats a date (like `dateI18n()` in PHP).
+Formats a date (like `date_i18n()` in PHP).
 
 _Parameters_
 

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -342,7 +342,7 @@ export function gmdate( dateFormat, dateValue = new Date() ) {
 }
 
 /**
- * Formats a date (like `dateI18n()` in PHP).
+ * Formats a date (like `date_i18n()` in PHP).
  *
  * @param {string}                    dateFormat PHP-style formatting string.
  *                                               See php.net/date.


### PR DESCRIPTION
The PHP function being referenced is named with underscore_case.