### PR TITLE
Add check for author in post data before submission

### DIFF
--- a/packages/edit-post/src/store/effects.js
+++ b/packages/edit-post/src/store/effects.js
@@ -87,7 +87,7 @@ const effects = {
 			post.comment_status ? [ 'comment_status', post.comment_status ] : false,
 			post.ping_status ? [ 'ping_status', post.ping_status ] : false,
 			post.sticky ? [ 'sticky', post.sticky ] : false,
-			[ 'post_author', post.author ],
+			post.author ? [ 'post_author', post.author ] : false,
 		].filter( Boolean );
 
 		// We gather all the metaboxes locations data and the base form data


### PR DESCRIPTION
## Description

Previously, the submission code on the Post Edit page assumed that the Post data from the REST API contained a `post_author` field. But this is not the case for CPT's that do not include `author` in their `supports` array. This PR only includes the author in the submission if the field exists.

A real-world example of this causing a bug is here: https://github.com/Automattic/sensei/issues/2525

## How has this been tested?

To reproduce the bug on `master`, add the following code snippet to a site:

```php
add_action( 'init', function() {
	$args = array(
		'labels'       => [ 'name' => 'Books', 'singular_name' => 'Book' ],
		'public'       => true,
		'supports'     => [ 'title', 'editor', 'excerpt', 'thumbnail', 'revisions' ],
		'show_in_rest' => true,
	);
	
	register_post_type( 'book', $args );
} );

function book_metabox_content() {
	echo 'This is a metabox for Books';
}

add_action( 'add_meta_boxes', function() {
	add_meta_box( 'book-meta', 'Book Meta', 'book_metabox_content', 'book', 'side', 'default' );
} );
```

Then log in as a user with the `author` role and try to create/update a Book, while watching the Network tab of the developer console. You should see a `500` error in the request to update the metaboxes, and the progress indicator on the page will show indefinitely.

Switching to this branch should cause the request to succeed.

## More details

Before this PR, in the case described above, the JS code would send a value of `undefined` in the `post_author` field when submitting the metabox data. In WordPress, this would be converted to `0` [here](https://github.com/WordPress/WordPress/blob/18267e68232aa342ad5ac6a15da076831f0cf547/wp-admin/includes/post.php#L68) and then cause an error condition [here](https://github.com/WordPress/WordPress/blob/18267e68232aa342ad5ac6a15da076831f0cf547/wp-admin/includes/post.php#L74).

With the change in this PR, the condition [here](https://github.com/WordPress/WordPress/blob/18267e68232aa342ad5ac6a15da076831f0cf547/wp-admin/includes/post.php#L70) is run instead, which fixes the bug.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
