### PR TITLE
iOS: Remove p tags from image caption paragraphs

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -444,6 +444,7 @@ class ImageEdit extends React.Component {
 								setRef={ ( ref ) => {
 									this._caption = ref;
 								} }
+								rootTagsToEliminate={ [ 'p' ] }
 								placeholder={ __( 'Write caption…' ) }
 								value={ caption }
 								onChange={ ( newCaption ) => setAttributes( { caption: newCaption } ) }


### PR DESCRIPTION
This PR uses the already existing `rootTagsToEliminate` on RichText to remove the enclosing `p` tags for paragraphs in the iOS image caption field.

Gutenberg mobile side PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/945

![IMG_1669](https://user-images.githubusercontent.com/9772967/57010641-08804500-6bfe-11e9-854b-aad980f653cd.PNG)

```html
<!-- wp:image -->
<figure class="wp-block-image">
<img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/>
  <figcaption>Hello<br>World</figcaption>
</figure>
<!-- /wp:image -->
```

**To test iOS:**
- Run the example app.
- Select the image block with image.
- Write a caption and add multiple paragraphs (with enter).
- Switch to HTML mode.
- Check that the caption content has `br` for each new line and no `p` tags.

@mchowning could you also check that this doesn't break Android caption field?
Thank you! 🙏 