### PR TITLE
Writing Flow: Compute caret DOMRect on-demand for vertical traversal

### DIFF
--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -78,25 +78,11 @@ class WritingFlow extends Component {
 
 		this.onKeyDown = this.onKeyDown.bind( this );
 		this.bindContainer = this.bindContainer.bind( this );
-		this.clearVerticalRect = this.clearVerticalRect.bind( this );
 		this.focusLastTextField = this.focusLastTextField.bind( this );
-
-		/**
-		 * Here a rectangle is stored while moving the caret vertically so
-		 * vertical position of the start position can be restored.
-		 * This is to recreate browser behaviour across blocks.
-		 *
-		 * @type {?DOMRect}
-		 */
-		this.verticalRect = null;
 	}
 
 	bindContainer( ref ) {
 		this.container = ref;
-	}
-
-	clearVerticalRect() {
-		this.verticalRect = null;
 	}
 
 	/**
@@ -281,12 +267,6 @@ class WritingFlow extends Component {
 			return;
 		}
 
-		if ( ! isVertical ) {
-			this.verticalRect = null;
-		} else if ( ! this.verticalRect ) {
-			this.verticalRect = computeCaretRect();
-		}
-
 		if ( isShift ) {
 			if (
 				(
@@ -313,7 +293,7 @@ class WritingFlow extends Component {
 			const closestTabbable = this.getClosestTabbable( target, isReverse );
 
 			if ( closestTabbable ) {
-				placeCaretAtVerticalEdge( closestTabbable, isReverse, this.verticalRect );
+				placeCaretAtVerticalEdge( closestTabbable, isReverse, computeCaretRect() );
 				event.preventDefault();
 			}
 		} else if ( isHorizontal && getSelection().isCollapsed && isHorizontalEdge( target, isReverse ) ) {
@@ -345,7 +325,6 @@ class WritingFlow extends Component {
 				<div
 					ref={ this.bindContainer }
 					onKeyDown={ this.onKeyDown }
-					onMouseDown={ this.clearVerticalRect }
 				>
 					{ children }
 				</div>

--- a/packages/e2e-tests/specs/__snapshots__/writing-flow.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/writing-flow.test.js.snap
@@ -197,3 +197,13 @@ exports[`adding blocks should not prematurely multi-select 1`] = `
 <p>></p>
 <!-- /wp:paragraph -->"
 `;
+
+exports[`adding blocks should preserve horizontal position when navigating vertically between blocks 1`] = `
+"<!-- wp:paragraph -->
+<p>abc</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>123</p>
+<!-- /wp:paragraph -->"
+`;

--- a/packages/e2e-tests/specs/writing-flow.test.js
+++ b/packages/e2e-tests/specs/writing-flow.test.js
@@ -355,4 +355,18 @@ describe( 'adding blocks', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should preserve horizontal position when navigating vertically between blocks', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'abc' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '23' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.type( '1' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );


### PR DESCRIPTION
Fixes #15604
Regression of #13697

This pull request seeks to resolve an issue where, when vertically navigating between paragraphs using <kbd>ArrowUp</kbd>, <kbd>ArrowDown</kbd>, the caret does not always land where would be expected to preserve its horizontal position.

**Implementation notes:**

See exhaustive debugging detail at https://github.com/WordPress/gutenberg/issues/15604#issuecomment-491938545.

**Testing instructions:**

Repeat Steps to Reproduce from #15604, verifying expected result.

Ensure end-to-end tests pass:

```
npm run build && npm run test-e2e packages/e2e-tests/specs/writing-flow.test.js
```

Verify ArrowUp, ArrowDown vertical traversal works generally well in a variety of circumstances.