### PR TITLE
Add back focus style to Document Outline panel

### DIFF
--- a/packages/editor/src/components/table-of-contents/style.scss
+++ b/packages/editor/src/components/table-of-contents/style.scss
@@ -4,7 +4,7 @@
 
 .table-of-contents__popover {
 	.components-popover__content {
-		padding: 16px;
+		padding: $grid-size-large;
 
 		@include break-small {
 			max-height: calc(100vh - 120px);
@@ -20,6 +20,11 @@
 .table-of-contents__counts {
 	display: flex;
 	flex-wrap: wrap;
+
+	&:focus {
+		@include square-style__focus();
+		outline-offset: $grid-size;
+	}
 }
 
 .table-of-contents__count {


### PR DESCRIPTION
This PR intends to, and maybe fixes #15324. That is, it restores the focus outline style to the document outline popover which regressed.

GIF:

![focus](https://user-images.githubusercontent.com/1204802/57284017-a6698900-70b0-11e9-888b-384e4d464ed3.gif)
