### PR TITLE
Refactor fill component to avoid relying on componentWillUpdate and use React Hooks instead

### DIFF
--- a/packages/components/src/slot-fill/context.js
+++ b/packages/components/src/slot-fill/context.js
@@ -97,13 +97,12 @@ class SlotFillProvider extends Component {
 		if ( this.slots[ name ] !== slotInstance ) {
 			return [];
 		}
-
 		return sortBy( this.fills[ name ], 'occurrence' );
 	}
 
 	resetFillOccurrence( name ) {
 		forEach( this.fills[ name ], ( instance ) => {
-			instance.resetOccurrence();
+			instance.occurrence = undefined;
 		} );
 	}
 

--- a/packages/components/src/slot-fill/fill.js
+++ b/packages/components/src/slot-fill/fill.js
@@ -6,7 +6,7 @@ import { isFunction } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Component, createPortal } from '@wordpress/element';
+import { createPortal, useEffect, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -15,64 +15,55 @@ import { Consumer } from './context';
 
 let occurrences = 0;
 
-class FillComponent extends Component {
-	constructor() {
-		super( ...arguments );
-		this.occurrence = ++occurrences;
-	}
+function FillComponent( { name, getSlot, children, registerFill, unregisterFill } ) {
+	// Random state used to rerender the component if needed, ideally we don't need this
+	const [ , updateRerenderState ] = useState( {} );
+	const rerender = () => updateRerenderState( {} );
 
-	componentDidMount() {
-		const { registerFill } = this.props;
+	const ref = useRef( {
+		name,
+		children,
+	} );
 
-		registerFill( this.props.name, this );
-	}
+	useEffect( () => {
+		ref.current.occurence = ++occurrences;
+		ref.current.resetOccurrence = () => {
+			ref.current.occurence = null;
+		};
+		ref.current.forceUpdate = rerender;
+		registerFill( name, ref.current );
+		return () => unregisterFill( name, ref.current );
+	}, [] );
 
-	componentWillUpdate() {
-		if ( ! this.occurrence ) {
-			this.occurrence = ++occurrences;
+	useEffect( () => {
+		if ( ! ref.current.occurence ) {
+			ref.current.occurence = ++occurrences;
 		}
-		const { getSlot } = this.props;
-		const slot = getSlot( this.props.name );
+		ref.current.children = children;
+		const slot = getSlot( name );
 		if ( slot && ! slot.props.bubblesVirtually ) {
 			slot.forceUpdate();
 		}
+	}, [ children ] );
+
+	useEffect( () => {
+		unregisterFill( ref.current.name, ref.current );
+		ref.current.name = name;
+		registerFill( name, ref.current );
+	}, [ name ] );
+
+	const slot = getSlot( name );
+
+	if ( ! slot || ! slot.node || ! slot.props.bubblesVirtually ) {
+		return null;
 	}
 
-	componentWillUnmount() {
-		const { unregisterFill } = this.props;
-
-		unregisterFill( this.props.name, this );
+	// If a function is passed as a child, provide it with the fillProps.
+	if ( isFunction( children ) ) {
+		children = children( slot.props.fillProps );
 	}
 
-	componentDidUpdate( prevProps ) {
-		const { name, unregisterFill, registerFill } = this.props;
-
-		if ( prevProps.name !== name ) {
-			unregisterFill( prevProps.name, this );
-			registerFill( name, this );
-		}
-	}
-
-	resetOccurrence() {
-		this.occurrence = null;
-	}
-
-	render() {
-		const { name, getSlot } = this.props;
-		let { children } = this.props;
-		const slot = getSlot( name );
-
-		if ( ! slot || ! slot.node || ! slot.props.bubblesVirtually ) {
-			return null;
-		}
-
-		// If a function is passed as a child, provide it with the fillProps.
-		if ( isFunction( children ) ) {
-			children = children( slot.props.fillProps );
-		}
-
-		return createPortal( children, slot.node );
-	}
+	return createPortal( children, slot.node );
 }
 
 const Fill = ( props ) => (

--- a/packages/components/src/slot-fill/fill.js
+++ b/packages/components/src/slot-fill/fill.js
@@ -6,7 +6,7 @@ import { isFunction } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { createPortal, useEffect, useRef, useState } from '@wordpress/element';
+import { createPortal, useLayoutEffect, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -25,20 +25,17 @@ function FillComponent( { name, getSlot, children, registerFill, unregisterFill 
 		children,
 	} );
 
-	useEffect( () => {
-		ref.current.occurence = ++occurrences;
-		ref.current.resetOccurrence = () => {
-			ref.current.occurence = null;
-		};
+	if ( ! ref.current.occurrence ) {
+		ref.current.occurrence = ++occurrences;
+	}
+
+	useLayoutEffect( () => {
 		ref.current.forceUpdate = rerender;
 		registerFill( name, ref.current );
 		return () => unregisterFill( name, ref.current );
 	}, [] );
 
-	useEffect( () => {
-		if ( ! ref.current.occurence ) {
-			ref.current.occurence = ++occurrences;
-		}
+	useLayoutEffect( () => {
 		ref.current.children = children;
 		const slot = getSlot( name );
 		if ( slot && ! slot.props.bubblesVirtually ) {
@@ -46,7 +43,11 @@ function FillComponent( { name, getSlot, children, registerFill, unregisterFill 
 		}
 	}, [ children ] );
 
-	useEffect( () => {
+	useLayoutEffect( () => {
+		if ( name === ref.current.name ) {
+			// ignore initial effect
+			return;
+		}
 		unregisterFill( ref.current.name, ref.current );
 		ref.current.name = name;
 		registerFill( name, ref.current );

--- a/packages/components/src/slot-fill/slot.js
+++ b/packages/components/src/slot-fill/slot.js
@@ -64,7 +64,7 @@ class SlotComponent extends Component {
 
 		const fills = map( getFills( name, this ), ( fill ) => {
 			const fillKey = fill.occurrence;
-			const fillChildren = isFunction( fill.props.children ) ? fill.props.children( fillProps ) : fill.props.children;
+			const fillChildren = isFunction( fill.children ) ? fill.children( fillProps ) : fill.children;
 
 			return Children.map( fillChildren, ( child, childIndex ) => {
 				if ( ! child || isString( child ) ) {


### PR DESCRIPTION
Refs #11360 

I'm not familiar with the details of the slot/fill implementation especially the occurences thing so please make sure to test this extensively.

**Testing instructions**

 - Check the block toolbars and inspectors
 - Check the plugin slots (install dropit or similar...)