### PR TITLE
Add private tag to INSERTER_UTILITY_* constants

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -27,12 +27,22 @@ import {
 	hasChildBlocksWithInserterSupport,
 } from '@wordpress/blocks';
 
-/***
- * Module constants
+// Module constants
+/**
+ * @private
  */
 export const INSERTER_UTILITY_HIGH = 3;
+/**
+ * @private
+ */
 export const INSERTER_UTILITY_MEDIUM = 2;
+/**
+ * @private
+ */
 export const INSERTER_UTILITY_LOW = 1;
+/**
+ * @private
+ */
 export const INSERTER_UTILITY_NONE = 0;
 const MILLISECONDS_PER_HOUR = 3600 * 1000;
 const MILLISECONDS_PER_DAY = 24 * 3600 * 1000;

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -28,22 +28,27 @@ import {
 } from '@wordpress/blocks';
 
 // Module constants
+
 /**
  * @private
  */
 export const INSERTER_UTILITY_HIGH = 3;
+
 /**
  * @private
  */
 export const INSERTER_UTILITY_MEDIUM = 2;
+
 /**
  * @private
  */
 export const INSERTER_UTILITY_LOW = 1;
+
 /**
  * @private
  */
 export const INSERTER_UTILITY_NONE = 0;
+
 const MILLISECONDS_PER_HOUR = 3600 * 1000;
 const MILLISECONDS_PER_DAY = 24 * 3600 * 1000;
 const MILLISECONDS_PER_WEEK = 7 * 24 * 3600 * 1000;


### PR DESCRIPTION
So it's clear that they aren't part of public API. This also will help us to exclude them from any generated documentation (see https://github.com/WordPress/gutenberg/pull/15421).

## Test

Make sure no changes are seen in the docs:

> npm run docs:build
