### PR TITLE
Blocks: Upgrade simple-html-tokenizer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3045,7 +3045,7 @@
 				"lodash": "^4.17.11",
 				"rememo": "^3.0.0",
 				"showdown": "^1.8.6",
-				"simple-html-tokenizer": "^0.4.1",
+				"simple-html-tokenizer": "^0.5.7",
 				"tinycolor2": "^1.4.1",
 				"uuid": "^3.3.2"
 			}
@@ -19535,9 +19535,9 @@
 			}
 		},
 		"simple-html-tokenizer": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.4.1.tgz",
-			"integrity": "sha1-AomIu3/osuZkVnbYIFJYfUQLAtM="
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.7.tgz",
+			"integrity": "sha512-APW9iYbkJ5cijjX4Ljhf3VG8SwYPUJT5gZrwci/wieMabQxWFiV5VwsrP5c6GMRvXKEQMGkAB1d9dvW66dTqpg=="
 		},
 		"simple-swizzle": {
 			"version": "0.2.2",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -38,7 +38,7 @@
 		"lodash": "^4.17.11",
 		"rememo": "^3.0.0",
 		"showdown": "^1.8.6",
-		"simple-html-tokenizer": "^0.4.1",
+		"simple-html-tokenizer": "^0.5.7",
 		"tinycolor2": "^1.4.1",
 		"uuid": "^3.3.2"
 	},

--- a/packages/blocks/src/api/validation.js
+++ b/packages/blocks/src/api/validation.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import Tokenizer from 'simple-html-tokenizer/dist/es6/tokenizer';
+import { Tokenizer } from 'simple-html-tokenizer';
 import {
 	identity,
 	xor,

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -25,7 +25,4 @@ module.exports = {
 		'<rootDir>/.*/build/',
 		'<rootDir>/.*/build-module/',
 	],
-	transformIgnorePatterns: [
-		'node_modules/(?!(simple-html-tokenizer)/)',
-	],
 };


### PR DESCRIPTION
## Description

Originally raised by @swissspidy in #15138:

> I am trying to use `@wordpress/scripts` for unit tests. Still running into #13364, but there's also another issue when running `wp-scripts test-unit-js`:

and further commented by @nerrad in #13364 after the previous discussion on WordPress.org Slack. 

> I'm guessing the issue here is that the import is coming from a specific es6 directory from the `simple-html-tokenizer` module:
>
> https://github.com/WordPress/gutenberg/blob/93c5ad329bd407d9b2162dee1113579895939409/packages/blocks/src/api/validation.js#L4

We had this line added to Jest config:
https://github.com/WordPress/gutenberg/blob/master/test/unit/jest.config.js#L29
to ensure this unusual import statement works as expected with our test setup.

This PR tries to resolve this issue for projects which depend on `@wordpress/blocks`. It brings the latest version of the `simple-html-tokenizer` package and uses it as a usual npm module through the entry point rather than trying to use a file based on the filesystem structure.

## Impact

There is only 1 kB difference in the size of uncompressed production build file which means we can ignore it for the benefit of fixing issues for 3rd party developers.

### Before

![Screen Shot 2019-04-29 at 10 58 04](https://user-images.githubusercontent.com/699132/56886845-3c2d6480-6a70-11e9-9276-4237f4df8926.png)

### After

![Screen Shot 2019-04-29 at 11 06 02](https://user-images.githubusercontent.com/699132/56886855-42234580-6a70-11e9-8e7b-8f369c1c9225.png)

## Testing instructions

Based on #11771.

Verify that block invalidation is not triggered by encoding variations.

For example, inserting the following HTML as the contents of a post (in Text Mode, Classic Editor Text tab, or directly in the database) should not be presented as an invalid block when next viewing the Visual Mode of the editor:

```html
<!-- wp:paragraph -->
<p>This works. &#128517;</p>
<!-- /wp:paragraph -->
```