### PR TITLE
Tests: Disable randomly failing e2e tests

### DIFF
--- a/packages/e2e-tests/specs/links.test.js
+++ b/packages/e2e-tests/specs/links.test.js
@@ -308,7 +308,9 @@ describe( 'Links', () => {
 	} );
 
 	// Test for regressions of https://github.com/WordPress/gutenberg/issues/10496.
-	it( 'allows autocomplete suggestions to be navigated with the keyboard', async () => {
+	// This test isn't reliable on Travis and fails from time to time.
+	// See: https://github.com/WordPress/gutenberg/pull/15211.
+	it.skip( 'allows autocomplete suggestions to be navigated with the keyboard', async () => {
 		const titleText = 'Test post keyboard';
 		const postURL = await createPostWithTitle( titleText );
 

--- a/packages/e2e-tests/specs/plugins/wp-editor-meta-box.test.js
+++ b/packages/e2e-tests/specs/plugins/wp-editor-meta-box.test.js
@@ -8,7 +8,9 @@ import {
 	publishPost,
 } from '@wordpress/e2e-test-utils';
 
-describe( 'WP Editor Meta Boxes', () => {
+// This test isn't reliable on Travis and fails from time to time.
+// See: https://github.com/WordPress/gutenberg/pull/15211.
+describe.skip( 'WP Editor Meta Boxes', () => {
 	beforeAll( async () => {
 		await activatePlugin( 'gutenberg-test-plugin-wp-editor-meta-box' );
 		await createNewPost();

--- a/packages/e2e-tests/specs/taxonomies.test.js
+++ b/packages/e2e-tests/specs/taxonomies.test.js
@@ -110,7 +110,10 @@ describe( 'Taxonomies', () => {
 		expect( selectedCategories[ 0 ] ).toEqual( 'z rand category 1' );
 	} );
 
-	it( 'should be able to open the tags panel and create a new tag if the user has the right capabilities', async () => {
+	// This test isn't reliable locally because repeated execution of the test triggers 400 network
+	// because of the tag's duplication. Also, it randomly doesn't add a new tag after pressing enter.
+	// See: https://github.com/WordPress/gutenberg/pull/15211.
+	it.skip( 'should be able to open the tags panel and create a new tag if the user has the right capabilities', async () => {
 		await createNewPost();
 
 		await openDocumentSettingsSidebar();


### PR DESCRIPTION
## Description

I got several pings about failing e2e tests on Travis in the past weeks. We don't know why some tests fail randomly so I went through Travis reports for PRs merged to `master` branch in last week and through newly opened PRs to identify them. This PR disables 3 tests that were listed the most often.

## Disabled tests

https://travis-ci.com/WordPress/gutenberg/jobs/195867138#L1098
https://travis-ci.com/WordPress/gutenberg/jobs/195696939#L1097
https://travis-ci.com/WordPress/gutenberg/jobs/195391880#L1097
https://travis-ci.com/WordPress/gutenberg/jobs/195627327#L1101
```
FAIL packages/e2e-tests/specs/taxonomies.test.js (5.824s)
  ● Taxonomies › should be able to open the tags panel and create a new tag if the user has the right capabilities
    expect(received).toHaveLength(expected)
    Expected length: 1
    Received length: 0
    Received array:  []
      153 | 
      154 | 		// The post should only contain the tag we added.
    > 155 | 		expect( tags ).toHaveLength( 1 );
          | 		               ^
      156 | 		expect( tags[ 0 ] ).toEqual( 'tag1' );
      157 | 
      158 | 		// Type something in the title so we can publish the post.
      at Object.toHaveLength (specs/taxonomies.test.js:155:18)
      at tryCatch (../../node_modules/regenerator-runtime/runtime.js:62:40)
      at Generator.invoke [as _invoke] (../../node_modules/regenerator-runtime/runtime.js:288:22)
      at Generator.prototype.(anonymous function) [as next] (../../node_modules/regenerator-runtime/runtime.js:114:21)
      at asyncGeneratorStep (specs/taxonomies.test.js:13:103)
      at _next (specs/taxonomies.test.js:15:194)
```

https://travis-ci.com/WordPress/gutenberg/jobs/195887677#L1101
https://travis-ci.com/WordPress/gutenberg/jobs/195790721#L1100
https://travis-ci.com/WordPress/gutenberg/jobs/195293180#L1099
https://travis-ci.com/WordPress/gutenberg/jobs/195237225#L1102
```
FAIL packages/e2e-tests/specs/plugins/wp-editor-meta-box.test.js (6.002s)
  ● WP Editor Meta Boxes › Should save the changes
    expect(received).toMatchSnapshot()
    Snapshot name: `WP Editor Meta Boxes Should save the changes 1`
    - Snapshot
    + Received
    - "<p>Typing in a metabox</p>"
    + ""
      38 | 		);
      39 | 
    > 40 | 		expect( content ).toMatchSnapshot();
         | 		                  ^
      41 | 	} );
      42 | } );
      43 | 
      at Object.toMatchSnapshot (specs/plugins/wp-editor-meta-box.test.js:40:21)
      at tryCatch (../../node_modules/regenerator-runtime/runtime.js:62:40)
      at Generator.invoke [as _invoke] (../../node_modules/regenerator-runtime/runtime.js:288:22)
      at Generator.prototype.(anonymous function) [as next] (../../node_modules/regenerator-runtime/runtime.js:114:21)
      at asyncGeneratorStep (specs/plugins/wp-editor-meta-box.test.js:9:103)
      at _next (specs/plugins/wp-editor-meta-box.test.js:11:194)
 › 1 snapshot failed.
```

https://travis-ci.com/WordPress/gutenberg/jobs/195586217#L1080
```
FAIL packages/e2e-tests/specs/links.test.js (50.467s)
  ● Links › allows autocomplete suggestions to be navigated with the keyboard
    expect(received).toBe(expected) // Object.is equality
    Expected: "true"
    Received: "false"
      336 | 		await page.keyboard.press( 'ArrowDown' );
      337 | 		const isSelected = await page.evaluate( () => document.querySelector( '.block-editor-url-input__suggestion' ).getAttribute( 'aria-selected' ) );
    > 338 | 		expect( isSelected ).toBe( 'true' );
          | 		                     ^
      339 | 
      340 | 		// Expect the link to apply correctly when pressing Enter.
      341 | 		// Note - have avoided using snapshots here since the link url can't be determined ahead of time.
      at Object.toBe (specs/links.test.js:338:24)
      at tryCatch (../../node_modules/regenerator-runtime/runtime.js:62:40)
      at Generator.invoke [as _invoke] (../../node_modules/regenerator-runtime/runtime.js:288:22)
      at Generator.prototype.(anonymous function) [as next] (../../node_modules/regenerator-runtime/runtime.js:114:21)
      at asyncGeneratorStep (specs/links.test.js:15:103)
      at _next (specs/links.test.js:17:194)
```