### PR TITLE
Fix: SandBox component does not work outside WordPress context.

### DIFF
--- a/packages/components/src/sandbox/style.scss
+++ b/packages/components/src/sandbox/style.scss
@@ -1,6 +1,7 @@
 .components-sandbox {
 	overflow: hidden;
 }
+
 iframe.components-sandbox {
 	width: 100%;
 }

--- a/packages/components/src/sandbox/style.scss
+++ b/packages/components/src/sandbox/style.scss
@@ -1,3 +1,6 @@
 .components-sandbox {
 	overflow: hidden;
 }
+iframe.components-sandbox {
+	width: 100%;
+}


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/8565

The sandbox component resizing logic required the iframe to have a style setting the widget to 100%. In the block editor context, things worked as expected because the block styles include a style that sets iframes to 100%.
https://github.com/WordPress/gutenberg/blob/5430dced1e3594ca28f5a9c829aa9baac8905e27/packages/block-library/src/style.scss#L162-L164
The component should not rely on this style being available.
This PR makes sure the component sets the style it needs.

## How has this been tested?
I pasted the content available on this gist https://gist.github.com/jorgefilipecosta/94673924b3c426f2a0cb3c7fa179a984 on the playground playground/src/index.js.
I verified I could read the "Content" string.

