### PR TITLE
@wordpress/data: Export entire registry context

### DIFF
--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ### Bug Fix
 
-- Restore functionality of action-generators returning a Promise.  Clarify intent and behaviour for `wp.data.dispatch` behaviour. Dispatch actions now always
- return a promise ([#14830](https://github.com/WordPress/gutenberg/pull/14830)
+- Restore functionality of action-generators returning a Promise.  Clarify intent and behaviour for `wp.data.dispatch` behaviour. Dispatch actions now always return a promise ([#14830](https://github.com/WordPress/gutenberg/pull/14830))
+ 
+### Enhancements
+
+- Export the entire registry context (as `RegistryContext`) so consuming code can implement it using the `useContext` react hook ([#15445](https://github.com/WordPress/gutenberg/pull/15445))
 
 ## 4.3.0 (2019-03-06)
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -381,6 +381,10 @@ _Returns_
 
 Undocumented declaration.
 
+<a name="RegistryContext" href="#RegistryContext">#</a> **RegistryContext**
+
+Undocumented declaration.
+
 <a name="RegistryProvider" href="#RegistryProvider">#</a> **RegistryProvider**
 
 Undocumented declaration.

--- a/packages/data/src/components/registry-provider/index.js
+++ b/packages/data/src/components/registry-provider/index.js
@@ -8,7 +8,9 @@ import { createContext } from '@wordpress/element';
  */
 import defaultRegistry from '../../default-registry';
 
-const { Consumer, Provider } = createContext( defaultRegistry );
+export const RegistryContext = createContext( defaultRegistry );
+
+const { Consumer, Provider } = RegistryContext;
 
 export const RegistryConsumer = Consumer;
 

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -12,7 +12,11 @@ import * as plugins from './plugins';
 export { default as withSelect } from './components/with-select';
 export { default as withDispatch } from './components/with-dispatch';
 export { default as withRegistry } from './components/with-registry';
-export { default as RegistryProvider, RegistryConsumer } from './components/registry-provider';
+export {
+	default as RegistryProvider,
+	RegistryConsumer,
+	RegistryContext,
+} from './components/registry-provider';
 export { default as __experimentalAsyncModeProvider } from './components/async-mode-provider';
 export { createRegistry } from './registry';
 export { plugins };


### PR DESCRIPTION
## Description

As a part of the work being done on #15444, the `useContext` hook is being used to obtain the `registry` value from the context.  However in order to do this the entire registry context object must be exposed from `@wordpress/data`.  This pull does so.

This has utility for anywhere else where `useContext` might be implemented with the registry context.

## How has this been tested?

* [x] Cherrypicked into #15444 and verified it works as expected there.

## Types of changes

This is a non-breaking change and is an enhancement exposing the entire RegistryContext object.  Existing Consumer and Provider values are left alone so there's no impact to existing code.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
