### PR TITLE
Block Library: Add width attribute for resizable Column blocks

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Temporary compatibility shims for features present in Gutenberg, pending
+ * upstream commit to the WordPress core source repository. Functions here
+ * exist only as long as necessary for corresponding WordPress support, and
+ * each should be associated with a Trac ticket.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Filters allowed CSS attributes to include `flex-basis`, included in saved
+ * markup of the Column block.
+ *
+ * @since 5.7.0
+ *
+ * @param string[] $attr Array of allowed CSS attributes.
+ *
+ * @return string[] Filtered array of allowed CSS attributes.
+ */
+function gutenberg_safe_style_css_column_flex_basis( $attr ) {
+	$attr[] = 'flex-basis';
+
+	return $attr;
+}
+add_filter( 'safe_style_css', 'gutenberg_safe_style_css_column_flex_basis' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -24,6 +24,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require dirname( __FILE__ ) . '/rest-api.php';
 }
 
+require dirname( __FILE__ ) . '/compat.php';
 require dirname( __FILE__ ) . '/blocks.php';
 require dirname( __FILE__ ) . '/client-assets.php';
 require dirname( __FILE__ ) . '/demo.php';

--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -4,6 +4,11 @@
 	"attributes": {
 		"verticalAlignment": {
 			"type": "string"
+		},
+		"width": {
+			"type": "number",
+			"min": 0,
+			"max": 100
 		}
 	}
 }

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { forEach, find, difference } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -16,6 +17,17 @@ import { PanelBody, RangeControl } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import {
+	toWidthPrecision,
+	getTotalColumnsWidth,
+	getColumnWidths,
+	getAdjacentBlocks,
+	getRedistributedColumnWidths,
+} from '../columns/utils';
 
 function ColumnEdit( {
 	attributes,
@@ -85,35 +97,37 @@ export default compose(
 				updateBlockAttributes( rootClientId, { verticalAlignment: null } );
 			},
 			updateWidth( width ) {
-				const { clientId, attributes, setAttributes } = ownProps;
+				const { clientId } = ownProps;
 				const { updateBlockAttributes } = dispatch( 'core/block-editor' );
-				const {
-					getBlockRootClientId,
-					getBlockOrder,
-					getBlockAttributes,
-				} = registry.select( 'core/block-editor' );
-
-				// Update own width.
-				setAttributes( { width } );
+				const { getBlockRootClientId, getBlocks } = registry.select( 'core/block-editor' );
 
 				// Constrain or expand siblings to account for gain or loss of
 				// total columns area.
-				const rootClientId = getBlockRootClientId( clientId );
-				const columnClientIds = getBlockOrder( rootClientId );
-				const { width: previousWidth = 100 / columnClientIds.length } = attributes;
-				const index = columnClientIds.indexOf( clientId );
-				const isLastColumn = index === columnClientIds.length - 1;
-				const increment = isLastColumn ? -1 : 1;
-				const endIndex = isLastColumn ? 0 : columnClientIds.length - 1;
-				const adjustment = ( previousWidth - width ) / Math.abs( index - endIndex );
+				const columns = getBlocks( getBlockRootClientId( clientId ) );
+				const adjacentColumns = getAdjacentBlocks( columns, clientId );
 
-				for ( let i = index + increment; i - increment !== endIndex; i += increment ) {
-					const columnClientId = columnClientIds[ i ];
-					const { width: columnWidth = 100 / columnClientIds.length } = getBlockAttributes( columnClientId );
-					updateBlockAttributes( columnClientId, {
-						width: columnWidth + adjustment,
-					} );
-				}
+				// The occupied width is calculated as the sum of the new width
+				// and the total width of blocks _not_ in the adjacent set.
+				const occupiedWidth = width + getTotalColumnsWidth(
+					difference( columns, [
+						find( columns, { clientId } ),
+						...adjacentColumns,
+					] )
+				);
+
+				// Compute _all_ next column widths, in case the updated column
+				// is in the middle of a set of columns which don't yet have
+				// any explicit widths assigned (include updates to those not
+				// part of the adjacent blocks).
+				const nextColumnWidths = {
+					...getColumnWidths( columns, columns.length ),
+					[ clientId ]: toWidthPrecision( width ),
+					...getRedistributedColumnWidths( adjacentColumns, 100 - occupiedWidth, columns.length ),
+				};
+
+				forEach( nextColumnWidths, ( nextColumnWidth, columnClientId ) => {
+					updateBlockAttributes( columnClientId, { width: nextColumnWidth } );
+				} );
 			},
 		};
 	} )

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -10,7 +10,11 @@ import { InnerBlocks, BlockControls, BlockVerticalAlignmentToolbar } from '@word
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
-const ColumnEdit = ( { attributes, updateAlignment } ) => {
+function ColumnEdit( {
+	attributes,
+	updateAlignment,
+	hasChildBlocks,
+} ) {
 	const { verticalAlignment } = attributes;
 
 	const classes = classnames( 'block-core-columns', {
@@ -27,17 +31,29 @@ const ColumnEdit = ( { attributes, updateAlignment } ) => {
 					value={ verticalAlignment }
 				/>
 			</BlockControls>
-			<InnerBlocks templateLock={ false } />
+			<InnerBlocks
+				templateLock={ false }
+				renderAppender={ (
+					hasChildBlocks ?
+						undefined :
+						() => <InnerBlocks.ButtonBlockAppender />
+				) }
+			/>
 		</div>
 	);
-};
+}
 
 export default compose(
-	withSelect( ( select, { clientId } ) => {
-		const { getBlockRootClientId } = select( 'core/editor' );
+	withSelect( ( select, ownProps ) => {
+		const { clientId } = ownProps;
+		const {
+			getBlockRootClientId,
+			getBlockOrder,
+		} = select( 'core/block-editor' );
 
 		return {
 			parentColumnsBlockClientId: getBlockRootClientId( clientId ),
+			hasChildBlocks: getBlockOrder( clientId ).length > 0,
 		};
 	} ),
 	withDispatch( ( dispatch, { clientId, parentColumnsBlockClientId } ) => {

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -58,6 +58,7 @@ function ColumnEdit( {
 						min={ 0 }
 						max={ 100 }
 						required
+						allowReset
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -40,7 +40,7 @@ function ColumnEdit( {
 			<InspectorControls>
 				<PanelBody title={ __( 'Column Settings' ) }>
 					<RangeControl
-						label={ __( 'Width' ) }
+						label={ __( 'Percentage width' ) }
 						value={ width }
 						onChange={ updateWidth }
 						min={ 0 }

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -53,7 +53,7 @@ function ColumnEdit( {
 				<PanelBody title={ __( 'Column Settings' ) }>
 					<RangeControl
 						label={ __( 'Percentage width' ) }
-						value={ width }
+						value={ width || '' }
 						onChange={ updateWidth }
 						min={ 0 }
 						max={ 100 }

--- a/packages/block-library/src/column/index.js
+++ b/packages/block-library/src/column/index.js
@@ -25,6 +25,16 @@ export const settings = {
 		reusable: false,
 		html: false,
 	},
+	getEditWrapperProps( attributes ) {
+		const { width } = attributes;
+		if ( Number.isFinite( width ) ) {
+			return {
+				style: {
+					flexBasis: width + '%',
+				},
+			};
+		}
+	},
 	edit,
 	save,
 };

--- a/packages/block-library/src/column/save.js
+++ b/packages/block-library/src/column/save.js
@@ -9,13 +9,19 @@ import classnames from 'classnames';
 import { InnerBlocks } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { verticalAlignment } = attributes;
+	const { verticalAlignment, width } = attributes;
+
 	const wrapperClasses = classnames( {
 		[ `is-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
 	} );
 
+	let style;
+	if ( Number.isFinite( width ) ) {
+		style = { flexBasis: width + '%' };
+	}
+
 	return (
-		<div className={ wrapperClasses }>
+		<div className={ wrapperClasses } style={ style }>
 			<InnerBlocks.Content />
 		</div>
 	);

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { last } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { compose } from '@wordpress/compose';
 import {
 	PanelBody,
 	RangeControl,
@@ -18,7 +18,8 @@ import {
 	BlockControls,
 	BlockVerticalAlignmentToolbar,
 } from '@wordpress/block-editor';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { withDispatch } from '@wordpress/data';
+import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -36,17 +37,17 @@ import { getColumnsTemplate } from './utils';
 */
 const ALLOWED_BLOCKS = [ 'core/column' ];
 
-export const ColumnsEdit = function( { attributes, setAttributes, className, updateAlignment } ) {
+export function ColumnsEdit( {
+	attributes,
+	className,
+	updateAlignment,
+	updateColumns,
+} ) {
 	const { columns, verticalAlignment } = attributes;
 
 	const classes = classnames( className, `has-${ columns }-columns`, {
 		[ `are-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
 	} );
-
-	const onChange = ( alignment ) => {
-		// Update all the (immediate) child Column Blocks
-		updateAlignment( alignment );
-	};
 
 	return (
 		<>
@@ -55,11 +56,7 @@ export const ColumnsEdit = function( { attributes, setAttributes, className, upd
 					<RangeControl
 						label={ __( 'Columns' ) }
 						value={ columns }
-						onChange={ ( nextColumns ) => {
-							setAttributes( {
-								columns: nextColumns,
-							} );
-						} }
+						onChange={ updateColumns }
 						min={ 2 }
 						max={ 6 }
 					/>
@@ -67,7 +64,7 @@ export const ColumnsEdit = function( { attributes, setAttributes, className, upd
 			</InspectorControls>
 			<BlockControls>
 				<BlockVerticalAlignmentToolbar
-					onChange={ onChange }
+					onChange={ updateAlignment }
 					value={ verticalAlignment }
 				/>
 			</BlockControls>
@@ -79,45 +76,92 @@ export const ColumnsEdit = function( { attributes, setAttributes, className, upd
 			</div>
 		</>
 	);
-};
+}
 
-const DEFAULT_EMPTY_ARRAY = [];
-
-export default compose(
+export default withDispatch( ( dispatch, ownProps, registry ) => ( {
 	/**
-	 * Selects the child column Blocks for this parent Column
+	 * Update all child Column blocks with a new vertical alignment setting
+	 * based on whatever alignment is passed in. This allows change to parent
+	 * to overide anything set on a individual column basis.
+	 *
+	 * @param {string} verticalAlignment the vertical alignment setting
 	 */
-	withSelect( ( select, { clientId } ) => {
-		const { getBlocksByClientId } = select( 'core/editor' );
-		const block = getBlocksByClientId( clientId )[ 0 ];
+	updateAlignment( verticalAlignment ) {
+		const { clientId, setAttributes } = ownProps;
+		const { updateBlockAttributes } = dispatch( 'core/block-editor' );
+		const { getBlockOrder } = registry.select( 'core/block-editor' );
 
-		return {
-			childColumns: block ? block.innerBlocks : DEFAULT_EMPTY_ARRAY,
-		};
-	} ),
-	withDispatch( ( dispatch, { clientId, childColumns } ) => {
-		return {
-			/**
-			 * Update all child column Blocks with a new
-			 * vertical alignment setting based on whatever
-			 * alignment is passed in. This allows change to parent
-			 * to overide anything set on a individual column basis
-			 *
-			 * @param  {string} alignment the vertical alignment setting
-			 */
-			updateAlignment( alignment ) {
-				// Update self...
-				dispatch( 'core/editor' ).updateBlockAttributes( clientId, {
-					verticalAlignment: alignment,
-				} );
+		// Update own alignment.
+		setAttributes( { verticalAlignment } );
 
-				// Update all child Column Blocks to match
-				childColumns.forEach( ( childColumn ) => {
-					dispatch( 'core/editor' ).updateBlockAttributes( childColumn.clientId, {
-						verticalAlignment: alignment,
-					} );
-				} );
-			},
-		};
-	} ),
-)( ColumnsEdit );
+		// Update all child Column Blocks to match
+		const innerBlockClientIds = getBlockOrder( clientId );
+		innerBlockClientIds.forEach( ( innerBlockClientId ) => {
+			updateBlockAttributes( innerBlockClientId, {
+				verticalAlignment,
+			} );
+		} );
+	},
+
+	/**
+	 * Updates the column count, including necessary revisions to child Column
+	 * blocks to grant required or redistribute available space.
+	 *
+	 * @param {number} columns New column count.
+	 */
+	updateColumns( columns ) {
+		const { clientId, setAttributes, attributes } = ownProps;
+		const { replaceInnerBlocks } = dispatch( 'core/block-editor' );
+		const { getBlocks } = registry.select( 'core/block-editor' );
+
+		// Update columns count.
+		setAttributes( { columns } );
+
+		let innerBlocks = getBlocks( clientId );
+		const hasExplicitColumnWidths = innerBlocks.some( ( innerBlock ) => (
+			innerBlock.attributes.width !== undefined
+		) );
+
+		let newOrRemovedColumnWidth;
+		if ( ! hasExplicitColumnWidths ) {
+			return;
+		}
+
+		// Redistribute available width for existing inner blocks.
+		const { columns: previousColumns } = attributes;
+		const isAddingColumn = columns > previousColumns;
+
+		if ( isAddingColumn ) {
+			// If adding a new column, assign width to the new column equal to
+			// as if it were `1 / columns` of the total available space.
+			newOrRemovedColumnWidth = ( 100 / columns );
+		} else {
+			// The removed column will be the last of the inner blocks.
+			newOrRemovedColumnWidth = last( innerBlocks ).attributes.width || ( 100 / previousColumns );
+		}
+
+		const adjustment = newOrRemovedColumnWidth / ( isAddingColumn ? -1 * previousColumns : columns );
+		innerBlocks = innerBlocks.map( ( innerBlock ) => {
+			const { width: columnWidth = ( 100 / previousColumns ) } = innerBlock.attributes;
+			return {
+				...innerBlock,
+				attributes: {
+					...innerBlocks.attributes,
+					width: parseFloat( ( columnWidth + adjustment ).toFixed( 2 ) ),
+				},
+			};
+		} );
+
+		// Explicitly manage the new column block, since template would not
+		// account for the explicitly assigned width.
+		if ( isAddingColumn ) {
+			const block = createBlock( 'core/column', {
+				width: parseFloat( newOrRemovedColumnWidth.toFixed( 2 ) ),
+			} );
+
+			innerBlocks = [ ...innerBlocks, block ];
+		}
+
+		replaceInnerBlocks( clientId, innerBlocks, false );
+	},
+} ) )( ColumnsEdit );

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -178,14 +178,3 @@ div.block-core-columns.is-vertically-aligned-bottom {
 		display: none;
 	}
 }
-
-// In absence of making the individual columns resizable, we prevent them from being clickable.
-// This makes them less fiddly. @todo: This should be revisited as the interface is refined.
-.wp-block-columns [data-type="core/column"] {
-	pointer-events: none;
-
-	// This selector re-enables clicking on any child of a column block.
-	.block-core-columns .block-editor-block-list__layout {
-		pointer-events: all;
-	}
-}

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -14,7 +14,7 @@
 	margin-bottom: 1em;
 	flex-grow: 1;
 
-	@media (max-width: #{ ($break-medium) }) {
+	@media (max-width: #{ ($break-small - 1) }) {
 		// Responsiveness: Show at most one columns on mobile. This must be
 		// important since the Column assigns its own width as an inline style.
 		flex-basis: 100% !important;
@@ -29,6 +29,8 @@
 
 	@include break-small() {
 
+		// Beyond mobile, allow 2 columns.
+		flex-basis: calc(50% - #{$grid-size-large});
 		flex-grow: 0;
 
 		// Add space between the multiple columns. Themes can customize this if they wish to work differently.

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -14,8 +14,11 @@
 	margin-bottom: 1em;
 	flex-grow: 1;
 
-	// Responsiveness: Show at most one columns on mobile.
-	flex-basis: 100%;
+	@media (max-width: #{ ($break-medium) }) {
+		// Responsiveness: Show at most one columns on mobile. This must be
+		// important since the Column assigns its own width as an inline style.
+		flex-basis: 100% !important;
+	}
 
 	// Prevent the columns from growing wider than their distributed sizes.
 	min-width: 0;
@@ -26,11 +29,9 @@
 
 	@include break-small() {
 
-		// Beyond mobile, allow 2 columns.
-		flex-basis: calc(50% - #{$grid-size-large});
 		flex-grow: 0;
 
-		// Add space between the 2 columns. Themes can customize this if they wish to work differently.
+		// Add space between the multiple columns. Themes can customize this if they wish to work differently.
 		// Only apply this beyond the mobile breakpoint, as there's only a single column on mobile.
 		&:nth-child(even) {
 			margin-left: $grid-size-large * 2;

--- a/packages/block-library/src/columns/test/utils.js
+++ b/packages/block-library/src/columns/test/utils.js
@@ -32,6 +32,11 @@ describe( 'toWidthPrecision', () => {
 
 		expect( value ).toBe( 50.11 );
 	} );
+
+	it( 'should return undefined for invalid number', () => {
+		expect( toWidthPrecision( null ) ).toBe( undefined );
+		expect( toWidthPrecision( undefined ) ).toBe( undefined );
+	} );
 } );
 
 describe( 'getAdjacentBlocks', () => {

--- a/packages/block-library/src/columns/test/utils.js
+++ b/packages/block-library/src/columns/test/utils.js
@@ -1,0 +1,224 @@
+/**
+ * Internal dependencies
+ */
+import {
+	getColumnsTemplate,
+	toWidthPrecision,
+	getAdjacentBlocks,
+	getEffectiveColumnWidth,
+	getTotalColumnsWidth,
+	getColumnWidths,
+	getRedistributedColumnWidths,
+	hasExplicitColumnWidths,
+	getMappedColumnWidths,
+} from '../utils';
+
+describe( 'getColumnsTemplate', () => {
+	it( 'should return a template corresponding to columns count', () => {
+		const template = getColumnsTemplate( 4 );
+
+		expect( template ).toEqual( [
+			[ 'core/column' ],
+			[ 'core/column' ],
+			[ 'core/column' ],
+			[ 'core/column' ],
+		] );
+	} );
+} );
+
+describe( 'toWidthPrecision', () => {
+	it( 'should round value to standard precision', () => {
+		const value = toWidthPrecision( 50.108 );
+
+		expect( value ).toBe( 50.11 );
+	} );
+} );
+
+describe( 'getAdjacentBlocks', () => {
+	const blockA = { clientId: 'a' };
+	const blockB = { clientId: 'b' };
+	const blockC = { clientId: 'c' };
+	const blocks = [ blockA, blockB, blockC ];
+
+	it( 'should return blocks after clientId', () => {
+		const result = getAdjacentBlocks( blocks, 'b' );
+
+		expect( result ).toEqual( [ blockC ] );
+	} );
+
+	it( 'should return blocks before clientId if clientId is last', () => {
+		const result = getAdjacentBlocks( blocks, 'c' );
+
+		expect( result ).toEqual( [ blockA, blockB ] );
+	} );
+} );
+
+describe( 'getEffectiveColumnWidth', () => {
+	it( 'should return attribute value if set, rounded to precision', () => {
+		const block = { attributes: { width: 50.108 } };
+
+		const width = getEffectiveColumnWidth( block, 3 );
+
+		expect( width ).toBe( 50.11 );
+	} );
+
+	it( 'should return assumed width if attribute value not set, rounded to precision', () => {
+		const block = { attributes: {} };
+
+		const width = getEffectiveColumnWidth( block, 3 );
+
+		expect( width ).toBe( 33.33 );
+	} );
+} );
+
+describe( 'getTotalColumnsWidth', () => {
+	describe( 'explicit width', () => {
+		const blocks = [
+			{ clientId: 'a', attributes: { width: 30 } },
+			{ clientId: 'b', attributes: { width: 40 } },
+		];
+
+		it( 'returns the sum total of columns width', () => {
+			const width = getTotalColumnsWidth( blocks );
+
+			expect( width ).toBe( 70 );
+		} );
+	} );
+
+	describe( 'implicit width', () => {
+		const blocks = [
+			{ clientId: 'a', attributes: {} },
+			{ clientId: 'b', attributes: {} },
+		];
+
+		it( 'returns the sum total of columns width', () => {
+			const widths = getTotalColumnsWidth( blocks );
+
+			expect( widths ).toBe( 100 );
+		} );
+	} );
+} );
+
+describe( 'getColumnWidths', () => {
+	describe( 'explicit width', () => {
+		const blocks = [
+			{ clientId: 'a', attributes: { width: 30.459 } },
+			{ clientId: 'b', attributes: { width: 29.543 } },
+		];
+
+		it( 'returns the column widths', () => {
+			const widths = getColumnWidths( blocks );
+
+			expect( widths ).toEqual( {
+				a: 30.46,
+				b: 29.54,
+			} );
+		} );
+	} );
+
+	describe( 'implicit width', () => {
+		const blocks = [
+			{ clientId: 'a', attributes: {} },
+			{ clientId: 'b', attributes: {} },
+		];
+
+		it( 'returns the column widths', () => {
+			const widths = getColumnWidths( blocks );
+
+			expect( widths ).toEqual( {
+				a: 50,
+				b: 50,
+			} );
+		} );
+	} );
+} );
+
+describe( 'getRedistributedColumnWidths', () => {
+	describe( 'explicit width', () => {
+		const blocks = [
+			{ clientId: 'a', attributes: { width: 30 } },
+			{ clientId: 'b', attributes: { width: 40 } },
+		];
+
+		it( 'should constrain to fit available width', () => {
+			const widths = getRedistributedColumnWidths( blocks, 60 );
+
+			expect( widths ).toEqual( {
+				a: 25,
+				b: 35,
+			} );
+		} );
+
+		it( 'should expand to fit available width', () => {
+			const widths = getRedistributedColumnWidths( blocks, 80 );
+
+			expect( widths ).toEqual( {
+				a: 35,
+				b: 45,
+			} );
+		} );
+	} );
+
+	describe( 'implicit width', () => {
+		const blocks = [
+			{ clientId: 'a', attributes: {} },
+			{ clientId: 'b', attributes: {} },
+		];
+
+		it( 'should equally distribute to available width', () => {
+			const widths = getRedistributedColumnWidths( blocks, 60 );
+
+			expect( widths ).toEqual( {
+				a: 30,
+				b: 30,
+			} );
+		} );
+
+		it( 'should constrain to fit available width', () => {
+			const widths = getRedistributedColumnWidths( blocks, 66.66, 3 );
+
+			expect( widths ).toEqual( {
+				a: 33.33,
+				b: 33.33,
+			} );
+		} );
+	} );
+} );
+
+describe( 'hasExplicitColumnWidths', () => {
+	it( 'returns false if no blocks have explicit width', () => {
+		const blocks = [ { attributes: {} } ];
+
+		const result = hasExplicitColumnWidths( blocks );
+
+		expect( result ).toBe( false );
+	} );
+
+	it( 'returns true if a block has explicit width', () => {
+		const blocks = [ { attributes: { width: 10 } } ];
+
+		const result = hasExplicitColumnWidths( blocks );
+
+		expect( result ).toBe( true );
+	} );
+} );
+
+describe( 'getMappedColumnWidths', () => {
+	it( 'merges to block attributes using provided widths', () => {
+		const blocks = [
+			{ clientId: 'a', attributes: { width: 30 } },
+			{ clientId: 'b', attributes: { width: 40 } },
+		];
+		const widths = {
+			a: 25,
+			b: 35,
+		};
+
+		const result = getMappedColumnWidths( blocks, widths );
+
+		expect( result ).toEqual( [
+			{ clientId: 'a', attributes: { width: 25 } },
+			{ clientId: 'b', attributes: { width: 35 } },
+		] );
+	} );
+} );

--- a/packages/block-library/src/columns/utils.js
+++ b/packages/block-library/src/columns/utils.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import memoize from 'memize';
-import { times } from 'lodash';
+import { times, findIndex, sumBy, merge, mapValues } from 'lodash';
 
 /**
  * Returns the layouts configuration for a given number of columns.
@@ -14,3 +14,125 @@ import { times } from 'lodash';
 export const getColumnsTemplate = memoize( ( columns ) => {
 	return times( columns, () => [ 'core/column' ] );
 } );
+
+/**
+ * Returns a column width attribute value rounded to standard precision.
+ *
+ * @param {number} value Raw value.
+ *
+ * @return {number} Value rounded to standard precision.
+ */
+export const toWidthPrecision = ( value ) => parseFloat( value.toFixed( 2 ) );
+
+/**
+ * Returns the considered adjacent to that of the specified `clientId` for
+ * resizing consideration. Adjacent blocks are those occurring after, except
+ * when the given block is the last block in the set. For the last block, the
+ * behavior is reversed.
+ *
+ * @param {WPBlock[]} blocks   Block objects.
+ * @param {string}    clientId Client ID to consider for adjacent blocks.
+ *
+ * @return {WPBlock[]} Adjacent block objects.
+ */
+export function getAdjacentBlocks( blocks, clientId ) {
+	const index = findIndex( blocks, { clientId } );
+	const isLastBlock = index === blocks.length - 1;
+
+	return isLastBlock ? blocks.slice( 0, index ) : blocks.slice( index + 1 );
+}
+
+/**
+ * Returns an effective width for a given block. An effective width is equal to
+ * its attribute value if set, or a computed value assuming equal distribution.
+ *
+ * @param {WPBlock} block           Block object.
+ * @param {number}  totalBlockCount Total number of blocks in Columns.
+ *
+ * @return {number} Effective column width.
+ */
+export function getEffectiveColumnWidth( block, totalBlockCount ) {
+	const { width = 100 / totalBlockCount } = block.attributes;
+	return toWidthPrecision( width );
+}
+
+/**
+ * Returns the total width occupied by the given set of column blocks.
+ *
+ * @param {WPBlock[]} blocks          Block objects.
+ * @param {?number}   totalBlockCount Total number of blocks in Columns.
+ *                                    Defaults to number of blocks passed.
+ *
+ * @return {number} Total width occupied by blocks.
+ */
+export function getTotalColumnsWidth( blocks, totalBlockCount = blocks.length ) {
+	return sumBy( blocks, ( block ) => getEffectiveColumnWidth( block, totalBlockCount ) );
+}
+
+/**
+ * Returns an object of `clientId` → `width` of effective column widths.
+ *
+ * @param {WPBlock[]} blocks          Block objects.
+ * @param {?number}   totalBlockCount Total number of blocks in Columns.
+ *                                    Defaults to number of blocks passed.
+ *
+ * @return {Object<string,number>} Column widths.
+ */
+export function getColumnWidths( blocks, totalBlockCount = blocks.length ) {
+	return blocks.reduce( ( result, block ) => {
+		const width = getEffectiveColumnWidth( block, totalBlockCount );
+		return Object.assign( result, { [ block.clientId ]: width } );
+	}, {} );
+}
+
+/**
+ * Returns an object of `clientId` → `width` of column widths as redistributed
+ * proportional to their current widths, constrained or expanded to fit within
+ * the given available width.
+ *
+ * @param {WPBlock[]} blocks          Block objects.
+ * @param {number}    availableWidth  Maximum width to fit within.
+ * @param {?number}   totalBlockCount Total number of blocks in Columns.
+ *                                    Defaults to number of blocks passed.
+ *
+ * @return {Object<string,number>} Redistributed column widths.
+ */
+export function getRedistributedColumnWidths( blocks, availableWidth, totalBlockCount = blocks.length ) {
+	const totalWidth = getTotalColumnsWidth( blocks, totalBlockCount );
+	const difference = availableWidth - totalWidth;
+	const adjustment = difference / blocks.length;
+
+	return mapValues(
+		getColumnWidths( blocks, totalBlockCount ),
+		( width ) => toWidthPrecision( width + adjustment ),
+	);
+}
+
+/**
+ * Returns true if column blocks within the provided set are assigned with
+ * explicit widths, or false otherwise.
+ *
+ * @param {WPBlock[]} blocks Block objects.
+ *
+ * @return {boolean} Whether columns have explicit widths.
+ */
+export function hasExplicitColumnWidths( blocks ) {
+	return blocks.some( ( block ) => Number.isFinite( block.attributes.width ) );
+}
+
+/**
+ * Returns a copy of the given set of blocks with new widths assigned from the
+ * provided object of redistributed column widths.
+ *
+ * @param {WPBlock[]}             blocks Block objects.
+ * @param {Object<string,number>} widths Redistributed column widths.
+ *
+ * @return {WPBlock[]} blocks Mapped block objects.
+ */
+export function getMappedColumnWidths( blocks, widths ) {
+	return blocks.map( ( block ) => merge( {}, block, {
+		attributes: {
+			width: widths[ block.clientId ],
+		},
+	} ) );
+}

--- a/packages/block-library/src/columns/utils.js
+++ b/packages/block-library/src/columns/utils.js
@@ -17,12 +17,16 @@ export const getColumnsTemplate = memoize( ( columns ) => {
 
 /**
  * Returns a column width attribute value rounded to standard precision.
+ * Returns `undefined` if the value is not a valid finite number.
  *
- * @param {number} value Raw value.
+ * @param {?number} value Raw value.
  *
  * @return {number} Value rounded to standard precision.
  */
-export const toWidthPrecision = ( value ) => parseFloat( value.toFixed( 2 ) );
+export const toWidthPrecision = ( value ) =>
+	Number.isFinite( value ) ?
+		parseFloat( value.toFixed( 2 ) ) :
+		undefined;
 
 /**
  * Returns the considered adjacent to that of the specified `clientId` for

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,6 +1,12 @@
-## 7.4.0 (Unreleased)
+## Master
+
+### New Features
 
 - Added a new `HorizontalRule` component.
+
+### Bug Fixes
+
+- Fixed display of reset button when using RangeControl `allowReset` prop.
 
 ## 7.3.0 (2019-04-16)
 

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -98,11 +98,17 @@ function RangeControl( {
 				onBlur={ resetCurrentInput }
 				{ ...props }
 			/>
-			{ allowReset &&
-				<Button onClick={ resetValue } disabled={ value === undefined }>
+			{ allowReset && (
+				<Button
+					onClick={ resetValue }
+					disabled={ value === undefined }
+					isSmall
+					isDefault
+					className="components-range-control__reset"
+				>
 					{ __( 'Reset' ) }
 				</Button>
-			}
+			) }
 		</BaseControl>
 	);
 }

--- a/packages/components/src/range-control/style.scss
+++ b/packages/components/src/range-control/style.scss
@@ -22,6 +22,10 @@
 	}
 }
 
+.components-range-control__reset {
+	margin-left: $grid-size;
+}
+
 // creating mixin because we can't do multiline variables, and we can't comma-group the selectors for styling the range slider
 @mixin range-thumb() {
 	height: 18px;

--- a/packages/e2e-tests/specs/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/block-hierarchy-navigation.test.js
@@ -22,6 +22,11 @@ describe( 'Navigating the block hierarchy', () => {
 		await insertBlock( 'Columns' );
 
 		// Add a paragraph in the first column.
+		await pressKeyTimes( 'Tab', 5 ); // Tab to inserter.
+		await page.keyboard.press( 'Enter' ); // Activate inserter.
+		await page.keyboard.type( 'Paragraph' );
+		await pressKeyTimes( 'Tab', 3 ); // Tab to paragraph result.
+		await page.keyboard.press( 'Enter' ); // Insert paragraph.
 		await page.keyboard.type( 'First column' );
 
 		// Navigate to the columns blocks.
@@ -44,7 +49,11 @@ describe( 'Navigating the block hierarchy', () => {
 		await lastColumnsBlockMenuItem.click();
 
 		// Insert text in the last column block.
-		await pressKeyTimes( 'Tab', 5 ); // Navigate to the appender.
+		await pressKeyTimes( 'Tab', 5 ); // Tab to inserter.
+		await page.keyboard.press( 'Enter' ); // Activate inserter.
+		await page.keyboard.type( 'Paragraph' );
+		await pressKeyTimes( 'Tab', 3 ); // Tab to paragraph result.
+		await page.keyboard.press( 'Enter' ); // Insert paragraph.
 		await page.keyboard.type( 'Third column' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
@@ -54,6 +63,11 @@ describe( 'Navigating the block hierarchy', () => {
 		await insertBlock( 'Columns' );
 
 		// Add a paragraph in the first column.
+		await pressKeyTimes( 'Tab', 5 ); // Tab to inserter.
+		await page.keyboard.press( 'Enter' ); // Activate inserter.
+		await page.keyboard.type( 'Paragraph' );
+		await pressKeyTimes( 'Tab', 3 ); // Tab to paragraph result.
+		await page.keyboard.press( 'Enter' ); // Insert paragraph.
 		await page.keyboard.type( 'First column' );
 
 		// Navigate to the columns blocks using the keyboard.
@@ -76,7 +90,11 @@ describe( 'Navigating the block hierarchy', () => {
 		await page.keyboard.press( 'Enter' );
 
 		// Insert text in the last column block
-		await pressKeyTimes( 'Tab', 5 ); // Navigate to the appender.
+		await pressKeyTimes( 'Tab', 5 ); // Tab to inserter.
+		await page.keyboard.press( 'Enter' ); // Activate inserter.
+		await page.keyboard.type( 'Paragraph' );
+		await pressKeyTimes( 'Tab', 3 ); // Tab to paragraph result.
+		await page.keyboard.press( 'Enter' ); // Insert paragraph.
 		await page.keyboard.type( 'Third column' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();

--- a/packages/e2e-tests/specs/writing-flow.test.js
+++ b/packages/e2e-tests/specs/writing-flow.test.js
@@ -24,13 +24,22 @@ describe( 'adding blocks', () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '/columns' );
 		await page.keyboard.press( 'Enter' );
+		await pressKeyTimes( 'Tab', 5 ); // Tab to inserter.
+		await page.keyboard.press( 'Enter' ); // Activate inserter.
+		await page.keyboard.type( 'Paragraph' );
+		await pressKeyTimes( 'Tab', 3 ); // Tab to paragraph result.
+		await page.keyboard.press( 'Enter' ); // Insert paragraph.
 		await page.keyboard.type( 'First col' );
 
 		// Arrow down should navigate through layouts in columns block (to
 		// its default appender). Two key presses are required since the first
 		// will land user on the Column wrapper block.
 		await page.keyboard.press( 'ArrowDown' );
-		await page.keyboard.press( 'ArrowDown' );
+		await pressKeyTimes( 'Tab', 5 ); // Tab to inserter.
+		await page.keyboard.press( 'Enter' ); // Activate inserter.
+		await page.keyboard.type( 'Paragraph' );
+		await pressKeyTimes( 'Tab', 3 ); // Tab to paragraph result.
+		await page.keyboard.press( 'Enter' ); // Insert paragraph.
 		await page.keyboard.type( 'Second col' );
 
 		// Arrow down from last of layouts exits nested context to default

--- a/packages/e2e-tests/specs/writing-flow.test.js
+++ b/packages/e2e-tests/specs/writing-flow.test.js
@@ -16,6 +16,10 @@ describe( 'adding blocks', () => {
 	} );
 
 	it( 'Should navigate inner blocks with arrow keys', async () => {
+		// TODO: The `waitForSelector` calls in this function should ultimately
+		// not be necessary for interactions, and exist as a stop-gap solution
+		// where rendering delays in slower CPU can cause intermittent failure.
+
 		let activeElementText;
 
 		// Add demo content
@@ -24,19 +28,19 @@ describe( 'adding blocks', () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '/columns' );
 		await page.keyboard.press( 'Enter' );
-		await pressKeyTimes( 'Tab', 5 ); // Tab to inserter.
-		await page.keyboard.press( 'Enter' ); // Activate inserter.
+		await page.click( ':focus .block-editor-button-block-appender' );
+		await page.waitForSelector( ':focus.block-editor-inserter__search' );
 		await page.keyboard.type( 'Paragraph' );
 		await pressKeyTimes( 'Tab', 3 ); // Tab to paragraph result.
 		await page.keyboard.press( 'Enter' ); // Insert paragraph.
 		await page.keyboard.type( 'First col' );
 
-		// Arrow down should navigate through layouts in columns block (to
-		// its default appender). Two key presses are required since the first
-		// will land user on the Column wrapper block.
-		await page.keyboard.press( 'ArrowDown' );
-		await pressKeyTimes( 'Tab', 5 ); // Tab to inserter.
-		await page.keyboard.press( 'Enter' ); // Activate inserter.
+		// TODO: ArrowDown should traverse into the second column. In slower
+		// CPUs, it can sometimes remain in the first column paragraph. This
+		// is a temporary solution.
+		await page.focus( '.wp-block[data-type="core/column"]:nth-child(2)' );
+		await page.click( ':focus .block-editor-button-block-appender' );
+		await page.waitForSelector( ':focus.block-editor-inserter__search' );
 		await page.keyboard.type( 'Paragraph' );
 		await pressKeyTimes( 'Tab', 3 ); // Tab to paragraph result.
 		await page.keyboard.press( 'Enter' ); // Insert paragraph.


### PR DESCRIPTION
This pull request seeks to implement an initial exploration of resizable column blocks. It should serve as some foundation upon which to improve the usefulness of the Columns block.

![columns](https://user-images.githubusercontent.com/1779930/57376626-7ed8f600-716e-11e9-97fa-c1634a92cb9e.gif)

In this first iteration:

- An empty Column block displays with the "Button" appender introduced in #14241, similar to the Group block (#14943). The thinking is that this allows for a simpler gauge of columns width before adding content.
- An individual column block can be assigned with a `width` attribute which overrides the default equal distribution of column widths in a Columns block. Widths of all adjacent Column blocks are updated automatically, and widths redistributed when a Column is added or removed from the Columns block.

Not yet included, but planned for future iterations:

- A draggable resizer handle to adjust columns width. I have the bulk of the code for this complete already.
- Quick-select "template" options for columns distribution when initially creating a Columns block.
- Improved methods to select a Column and a Columns block to adjust settings.

**Specific Behavior:**

- When changing the width of a Column, the amount of increase or decrease is respectively removed or added in equal distribution across the Column blocks _after_ the block being changed, unless the Column block is the last in the set (in which case, the redistribution occurs in reverse).
- When adding or removing a Column to a Columns block, the new Column is assigned a width as if there were equal distribution. For example, increasing Columns from 2 to 3 would assume a width of 33.3% for the new block (100 / 3). This width (or, in the case of removal, the width of the removed block) is removed from or added to other blocks in the Columns.
- The default behavior of Columns remains unchanged in that `width` is only assigned or adjusted if a width value was assigned to a Column block in the set. This also helps ensure backwards-compatibility with previously-existing Column blocks.

**Testing Instructions:**

Verify that you can resize a Column block, and that in doing so, adjacent Column blocks are resized accordingly. Similarly, verify that adding or removing new Columns should redistribute widths to/from other columns.

1. Navigate to Posts > Add New
2. Insert a Columns block
3. Select the Column block (ArrowUp and ArrowDown are reliable here)
4. Adjust width value in the Inspector
5. Observe that the second column updates its width accordingly (to a sum of 100)
6. Select the Columns block
7. Increase / decrease Colujmsn count
8. Observe that the previous two columns update their widths accordingly (to a sum of 100)
9. Repeat steps 3 through 8 with a variation of Column combinations

**Remaining tasks:**

- [x] There is occasionally some issue in columns redistribution related to precision, where the sum total of Column widths may not equal 100 (but rather, e.g. 99.98%)