### PR TITLE
Fix: Block toolbar does not appear and movers can not be used on block editor without editor module

### DIFF
--- a/packages/edit-widgets/src/components/widget-area/index.js
+++ b/packages/edit-widgets/src/components/widget-area/index.js
@@ -5,6 +5,8 @@ import { Panel, PanelBody } from '@wordpress/components';
 import {
 	BlockEditorProvider,
 	BlockList,
+	ObserveTyping,
+	WritingFlow,
 } from '@wordpress/block-editor';
 import { useState } from '@wordpress/element';
 
@@ -22,7 +24,11 @@ function WidgetArea( { title, initialOpen } ) {
 					onInput={ updateBlocks }
 					onChange={ updateBlocks }
 				>
-					<BlockList />
+					<WritingFlow>
+						<ObserveTyping>
+							<BlockList />
+						</ObserveTyping>
+					</WritingFlow>
 				</BlockEditorProvider>
 			</PanelBody>
 		</Panel>


### PR DESCRIPTION
On the widgets screen, we were not loading the ObserveTyping component, this made actions that change the isTyping flag not being fired as expected, the editors stayed most of the types in an isTyping state = true. This made the block tollbar not appear as expected and made it hard/impossible to use the block movers.

## How has this been tested?
I went to /wp-admin/admin.php?page=gutenberg-widgets.
I added some blocks, I verified the block toolbar appears as expected, and I could correctly use the block movers.


