### PR TITLE
Fix: Publish date not announced in voice over; Redundant duplicate labels;

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-schedule/index.js
+++ b/packages/edit-post/src/components/sidebar/post-schedule/index.js
@@ -22,7 +22,6 @@ export function PostSchedule() {
 								className="edit-post-post-schedule__toggle"
 								onClick={ onToggle }
 								aria-expanded={ isOpen }
-								aria-live="polite"
 								isLink
 							>
 								<PostScheduleLabel />

--- a/packages/edit-post/src/components/sidebar/post-schedule/index.js
+++ b/packages/edit-post/src/components/sidebar/post-schedule/index.js
@@ -3,32 +3,21 @@
  */
 import { __ } from '@wordpress/i18n';
 import { PanelRow, Dropdown, Button } from '@wordpress/components';
-import { withInstanceId } from '@wordpress/compose';
 import { PostSchedule as PostScheduleForm, PostScheduleLabel, PostScheduleCheck } from '@wordpress/editor';
 
-export function PostSchedule( { instanceId } ) {
+export function PostSchedule() {
 	return (
 		<PostScheduleCheck>
 			<PanelRow className="edit-post-post-schedule">
-				<label
-					htmlFor={ `edit-post-post-schedule__toggle-${ instanceId }` }
-					id={ `edit-post-post-schedule__heading-${ instanceId }` }
-				>
+				<span>
 					{ __( 'Publish' ) }
-				</label>
+				</span>
 				<Dropdown
 					position="bottom left"
 					contentClassName="edit-post-post-schedule__dialog"
 					renderToggle={ ( { onToggle, isOpen } ) => (
 						<>
-							<label
-								className="edit-post-post-schedule__label"
-								htmlFor={ `edit-post-post-schedule__toggle-${ instanceId }` }
-							>
-								<PostScheduleLabel /> { __( 'Click to change' ) }
-							</label>
 							<Button
-								id={ `edit-post-post-schedule__toggle-${ instanceId }` }
 								type="button"
 								className="edit-post-post-schedule__toggle"
 								onClick={ onToggle }
@@ -47,4 +36,4 @@ export function PostSchedule( { instanceId } ) {
 	);
 }
 
-export default withInstanceId( PostSchedule );
+export default PostSchedule;

--- a/packages/edit-post/src/components/sidebar/post-schedule/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-schedule/style.scss
@@ -3,10 +3,6 @@
 	position: relative;
 }
 
-.edit-post-post-schedule__label {
-	display: none;
-}
-
 .components-button.edit-post-post-schedule__toggle {
 	text-align: right;
 }


### PR DESCRIPTION
Fix: https://github.com/WordPress/gutenberg/issues/11747

This PR fixes https://github.com/WordPress/gutenberg/issues/11747 by removing a duplicate label.
It also addresses another problem. Given that we have a Publish label labeling the button, the publish date is never announced for users of assistive technologies. Only the word publish is announced, this PR addresses that problem.
I'm using an aria-label for the button because, besides the date normally shown in the button, I also want assistive technologies to announce  'Click to change'. I'm not sure if announcing  'Click to change' is required but it seemed helpful.



## How has this been tested?
I used voice over and verified the select date is now announced when the button gets focus.

## Screenshots <!-- if applicable -->
![May-01-2019 23-01-17](https://user-images.githubusercontent.com/11271197/57045615-0e117580-6c66-11e9-83e1-e37e689c78d5.gif)

