### PR TITLE
Webpack dependency plugin: Document unsupported multiple instances

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -27,12 +27,12 @@ Use this plugin as you would other webpack plugins:
 
 ```js
 // webpack.config.js
-const WordPressExternalDependenciesPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
 
 module.exports = {
   // …snip
   plugins: [
-    new WordPressExternalDependenciesPlugin(),
+    new DependencyExtractionWebpackPlugin(),
   ]
 }
 ```
@@ -83,7 +83,7 @@ An object can be passed to the constructor to customize the behavior, for exampl
 ```js
 module.exports = {
   plugins: [
-    new WordPressExternalDependenciesPlugin( { injectPolyfill: true } ),
+    new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),
   ]
 }
 ```
@@ -134,7 +134,7 @@ function requestToExternal( request ) {
 
 module.exports = {
   plugins: [
-    new WordPressExternalDependenciesPlugin( { requestToExternal } ),
+    new DependencyExtractionWebpackPlugin( { requestToExternal } ),
   ]
 }
 ```
@@ -162,14 +162,14 @@ function requestToHandle( request ) {
 
   // Handle imports like `import myModule from 'my-module'`
   if ( request === 'my-module' ) {
-    // Expect to find `my-module` as myModule in the global scope:
+    // `my-module` depends on the script with the 'my-module-script-handle' handle.
     return 'my-module-script-handle';
   }
 }
 
 module.exports = {
   plugins: [
-    new WordPressExternalDependenciesPlugin( { requestToExternal } ),
+    new DependencyExtractionWebpackPlugin( { requestToExternal } ),
   ]
 }
 ```

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -37,6 +37,28 @@ module.exports = {
 }
 ```
 
+**Note:** Multiple instances of the plugin are not supported and may produced unexpected results. If
+you plan to extend the webpack configuration from `@wordpress/scripts` with your own `DependencyExtractionWebpackPlugin`, be sure to
+remove the default instance of the plugin:
+
+```js
+const defaultConfig = require('@wordpress/scripts/config/webpack.config');
+const config = {
+  ...defaultConfig,
+  plugins: [
+    ...defaultConfig.plugins.filter(
+      plugin => plugin.constructor.name !== 'DependencyExtractionWebpackPlugin',
+    ),
+    new DependencyExtractionWebpackPlugin({
+      injectPolyfill: true,
+      requestToExternal(request) {
+        /* My externals */
+      },
+    }),
+  ],
+};
+```
+
 Each entrypoint in the webpack bundle will include JSON file that declares the WordPress script dependencies that should be enqueued.
 
 For example:

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -81,7 +81,6 @@ By default, the following module requests are handled:
 | `@babel/runtime/regenerator` | `regeneratorRuntime` | `wp-polyfill` |
 | `@wordpress/*` | `wp['*']` | `wp-*` |
 | `jquery` | `jQuery` | `jquery` |
-| `jquery` | `jQuery` | `jquery` |
 | `lodash-es` | `lodash` | `lodash` |
 | `lodash` | `lodash` | `lodash` |
 | `moment` | `moment` | `moment` |

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -42,19 +42,19 @@ you plan to extend the webpack configuration from `@wordpress/scripts` with your
 remove the default instance of the plugin:
 
 ```js
-const defaultConfig = require('@wordpress/scripts/config/webpack.config');
+const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 const config = {
   ...defaultConfig,
   plugins: [
     ...defaultConfig.plugins.filter(
       plugin => plugin.constructor.name !== 'DependencyExtractionWebpackPlugin',
     ),
-    new DependencyExtractionWebpackPlugin({
+    new DependencyExtractionWebpackPlugin( {
       injectPolyfill: true,
       requestToExternal(request) {
         /* My externals */
       },
-    }),
+    } ),
   ],
 };
 ```


### PR DESCRIPTION
## Description

Multiple instances of the `@wordpress/dependency-extraction-webpack-plugin` produce unexpected results:

```js
webpack.config.plugins = [
const defaultConfig = require('@wordpress/scripts/config/webpack.config');
const config = {
   new DependencyExtractionWebpackPlugin({
      injectPolyfill: true,
  }),
   new DependencyExtractionWebpackPlugin({
      useDefaults: false,
  }),
   new DependencyExtractionWebpackPlugin({
      requestToExternal( request ) { return 'foobar'; }
  }),
]
```

Each of the above plugin instances has different options and different expectations. This is problematic mostly because each of the plugin instances will attempt to produce the same output, colliding and overwriting with unexpected results. While the above example is contrived, the following shows a case where multiple instances are created and are less obvious, from https://github.com/WordPress/gutenberg/pull/15430#issuecomment-489521752:

```js
const defaultConfig = require('@wordpress/scripts/config/webpack.config');
const config = {
  ...defaultConfig,
  plugins: [
    ...defaultConfig.plugins,
    new DependencyExtractionWebpackPlugin( {
      requestToExternal: ( request ) => {},
      requestToHandle: ( request ) => {},
    } ),
  ],
};
```

Add documentation discouraging multiple instances and provide instructions about removing the default instance from scripts.

### Question

While updating the documentation is helpful, it does not prevent painful bugs from being introduced. It's straightforward for the plugin to detect multiple instances, should the plugin throw an error?

```diff
diff --git a/packages/dependency-extraction-webpack-plugin/index.js b/packages/dependency-extraction-webpack-plugin/index.js
index f99ec61fa..9e8e613de 100644
--- a/packages/dependency-extraction-webpack-plugin/index.js
+++ b/packages/dependency-extraction-webpack-plugin/index.js
@@ -75,6 +75,19 @@ class DependencyExtractionWebpackPlugin {
 	}
 
 	apply( compiler ) {
+		// Multiple instances of this plugin is unsupported. Warn if detected.
+		if (
+			compiler.options.plugins.filter(
+				( plugin ) => this !== plugin && plugin.constructor.name === this.constructor.name
+			).length
+		) {
+			throw new Error(
+				`Multiple instances of the webpack plugin ${ this.constructor.name } found.\n` +
+					'This is unsupported and may produce unexpected results.\n' +
+					'See [some-link].'
+			);
+		}
+
 		this.externalsPlugin.apply( compiler );
 
 		const { output } = compiler.options;
```

### Janitorial changes included in this PR
- Update local binding in README to `DependencyExtractionWebpackPlugin`, better matching package name
- Fix `requestToHandle` inline comment in README.

## How has this been tested?
Recommended documentation was tested locally.

## Types of changes

Documentation

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
