### PR TITLE
Removing hardcoded colors in favor of InnerBlocks

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -118,19 +118,8 @@
 	.wp-block-cover__inner-container {
 		width: calc(100% - 70px);
 		z-index: z-index(".wp-block-cover__inner-container");
-		color: $light-gray-100;
 	}
 
-	p,
-	h1,
-	h2,
-	h3,
-	h4,
-	h5,
-	h6,
-	.wp-block-subhead {
-		color: inherit;
-	}
 }
 
 .wp-block-cover__video-background {


### PR DESCRIPTION
## Description
Removed previously added CSS colors in favor of inner blocks.

![](https://i.imgsafe.org/32/325a640474.gif)