### PR TITLE
RichText: show boundary only with editable element focus

### DIFF
--- a/packages/block-editor/src/components/rich-text/editable.js
+++ b/packages/block-editor/src/components/rich-text/editable.js
@@ -83,7 +83,10 @@ function applyInternetExplorerInputFix( editorNode ) {
 }
 
 const IS_PLACEHOLDER_VISIBLE_ATTR_NAME = 'data-is-placeholder-visible';
-const CLASS_NAME = 'editor-rich-text__editable block-editor-rich-text__editable';
+
+const oldClassName = 'editor-rich-text__editable';
+
+export const className = 'block-editor-rich-text__editable';
 
 /**
  * Whether or not the user agent is Internet Explorer.
@@ -116,7 +119,11 @@ export default class Editable extends Component {
 		}
 
 		if ( ! isEqual( this.props.className, nextProps.className ) ) {
-			this.editorNode.className = classnames( nextProps.className, CLASS_NAME );
+			this.editorNode.className = classnames(
+				className,
+				oldClassName,
+				nextProps.className
+			);
 		}
 
 		const { removedKeys, updatedKeys } = diffAriaProps( this.props, nextProps );
@@ -156,7 +163,7 @@ export default class Editable extends Component {
 			style,
 			record,
 			valueToEditableHTML,
-			className,
+			className: additionalClassName,
 			isPlaceholderVisible,
 			...remainingProps
 		} = this.props;
@@ -166,7 +173,7 @@ export default class Editable extends Component {
 		return createElement( tagName, {
 			role: 'textbox',
 			'aria-multiline': true,
-			className: classnames( className, CLASS_NAME ),
+			className: classnames( className, oldClassName, additionalClassName ),
 			contentEditable: true,
 			[ IS_PLACEHOLDER_VISIBLE_ATTR_NAME ]: isPlaceholderVisible,
 			ref: this.bindEditorNode,

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -52,7 +52,7 @@ import Autocomplete from '../autocomplete';
 import BlockFormatControls from '../block-format-controls';
 import FormatEdit from './format-edit';
 import FormatToolbar from './format-toolbar';
-import Editable from './editable';
+import Editable, { className as editableClassName } from './editable';
 import { pickAriaProps } from './aria';
 import { getPatterns } from './patterns';
 import { withBlockEditContext } from '../block-edit/context';
@@ -502,16 +502,18 @@ export class RichText extends Component {
 		const boundarySelector = '*[data-rich-text-format-boundary]';
 		const element = this.editableRef.querySelector( boundarySelector );
 
-		if ( element ) {
-			const computedStyle = getComputedStyle( element );
-			const newColor = computedStyle.color
-				.replace( ')', ', 0.2)' )
-				.replace( 'rgb', 'rgba' );
-			const path = `[contenteditable]:focus ${ boundarySelector }`;
-			const rules = `{background-color: ${ newColor }}`;
-
-			globalStyle.innerHTML = path + rules;
+		if ( ! element ) {
+			return;
 		}
+
+		const computedStyle = getComputedStyle( element );
+		const newColor = computedStyle.color
+			.replace( ')', ', 0.2)' )
+			.replace( 'rgb', 'rgba' );
+		const selector = `.${ editableClassName }:focus ${ boundarySelector }`;
+		const rule = `background-color: ${ newColor }`;
+
+		globalStyle.innerHTML = `${ selector } {${ rule }}`;
 	}
 
 	/**

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -507,9 +507,10 @@ export class RichText extends Component {
 			const newColor = computedStyle.color
 				.replace( ')', ', 0.2)' )
 				.replace( 'rgb', 'rgba' );
+			const path = `[contenteditable]:focus ${ boundarySelector }`;
+			const rules = `{background-color: ${ newColor }}`;
 
-			globalStyle.innerHTML =
-				`*:focus ${ boundarySelector }{background-color: ${ newColor }}`;
+			globalStyle.innerHTML = path + rules;
 		}
 	}
 


### PR DESCRIPTION
## Description

Fixes #15463. The focus check should be more specific to editable elements. If a parent element has focus, e.g. the block or body element, the boundary should not be visible.

Of course the boundary attribute should be removed on blur, but we're not ready yet to remove "lingering" selection state on blur (e.g. formatting buttons would not work).

## How has this been tested?
See #15463.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
