### PR TITLE
Fix id attribute to match aria-owns attribute

### DIFF
--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -226,6 +226,10 @@ class URLInput extends Component {
 	render() {
 		const { value = '', autoFocus = true, instanceId, className } = this.props;
 		const { showSuggestions, suggestions, selectedSuggestion, loading } = this.state;
+
+		const suggestionsListboxId = `block-editor-url-input-suggestions-${ instanceId }`;
+		const suggestionOptionIdPrefix = `block-editor-url-input-suggestion-${ instanceId }`;
+
 		/* eslint-disable jsx-a11y/no-autofocus */
 		return (
 			<div className={ classnames( 'editor-url-input block-editor-url-input', className ) }>
@@ -242,8 +246,8 @@ class URLInput extends Component {
 					role="combobox"
 					aria-expanded={ showSuggestions }
 					aria-autocomplete="list"
-					aria-owns={ `block-editor-url-input-suggestions-${ instanceId }` }
-					aria-activedescendant={ selectedSuggestion !== null ? `block-editor-url-input-suggestion-${ instanceId }-${ selectedSuggestion }` : undefined }
+					aria-owns={ suggestionsListboxId }
+					aria-activedescendant={ selectedSuggestion !== null ? `${ suggestionOptionIdPrefix }-${ selectedSuggestion }` : undefined }
 					ref={ this.inputRef }
 				/>
 
@@ -253,7 +257,7 @@ class URLInput extends Component {
 					<Popover position="bottom" noArrow focusOnMount={ false }>
 						<div
 							className="editor-url-input__suggestions block-editor-url-input__suggestions"
-							id={ `block-editor-url-input-suggestions-${ instanceId }` }
+							id={ suggestionsListboxId }
 							ref={ this.autocompleteRef }
 							role="listbox"
 						>
@@ -262,7 +266,7 @@ class URLInput extends Component {
 									key={ suggestion.id }
 									role="option"
 									tabIndex="-1"
-									id={ `block-editor-url-input-suggestion-${ instanceId }-${ index }` }
+									id={ `${ suggestionOptionIdPrefix }-${ index }` }
 									ref={ this.bindSuggestionNode( index ) }
 									className={ classnames( 'editor-url-input__suggestion block-editor-url-input__suggestion', {
 										'is-selected': index === selectedSuggestion,

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -253,7 +253,7 @@ class URLInput extends Component {
 					<Popover position="bottom" noArrow focusOnMount={ false }>
 						<div
 							className="editor-url-input__suggestions block-editor-url-input__suggestions"
-							id={ `editor-url-input-suggestions-${ instanceId }` }
+							id={ `block-editor-url-input-suggestions-${ instanceId }` }
 							ref={ this.autocompleteRef }
 							role="listbox"
 						>


### PR DESCRIPTION
## Description

In https://github.com/WordPress/gutenberg/pull/14420, class names were changed from `editor` to `block-editor`. In that pull request,

```jsx
aria-owns={ `editor-url-input-suggestions-${ instanceId }` }
```

has been changed to

```jsx
aria-owns={ `block-editor-url-input-suggestions-${ instanceId }` }
```

But the matching `id` attribute wasn’t changed. This pull request fixes that.

## How has this been tested?

I ran tests with `npm run test-unit` and `npm run test-e2e`. I also tested by checking the attributes in the browser console.

I didn’t test this with any screen reader software. Maybe someone from the accessibility team wants to look at this.

## Types of changes

Accessibility bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
