### PR TITLE
Framework: Add REST API codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -83,6 +83,7 @@
 
 # PHP
 /lib                                            @youknowriad @gziolo @aduth
+*-controller.php                                @youknowriad @gziolo @aduth @timothybjacobs
 
 # Styles
 *.scss                                          @chrisvanpatten


### PR DESCRIPTION
This pull request seeks to add a new entry in the CODEOWNERS file to reflect ownership of REST API controller files. It currently includes those who would have already been notified of changes from `lib/`, plus those who had explicitly volunteered to be notified (@TimothyBJacobs).

Relevant Slack conversation ([link requires registration](https://make.wordpress.org/chat/)):

https://wordpress.slack.com/archives/C02RQC26G/p1554403752082300
https://wordpress.slack.com/archives/C02RQC26G/p1554403746082100

**Testing Instructions:**

This is a repository metadata file. There is no impact on the application.