### PR TITLE
Re-exported React.memo in packages/element/src/react.js

### DIFF
--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -219,6 +219,12 @@ _Related_
 
 -   <https://reactjs.org/docs/react-api.html#reactlazy>
 
+<a name="memo" href="#memo">#</a> **memo**
+
+_Related_
+
+-   <https://reactjs.org/docs/react-api.html#reactmemo>
+
 <a name="RawHTML" href="#RawHTML">#</a> **RawHTML**
 
 Component used as equivalent of Fragment with unescaped HTML, in cases where

--- a/packages/element/src/react.js
+++ b/packages/element/src/react.js
@@ -185,7 +185,7 @@ export { Suspense };
  * @return {Array} The concatenated value.
  */
 export function concatChildren( ...childrenArguments ) {
-	return childrenArguments.reduce( ( memoized, children, i ) => {
+	return childrenArguments.reduce( ( result, children, i ) => {
 		Children.forEach( children, ( child, j ) => {
 			if ( child && 'string' !== typeof child ) {
 				child = cloneElement( child, {
@@ -193,10 +193,10 @@ export function concatChildren( ...childrenArguments ) {
 				} );
 			}
 
-			memoized.push( child );
+			result.push( child );
 		} );
 
-		return memoized;
+		return result;
 	}, [] );
 }
 

--- a/packages/element/src/react.js
+++ b/packages/element/src/react.js
@@ -11,6 +11,7 @@ import {
 	forwardRef,
 	Fragment,
 	isValidElement,
+	memo,
 	StrictMode,
 	useState,
 	useEffect,
@@ -107,6 +108,11 @@ export { Fragment };
 export { isValidElement };
 
 /**
+ * @see https://reactjs.org/docs/react-api.html#reactmemo
+ */
+export { memo };
+
+/**
  * Component that activates additional checks and warnings for its descendants.
  */
 export { StrictMode };
@@ -179,7 +185,7 @@ export { Suspense };
  * @return {Array} The concatenated value.
  */
 export function concatChildren( ...childrenArguments ) {
-	return childrenArguments.reduce( ( memo, children, i ) => {
+	return childrenArguments.reduce( ( memoized, children, i ) => {
 		Children.forEach( children, ( child, j ) => {
 			if ( child && 'string' !== typeof child ) {
 				child = cloneElement( child, {
@@ -187,10 +193,10 @@ export function concatChildren( ...childrenArguments ) {
 				} );
 			}
 
-			memo.push( child );
+			memoized.push( child );
 		} );
 
-		return memo;
+		return memoized;
 	}, [] );
 }
 


### PR DESCRIPTION
## Description
Resolves: https://github.com/WordPress/gutenberg/issues/15242

## Types of changes
This PR is re-exporting React.js core `memo` method.
Also refactored `concatChildren` internal memo to avoid conflicts with global one.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
