### PR TITLE
Build Tooling: Pass individual files as arguments from watch to build script

### DIFF
--- a/bin/packages/watch.js
+++ b/bin/packages/watch.js
@@ -3,7 +3,7 @@
  */
 const fs = require( 'fs' );
 const watch = require( 'node-watch' );
-const { execSync } = require( 'child_process' );
+const { spawn } = require( 'child_process' );
 const path = require( 'path' );
 const chalk = require( 'chalk' );
 
@@ -12,7 +12,7 @@ const chalk = require( 'chalk' );
  */
 const getPackages = require( './get-packages' );
 
-const BUILD_CMD = `node \"${ path.resolve( __dirname, './build.js' ) }\"`;
+const BUILD_SCRIPT = path.resolve( __dirname, './build.js' );
 
 let filesToBuild = new Map();
 
@@ -69,7 +69,7 @@ setInterval( () => {
 	if ( files.length ) {
 		filesToBuild = new Map();
 		try {
-			execSync( `${ BUILD_CMD } \"${ files.join( ' ' ) }\"`, { stdio: [ 0, 1, 2 ] } );
+			spawn( 'node', [ BUILD_SCRIPT, ...files ], { stdio: [ 0, 1, 2 ] } );
 		} catch ( e ) {}
 	}
 }, 100 );


### PR DESCRIPTION
Fixes #14960 

This pull request seeks to resolve an error which can occur while running `npm run dev`, often when switching between branches (`Error: ENAMETOOLONG: name too long`).

The underlying cause is that when passing files as arguments to `build.js`, it expects many arguments:

https://github.com/WordPress/gutenberg/blob/db990fc8c0eff8b4210e0839cdb0dbfc92b074ba/bin/packages/build.js#L211

...but in fact, the `watch` script would have only passed at most one, a single argument of space-separated changed files:

https://github.com/WordPress/gutenberg/blob/db990fc8c0eff8b4210e0839cdb0dbfc92b074ba/bin/packages/watch.js#L72

The changes here address this by assuring that each file is passed as its own argument, made simpler by substituting [`exec`](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback) with [`spawn`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options), which accepts `args` as part of its function signature.

**_However_**, while this addresses the immediate issue, testing the effects had me begging the question: This was previously never working correctly to rebuild files, and it's unclear why we'd want to watch them at all. Notably, the files being built here are the ones generated to the `build` directory _of the individual packages_, which is relevant for NPM publishing, but not so much for use by the plugin. Separately, we may want to consider whether `wp-scripts start` should be the sole command of `npm run dev`.

**Testing Instructions:**

With this branch checked out, start `npm run dev`. Then, switch between branches where watched files would be changed (e.g. between `master` and `try/scroll=beyond-end`) and verify that the `[1] -> update:` entries are shown correctly, and no errors occur.