### PR TITLE
Accessibility: Fixed links as buttons focus state.

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -173,7 +173,7 @@
 		opacity: 0.3;
 	}
 
-	&:focus:enabled {
+	&:focus:not(:disabled) {
 		@include button-style__focus-active;
 	}
 


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/13267

## How has this been tested?

> To reproduce:
> 
> - use a keyboard
> - tab to the "Preview" button (it's a link)
> - in Chrome, there's a subtle focus style
> - in Firefox, Safari, Edge, IE11 there's no focus style

It should work properly from now on.

## Types of changes
Changed `&:focus:enabled` to `&:focus:not(:disabled)`.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
