### PR TITLE
Update i18n docs to use make-json command from wp-cli

### DIFF
--- a/docs/designers-developers/developers/internationalization.md
+++ b/docs/designers-developers/developers/internationalization.md
@@ -176,31 +176,32 @@ msgid "Hello World"
 msgstr "Saltuon mundo"
 ```
 
-The last step to create the translation file is to convert the `myguten-eo.po` to the JSON format needed. For this, you can use the [po2json utility](https://github.com/mikeedwards/po2json) which you install using npm. It might be easiest to install globally using: `npm install -g po2json`. Once installed, use the following command to convert to JED format:
+The last step to create the translation file is to convert the `myguten-eo.po` to the JSON format needed. For this, you can use the wp-cli [make-json command](https://developer.wordpress.org/cli/commands/i18n/make-json/), requires wp-cli v2.2.0 and later.
 
 ```
-po2json myguten-eo.po myguten-eo.json -f jed
+wp i18n make-json myguten-eo.po --no-purge
 ```
 
-This will generate the JSON file `myguten-eo.json` which looks like:
+This will generate the JSON file `myguten-eo-[md5].json` with the contents:
 
 ```json
 {
+  "translation-revision-date": "2019-04-26T13:30:11-07:00",
+  "generator": "WP-CLI/2.2.0",
+  "source": "block.js",
   "domain": "messages",
   "locale_data": {
     "messages": {
       "": {
         "domain": "messages",
-        "lang": "eo"
+        "lang": "eo",
+        "plural-forms": "nplurals=2; plural=(n != 1);"
       },
-      "Scratch Plugin": [
-        "Scratch kromprogrameto"
-      ],
       "Simple Block": [
-        "Simpla bloko"
+        "Simpla Bloko"
       ],
       "Hello World": [
-        "Saltuon mundo"
+        "Salunton mondo"
       ]
     }
   }
@@ -222,7 +223,7 @@ The final part is to tell WordPress where it can look to find the translation fi
 
 WordPress will check for a file in that path with the format `${domain}-${locale}-${handle}.json` as the source of translations. Alternatively, instead of the registered handle you can use the md5 hash of the relative path of the file, `${domain}-${locale} in the form of ${domain}-${locale}-${md5}.json.`
 
-This example uses the handle, rename the `myguten-eo.json` file to `myguten-eo-myguten-script.json`.
+Using `make-json` automatically names the file with the md5 hash, so it is ready as-is. You could rename to use the handle, in this case would be `myguten-eo-myguten-script.json`.
 
 ### Test Translations
 

--- a/docs/designers-developers/developers/internationalization.md
+++ b/docs/designers-developers/developers/internationalization.md
@@ -176,7 +176,7 @@ msgid "Hello World"
 msgstr "Saltuon mundo"
 ```
 
-The last step to create the translation file is to convert the `myguten-eo.po` to the JSON format needed. For this, you can use the wp-cli [make-json command](https://developer.wordpress.org/cli/commands/i18n/make-json/), requires wp-cli v2.2.0 and later.
+The last step to create the translation file is to convert the `myguten-eo.po` to the JSON format needed. For this, you can use WP-CLI's [`wp i18n make-json` command](https://developer.wordpress.org/cli/commands/i18n/make-json/), which requires WP-CLI v2.2.0 and later.
 
 ```
 wp i18n make-json myguten-eo.po --no-purge
@@ -223,7 +223,7 @@ The final part is to tell WordPress where it can look to find the translation fi
 
 WordPress will check for a file in that path with the format `${domain}-${locale}-${handle}.json` as the source of translations. Alternatively, instead of the registered handle you can use the md5 hash of the relative path of the file, `${domain}-${locale} in the form of ${domain}-${locale}-${md5}.json.`
 
-Using `make-json` automatically names the file with the md5 hash, so it is ready as-is. You could rename to use the handle, in this case would be `myguten-eo-myguten-script.json`.
+Using `make-json` automatically names the file with the md5 hash, so it is ready as-is. You could rename the file to use the handle instead, in which case the file name would be `myguten-eo-myguten-script.json`.
 
 ### Test Translations
 


### PR DESCRIPTION
## Description

Updates the Internationalization documentation recommending to use the wp-cli make-json command to generate the necessary json file needed for translations.

This replaces the instructions to use the npm po2json module, it is simpler for a user to use only the wp-cli tool which is also used earlier in the documentation for creating the pot files.

There was a bug fixed in wp-cli https://github.com/wp-cli/i18n-command/issues/146

Fixes #14093


## How has this been tested?

Follow instructions in documentation to confirm JSON file is created and translations work.


## Types of changes

Documentation.
