### PR TITLE
Fix: Server side rendered blocks are not parsed on the widgets screen.

### DIFF
--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -33,6 +33,11 @@ function gutenberg_widgets_init( $hook ) {
 		'wp-edit-widgets',
 		'wp.editWidgets.initialize( "widgets-editor" );'
 	);
+	// Preload server-registered block schemas.
+	wp_add_inline_script(
+		'wp-blocks',
+		'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( get_block_editor_server_block_settings() ) . ');'
+	);
 	wp_enqueue_script( 'wp-edit-widgets' );
 	wp_enqueue_style( 'wp-edit-widgets' );
 }


### PR DESCRIPTION
## Description
Server-side rendered blocks are not being correctly parsed on widgets screen making legacy widget blocks not load correctly on https://github.com/WordPress/gutenberg/pull/15074.
The problem was that the server side block definitions were not being bootstrapped on the widgets page.

## How has this been tested?
I went to the widgets page http://yah.local/wp-admin/admin.php?page=gutenberg-widgets.
I pasted `wp.blocks.parse('<!-- wp:latest-posts {"postsToShow":34,"displayPostDate":true} /-->');`on the developer tools command line.
I verified the attributes were correctly parsed on the return value.

