### PR TITLE
RichText: Add (foot)notes

### DIFF
--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -376,6 +376,18 @@ _Related_
 
 -   getFirstMultiSelectedBlockClientId in core/block-editor store.
 
+<a name="getFootnotes" href="#getFootnotes">#</a> **getFootnotes**
+
+Returns the post footnotes.
+
+_Parameters_
+
+-   _state_ `Object`: Editor state.
+
+_Returns_
+
+-   `Object`: The footnotes.
+
 <a name="getGlobalBlockCount" href="#getGlobalBlockCount">#</a> **getGlobalBlockCount**
 
 _Related_
@@ -1399,6 +1411,18 @@ _Related_
 <a name="updateEditorSettings" href="#updateEditorSettings">#</a> **updateEditorSettings**
 
 Undocumented declaration.
+
+<a name="updateFootnotes" href="#updateFootnotes">#</a> **updateFootnotes**
+
+Returns an action object used in signalling that the footnotes should be updated.
+
+_Parameters_
+
+-   _footnotes_ `Object`: The footnotes.
+
+_Returns_
+
+-   `Object`: Action object.
 
 <a name="updatePost" href="#updatePost">#</a> **updatePost**
 

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -118,3 +118,23 @@ function enqueue_editor_block_styles_assets() {
 	wp_enqueue_script( 'wp-block-styles' );
 }
 add_action( 'enqueue_block_editor_assets', 'enqueue_editor_block_styles_assets' );
+
+/**
+ * Adds the `footnotes` block category.
+ *
+ * @param string $categories The categories to filter.
+ *
+ * @return string The filtered categories.
+ */
+function gutenberg_add_block_categories( $categories ) {
+	array_push(
+		$categories,
+		array(
+			'slug'  => 'footnotes',
+			'title' => __( 'Footnotes', 'gutenberg' ),
+		)
+	);
+
+	return $categories;
+}
+add_filter( 'block_categories', 'gutenberg_add_block_categories' );

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -201,6 +201,7 @@ class BlockList extends Component {
 			hasMultiSelection,
 			renderAppender,
 			enableAnimation,
+			children,
 		} = this.props;
 
 		return (
@@ -242,6 +243,8 @@ class BlockList extends Component {
 					rootClientId={ rootClientId }
 					renderAppender={ renderAppender }
 				/>
+
+				{ children }
 			</div>
 		);
 	}

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -509,6 +509,8 @@ RichTextContainer.Content.defaultProps = {
 	value: '',
 };
 
+RichTextContainer.Bare = RichTextWrapper;
+
 /**
  * @see https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/rich-text/README.md
  */

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -7,6 +7,7 @@
 @import "./cover/editor.scss";
 @import "./embed/editor.scss";
 @import "./file/editor.scss";
+@import "./footnotes/editor.scss";
 @import "./classic/editor.scss";
 @import "./gallery/editor.scss";
 @import "./group/editor.scss";

--- a/packages/block-library/src/footnotes/block.json
+++ b/packages/block-library/src/footnotes/block.json
@@ -1,0 +1,9 @@
+{
+	"name": "core/footnotes",
+	"category": "footnotes",
+	"attributes": {
+		"footnotes": {
+			"type": "array"
+		}
+	}
+}

--- a/packages/block-library/src/footnotes/edit.js
+++ b/packages/block-library/src/footnotes/edit.js
@@ -11,6 +11,7 @@ import { IconButton, Toolbar, Slot } from '@wordpress/components';
 import { useRef } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { withSafeTimeout } from '@wordpress/compose';
+import { RichText } from '@wordpress/rich-text';
 
 function Edit( { attributes, setAttributes, className, setTimeout } ) {
 	const { footnotes } = attributes;
@@ -67,10 +68,9 @@ function Edit( { attributes, setAttributes, className, setTimeout } ) {
 							↑
 						</a>
 						{ ' ' }
-						<input
-							aria-label={ __( 'Note' ) }
+						<RichText
 							value={ text }
-							onChange={ ( event ) => {
+							onChange={ ( value ) => {
 								setAttributes( {
 									footnotes: footnotes.map( ( footnote, i ) => {
 										if ( i !== index ) {
@@ -79,7 +79,7 @@ function Edit( { attributes, setAttributes, className, setTimeout } ) {
 
 										return {
 											...footnote,
-											text: event.target.value,
+											text: value,
 										};
 									} ),
 								} );

--- a/packages/block-library/src/footnotes/edit.js
+++ b/packages/block-library/src/footnotes/edit.js
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export default function Edit( { attributes, setAttributes, className } ) {
+	const { footnotes } = attributes;
+
+	if ( ! footnotes.length ) {
+		return null;
+	}
+
+	return (
+		<div className={ classnames( 'wp-block block-library-list', className, {
+			'is-selected': footnotes.some( ( { isSelected } ) => isSelected ),
+		} ) }>
+			<ol>
+				{ footnotes.map( ( { id, text, isSelected }, index ) =>
+					<li
+						key={ id }
+						id={ id }
+						className={ classnames( { 'is-selected': isSelected } ) }
+					>
+						<a
+							href={ `#${ id }-anchor` }
+							aria-label={ __( 'Back to content' ) }
+							onClick={ () => {
+								// This is a hack to get the target to focus.
+								// The attribute will later be removed when selection is set.
+								document.getElementById( `${ id }-anchor` ).contentEditable = 'false';
+							} }
+						>
+							↑
+						</a>
+						{ ' ' }
+						<input
+							aria-label={ __( 'Note' ) }
+							value={ text }
+							onChange={ ( event ) => {
+								setAttributes( {
+									footnotes: footnotes.map( ( footnote, i ) => {
+										if ( i !== index ) {
+											return footnote;
+										}
+
+										return {
+											...footnote,
+											text: event.target.value,
+										};
+									} ),
+								} );
+							} }
+							placeholder={ __( 'Footnote' ) }
+						/>
+					</li>
+				) }
+			</ol>
+		</div>
+	);
+}

--- a/packages/block-library/src/footnotes/edit.js
+++ b/packages/block-library/src/footnotes/edit.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton, Toolbar } from '@wordpress/components';
+import { IconButton, Toolbar, Slot } from '@wordpress/components';
 import { useRef } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { withSafeTimeout } from '@wordpress/compose';
@@ -45,9 +45,7 @@ function Edit( { attributes, setAttributes, className, setTimeout } ) {
 					<IconButton icon="editor-ol" onClick={ viewAll }>
 						View all Footnotes
 					</IconButton>
-					<IconButton icon="trash">
-						Remove Footnote
-					</IconButton>
+					<Slot name="__unstable-footnote-controls" />
 				</Toolbar>
 			}
 			<ol>

--- a/packages/block-library/src/footnotes/edit.js
+++ b/packages/block-library/src/footnotes/edit.js
@@ -57,7 +57,7 @@ function Edit( { attributes, setAttributes, className, setTimeout } ) {
 				<>
 					<Toolbar>
 						<IconButton icon="editor-ol" onClick={ viewAll }>
-							View all Footnotes
+							__( 'View all Footnotes' )
 						</IconButton>
 						<Slot name="__unstable-footnote-controls" />
 					</Toolbar>

--- a/packages/block-library/src/footnotes/edit.js
+++ b/packages/block-library/src/footnotes/edit.js
@@ -56,36 +56,39 @@ function Edit( { attributes, setAttributes, className, setTimeout } ) {
 						id={ id }
 						className={ classnames( { 'is-selected': isSelected } ) }
 					>
-						<a
-							href={ `#${ id }-anchor` }
-							aria-label={ __( 'Back to content' ) }
-							onClick={ () => {
-								// This is a hack to get the target to focus.
-								// The attribute will later be removed when selection is set.
-								document.getElementById( `${ id }-anchor` ).contentEditable = 'false';
-							} }
-						>
-							↑
-						</a>
-						{ ' ' }
-						<RichText
-							value={ text }
-							onChange={ ( value ) => {
-								setAttributes( {
-									footnotes: footnotes.map( ( footnote, i ) => {
-										if ( i !== index ) {
-											return footnote;
-										}
+						{ /* Needed for alignment. */ }
+						<div>
+							<a
+								href={ `#${ id }-anchor` }
+								aria-label={ __( 'Back to content' ) }
+								onClick={ () => {
+									// This is a hack to get the target to focus.
+									// The attribute will later be removed when selection is set.
+									document.getElementById( `${ id }-anchor` ).contentEditable = 'false';
+								} }
+							>
+								↑
+							</a>
+							{ ' ' }
+							<RichText
+								value={ text }
+								onChange={ ( value ) => {
+									setAttributes( {
+										footnotes: footnotes.map( ( footnote, i ) => {
+											if ( i !== index ) {
+												return footnote;
+											}
 
-										return {
-											...footnote,
-											text: value,
-										};
-									} ),
-								} );
-							} }
-							placeholder={ __( 'Footnote' ) }
-						/>
+											return {
+												...footnote,
+												text: value,
+											};
+										} ),
+									} );
+								} }
+								placeholder={ __( 'Footnote' ) }
+							/>
+						</div>
 					</li>
 				) }
 			</ol>

--- a/packages/block-library/src/footnotes/edit.js
+++ b/packages/block-library/src/footnotes/edit.js
@@ -11,7 +11,7 @@ import { IconButton, Toolbar, Slot } from '@wordpress/components';
 import { useRef } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { withSafeTimeout } from '@wordpress/compose';
-import { RichText } from '@wordpress/rich-text';
+import { RichText, BlockFormatControls } from '@wordpress/block-editor';
 
 function Edit( { attributes, setAttributes, className, setTimeout } ) {
 	const { footnotes } = attributes;
@@ -42,12 +42,15 @@ function Edit( { attributes, setAttributes, className, setTimeout } ) {
 			ref={ ref }
 		>
 			{ hasSelection &&
-				<Toolbar>
-					<IconButton icon="editor-ol" onClick={ viewAll }>
-						View all Footnotes
-					</IconButton>
-					<Slot name="__unstable-footnote-controls" />
-				</Toolbar>
+				<>
+					<Toolbar>
+						<IconButton icon="editor-ol" onClick={ viewAll }>
+							View all Footnotes
+						</IconButton>
+						<Slot name="__unstable-footnote-controls" />
+					</Toolbar>
+					<BlockFormatControls.Slot />
+				</>
 			}
 			<ol>
 				{ footnotes.map( ( { id, text, isSelected }, index ) =>
@@ -70,7 +73,7 @@ function Edit( { attributes, setAttributes, className, setTimeout } ) {
 								↑
 							</a>
 							{ ' ' }
-							<RichText
+							<RichText.Bare
 								value={ text }
 								onChange={ ( value ) => {
 									setAttributes( {

--- a/packages/block-library/src/footnotes/edit.js
+++ b/packages/block-library/src/footnotes/edit.js
@@ -7,18 +7,49 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { IconButton, Toolbar } from '@wordpress/components';
+import { useRef } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { withSafeTimeout } from '@wordpress/compose';
 
-export default function Edit( { attributes, setAttributes, className } ) {
+function Edit( { attributes, setAttributes, className, setTimeout } ) {
 	const { footnotes } = attributes;
+	const ref = useRef( null );
+	const { clearSelectedBlock } = useDispatch( 'core/block-editor' );
 
 	if ( ! footnotes.length ) {
 		return null;
 	}
 
+	const hasSelection = footnotes.some( ( { isSelected } ) => isSelected );
+	const viewAll = () => {
+		ref.current.focus();
+		clearSelectedBlock();
+		// Wait for footnotes to be recalculated after the DOM change.
+		setTimeout( () =>
+			// Wait for DOM to update.
+			setTimeout( () => ref.current.scrollIntoView() )
+		);
+	};
+
 	return (
-		<div className={ classnames( 'wp-block block-library-list', className, {
-			'is-selected': footnotes.some( ( { isSelected } ) => isSelected ),
-		} ) }>
+		<div
+			className={ classnames( 'wp-block block-library-list', className, {
+				'is-selected': hasSelection,
+			} ) }
+			tabIndex="0"
+			ref={ ref }
+		>
+			{ hasSelection &&
+				<Toolbar>
+					<IconButton icon="editor-ol" onClick={ viewAll }>
+						View all Footnotes
+					</IconButton>
+					<IconButton icon="trash">
+						Remove Footnote
+					</IconButton>
+				</Toolbar>
+			}
 			<ol>
 				{ footnotes.map( ( { id, text, isSelected }, index ) =>
 					<li
@@ -63,3 +94,5 @@ export default function Edit( { attributes, setAttributes, className } ) {
 		</div>
 	);
 }
+
+export default withSafeTimeout( Edit );

--- a/packages/block-library/src/footnotes/edit.js
+++ b/packages/block-library/src/footnotes/edit.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import { __ } from '@wordpress/i18n';
 import { IconButton, Toolbar, Slot } from '@wordpress/components';
-import { useRef } from '@wordpress/element';
+import { useRef, useState } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { withSafeTimeout } from '@wordpress/compose';
 import { RichText, BlockFormatControls } from '@wordpress/block-editor';
@@ -17,6 +17,7 @@ function Edit( { attributes, setAttributes, className, setTimeout } ) {
 	const { footnotes } = attributes;
 	const ref = useRef( null );
 	const { clearSelectedBlock } = useDispatch( 'core/block-editor' );
+	const [ selected, select ] = useState( false );
 
 	if ( ! footnotes.length ) {
 		return null;
@@ -33,12 +34,23 @@ function Edit( { attributes, setAttributes, className, setTimeout } ) {
 		);
 	};
 
+	const onFocus = () => {
+		clearSelectedBlock();
+		select( true );
+	};
+
+	const onBlur = () => {
+		select( false );
+	};
+
 	return (
 		<div
 			className={ classnames( 'wp-block block-library-list', className, {
 				'is-selected': hasSelection,
 			} ) }
 			tabIndex="0"
+			onFocus={ onFocus }
+			onBlur={ onBlur }
 			ref={ ref }
 		>
 			{ hasSelection &&
@@ -49,7 +61,7 @@ function Edit( { attributes, setAttributes, className, setTimeout } ) {
 						</IconButton>
 						<Slot name="__unstable-footnote-controls" />
 					</Toolbar>
-					<BlockFormatControls.Slot />
+					{ selected && <BlockFormatControls.Slot /> }
 				</>
 			}
 			<ol>

--- a/packages/block-library/src/footnotes/edit.js
+++ b/packages/block-library/src/footnotes/edit.js
@@ -57,7 +57,7 @@ function Edit( { attributes, setAttributes, className, setTimeout } ) {
 				<>
 					<Toolbar>
 						<IconButton icon="editor-ol" onClick={ viewAll }>
-							__( 'View all Footnotes' )
+							{ __( 'View all Footnotes' ) }
 						</IconButton>
 						<Slot name="__unstable-footnote-controls" />
 					</Toolbar>

--- a/packages/block-library/src/footnotes/editor.scss
+++ b/packages/block-library/src/footnotes/editor.scss
@@ -47,13 +47,8 @@
 		}
 	}
 
-	input {
+	div[contenteditable] {
 		display: inline-block;
-		font-size: inherit;
-		border: none;
-		outline: none;
-		padding: 0;
-		margin: 0;
 		width: 95%;
 	}
 }

--- a/packages/block-library/src/footnotes/editor.scss
+++ b/packages/block-library/src/footnotes/editor.scss
@@ -10,7 +10,6 @@
 
 .editor-styles-wrapper .wp-block-footnotes {
 	margin: 0;
-	padding: 10px 10px 10px 40px;
 
 	&.is-selected {
 		background: #fff;

--- a/packages/block-library/src/footnotes/editor.scss
+++ b/packages/block-library/src/footnotes/editor.scss
@@ -47,8 +47,8 @@
 		}
 	}
 
-	div[contenteditable] {
-		display: inline-block;
-		width: 95%;
+	li > div > a {
+		float: left;
+		margin-right: 5px;
 	}
 }

--- a/packages/block-library/src/footnotes/editor.scss
+++ b/packages/block-library/src/footnotes/editor.scss
@@ -11,6 +11,11 @@
 .editor-styles-wrapper .wp-block-footnotes {
 	margin: 0;
 
+	.components-toolbar {
+		border: none;
+		padding: 10px;
+	}
+
 	&.is-selected {
 		background: #fff;
 		position: sticky;
@@ -21,6 +26,25 @@
 		animation-timing-function: ease;
 		box-shadow: -3px 0 0 0 #555d66;
 		margin: 0 1px;
+		border-top: 1px solid rgba(66, 88, 99, 0.4);
+
+		// Vertically center the single list item.
+		ol {
+			margin-top: 0;
+			margin-bottom: 0;
+			padding-bottom: 10px;
+		}
+
+		// We cannot use display as it will affect the numbering.
+		li {
+			visibility: hidden;
+			height: 0;
+		}
+
+		li.is-selected {
+			visibility: visible;
+			height: auto;
+		}
 	}
 
 	input {

--- a/packages/block-library/src/footnotes/editor.scss
+++ b/packages/block-library/src/footnotes/editor.scss
@@ -1,0 +1,36 @@
+@keyframes slide-in-note {
+	from {
+		transform: translateY(100%);
+	}
+
+	to {
+		transform: translateY(0);
+	}
+}
+
+.editor-styles-wrapper .wp-block-footnotes {
+	margin: 0;
+	padding: 10px 10px 10px 40px;
+
+	&.is-selected {
+		background: #fff;
+		position: sticky;
+		bottom: 0;
+		z-index: 1000;
+		animation-duration: 0.2s;
+		animation-name: slide-in-note;
+		animation-timing-function: ease;
+		box-shadow: -3px 0 0 0 #555d66;
+		margin: 0 1px;
+	}
+
+	input {
+		display: inline-block;
+		font-size: inherit;
+		border: none;
+		outline: none;
+		padding: 0;
+		margin: 0;
+		width: 95%;
+	}
+}

--- a/packages/block-library/src/footnotes/index.js
+++ b/packages/block-library/src/footnotes/index.js
@@ -1,0 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import save from './save';
+import edit from './edit';
+
+const { name } = metadata;
+
+export { metadata, name };
+
+export const settings = {
+	title: __( 'Footnotes' ),
+	supports: {
+		inserter: false,
+	},
+	save,
+	edit,
+};

--- a/packages/block-library/src/footnotes/save.js
+++ b/packages/block-library/src/footnotes/save.js
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export default function Save( { attributes } ) {
+	const { footnotes } = attributes;
+
+	if ( ! footnotes.length ) {
+		return null;
+	}
+
+	return (
+		<ol>
+			{ footnotes.map( ( { id, text } ) =>
+				<li key={ id }>
+					<a
+						id={ id }
+						href={ `#${ id }-anchor` }
+						aria-label={ __( 'Back to content' ) }
+					>
+						↑
+					</a>
+					{ ` ${ text }` }
+				</li>
+			) }
+		</ol>
+	);
+}

--- a/packages/block-library/src/footnotes/style.scss
+++ b/packages/block-library/src/footnotes/style.scss
@@ -1,0 +1,15 @@
+// Ideally, this should be the post wrapper element. So `.post` or similar.
+body {
+	counter-reset: footnotes;
+}
+
+.footnote-anchor {
+	counter-increment: footnotes;
+}
+
+.footnote-anchor::after {
+	margin-left: 2px;
+	content: "[" counter(footnotes) "]";
+	vertical-align: super;
+	font-size: smaller;
+}

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -32,6 +32,7 @@ import * as column from './column';
 import * as cover from './cover';
 import * as embed from './embed';
 import * as file from './file';
+import * as footnotes from './footnotes';
 import * as html from './html';
 import * as mediaText from './media-text';
 import * as navigationMenu from './navigation-menu';
@@ -115,6 +116,7 @@ export const registerCoreBlocks = () => {
 		...embed.common,
 		...embed.others,
 		file,
+		footnotes,
 		group,
 		window.wp && window.wp.oldEditor ? classic : null, // Only add the classic block in WP Context
 		html,

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -6,6 +6,7 @@
 @import "./cover/style.scss";
 @import "./embed/style.scss";
 @import "./file/style.scss";
+@import "./footnotes/style.scss";
 @import "./gallery/style.scss";
 @import "./image/style.scss";
 @import "./latest-comments/style.scss";

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -29,6 +29,7 @@ export const DEFAULT_CATEGORIES = [
 	{ slug: 'widgets', title: __( 'Widgets' ) },
 	{ slug: 'embed', title: __( 'Embeds' ) },
 	{ slug: 'reusable', title: __( 'Reusable Blocks' ) },
+	{ slug: 'footnotes', title: __( 'Footnotes' ) },
 ];
 
 /**

--- a/packages/e2e-tests/fixtures/block-transforms.js
+++ b/packages/e2e-tests/fixtures/block-transforms.js
@@ -150,6 +150,12 @@ export const EXPECTED_TRANSFORMS = {
 			'Group',
 		],
 	},
+	core__footnotes: {
+		originalBlock: 'Footnotes',
+		availableTransforms: [
+			'Group',
+		],
+	},
 	core__gallery: {
 		originalBlock: 'Gallery',
 		availableTransforms: [

--- a/packages/e2e-tests/fixtures/blocks/core__footnotes.html
+++ b/packages/e2e-tests/fixtures/blocks/core__footnotes.html
@@ -1,0 +1,3 @@
+<!-- wp:footnotes {"footnotes":[{"id":"0","text":"test"}]} -->
+<ol class="wp-block-footnotes"><li><a id="0" href="#0-anchor" aria-label="Back to content">↑</a> test</li></ol>
+<!-- /wp:footnotes -->

--- a/packages/e2e-tests/fixtures/blocks/core__footnotes.json
+++ b/packages/e2e-tests/fixtures/blocks/core__footnotes.json
@@ -1,0 +1,17 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/footnotes",
+        "isValid": true,
+        "attributes": {
+            "footnotes": [
+                {
+                    "id": "0",
+                    "text": "test"
+                }
+            ]
+        },
+        "innerBlocks": [],
+        "originalContent": "<ol class=\"wp-block-footnotes\"><li><a id=\"0\" href=\"#0-anchor\" aria-label=\"Back to content\">↑</a> test</li></ol>"
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__footnotes.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__footnotes.parsed.json
@@ -1,0 +1,27 @@
+[
+    {
+        "blockName": "core/footnotes",
+        "attrs": {
+            "footnotes": [
+                {
+                    "id": "0",
+                    "text": "test"
+                }
+            ]
+        },
+        "innerBlocks": [],
+        "innerHTML": "\n<ol class=\"wp-block-footnotes\"><li><a id=\"0\" href=\"#0-anchor\" aria-label=\"Back to content\">↑</a> test</li></ol>\n",
+        "innerContent": [
+            "\n<ol class=\"wp-block-footnotes\"><li><a id=\"0\" href=\"#0-anchor\" aria-label=\"Back to content\">↑</a> test</li></ol>\n"
+        ]
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__footnotes.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__footnotes.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:footnotes {"footnotes":[{"id":"0","text":"test"}]} -->
+<ol class="wp-block-footnotes"><li><a id="0" href="#0-anchor" aria-label="Back to content">↑</a> test</li></ol>
+<!-- /wp:footnotes -->

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -4,6 +4,7 @@
 import {
 	PostTitle,
 	VisualEditorGlobalKeyboardShortcuts,
+	Footnotes,
 } from '@wordpress/editor';
 import {
 	WritingFlow,
@@ -33,7 +34,9 @@ function VisualEditor() {
 					<ObserveTyping>
 						<CopyHandler>
 							<PostTitle />
-							<BlockList />
+							<BlockList>
+								<Footnotes />
+							</BlockList>
 						</CopyHandler>
 					</ObserveTyping>
 				</WritingFlow>

--- a/packages/editor/src/components/footnotes/edit.js
+++ b/packages/editor/src/components/footnotes/edit.js
@@ -39,7 +39,10 @@ class Edit extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		if ( this.props.contentRef === prevProps.contentRef ) {
+		if (
+			this.props.contentRef === prevProps.contentRef &&
+			this.props.selectionStart === prevProps.selectionStart
+		) {
 			return;
 		}
 
@@ -111,9 +114,11 @@ export default compose( [
 	withSafeTimeout,
 	withSelect( ( select ) => {
 		const { getEditorBlocks, getFootnotes } = select( 'core/editor' );
+		const { getSelectionStart } = select( 'core/block-editor' );
 		return {
 			contentRef: getEditorBlocks(),
 			footnotes: getFootnotes(),
+			selectionStart: getSelectionStart(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/editor/src/components/footnotes/edit.js
+++ b/packages/editor/src/components/footnotes/edit.js
@@ -59,9 +59,8 @@ class Edit extends Component {
 			const id = ( element.getAttribute( 'href' ) || '' ).slice( 1 );
 
 			if (
-				document.activeElement.isContentEditable &&
-				document.activeElement.contains( element ) &&
-				!! element.getAttribute( 'data-rich-text-format-boundary' )
+				element.getAttribute( 'data-rich-text-format-boundary' ) !== null &&
+				element.closest( '.is-selected[contenteditable="true"]' ) !== null
 			) {
 				selectedId = id;
 			}

--- a/packages/editor/src/components/footnotes/edit.js
+++ b/packages/editor/src/components/footnotes/edit.js
@@ -1,0 +1,124 @@
+/**
+ * External dependencies
+ */
+import { debounce } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import {
+	withSelect,
+	withDispatch,
+} from '@wordpress/data';
+import { compose, withSafeTimeout } from '@wordpress/compose';
+
+class Edit extends Component {
+	constructor() {
+		super( ...arguments );
+		this.updateList = this.updateList.bind( this );
+		this.debouncedUpdateList = debounce( this.updateList.bind( this ), 100 );
+		this.getAttributes = this.getAttributes.bind( this );
+		this.setAttributes = this.setAttributes.bind( this );
+		this.state = {
+			order: [],
+			selected: null,
+		};
+	}
+
+	componentDidMount() {
+		// Hack: need to wait for selection to be stored in editor store.
+		document.addEventListener( 'selectionchange', this.debouncedUpdateList );
+
+		// Wait for the DOM to update.
+		this.props.setTimeout( this.updateList );
+	}
+
+	componentWillUnmount() {
+		document.removeEventListener( 'selectionchange', this.debouncedUpdateList );
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( this.props.contentRef === prevProps.contentRef ) {
+			return;
+		}
+
+		// Wait for the DOM to update.
+		this.props.setTimeout( this.updateList );
+	}
+
+	updateList() {
+		const attributePart = this.props.blockType.name.replace( '/', '-' );
+		const attribute = `data-${ attributePart }-id`;
+
+		// This is much faster than having to serialize the blocks and search
+		// the HTML. Perhaps this should also be debounced.
+		const anchors = document.querySelectorAll( `[${ attribute }]` );
+		let selectedId;
+		const order = Array.from( anchors ).map( ( element ) => {
+			const id = ( element.getAttribute( 'href' ) || '' ).slice( 1 );
+
+			if (
+				document.activeElement.isContentEditable &&
+				document.activeElement.contains( element ) &&
+				!! element.getAttribute( 'data-rich-text-format-boundary' )
+			) {
+				selectedId = id;
+			}
+
+			return id;
+		} );
+
+		this.setState( { order, selectedId } );
+	}
+
+	getAttributes() {
+		const { footnotes } = this.props;
+		const { order, selectedId } = this.state;
+		return {
+			footnotes: order.map( ( id ) => {
+				const text = footnotes[ id ] || '';
+				const isSelected = selectedId === id;
+				return { id, text, isSelected };
+			} ),
+		};
+	}
+
+	setAttributes( { footnotes } ) {
+		const { updateFootnotes } = this.props;
+
+		updateFootnotes( footnotes.reduce( ( acc, footnote ) => {
+			return { ...acc, [ footnote.id ]: footnote.text };
+		}, {} ) );
+	}
+
+	render() {
+		if ( ! this.state.order.length ) {
+			return null;
+		}
+
+		const { edit: BlockEdit } = this.props.blockType;
+		return (
+			<BlockEdit
+				attributes={ this.getAttributes() }
+				setAttributes={ this.setAttributes }
+				className="wp-block-footnotes"
+			/>
+		);
+	}
+}
+
+export default compose( [
+	withSafeTimeout,
+	withSelect( ( select ) => {
+		const { getEditorBlocks, getFootnotes } = select( 'core/editor' );
+		return {
+			contentRef: getEditorBlocks(),
+			footnotes: getFootnotes(),
+		};
+	} ),
+	withDispatch( ( dispatch ) => {
+		const { updateFootnotes } = dispatch( 'core/editor' );
+		return { updateFootnotes };
+	} ),
+] )( Edit );

--- a/packages/editor/src/components/footnotes/edit.js
+++ b/packages/editor/src/components/footnotes/edit.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { debounce } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
@@ -17,7 +12,6 @@ class Edit extends Component {
 	constructor() {
 		super( ...arguments );
 		this.updateList = this.updateList.bind( this );
-		this.debouncedUpdateList = debounce( this.updateList.bind( this ), 100 );
 		this.getAttributes = this.getAttributes.bind( this );
 		this.setAttributes = this.setAttributes.bind( this );
 		this.state = {
@@ -27,15 +21,8 @@ class Edit extends Component {
 	}
 
 	componentDidMount() {
-		// Hack: need to wait for selection to be stored in editor store.
-		document.addEventListener( 'selectionchange', this.debouncedUpdateList );
-
 		// Wait for the DOM to update.
 		this.props.setTimeout( this.updateList );
-	}
-
-	componentWillUnmount() {
-		document.removeEventListener( 'selectionchange', this.debouncedUpdateList );
 	}
 
 	componentDidUpdate( prevProps ) {

--- a/packages/editor/src/components/footnotes/index.js
+++ b/packages/editor/src/components/footnotes/index.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+import { getBlockTypes } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import Edit from './edit';
+
+export default function Footnotes() {
+	return getBlockTypes()
+		.filter( ( { category } ) => category === 'footnotes' )
+		.map( ( blockType, index ) =>
+			<Edit key={ index } blockType={ blockType } />
+		);
+}

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -14,6 +14,7 @@ export { default as EditorHistoryRedo } from './editor-history/redo';
 export { default as EditorHistoryUndo } from './editor-history/undo';
 export { default as EditorNotices } from './editor-notices';
 export { default as ErrorBoundary } from './error-boundary';
+export { default as Footnotes } from './footnotes';
 export { default as PageAttributesCheck } from './page-attributes/check';
 export { default as PageAttributesOrder } from './page-attributes/order';
 export { default as PageAttributesParent } from './page-attributes/parent';

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -142,18 +142,34 @@ export const editor = flow( [
 ] )( {
 	// Track whether changes exist, resetting at each post save. Relies on
 	// editor initialization firing post reset as an effect.
-	blocks: withChangeDetection( {
-		resetTypes: [ 'SETUP_EDITOR_STATE', 'REQUEST_POST_UPDATE_START' ],
-	} )( ( state = { value: [] }, action ) => {
-		switch ( action.type ) {
-			case 'RESET_EDITOR_BLOCKS':
-				if ( action.blocks === state.value ) {
-					return state;
-				}
-				return { value: action.blocks };
-		}
+	blocks: flow( [
+		combineReducers,
+		withChangeDetection( {
+			resetTypes: [ 'SETUP_EDITOR_STATE', 'REQUEST_POST_UPDATE_START' ],
+		} ),
+	] )( {
+		value( state = [], action ) {
+			switch ( action.type ) {
+				case 'RESET_EDITOR_BLOCKS':
+					if ( action.blocks === state ) {
+						return state;
+					}
+					return action.blocks;
+			}
 
-		return state;
+			return state;
+		},
+		footnotes( state = {}, action ) {
+			switch ( action.type ) {
+				case 'UPDATE_FOOTNOTES':
+					if ( action.footnotes === state ) {
+						return state;
+					}
+					return action.footnotes;
+			}
+
+			return state;
+		},
 	} ),
 	edits( state = {}, action ) {
 		switch ( action.type ) {

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -665,6 +665,10 @@ describe( 'Editor actions', () => {
 			const { value } = fulfillment.next();
 			expect( value ).toEqual( actions.resetEditorBlocks( [] ) );
 		} );
+		it( 'should yield action object for updateFootnotes', () => {
+			const { value } = fulfillment.next();
+			expect( value ).toEqual( actions.updateFootnotes( {} ) );
+		} );
 		it( 'should yield action object for setupEditorState', () => {
 			const { value } = fulfillment.next();
 			expect( value ).toEqual(

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -1109,6 +1109,7 @@ describe( 'selectors', () => {
 					present: {
 						blocks: {
 							value: [],
+							footnotes: {},
 						},
 						edits: {},
 					},
@@ -1228,6 +1229,7 @@ describe( 'selectors', () => {
 									},
 								},
 							],
+							footnotes: {},
 						},
 						edits: {},
 					},
@@ -1483,6 +1485,7 @@ describe( 'selectors', () => {
 					present: {
 						blocks: {
 							value: [],
+							footnotes: {},
 						},
 						edits: {},
 					},
@@ -1535,6 +1538,7 @@ describe( 'selectors', () => {
 									modified: false,
 								},
 							} ],
+							footnotes: {},
 						},
 						edits: {},
 					},
@@ -1580,6 +1584,7 @@ describe( 'selectors', () => {
 					present: {
 						blocks: {
 							value: [],
+							footnotes: {},
 						},
 						edits: {},
 					},
@@ -1625,6 +1630,7 @@ describe( 'selectors', () => {
 									content: '',
 								},
 							} ],
+							footnotes: {},
 						},
 						edits: {},
 					},
@@ -1649,6 +1655,7 @@ describe( 'selectors', () => {
 									content: '',
 								},
 							} ],
+							footnotes: {},
 						},
 						edits: {},
 					},
@@ -1675,6 +1682,7 @@ describe( 'selectors', () => {
 									content: 'Test Data',
 								},
 							} ],
+							footnotes: {},
 						},
 						edits: {},
 					},
@@ -2133,6 +2141,7 @@ describe( 'selectors', () => {
 					present: {
 						blocks: {
 							value: [ block ],
+							footnotes: {},
 						},
 						edits: {},
 					},
@@ -2155,6 +2164,7 @@ describe( 'selectors', () => {
 					present: {
 						blocks: {
 							value: [ unknownBlock ],
+							footnotes: {},
 						},
 						edits: {},
 					},
@@ -2180,6 +2190,7 @@ describe( 'selectors', () => {
 					present: {
 						blocks: {
 							value: [ firstUnknown, secondUnknown ],
+							footnotes: {},
 						},
 						edits: {},
 					},
@@ -2200,6 +2211,7 @@ describe( 'selectors', () => {
 					present: {
 						blocks: {
 							value: [ defaultBlock ],
+							footnotes: {},
 						},
 						edits: {},
 					},
@@ -2226,6 +2238,7 @@ describe( 'selectors', () => {
 									modified: true,
 								},
 							} ],
+							footnotes: {},
 						},
 						edits: {},
 					},

--- a/packages/format-library/src/default-formats.js
+++ b/packages/format-library/src/default-formats.js
@@ -6,6 +6,7 @@ import { code } from './code';
 import { image } from './image';
 import { italic } from './italic';
 import { link } from './link';
+import { footnote } from './footnote';
 import { strikethrough } from './strikethrough';
 import { underline } from './underline';
 
@@ -15,6 +16,7 @@ export default [
 	image,
 	italic,
 	link,
+	footnote,
 	strikethrough,
 	underline,
 ];

--- a/packages/format-library/src/footnote/index.js
+++ b/packages/format-library/src/footnote/index.js
@@ -1,0 +1,84 @@
+/**
+ * External dependencies
+ */
+import uuid from 'uuid/v4';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { RichTextToolbarButton } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
+import {
+	removeFormat,
+	isCollapsed,
+	insertObject,
+	applyFormat,
+} from '@wordpress/rich-text';
+
+const name = 'core/footnote';
+const title = __( 'Footnote' );
+
+const addFootnote = ( value ) => {
+	// It does not matter what this is, as long as it is unique per page.
+	const id = uuid();
+	const format = {
+		type: name,
+		attributes: {
+			href: `#${ id }`,
+			id: `${ id }-anchor`,
+			'data-core-footnotes-id': id,
+		},
+	};
+
+	let newValue;
+
+	if ( isCollapsed( value ) ) {
+		const prevStart = value.start;
+		newValue = insertObject( value, format );
+		newValue.start = prevStart;
+	} else {
+		newValue = applyFormat( value, format );
+	}
+
+	return newValue;
+};
+
+function Edit( { value, onChange, isActive } ) {
+	const blockType = useSelect( ( select ) =>
+		select( 'core/blocks' ).getBlockType( 'core/footnotes' )
+	);
+
+	// Don't render any UI if the footnotes block is missing.
+	if ( ! blockType ) {
+		return null;
+	}
+
+	const add = () => {
+		onChange( addFootnote( value ) );
+	};
+	const remove = () => {
+		onChange( removeFormat( value, name ) );
+	};
+
+	return (
+		<RichTextToolbarButton
+			icon="editor-ol"
+			title={ title }
+			onClick={ isActive ? remove : add }
+			isActive={ isActive }
+		/>
+	);
+}
+
+export const footnote = {
+	name,
+	title,
+	tagName: 'a',
+	className: 'footnote-anchor',
+	attributes: {
+		href: 'href',
+		id: 'id',
+	},
+	edit: Edit,
+};

--- a/packages/format-library/src/footnote/index.js
+++ b/packages/format-library/src/footnote/index.js
@@ -15,6 +15,7 @@ import {
 	insertObject,
 	applyFormat,
 } from '@wordpress/rich-text';
+import { Fill, IconButton } from '@wordpress/components';
 
 const name = 'core/footnote';
 const title = __( 'Footnote' );
@@ -62,12 +63,19 @@ function Edit( { value, onChange, isActive } ) {
 	};
 
 	return (
-		<RichTextToolbarButton
-			icon="editor-ol"
-			title={ title }
-			onClick={ isActive ? remove : add }
-			isActive={ isActive }
-		/>
+		<>
+			<RichTextToolbarButton
+				icon="editor-ol"
+				title={ title }
+				onClick={ isActive ? remove : add }
+				isActive={ isActive }
+			/>
+			<Fill name="__unstable-footnote-controls">
+				<IconButton icon="trash" onClick={ remove }>
+					Remove Footnote
+				</IconButton>
+			</Fill>
+		</>
 	);
 }
 

--- a/packages/format-library/src/footnote/index.js
+++ b/packages/format-library/src/footnote/index.js
@@ -14,6 +14,8 @@ import {
 	isCollapsed,
 	insertObject,
 	applyFormat,
+	getActiveObject,
+	remove,
 } from '@wordpress/rich-text';
 import { Fill, IconButton } from '@wordpress/components';
 
@@ -45,6 +47,16 @@ const addFootnote = ( value ) => {
 	return newValue;
 };
 
+const removeFootnote = ( value ) => {
+	const activeObject = getActiveObject( value );
+
+	if ( activeObject && activeObject.type === name ) {
+		return remove( value );
+	}
+
+	return removeFormat( value, name );
+};
+
 function Edit( { value, onChange, isActive } ) {
 	const blockType = useSelect( ( select ) =>
 		select( 'core/blocks' ).getBlockType( 'core/footnotes' )
@@ -58,8 +70,8 @@ function Edit( { value, onChange, isActive } ) {
 	const add = () => {
 		onChange( addFootnote( value ) );
 	};
-	const remove = () => {
-		onChange( removeFormat( value, name ) );
+	const rm = () => {
+		onChange( removeFootnote( value ) );
 	};
 
 	return (
@@ -67,11 +79,11 @@ function Edit( { value, onChange, isActive } ) {
 			<RichTextToolbarButton
 				icon="editor-ol"
 				title={ title }
-				onClick={ isActive ? remove : add }
+				onClick={ isActive ? rm : add }
 				isActive={ isActive }
 			/>
 			<Fill name="__unstable-footnote-controls">
-				<IconButton icon="trash" onClick={ remove }>
+				<IconButton icon="trash" onClick={ rm }>
 					Remove Footnote
 				</IconButton>
 			</Fill>

--- a/packages/rich-text/src/component/format-edit.js
+++ b/packages/rich-text/src/component/format-edit.js
@@ -58,7 +58,10 @@ const FormatEdit = ( {
 		const activeFormat = getActiveFormat( value, name );
 		const isActive = activeFormat !== undefined;
 		const activeObject = getActiveObject( value );
-		const isObjectActive = activeObject !== undefined;
+		const isObjectActive = (
+			activeObject !== undefined &&
+			activeObject.type === name
+		);
 
 		return (
 			<Edit

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -105,7 +105,7 @@ class RichText extends Component {
 		this.valueToFormat = this.valueToFormat.bind( this );
 		this.setRef = this.setRef.bind( this );
 		this.valueToEditableHTML = this.valueToEditableHTML.bind( this );
-		this.onPointerDown = this.onPointerDown.bind( this );
+		this.maybeSelectObject = this.maybeSelectObject.bind( this );
 		this.formatToValue = this.formatToValue.bind( this );
 		this.Editable = this.Editable.bind( this );
 
@@ -267,8 +267,10 @@ class RichText extends Component {
 	 * @see setFocusedElement
 	 *
 	 * @private
+	 *
+	 * @param {SyntheticEvent} event Synthetic focus event.
 	 */
-	onFocus() {
+	onFocus( event ) {
 		const { unstableOnFocus } = this.props;
 
 		if ( unstableOnFocus ) {
@@ -298,6 +300,8 @@ class RichText extends Component {
 		this.rafId = window.requestAnimationFrame( this.onSelectionChange );
 
 		document.addEventListener( 'selectionchange', this.onSelectionChange );
+
+		this.maybeSelectObject( event );
 	}
 
 	onBlur() {
@@ -724,13 +728,16 @@ class RichText extends Component {
 	 * Select object when they are clicked. The browser will not set any
 	 * selection when clicking e.g. an image.
 	 *
-	 * @param  {SyntheticEvent} event Synthetic mousedown or touchstart event.
+	 * @param  {SyntheticEvent} event Synthetic event.
 	 */
-	onPointerDown( event ) {
-		const { target } = event;
+	maybeSelectObject( event ) {
+		const { target, type } = event;
 
-		// If the child element has no text content, it must be an object.
-		if ( target === this.editableRef || target.textContent ) {
+		if ( target === this.editableRef ) {
+			return;
+		}
+
+		if ( type !== 'focus' && target.textContent ) {
 			return;
 		}
 
@@ -744,6 +751,8 @@ class RichText extends Component {
 
 		selection.removeAllRanges();
 		selection.addRange( range );
+
+		event.preventDefault();
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -915,8 +924,7 @@ class RichText extends Component {
 				onKeyDown={ this.onKeyDown }
 				onFocus={ this.onFocus }
 				onBlur={ this.onBlur }
-				onMouseDown={ this.onPointerDown }
-				onTouchStart={ this.onPointerDown }
+				onClick={ this.maybeSelectObject }
 				setRef={ this.setRef }
 				// Selection updates must be done at these events as they
 				// happen before the `selectionchange` event. In some cases,

--- a/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
+++ b/packages/rich-text/src/test/__snapshots__/to-dom.js.snap
@@ -38,6 +38,7 @@ exports[`recordToDom should create a value with image object 1`] = `
 <body>
   
   <img
+    data-rich-text-format-boundary="true"
     src=""
   />
   
@@ -51,6 +52,7 @@ exports[`recordToDom should create a value with image object and formatting 1`] 
   >
     
     <img
+      data-rich-text-format-boundary="true"
       src=""
     />
     
@@ -66,6 +68,7 @@ exports[`recordToDom should create a value with image object and text after 1`] 
   >
     
     <img
+      data-rich-text-format-boundary="true"
       src=""
     />
     te

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -287,6 +287,11 @@ export function applySelection( { startPath, endPath }, current ) {
 		// If the to be added range and the live range are the same, there's no
 		// need to remove the live range and add the equivalent range.
 		if ( isRangeEqual( range, selection.getRangeAt( 0 ) ) ) {
+			// Set back focus if focus is lost.
+			if ( ownerDocument.activeElement !== current ) {
+				current.focus();
+			}
+
 			return;
 		}
 

--- a/packages/rich-text/src/to-html-string.js
+++ b/packages/rich-text/src/to-html-string.js
@@ -86,7 +86,7 @@ function remove( object ) {
 	return object;
 }
 
-function createElementHTML( { type, attributes, object, children } ) {
+function createElementHTML( { type, attributes, selfClosing, children } ) {
 	let attributeString = '';
 
 	for ( const key in attributes ) {
@@ -97,7 +97,7 @@ function createElementHTML( { type, attributes, object, children } ) {
 		attributeString += ` ${ key }="${ escapeAttribute( attributes[ key ] ) }"`;
 	}
 
-	if ( object ) {
+	if ( selfClosing ) {
 		return `<${ type }${ attributeString }>`;
 	}
 

--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -26,7 +26,7 @@ import {
  * @return {Object}                            Information to be used for
  *                                             element creation.
  */
-function fromFormat( { type, attributes, unregisteredAttributes, object, boundaryClass } ) {
+function fromFormat( { type, attributes, unregisteredAttributes, object, boundaryClass, isEditableTree } ) {
 	const formatType = getFormatType( type );
 
 	let elementAttributes = {};
@@ -40,12 +40,18 @@ function fromFormat( { type, attributes, unregisteredAttributes, object, boundar
 			elementAttributes = { ...attributes, ...elementAttributes };
 		}
 
-		return { type, attributes: elementAttributes, object };
+		return { type, attributes: elementAttributes, selfClosing: object };
 	}
 
 	elementAttributes = { ...unregisteredAttributes, ...elementAttributes };
 
 	for ( const name in attributes ) {
+		const value = attributes[ name ];
+
+		if ( value === undefined ) {
+			continue;
+		}
+
 		const key = formatType.attributes ? formatType.attributes[ name ] : false;
 
 		if ( key ) {
@@ -53,6 +59,10 @@ function fromFormat( { type, attributes, unregisteredAttributes, object, boundar
 		} else {
 			elementAttributes[ name ] = attributes[ name ];
 		}
+	}
+
+	if ( isEditableTree && object && ! formatType.object ) {
+		elementAttributes.contenteditable = 'false';
 	}
 
 	if ( formatType.className ) {
@@ -65,7 +75,7 @@ function fromFormat( { type, attributes, unregisteredAttributes, object, boundar
 
 	return {
 		type: formatType.tagName,
-		object: formatType.object,
+		selfClosing: formatType.object,
 		attributes: elementAttributes,
 	};
 }
@@ -219,7 +229,9 @@ export function toTree( {
 		if ( character === OBJECT_REPLACEMENT_CHARACTER ) {
 			pointer = append( getParent( pointer ), fromFormat( {
 				...replacements[ i ],
+				isEditableTree,
 				object: true,
+				boundaryClass: isEditableTree && start === i,
 			} ) );
 			// Ensure pointer is text node.
 			pointer = append( getParent( pointer ), '' );
@@ -229,7 +241,7 @@ export function toTree( {
 				attributes: isEditableTree ? {
 					'data-rich-text-line-break': 'true',
 				} : undefined,
-				object: true,
+				selfClosing: true,
 			} );
 			// Ensure pointer is text node.
 			pointer = append( getParent( pointer ), '' );


### PR DESCRIPTION
## Description

Fixes #1890.
Blocked by #16428.

![notes](https://user-images.githubusercontent.com/4710635/62622806-8f406e80-b91f-11e9-9574-1be7a7f01bd4.gif)

Front end:

<img width="671" alt="Screenshot 2019-08-07 at 14 31 11" src="https://user-images.githubusercontent.com/4710635/62623000-0a098980-b920-11e9-8536-ef92a81c7196.png">

Notes are not a trivial thing to implement, but they are commonly used, even customary in a lot of fields. I think it’s important that core adds support for them. Adding support for footnotes will also the door for adding comments. They are basically the same thing, just styled differently and only displayed in the editor.

### Positioning

There are three possible ways to position footnotes:

* Endnotes: list at the end of a page.
* In the page margin (possible to do in JS).
* In a popover on hover/click (possible to do in JS and perhaps CSS as well).

“Footnotes” don’t really make sense in the context of a web page, so let's call them "notes".

The first is probably the most common way in print, but the latter seems to become more popular on the web.

It’s worth noting that even though the author may not want to display the notes at the end of the page, the markup should still be there so it can be printed and indexed correctly.

### Markup

There is no standard way to create notes in HTML. Ideally they should have as little markup as possible, so it’s clear, compact and sensible when editing the HTML directly.

There are two parts:

* The note anchor.
* The note list.

The note anchor should obviously be an `a` element and link to the relevant list item. But what should be linked? What should the text be? Any other markup?

A very common thing to do is to “hardcode” the numbering, but that seems too hard to maintain, both manually and programatically. In addition it may depend on the language, script, and convention. The numbering should be added in CSS. Numbering is just a stylistic choice when using endnotes.

Another common thing is to use `sup`, which seems to just be used for convenience. Again, notes might be styled differently depending on your taste, field of work, or language. We should not force a certain style. The markup should be flexible enough to work in a variety of cases.

Notes were originally implemented for print. They where not explicitly linked. Linking is a thing of the web, and we should take it to our advantage as much as possible. E.g. the numbering matters less because of the bidirectional linking. We can also explicitly link the exact text the author wants to reference comment on. If you want to style it differently, fine. You could choose to add a number with CSS `:after`, in any style you like.

This whole idea to only link text starts crumbling down for two reasons though:

* It’s not possible to link anything inside the text you’re commenting on.
* It’s not possible to have multiple references.

So I made it so that you can both link selections of text or insert a reference mark if there is no selection. I do like linked text much more as it’s more explicit than a reference mark, but as said before, it has limitations.

Finally, an `ol` element for the note list makes sense to me to automate the numbering. Inside every list item, a back link should be added that can bring you back to the anchor. Here again, there are different styles: adding it before or after the note. It has never been a thing in print, and there is no standard. Also different characters are used for it. Common ones are ↵ and ↑. In any case, the anchor seems to be in need of an `aria-label`, which should be translatable.

I’m a bit torn on what to do here. We could either save the list in the post content, or dynamically add it to PHP.

I do see the list as derived data, so in that regard it doesn’t make sense to me to store it in the post content. In addition some parts need translation.

But I also see the list as a fallback mechanism if the theme doesn’t have any logic to position them elsewhere. I also don’t really see much of a problem with the list _not_ being dynamically added. Once the post is written and published, it shouldn’t change anyway.

My suggestion is:

```html
<!-- Note for uncollapsed selection -->
Hello <a id="{ id }-anchor" class="note-anchor" href="#{ id }" aria-labelledby="note">world</a>.

<!-- Note for collapsed selection -->
Hello world<a id="{ id }-anchor" class="note-anchor" href="#{ id }" aria-labelledby="note"></a>.

[…]

<!-- Add dynamically or to post content? -->

<footer>
	<h2 id="notes">Notes</h2>
	<ol>
		<li><a id="{ id }" href="#{ id }-anchor" aria-label="?">↑</a> A note about the world.</li>
	</ol>
</footer>
```

<!-- ### Data

The footnote text will be stored in a link attribute. This makes the most sense to me. This way it’s stored right where the link is, which makes it easier to manage changes after moving notes, blocks, etc. The list at the bottom of the page is derived data from the post content.

-->

### First Version

* I decided not to make the note list at the bottom editable for now, but each note _is_ linked to the source where it can be edited. We could add this enhancement in the future if there is demand.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->