### PR TITLE
Fix Safari Linking: Check for selection range count before calling getRangeAt

### DIFF
--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -79,7 +79,8 @@ const LinkViewerUrl = ( { url } ) => {
 
 const URLPopoverAtLink = ( { isActive, addingLink, value, ...props } ) => {
 	const anchorRect = useMemo( () => {
-		const range = window.getSelection().getRangeAt( 0 );
+		const selection = window.getSelection();
+		const range = selection.rangeCount > 0 ? selection.getRangeAt( 0 ) : null;
 		if ( ! range ) {
 			return;
 		}


### PR DESCRIPTION
Calling `window.getSelection.getRangeAt(0)` is unsafe without first checking for `selection.rangeCount > 0`. In certain situations this can cause unexpected block errors like the gif below. This is most easily reproducible in Safari, but will be inconsistent.

To attempt to reproduce:
1. Add a new link
2. Focus on another paragraph
3. Focus on the original paragraph, or on the link directly

See also related: https://github.com/Automattic/wp-calypso/issues/32965 and https://github.com/WordPress/gutenberg/pull/11209 and potentially https://github.com/WordPress/gutenberg/issues/15491

Before:
![May-10-2019 14-49-33](https://user-images.githubusercontent.com/1270189/57560164-e5f6d600-7339-11e9-8354-a079e686a4f1.gif)

See https://stackoverflow.com/questions/22935320/uncaught-indexsizeerror-failed-to-execute-getrangeat-on-selection-0-is-not/23699875 for a short example of the `window.getSelection.getRangeAt(0)` issue.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
