### PR TITLE
Fix or improve eslint disable comments

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -602,7 +602,7 @@ export class BlockListBlock extends Component {
 							) }
 						</IgnoreNestedEvents>
 					);
-					/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
+					/* eslint-enable jsx-a11y/mouse-events-have-key-events, jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 				} }
 			</HoverArea>
 		);

--- a/packages/block-editor/src/components/inserter/test/menu.js
+++ b/packages/block-editor/src/components/inserter/test/menu.js
@@ -107,9 +107,8 @@ const getWrapperForProps = ( propOverrides ) => {
 
 const initializeMenuDefaultStateAndReturnElement = ( propOverrides ) => {
 	const wrapper = getWrapperForProps( propOverrides );
-	/* eslint-disable react/no-find-dom-node */
+	// eslint-disable-next-line react/no-find-dom-node
 	return ReactDOM.findDOMNode( wrapper );
-	/* eslint-enable react/no-find-dom-node */
 };
 
 const initializeAllClosedMenuStateAndReturnElement = ( propOverrides ) => {

--- a/packages/block-editor/src/components/url-input/test/button.js
+++ b/packages/block-editor/src/components/url-input/test/button.js
@@ -75,8 +75,7 @@ describe( 'URLInputButton', () => {
 		expect( wrapper.state.expanded ).toBe( true );
 		TestUtils.Simulate.submit( formElement() );
 		expect( wrapper.state.expanded ).toBe( false );
-		/* eslint-disable react/no-find-dom-node */
+		// eslint-disable-next-line react/no-find-dom-node
 		ReactDOM.unmountComponentAtNode( ReactDOM.findDOMNode( wrapper ).parentNode );
-		/* eslint-enable react/no-find-dom-node */
 	} );
 } );

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -357,7 +357,7 @@ class WritingFlow extends Component {
 				/>
 			</div>
 		);
-		/* eslint-disable jsx-a11y/no-static-element-interactions */
+		/* eslint-enable jsx-a11y/no-static-element-interactions */
 	}
 }
 

--- a/packages/block-library/src/classic/edit.js
+++ b/packages/block-library/src/classic/edit.js
@@ -178,13 +178,18 @@ export default class ClassicEdit extends Component {
 	render() {
 		const { clientId } = this.props;
 
-		// Disable reason: the toolbar itself is non-interactive, but must capture
-		// events from the KeyboardShortcuts component to stop their propagation.
-		/* eslint-disable jsx-a11y/no-static-element-interactions */
+		// Disable reasons:
+		//
+		// jsx-a11y/no-static-element-interactions
+		//  - the toolbar itself is non-interactive, but must capture events
+		//    from the KeyboardShortcuts component to stop their propagation.
+		//
+		// jsx-a11y/no-static-element-interactions
+		//  - Clicking on this visual placeholder should create the
+		//    toolbar, it can also be created by focussing the field below.
+
+		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 		return [
-			// Disable reason: Clicking on this visual placeholder should create
-			// the toolbar, it can also be created by focussing the field below.
-			/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 			<div
 				key="toolbar"
 				id={ `toolbar-${ clientId }` }
@@ -200,6 +205,6 @@ export default class ClassicEdit extends Component {
 				className="wp-block-freeform block-library-rich-text__tinymce"
 			/>,
 		];
-		/* eslint-enable jsx-a11y/no-static-element-interactions */
+		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 	}
 }

--- a/packages/block-library/src/embed/embed-preview.js
+++ b/packages/block-library/src/embed/embed-preview.js
@@ -69,8 +69,7 @@ class EmbedPreview extends Component {
 		// Disabled because the overlay div doesn't actually have a role or functionality
 		// as far as the user is concerned. We're just catching the first click so that
 		// the block can be selected without interacting with the embed preview that the overlay covers.
-		/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-		/* eslint-disable jsx-a11y/no-static-element-interactions */
+		/* eslint-disable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/no-static-element-interactions */
 		const embedWrapper = 'wp-embed' === type ? (
 			<WpEmbedPreview
 				html={ html }
@@ -89,8 +88,7 @@ class EmbedPreview extends Component {
 					onMouseUp={ this.hideOverlay } /> }
 			</div>
 		);
-		/* eslint-enable jsx-a11y/no-static-element-interactions */
-		/* eslint-enable jsx-a11y/no-noninteractive-element-interactions */
+		/* eslint-enable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/no-static-element-interactions */
 
 		return (
 			<figure className={ classnames( className, 'wp-block-embed', { 'is-type-video': 'video' === type } ) }>

--- a/packages/components/src/external-link/index.js
+++ b/packages/components/src/external-link/index.js
@@ -24,7 +24,8 @@ export function ExternalLink( { href, children, className, rel = '', ...addition
 	] ) ).join( ' ' );
 	const classes = classnames( 'components-external-link', className );
 	return (
-		<a { ...additionalProps } className={ classes } href={ href } target="_blank" rel={ rel } ref={ ref }> { /* eslint-disable-line react/jsx-no-target-blank */ }
+		// eslint-disable-next-line react/jsx-no-target-blank
+		<a { ...additionalProps } className={ classes } href={ href } target="_blank" rel={ rel } ref={ ref }>
 			{ children }
 			<span className="screen-reader-text">
 				{

--- a/packages/components/src/higher-order/with-filters/test/index.js
+++ b/packages/components/src/higher-order/with-filters/test/index.js
@@ -17,9 +17,8 @@ import { Component } from '@wordpress/element';
 import withFilters from '..';
 
 const assertExpectedHtml = ( wrapper, expectedHTML ) => {
-	/* eslint-disable react/no-find-dom-node */
+	// eslint-disable-next-line react/no-find-dom-node
 	const element = ReactDOM.findDOMNode( wrapper );
-	/* eslint-enable react/no-find-dom-node */
 	expect( element.outerHTML ).toBe( expectedHTML );
 };
 
@@ -42,13 +41,12 @@ describe( 'withFilters', () => {
 
 	afterEach( () => {
 		if ( wrapper ) {
-			/* eslint-disable react/no-find-dom-node */
+			// eslint-disable-next-line react/no-find-dom-node
 			ReactDOM.unmountComponentAtNode( ReactDOM.findDOMNode( wrapper ).parentNode );
 		}
 		if ( shallowWrapper ) {
 			shallowWrapper.unmount();
 		}
-		/* eslint-enable react/no-find-dom-node */
 		removeAllFilters( hookName );
 	} );
 

--- a/packages/components/src/higher-order/with-focus-outside/test/index.js
+++ b/packages/components/src/higher-order/with-focus-outside/test/index.js
@@ -95,9 +95,8 @@ describe( 'withFocusOutside', () => {
 		simulateEvent( 'focus' );
 		simulateEvent( 'input' );
 
-		/* eslint-disable react/no-find-dom-node */
+		// eslint-disable-next-line react/no-find-dom-node
 		ReactDOM.unmountComponentAtNode( ReactDOM.findDOMNode( wrapper ).parentNode );
-		/* eslint-enable react/no-find-dom-node */
 
 		jest.runAllTimers();
 

--- a/packages/components/src/isolated-event-container/index.js
+++ b/packages/components/src/isolated-event-container/index.js
@@ -28,6 +28,7 @@ class IsolatedEventContainer extends Component {
 				{ children }
 			</div>
 		);
+		/* eslint-enable jsx-a11y/no-static-element-interactions */
 	}
 }
 

--- a/packages/components/src/navigable-container/container.js
+++ b/packages/components/src/navigable-container/container.js
@@ -120,6 +120,7 @@ class NavigableContainer extends Component {
 				{ children }
 			</div>
 		);
+		/* eslint-enable jsx-a11y/no-static-element-interactions */
 	}
 }
 

--- a/packages/components/src/popover/test/index.js
+++ b/packages/components/src/popover/test/index.js
@@ -38,10 +38,8 @@ describe( 'Popover', () => {
 
 		it( 'should turn off auto refresh', () => {
 			wrapper = TestUtils.renderIntoDocument( <Popover /> );
-			/* eslint-disable react/no-find-dom-node */
+			// eslint-disable-next-line react/no-find-dom-node
 			ReactDOM.unmountComponentAtNode( ReactDOM.findDOMNode( wrapper ).parentNode );
-			/* eslint-enable react/no-find-dom-node */
-
 			expect( Popover.prototype.toggleAutoRefresh ).toHaveBeenCalledWith( false );
 		} );
 

--- a/packages/components/src/tooltip/test/index.js
+++ b/packages/components/src/tooltip/test/index.js
@@ -90,10 +90,9 @@ describe( 'Tooltip', () => {
 				</Tooltip>
 			);
 
-			/* eslint-disable react/no-find-dom-node */
 			const button = TestUtils.findRenderedDOMComponentWithTag( wrapper, 'button' );
+			// eslint-disable-next-line react/no-find-dom-node
 			TestUtils.Simulate.mouseEnter( ReactDOM.findDOMNode( button ) );
-			/* eslint-enable react/no-find-dom-node */
 
 			expect( originalMouseEnter ).toHaveBeenCalledTimes( 1 );
 			expect( wrapper.state.isOver ).toBe( false );

--- a/packages/format-library/src/link/modal.native.js
+++ b/packages/format-library/src/link/modal.native.js
@@ -130,19 +130,19 @@ class ModalLinkUI extends Component {
 				onClose={ this.onDismiss }
 				hideHeader
 			>
-				{ /* eslint-disable jsx-a11y/no-autofocus */
-					<BottomSheet.Cell
-						icon={ 'admin-links' }
-						label={ __( 'URL' ) }
-						value={ this.state.inputValue }
-						placeholder={ __( 'Add URL' ) }
-						autoCapitalize="none"
-						autoCorrect={ false }
-						keyboardType="url"
-						onChangeValue={ this.onChangeInputValue }
-						autoFocus={ Platform.OS === 'ios' }
-					/>
-				/* eslint-enable jsx-a11y/no-autofocus */ }
+				{ /* eslint-disable jsx-a11y/no-autofocus */ }
+				<BottomSheet.Cell
+					icon={ 'admin-links' }
+					label={ __( 'URL' ) }
+					value={ this.state.inputValue }
+					placeholder={ __( 'Add URL' ) }
+					autoCapitalize="none"
+					autoCorrect={ false }
+					keyboardType="url"
+					onChangeValue={ this.onChangeInputValue }
+					autoFocus={ Platform.OS === 'ios' }
+				/>
+				{ /* eslint-enable jsx-a11y/no-autofocus */ }
 				<BottomSheet.Cell
 					icon={ 'editor-textcolor' }
 					label={ __( 'Link Text' ) }


### PR DESCRIPTION
## Description
I noticed while working on some code that the `eslint-disable` comment in the `WritingFlow` component didn't have a correct corresponding closing comment (instead it had another `eslint-disable` comment).

I decided to have a quick look through the code base for other issues and tidy up the rules where I could. The changes:
- Ensure `eslint-disable` comments have a corresponding `eslint-enable` comment (except for cases where the whole file was disabled).
- Prefer `eslint-disable-next-line` where possible
- Combine some adjacent `eslint-disable` comments
- Some other general tidy-up of comments

## How has this been tested?
- Check disable rule still works

## Types of changes
Code quality (non-breaking change)
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
