### PR TITLE
adds new edit flow for the embed block

### DIFF
--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -153,6 +153,7 @@ export function getEmbedEditComponent( title, icon, responsive = true ) {
 							getResponsiveHelp={ this.getResponsiveHelp }
 							toggleResponsive={ this.toggleResponsive }
 							switchBackToURLInput={ this.switchBackToURLInput }
+							hasEmbed={ this.props.preview }
 						/>
 						<EmbedPlaceholder
 							icon={ icon }
@@ -166,6 +167,7 @@ export function getEmbedEditComponent( title, icon, responsive = true ) {
 							switchBackToURLInput={ this.switchBackToURLInput }
 							editingURL={ this.state.editingURL }
 							url={ this.state.url }
+							hasEmbed={ this.props.preview }
 						/>
 					</>
 				);
@@ -195,6 +197,7 @@ export function getEmbedEditComponent( title, icon, responsive = true ) {
 						getResponsiveHelp={ this.getResponsiveHelp }
 						toggleResponsive={ this.toggleResponsive }
 						switchBackToURLInput={ this.switchBackToURLInput }
+						hasEmbed={ this.props.preview }
 					/>
 					<EmbedPreview
 						preview={ preview }

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -177,7 +177,7 @@ export function getEmbedEditComponent( title, icon, responsive = true ) {
 						hasEmbed={ this.props.preview }
 					/>
 					}
-					{ ! fetching && preview && ! editingURL &&
+					{ preview && ! cannotEmbed && ! fetching && ! editingURL &&
 					<EmbedPreview
 						preview={ preview }
 						className={ className }

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -106,7 +106,7 @@ export function getEmbedEditComponent( title, icon, responsive = true ) {
 		}
 
 		switchBackToURLInput() {
-			this.setState( { editingURL: true } );
+			this.setState( { editingURL: ! this.state.editingURL } );
 		}
 
 		getResponsiveHelp( checked ) {
@@ -142,16 +142,32 @@ export function getEmbedEditComponent( title, icon, responsive = true ) {
 			// No preview, or we can't embed the current URL, or we've clicked the edit button.
 			if ( ! preview || cannotEmbed || editingURL ) {
 				return (
-					<EmbedPlaceholder
-						icon={ icon }
-						label={ label }
-						onSubmit={ this.setUrl }
-						value={ url }
-						cannotEmbed={ cannotEmbed }
-						onChange={ ( event ) => this.setState( { url: event.target.value } ) }
-						fallback={ () => fallback( url, this.props.onReplace ) }
-						tryAgain={ tryAgain }
-					/>
+					<>
+						<EmbedControls
+							showEditButton={ preview && ! cannotEmbed }
+							editingURL={ this.state.editingURL }
+							url={ this.state.url }
+							themeSupportsResponsive={ themeSupportsResponsive }
+							blockSupportsResponsive={ responsive }
+							allowResponsive={ allowResponsive }
+							getResponsiveHelp={ this.getResponsiveHelp }
+							toggleResponsive={ this.toggleResponsive }
+							switchBackToURLInput={ this.switchBackToURLInput }
+						/>
+						<EmbedPlaceholder
+							icon={ icon }
+							label={ label }
+							onSubmit={ this.setUrl }
+							value={ url }
+							cannotEmbed={ cannotEmbed }
+							onChange={ ( event ) => this.setState( { url: event.target.value } ) }
+							fallback={ () => fallback( url, this.props.onReplace ) }
+							tryAgain={ tryAgain }
+							switchBackToURLInput={ this.switchBackToURLInput }
+							editingURL={ this.state.editingURL }
+							url={ this.state.url }
+						/>
+					</>
 				);
 			}
 
@@ -171,6 +187,8 @@ export function getEmbedEditComponent( title, icon, responsive = true ) {
 				<>
 					<EmbedControls
 						showEditButton={ preview && ! cannotEmbed }
+						editingURL={ this.state.editingURL }
+						url={ this.state.url }
 						themeSupportsResponsive={ themeSupportsResponsive }
 						blockSupportsResponsive={ responsive }
 						allowResponsive={ allowResponsive }

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -130,48 +130,8 @@ export function getEmbedEditComponent( title, icon, responsive = true ) {
 			const { url, editingURL } = this.state;
 			const { fetching, setAttributes, isSelected, preview, cannotEmbed, themeSupportsResponsive, tryAgain } = this.props;
 
-			if ( fetching ) {
-				return (
-					<EmbedLoading />
-				);
-			}
-
 			// translators: %s: type of embed e.g: "YouTube", "Twitter", etc. "Embed" is used when no specific type exists
 			const label = sprintf( __( '%s URL' ), title );
-
-			// No preview, or we can't embed the current URL, or we've clicked the edit button.
-			if ( ! preview || cannotEmbed || editingURL ) {
-				return (
-					<>
-						<EmbedControls
-							showEditButton={ preview && ! cannotEmbed }
-							editingURL={ this.state.editingURL }
-							url={ this.state.url }
-							themeSupportsResponsive={ themeSupportsResponsive }
-							blockSupportsResponsive={ responsive }
-							allowResponsive={ allowResponsive }
-							getResponsiveHelp={ this.getResponsiveHelp }
-							toggleResponsive={ this.toggleResponsive }
-							switchBackToURLInput={ this.switchBackToURLInput }
-							hasEmbed={ this.props.preview }
-						/>
-						<EmbedPlaceholder
-							icon={ icon }
-							label={ label }
-							onSubmit={ this.setUrl }
-							value={ url }
-							cannotEmbed={ cannotEmbed }
-							onChange={ ( event ) => this.setState( { url: event.target.value } ) }
-							fallback={ () => fallback( url, this.props.onReplace ) }
-							tryAgain={ tryAgain }
-							switchBackToURLInput={ this.switchBackToURLInput }
-							editingURL={ this.state.editingURL }
-							url={ this.state.url }
-							hasEmbed={ this.props.preview }
-						/>
-					</>
-				);
-			}
 
 			// Even though we set attributes that get derived from the preview,
 			// we don't access them directly because for the initial render,
@@ -188,7 +148,7 @@ export function getEmbedEditComponent( title, icon, responsive = true ) {
 			return (
 				<>
 					<EmbedControls
-						showEditButton={ preview && ! cannotEmbed }
+						showEditButton={ ! cannotEmbed }
 						editingURL={ this.state.editingURL }
 						url={ this.state.url }
 						themeSupportsResponsive={ themeSupportsResponsive }
@@ -199,6 +159,25 @@ export function getEmbedEditComponent( title, icon, responsive = true ) {
 						switchBackToURLInput={ this.switchBackToURLInput }
 						hasEmbed={ this.props.preview }
 					/>
+					{ fetching && <EmbedLoading /> }
+					{ /*No preview, or we can't embed the current URL, or we've clicked the edit button.*/ }
+					{ ! fetching && ( ! preview || cannotEmbed || editingURL ) &&
+					<EmbedPlaceholder
+						icon={ icon }
+						label={ label }
+						onSubmit={ this.setUrl }
+						value={ url }
+						cannotEmbed={ cannotEmbed }
+						onChange={ ( event ) => this.setState( { url: event.target.value } ) }
+						fallback={ () => fallback( url, this.props.onReplace ) }
+						tryAgain={ tryAgain }
+						switchBackToURLInput={ this.switchBackToURLInput }
+						editingURL={ this.state.editingURL }
+						url={ this.state.url }
+						hasEmbed={ this.props.preview }
+					/>
+					}
+					{ ! fetching && preview && ! editingURL &&
 					<EmbedPreview
 						preview={ preview }
 						className={ className }
@@ -210,6 +189,7 @@ export function getEmbedEditComponent( title, icon, responsive = true ) {
 						icon={ icon }
 						label={ label }
 					/>
+					}
 				</>
 			);
 		}

--- a/packages/block-library/src/embed/editor.scss
+++ b/packages/block-library/src/embed/editor.scss
@@ -37,6 +37,13 @@
 	.components-placeholder__error {
 		word-break: break-word;
 	}
+
+	.components-placeholder__cancel {
+		padding-top: 10px;
+		width: 100%;
+		float: none;
+		text-align: center;
+	}
 }
 
 .block-library-embed__interactive-overlay {

--- a/packages/block-library/src/embed/embed-controls.js
+++ b/packages/block-library/src/embed/embed-controls.js
@@ -1,33 +1,39 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton, Toolbar, PanelBody, ToggleControl } from '@wordpress/components';
+import { IconButton, Toolbar, PanelBody, ToggleControl, SVG, Rect, Path } from '@wordpress/components';
 import { BlockControls, InspectorControls } from '@wordpress/block-editor';
 
 const EmbedControls = ( props ) => {
 	const {
 		blockSupportsResponsive,
-		showEditButton,
 		themeSupportsResponsive,
 		allowResponsive,
 		getResponsiveHelp,
 		toggleResponsive,
 		switchBackToURLInput,
+		editingURL,
+		url,
 	} = props;
+	const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
 	return (
 		<>
 			<BlockControls>
-				<Toolbar>
-					{ showEditButton && (
-						<IconButton
-							className="components-toolbar__control"
-							label={ __( 'Edit URL' ) }
-							icon="edit"
-							onClick={ switchBackToURLInput }
-						/>
-					) }
-				</Toolbar>
+				{ !! url && ( <Toolbar>
+					<IconButton
+						className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': editingURL } ) }
+						aria-pressed={ editingURL }
+						label={ __( 'Edit URL' ) }
+						icon={ editImageIcon }
+						onClick={ switchBackToURLInput }
+					/>
+				</Toolbar> ) }
 			</BlockControls>
 			{ themeSupportsResponsive && blockSupportsResponsive && (
 				<InspectorControls>

--- a/packages/block-library/src/embed/embed-controls.js
+++ b/packages/block-library/src/embed/embed-controls.js
@@ -19,13 +19,13 @@ const EmbedControls = ( props ) => {
 		toggleResponsive,
 		switchBackToURLInput,
 		editingURL,
-		url,
+		hasEmbed,
 	} = props;
 	const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
 	return (
 		<>
 			<BlockControls>
-				{ !! url && ( <Toolbar>
+				{ !! hasEmbed && ( <Toolbar>
 					<IconButton
 						className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': editingURL } ) }
 						aria-pressed={ editingURL }

--- a/packages/block-library/src/embed/embed-controls.js
+++ b/packages/block-library/src/embed/embed-controls.js
@@ -25,15 +25,15 @@ const EmbedControls = ( props ) => {
 	return (
 		<>
 			<BlockControls>
-				{ !! hasEmbed && ( <Toolbar>
+				<Toolbar>
 					<IconButton
-						className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': editingURL } ) }
+						className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': ( editingURL || ! hasEmbed ) } ) }
 						aria-pressed={ editingURL }
 						label={ __( 'Edit URL' ) }
 						icon={ editImageIcon }
 						onClick={ switchBackToURLInput }
 					/>
-				</Toolbar> ) }
+				</Toolbar>
 			</BlockControls>
 			{ themeSupportsResponsive && blockSupportsResponsive && (
 				<InspectorControls>

--- a/packages/block-library/src/embed/embed-placeholder.js
+++ b/packages/block-library/src/embed/embed-placeholder.js
@@ -6,7 +6,8 @@ import { Button, Placeholder } from '@wordpress/components';
 import { BlockIcon } from '@wordpress/block-editor';
 
 const EmbedPlaceholder = ( props ) => {
-	const { icon, label, value, onSubmit, onChange, switchBackToURLInput, cannotEmbed, fallback, tryAgain } = props;
+	const { icon, label, value, onSubmit, onChange, switchBackToURLInput, cannotEmbed, fallback, tryAgain, hasEmbed } = props;
+
 	return (
 		<Placeholder icon={ <BlockIcon icon={ icon } showColors /> } label={ label } className="wp-block-embed">
 			<>
@@ -30,7 +31,7 @@ const EmbedPlaceholder = ( props ) => {
 					</p>
 					}
 				</form>
-				{ value && <div className="components-placeholder__cancel">
+				{ hasEmbed && <div className="components-placeholder__cancel">
 					<Button
 						className="block-editor-embed-placeholder__cancel-button"
 						title={ __( 'Cancel' ) }

--- a/packages/block-library/src/embed/embed-placeholder.js
+++ b/packages/block-library/src/embed/embed-placeholder.js
@@ -6,29 +6,41 @@ import { Button, Placeholder } from '@wordpress/components';
 import { BlockIcon } from '@wordpress/block-editor';
 
 const EmbedPlaceholder = ( props ) => {
-	const { icon, label, value, onSubmit, onChange, cannotEmbed, fallback, tryAgain } = props;
+	const { icon, label, value, onSubmit, onChange, switchBackToURLInput, cannotEmbed, fallback, tryAgain } = props;
 	return (
 		<Placeholder icon={ <BlockIcon icon={ icon } showColors /> } label={ label } className="wp-block-embed">
-			<form onSubmit={ onSubmit }>
-				<input
-					type="url"
-					value={ value || '' }
-					className="components-placeholder__input"
-					aria-label={ label }
-					placeholder={ __( 'Enter URL to embed here…' ) }
-					onChange={ onChange } />
-				<Button
-					isLarge
-					type="submit">
-					{ _x( 'Embed', 'button label' ) }
-				</Button>
-				{ cannotEmbed &&
+			<>
+				<form onSubmit={ onSubmit }>
+					<input
+						type="url"
+						value={ value || '' }
+						className="components-placeholder__input"
+						aria-label={ label }
+						placeholder={ __( 'Enter URL to embed here…' ) }
+						onChange={ onChange } />
+					<Button
+						isLarge
+						type="submit">
+						{ _x( 'Embed', 'button label' ) }
+					</Button>
+					{ cannotEmbed &&
 					<p className="components-placeholder__error">
 						{ __( 'Sorry, this content could not be embedded.' ) }<br />
 						<Button isLarge onClick={ tryAgain }>{ _x( 'Try again', 'button label' ) }</Button> <Button isLarge onClick={ fallback }>{ _x( 'Convert to link', 'button label' ) }</Button>
 					</p>
-				}
-			</form>
+					}
+				</form>
+				{ value && <div className="components-placeholder__cancel">
+					<Button
+						className="block-editor-embed-placeholder__cancel-button"
+						title={ __( 'Cancel' ) }
+						isLink
+						onClick={ switchBackToURLInput }
+					>
+						{ __( 'Cancel' ) }
+					</Button>
+				</div> }
+			</>
 		</Placeholder>
 	);
 };


### PR DESCRIPTION
# Description

Closes #14795

This is a follow up to the image block edit flow update which ports the new flow to all the blocks which have media with an edit state.

# How has this been tested?
For now I've only tested locally.

# Types of change
New feature (non-breaking change which adds functionality)

# Screenshots

![embed](https://user-images.githubusercontent.com/107534/55976429-daf64a80-5c94-11e9-8ebc-e95a552e8f8f.gif)
