### PR TITLE
Add text warning about usability when autoplay is selected 

### DIFF
--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -98,6 +98,10 @@ class AudioEdit extends Component {
 		this.setState( { editing: false } );
 	}
 
+	getAutoplayHelp( checked ) {
+		return checked ? __( 'Note: Autoplaying audio may cause usability issues for some visitors.' ) : null;
+	}
+
 	render() {
 		const { autoplay, caption, loop, preload, src } = this.props.attributes;
 		const { setAttributes, isSelected, className, noticeOperations, noticeUI } = this.props;
@@ -153,6 +157,7 @@ class AudioEdit extends Component {
 							label={ __( 'Autoplay' ) }
 							onChange={ this.toggleAttribute( 'autoplay' ) }
 							checked={ autoplay }
+							help={ this.getAutoplayHelp }
 						/>
 						<ToggleControl
 							label={ __( 'Loop' ) }

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -126,6 +126,10 @@ class VideoEdit extends Component {
 		this.posterImageButton.current.focus();
 	}
 
+	getAutoplayHelp( checked ) {
+		return checked ? __( 'Note: Autoplaying videos may cause usability issues for some visitors.' ) : null;
+	}
+
 	render() {
 		const {
 			autoplay,
@@ -200,6 +204,7 @@ class VideoEdit extends Component {
 							label={ __( 'Autoplay' ) }
 							onChange={ this.toggleAttribute( 'autoplay' ) }
 							checked={ autoplay }
+							help={ this.getAutoplayHelp }
 						/>
 						<ToggleControl
 							label={ __( 'Loop' ) }


### PR DESCRIPTION
## Description
Add the following as help text on the toggles for autoplay for both audio and video blocks:
"Note: Autoplaying [media type] may cause usability issues for some visitors."

Fixes #13550
 
## How has this been tested?
Added an audio block and video block
Toggle autoplay and see that the appropriate text is displayed when it is toggled

## Screenshots
![JxHXwG76ct](https://user-images.githubusercontent.com/6653970/57554162-b4ccd480-733e-11e9-85de-d06e7509284a.gif)
(Note: screenshot has a typo in video message that has been fixed)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
