### PR TITLE
Fixes #15270. Removes the custom highlight on selected text.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -174,13 +174,6 @@
  */
 
 .block-editor-block-list__layout .block-editor-block-list__block {
-	::-moz-selection {
-		background-color: $blue-medium-highlight;
-	}
-
-	::selection {
-		background-color: $blue-medium-highlight;
-	}
 
 	// Selection style for multiple blocks.
 	&.is-multi-selected *::selection {


### PR DESCRIPTION
## Description
Fixes #15270. Removes the custom light blue highlight on selected text. 

## How has this been tested?
Tested locally on both Chrome and Firefox.

## Screenshots

**CURRENT**

![highlight-old](https://user-images.githubusercontent.com/617986/57738316-cd512d80-7663-11e9-885c-6fa7b021e5e5.gif)

**PROPOSED**

![highlight-new](https://user-images.githubusercontent.com/617986/57738457-64b68080-7664-11e9-8b2d-c6705bac0f03.gif)


## Types of changes
Removed the CSS that added a custom highlight to selected text. Now Gutenberg just relies on the native browser highlight.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
