### PR TITLE
Use Block Editor instead of Gutenberg when appropriatte in the Handbook

### DIFF
--- a/docs/contributors/coding-guidelines.md
+++ b/docs/contributors/coding-guidelines.md
@@ -1,6 +1,6 @@
 # Coding Guidelines
 
-This living document serves to prescribe coding guidelines specific to the Gutenberg editor project. Base coding guidelines follow the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/). The following sections outline additional patterns and conventions used in the Gutenberg project.
+This living document serves to prescribe coding guidelines specific to the Gutenberg project. Base coding guidelines follow the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/). The following sections outline additional patterns and conventions used in the Gutenberg project.
 
 ## CSS
 

--- a/docs/contributors/design.md
+++ b/docs/contributors/design.md
@@ -8,7 +8,7 @@ This is a living document that outlines the design principles and patterns of th
 
 ### Goal of Gutenberg
 
-Gutenberg's all-encompassing goal is a post- and page-building experience that makes it easy to create rich layouts.
+Gutenberg's all-encompassing goal is a post- and page-building experience that makes it easy to create rich layouts. The block editor was the first product launched following this methodology for working with content.
 
 From the [kickoff post](https://make.wordpress.org/core/2017/01/04/focus-tech-and-design-leads/):
 
@@ -18,13 +18,13 @@ We can extract a few key principles from this:
 
 - **Authoring rich posts is a key strength of WordPress.**
 - **Blocks will unify features and types of interaction under a single interface.** Users shouldn’t have to write shortcodes, custom HTML, or paste URLs to embed. Users only need to learn how the block works in order to use all of its features.
-- **Gutenberg makes core features more discoverable**, reducing hard-to-find “Mystery meat.” WordPress supports a large number of blocks and 30+ embeds. Let’s increase their visibility.
+- **Make core features more discoverable**, reducing hard-to-find “Mystery meat.” WordPress supports a large number of blocks and 30+ embeds. Let’s increase their visibility.
 
 ### Why
 
 One thing that sets WordPress apart from other systems is that it allows users to create as rich a post layout as they can imagine — as long as they know HTML and CSS and build a custom theme.
 
-Gutenberg reshapes the editor into tool that allows users write rich posts and build beautiful layouts in a few clicks — no technical knowledge needed. WordPress will become a powerful and flexible content tool that’s accessible to all.
+Gutenberg reshapes the editor into a tool that allows users write rich posts and build beautiful layouts in a few clicks — no technical knowledge needed. WordPress will become a powerful and flexible content tool that’s accessible to all.
 
 ### Vision
 

--- a/docs/contributors/document.md
+++ b/docs/contributors/document.md
@@ -15,7 +15,7 @@ To add a new documentation page:
 
 It's very likely that at some point you will want to link to other documentation pages. It's worth emphasizing that all documents can be browsed in different contexts:
 
-- Gutenberg Handbook
+- Block Editor Handbook
 - GitHub website
 - npm website
 

--- a/docs/contributors/history.md
+++ b/docs/contributors/history.md
@@ -4,7 +4,7 @@
 There was a survey done: [https://make.wordpress.org/core/2017/04/07/editor-experience-survey-results/](https://make.wordpress.org/core/2017/04/07/editor-experience-survey-results/)
 
 ## Inspiration
-This includes a list of historical articles and influences on Gutenberg.
+This includes a list of historical articles and influences on the Gutenberg project.
 
 - LivingDocs: [https://beta.livingdocs.io/articles](https://beta.livingdocs.io/articles)
 - Parrot: [https://intenseminimalism.com/2017/parrot-an-integrated-site-builder-and-editor-concept-for-wordpress/](https://intenseminimalism.com/2017/parrot-an-integrated-site-builder-and-editor-concept-for-wordpress/)

--- a/docs/contributors/localizing.md
+++ b/docs/contributors/localizing.md
@@ -6,4 +6,4 @@ A Global Translation Editor (GTE) or Project Translation Editor (PTE) with suita
 
 Language packs are automatically generated once 95% of the plugin's strings are translated and approved for a locale.
 
-The eventual inclusion of Gutenberg into WordPress core means that more than 51% of WordPress installations running a translated WordPress installation will have Gutenberg's translated strings compiled into the core language pack as well.
+The inclusion of Gutenberg into WordPress core means that more than 51% of WordPress installations running a translated WordPress installation have Gutenberg's translated strings compiled into the core language pack as well.

--- a/docs/contributors/principles.md
+++ b/docs/contributors/principles.md
@@ -1,6 +1,6 @@
 # Principles
 
-First, let’s look at the big picture. If the architectural and UX principles described here are activated at scale, how will Gutenberg improve and transform both users and creators experiences?
+First, let’s look at the big picture. If the architectural and UX principles described here are activated at scale, how will the Gutenberg project improve and transform both users and creators experiences?
 
 How Gutenberg can transform the *user experience*:
 

--- a/docs/designers-developers/designers/design-patterns.md
+++ b/docs/designers-developers/designers/design-patterns.md
@@ -2,7 +2,7 @@
 
 ## Basic Editor Interface
 
-Gutenberg’s general layout uses on a bar at the top, with content below.
+The Block Editor’s general layout uses on a bar at the top, with content below.
 
 ![Editor Interface](https://cldup.com/VWA_jMcIRw-3000x3000.png)
 
@@ -22,7 +22,7 @@ A selected block shows a number of contextual actions:
 
 ![Block Interface](https://cldup.com/3tQqIncKPB-3000x3000.png)
 
-The block interface has basic actions. Gutenberg aims for good, common defaults, so users should be able to create a complete document without actually needing the advanced actions in the Settings Sidebar.
+The block interface has basic actions. The Block Editor aims for good, common defaults, so users should be able to create a complete document without actually needing the advanced actions in the Settings Sidebar.
 
 **The Block Toolbar** highlights commonly-used actions. The **Block Chip** lives in the block toolbar, and contains high-level controls for the selected block. It primarily allows users to transform a block into another type of compatible block. Some blocks also use the block chip to users to choose from a set of alternate block styles.
 

--- a/docs/designers-developers/designers/design-patterns.md
+++ b/docs/designers-developers/designers/design-patterns.md
@@ -2,7 +2,7 @@
 
 ## Basic Editor Interface
 
-The Block Editor’s general layout uses on a bar at the top, with content below.
+The block editor’s general layout uses on a bar at the top, with content below.
 
 ![Editor Interface](https://cldup.com/VWA_jMcIRw-3000x3000.png)
 
@@ -22,7 +22,7 @@ A selected block shows a number of contextual actions:
 
 ![Block Interface](https://cldup.com/3tQqIncKPB-3000x3000.png)
 
-The block interface has basic actions. The Block Editor aims for good, common defaults, so users should be able to create a complete document without actually needing the advanced actions in the Settings Sidebar.
+The block interface has basic actions. The block editor aims for good, common defaults, so users should be able to create a complete document without actually needing the advanced actions in the Settings Sidebar.
 
 **The Block Toolbar** highlights commonly-used actions. The **Block Chip** lives in the block toolbar, and contains high-level controls for the selected block. It primarily allows users to transform a block into another type of compatible block. Some blocks also use the block chip to users to choose from a set of alternate block styles.
 

--- a/docs/designers-developers/designers/design-resources.md
+++ b/docs/designers-developers/designers/design-resources.md
@@ -1,6 +1,6 @@
 # Resources
 
-The [SketchPress](https://github.com/10up/SketchPress) project includes a library of Gutenberg design components helpful for designing and prototyping Gutenberg and Gutenberg blocks:
+The [SketchPress](https://github.com/10up/SketchPress) project includes a library of Gutenberg design components helpful for designing and prototyping:
 
 [Download Sketch mockups & patterns files](https://github.com/10up/SketchPress)
 

--- a/docs/designers-developers/developers/backward-compatibility/meta-box.md
+++ b/docs/designers-developers/developers/backward-compatibility/meta-box.md
@@ -1,12 +1,12 @@
 # Meta Boxes
 
-This is a brief document detailing how meta box support works in the Block Editor. With the superior developer and user experience of blocks, especially once block templates are available, **porting PHP meta boxes to blocks is highly encouraged!** See the [Meta Block tutorial](/docs/designers-developers/developers/tutorials/metabox/meta-block-1-intro.md) for how to store post meta data using blocks.
+This is a brief document detailing how meta box support works in the block editor. With the superior developer and user experience of blocks, especially once block templates are available, **porting PHP meta boxes to blocks is highly encouraged!** See the [Meta Block tutorial](/docs/designers-developers/developers/tutorials/metabox/meta-block-1-intro.md) for how to store post meta data using blocks.
 
 ### Testing, Converting, and Maintaining Existing Meta Boxes
 
-Before converting meta boxes to blocks, it may be  easier to test if a meta box works with the Block Editor, and explicitly mark it as such.
+Before converting meta boxes to blocks, it may be  easier to test if a meta box works with the block editor, and explicitly mark it as such.
 
-If a meta box *doesn't* work with the Block Editor, and updating it to work correctly is not an option, the next step is to add the `__block_editor_compatible_meta_box` argument to the meta box declaration:
+If a meta box *doesn't* work with the block editor, and updating it to work correctly is not an option, the next step is to add the `__block_editor_compatible_meta_box` argument to the meta box declaration:
 
 ```php
 add_meta_box( 'my-meta-box', 'My Meta Box', 'my_meta_box_callback',
@@ -30,11 +30,11 @@ add_meta_box( 'my-meta-box', 'My Meta Box', 'my_meta_box_callback',
 );
 ```
 
-When the Block Editor is used, this meta box will no longer be displayed in the meta box area, as it now only exists for backward compatibility purposes. It will continue to display correctly in the classic editor.
+When the block editor is used, this meta box will no longer be displayed in the meta box area, as it now only exists for backward compatibility purposes. It will continue to display correctly in the classic editor.
 
 ### Meta Box Data Collection
 
-On each Block Editor page load, we register an action that collects the meta box data to determine if an area is empty. The original global state is reset upon collection of meta box data.
+On each block editor page load, we register an action that collects the meta box data to determine if an area is empty. The original global state is reset upon collection of meta box data.
 
 See [`register_and_do_post_meta_boxes`](https://developer.wordpress.org/reference/functions/register_and_do_post_meta_boxes/).
 
@@ -48,7 +48,7 @@ Ideally, this could be done at instantiation of the editor and help simplify thi
 
 ### Redux and React Meta Box Management
 
-When rendering the Block Editor, the meta boxes are rendered to a hidden div `#metaboxes`.
+When rendering the block editor, the meta boxes are rendered to a hidden div `#metaboxes`.
 
 *The Redux store will hold all meta boxes as inactive by default*. When
 `INITIALIZE_META_BOX_STATE` comes in, the store will update any active meta box areas by setting the `isActive` flag to `true`. Once this happens React will check for the new props sent in by Redux on the `MetaBox` component. If that `MetaBox` is now active, instead of rendering null, a `MetaBoxArea` component will be rendered. The `MetaBox` component is the container component that mediates between the `MetaBoxArea` and the Redux Store. *If no meta boxes are active, nothing happens. This will be the default behavior, as all core meta boxes have been stripped.*
@@ -71,10 +71,10 @@ This page mimics the `post.php` post form, so when it is submitted it will fire 
 
 ### Common Compatibility Issues
 
-Most PHP meta boxes should continue to work in the Block Editor, but some meta boxes that include advanced functionality could break. Here are some common reasons why meta boxes might not work as expected in the Block Editor:
+Most PHP meta boxes should continue to work in the block editor, but some meta boxes that include advanced functionality could break. Here are some common reasons why meta boxes might not work as expected in the block editor:
 
 - Plugins relying on selectors that target the post title, post content fields, and other metaboxes (of the old editor).
-- Plugins relying on TinyMCE's API because there's no longer a single TinyMCE instance to talk to in the Block Editor.
+- Plugins relying on TinyMCE's API because there's no longer a single TinyMCE instance to talk to in the block editor.
 - Plugins making updates to their DOM on "submit" or on "save".
 
 Please also note that if your plugin triggers a PHP warning or notice to be output on the page, this will cause the HTML document type (`<!DOCTYPE html>`) to be output incorrectly. This will cause the browser to render using "Quirks Mode", which is a compatibility layer that gets enabled when the browser doesn't know what type of document it is parsing. The block editor is not meant to work in this mode, but it can _appear_ to be working just fine. If you encounter issues such as *meta boxes overlaying the editor* or other layout issues, please check the raw page source of your document to see that the document type definition is the first thing output on the page. There will also be a warning in the JavaScript console, noting the issue.

--- a/docs/designers-developers/developers/backward-compatibility/meta-box.md
+++ b/docs/designers-developers/developers/backward-compatibility/meta-box.md
@@ -1,12 +1,12 @@
 # Meta Boxes
 
-This is a brief document detailing how meta box support works in Gutenberg. With the superior developer and user experience of blocks, especially once block templates are available, **porting PHP meta boxes to blocks is highly encouraged!** See the [Meta Block tutorial](/docs/designers-developers/developers/tutorials/metabox/meta-block-1-intro.md) for how to store post meta data using blocks.
+This is a brief document detailing how meta box support works in the Block Editor. With the superior developer and user experience of blocks, especially once block templates are available, **porting PHP meta boxes to blocks is highly encouraged!** See the [Meta Block tutorial](/docs/designers-developers/developers/tutorials/metabox/meta-block-1-intro.md) for how to store post meta data using blocks.
 
 ### Testing, Converting, and Maintaining Existing Meta Boxes
 
-Before converting meta boxes to blocks, it may be  easier to test if a meta box works with Gutenberg, and explicitly mark it as such.
+Before converting meta boxes to blocks, it may be  easier to test if a meta box works with the Block Editor, and explicitly mark it as such.
 
-If a meta box *doesn't* work with in Gutenberg, and updating it to work correctly is not an option, the next step is to add the `__block_editor_compatible_meta_box` argument to the meta box declaration:
+If a meta box *doesn't* work with the Block Editor, and updating it to work correctly is not an option, the next step is to add the `__block_editor_compatible_meta_box` argument to the meta box declaration:
 
 ```php
 add_meta_box( 'my-meta-box', 'My Meta Box', 'my_meta_box_callback',
@@ -30,11 +30,11 @@ add_meta_box( 'my-meta-box', 'My Meta Box', 'my_meta_box_callback',
 );
 ```
 
-When Gutenberg is used, this meta box will no longer be displayed in the meta box area, as it now only exists for backward compatibility purposes. It will continue to display correctly in the classic editor.
+When the Block Editor is used, this meta box will no longer be displayed in the meta box area, as it now only exists for backward compatibility purposes. It will continue to display correctly in the classic editor.
 
 ### Meta Box Data Collection
 
-On each Gutenberg page load, we register an action that collects the meta box data to determine if an area is empty. The original global state is reset upon collection of meta box data.
+On each Block Editor page load, we register an action that collects the meta box data to determine if an area is empty. The original global state is reset upon collection of meta box data.
 
 See [`register_and_do_post_meta_boxes`](https://developer.wordpress.org/reference/functions/register_and_do_post_meta_boxes/).
 
@@ -48,7 +48,7 @@ Ideally, this could be done at instantiation of the editor and help simplify thi
 
 ### Redux and React Meta Box Management
 
-When rendering the Gutenberg Page, the meta boxes are rendered to a hidden div `#metaboxes`.
+When rendering the Block Editor, the meta boxes are rendered to a hidden div `#metaboxes`.
 
 *The Redux store will hold all meta boxes as inactive by default*. When
 `INITIALIZE_META_BOX_STATE` comes in, the store will update any active meta box areas by setting the `isActive` flag to `true`. Once this happens React will check for the new props sent in by Redux on the `MetaBox` component. If that `MetaBox` is now active, instead of rendering null, a `MetaBoxArea` component will be rendered. The `MetaBox` component is the container component that mediates between the `MetaBoxArea` and the Redux Store. *If no meta boxes are active, nothing happens. This will be the default behavior, as all core meta boxes have been stripped.*
@@ -71,10 +71,10 @@ This page mimics the `post.php` post form, so when it is submitted it will fire 
 
 ### Common Compatibility Issues
 
-Most PHP meta boxes should continue to work in Gutenberg, but some meta boxes that include advanced functionality could break. Here are some common reasons why meta boxes might not work as expected in Gutenberg:
+Most PHP meta boxes should continue to work in the Block Editor, but some meta boxes that include advanced functionality could break. Here are some common reasons why meta boxes might not work as expected in the Block Editor:
 
 - Plugins relying on selectors that target the post title, post content fields, and other metaboxes (of the old editor).
-- Plugins relying on TinyMCE's API because there's no longer a single TinyMCE instance to talk to in Gutenberg.
+- Plugins relying on TinyMCE's API because there's no longer a single TinyMCE instance to talk to in the Block Editor.
 - Plugins making updates to their DOM on "submit" or on "save".
 
 Please also note that if your plugin triggers a PHP warning or notice to be output on the page, this will cause the HTML document type (`<!DOCTYPE html>`) to be output incorrectly. This will cause the browser to render using "Quirks Mode", which is a compatibility layer that gets enabled when the browser doesn't know what type of document it is parsing. The block editor is not meant to work in this mode, but it can _appear_ to be working just fine. If you encounter issues such as *meta boxes overlaying the editor* or other layout issues, please check the raw page source of your document to see that the document type definition is the first thing output on the page. There will also be a warning in the JavaScript console, noting the issue.

--- a/docs/designers-developers/developers/block-api/block-annotations.md
+++ b/docs/designers-developers/developers/block-api/block-annotations.md
@@ -2,7 +2,7 @@
 
 **Note: This API is experimental, that means it is subject to non-backward compatible changes or removal in any future version.**
 
-Annotations are a way to highlight a specific piece in a post created with the Block Editor. Examples of this include commenting on a piece of text and spellchecking. Both can use the annotations API to mark a piece of text.
+Annotations are a way to highlight a specific piece in a post created with the block editor. Examples of this include commenting on a piece of text and spellchecking. Both can use the annotations API to mark a piece of text.
 
 ## API
 

--- a/docs/designers-developers/developers/block-api/block-annotations.md
+++ b/docs/designers-developers/developers/block-api/block-annotations.md
@@ -2,7 +2,7 @@
 
 **Note: This API is experimental, that means it is subject to non-backward compatible changes or removal in any future version.**
 
-Annotations are a way to highlight a specific piece in a Gutenberg post. Examples of this include commenting on a piece of text and spellchecking. Both can use the annotations API to mark a piece of text.
+Annotations are a way to highlight a specific piece in a post created with the Block Editor. Examples of this include commenting on a piece of text and spellchecking. Both can use the annotations API to mark a piece of text.
 
 ## API
 

--- a/docs/designers-developers/developers/block-api/block-deprecation.md
+++ b/docs/designers-developers/developers/block-api/block-deprecation.md
@@ -3,7 +3,7 @@
 When updating static blocks markup and attributes, block authors need to consider existing posts using the old versions of their block. In order to provide a good upgrade path, you can choose one of the following strategies:
 
  - Do not deprecate the block and create a new one (a different name)
- - Provide a "deprecated" version of the block allowing users opening these blocks in Gutenberg to edit them using the updated block.
+ - Provide a "deprecated" version of the block allowing users opening these in the Block Editor to edit them using the updated block.
 
 A block can have several deprecated versions. A deprecation will be tried if a parsed block appears to be invalid, or if there is a deprecation defined for which its `isEligible` property function returns true.
 

--- a/docs/designers-developers/developers/block-api/block-deprecation.md
+++ b/docs/designers-developers/developers/block-api/block-deprecation.md
@@ -3,7 +3,7 @@
 When updating static blocks markup and attributes, block authors need to consider existing posts using the old versions of their block. In order to provide a good upgrade path, you can choose one of the following strategies:
 
  - Do not deprecate the block and create a new one (a different name)
- - Provide a "deprecated" version of the block allowing users opening these in the Block Editor to edit them using the updated block.
+ - Provide a "deprecated" version of the block allowing users opening these in the block editor to edit them using the updated block.
 
 A block can have several deprecated versions. A deprecation will be tried if a parsed block appears to be invalid, or if there is a deprecation defined for which its `isEligible` property function returns true.
 

--- a/docs/designers-developers/developers/block-api/block-edit-save.md
+++ b/docs/designers-developers/developers/block-api/block-edit-save.md
@@ -197,11 +197,11 @@ const addListItem = ( newListItem ) => {
 ```
 {% end %}
 
-Why do this? In JavaScript, arrays and objects are passed by reference, so this practice ensures changes won't affect other code that might hold references to the same data. Furthermore, Gutenberg follows the philosophy of the Redux library that [state should be immutable](https://redux.js.org/faq/immutable-data#what-are-the-benefits-of-immutability)—data should not be changed directly, but instead a new version of the data created containing the changes.
+Why do this? In JavaScript, arrays and objects are passed by reference, so this practice ensures changes won't affect other code that might hold references to the same data. Furthermore, the Gutenberg project follows the philosophy of the Redux library that [state should be immutable](https://redux.js.org/faq/immutable-data#what-are-the-benefits-of-immutability)—data should not be changed directly, but instead a new version of the data created containing the changes.
 
 ## Save
 
-The `save` function defines the way in which the different attributes should be combined into the final markup, which is then serialized by Gutenberg into `post_content`.
+The `save` function defines the way in which the different attributes should be combined into the final markup, which is then serialized into `post_content`.
 
 {% codetabs %}
 {% ES5 %}

--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -546,21 +546,21 @@ anchor: true,
 customClassName: false,
 ```
 
-- `className` (default `true`): By default, Gutenberg adds a class with the form `.wp-block-your-block-name` to the root element of your saved markup. This helps having a consistent mechanism for styling blocks that themes and plugins can rely on. If for whatever reason a class is not desired on the markup, this functionality can be disabled.
+- `className` (default `true`): By default, the class `.wp-block-your-block-name` is added to the root element of your saved markup. This helps having a consistent mechanism for styling blocks that themes and plugins can rely on. If for whatever reason a class is not desired on the markup, this functionality can be disabled.
 
 ```js
 // Remove the support for the generated className.
 className: false,
 ```
 
-- `html` (default `true`): By default, Gutenberg will allow a block's markup to be edited individually. To disable this behavior, set `html` to `false`.
+- `html` (default `true`): By default, a block's markup can be edited individually. To disable this behavior, set `html` to `false`.
 
 ```js
 // Remove support for an HTML mode.
 html: false,
 ```
 
-- `inserter` (default `true`): By default, all blocks will appear in the Gutenberg inserter. To hide a block so that it can only be inserted programmatically, set `inserter` to `false`.
+- `inserter` (default `true`): By default, all blocks will appear in the inserter. To hide a block so that it can only be inserted programmatically, set `inserter` to `false`.
 
 ```js
 // Hide this block from the inserter.

--- a/docs/designers-developers/developers/themes/README.md
+++ b/docs/designers-developers/developers/themes/README.md
@@ -1,4 +1,4 @@
-# Theming for Gutenberg
+# Theming for the Block Editor
 
 The new editor provides a number of options for theme designers and developers, including theme-defined color settings, font size control, and much more.
 

--- a/docs/designers-developers/developers/themes/theme-support.md
+++ b/docs/designers-developers/developers/themes/theme-support.md
@@ -61,7 +61,7 @@ For more information about this function, see [the developer docs on `add_theme_
 
 It can be difficult to create a responsive layout that accommodates wide images, a sidebar, a centered column, and floated elements that stay within that centered column.
 
-Gutenberg adds additional markup to floated images to make styling them easier.
+The block editor adds additional markup to floated images to make styling them easier.
 
 Here's the markup for an `Image` with a caption:
 
@@ -87,7 +87,7 @@ Here's an example using the above markup to achieve a responsive layout that fea
 
 ### Block Color Palettes
 
-Different blocks have the possibility of customizing colors. Gutenberg provides a default palette, but a theme can overwrite it and provide its own:
+Different blocks have the possibility of customizing colors. The block editor provides a default palette, but a theme can overwrite it and provide its own:
 
 ```php
 add_theme_support( 'editor-color-palette', array(
@@ -114,7 +114,7 @@ add_theme_support( 'editor-color-palette', array(
 ) );
 ```
 
-`name` is a human-readable label (demonstrated above) that appears in the tooltip and provides a meaningful description of the color to users. It is especially important for those who rely on screen readers or would otherwise have difficulty perceiving the color. `slug` is a unique identifier for the color and is used to generate the CSS classes used by the Gutenberg color palette. `color` is the hexadecimal code to specify the color.
+`name` is a human-readable label (demonstrated above) that appears in the tooltip and provides a meaningful description of the color to users. It is especially important for those who rely on screen readers or would otherwise have difficulty perceiving the color. `slug` is a unique identifier for the color and is used to generate the CSS classes used by the block editor color palette. `color` is the hexadecimal code to specify the color.
 
 Some colors change dynamically — such as "Primary" and "Secondary" color — such as in the Twenty Nineteen theme and cannot be described programmatically. In spite of that, it is still advisable to provide meaningful `name`s for at least the default values when applicable.
 
@@ -136,7 +136,7 @@ The class name is built appending 'has-', followed by the class name _using_ keb
 
 ### Block Font Sizes:
 
-Blocks may allow the user to configure the font sizes they use, e.g., the paragraph block. Gutenberg provides a default set of font sizes, but a theme can overwrite it and provide its own:
+Blocks may allow the user to configure the font sizes they use, e.g., the paragraph block. The block  provides a default set of font sizes, but a theme can overwrite it and provide its own:
 
 ```php
 add_theme_support( 'editor-font-sizes', array(
@@ -184,7 +184,7 @@ Themes can disable the ability to set custom font sizes with the following code:
 add_theme_support('disable-custom-font-sizes');
 ```
 
-When set, users will be restricted to the default sizes provided in Gutenberg or the sizes provided via the `editor-font-sizes` theme support setting.
+When set, users will be restricted to the default sizes provided in the block editor or the sizes provided via the `editor-font-sizes` theme support setting.
 
 ### Disabling custom colors in block Color Palettes
 
@@ -200,9 +200,9 @@ This flag will make sure users are only able to choose colors from the `editor-c
 
 ## Editor styles
 
-Gutenberg supports the theme's [editor styles](https://codex.wordpress.org/Editor_Style), however it works a little differently than in the classic editor.
+The block editor supports the theme's [editor styles](https://codex.wordpress.org/Editor_Style), however it works a little differently than in the classic editor.
 
-In the classic editor, the editor stylesheet is loaded directly into the iframe of the WYSIWYG editor, with no changes. Gutenberg, however, doesn't use iframes. To make sure your styles are applied only to the content of the editor, we automatically transform your editor styles by selectively rewriting or adjusting certain CSS selectors. This also allows Gutenberg to leverage your editor style in block variation previews.
+In the classic editor, the editor stylesheet is loaded directly into the iframe of the WYSIWYG editor, with no changes. The block editor, however, doesn't use iframes. To make sure your styles are applied only to the content of the editor, we automatically transform your editor styles by selectively rewriting or adjusting certain CSS selectors. This also allows the block editor to leverage your editor style in block variation previews.
 
 For example, if you write `body { ... }` in your editor style, this is rewritten to `.editor-styles-wrapper { ... }`.  This also means that you should _not_ target any of the editor class names directly.
 
@@ -212,7 +212,7 @@ Because it works a little differently, you need to opt-in to this by adding an e
 add_theme_support('editor-styles');
 ```
 
-You shouldn't need to change your editor styles too much; most themes can add the snippet above and get similar results in the classic editor and inside Gutenberg.
+You shouldn't need to change your editor styles too much; most themes can add the snippet above and get similar results in the classic editor and inside the block editor.
 
 ### Dark backgrounds
 

--- a/docs/designers-developers/developers/tutorials/block-tutorial/creating-dynamic-blocks.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/creating-dynamic-blocks.md
@@ -130,7 +130,7 @@ There are a few things to notice:
 * The built-in `save` function just returns `null` because the rendering is performed server-side.
 * The server-side rendering is a function taking the block attributes and the block inner content as arguments, and returning the markup (quite similar to shortcodes)
 
-## Live rendering in Gutenberg editor
+## Live rendering in the block editor
 
 Gutenberg 2.8 added the [`<ServerSideRender>`](/packages/components/src/server-side-render) block which enables rendering to take place on the server using PHP rather than in JavaScript. 
 

--- a/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md
+++ b/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md
@@ -2,7 +2,7 @@
 
 This page covers how to set up your development environment to use the ESNext and [JSX](https://reactjs.org/docs/introducing-jsx.html) syntaxes. ESNext is JavaScript code written using features that are only available in a specification greater than ECMAScript 5 (ES5 for short). JSX is a custom syntax extension to JavaScript which helps you to describe what the UI should look like.
 
-This documentation covers development for your plugin to work with Gutenberg. If you want to setup a development environment for developing Gutenberg itself, see the [Getting Started](/docs/contributors/getting-started.md) documentation.
+This documentation covers development for your plugin to work with the new setup provided by the Gutenberg project (ie: the block editor). If you want to develop Gutenberg itself, see the [Getting Started](/docs/contributors/getting-started.md) documentation.
 
 Most browsers can not interpret or run ESNext and JSX syntaxes, so we use a transformation step to convert these syntaxes to code that browsers can understand.
 

--- a/docs/designers-developers/developers/tutorials/javascript/readme.md
+++ b/docs/designers-developers/developers/tutorials/javascript/readme.md
@@ -1,6 +1,6 @@
 # Getting Started with JavaScript
 
-The purpose of this tutorial is to step through getting started with JavaScript and WordPress, specifically around the new block editor. The Gutenberg Handbook documentation contains information on the APIs available for working with the block editor. The goal of this tutorial is to get you comfortable on how to use the API reference and snippets of code found within.
+The purpose of this tutorial is to step through getting started with JavaScript and WordPress, specifically around the new block editor. The Block Editor Handbook contains information on the APIs available for working with this new setup. The goal of this tutorial is to get you comfortable on how to use the API reference and snippets of code found within.
 
 ### What is JavaScript
 

--- a/docs/designers-developers/developers/tutorials/javascript/versions-and-building.md
+++ b/docs/designers-developers/developers/tutorials/javascript/versions-and-building.md
@@ -1,12 +1,12 @@
 # JavaScript Versions and Build Step
 
-The Gutenberg Handbook shows JavaScript examples in two syntaxes: ES5 and ESNext. These are version names for the JavaScript language standard definitions. You may also see elsewhere the names ES6, or ECMAScript 2015 mentioned. See the [ECMAScript](https://en.wikipedia.org/wiki/ECMAScript) Wikipedia article for all the details.
+The Block Editor Handbook shows JavaScript examples in two syntaxes: ES5 and ESNext. These are version names for the JavaScript language standard definitions. You may also see elsewhere the names ES6, or ECMAScript 2015 mentioned. See the [ECMAScript](https://en.wikipedia.org/wiki/ECMAScript) Wikipedia article for all the details.
 
 ES5 code is compatible with WordPress's minimum [target for browser support](https://make.wordpress.org/core/handbook/best-practices/browser-support/).
 
 "ESNext" doesn't refer to a specific version of JavaScript, but is "dynamic" and refers to the next language definitions, whatever they might be. Because some browsers won't support these features yet (because they're new or proposed), an extra build step is required to transform the code to a syntax that works in all browsers. Webpack and babel are the tools that perform this transformation step.
 
-Additionally, the ESNext code examples in the Gutenberg handbook include [JSX syntax](https://reactjs.org/docs/introducing-jsx.html), a syntax that blends HTML and JavaScript. It makes it easier to read and write markup code, but likewise requires the build step using Webpack and Babel to transform into compatible code.
+Additionally, the ESNext code examples in the handbook include [JSX syntax](https://reactjs.org/docs/introducing-jsx.html), a syntax that blends HTML and JavaScript. It makes it easier to read and write markup code, but likewise requires the build step using Webpack and Babel to transform into compatible code.
 
 For simplicity, the JavaScript tutorial uses the ES5 definition, without JSX. This code can run straight in your browser and does not require an additional build step. In many cases, it will be perfectly fine to follow the same approach to quickly start experimenting with your plugin or theme. As soon as your codebase grows to hundreds of lines it might be a good idea to get familiar with the [JavaScript Build Setup documentation](/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md) for setting up a development environment to use ESNext syntax.
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -132,7 +132,7 @@
 		"parent": "developers"
 	},
 	{
-		"title": "Theming for Gutenberg",
+		"title": "Theming for the Block Editor",
 		"slug": "themes",
 		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/themes/README.md",
 		"parent": "developers"


### PR DESCRIPTION
The current thinking is that _Gutenberg_ should be used for the project itself, and _BlockEditor_ for the first product of this project.
