### PR TITLE
Docs: Clarify migrate in deprecated blocks

### DIFF
--- a/docs/designers-developers/developers/block-api/block-deprecation.md
+++ b/docs/designers-developers/developers/block-api/block-deprecation.md
@@ -12,7 +12,7 @@ Deprecations are defined on a block type as its `deprecated` property, an array 
 - `attributes` (Object): The [attributes definition](/docs/designers-developers/developers/block-api/block-attributes.md) of the deprecated form of the block.
 - `support` (Object): The [supports definition](/docs/designers-developers/developers/block-api/block-registration.md) of the deprecated form of the block.
 - `save` (Function): The [save implementation](/docs/designers-developers/developers/block-api/block-edit-save.md) of the deprecated form of the block.
-- `migrate` (Function, Optional): A function which, given the attributes and inner blocks of the parsed block, is expected to return either the attributes compatible with the deprecated block, or a tuple array of `[ attributes, innerBlocks ]`.
+- `migrate` (Function, Optional): A function which, given the old attributes and inner blocks is expected to return either the new attributes or a tuple array of `[ attributes, innerBlocks ]` compatible with the block.
 - `isEligible` (Function, Optional): A function which, given the attributes and inner blocks of the parsed block, returns true if the deprecation can handle the block migration. This is particularly useful in cases where a block is technically valid even once deprecated, and requires updates to its attributes or inner blocks.
 
 It's important to note that `attributes`, `support`, and `save` are not automatically inherited from the current version, since they can impact parsing and serialization of a block, so they must be defined on the deprecated object in order to be processed during a migration.


### PR DESCRIPTION
## Description

The wording in migrate was confusing around which attributes should be
supplied and returned. Added old/new to clarify the old attributes are
passed in, and new attributes are returned.

Confirmed this with the code, which you can see in the test here:
https://github.com/WordPress/gutenberg/blob/master/packages/blocks/src/api/test/parser.js#L558

Fixes #15111

## Types of changes

Documentation. [View on branch here](https://github.com/WordPress/gutenberg/blob/docs/15111/deprecated/docs/designers-developers/developers/block-api/block-deprecation.md).
