### PR TITLE
RichText: fix RTL keyboard interactions

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -380,7 +380,6 @@ export class RichText extends Component {
 		}
 
 		this.recalculateBoundaryStyle();
-		this.onSelectionChange();
 
 		document.addEventListener( 'selectionchange', this.onSelectionChange );
 	}
@@ -471,10 +470,10 @@ export class RichText extends Component {
 
 			// When the selection changes as a result of a key press, then
 			// the active formats should be set depending on direction.
-			if ( this.isKeyPressed ) {
+			if ( this.isKeyPressed && this.props.selectionStart !== undefined ) {
 				// Selection is moved forward if the new start is higher than
 				// the last.
-				const isForward = start < this.selectionStart;
+				const isForward = start < this.props.selectionStart;
 
 				if ( isForward ) {
 					activeFormats = formats[ start ] || [];
@@ -597,15 +596,15 @@ export class RichText extends Component {
 		}
 
 		if ( onMerge ) {
-			onMerge( ! isReverse );
+			onMerge( keyCode === DELETE );
 		}
 
 		// Only handle remove on Backspace. This serves dual-purpose of being
 		// an intentional user interaction distinguishing between Backspace and
 		// Delete to remove the empty field, but also to avoid merge & remove
 		// causing destruction of two fields (merge, then removed merged).
-		if ( onRemove && empty && isReverse ) {
-			onRemove( ! isReverse );
+		if ( onRemove && empty && keyCode === BACKSPACE ) {
+			onRemove();
 		}
 
 		event.preventDefault();

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -166,6 +166,7 @@ export class RichText extends Component {
 
 	componentWillUnmount() {
 		document.removeEventListener( 'selectionchange', this.onSelectionChange );
+		window.cancelAnimationFrame( this.rafID );
 	}
 
 	setRef( node ) {
@@ -636,7 +637,7 @@ export class RichText extends Component {
 			! shiftKey && ! altKey && ! metaKey && ! ctrlKey &&
 			( keyCode === LEFT || keyCode === RIGHT )
 		) {
-			window.requestAnimationFrame( () => this.onSelectionChange() );
+			this.rafID = window.requestAnimationFrame( () => this.onSelectionChange() );
 			this.handleHorizontalNavigation( event );
 		}
 

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -145,7 +145,6 @@ export class RichText extends Component {
 		this.valueToEditableHTML = this.valueToEditableHTML.bind( this );
 		this.handleHorizontalNavigation = this.handleHorizontalNavigation.bind( this );
 		this.onPointerDown = this.onPointerDown.bind( this );
-		this.getDirection = this.getDirection.bind( this );
 
 		this.formatToValue = memize(
 			this.formatToValue.bind( this ),
@@ -755,10 +754,6 @@ export class RichText extends Component {
 		delete this.keyPressed;
 	}
 
-	getDirection() {
-		return getComputedStyle( this.editableRef ).direction;
-	}
-
 	/**
 	 * Handles horizontal keyboard navigation when no modifiers are pressed. The
 	 * navigation is handled separately to move correctly around format
@@ -772,7 +767,7 @@ export class RichText extends Component {
 		const { activeFormats = [] } = this.state;
 		const collapsed = isCollapsed( value );
 		// To do: ideally, we should look at visual position instead.
-		const direction = this.getDirection();
+		const { direction } = getComputedStyle( this.editableRef );
 		const reverseKey = direction === 'rtl' ? RIGHT : LEFT;
 		const isReverse = event.keyCode === reverseKey;
 

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -559,7 +559,9 @@ export class RichText extends Component {
 		}
 
 		const { keyCode } = event;
-		const isReverse = keyCode === BACKSPACE;
+		const direction = this.getDirection();
+		const reverseKey = direction === 'rtl' ? DELETE : BACKSPACE;
+		const isReverse = keyCode === reverseKey;
 
 		// Only process delete if the key press occurs at uncollapsed edge.
 		if ( ! isCollapsed( this.createRecord() ) ) {

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -369,7 +369,7 @@ export class RichText extends Component {
 
 		this.recalculateBoundaryStyle();
 
-		// We know for certain that of focus, the old selection is invalid. It
+		// We know for certain that on focus, the old selection is invalid. It
 		// will be recalculated on `selectionchange`.
 		const index = undefined;
 		const activeFormats = undefined;
@@ -613,8 +613,8 @@ export class RichText extends Component {
 	onKeyDown( event ) {
 		const { keyCode, shiftKey, altKey, metaKey, ctrlKey } = event;
 
-		// Only override left and right keys without modifiers pressed.
 		if (
+			// Only override left and right keys without modifiers pressed.
 			! shiftKey && ! altKey && ! metaKey && ! ctrlKey &&
 			( keyCode === LEFT || keyCode === RIGHT )
 		) {
@@ -946,14 +946,9 @@ export class RichText extends Component {
 		if ( shouldReapply ) {
 			this.value = value;
 			this.record = this.formatToValue( value );
-		} else {
-			this.record = { ...this.record };
-		}
+			this.record.start = selectionStart;
+			this.record.end = selectionEnd;
 
-		this.record.start = selectionStart;
-		this.record.end = selectionEnd;
-
-		if ( shouldReapply ) {
 			updateFormats( {
 				value: this.record,
 				start: this.record.start,
@@ -962,6 +957,15 @@ export class RichText extends Component {
 			} );
 
 			this.applyRecord( this.record );
+		} else if (
+			this.record.start !== selectionStart ||
+			this.record.end !== selectionEnd
+		) {
+			this.record = {
+				...this.record,
+				start: selectionStart,
+				end: selectionEnd,
+			};
 		}
 	}
 

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -144,6 +144,7 @@ export class RichText extends Component {
 		this.valueToEditableHTML = this.valueToEditableHTML.bind( this );
 		this.handleHorizontalNavigation = this.handleHorizontalNavigation.bind( this );
 		this.onPointerDown = this.onPointerDown.bind( this );
+		this.getDirection = this.getDirection.bind( this );
 
 		this.formatToValue = memize(
 			this.formatToValue.bind( this ),
@@ -731,6 +732,10 @@ export class RichText extends Component {
 		}
 	}
 
+	getDirection() {
+		return getComputedStyle( this.editableRef ).direction;
+	}
+
 	/**
 	 * Handles horizontal keyboard navigation when no modifiers are pressed. The
 	 * navigation is handled separately to move correctly around format
@@ -743,7 +748,9 @@ export class RichText extends Component {
 		const { formats, text, start, end } = value;
 		const { activeFormats = [] } = this.state;
 		const collapsed = isCollapsed( value );
-		const isReverse = event.keyCode === LEFT;
+		const direction = this.getDirection();
+		const reverseKey = direction === 'rtl' ? RIGHT : LEFT;
+		const isReverse = event.keyCode === reverseKey;
 
 		// If the selection is collapsed and at the very start, do nothing if
 		// navigating backward.

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -376,8 +376,10 @@ export class RichText extends Component {
 			...this.record,
 			start: undefined,
 			end: undefined,
+			activeFormats: undefined,
 		};
 		this.props.onSelectionChange( undefined, undefined );
+		this.setState( { activeFormats: undefined } );
 
 		document.addEventListener( 'selectionchange', this.onSelectionChange );
 	}
@@ -504,6 +506,7 @@ export class RichText extends Component {
 			this.record = newValue;
 			this.applyRecord( newValue, { domOnly: true } );
 			this.props.onSelectionChange( start, end );
+			this.setState( { activeFormats } );
 
 			if ( activeFormats.length > 0 ) {
 				this.recalculateBoundaryStyle();
@@ -538,7 +541,7 @@ export class RichText extends Component {
 	onChange( record, { withoutHistory } = {} ) {
 		this.applyRecord( record );
 
-		const { start, end } = record;
+		const { start, end, activeFormats = [] } = record;
 		const changeHandlers = pickBy( this.props, ( v, key ) =>
 			key.startsWith( 'format_on_change_functions_' )
 		);
@@ -551,6 +554,7 @@ export class RichText extends Component {
 		this.record = record;
 		this.props.onChange( this.value );
 		this.props.onSelectionChange( start, end );
+		this.setState( { activeFormats } );
 
 		if ( ! withoutHistory ) {
 			this.onCreateUndoLevel();
@@ -840,8 +844,7 @@ export class RichText extends Component {
 
 		this.record = newValue;
 		this.applyRecord( newValue );
-		// active format data is not stored in state or props.
-		this.forceUpdate();
+		this.setState( { activeFormats } );
 
 		// Wait for boundary class to be added.
 		this.props.setTimeout( () => this.recalculateBoundaryStyle() );

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -636,6 +636,7 @@ export class RichText extends Component {
 			! shiftKey && ! altKey && ! metaKey && ! ctrlKey &&
 			( keyCode === LEFT || keyCode === RIGHT )
 		) {
+			window.requestAnimationFrame( () => this.onSelectionChange() );
 			this.handleHorizontalNavigation( event );
 		}
 

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -483,7 +483,7 @@ export class RichText extends Component {
 			if ( isHorizontal && this.selectionStart !== undefined ) {
 				// Selection is moved forward if the new start is higher than
 				// the last.
-				const isForward = start < this.props.selectionStart;
+				const isForward = start < this.selectionStart;
 
 				if ( isForward ) {
 					activeFormats = value.formats[ start ] || [];

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -750,6 +750,7 @@ export class RichText extends Component {
 		const { formats, text, start, end } = value;
 		const { activeFormats = [] } = this.state;
 		const collapsed = isCollapsed( value );
+		// To do: ideally, we should look at visual position instead.
 		const direction = this.getDirection();
 		const reverseKey = direction === 'rtl' ? RIGHT : LEFT;
 		const isReverse = event.keyCode === reverseKey;
@@ -774,9 +775,6 @@ export class RichText extends Component {
 		if ( ! collapsed ) {
 			return;
 		}
-
-		// In all other cases, prevent default behaviour.
-		event.preventDefault();
 
 		const formatsBefore = formats[ start - 1 ] || [];
 		const formatsAfter = formats[ start ] || [];
@@ -808,29 +806,19 @@ export class RichText extends Component {
 			}
 		}
 
-		// Wait for boundary class to be added.
-		this.props.setTimeout( () => this.recalculateBoundaryStyle() );
-
-		if ( newActiveFormatsLength !== activeFormats.length ) {
-			const newActiveFormats = source.slice( 0, newActiveFormatsLength );
-			this.applyRecord( { ...value, activeFormats: newActiveFormats } );
-			this.setState( { activeFormats: newActiveFormats } );
+		if ( newActiveFormatsLength === activeFormats.length ) {
 			return;
 		}
 
-		const newPos = value.start + ( isReverse ? -1 : 1 );
-		const newActiveFormats = isReverse ? formatsBefore.length : formatsAfter.length;
+		event.preventDefault();
 
-		this.setState( { selectedFormat: newActiveFormats } );
-		this.props.onSelectionChange( newPos, newPos );
-		this.selectionStart = newPos;
-		this.selectionEnd = newPos;
-		this.applyRecord( {
-			...value,
-			start: newPos,
-			end: newPos,
-			activeFormats: newActiveFormats,
-		} );
+		const newActiveFormats = source.slice( 0, newActiveFormatsLength );
+
+		this.applyRecord( { ...value, activeFormats: newActiveFormats } );
+		this.setState( { activeFormats: newActiveFormats } );
+
+		// Wait for boundary class to be added.
+		this.props.setTimeout( () => this.recalculateBoundaryStyle() );
 	}
 
 	/**

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -574,9 +574,7 @@ export class RichText extends Component {
 		}
 
 		const { keyCode } = event;
-		const direction = this.getDirection();
-		const reverseKey = direction === 'rtl' ? DELETE : BACKSPACE;
-		const isReverse = keyCode === reverseKey;
+		const isReverse = keyCode === BACKSPACE;
 
 		// Only process delete if the key press occurs at uncollapsed edge.
 		if ( ! isCollapsed( this.createRecord() ) ) {
@@ -596,15 +594,15 @@ export class RichText extends Component {
 		}
 
 		if ( onMerge ) {
-			onMerge( keyCode === DELETE );
+			onMerge( ! isReverse );
 		}
 
 		// Only handle remove on Backspace. This serves dual-purpose of being
 		// an intentional user interaction distinguishing between Backspace and
 		// Delete to remove the empty field, but also to avoid merge & remove
 		// causing destruction of two fields (merge, then removed merged).
-		if ( onRemove && empty && keyCode === BACKSPACE ) {
-			onRemove();
+		if ( onRemove && empty && isReverse ) {
+			onRemove( ! isReverse );
 		}
 
 		event.preventDefault();

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -372,8 +372,11 @@ export class RichText extends Component {
 
 		// We know for certain that of focus, the old selection is invalid. It
 		// will be recalculated on `selectionchange`.
-		delete this.internalValue.start;
-		delete this.internalValue.end;
+		this.internalValue = {
+			...this.internalValue,
+			start: undefined,
+			end: undefined,
+		};
 		this.props.onSelectionChange( undefined, undefined );
 
 		document.addEventListener( 'selectionchange', this.onSelectionChange );
@@ -415,7 +418,7 @@ export class RichText extends Component {
 		}
 
 		const value = this.createRecord();
-		const { start, activeFormats = [] } = this.internalValue;
+		const { start, activeFormats = [] } = this.getRecord();
 
 		// Update the formats between the last and new caret position.
 		const change = updateFormats( {
@@ -455,7 +458,7 @@ export class RichText extends Component {
 	 */
 	onSelectionChange() {
 		const { start, end } = this.createRecord();
-		const value = this.internalValue;
+		const value = this.getRecord();
 
 		if ( start !== value.start || end !== value.end ) {
 			const { isCaretWithinFormattedText } = this.props;
@@ -544,7 +547,7 @@ export class RichText extends Component {
 		} );
 
 		this.value = this.valueToFormat( record );
-		this.internalValue = record;
+		this.internalValue = { ...record };
 		this.props.onChange( this.value );
 		this.setState( { activeFormats } );
 		this.props.onSelectionChange( start, end );
@@ -944,15 +947,21 @@ export class RichText extends Component {
 			! isShallowEqual( prepareProps, prevPrepareProps );
 
 		if ( shouldReapply ) {
+			this.value = value;
 			this.internalValue = this.formatToValue( value );
 			this.internalValue.start = selectionStart;
 			this.internalValue.end = selectionEnd;
 			this.applyRecord( this.internalValue );
+		} else if (
+			this.internalValue.start !== selectionStart ||
+			this.internalValue.end !== selectionEnd
+		) {
+			this.internalValue = {
+				...this.internalValue,
+				start: selectionStart,
+				end: selectionEnd,
+			};
 		}
-
-		this.value = value;
-		this.internalValue.start = selectionStart;
-		this.internalValue.end = selectionEnd;
 	}
 
 	/**

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -465,12 +465,14 @@ export class RichText extends Component {
 
 		if ( start !== this.selectionStart || end !== this.selectionEnd ) {
 			const { isCaretWithinFormattedText } = this.props;
+			const isHorizontal =
+				this.keyPressed === LEFT || this.keyPressed === RIGHT;
 
 			let activeFormats = getActiveFormats( value );
 
 			// When the selection changes as a result of a key press, then
 			// the active formats should be set depending on direction.
-			if ( this.isKeyPressed && this.props.selectionStart !== undefined ) {
+			if ( isHorizontal && this.props.selectionStart !== undefined ) {
 				// Selection is moved forward if the new start is higher than
 				// the last.
 				const isForward = start < this.props.selectionStart;
@@ -616,7 +618,7 @@ export class RichText extends Component {
 	onKeyDown( event ) {
 		const { keyCode, shiftKey, altKey, metaKey, ctrlKey } = event;
 
-		this.isKeyPressed = true;
+		this.keyPressed = keyCode;
 
 		if (
 			// Only override left and right keys without modifiers pressed.
@@ -750,7 +752,7 @@ export class RichText extends Component {
 	}
 
 	onKeyUp() {
-		delete this.isKeyPressed;
+		delete this.keyPressed;
 	}
 
 	getDirection() {

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -656,13 +656,13 @@ export class RichText extends Component {
 
 		this.keyPressed = keyCode;
 
-		if (
-			// Only override left and right keys without modifiers pressed.
-			! shiftKey && ! altKey && ! metaKey && ! ctrlKey &&
-			( keyCode === LEFT || keyCode === RIGHT )
-		) {
-			this.handleHorizontalNavigation( event );
+		if ( keyCode === LEFT || keyCode === RIGHT ) {
 			this.updateSelection();
+
+			// Only override left and right keys without modifiers pressed.
+			if ( ! shiftKey && ! altKey && ! metaKey && ! ctrlKey ) {
+				this.handleHorizontalNavigation( event );
+			}
 		}
 
 		// Use the space key in list items (at the start of an item) to indent

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -459,8 +459,13 @@ export class RichText extends Component {
 	 * Handles the `selectionchange` event: sync the selection to local state.
 	 */
 	onSelectionChange() {
-		const value = this.createRecord();
-		const { start, end, formats } = value;
+		const { start, end } = this.createRecord();
+
+		// Reuse the current references.
+		const value = this.getRecord();
+
+		value.start = start;
+		value.end = end;
 
 		if ( start !== this.selectionStart || end !== this.selectionEnd ) {
 			const { isCaretWithinFormattedText } = this.props;
@@ -477,9 +482,9 @@ export class RichText extends Component {
 				const isForward = start < this.props.selectionStart;
 
 				if ( isForward ) {
-					activeFormats = formats[ start ] || [];
+					activeFormats = value.formats[ start ] || [];
 				} else {
-					activeFormats = formats[ start - 1 ] || [];
+					activeFormats = value.formats[ start - 1 ] || [];
 				}
 			}
 

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -34,7 +34,7 @@ import {
  * Browser constants
  */
 
-const { getSelection } = window;
+const { getSelection, getComputedStyle } = window;
 
 /**
  * Given an element, returns true if the element is a tabbable text field, or
@@ -318,7 +318,9 @@ class WritingFlow extends Component {
 			}
 		} else if ( isHorizontal && getSelection().isCollapsed && isHorizontalEdge( target, isReverse ) ) {
 			const closestTabbable = this.getClosestTabbable( target, isReverse );
-			placeCaretAtHorizontalEdge( closestTabbable, isReverse );
+			const { direction } = getComputedStyle( target );
+			const atStart = direction === 'rtl' ? ( ! isReverse ) : isReverse;
+			placeCaretAtHorizontalEdge( closestTabbable, atStart );
 			event.preventDefault();
 		}
 	}

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -317,10 +317,10 @@ class WritingFlow extends Component {
 				event.preventDefault();
 			}
 		} else if ( isHorizontal && getSelection().isCollapsed && isHorizontalEdge( target, isReverse ) ) {
-			const closestTabbable = this.getClosestTabbable( target, isReverse );
 			const { direction } = getComputedStyle( target );
-			const atStart = direction === 'rtl' ? ( ! isReverse ) : isReverse;
-			placeCaretAtHorizontalEdge( closestTabbable, atStart );
+			const isBackward = direction === 'rtl' ? ( ! isReverse ) : isReverse;
+			const closestTabbable = this.getClosestTabbable( target, isBackward );
+			placeCaretAtHorizontalEdge( closestTabbable, isBackward );
 			event.preventDefault();
 		}
 	}

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -287,6 +287,8 @@ class WritingFlow extends Component {
 			this.verticalRect = computeCaretRect();
 		}
 
+		// In the case of RTL scripts, right means previous and left means next,
+		// which is the exact reverse of LTR.
 		const { direction } = getComputedStyle( target );
 		const isReverseDir = direction === 'rtl' ? ( ! isReverse ) : isReverse;
 

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -287,6 +287,9 @@ class WritingFlow extends Component {
 			this.verticalRect = computeCaretRect();
 		}
 
+		const { direction } = getComputedStyle( target );
+		const isReverseDir = direction === 'rtl' ? ( ! isReverse ) : isReverse;
+
 		if ( isShift ) {
 			if (
 				(
@@ -316,11 +319,9 @@ class WritingFlow extends Component {
 				placeCaretAtVerticalEdge( closestTabbable, isReverse, this.verticalRect );
 				event.preventDefault();
 			}
-		} else if ( isHorizontal && getSelection().isCollapsed && isHorizontalEdge( target, isReverse ) ) {
-			const { direction } = getComputedStyle( target );
-			const isBackward = direction === 'rtl' ? ( ! isReverse ) : isReverse;
-			const closestTabbable = this.getClosestTabbable( target, isBackward );
-			placeCaretAtHorizontalEdge( closestTabbable, isBackward );
+		} else if ( isHorizontal && getSelection().isCollapsed && isHorizontalEdge( target, isReverseDir ) ) {
+			const closestTabbable = this.getClosestTabbable( target, isReverseDir );
+			placeCaretAtHorizontalEdge( closestTabbable, isReverseDir );
 			event.preventDefault();
 		}
 	}

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -143,12 +143,15 @@ function isEdge( container, isReverse, onlyVertical ) {
 		return true;
 	}
 
+	const { direction } = computedStyle;
+	const isReverseDir = direction === 'rtl' ? ( ! isReverse ) : isReverse;
+
 	// To calculate the horizontal position, we insert a test range and see if
 	// this test range has the same horizontal position. This method proves to
 	// be better than a DOM-based calculation, because it ignores empty text
 	// nodes and a trailing line break element. In other words, we need to check
 	// visual positioning, not DOM positioning.
-	const x = isReverse ? containerRect.left + 1 : containerRect.right - 1;
+	const x = isReverseDir ? containerRect.left + 1 : containerRect.right - 1;
 	const y = isReverse ? containerRect.top + buffer : containerRect.bottom - buffer;
 	const testRange = hiddenCaretRangeFromPoint( document, x, y, container );
 
@@ -156,7 +159,7 @@ function isEdge( container, isReverse, onlyVertical ) {
 		return false;
 	}
 
-	const side = isReverse ? 'left' : 'right';
+	const side = isReverseDir ? 'left' : 'right';
 	const testRect = getRectangleFromRange( testRange );
 
 	return Math.round( testRect[ side ] ) === Math.round( rangeRect[ side ] );

--- a/packages/dom/src/dom.js
+++ b/packages/dom/src/dom.js
@@ -143,6 +143,7 @@ function isEdge( container, isReverse, onlyVertical ) {
 		return true;
 	}
 
+	// In the case of RTL scripts, the horizontal edge is at the opposite side.
 	const { direction } = computedStyle;
 	const isReverseDir = direction === 'rtl' ? ( ! isReverse ) : isReverse;
 

--- a/packages/e2e-tests/specs/__snapshots__/rich-text.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/rich-text.test.js.snap
@@ -24,6 +24,12 @@ exports[`RichText should apply multiple formats when selection is collapsed 1`] 
 <!-- /wp:paragraph -->"
 `;
 
+exports[`RichText should handle Home and End keys 1`] = `
+"<!-- wp:paragraph -->
+<p>-<strong>12</strong>+</p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`RichText should handle change in tag name gracefully 1`] = `
 "<!-- wp:heading {\\"level\\":3} -->
 <h3></h3>

--- a/packages/e2e-tests/specs/__snapshots__/rtl.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/rtl.test.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RTL should arrow navigate 1`] = `
+"<!-- wp:paragraph -->
+<p>٠١٢</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`RTL should merge backward 1`] = `
+"<!-- wp:paragraph -->
+<p>٠١</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`RTL should merge forward 1`] = `
+"<!-- wp:paragraph -->
+<p>٠١</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`RTL should split 1`] = `
+"<!-- wp:paragraph -->
+<p>٠</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>١</p>
+<!-- /wp:paragraph -->"
+`;

--- a/packages/e2e-tests/specs/__snapshots__/rtl.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/rtl.test.js.snap
@@ -6,6 +6,16 @@ exports[`RTL should arrow navigate 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`RTL should arrow navigate between blocks 1`] = `
+"<!-- wp:paragraph -->
+<p>٠<br>١</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>٠<br>١<br>٢</p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`RTL should merge backward 1`] = `
 "<!-- wp:paragraph -->
 <p>٠١</p>
@@ -15,6 +25,30 @@ exports[`RTL should merge backward 1`] = `
 exports[`RTL should merge forward 1`] = `
 "<!-- wp:paragraph -->
 <p>٠١</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`RTL should navigate inline boundaries 1`] = `
+"<!-- wp:paragraph -->
+<p><strong>١</strong>٠٢</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`RTL should navigate inline boundaries 2`] = `
+"<!-- wp:paragraph -->
+<p><strong>١٠</strong>٢</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`RTL should navigate inline boundaries 3`] = `
+"<!-- wp:paragraph -->
+<p><strong>٠١</strong>٢</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`RTL should navigate inline boundaries 4`] = `
+"<!-- wp:paragraph -->
+<p>٠<strong>١</strong>٢</p>
 <!-- /wp:paragraph -->"
 `;
 

--- a/packages/e2e-tests/specs/rich-text.test.js
+++ b/packages/e2e-tests/specs/rich-text.test.js
@@ -208,4 +208,19 @@ describe( 'RichText', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should handle Home and End keys', async () => {
+		await page.keyboard.press( 'Enter' );
+
+		await pressKeyWithModifier( 'primary', 'b' );
+		await page.keyboard.type( '12' );
+		await pressKeyWithModifier( 'primary', 'b' );
+
+		await page.keyboard.press( 'Home' );
+		await page.keyboard.type( '-' );
+		await page.keyboard.press( 'End' );
+		await page.keyboard.type( '+' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );

--- a/packages/e2e-tests/specs/rtl.test.js
+++ b/packages/e2e-tests/specs/rtl.test.js
@@ -1,0 +1,75 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	createNewPost,
+	getEditedPostContent,
+} from '@wordpress/e2e-test-utils';
+
+// Avoid using three, as it looks too much like two with some fonts.
+const ARABIC_ZERO = '٠';
+const ARABIC_ONE = '١';
+const ARABIC_TWO = '٢';
+
+describe( 'RTL', () => {
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	it( 'should arrow navigate', async () => {
+		await page.evaluate( () => document.dir = 'rtl' );
+		await page.keyboard.press( 'Enter' );
+
+		// We need at least three characters as arrow navigation *from* the
+		// edges might be handled differently.
+		await page.keyboard.type( ARABIC_ONE );
+		await page.keyboard.type( ARABIC_TWO );
+		await page.keyboard.press( 'ArrowRight' );
+		// This is the important key press: arrow nav *from* the middle.
+		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.type( ARABIC_ZERO );
+
+		// Expect: ARABIC_ZERO + ARABIC_ONE + ARABIC_TWO (<p>٠١٢</p>).
+		// N.b.: HTML is LTR, so direction will be reversed!
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should split', async () => {
+		await page.evaluate( () => document.dir = 'rtl' );
+		await page.keyboard.press( 'Enter' );
+
+		await page.keyboard.type( ARABIC_ZERO );
+		await page.keyboard.type( ARABIC_ONE );
+		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.press( 'Enter' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should merge backward', async () => {
+		await page.evaluate( () => document.dir = 'rtl' );
+		await page.keyboard.press( 'Enter' );
+
+		await page.keyboard.type( ARABIC_ZERO );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( ARABIC_ONE );
+		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.press( 'Backspace' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should merge forward', async () => {
+		await page.evaluate( () => document.dir = 'rtl' );
+		await page.keyboard.press( 'Enter' );
+
+		await page.keyboard.type( ARABIC_ZERO );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( ARABIC_ONE );
+		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.press( 'Delete' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+} );

--- a/packages/e2e-tests/specs/rtl.test.js
+++ b/packages/e2e-tests/specs/rtl.test.js
@@ -4,6 +4,7 @@
 import {
 	createNewPost,
 	getEditedPostContent,
+	pressKeyWithModifier,
 } from '@wordpress/e2e-test-utils';
 
 // Avoid using three, as it looks too much like two with some fonts.
@@ -71,5 +72,51 @@ describe( 'RTL', () => {
 		await page.keyboard.press( 'Delete' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should arrow navigate between blocks', async () => {
+		await page.evaluate( () => document.dir = 'rtl' );
+		await page.keyboard.press( 'Enter' );
+
+		await page.keyboard.type( ARABIC_ZERO );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( ARABIC_ONE );
+		await pressKeyWithModifier( 'shift', 'Enter' );
+		await page.keyboard.type( ARABIC_TWO );
+		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.press( 'ArrowRight' );
+
+		// Move to the previous block with two lines in the current block.
+		await page.keyboard.press( 'ArrowRight' );
+		await pressKeyWithModifier( 'shift', 'Enter' );
+		await page.keyboard.type( ARABIC_ONE );
+
+		// Move to the next block with two lines in the current block.
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.type( ARABIC_ZERO );
+		await pressKeyWithModifier( 'shift', 'Enter' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should navigate inline boundaries', async () => {
+		await page.evaluate( () => document.dir = 'rtl' );
+		await page.keyboard.press( 'Enter' );
+
+		await pressKeyWithModifier( 'primary', 'b' );
+		await page.keyboard.type( ARABIC_ONE );
+		await pressKeyWithModifier( 'primary', 'b' );
+		await page.keyboard.type( ARABIC_TWO );
+
+		// Insert a character at each boundary position.
+		for ( let i = 4; i > 0; i-- ) {
+			await page.keyboard.press( 'ArrowRight' );
+			await page.keyboard.type( ARABIC_ZERO );
+
+			expect( await getEditedPostContent() ).toMatchSnapshot();
+
+			await page.keyboard.press( 'Backspace' );
+		}
 	} );
 } );

--- a/packages/rich-text/src/register-format-type.js
+++ b/packages/rich-text/src/register-format-type.js
@@ -146,15 +146,20 @@ export function registerFormatType( name, settings ) {
 					blockClientId: props.clientId,
 				};
 
-				newProps[ `format_prepare_functions_(${ name })` ] =
-					settings.__experimentalCreatePrepareEditableTree(
-						propsByPrefix,
-						args
-					);
-
 				if ( settings.__experimentalCreateOnChangeEditableValue ) {
+					newProps[ `format_value_functions_(${ name })` ] =
+						settings.__experimentalCreatePrepareEditableTree(
+							propsByPrefix,
+							args
+						);
 					newProps[ `format_on_change_functions_(${ name })` ] =
 						settings.__experimentalCreateOnChangeEditableValue(
+							propsByPrefix,
+							args
+						);
+				} else {
+					newProps[ `format_prepare_functions_(${ name })` ] =
+						settings.__experimentalCreatePrepareEditableTree(
 							propsByPrefix,
 							args
 						);


### PR DESCRIPTION
## Description

Fixes https://core.trac.wordpress.org/ticket/47180.
Fixes arrow left/right navigation and backspace/delete at the edges of rich text areas.
Fixes some boundary issues https://github.com/WordPress/gutenberg/pull/15466#pullrequestreview-234184993.

* In `RichText`, I removed some left/right key handling. We should let the browser do its thing and only interfere at boundaries.
* I had the rework some boundary code, so coincidentally it fixes 2 issues where the boundary attribute would disappear on left/right key and on initial focus.
* In `isHorizontalEdge`, the horizontal checks need to reversed in RTL.
* In `WritingFlow`, the left/right arrow key handling needs to be reversed as right means previous and left means next.
* I added e2e tests and made sure they fail in `master`.

Any other broken interactions?

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->

closes #15553 and closes #15364