### PR TITLE
Experiment with the toolbar pattern

### DIFF
--- a/packages/components/src/dropdown-menu/index.js
+++ b/packages/components/src/dropdown-menu/index.js
@@ -57,6 +57,7 @@ function DropdownMenu( {
 						aria-expanded={ isOpen }
 						label={ label }
 						tooltip={ label }
+						tabIndex={ -1 }
 					>
 						<span className="components-dropdown-menu__indicator" />
 					</IconButton>

--- a/packages/components/src/toolbar-button/index.js
+++ b/packages/components/src/toolbar-button/index.js
@@ -40,6 +40,7 @@ function ToolbarButton( {
 				) }
 				aria-pressed={ isActive }
 				disabled={ isDisabled }
+				tabIndex={ -1 }
 				{ ...extraProps }
 			/>
 			{ children }

--- a/packages/components/src/toolbar/toolbar-container.js
+++ b/packages/components/src/toolbar/toolbar-container.js
@@ -1,5 +1,5 @@
 const ToolbarContainer = ( props ) => (
-	<div className={ props.className }>
+	<div className={ props.className } role="toolbar">
 		{ props.children }
 	</div>
 );


### PR DESCRIPTION
Closes #15331.

This a proof of concept to reduce the number of tab stops to navigate through the app with the keyboard.

It proposes to adopt the WAI ARIA's [toolbar pattern](https://www.w3.org/TR/wai-aria-practices-1.1/#toolbar) ([see example](https://www.w3.org/TR/wai-aria-practices-1.1/examples/toolbar/toolbar.html)) to move through the block toolbar (could be extended to other parts of the app):

![Peek 2019-05-10 19-07](https://user-images.githubusercontent.com/583546/57544363-6677ff80-7357-11e9-9f11-2176bd786550.gif)

The GIF doesn't really does justice, but the fundamental idea is that:

* TAB and TAB+SHIFT move focus in and out the toolbar.
* Arrow keys are used to navigate within the toolbar.

Please, understand that this a Proof Of Concept: it's buggy and by no means is ready code-wise. Wanted to share early to gather feedback on the direction: is this something we'd want?