### PR TITLE
Scripts: Allow non-production env in wp-scripts build

### DIFF
--- a/packages/scripts/scripts/build.js
+++ b/packages/scripts/scripts/build.js
@@ -9,7 +9,7 @@ const { sync: resolveBin } = require( 'resolve-bin' );
  */
 const { getWebpackArgs } = require( '../utils' );
 
-process.env.NODE_ENV = 'production';
+process.env.NODE_ENV = process.env.NODE_ENV || 'production';
 const { status } = spawn(
 	resolveBin( 'webpack' ),
 	getWebpackArgs(),


### PR DESCRIPTION
## Description

As of today `wp-scripts build` enforces `production` env:

https://github.com/WordPress/gutenberg/blob/ea1878098fa4862d569919d9a4f2d53f76e3ceb5/packages/scripts/scripts/build.js#L12

It was never an intent to disallow other values, it was rather a side-effect of porting the existing functionality from Gutenberg :)

## Testing

`npm run build` should work as before
`NODE_ENV=development npm run build` should run a single build in development mode