### PR TITLE
Framework: Remove SCSS entry from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -84,9 +84,6 @@
 # PHP
 /lib                                            @youknowriad @gziolo @aduth
 
-# Styles
-*.scss                                          @chrisvanpatten
-
 # Native (Unowned)
 *.native.js                                     @ghost
 *.android.js                                    @ghost


### PR DESCRIPTION
Previously: https://github.com/WordPress/gutenberg/pull/14062#issuecomment-486428768

This pull request seeks to remove the `*.scss` entry from the `CODEOWNERS` file.

The behavior of CODEOWNERS is such that the last match will take precedence:

>```
># Order is important; the last matching pattern takes the most
># precedence. When someone opens a pull request that only
># modifies JS files, only @js-owner and not the global
># owner(s) will be requested for a review.
>*.js    @js-owner
>```

https://help.github.com/en/articles/about-code-owners#codeowners-syntax

The proposed benefit of removing this entry is:

- Avoid overburdening a small set of individuals
- Ensure to notify those who are otherwise marked as code owners for the given file placement

**Testing Instructions:**

This is a repository metadata file. There is no impact on the application.