### PR TITLE
adds new edit flow to the media+text block

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -80,6 +80,9 @@ class MediaTextEdit extends Component {
 			this.props.setAttributes( {
 				mediaUrl: newURL,
 				mediaId: undefined,
+				mediaAlt: undefined,
+				imageFill: undefined,
+				focalPoint: undefined,
 			} );
 		}
 

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -290,13 +290,13 @@ class MediaTextEdit extends Component {
 						controls={ toolbarControls }
 					/>
 					<Toolbar>
-						{ mediaUrl && <IconButton
+						<IconButton
 							className={ classnames( 'components-toolbar__control', { 'is-active': this.state.isEditing } ) }
 							label={ __( 'Edit Media' ) }
 							aria-pressed={ this.state.isEditing }
-							onClick={ this.toggleIsEditing }
+							onClick={ mediaUrl && this.toggleIsEditing }
 							icon={ editImageIcon }
-						/> }
+						/>
 					</Toolbar>
 					<BlockVerticalAlignmentToolbar
 						onChange={ onVerticalAlignmentChange }

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -83,9 +83,7 @@ class MediaTextEdit extends Component {
 			} );
 		}
 
-		this.setState( {
-			isEditing: false,
-		} );
+		this.toggleIsEditing();
 	}
 
 	onSelectMedia( media ) {
@@ -111,9 +109,7 @@ class MediaTextEdit extends Component {
 			src = get( media, [ 'sizes', 'large', 'url' ] ) || get( media, [ 'media_details', 'sizes', 'large', 'source_url' ] );
 		}
 
-		this.setState( {
-			isEditing: false,
-		} );
+		this.toggleIsEditing();
 
 		setAttributes( {
 			mediaAlt: media.alt,

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -144,6 +144,7 @@ class MediaTextEdit extends Component {
 
 	renderMediaArea() {
 		const { attributes } = this.props;
+
 		const {
 			mediaAlt,
 			mediaId,
@@ -154,6 +155,7 @@ class MediaTextEdit extends Component {
 			imageFill,
 			focalPoint,
 		} = attributes;
+
 		return (
 			<MediaContainer
 				className="block-library-media-text__media-container"
@@ -177,6 +179,7 @@ class MediaTextEdit extends Component {
 			setAttributes,
 			setBackgroundColor,
 		} = this.props;
+
 		const {
 			isStackedOnMobile,
 			mediaAlt,
@@ -188,7 +191,9 @@ class MediaTextEdit extends Component {
 			imageFill,
 			focalPoint,
 		} = attributes;
+
 		const temporaryMediaWidth = this.state.mediaWidth;
+
 		const classNames = classnames( className, {
 			'has-media-on-the-right': 'right' === mediaPosition,
 			'is-selected': isSelected,
@@ -197,16 +202,20 @@ class MediaTextEdit extends Component {
 			[ `is-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
 			'is-image-fill': imageFill,
 		} );
+
 		const widthString = `${ temporaryMediaWidth || mediaWidth }%`;
+
 		const style = {
 			gridTemplateColumns: 'right' === mediaPosition ? `auto ${ widthString }` : `${ widthString } auto`,
 			backgroundColor: backgroundColor.color,
 		};
+
 		const colorSettings = [ {
 			value: backgroundColor.color,
 			onChange: setBackgroundColor,
 			label: __( 'Background Color' ),
 		} ];
+
 		const toolbarControls = [ {
 			icon: 'align-pull-left',
 			title: __( 'Show media on left' ),
@@ -218,12 +227,15 @@ class MediaTextEdit extends Component {
 			isActive: mediaPosition === 'right',
 			onClick: () => setAttributes( { mediaPosition: 'right' } ),
 		} ];
+
 		const onMediaAltChange = ( newMediaAlt ) => {
 			setAttributes( { mediaAlt: newMediaAlt } );
 		};
+
 		const onVerticalAlignmentChange = ( alignment ) => {
 			setAttributes( { verticalAlignment: alignment } );
 		};
+
 		const mediaTextGeneralSettings = (
 			<PanelBody title={ __( 'Media & Text Settings' ) }>
 				<ToggleControl
@@ -261,6 +273,7 @@ class MediaTextEdit extends Component {
 				/> ) }
 			</PanelBody>
 		);
+
 		const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
 
 		return (

--- a/packages/block-library/src/media-text/editor.scss
+++ b/packages/block-library/src/media-text/editor.scss
@@ -51,7 +51,7 @@ figure.block-library-media-text__media-container {
 	width: 100%;
 }
 
-.wp-block-media-text .block-library-media-text__media-container .components-placeholder__preview img {
+.wp-block-media-text .components-placeholder__preview img {
 	width: 80%;
 }
 

--- a/packages/block-library/src/media-text/editor.scss
+++ b/packages/block-library/src/media-text/editor.scss
@@ -51,6 +51,10 @@ figure.block-library-media-text__media-container {
 	width: 100%;
 }
 
+.wp-block-media-text .block-library-media-text__media-container .components-placeholder__preview img {
+	width: 80%;
+}
+
 .editor-media-container__resizer .components-resizable-box__handle {
 	display: none;
 }

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -68,3 +68,7 @@
 	margin: 3%;
 	width: 50%;
 }
+
+.block-editor-media-placeholder__url-input-container {
+	margin-top: 4%;
+}

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -30,6 +30,7 @@
 	justify-content: center;
 	font-weight: 600;
 	margin-bottom: 1em;
+	margin-top: 1em;
 
 	.dashicon,
 	.block-editor-block-icon {

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -68,7 +68,3 @@
 	margin: 3%;
 	width: 50%;
 }
-
-.block-editor-media-placeholder__url-input-container {
-	margin-top: 4%;
-}


### PR DESCRIPTION
# Description

Closes #14795

This is a follow up to the image block edit flow update which ports the new flow to all the blocks which have media with an edit state.

# How has this been tested?
For now I've only tested locally.

# Types of change
New feature (non-breaking change which adds functionality)

# Screenshots

![media+text](https://user-images.githubusercontent.com/107534/55975613-0bd58000-5c93-11e9-9cd2-0dfca34fc26f.gif)