### PR TITLE
Allow core widgets to be used in the legacy widgets block

### DIFF
--- a/lib/widgets.php
+++ b/lib/widgets.php
@@ -102,18 +102,17 @@ function gutenberg_get_legacy_widget_settings() {
 	$available_legacy_widgets          = array();
 	global $wp_widget_factory, $wp_registered_widgets;
 	foreach ( $wp_widget_factory->widgets as $class => $widget_obj ) {
-		if ( ! in_array( $class, $core_widgets ) ) {
-			$available_legacy_widgets[ $class ] = array(
-				'name'             => html_entity_decode( $widget_obj->name ),
-				// wp_widget_description is not being used because its input parameter is a Widget Id.
-				// Widgets id's reference to a specific widget instance.
-				// Here we are iterating on all the available widget classes even if no widget instance exists for them.
-				'description'      => isset( $widget_obj->widget_options['description'] ) ?
-					html_entity_decode( $widget_obj->widget_options['description'] ) :
-					null,
-				'isCallbackWidget' => false,
-			);
-		}
+		$available_legacy_widgets[ $class ] = array(
+			'name'             => html_entity_decode( $widget_obj->name ),
+			// wp_widget_description is not being used because its input parameter is a Widget Id.
+			// Widgets id's reference to a specific widget instance.
+			// Here we are iterating on all the available widget classes even if no widget instance exists for them.
+			'description'      => isset( $widget_obj->widget_options['description'] ) ?
+				html_entity_decode( $widget_obj->widget_options['description'] ) :
+				null,
+			'isCallbackWidget' => false,
+			'isHidden'         => in_array( $class, $core_widgets, true ),
+		);
 	}
 	foreach ( $wp_registered_widgets as $widget_id => $widget_obj ) {
 		if (

--- a/packages/block-library/src/legacy-widget/edit/index.js
+++ b/packages/block-library/src/legacy-widget/edit/index.js
@@ -1,7 +1,10 @@
 /**
  * External dependencies
  */
-import { map } from 'lodash';
+import {
+	map,
+	pickBy,
+} from 'lodash';
 
 /**
  * WordPress dependencies
@@ -47,6 +50,10 @@ class LegacyWidgetEdit extends Component {
 			hasPermissionsToManageWidgets,
 			setAttributes,
 		} = this.props;
+		const visibleLegacyWidgets = pickBy(
+			availableLegacyWidgets,
+			( { isHidden } ) => ! isHidden
+		);
 		const { isPreview } = this.state;
 		const { identifier, isCallbackWidget } = attributes;
 		const widgetObject = identifier && availableLegacyWidgets[ identifier ];
@@ -55,7 +62,7 @@ class LegacyWidgetEdit extends Component {
 
 			if ( ! hasPermissionsToManageWidgets ) {
 				placeholderContent = __( 'You don\'t have permissions to use widgets on this site.' );
-			} else if ( availableLegacyWidgets.length === 0 ) {
+			} else if ( visibleLegacyWidgets.length === 0 ) {
 				placeholderContent = __( 'There are no widgets available.' );
 			} else {
 				placeholderContent = (
@@ -68,7 +75,7 @@ class LegacyWidgetEdit extends Component {
 							isCallbackWidget: availableLegacyWidgets[ value ].isCallbackWidget,
 						} ) }
 						options={ [ { value: 'none', label: 'Select widget' } ].concat(
-							map( availableLegacyWidgets, ( widget, key ) => {
+							map( visibleLegacyWidgets, ( widget, key ) => {
 								return {
 									value: key,
 									label: widget.name,

--- a/packages/block-library/src/legacy-widget/edit/index.js
+++ b/packages/block-library/src/legacy-widget/edit/index.js
@@ -1,29 +1,17 @@
 /**
- * External dependencies
- */
-import {
-	map,
-	isEmpty,
-	pickBy,
-} from 'lodash';
-
-/**
  * WordPress dependencies
  */
-import { Component, useMemo } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import {
 	Button,
 	IconButton,
 	PanelBody,
-	Placeholder,
-	SelectControl,
 	Toolbar,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { withSelect } from '@wordpress/data';
 import {
 	BlockControls,
-	BlockIcon,
 	InspectorControls,
 } from '@wordpress/block-editor';
 import { ServerSideRender } from '@wordpress/editor';
@@ -32,51 +20,7 @@ import { ServerSideRender } from '@wordpress/editor';
  * Internal dependencies
  */
 import LegacyWidgetEditHandler from './handler';
-
-const LegacyWidgetPlaceholder = ( {
-	availableLegacyWidgets,
-	currentWidget,
-	hasPermissionsToManageWidgets,
-	onChangeWidget,
-} ) => {
-	const visibleLegacyWidgets = useMemo(
-		() => pickBy(
-			availableLegacyWidgets,
-			( { isHidden } ) => ! isHidden
-		),
-		[ availableLegacyWidgets ]
-	);
-	let placeholderContent;
-	if ( ! hasPermissionsToManageWidgets ) {
-		placeholderContent = __( 'You don\'t have permissions to use widgets on this site.' );
-	}
-	if ( isEmpty( visibleLegacyWidgets ) ) {
-		placeholderContent = __( 'There are no widgets available.' );
-	}
-	placeholderContent = (
-		<SelectControl
-			label={ __( 'Select a legacy widget to display:' ) }
-			value={ currentWidget || 'none' }
-			onChange={ onChangeWidget }
-			options={ [ { value: 'none', label: 'Select widget' } ].concat(
-				map( visibleLegacyWidgets, ( widget, key ) => {
-					return {
-						value: key,
-						label: widget.name,
-					};
-				} )
-			) }
-		/>
-	);
-	return (
-		<Placeholder
-			icon={ <BlockIcon icon="admin-customizer" /> }
-			label={ __( 'Legacy Widget' ) }
-		>
-			{ placeholderContent }
-		</Placeholder>
-	);
-};
+import LegacyWidgetPlaceholder from './placeholder';
 
 class LegacyWidgetEdit extends Component {
 	constructor() {

--- a/packages/block-library/src/legacy-widget/edit/index.js
+++ b/packages/block-library/src/legacy-widget/edit/index.js
@@ -134,12 +134,13 @@ class LegacyWidgetEdit extends Component {
 			<>
 				<BlockControls>
 					<Toolbar>
-						<IconButton
-							onClick={ this.changeWidget }
-							label={ __( 'Change widget' ) }
-							icon="update"
-						>
-						</IconButton>
+						{ ! widgetObject.isHidden && (
+							<IconButton
+								onClick={ this.changeWidget }
+								label={ __( 'Change widget' ) }
+								icon="update"
+							/>
+						) }
 						{ ! isCallbackWidget && (
 							<>
 								<Button

--- a/packages/block-library/src/legacy-widget/edit/placeholder.js
+++ b/packages/block-library/src/legacy-widget/edit/placeholder.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { pickBy, isEmpty, map } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { SelectControl, Placeholder } from '@wordpress/components';
+import { BlockIcon } from '@wordpress/block-editor';
+
+export default function LegacyWidgetPlaceholder( {
+	availableLegacyWidgets,
+	currentWidget,
+	hasPermissionsToManageWidgets,
+	onChangeWidget,
+} ) {
+	const visibleLegacyWidgets = useMemo(
+		() => pickBy(
+			availableLegacyWidgets,
+			( { isHidden } ) => ! isHidden
+		),
+		[ availableLegacyWidgets ]
+	);
+	let placeholderContent;
+	if ( ! hasPermissionsToManageWidgets ) {
+		placeholderContent = __( 'You don\'t have permissions to use widgets on this site.' );
+	}
+	if ( isEmpty( visibleLegacyWidgets ) ) {
+		placeholderContent = __( 'There are no widgets available.' );
+	}
+	placeholderContent = (
+		<SelectControl
+			label={ __( 'Select a legacy widget to display:' ) }
+			value={ currentWidget || 'none' }
+			onChange={ onChangeWidget }
+			options={ [ { value: 'none', label: 'Select widget' } ].concat(
+				map( visibleLegacyWidgets, ( widget, key ) => {
+					return {
+						value: key,
+						label: widget.name,
+					};
+				} )
+			) }
+		/>
+	);
+	return (
+		<Placeholder
+			icon={ <BlockIcon icon="admin-customizer" /> }
+			label={ __( 'Legacy Widget' ) }
+		>
+			{ placeholderContent }
+		</Placeholder>
+	);
+}


### PR DESCRIPTION
The legacy widget block should not be able to allow users to use core legacy widgets for which we already have an equivalent block, but it should still load these widgets.

For example, if the user uses a calendar widget on the blocks widget screen we want to show the calendar widget inside the legacy widget, and then allow the user to convert it to the calendar block.


Currently, the legacy widget did not load the core blocks, this PR fixes this problem and makes sure the core blocks are correctly loaded, although the user can not select them when inserting a new legacy widget.


## How has this been tested?
I created a new post.
I pasted the following code on the code editor:
```
<!-- wp:legacy-widget {"identifier":"WP_Widget_Calendar","instance":{"title":"My calendar"},"isCallbackWidget":false} /-->

<!-- wp:legacy-widget {"identifier":"WP_Widget_Calendar","instance":{"title":"My calendar"},"isCallbackWidget":false} /-->

<!-- wp:legacy-widget {"identifier":"WP_Widget_Tag_Cloud","instance":{"title":"Tags","count":0,"taxonomy":"post_tag"},"isCallbackWidget":false} /-->

<!-- wp:legacy-widget {"identifier":"WP_Widget_Archives","instance":{"title":"My archives","count":0,"dropdown":0},"isCallbackWidget":false} /-->
```

I switched to the visual editor and verified the legacy widgets loaded correctly and I was able to preview them.
