### PR TITLE
[Mobile] Hotfix release v1.3.1 - Fix crash on undefined image url

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -128,7 +128,7 @@ class ImageEdit extends React.Component {
 				this.finishMediaUploadWithFailure( payload );
 				break;
 			case MEDIA_UPLOAD_STATE_RESET:
-				this.mediaUploadStateReset( payload );
+				this.mediaUploadStateReset();
 				break;
 		}
 	}
@@ -155,10 +155,10 @@ class ImageEdit extends React.Component {
 		this.setState( { isUploadInProgress: false, isUploadFailed: true } );
 	}
 
-	mediaUploadStateReset( payload ) {
+	mediaUploadStateReset() {
 		const { setAttributes } = this.props;
 
-		setAttributes( { id: payload.mediaId, url: null } );
+		setAttributes( { id: null, url: null } );
 		this.setState( { isUploadInProgress: false, isUploadFailed: false } );
 	}
 

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -80,6 +80,13 @@ class ImageEdit extends React.Component {
 
 		const { attributes, setAttributes } = this.props;
 
+    // This will warn when we have `id` defined, while `url` is undefined.
+    // This may help track this issue: https://github.com/wordpress-mobile/WordPress-Android/issues/9768
+    // where a cancelled image upload was resulting in a subsequent crash.
+    if ( attributes.id && ! attributes.url ) {
+      console.warn( "Attributes has id with no url." );
+    }
+
 		if ( attributes.id && attributes.url && ! isURL( attributes.url ) ) {
 			if ( attributes.url.indexOf( 'file:' ) === 0 ) {
 				requestMediaImport( attributes.url, ( mediaId, mediaUri ) => {

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -80,7 +80,7 @@ class ImageEdit extends React.Component {
 
 		const { attributes, setAttributes } = this.props;
 
-		if ( attributes.id && ! isURL( attributes.url ) ) {
+		if ( attributes.id && attributes.url && ! isURL( attributes.url ) ) {
 			if ( attributes.url.indexOf( 'file:' ) === 0 ) {
 				requestMediaImport( attributes.url, ( mediaId, mediaUri ) => {
 					if ( mediaUri ) {


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
**Note:** This PR targets the gutenberg branch used for the `v1.3.0` release of gutenberg-mobile, which is used in WordPress-Android `v12.3.1`.

This PR adds a check to ensure `attributes.url` exists before attempting to call `indexOf`. Currently, there are scenarios which can result in `attributes.id` being truthy, while `attributes.url` is `null` or `undefined` for an image block.

When an image is cancelled before it is finished uploading, the `url` is set to `null`, but the `id` of the block remains. The next time the post is edited, the local draft will contain the state which triggers the crash.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
This was tested using the steps here: https://github.com/wordpress-mobile/WordPress-Android/issues/9768#issuecomment-490852531

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
This is a bug fix for the crash discovered here: https://github.com/wordpress-mobile/WordPress-Android/issues/9768

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
