### PR TITLE
@wordpress/data: Expose `hasResolver` property on returned selectors

### DIFF
--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Restore functionality of action-generators returning a Promise.  Clarify intent and behaviour for `wp.data.dispatch` behaviour. Dispatch actions now always
  return a promise ([#14830](https://github.com/WordPress/gutenberg/pull/14830)
+ 
+### Enhancements
+
+- Expose `hasResolver` property on returned selectors indicating whether the selector has a corresponding resolver.
 
 ## 4.3.0 (2019-03-06)
 

--- a/packages/data/src/namespace-store/index.js
+++ b/packages/data/src/namespace-store/index.js
@@ -155,9 +155,11 @@ function createReduxStore( key, options, registry ) {
  */
 function mapSelectors( selectors, store, registry ) {
 	const createStateSelector = ( registeredSelector ) => {
-		const selector = registeredSelector.isRegistrySelector ? registeredSelector( registry.select ) : registeredSelector;
+		const registrySelector = registeredSelector.isRegistrySelector ?
+			registeredSelector( registry.select ) :
+			registeredSelector;
 
-		return function runSelector() {
+		const selector = function runSelector() {
 			// This function is an optimized implementation of:
 			//
 			//   selector( store.getState(), ...arguments )
@@ -172,8 +174,10 @@ function mapSelectors( selectors, store, registry ) {
 				args[ i + 1 ] = arguments[ i ];
 			}
 
-			return selector( ...args );
+			return registrySelector( ...args );
 		};
+		selector.hasResolver = false;
+		return selector;
 	};
 
 	return mapValues( selectors, createStateSelector );

--- a/packages/data/src/namespace-store/index.js
+++ b/packages/data/src/namespace-store/index.js
@@ -213,10 +213,11 @@ function mapResolvers( resolvers, selectors, store ) {
 	const mapSelector = ( selector, selectorName ) => {
 		const resolver = resolvers[ selectorName ];
 		if ( ! resolver ) {
+			selector.hasResolver = false;
 			return selector;
 		}
 
-		return ( ...args ) => {
+		const selectorResolver = ( ...args ) => {
 			async function fulfillSelector() {
 				const state = store.getState();
 				if ( typeof resolver.isFulfilled === 'function' && resolver.isFulfilled( state, ...args ) ) {
@@ -236,6 +237,8 @@ function mapResolvers( resolvers, selectors, store ) {
 			fulfillSelector( ...args );
 			return selector( ...args );
 		};
+		selectorResolver.hasResolver = true;
+		return selectorResolver;
 	};
 
 	return {

--- a/packages/data/src/namespace-store/test/index.js
+++ b/packages/data/src/namespace-store/test/index.js
@@ -80,21 +80,32 @@ describe( 'controls', () => {
 
 		registry.select( 'store' ).getItems();
 	} );
-	it( 'selectors have expected value for the `hasResolver` property', () => {
-		registry.registerStore( 'store', {
-			reducer: jest.fn(),
-			selectors: {
-				getItems: ( state ) => state,
-				getItem: ( state ) => state,
-			},
-			resolvers: {
-				* getItems() {
-					yield 'foo';
+	describe( 'selectors have expected value for the `hasResolver` property', () => {
+		it( 'when custom store has resolvers defined', () => {
+			registry.registerStore( 'store', {
+				reducer: jest.fn(),
+				selectors: {
+					getItems: ( state ) => state,
+					getItem: ( state ) => state,
 				},
-			},
+				resolvers: {
+					* getItems() {
+						yield 'foo';
+					},
+				},
+			} );
+			expect( registry.select( 'store' ).getItems.hasResolver ).toBe( true );
+			expect( registry.select( 'store' ).getItem.hasResolver ).toBe( false );
 		} );
-		expect( registry.select( 'store' ).getItems.hasResolver ).toBe( true );
-		expect( registry.select( 'store' ).getItem.hasResolver ).toBe( false );
+		it( 'when custom store does not have resolvers defined', () => {
+			registry.registerStore( 'store', {
+				reducer: jest.fn(),
+				selectors: {
+					getItems: ( state ) => state,
+				},
+			} );
+			expect( registry.select( 'store' ).getItems.hasResolver ).toBe( false );
+		} );
 	} );
 	describe( 'various action types have expected response and resolve as ' +
 		'expected with controls middleware', () => {

--- a/packages/data/src/namespace-store/test/index.js
+++ b/packages/data/src/namespace-store/test/index.js
@@ -80,6 +80,22 @@ describe( 'controls', () => {
 
 		registry.select( 'store' ).getItems();
 	} );
+	it( 'selectors have expected value for the `hasResolver` property', () => {
+		registry.registerStore( 'store', {
+			reducer: jest.fn(),
+			selectors: {
+				getItems: ( state ) => state,
+				getItem: ( state ) => state,
+			},
+			resolvers: {
+				* getItems() {
+					yield 'foo';
+				},
+			},
+		} );
+		expect( registry.select( 'store' ).getItems.hasResolver ).toBe( true );
+		expect( registry.select( 'store' ).getItem.hasResolver ).toBe( false );
+	} );
 	describe( 'various action types have expected response and resolve as ' +
 		'expected with controls middleware', () => {
 		const actions = {


### PR DESCRIPTION
## Description

While implementing the new `RESOLVE_SELECT` control as a part of #13716, I remarked [in a comment](https://github.com/WordPress/gutenberg/pull/13716#discussion_r258073723) that it would be more dev friendly if the select control would automatically handle when there's a resolver involved.  In order to do that, `wp.data` needs to expose whether a selector has a resolver.  I figured the cleanest way to do this would be to add a `hasResolver` property to the selectors while they are mapped to resolvers.

## How has this been tested?

* [x] added unit tests, verify they pass
* [x] cherry-picked into #15435 (and will be removed there once this pull lands) and verified to do the job for that package. (see [implementation here](https://github.com/WordPress/gutenberg/pull/15435/commits/47c486373ebd0a798f860936da43a3df85d0ec43#diff-9fb42816127c9fa3299026bdc8a283dfR158) )

## Types of changes

This is an enhancement and a non-breaking change.

## Other:

I didn't add much documentation about this new property as I think its primarily for low-level usage.  Should there be more documentation?  I think the code (and tests) is fairly clear on its intended purpose?

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
