### PR TITLE
Fix: DateTimePicker passes current seconds as the selected seconds value

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,6 +17,9 @@
 
 - `ServerSideRender` is no longer part of components. It was extracted to an independent package `@wordpress/server-side-render`.
 
+### Bug Fix
+
+- Although `DateTimePicker` does not allow picking the seconds, passed the current seconds as the selected value for seconds when calling `onChange`. Now it passes zero.
 
 ## 7.4.0 (2019-05-21)
 

--- a/packages/components/src/date-time/date.js
+++ b/packages/components/src/date-time/date.js
@@ -30,7 +30,7 @@ class DatePicker extends Component {
 		const momentTime = {
 			hours: momentDate.hours(),
 			minutes: momentDate.minutes(),
-			seconds: momentDate.seconds(),
+			seconds: 0,
 		};
 
 		onChange( newDate.set( momentTime ).format( TIMEZONELESS_FORMAT ) );

--- a/packages/components/src/date-time/time.js
+++ b/packages/components/src/date-time/time.js
@@ -33,6 +33,7 @@ class TimePicker extends Component {
 			am: true,
 			date: null,
 		};
+		this.changeDate = this.changeDate.bind( this );
 		this.updateMonth = this.updateMonth.bind( this );
 		this.onChangeMonth = this.onChangeMonth.bind( this );
 		this.updateDay = this.updateDay.bind( this );
@@ -61,6 +62,17 @@ class TimePicker extends Component {
 			this.syncState( this.props );
 		}
 	}
+	/**
+	 * Function that sets the date state and calls the onChange with a new date.
+	 * The date is truncated at the minutes.
+	 *
+	 * @param {Object} newDate The date object.
+	 */
+	changeDate( newDate ) {
+		const dateWithStartOfMinutes = newDate.clone().startOf( 'minute' );
+		this.setState( { date: dateWithStartOfMinutes } );
+		this.props.onChange( newDate.format( TIMEZONELESS_FORMAT ) );
+	}
 
 	getMaxHours() {
 		return this.props.is12Hour ? 12 : 23;
@@ -83,7 +95,7 @@ class TimePicker extends Component {
 	}
 
 	updateHours() {
-		const { is12Hour, onChange } = this.props;
+		const { is12Hour } = this.props;
 		const { am, hours, date } = this.state;
 		const value = parseInt( hours, 10 );
 		if (
@@ -98,12 +110,10 @@ class TimePicker extends Component {
 		const newDate = is12Hour ?
 			date.clone().hours( am === 'AM' ? value % 12 : ( ( ( value % 12 ) + 12 ) % 24 ) ) :
 			date.clone().hours( value );
-		this.setState( { date: newDate } );
-		onChange( newDate.format( TIMEZONELESS_FORMAT ) );
+		this.changeDate( newDate );
 	}
 
 	updateMinutes() {
-		const { onChange } = this.props;
 		const { minutes, date } = this.state;
 		const value = parseInt( minutes, 10 );
 		if ( ! isInteger( value ) || value < 0 || value > 59 ) {
@@ -111,12 +121,10 @@ class TimePicker extends Component {
 			return;
 		}
 		const newDate = date.clone().minutes( value );
-		this.setState( { date: newDate } );
-		onChange( newDate.format( TIMEZONELESS_FORMAT ) );
+		this.changeDate( newDate );
 	}
 
 	updateDay() {
-		const { onChange } = this.props;
 		const { day, date } = this.state;
 		const value = parseInt( day, 10 );
 		if ( ! isInteger( value ) || value < 1 || value > 31 ) {
@@ -124,12 +132,10 @@ class TimePicker extends Component {
 			return;
 		}
 		const newDate = date.clone().date( value );
-		this.setState( { date: newDate } );
-		onChange( newDate.format( TIMEZONELESS_FORMAT ) );
+		this.changeDate( newDate );
 	}
 
 	updateMonth() {
-		const { onChange } = this.props;
 		const { month, date } = this.state;
 		const value = parseInt( month, 10 );
 		if ( ! isInteger( value ) || value < 1 || value > 12 ) {
@@ -137,12 +143,10 @@ class TimePicker extends Component {
 			return;
 		}
 		const newDate = date.clone().month( value - 1 );
-		this.setState( { date: newDate } );
-		onChange( newDate.format( TIMEZONELESS_FORMAT ) );
+		this.changeDate( newDate );
 	}
 
 	updateYear() {
-		const { onChange } = this.props;
 		const { year, date } = this.state;
 		const value = parseInt( year, 10 );
 		if ( ! isInteger( value ) || value < 0 || value > 9999 ) {
@@ -150,13 +154,11 @@ class TimePicker extends Component {
 			return;
 		}
 		const newDate = date.clone().year( value );
-		this.setState( { date: newDate } );
-		onChange( newDate.format( TIMEZONELESS_FORMAT ) );
+		this.changeDate( newDate );
 	}
 
 	updateAmPm( value ) {
 		return () => {
-			const { onChange } = this.props;
 			const { am, date, hours } = this.state;
 			if ( am === value ) {
 				return;
@@ -167,8 +169,7 @@ class TimePicker extends Component {
 			} else {
 				newDate = date.clone().hours( parseInt( hours, 10 ) % 12 );
 			}
-			this.setState( { date: newDate } );
-			onChange( newDate.format( TIMEZONELESS_FORMAT ) );
+			this.changeDate( newDate );
 		};
 	}
 


### PR DESCRIPTION
Closes: https://github.com/WordPress/gutenberg/issues/13898

DateTimePicker does not allow users to pick a value for seconds, so when the user changes a time/date, it should look like a value of 0 was selected as the seconds value. Currently, the seconds of the current date are passed as the selected seconds, which may make it look like a "random" value was selected as the seconds value.

This causes a regression where WP_CRON missed some scheduled posts.



## How has this been tested?
I created a new post.
I changed the date/time fields in the post scheduling dialog and I verified with redux dev tools that the editPost action contained a date whose seconds were equal to 0.

