### PR TITLE
Make editor UI elements immutable to outside styles

### DIFF
--- a/bin/packages/postcss-specificity.js
+++ b/bin/packages/postcss-specificity.js
@@ -1,0 +1,54 @@
+const postcss = require( 'postcss' );
+
+module.exports = postcss.plugin( 'postcss-specificity', ( options ) => {
+	const defaults = {
+
+		// The wrapping selector we're working within.
+		scopeTo: ':root',
+
+		// Increase specificity by repeating the selector.
+		repeat: 1,
+
+		remove: [],
+
+		replace: [],
+
+		ignore: [],
+	};
+
+	const opts = { ...defaults, ...options };
+
+	return ( root ) => {
+		root.walkRules( ( rule ) => {
+			rule.selectors = rule.selectors.map( ( selector ) => {
+				// Get rid of the remove selectors.
+				if ( -1 !== opts.remove.indexOf( selector ) ) {
+					return rule.remove();
+				}
+
+				// Replace the replace selector with scopeTo.
+				if ( -1 !== opts.replace.indexOf( selector ) ) {
+					return opts.scopeTo.repeat( opts.repeat );
+				}
+
+				// Skip the ignored selectors.
+				if ( -1 !== opts.ignore.indexOf( selector ) ) {
+					return selector;
+				}
+
+				// Ignore descendant rules of @keyframes {}.
+				if ( rule.parent.type === 'atrule' && rule.parent.name === 'keyframes' ) {
+					return selector;
+				}
+
+				// If its the scopeTo selector already, re-add with repeats.
+				if ( -1 !== selector.indexOf( opts.scopeTo ) ) {
+					return opts.scopeTo.repeat( opts.repeat );
+				}
+
+				// For anything else add the scopeTo before the selector.
+				return `${ opts.scopeTo.repeat( opts.repeat ) } ${ selector }`;
+			} );
+		} );
+	};
+} );

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -34,13 +34,23 @@
 @import "./verse/editor.scss";
 @import "./video/editor.scss";
 
-
 /**
  * Editor Normalization Styles
  *
  * These are only output in the editor, but styles here are NOT prefixed .editor-styles-wrapper.
  * This allows us to create normalization styles that are easily overridden by editor styles.
  */
+
+// Reset class selectors that are used on HTML elements.
+// Raise the specificity to keep theme styles from overriding.
+// Specificity = 030.
+:root .editor-styles-wrapper .dashicon,
+:root .editor-styles-wrapper .components-button,
+:root .editor-styles-wrapper .components-dropdown-menu__indicator,
+:root .editor-styles-wrapper .block-editor-block-icon {
+	all: unset;
+	box-sizing: inherit;
+}
 
 // Provide every block with a default base margin. This margin provides a consistent spacing
 // between blocks in the editor.

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -44,6 +44,8 @@
 // Reset class selectors that are used on HTML elements.
 // Raise the specificity to keep theme styles from overriding.
 // Specificity = 030.
+:root .editor-styles-wrapper .components-tab-button,
+:root .editor-styles-wrapper .block-editor-url-input > input,
 :root .editor-styles-wrapper .dashicon,
 :root .editor-styles-wrapper .components-button,
 :root .editor-styles-wrapper .components-dropdown-menu__indicator,
@@ -57,4 +59,38 @@
 [data-block] {
 	margin-top: $default-block-margin;
 	margin-bottom: $default-block-margin;
+}
+
+// block-library styles
+:root:root:root .block-library-gallery-item__inline-menu .components-button {
+	color: #fff;
+}
+
+:root:root:root .blocks-gallery-item__remove {
+	padding: 0;
+}
+
+:root:root:root .blocks-gallery-item .block-editor-rich-text {
+	position: absolute;
+}
+
+:root:root:root .wp-block-cover .block-editor-block-list__block {
+	color: #f8f9f9;
+}
+
+:root:root:root .components-tab-button {
+	display: inline-flex;
+	align-items: flex-end;
+	margin: 0;
+	padding: 3px;
+	background: none;
+	outline: none;
+	color: #555d66;
+	cursor: pointer;
+	position: relative;
+	height: 36px;
+	font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
+	font-size: 13px;
+	font-weight: 500;
+	border: 0;
 }

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -63,22 +63,83 @@
 }
 
 // block-library styles. This isn't a good place for this and should be temporary.
+
+// packages/block-library/src/gallery/editor.scss
+:root:root:root .blocks-gallery-item {
+	// Hide the focus outline that otherwise briefly appears when selecting a block.
+	figure:not(.is-selected):focus {
+		outline: none;
+	}
+
+	.is-selected {
+		outline: 4px solid theme(primary);
+	}
+
+	.is-transient img {
+		opacity: 0.3;
+	}
+
+	.block-editor-rich-text {
+		position: absolute;
+		bottom: 0;
+		width: 100%;
+		max-height: 100%;
+		overflow-y: auto;
+	}
+
+	.block-editor-rich-text figcaption:not([data-is-placeholder-visible="true"]) {
+		position: relative;
+		overflow: hidden;
+	}
+
+	.is-selected .block-editor-rich-text {
+		// IE calculates this incorrectly, so leave it to modern browsers.
+		@supports (position: sticky) {
+			right: 0;
+			left: 0;
+			margin-top: -4px;
+		}
+
+		// Override negative margins so this toolbar isn't hidden by overflow. Overflow is needed for long captions.
+		.block-editor-rich-text__inline-toolbar {
+			top: 0;
+		}
+
+		// Make extra space for the inline toolbar.
+		figcaption {
+			padding-top: 48px;
+		}
+	}
+
+	.block-editor-rich-text figcaption {
+		a {
+			color: $white;
+		}
+	}
+}
+
 :root:root:root .block-library-gallery-item__inline-menu .components-button {
-	color: #fff;
+	color: $white;
+	&:hover,
+	&:focus {
+		color: $white;
+	}
 }
 
 :root:root:root .blocks-gallery-item__remove {
 	padding: 0;
+
+	&.components-button:focus {
+		color: inherit;
+	}
 }
 
-:root:root:root .blocks-gallery-item .block-editor-rich-text {
-	position: absolute;
-}
-
+// packages/block-library/src/cover/editor.scss
 :root:root:root .wp-block-cover .block-editor-block-list__block {
-	color: #f8f9f9;
+	color: $light-gray-100;
 }
 
+// packages/block-library/src/code/editor.scss
 :root:root:root .components-tab-button {
 	display: inline-flex;
 	align-items: flex-end;
@@ -86,34 +147,107 @@
 	padding: 3px;
 	background: none;
 	outline: none;
-	color: #555d66;
+	color: $dark-gray-500;
 	cursor: pointer;
 	position: relative;
-	height: 36px;
-	font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
-	font-size: 13px;
+	height: $icon-button-size;
+	font-family: $default-font;
+	font-size: $default-font-size;
 	font-weight: 500;
 	border: 0;
+
+	&.is-active,
+	&.is-active:hover {
+		color: $white;
+	}
+
+	&:disabled {
+		cursor: default;
+	}
+
+	& > span {
+		border: $border-width solid transparent;
+		padding: 0 6px;
+		box-sizing: content-box;
+		height: 28px;
+		line-height: 28px;
+	}
+
+	&:hover > span,
+	&:focus > span {
+		color: $dark-gray-500;
+	}
+
+	&:not(:disabled) {
+		&.is-active > span,
+		&:hover > span,
+		&:focus > span {
+			border: $border-width solid $dark-gray-500;
+		}
+	}
+
+	&.is-active > span,
+	&.is-active:hover > span {
+		background-color: $dark-gray-500;
+		color: $white;
+	}
 }
 
+// packages/block-library/src/image/editor.scss
+// Ensure the resize handles are visible when the image is focused.
 :root:root:root .wp-block-image.is-focused .components-resizable-box__handle {
 	display: block;
-	z-index: 1;
+	z-index: z-index(".block-library-image__resize-handlers");
 }
 
-:root:root:root .block-library-button__inline-link .dashicon {
-	color: #8f98a1;
-}
-
+// packages/block-library/src/button/editor.scss
 :root:root:root .block-library-button__inline-link {
-	background: #fff;
+	background: $white;
 	display: flex;
 	flex-wrap: wrap;
 	align-items: center;
-	font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue,
-		sans-serif;
-	font-size: 13px;
-	line-height: 1.4;
-	width: 374px;
+	font-family: $default-font;
+	font-size: $default-font-size;
+	line-height: $default-line-height;
+
+	// The width of input box plus padding plus two icon buttons.
+	$blocks-button__link-input-width: 300px + 2px + 2 * $icon-button-size;
+	width: $blocks-button__link-input-width;
+
+	// Move it down by 2px so that it doesn't overlap the button focus outline.
 	margin-top: 2px;
+
+	.block-editor-url-input {
+		width: auto;
+	}
+
+	.block-editor-url-input__suggestions {
+		width: $blocks-button__link-input-width - $icon-button-size - $icon-button-size;
+		z-index: z-index(".block-library-button__inline-link .block-editor-url-input__suggestions");
+	}
+
+	> .dashicon {
+		width: $icon-button-size;
+
+		// adds the inline height back, after reset.
+		height: 20px;
+	}
+
+	.dashicon {
+		color: $dark-gray-100;
+	}
+
+	.block-editor-url-input input[type="text"]::placeholder {
+		color: $dark-gray-100;
+	}
+}
+
+:root:root:root [data-align="center"] .block-library-button__inline-link {
+	margin-left: auto;
+	margin-right: auto;
+}
+
+:root:root:root [data-align="right"] .block-library-button__inline-link {
+	margin-left: auto;
+	margin-right: 0;
 }

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -44,6 +44,7 @@
 // Reset class selectors that are used on HTML elements.
 // Raise the specificity to keep theme styles from overriding.
 // Specificity = 030.
+:root .editor-styles-wrapper .editor-post-permalink__link,
 :root .editor-styles-wrapper .components-tab-button,
 :root .editor-styles-wrapper .block-editor-url-input > input,
 :root .editor-styles-wrapper .dashicon,

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -62,192 +62,194 @@
 	margin-bottom: $default-block-margin;
 }
 
-// block-library styles. This isn't a good place for this and should be temporary.
-
-// packages/block-library/src/gallery/editor.scss
-:root:root:root .blocks-gallery-item {
-	// Hide the focus outline that otherwise briefly appears when selecting a block.
-	figure:not(.is-selected):focus {
-		outline: none;
-	}
-
-	.is-selected {
-		outline: 4px solid theme(primary);
-	}
-
-	.is-transient img {
-		opacity: 0.3;
-	}
-
-	.block-editor-rich-text {
-		position: absolute;
-		bottom: 0;
-		width: 100%;
-		max-height: 100%;
-		overflow-y: auto;
-	}
-
-	.block-editor-rich-text figcaption:not([data-is-placeholder-visible="true"]) {
-		position: relative;
-		overflow: hidden;
-	}
-
-	.is-selected .block-editor-rich-text {
-		// IE calculates this incorrectly, so leave it to modern browsers.
-		@supports (position: sticky) {
-			right: 0;
-			left: 0;
-			margin-top: -4px;
+// Some components get styled in block-library/ and miss our specificity prefixing.
+// They probably shouldn't. This is temporary for testing.
+:root:root:root {
+	// packages/block-library/src/gallery/editor.scss
+	.blocks-gallery-item {
+		// Hide the focus outline that otherwise briefly appears when selecting a block.
+		figure:not(.is-selected):focus {
+			outline: none;
 		}
 
-		// Override negative margins so this toolbar isn't hidden by overflow. Overflow is needed for long captions.
-		.block-editor-rich-text__inline-toolbar {
-			top: 0;
+		.is-selected {
+			outline: 4px solid theme(primary);
 		}
 
-		// Make extra space for the inline toolbar.
-		figcaption {
-			padding-top: 48px;
+		.is-transient img {
+			opacity: 0.3;
+		}
+
+		.block-editor-rich-text {
+			position: absolute;
+			bottom: 0;
+			width: 100%;
+			max-height: 100%;
+			overflow-y: auto;
+		}
+
+		.block-editor-rich-text figcaption:not([data-is-placeholder-visible="true"]) {
+			position: relative;
+			overflow: hidden;
+		}
+
+		.is-selected .block-editor-rich-text {
+			// IE calculates this incorrectly, so leave it to modern browsers.
+			@supports (position: sticky) {
+				right: 0;
+				left: 0;
+				margin-top: -4px;
+			}
+
+			// Override negative margins so this toolbar isn't hidden by overflow. Overflow is needed for long captions.
+			.block-editor-rich-text__inline-toolbar {
+				top: 0;
+			}
+
+			// Make extra space for the inline toolbar.
+			figcaption {
+				padding-top: 48px;
+			}
+		}
+
+		.block-editor-rich-text figcaption {
+			a {
+				color: $white;
+			}
 		}
 	}
 
-	.block-editor-rich-text figcaption {
-		a {
+	.block-library-gallery-item__inline-menu .components-button {
+		color: $white;
+		&:hover,
+		&:focus {
 			color: $white;
 		}
 	}
-}
 
-:root:root:root .block-library-gallery-item__inline-menu .components-button {
-	color: $white;
-	&:hover,
-	&:focus {
-		color: $white;
-	}
-}
+	.blocks-gallery-item__remove {
+		padding: 0;
 
-:root:root:root .blocks-gallery-item__remove {
-	padding: 0;
-
-	&.components-button:focus {
-		color: inherit;
-	}
-}
-
-// packages/block-library/src/cover/editor.scss
-:root:root:root .wp-block-cover .block-editor-block-list__block {
-	color: $light-gray-100;
-}
-
-// packages/block-library/src/code/editor.scss
-:root:root:root .components-tab-button {
-	display: inline-flex;
-	align-items: flex-end;
-	margin: 0;
-	padding: 3px;
-	background: none;
-	outline: none;
-	color: $dark-gray-500;
-	cursor: pointer;
-	position: relative;
-	height: $icon-button-size;
-	font-family: $default-font;
-	font-size: $default-font-size;
-	font-weight: 500;
-	border: 0;
-
-	&.is-active,
-	&.is-active:hover {
-		color: $white;
-	}
-
-	&:disabled {
-		cursor: default;
-	}
-
-	& > span {
-		border: $border-width solid transparent;
-		padding: 0 6px;
-		box-sizing: content-box;
-		height: 28px;
-		line-height: 28px;
-	}
-
-	&:hover > span,
-	&:focus > span {
-		color: $dark-gray-500;
-	}
-
-	&:not(:disabled) {
-		&.is-active > span,
-		&:hover > span,
-		&:focus > span {
-			border: $border-width solid $dark-gray-500;
+		&.components-button:focus {
+			color: inherit;
 		}
 	}
 
-	&.is-active > span,
-	&.is-active:hover > span {
-		background-color: $dark-gray-500;
-		color: $white;
-	}
-}
-
-// packages/block-library/src/image/editor.scss
-// Ensure the resize handles are visible when the image is focused.
-:root:root:root .wp-block-image.is-focused .components-resizable-box__handle {
-	display: block;
-	z-index: z-index(".block-library-image__resize-handlers");
-}
-
-// packages/block-library/src/button/editor.scss
-:root:root:root .block-library-button__inline-link {
-	background: $white;
-	display: flex;
-	flex-wrap: wrap;
-	align-items: center;
-	font-family: $default-font;
-	font-size: $default-font-size;
-	line-height: $default-line-height;
-
-	// The width of input box plus padding plus two icon buttons.
-	$blocks-button__link-input-width: 300px + 2px + 2 * $icon-button-size;
-	width: $blocks-button__link-input-width;
-
-	// Move it down by 2px so that it doesn't overlap the button focus outline.
-	margin-top: 2px;
-
-	.block-editor-url-input {
-		width: auto;
+	// packages/block-library/src/cover/editor.scss
+	.wp-block-cover .block-editor-block-list__block {
+		color: $light-gray-100;
 	}
 
-	.block-editor-url-input__suggestions {
-		width: $blocks-button__link-input-width - $icon-button-size - $icon-button-size;
-		z-index: z-index(".block-library-button__inline-link .block-editor-url-input__suggestions");
+	// packages/block-library/src/code/editor.scss
+	.components-tab-button {
+		display: inline-flex;
+		align-items: flex-end;
+		margin: 0;
+		padding: 3px;
+		background: none;
+		outline: none;
+		color: $dark-gray-500;
+		cursor: pointer;
+		position: relative;
+		height: $icon-button-size;
+		font-family: $default-font;
+		font-size: $default-font-size;
+		font-weight: 500;
+		border: 0;
+
+		&.is-active,
+		&.is-active:hover {
+			color: $white;
+		}
+
+		&:disabled {
+			cursor: default;
+		}
+
+		& > span {
+			border: $border-width solid transparent;
+			padding: 0 6px;
+			box-sizing: content-box;
+			height: 28px;
+			line-height: 28px;
+		}
+
+		&:hover > span,
+		&:focus > span {
+			color: $dark-gray-500;
+		}
+
+		&:not(:disabled) {
+			&.is-active > span,
+			&:hover > span,
+			&:focus > span {
+				border: $border-width solid $dark-gray-500;
+			}
+		}
+
+		&.is-active > span,
+		&.is-active:hover > span {
+			background-color: $dark-gray-500;
+			color: $white;
+		}
 	}
 
-	> .dashicon {
-		width: $icon-button-size;
-
-		// adds the inline height back, after reset.
-		height: 20px;
+	// packages/block-library/src/image/editor.scss
+	// Ensure the resize handles are visible when the image is focused.
+	.wp-block-image.is-focused .components-resizable-box__handle {
+		display: block;
+		z-index: z-index(".block-library-image__resize-handlers");
 	}
 
-	.dashicon {
-		color: $dark-gray-100;
+	// packages/block-library/src/button/editor.scss
+	.block-library-button__inline-link {
+		background: $white;
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		font-family: $default-font;
+		font-size: $default-font-size;
+		line-height: $default-line-height;
+
+		// The width of input box plus padding plus two icon buttons.
+		$blocks-button__link-input-width: 300px + 2px + 2 * $icon-button-size;
+		width: $blocks-button__link-input-width;
+
+		// Move it down by 2px so that it doesn't overlap the button focus outline.
+		margin-top: 2px;
+
+		.block-editor-url-input {
+			width: auto;
+		}
+
+		.block-editor-url-input__suggestions {
+			width: $blocks-button__link-input-width - $icon-button-size - $icon-button-size;
+			z-index: z-index(".block-library-button__inline-link .block-editor-url-input__suggestions");
+		}
+
+		> .dashicon {
+			width: $icon-button-size;
+
+			// adds the inline height back, after reset.
+			height: 20px;
+		}
+
+		.dashicon {
+			color: $dark-gray-100;
+		}
+
+		.block-editor-url-input input[type="text"]::placeholder {
+			color: $dark-gray-100;
+		}
 	}
 
-	.block-editor-url-input input[type="text"]::placeholder {
-		color: $dark-gray-100;
+	[data-align="center"] .block-library-button__inline-link {
+		margin-left: auto;
+		margin-right: auto;
 	}
-}
 
-:root:root:root [data-align="center"] .block-library-button__inline-link {
-	margin-left: auto;
-	margin-right: auto;
-}
-
-:root:root:root [data-align="right"] .block-library-button__inline-link {
-	margin-left: auto;
-	margin-right: 0;
+	[data-align="right"] .block-library-button__inline-link {
+		margin-left: auto;
+		margin-right: 0;
+	}
 }

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -62,7 +62,7 @@
 	margin-bottom: $default-block-margin;
 }
 
-// block-library styles
+// block-library styles. This isn't a good place for this and should be temporary.
 :root:root:root .block-library-gallery-item__inline-menu .components-button {
 	color: #fff;
 }
@@ -94,4 +94,26 @@
 	font-size: 13px;
 	font-weight: 500;
 	border: 0;
+}
+
+:root:root:root .wp-block-image.is-focused .components-resizable-box__handle {
+	display: block;
+	z-index: 1;
+}
+
+:root:root:root .block-library-button__inline-link .dashicon {
+	color: #8f98a1;
+}
+
+:root:root:root .block-library-button__inline-link {
+	background: #fff;
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue,
+		sans-serif;
+	font-size: 13px;
+	line-height: 1.4;
+	width: 374px;
+	margin-top: 2px;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,8 @@ const gutenbergPackages = Object.keys( dependencies )
 	.filter( ( packageName ) => packageName.startsWith( WORDPRESS_NAMESPACE ) )
 	.map( ( packageName ) => packageName.replace( WORDPRESS_NAMESPACE, '' ) );
 
+const cssSpecificity = require( './bin/packages/postcss-specificity' );
+
 module.exports = {
 	...defaultConfig,
 	entry: gutenbergPackages.reduce( ( memo, packageName ) => {
@@ -105,6 +107,28 @@ module.exports = {
 				},
 			} ) )
 		),
+
+		new CopyWebpackPlugin(
+			[
+				'block-editor',
+				'editor',
+				'components',
+				'edit-post',
+			].map( ( packageName ) => ( {
+				from: `./packages/${ packageName }/build-style/style.css`,
+				to: `./build/${ packageName }/`,
+				flatten: true,
+				force: true,
+				transform: ( content ) => {
+					return postcss( [
+						cssSpecificity( { scopeTo: ':root', repeat: 3 } ),
+					] )
+						.process( content, { from: 'src/app.css', to: 'dest/app.css' } )
+						.then( ( result ) => result.css );
+				},
+			} ) )
+		),
+
 		new CopyWebpackPlugin( [
 			{
 				from: './packages/block-library/src/**/index.php',


### PR DESCRIPTION
## Description
Any HTML element like `a`,`button`,`input`,`svg`, etc, used in the Editor UI is currently left wide open for theme styles to accidentally skew it's appearance.

Themes could easily override a `.components-icon-button {}` style by accidentally leaving a `button` style in their `editor-style.css`. The `button` + the theme wrapper = `.editor-styles-wrapper button {}` which could override anything on a single class component style.

Another unpredictable and perhaps more likely scenario is where a theme style isn't overriding an editor style but is a new style property. Specificity on our components wouldn't help in this case.
Something like this would ruin the entire editor experience:
```css
button {
	box-shadow: 10px 5px 5px red;
	min-height: 2.5rem;
}
```
Some discussion about the problem here https://github.com/WordPress/gutenberg/issues/10178

This PR hasn't been tested a ton but I wanted to get it up here so that it could be.

Basically it creates a strong reset for all editor UI component which uses an HTML element.
```css
/* Specificity = 030 */
:root .editor-styles-wrapper .dashicon,
:root .editor-styles-wrapper .components-button,
:root .editor-styles-wrapper .components-dropdown-menu__indicator,
:root .editor-styles-wrapper .block-editor-block-icon {
	all: unset;
}
```
The only way to change any style property, from the initial browser default, on one of these elements is to do it with a more specific selector.

So we need to raise the specificity or our editor styles. But we need to raise all editor component styles equally so the current cascade isn't altered. 
I've done this with postCSS during the build process. The resulting editor CSS looks like this:
```css
:root:root:root .components-button {
    font-size: 13px;
}
```

## How has this been tested?
I've tested this by changing the default themes to use `add_editor_style( 'style.css' )` for their editor styles.

**twentyseventeen `style.css` without the reset**
![2017old](https://user-images.githubusercontent.com/3585901/56991799-9f99be00-6b66-11e9-8f85-dba752f2fa01.gif)

**twentyseventeen `style.css` with reset**
![2017new](https://user-images.githubusercontent.com/3585901/56991846-b3452480-6b66-11e9-9a9d-d19e4e09acaf.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
