### PR TITLE
Fix focus color contrast

### DIFF
--- a/assets/stylesheets/_mixins.scss
+++ b/assets/stylesheets/_mixins.scss
@@ -180,8 +180,8 @@
 
 @mixin input-style__focus() {
 	color: $dark-gray-900;
-	border-color: $blue-medium-500;
-	box-shadow: 0 0 0 1px $blue-medium-500;
+	border-color: $blue-medium-focus;
+	box-shadow: 0 0 0 1px $blue-medium-focus;
 
 	// Windows High Contrast mode will show this outline, but not the box-shadow.
 	outline: 2px solid transparent;

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -40,7 +40,8 @@
 			border-color: #999;
 			box-shadow:
 				inset 0 -1px 0 #999,
-				0 0 0 2px $blue-medium-200;
+				0 0 0 1px $white,
+				0 0 0 3px $blue-medium-focus;
 			text-decoration: none;
 
 		}
@@ -88,7 +89,8 @@
 		&:focus:enabled {
 			box-shadow:
 				inset 0 -1px 0 color(theme(button) shade(50%)),
-				0 0 0 2px $blue-medium-200;
+				0 0 0 1px $white,
+				0 0 0 3px $blue-medium-focus;
 		}
 
 		&:active:enabled {

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -50,6 +50,11 @@
 	.DayPickerNavigation_button__horizontalDefault {
 		padding: 2px 8px;
 		top: 20px;
+
+		&:focus {
+			border-color: $blue-medium-focus;
+			box-shadow: 0 0 0 1px $blue-medium-focus;
+		}
 	}
 
 	.DayPicker_weekHeader {

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -99,6 +99,12 @@
 			border-radius: 0 3px 3px 0;
 		}
 
+		.components-datetime__time-am-button:focus,
+		.components-datetime__time-pm-button:focus {
+			position: relative;
+			z-index: 1;
+		}
+
 		.components-datetime__time-am-button.is-toggled,
 		.components-datetime__time-pm-button.is-toggled {
 			background: $light-gray-300;


### PR DESCRIPTION
In order to fix my Pull Request [#15535](https://github.com/WordPress/gutenberg/pull/15535)

Fixes #15432 & fixes #15325

## Description
Fix low contrast color when button or input are focus as mentioned in [#15432](https://github.com/WordPress/gutenberg/issues/15432) & [#15325](https://github.com/WordPress/gutenberg/issues/15325)
I choose `$blue-medium-focus` color for more consistency

## Screenshots
![localhost_8888_wp-admin_post php_post=1 action=edit (2)](https://user-images.githubusercontent.com/36343370/57475891-a37bbd80-7295-11e9-8e7c-8406699ba580.png)

![localhost_8888_wp-admin_post php_post=1 action=edit (3)](https://user-images.githubusercontent.com/36343370/57475897-a7a7db00-7295-11e9-9c97-a715abaffcef.png)

![localhost_8888_wp-admin_post php_post=7 action=edit](https://user-images.githubusercontent.com/36343370/57488478-7f2ed980-72b3-11e9-9a47-38c4b27e557a.png)

