### PR TITLE
Remove aria-label from block inserter list item

### DIFF
--- a/packages/block-editor/src/components/inserter-list-item/index.js
+++ b/packages/block-editor/src/components/inserter-list-item/index.js
@@ -43,7 +43,6 @@ function InserterListItem( {
 					onClick();
 				} }
 				disabled={ isDisabled }
-				aria-label={ title } // Fix for IE11 and JAWS 2018.
 				{ ...props }
 			>
 				<span

--- a/packages/e2e-test-utils/src/get-available-block-transforms.js
+++ b/packages/e2e-test-utils/src/get-available-block-transforms.js
@@ -21,7 +21,7 @@ export const getAvailableBlockTransforms = async () => {
 			)
 		).map(
 			( button ) => {
-				return button.getAttribute( 'aria-label' );
+				return button.textContent;
 			}
 		);
 	}, '.block-editor-block-types-list .block-editor-block-types-list__list-item button' );

--- a/packages/e2e-test-utils/src/insert-block.js
+++ b/packages/e2e-test-utils/src/insert-block.js
@@ -18,5 +18,8 @@ export async function insertBlock( searchTerm, panelName = null ) {
 		) )[ 0 ];
 		await panelButton.click();
 	}
-	await page.click( `button[aria-label="${ searchTerm }"]` );
+	const insertButton = ( await page.$x(
+		`//button//span[contains(text(), '${ searchTerm }')]`
+	) )[ 0 ];
+	await insertButton.click();
 }

--- a/packages/e2e-test-utils/src/transform-block-to.js
+++ b/packages/e2e-test-utils/src/transform-block-to.js
@@ -7,8 +7,10 @@ export async function transformBlockTo( name ) {
 	await page.mouse.move( 200, 300, { steps: 10 } );
 	await page.mouse.move( 250, 350, { steps: 10 } );
 	await page.click( '.block-editor-block-switcher__toggle' );
-	await page.waitForSelector( `.block-editor-block-types-list__item[aria-label="${ name }"]` );
-	await page.click( `.block-editor-block-types-list__item[aria-label="${ name }"]` );
+	const insertButton = ( await page.$x(
+		`//button//span[contains(text(), '${ name }')]`
+	) )[ 0 ];
+	await insertButton.click();
 	const BLOCK_SELECTOR = '.block-editor-block-list__block';
 	const BLOCK_NAME_SELECTOR = `[aria-label="Block: ${ name }"]`;
 	// Wait for the transformed block to appear.

--- a/packages/e2e-tests/specs/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/block-hierarchy-navigation.test.js
@@ -96,6 +96,7 @@ describe( 'Navigating the block hierarchy', () => {
 
 		// Return to first block.
 		await openBlockNavigator();
+		await page.waitForSelector( '.editor-block-navigation__container' );
 		await page.keyboard.press( 'Space' );
 
 		// Replace its content.

--- a/packages/e2e-tests/specs/plugins/allowed-blocks.test.js
+++ b/packages/e2e-tests/specs/plugins/allowed-blocks.test.js
@@ -24,13 +24,18 @@ describe( 'Allowed Blocks Filter', () => {
 	it( 'should restrict the allowed blocks in the inserter', async () => {
 		// The paragraph block is available.
 		await searchForBlock( 'Paragraph' );
-		const paragraphBlock = await page.$( `button[aria-label="Paragraph"]` );
-		expect( paragraphBlock ).not.toBeNull();
-		await paragraphBlock.click();
+		const paragraphBlockButton = ( await page.$x(
+			`//button//span[contains(text(), 'Paragraph')]`
+		) )[ 0 ];
+		expect( paragraphBlockButton ).not.toBeNull();
+		await paragraphBlockButton.click();
 
 		// The gallery block is not available.
 		await searchForBlock( 'Gallery' );
-		const galleryBlock = await page.$( `button[aria-label="Gallery"]` );
-		expect( galleryBlock ).toBeNull();
+
+		const galleryBlockButton = ( await page.$x(
+			`//button//span[contains(text(), 'Gallery')]`
+		) )[ 0 ];
+		expect( galleryBlockButton ).toBeUndefined();
 	} );
 } );

--- a/packages/e2e-tests/specs/plugins/container-blocks.test.js
+++ b/packages/e2e-tests/specs/plugins/container-blocks.test.js
@@ -82,7 +82,10 @@ describe( 'Container block without paragraph support', () => {
 		await page.click( '.block-editor-inner-blocks .block-list-appender .block-list-appender__toggle' );
 
 		// Insert an image block.
-		await page.click( '.block-editor-inserter__results button[aria-label="Image"]' );
+		const insertButton = ( await page.$x(
+			`//button//span[contains(text(), 'Image')]`
+		) )[ 0 ];
+		await insertButton.click();
 
 		// Check the inserted content.
 		expect( await getEditedPostContent() ).toMatchSnapshot();

--- a/packages/e2e-tests/specs/plugins/inner-blocks-allowed-blocks.test.js
+++ b/packages/e2e-tests/specs/plugins/inner-blocks-allowed-blocks.test.js
@@ -71,7 +71,10 @@ describe( 'Allowed Blocks Setting on InnerBlocks ', () => {
 			'Image',
 			'List',
 		] );
-		await page.click( `.block-editor-block-types-list__item[aria-label="List"]` );
+		const insertButton = ( await page.$x(
+			`//button//span[contains(text(), 'List')]`
+		) )[ 0 ];
+		await insertButton.click();
 		await insertBlock( 'Image' );
 		await page.click( appenderSelector );
 		await openAllBlockInserterCategories();


### PR DESCRIPTION
## Description
Removed an aria-label that was flagged as unnecessary in item WUT-18 of the WPCampus accessibility audit. Fixes #15337.

**Note:**
There is a code comment from @ellatrix that the aria-label was added to handle IE11 and JAWS2018. I do not have access to that configuration, so it should be tested by someone who does before this is merged to prevent a possible recursion. 

In my opinion, if the aria-label makes it work in IE11/Jaws that should override the potential issue brought up in the audit and it should stay.

## How has this been tested?
Tested with Apple VoiceOver on a Mac and it still reads out the button text correctly when navigated to with the keyboard. 

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
