### PR TITLE
JSX: Use <> Fragments with transforms

### DIFF
--- a/packages/block-editor/src/components/block-editor-keyboard-shortcuts/index.js
+++ b/packages/block-editor/src/components/block-editor-keyboard-shortcuts/index.js
@@ -6,7 +6,7 @@ import { first, last, some, flow } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { KeyboardShortcuts } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { rawShortcut, displayShortcut } from '@wordpress/keycodes';
@@ -80,7 +80,7 @@ class BlockEditorKeyboardShortcuts extends Component {
 	render() {
 		const { selectedBlockClientIds } = this.props;
 		return (
-			<Fragment>
+			<>
 				<KeyboardShortcuts
 					shortcuts={ {
 						[ rawShortcut.primary( 'a' ) ]: this.selectAll,
@@ -114,7 +114,7 @@ class BlockEditorKeyboardShortcuts extends Component {
 						) }
 					</BlockActions>
 				) }
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -10,7 +10,6 @@ import { __ } from '@wordpress/i18n';
 import { getBlockType, getUnregisteredTypeHandlerName } from '@wordpress/blocks';
 import { PanelBody } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
-import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -38,7 +37,7 @@ const BlockInspector = ( { selectedBlockClientId, selectedBlockName, blockType, 
 	}
 
 	return (
-		<Fragment>
+		<>
 			<div className="editor-block-inspector__card block-editor-block-inspector__card">
 				<BlockIcon icon={ blockType.icon } showColors />
 				<div className="editor-block-inspector__card-content block-editor-block-inspector__card-content">
@@ -73,7 +72,7 @@ const BlockInspector = ( { selectedBlockClientId, selectedBlockName, blockType, 
 				</InspectorAdvancedControls.Slot>
 			</div>
 			<SkipToSelectedBlock key="back" />
-		</Fragment>
+		</>
 	);
 };
 

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -7,7 +7,7 @@ import { get, reduce, size, first, last } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import {
 	focus,
 	isTextField,
@@ -582,7 +582,7 @@ export class BlockListBlock extends Component {
 								</IgnoreNestedEvents>
 							</div>
 							{ showEmptyBlockSideInserter && (
-								<Fragment>
+								<>
 									<div className="editor-block-list__side-inserter block-editor-block-list__side-inserter">
 										<InserterWithShortcuts
 											clientId={ clientId }
@@ -598,7 +598,7 @@ export class BlockListBlock extends Component {
 											clientId={ clientId }
 										/>
 									</div>
-								</Fragment>
+								</>
 							) }
 						</IgnoreNestedEvents>
 					);

--- a/packages/block-editor/src/components/block-list/breadcrumb.js
+++ b/packages/block-editor/src/components/block-list/breadcrumb.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { Toolbar } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
@@ -54,10 +54,10 @@ export class BlockBreadcrumb extends Component {
 			<div className={ 'editor-block-list__breadcrumb block-editor-block-list__breadcrumb' }>
 				<Toolbar>
 					{ rootClientId && (
-						<Fragment>
+						<>
 							<BlockTitle clientId={ rootClientId } />
 							<span className="editor-block-list__descendant-arrow block-editor-block-list__descendant-arrow" />
-						</Fragment>
+						</>
 					) }
 					<BlockTitle clientId={ clientId } />
 				</Toolbar>

--- a/packages/block-editor/src/components/block-navigation/dropdown.js
+++ b/packages/block-editor/src/components/block-navigation/dropdown.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { Fragment } from '@wordpress/element';
 import { IconButton, Dropdown, SVG, Path, KeyboardShortcuts } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { rawShortcut, displayShortcut } from '@wordpress/keycodes';
@@ -24,7 +23,7 @@ function BlockNavigationDropdown( { hasBlocks, isDisabled } ) {
 	return	(
 		<Dropdown
 			renderToggle={ ( { isOpen, onToggle } ) => (
-				<Fragment>
+				<>
 					{ isEnabled && <KeyboardShortcuts
 						bindGlobal
 						shortcuts={ {
@@ -41,7 +40,7 @@ function BlockNavigationDropdown( { hasBlocks, isDisabled } ) {
 						shortcut={ displayShortcut.access( 'o' ) }
 						aria-disabled={ ! isEnabled }
 					/>
-				</Fragment>
+				</>
 			) }
 			renderContent={ ( { onClose } ) => (
 				<BlockNavigation onSelect={ onClose } />

--- a/packages/block-editor/src/components/block-settings-menu/index.js
+++ b/packages/block-editor/src/components/block-settings-menu/index.js
@@ -8,7 +8,6 @@ import { castArray } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { Toolbar, Dropdown, NavigableMenu, MenuItem } from '@wordpress/components';
 import { withDispatch } from '@wordpress/data';
 
@@ -79,7 +78,7 @@ export function BlockSettingsMenu( { clientIds, onSelect } ) {
 								</MenuItem>
 							) }
 							{ ! isLocked && (
-								<Fragment>
+								<>
 									<MenuItem
 										className="editor-block-settings-menu__control block-editor-block-settings-menu__control"
 										onClick={ onInsertBefore }
@@ -96,7 +95,7 @@ export function BlockSettingsMenu( { clientIds, onSelect } ) {
 									>
 										{ __( 'Insert After' ) }
 									</MenuItem>
-								</Fragment>
+								</>
 							) }
 							{ count === 1 && (
 								<BlockModeToggle

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -9,7 +9,7 @@ import { castArray, filter, first, mapKeys, orderBy, uniq, map } from 'lodash';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Dropdown, IconButton, Toolbar, PanelBody, Path, SVG } from '@wordpress/components';
 import { getBlockType, getPossibleBlockTransformations, switchToBlockType, hasChildBlocksWithInserterSupport } from '@wordpress/blocks';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { DOWN } from '@wordpress/keycodes';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
@@ -117,17 +117,17 @@ export class BlockSwitcher extends Component {
 								tooltip={ label }
 								onKeyDown={ openOnArrowDown }
 								icon={ (
-									<Fragment>
+									<>
 										<BlockIcon icon={ icon } showColors />
 										<SVG className="editor-block-switcher__transform block-editor-block-switcher__transform" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M6.5 8.9c.6-.6 1.4-.9 2.2-.9h6.9l-1.3 1.3 1.4 1.4L19.4 7l-3.7-3.7-1.4 1.4L15.6 6H8.7c-1.4 0-2.6.5-3.6 1.5l-2.8 2.8 1.4 1.4 2.8-2.8zm13.8 2.4l-2.8 2.8c-.6.6-1.3.9-2.1.9h-7l1.3-1.3-1.4-1.4L4.6 16l3.7 3.7 1.4-1.4L8.4 17h6.9c1.3 0 2.6-.5 3.5-1.5l2.8-2.8-1.3-1.4z" /></SVG>
-									</Fragment>
+									</>
 								) }
 							/>
 						</Toolbar>
 					);
 				} }
 				renderContent={ ( { onClose } ) => (
-					<Fragment>
+					<>
 						{ hasBlockStyles &&
 							<PanelBody
 								title={ __( 'Block Styles' ) }
@@ -166,7 +166,7 @@ export class BlockSwitcher extends Component {
 								attributes={ { ...blocks[ 0 ].attributes, className: hoveredClassName } }
 							/>
 						}
-					</Fragment>
+					</>
 				) }
 			/>
 		);

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { withSelect } from '@wordpress/data';
-import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -30,11 +29,11 @@ function BlockToolbar( { blockClientIds, isValid, mode } ) {
 	return (
 		<div className="editor-block-toolbar block-editor-block-toolbar">
 			{ mode === 'visual' && isValid && (
-				<Fragment>
+				<>
 					<BlockSwitcher clientIds={ blockClientIds } />
 					<BlockControls.Slot />
 					<BlockFormatControls.Slot />
-				</Fragment>
+				</>
 			) }
 			<BlockSettingsMenu clientIds={ blockClientIds } />
 		</div>

--- a/packages/block-editor/src/components/block-vertical-alignment-toolbar/README.md
+++ b/packages/block-editor/src/components/block-vertical-alignment-toolbar/README.md
@@ -12,7 +12,6 @@ In a block's `edit` implementation, render a `<BlockControls />` component. Then
 
 ```jsx
 import { registerBlockType } from '@wordpress/blocks';
-import { Fragment } from '@wordpress/element';
 import {
 	BlockControls,
 	BlockVerticalAlignmentToolbar,
@@ -38,7 +37,7 @@ registerBlockType( 'my-plugin/my-block', {
 		const onChange = ( alignment ) => setAttributes( { verticalAlignment: alignment } );
 
 		return (
-			<Fragment>
+			<>
 				<BlockControls>
 					<BlockVerticalAlignmentToolbar
 						onChange={ onChange }
@@ -48,7 +47,7 @@ registerBlockType( 'my-plugin/my-block', {
 				<div>
 					// your Block here
 				</div>
-			</Fragment>
+			</>
 		);
 	}
 } );

--- a/packages/block-editor/src/components/inspector-controls/README.md
+++ b/packages/block-editor/src/components/inspector-controls/README.md
@@ -236,7 +236,6 @@ registerBlockType( 'my-plugin/inspector-controls-example', {
 {% ESNext %}
 ```js
 const { registerBlockType } = wp.blocks;
-const { Fragment } = wp.element;
 const {
 	CheckboxControl,
 	RadioControl,
@@ -309,7 +308,7 @@ registerBlockType( 'my-plugin/inspector-controls-example', {
 		}
 
 		return (
-			<Fragment>
+			<>
 				<InspectorControls>
 
 					<CheckboxControl
@@ -366,7 +365,7 @@ registerBlockType( 'my-plugin/inspector-controls-example', {
 					onChange={ onChangeContent }
 					value={ content }
 				/>
-			</Fragment>
+			</>
 		);
 	},
 

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -22,7 +22,7 @@ import {
 	withFilters,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 
@@ -327,7 +327,7 @@ export class MediaPlaceholder extends Component {
 
 		if ( mediaUpload && isAppender ) {
 			return (
-				<Fragment>
+				<>
 					{ this.renderDropZone() }
 					<FormFileUpload
 						onChange={ this.onUpload }
@@ -335,7 +335,7 @@ export class MediaPlaceholder extends Component {
 						multiple={ multiple }
 						render={ ( { openFileDialog } ) => {
 							const content = (
-								<Fragment>
+								<>
 									<IconButton
 										isLarge
 										className={ classnames(
@@ -350,17 +350,17 @@ export class MediaPlaceholder extends Component {
 									{ mediaLibraryButton }
 									{ this.renderUrlSelectionUI() }
 									{ this.renderCancelLink() }
-								</Fragment>
+								</>
 							);
 							return this.renderPlaceholder( content, openFileDialog );
 						} }
 					/>
-				</Fragment>
+				</>
 			);
 		}
 		if ( mediaUpload ) {
 			const content = (
-				<Fragment>
+				<>
 					{ this.renderDropZone() }
 					<FormFileUpload
 						isLarge
@@ -378,7 +378,7 @@ export class MediaPlaceholder extends Component {
 					{ mediaLibraryButton }
 					{ this.renderUrlSelectionUI() }
 					{ this.renderCancelLink() }
-				</Fragment>
+				</>
 			);
 			return this.renderPlaceholder( content );
 		}

--- a/packages/block-editor/src/components/rich-text/format-edit.js
+++ b/packages/block-editor/src/components/rich-text/format-edit.js
@@ -2,12 +2,11 @@
  * WordPress dependencies
  */
 import { withSelect } from '@wordpress/data';
-import { Fragment } from '@wordpress/element';
 import { getActiveFormat, getActiveObject } from '@wordpress/rich-text';
 
 const FormatEdit = ( { formatTypes, onChange, value } ) => {
 	return (
-		<Fragment>
+		<>
 			{ formatTypes.map( ( { name, edit: Edit } ) => {
 				if ( ! Edit ) {
 					return null;
@@ -34,7 +33,7 @@ const FormatEdit = ( { formatTypes, onChange, value } ) => {
 					/>
 				);
 			} ) }
-		</Fragment>
+		</>
 	);
 };
 

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -13,7 +13,7 @@ import memize from 'memize';
 /**
  * WordPress dependencies
  */
-import { Component, Fragment, RawHTML } from '@wordpress/element';
+import { Component, RawHTML } from '@wordpress/element';
 import { isHorizontalEdge } from '@wordpress/dom';
 import { createBlobURL } from '@wordpress/blob';
 import { BACKSPACE, DELETE, ENTER, LEFT, RIGHT, SPACE } from '@wordpress/keycodes';
@@ -1080,7 +1080,7 @@ export class RichText extends Component {
 					onChange={ this.onChange }
 				>
 					{ ( { listBoxId, activeId } ) => (
-						<Fragment>
+						<>
 							<Editable
 								tagName={ Tagname }
 								style={ style }
@@ -1113,7 +1113,7 @@ export class RichText extends Component {
 								</Tagname>
 							}
 							{ isSelected && <FormatEdit value={ record } onChange={ this.onChange } /> }
-						</Fragment>
+						</>
 					) }
 				</Autocomplete>
 				{ isSelected && <RemoveBrowserShortcuts /> }

--- a/packages/block-editor/src/components/rich-text/list-edit.js
+++ b/packages/block-editor/src/components/rich-text/list-edit.js
@@ -4,7 +4,6 @@
 
 import { Toolbar } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import {
 	__unstableIndentListItems as indentListItems,
 	__unstableOutdentListItems as outdentListItems,
@@ -26,7 +25,7 @@ export const ListEdit = ( {
 	value,
 	onChange,
 } ) => (
-	<Fragment>
+	<>
 		<RichTextShortcut
 			type="primary"
 			character="["
@@ -101,5 +100,5 @@ export const ListEdit = ( {
 				].filter( Boolean ) }
 			/>
 		</BlockFormatControls>
-	</Fragment>
+	</>
 );

--- a/packages/block-editor/src/components/url-popover/README.md
+++ b/packages/block-editor/src/components/url-popover/README.md
@@ -8,7 +8,6 @@ URLPopover is a presentational React component used to render a popover used for
 The component will be rendered adjacent to its parent.
 
 ```jsx
-import { Fragment } from '@wordpress/element';
 import { ToggleControl, IconButton, Button } from '@wordpress/components';
 import { URLPopover } from '@wordpress/block-editor';
 
@@ -58,7 +57,7 @@ class MyURLPopover extends Component {
 		const { url, isVisible, isEditing } = this.state;
 
 		return (
-			<Fragment>
+			<>
 				<Button onClick={ this.openURLPopover }>Edit URL</Button>
 				{ isVisible && (
 					<URLPopover
@@ -77,7 +76,7 @@ class MyURLPopover extends Component {
 						</form>
 					</URLPopover>
 				) }
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -6,7 +6,6 @@ import { assign } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Fragment } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import { TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -63,7 +62,7 @@ export const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) =>
 
 		if ( hasAnchor && props.isSelected ) {
 			return (
-				<Fragment>
+				<>
 					<BlockEdit { ...props } />
 					<InspectorAdvancedControls>
 						<TextControl
@@ -77,7 +76,7 @@ export const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) =>
 								} );
 							} } />
 					</InspectorAdvancedControls>
-				</Fragment>
+				</>
 			);
 		}
 

--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -7,7 +7,6 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Fragment } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import { TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -57,7 +56,7 @@ export const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) =>
 		const hasCustomClassName = hasBlockSupport( props.name, 'customClassName', true );
 		if ( hasCustomClassName && props.isSelected ) {
 			return (
-				<Fragment>
+				<>
 					<BlockEdit { ...props } />
 					<InspectorAdvancedControls>
 						<TextControl
@@ -70,7 +69,7 @@ export const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) =>
 							} }
 						/>
 					</InspectorAdvancedControls>
-				</Fragment>
+				</>
 			);
 		}
 

--- a/packages/block-library/src/archives/edit.js
+++ b/packages/block-library/src/archives/edit.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { Fragment } from '@wordpress/element';
 import {
 	PanelBody,
 	ToggleControl,
@@ -15,7 +14,7 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 	const { showPostCounts, displayAsDropdown } = attributes;
 
 	return (
-		<Fragment>
+		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Archives Settings' ) }>
 					<ToggleControl
@@ -33,6 +32,6 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 			<Disabled>
 				<ServerSideRender block="core/archives" attributes={ attributes } />
 			</Disabled>
-		</Fragment>
+		</>
 	);
 }

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -19,7 +19,7 @@ import {
 	RichText,
 } from '@wordpress/block-editor';
 import { mediaUpload } from '@wordpress/editor';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -136,7 +136,7 @@ class AudioEdit extends Component {
 
 		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 		return (
-			<Fragment>
+			<>
 				<BlockControls>
 					<Toolbar>
 						<IconButton
@@ -190,7 +190,7 @@ class AudioEdit extends Component {
 						/>
 					) }
 				</figure>
-			</Fragment>
+			</>
 		);
 		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 	}

--- a/packages/block-library/src/block/edit-panel/index.js
+++ b/packages/block-library/src/block/edit-panel/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
-import { Component, Fragment, createRef } from '@wordpress/element';
+import { Component, createRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ESCAPE } from '@wordpress/keycodes';
 import { withInstanceId } from '@wordpress/compose';
@@ -56,7 +56,7 @@ class ReusableBlockEditPanel extends Component {
 		const { isEditing, title, isSaving, isEditDisabled, onEdit, instanceId } = this.props;
 
 		return (
-			<Fragment>
+			<>
 				{ ( ! isEditing && ! isSaving ) && (
 					<div className="reusable-block-edit-panel">
 						<b className="reusable-block-edit-panel__info">
@@ -102,7 +102,7 @@ class ReusableBlockEditPanel extends Component {
 						</Button>
 					</form>
 				) }
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -6,7 +6,7 @@ import { noop, partial } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { Placeholder, Spinner, Disabled } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -124,7 +124,7 @@ class ReusableBlockEdit extends Component {
 		}
 
 		return (
-			<Fragment>
+			<>
 				{ ( isSelected || isEditing ) && (
 					<ReusableBlockEditPanel
 						isEditing={ isEditing }
@@ -139,7 +139,7 @@ class ReusableBlockEdit extends Component {
 				) }
 				{ ! isSelected && ! isEditing && <ReusableBlockIndicator title={ reusableBlock.title } /> }
 				{ element }
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -7,10 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	Component,
-	Fragment,
-} from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import {
 	Dashicon,
@@ -75,7 +72,7 @@ class ButtonEdit extends Component {
 		} = attributes;
 
 		return (
-			<Fragment>
+			<>
 				<div className={ className } title={ title } ref={ this.bindRef }>
 					<RichText
 						placeholder={ __( 'Add text…' ) }
@@ -138,7 +135,7 @@ class ButtonEdit extends Component {
 						<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />
 					</form>
 				) }
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -10,7 +10,7 @@ import { PanelBody, Placeholder, Spinner, ToggleControl } from '@wordpress/compo
 import { compose, withInstanceId } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { InspectorControls } from '@wordpress/block-editor';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 class CategoriesEdit extends Component {
@@ -112,14 +112,14 @@ class CategoriesEdit extends Component {
 		const categories = this.getCategories( parentId );
 		const selectId = `blocks-category-select-${ instanceId }`;
 		return (
-			<Fragment>
+			<>
 				<label htmlFor={ selectId } className="screen-reader-text">
 					{ __( 'Categories' ) }
 				</label>
 				<select id={ selectId } className="wp-block-categories__dropdown">
 					{ categories.map( ( category ) => this.renderCategoryDropdownItem( category, 0 ) ) }
 				</select>
-			</Fragment>
+			</>
 		);
 	}
 
@@ -172,7 +172,7 @@ class CategoriesEdit extends Component {
 
 		if ( isRequesting ) {
 			return (
-				<Fragment>
+				<>
 					{ inspectorControls }
 					<Placeholder
 						icon="admin-post"
@@ -180,12 +180,12 @@ class CategoriesEdit extends Component {
 					>
 						<Spinner />
 					</Placeholder>
-				</Fragment>
+				</>
 			);
 		}
 
 		return (
-			<Fragment>
+			<>
 				{ inspectorControls }
 				<div className={ this.props.className }>
 					{
@@ -194,7 +194,7 @@ class CategoriesEdit extends Component {
 							this.renderCategoryList()
 					}
 				</div>
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -12,7 +12,6 @@ import {
 	PanelBody,
 	RangeControl,
 } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 import {
 	InspectorControls,
 	InnerBlocks,
@@ -50,7 +49,7 @@ export const ColumnsEdit = function( { attributes, setAttributes, className, upd
 	};
 
 	return (
-		<Fragment>
+		<>
 			<InspectorControls>
 				<PanelBody>
 					<RangeControl
@@ -78,7 +77,7 @@ export const ColumnsEdit = function( { attributes, setAttributes, className, upd
 					templateLock="all"
 					allowedBlocks={ ALLOWED_BLOCKS } />
 			</div>
-		</Fragment>
+		</>
 	);
 };
 

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -29,7 +29,7 @@ import {
 	PanelColorSettings,
 	withColors,
 } from '@wordpress/editor';
-import { Component, createRef, Fragment } from '@wordpress/element';
+import { Component, createRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -158,10 +158,10 @@ class CoverEdit extends Component {
 		}
 
 		const controls = (
-			<Fragment>
+			<>
 				<BlockControls>
 					{ !! url && (
-						<Fragment>
+						<>
 							<MediaUploadCheck>
 								<Toolbar>
 									<MediaUpload
@@ -179,7 +179,7 @@ class CoverEdit extends Component {
 									/>
 								</Toolbar>
 							</MediaUploadCheck>
-						</Fragment>
+						</>
 					) }
 				</BlockControls>
 				{ !! url && (
@@ -222,7 +222,7 @@ class CoverEdit extends Component {
 						</PanelBody>
 					</InspectorControls>
 				) }
-			</Fragment>
+			</>
 		);
 
 		if ( ! url ) {
@@ -230,7 +230,7 @@ class CoverEdit extends Component {
 			const label = __( 'Cover' );
 
 			return (
-				<Fragment>
+				<>
 					{ controls }
 					<MediaPlaceholder
 						icon={ placeholderIcon }
@@ -245,7 +245,7 @@ class CoverEdit extends Component {
 						notices={ noticeUI }
 						onError={ noticeOperations.createErrorNotice }
 					/>
-				</Fragment>
+				</>
 			);
 		}
 
@@ -260,7 +260,7 @@ class CoverEdit extends Component {
 		);
 
 		return (
-			<Fragment>
+			<>
 				{ controls }
 				<div
 					data-url={ url }
@@ -296,7 +296,7 @@ class CoverEdit extends Component {
 						/>
 					</div>
 				</div>
-			</Fragment>
+			</>
 		);
 	}
 

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -16,7 +16,7 @@ import { kebabCase, toLower } from 'lodash';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 
 export function getEmbedEditComponent( title, icon, responsive = true ) {
 	return class extends Component {
@@ -180,7 +180,7 @@ export function getEmbedEditComponent( title, icon, responsive = true ) {
 			}
 
 			return (
-				<Fragment>
+				<>
 					<EmbedControls
 						showEditButton={ preview && ! cannotEmbed }
 						themeSupportsResponsive={ themeSupportsResponsive }
@@ -201,7 +201,7 @@ export function getEmbedEditComponent( title, icon, responsive = true ) {
 						icon={ icon }
 						label={ label }
 					/>
-				</Fragment>
+				</>
 			);
 		}
 	};

--- a/packages/block-library/src/embed/embed-controls.js
+++ b/packages/block-library/src/embed/embed-controls.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { IconButton, Toolbar, PanelBody, ToggleControl } from '@wordpress/components';
 import { BlockControls, InspectorControls } from '@wordpress/block-editor';
 
@@ -17,7 +16,7 @@ const EmbedControls = ( props ) => {
 		switchBackToURLInput,
 	} = props;
 	return (
-		<Fragment>
+		<>
 			<BlockControls>
 				<Toolbar>
 					{ showEditButton && (
@@ -42,7 +41,7 @@ const EmbedControls = ( props ) => {
 					</PanelBody>
 				</InspectorControls>
 			) }
-		</Fragment>
+		</>
 	);
 };
 

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -28,7 +28,7 @@ import {
 	RichText,
 } from '@wordpress/block-editor';
 import { mediaUpload } from '@wordpress/editor';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 
 /**
@@ -166,7 +166,7 @@ class FileEdit extends Component {
 		} );
 
 		return (
-			<Fragment>
+			<>
 				<FileBlockInspector
 					hrefs={ { href, textLinkHref, attachmentPage } }
 					{ ...{
@@ -234,7 +234,7 @@ class FileEdit extends Component {
 						</ClipboardButton>
 					}
 				</div>
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/packages/block-library/src/file/inspector.js
+++ b/packages/block-library/src/file/inspector.js
@@ -7,7 +7,6 @@ import {
 	SelectControl,
 	ToggleControl,
 } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/block-editor';
 
 export default function FileBlockInspector( {
@@ -29,7 +28,7 @@ export default function FileBlockInspector( {
 	}
 
 	return (
-		<Fragment>
+		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Text Link Settings' ) }>
 					<SelectControl
@@ -52,6 +51,6 @@ export default function FileBlockInspector( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-		</Fragment>
+		</>
 	);
 }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -23,7 +23,7 @@ import {
 	MediaUpload,
 	InspectorControls,
 } from '@wordpress/block-editor';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -201,15 +201,15 @@ class GalleryEdit extends Component {
 
 		if ( ! hasImages ) {
 			return (
-				<Fragment>
+				<>
 					{ controls }
 					{ mediaPlaceholder }
-				</Fragment>
+				</>
 			);
 		}
 
 		return (
-			<Fragment>
+			<>
 				{ controls }
 				<InspectorControls>
 					<PanelBody title={ __( 'Gallery Settings' ) }>
@@ -268,7 +268,7 @@ class GalleryEdit extends Component {
 					} ) }
 				</ul>
 				{ mediaPlaceholder }
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { IconButton, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { BACKSPACE, DELETE } from '@wordpress/keycodes';
@@ -103,7 +103,7 @@ class GalleryImage extends Component {
 			// Disable reason: Image itself is not meant to be interactive, but should
 			// direct image selection and unfocus caption fields.
 			/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-			<Fragment>
+			<>
 				<img
 					src={ url }
 					alt={ alt }
@@ -116,7 +116,7 @@ class GalleryImage extends Component {
 					ref={ this.bindContainer }
 				/>
 				{ isBlobURL( url ) && <Spinner /> }
-			</Fragment>
+			</>
 			/* eslint-enable jsx-a11y/no-noninteractive-element-interactions */
 		);
 

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -6,7 +6,6 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Fragment } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
@@ -32,7 +31,7 @@ function GroupEdit( {
 	} );
 
 	return (
-		<Fragment>
+		<>
 			<InspectorControls>
 				<PanelColorSettings
 					title={ __( 'Color Settings' ) }
@@ -50,7 +49,7 @@ function GroupEdit( {
 					renderAppender={ ! hasInnerBlocks && InnerBlocks.ButtonBlockAppender }
 				/>
 			</div>
-		</Fragment>
+		</>
 	);
 }
 

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -7,7 +7,6 @@ import HeadingToolbar from './heading-toolbar';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { PanelBody } from '@wordpress/components';
 import { createBlock } from '@wordpress/blocks';
 import {
@@ -29,7 +28,7 @@ export default function HeadingEdit( {
 	const tagName = 'h' + level;
 
 	return (
-		<Fragment>
+		<>
 			<BlockControls>
 				<HeadingToolbar minLevel={ 2 } maxLevel={ 5 } selectedLevel={ level } onChange={ ( newLevel ) => setAttributes( { level: newLevel } ) } />
 			</BlockControls>
@@ -69,6 +68,6 @@ export default function HeadingEdit( {
 				className={ className }
 				placeholder={ placeholder || __( 'Write heading…' ) }
 			/>
-		</Fragment>
+		</>
 	);
 }

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -44,7 +44,7 @@ import {
 	RichText,
 } from '@wordpress/block-editor';
 import { mediaUpload } from '@wordpress/editor';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { getPath } from '@wordpress/url';
 import { withViewportMatch } from '@wordpress/viewport';
@@ -431,10 +431,10 @@ class ImageEdit extends Component {
 		);
 		if ( isEditing || ! url ) {
 			return (
-				<Fragment>
+				<>
 					{ controls }
 					{ mediaPlaceholder }
-				</Fragment>
+				</>
 			);
 		}
 
@@ -456,12 +456,12 @@ class ImageEdit extends Component {
 						value={ alt }
 						onChange={ this.updateAlt }
 						help={
-							<Fragment>
+							<>
 								<ExternalLink href="https://www.w3.org/WAI/tutorials/images/decision-tree">
 									{ __( 'Describe the purpose of the image' ) }
 								</ExternalLink>
 								{ __( 'Leave empty if the image is purely decorative.' ) }
-							</Fragment>
+							</>
 						}
 					/>
 					{ ! isEmpty( imageSizeOptions ) && (
@@ -534,7 +534,7 @@ class ImageEdit extends Component {
 						onChange={ this.onSetLinkDestination }
 					/>
 					{ linkDestination !== LINK_DESTINATION_NONE && (
-						<Fragment>
+						<>
 							<TextControl
 								label={ __( 'Link URL' ) }
 								value={ href || '' }
@@ -556,7 +556,7 @@ class ImageEdit extends Component {
 								value={ rel || '' }
 								onChange={ this.onSetLinkRel }
 							/>
-						</Fragment>
+						</>
 					) }
 				</PanelBody>
 			</InspectorControls>
@@ -565,7 +565,7 @@ class ImageEdit extends Component {
 		// Disable reason: Each block can be selected by clicking on it
 		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 		return (
-			<Fragment>
+			<>
 				{ controls }
 				<figure className={ classes }>
 					<ImageSize src={ url } dirtynessTrigger={ align }>
@@ -591,7 +591,7 @@ class ImageEdit extends Component {
 								// Disable reason: Image itself is not meant to be interactive, but
 								// should direct focus to block.
 								/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-								<Fragment>
+								<>
 									<img
 										src={ url }
 										alt={ defaultedAlt }
@@ -600,18 +600,18 @@ class ImageEdit extends Component {
 										onError={ () => this.onImageError( url ) }
 									/>
 									{ isBlobURL( url ) && <Spinner /> }
-								</Fragment>
+								</>
 								/* eslint-enable jsx-a11y/no-noninteractive-element-interactions */
 							);
 
 							if ( ! isResizable || ! imageWidthWithinContainer ) {
 								return (
-									<Fragment>
+									<>
 										{ getInspectorControls( imageWidth, imageHeight ) }
 										<div style={ { width, height } }>
 											{ img }
 										</div>
-									</Fragment>
+									</>
 								);
 							}
 
@@ -659,7 +659,7 @@ class ImageEdit extends Component {
 							/* eslint-enable no-lonely-if */
 
 							return (
-								<Fragment>
+								<>
 									{ getInspectorControls( imageWidth, imageHeight ) }
 									<ResizableBox
 										size={
@@ -692,7 +692,7 @@ class ImageEdit extends Component {
 									>
 										{ img }
 									</ResizableBox>
-								</Fragment>
+								</>
 							);
 						} }
 					</ImageSize>
@@ -709,7 +709,7 @@ class ImageEdit extends Component {
 					) }
 				</figure>
 				{ mediaPlaceholder }
-			</Fragment>
+			</>
 		);
 		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 	}

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -7,7 +7,6 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { RichText } from '@wordpress/block-editor';
-import { Fragment } from '@wordpress/element';
 
 export default function save( { attributes } ) {
 	const {
@@ -40,7 +39,7 @@ export default function save( { attributes } ) {
 	);
 
 	const figure = (
-		<Fragment>
+		<>
 			{ href ? (
 				<a
 					className={ linkClass }
@@ -52,7 +51,7 @@ export default function save( { attributes } ) {
 				</a>
 			) : image }
 			{ ! RichText.isEmpty( caption ) && <RichText.Content tagName="figcaption" value={ caption } /> }
-		</Fragment>
+		</>
 	);
 
 	if ( 'left' === align || 'right' === align || 'center' === align ) {

--- a/packages/block-library/src/latest-comments/edit.js
+++ b/packages/block-library/src/latest-comments/edit.js
@@ -9,7 +9,7 @@ import {
 	ToggleControl,
 } from '@wordpress/components';
 import { ServerSideRender } from '@wordpress/editor';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -61,7 +61,7 @@ class LatestComments extends Component {
 		} = this.props.attributes;
 
 		return (
-			<Fragment>
+			<>
 				<InspectorControls>
 					<PanelBody title={ __( 'Latest Comments Settings' ) }>
 						<ToggleControl
@@ -95,7 +95,7 @@ class LatestComments extends Component {
 						attributes={ this.props.attributes }
 					/>
 				</Disabled>
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Component, Fragment, RawHTML } from '@wordpress/element';
+import { Component, RawHTML } from '@wordpress/element';
 import {
 	PanelBody,
 	Placeholder,
@@ -138,7 +138,7 @@ class LatestPostsEdit extends Component {
 		const hasPosts = Array.isArray( latestPosts ) && latestPosts.length;
 		if ( ! hasPosts ) {
 			return (
-				<Fragment>
+				<>
 					{ inspectorControls }
 					<Placeholder
 						icon="admin-post"
@@ -149,7 +149,7 @@ class LatestPostsEdit extends Component {
 							__( 'No posts found.' )
 						}
 					</Placeholder>
-				</Fragment>
+				</>
 			);
 		}
 
@@ -176,7 +176,7 @@ class LatestPostsEdit extends Component {
 		const dateFormat = __experimentalGetSettings().formats.date;
 
 		return (
-			<Fragment>
+			<>
 				{ inspectorControls }
 				<BlockControls>
 					<Toolbar controls={ layoutControls } />
@@ -238,7 +238,7 @@ class LatestPostsEdit extends Component {
 						);
 					} ) }
 				</ul>
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/packages/block-library/src/legacy-widget/edit.js
+++ b/packages/block-library/src/legacy-widget/edit.js
@@ -6,7 +6,7 @@ import { map } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import {
 	Button,
 	IconButton,
@@ -99,15 +99,15 @@ class LegacyWidgetEdit extends Component {
 		);
 		if ( ! hasPermissionsToManageWidgets ) {
 			return (
-				<Fragment>
+				<>
 					{ inspectorControls }
 					{ this.renderWidgetPreview() }
-				</Fragment>
+				</>
 			);
 		}
 
 		return (
-			<Fragment>
+			<>
 				<BlockControls>
 					<Toolbar>
 						<IconButton
@@ -117,7 +117,7 @@ class LegacyWidgetEdit extends Component {
 						>
 						</IconButton>
 						{ ! isCallbackWidget && (
-							<Fragment>
+							<>
 								<Button
 									className={ `components-tab-button ${ ! isPreview ? 'is-active' : '' }` }
 									onClick={ this.switchToEdit }
@@ -130,7 +130,7 @@ class LegacyWidgetEdit extends Component {
 								>
 									<span>{ __( 'Preview' ) }</span>
 								</Button>
-							</Fragment>
+							</>
 						) }
 					</Toolbar>
 				</BlockControls>
@@ -150,7 +150,7 @@ class LegacyWidgetEdit extends Component {
 					/>
 				) }
 				{ ( isPreview || isCallbackWidget ) && this.renderWidgetPreview() }
-			</Fragment>
+			</>
 		);
 	}
 

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -16,7 +16,7 @@ import {
 	PanelColorSettings,
 	withColors,
 } from '@wordpress/block-editor';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import {
 	PanelBody,
 	TextareaControl,
@@ -198,18 +198,18 @@ class MediaTextEdit extends Component {
 					value={ mediaAlt }
 					onChange={ onMediaAltChange }
 					help={
-						<Fragment>
+						<>
 							<ExternalLink href="https://www.w3.org/WAI/tutorials/images/decision-tree">
 								{ __( 'Describe the purpose of the image' ) }
 							</ExternalLink>
 							{ __( 'Leave empty if the image is purely decorative.' ) }
-						</Fragment>
+						</>
 					}
 				/> ) }
 			</PanelBody>
 		);
 		return (
-			<Fragment>
+			<>
 				<InspectorControls>
 					{ mediaTextGeneralSettings }
 					<PanelColorSettings
@@ -235,7 +235,7 @@ class MediaTextEdit extends Component {
 						templateInsertUpdatesSelection={ false }
 					/>
 				</div>
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/packages/block-library/src/media-text/media-container.js
+++ b/packages/block-library/src/media-text/media-container.js
@@ -8,7 +8,7 @@ import {
 	MediaPlaceholder,
 	MediaUpload,
 } from '@wordpress/block-editor';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -58,24 +58,24 @@ class MediaContainer extends Component {
 		const { mediaAlt, mediaUrl, className, imageFill, focalPoint } = this.props;
 		const backgroundStyles = imageFill ? imageFillStyles( mediaUrl, focalPoint ) : {};
 		return (
-			<Fragment>
+			<>
 				{ this.renderToolbarEditButton() }
 				<figure className={ className } style={ backgroundStyles }>
 					<img src={ mediaUrl } alt={ mediaAlt } />
 				</figure>
-			</Fragment>
+			</>
 		);
 	}
 
 	renderVideo() {
 		const { mediaUrl, className } = this.props;
 		return (
-			<Fragment>
+			<>
 				{ this.renderToolbarEditButton() }
 				<figure className={ className }>
 					<video controls src={ mediaUrl } />
 				</figure>
-			</Fragment>
+			</>
 		);
 	}
 

--- a/packages/block-library/src/missing/edit.js
+++ b/packages/block-library/src/missing/edit.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { RawHTML, Fragment } from '@wordpress/element';
+import { RawHTML } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { getBlockType, createBlock } from '@wordpress/blocks';
 import { withDispatch } from '@wordpress/data';
@@ -33,12 +33,12 @@ function MissingBlockWarning( { attributes, convertToHTML } ) {
 	}
 
 	return (
-		<Fragment>
+		<>
 			<Warning actions={ actions }>
 				{ messageHTML }
 			</Warning>
 			<RawHTML>{ originalUndelimitedContent }</RawHTML>
-		</Fragment>
+		</>
 	);
 }
 

--- a/packages/block-library/src/more/edit.js
+++ b/packages/block-library/src/more/edit.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { PanelBody, ToggleControl } from '@wordpress/components';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/block-editor';
 import { ENTER } from '@wordpress/keycodes';
 import {
@@ -56,7 +56,7 @@ export default class MoreEdit extends Component {
 		const inputLength = value.length + 1;
 
 		return (
-			<Fragment>
+			<>
 				<InspectorControls>
 					<PanelBody>
 						<ToggleControl
@@ -76,7 +76,7 @@ export default class MoreEdit extends Component {
 						onKeyDown={ this.onKeyDown }
 					/>
 				</div>
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -7,10 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
-import {
-	Component,
-	Fragment,
-} from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import {
 	PanelBody,
 	ToggleControl,
@@ -151,7 +148,7 @@ class ParagraphBlock extends Component {
 		} = attributes;
 
 		return (
-			<Fragment>
+			<>
 				<BlockControls>
 					<AlignmentToolbar
 						value={ align }
@@ -249,7 +246,7 @@ class ParagraphBlock extends Component {
 					aria-label={ content ? __( 'Paragraph block' ) : __( 'Empty block; start writing or type forward slash to choose a block' ) }
 					placeholder={ placeholder || __( 'Start writing or type / to choose a block' ) }
 				/>
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -8,10 +8,7 @@ import { includes } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	Component,
-	Fragment,
-} from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import {
 	RichText,
 	ContrastChecker,
@@ -76,7 +73,7 @@ class PullQuoteEdit extends Component {
 			[ textColor.class ]: textColor.class,
 		} ) : undefined;
 		return (
-			<Fragment>
+			<>
 				<figure style={ figureStyle } className={ classnames(
 					className, {
 						[ mainColor.class ]: isSolidColorStyle && mainColor.class,
@@ -140,7 +137,7 @@ class PullQuoteEdit extends Component {
 						) }
 					</PanelColorSettings>
 				</InspectorControls>
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -2,13 +2,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { AlignmentToolbar, BlockControls, RichText } from '@wordpress/block-editor';
 
 export default function QuoteEdit( { attributes, setAttributes, isSelected, mergeBlocks, onReplace, className } ) {
 	const { align, value, citation } = attributes;
 	return (
-		<Fragment>
+		<>
 			<BlockControls>
 				<AlignmentToolbar
 					value={ align }
@@ -56,6 +55,6 @@ export default function QuoteEdit( { attributes, setAttributes, isSelected, merg
 					/>
 				) }
 			</blockquote>
-		</Fragment>
+		</>
 	);
 }

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import {
 	Button,
 	Disabled,
@@ -107,7 +107,7 @@ class RSSEdit extends Component {
 		];
 
 		return (
-			<Fragment>
+			<>
 				<BlockControls>
 					<Toolbar controls={ toolbarControls } />
 				</BlockControls>
@@ -164,7 +164,7 @@ class RSSEdit extends Component {
 						attributes={ this.props.attributes }
 					/>
 				</Disabled>
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Fragment, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
 import { BaseControl, PanelBody, ResizableBox } from '@wordpress/components';
@@ -18,7 +18,7 @@ const SpacerEdit = ( { attributes, isSelected, setAttributes, toggleSelection, i
 	const [ inputHeightValue, setInputHeightValue ] = useState( height );
 
 	return (
-		<Fragment>
+		<>
 			<ResizableBox
 				className={ classnames(
 					'block-library-spacer__resize-container',
@@ -78,7 +78,7 @@ const SpacerEdit = ( { attributes, isSelected, setAttributes, toggleSelection, i
 					</BaseControl>
 				</PanelBody>
 			</InspectorControls>
-		</Fragment>
+		</>
 	);
 };
 

--- a/packages/block-library/src/subhead/edit.js
+++ b/packages/block-library/src/subhead/edit.js
@@ -3,7 +3,6 @@
  */
 import deprecated from '@wordpress/deprecated';
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import {
 	RichText,
 	BlockControls,
@@ -19,7 +18,7 @@ export default function SubheadEdit( { attributes, setAttributes, className } ) 
 	} );
 
 	return (
-		<Fragment>
+		<>
 			<BlockControls>
 				<AlignmentToolbar
 					value={ align }
@@ -40,6 +39,6 @@ export default function SubheadEdit( { attributes, setAttributes, className } ) 
 				className={ className }
 				placeholder={ placeholder || __( 'Write subheading…' ) }
 			/>
-		</Fragment>
+		</>
 	);
 }

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Fragment, Component } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import {
 	InspectorControls,
 	BlockControls,
@@ -431,7 +431,7 @@ export class TableEdit extends Component {
 		} );
 
 		return (
-			<Fragment>
+			<>
 				<BlockControls>
 					<Toolbar>
 						<DropdownMenu
@@ -468,7 +468,7 @@ export class TableEdit extends Component {
 					<Section type="body" rows={ body } />
 					<Section type="foot" rows={ foot } />
 				</table>
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/packages/block-library/src/tag-cloud/edit.js
+++ b/packages/block-library/src/tag-cloud/edit.js
@@ -6,7 +6,7 @@ import { map, filter } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import {
 	PanelBody,
 	ToggleControl,
@@ -82,14 +82,14 @@ class TagCloudEdit extends Component {
 		);
 
 		return (
-			<Fragment>
+			<>
 				{ inspectorControls }
 				<ServerSideRender
 					key="tag-cloud"
 					block="core/tag-cloud"
 					attributes={ attributes }
 				/>
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/packages/block-library/src/text-columns/edit.js
+++ b/packages/block-library/src/text-columns/edit.js
@@ -8,7 +8,6 @@ import { get, times } from 'lodash';
  */
 import { __ } from '@wordpress/i18n';
 import { PanelBody, RangeControl } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 import {
 	BlockControls,
 	BlockAlignmentToolbar,
@@ -26,7 +25,7 @@ export default function TextColumnsEdit( { attributes, setAttributes, className 
 	} );
 
 	return (
-		<Fragment>
+		<>
 			<BlockControls>
 				<BlockAlignmentToolbar
 					value={ width }
@@ -68,6 +67,6 @@ export default function TextColumnsEdit( { attributes, setAttributes, className 
 					);
 				} ) }
 			</div>
-		</Fragment>
+		</>
 	);
 }

--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import {
 	RichText,
 	BlockControls,
@@ -13,7 +12,7 @@ export default function VerseEdit( { attributes, setAttributes, className, merge
 	const { textAlign, content } = attributes;
 
 	return (
-		<Fragment>
+		<>
 			<BlockControls>
 				<AlignmentToolbar
 					value={ textAlign }
@@ -35,6 +34,6 @@ export default function VerseEdit( { attributes, setAttributes, className, merge
 				wrapperClassName={ className }
 				onMerge={ mergeBlocks }
 			/>
-		</Fragment>
+		</>
 	);
 }

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -23,7 +23,7 @@ import {
 	RichText,
 } from '@wordpress/block-editor';
 import { mediaUpload } from '@wordpress/editor';
-import { Component, Fragment, createRef } from '@wordpress/element';
+import { Component, createRef } from '@wordpress/element';
 import {
 	__,
 	sprintf,
@@ -183,7 +183,7 @@ class VideoEdit extends Component {
 
 		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 		return (
-			<Fragment>
+			<>
 				<BlockControls>
 					<Toolbar>
 						<IconButton
@@ -294,7 +294,7 @@ class VideoEdit extends Component {
 						/>
 					) }
 				</figure>
-			</Fragment>
+			</>
 		);
 		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 	}

--- a/packages/components/src/date-time/index.js
+++ b/packages/components/src/date-time/index.js
@@ -8,7 +8,7 @@ import 'react-dates/initialize';
 /**
  * WordPress dependencies
  */
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 
 /**
@@ -39,7 +39,7 @@ export class DateTimePicker extends Component {
 		return (
 			<div className="components-datetime">
 				{ ! this.state.calendarHelpIsVisible && (
-					<Fragment>
+					<>
 						<TimePicker
 							currentTime={ currentDate }
 							onChange={ onChange }
@@ -49,11 +49,11 @@ export class DateTimePicker extends Component {
 							currentDate={ currentDate }
 							onChange={ onChange }
 						/>
-					</Fragment>
+					</>
 				) }
 
 				{ this.state.calendarHelpIsVisible && (
-					<Fragment>
+					<>
 						<div className="components-datetime__calendar-help">
 							<h4>{ __( 'Click to Select' ) }</h4>
 							<ul>
@@ -94,7 +94,7 @@ export class DateTimePicker extends Component {
 								{ __( 'Close' ) }
 							</Button>
 						</div>
-					</Fragment>
+					</>
 				) }
 
 				{ ! this.state.calendarHelpIsVisible && (

--- a/packages/components/src/higher-order/with-filters/README.md
+++ b/packages/components/src/higher-order/with-filters/README.md
@@ -7,7 +7,6 @@ Wrapping a component with `withFilters` provides a filtering capability controll
 ## Usage
 
 ```jsx
-import { Fragment } from '@wordpress/element';
 import { withFilters } from '@wordpress/components';
 import { addFilter } from '@wordpress/hooks';
 
@@ -17,10 +16,10 @@ const ComponentToAppend = () => <div>Appended component</div>;
 
 function withComponentAppended( FilteredComponent ) {
 	return ( props ) => (
-		<Fragment>
+		<>
 			<FilteredComponent { ...props } />
 			<ComponentToAppend />
-		</Fragment>
+		</>
 	);
 }
 
@@ -38,15 +37,14 @@ const MyComponentWithFilters = withFilters( 'MyHookName' )( MyComponent );
 It is also possible to override props by implementing a higher-order component which works as follows:
 
 ```jsx
-import { Fragment } from '@wordpress/element';
 import { withFilters } from '@wordpress/components';
 import { addFilter } from '@wordpress/hooks';
 
 const MyComponent = ( { hint, title } ) => (
-	<Fragment>
+	<>
 		<h1>{ title }</h1>
 		<p>{ hint }</p>
-	</Fragment>
+	</>
 );
 
 function withHintOverridden( FilteredComponent ) {

--- a/packages/components/src/slot-fill/slot.js
+++ b/packages/components/src/slot-fill/slot.js
@@ -15,7 +15,6 @@ import {
 	Children,
 	Component,
 	cloneElement,
-	Fragment,
 	isEmptyElement,
 } from '@wordpress/element';
 
@@ -83,9 +82,9 @@ class SlotComponent extends Component {
 		);
 
 		return (
-			<Fragment>
+			<>
 				{ isFunction( children ) ? children( fills ) : fills }
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-group.js
+++ b/packages/edit-post/src/components/block-settings-menu/plugin-block-settings-menu-group.js
@@ -7,7 +7,6 @@ import { isEmpty, map } from 'lodash';
  * WordPress dependencies
  */
 import { createSlotFill } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 
 const { Fill: PluginBlockSettingsMenuGroup, Slot } = createSlotFill( 'PluginBlockSettingsMenuGroup' );
@@ -17,10 +16,10 @@ const PluginBlockSettingsMenuGroupSlot = ( { fillProps, selectedBlocks } ) => {
 	return (
 		<Slot fillProps={ { ...fillProps, selectedBlocks } } >
 			{ ( fills ) => ! isEmpty( fills ) && (
-				<Fragment>
+				<>
 					<div className="editor-block-settings-menu__separator block-editor-block-settings-menu__separator" />
 					{ fills }
-				</Fragment>
+				</>
 			) }
 		</Slot>
 	);

--- a/packages/edit-post/src/components/header/more-menu/index.js
+++ b/packages/edit-post/src/components/header/more-menu/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { IconButton, Dropdown, MenuGroup } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -32,7 +31,7 @@ const MoreMenu = () => (
 			/>
 		) }
 		renderContent={ ( { onClose } ) => (
-			<Fragment>
+			<>
 				<WritingMenu />
 				<ModeSwitcher />
 				<PluginMoreMenuGroup.Slot fillProps={ { onClose } } />
@@ -40,7 +39,7 @@ const MoreMenu = () => (
 				<MenuGroup>
 					<OptionsMenuItem onSelect={ onClose } />
 				</MenuGroup>
-			</Fragment>
+			</>
 		) }
 	/>
 );

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -22,7 +22,6 @@ import {
 	PostPublishPanel,
 } from '@wordpress/editor';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { Fragment } from '@wordpress/element';
 import { PluginArea } from '@wordpress/plugins';
 import { withViewportMatch } from '@wordpress/viewport';
 import { compose } from '@wordpress/compose';
@@ -111,7 +110,7 @@ function Layout( {
 					PostPublishExtension={ PluginPostPublishPanel.Slot }
 				/>
 			) : (
-				<Fragment>
+				<>
 					<div className="edit-post-toggle-publish-panel" { ...publishLandmarkProps }>
 						<Button
 							isDefault
@@ -128,7 +127,7 @@ function Layout( {
 					{
 						isMobileViewport && sidebarIsOpened && <ScrollLock />
 					}
-				</Fragment>
+				</>
 			) }
 			<Popover.Slot />
 			<PluginArea />

--- a/packages/edit-post/src/components/manage-blocks-modal/checklist.js
+++ b/packages/edit-post/src/components/manage-blocks-modal/checklist.js
@@ -6,7 +6,6 @@ import { partial } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Fragment } from '@wordpress/element';
 import { BlockIcon } from '@wordpress/block-editor';
 import { CheckboxControl } from '@wordpress/components';
 
@@ -20,10 +19,10 @@ function BlockTypesChecklist( { blockTypes, value, onItemChange } ) {
 				>
 					<CheckboxControl
 						label={ (
-							<Fragment>
+							<>
 								{ blockType.title }
 								<BlockIcon icon={ blockType.icon } />
-							</Fragment>
+							</>
 						) }
 						checked={ value.includes( blockType.name ) }
 						onChange={ partial( onItemChange, blockType.name ) }

--- a/packages/edit-post/src/components/meta-boxes/index.js
+++ b/packages/edit-post/src/components/meta-boxes/index.js
@@ -7,7 +7,6 @@ import { map } from 'lodash';
  * WordPress dependencies
  */
 import { withSelect } from '@wordpress/data';
-import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -17,12 +16,12 @@ import MetaBoxVisibility from './meta-box-visibility';
 
 function MetaBoxes( { location, isVisible, metaBoxes } ) {
 	return (
-		<Fragment>
+		<>
 			{ map( metaBoxes, ( { id } ) => (
 				<MetaBoxVisibility key={ id } id={ id } />
 			) ) }
 			{ isVisible && <MetaBoxesArea location={ location } /> }
-		</Fragment>
+		</>
 	);
 }
 

--- a/packages/edit-post/src/components/sidebar/plugin-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-sidebar/index.js
@@ -3,7 +3,6 @@
  */
 import { IconButton, Panel } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { withPluginContext } from '@wordpress/plugins';
 import { compose } from '@wordpress/compose';
@@ -30,7 +29,7 @@ function PluginSidebar( props ) {
 	} = props;
 
 	return (
-		<Fragment>
+		<>
 			{ isPinnable && (
 				<PinnedPlugins>
 					{ isPinned && <IconButton
@@ -64,7 +63,7 @@ function PluginSidebar( props ) {
 					{ children }
 				</Panel>
 			</Sidebar>
-		</Fragment>
+		</>
 	);
 }
 

--- a/packages/edit-post/src/components/sidebar/post-link/index.js
+++ b/packages/edit-post/src/components/sidebar/post-link/index.js
@@ -6,7 +6,6 @@ import { get } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { PanelBody, TextControl, ExternalLink } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -104,9 +103,9 @@ function PostLink( {
 				target="_blank"
 			>
 				{ isEditable ?
-					( <Fragment>
+					( <>
 						{ prefixElement }{ postNameElement }{ suffixElement }
-					</Fragment> ) :
+					</> ) :
 					postLink
 				}
 			</ExternalLink>

--- a/packages/edit-post/src/components/sidebar/post-schedule/index.js
+++ b/packages/edit-post/src/components/sidebar/post-schedule/index.js
@@ -5,7 +5,6 @@ import { __ } from '@wordpress/i18n';
 import { PanelRow, Dropdown, Button } from '@wordpress/components';
 import { withInstanceId } from '@wordpress/compose';
 import { PostSchedule as PostScheduleForm, PostScheduleLabel, PostScheduleCheck } from '@wordpress/editor';
-import { Fragment } from '@wordpress/element';
 
 export function PostSchedule( { instanceId } ) {
 	return (
@@ -21,7 +20,7 @@ export function PostSchedule( { instanceId } ) {
 					position="bottom left"
 					contentClassName="edit-post-post-schedule__dialog"
 					renderToggle={ ( { onToggle, isOpen } ) => (
-						<Fragment>
+						<>
 							<label
 								className="edit-post-post-schedule__label"
 								htmlFor={ `edit-post-post-schedule__toggle-${ instanceId }` }
@@ -39,7 +38,7 @@ export function PostSchedule( { instanceId } ) {
 							>
 								<PostScheduleLabel />
 							</Button>
-						</Fragment>
+						</>
 					) }
 					renderContent={ () => <PostScheduleForm /> }
 				/>

--- a/packages/edit-post/src/components/sidebar/post-status/index.js
+++ b/packages/edit-post/src/components/sidebar/post-status/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { PanelBody } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
@@ -29,7 +28,7 @@ function PostStatus( { isOpened, onTogglePanel } ) {
 		<PanelBody className="edit-post-post-status" title={ __( 'Status & Visibility' ) } opened={ isOpened } onToggle={ onTogglePanel }>
 			<PluginPostStatusInfo.Slot>
 				{ ( fills ) => (
-					<Fragment>
+					<>
 						<PostVisibility />
 						<PostSchedule />
 						<PostFormat />
@@ -38,7 +37,7 @@ function PostStatus( { isOpened, onTogglePanel } ) {
 						<PostAuthor />
 						{ fills }
 						<PostTrash />
-					</Fragment>
+					</>
 				) }
 			</PluginPostStatusInfo.Slot>
 		</PanelBody>

--- a/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
@@ -5,7 +5,6 @@ import { Panel, PanelBody } from '@wordpress/components';
 import { compose, ifCondition } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { BlockInspector } from '@wordpress/block-editor';
-import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -30,7 +29,7 @@ const SettingsSidebar = ( { sidebarName } ) => (
 		<SettingsHeader sidebarName={ sidebarName } />
 		<Panel>
 			{ sidebarName === 'edit-post/document' && (
-				<Fragment>
+				<>
 					<PostStatus />
 					<LastRevision />
 					<PostLink />
@@ -40,7 +39,7 @@ const SettingsSidebar = ( { sidebarName } ) => (
 					<DiscussionPanel />
 					<PageAttributes />
 					<MetaBoxes location="side" />
-				</Fragment>
+				</>
 			) }
 			{ sidebarName === 'edit-post/block' && (
 				<PanelBody className="edit-post-settings-sidebar__panel-block">

--- a/packages/edit-post/src/components/sidebar/sidebar-header/index.js
+++ b/packages/edit-post/src/components/sidebar/sidebar-header/index.js
@@ -6,7 +6,6 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/components';
@@ -19,7 +18,7 @@ import shortcuts from '../../../keyboard-shortcuts';
 
 const SidebarHeader = ( { children, className, closeLabel, closeSidebar, title } ) => {
 	return (
-		<Fragment>
+		<>
 			<div className="components-panel__header edit-post-sidebar-header__small">
 				<span className="edit-post-sidebar-header__title">
 					{ title || __( '(no title)' ) }
@@ -39,7 +38,7 @@ const SidebarHeader = ( { children, className, closeLabel, closeSidebar, title }
 					shortcut={ shortcuts.toggleSidebar }
 				/>
 			</div>
-		</Fragment>
+		</>
 	);
 };
 

--- a/packages/edit-post/src/plugins/index.js
+++ b/packages/edit-post/src/plugins/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { MenuItem } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 import { addQueryArgs } from '@wordpress/url';
@@ -18,10 +17,10 @@ import ToolsMoreMenuGroup from '../components/header/tools-more-menu-group';
 registerPlugin( 'edit-post', {
 	render() {
 		return (
-			<Fragment>
+			<>
 				<ToolsMoreMenuGroup>
 					{ ( { onClose } ) => (
-						<Fragment>
+						<>
 							<ManageBlocksMenuItem onSelect={ onClose } />
 							<MenuItem
 								role="menuitem"
@@ -31,10 +30,10 @@ registerPlugin( 'edit-post', {
 							</MenuItem>
 							<KeyboardShortcutsHelpMenuItem onSelect={ onClose } />
 							<CopyContentMenuItem />
-						</Fragment>
+						</>
 					) }
 				</ToolsMoreMenuGroup>
-			</Fragment>
+			</>
 		);
 	},
 } );

--- a/packages/edit-widgets/src/components/layout/index.js
+++ b/packages/edit-widgets/src/components/layout/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { navigateRegions } from '@wordpress/components';
 
@@ -20,7 +19,7 @@ function Layout() {
 	];
 
 	return (
-		<Fragment>
+		<>
 			<Header />
 			<Sidebar />
 			<div
@@ -35,7 +34,7 @@ function Layout() {
 					</div>
 				) ) }
 			</div>
-		</Fragment>
+		</>
 	);
 }
 

--- a/packages/editor/src/components/global-keyboard-shortcuts/visual-editor-shortcuts.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/visual-editor-shortcuts.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { KeyboardShortcuts } from '@wordpress/components';
 import { withDispatch } from '@wordpress/data';
 import { rawShortcut } from '@wordpress/keycodes';
@@ -33,7 +33,7 @@ class VisualEditorGlobalKeyboardShortcuts extends Component {
 
 	render() {
 		return (
-			<Fragment>
+			<>
 				<BlockEditorKeyboardShortcuts />
 				<KeyboardShortcuts
 					shortcuts={ {
@@ -42,7 +42,7 @@ class VisualEditorGlobalKeyboardShortcuts extends Component {
 					} }
 				/>
 				<SaveShortcut />
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/packages/editor/src/components/post-publish-panel/postpublish.js
+++ b/packages/editor/src/components/post-publish-panel/postpublish.js
@@ -8,7 +8,7 @@ import { get } from 'lodash';
  */
 import { PanelBody, Button, ClipboardButton, TextControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { Component, Fragment, createRef } from '@wordpress/element';
+import { Component, createRef } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 import { safeDecodeURIComponent } from '@wordpress/url';
 
@@ -61,7 +61,7 @@ class PostPublishPanelPostpublish extends Component {
 		const viewPostLabel = get( postType, [ 'labels', 'view_item' ] );
 
 		const postPublishNonLinkHeader = isScheduled ?
-			<Fragment>{ __( 'is now scheduled. It will go live on' ) } <PostScheduleLabel />.</Fragment> :
+			<>{ __( 'is now scheduled. It will go live on' ) } <PostScheduleLabel />.</> :
 			__( 'is now live.' );
 
 		return (

--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -7,7 +7,6 @@ import { get } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { PanelBody } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 
@@ -44,7 +43,7 @@ function PostPublishPanelPrepublish( {
 			<div><strong>{ prePublishTitle }</strong></div>
 			<p>{ prePublishBodyText }</p>
 			{ hasPublishAction && (
-				<Fragment>
+				<>
 					<PanelBody initialOpen={ false } title={ [
 						__( 'Visibility:' ),
 						<span className="editor-post-publish-panel__link" key="label"><PostVisibilityLabel /></span>,
@@ -60,7 +59,7 @@ function PostPublishPanelPrepublish( {
 					<MaybePostFormatPanel />
 					<MaybeTagsPanel />
 					{ children }
-				</Fragment>
+				</>
 			) }
 		</div>
 	);

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -7,7 +7,7 @@ import Textarea from 'react-autosize-textarea';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { parse } from '@wordpress/blocks';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { withInstanceId, compose } from '@wordpress/compose';
@@ -66,7 +66,7 @@ export class PostTextEditor extends Component {
 		const { value } = this.state;
 		const { instanceId } = this.props;
 		return (
-			<Fragment>
+			<>
 				<label htmlFor={ `post-content-${ instanceId }` } className="screen-reader-text">
 					{ __( 'Type text or HTML' ) }
 				</label>
@@ -80,7 +80,7 @@ export class PostTextEditor extends Component {
 					id={ `post-content-${ instanceId }` }
 					placeholder={ __( 'Start writing with text or HTML' ) }
 				/>
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/packages/editor/src/components/reusable-blocks-buttons/index.js
+++ b/packages/editor/src/components/reusable-blocks-buttons/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { Fragment } from '@wordpress/element';
 import { __experimentalBlockSettingsMenuPluginsExtension } from '@wordpress/block-editor';
 import { withSelect } from '@wordpress/data';
 
@@ -15,7 +14,7 @@ function ReusableBlocksButtons( { clientIds } ) {
 	return (
 		<__experimentalBlockSettingsMenuPluginsExtension>
 			{ ( { onClose } ) => (
-				<Fragment>
+				<>
 					<ReusableBlockConvertButton
 						clientIds={ clientIds }
 						onToggle={ onClose }
@@ -26,7 +25,7 @@ function ReusableBlocksButtons( { clientIds } ) {
 							onToggle={ onClose }
 						/>
 					) }
-				</Fragment>
+				</>
 			) }
 		</__experimentalBlockSettingsMenuPluginsExtension>
 	);

--- a/packages/editor/src/components/reusable-blocks-buttons/reusable-block-convert-button.js
+++ b/packages/editor/src/components/reusable-blocks-buttons/reusable-block-convert-button.js
@@ -6,7 +6,6 @@ import { noop, every } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Fragment } from '@wordpress/element';
 import { MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { hasBlockSupport, isReusableBlock } from '@wordpress/blocks';
@@ -24,7 +23,7 @@ export function ReusableBlockConvertButton( {
 	}
 
 	return (
-		<Fragment>
+		<>
 			{ ! isReusable && (
 				<MenuItem
 					className="editor-block-settings-menu__control block-editor-block-settings-menu__control"
@@ -43,7 +42,7 @@ export function ReusableBlockConvertButton( {
 					{ __( 'Convert to Regular Block' ) }
 				</MenuItem>
 			) }
-		</Fragment>
+		</>
 	);
 }
 

--- a/packages/editor/src/components/table-of-contents/panel.js
+++ b/packages/editor/src/components/table-of-contents/panel.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { withSelect } from '@wordpress/data';
 
@@ -13,7 +12,7 @@ import DocumentOutline from '../document-outline';
 
 function TableOfContentsPanel( { headingCount, paragraphCount, numberOfBlocks, hasOutlineItemsDisabled, onRequestClose } ) {
 	return (
-		<Fragment>
+		<>
 			<div
 				className="table-of-contents__counts"
 				role="note"
@@ -44,15 +43,15 @@ function TableOfContentsPanel( { headingCount, paragraphCount, numberOfBlocks, h
 				</div>
 			</div>
 			{ headingCount > 0 && (
-				<Fragment>
+				<>
 					<hr />
 					<span className="table-of-contents__title">
 						{ __( 'Document Outline' ) }
 					</span>
 					<DocumentOutline onSelect={ onRequestClose } hasOutlineItemsDisabled={ hasOutlineItemsDisabled } />
-				</Fragment>
+				</>
 			) }
-		</Fragment>
+		</>
 	);
 }
 

--- a/packages/format-library/src/bold/index.js
+++ b/packages/format-library/src/bold/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { toggleFormat } from '@wordpress/rich-text';
 import { RichTextToolbarButton, RichTextShortcut, __unstableRichTextInputEvent } from '@wordpress/block-editor';
 
@@ -18,7 +17,7 @@ export const bold = {
 		const onToggle = () => onChange( toggleFormat( value, { type: name } ) );
 
 		return (
-			<Fragment>
+			<>
 				<RichTextShortcut
 					type="primary"
 					character="b"
@@ -37,7 +36,7 @@ export const bold = {
 					inputType="formatBold"
 					onInput={ onToggle }
 				/>
-			</Fragment>
+			</>
 		);
 	},
 };

--- a/packages/format-library/src/code/index.js
+++ b/packages/format-library/src/code/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { toggleFormat } from '@wordpress/rich-text';
 import { RichTextShortcut, RichTextToolbarButton } from '@wordpress/block-editor';
 
@@ -18,7 +17,7 @@ export const code = {
 		const onToggle = () => onChange( toggleFormat( value, { type: name } ) );
 
 		return (
-			<Fragment>
+			<>
 				<RichTextShortcut
 					type="access"
 					character="x"
@@ -32,7 +31,7 @@ export const code = {
 					shortcutType="access"
 					shortcutCharacter="x"
 				/>
-			</Fragment>
+			</>
 		);
 	},
 };

--- a/packages/format-library/src/italic/index.js
+++ b/packages/format-library/src/italic/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { toggleFormat } from '@wordpress/rich-text';
 import { RichTextToolbarButton, RichTextShortcut, __unstableRichTextInputEvent } from '@wordpress/block-editor';
 
@@ -18,7 +17,7 @@ export const italic = {
 		const onToggle = () => onChange( toggleFormat( value, { type: name } ) );
 
 		return (
-			<Fragment>
+			<>
 				<RichTextShortcut
 					type="primary"
 					character="i"
@@ -37,7 +36,7 @@ export const italic = {
 					inputType="formatItalic"
 					onInput={ onToggle }
 				/>
-			</Fragment>
+			</>
 		);
 	},
 };

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { withSpokenMessages } from '@wordpress/components';
 import {
 	getTextContent,
@@ -70,7 +70,7 @@ export const link = {
 			const { isActive, activeAttributes, value, onChange } = this.props;
 
 			return (
-				<Fragment>
+				<>
 					<RichTextShortcut
 						type="access"
 						character="a"
@@ -117,7 +117,7 @@ export const link = {
 						value={ value }
 						onChange={ onChange }
 					/>
-				</Fragment>
+				</>
 			);
 		}
 	} ),

--- a/packages/format-library/src/link/index.native.js
+++ b/packages/format-library/src/link/index.native.js
@@ -7,7 +7,7 @@ import { find } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { withSpokenMessages } from '@wordpress/components';
 import { RichTextToolbarButton } from '@wordpress/block-editor';
 import {
@@ -106,7 +106,7 @@ export const link = {
 			const linkSelection = this.getLinkSelection();
 
 			return (
-				<Fragment>
+				<>
 					<ModalLinkUI
 						isVisible={ this.state.addingLink }
 						isActive={ isActive }
@@ -125,7 +125,7 @@ export const link = {
 						shortcutType="primary"
 						shortcutCharacter="k"
 					/>
-				</Fragment>
+				</>
 			);
 		}
 	} ),

--- a/packages/format-library/src/strikethrough/index.js
+++ b/packages/format-library/src/strikethrough/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { toggleFormat } from '@wordpress/rich-text';
 import { RichTextToolbarButton, RichTextShortcut } from '@wordpress/block-editor';
 
@@ -18,7 +17,7 @@ export const strikethrough = {
 		const onToggle = () => onChange( toggleFormat( value, { type: name } ) );
 
 		return (
-			<Fragment>
+			<>
 				<RichTextShortcut
 					type="access"
 					character="d"
@@ -32,7 +31,7 @@ export const strikethrough = {
 					shortcutType="access"
 					shortcutCharacter="d"
 				/>
-			</Fragment>
+			</>
 		);
 	},
 };

--- a/packages/format-library/src/underline/index.js
+++ b/packages/format-library/src/underline/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { toggleFormat } from '@wordpress/rich-text';
 import { RichTextShortcut, __unstableRichTextInputEvent } from '@wordpress/block-editor';
 
@@ -28,7 +27,7 @@ export const underline = {
 		};
 
 		return (
-			<Fragment>
+			<>
 				<RichTextShortcut
 					type="primary"
 					character="u"
@@ -38,7 +37,7 @@ export const underline = {
 					inputType="formatUnderline"
 					onInput={ onToggle }
 				/>
-			</Fragment>
+			</>
 		);
 	},
 };

--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -116,12 +116,11 @@ registerPlugin( 'plugin-name', {
 
 ```js
 // Using ESNext syntax
-const { Fragment } = wp.element;
 const { PluginSidebar, PluginSidebarMoreMenuItem } = wp.editPost;
 const { registerPlugin } = wp.plugins;
 
 const Component = () => (
-	<Fragment>
+	<>
 		<PluginSidebarMoreMenuItem
 			target="sidebar-name"
 		>
@@ -133,7 +132,7 @@ const Component = () => (
 		>
 			Content of the sidebar
 		</PluginSidebar>
-	</Fragment>
+	</>
 );
 
 registerPlugin( 'plugin-name', {

--- a/packages/plugins/src/api/index.js
+++ b/packages/plugins/src/api/index.js
@@ -65,12 +65,11 @@ const plugins = {};
  * @example <caption>ESNext</caption>
  * ```js
  * // Using ESNext syntax
- * const { Fragment } = wp.element;
  * const { PluginSidebar, PluginSidebarMoreMenuItem } = wp.editPost;
  * const { registerPlugin } = wp.plugins;
  *
  * const Component = () => (
- * 	<Fragment>
+ * 	<>
  * 		<PluginSidebarMoreMenuItem
  * 			target="sidebar-name"
  * 		>
@@ -82,7 +81,7 @@ const plugins = {};
  * 		>
  * 			Content of the sidebar
  * 		</PluginSidebar>
- * 	</Fragment>
+ * 	</>
  * );
  *
  * registerPlugin( 'plugin-name', {


### PR DESCRIPTION
## Description

#15120 adds `Fragment` handling to `@wordpress/babel-plugin-import-jsx-pragma` and prepares `@wordpress/babel-preset-default` for the WordPress environment.

Leverage the `<></>` automatic `Fragment` import provided by the babel transform included in the preset. Follow-up to #15120.

## How has this been tested?
Inspect transformed code to ensure imports and JSX transforms are working correctly.
Smoke test code using `<></>`.

## Types of changes
Janitorial.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
