### PR TITLE
Update node-sass

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13784,12 +13784,6 @@
 			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
 			"dev": true
 		},
-		"lodash.assign": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-			"dev": true
-		},
 		"lodash.clone": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
@@ -13842,12 +13836,6 @@
 			"version": "4.6.1",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
 			"integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
-			"dev": true
-		},
-		"lodash.mergewith": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-			"integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
 			"dev": true
 		},
 		"lodash.set": {
@@ -14732,7 +14720,8 @@
 			"version": "2.10.0",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
 			"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -14923,9 +14912,9 @@
 			}
 		},
 		"node-sass": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.11.0.tgz",
-			"integrity": "sha512-bHUdHTphgQJZaF1LASx0kAviPH7sGlcyNhWade4eVIpFp6tsn7SV8xNMTbsQFpEV9VXpnwTTnNYlfsZXgGgmkA==",
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.12.0.tgz",
+			"integrity": "sha512-A1Iv4oN+Iel6EPv77/HddXErL2a+gZ4uBeZUy+a8O35CFYTXhgA8MgLCWBtwpGZdCvTvQ9d+bQxX/QC36GDPpQ==",
 			"dev": true,
 			"requires": {
 				"async-foreach": "^0.1.3",
@@ -14935,12 +14924,10 @@
 				"get-stdin": "^4.0.1",
 				"glob": "^7.0.3",
 				"in-publish": "^2.0.0",
-				"lodash.assign": "^4.2.0",
-				"lodash.clonedeep": "^4.3.2",
-				"lodash.mergewith": "^4.6.0",
+				"lodash": "^4.17.11",
 				"meow": "^3.7.0",
 				"mkdirp": "^0.5.1",
-				"nan": "^2.10.0",
+				"nan": "^2.13.2",
 				"node-gyp": "^3.8.0",
 				"npmlog": "^4.0.0",
 				"request": "^2.88.0",
@@ -15080,24 +15067,30 @@
 					}
 				},
 				"mime-db": {
-					"version": "1.38.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-					"integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
+					"version": "1.40.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+					"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
 					"dev": true
 				},
 				"mime-types": {
-					"version": "2.1.22",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
-					"integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+					"version": "2.1.24",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+					"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
 					"dev": true,
 					"requires": {
-						"mime-db": "~1.38.0"
+						"mime-db": "1.40.0"
 					}
 				},
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				},
+				"nan": {
+					"version": "2.13.2",
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+					"integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
 					"dev": true
 				},
 				"oauth-sign": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
 		"lint-staged": "8.1.5",
 		"lodash": "4.17.11",
 		"mkdirp": "0.5.1",
-		"node-sass": "4.11.0",
+		"node-sass": "4.12.0",
 		"node-watch": "0.6.0",
 		"parcel-bundler": "1.12.3",
 		"pegjs": "0.10.0",


### PR DESCRIPTION
Running `npm install` currently fails when running the latest version of Node (12.2.0 with NPM 6.9.0).

The repo currently requires ~4.11.0 of `node-sass`, but only `4.12+` [supports Node 12.2.0](https://www.npmjs.com/package/node-sass).