### PR TITLE
Fix: DateTimePicker styles don't load as expected outside WordPress context

### DIFF
--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -19,6 +19,21 @@
 		margin-right: $grid-size;
 		margin-top: 0.5em;
 	}
+
+	fieldset {
+		border: 0;
+		padding: 0;
+		margin: 0;
+	}
+
+	select,
+	input {
+		box-sizing: border-box;
+		height: 28px;
+		vertical-align: middle;
+		padding: 0;
+		@include input-style__neutral();
+	}
 }
 
 .components-datetime__date {


### PR DESCRIPTION
Closes: https://github.com/WordPress/gutenberg/issues/8870


I started this PR with the objective of closing https://github.com/WordPress/gutenberg/issues/8870 which is a very old issue. Meanwhile, I noticed the arrow styles referenced on the issue were already fixed, but the component still had some styling problems outside WordPress this PR fixes these problems.

Before:
![image](https://user-images.githubusercontent.com/11271197/57071543-aba28e80-6cd2-11e9-91e2-71f7c9550345.png)

After:
![image](https://user-images.githubusercontent.com/11271197/57071592-d0970180-6cd2-11e9-911e-94ce514bd443.png)


## How has this been tested?
I pasted the following gist https://gist.github.com/jorgefilipecosta/6e55059202ccbcb683a56f0546ea6f93 on playground/src/index.js.
I executed the playground and verified the DateTimePicker component appears with the same look as it appears inside WordPress context e.g: the post scheduler.
