### PR TITLE
Fix: ServerSideRender remains in loading state when nothing is rendered.

### DIFF
--- a/packages/components/src/server-side-render/index.js
+++ b/packages/components/src/server-side-render/index.js
@@ -68,7 +68,7 @@ export class ServerSideRender extends Component {
 		// check if it is the current request, to avoid race conditions on slow networks.
 		const fetchRequest = this.currentFetchRequest = apiFetch( { path } )
 			.then( ( response ) => {
-				if ( this.isStillMounted && fetchRequest === this.currentFetchRequest && response && response.rendered ) {
+				if ( this.isStillMounted && fetchRequest === this.currentFetchRequest && response ) {
 					this.setState( { response: response.rendered } );
 				}
 			} )
@@ -86,7 +86,15 @@ export class ServerSideRender extends Component {
 	render() {
 		const response = this.state.response;
 		const { className } = this.props;
-		if ( ! response ) {
+		if ( response === '' ) {
+			return (
+				<Placeholder
+					className={ className }
+				>
+					{ __( 'Block rendered as empty.' ) }
+				</Placeholder>
+			);
+		} else if ( ! response ) {
 			return (
 				<Placeholder
 					className={ className }
@@ -102,14 +110,6 @@ export class ServerSideRender extends Component {
 					className={ className }
 				>
 					{ errorMessage }
-				</Placeholder>
-			);
-		} else if ( ! response.length ) {
-			return (
-				<Placeholder
-					className={ className }
-				>
-					{ __( 'No results found.' ) }
 				</Placeholder>
 			);
 		}


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/13870

The server-side render component stayed loading forever if the block rendered an empty string. This PR addresses this problem.

## How has this been tested?
I added return ""; to the archives block:
```
function render_block_core_archives( $attributes ) {
	return "";
...
```

I added the archives block in the editor and verified the block does not stay loading forever.
## Screenshots <!-- if applicable -->
After:
![image](https://user-images.githubusercontent.com/11271197/57130546-b2dca180-6d91-11e9-9eb8-cfc5643fb69d.png)

Before:
![image](https://user-images.githubusercontent.com/11271197/57130554-bb34dc80-6d91-11e9-9214-935f6eabcada.png)

