### PR TITLE
Fix broken active state on formatting buttons

### DIFF
--- a/packages/components/src/toolbar-button/style.scss
+++ b/packages/components/src/toolbar-button/style.scss
@@ -10,7 +10,7 @@
 	height: $icon-button-size;
 
 	// Unset icon button styles
-	&:active,
+	&:not([aria-disabled="true"]):not(.is-default):active,
 	&:not([aria-disabled="true"]):hover,
 	&:not([aria-disabled="true"]):focus {
 		outline: none;


### PR DESCRIPTION
At some point recently a small regression was introduced to the formatting button styles where the `:active` state box shadow that is inherited from the IconButton component lingered. To reproduce in master, click and drag out while holding the mouse button down on a formatting button and note a gray box shadow lingering. This PR fixes that.

I'm unsure as to how the regression was introduced, but it was likely due to the rather long selectors the IconButton component uses, which would be good to refactor.

Before:

<img width="465" alt="Screenshot 2019-05-13 at 11 51 33" src="https://user-images.githubusercontent.com/1204802/57612625-79681b00-7575-11e9-8e25-0b096f5257d3.png">

After:

<img width="425" alt="Screenshot 2019-05-13 at 11 45 26" src="https://user-images.githubusercontent.com/1204802/57612494-3d34ba80-7575-11e9-9e82-d7f02795a68b.png">
