### PR TITLE
Proxy the code/block-editor replaceBlock action in the core/editor package

### DIFF
--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -1169,6 +1169,12 @@ _Related_
 
 -   removeBlocks in core/block-editor store.
 
+<a name="replaceBlock" href="#replaceBlock">#</a> **replaceBlock**
+
+_Related_
+
+-   replaceBlock in core/block-editor store.
+
 <a name="replaceBlocks" href="#replaceBlocks">#</a> **replaceBlocks**
 
 _Related_

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -825,6 +825,11 @@ export const toggleSelection = getBlockEditorAction( 'toggleSelection' );
 export const replaceBlocks = getBlockEditorAction( 'replaceBlocks' );
 
 /**
+ * @see replaceBlock in core/block-editor store.
+ */
+export const replaceBlock = getBlockEditorAction( 'replaceBlock' );
+
+/**
  * @see moveBlocksDown in core/block-editor store.
  */
 export const moveBlocksDown = getBlockEditorAction( 'moveBlocksDown' );


### PR DESCRIPTION
It looks like we forgot to proxy this action when we created the block editor module.