### PR TITLE
Resolve block modal: make the columns have the same content space

### DIFF
--- a/packages/block-editor/src/components/block-compare/style.scss
+++ b/packages/block-editor/src/components/block-compare/style.scss
@@ -32,6 +32,7 @@
 	.block-editor-block-compare__converted {
 		border-left: 1px solid #ddd;
 		padding-left: 15px;
+		padding-right: 0;
 	}
 
 	.block-editor-block-compare__html {


### PR DESCRIPTION
## Description
The purpose is to make both column content space same on "Resolve block" modal. Cause it is for show a visual deference to user before and after resolving  block. So, line to line with same content should be accurate on view of both side to compare. This is the solve of this issue - #15235 

## How has this been tested?
It has been build and tested on WordPress locally by using xampp localhost

## Screenshots 
**Before:**
![before](https://user-images.githubusercontent.com/5968192/57568665-874e5c80-740c-11e9-857d-124006eb60f9.png)
**After**
![after](https://user-images.githubusercontent.com/5968192/57568664-86b5c600-740c-11e9-85c8-e530033503df.png)




## Types of changes
CSS only change on .scss 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
