### PR TITLE
adds new edit flow for the cover block

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -250,7 +250,12 @@ class CoverEdit extends Component {
 				title: __( 'Cover' ),
 				instructions: __( 'Drag an image or a video, upload a new one or select a file from your library.' ),
 			};
-
+			const mediaPreview = ( !! url && IMAGE_BACKGROUND_TYPE === backgroundType && <img
+				alt={ __( 'Edit background' ) }
+				title={ __( 'Edit background' ) }
+				className={ 'edit-background-preview' }
+				src={ url }
+			/> );
 			return (
 				<>
 					{ controls }
@@ -265,6 +270,7 @@ class CoverEdit extends Component {
 						notices={ noticeUI }
 						onError={ noticeOperations.createErrorNotice }
 						accept="image/*,video/*"
+						mediaPreview={ mediaPreview }
 						allowedTypes={ ALLOWED_MEDIA_TYPES }
 					/>
 				</>

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -190,17 +190,15 @@ class CoverEdit extends Component {
 		const controls = (
 			<>
 				<BlockControls>
-					{ !! url && (
-						<Toolbar>
-							<IconButton
-								className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': this.state.isEditing } ) }
-								aria-pressed={ isEditing }
-								label={ __( 'Edit media' ) }
-								icon={ editImageIcon }
-								onClick={ this.toggleIsEditing }
-							/>
-						</Toolbar>
-					) }
+					<Toolbar>
+						<IconButton
+							className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': ! url || this.state.isEditing } ) }
+							aria-pressed={ isEditing }
+							label={ __( 'Edit media' ) }
+							icon={ editImageIcon }
+							onClick={ url && this.toggleIsEditing }
+						/>
+					</Toolbar>
 				</BlockControls>
 				{ !! url && (
 					<InspectorControls>

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -27,7 +27,6 @@ import {
 	InnerBlocks,
 	InspectorControls,
 	MediaPlaceholder,
-	MediaUploadCheck,
 	PanelColorSettings,
 	withColors,
 } from '@wordpress/block-editor';
@@ -125,9 +124,7 @@ class CoverEdit extends Component {
 				} );
 			}
 
-			this.setState( {
-				isEditing: false,
-			} );
+			this.toggleIsEditing();
 		};
 
 		const onSelectMedia = ( media ) => {
@@ -165,9 +162,7 @@ class CoverEdit extends Component {
 				),
 			} );
 
-			this.setState( {
-				isEditing: false,
-			} );
+			this.toggleIsEditing();
 		};
 
 		const toggleParallax = () => {
@@ -196,19 +191,15 @@ class CoverEdit extends Component {
 			<>
 				<BlockControls>
 					{ !! url && (
-						<>
-							<MediaUploadCheck>
-								<Toolbar>
-									<IconButton
-										className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': this.state.isEditing } ) }
-										aria-pressed={ this.state.isEditing }
-										label={ __( 'Edit media' ) }
-										icon={ editImageIcon }
-										onClick={ this.toggleIsEditing }
-									/>
-								</Toolbar>
-							</MediaUploadCheck>
-						</>
+						<Toolbar>
+							<IconButton
+								className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': this.state.isEditing } ) }
+								aria-pressed={ isEditing }
+								label={ __( 'Edit media' ) }
+								icon={ editImageIcon }
+								onClick={ this.toggleIsEditing }
+							/>
+						</Toolbar>
 					) }
 				</BlockControls>
 				{ !! url && (
@@ -254,7 +245,7 @@ class CoverEdit extends Component {
 			</>
 		);
 
-		if ( isEditing || ! url ) {
+		if ( isEditing ) {
 			const labels = {
 				title: __( 'Cover' ),
 				instructions: __( 'Drag an image or a video, upload a new one or select a file from your library.' ),


### PR DESCRIPTION
# Description

Closes #14795, https://github.com/WordPress/gutenberg/issues/10853, https://github.com/WordPress/gutenberg/issues/16350

This is a follow up to the image block edit flow update which ports the new flow to all the blocks which have media with an edit state.

# How has this been tested?
For now I've only tested locally.

# Types of change
New feature (non-breaking change which adds functionality)

# Screenshots

![cover](https://user-images.githubusercontent.com/107534/55975900-a33ad300-5c93-11e9-92f5-71f86914cf64.gif)
