### PR TITLE
Build Tooling: Split JavaScript tasks to individual jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,10 @@ jobs:
       install:
         - npm ci
       script:
+        # It's not necessary to run the full build, since Jest can interpret
+        # source files with `babel-jest`. Some packages have their own custom
+        # build tasks, however. These must be run.
+        - npx lerna run build
         - npm run test-unit -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache"
 
     - name: PHP unit tests (Docker)

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,24 +30,32 @@ jobs:
     - name: Lint
       before_install:
         - nvm install --latest-npm
+      install:
+        - npm ci
       script:
         - npm run lint
 
     - name: Build artifacts
       before_install:
         - nvm install --latest-npm
+      install:
+        - npm ci
       script:
         - npm run check-local-changes
 
     - name: License compatibility
       before_install:
         - nvm install --latest-npm
+      install:
+        - npm ci
       script:
         - npm run check-licenses
 
     - name: JavaScript unit tests
       before_install:
         - nvm install --latest-npm
+      install:
+        - npm ci
       script:
         - npm run test-unit -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,17 +27,28 @@ before_install:
 
 jobs:
   include:
-    - name: JS unit tests
-      env: WP_VERSION=latest
+    - name: Lint
       before_install:
         - nvm install --latest-npm
-      install:
-        - npm ci
       script:
-        - npm run build
         - npm run lint
+
+    - name: Build artifacts
+      before_install:
+        - nvm install --latest-npm
+      script:
         - npm run check-local-changes
+
+    - name: License compatibility
+      before_install:
+        - nvm install --latest-npm
+      script:
         - npm run check-licenses
+
+    - name: JavaScript unit tests
+      before_install:
+        - nvm install --latest-npm
+      script:
         - npm run test-unit -- --ci --maxWorkers=2 --cacheDirectory="$HOME/.jest-cache"
 
     - name: PHP unit tests (Docker)


### PR DESCRIPTION
Related: #15159
Closes #10625

This pull request seeks to update the Travis configuration to run each individual script of the current "JS unit tests" job as its own separate job. As part of this, and as noted by @gziolo at https://github.com/WordPress/gutenberg/pull/14289#discussion_r265569094 , there is an added benefit here in that none of these scripts require `npm run build`, despite the fact that we run the build task. This has been removed here, and should help avoid any one of these containers from taking a particularly long time to run.

The proposed benefit is:

- Easier to determine what caused a build to fail
- Reduce the total time to run all of these tests, as each occurs in their own container
   - Note: There is some added overhead here in that each container must install its own dependencies.

**Testing instructions:**

Verify the build passes.