### PR TITLE
Fix: Intermittent problem on block transforms tests.

### DIFF
--- a/packages/e2e-test-utils/src/transform-block-to.js
+++ b/packages/e2e-test-utils/src/transform-block-to.js
@@ -9,4 +9,10 @@ export async function transformBlockTo( name ) {
 	await page.click( '.block-editor-block-switcher__toggle' );
 	await page.waitForSelector( `.block-editor-block-types-list__item[aria-label="${ name }"]` );
 	await page.click( `.block-editor-block-types-list__item[aria-label="${ name }"]` );
+	const BLOCK_SELECTOR = '.block-editor-block-list__block';
+	const BLOCK_NAME_SELECTOR = `[aria-label="Block: ${ name }"]`;
+	// Wait for the transformed block to appear.
+	await page.waitForSelector(
+		`${ BLOCK_SELECTOR }${ BLOCK_NAME_SELECTOR }`
+	);
 }


### PR DESCRIPTION
## Description
@gziolo noticed that the block-transforms end to end tests failed on https://travis-ci.com/WordPress/gutenberg/jobs/198177156#L1081, without an apparent reason for the failure.
It seems the test had an intermittent problem, where fails are very rare. Locally, I never managed to reproduce the problem.
Watching the error available in https://travis-ci.com/WordPress/gutenberg/jobs/198177156#L1081 it seems everything went as expected and the right selectors were clicked (otherwise the selector unmatch would be reported as error), but the block was not transformed.
Checking the code we notice the following two lines:
```
	await transformBlockTo( transformName );
	return getEditedPostContent();
```

And inside transformBlockTo we see:
```
....
	await page.click( `.block-editor-block-types-list__item[aria-label="${ name }"]` );
```

I think the click to transform was executed with success, but the content change was not processed immediately and getEditedPostContent() still returned the content before the block was transformed.
In this PR we add a wait for selector call at the end of transformBlockTo, that makes the function wait for the new block to appear.
## How has this been tested?
Verify the end 2 end test packages/e2e-test-utils/src/transform-block-to.js executes with success.