### PR TITLE
Remove DropZone's not used state

### DIFF
--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -69,9 +69,7 @@ class DropZoneProvider extends Component {
 		this.state = {
 			hoveredDropZone: -1,
 			isDraggingOverDocument: false,
-			isDraggingOverElement: false,
 			position: null,
-			type: null,
 		};
 	}
 
@@ -105,9 +103,7 @@ class DropZoneProvider extends Component {
 		this.setState( {
 			hoveredDropZone: -1,
 			isDraggingOverDocument: false,
-			isDraggingOverElement: false,
 			position: null,
-			type: null,
 		} );
 
 		this.dropZones.forEach( ( dropZone ) => dropZone.setState( {


### PR DESCRIPTION
This removes some state that is not being used anywhere by the component.

## Test 

Open the demo post and try to Drag&Drop some blocks. Check that it works normally.
