### PR TITLE
Fix: Use block-editor instead of editor in cover block.

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -28,7 +28,7 @@ import {
 	MediaUploadCheck,
 	PanelColorSettings,
 	withColors,
-} from '@wordpress/editor';
+} from '@wordpress/block-editor';
 import { Component, createRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 


### PR DESCRIPTION
## Description
These dependencies should have been updated. Blocks should not use the editor dependency directly as for example in the widget screen and the playground editor will not be available. 

## How has this been tested?
I did some smoke testing in the cover block.
I pasted the following code:
```
const {
	BlockControls,
	BlockIcon,
	InnerBlocks,
	InspectorControls,
	MediaPlaceholder,
	MediaUpload,
	MediaUploadCheck,
	PanelColorSettings,
	withColors,
} = wp.blockEditor;
const ok = {
	BlockControls,
	BlockIcon,
	InnerBlocks,
	InspectorControls,
	MediaPlaceholder,
	MediaUpload,
	MediaUploadCheck,
	PanelColorSettings,
	withColors,
};
ok;
```
I verified that all properties are defined.

