### PR TITLE
Fixes #15032. Allows field to expand with text.

### DIFF
--- a/packages/block-library/src/shortcode/editor.scss
+++ b/packages/block-library/src/shortcode/editor.scss
@@ -17,6 +17,7 @@
 
 	.block-editor-plain-text {
 		width: 80%;
+		max-height: 250px;
 	}
 
 	.dashicon {

--- a/packages/block-library/src/shortcode/editor.scss
+++ b/packages/block-library/src/shortcode/editor.scss
@@ -16,9 +16,6 @@
 	}
 
 	.block-editor-plain-text {
-		flex-grow: 1;
-		line-height: 1;
-		max-height: 30px;
 		width: 80%;
 	}
 


### PR DESCRIPTION
This fixes #15032. 
Allowing the Shortcode block field to grow with the text.

## How has this been tested?
Tested locally.

## Screenshots

**Without text**

<img width="568" alt="Screen Shot 2019-04-30 at 10 31 15 PM" src="https://user-images.githubusercontent.com/617986/57006715-cfad8500-6b97-11e9-96e8-698290fe8499.png">

**With text**

<img width="575" alt="Screen Shot 2019-04-30 at 10 31 50 PM" src="https://user-images.githubusercontent.com/617986/57006719-d936ed00-6b97-11e9-80ea-1e34b03a56e7.png">
