### PR TITLE
Support replacing multiple custom template tags in one output path.

### DIFF
--- a/packages/custom-templated-path-webpack-plugin/CHANGELOG.md
+++ b/packages/custom-templated-path-webpack-plugin/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes
+
+- Resolved an issue where only the value of the first matched tag would be produced.
+
 ## 1.1.0 (2018-07-12)
 
 ### Internal

--- a/packages/custom-templated-path-webpack-plugin/src/index.js
+++ b/packages/custom-templated-path-webpack-plugin/src/index.js
@@ -39,7 +39,7 @@ class CustomTemplatedPathPlugin {
 				for ( let i = 0; i < this.handlers.length; i++ ) {
 					const [ regexp, handler ] = this.handlers[ i ];
 					if ( regexp.test( path ) ) {
-						return path.replace( regexp, handler( path, data ) );
+						path = path.replace( regexp, handler( path, data ) );
 					}
 				}
 

--- a/packages/custom-templated-path-webpack-plugin/test/fixtures/webpack.config.js
+++ b/packages/custom-templated-path-webpack-plugin/test/fixtures/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = {
 	context: __dirname,
 	entry: './entry',
 	output: {
-		filename: 'build/[basename].js',
+		filename: 'build/[basename]-[theanswertolife].js',
 		path: __dirname,
 	},
 	plugins: [
@@ -31,6 +31,9 @@ module.exports = {
 				}
 
 				return path;
+			},
+			theanswertolife() {
+				return 42;
 			},
 		} ),
 	],

--- a/packages/custom-templated-path-webpack-plugin/test/index.js
+++ b/packages/custom-templated-path-webpack-plugin/test/index.js
@@ -19,7 +19,7 @@ const unlinkAsync = promisify( unlink );
 const webpackAsync = promisify( webpack );
 
 describe( 'CustomTemplatedPathPlugin', () => {
-	const outputFile = path.join( __dirname, '/fixtures/build/entry.js' );
+	const outputFile = path.join( __dirname, '/fixtures/build/entry-42.js' );
 
 	beforeAll( async () => {
 		// Remove output file so as not to report false positive from previous


### PR DESCRIPTION
Fixes #15567

## Description
Instead of returning after the first template match, continue looping and just update the `path` variable. 

## How has this been tested?
I've tested the change in my project and it works as expected.

I really have no idea how to unit test this.

## Types of changes
Bug Fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
