### PR TITLE
Fix: change block-level @link tag to @see tag

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -69,7 +69,7 @@ const { getSelection, getComputedStyle } = window;
 /**
  * All inserting input types that would insert HTML into the DOM.
  *
- * @see  https://www.w3.org/TR/input-events-2/#interface-InputEvent-Attributes
+ * @see https://www.w3.org/TR/input-events-2/#interface-InputEvent-Attributes
  *
  * @type {Set}
  */
@@ -547,7 +547,7 @@ export class RichText extends Component {
 	 * selection where caret is at directional edge: forward for a delete key,
 	 * reverse for a backspace key.
 	 *
-	 * @link https://en.wikipedia.org/wiki/Caret_navigation
+	 * @see https://en.wikipedia.org/wiki/Caret_navigation
 	 *
 	 * @param {KeyboardEvent} event Keydown event.
 	 */

--- a/packages/blocks/src/api/parser.js
+++ b/packages/blocks/src/api/parser.js
@@ -120,7 +120,7 @@ export function isOfTypes( value, types ) {
  * Returns true if value is valid per the given block attribute schema type
  * definition, or false otherwise.
  *
- * @link https://json-schema.org/latest/json-schema-validation.html#rfc.section.6.1.1
+ * @see https://json-schema.org/latest/json-schema-validation.html#rfc.section.6.1.1
  *
  * @param {*}                       value Value to test.
  * @param {?(Array<string>|string)} type  Block attribute schema type.
@@ -135,7 +135,7 @@ export function isValidByType( value, type ) {
  * Returns true if value is valid per the given block attribute schema enum
  * definition, or false otherwise.
  *
- * @link https://json-schema.org/latest/json-schema-validation.html#rfc.section.6.1.2
+ * @see https://json-schema.org/latest/json-schema-validation.html#rfc.section.6.1.2
  *
  * @param {*}      value   Value to test.
  * @param {?Array} enumSet Block attribute schema enum.

--- a/packages/blocks/src/api/validation.js
+++ b/packages/blocks/src/api/validation.js
@@ -170,8 +170,8 @@ const TEXT_NORMALIZATIONS = [
  * references.every( ( reference ) => /^[\da-z]+$/i.test( reference ) )
  * ```
  *
- * @link https://html.spec.whatwg.org/multipage/syntax.html#character-references
- * @link https://html.spec.whatwg.org/multipage/named-characters.html#named-character-references
+ * @see https://html.spec.whatwg.org/multipage/syntax.html#character-references
+ * @see https://html.spec.whatwg.org/multipage/named-characters.html#named-character-references
  *
  * @type {RegExp}
  */
@@ -183,7 +183,7 @@ const REGEXP_NAMED_CHARACTER_REFERENCE = /^[\da-z]+$/i;
  * "The ampersand must be followed by a U+0023 NUMBER SIGN character (#),
  * followed by one or more ASCII digits, representing a base-ten integer"
  *
- * @link https://html.spec.whatwg.org/multipage/syntax.html#character-references
+ * @see https://html.spec.whatwg.org/multipage/syntax.html#character-references
  *
  * @type {RegExp}
  */
@@ -197,7 +197,7 @@ const REGEXP_DECIMAL_CHARACTER_REFERENCE = /^#\d+$/;
  * U+0058 LATIN CAPITAL LETTER X character (X), which must then be followed by
  * one or more ASCII hex digits, representing a hexadecimal integer"
  *
- * @link https://html.spec.whatwg.org/multipage/syntax.html#character-references
+ * @see https://html.spec.whatwg.org/multipage/syntax.html#character-references
  *
  * @type {RegExp}
  */

--- a/packages/components/src/disabled/index.js
+++ b/packages/components/src/disabled/index.js
@@ -17,7 +17,7 @@ const { Consumer, Provider } = createContext( false );
  *
  * See WHATWG HTML Standard: 4.10.18.5: "Enabling and disabling form controls: the disabled attribute".
  *
- * @link https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#enabling-and-disabling-form-controls:-the-disabled-attribute
+ * @see https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#enabling-and-disabling-form-controls:-the-disabled-attribute
  *
  * @type {string[]}
  */

--- a/packages/docgen/src/test/fixtures/tags-function/code.js
+++ b/packages/docgen/src/test/fixtures/tags-function/code.js
@@ -5,7 +5,7 @@
  * @since v2
  *
  * @see addition
- * @link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators
  *
  * @param {number} firstParam The first param to add.
  * @param {number} secondParam The second param to add.

--- a/packages/e2e-test-utils/src/press-key-with-modifier.js
+++ b/packages/e2e-test-utils/src/press-key-with-modifier.js
@@ -16,8 +16,8 @@ import { modifiers, SHIFT, ALT, CTRL } from '@wordpress/keycodes';
  * that any `Event#preventDefault` which would have normally occurred in the
  * application as a result of Ctrl+A is respected.
  *
- * @link https://github.com/GoogleChrome/puppeteer/issues/1313
- * @link https://w3c.github.io/uievents/tools/key-event-viewer.html
+ * @see https://github.com/GoogleChrome/puppeteer/issues/1313
+ * @see https://w3c.github.io/uievents/tools/key-event-viewer.html
  *
  * @return {Promise} Promise resolving once the SelectAll emulation completes.
  */

--- a/packages/edit-post/src/hooks/components/media-upload/index.js
+++ b/packages/edit-post/src/hooks/components/media-upload/index.js
@@ -16,7 +16,7 @@ const getGalleryDetailsMediaFrame = () => {
 	/**
 	 * Custom gallery details frame.
 	 *
-	 * @link https://github.com/xwp/wp-core-media-widgets/blob/905edbccfc2a623b73a93dac803c5335519d7837/wp-admin/js/widgets/media-gallery-widget.js
+	 * @see https://github.com/xwp/wp-core-media-widgets/blob/905edbccfc2a623b73a93dac803c5335519d7837/wp-admin/js/widgets/media-gallery-widget.js
 	 * @class GalleryDetailsMediaFrame
 	 * @constructor
 	 */

--- a/packages/escape-html/src/index.js
+++ b/packages/escape-html/src/index.js
@@ -10,7 +10,7 @@ import __unstableEscapeGreaterThan from './escape-greater';
  * U+0020 SPACE, U+0022 ("), U+0027 ('), U+003E (>), U+002F (/), U+003D (=),
  * and noncharacters."
  *
- * @link https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
+ * @see https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
  *
  * @type {RegExp}
  */
@@ -22,9 +22,9 @@ const REGEXP_INVALID_ATTRIBUTE_NAME = /[\u007F-\u009F "'>/="\uFDD0-\uFDEF]/;
  * named, decimal, or hexadecimal character references are escaped. Invalid
  * named references (i.e. ambiguous ampersand) are are still permitted.
  *
- * @link https://w3c.github.io/html/syntax.html#character-references
- * @link https://w3c.github.io/html/syntax.html#ambiguous-ampersand
- * @link https://w3c.github.io/html/syntax.html#named-character-references
+ * @see https://w3c.github.io/html/syntax.html#character-references
+ * @see https://w3c.github.io/html/syntax.html#ambiguous-ampersand
+ * @see https://w3c.github.io/html/syntax.html#named-character-references
  *
  * @param {string} value Original string.
  *
@@ -59,7 +59,7 @@ export function escapeLessThan( value ) {
 /**
  * Returns an escaped attribute value.
  *
- * @link https://w3c.github.io/html/syntax.html#elements-attributes
+ * @see https://w3c.github.io/html/syntax.html#elements-attributes
  *
  * "[...] the text cannot contain an ambiguous ampersand [...] must not contain
  * any literal U+0022 QUOTATION MARK characters (")"
@@ -83,7 +83,7 @@ export function escapeAttribute( value ) {
 /**
  * Returns an escaped HTML element value.
  *
- * @link https://w3c.github.io/html/syntax.html#writing-html-documents-elements
+ * @see https://w3c.github.io/html/syntax.html#writing-html-documents-elements
  *
  * "the text must not contain the character U+003C LESS-THAN SIGN (<) or an
  * ambiguous ampersand."

--- a/packages/redux-routine/src/is-generator.js
+++ b/packages/redux-routine/src/is-generator.js
@@ -1,7 +1,7 @@
 /**
  * Returns true if the given object is a generator, or false otherwise.
  *
- * @link https://www.ecma-international.org/ecma-262/6.0/#sec-generator-objects
+ * @see https://www.ecma-international.org/ecma-262/6.0/#sec-generator-objects
  *
  * @param {*} object Object to test.
  *

--- a/packages/token-list/src/index.js
+++ b/packages/token-list/src/index.js
@@ -6,7 +6,7 @@ import { uniq, compact, without } from 'lodash';
 /**
  * A set of tokens.
  *
- * @link https://dom.spec.whatwg.org/#domtokenlist
+ * @see https://dom.spec.whatwg.org/#domtokenlist
  */
 export default class TokenList {
 	/**
@@ -27,7 +27,7 @@ export default class TokenList {
 	/**
 	 * Returns the associated set as string.
 	 *
-	 * @link https://dom.spec.whatwg.org/#dom-domtokenlist-value
+	 * @see https://dom.spec.whatwg.org/#dom-domtokenlist-value
 	 *
 	 * @return {string} Token set as string.
 	 */
@@ -38,7 +38,7 @@ export default class TokenList {
 	/**
 	 * Replaces the associated set with a new string value.
 	 *
-	 * @link https://dom.spec.whatwg.org/#dom-domtokenlist-value
+	 * @see https://dom.spec.whatwg.org/#dom-domtokenlist-value
 	 *
 	 * @param {string} value New token set as string.
 	 */
@@ -51,7 +51,7 @@ export default class TokenList {
 	/**
 	 * Returns the number of tokens.
 	 *
-	 * @link https://dom.spec.whatwg.org/#dom-domtokenlist-length
+	 * @see https://dom.spec.whatwg.org/#dom-domtokenlist-length
 	 *
 	 * @return {number} Number of tokens.
 	 */
@@ -62,8 +62,8 @@ export default class TokenList {
 	/**
 	 * Returns the stringified form of the TokenList.
 	 *
-	 * @link https://dom.spec.whatwg.org/#DOMTokenList-stringification-behavior
-	 * @link https://www.ecma-international.org/ecma-262/9.0/index.html#sec-tostring
+	 * @see https://dom.spec.whatwg.org/#DOMTokenList-stringification-behavior
+	 * @see https://www.ecma-international.org/ecma-262/9.0/index.html#sec-tostring
 	 *
 	 * @return {string} Token set as string.
 	 */
@@ -74,7 +74,7 @@ export default class TokenList {
 	/**
 	 * Returns an iterator for the TokenList, iterating items of the set.
 	 *
-	 * @link https://dom.spec.whatwg.org/#domtokenlist
+	 * @see https://dom.spec.whatwg.org/#domtokenlist
 	 *
 	 * @return {Generator} TokenList iterator.
 	 */
@@ -85,7 +85,7 @@ export default class TokenList {
 	/**
 	 * Returns the token with index `index`.
 	 *
-	 * @link https://dom.spec.whatwg.org/#dom-domtokenlist-item
+	 * @see https://dom.spec.whatwg.org/#dom-domtokenlist-item
 	 *
 	 * @param {number} index Index at which to return token.
 	 *
@@ -98,7 +98,7 @@ export default class TokenList {
 	/**
 	 * Returns true if `token` is present, and false otherwise.
 	 *
-	 * @link https://dom.spec.whatwg.org/#dom-domtokenlist-contains
+	 * @see https://dom.spec.whatwg.org/#dom-domtokenlist-contains
 	 *
 	 * @param {string} item Token to test.
 	 *
@@ -111,7 +111,7 @@ export default class TokenList {
 	/**
 	 * Adds all arguments passed, except those already present.
 	 *
-	 * @link https://dom.spec.whatwg.org/#dom-domtokenlist-add
+	 * @see https://dom.spec.whatwg.org/#dom-domtokenlist-add
 	 *
 	 * @param {...string} items Items to add.
 	 */
@@ -122,7 +122,7 @@ export default class TokenList {
 	/**
 	 * Removes arguments passed, if they are present.
 	 *
-	 * @link https://dom.spec.whatwg.org/#dom-domtokenlist-remove
+	 * @see https://dom.spec.whatwg.org/#dom-domtokenlist-remove
 	 *
 	 * @param {...string} items Items to remove.
 	 */
@@ -136,7 +136,7 @@ export default class TokenList {
 	 * as add()). If force is false, removes token (same as remove()). Returns
 	 * true if `token` is now present, and false otherwise.
 	 *
-	 * @link https://dom.spec.whatwg.org/#dom-domtokenlist-toggle
+	 * @see https://dom.spec.whatwg.org/#dom-domtokenlist-toggle
 	 *
 	 * @param {string}   token Token to toggle.
 	 * @param {?boolean} force Presence to force.
@@ -161,7 +161,7 @@ export default class TokenList {
 	 * Replaces `token` with `newToken`. Returns true if `token` was replaced
 	 * with `newToken`, and false otherwise.
 	 *
-	 * @link https://dom.spec.whatwg.org/#dom-domtokenlist-replace
+	 * @see https://dom.spec.whatwg.org/#dom-domtokenlist-replace
 	 *
 	 * @param {string} token    Token to replace with `newToken`.
 	 * @param {string} newToken Token to use in place of `token`.
@@ -185,7 +185,7 @@ export default class TokenList {
 	 *
 	 * Always returns `true` in this implementation.
 	 *
-	 * @link https://dom.spec.whatwg.org/#dom-domtokenlist-supports
+	 * @see https://dom.spec.whatwg.org/#dom-domtokenlist-supports
 	 *
 	 * @return {boolean} Whether token is supported.
 	 */


### PR DESCRIPTION
## Description
- Replaced the `@link` tag with the `@see` tag when `@link` was used as a block level tag.
- Did not change the tests and data in [get-jsdoc-from-token.js](https://github.com/WordPress/gutenberg/blob/master/packages/docgen/src/test/get-jsdoc-from-token.js) or in [fixtures/tags-function/exports.json](https://github.com/WordPress/gutenberg/blob/master/packages/docgen/src/test/fixtures/tags-function/exports.json).

This fixes part of issue #14334.

## How has this been tested?
Visually

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
