### PR TITLE
Replace "Page Break" icon with a Material version

### DIFF
--- a/packages/block-library/src/nextpage/icon.js
+++ b/packages/block-library/src/nextpage/icon.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { G, Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/components';
 
 export default (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><G><Path d="M9 12h6v-2H9zm-7 0h5v-2H2zm15 0h5v-2h-5zm3 2v2l-6 6H6a2 2 0 0 1-2-2v-6h2v6h6v-4a2 2 0 0 1 2-2h6zM4 8V4a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v4h-2V4H6v4z" /></G></SVG>
+	<SVG xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24"><Path d="M0 0h24v24H0z" fill="none" /><Path d="M9 11h6v2H9zM2 11h5v2H2zM17 11h5v2h-5zM6 4h7v5h7V8l-6-6H6a2 2 0 0 0-2 2v5h2zM18 20H6v-5H4v5a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-5h-2z" /></SVG>
 );


### PR DESCRIPTION
The current "Page Break" block icon appears to be based on [the "Pages" Gridicon](https://github.com/Automattic/gridicons/blob/master/svg-min/gridicons-pages.svg). For greater consistency as we expand into more blocks that use a "page" icon, we should source from either Material or Dashicons. To that end, this PR replaces the page break icon with one based on [the "File" icon from Material](https://material.io/tools/icons/?search=file&icon=insert_drive_file&style=outline). 

---

_Before:_ 

![Screen Shot 2019-05-14 at 8 53 35 AM](https://user-images.githubusercontent.com/1202812/57700376-de7c4900-7627-11e9-9488-bd1a3e9a56e0.png)

_After:_ 

![Screen Shot 2019-05-14 at 8 53 35 AM](https://user-images.githubusercontent.com/1202812/57700417-f2c04600-7627-11e9-9d10-01eb9a037a5d.png)