### PR TITLE
Input Interaction: set caret correctly on merge forward (Delete)

### DIFF
--- a/packages/block-editor/src/store/effects.js
+++ b/packages/block-editor/src/store/effects.js
@@ -70,8 +70,8 @@ export default {
 	MERGE_BLOCKS( action, store ) {
 		const { dispatch } = store;
 		const state = store.getState();
-		const [ firstBlockClientId, secondBlockClientId ] = action.blocks;
-		const blockA = getBlock( state, firstBlockClientId );
+		const [ clientIdA, clientIdB ] = action.blocks;
+		const blockA = getBlock( state, clientIdA );
 		const blockAType = getBlockType( blockA.name );
 
 		// Only focus the previous block if it's not mergeable
@@ -80,27 +80,33 @@ export default {
 			return;
 		}
 
-		// We can only merge blocks with similar types
-		// thus, we transform the block to merge first
-		const blockB = getBlock( state, secondBlockClientId );
+		const blockB = getBlock( state, clientIdB );
 		const blockBType = getBlockType( blockB.name );
+		const { clientId, attributeKey, offset } = getSelectionStart( state );
+		const hasSelection = clientId === clientIdA || clientId === clientIdB;
 
 		// A robust way to retain selection position through various transforms
 		// is to insert a special character at the position and then recover it.
 		const START_OF_SELECTED_AREA = '\u0086';
-		const { attributeKey, offset } = getSelectionStart( state );
-		const html = blockB.attributes[ attributeKey ];
-		const multilineTagB = blockBType.attributes[ attributeKey ].multiline;
-		const value = insert( create( {
-			html,
-			multilineTag: multilineTagB,
-		} ), START_OF_SELECTED_AREA, offset, offset );
 
-		blockB.attributes[ attributeKey ] = toHTMLString( {
-			value,
-			multilineTag: multilineTagB,
-		} );
+		if ( hasSelection ) {
+			const selectedBlock = clientId === clientIdA ? blockA : blockB;
+			const selectedBlockType = clientId === clientIdA ? blockAType : blockBType;
+			const html = selectedBlock.attributes[ attributeKey ];
+			const multilineTag = selectedBlockType.attributes[ attributeKey ].multiline;
+			const value = insert( create( {
+				html,
+				multilineTag,
+			} ), START_OF_SELECTED_AREA, offset, offset );
 
+			selectedBlock.attributes[ attributeKey ] = toHTMLString( {
+				value,
+				multilineTag,
+			} );
+		}
+
+		// We can only merge blocks with similar types
+		// thus, we transform the block to merge first
 		const blocksWithTheSameType = blockA.name === blockB.name ?
 			[ blockB ] :
 			switchToBlockType( blockB, blockA.name );
@@ -116,24 +122,26 @@ export default {
 			blocksWithTheSameType[ 0 ].attributes
 		);
 
-		const newAttributeKey = findKey( updatedAttributes, ( v ) =>
-			typeof v === 'string' && v.indexOf( START_OF_SELECTED_AREA ) !== -1
-		);
-		const convertedHtml = updatedAttributes[ newAttributeKey ];
-		const multilineTagA = blockAType.attributes[ newAttributeKey ].multiline;
-		const convertedValue = create( { html: convertedHtml, multilineTag: multilineTagA } );
-		const newOffset = convertedValue.text.indexOf( START_OF_SELECTED_AREA );
-		const newValue = remove( convertedValue, newOffset, newOffset + 1 );
-		const newHtml = toHTMLString( { value: newValue, multilineTag: multilineTagA } );
+		if ( hasSelection ) {
+			const newAttributeKey = findKey( updatedAttributes, ( v ) =>
+				typeof v === 'string' && v.indexOf( START_OF_SELECTED_AREA ) !== -1
+			);
+			const convertedHtml = updatedAttributes[ newAttributeKey ];
+			const multilineTag = blockAType.attributes[ newAttributeKey ].multiline;
+			const convertedValue = create( { html: convertedHtml, multilineTag } );
+			const newOffset = convertedValue.text.indexOf( START_OF_SELECTED_AREA );
+			const newValue = remove( convertedValue, newOffset, newOffset + 1 );
+			const newHtml = toHTMLString( { value: newValue, multilineTag } );
 
-		updatedAttributes[ newAttributeKey ] = newHtml;
+			updatedAttributes[ newAttributeKey ] = newHtml;
 
-		dispatch( selectionChange(
-			blockA.clientId,
-			newAttributeKey,
-			newOffset,
-			newOffset
-		) );
+			dispatch( selectionChange(
+				blockA.clientId,
+				newAttributeKey,
+				newOffset,
+				newOffset
+			) );
+		}
 
 		dispatch( replaceBlocks(
 			[ blockA.clientId, blockB.clientId ],

--- a/packages/block-editor/src/store/effects.js
+++ b/packages/block-editor/src/store/effects.js
@@ -84,15 +84,15 @@ export default {
 		const blockBType = getBlockType( blockB.name );
 		const { clientId, attributeKey, offset } = getSelectionStart( state );
 		const hasSelection = clientId === clientIdA || clientId === clientIdB;
+		const selectedBlock = clientId === clientIdA ? blockA : blockB;
+		const html = selectedBlock.attributes[ attributeKey ];
 
 		// A robust way to retain selection position through various transforms
 		// is to insert a special character at the position and then recover it.
 		const START_OF_SELECTED_AREA = '\u0086';
 
 		if ( hasSelection ) {
-			const selectedBlock = clientId === clientIdA ? blockA : blockB;
 			const selectedBlockType = clientId === clientIdA ? blockAType : blockBType;
-			const html = selectedBlock.attributes[ attributeKey ];
 			const multilineTag = selectedBlockType.attributes[ attributeKey ].multiline;
 			const value = insert( create( {
 				html,
@@ -134,6 +134,7 @@ export default {
 			const newHtml = toHTMLString( { value: newValue, multilineTag } );
 
 			updatedAttributes[ newAttributeKey ] = newHtml;
+			selectedBlock.attributes[ attributeKey ] = html;
 
 			dispatch( selectionChange(
 				blockA.clientId,

--- a/packages/e2e-tests/specs/__snapshots__/writing-flow.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/writing-flow.test.js.snap
@@ -100,6 +100,12 @@ exports[`adding blocks should insert line break mid text 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`adding blocks should merge forwards 1`] = `
+"<!-- wp:paragraph -->
+<p>123</p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`adding blocks should navigate around inline boundaries 1`] = `
 "<!-- wp:paragraph -->
 <p>FirstAfter</p>

--- a/packages/e2e-tests/specs/writing-flow.test.js
+++ b/packages/e2e-tests/specs/writing-flow.test.js
@@ -342,4 +342,16 @@ describe( 'adding blocks', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should merge forwards', async () => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '3' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'Delete' );
+		await page.keyboard.type( '2' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );


### PR DESCRIPTION
## Description

Probably regressed in #14640. The problem is that we are just assuming that the caret is in block B when merging blocks, while it could be in either. I updated the code to look which block is selected.

## How has this been tested?

Merge two paragraph blocks with the `Delete` key (or `Fn+Delete` for Mac). Caret should be at merge point.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
