### PR TITLE
Dependency extraction webpack plugin: Change option name consistent with docs

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/index.js
+++ b/packages/dependency-extraction-webpack-plugin/index.js
@@ -54,9 +54,9 @@ class DependencyExtractionWebpackPlugin {
 	}
 
 	mapRequestToDependency( request ) {
-		// Handle via options.requestToDependency first
-		if ( typeof this.options.requestToDependency === 'function' ) {
-			const scriptDependency = this.options.requestToDependency( request );
+		// Handle via options.requestToHandle first
+		if ( typeof this.options.requestToHandle === 'function' ) {
+			const scriptDependency = this.options.requestToHandle( request );
 			if ( scriptDependency ) {
 				return scriptDependency;
 			}

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/overrides/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/overrides/webpack.config.js
@@ -12,7 +12,7 @@ module.exports = {
 					return [ 'rxjs', 'operators' ];
 				}
 			},
-			requestToDependency( request ) {
+			requestToHandle( request ) {
 				if ( request === 'rxjs' || request === 'rxjs/operators' ) {
 					return 'wp-script-handle-for-rxjs';
 				}


### PR DESCRIPTION
## Description

In the [docs](https://github.com/WordPress/gutenberg/tree/master/packages/dependency-extraction-webpack-plugin#requesttohandle), an option name was provided as `requestToHandle`, but the
actual option in use was `requestToDependency`.

Update the code and related tests to use `requestToHandle` as described
in the documentation instead of `requestToDependency`.

## How has this been tested?

The test suite is updated to use the updated option name without regressions.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
