### PR TITLE
Fix: Notice blocks don't match template doesn't appear; Add test case;

### DIFF
--- a/packages/e2e-tests/specs/plugins/cpt-locking.test.js
+++ b/packages/e2e-tests/specs/plugins/cpt-locking.test.js
@@ -9,6 +9,7 @@ import {
 	getEditedPostContent,
 	insertBlock,
 	pressKeyTimes,
+	setPostContent,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'cpt locking', () => {
@@ -66,6 +67,20 @@ describe( 'cpt locking', () => {
 			await page.keyboard.type( 'Paragraph' );
 			await pressKeyTimes( 'Backspace', textToType.length + 1 );
 			expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+
+		it( 'should show invalid template notice if the blocks do not match the templte', async () => {
+			const content = await getEditedPostContent();
+			const [ , contentWithoutImage ] = content.split( '<!-- /wp:image -->' );
+			await setPostContent( contentWithoutImage );
+			const VALIDATION_PARAGRAPH_SELECTOR = '.editor-template-validation-notice .components-notice__content p';
+			await page.waitForSelector( VALIDATION_PARAGRAPH_SELECTOR );
+			expect(
+				await page.evaluate(
+					( element ) => element.textContent,
+					await page.$( VALIDATION_PARAGRAPH_SELECTOR )
+				)
+			).toEqual( 'The content of your post doesn’t match the template assigned to your post type.' );
 		} );
 	} );
 

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -89,6 +89,7 @@ class EditorProvider extends Component {
 				'isRTL',
 				'maxWidth',
 				'styles',
+				'template',
 				'templateLock',
 				'titlePlaceholder',
 			] ),


### PR DESCRIPTION
## Description

Fix: https://github.com/WordPress/gutenberg/issues/15743

During the refactor to use block-editor package we missed to pass the template setting. This caused a regression where the notice that should appear when the blocks don't match the template stopped appearing.

This PR's simply passes the missing setting and adds a test case to avoid this bug in the future.

## How has this been tested?
I added the following CPT:
```
function gutenberg_test_cpt_locking() {
	$template = array(
		array( 'core/image' ),
		array(
			'core/paragraph',
			array(
				'placeholder' => 'Add a description',
			),
		),
		array( 'core/quote' ),
	);
	register_post_type(
		'locked-all-post',
		array(
			'public'        => true,
			'label'         => 'Locked All Post',
			'show_in_rest'  => true,
			'template'      => $template,
			'template_lock' => 'all',
		)
	);
}
add_action( 'init', 'gutenberg_test_cpt_locking' );
```


I created a new 'Locked All Post' I went to the code editor.
I removed the first image block.
I verified a notice saying the blocks don't match the template appeared.
