### PR TITLE
docgen: Remove unneccessary argument from Array#pop

### DIFF
--- a/packages/docgen/CHANGELOG.md
+++ b/packages/docgen/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### Internal
+
+- Remove unneccessary argument from an instance of `Array#pop`.
+
 ## 1.0.0 (2019-03-06)
 
 - Initial release

--- a/packages/docgen/src/index.js
+++ b/packages/docgen/src/index.js
@@ -51,7 +51,7 @@ const processFile = ( rootDir, inputFile ) => {
 		currentFileStack.push( inputFile );
 		const relativePath = path.relative( rootDir, inputFile );
 		const result = engine( relativePath, data, getIRFromRelativePath( rootDir, last( currentFileStack ) ) );
-		currentFileStack.pop( inputFile );
+		currentFileStack.pop();
 		return result;
 	} catch ( e ) {
 		process.stderr.write( `\n${ e }` );


### PR DESCRIPTION
Previously: https://github.com/WordPress/gutenberg/pull/13329#discussion_r278545491

This pull request seeks to remove an unnecessary argument from an instance of `Array#pop` in the `docgen` package. `Array#pop` receives no arguments, and it is thus unnecessary.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/pop

**Testing Instructions:**

Ensure unit tests pass:

```
npm run test-unit
```