### PR TITLE
Fix the anchor links in the Table of Contents

### DIFF
--- a/packages/components/src/select-control/README.md
+++ b/packages/components/src/select-control/README.md
@@ -6,9 +6,9 @@ SelectControl allow users to select from a single-option menu. It functions as a
 
 ## Table of contents
 
-1. [Design guidelines](http://##design-guidelines)
-2. [Development guidelines](http://##development-guidelines)
-3. [Related components](http://##related-components)
+1. [Design guidelines](#design-guidelines)
+2. [Development guidelines](#development-guidelines)
+3. [Related components](#related-components)
 
 ## Design guidelines
 


### PR DESCRIPTION
## Description
Currently the anchor links are broken here;
https://wordpress.org/gutenberg/handbook/designers-developers/developers/components/select-control/

This patch removes the 'http://#' part of these links which was making them invalid.

Reference - https://meta.trac.wordpress.org/ticket/4446

## How has this been tested?
It hasn't, will need to confirm they work once the handbook syncs

## Screenshots 
https://www.screencast.com/t/H8SuqbuKA5u5

## Types of changes
Handbook changes to fix anchor links

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
