### PR TITLE
Update Calendar block icon for better alignment with the Archives block icon

### DIFF
--- a/packages/block-library/src/archives/icon.js
+++ b/packages/block-library/src/archives/icon.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { G, Path, SVG } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/components';
 
 export default (
-	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M7 11h2v2H7v-2zm14-5v14c0 1.1-.9 2-2 2H5c-1.11 0-2-.9-2-2l.01-14c0-1.1.88-2 1.99-2h1V2h2v2h8V2h2v2h1c1.1 0 2 .9 2 2zM5 8h14V6H5v2zm14 12V10H5v10h14zm-4-7h2v-2h-2v2zm-4 0h2v-2h-2v2z" /></G></SVG>
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M21 6V20C21 21.1 20.1 22 19 22H5C3.89 22 3 21.1 3 20L3.01 6C3.01 4.9 3.89 4 5 4H6V2H8V4H16V2H18V4H19C20.1 4 21 4.9 21 6ZM5 8H19V6H5V8ZM19 20V10H5V20H19ZM11 12H17V14H11V12ZM17 16H11V18H17V16ZM7 12H9V14H7V12ZM9 18V16H7V18H9Z" /></SVG>
 );

--- a/packages/block-library/src/calendar/icon.js
+++ b/packages/block-library/src/calendar/icon.js
@@ -4,5 +4,5 @@
 import { Path, SVG } from '@wordpress/components';
 
 export default (
-	<SVG width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><Path d="M21 6V20C21 21.1 20.1 22 19 22H5C3.89 22 3 21.1 3 20L3.01 6C3.01 4.9 3.89 4 5 4H6V2H8V4H16V2H18V4H19C20.1 4 21 4.9 21 6ZM5 8H19V6H5V8ZM19 20V10H5V20H19Z" /></SVG>
+	<SVG width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M21 6V20C21 21.1 20.1 22 19 22H5C3.89 22 3 21.1 3 20L3.01 6C3.01 4.9 3.89 4 5 4H6V2H8V4H16V2H18V4H19C20.1 4 21 4.9 21 6ZM5 8H19V6H5V8ZM19 20V10H5V20H19Z" /></SVG>
 );

--- a/packages/block-library/src/calendar/icon.js
+++ b/packages/block-library/src/calendar/icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+export default (
+	<SVG width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><Path d="M21 6V20C21 21.1 20.1 22 19 22H5C3.89 22 3 21.1 3 20L3.01 6C3.01 4.9 3.89 4 5 4H6V2H8V4H16V2H18V4H19C20.1 4 21 4.9 21 6ZM5 8H19V6H5V8ZM19 20V10H5V20H19Z" /></SVG>
+);

--- a/packages/block-library/src/calendar/icon.js
+++ b/packages/block-library/src/calendar/icon.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { Path, SVG } from '@wordpress/components';
+import { G, Path, SVG } from '@wordpress/components';
 
 export default (
-	<SVG width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path d="M21 6V20C21 21.1 20.1 22 19 22H5C3.89 22 3 21.1 3 20L3.01 6C3.01 4.9 3.89 4 5 4H6V2H8V4H16V2H18V4H19C20.1 4 21 4.9 21 6ZM5 8H19V6H5V8ZM19 20V10H5V20H19Z" /></SVG>
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M7 11h2v2H7v-2zm14-5v14c0 1.1-.9 2-2 2H5c-1.11 0-2-.9-2-2l.01-14c0-1.1.88-2 1.99-2h1V2h2v2h8V2h2v2h1c1.1 0 2 .9 2 2zM5 8h14V6H5v2zm14 12V10H5v10h14zm-4-7h2v-2h-2v2zm-4 0h2v-2h-2v2z" /></G></SVG>
 );

--- a/packages/block-library/src/calendar/index.js
+++ b/packages/block-library/src/calendar/index.js
@@ -7,13 +7,14 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import edit from './edit';
+import icon from './icon';
 
 export const name = 'core/calendar';
 
 export const settings = {
 	title: __( 'Calendar' ),
 	description: __( 'A calendar of your site’s posts.' ),
-	icon: 'calendar',
+	icon,
 	category: 'widgets',
 	keywords: [ __( 'posts' ), __( 'archive' ) ],
 	supports: {


### PR DESCRIPTION
The current Calendar block icon uses the Calendar Dashicon, which is stylistically different from the Calendar used in the Archives block. To better align these, I suggest we adopt the [`calendar_today` icon from Material](https://material.io/tools/icons/?search=cal&icon=calendar_today&style=outline) to represent the calendar block. 

Alternatively, to separate these two icons visually, we could use the current "Archives" icon for the Calendar block instead, and explore a new icon for the Archives block — Perhaps the [`history`](https://material.io/tools/icons/?icon=history&style=outline), [`book`](https://material.io/tools/icons/?search=book&icon=book&style=outline), or [`library_book`](https://material.io/tools/icons/?search=book&icon=library_books&style=outline) icons?

---

_Before:_ 

![Screen Shot 2019-05-14 at 9 32 47 AM](https://user-images.githubusercontent.com/1202812/57702203-8e9f8100-762b-11e9-8931-723809ab84d1.png)


_After:_ 

![Screen Shot 2019-05-14 at 9 30 24 AM](https://user-images.githubusercontent.com/1202812/57702208-9101db00-762b-11e9-8113-0258f45259d3.png)