### PR TITLE
FormTokenField: Add Help Text

### DIFF
--- a/packages/components/src/form-token-field/index.js
+++ b/packages/components/src/form-token-field/index.js
@@ -585,8 +585,8 @@ class FormTokenField extends Component {
 				</div>
 				<p id={ `components-form-token-suggestions-howto-${ instanceId }` } className="components-form-token-field__help">
 					{ this.props.tokenizeOnSpace ?
-						__( 'Separate using commas, spaces, or the Enter key' ) :
-						__( 'Separate using commas or the Enter key' )
+						__( 'Separate with commas, spaces, or the Enter key.' ) :
+						__( 'Separate with commas or the Enter key.' )
 					}
 				</p>
 			</div>

--- a/packages/components/src/form-token-field/index.js
+++ b/packages/components/src/form-token-field/index.js
@@ -583,8 +583,11 @@ class FormTokenField extends Component {
 						/>
 					) }
 				</div>
-				<div id={ `components-form-token-suggestions-howto-${ instanceId }` } className="screen-reader-text">
-					{ __( 'Separate with commas' ) }
+				<div id={ `components-form-token-suggestions-howto-${ instanceId }` } className="components-form-token-field__help">
+					{ this.props.tokenizeOnSpace ?
+						__( 'Separate using commas, spaces or the enter key' ) :
+						__( 'Separate using commas or the enter key' )
+					}
 				</div>
 			</div>
 		);

--- a/packages/components/src/form-token-field/index.js
+++ b/packages/components/src/form-token-field/index.js
@@ -583,12 +583,12 @@ class FormTokenField extends Component {
 						/>
 					) }
 				</div>
-				<div id={ `components-form-token-suggestions-howto-${ instanceId }` } className="components-form-token-field__help">
+				<p id={ `components-form-token-suggestions-howto-${ instanceId }` } className="components-form-token-field__help">
 					{ this.props.tokenizeOnSpace ?
-						__( 'Separate using commas, spaces or the enter key' ) :
-						__( 'Separate using commas or the enter key' )
+						__( 'Separate using commas, spaces, or the Enter key' ) :
+						__( 'Separate using commas or the Enter key' )
 					}
-				</div>
+				</p>
 			</div>
 		);
 		/* eslint-enable jsx-a11y/no-static-element-interactions */

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -3,7 +3,7 @@
 	flex-wrap: wrap;
 	align-items: flex-start;
 	width: 100%;
-	margin: 0;
+	margin: 0 0 $grid-size 0;
 	padding: $grid-size-small;
 	background-color: $white;
 	border: $border-width solid $light-gray-700;
@@ -46,8 +46,13 @@
 }
 
 .components-form-token-field__label {
-	display: inline-block;
+	display: block;
 	margin-bottom: $grid-size-small;
+}
+
+.components-form-token-field__help {
+	display: block;
+	font-style: italic;
 }
 
 // Tokens

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -46,12 +46,11 @@
 }
 
 .components-form-token-field__label {
-	display: block;
+	display: inline-block;
 	margin-bottom: $grid-size-small;
 }
 
 .components-form-token-field__help {
-	display: block;
 	font-style: italic;
 }
 


### PR DESCRIPTION
## Description
Fixes #15355

I've made the message visible and added the mention of the enter key. It's styled to look the same way as other help texts in the sidebar.

The component allows developers to opt-in for using spacebar as a separator too. I've reflected that and made two versions of the help text based on the configuration.

## How has this been tested?
- New Post
- In the sidebar, open "Tags" Panel and explore the new message

The sidebar term selector (Tags, Categories) is the only place where this component is used in core.

## Screenshots

| Standard Usage | With Spacebar Separator Enabled |
| - | - |
| <img width="280" alt="Screenshot 2019-05-06 at 17 49 59" src="https://user-images.githubusercontent.com/156676/57238016-b3429a00-7028-11e9-86be-fc6f6388a919.png"> | <img width="277" alt="Screenshot 2019-05-06 at 17 51 16" src="https://user-images.githubusercontent.com/156676/57238029-bb023e80-7028-11e9-836f-0a6baa26bac4.png">
