### PR TITLE
Include icon in documentation for MediaPlaceholder

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/README.md
+++ b/packages/block-editor/src/components/media-placeholder/README.md
@@ -67,9 +67,9 @@ Class name added to the placeholder.
 
 ### icon
 
-Dashicon to display left of the title.
+Icon to display left of the title. When passed as a `String`, the icon will be resolved as a [Dashicon](https://developer.wordpress.org/resource/dashicons/). Alternatively, you can pass in a `WPComponent` such as `BlockIcon`to render instead.
 
-- Type: `String`
+- Type: `String|WPComponent`
 - Required: No
 
 ### isAppender

--- a/packages/block-editor/src/components/media-placeholder/README.md
+++ b/packages/block-editor/src/components/media-placeholder/README.md
@@ -65,6 +65,13 @@ Class name added to the placeholder.
 - Type: `String`
 - Required: No
 
+### icon
+
+Dashicon to display left of the title.
+
+- Type: `String`
+- Required: No
+
 ### isAppender
 
 If true, the property changes the look of the placeholder to be adequate to scenarios where new files are added to an already existing set of files, e.g., adding files to a gallery.


### PR DESCRIPTION
## Description
Just adds `icon` to the `README`.

## How has this been tested?
N/A

## Screenshots
N/A

## Types of changes
Simple README tweak.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
