### PR TITLE
Fix menu item colors

### DIFF
--- a/assets/stylesheets/_mixins.scss
+++ b/assets/stylesheets/_mixins.scss
@@ -203,6 +203,7 @@
 @mixin menu-style__neutral() {
 	border: none;
 	box-shadow: none;
+	color: $dark-gray-600;
 }
 
 @mixin menu-style__hover() {

--- a/assets/stylesheets/_mixins.scss
+++ b/assets/stylesheets/_mixins.scss
@@ -203,7 +203,6 @@
 @mixin menu-style__neutral() {
 	border: none;
 	box-shadow: none;
-	color: $dark-gray-600;
 }
 
 @mixin menu-style__hover() {

--- a/packages/block-editor/src/components/block-settings-menu/style.scss
+++ b/packages/block-editor/src/components/block-settings-menu/style.scss
@@ -39,7 +39,6 @@
 		background: none;
 		outline: none;
 		border-radius: 0;
-		color: $dark-gray-500;
 		text-align: left;
 		cursor: pointer;
 		@include menu-style__neutral;

--- a/packages/block-editor/src/components/block-settings-menu/style.scss
+++ b/packages/block-editor/src/components/block-settings-menu/style.scss
@@ -41,6 +41,7 @@
 		border-radius: 0;
 		text-align: left;
 		cursor: pointer;
+		color: $dark-gray-600;
 		@include menu-style__neutral;
 
 		&:hover:not(:disabled):not([aria-disabled="true"]) {

--- a/packages/components/src/menu-item/style.scss
+++ b/packages/components/src/menu-item/style.scss
@@ -3,6 +3,7 @@
 	width: 100%;
 	padding: $grid-size ($grid-size-large - $border-width);
 	text-align: left;
+	color: $dark-gray-600;
 	@include menu-style__neutral;
 
 	// Target plugin icons that can have arbitrary classes by using an aggressive selector.

--- a/packages/components/src/menu-item/style.scss
+++ b/packages/components/src/menu-item/style.scss
@@ -3,7 +3,7 @@
 	width: 100%;
 	padding: $grid-size ($grid-size-large - $border-width);
 	text-align: left;
-	color: $dark-gray-600;
+	@include menu-style__neutral;
 
 	// Target plugin icons that can have arbitrary classes by using an aggressive selector.
 	.dashicon,
@@ -18,7 +18,6 @@
 	}
 
 	&:hover:not(:disabled):not([aria-disabled="true"]) {
-		color: $dark-gray-500;
 		// Disable hover style on mobile to prevent odd scroll behaviour.
 		// See: https://github.com/WordPress/gutenberg/pull/10333
 		@include break-medium() {
@@ -26,7 +25,7 @@
 		}
 
 		.components-menu-item__shortcut {
-			opacity: 1;
+			color: $dark-gray-600;
 		}
 	}
 
@@ -43,12 +42,12 @@
 .components-menu-item__info {
 	margin-top: $grid-size-small;
 	font-size: $default-font-size - 1px;
-	opacity: 0.84;
+	color: $dark-gray-300;
 }
 
 .components-menu-item__shortcut {
 	align-self: center;
-	opacity: 0.84;
+	color: $dark-gray-300;
 	margin-right: 0;
 	margin-left: auto;
 	padding-left: $grid-size;


### PR DESCRIPTION
Fixes #15387

This PR fixes an inconsistency in menu item colors. There were some redundant CSS that had not been cleaned up properly with the move to the color mixins.

Additionally it replaces the use of opacity for the lighter text in the menus, and uses the color variables instead, as those colors do not need to work on differently colored backgrounds, just white.

Screenshots:

<img width="346" alt="Screenshot 2019-05-09 at 12 44 01" src="https://user-images.githubusercontent.com/1204802/57447918-81b01580-7258-11e9-8a38-e948024fa029.png">

<img width="391" alt="Screenshot 2019-05-09 at 12 44 08" src="https://user-images.githubusercontent.com/1204802/57447921-82e14280-7258-11e9-8b0a-ec85c6a5fa20.png">
