### PR TITLE
fix typo in withDispatch documentation

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -464,7 +464,7 @@ const SaleButton = withDispatch( ( dispatch, ownProps ) => {
 //  <SaleButton discountPercent="20">Start Sale!</SaleButton>
 ```
 
-In the majority of cases, it will be sufficient to use only two first params passed to `mapDispatchToProps` as illustrated in the previous example. However, there might be some very advanced use cases where using the `registry` object might be used as a tool to optimize the performance of your component. Using `select` function from the registry might be useful when you need to fetch some dynamic data from the store at the time when the event is fired, but at the same time, you never use it to render your component. In such scenario, you can avoid using the `withSelect` higher order component to compute such prop, which might lead to unnecessary re-renders of you component caused by its frequent value change. Keep in mind, that `mapDispatchToProps` must return an object with functions only.
+In the majority of cases, it will be sufficient to use only two first params passed to `mapDispatchToProps` as illustrated in the previous example. However, there might be some very advanced use cases where using the `registry` object might be used as a tool to optimize the performance of your component. Using `select` function from the registry might be useful when you need to fetch some dynamic data from the store at the time when the event is fired, but at the same time, you never use it to render your component. In such scenario, you can avoid using the `withSelect` higher order component to compute such prop, which might lead to unnecessary re-renders of your component caused by its frequent value change. Keep in mind, that `mapDispatchToProps` must return an object with functions only.
 
 ```jsx
 function Button( { onClick, children } ) {
@@ -495,7 +495,7 @@ _Note:_ It is important that the `mapDispatchToProps` function always returns an
 
 _Parameters_
 
--   _mapDispatchToProps_ `Object`: Object of prop names where value is a dispatch-bound action creator, or a function to be called with with the component's props and returning an action creator.
+-   _mapDispatchToProps_ `Object`: Object of prop names where value is a dispatch-bound action creator, or a function to be called with the component's props and returning an action creator.
 
 _Returns_
 

--- a/packages/data/src/components/with-dispatch/index.js
+++ b/packages/data/src/components/with-dispatch/index.js
@@ -19,7 +19,7 @@ import { RegistryConsumer } from '../registry-provider';
  *
  * @param {Object} mapDispatchToProps Object of prop names where value is a
  *                                    dispatch-bound action creator, or a
- *                                    function to be called with with the
+ *                                    function to be called with the
  *                                    component's props and returning an
  *                                    action creator.
  *
@@ -48,7 +48,7 @@ import { RegistryConsumer } from '../registry-provider';
  * ```
  *
  * @example
- * In the majority of cases, it will be sufficient to use only two first params passed to `mapDispatchToProps` as illustrated in the previous example. However, there might be some very advanced use cases where using the `registry` object might be used as a tool to optimize the performance of your component. Using `select` function from the registry might be useful when you need to fetch some dynamic data from the store at the time when the event is fired, but at the same time, you never use it to render your component. In such scenario, you can avoid using the `withSelect` higher order component to compute such prop, which might lead to unnecessary re-renders of you component caused by its frequent value change. Keep in mind, that `mapDispatchToProps` must return an object with functions only.
+ * In the majority of cases, it will be sufficient to use only two first params passed to `mapDispatchToProps` as illustrated in the previous example. However, there might be some very advanced use cases where using the `registry` object might be used as a tool to optimize the performance of your component. Using `select` function from the registry might be useful when you need to fetch some dynamic data from the store at the time when the event is fired, but at the same time, you never use it to render your component. In such scenario, you can avoid using the `withSelect` higher order component to compute such prop, which might lead to unnecessary re-renders of your component caused by its frequent value change. Keep in mind, that `mapDispatchToProps` must return an object with functions only.
  *
  * ```jsx
  * function Button( { onClick, children } ) {


### PR DESCRIPTION
Closes #15249 
I modified comments in code and built with ```npm run docs:builds```