### PR TITLE
Input Interaction: always reset initial vertical position rect

### DIFF
--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -241,6 +241,12 @@ class WritingFlow extends Component {
 		const hasModifier = isShift || event.ctrlKey || event.altKey || event.metaKey;
 		const isNavEdge = isVertical ? isVerticalEdge : isHorizontalEdge;
 
+		if ( ! isVertical ) {
+			this.verticalRect = null;
+		} else if ( ! this.verticalRect ) {
+			this.verticalRect = computeCaretRect();
+		}
+
 		// This logic inside this condition needs to be checked before
 		// the check for event.nativeEvent.defaultPrevented.
 		// The logic handles meta+a keypress and this event is default prevented
@@ -279,12 +285,6 @@ class WritingFlow extends Component {
 		// preserve native input behaviors).
 		if ( ! isNavigationCandidate( target, keyCode, hasModifier ) ) {
 			return;
-		}
-
-		if ( ! isVertical ) {
-			this.verticalRect = null;
-		} else if ( ! this.verticalRect ) {
-			this.verticalRect = computeCaretRect();
 		}
 
 		// In the case of RTL scripts, right means previous and left means next,

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -242,7 +242,11 @@ class WritingFlow extends Component {
 		const isNavEdge = isVertical ? isVerticalEdge : isHorizontalEdge;
 
 		// When presing any key other than up or down, the initial vertical
-		// position must ALWAYS be reset.
+		// position must ALWAYS be reset. The vertical position is saved so it
+		// can be restored as well as possible on sebsequent vertical arrow key
+		// presses. It may not always be possible to restore the exact same
+		// position (such as at an empty line), so it wouldn't be good to
+		// compute the position right before any vertical arrow key press.
 		if ( ! isVertical ) {
 			this.verticalRect = null;
 		} else if ( ! this.verticalRect ) {

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -241,6 +241,8 @@ class WritingFlow extends Component {
 		const hasModifier = isShift || event.ctrlKey || event.altKey || event.metaKey;
 		const isNavEdge = isVertical ? isVerticalEdge : isHorizontalEdge;
 
+		// When presing any key other than up or down, the initial vertical
+		// position must ALWAYS be reset.
 		if ( ! isVertical ) {
 			this.verticalRect = null;
 		} else if ( ! this.verticalRect ) {

--- a/packages/e2e-tests/specs/__snapshots__/writing-flow.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/writing-flow.test.js.snap
@@ -203,3 +203,13 @@ exports[`adding blocks should not prematurely multi-select 1`] = `
 <p>></p>
 <!-- /wp:paragraph -->"
 `;
+
+exports[`adding blocks should preserve horizontal position when navigating vertically between blocks 1`] = `
+"<!-- wp:paragraph -->
+<p>abc</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>123</p>
+<!-- /wp:paragraph -->"
+`;

--- a/packages/e2e-tests/specs/__snapshots__/writing-flow.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/writing-flow.test.js.snap
@@ -213,3 +213,13 @@ exports[`adding blocks should preserve horizontal position when navigating verti
 <p>123</p>
 <!-- /wp:paragraph -->"
 `;
+
+exports[`adding blocks should remember initial vertical position 1`] = `
+"<!-- wp:paragraph -->
+<p>1x</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><br>2</p>
+<!-- /wp:paragraph -->"
+`;

--- a/packages/e2e-tests/specs/writing-flow.test.js
+++ b/packages/e2e-tests/specs/writing-flow.test.js
@@ -369,7 +369,7 @@ describe( 'adding blocks', () => {
 	} );
 
 	it( 'should preserve horizontal position when navigating vertically between blocks', async () => {
-		await clickBlockAppender();
+		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'abc' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '23' );
@@ -378,6 +378,19 @@ describe( 'adding blocks', () => {
 		await page.keyboard.press( 'ArrowLeft' );
 		await page.keyboard.press( 'ArrowDown' );
 		await page.keyboard.type( '1' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should remember initial vertical position', async () => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '1' );
+		await page.keyboard.press( 'Enter' );
+		await pressKeyWithModifier( 'shift', 'Enter' );
+		await page.keyboard.type( '2' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.type( 'x' ); // Should be right after "1".
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );

--- a/packages/e2e-tests/specs/writing-flow.test.js
+++ b/packages/e2e-tests/specs/writing-flow.test.js
@@ -367,4 +367,18 @@ describe( 'adding blocks', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should preserve horizontal position when navigating vertically between blocks', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'abc' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '23' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.type( '1' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );


### PR DESCRIPTION
## Description

Alternative to #15607.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
