### PR TITLE
Fix/buttons should not appear as links

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -137,8 +137,6 @@
 		outline: none;
 		text-align: left;
 		/* Mimics the default link style in common.css */
-		color: #0073aa;
-		text-decoration: underline;
 		transition-property: border, background, color;
 		transition-duration: 0.05s;
 		transition-timing-function: ease-in-out;

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -137,6 +137,8 @@
 		outline: none;
 		text-align: left;
 		/* Mimics the default link style in common.css */
+		color: #0073aa;
+		text-decoration: underline;
 		transition-property: border, background, color;
 		transition-duration: 0.05s;
 		transition-timing-function: ease-in-out;

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -54,10 +54,9 @@
 }
 
 .editor-post-publish-panel__link {
-	color: $blue-medium-700;
 	font-weight: 400;
 	padding-left: 4px;
-	text-decoration: underline;
+	text-decoration: none;
 }
 
 .editor-post-publish-panel__prepublish {

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -56,7 +56,6 @@
 .editor-post-publish-panel__link {
 	font-weight: 400;
 	padding-left: 4px;
-	text-decoration: none;
 }
 
 .editor-post-publish-panel__prepublish {


### PR DESCRIPTION
## Description
Closes https://github.com/WordPress/gutenberg/issues/15358#issuecomment-489615758.

Addresses issue from a11y report by removing link styling from buttons elements within the prepublish sidebar.

## How has this been tested?
* Open prepublish sidebar
* Verify the button text is not styled to visually appear as a link (eg: underlined and blue color)

## Screenshots <!-- if applicable -->

![Screen Shot 2019-05-06 at 15 42 55](https://user-images.githubusercontent.com/444434/57229129-a8cad500-7015-11e9-8af1-ae9851bb8187.png)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
