### PR TITLE
@wordpress/data: Allow for subscribing listeners to specific stores.

### DIFF
--- a/packages/data/src/namespace-store/index.js
+++ b/packages/data/src/namespace-store/index.js
@@ -78,9 +78,8 @@ export default function createNamespace( key, options, registry ) {
 			const state = store.__unstableOriginalGetState();
 			const hasChanged = state !== lastState;
 			lastState = state;
-
 			if ( hasChanged ) {
-				listener();
+				listener( key );
 			}
 		} );
 	};

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -494,6 +494,27 @@ describe( 'createRegistry', () => {
 			expect( incrementedValue ).toBe( 3 );
 		} );
 
+		it( 'only calls listeners registered to the specific store', () => {
+			const store1 = registry.registerStore( 'store1', {
+				reducer: ( state ) => state + 1,
+			} );
+			const store2 = registry.registerStore( 'store2', {
+				reducer: ( state ) => state + 1,
+			} );
+
+			const action = { type: 'dummy' };
+
+			const subscription1 = jest.fn();
+			const subscription2 = jest.fn();
+			registry.subscribe( subscription1, [ 'store1' ] );
+			registry.subscribe( subscription2, [ 'store2' ] );
+
+			store1.dispatch( action );
+			store2.dispatch( action );
+			expect( subscription1 ).toHaveBeenCalledTimes( 1 );
+			expect( subscription2 ).toHaveBeenCalledTimes( 1 );
+		} );
+
 		it( 'snapshots listeners on change, avoiding a later listener if subscribed during earlier callback', () => {
 			const store = registry.registerStore( 'myAwesomeReducer', {
 				reducer: ( state = 0 ) => state + 1,
@@ -506,7 +527,6 @@ describe( 'createRegistry', () => {
 			subscribeWithUnsubscribe( firstListener );
 
 			store.dispatch( { type: 'dummy' } );
-
 			expect( secondListener ).not.toHaveBeenCalled();
 		} );
 


### PR DESCRIPTION
## Description

This allows consuming code to pass in a list of stores the listener is specifically subscribing to.  The listener will only get invoked when for any state changes on the dependent stores.

Default behaviour is preserved if no dependency array is passed in.

This behaviour will be useful in implementing store dependencies for `withSelect` and `useSelect` as a part of the explorations for #15473.  There's also likely some performance improvements that can be gained via the store dependency argument.

## How has this been tested?

* [x] ensure existing tests pass
* [x] added new tests for dependencies.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

This is a non-breaking change in that existing behaviour of subscribes is preserved. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
