### PR TITLE
Selecting Parent Blocks: Try clickthrough

### DIFF
--- a/assets/stylesheets/_z-index.scss
+++ b/assets/stylesheets/_z-index.scss
@@ -19,7 +19,6 @@ $z-layers: (
 	".components-modal__header": 10,
 	".edit-post-meta-boxes-area.is-loading::before": 1,
 	".edit-post-meta-boxes-area .spinner": 5,
-	".block-editor-block-contextual-toolbar": 21,
 	".components-popover__close": 5,
 	".block-editor-block-list__insertion-point": 6,
 	".block-editor-inserter-with-shortcuts": 5,
@@ -60,7 +59,10 @@ $z-layers: (
 
 	// Small screen inner blocks overlay must be displayed above drop zone,
 	// settings menu, and movers.
-	".block-editor-inner-blocks__small-screen-overlay:after": 120,
+	".block-editor-inner-blocks.has-overlay::after": 120,
+
+	// The toolbar, when contextual, should be above any adjacent nested block click overlays.
+	".block-editor-block-contextual-toolbar": 121,
 
 	// Show sidebar above wp-admin navigation bar for mobile viewports:
 	// #wpadminbar { z-index: 99999 }

--- a/assets/stylesheets/_z-index.scss
+++ b/assets/stylesheets/_z-index.scss
@@ -9,7 +9,6 @@ $z-layers: (
 	".block-library-classic__toolbar": 10,
 	".block-editor-block-list__layout .reusable-block-indicator": 1,
 	".block-editor-block-list__breadcrumb": 2,
-	".editor-inner-blocks .block-editor-block-list__breadcrumb": 22,
 	".components-form-toggle__input": 1,
 	".components-panel__header.edit-post-sidebar__panel-tabs": -1,
 	".edit-post-sidebar .components-panel": -2,
@@ -63,6 +62,7 @@ $z-layers: (
 
 	// The toolbar, when contextual, should be above any adjacent nested block click overlays.
 	".block-editor-block-contextual-toolbar": 121,
+	".editor-inner-blocks .block-editor-block-list__breadcrumb": 122,
 
 	// Show sidebar above wp-admin navigation bar for mobile viewports:
 	// #wpadminbar { z-index: 99999 }

--- a/assets/stylesheets/_z-index.scss
+++ b/assets/stylesheets/_z-index.scss
@@ -49,10 +49,6 @@ $z-layers: (
 	".components-drop-zone": 100,
 	".components-drop-zone__content": 110,
 
-	// The block mover, particularly in nested contexts,
-	// should overlap most block content.
-	".block-editor-block-list__block.is-{selected,hovered} .block-editor-block-mover": 80,
-
 	// The block mover for floats should overlap the controls of adjacent blocks.
 	".block-editor-block-list__block {core/image aligned left or right}": 81,
 
@@ -64,6 +60,10 @@ $z-layers: (
 	".block-editor-block-list__layout .reusable-block-edit-panel": 121,
 	".block-editor-block-contextual-toolbar": 121,
 	".editor-inner-blocks .block-editor-block-list__breadcrumb": 122,
+
+	// The block mover, particularly in nested contexts,
+	// should overlap most block content.
+	".block-editor-block-list__block.is-{selected,hovered} .block-editor-block-mover": 121,
 
 	// Show sidebar above wp-admin navigation bar for mobile viewports:
 	// #wpadminbar { z-index: 99999 }

--- a/assets/stylesheets/_z-index.scss
+++ b/assets/stylesheets/_z-index.scss
@@ -61,6 +61,7 @@ $z-layers: (
 	".block-editor-inner-blocks.has-overlay::after": 120,
 
 	// The toolbar, when contextual, should be above any adjacent nested block click overlays.
+	".block-editor-block-list__layout .reusable-block-edit-panel": 121,
 	".block-editor-block-contextual-toolbar": 121,
 	".editor-inner-blocks .block-editor-block-list__breadcrumb": 122,
 

--- a/packages/block-editor/src/components/block-list/block-async-mode-provider.js
+++ b/packages/block-editor/src/components/block-list/block-async-mode-provider.js
@@ -6,22 +6,12 @@ import {
 	useSelect,
 } from '@wordpress/data';
 
-const BlockAsyncModeProvider = ( { children, clientId } ) => {
-	const isSyncModeForced = useSelect( ( select ) => {
-		const {
-			hasSelectedInnerBlock,
-			isAncestorMultiSelected,
-			isBlockMultiSelected,
-			isBlockSelected,
-		} = select( 'core/block-editor' );
-
-		const isSelected = isBlockSelected( clientId );
-		const isParentOfSelectedBlock = hasSelectedInnerBlock( clientId, true );
-		const isPartOfMultiSelection = isBlockMultiSelected( clientId ) ||
-			isAncestorMultiSelected( clientId );
-
-		return isSelected || isParentOfSelectedBlock || isPartOfMultiSelection;
+const BlockAsyncModeProvider = ( { children, clientId, isBlockInSelection } ) => {
+	const isParentOfSelectedBlock = useSelect( ( select ) => {
+		return select( 'core/block-editor' ).hasSelectedInnerBlock( clientId, true );
 	} );
+
+	const isSyncModeForced = isBlockInSelection || isParentOfSelectedBlock;
 
 	return (
 		<AsyncModeProvider value={ ! isSyncModeForced }>

--- a/packages/block-editor/src/components/block-list/block-async-mode-provider.js
+++ b/packages/block-editor/src/components/block-list/block-async-mode-provider.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalAsyncModeProvider as AsyncModeProvider,
+	useSelect,
+} from '@wordpress/data';
+
+const BlockAsyncModeProvider = ( { children, clientId } ) => {
+	const isSyncModeForced = useSelect( ( select ) => {
+		const {
+			hasSelectedInnerBlock,
+			isAncestorMultiSelected,
+			isBlockMultiSelected,
+			isBlockSelected,
+		} = select( 'core/block-editor' );
+
+		const isSelected = isBlockSelected( clientId );
+		const isParentOfSelectedBlock = hasSelectedInnerBlock( clientId, true );
+		const isPartOfMultiSelection = isBlockMultiSelected( clientId ) ||
+			isAncestorMultiSelected( clientId );
+
+		return isSelected || isParentOfSelectedBlock || isPartOfMultiSelection;
+	} );
+
+	return (
+		<AsyncModeProvider value={ ! isSyncModeForced }>
+			{ children }
+		</AsyncModeProvider>
+	);
+};
+
+export default BlockAsyncModeProvider;

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -23,7 +23,10 @@ import {
 } from '@wordpress/blocks';
 import { KeyboardShortcuts, withFilters } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { withDispatch, withSelect } from '@wordpress/data';
+import {
+	withDispatch,
+	withSelect,
+} from '@wordpress/data';
 import { withViewportMatch } from '@wordpress/viewport';
 import { compose, pure } from '@wordpress/compose';
 

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -24,6 +24,7 @@ import { compose } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
+import BlockAsyncModeProvider from './block-async-mode-provider';
 import BlockListBlock from './block';
 import BlockListAppender from '../block-list-appender';
 import { getBlockDOMNode } from '../../utils/dom';
@@ -193,34 +194,25 @@ class BlockList extends Component {
 			blockClientIds,
 			rootClientId,
 			isDraggable,
-			selectedBlockClientId,
-			selectedBlockRootClientId,
-			multiSelectedBlockClientIds,
-			hasMultiSelection,
 			renderAppender,
 		} = this.props;
 
 		return (
 			<div className="editor-block-list__layout block-editor-block-list__layout">
 				{ map( blockClientIds, ( clientId ) => {
-					const isBlockInSelection = hasMultiSelection ?
-						multiSelectedBlockClientIds.includes( clientId ) :
-						[ selectedBlockRootClientId, selectedBlockClientId ].includes( clientId );
-
 					return (
-						<AsyncModeProvider
+						<BlockAsyncModeProvider
 							key={ 'block-' + clientId }
-							value={ ! isBlockInSelection }
+							clientId={ clientId }
 						>
 							<BlockListBlock
-								className={ isBlockInSelection ? 'is-sync' : 'is-async' }
 								clientId={ clientId }
 								blockRef={ this.setBlockRef }
 								onSelectionStart={ this.onSelectionStart }
 								rootClientId={ rootClientId }
 								isDraggable={ isDraggable }
 							/>
-						</AsyncModeProvider>
+						</BlockAsyncModeProvider>
 					);
 				} ) }
 
@@ -241,18 +233,13 @@ export default compose( [
 	withSelect( ( select, ownProps ) => {
 		const {
 			getBlockOrder,
-			getBlockHierarchyRootClientId,
 			isSelectionEnabled,
 			isMultiSelecting,
 			getMultiSelectedBlocksStartClientId,
 			getMultiSelectedBlocksEndClientId,
-			getSelectedBlockClientId,
-			getMultiSelectedBlockClientIds,
-			hasMultiSelection,
 		} = select( 'core/block-editor' );
 
 		const { rootClientId } = ownProps;
-		const selectedBlockClientId = getSelectedBlockClientId();
 
 		return {
 			blockClientIds: getBlockOrder( rootClientId ),
@@ -260,10 +247,6 @@ export default compose( [
 			selectionEnd: getMultiSelectedBlocksEndClientId(),
 			isSelectionEnabled: isSelectionEnabled(),
 			isMultiSelecting: isMultiSelecting(),
-			selectedBlockClientId,
-			selectedBlockRootClientId: getBlockHierarchyRootClientId( selectedBlockClientId ),
-			multiSelectedBlockClientIds: getMultiSelectedBlockClientIds(),
-			hasMultiSelection: hasMultiSelection(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -194,6 +194,7 @@ class BlockList extends Component {
 			rootClientId,
 			isDraggable,
 			selectedBlockClientId,
+			selectedBlockRootClientId,
 			multiSelectedBlockClientIds,
 			hasMultiSelection,
 			renderAppender,
@@ -204,7 +205,7 @@ class BlockList extends Component {
 				{ map( blockClientIds, ( clientId ) => {
 					const isBlockInSelection = hasMultiSelection ?
 						multiSelectedBlockClientIds.includes( clientId ) :
-						selectedBlockClientId === clientId;
+						[ selectedBlockRootClientId, selectedBlockClientId ].includes( clientId );
 
 					return (
 						<AsyncModeProvider
@@ -212,6 +213,7 @@ class BlockList extends Component {
 							value={ ! isBlockInSelection }
 						>
 							<BlockListBlock
+								className={ isBlockInSelection ? 'is-sync' : 'is-async' }
 								clientId={ clientId }
 								blockRef={ this.setBlockRef }
 								onSelectionStart={ this.onSelectionStart }
@@ -239,6 +241,7 @@ export default compose( [
 	withSelect( ( select, ownProps ) => {
 		const {
 			getBlockOrder,
+			getBlockHierarchyRootClientId,
 			isSelectionEnabled,
 			isMultiSelecting,
 			getMultiSelectedBlocksStartClientId,
@@ -249,6 +252,7 @@ export default compose( [
 		} = select( 'core/block-editor' );
 
 		const { rootClientId } = ownProps;
+		const selectedBlockClientId = getSelectedBlockClientId();
 
 		return {
 			blockClientIds: getBlockOrder( rootClientId ),
@@ -256,7 +260,8 @@ export default compose( [
 			selectionEnd: getMultiSelectedBlocksEndClientId(),
 			isSelectionEnabled: isSelectionEnabled(),
 			isMultiSelecting: isMultiSelecting(),
-			selectedBlockClientId: getSelectedBlockClientId(),
+			selectedBlockClientId,
+			selectedBlockRootClientId: getBlockHierarchyRootClientId( selectedBlockClientId ),
 			multiSelectedBlockClientIds: getMultiSelectedBlockClientIds(),
 			hasMultiSelection: hasMultiSelection(),
 		};

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -194,16 +194,24 @@ class BlockList extends Component {
 			blockClientIds,
 			rootClientId,
 			isDraggable,
+			selectedBlockClientId,
+			multiSelectedBlockClientIds,
+			hasMultiSelection,
 			renderAppender,
 		} = this.props;
 
 		return (
 			<div className="editor-block-list__layout block-editor-block-list__layout">
 				{ map( blockClientIds, ( clientId ) => {
+					const isBlockInSelection = hasMultiSelection ?
+						multiSelectedBlockClientIds.includes( clientId ) :
+						selectedBlockClientId === clientId;
+
 					return (
 						<BlockAsyncModeProvider
 							key={ 'block-' + clientId }
 							clientId={ clientId }
+							isBlockInSelection={ isBlockInSelection }
 						>
 							<BlockListBlock
 								clientId={ clientId }
@@ -237,6 +245,9 @@ export default compose( [
 			isMultiSelecting,
 			getMultiSelectedBlocksStartClientId,
 			getMultiSelectedBlocksEndClientId,
+			getSelectedBlockClientId,
+			getMultiSelectedBlockClientIds,
+			hasMultiSelection,
 		} = select( 'core/block-editor' );
 
 		const { rootClientId } = ownProps;
@@ -247,6 +258,9 @@ export default compose( [
 			selectionEnd: getMultiSelectedBlocksEndClientId(),
 			isSelectionEnabled: isSelectionEnabled(),
 			isMultiSelecting: isMultiSelecting(),
+			selectedBlockClientId: getSelectedBlockClientId(),
+			multiSelectedBlockClientIds: getMultiSelectedBlockClientIds(),
+			hasMultiSelection: hasMultiSelection(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -211,6 +211,10 @@
  */
 
 .block-editor-block-list__layout .block-editor-block-list__block {
+	&.is-sync {
+		background-color: $alert-red;
+	}
+
 	&.has-warning {
 		min-height: ( $block-padding + $block-spacing ) * 2;
 	}

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -211,10 +211,6 @@
  */
 
 .block-editor-block-list__layout .block-editor-block-list__block {
-	&.is-sync {
-		background-color: $alert-red;
-	}
-
 	&.has-warning {
 		min-height: ( $block-padding + $block-spacing ) * 2;
 	}

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -305,6 +305,20 @@
 		}
 	}
 
+	// Reusable Blocks clickthrough overlays
+	&.is-reusable > .block-editor-block-list__block-edit .block-editor-inner-blocks.has-overlay {
+		// Remove only the top click overlay.
+		&::after {
+			display: none;
+		}
+
+		// Restore it for subsequent.
+		.block-editor-inner-blocks.has-overlay::after {
+			display: block;
+		}
+	}
+
+
 	// Alignments
 	&[data-align="left"],
 	&[data-align="right"] {

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -7,7 +7,6 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { withViewportMatch } from '@wordpress/viewport';
 import { Component } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { synchronizeBlocksWithTemplate, withBlockContentContext } from '@wordpress/blocks';
@@ -106,13 +105,13 @@ class InnerBlocks extends Component {
 	render() {
 		const {
 			clientId,
-			isSelectedBlockInRoot,
+			hasOverlay,
 			renderAppender,
 		} = this.props;
 		const { templateInProcess } = this.state;
 
 		const classes = classnames( 'editor-inner-blocks block-editor-inner-blocks', {
-			'has-overlay': ! isSelectedBlockInRoot,
+			'has-overlay': hasOverlay,
 		} );
 
 		return (
@@ -130,7 +129,6 @@ class InnerBlocks extends Component {
 
 InnerBlocks = compose( [
 	withBlockEditContext( ( context ) => pick( context, [ 'clientId' ] ) ),
-	withViewportMatch( { isSmallScreen: '< medium' } ),
 	withSelect( ( select, ownProps ) => {
 		const {
 			isBlockSelected,
@@ -144,9 +142,9 @@ InnerBlocks = compose( [
 		const rootClientId = getBlockRootClientId( clientId );
 
 		return {
-			isSelectedBlockInRoot: isBlockSelected( clientId ) || hasSelectedInnerBlock( clientId ),
 			block: getBlock( clientId ),
 			blockListSettings: getBlockListSettings( clientId ),
+			hasOverlay: ! isBlockSelected( clientId ) && ! hasSelectedInnerBlock( clientId, true ),
 			parentLock: getTemplateLock( rootClientId ),
 		};
 	} ),

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -106,14 +106,13 @@ class InnerBlocks extends Component {
 	render() {
 		const {
 			clientId,
-			isSmallScreen,
 			isSelectedBlockInRoot,
 			renderAppender,
 		} = this.props;
 		const { templateInProcess } = this.state;
 
 		const classes = classnames( 'editor-inner-blocks block-editor-inner-blocks', {
-			'has-overlay': isSmallScreen && ! isSelectedBlockInRoot,
+			'has-overlay': ! isSelectedBlockInRoot,
 		} );
 
 		return (

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -139,12 +139,13 @@ InnerBlocks = compose( [
 			getTemplateLock,
 		} = select( 'core/block-editor' );
 		const { clientId } = ownProps;
+		const block = getBlock( clientId );
 		const rootClientId = getBlockRootClientId( clientId );
 
 		return {
-			block: getBlock( clientId ),
+			block,
 			blockListSettings: getBlockListSettings( clientId ),
-			hasOverlay: ! isBlockSelected( clientId ) && ! hasSelectedInnerBlock( clientId, true ),
+			hasOverlay: block.name !== 'core/template' && ! isBlockSelected( clientId ) && ! hasSelectedInnerBlock( clientId, true ),
 			parentLock: getTemplateLock( rootClientId ),
 		};
 	} ),

--- a/packages/block-editor/src/components/inner-blocks/style.scss
+++ b/packages/block-editor/src/components/inner-blocks/style.scss
@@ -1,9 +1,31 @@
 .block-editor-inner-blocks.has-overlay::after {
 	content: "";
 	position: absolute;
-	top: 0;
+	top: -$block-padding;
 	right: 0;
-	bottom: 0;
+	bottom: -$block-padding;
 	left: 0;
-	z-index: z-index(".block-editor-inner-blocks__small-screen-overlay:after");
+	z-index: z-index(".block-editor-inner-blocks.has-overlay::after");
+}
+
+// These are temporary debug colors.
+/*.block-editor-inner-blocks.has-overlay {
+	background-color: #00a0d2;
+
+	.block-editor-inner-blocks.has-overlay {
+		background-color: #4ab866;
+	}
+}
+*/
+
+// Temporary hover style for testing
+.block-editor-block-list__block.is-hovered .block-editor-inner-blocks.has-overlay {
+	&::after {
+		background: rgba($blue-medium-500, 0.5);
+	}
+
+	// Stop propogating beyond one level
+	.block-editor-inner-blocks.has-overlay::after {
+		background: none;
+	}
 }

--- a/packages/block-editor/src/components/inner-blocks/style.scss
+++ b/packages/block-editor/src/components/inner-blocks/style.scss
@@ -1,27 +1,20 @@
-.block-editor-inner-blocks.has-overlay::after {
-	content: "";
-	position: absolute;
-	top: -$block-padding;
-	right: 0;
-	bottom: -$block-padding;
-	left: 0;
-	z-index: z-index(".block-editor-inner-blocks.has-overlay::after");
-}
-
-// These are temporary debug colors.
-/*.block-editor-inner-blocks.has-overlay {
-	background-color: #00a0d2;
-
-	.block-editor-inner-blocks.has-overlay {
-		background-color: #4ab866;
+.block-editor-inner-blocks.has-overlay {
+	&::after {
+		content: "";
+		position: absolute;
+		top: -$block-padding;
+		right: -$block-padding;
+		bottom: -$block-padding;
+		left: -$block-padding;
+		z-index: z-index(".block-editor-inner-blocks.has-overlay::after");
 	}
 }
-*/
 
-// Temporary hover style for testing
+// Visual overlay style to indicate nesting.
+// We should revisit this with the nested block outlines,
 .block-editor-block-list__block.is-hovered .block-editor-inner-blocks.has-overlay {
 	&::after {
-		background: rgba($blue-medium-500, 0.5);
+		background: rgba($blue-medium-500, 0.1);
 	}
 
 	// Stop propogating beyond one level

--- a/packages/block-editor/src/components/inner-blocks/style.scss
+++ b/packages/block-editor/src/components/inner-blocks/style.scss
@@ -9,16 +9,3 @@
 		z-index: z-index(".block-editor-inner-blocks.has-overlay::after");
 	}
 }
-
-// Visual overlay style to indicate nesting.
-// We should revisit this with the nested block outlines,
-.block-editor-block-list__block.is-hovered .block-editor-inner-blocks.has-overlay {
-	&::after {
-		background: rgba($blue-medium-500, 0.1);
-	}
-
-	// Stop propogating beyond one level
-	.block-editor-inner-blocks.has-overlay::after {
-		background: none;
-	}
-}

--- a/packages/block-library/src/block/edit-panel/editor.scss
+++ b/packages/block-library/src/block/edit-panel/editor.scss
@@ -11,6 +11,10 @@
 	margin: 0 (-$block-padding);
 	padding: $grid-size $block-padding;
 
+	// Elevate the reusable blocks toolbar above the clickthrough overlay.
+	position: relative;
+	z-index: z-index(".block-editor-block-list__layout .reusable-block-edit-panel");
+
 	// Use opacity to work in various editor styles.
 	border: $border-width dashed $dark-opacity-light-500;
 	border-bottom: none;

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -166,3 +166,11 @@ div.block-core-columns.is-vertically-aligned-bottom {
 	right: 0;
 	left: auto;
 }
+
+/**
+ * Make single Column overlay not extend past boundaries of parent
+ */
+.block-core-columns > .block-editor-inner-blocks.has-overlay::after {
+	left: 0;
+	right: 0;
+}

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -164,17 +164,5 @@ div.block-core-columns.is-vertically-aligned-bottom {
  */
 [data-type="core/column"] > .editor-block-list__block-edit > .editor-block-list__breadcrumb {
 	right: 0;
-}
-
-// The empty state of a columns block has the default appenders.
-// Since those appenders are not blocks, the parent, actual block, appears "hovered" when hovering the appenders.
-// Because the column shouldn't be hovered as part of this temporary passthrough, we unset the hover style.
-.wp-block-columns [data-type="core/column"].is-hovered {
-	> .block-editor-block-list__block-edit::before {
-		content: none;
-	}
-
-	.block-editor-block-list__breadcrumb {
-		display: none;
-	}
+	left: auto;
 }

--- a/packages/e2e-tests/specs/reusable-blocks.test.js
+++ b/packages/e2e-tests/specs/reusable-blocks.test.js
@@ -45,10 +45,8 @@ describe( 'Reusable Blocks', () => {
 			'//*[contains(@class, "components-snackbar")]/*[text()="Block created."]'
 		);
 
-		// Select all of the text in the title field by triple-clicking on it. We
-		// triple-click because, on Mac, Mod+A doesn't work. This step can be removed
-		// when https://github.com/WordPress/gutenberg/issues/7972 is fixed
-		await page.click( '.reusable-block-edit-panel__title', { clickCount: 3 } );
+		// Select all of the text in the title field.
+		await pressKeyWithModifier( 'primary', 'a' );
 
 		// Give the reusable block a title
 		await page.keyboard.type( 'Greeting block' );
@@ -223,10 +221,8 @@ describe( 'Reusable Blocks', () => {
 			'//*[contains(@class, "components-snackbar")]/*[text()="Block created."]'
 		);
 
-		// Select all of the text in the title field by triple-clicking on it. We
-		// triple-click because, on Mac, Mod+A doesn't work. This step can be removed
-		// when https://github.com/WordPress/gutenberg/issues/7972 is fixed
-		await page.click( '.reusable-block-edit-panel__title', { clickCount: 3 } );
+		// Select all of the text in the title field.
+		await pressKeyWithModifier( 'primary', 'a' );
 
 		// Give the reusable block a title
 		await page.keyboard.type( 'Multi-selection reusable block' );


### PR DESCRIPTION
This PR takes a stab at using existing code by @aduth that is implemented on mobile, and expanding it to the desktop breakpoint as well. Specifically, it enables what we in #9628 refer to as "click-through". 

With "click-through", whenever you interact with a block that has innerblocks, a click first select the parent, and then it selects direct descendants. For example you first click the Cover block, then you click the Paragraph block inside. Or you first click the Columns block, then you get to select the Column (singular) block, and then you can select content inside. GIF:

![clickthrough](https://user-images.githubusercontent.com/1204802/57453915-e1fa8380-7267-11e9-960c-2a44230f11dc.gif)

**This branch is a work in progress. There are issues to refine and work out.**

Click-through is inspired by how many desktop applications handle "groups". There, you commonly have to double-click a group to be able to select items inside. This PR is the same, except you click only once to "open" the group. There are a great deal of benefits to this approach:

1. It's very simple. It makes it trivial to select each layer of even complex blocks as they are today. 
2. It's safe, in that it can accommodate almost any complex block you can throw at it, with a few exceptions I'll get into in a bit.
3. It does not require fine motor skills to select a parent block. The hit areas are most literally as big as the block itself. 

The first thing you might think is: **what about situations where you want to edit text quickly?**

That specific question is the primary reason it's taken until now to test this out in practice. My assumption was that this would create unnecessary friction to editing text. However:

- In testing this actual PR, that feels like a complete non-issue. I invite you to test this PR out, even in this buggy early form. 
- The behavior feels completely intuitive in actual practice. Even if you select the parent first, you get visual feedback all along the way, and you'll quickly learn that if you mean to edit text inside the Cover block quickly, you can just double-click — one click to select the Cover block, another to select the text you're pointing at.

**Issues**

1. The current behavior "cycles through" the layers if there are more than two levels of nesting, i.e. as it the case in the Columns block:

![cycle](https://user-images.githubusercontent.com/1204802/57454833-0bb4aa00-726a-11e9-8b39-937b269c4011.gif)

This is the code: `! isSelectedBlockInRoot` — we'll likely need an additional variable that is aware of immediate parent and not just the root ancestor. 

2. There is an issue with blocks being inserted using the slash command — those are still "locked" behind the click-through, even though it is keyboard selected. This will likely be similar to if you set focus inside a child block with the keyboard: however you selected the child block, if it's selected, it should be "ungrouped". 

**Other considerations**

For now this is a draft PR, but I strongly urge you to try it out and _not just look at the GIF_. It feels better in actual practice, than it looks, and with things like #15499 on the horizon, this could be a good baseline improvement to improve the situation with selecting parent and child blocks. 

It also doesn't preclude additional and separate improvements from taking place, such as:

- #14961 which adds dashed outlines to show the presence of parent or child blocks. 
- Refactors of blocks such as columns to maybe be closer to the Media & Text block in terms of how child blocks are surfaced to the user. For example it seems like it should be possible to create a columns block with just 2 levels of nesting, rather than 3.

For now, though, I would really appreciate your thoughts on this PR. Please, more than anything, take it for a spin!