### PR TITLE
Try using createElement for renderAppender render prop

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -6,7 +6,6 @@ import { last } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { createElement } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 import { getDefaultBlockName } from '@wordpress/blocks';
 
@@ -22,17 +21,17 @@ function BlockListAppender( {
 	rootClientId,
 	canInsertDefaultBlock,
 	isLocked,
-	renderAppender,
+	renderAppender: CustomAppender,
 } ) {
 	if ( isLocked ) {
 		return null;
 	}
 
 	// A render prop has been provided, use it to render the appender.
-	if ( renderAppender ) {
+	if ( CustomAppender ) {
 		return (
 			<div className="block-list-appender">
-				{ createElement( renderAppender ) }
+				<CustomAppender />
 			</div>
 		);
 	}

--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -6,6 +6,7 @@ import { last } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { createElement } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 import { getDefaultBlockName } from '@wordpress/blocks';
 
@@ -31,7 +32,7 @@ function BlockListAppender( {
 	if ( renderAppender ) {
 		return (
 			<div className="block-list-appender">
-				{ renderAppender() }
+				{ createElement( renderAppender ) }
 			</div>
 		);
 	}

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -17,8 +17,6 @@ import {
 	withColors,
 } from '@wordpress/block-editor';
 
-const renderAppender = () => <InnerBlocks.ButtonBlockAppender />;
-
 function GroupEdit( {
 	className,
 	setBackgroundColor,
@@ -49,7 +47,7 @@ function GroupEdit( {
 			</InspectorControls>
 			<div className={ classes } style={ styles }>
 				<InnerBlocks
-					renderAppender={ ! hasInnerBlocks && renderAppender }
+					renderAppender={ ! hasInnerBlocks && InnerBlocks.ButtonBlockAppender }
 				/>
 			</div>
 		</Fragment>


### PR DESCRIPTION
## Description
This PR serves as an iteration on #14241 and #14943.

As mentioned in a [couple](https://github.com/WordPress/gutenberg/pull/14241#discussion_r274571994) of [comments](https://github.com/WordPress/gutenberg/pull/14943#discussion_r279513795) by @aduth, using `createElement` instead of the traditional function call when rendering a render prop offers more flexibility for the implementor of the render prop. The implementor can use the traditional render prop style:
```
renderAppender={ () =>  ( <MyComponent /> ) }
```

as well as using a simpler style without the need for the wrapping function:
```
renderAppender={ MyComponent }
```

The only downside I can see is that if parameters were added to `renderAppender`, they'd need to be expressed as props:
```
renderAppender={ ( { someParam } ) => ( <MyComponent someProp={ someParam } /> ) }
```

instead of a plain argument:
```
renderAppender={ ( someParam ) => ( <MyComponent someProp={ someParam } /> ) }
```

which is inconsistent with other render props.

## How has this been tested?
1. Create a Group Block
2. Observe that the button appender is initially rendered
3. Click the button appender and add an image block to the group block
4. Observe that button appender is no longer shown and a trailing appender is displayed after the image block
5. Add a paragraph to the group block
6. Observe that no trailing appender (or button appender) is shown in the group block (the user can press 'enter' to add another block.)

## Types of changes
Non-breaking refactor
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
