### PR TITLE
Tests: Fix failing block hierarchy navigation e2e test

### DIFF
--- a/packages/e2e-tests/specs/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/block-hierarchy-navigation.test.js
@@ -68,7 +68,7 @@ describe( 'Navigating the block hierarchy', () => {
 		await pressKeyTimes( 'Tab', 4 );
 
 		// Tweak the columns count by increasing it by one.
-		page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.press( 'ArrowRight' );
 
 		// Navigate to the last column in the columns block.
 		await openBlockNavigator();


### PR DESCRIPTION
## Description
Originally reported in https://github.com/WordPress/gutenberg/pull/15241#issuecomment-487488382

> There is an unrelated issue with e2e test:
> 
> https://travis-ci.com/WordPress/gutenberg/jobs/196208309#L1161
> 
> ```
> FAIL specs/block-hierarchy-navigation.test.js (7.863s)
>   ● Navigating the block hierarchy › should navigate block hierarchy using only the keyboard
>     expect(received).toMatchSnapshot()
>     Snapshot name: `Navigating the block hierarchy should navigate block hierarchy using only the keyboard 1`
>     - Snapshot
>     + Received
>     @@ -9,9 +9,13 @@
>       <div class="wp-block-column"></div>
>       <!-- /wp:column -->
>       
>       <!-- wp:column -->
>       <div class="wp-block-column"><!-- wp:paragraph -->
>     - <p>Third column</p>
>     + <p></p>
>       <!-- /wp:paragraph --></div>
>       <!-- /wp:column --></div>
>     - <!-- /wp:columns -->"
>     + <!-- /wp:columns -->
>     + 
>     + <!-- wp:image -->
>     + <figure class="wp-block-image"><img alt=""/></figure>
>     + <!-- /wp:image -->"
>       80 | 		await page.keyboard.type( 'Third column' );
>       81 | 
>     > 82 | 		expect( await getEditedPostContent() ).toMatchSnapshot();
>          | 		                                       ^
>       83 | 	} );
>       84 | 
>       85 | 	it( 'should appear and function even without nested blocks', async () => {
>       at Object.toMatchSnapshot (specs/block-hierarchy-navigation.test.js:82:42)
>       at tryCatch (../../node_modules/regenerator-runtime/runtime.js:62:40)
>       at Generator.invoke [as _invoke] (../../node_modules/regenerator-runtime/runtime.js:288:22)
>       at Generator.prototype.(anonymous function) [as next] (../../node_modules/regenerator-runtime/runtime.js:114:21)
>       at asyncGeneratorStep (specs/block-hierarchy-navigation.test.js:9:103)
>       at _next (specs/block-hierarchy-navigation.test.js:11:194)
> ```

It looks like it's an easy fix. Missing `await` seems to be the root cause.

## How has this been tested?
With the local Docker setup up and running (`./bin/setup-local-env.sh`):

```sh
for i in {1..20}; do npx wp-scripts test-e2e --config packages/e2e-tests/jest.config.js packages/e2e-tests/specs/block-hierarchy-navigation.test.js; done;
```
