### PR TITLE
Block library: refactor edit components in Legacy Widget block

### DIFF
--- a/packages/block-library/src/legacy-widget/edit/dom-manager.js
+++ b/packages/block-library/src/legacy-widget/edit/dom-manager.js
@@ -9,7 +9,7 @@ import { includes } from 'lodash';
 import { Component, createRef } from '@wordpress/element';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 
-class WidgetEditDomManager extends Component {
+class LegacyWidgetEditDomManager extends Component {
 	constructor() {
 		super( ...arguments );
 
@@ -139,5 +139,5 @@ class WidgetEditDomManager extends Component {
 	}
 }
 
-export default WidgetEditDomManager;
+export default LegacyWidgetEditDomManager;
 

--- a/packages/block-library/src/legacy-widget/edit/handler.js
+++ b/packages/block-library/src/legacy-widget/edit/handler.js
@@ -9,9 +9,9 @@ import { withInstanceId } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import WidgetEditDomManager from './WidgetEditDomManager';
+import LegacyWidgetEditDomManager from './dom-manager';
 
-class WidgetEditHandler extends Component {
+class LegacyWidgetEditHandler extends Component {
 	constructor() {
 		super( ...arguments );
 		this.state = {
@@ -64,7 +64,7 @@ class WidgetEditHandler extends Component {
 					display: this.props.isVisible ? 'block' : 'none',
 				} }
 			>
-				<WidgetEditDomManager
+				<LegacyWidgetEditDomManager
 					ref={ ( ref ) => {
 						this.widgetEditDomManagerRef = ref;
 					} }
@@ -118,5 +118,5 @@ class WidgetEditHandler extends Component {
 	}
 }
 
-export default withInstanceId( WidgetEditHandler );
+export default withInstanceId( LegacyWidgetEditHandler );
 

--- a/packages/block-library/src/legacy-widget/edit/index.js
+++ b/packages/block-library/src/legacy-widget/edit/index.js
@@ -17,18 +17,17 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { withSelect } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
 import {
 	BlockControls,
 	BlockIcon,
 	InspectorControls,
-	ServerSideRender,
-} from '@wordpress/editor';
+} from '@wordpress/block-editor';
+import { ServerSideRender } from '@wordpress/editor';
 
-import WidgetEditHandler from './WidgetEditHandler';
+/**
+ * Internal dependencies
+ */
+import LegacyWidgetEditHandler from './handler';
 
 class LegacyWidgetEdit extends Component {
 	constructor() {
@@ -136,7 +135,7 @@ class LegacyWidgetEdit extends Component {
 				</BlockControls>
 				{ inspectorControls }
 				{ ! isCallbackWidget && (
-					<WidgetEditHandler
+					<LegacyWidgetEditHandler
 						isVisible={ ! isPreview }
 						identifier={ attributes.identifier }
 						instance={ attributes.instance }


### PR DESCRIPTION
## Description
Addressed my own comment in https://github.com/WordPress/gutenberg/pull/15547#issuecomment-491202401:

> This might need to be updated as well:
https://github.com/WordPress/gutenberg/blob/master/packages/block-library/src/legacy-widget/edit.js#L21-L29

In addition, I noticed that some names of files don't follow the coding styles so I fixed them by moving all `edit` components in their own subfolder.

## Testing

Insert Legacy Widget block and make sure it works properly.