### PR TITLE
Build Tooling: Increase number of Travis E2E test jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,41 +64,77 @@ jobs:
       script:
         - ./bin/run-wp-unit-tests.sh
 
-    - name: E2E tests (Admin with plugins) (1/2)
+    - name: E2E tests (Admin with plugins) (1/4)
       env: WP_VERSION=latest SCRIPT_DEBUG=false POPULAR_PLUGINS=true
       install:
         - ./bin/setup-local-env.sh
       script:
         - $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --listTests > ~/.jest-e2e-tests
         - npm run build
-        - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 2 == 0' < ~/.jest-e2e-tests )
+        - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 0' < ~/.jest-e2e-tests )
 
-    - name: E2E tests (Admin with plugins) (2/2)
+    - name: E2E tests (Admin with plugins) (2/4)
       env: WP_VERSION=latest SCRIPT_DEBUG=false POPULAR_PLUGINS=true
       install:
         - ./bin/setup-local-env.sh
       script:
         - $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --listTests > ~/.jest-e2e-tests
         - npm run build
-        - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 2 == 1' < ~/.jest-e2e-tests )
+        - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 1' < ~/.jest-e2e-tests )
 
-    - name: E2E tests (Author without plugins) (1/2)
+    - name: E2E tests (Admin with plugins) (3/4)
+      env: WP_VERSION=latest SCRIPT_DEBUG=false POPULAR_PLUGINS=true
+      install:
+        - ./bin/setup-local-env.sh
+      script:
+        - $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --listTests > ~/.jest-e2e-tests
+        - npm run build
+        - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 2' < ~/.jest-e2e-tests )
+
+    - name: E2E tests (Admin with plugins) (4/4)
+      env: WP_VERSION=latest SCRIPT_DEBUG=false POPULAR_PLUGINS=true
+      install:
+        - ./bin/setup-local-env.sh
+      script:
+        - $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --listTests > ~/.jest-e2e-tests
+        - npm run build
+        - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 3' < ~/.jest-e2e-tests )
+
+    - name: E2E tests (Author without plugins) (1/4)
       env: WP_VERSION=latest SCRIPT_DEBUG=false E2E_ROLE=author
       install:
         - ./bin/setup-local-env.sh
       script:
         - $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --listTests > ~/.jest-e2e-tests
         - npm run build
-        - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 2 == 0' < ~/.jest-e2e-tests )
+        - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 0' < ~/.jest-e2e-tests )
 
-    - name: E2E tests (Author without plugins) (2/2)
+    - name: E2E tests (Author without plugins) (2/4)
       env: WP_VERSION=latest SCRIPT_DEBUG=false E2E_ROLE=author
       install:
         - ./bin/setup-local-env.sh
       script:
         - $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --listTests > ~/.jest-e2e-tests
         - npm run build
-        - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 2 == 1' < ~/.jest-e2e-tests )
+        - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 1' < ~/.jest-e2e-tests )
+
+    - name: E2E tests (Author without plugins) (3/4)
+      env: WP_VERSION=latest SCRIPT_DEBUG=false E2E_ROLE=author
+      install:
+        - ./bin/setup-local-env.sh
+      script:
+        - $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --listTests > ~/.jest-e2e-tests
+        - npm run build
+        - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 2' < ~/.jest-e2e-tests )
+
+    - name: E2E tests (Author without plugins) (4/4)
+      env: WP_VERSION=latest SCRIPT_DEBUG=false E2E_ROLE=author
+      install:
+        - ./bin/setup-local-env.sh
+      script:
+        - $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --listTests > ~/.jest-e2e-tests
+        - npm run build
+        - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 3' < ~/.jest-e2e-tests )
   allow_failures:
     - name: PHP unit tests (PHP 5.3)
       env: WP_VERSION=latest SWITCH_TO_PHP=5.3


### PR DESCRIPTION
Related: #15159, https://github.com/WordPress/gutenberg/pull/14289#issuecomment-470285204

This pull request seeks to double the number of Travis jobs dedicated to running end-to-end tests. In other words, it distributes the number of tests across 4 containers (vs. 2 previously) for each of the "Admin with plugins" and "Author without plugins" variations.

The desired effect here is that the total duration of a build decreases, since the number of end-to-end tests handled by any one Travis container will have lessened by a half.

To the potential question of whether "more containers" is okay or not, see also https://github.com/WordPress/gutenberg/pull/14289#issuecomment-470749878 .

**Testing Instructions:**

Verify that the build passes.