### PR TITLE
Prevent stray line breaks in RichText after pasting (e.g., from Google Doc)

### DIFF
--- a/packages/blocks/src/api/raw-handling/test/utils.js
+++ b/packages/blocks/src/api/raw-handling/test/utils.js
@@ -175,8 +175,20 @@ describe( 'removeInvalidHTML', () => {
 		expect( removeInvalidHTML( input, schema ) ).toBe( output );
 	} );
 
+	it( 'should remove comment nodes', () => {
+		const input = '<!-- This is a comment -->';
+		const output = '';
+		expect( removeInvalidHTML( input, schema ) ).toBe( output );
+	} );
+
 	it( 'should break up block content with phrasing schema', () => {
 		const input = '<p>test</p><p>test</p>';
+		const output = 'test<br>test';
+		expect( removeInvalidHTML( input, phrasingContentSchema, true ) ).toBe( output );
+	} );
+
+	it( 'should ignore comment nodes when breaking up block content', () => {
+		const input = '<!-- Comment 1 --><p>test</p><!-- Comment 2 --><p>test</p><!-- Comment 3 -->';
 		const output = 'test<br>test';
 		expect( removeInvalidHTML( input, phrasingContentSchema, true ) ).toBe( output );
 	} );

--- a/packages/blocks/src/api/raw-handling/utils.js
+++ b/packages/blocks/src/api/raw-handling/utils.js
@@ -17,7 +17,7 @@ import { isPhrasingContent } from './phrasing-content';
 /**
  * Browser dependencies
  */
-const { ELEMENT_NODE, TEXT_NODE } = window.Node;
+const { COMMENT_NODE, ELEMENT_NODE, TEXT_NODE } = window.Node;
 
 /**
  * Given raw transforms from blocks, merges all schemas into one.
@@ -275,8 +275,8 @@ function cleanNodeList( nodeList, doc, schema, inline ) {
 			cleanNodeList( node.childNodes, doc, schema, inline );
 
 			// For inline mode, insert a line break when unwrapping nodes that
-			// are not phrasing content.
-			if ( inline && ! isPhrasingContent( node ) && node.nextElementSibling ) {
+			// are not phrasing content and no comments.
+			if ( inline && node.nodeType !== COMMENT_NODE && ! isPhrasingContent( node ) && node.nextElementSibling ) {
 				insertAfter( doc.createElement( 'br' ), node );
 			}
 


### PR DESCRIPTION
## Description
When pasting something from a Google Doc into a `RichText`-based block, I ended up having a stray (leading) line break.

Having chased through quite a few files and functions, I finally found that the culprit is the (internal) `cleanNodeList` function in `@wordpress/blocks` (`src/api/raw-handling/utils.js`).
This function inserts a line break ( i.e., ultimately, a `<br>` tag) after non-phrasing-content elements.

The problem with Google Docs, as with potential other sources, is that there are HTML comments, and they, too, would trigger insertion of line breaks.

### Steps to Reproduce

1. Create a Google Doc and input some content, for example, this:.

```
Some

Content

Here
```

2. Select "Content", copy and paste into a `RichText` component.
3. The console will show something like that:

```
Received HTML:

 <html><body>
<!--StartFragment--><meta charset="utf-8"><span style="font-size:11pt;font-family:Arial;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;" id="docs-internal-guid-27e8f390-7fff-ad20-17df-378c134770be">Content</span><!--EndFragment-->
</body>
</html>
Received plain text:

 Content
Processed inline HTML:

 
<br>Content
```

The actual problem is the `<!--StartFragment-->` comment node.

## How has this been tested?
Copy-and-paste content from a Google Doc into a `RichText` component. No leading line break. 😉

## Screenshots

![gdoc-gutenberg](https://user-images.githubusercontent.com/6049306/57016585-18f2e880-6c1b-11e9-84a4-e1041bd9d602.png)

## Types of changes
Insertion of line breaks after comment nodes is now being prevented.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
