### PR TITLE
Fix incorrect ID in FocalPointPicker

### DIFF
--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -178,7 +178,7 @@ export class FocalPointPicker extends Component {
 		);
 		const id = `inspector-focal-point-picker-control-${ instanceId }`;
 		const horizontalPositionId = `inspector-focal-point-picker-control-horizontal-position-${ instanceId }`;
-		const verticalPositionId = `inspector-focal-point-picker-control-horizontal-position-${ instanceId }`;
+		const verticalPositionId = `inspector-focal-point-picker-control-vertical-position-${ instanceId }`;
 		return (
 			<BaseControl label={ label } id={ id } help={ help } className={ className }>
 				<div className="components-focal-point-picker-wrapper">


### PR DESCRIPTION
## Description

In the `FocalPointPicker` component, the "Vertical Pos." input ID is incorrectly referencing the horizontal label, so VoiceOver reads both inputs as "Horizontal Pos." This PR fixes the ID name so both are unique.

## How has this been tested?

Checked in VoiceOver again, also looked at the IDs & accessible names in dev tools 👍 

## Types of changes

Bug fix (non-breaking change which fixes an issue)
