### PR TITLE
Fix pinned plugins button styles when toggled.

### DIFF
--- a/packages/edit-post/src/components/header/pinned-plugins/style.scss
+++ b/packages/edit-post/src/components/header/pinned-plugins/style.scss
@@ -7,6 +7,10 @@
 
 	.components-icon-button {
 		margin-left: 4px;
+
+		&.is-toggled {
+			margin-left: 5px;
+		}
 	}
 
 	// Colorize plugin icons to ensure contrast and cohesion, but allow plugin developers to override.
@@ -19,7 +23,9 @@
 
 	// Forcefully colorize hover and toggled plugin icon states to ensure legibility and consistency.
 	.components-icon-button.is-toggled svg,
-	.components-icon-button.is-toggled svg * {
+	.components-icon-button.is-toggled svg *,
+	.components-icon-button.is-toggled:hover svg,
+	.components-icon-button.is-toggled:hover svg * {
 		stroke: $white !important;
 		fill: $white !important;
 		stroke-width: 0; // !important is omitted here, so stroke-only icons can override easily.


### PR DESCRIPTION
## Description

Fixes the Pinned Plugins button styles when the button is toggled

Please see #15608 for details on the issue and steps to reproduce.

Animated GIF to illustrate the current state of the Pinned Plugins button on master:

![toggle](https://user-images.githubusercontent.com/1682452/57647267-c7efd680-75c2-11e9-8444-cb75c1bd132e.gif)

On this branch, the Pinned Plugins button styles should look the same as the Settings button.

Fixes #15608



