### PR TITLE
Accessibility: Fixed reading order of keyboard shortcuts.

### DIFF
--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/index.js
@@ -40,23 +40,23 @@ const mapKeyCombination = ( keyCombination ) => keyCombination.map( ( character,
 } );
 
 const ShortcutList = ( { shortcuts } ) => (
-	<dl className="edit-post-keyboard-shortcut-help__shortcut-list">
+	<ul className="edit-post-keyboard-shortcut-help__shortcut-list">
 		{ shortcuts.map( ( { keyCombination, description, ariaLabel }, index ) => (
-			<div
+			<li
 				className="edit-post-keyboard-shortcut-help__shortcut"
 				key={ index }
 			>
-				<dt className="edit-post-keyboard-shortcut-help__shortcut-term">
+				<div className="edit-post-keyboard-shortcut-help__shortcut-description">
+					{ description }
+				</div>
+				<div className="edit-post-keyboard-shortcut-help__shortcut-term">
 					<kbd className="edit-post-keyboard-shortcut-help__shortcut-key-combination" aria-label={ ariaLabel }>
 						{ mapKeyCombination( castArray( keyCombination ) ) }
 					</kbd>
-				</dt>
-				<dd className="edit-post-keyboard-shortcut-help__shortcut-description">
-					{ description }
-				</dd>
-			</div>
+				</div>
+			</li>
 		) ) }
-	</dl>
+	</ul>
 );
 
 const ShortcutSection = ( { title, shortcuts } ) => (

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/index.js
@@ -40,7 +40,12 @@ const mapKeyCombination = ( keyCombination ) => keyCombination.map( ( character,
 } );
 
 const ShortcutList = ( { shortcuts } ) => (
-	<ul className="edit-post-keyboard-shortcut-help__shortcut-list">
+	/*
+	 * Disable reason: The `list` ARIA role is redundant but
+	 * Safari+VoiceOver won't announce the list otherwise.
+	 */
+	/* eslint-disable jsx-a11y/no-redundant-roles */
+	<ul className="edit-post-keyboard-shortcut-help__shortcut-list" role="list">
 		{ shortcuts.map( ( { keyCombination, description, ariaLabel }, index ) => (
 			<li
 				className="edit-post-keyboard-shortcut-help__shortcut"

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/style.scss
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/style.scss
@@ -22,14 +22,12 @@
 	}
 
 	&__shortcut-term {
-		order: 1;
 		font-weight: 600;
 		margin: 0 0 0 1rem;
 	}
 
 	&__shortcut-description {
 		flex: 1;
-		order: 0;
 		margin: 0;
 
 		// IE 11 flex item fix - ensure the item does not collapse

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/style.scss
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/style.scss
@@ -15,6 +15,7 @@
 		align-items: center;
 		padding: 0.6rem 0;
 		border-top: 1px solid $light-gray-500;
+		margin-bottom: 0;
 
 		&:last-child {
 			border-bottom: 1px solid $light-gray-500;


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/15317

## How has this been tested?
This was tested locally.

## Types of changes
Replaced description list with unordered list.
Removed `order` prop and changed the order of elements.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
