### PR TITLE
Fix: webpack does not watch for block.json changes

### DIFF
--- a/bin/packages/watch.js
+++ b/bin/packages/watch.js
@@ -27,7 +27,7 @@ const exists = ( filename ) => {
 // and files with a suffix of .test or .spec (e.g. blocks.test.js),
 // and deceitful source-like files, such as editor swap files.
 const isSourceFile = ( filename ) => {
-	return ! [ /\/(__tests__|test)\/.+.js$/, /.\.(spec|test)\.js$/ ].some( ( regex ) => regex.test( filename ) ) && /.\.(js|scss)$/.test( filename );
+	return ! [ /\/(__tests__|test)\/.+.js$/, /.\.(spec|test)\.js$/ ].some( ( regex ) => regex.test( filename ) ) && /.\.(js|json|scss)$/.test( filename );
 };
 
 const rebuild = ( filename ) => filesToBuild.set( filename, true );


### PR DESCRIPTION
Fixes #15135:

> *Describe the bug**
> Since #14770, the block.json is introduced. However, the webpack does not watch for the json files changes.
> 
> **To reproduce**
> Steps to reproduce the behavior:
> 1. `npm run dev`
> 2. modify a block.json file
> The webpack does not rebuild the package automatically.

## Testing

1. `npm run dev`
2. modify any `block.json` file
3. confirm that webpack rebuild files
