### PR TITLE
Fix: Header text scale is inconsistent between classic and heading block

### DIFF
--- a/packages/block-library/src/classic/editor.scss
+++ b/packages/block-library/src/classic/editor.scss
@@ -24,30 +24,6 @@
 		color: $dark-gray-800;
 	}
 
-	h1 {
-		font-size: 2em;
-	}
-
-	h2 {
-		font-size: 1.6em;
-	}
-
-	h3 {
-		font-size: 1.4em;
-	}
-
-	h4 {
-		font-size: 1.2em;
-	}
-
-	h5 {
-		font-size: 1.1em;
-	}
-
-	h6 {
-		font-size: 1em;
-	}
-
 	> *:first-child {
 		margin-top: 0;
 	}


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/8373

The classic blocks styles specified styles for the headings, this made the text scale inconsistent with the styles used for header blocks that normally use theme styles.

This PR removes the style changes applied to headings by the classic block.


## How has this been tested?
I used the "Twenty Fourteen", "Twenty Seventeen", and "Twenty Nineteen" themes and verified the heading styles were the same for headings on the classic block and for headings on the header block.

## Screenshots <!-- if applicable -->
<img width="776" alt="Screenshot 2019-05-02 at 13 36 58" src="https://user-images.githubusercontent.com/11271197/57075695-6cc70580-6cdf-11e9-8c10-3beeaa8e9dcf.png">

