### PR TITLE
Target docs to manifest.json

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,962 +1,212 @@
 [
 	{
-		"title": "Gutenberg Handbook",
+		"title": "Block Editor Handbook",
 		"slug": "handbook",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/readme.md",
+		"markdown_source": "../docs/readme.md",
 		"parent": null
 	},
 	{
-		"title": "Designer & Developer Handbook",
-		"slug": "designers-developers",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/readme.md",
+		"title": "Project Overview",
+		"slug": "principles",
+		"markdown_source": "../docs/contributors/principles.md",
 		"parent": null
 	},
 	{
 		"title": "Key Concepts",
 		"slug": "key-concepts",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/key-concepts.md",
-		"parent": "designers-developers"
+		"markdown_source": "../docs/designers-developers/key-concepts.md",
+		"parent": "principles"
+	},
+	{
+		"title": "Glossary",
+		"slug": "glossary",
+		"markdown_source": "../docs/designers-developers/glossary.md",
+		"parent": "principles"
+	},
+	{
+		"title": "Frequently Asked Questions",
+		"slug": "faq",
+		"markdown_source": "../docs/designers-developers/faq.md",
+		"parent": "principles"
+	},
+	{
+		"title": "History",
+		"slug": "history",
+		"markdown_source": "../docs/contributors/history.md",
+		"parent": "principles"
+	},
+	{
+		"title": "Outreach",
+		"slug": "outreach",
+		"markdown_source": "../docs/contributors/outreach.md",
+		"parent": "principles"
 	},
 	{
 		"title": "Developer Documentation",
 		"slug": "developers",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/README.md",
-		"parent": "designers-developers"
+		"markdown_source": "../docs/designers-developers/developers/README.md",
+		"parent": null
 	},
 	{
 		"title": "Block API Reference",
 		"slug": "block-api",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/block-api/README.md",
+		"markdown_source": "../docs/designers-developers/developers/block-api/README.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Block Registration",
 		"slug": "block-registration",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/block-api/block-registration.md",
+		"markdown_source": "../docs/designers-developers/developers/block-api/block-registration.md",
 		"parent": "block-api"
 	},
 	{
 		"title": "Edit and Save",
 		"slug": "block-edit-save",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/block-api/block-edit-save.md",
+		"markdown_source": "../docs/designers-developers/developers/block-api/block-edit-save.md",
 		"parent": "block-api"
 	},
 	{
 		"title": "Attributes",
 		"slug": "block-attributes",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/block-api/block-attributes.md",
+		"markdown_source": "../docs/designers-developers/developers/block-api/block-attributes.md",
 		"parent": "block-api"
 	},
 	{
 		"title": "Deprecated Blocks",
 		"slug": "block-deprecation",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/block-api/block-deprecation.md",
+		"markdown_source": "../docs/designers-developers/developers/block-api/block-deprecation.md",
 		"parent": "block-api"
 	},
 	{
 		"title": "Templates",
 		"slug": "block-templates",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/block-api/block-templates.md",
+		"markdown_source": "../docs/designers-developers/developers/block-api/block-templates.md",
 		"parent": "block-api"
 	},
 	{
 		"title": "Annotations",
 		"slug": "block-annotations",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/block-api/block-annotations.md",
+		"markdown_source": "../docs/designers-developers/developers/block-api/block-annotations.md",
 		"parent": "block-api"
 	},
 	{
 		"title": "Filter Reference",
 		"slug": "filters",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/filters/README.md",
+		"markdown_source": "../docs/designers-developers/developers/filters/README.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Block Filters",
 		"slug": "block-filters",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/filters/block-filters.md",
+		"markdown_source": "../docs/designers-developers/developers/filters/block-filters.md",
 		"parent": "filters"
 	},
 	{
 		"title": "Editor Filters (Experimental)",
 		"slug": "editor-filters",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/filters/editor-filters.md",
+		"markdown_source": "../docs/designers-developers/developers/filters/editor-filters.md",
 		"parent": "filters"
 	},
 	{
 		"title": "Parser Filters",
 		"slug": "parser-filters",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/filters/parser-filters.md",
+		"markdown_source": "../docs/designers-developers/developers/filters/parser-filters.md",
 		"parent": "filters"
 	},
 	{
 		"title": "Autocomplete",
 		"slug": "autocomplete-filters",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/filters/autocomplete-filters.md",
+		"markdown_source": "../docs/designers-developers/developers/filters/autocomplete-filters.md",
 		"parent": "filters"
+	},
+	{
+		"title": "SlotFills Reference",
+		"slug": "slotfills",
+		"markdown_source": "../docs/designers-developers/developers/slotfills/README.md",
+		"parent": "developers"
+	},
+	{
+		"title": "PluginBlockSettingsMenuItem",
+		"slug": "plugin-block-settings-menu-item",
+		"markdown_source": "../docs/designers-developers/developers/slotfills/plugin-block-settings-menu-item.md",
+		"parent": "slotfills"
+	},
+	{
+		"title": "PluginDocumentSettingPanel",
+		"slug": "plugin-document-setting-panel",
+		"markdown_source": "../docs/designers-developers/developers/slotfills/plugin-document-setting-panel.md",
+		"parent": "slotfills"
+	},
+	{
+		"title": "PluginMoreMenuItem",
+		"slug": "plugin-more-menu-item",
+		"markdown_source": "../docs/designers-developers/developers/slotfills/plugin-more-menu-item.md",
+		"parent": "slotfills"
+	},
+	{
+		"title": "PluginPostPublishPanel",
+		"slug": "plugin-post-publish-panel",
+		"markdown_source": "../docs/designers-developers/developers/slotfills/plugin-post-publish-panel.md",
+		"parent": "slotfills"
+	},
+	{
+		"title": "PluginPostStatusInfo",
+		"slug": "plugin-post-status-info",
+		"markdown_source": "../docs/designers-developers/developers/slotfills/plugin-post-status-info.md",
+		"parent": "slotfills"
+	},
+	{
+		"title": "PluginPrePublishPanel",
+		"slug": "plugin-pre-publish-panel",
+		"markdown_source": "../docs/designers-developers/developers/slotfills/plugin-pre-publish-panel.md",
+		"parent": "slotfills"
+	},
+	{
+		"title": "PluginSidebar",
+		"slug": "plugin-sidebar",
+		"markdown_source": "../docs/designers-developers/developers/slotfills/plugin-sidebar.md",
+		"parent": "slotfills"
+	},
+	{
+		"title": "PluginSidebarMoreMenuItem",
+		"slug": "plugin-sidebar-more-menu-item",
+		"markdown_source": "../docs/designers-developers/developers/slotfills/plugin-sidebar-more-menu-item.md",
+		"parent": "slotfills"
+	},
+	{
+		"title": "RichText Reference",
+		"slug": "richtext",
+		"markdown_source": "../docs/designers-developers/developers/richtext.md",
+		"parent": "developers"
 	},
 	{
 		"title": "Internationalization",
 		"slug": "internationalization",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/internationalization.md",
+		"markdown_source": "../docs/designers-developers/developers/internationalization.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Accessibility",
 		"slug": "accessibility",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/accessibility.md",
+		"markdown_source": "../docs/designers-developers/developers/accessibility.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Feature Flags",
 		"slug": "feature-flags",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/feature-flags.md",
+		"markdown_source": "../docs/designers-developers/developers/feature-flags.md",
 		"parent": "developers"
-	},
-	{
-		"title": "Data Module Reference",
-		"slug": "data",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/data/README.md",
-		"parent": "developers"
-	},
-	{
-		"title": "WordPress Core Data",
-		"slug": "data-core",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/data/data-core.md",
-		"parent": "data"
-	},
-	{
-		"title": "Annotations",
-		"slug": "data-core-annotations",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/data/data-core-annotations.md",
-		"parent": "data"
-	},
-	{
-		"title": "Block Types Data",
-		"slug": "data-core-blocks",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/data/data-core-blocks.md",
-		"parent": "data"
-	},
-	{
-		"title": "The Block Editor’s Data",
-		"slug": "data-core-block-editor",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/data/data-core-block-editor.md",
-		"parent": "data"
-	},
-	{
-		"title": "The Post Editor’s Data",
-		"slug": "data-core-editor",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/data/data-core-editor.md",
-		"parent": "data"
-	},
-	{
-		"title": "The Editor’s UI Data",
-		"slug": "data-core-edit-post",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/data/data-core-edit-post.md",
-		"parent": "data"
-	},
-	{
-		"title": "Notices Data",
-		"slug": "data-core-notices",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/data/data-core-notices.md",
-		"parent": "data"
-	},
-	{
-		"title": "The NUX (New User Experience) Data",
-		"slug": "data-core-nux",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/data/data-core-nux.md",
-		"parent": "data"
-	},
-	{
-		"title": "The Viewport Data",
-		"slug": "data-core-viewport",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/data/data-core-viewport.md",
-		"parent": "data"
-	},
-	{
-		"title": "Packages",
-		"slug": "packages",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/packages.md",
-		"parent": "developers"
-	},
-	{
-		"title": "@wordpress/a11y",
-		"slug": "packages-a11y",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/a11y/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/annotations",
-		"slug": "packages-annotations",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/annotations/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/api-fetch",
-		"slug": "packages-api-fetch",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/api-fetch/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/autop",
-		"slug": "packages-autop",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/autop/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/babel-plugin-import-jsx-pragma",
-		"slug": "packages-babel-plugin-import-jsx-pragma",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/babel-plugin-import-jsx-pragma/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/babel-plugin-makepot",
-		"slug": "packages-babel-plugin-makepot",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/babel-plugin-makepot/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/babel-preset-default",
-		"slug": "packages-babel-preset-default",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/babel-preset-default/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/blob",
-		"slug": "packages-blob",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/blob/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/block-editor",
-		"slug": "packages-block-editor",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/block-editor/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/block-library",
-		"slug": "packages-block-library",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/block-library/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/block-serialization-default-parser",
-		"slug": "packages-block-serialization-default-parser",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/block-serialization-default-parser/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/block-serialization-spec-parser",
-		"slug": "packages-block-serialization-spec-parser",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/block-serialization-spec-parser/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/blocks",
-		"slug": "packages-blocks",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/blocks/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/browserslist-config",
-		"slug": "packages-browserslist-config",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/browserslist-config/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/components",
-		"slug": "packages-components",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/compose",
-		"slug": "packages-compose",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/compose/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/core-data",
-		"slug": "packages-core-data",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/core-data/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/custom-templated-path-webpack-plugin",
-		"slug": "packages-custom-templated-path-webpack-plugin",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/custom-templated-path-webpack-plugin/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/data-controls",
-		"slug": "packages-data-controls",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/data-controls/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/data",
-		"slug": "packages-data",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/data/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/date",
-		"slug": "packages-date",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/date/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/dependency-extraction-webpack-plugin",
-		"slug": "packages-dependency-extraction-webpack-plugin",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/dependency-extraction-webpack-plugin/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/deprecated",
-		"slug": "packages-deprecated",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/deprecated/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/docgen",
-		"slug": "packages-docgen",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/docgen/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/dom-ready",
-		"slug": "packages-dom-ready",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/dom-ready/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/dom",
-		"slug": "packages-dom",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/dom/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/e2e-test-utils",
-		"slug": "packages-e2e-test-utils",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/e2e-test-utils/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/e2e-tests",
-		"slug": "packages-e2e-tests",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/e2e-tests/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/edit-post",
-		"slug": "packages-edit-post",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/edit-post/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/edit-widgets",
-		"slug": "packages-edit-widgets",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/edit-widgets/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/editor",
-		"slug": "packages-editor",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/editor/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/element",
-		"slug": "packages-element",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/element/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/escape-html",
-		"slug": "packages-escape-html",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/escape-html/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/eslint-plugin",
-		"slug": "packages-eslint-plugin",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/eslint-plugin/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/format-library",
-		"slug": "packages-format-library",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/format-library/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/hooks",
-		"slug": "packages-hooks",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/hooks/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/html-entities",
-		"slug": "packages-html-entities",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/html-entities/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/i18n",
-		"slug": "packages-i18n",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/i18n/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/is-shallow-equal",
-		"slug": "packages-is-shallow-equal",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/is-shallow-equal/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/jest-console",
-		"slug": "packages-jest-console",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/jest-console/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/jest-preset-default",
-		"slug": "packages-jest-preset-default",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/jest-preset-default/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/jest-puppeteer-axe",
-		"slug": "packages-jest-puppeteer-axe",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/jest-puppeteer-axe/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/keycodes",
-		"slug": "packages-keycodes",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/keycodes/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/library-export-default-webpack-plugin",
-		"slug": "packages-library-export-default-webpack-plugin",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/library-export-default-webpack-plugin/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/list-reusable-blocks",
-		"slug": "packages-list-reusable-blocks",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/list-reusable-blocks/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/media-utils",
-		"slug": "packages-media-utils",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/media-utils/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/notices",
-		"slug": "packages-notices",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/notices/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/npm-package-json-lint-config",
-		"slug": "packages-npm-package-json-lint-config",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/npm-package-json-lint-config/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/nux",
-		"slug": "packages-nux",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/nux/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/plugins",
-		"slug": "packages-plugins",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/plugins/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/postcss-themes",
-		"slug": "packages-postcss-themes",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/postcss-themes/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/priority-queue",
-		"slug": "packages-priority-queue",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/priority-queue/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/redux-routine",
-		"slug": "packages-redux-routine",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/redux-routine/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/rich-text",
-		"slug": "packages-rich-text",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/rich-text/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/scripts",
-		"slug": "packages-scripts",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/scripts/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/shortcode",
-		"slug": "packages-shortcode",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/shortcode/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/token-list",
-		"slug": "packages-token-list",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/token-list/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/url",
-		"slug": "packages-url",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/url/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/viewport",
-		"slug": "packages-viewport",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/viewport/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "@wordpress/wordcount",
-		"slug": "packages-wordcount",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/wordcount/README.md",
-		"parent": "packages"
-	},
-	{
-		"title": "Components",
-		"slug": "components",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/README.md",
-		"parent": "developers"
-	},
-	{
-		"title": "Animate",
-		"slug": "animate",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/animate/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "Autocomplete",
-		"slug": "autocomplete",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/autocomplete/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "BaseControl",
-		"slug": "base-control",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/base-control/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "ButtonGroup",
-		"slug": "button-group",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/button-group/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "Button",
-		"slug": "button",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/button/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "CheckboxControl",
-		"slug": "checkbox-control",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/checkbox-control/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "ClipboardButton",
-		"slug": "clipboard-button",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/clipboard-button/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "ColorIndicator",
-		"slug": "color-indicator",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/color-indicator/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "ColorPalette",
-		"slug": "color-palette",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/color-palette/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "ColorPicker",
-		"slug": "color-picker",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/color-picker/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "Dashicon",
-		"slug": "dashicon",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/dashicon/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "DateTime",
-		"slug": "date-time",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/date-time/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "Disabled",
-		"slug": "disabled",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/disabled/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "Draggable",
-		"slug": "draggable",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/draggable/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "DropZone",
-		"slug": "drop-zone",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/drop-zone/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "DropdownMenu",
-		"slug": "dropdown-menu",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/dropdown-menu/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "Dropdown",
-		"slug": "dropdown",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/dropdown/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "ExternalLink",
-		"slug": "external-link",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/external-link/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "FocalPointPicker",
-		"slug": "focal-point-picker",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/focal-point-picker/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "FocusableIframe",
-		"slug": "focusable-iframe",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/focusable-iframe/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "FontSizePicker",
-		"slug": "font-size-picker",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/font-size-picker/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "FormFileUpload",
-		"slug": "form-file-upload",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/form-file-upload/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "FormToggle",
-		"slug": "form-toggle",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/form-toggle/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "FormTokenField",
-		"slug": "form-token-field",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/form-token-field/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "NavigateRegions",
-		"slug": "navigate-regions",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/higher-order/navigate-regions/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "HigherOrder",
-		"slug": "higher-order",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/higher-order/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "WithConstrainedTabbing",
-		"slug": "with-constrained-tabbing",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/higher-order/with-constrained-tabbing/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "WithFallbackStyles",
-		"slug": "with-fallback-styles",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/higher-order/with-fallback-styles/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "WithFilters",
-		"slug": "with-filters",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/higher-order/with-filters/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "WithFocusOutside",
-		"slug": "with-focus-outside",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/higher-order/with-focus-outside/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "WithFocusReturn",
-		"slug": "with-focus-return",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/higher-order/with-focus-return/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "WithNotices",
-		"slug": "with-notices",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/higher-order/with-notices/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "WithSpokenMessages",
-		"slug": "with-spoken-messages",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/higher-order/with-spoken-messages/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "IconButton",
-		"slug": "icon-button",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/icon-button/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "Icon",
-		"slug": "icon",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/icon/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "IsolatedEventContainer",
-		"slug": "isolated-event-container",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/isolated-event-container/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "KeyboardShortcuts",
-		"slug": "keyboard-shortcuts",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/keyboard-shortcuts/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "MenuGroup",
-		"slug": "menu-group",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/menu-group/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "MenuItem",
-		"slug": "menu-item",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/menu-item/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "MenuItemsChoice",
-		"slug": "menu-items-choice",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/menu-items-choice/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "Modal",
-		"slug": "modal",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/modal/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "NavigableContainer",
-		"slug": "navigable-container",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/navigable-container/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "Notice",
-		"slug": "notice",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/notice/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "Panel",
-		"slug": "panel",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/panel/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "Placeholder",
-		"slug": "placeholder",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/placeholder/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "Popover",
-		"slug": "popover",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/popover/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "HorizontalRule",
-		"slug": "horizontal-rule",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/primitives/horizontal-rule/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "Svg",
-		"slug": "svg",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/primitives/svg/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "QueryControls",
-		"slug": "query-controls",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/query-controls/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "RadioControl",
-		"slug": "radio-control",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/radio-control/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "RangeControl",
-		"slug": "range-control",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/range-control/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "ResizableBox",
-		"slug": "resizable-box",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/resizable-box/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "ResponsiveWrapper",
-		"slug": "responsive-wrapper",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/responsive-wrapper/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "Sandbox",
-		"slug": "sandbox",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/sandbox/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "ScrollLock",
-		"slug": "scroll-lock",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/scroll-lock/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "SelectControl",
-		"slug": "select-control",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/select-control/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "ServerSideRender",
-		"slug": "server-side-render",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/server-side-render/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "SlotFill",
-		"slug": "slot-fill",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/slot-fill/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "Snackbar",
-		"slug": "snackbar",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/snackbar/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "Spinner",
-		"slug": "spinner",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/spinner/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "TabPanel",
-		"slug": "tab-panel",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/tab-panel/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "TextControl",
-		"slug": "text-control",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/text-control/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "TextareaControl",
-		"slug": "textarea-control",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/textarea-control/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "ToggleControl",
-		"slug": "toggle-control",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/toggle-control/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "Toolbar",
-		"slug": "toolbar",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/toolbar/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "Tooltip",
-		"slug": "tooltip",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/tooltip/README.md",
-		"parent": "components"
-	},
-	{
-		"title": "TreeSelect",
-		"slug": "tree-select",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/packages/components/src/tree-select/README.md",
-		"parent": "components"
 	},
 	{
 		"title": "Theming for the Block Editor",
 		"slug": "themes",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/themes/README.md",
+		"markdown_source": "../docs/designers-developers/developers/themes/README.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Theme Support",
 		"slug": "theme-support",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/themes/theme-support.md",
+		"markdown_source": "../docs/designers-developers/developers/themes/theme-support.md",
 		"parent": "themes"
 	},
 	{
@@ -968,385 +218,1285 @@
 	{
 		"title": "Backward Compatibility",
 		"slug": "backward-compatibility",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/backward-compatibility/README.md",
+		"markdown_source": "../docs/designers-developers/developers/backward-compatibility/README.md",
 		"parent": "developers"
 	},
 	{
 		"title": "Deprecations",
 		"slug": "deprecations",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/backward-compatibility/deprecations.md",
+		"markdown_source": "../docs/designers-developers/developers/backward-compatibility/deprecations.md",
 		"parent": "backward-compatibility"
 	},
 	{
 		"title": "Meta Boxes",
 		"slug": "meta-box",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/backward-compatibility/meta-box.md",
+		"markdown_source": "../docs/designers-developers/developers/backward-compatibility/meta-box.md",
 		"parent": "backward-compatibility"
-	},
-	{
-		"title": "Tutorials",
-		"slug": "tutorials",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/readme.md",
-		"parent": "developers"
-	},
-	{
-		"title": "Getting Started with JavaScript",
-		"slug": "javascript",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/javascript/readme.md",
-		"parent": "tutorials"
-	},
-	{
-		"title": "Plugins Background",
-		"slug": "plugins-background",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/javascript/plugins-background.md",
-		"parent": "javascript"
-	},
-	{
-		"title": "Loading JavaScript",
-		"slug": "loading-javascript",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/javascript/loading-javascript.md",
-		"parent": "javascript"
-	},
-	{
-		"title": "Extending the Block Editor",
-		"slug": "extending-the-block-editor",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/javascript/extending-the-block-editor.md",
-		"parent": "javascript"
-	},
-	{
-		"title": "Troubleshooting",
-		"slug": "troubleshooting",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/javascript/troubleshooting.md",
-		"parent": "javascript"
-	},
-	{
-		"title": "JavaScript Versions and Build Step",
-		"slug": "versions-and-building",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/javascript/versions-and-building.md",
-		"parent": "javascript"
-	},
-	{
-		"title": "Scope Your Code",
-		"slug": "scope-your-code",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/javascript/scope-your-code.md",
-		"parent": "javascript"
-	},
-	{
-		"title": "JavaScript Build Setup",
-		"slug": "js-build-setup",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md",
-		"parent": "javascript"
-	},
-	{
-		"title": "Blocks",
-		"slug": "block-tutorial",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/block-tutorial/readme.md",
-		"parent": "tutorials"
-	},
-	{
-		"title": "Writing Your First Block Type",
-		"slug": "writing-your-first-block-type",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md",
-		"parent": "block-tutorial"
-	},
-	{
-		"title": "Applying Styles From a Stylesheet",
-		"slug": "applying-styles-with-stylesheets",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/block-tutorial/applying-styles-with-stylesheets.md",
-		"parent": "block-tutorial"
-	},
-	{
-		"title": "Introducing Attributes and Editable Fields",
-		"slug": "introducing-attributes-and-editable-fields",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md",
-		"parent": "block-tutorial"
-	},
-	{
-		"title": "Block Controls: Block Toolbar and Settings Sidebar",
-		"slug": "block-controls-toolbar-and-sidebar",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/block-tutorial/block-controls-toolbar-and-sidebar.md",
-		"parent": "block-tutorial"
-	},
-	{
-		"title": "Creating dynamic blocks",
-		"slug": "creating-dynamic-blocks",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/block-tutorial/creating-dynamic-blocks.md",
-		"parent": "block-tutorial"
-	},
-	{
-		"title": "Generate Blocks with WP-CLI",
-		"slug": "generate-blocks-with-wp-cli",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/block-tutorial/generate-blocks-with-wp-cli.md",
-		"parent": "block-tutorial"
-	},
-	{
-		"title": "Meta Boxes",
-		"slug": "metabox",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/metabox/readme.md",
-		"parent": "tutorials"
-	},
-	{
-		"title": "Store Post Meta with a Block",
-		"slug": "meta-block-1-intro",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/metabox/meta-block-1-intro.md",
-		"parent": "metabox"
-	},
-	{
-		"title": "Register Meta Field",
-		"slug": "meta-block-2-register-meta",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/metabox/meta-block-2-register-meta.md",
-		"parent": "metabox"
-	},
-	{
-		"title": "Create Meta Block",
-		"slug": "meta-block-3-add",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md",
-		"parent": "metabox"
-	},
-	{
-		"title": "Use Post Meta Data",
-		"slug": "meta-block-4-use-data",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/metabox/meta-block-4-use-data.md",
-		"parent": "metabox"
-	},
-	{
-		"title": "Finishing Touches",
-		"slug": "meta-block-5-finishing",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/metabox/meta-block-5-finishing.md",
-		"parent": "metabox"
-	},
-	{
-		"title": "Displaying Notices from Your Plugin or Theme",
-		"slug": "notices",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/notices/README.md",
-		"parent": "tutorials"
-	},
-	{
-		"title": "Creating a Sidebar for Your Plugin",
-		"slug": "plugin-sidebar-0",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-0.md",
-		"parent": "tutorials"
-	},
-	{
-		"title": "Get a Sidebar up and Running",
-		"slug": "plugin-sidebar-1-up-and-running",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-1-up-and-running.md",
-		"parent": "plugin-sidebar-0"
-	},
-	{
-		"title": "Tweak the sidebar style and add controls",
-		"slug": "plugin-sidebar-2-styles-and-controls",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-2-styles-and-controls.md",
-		"parent": "plugin-sidebar-0"
-	},
-	{
-		"title": "Register the Meta Field",
-		"slug": "plugin-sidebar-3-register-meta",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-3-register-meta.md",
-		"parent": "plugin-sidebar-0"
-	},
-	{
-		"title": "Initialize the Input Control",
-		"slug": "plugin-sidebar-4-initialize-input",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-4-initialize-input.md",
-		"parent": "plugin-sidebar-0"
-	},
-	{
-		"title": "Update the Meta Field When the Input's Content Changes",
-		"slug": "plugin-sidebar-5-update-meta",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-5-update-meta.md",
-		"parent": "plugin-sidebar-0"
-	},
-	{
-		"title": "Finishing Touches",
-		"slug": "plugin-sidebar-6-finishing-touches",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-6-finishing-touches.md",
-		"parent": "plugin-sidebar-0"
-	},
-	{
-		"title": "Introduction to the Format API",
-		"slug": "format-api",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/format-api/README.md",
-		"parent": "tutorials"
-	},
-	{
-		"title": "Register a New Format",
-		"slug": "1-register-format",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/format-api/1-register-format.md",
-		"parent": "format-api"
-	},
-	{
-		"title": "Add a Button to the Toolbar",
-		"slug": "2-toolbar-button",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/format-api/2-toolbar-button.md",
-		"parent": "format-api"
-	},
-	{
-		"title": "Apply the Format When the Button Is Clicked",
-		"slug": "3-apply-format",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/developers/tutorials/format-api/3-apply-format.md",
-		"parent": "format-api"
 	},
 	{
 		"title": "Designer Documentation",
 		"slug": "designers",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/designers/README.md",
-		"parent": "designers-developers"
+		"markdown_source": "../docs/designers-developers/designers/README.md",
+		"parent": null
 	},
 	{
 		"title": "Block Design",
 		"slug": "block-design",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/designers/block-design.md",
+		"markdown_source": "../docs/designers-developers/designers/block-design.md",
 		"parent": "designers"
 	},
 	{
 		"title": "Patterns",
 		"slug": "design-patterns",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/designers/design-patterns.md",
+		"markdown_source": "../docs/designers-developers/designers/design-patterns.md",
 		"parent": "designers"
 	},
 	{
 		"title": "Resources",
 		"slug": "design-resources",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/designers/design-resources.md",
+		"markdown_source": "../docs/designers-developers/designers/design-resources.md",
 		"parent": "designers"
 	},
 	{
 		"title": "Animation",
 		"slug": "animation",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/designers/animation.md",
+		"markdown_source": "../docs/designers-developers/designers/animation.md",
 		"parent": "designers"
 	},
 	{
-		"title": "Contributors Guide",
+		"title": "Contributor Guide",
 		"slug": "contributors",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/readme.md",
+		"markdown_source": "../docs/contributors/readme.md",
 		"parent": null
-	},
-	{
-		"title": "Principles",
-		"slug": "principles",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/principles.md",
-		"parent": "contributors"
-	},
-	{
-		"title": "Design Principles & Vision",
-		"slug": "design",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/design.md",
-		"parent": "contributors"
-	},
-	{
-		"title": "Blocks are the Interface",
-		"slug": "the-block",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/principles/the-block.md",
-		"parent": "design"
-	},
-	{
-		"title": "Reference",
-		"slug": "reference",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/reference.md",
-		"parent": "design"
 	},
 	{
 		"title": "Developer Contributions",
 		"slug": "develop",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/develop.md",
+		"markdown_source": "../docs/contributors/develop.md",
 		"parent": "contributors"
 	},
 	{
 		"title": "Getting Started",
 		"slug": "getting-started",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/getting-started.md",
+		"markdown_source": "../docs/contributors/getting-started.md",
 		"parent": "develop"
 	},
 	{
 		"title": "Git Workflow",
 		"slug": "git-workflow",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/git-workflow.md",
+		"markdown_source": "../docs/contributors/git-workflow.md",
 		"parent": "develop"
 	},
 	{
 		"title": "Coding Guidelines",
 		"slug": "coding-guidelines",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/coding-guidelines.md",
+		"markdown_source": "../docs/contributors/coding-guidelines.md",
 		"parent": "develop"
 	},
 	{
 		"title": "Testing Overview",
 		"slug": "testing-overview",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/testing-overview.md",
+		"markdown_source": "../docs/contributors/testing-overview.md",
 		"parent": "develop"
 	},
 	{
 		"title": "Block Grammar",
 		"slug": "grammar",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/grammar.md",
+		"markdown_source": "../docs/contributors/grammar.md",
 		"parent": "develop"
 	},
 	{
 		"title": "Scripts",
 		"slug": "scripts",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/scripts.md",
+		"markdown_source": "../docs/contributors/scripts.md",
 		"parent": "develop"
 	},
 	{
 		"title": "Managing Packages",
 		"slug": "managing-packages",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/managing-packages.md",
+		"markdown_source": "../docs/contributors/managing-packages.md",
 		"parent": "develop"
 	},
 	{
 		"title": "Gutenberg Release Process",
 		"slug": "release",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/release.md",
+		"markdown_source": "../docs/contributors/release.md",
 		"parent": "develop"
 	},
 	{
-		"title": "Localizing Gutenberg Plugin",
-		"slug": "localizing",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/localizing.md",
+		"title": "React Native based mobile Gutenberg",
+		"slug": "native-mobile",
+		"markdown_source": "../docs/contributors/native-mobile.md",
 		"parent": "develop"
+	},
+	{
+		"title": "Design Principles & Vision",
+		"slug": "design",
+		"markdown_source": "../docs/contributors/design.md",
+		"parent": "contributors"
+	},
+	{
+		"title": "Blocks are the Interface",
+		"slug": "the-block",
+		"markdown_source": "../docs/contributors/principles/the-block.md",
+		"parent": "design"
+	},
+	{
+		"title": "Reference",
+		"slug": "reference",
+		"markdown_source": "../docs/contributors/reference.md",
+		"parent": "design"
 	},
 	{
 		"title": "Documentation Contributions",
 		"slug": "document",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/document.md",
+		"markdown_source": "../docs/contributors/document.md",
 		"parent": "contributors"
 	},
 	{
 		"title": "Copy Guidelines",
 		"slug": "copy-guide",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/copy-guide.md",
+		"markdown_source": "../docs/contributors/copy-guide.md",
 		"parent": "document"
 	},
 	{
-		"title": "History",
-		"slug": "history",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/history.md",
-		"parent": "contributors"
-	},
-	{
-		"title": "Glossary",
-		"slug": "glossary",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/glossary.md",
-		"parent": "contributors"
-	},
-	{
-		"title": "Frequently Asked Questions",
-		"slug": "faq",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/faq.md",
+		"title": "Localizing Gutenberg Plugin",
+		"slug": "localizing",
+		"markdown_source": "../docs/contributors/localizing.md",
 		"parent": "contributors"
 	},
 	{
 		"title": "Repository Management",
 		"slug": "repository-management",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/repository-management.md",
+		"markdown_source": "../docs/contributors/repository-management.md",
 		"parent": "contributors"
 	},
 	{
-		"title": "Outreach",
-		"slug": "outreach",
-		"markdown_source": "https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/contributors/outreach.md",
-		"parent": "contributors"
+		"title": "Tutorials",
+		"slug": "tutorials",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/readme.md",
+		"parent": null
+	},
+	{
+		"title": "Getting Started with JavaScript",
+		"slug": "javascript",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/javascript/readme.md",
+		"parent": "tutorials"
+	},
+	{
+		"title": "Plugins Background",
+		"slug": "plugins-background",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/javascript/plugins-background.md",
+		"parent": "javascript"
+	},
+	{
+		"title": "Loading JavaScript",
+		"slug": "loading-javascript",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/javascript/loading-javascript.md",
+		"parent": "javascript"
+	},
+	{
+		"title": "Extending the Block Editor",
+		"slug": "extending-the-block-editor",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/javascript/extending-the-block-editor.md",
+		"parent": "javascript"
+	},
+	{
+		"title": "Troubleshooting",
+		"slug": "troubleshooting",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/javascript/troubleshooting.md",
+		"parent": "javascript"
+	},
+	{
+		"title": "JavaScript Versions and Build Step",
+		"slug": "versions-and-building",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/javascript/versions-and-building.md",
+		"parent": "javascript"
+	},
+	{
+		"title": "Scope Your Code",
+		"slug": "scope-your-code",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/javascript/scope-your-code.md",
+		"parent": "javascript"
+	},
+	{
+		"title": "JavaScript Build Setup",
+		"slug": "js-build-setup",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/javascript/js-build-setup.md",
+		"parent": "javascript"
+	},
+	{
+		"title": "Blocks",
+		"slug": "block-tutorial",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/block-tutorial/readme.md",
+		"parent": "tutorials"
+	},
+	{
+		"title": "Writing Your First Block Type",
+		"slug": "writing-your-first-block-type",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/block-tutorial/writing-your-first-block-type.md",
+		"parent": "block-tutorial"
+	},
+	{
+		"title": "Applying Styles From a Stylesheet",
+		"slug": "applying-styles-with-stylesheets",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/block-tutorial/applying-styles-with-stylesheets.md",
+		"parent": "block-tutorial"
+	},
+	{
+		"title": "Introducing Attributes and Editable Fields",
+		"slug": "introducing-attributes-and-editable-fields",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields.md",
+		"parent": "block-tutorial"
+	},
+	{
+		"title": "Block Controls: Block Toolbar and Settings Sidebar",
+		"slug": "block-controls-toolbar-and-sidebar",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/block-tutorial/block-controls-toolbar-and-sidebar.md",
+		"parent": "block-tutorial"
+	},
+	{
+		"title": "Creating dynamic blocks",
+		"slug": "creating-dynamic-blocks",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/block-tutorial/creating-dynamic-blocks.md",
+		"parent": "block-tutorial"
+	},
+	{
+		"title": "Generate Blocks with WP-CLI",
+		"slug": "generate-blocks-with-wp-cli",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/block-tutorial/generate-blocks-with-wp-cli.md",
+		"parent": "block-tutorial"
+	},
+	{
+		"title": "Nested Blocks: Using InnerBlocks",
+		"slug": "nested-blocks-inner-blocks",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/block-tutorial/nested-blocks-inner-blocks.md",
+		"parent": "block-tutorial"
+	},
+	{
+		"title": "Meta Boxes",
+		"slug": "metabox",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/metabox/readme.md",
+		"parent": "tutorials"
+	},
+	{
+		"title": "Store Post Meta with a Block",
+		"slug": "meta-block-1-intro",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/metabox/meta-block-1-intro.md",
+		"parent": "metabox"
+	},
+	{
+		"title": "Register Meta Field",
+		"slug": "meta-block-2-register-meta",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/metabox/meta-block-2-register-meta.md",
+		"parent": "metabox"
+	},
+	{
+		"title": "Create Meta Block",
+		"slug": "meta-block-3-add",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/metabox/meta-block-3-add.md",
+		"parent": "metabox"
+	},
+	{
+		"title": "Use Post Meta Data",
+		"slug": "meta-block-4-use-data",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/metabox/meta-block-4-use-data.md",
+		"parent": "metabox"
+	},
+	{
+		"title": "Finishing Touches",
+		"slug": "meta-block-5-finishing",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/metabox/meta-block-5-finishing.md",
+		"parent": "metabox"
+	},
+	{
+		"title": "Displaying Notices from Your Plugin or Theme",
+		"slug": "notices",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/notices/README.md",
+		"parent": "tutorials"
+	},
+	{
+		"title": "Creating a Sidebar for Your Plugin",
+		"slug": "plugin-sidebar-0",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-0.md",
+		"parent": "tutorials"
+	},
+	{
+		"title": "Get a Sidebar up and Running",
+		"slug": "plugin-sidebar-1-up-and-running",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-1-up-and-running.md",
+		"parent": "plugin-sidebar-0"
+	},
+	{
+		"title": "Tweak the sidebar style and add controls",
+		"slug": "plugin-sidebar-2-styles-and-controls",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-2-styles-and-controls.md",
+		"parent": "plugin-sidebar-0"
+	},
+	{
+		"title": "Register the Meta Field",
+		"slug": "plugin-sidebar-3-register-meta",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-3-register-meta.md",
+		"parent": "plugin-sidebar-0"
+	},
+	{
+		"title": "Initialize the Input Control",
+		"slug": "plugin-sidebar-4-initialize-input",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-4-initialize-input.md",
+		"parent": "plugin-sidebar-0"
+	},
+	{
+		"title": "Update the Meta Field When the Input's Content Changes",
+		"slug": "plugin-sidebar-5-update-meta",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-5-update-meta.md",
+		"parent": "plugin-sidebar-0"
+	},
+	{
+		"title": "Finishing Touches",
+		"slug": "plugin-sidebar-6-finishing-touches",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-6-finishing-touches.md",
+		"parent": "plugin-sidebar-0"
+	},
+	{
+		"title": "Introduction to the Format API",
+		"slug": "format-api",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/format-api/README.md",
+		"parent": "tutorials"
+	},
+	{
+		"title": "Register a New Format",
+		"slug": "1-register-format",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/format-api/1-register-format.md",
+		"parent": "format-api"
+	},
+	{
+		"title": "Add a Button to the Toolbar",
+		"slug": "2-toolbar-button",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/format-api/2-toolbar-button.md",
+		"parent": "format-api"
+	},
+	{
+		"title": "Apply the Format When the Button Is Clicked",
+		"slug": "3-apply-format",
+		"markdown_source": "../docs/designers-developers/developers/tutorials/format-api/3-apply-format.md",
+		"parent": "format-api"
+	},
+	{
+		"title": "Component Reference",
+		"slug": "components",
+		"markdown_source": "../packages/components/README.md",
+		"parent": null
+	},
+	{
+		"title": "Animate",
+		"slug": "animate",
+		"markdown_source": "../packages/components/src/animate/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "Autocomplete",
+		"slug": "autocomplete",
+		"markdown_source": "../packages/components/src/autocomplete/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "BaseControl",
+		"slug": "base-control",
+		"markdown_source": "../packages/components/src/base-control/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "ButtonGroup",
+		"slug": "button-group",
+		"markdown_source": "../packages/components/src/button-group/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "Button",
+		"slug": "button",
+		"markdown_source": "../packages/components/src/button/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "Card",
+		"slug": "card",
+		"markdown_source": "../packages/components/src/card/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "CheckboxControl",
+		"slug": "checkbox-control",
+		"markdown_source": "../packages/components/src/checkbox-control/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "ClipboardButton",
+		"slug": "clipboard-button",
+		"markdown_source": "../packages/components/src/clipboard-button/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "ColorIndicator",
+		"slug": "color-indicator",
+		"markdown_source": "../packages/components/src/color-indicator/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "ColorPalette",
+		"slug": "color-palette",
+		"markdown_source": "../packages/components/src/color-palette/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "ColorPicker",
+		"slug": "color-picker",
+		"markdown_source": "../packages/components/src/color-picker/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "CustomSelectControl",
+		"slug": "custom-select-control",
+		"markdown_source": "../packages/components/src/custom-select-control/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "Dashicon",
+		"slug": "dashicon",
+		"markdown_source": "../packages/components/src/dashicon/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "DateTime",
+		"slug": "date-time",
+		"markdown_source": "../packages/components/src/date-time/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "DimensionControl",
+		"slug": "dimension-control",
+		"markdown_source": "../packages/components/src/dimension-control/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "Disabled",
+		"slug": "disabled",
+		"markdown_source": "../packages/components/src/disabled/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "Draggable",
+		"slug": "draggable",
+		"markdown_source": "../packages/components/src/draggable/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "DropZone",
+		"slug": "drop-zone",
+		"markdown_source": "../packages/components/src/drop-zone/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "DropdownMenu",
+		"slug": "dropdown-menu",
+		"markdown_source": "../packages/components/src/dropdown-menu/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "Dropdown",
+		"slug": "dropdown",
+		"markdown_source": "../packages/components/src/dropdown/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "ExternalLink",
+		"slug": "external-link",
+		"markdown_source": "../packages/components/src/external-link/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "FocalPointPicker",
+		"slug": "focal-point-picker",
+		"markdown_source": "../packages/components/src/focal-point-picker/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "FocusableIframe",
+		"slug": "focusable-iframe",
+		"markdown_source": "../packages/components/src/focusable-iframe/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "FontSizePicker",
+		"slug": "font-size-picker",
+		"markdown_source": "../packages/components/src/font-size-picker/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "FormFileUpload",
+		"slug": "form-file-upload",
+		"markdown_source": "../packages/components/src/form-file-upload/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "FormToggle",
+		"slug": "form-toggle",
+		"markdown_source": "../packages/components/src/form-toggle/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "FormTokenField",
+		"slug": "form-token-field",
+		"markdown_source": "../packages/components/src/form-token-field/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "Guide",
+		"slug": "guide",
+		"markdown_source": "../packages/components/src/guide/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "NavigateRegions",
+		"slug": "navigate-regions",
+		"markdown_source": "../packages/components/src/higher-order/navigate-regions/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "HigherOrder",
+		"slug": "higher-order",
+		"markdown_source": "../packages/components/src/higher-order/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "WithConstrainedTabbing",
+		"slug": "with-constrained-tabbing",
+		"markdown_source": "../packages/components/src/higher-order/with-constrained-tabbing/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "WithFallbackStyles",
+		"slug": "with-fallback-styles",
+		"markdown_source": "../packages/components/src/higher-order/with-fallback-styles/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "WithFilters",
+		"slug": "with-filters",
+		"markdown_source": "../packages/components/src/higher-order/with-filters/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "WithFocusOutside",
+		"slug": "with-focus-outside",
+		"markdown_source": "../packages/components/src/higher-order/with-focus-outside/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "WithFocusReturn",
+		"slug": "with-focus-return",
+		"markdown_source": "../packages/components/src/higher-order/with-focus-return/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "WithNotices",
+		"slug": "with-notices",
+		"markdown_source": "../packages/components/src/higher-order/with-notices/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "WithSpokenMessages",
+		"slug": "with-spoken-messages",
+		"markdown_source": "../packages/components/src/higher-order/with-spoken-messages/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "Icon",
+		"slug": "icon",
+		"markdown_source": "../packages/components/src/icon/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "IsolatedEventContainer",
+		"slug": "isolated-event-container",
+		"markdown_source": "../packages/components/src/isolated-event-container/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "KeyboardShortcuts",
+		"slug": "keyboard-shortcuts",
+		"markdown_source": "../packages/components/src/keyboard-shortcuts/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "MenuGroup",
+		"slug": "menu-group",
+		"markdown_source": "../packages/components/src/menu-group/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "MenuItem",
+		"slug": "menu-item",
+		"markdown_source": "../packages/components/src/menu-item/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "MenuItemsChoice",
+		"slug": "menu-items-choice",
+		"markdown_source": "../packages/components/src/menu-items-choice/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "Modal",
+		"slug": "modal",
+		"markdown_source": "../packages/components/src/modal/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "NavigableContainer",
+		"slug": "navigable-container",
+		"markdown_source": "../packages/components/src/navigable-container/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "Notice",
+		"slug": "notice",
+		"markdown_source": "../packages/components/src/notice/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "Panel",
+		"slug": "panel",
+		"markdown_source": "../packages/components/src/panel/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "Placeholder",
+		"slug": "placeholder",
+		"markdown_source": "../packages/components/src/placeholder/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "Popover",
+		"slug": "popover",
+		"markdown_source": "../packages/components/src/popover/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "QueryControls",
+		"slug": "query-controls",
+		"markdown_source": "../packages/components/src/query-controls/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "RadioControl",
+		"slug": "radio-control",
+		"markdown_source": "../packages/components/src/radio-control/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "RangeControl",
+		"slug": "range-control",
+		"markdown_source": "../packages/components/src/range-control/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "ResizableBox",
+		"slug": "resizable-box",
+		"markdown_source": "../packages/components/src/resizable-box/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "ResponsiveWrapper",
+		"slug": "responsive-wrapper",
+		"markdown_source": "../packages/components/src/responsive-wrapper/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "Sandbox",
+		"slug": "sandbox",
+		"markdown_source": "../packages/components/src/sandbox/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "ScrollLock",
+		"slug": "scroll-lock",
+		"markdown_source": "../packages/components/src/scroll-lock/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "SelectControl",
+		"slug": "select-control",
+		"markdown_source": "../packages/components/src/select-control/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "SlotFill",
+		"slug": "slot-fill",
+		"markdown_source": "../packages/components/src/slot-fill/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "Snackbar",
+		"slug": "snackbar",
+		"markdown_source": "../packages/components/src/snackbar/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "Spinner",
+		"slug": "spinner",
+		"markdown_source": "../packages/components/src/spinner/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "TabPanel",
+		"slug": "tab-panel",
+		"markdown_source": "../packages/components/src/tab-panel/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "TextControl",
+		"slug": "text-control",
+		"markdown_source": "../packages/components/src/text-control/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "TextHighlight",
+		"slug": "text-highlight",
+		"markdown_source": "../packages/components/src/text-highlight/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "Text",
+		"slug": "text",
+		"markdown_source": "../packages/components/src/text/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "TextareaControl",
+		"slug": "textarea-control",
+		"markdown_source": "../packages/components/src/textarea-control/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "ToggleControl",
+		"slug": "toggle-control",
+		"markdown_source": "../packages/components/src/toggle-control/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "Toolbar",
+		"slug": "toolbar",
+		"markdown_source": "../packages/components/src/toolbar/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "Tooltip",
+		"slug": "tooltip",
+		"markdown_source": "../packages/components/src/tooltip/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "TreeSelect",
+		"slug": "tree-select",
+		"markdown_source": "../packages/components/src/tree-select/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "VisuallyHidden",
+		"slug": "visually-hidden",
+		"markdown_source": "../packages/components/src/visually-hidden/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "Data Module Reference",
+		"slug": "data",
+		"markdown_source": "../docs/designers-developers/developers/data/README.md",
+		"parent": null
+	},
+	{
+		"title": "WordPress Core Data",
+		"slug": "data-core",
+		"markdown_source": "../docs/designers-developers/developers/data/data-core.md",
+		"parent": "data"
+	},
+	{
+		"title": "Annotations",
+		"slug": "data-core-annotations",
+		"markdown_source": "../docs/designers-developers/developers/data/data-core-annotations.md",
+		"parent": "data"
+	},
+	{
+		"title": "Block Types Data",
+		"slug": "data-core-blocks",
+		"markdown_source": "../docs/designers-developers/developers/data/data-core-blocks.md",
+		"parent": "data"
+	},
+	{
+		"title": "The Block Editor’s Data",
+		"slug": "data-core-block-editor",
+		"markdown_source": "../docs/designers-developers/developers/data/data-core-block-editor.md",
+		"parent": "data"
+	},
+	{
+		"title": "The Post Editor’s Data",
+		"slug": "data-core-editor",
+		"markdown_source": "../docs/designers-developers/developers/data/data-core-editor.md",
+		"parent": "data"
+	},
+	{
+		"title": "The Editor’s UI Data",
+		"slug": "data-core-edit-post",
+		"markdown_source": "../docs/designers-developers/developers/data/data-core-edit-post.md",
+		"parent": "data"
+	},
+	{
+		"title": "Notices Data",
+		"slug": "data-core-notices",
+		"markdown_source": "../docs/designers-developers/developers/data/data-core-notices.md",
+		"parent": "data"
+	},
+	{
+		"title": "The NUX (New User Experience) Data",
+		"slug": "data-core-nux",
+		"markdown_source": "../docs/designers-developers/developers/data/data-core-nux.md",
+		"parent": "data"
+	},
+	{
+		"title": "The Viewport Data",
+		"slug": "data-core-viewport",
+		"markdown_source": "../docs/designers-developers/developers/data/data-core-viewport.md",
+		"parent": "data"
+	},
+	{
+		"title": "Package Reference",
+		"slug": "packages",
+		"markdown_source": "../docs/designers-developers/developers/packages.md",
+		"parent": null
+	},
+	{
+		"title": "@wordpress/a11y",
+		"slug": "packages-a11y",
+		"markdown_source": "../packages/a11y/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/annotations",
+		"slug": "packages-annotations",
+		"markdown_source": "../packages/annotations/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/api-fetch",
+		"slug": "packages-api-fetch",
+		"markdown_source": "../packages/api-fetch/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/autop",
+		"slug": "packages-autop",
+		"markdown_source": "../packages/autop/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/babel-plugin-import-jsx-pragma",
+		"slug": "packages-babel-plugin-import-jsx-pragma",
+		"markdown_source": "../packages/babel-plugin-import-jsx-pragma/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/babel-plugin-makepot",
+		"slug": "packages-babel-plugin-makepot",
+		"markdown_source": "../packages/babel-plugin-makepot/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/babel-preset-default",
+		"slug": "packages-babel-preset-default",
+		"markdown_source": "../packages/babel-preset-default/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/base-styles",
+		"slug": "packages-base-styles",
+		"markdown_source": "../packages/base-styles/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/blob",
+		"slug": "packages-blob",
+		"markdown_source": "../packages/blob/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/block-directory",
+		"slug": "packages-block-directory",
+		"markdown_source": "../packages/block-directory/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/block-editor",
+		"slug": "packages-block-editor",
+		"markdown_source": "../packages/block-editor/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/block-library",
+		"slug": "packages-block-library",
+		"markdown_source": "../packages/block-library/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/block-serialization-default-parser",
+		"slug": "packages-block-serialization-default-parser",
+		"markdown_source": "../packages/block-serialization-default-parser/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/block-serialization-spec-parser",
+		"slug": "packages-block-serialization-spec-parser",
+		"markdown_source": "../packages/block-serialization-spec-parser/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/blocks",
+		"slug": "packages-blocks",
+		"markdown_source": "../packages/blocks/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/browserslist-config",
+		"slug": "packages-browserslist-config",
+		"markdown_source": "../packages/browserslist-config/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/components",
+		"slug": "packages-components",
+		"markdown_source": "../packages/components/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/compose",
+		"slug": "packages-compose",
+		"markdown_source": "../packages/compose/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/core-data",
+		"slug": "packages-core-data",
+		"markdown_source": "../packages/core-data/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/create-block",
+		"slug": "packages-create-block",
+		"markdown_source": "../packages/create-block/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/custom-templated-path-webpack-plugin",
+		"slug": "packages-custom-templated-path-webpack-plugin",
+		"markdown_source": "../packages/custom-templated-path-webpack-plugin/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/data-controls",
+		"slug": "packages-data-controls",
+		"markdown_source": "../packages/data-controls/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/data",
+		"slug": "packages-data",
+		"markdown_source": "../packages/data/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/date",
+		"slug": "packages-date",
+		"markdown_source": "../packages/date/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/dependency-extraction-webpack-plugin",
+		"slug": "packages-dependency-extraction-webpack-plugin",
+		"markdown_source": "../packages/dependency-extraction-webpack-plugin/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/deprecated",
+		"slug": "packages-deprecated",
+		"markdown_source": "../packages/deprecated/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/docgen",
+		"slug": "packages-docgen",
+		"markdown_source": "../packages/docgen/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/dom-ready",
+		"slug": "packages-dom-ready",
+		"markdown_source": "../packages/dom-ready/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/dom",
+		"slug": "packages-dom",
+		"markdown_source": "../packages/dom/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/e2e-test-utils",
+		"slug": "packages-e2e-test-utils",
+		"markdown_source": "../packages/e2e-test-utils/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/e2e-tests",
+		"slug": "packages-e2e-tests",
+		"markdown_source": "../packages/e2e-tests/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/edit-post",
+		"slug": "packages-edit-post",
+		"markdown_source": "../packages/edit-post/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/edit-site",
+		"slug": "packages-edit-site",
+		"markdown_source": "../packages/edit-site/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/edit-widgets",
+		"slug": "packages-edit-widgets",
+		"markdown_source": "../packages/edit-widgets/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/editor",
+		"slug": "packages-editor",
+		"markdown_source": "../packages/editor/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/element",
+		"slug": "packages-element",
+		"markdown_source": "../packages/element/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/env",
+		"slug": "packages-env",
+		"markdown_source": "../packages/env/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/escape-html",
+		"slug": "packages-escape-html",
+		"markdown_source": "../packages/escape-html/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/eslint-plugin",
+		"slug": "packages-eslint-plugin",
+		"markdown_source": "../packages/eslint-plugin/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/format-library",
+		"slug": "packages-format-library",
+		"markdown_source": "../packages/format-library/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/hooks",
+		"slug": "packages-hooks",
+		"markdown_source": "../packages/hooks/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/html-entities",
+		"slug": "packages-html-entities",
+		"markdown_source": "../packages/html-entities/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/i18n",
+		"slug": "packages-i18n",
+		"markdown_source": "../packages/i18n/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/icons",
+		"slug": "packages-icons",
+		"markdown_source": "../packages/icons/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/is-shallow-equal",
+		"slug": "packages-is-shallow-equal",
+		"markdown_source": "../packages/is-shallow-equal/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/jest-console",
+		"slug": "packages-jest-console",
+		"markdown_source": "../packages/jest-console/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/jest-preset-default",
+		"slug": "packages-jest-preset-default",
+		"markdown_source": "../packages/jest-preset-default/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/jest-puppeteer-axe",
+		"slug": "packages-jest-puppeteer-axe",
+		"markdown_source": "../packages/jest-puppeteer-axe/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/keyboard-shortcuts",
+		"slug": "packages-keyboard-shortcuts",
+		"markdown_source": "../packages/keyboard-shortcuts/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/keycodes",
+		"slug": "packages-keycodes",
+		"markdown_source": "../packages/keycodes/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/library-export-default-webpack-plugin",
+		"slug": "packages-library-export-default-webpack-plugin",
+		"markdown_source": "../packages/library-export-default-webpack-plugin/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/list-reusable-blocks",
+		"slug": "packages-list-reusable-blocks",
+		"markdown_source": "../packages/list-reusable-blocks/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/media-utils",
+		"slug": "packages-media-utils",
+		"markdown_source": "../packages/media-utils/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/notices",
+		"slug": "packages-notices",
+		"markdown_source": "../packages/notices/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/npm-package-json-lint-config",
+		"slug": "packages-npm-package-json-lint-config",
+		"markdown_source": "../packages/npm-package-json-lint-config/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/nux",
+		"slug": "packages-nux",
+		"markdown_source": "../packages/nux/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/plugins",
+		"slug": "packages-plugins",
+		"markdown_source": "../packages/plugins/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/postcss-themes",
+		"slug": "packages-postcss-themes",
+		"markdown_source": "../packages/postcss-themes/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/primitives",
+		"slug": "packages-primitives",
+		"markdown_source": "../packages/primitives/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/priority-queue",
+		"slug": "packages-priority-queue",
+		"markdown_source": "../packages/priority-queue/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/project-management-automation",
+		"slug": "packages-project-management-automation",
+		"markdown_source": "../packages/project-management-automation/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/redux-routine",
+		"slug": "packages-redux-routine",
+		"markdown_source": "../packages/redux-routine/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/rich-text",
+		"slug": "packages-rich-text",
+		"markdown_source": "../packages/rich-text/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/scripts",
+		"slug": "packages-scripts",
+		"markdown_source": "../packages/scripts/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/server-side-render",
+		"slug": "packages-server-side-render",
+		"markdown_source": "../packages/server-side-render/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/shortcode",
+		"slug": "packages-shortcode",
+		"markdown_source": "../packages/shortcode/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/token-list",
+		"slug": "packages-token-list",
+		"markdown_source": "../packages/token-list/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/url",
+		"slug": "packages-url",
+		"markdown_source": "../packages/url/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/viewport",
+		"slug": "packages-viewport",
+		"markdown_source": "../packages/viewport/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/warning",
+		"slug": "packages-warning",
+		"markdown_source": "../packages/warning/README.md",
+		"parent": "packages"
+	},
+	{
+		"title": "@wordpress/wordcount",
+		"slug": "packages-wordcount",
+		"markdown_source": "../packages/wordcount/README.md",
+		"parent": "packages"
 	}
 ]

--- a/docs/tool/index.js
+++ b/docs/tool/index.js
@@ -12,7 +12,7 @@ const path = require( 'path' );
 const { getRootManifest } = require( './manifest' );
 
 const tocFileInput = path.resolve( __dirname, '../toc.json' );
-const manifestOutput = path.resolve( __dirname, '../manifest-devhub.json' );
+const manifestOutput = path.resolve( __dirname, '../manifest.json' );
 
 // Update data files from code
 execFileSync( 'node', [ join( __dirname, 'update-data.js' ) ] );


### PR DESCRIPTION
## Description
This PR re-enables a docs manifest at `manifest.json`. It's the next step to normalizing our docs build workflow.

I've left `manifest-devhub.json` in the repo so we can merge this change and repoint DevHub to `manifest.json` without any temporary breaks.

Once that change has been made, I'll follow up with a final PR to remove `devhub-manifest.json` entirely.

I'd like to hold this PR for a few days in case we need to re-enable the old handbook for some reason, so I'll mark it as a draft. This is more of a placeholder for myself :)