### PR TITLE
Bump version number to 5.6.1

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -3,7 +3,7 @@
  * Plugin Name: Gutenberg
  * Plugin URI: https://github.com/WordPress/gutenberg
  * Description: Printing since 1440. This is the development plugin for the new block editor in core.
- * Version: 5.6.0
+ * Version: 5.6.1
  * Author: Gutenberg Team
  * Text Domain: gutenberg
  *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "5.6.0",
+	"version": "5.6.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "5.6.0",
+	"version": "5.6.1",
 	"private": true,
 	"description": "A new WordPress editor experience",
 	"repository": "git+https://github.com/WordPress/gutenberg.git",


### PR DESCRIPTION
Previously: #15373 

Republish due to missing file from original 5.6.0 release causing updates to be missing (`gutenberg.php` headers not reflecting ).

## Changelog

### Miscellaneous

- Republish Gutenberg 5.6.0.