### PR TITLE
Fix: Draggable component depends on an element with id editor being available.

### DIFF
--- a/packages/components/src/draggable/index.js
+++ b/packages/components/src/draggable/index.js
@@ -1,7 +1,10 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
+import {
+	invoke,
+	noop,
+} from 'lodash';
 
 /**
  * WordPress dependencies
@@ -15,7 +18,9 @@ const cloneHeightTransformationBreakpoint = 700;
 const clonePadding = 20;
 
 const isChromeUA = ( ) => /Chrome/i.test( window.navigator.userAgent );
-const documentHasIframes = ( ) => [ ...document.getElementById( 'editor' ).querySelectorAll( 'iframe' ) ].length > 0;
+const documentHasIframes = () => {
+	return !! invoke( document, [ 'body', 'querySelector' ], 'iframe' );
+};
 
 class Draggable extends Component {
 	constructor() {


### PR DESCRIPTION
If the Draggable component was used in a document without an element with "editor" id, the component crashed when the user tried to use it.

The components should be as generic as possible and not relying on specific elements being available.


## How has this been tested?
I cherry-picked the commit from https://github.com/WordPress/gutenberg/pull/15470 that makes sure the movers can be used (only required if testing before that PR is merged).
I went to /wp-admin/admin.php?page=gutenberg-widgets.
I added some blocks I tried to drag them and verified the draggable element did not crash because of an element with id editor not being found. (dropping blocks still does not work because of another unrelated problem).
