### PR TITLE
A11y: update icon for heading block

### DIFF
--- a/packages/block-library/src/heading/icon.js
+++ b/packages/block-library/src/heading/icon.js
@@ -1,8 +1,0 @@
-/**
- * WordPress dependencies
- */
-import { Path, SVG } from '@wordpress/components';
-
-export default (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M5 4v3h5.5v12h3V7H19V4z" /><Path fill="none" d="M0 0h24v24H0V0z" /></SVG>
-);

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -13,7 +13,6 @@ import { RichText } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import edit from './edit';
-import icon from './icon';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
@@ -31,7 +30,7 @@ const supports = {
 export const settings = {
 	title: __( 'Heading' ),
 	description: __( 'Introduce new sections and organize content to help visitors (and search engines) understand the structure of your content.' ),
-	icon,
+	icon: 'heading',
 	keywords: [ __( 'title' ), __( 'subtitle' ) ],
 	supports,
 	transforms,


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Fixes https://github.com/WordPress/gutenberg/issues/15340

**Issue description**
The "Block Type" menu, and block editor type button, use icons for
each block, and in most cases these are good representations of the
block. However the "Heading" block type uses the letter "T", which
is potentially confusing, since "Heading" doesn't start with "T".

**Remediation Guidance**
Use the letter "H" as the icon for the Heading block type. This also
matches the other H icons used for setting the level (H2, H3, etc.).

## Screenshots <!-- if applicable -->

<img width="619" alt="Screen Shot 2019-05-06 at 16 09 56" src="https://user-images.githubusercontent.com/1562646/57231519-f269ee80-701a-11e9-9747-a6a508d2f4e4.png">



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
- change icon to `heading`
- remove unused title icon

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
