### PR TITLE
Try adding an inner container to the Group block.

### DIFF
--- a/packages/block-library/src/group/deprecated.js
+++ b/packages/block-library/src/group/deprecated.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks, getColorClassName } from '@wordpress/block-editor';
+
+const deprecated = [
+	// v1 of group block. Deprecated to add an inner-container div around `InnerBlocks.Content`.
+	{
+		attributes: {
+			backgroundColor: {
+				type: 'string',
+			},
+			customBackgroundColor: {
+				type: 'string',
+			},
+		},
+		supports: {
+			align: [ 'wide', 'full' ],
+			anchor: true,
+			html: false,
+		},
+		save( { attributes } ) {
+			const { backgroundColor, customBackgroundColor } = attributes;
+
+			const backgroundClass = getColorClassName( 'background-color', backgroundColor );
+			const className = classnames( backgroundClass, {
+				'has-background': backgroundColor || customBackgroundColor,
+			} );
+
+			const styles = {
+				backgroundColor: backgroundClass ? undefined : customBackgroundColor,
+			};
+
+			return (
+				<div className={ className } style={ styles }>
+					<InnerBlocks.Content />
+				</div>
+			);
+		},
+	},
+];
+
+export default deprecated;

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -45,9 +45,11 @@ function GroupEdit( {
 				/>
 			</InspectorControls>
 			<div className={ classes } style={ styles }>
-				<InnerBlocks
-					renderAppender={ ! hasInnerBlocks && InnerBlocks.ButtonBlockAppender }
-				/>
+				<div className="wp-block-group__inner-container">
+					<InnerBlocks
+						renderAppender={ ! hasInnerBlocks && InnerBlocks.ButtonBlockAppender }
+					/>
+				</div>
 			</div>
 		</>
 	);

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -11,14 +11,14 @@
 	}
 
 	// Only applied when background is added to cancel out padding
-	> .editor-block-list__block-edit > div > .wp-block-group.has-background > .editor-inner-blocks {
+	> .editor-block-list__block-edit > div > .wp-block-group.has-background > .wp-block-group__inner-container > .editor-inner-blocks {
 		margin-top: -#{$block-padding*2 + $block-spacing};
 		margin-bottom: -#{$block-padding*2 + $block-spacing};
 	}
 
 	// Full Width Blocks
 	// specificity required to only target immediate child Blocks of a Group
-	> .editor-block-list__block-edit > div > .wp-block-group > .editor-inner-blocks > .editor-block-list__layout > .wp-block[data-align="full"] {
+	> .editor-block-list__block-edit > div > .wp-block-group > .wp-block-group__inner-container > .editor-inner-blocks > .editor-block-list__layout > .wp-block[data-align="full"] {
 		margin-left: auto;
 		margin-right: auto;
 		padding-left: $block-padding*2;
@@ -31,7 +31,7 @@
 	}
 
 	// Full Width Blocks with a background (ie: has padding)
-	> .editor-block-list__block-edit > div > .wp-block-group.has-background > .editor-inner-blocks > .editor-block-list__layout > .wp-block[data-align="full"] {
+	> .editor-block-list__block-edit > div > .wp-block-group.has-background > .wp-block-group__inner-container > .editor-inner-blocks > .editor-block-list__layout > .wp-block[data-align="full"] {
 		// note: using position `left` causes hoz scrollbars so
 		// we opt to use margin instead
 		// the 30px matches the hoz padding applied in `theme.scss`
@@ -51,7 +51,7 @@
 .wp-block[data-type="core/group"][data-align="full"] {
 
 	// First tier of InnerBlocks must act like the container of the standard canvas
-	> .editor-block-list__block-edit > div > .wp-block-group > .editor-inner-blocks {
+	> .editor-block-list__block-edit > div > .wp-block-group > .wp-block-group__inner-container > .editor-inner-blocks {
 		margin-left: auto;
 		margin-right: auto;
 		padding-left: 0;
@@ -65,7 +65,7 @@
 
 	// Full Width Blocks
 	// specificity required to only target immediate child Blocks of Group
-	> .editor-block-list__block-edit > div > .wp-block-group > .editor-inner-blocks > .editor-block-list__layout > .wp-block[data-align="full"] {
+	> .editor-block-list__block-edit > div > .wp-block-group > .wp-block-group__inner-container > .editor-inner-blocks > .editor-block-list__layout > .wp-block[data-align="full"] {
 		padding-right: 0;
 		padding-left: 0;
 		left: 0;
@@ -81,7 +81,7 @@
 
 	// Full Width Blocks with a background (ie: has padding)
 	// note: also duplicated above for all Group widths
-	> .editor-block-list__block-edit > div > .wp-block-group.has-background > .editor-inner-blocks > .editor-block-list__layout > .wp-block[data-align="full"] {
+	> .editor-block-list__block-edit > div > .wp-block-group.has-background > .wp-block-group__inner-container > .editor-inner-blocks > .editor-block-list__layout > .wp-block[data-align="full"] {
 		width: calc(100% + 60px);
 	}
 }

--- a/packages/block-library/src/group/index.js
+++ b/packages/block-library/src/group/index.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import deprecated from './deprecated';
 import edit from './edit';
 import icon from './icon';
 import metadata from './block.json';
@@ -27,4 +28,5 @@ export const settings = {
 	},
 	edit,
 	save,
+	deprecated,
 };

--- a/packages/block-library/src/group/save.js
+++ b/packages/block-library/src/group/save.js
@@ -22,7 +22,9 @@ export default function save( { attributes } ) {
 
 	return (
 		<div className={ className } style={ styles }>
-			<InnerBlocks.Content />
+			<div className="wp-block-group__inner-container">
+				<InnerBlocks.Content />
+			</div>
 		</div>
 	);
 }

--- a/packages/e2e-tests/fixtures/blocks/core__group.html
+++ b/packages/e2e-tests/fixtures/blocks/core__group.html
@@ -1,10 +1,12 @@
 <!-- wp:group {"backgroundColor":"secondary","align":"full"} -->
 <div class="wp-block-group alignfull has-secondary-background-color has-background">
-	<!-- wp:paragraph -->
-	<p>This is a group block.</p>
-	<!-- /wp:paragraph -->
+	<div class="wp-block-group__inner-container">
+		<!-- wp:paragraph -->
+		<p>This is a group block.</p>
+		<!-- /wp:paragraph -->
 
-	<!-- wp:paragraph -->
-	<p>Group block content.</p>
-	<!-- /wp:paragraph --></div>
+		<!-- wp:paragraph -->
+		<p>Group block content.</p>
+		<!-- /wp:paragraph --></div>
+	</div>
 <!-- /wp:group -->

--- a/packages/e2e-tests/fixtures/blocks/core__group.json
+++ b/packages/e2e-tests/fixtures/blocks/core__group.json
@@ -31,6 +31,6 @@
                 "originalContent": "<p>Group block content.</p>"
             }
         ],
-        "originalContent": "<div class=\"wp-block-group alignfull has-secondary-background-color has-background\">\n\t\n\n\t</div>"
+        "originalContent": "<div class=\"wp-block-group alignfull has-secondary-background-color has-background\">\n\t<div class=\"wp-block-group__inner-container\">\n\t\t\n\n\t\t</div>\n\t</div>"
     }
 ]

--- a/packages/e2e-tests/fixtures/blocks/core__group.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__group.parsed.json
@@ -10,28 +10,28 @@
                 "blockName": "core/paragraph",
                 "attrs": {},
                 "innerBlocks": [],
-                "innerHTML": "\n\t<p>This is a group block.</p>\n\t",
+                "innerHTML": "\n\t\t<p>This is a group block.</p>\n\t\t",
                 "innerContent": [
-                    "\n\t<p>This is a group block.</p>\n\t"
+                    "\n\t\t<p>This is a group block.</p>\n\t\t"
                 ]
             },
             {
                 "blockName": "core/paragraph",
                 "attrs": {},
                 "innerBlocks": [],
-                "innerHTML": "\n\t<p>Group block content.</p>\n\t",
+                "innerHTML": "\n\t\t<p>Group block content.</p>\n\t\t",
                 "innerContent": [
-                    "\n\t<p>Group block content.</p>\n\t"
+                    "\n\t\t<p>Group block content.</p>\n\t\t"
                 ]
             }
         ],
-        "innerHTML": "\n<div class=\"wp-block-group alignfull has-secondary-background-color has-background\">\n\t\n\n\t</div>\n",
+        "innerHTML": "\n<div class=\"wp-block-group alignfull has-secondary-background-color has-background\">\n\t<div class=\"wp-block-group__inner-container\">\n\t\t\n\n\t\t</div>\n\t</div>\n",
         "innerContent": [
-            "\n<div class=\"wp-block-group alignfull has-secondary-background-color has-background\">\n\t",
+            "\n<div class=\"wp-block-group alignfull has-secondary-background-color has-background\">\n\t<div class=\"wp-block-group__inner-container\">\n\t\t",
             null,
-            "\n\n\t",
+            "\n\n\t\t",
             null,
-            "</div>\n"
+            "</div>\n\t</div>\n"
         ]
     },
     {

--- a/packages/e2e-tests/fixtures/blocks/core__group.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__group.serialized.html
@@ -1,9 +1,9 @@
 <!-- wp:group {"backgroundColor":"secondary","align":"full"} -->
-<div class="wp-block-group alignfull has-secondary-background-color has-background"><!-- wp:paragraph -->
+<div class="wp-block-group alignfull has-secondary-background-color has-background"><div class="wp-block-group__inner-container"><!-- wp:paragraph -->
 <p>This is a group block.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
 <p>Group block content.</p>
-<!-- /wp:paragraph --></div>
+<!-- /wp:paragraph --></div></div>
 <!-- /wp:group -->

--- a/packages/e2e-tests/fixtures/blocks/core__group__deprecated.html
+++ b/packages/e2e-tests/fixtures/blocks/core__group__deprecated.html
@@ -1,0 +1,7 @@
+<!-- wp:group {"backgroundColor":"lighter-blue","align":"full"} -->
+<div class="wp-block-group alignfull has-lighter-blue-background-color has-background">
+	<!-- wp:paragraph -->
+	<p>test</p>
+	<!-- /wp:paragraph -->
+</div>
+<!-- /wp:group -->

--- a/packages/e2e-tests/fixtures/blocks/core__group__deprecated.json
+++ b/packages/e2e-tests/fixtures/blocks/core__group__deprecated.json
@@ -1,0 +1,25 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/group",
+        "isValid": true,
+        "attributes": {
+            "backgroundColor": "lighter-blue",
+            "className": "alignfull"
+        },
+        "innerBlocks": [
+            {
+                "clientId": "_clientId_0",
+                "name": "core/paragraph",
+                "isValid": true,
+                "attributes": {
+                    "content": "test",
+                    "dropCap": false
+                },
+                "innerBlocks": [],
+                "originalContent": "<p>test</p>"
+            }
+        ],
+        "originalContent": "<div class=\"wp-block-group alignfull has-lighter-blue-background-color has-background\">\n\t\n</div>"
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__group__deprecated.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__group__deprecated.parsed.json
@@ -1,0 +1,35 @@
+[
+    {
+        "blockName": "core/group",
+        "attrs": {
+            "backgroundColor": "lighter-blue",
+            "align": "full"
+        },
+        "innerBlocks": [
+            {
+                "blockName": "core/paragraph",
+                "attrs": {},
+                "innerBlocks": [],
+                "innerHTML": "\n\t<p>test</p>\n\t",
+                "innerContent": [
+                    "\n\t<p>test</p>\n\t"
+                ]
+            }
+        ],
+        "innerHTML": "\n<div class=\"wp-block-group alignfull has-lighter-blue-background-color has-background\">\n\t\n</div>\n",
+        "innerContent": [
+            "\n<div class=\"wp-block-group alignfull has-lighter-blue-background-color has-background\">\n\t",
+            null,
+            "\n</div>\n"
+        ]
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__group__deprecated.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__group__deprecated.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:group {"backgroundColor":"lighter-blue","className":"alignfull"} -->
+<div class="wp-block-group has-lighter-blue-background-color has-background alignfull"><div class="wp-block-group__inner-container"><!-- wp:paragraph -->
+<p>test</p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:group -->

--- a/packages/e2e-tests/specs/blocks/__snapshots__/group.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/group.test.js.snap
@@ -2,20 +2,20 @@
 
 exports[`Group can be created using the block inserter 1`] = `
 "<!-- wp:group -->
-<div class=\\"wp-block-group\\"></div>
+<div class=\\"wp-block-group\\"><div class=\\"wp-block-group__inner-container\\"></div></div>
 <!-- /wp:group -->"
 `;
 
 exports[`Group can be created using the slash inserter 1`] = `
 "<!-- wp:group -->
-<div class=\\"wp-block-group\\"></div>
+<div class=\\"wp-block-group\\"><div class=\\"wp-block-group__inner-container\\"></div></div>
 <!-- /wp:group -->"
 `;
 
 exports[`Group can have other blocks appended to it using the button appender 1`] = `
 "<!-- wp:group -->
-<div class=\\"wp-block-group\\"><!-- wp:paragraph -->
+<div class=\\"wp-block-group\\"><div class=\\"wp-block-group__inner-container\\"><!-- wp:paragraph -->
 <p>Group Block with a Paragraph</p>
-<!-- /wp:paragraph --></div>
+<!-- /wp:paragraph --></div></div>
 <!-- /wp:group -->"
 `;


### PR DESCRIPTION
Fixes #15042. 

This PR adds a `wp-block-group__inner-container` container within the Group block. This follows the example of the Cover block, which has a similar `wp-block-cover__inner-container` block inside of it. 

This idea is explained in more detail [in the ticket](#15042), but in a few words: for themes that already add margin/padding/max-width to `entry-content`, this change has the potential to make theme styling easier, if themes are following the recommended behavior for wide + full child blocks outlined in https://github.com/WordPress/gutenberg/pull/13964#issuecomment-472562800. 

To illustrate the potential benefits, here's a CodePen using some simplified code for wide + full alignments: 

https://codepen.io/kjellr/pen/WWKEqN

Today, this scenario requires 19 lines of code to implement the group block + all of its child block alignments:

https://codepen.io/kjellr/pen/QPBgJV

With a container div, it would take just 6 lines of code instead:

https://codepen.io/kjellr/pen/eoPQde

---

Note that since this changes the markup for the Group block, any themes that have rushed to implement the Group block in the past couple weeks would need to patch to support it. The container block would be unstyled though, so if anything, they'd likely just need to change some CSS selectors. 

As of the opening of this PR, the two Core themes that need patches to support the group block do not have approved patches yet ([46750-Trac](https://core.trac.wordpress.org/ticket/46750), [46778-Trac](https://core.trac.wordpress.org/ticket/46778)). The currently in-progress patches would need to be rewritten, but this change should end up making those implementations simpler. 