### PR TITLE
Webpack dependency plugin: Fix filename function handling

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/index.js
+++ b/packages/dependency-extraction-webpack-plugin/index.js
@@ -104,9 +104,8 @@ class DependencyExtractionWebpackPlugin {
 
 				// Determine a filename for the `[entrypoint].deps.json` file.
 				const [ filename, query ] = entrypointName.split( '?', 2 );
-				const depsFilename = compilation.getPath(
-					outputFilename.replace( /\.js$/i, '.deps.json' ),
-					{
+				const depsFilename = compilation
+					.getPath( outputFilename, {
 						chunk: entrypoint.getRuntimeChunk(),
 						filename,
 						query,
@@ -114,8 +113,8 @@ class DependencyExtractionWebpackPlugin {
 						contentHash: createHash( 'md4' )
 							.update( depsString )
 							.digest( 'hex' ),
-					}
-				);
+					} )
+					.replace( /\.js$/i, '.deps.json' );
 
 				// Add source and file into compilation for webpack to output.
 				compilation.assets[ depsFilename ] = new RawSource( depsString );

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -29,6 +29,35 @@ Array [
 ]
 `;
 
+exports[`Webpack \`function-output-filename\` should produce expected output: Dependencies JSON should match snapshot 1`] = `
+Array [
+  "lodash",
+  "wp-blob",
+]
+`;
+
+exports[`Webpack \`function-output-filename\` should produce expected output: External modules should match snapshot 1`] = `
+Array [
+  Object {
+    "externalType": "this",
+    "request": Object {
+      "this": Array [
+        "wp",
+        "blob",
+      ],
+    },
+    "userRequest": "@wordpress/blob",
+  },
+  Object {
+    "externalType": "this",
+    "request": Object {
+      "this": "lodash",
+    },
+    "userRequest": "lodash",
+  },
+]
+`;
+
 exports[`Webpack \`no-default\` should produce expected output: Dependencies JSON should match snapshot 1`] = `Array []`;
 
 exports[`Webpack \`no-default\` should produce expected output: External modules should match snapshot 1`] = `Array []`;

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/function-output-filename/index.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/function-output-filename/index.js
@@ -1,0 +1,11 @@
+/**
+ * WordPress dependencies
+ */
+import { isBlobURL } from '@wordpress/blob';
+
+/**
+ * External dependencies
+ */
+import _ from 'lodash';
+
+_.isEmpty( isBlobURL( '' ) );

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/function-output-filename/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/function-output-filename/webpack.config.js
@@ -1,0 +1,10 @@
+const DependencyExtractionWebpackPlugin = require( '../../..' );
+
+module.exports = {
+	output: {
+		filename( chunkData ) {
+			return `chunk--${ chunkData.chunk.name }--[name].js`;
+		},
+	},
+	plugins: [ new DependencyExtractionWebpackPlugin() ],
+};


### PR DESCRIPTION
## Description
As described in #15410, webpack accepts either a string or function for its `output.filename` configuration. `@wordpress/dependency-extraction-webpack-plugin` would error when a function `filename` was passed.

This was caused by attempting to replace the `.js` extension with `.deps.json` on the filename option string. The fix was to move the `.js` extension replacement to the result of `compilation.getPath`. This will correctly handle function filenames and allow replace to be called reliably on the string.

- Add a test for webpack configuration with a function `filename`.
- Apply the fix (call `.replace` on the result of `compilation.getPath` instead of the input).
- Add new test snapshots.

Fixes #15410

## How has this been tested?
Includes tests.

## Types of changes

Bug fix in the unpublished `@wordpress/dependency-extraction-webpack-plugin` package.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
