### PR TITLE
Removes redundant aria-label from block inserter

### DIFF
--- a/packages/block-editor/src/components/inserter-list-item/index.js
+++ b/packages/block-editor/src/components/inserter-list-item/index.js
@@ -43,7 +43,6 @@ function InserterListItem( {
 					onClick();
 				} }
 				disabled={ isDisabled }
-				aria-label={ title } // Fix for IE11 and JAWS 2018.
 				{ ...props }
 			>
 				<span


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/15337

Removes the (potentially) redundant aria-label from the block inserter. This needs testing in IE11 and JAWs as it was [originally added](https://github.com/WordPress/gutenberg/pull/5828) to work around an edge cases there.

## Description
Removed `aria-label` attribute.

