### PR TITLE
adds new edit flow for the audio block

### DIFF
--- a/packages/block-library/src/audio/audio-toolbar.js
+++ b/packages/block-library/src/audio/audio-toolbar.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	IconButton,
+	Path,
+	Rect,
+	SVG,
+	Toolbar,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+export default function AudioToolbar( props ) {
+	const { isEditing, onClick } = props;
+
+	const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
+
+	return <Toolbar>
+		<IconButton
+			className={ classnames( 'components-toolbar__control', { 'is-active': isEditing } ) }
+			label={ __( 'Edit audio' ) }
+			onClick={ onClick }
+			icon={ editImageIcon }
+		/>
+	</Toolbar>;
+}

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { getBlobByURL, isBlobURL } from '@wordpress/blob';
@@ -6,7 +11,10 @@ import {
 	Disabled,
 	IconButton,
 	PanelBody,
+	Path,
+	Rect,
 	SelectControl,
+	SVG,
 	ToggleControl,
 	Toolbar,
 	withNotices,
@@ -19,7 +27,7 @@ import {
 	RichText,
 } from '@wordpress/block-editor';
 import { mediaUpload } from '@wordpress/editor';
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -81,7 +89,7 @@ class AudioEdit extends Component {
 		const { attributes, setAttributes } = this.props;
 		const { src } = attributes;
 
-		// Set the block's src from the edit component's state, and switch off
+		// Set the block's src from the edit component's state, and toggle off
 		// the editing UI.
 		if ( newSrc !== src ) {
 			// Check if there's an embed block that handles this URL.
@@ -106,35 +114,49 @@ class AudioEdit extends Component {
 		const { autoplay, caption, loop, preload, src } = this.props.attributes;
 		const { setAttributes, isSelected, className, noticeOperations, noticeUI } = this.props;
 		const { editing } = this.state;
-		const switchToEditing = () => {
-			this.setState( { editing: true } );
+		const toggleEditing = () => {
+			this.setState( { editing: ! this.state.editing } );
 		};
 		const onSelectAudio = ( media ) => {
 			if ( ! media || ! media.url ) {
 				// in this case there was an error and we should continue in the editing state
 				// previous attributes should be removed because they may be temporary blob urls
 				setAttributes( { src: undefined, id: undefined } );
-				switchToEditing();
+				toggleEditing();
 				return;
 			}
 			// sets the block's attribute and updates the edit component from the
-			// selected media, then switches off the editing UI
+			// selected media, then toggles off the editing UI
 			setAttributes( { src: media.url, id: media.id } );
 			this.setState( { src: media.url, editing: false } );
 		};
+		const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
 		if ( editing ) {
 			return (
-				<MediaPlaceholder
-					icon={ <BlockIcon icon={ icon } /> }
-					className={ className }
-					onSelect={ onSelectAudio }
-					onSelectURL={ this.onSelectURL }
-					accept="audio/*"
-					allowedTypes={ ALLOWED_MEDIA_TYPES }
-					value={ this.props.attributes }
-					notices={ noticeUI }
-					onError={ noticeOperations.createErrorNotice }
-				/>
+				<Fragment>
+					<BlockControls>
+						{ !! src && ( <Toolbar>
+							<IconButton
+								className={ classnames( 'components-toolbar__control is-active' ) }
+								label={ __( 'Edit audio' ) }
+								onClick={ toggleEditing }
+								icon={ editImageIcon }
+							/>
+						</Toolbar> ) }
+					</BlockControls>
+					<MediaPlaceholder
+						icon={ <BlockIcon icon={ icon } /> }
+						className={ className }
+						onCancel={ !! src && toggleEditing }
+						onSelect={ onSelectAudio }
+						onSelectURL={ this.onSelectURL }
+						accept="audio/*"
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
+						value={ this.props.attributes }
+						notices={ noticeUI }
+						onError={ noticeOperations.createErrorNotice }
+					/>
+				</Fragment>
 			);
 		}
 
@@ -144,10 +166,10 @@ class AudioEdit extends Component {
 				<BlockControls>
 					<Toolbar>
 						<IconButton
-							className="components-icon-button components-toolbar__control"
+							class={ classnames( 'components-toolbar__control' ) }
 							label={ __( 'Edit audio' ) }
-							onClick={ switchToEditing }
-							icon="edit"
+							onClick={ toggleEditing }
+							icon={ editImageIcon }
 						/>
 					</Toolbar>
 				</BlockControls>

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -48,7 +48,7 @@ class AudioEdit extends Component {
 		// edit component has its own src in the state so it can be edited
 		// without setting the actual value outside of the edit UI
 		this.state = {
-			editing: ! this.props.attributes.src,
+			isEditing: ! this.props.attributes.src,
 		};
 
 		this.toggleAttribute = this.toggleAttribute.bind( this );
@@ -70,7 +70,7 @@ class AudioEdit extends Component {
 					},
 					onError: ( e ) => {
 						setAttributes( { src: undefined, id: undefined } );
-						this.setState( { editing: true } );
+						this.setState( { isEditing: true } );
 						noticeOperations.createErrorNotice( e );
 					},
 					allowedTypes: ALLOWED_MEDIA_TYPES,
@@ -90,7 +90,7 @@ class AudioEdit extends Component {
 		const { src } = attributes;
 
 		// Set the block's src from the edit component's state, and toggle off
-		// the editing UI.
+		// the isEditing UI.
 		if ( newSrc !== src ) {
 			// Check if there's an embed block that handles this URL.
 			const embedBlock = createUpgradedEmbedBlock(
@@ -103,7 +103,7 @@ class AudioEdit extends Component {
 			setAttributes( { src: newSrc, id: undefined } );
 		}
 
-		this.setState( { editing: false } );
+		this.setState( { isEditing: false } );
 	}
 
 	getAutoplayHelp( checked ) {
@@ -113,25 +113,25 @@ class AudioEdit extends Component {
 	render() {
 		const { autoplay, caption, loop, preload, src } = this.props.attributes;
 		const { setAttributes, isSelected, className, noticeOperations, noticeUI } = this.props;
-		const { editing } = this.state;
-		const toggleEditing = () => {
-			this.setState( { editing: ! this.state.editing } );
+		const { isEditing } = this.state;
+		const toggleIsEditing = () => {
+			this.setState( { isEditing: ! this.state.isEditing } );
 		};
 		const onSelectAudio = ( media ) => {
 			if ( ! media || ! media.url ) {
-				// in this case there was an error and we should continue in the editing state
+				// in this case there was an error and we should continue in the isEditing state
 				// previous attributes should be removed because they may be temporary blob urls
 				setAttributes( { src: undefined, id: undefined } );
-				toggleEditing();
+				toggleIsEditing();
 				return;
 			}
 			// sets the block's attribute and updates the edit component from the
-			// selected media, then toggles off the editing UI
+			// selected media, then toggles off the isEditing UI
 			setAttributes( { src: media.url, id: media.id } );
-			this.setState( { src: media.url, editing: false } );
+			this.setState( { src: media.url, isEditing: false } );
 		};
 		const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
-		if ( editing ) {
+		if ( isEditing ) {
 			return (
 				<Fragment>
 					<BlockControls>
@@ -139,7 +139,7 @@ class AudioEdit extends Component {
 							<IconButton
 								className={ classnames( 'components-toolbar__control is-active' ) }
 								label={ __( 'Edit audio' ) }
-								onClick={ toggleEditing }
+								onClick={ toggleIsEditing }
 								icon={ editImageIcon }
 							/>
 						</Toolbar> ) }
@@ -147,7 +147,7 @@ class AudioEdit extends Component {
 					<MediaPlaceholder
 						icon={ <BlockIcon icon={ icon } /> }
 						className={ className }
-						onCancel={ !! src && toggleEditing }
+						onCancel={ !! src && toggleIsEditing }
 						onSelect={ onSelectAudio }
 						onSelectURL={ this.onSelectURL }
 						accept="audio/*"
@@ -168,7 +168,7 @@ class AudioEdit extends Component {
 						<IconButton
 							class={ classnames( 'components-toolbar__control' ) }
 							label={ __( 'Edit audio' ) }
-							onClick={ toggleEditing }
+							onClick={ toggleIsEditing }
 							icon={ editImageIcon }
 						/>
 					</Toolbar>

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -17,7 +17,7 @@ import {
 	RichText,
 } from '@wordpress/block-editor';
 import { mediaUpload } from '@wordpress/editor';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -128,37 +128,27 @@ class AudioEdit extends Component {
 			this.setState( { src: media.url, isEditing: false } );
 		};
 
-		if ( isEditing ) {
-			return (
-				<Fragment>
-					<BlockControls>
-						{ !! src &&
-							<AudioToolbar isEditing={ isEditing } onClick={ toggleIsEditing } />
-						}
-					</BlockControls>
-					<MediaPlaceholder
-						icon={ <BlockIcon icon={ icon } /> }
-						className={ className }
-						onCancel={ !! src && toggleIsEditing }
-						onSelect={ onSelectAudio }
-						onSelectURL={ this.onSelectURL }
-						accept="audio/*"
-						allowedTypes={ ALLOWED_MEDIA_TYPES }
-						value={ this.props.attributes }
-						notices={ noticeUI }
-						onError={ noticeOperations.createErrorNotice }
-					/>
-				</Fragment>
-			);
-		}
-
 		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
 		return (
 			<>
 				<BlockControls>
+					{ !! src &&
 					<AudioToolbar isEditing={ isEditing } onClick={ toggleIsEditing } />
+					}
 				</BlockControls>
-				<InspectorControls>
+				{ isEditing && <MediaPlaceholder
+					icon={ <BlockIcon icon={ icon } /> }
+					className={ className }
+					onCancel={ !! src && toggleIsEditing }
+					onSelect={ onSelectAudio }
+					onSelectURL={ this.onSelectURL }
+					accept="audio/*"
+					allowedTypes={ ALLOWED_MEDIA_TYPES }
+					value={ this.props.attributes }
+					notices={ noticeUI }
+					onError={ noticeOperations.createErrorNotice }
+				/> }
+				{ ! isEditing && <InspectorControls>
 					<PanelBody title={ __( 'Audio Settings' ) }>
 						<ToggleControl
 							label={ __( 'Autoplay' ) }
@@ -183,8 +173,8 @@ class AudioEdit extends Component {
 							] }
 						/>
 					</PanelBody>
-				</InspectorControls>
-				<figure className={ className }>
+				</InspectorControls> }
+				{ ! isEditing && <figure className={ className }>
 					{ /*
 						Disable the audio tag so the user clicking on it won't play the
 						file or change the position slider when the controls are enabled.
@@ -201,7 +191,7 @@ class AudioEdit extends Component {
 							inlineToolbar
 						/>
 					) }
-				</figure>
+				</figure> }
 			</>
 		);
 		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -172,7 +172,7 @@ class AudioEdit extends Component {
 				<BlockControls>
 					<Toolbar>
 						<IconButton
-							class={ classnames( 'components-toolbar__control' ) }
+							class={ 'components-toolbar__control' }
 							label={ __( 'Edit audio' ) }
 							onClick={ toggleIsEditing }
 							icon={ editImageIcon }

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -137,18 +137,22 @@ class AudioEdit extends Component {
 			this.setState( { src: media.url, isEditing: false } );
 		};
 		const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
+		const getEditToolbar = ( isActive ) => {
+			return <Toolbar>
+				<IconButton
+					className={ classnames( 'components-toolbar__control', { 'is-active': isActive } ) }
+					label={ __( 'Edit audio' ) }
+					onClick={ toggleIsEditing }
+					icon={ editImageIcon }
+				/>
+			</Toolbar>;
+		};
+
 		if ( isEditing ) {
 			return (
 				<Fragment>
 					<BlockControls>
-						{ !! src && ( <Toolbar>
-							<IconButton
-								className={ classnames( 'components-toolbar__control is-active' ) }
-								label={ __( 'Edit audio' ) }
-								onClick={ toggleIsEditing }
-								icon={ editImageIcon }
-							/>
-						</Toolbar> ) }
+						{ !! src && getEditToolbar( true ) }
 					</BlockControls>
 					<MediaPlaceholder
 						icon={ <BlockIcon icon={ icon } /> }
@@ -170,14 +174,7 @@ class AudioEdit extends Component {
 		return (
 			<>
 				<BlockControls>
-					<Toolbar>
-						<IconButton
-							class={ 'components-toolbar__control' }
-							label={ __( 'Edit audio' ) }
-							onClick={ toggleIsEditing }
-							icon={ editImageIcon }
-						/>
-					</Toolbar>
+					{ getEditToolbar( false ) }
 				</BlockControls>
 				<InspectorControls>
 					<PanelBody title={ __( 'Audio Settings' ) }>

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -39,6 +39,7 @@ import icon from './icon';
  * Internal dependencies
  */
 import { createUpgradedEmbedBlock } from '../embed/util';
+import { speak } from '@wordpress/a11y';
 
 const ALLOWED_MEDIA_TYPES = [ 'audio' ];
 
@@ -116,6 +117,11 @@ class AudioEdit extends Component {
 		const { isEditing } = this.state;
 		const toggleIsEditing = () => {
 			this.setState( { isEditing: ! this.state.isEditing } );
+			if ( this.state.isEditing ) {
+				speak( __( 'You can now listen to the audio in the audio block.' ) );
+			} else {
+				speak( __( 'You are now editing the audio in the audio block.' ) );
+			}
 		};
 		const onSelectAudio = ( media ) => {
 			if ( ! media || ! media.url ) {

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -1,22 +1,12 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { getBlobByURL, isBlobURL } from '@wordpress/blob';
 import {
 	Disabled,
-	IconButton,
 	PanelBody,
-	Path,
-	Rect,
 	SelectControl,
-	SVG,
 	ToggleControl,
-	Toolbar,
 	withNotices,
 } from '@wordpress/components';
 import {
@@ -34,6 +24,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import icon from './icon';
+import AudioToolbar from './audio-toolbar';
 
 /**
  * Internal dependencies
@@ -136,23 +127,14 @@ class AudioEdit extends Component {
 			setAttributes( { src: media.url, id: media.id } );
 			this.setState( { src: media.url, isEditing: false } );
 		};
-		const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
-		const getEditToolbar = ( isActive ) => {
-			return <Toolbar>
-				<IconButton
-					className={ classnames( 'components-toolbar__control', { 'is-active': isActive } ) }
-					label={ __( 'Edit audio' ) }
-					onClick={ toggleIsEditing }
-					icon={ editImageIcon }
-				/>
-			</Toolbar>;
-		};
 
 		if ( isEditing ) {
 			return (
 				<Fragment>
 					<BlockControls>
-						{ !! src && getEditToolbar( true ) }
+						{ !! src &&
+							<AudioToolbar isEditing={ isEditing } onClick={ toggleIsEditing } />
+						}
 					</BlockControls>
 					<MediaPlaceholder
 						icon={ <BlockIcon icon={ icon } /> }
@@ -174,7 +156,7 @@ class AudioEdit extends Component {
 		return (
 			<>
 				<BlockControls>
-					{ getEditToolbar( false ) }
+					<AudioToolbar isEditing={ isEditing } onClick={ toggleIsEditing } />
 				</BlockControls>
 				<InspectorControls>
 					<PanelBody title={ __( 'Audio Settings' ) }>


### PR DESCRIPTION
# Description

Closes #14795

This is a follow up to the image block edit flow update which ports the new flow to all the blocks which have media with an edit state.

# How has this been tested?
For now I've only tested locally.

# Types of change
New feature (non-breaking change which adds functionality)

# Screenshots

![audio](https://user-images.githubusercontent.com/107534/55976121-16444980-5c94-11e9-8858-a3d80ac636ef.gif)
