### PR TITLE
Accessibility: Fixed focus state of pressed AM/PM buttons.

### DIFF
--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -110,6 +110,12 @@
 			background: $light-gray-300;
 			border-color: $dark-gray-100;
 			box-shadow: inset 0 2px 5px -3px $dark-gray-500;
+			&:focus {
+				box-shadow:
+					inset 0 2px 5px -3px $dark-gray-500,
+					0 0 0 1px $white,
+					0 0 0 3px $blue-medium-focus;
+			}
 		}
 
 		.components-datetime__time-field {


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/15325#issuecomment-491263295

## Screencast
![Peek 2019-05-11 16-53](https://user-images.githubusercontent.com/1477453/57570720-cf21b380-740d-11e9-9b04-dcf886b8ce19.gif)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
