### PR TITLE
@wordpress/data: Create `useSelect` hook.

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -435,6 +435,19 @@ _Parameters_
 
 Undocumented declaration.
 
+<a name="useSelect" href="#useSelect">#</a> **useSelect**
+
+A custom hook used for retrieving enhanced selector hooks from the given
+store.
+
+_Parameters_
+
+-   _store_ `string`: The store from which to retrieve the selectors.
+
+_Returns_
+
+-   `Object`: A collection of enhanced selectors
+
 <a name="withDispatch" href="#withDispatch">#</a> **withDispatch**
 
 Higher-order component used to add dispatch props using registered action creators.

--- a/packages/data/src/components/registry-provider/index.js
+++ b/packages/data/src/components/registry-provider/index.js
@@ -8,7 +8,9 @@ import { createContext } from '@wordpress/element';
  */
 import defaultRegistry from '../../default-registry';
 
-const { Consumer, Provider } = createContext( defaultRegistry );
+export const RegistryContext = createContext( defaultRegistry );
+
+const { Consumer, Provider } = RegistryContext;
 
 export const RegistryConsumer = Consumer;
 

--- a/packages/data/src/hooks/use-select/index.js
+++ b/packages/data/src/hooks/use-select/index.js
@@ -1,0 +1,53 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState, useContext } from '@wordpress/element';
+
+/**
+ * External dependencies
+ */
+import { forEach } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { RegistryContext } from '../../components/registry-provider';
+
+/**
+ * A factory returning a enhanced selector as a custom hook.
+ *
+ * @param {function} subscribe  The subscribe function for the current registry.
+ * @param {function} selector   The selector being enhanced.
+ *
+ * @return {function} The enhanced selector
+ */
+const selectorHookFactory = ( subscribe, selector ) => ( ...args ) => {
+	const [ result, setResult ] = useState( null );
+	useEffect( () => {
+		const unsubscribe = subscribe( () => {
+			setResult( selector( ...args ) );
+		} );
+		return () => unsubscribe();
+	}, [ ...args, subscribe, selector ] );
+	return result;
+};
+
+/**
+ * A custom hook used for retrieving enhanced selector hooks from the given
+ * store.
+ *
+ * @param {string} store  The store from which to retrieve the selectors.
+ *
+ * @return {Object} A collection of enhanced selectors
+ */
+export default function useSelect( store ) {
+	const registry = useContext( RegistryContext );
+	const selectorHooks = {};
+	forEach( registry.select( store ), ( selector, selectorName ) => {
+		selectorHooks[ selectorName ] = selectorHookFactory(
+			registry.subscribe,
+			selector
+		);
+	} );
+	return selectorHooks;
+}

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -13,6 +13,7 @@ export { default as withSelect } from './components/with-select';
 export { default as withDispatch } from './components/with-dispatch';
 export { default as withRegistry } from './components/with-registry';
 export { default as RegistryProvider, RegistryConsumer } from './components/registry-provider';
+export { default as useSelect } from './hooks/use-select';
 export { default as __experimentalAsyncModeProvider } from './components/async-mode-provider';
 export { createRegistry } from './registry';
 export { plugins };

--- a/packages/editor/src/components/post-trash/check.js
+++ b/packages/editor/src/components/post-trash/check.js
@@ -1,20 +1,15 @@
 /**
  * WordPress dependencies
  */
-import { withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 
-function PostTrashCheck( { isNew, postId, children } ) {
+export default function PostTrashCheck( { children } ) {
+	const { isEditedPostNew, getCurrentPostId } = useSelect( 'core/editor' );
+	const isNew = isEditedPostNew();
+	const postId = getCurrentPostId();
 	if ( isNew || ! postId ) {
 		return null;
 	}
 
 	return children;
 }
-
-export default withSelect( ( select ) => {
-	const { isEditedPostNew, getCurrentPostId } = select( 'core/editor' );
-	return {
-		isNew: isEditedPostNew(),
-		postId: getCurrentPostId(),
-	};
-} )( PostTrashCheck );


### PR DESCRIPTION
## Description

See #15473 for background.  The purpose of this pull is to do some experiments on a new `useSelect` hook.  In this initial iteration:

* Signature is `useSelect( storeName: string ): Object`
* The hook receives a store name and will return an enhanced object of selectors from the store which themselves are hooks.

Example usage: 

https://github.com/WordPress/gutenberg/blob/faa39a72077a6b743491922ff13330391ae5f67f/packages/editor/src/components/post-trash/check.js#L1-L15

### Rationale:

* The api is fairly intuitive and easy to consume.
* In following the hook pattern, each selector on a store is enhanced to be itself a hook so that they are individually subscribed to changes in selector state.  This eliminates the need to provide a mapSelectToProps callback (although I do think we'll want something like that... see notes later).  
* Edit, this point and the example below actually break one of the [rules of Hooks](https://reactjs.org/docs/hooks-rules.html) so it's not a valid point/example. ~Subscriptions are not set until a returned enhanced selector is invoked.  This does allow for some lazy subscription registration on selector calls~.  Example:

```js
const myComponent = ( propA ) => {
    const { mySelectorA, mySelectorB } = useSelect( 'mystore' );
    // a subscription is created for the mySelectorB call.
    const valueB = mySelectorB();
    let valueA = null;
    if ( propA === 'foo' ) {
          // subscription doesn't get set until this condition is met
          valueA = mySelectorA();
    }
    /** ... rest of logic for component **/
}
```

### Some things to consider & potential drawbacks:

* Although subscriptions are not set until the enhanced selector is invoked, there is a bit more overhead involved than a single subscription created (as in `withSelect`).  For instance, one of the concerns here is that with multiple selectHooks with resolvers, there's more re-rendering that could happen as each selector is resolved.
* I'm not certain if the async context is needed here but obviously this would need reworked if we want to retain that.
* Related to the previous point and the proposed signatures listed in #15743, we may want to offer the alternative `mapSelectToProps` option as that would reduce the number of registry subscriptions.  However in the case of providing a mapSelectToProps, the returned object would be the props returned from the `mapSelectToProps` function.  This version would be more similar to the current behaviour of `withSelect`
* It's convention that hooks have the `use` prefix.  Although I didn't do that there, there's some advantages to returning our enhanced selectors with that prefix because it: 1. makes it clear these are hooks and should be treated as such. 2. Exposes them to the eslinting on hooks (which helps prevents incorrect usage - such as implementation order matters).

### Todos:

* [ ] evaluate current approach, get feedback.
* [ ] implement additional signatures outlined in #15473.  I'm thinking it should be pretty consistent that if you provide a function it is assumed it is a `mapSelectToProps` like callback and if its a string, it's assumed to be a store name (and thus return the enhanced selectors on that store).   
* [ ] Improve `withSelect` to incorporate a similar signature as what we land on for `useSelect` (although I don't think we need to strive for _complete_ consistency because there is varying paradigms in play here).
* [ ] Add tests
* [ ] Pick a component which should help us gauge performance impact to refactor as a part of this work?
* [ ] Benchmarks (what existing benchmarking tools do we have for the project that can be used?).
* [ ] Changelog/docs.

### Dependencies for this work:

* [ ] No matter what approach we take, there will be a dependency on #15445 so that `useContext` for the registry is possible.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
