### PR TITLE
Improve label for multiple additional css classes

### DIFF
--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -60,13 +60,14 @@ export const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) =>
 					<BlockEdit { ...props } />
 					<InspectorAdvancedControls>
 						<TextControl
-							label={ __( 'Additional CSS Class' ) }
+							label={ __( 'Additional CSS Class(es)' ) }
 							value={ props.attributes.className || '' }
 							onChange={ ( nextValue ) => {
 								props.setAttributes( {
 									className: nextValue !== '' ? nextValue : undefined,
 								} );
 							} }
+							help={ __( 'Space separate multiple classes.' ) }
 						/>
 					</InspectorAdvancedControls>
 				</>

--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -67,7 +67,7 @@ export const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) =>
 									className: nextValue !== '' ? nextValue : undefined,
 								} );
 							} }
-							help={ __( 'Space separate multiple classes.' ) }
+							help={ __( 'Separate multiple classes with spaces.' ) }
 						/>
 					</InspectorAdvancedControls>
 				</>


### PR DESCRIPTION
## Description

Add clarity around additional css classes so users know that multiple
classes are supported and the proper separator between classes.

Fixes #15597 


## How has this been tested?

Confirm change shows as expected, includes i18n
Uses standard controls

## Screenshots <!-- if applicable -->

## Types of changes

* Add "(es)" so new label is "Additional CSS Class(es)"

* Add help attribute with help message: "Space separate multiple classes."


## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
