### PR TITLE
Content structure: Fix Semantics

### DIFF
--- a/packages/editor/src/components/table-of-contents/panel.js
+++ b/packages/editor/src/components/table-of-contents/panel.js
@@ -45,9 +45,9 @@ function TableOfContentsPanel( { headingCount, paragraphCount, numberOfBlocks, h
 			{ headingCount > 0 && (
 				<>
 					<hr />
-					<span className="table-of-contents__title">
+					<h2 className="table-of-contents__title">
 						{ __( 'Document Outline' ) }
-					</span>
+					</h2>
 					<DocumentOutline onSelect={ onRequestClose } hasOutlineItemsDisabled={ hasOutlineItemsDisabled } />
 				</>
 			) }

--- a/packages/editor/src/components/table-of-contents/panel.js
+++ b/packages/editor/src/components/table-of-contents/panel.js
@@ -12,36 +12,46 @@ import DocumentOutline from '../document-outline';
 
 function TableOfContentsPanel( { headingCount, paragraphCount, numberOfBlocks, hasOutlineItemsDisabled, onRequestClose } ) {
 	return (
+		/*
+		* Disable reason: The `list` ARIA role is redundant but
+		* Safari+VoiceOver won't announce the list otherwise.
+		*/
+		/* eslint-disable jsx-a11y/no-redundant-roles */
 		<>
-			<ul
-				className="table-of-contents__counts"
+			<div
+				className="table-of-contents__wrapper"
 				role="note"
 				aria-label={ __( 'Document Statistics' ) }
 				tabIndex="0"
 			>
-				<li className="table-of-contents__count">
-					{ __( 'Words' ) }
-					<WordCount />
-				</li>
-				<li className="table-of-contents__count">
-					{ __( 'Headings' ) }
-					<span className="table-of-contents__number">
-						{ headingCount }
-					</span>
-				</li>
-				<li className="table-of-contents__count">
-					{ __( 'Paragraphs' ) }
-					<span className="table-of-contents__number">
-						{ paragraphCount }
-					</span>
-				</li>
-				<li className="table-of-contents__count">
-					{ __( 'Blocks' ) }
-					<span className="table-of-contents__number">
-						{ numberOfBlocks }
-					</span>
-				</li>
-			</ul>
+				<ul
+					role="list"
+					className="table-of-contents__counts"
+				>
+					<li className="table-of-contents__count">
+						{ __( 'Words' ) }
+						<WordCount />
+					</li>
+					<li className="table-of-contents__count">
+						{ __( 'Headings' ) }
+						<span className="table-of-contents__number">
+							{ headingCount }
+						</span>
+					</li>
+					<li className="table-of-contents__count">
+						{ __( 'Paragraphs' ) }
+						<span className="table-of-contents__number">
+							{ paragraphCount }
+						</span>
+					</li>
+					<li className="table-of-contents__count">
+						{ __( 'Blocks' ) }
+						<span className="table-of-contents__number">
+							{ numberOfBlocks }
+						</span>
+					</li>
+				</ul>
+			</div>
 			{ headingCount > 0 && (
 				<>
 					<hr />
@@ -52,6 +62,7 @@ function TableOfContentsPanel( { headingCount, paragraphCount, numberOfBlocks, h
 				</>
 			) }
 		</>
+		/* eslint-enable jsx-a11y/no-redundant-roles */
 	);
 }
 

--- a/packages/editor/src/components/table-of-contents/panel.js
+++ b/packages/editor/src/components/table-of-contents/panel.js
@@ -13,35 +13,35 @@ import DocumentOutline from '../document-outline';
 function TableOfContentsPanel( { headingCount, paragraphCount, numberOfBlocks, hasOutlineItemsDisabled, onRequestClose } ) {
 	return (
 		<>
-			<div
+			<ul
 				className="table-of-contents__counts"
 				role="note"
 				aria-label={ __( 'Document Statistics' ) }
 				tabIndex="0"
 			>
-				<div className="table-of-contents__count">
+				<li className="table-of-contents__count">
 					{ __( 'Words' ) }
 					<WordCount />
-				</div>
-				<div className="table-of-contents__count">
+				</li>
+				<li className="table-of-contents__count">
 					{ __( 'Headings' ) }
 					<span className="table-of-contents__number">
 						{ headingCount }
 					</span>
-				</div>
-				<div className="table-of-contents__count">
+				</li>
+				<li className="table-of-contents__count">
 					{ __( 'Paragraphs' ) }
 					<span className="table-of-contents__number">
 						{ paragraphCount }
 					</span>
-				</div>
-				<div className="table-of-contents__count">
+				</li>
+				<li className="table-of-contents__count">
 					{ __( 'Blocks' ) }
 					<span className="table-of-contents__number">
 						{ numberOfBlocks }
 					</span>
-				</div>
-			</div>
+				</li>
+			</ul>
 			{ headingCount > 0 && (
 				<>
 					<hr />

--- a/packages/editor/src/components/table-of-contents/style.scss
+++ b/packages/editor/src/components/table-of-contents/style.scss
@@ -20,6 +20,7 @@
 .table-of-contents__counts {
 	display: flex;
 	flex-wrap: wrap;
+	margin: 0;
 
 	&:focus {
 		@include square-style__focus();

--- a/packages/editor/src/components/table-of-contents/style.scss
+++ b/packages/editor/src/components/table-of-contents/style.scss
@@ -17,15 +17,15 @@
 	}
 }
 
+.table-of-contents__wrapper:focus {
+	@include square-style__focus();
+	outline-offset: $grid-size;
+}
+
 .table-of-contents__counts {
 	display: flex;
 	flex-wrap: wrap;
 	margin: 0;
-
-	&:focus {
-		@include square-style__focus();
-		outline-offset: $grid-size;
-	}
 }
 
 .table-of-contents__count {

--- a/packages/editor/src/components/table-of-contents/style.scss
+++ b/packages/editor/src/components/table-of-contents/style.scss
@@ -34,6 +34,7 @@
 	flex-direction: column;
 	font-size: $default-font-size;
 	color: $dark-gray-300;
+	margin-bottom: 0;
 }
 
 .table-of-contents__number,


### PR DESCRIPTION
## Description
Fixes #15290

I hope I understood the proposed solution correctly and I've updated the markup from divs into ul>li. This came with an additional need to reset the margin to match the original styling.

After updating to `<ul>`, the outline showed up after opening the popover as the focus moves there:

<img width="379" alt="Screenshot 2019-05-06 at 21 53 04" src="https://user-images.githubusercontent.com/156676/57251862-2b21bc00-704b-11e9-8d2f-e8c2a61d1581.png">

The outline of `<div>` is disabled globally in wp-admin/css/common.min.css. There is no such rule for `<ul>` but to 100% match the original behavior and looks, I have disabled the outline for this specific usage. Let me know if I should keep the outline enabled so the result looks like the screenshot above.

Title was updated to use `<h2>`. No visual regression there - it looks the same.

## How has this been tested?
- with post with some content
- open up the Content Structure
- confirm updated markup and no visual regression

## Screenshots <!-- if applicable -->

<img width="491" alt="Screenshot 2019-05-06 at 22 29 18" src="https://user-images.githubusercontent.com/156676/57253215-6ffb2200-704e-11e9-9744-224dcac40539.png">
