### PR TITLE
Update save indicator contrast to pass AA

### DIFF
--- a/packages/editor/src/components/post-saved-state/style.scss
+++ b/packages/editor/src/components/post-saved-state/style.scss
@@ -3,7 +3,7 @@
 	align-items: center;
 	width: $icon-button-size - 8px;
 	padding: #{ $grid-size-small * 3 } $grid-size-small;
-	color: $light-gray-900; // Doesn't need to meet AA because button is disabled and it's supporting text.
+	color: $dark-gray-500;
 	overflow: hidden;
 	white-space: nowrap;
 


### PR DESCRIPTION
Fixes one portion of the issues noted in #15280. 

This PR changes the "✔️ Saved" toolbar message from `#a2aab2` to `#555d66` in order to pass WCAG AA contrast ratios. It looks like there was a note in the code that this doesn't need to pass: 

```
// Doesn't need to meet AA because button is disabled and it's supporting text.
````

This change appears to come from #10552, but I don't see any discussion there around it. Personally, I don't particularly mind the darker shade, but I'm happy to keep it light if there's good reason to. 

---

**Before:**

<img width="388" alt="Screen Shot 2019-05-08 at 3 07 35 PM" src="https://user-images.githubusercontent.com/1202812/57401335-6d5e1100-71a3-11e9-920b-edc24d33e2f8.png">

**After:**

<img width="412" alt="Screen Shot 2019-05-08 at 3 07 18 PM" src="https://user-images.githubusercontent.com/1202812/57401384-88308580-71a3-11e9-9423-313464ea58f2.png">