### PR TITLE
Add role to the copy all content menu item

### DIFF
--- a/packages/edit-post/src/plugins/copy-content-menu-item/index.js
+++ b/packages/edit-post/src/plugins/copy-content-menu-item/index.js
@@ -10,6 +10,7 @@ function CopyContentMenuItem( { editedPostContent, hasCopied, setState } ) {
 	return (
 		<ClipboardButton
 			text={ editedPostContent }
+			role="menuitem"
 			className="components-menu-item__button"
 			onCopy={ () => setState( { hasCopied: true } ) }
 			onFinishCopy={ () => setState( { hasCopied: false } ) }


### PR DESCRIPTION
## Description
Adds the appropriate role="menuitem" to the 'Copy all Content' button in the editor menu. Item GUT-67 in the WPCampus accessibility audit. 

Fixes #15336 

## How has this been tested?
Inspect menu source, verify menu item role is present. Navigate the menu with VoiceOver on a Mac and verify it announces as a menu item when navigated to.

## Screenshots
![Fullscreen_5_1_19__8_07_PM](https://user-images.githubusercontent.com/6653970/57050933-e95cd400-6c4c-11e9-9d50-15997cb31f4c.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
