### PR TITLE
Testing: Skip test failures for font decoding warnings

### DIFF
--- a/packages/e2e-test-utils/CHANGELOG.md
+++ b/packages/e2e-test-utils/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - The minimum version of Gutenberg `5.6.0` or the minimum version of WordPress `5.2.0`.
 
+### Bug Fixes
+
+- WordPress 5.2: Fix a false positive build failure caused by Dashicons font file.
+
 ## 1.1.0 (2019-03-20)
 
 ### New Features

--- a/packages/e2e-test-utils/CHANGELOG.md
+++ b/packages/e2e-test-utils/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 
 - WordPress 5.2: Fix a false positive build failure caused by Dashicons font file.
+- WordPress 5.2: Fix a test failure for Classic Block media insertion caused by a change in tooltips text ([rWP45066](https://core.trac.wordpress.org/changeset/45066)).
 
 ## 1.1.0 (2019-03-20)
 

--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -122,6 +122,19 @@ function observeConsoleLogging() {
 			return;
 		}
 
+		// A bug present in WordPress 5.2 will produce console warnings when
+		// loading the Dashicons font. These can be safely ignored, as they do
+		// not otherwise regress on application behavior. This logic should be
+		// removed once the associated ticket has been closed.
+		//
+		// See: https://core.trac.wordpress.org/ticket/47183
+		if (
+			text.startsWith( 'Failed to decode downloaded font:' ) ||
+			text.startsWith( 'OTS parsing error:' )
+		) {
+			return;
+		}
+
 		const logFunction = OBSERVED_CONSOLE_MESSAGE_TYPES[ type ];
 
 		// As of Puppeteer 1.6.1, `message.text()` wrongly returns an object of

--- a/packages/e2e-tests/specs/blocks/classic.test.js
+++ b/packages/e2e-tests/specs/blocks/classic.test.js
@@ -43,8 +43,8 @@ describe( 'Classic', () => {
 		await page.keyboard.type( 'test' );
 
 		// Click the image button.
-		await page.waitForSelector( 'div[aria-label="Add Media"]' );
-		await page.click( 'div[aria-label="Add Media"]' );
+		await page.waitForSelector( 'div[aria-label^="Add Media"]' );
+		await page.click( 'div[aria-label^="Add Media"]' );
 
 		// Wait for media modal to appear and upload image.
 		await page.waitForSelector( '.media-modal input[type=file]' );


### PR DESCRIPTION
This pull request seeks to resolve an issue present in `master` currently causing all end-to-end tests to fail. There is a bug introduced with WordPress 5.2 which causes a console warning to be logged when loading the Dashicons font for some usage, notably radio buttons:

https://core.trac.wordpress.org/ticket/47183

The end-to-end tests are configured to automatically fail if any unexpected console warnings or errors occur (#8721).

The changes here allow for these specific console warnings to be exempt from this, thus allowing the tests to pass.

**Testing instructions:**

Ensure end-to-end tests pass (also obvious by Travis build pass):

```
npm run test-e2e
```