### PR TITLE
Address console warning for Image block inside Column block

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -447,7 +447,7 @@ class ImageEdit extends Component {
 		const isLinkURLInputReadOnly = linkDestination !== LINK_DESTINATION_CUSTOM;
 		const imageSizeOptions = this.getImageSizeOptions();
 
-		const getInspectorControls = ( imageWidth, imageHeight ) => (
+		const getInspectorControls = ( imageWidth = 0, imageHeight = 0 ) => (
 			<InspectorControls>
 				<PanelBody title={ __( 'Image Settings' ) }>
 					<TextareaControl

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -481,7 +481,7 @@ class ImageEdit extends Component {
 									type="number"
 									className="block-library-image__dimensions__width"
 									label={ __( 'Width' ) }
-									value={ width !== undefined ? width || '' : imageWidth }
+									value={ width || imageWidth || '' }
 									min={ 1 }
 									onChange={ this.updateWidth }
 								/>
@@ -489,7 +489,7 @@ class ImageEdit extends Component {
 									type="number"
 									className="block-library-image__dimensions__height"
 									label={ __( 'Height' ) }
-									value={ height !== undefined ? height || '' : imageHeight }
+									value={ height || imageHeight || '' }
 									min={ 1 }
 									onChange={ this.updateHeight }
 								/>

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -375,8 +375,8 @@ class ImageEdit extends Component {
 			rel,
 			linkClass,
 			linkDestination,
-			width = 0,
-			height = 0,
+			width,
+			height,
 			linkTarget,
 		} = attributes;
 		const isExternal = isExternalImage( id, url );
@@ -447,7 +447,7 @@ class ImageEdit extends Component {
 		const isLinkURLInputReadOnly = linkDestination !== LINK_DESTINATION_CUSTOM;
 		const imageSizeOptions = this.getImageSizeOptions();
 
-		const getInspectorControls = ( imageWidth = 0, imageHeight = 0 ) => (
+		const getInspectorControls = ( imageWidth, imageHeight ) => (
 			<InspectorControls>
 				<PanelBody title={ __( 'Image Settings' ) }>
 					<TextareaControl
@@ -481,7 +481,7 @@ class ImageEdit extends Component {
 									type="number"
 									className="block-library-image__dimensions__width"
 									label={ __( 'Width' ) }
-									value={ width ? width : imageWidth }
+									value={ width !== undefined ? width || '' : imageWidth }
 									min={ 1 }
 									onChange={ this.updateWidth }
 								/>
@@ -489,7 +489,7 @@ class ImageEdit extends Component {
 									type="number"
 									className="block-library-image__dimensions__height"
 									label={ __( 'Height' ) }
-									value={ height ? height : imageHeight }
+									value={ height !== undefined ? height || '' : imageHeight }
 									min={ 1 }
 									onChange={ this.updateHeight }
 								/>

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -375,8 +375,8 @@ class ImageEdit extends Component {
 			rel,
 			linkClass,
 			linkDestination,
-			width,
-			height,
+			width = 0,
+			height = 0,
 			linkTarget,
 		} = attributes;
 		const isExternal = isExternalImage( id, url );
@@ -481,7 +481,7 @@ class ImageEdit extends Component {
 									type="number"
 									className="block-library-image__dimensions__width"
 									label={ __( 'Width' ) }
-									value={ width !== undefined ? width : imageWidth }
+									value={ width ? width : imageWidth }
 									min={ 1 }
 									onChange={ this.updateWidth }
 								/>
@@ -489,7 +489,7 @@ class ImageEdit extends Component {
 									type="number"
 									className="block-library-image__dimensions__height"
 									label={ __( 'Height' ) }
-									value={ height !== undefined ? height : imageHeight }
+									value={ height ? height : imageHeight }
 									min={ 1 }
 									onChange={ this.updateHeight }
 								/>


### PR DESCRIPTION
## Description
There is a console warning that _sometimes_ appears when adding an Image block inside a Column block. 

We also saw this with the Image block inside custom block: https://github.com/ampproject/amp-wp/issues/2194#issue-437104605

This PR usually prevent this error locally. But the warning still appears sometimes with it. 

I'm not sure if it's the right approach, or if it has side-effects.

This is modeled after a few fixes for similar warnings, like https://github.com/WordPress/gutenberg/pull/5443.

Steps To Reproduce:

1. Create a post 
2. Add a "Columns block"
3. Add an "Image" block inside it
4. Click "Media Library" and select an image
5. A console warning appears:
```
react-dom.165d5c53.js:500 Warning: A component is changing an uncontrolled input of type number to be controlled. Input elements should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled input element for the lifetime of the component. More info: https://fb.me/react-controlled-components
    in input
    in div (created by De)
    in div (created by De)
    in De
    in Unknown (created by WithInstanceId(Component))
    in WithInstanceId(Component) (created by t)
    in div (created by t)
    in div (created by t)
    in div (created by t)
    in t (created by ForwardRef(PanelBody))
    in ForwardRef(PanelBody) (created by t)
    in t (created by Context.Consumer)
    in se (created by InspectorControlsSlot)
    in InspectorControlsSlot
    in div
    in Unknown (created by n)
    in n (created by Context.Consumer)
    in WithSelect(Component)
    in div (created by t)
    in t (created by ForwardRef(PanelBody))
    in ForwardRef(PanelBody)
    in div (created by sn)
    in sn
    in div (created by sn)
    in sn (created by n)
    in div (created by n)
    in n (created by Context.Consumer)
    in Unknown (created by b)
    in b
    in t (created by Context.Consumer)
    in se (created by SidebarSlot)
    in SidebarSlot
    in div (created by t)
    in t
    in Unknown (created by n)
    in n (created by Context.Consumer)
    in WithViewportMatch(Component) (created by NavigateRegions(WithViewportMatch(Component)))
    in div (created by NavigateRegions(WithViewportMatch(Component)))
    in NavigateRegions(WithViewportMatch(Component)) (created by r)
    in r (created by Context.Consumer)
    in WithDispatch(NavigateRegions(WithViewportMatch(Component))) (created by n)
    in n (created by Context.Consumer)
    in WithSelect(WithDispatch(NavigateRegions(WithViewportMatch(Component)))) (created by t)
    in t (created by t)
    in div (created by t)
    in t (created by t)
    in t (created by t)
    in t (created by r)
    in r (created by Context.Consumer)
    in WithDispatch(t)
    in Unknown (created by Context.Consumer)
    in WithRegistryProvider(WithDispatch(t)) (created by t)
    in t (created by r)
    in r (created by Context.Consumer)
    in WithDispatch(t) (created by n)
    in n (created by Context.Consumer)
    in WithSelect(WithDispatch(t)) (created by t)
    in StrictMode (created by t)
    in t (created by n)
    in n (created by Context.Consumer)
    in WithSelect(t)
```

## How has this been tested?
* Performing the steps above, and observing that there usually isn't a console warning
* Still, this could use feedback, as I'm not sure this is the best approach

## Screenshots
Before PR:
![similar-warning](https://user-images.githubusercontent.com/4063887/56842158-5b51a980-6858-11e9-90a6-c880b440301a.gif)

## Types of changes

Bug fix: This sets a default value of `0` for `width` and `height`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
