### PR TITLE
Add experimental indication to name and description of block area cpt

### DIFF
--- a/lib/widgets.php
+++ b/lib/widgets.php
@@ -134,9 +134,10 @@ function gutenberg_create_wp_area_post_type() {
 	register_post_type(
 		'wp_area',
 		array(
+			'description'  => __( 'Experimental custom post type that will store block areas referenced by themes.', 'gutenberg' ),
 			'labels'       => array(
-				'name'                     => _x( 'Block Area', 'post type general name', 'gutenberg' ),
-				'singular_name'            => _x( 'Block Area', 'post type singular name', 'gutenberg' ),
+				'name'                     => _x( 'Block Area (Experimental)', 'post type general name', 'gutenberg' ),
+				'singular_name'            => _x( 'Block Area (Experimental)', 'post type singular name', 'gutenberg' ),
 				'menu_name'                => _x( 'Block Areas', 'admin menu', 'gutenberg' ),
 				'name_admin_bar'           => _x( 'Block Area', 'add new on admin bar', 'gutenberg' ),
 				'add_new'                  => _x( 'Add New', 'Block', 'gutenberg' ),


### PR DESCRIPTION
## Description
This is a very simple PR that just adds experimental indication to name and description of block area custom post type.
The CPT already contained experimental indication on the rest base, but these changes give more awareness to the experimental nature.

The CPT is not yet used, so the change should not have practical implications.

