### PR TITLE
Experiment with adding drag&drop to image galleries

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -248,7 +248,10 @@ export class BlockListBlock extends Component {
 	 * @return {void}
 	 */
 	preventDrag( event ) {
-		event.preventDefault();
+		const { type } = JSON.parse( event.dataTransfer.getData( 'text' ) );
+		if ( type !== 'gallery' ) {
+			event.preventDefault();
+		}
 	}
 
 	/**

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -249,7 +249,7 @@ export class BlockListBlock extends Component {
 	 */
 	preventDrag( event ) {
 		const { type } = JSON.parse( event.dataTransfer.getData( 'text' ) );
-		if ( type !== 'gallery' ) {
+		if ( type !== 'image' ) {
 			event.preventDefault();
 		}
 	}

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -95,6 +95,12 @@ class GalleryEdit extends Component {
 		this.setAttributes( { images } );
 	}
 
+	onMoveTo( newIndex ) {
+		return ( oldIndex ) => {
+			this.onMove( oldIndex, newIndex );
+		};
+	}
+
 	onMoveForward( oldIndex ) {
 		return () => {
 			if ( oldIndex === this.props.attributes.images.length - 1 ) {
@@ -285,11 +291,13 @@ class GalleryEdit extends Component {
 									url={ img.url }
 									alt={ img.alt }
 									id={ img.id }
+									index={ index }
 									isFirstItem={ index === 0 }
 									isLastItem={ ( index + 1 ) === images.length }
 									isSelected={ isSelected && this.state.selectedImage === index }
 									onMoveBackward={ this.onMoveBackward( index ) }
 									onMoveForward={ this.onMoveForward( index ) }
+									onMoveTo={ this.onMoveTo( index ) }
 									onRemove={ this.onRemoveImage( index ) }
 									onSelect={ this.onSelectImage( index ) }
 									setAttributes={ ( attrs ) => this.setImageAttributes( index, attrs ) }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -51,8 +51,7 @@ class GalleryEdit extends Component {
 		this.setColumnsNumber = this.setColumnsNumber.bind( this );
 		this.toggleImageCrop = this.toggleImageCrop.bind( this );
 		this.onMove = this.onMove.bind( this );
-		this.onMoveForward = this.onMoveForward.bind( this );
-		this.onMoveBackward = this.onMoveBackward.bind( this );
+		this.onMoveTo = this.onMoveTo.bind( this );
 		this.onRemoveImage = this.onRemoveImage.bind( this );
 		this.setImageAttributes = this.setImageAttributes.bind( this );
 		this.setAttributes = this.setAttributes.bind( this );
@@ -101,24 +100,6 @@ class GalleryEdit extends Component {
 	onMoveTo( newIndex ) {
 		return ( oldIndex ) => {
 			this.onMove( oldIndex, newIndex );
-		};
-	}
-
-	onMoveForward( oldIndex ) {
-		return () => {
-			if ( oldIndex === this.props.attributes.images.length - 1 ) {
-				return;
-			}
-			this.onMove( oldIndex, oldIndex + 1 );
-		};
-	}
-
-	onMoveBackward( oldIndex ) {
-		return () => {
-			if ( oldIndex === 0 ) {
-				return;
-			}
-			this.onMove( oldIndex, oldIndex - 1 );
 		};
 	}
 
@@ -295,11 +276,7 @@ class GalleryEdit extends Component {
 									alt={ img.alt }
 									id={ img.id }
 									index={ index }
-									isFirstItem={ index === 0 }
-									isLastItem={ ( index + 1 ) === images.length }
 									isSelected={ isSelected && this.state.selectedImage === index }
-									onMoveBackward={ this.onMoveBackward( index ) }
-									onMoveForward={ this.onMoveForward( index ) }
 									onMoveTo={ this.onMoveTo( index ) }
 									onRemove={ this.onRemoveImage( index ) }
 									onSelect={ this.onSelectImage( index ) }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -88,9 +88,12 @@ class GalleryEdit extends Component {
 	}
 
 	onMove( oldIndex, newIndex ) {
+		if ( oldIndex === newIndex ) {
+			return;
+		}
 		const images = [ ...this.props.attributes.images ];
-		images.splice( newIndex, 1, this.props.attributes.images[ oldIndex ] );
-		images.splice( oldIndex, 1, this.props.attributes.images[ newIndex ] );
+		images.splice( oldIndex, 1 );
+		images.splice( newIndex, 0, this.props.attributes.images[ oldIndex ] );
 		this.setState( { selectedImage: newIndex } );
 		this.setAttributes( { images } );
 	}

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -50,6 +50,9 @@ class GalleryEdit extends Component {
 		this.setLinkTo = this.setLinkTo.bind( this );
 		this.setColumnsNumber = this.setColumnsNumber.bind( this );
 		this.toggleImageCrop = this.toggleImageCrop.bind( this );
+		this.onMove = this.onMove.bind( this );
+		this.onMoveForward = this.onMoveForward.bind( this );
+		this.onMoveBackward = this.onMoveBackward.bind( this );
 		this.onRemoveImage = this.onRemoveImage.bind( this );
 		this.setImageAttributes = this.setImageAttributes.bind( this );
 		this.setAttributes = this.setAttributes.bind( this );
@@ -81,6 +84,32 @@ class GalleryEdit extends Component {
 					selectedImage: index,
 				} );
 			}
+		};
+	}
+
+	onMove( oldIndex, newIndex ) {
+		const images = [ ...this.props.attributes.images ];
+		images.splice( newIndex, 1, this.props.attributes.images[ oldIndex ] );
+		images.splice( oldIndex, 1, this.props.attributes.images[ newIndex ] );
+		this.setState( { selectedImage: newIndex } );
+		this.setAttributes( { images } );
+	}
+
+	onMoveForward( oldIndex ) {
+		return () => {
+			if ( oldIndex === this.props.attributes.images.length - 1 ) {
+				return;
+			}
+			this.onMove( oldIndex, oldIndex + 1 );
+		};
+	}
+
+	onMoveBackward( oldIndex ) {
+		return () => {
+			if ( oldIndex === 0 ) {
+				return;
+			}
+			this.onMove( oldIndex, oldIndex - 1 );
 		};
 	}
 
@@ -256,7 +285,11 @@ class GalleryEdit extends Component {
 									url={ img.url }
 									alt={ img.alt }
 									id={ img.id }
+									isFirstItem={ index === 0 }
+									isLastItem={ ( index + 1 ) === images.length }
 									isSelected={ isSelected && this.state.selectedImage === index }
+									onMoveBackward={ this.onMoveBackward( index ) }
+									onMoveForward={ this.onMoveForward( index ) }
 									onRemove={ this.onRemoveImage( index ) }
 									onSelect={ this.onSelectImage( index ) }
 									setAttributes={ ( attrs ) => this.setImageAttributes( index, attrs ) }

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -66,9 +66,11 @@ ul.wp-block-gallery {
 	}
 }
 
-.block-library-gallery-item__move-menu,
 .block-library-gallery-item__inline-menu {
 	padding: 2px;
+	position: absolute;
+	top: -2px;
+	right: -2px;
 	background-color: theme(primary);
 	display: inline-flex;
 	z-index: z-index(".block-library-gallery-item__inline-menu");
@@ -80,18 +82,6 @@ ul.wp-block-gallery {
 			color: $white;
 		}
 	}
-}
-
-.block-library-gallery-item__inline-menu {
-	position: absolute;
-	top: -2px;
-	right: -2px;
-}
-
-.block-library-gallery-item__move-menu {
-	position: absolute;
-	top: -2px;
-	left: -2px;
 }
 
 .block-library-gallery-item__drop-zone {
@@ -111,8 +101,6 @@ ul.wp-block-gallery {
 	}
 }
 
-.blocks-gallery-item__move-backward,
-.blocks-gallery-item__move-forward,
 .blocks-gallery-item__remove {
 	padding: 0;
 

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -88,6 +88,11 @@ ul.wp-block-gallery {
 	border: none;
 	border-radius: 0;
 
+	.components-drop-zone__content,
+	&.is-dragging-over-element .components-drop-zone__content {
+		display: none;
+	}
+
 	&.is-close-to-left {
 		background: none;
 		border-left: 3px solid theme(primary);

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -94,6 +94,23 @@ ul.wp-block-gallery {
 	left: -2px;
 }
 
+.block-library-gallery-item__drop-zone {
+	border: none;
+	border-radius: 0;
+
+	&.is-close-to-left {
+		background: none;
+		border-left: 3px solid theme(primary);
+		border-right: none;
+	}
+
+	&.is-close-to-right {
+		background: none;
+		border-left: none;
+		border-right: 3px solid theme(primary);
+	}
+}
+
 .blocks-gallery-item__move-backward,
 .blocks-gallery-item__move-forward,
 .blocks-gallery-item__remove {

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -66,11 +66,9 @@ ul.wp-block-gallery {
 	}
 }
 
+.block-library-gallery-item__move-menu,
 .block-library-gallery-item__inline-menu {
 	padding: 2px;
-	position: absolute;
-	top: -2px;
-	right: -2px;
 	background-color: theme(primary);
 	display: inline-flex;
 	z-index: z-index(".block-library-gallery-item__inline-menu");
@@ -84,6 +82,20 @@ ul.wp-block-gallery {
 	}
 }
 
+.block-library-gallery-item__inline-menu {
+	position: absolute;
+	top: -2px;
+	right: -2px;
+}
+
+.block-library-gallery-item__move-menu {
+	position: absolute;
+	top: -2px;
+	left: -2px;
+}
+
+.blocks-gallery-item__move-backward,
+.blocks-gallery-item__move-forward,
 .blocks-gallery-item__remove {
 	padding: 0;
 

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -86,7 +86,7 @@ class GalleryImage extends Component {
 	}
 
 	render() {
-		const { url, alt, id, linkTo, link, isSelected, caption, onRemove, setAttributes, 'aria-label': ariaLabel } = this.props;
+		const { url, alt, id, linkTo, link, isFirstItem, isLastItem, isSelected, caption, onRemove, onMoveForward, onMoveBackward, setAttributes, 'aria-label': ariaLabel } = this.props;
 
 		let href;
 
@@ -139,6 +139,24 @@ class GalleryImage extends Component {
 		return (
 			<figure className={ className }>
 				<DropZone onImageDrop={ () => console.log( 'onImageDrop ', id ) } />
+				{ isSelected &&
+					<div className="block-library-gallery-item__move-menu">
+						<IconButton
+							icon="arrow-left"
+							onClick={ isFirstItem ? undefined : onMoveBackward }
+							className="blocks-gallery-item__move-backward"
+							label={ __( 'Move Image Backward' ) }
+							aria-disabled={ isFirstItem }
+						/>
+						<IconButton
+							icon="arrow-right"
+							onClick={ isLastItem ? undefined : onMoveForward }
+							className="blocks-gallery-item__move-forward"
+							label={ __( 'Move Image Forward' ) }
+							aria-disabled={ isLastItem }
+						/>
+					</div>
+				}
 				{ isSelected &&
 					<div className="block-library-gallery-item__inline-menu">
 						<IconButton

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Component, Fragment } from '@wordpress/element';
-import { Draggable, IconButton, Spinner } from '@wordpress/components';
+import { Draggable, DropZone, IconButton, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { BACKSPACE, DELETE } from '@wordpress/keycodes';
 import { withSelect } from '@wordpress/data';
@@ -138,6 +138,7 @@ class GalleryImage extends Component {
 
 		return (
 			<figure className={ className }>
+				<DropZone onImageDrop={ () => console.log( 'onImageDrop ', id ) } />
 				{ isSelected &&
 					<div className="block-library-gallery-item__inline-menu">
 						<IconButton

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -22,6 +22,7 @@ class GalleryImage extends Component {
 		this.onSelectCaption = this.onSelectCaption.bind( this );
 		this.onRemoveImage = this.onRemoveImage.bind( this );
 		this.bindContainer = this.bindContainer.bind( this );
+		this.onMoveTo = this.onMoveTo.bind( this );
 
 		this.state = {
 			captionSelected: false,
@@ -85,8 +86,16 @@ class GalleryImage extends Component {
 		}
 	}
 
+	onMoveTo( event ) {
+		const data = event.dataTransfer.getData( 'text' );
+		if ( data !== '' ) {
+			const oldIndex = JSON.parse( data ).index;
+			this.props.onMoveTo( oldIndex );
+		}
+	}
+
 	render() {
-		const { url, alt, id, linkTo, link, isFirstItem, isLastItem, isSelected, caption, onRemove, onMoveForward, onMoveBackward, setAttributes, 'aria-label': ariaLabel } = this.props;
+		const { url, alt, id, linkTo, link, index, isFirstItem, isLastItem, isSelected, caption, onRemove, onMoveForward, onMoveBackward, setAttributes, 'aria-label': ariaLabel } = this.props;
 
 		let href;
 
@@ -106,7 +115,7 @@ class GalleryImage extends Component {
 			<Fragment>
 				<Draggable
 					elementId={ id }
-					transferData={ { type: 'image', id } }
+					transferData={ { type: 'image', index } }
 				>
 					{ ( { onDraggableStart, onDraggableEnd } ) => (
 						<img
@@ -138,7 +147,7 @@ class GalleryImage extends Component {
 
 		return (
 			<figure className={ className }>
-				<DropZone onImageDrop={ () => console.log( 'onImageDrop ', id ) } />
+				<DropZone onImageDrop={ this.onMoveTo } />
 				{ isSelected &&
 					<div className="block-library-gallery-item__move-menu">
 						<IconButton

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -147,7 +147,7 @@ class GalleryImage extends Component {
 
 		return (
 			<figure className={ className }>
-				<DropZone onImageDrop={ this.onMoveTo } />
+				<DropZone className="block-library-gallery-item__drop-zone" onImageDrop={ this.onMoveTo } />
 				{ isSelected &&
 					<div className="block-library-gallery-item__move-menu">
 						<IconButton

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -106,7 +106,7 @@ class GalleryImage extends Component {
 			<Fragment>
 				<Draggable
 					elementId={ id }
-					transferData={ { type: 'gallery', id } }
+					transferData={ { type: 'image', id } }
 				>
 					{ ( { onDraggableStart, onDraggableEnd } ) => (
 						<img

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -95,7 +95,7 @@ class GalleryImage extends Component {
 	}
 
 	render() {
-		const { url, alt, id, linkTo, link, index, isFirstItem, isLastItem, isSelected, caption, onRemove, onMoveForward, onMoveBackward, setAttributes, 'aria-label': ariaLabel } = this.props;
+		const { url, alt, id, linkTo, link, index, isSelected, caption, onRemove, setAttributes, 'aria-label': ariaLabel } = this.props;
 
 		let href;
 
@@ -148,24 +148,6 @@ class GalleryImage extends Component {
 		return (
 			<figure className={ className }>
 				<DropZone className="block-library-gallery-item__drop-zone" onImageDrop={ this.onMoveTo } />
-				{ isSelected &&
-					<div className="block-library-gallery-item__move-menu">
-						<IconButton
-							icon="arrow-left"
-							onClick={ isFirstItem ? undefined : onMoveBackward }
-							className="blocks-gallery-item__move-backward"
-							label={ __( 'Move Image Backward' ) }
-							aria-disabled={ isFirstItem }
-						/>
-						<IconButton
-							icon="arrow-right"
-							onClick={ isLastItem ? undefined : onMoveForward }
-							className="blocks-gallery-item__move-forward"
-							label={ __( 'Move Image Forward' ) }
-							aria-disabled={ isLastItem }
-						/>
-					</div>
-				}
 				{ isSelected &&
 					<div className="block-library-gallery-item__inline-menu">
 						<IconButton

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Component, Fragment } from '@wordpress/element';
-import { IconButton, Spinner } from '@wordpress/components';
+import { Draggable, IconButton, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { BACKSPACE, DELETE } from '@wordpress/keycodes';
 import { withSelect } from '@wordpress/data';
@@ -104,17 +104,28 @@ class GalleryImage extends Component {
 			// direct image selection and unfocus caption fields.
 			/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 			<Fragment>
-				<img
-					src={ url }
-					alt={ alt }
-					data-id={ id }
-					onClick={ this.onSelectImage }
-					onFocus={ this.onSelectImage }
-					onKeyDown={ this.onRemoveImage }
-					tabIndex="0"
-					aria-label={ ariaLabel }
-					ref={ this.bindContainer }
-				/>
+				<Draggable
+					elementId={ id }
+					transferData={ { type: 'gallery', id } }
+				>
+					{ ( { onDraggableStart, onDraggableEnd } ) => (
+						<img
+							src={ url }
+							alt={ alt }
+							id={ id }
+							data-id={ id }
+							onClick={ this.onSelectImage }
+							onFocus={ this.onSelectImage }
+							onKeyDown={ this.onRemoveImage }
+							tabIndex="0"
+							aria-label={ ariaLabel }
+							ref={ this.bindContainer }
+							draggable={ true }
+							onDragStart={ onDraggableStart }
+							onDragEnd={ onDraggableEnd }
+						/>
+					) }
+				</Draggable>
 				{ isBlobURL( url ) && <Spinner /> }
 			</Fragment>
 			/* eslint-enable jsx-a11y/no-noninteractive-element-interactions */

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import uuid from 'uuid/v4';
 
 /**
  * WordPress dependencies
@@ -24,6 +25,7 @@ class GalleryImage extends Component {
 		this.bindContainer = this.bindContainer.bind( this );
 		this.onMoveTo = this.onMoveTo.bind( this );
 
+		this.imgUUID = uuid();
 		this.state = {
 			captionSelected: false,
 		};
@@ -114,14 +116,14 @@ class GalleryImage extends Component {
 			/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 			<Fragment>
 				<Draggable
-					elementId={ id }
+					elementId={ this.imgUUID }
 					transferData={ { type: 'image', index } }
 				>
 					{ ( { onDraggableStart, onDraggableEnd } ) => (
 						<img
 							src={ url }
 							alt={ alt }
-							id={ id }
+							id={ this.imgUUID }
 							data-id={ id }
 							onClick={ this.onSelectImage }
 							onFocus={ this.onSelectImage }

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -30,6 +30,11 @@
 			display: block;
 			max-width: 100%;
 			height: auto;
+			cursor: grab;
+
+			&:active {
+				cursor: grabbing;
+			}
 		}
 
 		// IE doesn't handle cropping, so we need an explicit width here.

--- a/packages/components/src/drop-zone/index.js
+++ b/packages/components/src/drop-zone/index.js
@@ -37,6 +37,7 @@ class DropZoneComponent extends Component {
 			onDrop: this.props.onDrop,
 			onFilesDrop: this.props.onFilesDrop,
 			onHTMLDrop: this.props.onHTMLDrop,
+			onImageDrop: this.props.onImageDrop,
 			setState: this.setState.bind( this ),
 		};
 		this.state = {

--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -14,10 +14,17 @@ const { Provider, Consumer } = createContext( {
 	removeDropZone: () => {},
 } );
 
+const getDeclaredDragEventType = ( dataTransfer ) => {
+	const data = dataTransfer.getData( 'text' );
+	if ( data !== '' ) {
+		return JSON.parse( data ).type;
+	}
+	return null;
+};
+
 const getDragEventType = ( { dataTransfer } ) => {
 	if ( dataTransfer ) {
-		// If the event has declared any type, use it.
-		const declaredDragEventType = JSON.parse( dataTransfer.getData( 'text' ) ).type;
+		const declaredDragEventType = getDeclaredDragEventType( dataTransfer );
 		if ( declaredDragEventType ) {
 			return declaredDragEventType;
 		}
@@ -27,6 +34,7 @@ const getDragEventType = ( { dataTransfer } ) => {
 		if ( includes( dataTransfer.types, 'Files' ) ) {
 			return 'file';
 		}
+
 		if ( includes( dataTransfer.types, 'text/html' ) ) {
 			return 'html';
 		}
@@ -39,7 +47,7 @@ const isTypeSupportedByDropZone = ( type, dropZone ) =>
 	( type === 'file' && !! dropZone.onFilesDrop ) ||
 	( type === 'html' && !! dropZone.onHTMLDrop ) ||
 	( type === 'block' && !! dropZone.onDrop ) ||
-	( type === 'image' && !! dropZone.onDropImage );
+	( type === 'image' && !! dropZone.onImageDrop );
 
 const isWithinElementBounds = ( element, x, y ) => {
 	const rect = element.getBoundingClientRect();
@@ -224,7 +232,7 @@ class DropZoneProvider extends Component {
 					dropZone.onDrop( event, position );
 					break;
 				case 'image':
-					dropZone.onDropImage( event, position );
+					dropZone.onImageDrop( event, position );
 					break;
 			}
 		}

--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -31,12 +31,11 @@ const getDragEventType = ( { dataTransfer } ) => {
 	return JSON.parse( dataTransfer.getData( 'text' ) ).type;
 };
 
-const isTypeSupportedByDropZone = ( type, dropZone ) => {
-	return ( type === 'file' && dropZone.onFilesDrop ) ||
-		( type === 'html' && dropZone.onHTMLDrop ) ||
-		( type === 'block' && dropZone.onDrop ) ||
-		( type === 'image' && dropZone.onDropImage );
-};
+const isTypeSupportedByDropZone = ( type, dropZone ) =>
+	( type === 'file' && !! dropZone.onFilesDrop ) ||
+	( type === 'html' && !! dropZone.onHTMLDrop ) ||
+	( type === 'block' && !! dropZone.onDrop ) ||
+	( type === 'image' && !! dropZone.onDropImage );
 
 const isWithinElementBounds = ( element, x, y ) => {
 	const rect = element.getBoundingClientRect();

--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -28,13 +28,14 @@ const getDragEventType = ( { dataTransfer } ) => {
 		}
 	}
 
-	return 'default';
+	return JSON.parse( dataTransfer.getData( 'text' ) ).type;
 };
 
 const isTypeSupportedByDropZone = ( type, dropZone ) => {
 	return ( type === 'file' && dropZone.onFilesDrop ) ||
 		( type === 'html' && dropZone.onHTMLDrop ) ||
-		( type === 'default' && dropZone.onDrop );
+		( type === 'block' && dropZone.onDrop ) ||
+		( type === 'image' && dropZone.onDropImage );
 };
 
 const isWithinElementBounds = ( element, x, y ) => {
@@ -216,8 +217,12 @@ class DropZoneProvider extends Component {
 				case 'html':
 					dropZone.onHTMLDrop( event.dataTransfer.getData( 'text/html' ), position );
 					break;
-				case 'default':
+				case 'block':
 					dropZone.onDrop( event, position );
+					break;
+				case 'image':
+					dropZone.onDropImage( event, position );
+					break;
 			}
 		}
 

--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -16,19 +16,23 @@ const { Provider, Consumer } = createContext( {
 
 const getDragEventType = ( { dataTransfer } ) => {
 	if ( dataTransfer ) {
-		// Use lodash `includes` here as in the Edge browser `types` is implemented
-		// as a DomStringList, whereas in other browsers it's an array. `includes`
-		// happily works with both types.
+		// If the event has declared any type, use it.
+		const declaredDragEventType = JSON.parse( dataTransfer.getData( 'text' ) ).type;
+		if ( declaredDragEventType ) {
+			return declaredDragEventType;
+		}
+
+		// The Edge browser `types` is implemented as a DomStringList,
+		// whereas in other browsers it's an array. `includes` works with both.
 		if ( includes( dataTransfer.types, 'Files' ) ) {
 			return 'file';
 		}
-
 		if ( includes( dataTransfer.types, 'text/html' ) ) {
 			return 'html';
 		}
 	}
 
-	return JSON.parse( dataTransfer.getData( 'text' ) ).type;
+	return 'unknown';
 };
 
 const isTypeSupportedByDropZone = ( type, dropZone ) =>


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/issues/743

This PR experiments with adding Drag&Drop support for moving images within a gallery.

![Peek 2019-04-26 19-27](https://user-images.githubusercontent.com/583546/56825614-f4cd8b00-6859-11e9-95c1-521cd2eaa5fb.gif)
