### PR TITLE
Fix a broken link in the readme of button-block-appender

### DIFF
--- a/packages/block-editor/src/components/button-block-appender/README.md
+++ b/packages/block-editor/src/components/button-block-appender/README.md
@@ -40,4 +40,4 @@ A CSS `class` to be _prepended_ to the default class of `"button-block-appender"
 
 ## Examples
 
-The [`<InnerBlocks>` component](packages/block-editor/src/components/inner-blocks/) exposes an enhanced version of `ButtonBlockAppender` to allow consumers to choose it as an alternative to the standard behaviour of auto-inserting the default Block (typically `core/paragraph`).
+The [`<InnerBlocks>` component](../inner-blocks/) exposes an enhanced version of `ButtonBlockAppender` to allow consumers to choose it as an alternative to the standard behaviour of auto-inserting the default Block (typically `core/paragraph`).


### PR DESCRIPTION
## Description
Fixed a broken link in a readme file.
Link pointed to:
https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/button-block-appender/packages/block-editor/src/components/inner-blocks
Changed it to be relative to the actual location of the readme.

## How has this been tested?
Clicked the fixed link in the preview.

## Types of changes
Simple documentation change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
