### PR TITLE
adds new edit flow to the video block

### DIFF
--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -139,6 +139,7 @@ class VideoEdit extends Component {
 	}
 
 	render() {
+		const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
 		const {
 			autoplay,
 			caption,
@@ -159,7 +160,7 @@ class VideoEdit extends Component {
 			setAttributes,
 		} = this.props;
 		const { editing } = this.state;
-		const switchToEditing = () => {
+		const toggleIsEditing = () => {
 			this.setState( { editing: ! this.state.editing } );
 		};
 		const onSelectVideo = ( media ) => {
@@ -167,7 +168,7 @@ class VideoEdit extends Component {
 				// in this case there was an error and we should continue in the editing state
 				// previous attributes should be removed because they may be temporary blob urls
 				setAttributes( { src: undefined, id: undefined } );
-				switchToEditing();
+				toggleIsEditing();
 				return;
 			}
 			// sets the block's attribute and updates the edit component from the
@@ -176,7 +177,6 @@ class VideoEdit extends Component {
 			this.setState( { src: media.url, editing: false } );
 		};
 
-		const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
 		if ( editing ) {
 			return (
 				<>
@@ -186,7 +186,7 @@ class VideoEdit extends Component {
 								className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': this.state.editing } ) }
 								aria-pressed={ this.state.editing }
 								label={ __( 'Edit video' ) }
-								onClick={ switchToEditing }
+								onClick={ toggleIsEditing }
 								icon={ editImageIcon }
 							/>
 						</Toolbar> ) }
@@ -196,7 +196,7 @@ class VideoEdit extends Component {
 						className={ className }
 						onSelect={ onSelectVideo }
 						onSelectURL={ this.onSelectURL }
-						onCancel={ !! src && switchToEditing }
+						onCancel={ !! src && toggleIsEditing }
 						accept="video/*"
 						allowedTypes={ ALLOWED_MEDIA_TYPES }
 						value={ this.props.attributes }
@@ -216,7 +216,7 @@ class VideoEdit extends Component {
 						<IconButton
 							className="components-icon-button components-toolbar__control"
 							label={ __( 'Edit video' ) }
-							onClick={ switchToEditing }
+							onClick={ toggleIsEditing }
 							icon={ editImageIcon }
 						/>
 					</Toolbar>

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { getBlobByURL, isBlobURL } from '@wordpress/blob';
@@ -8,7 +13,10 @@ import {
 	Disabled,
 	IconButton,
 	PanelBody,
+	Path,
+	Rect,
 	SelectControl,
+	SVG,
 	ToggleControl,
 	Toolbar,
 	withNotices,
@@ -152,7 +160,7 @@ class VideoEdit extends Component {
 		} = this.props;
 		const { editing } = this.state;
 		const switchToEditing = () => {
-			this.setState( { editing: true } );
+			this.setState( { editing: ! this.state.editing } );
 		};
 		const onSelectVideo = ( media ) => {
 			if ( ! media || ! media.url ) {
@@ -168,19 +176,34 @@ class VideoEdit extends Component {
 			this.setState( { src: media.url, editing: false } );
 		};
 
+		const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
 		if ( editing ) {
 			return (
-				<MediaPlaceholder
-					icon={ <BlockIcon icon={ icon } /> }
-					className={ className }
-					onSelect={ onSelectVideo }
-					onSelectURL={ this.onSelectURL }
-					accept="video/*"
-					allowedTypes={ ALLOWED_MEDIA_TYPES }
-					value={ this.props.attributes }
-					notices={ noticeUI }
-					onError={ noticeOperations.createErrorNotice }
-				/>
+				<>
+					<BlockControls>
+						{ !! src && ( <Toolbar>
+							<IconButton
+								className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': this.state.editing } ) }
+								aria-pressed={ this.state.editing }
+								label={ __( 'Edit video' ) }
+								onClick={ switchToEditing }
+								icon={ editImageIcon }
+							/>
+						</Toolbar> ) }
+					</BlockControls>
+					<MediaPlaceholder
+						icon={ <BlockIcon icon={ icon } /> }
+						className={ className }
+						onSelect={ onSelectVideo }
+						onSelectURL={ this.onSelectURL }
+						onCancel={ !! src && switchToEditing }
+						accept="video/*"
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
+						value={ this.props.attributes }
+						notices={ noticeUI }
+						onError={ noticeOperations.createErrorNotice }
+					/>
+				</>
 			);
 		}
 		const videoPosterDescription = `video-block__poster-image-description-${ instanceId }`;
@@ -194,7 +217,7 @@ class VideoEdit extends Component {
 							className="components-icon-button components-toolbar__control"
 							label={ __( 'Edit video' ) }
 							onClick={ switchToEditing }
-							icon="edit"
+							icon={ editImageIcon }
 						/>
 					</Toolbar>
 				</BlockControls>

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -177,35 +177,6 @@ class VideoEdit extends Component {
 			this.setState( { src: media.url, editing: false } );
 		};
 
-		if ( editing ) {
-			return (
-				<>
-					<BlockControls>
-						{ !! src && ( <Toolbar>
-							<IconButton
-								className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': this.state.editing } ) }
-								aria-pressed={ this.state.editing }
-								label={ __( 'Edit video' ) }
-								onClick={ toggleIsEditing }
-								icon={ editImageIcon }
-							/>
-						</Toolbar> ) }
-					</BlockControls>
-					<MediaPlaceholder
-						icon={ <BlockIcon icon={ icon } /> }
-						className={ className }
-						onSelect={ onSelectVideo }
-						onSelectURL={ this.onSelectURL }
-						onCancel={ !! src && toggleIsEditing }
-						accept="video/*"
-						allowedTypes={ ALLOWED_MEDIA_TYPES }
-						value={ this.props.attributes }
-						notices={ noticeUI }
-						onError={ noticeOperations.createErrorNotice }
-					/>
-				</>
-			);
-		}
 		const videoPosterDescription = `video-block__poster-image-description-${ instanceId }`;
 
 		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
@@ -214,14 +185,27 @@ class VideoEdit extends Component {
 				<BlockControls>
 					<Toolbar>
 						<IconButton
-							className="components-icon-button components-toolbar__control"
+							className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': ( this.state.editing && !! src ) } ) }
+							aria-pressed={ ( this.state.editing && !! src ) }
 							label={ __( 'Edit video' ) }
 							onClick={ toggleIsEditing }
 							icon={ editImageIcon }
 						/>
 					</Toolbar>
 				</BlockControls>
-				<InspectorControls>
+				{ editing && <MediaPlaceholder
+					icon={ <BlockIcon icon={ icon } /> }
+					className={ className }
+					onSelect={ onSelectVideo }
+					onSelectURL={ this.onSelectURL }
+					onCancel={ !! src && toggleIsEditing }
+					accept="video/*"
+					allowedTypes={ ALLOWED_MEDIA_TYPES }
+					value={ this.props.attributes }
+					notices={ noticeUI }
+					onError={ noticeOperations.createErrorNotice }
+				/> }
+				{ ! editing && <InspectorControls>
 					<PanelBody title={ __( 'Video Settings' ) }>
 						<ToggleControl
 							label={ __( 'Autoplay' ) }
@@ -291,15 +275,15 @@ class VideoEdit extends Component {
 									}
 								</p>
 								{ !! this.props.attributes.poster &&
-									<Button onClick={ this.onRemovePoster } isLink isDestructive>
-										{ __( 'Remove Poster Image' ) }
-									</Button>
+								<Button onClick={ this.onRemovePoster } isLink isDestructive>
+									{ __( 'Remove Poster Image' ) }
+								</Button>
 								}
 							</BaseControl>
 						</MediaUploadCheck>
 					</PanelBody>
-				</InspectorControls>
-				<figure className={ className }>
+				</InspectorControls> }
+				{ ! editing && <figure className={ className }>
 					{ /*
 						Disable the video tag so the user clicking on it won't play the
 						video when the controls are enabled.
@@ -321,7 +305,7 @@ class VideoEdit extends Component {
 							inlineToolbar
 						/>
 					) }
-				</figure>
+				</figure> }
 			</>
 		);
 		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */


### PR DESCRIPTION
# Description

Closes #14795

This is a follow up to the image block edit flow update which ports the new flow to all the blocks which have media with an edit state.

# How has this been tested?
For now I've only tested locally.

# Types of change
New feature (non-breaking change which adds functionality)

# Screenshots

![55976311-8783fc80-5c94-11e9-9262-1ac1cb55d890](https://user-images.githubusercontent.com/107534/57403724-fea0a800-71e2-11e9-866d-a4ca53068806.gif)
