### PR TITLE
Components: Include stylesheet in usage instructions.

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -27,4 +27,6 @@ export default function MyButton() {
 }
 ```
 
+Many components also include styles which will need to be output in order to appear correctly. Within WordPress, you can [add the `wp-components` stylesheet as a dependency of your plugin's stylesheet](https://developer.wordpress.org/reference/functions/wp_enqueue_style/#parameters). In other projects, you can link to the `build-style/style.css` file directly.
+
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/components/src/README.md
+++ b/packages/components/src/README.md
@@ -17,3 +17,5 @@ const MyButton = () => {
 	return <Button>Click Me!</Button>;
 }
 ```
+
+Many components also include styles which will need to be output in order to appear correctly. Within WordPress, you can [add the `wp-components` stylesheet as a dependency of your plugin's stylesheet](https://developer.wordpress.org/reference/functions/wp_enqueue_style/#parameters). In other projects, you can link to the `build-style/style.css` file directly.


### PR DESCRIPTION
Without these it's easy to think something is broken, or that you're doing something wrong, until you realize that it's just that the missing CSS. Documenting this will save time and frustrating.