### PR TITLE
Fix gallery tab order

### DIFF
--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -61,9 +61,15 @@ ul.wp-block-gallery {
 
 	.is-selected .block-library-gallery-item__inline-menu {
 		background-color: theme(primary);
+
 		.components-button {
 			color: $white;
 		}
+
+		.components-button:focus {
+			color: inherit;
+		}
+
 	}
 
 	.block-editor-rich-text figcaption {
@@ -83,19 +89,11 @@ ul.wp-block-gallery {
 
 	.components-button {
 		color: transparent;
-		&:hover,
-		&:focus {
-			color: $white;
-		}
 	}
 }
 
 .blocks-gallery-item__remove {
 	padding: 0;
-
-	&.components-button:focus {
-		color: inherit;
-	}
 }
 
 .blocks-gallery-item .components-spinner {

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -59,6 +59,13 @@ ul.wp-block-gallery {
 		}
 	}
 
+	.is-selected .block-library-gallery-item__inline-menu {
+		background-color: theme(primary);
+		.components-button {
+			color: $white;
+		}
+	}
+
 	.block-editor-rich-text figcaption {
 		a {
 			color: $white;
@@ -71,12 +78,11 @@ ul.wp-block-gallery {
 	position: absolute;
 	top: -2px;
 	right: -2px;
-	background-color: theme(primary);
 	display: inline-flex;
 	z-index: z-index(".block-library-gallery-item__inline-menu");
 
 	.components-button {
-		color: $white;
+		color: transparent;
 		&:hover,
 		&:focus {
 			color: $white;

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -127,17 +127,15 @@ class GalleryImage extends Component {
 
 		return (
 			<figure className={ className }>
-				{ isSelected &&
-					<div className="block-library-gallery-item__inline-menu">
-						<IconButton
-							icon="no-alt"
-							onClick={ onRemove }
-							className="blocks-gallery-item__remove"
-							label={ __( 'Remove Image' ) }
-						/>
-					</div>
-				}
 				{ href ? <a href={ href }>{ img }</a> : img }
+				<div className="block-library-gallery-item__inline-menu">
+					<IconButton
+						icon="no-alt"
+						onClick={ onRemove }
+						className="blocks-gallery-item__remove"
+						label={ __( 'Remove Image' ) }
+					/>
+				</div>
 				{ ( ! RichText.isEmpty( caption ) || isSelected ) ? (
 					<RichText
 						tagName="figcaption"

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -135,20 +135,17 @@ class GalleryImage extends Component {
 						onFocus={ this.onSelectImage }
 						className="blocks-gallery-item__remove"
 						label={ __( 'Remove Image' ) }
-						disabled={ ! isSelected }
 					/>
 				</div>
-				{ ( ! RichText.isEmpty( caption ) || isSelected ) ? (
-					<RichText
-						tagName="figcaption"
-						placeholder={ __( 'Write caption…' ) }
-						value={ caption }
-						isSelected={ this.state.captionSelected }
-						onChange={ ( newCaption ) => setAttributes( { caption: newCaption } ) }
-						unstableOnFocus={ this.onSelectCaption }
-						inlineToolbar
-					/>
-				) : null }
+				<RichText
+					tagName="figcaption"
+					placeholder={ __( 'Write caption…' ) }
+					value={ caption }
+					isSelected={ this.state.captionSelected }
+					onChange={ ( newCaption ) => setAttributes( { caption: newCaption } ) }
+					unstableOnFocus={ this.onSelectCaption }
+					inlineToolbar
+				/>
 			</figure>
 		);
 	}

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -132,6 +132,7 @@ class GalleryImage extends Component {
 					<IconButton
 						icon="no-alt"
 						onClick={ onRemove }
+						onFocus={ this.onSelectImage }
 						className="blocks-gallery-item__remove"
 						label={ __( 'Remove Image' ) }
 					/>

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -135,6 +135,7 @@ class GalleryImage extends Component {
 						onFocus={ this.onSelectImage }
 						className="blocks-gallery-item__remove"
 						label={ __( 'Remove Image' ) }
+						disabled={ ! isSelected }
 					/>
 				</div>
 				{ ( ! RichText.isEmpty( caption ) || isSelected ) ? (

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -135,6 +135,7 @@ class GalleryImage extends Component {
 						onFocus={ this.onSelectImage }
 						className="blocks-gallery-item__remove"
 						label={ __( 'Remove Image' ) }
+						disabled={ ! isSelected }
 					/>
 				</div>
 				<RichText

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -140,7 +140,7 @@ class GalleryImage extends Component {
 				</div>
 				<RichText
 					tagName="figcaption"
-					placeholder={ __( 'Write caption…' ) }
+					placeholder={ isSelected ? __( 'Write caption…' ) : null }
 					value={ caption }
 					isSelected={ this.state.captionSelected }
 					onChange={ ( newCaption ) => setAttributes( { caption: newCaption } ) }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/14814
Previous attempt: https://github.com/WordPress/gutenberg/issues/14931

This PR fixes the keyboard tab order for navigating through gallery items: 

Forward:

- TAB to select the image.
- TAB to select the remove button.
- TAB to select the caption.
- TAB to select the next image.

Backward:

- SHIFT+TAB to select the previous image's caption.
- SHIFT+TAB through the caption's toolbar.
- SHIFT+TAB to select the remove button.
- SHIFT+TAB to select the iimage.
- SHIFT+TAB to select the previous image's caption.

There is a related issue https://github.com/WordPress/gutenberg/issues/14823 for deselecting the image when it is the first/last after it losses focus. This will be fixed separately.
