### PR TITLE
FocalPointPicker: Supply default value as initial percentages state to fix NaN warning

### DIFF
--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -21,24 +21,19 @@ const TEXTCONTROL_MIN = 0;
 const TEXTCONTROL_MAX = 100;
 
 export class FocalPointPicker extends Component {
-	constructor() {
-		super( ...arguments );
+	constructor( props ) {
+		super( props );
 		this.onMouseMove = this.onMouseMove.bind( this );
 		this.state = {
 			isDragging: false,
 			bounds: {},
-			percentages: FocalPointPicker.defaultProps.value,
+			percentages: props.value,
 		};
 		this.containerRef = createRef();
 		this.imageRef = createRef();
 		this.horizontalPositionChanged = this.horizontalPositionChanged.bind( this );
 		this.verticalPositionChanged = this.verticalPositionChanged.bind( this );
 		this.onLoad = this.onLoad.bind( this );
-	}
-	componentDidMount() {
-		this.setState( {
-			percentages: this.props.value,
-		} );
 	}
 	componentDidUpdate( prevProps ) {
 		if ( prevProps.url !== this.props.url ) {

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -27,7 +27,7 @@ export class FocalPointPicker extends Component {
 		this.state = {
 			isDragging: false,
 			bounds: {},
-			percentages: {},
+			percentages: FocalPointPicker.defaultProps.value,
 		};
 		this.containerRef = createRef();
 		this.imageRef = createRef();


### PR DESCRIPTION
The `FocalPointPicker` component can result in a React warning being emitted from the console:

> Warning: Received NaN for the `value` attribute. If this is expected, cast the value to a string.

The reason for this that the `state` for the component has an empty `percentages` by default:

https://github.com/WordPress/gutenberg/blob/77b8234222f6c900d76e8087f863fe276c5a638e/packages/components/src/focal-point-picker/index.js#L30

Because of this `percentages.x` is initially `undefined` and in this code:

https://github.com/WordPress/gutenberg/blob/77b8234222f6c900d76e8087f863fe276c5a638e/packages/components/src/focal-point-picker/index.js#L220

The `this.fractionToPercentage( percentages.x )` call will return `NaN`.

The fix seems to be as simple as using the default prop `value` as the initial state for `percentages`.

Fixes #15136.