### PR TITLE
reverts the rename of postsToShow as it may cause breaking changes

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -70,7 +70,7 @@ class LatestPostsEdit extends Component {
 	render() {
 		const { attributes, setAttributes, latestPosts } = this.props;
 		const { categoriesList } = this.state;
-		const { displayPostContentRadio, displayPostContent, displayPostDate, postLayout, columns, order, orderBy, categories, postCount, excerptLength } = attributes;
+		const { displayPostContentRadio, displayPostContent, displayPostDate, postLayout, columns, order, orderBy, categories, postsToShow, excerptLength } = attributes;
 
 		const inspectorControls = (
 			<InspectorControls>
@@ -113,13 +113,13 @@ class LatestPostsEdit extends Component {
 				<PanelBody title={ __( 'Sorting and Filtering' ) }>
 					<QueryControls
 						{ ...{ order, orderBy } }
-						numberOfItems={ postCount }
+						numberOfItems={ postsToShow }
 						categoriesList={ categoriesList }
 						selectedCategoryId={ categories }
 						onOrderChange={ ( value ) => setAttributes( { order: value } ) }
 						onOrderByChange={ ( value ) => setAttributes( { orderBy: value } ) }
 						onCategoryChange={ ( value ) => setAttributes( { categories: '' !== value ? value : undefined } ) }
-						onNumberOfItemsChange={ ( value ) => setAttributes( { postCount: value } ) }
+						onNumberOfItemsChange={ ( value ) => setAttributes( { postsToShow: value } ) }
 					/>
 					{ postLayout === 'grid' &&
 						<RangeControl
@@ -154,8 +154,8 @@ class LatestPostsEdit extends Component {
 		}
 
 		// Removing posts from display should be instant.
-		const displayPosts = latestPosts.length > postCount ?
-			latestPosts.slice( 0, postCount ) :
+		const displayPosts = latestPosts.length > postsToShow ?
+			latestPosts.slice( 0, postsToShow ) :
 			latestPosts;
 
 		const layoutControls = [
@@ -244,13 +244,13 @@ class LatestPostsEdit extends Component {
 }
 
 export default withSelect( ( select, props ) => {
-	const { postCount, order, orderBy, categories } = props.attributes;
+	const { postsToShow, order, orderBy, categories } = props.attributes;
 	const { getEntityRecords } = select( 'core' );
 	const latestPostsQuery = pickBy( {
 		categories,
 		order,
 		orderby: orderBy,
-		per_page: postCount,
+		per_page: postsToShow,
 	}, ( value ) => ! isUndefined( value ) );
 	return {
 		latestPosts: getEntityRecords( 'postType', 'post', latestPostsQuery ),

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -124,16 +124,16 @@ function register_block_core_latest_posts() {
 	register_block_type(
 		'core/latest-posts',
 		array(
-			'attributes' => array(
+			'attributes'      => array(
 				'align'                   => array(
-					'type'    => 'string',
-					'enum'    => array( 'left', 'center', 'right', 'wide', 'full' ),
+					'type' => 'string',
+					'enum' => array( 'left', 'center', 'right', 'wide', 'full' ),
 				),
 				'className'               => array(
-					'type'    => 'string',
+					'type' => 'string',
 				),
 				'categories'              => array(
-					'type'    => 'string',
+					'type' => 'string',
 				),
 				'postsToShow'             => array(
 					'type'    => 'number',

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -124,18 +124,18 @@ function register_block_core_latest_posts() {
 	register_block_type(
 		'core/latest-posts',
 		array(
-			'attributes'      => array(
+			'attributes' => array(
 				'align'                   => array(
-					'type' => 'string',
-					'enum' => array( 'left', 'center', 'right', 'wide', 'full' ),
+					'type'    => 'string',
+					'enum'    => array( 'left', 'center', 'right', 'wide', 'full' ),
 				),
 				'className'               => array(
-					'type' => 'string',
+					'type'    => 'string',
 				),
 				'categories'              => array(
-					'type' => 'string',
+					'type'    => 'string',
 				),
-				'postsToShow'               => array(
+				'postsToShow'             => array(
 					'type'    => 'number',
 					'default' => 5,
 				),

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -14,7 +14,7 @@
  */
 function render_block_core_latest_posts( $attributes ) {
 	$args = array(
-		'posts_per_page'   => $attributes['postCount'],
+		'posts_per_page'   => $attributes['postsToShow'],
 		'post_status'      => 'publish',
 		'order'            => $attributes['order'],
 		'orderby'          => $attributes['orderBy'],
@@ -135,7 +135,7 @@ function register_block_core_latest_posts() {
 				'categories'              => array(
 					'type' => 'string',
 				),
-				'postCount'               => array(
+				'postsToShow'               => array(
 					'type'    => 'number',
 					'default' => 5,
 				),


### PR DESCRIPTION
## Description
#14627 renamed postsToShow to postCount on my suggestion in the latest posts block. This reverts that as I didn't consider that is a breaking change. It could be renamed still but the effor to write the deprecation code is not justified.

## How has this been tested?
Local testing of the latest posts code

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
