### PR TITLE
Removing Related components from ToC as it's not present

### DIFF
--- a/packages/components/src/menu-items-choice/README.md
+++ b/packages/components/src/menu-items-choice/README.md
@@ -10,7 +10,6 @@
 
 1. [Design guidelines](#design-guidelines)
 2. [Development guidelines](#development-guidelines)
-3. [Related components](#related-components)
 
 ## Design guidelines
 


### PR DESCRIPTION
## Description
The ToC listed 'Related components' but this page doesn't have that section. This PR removes it.

## How has this been tested?
Visually checked.

## Types of changes
Update to the Table of Contents.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
