### PR TITLE
Fix: Disabled block switcher icons are blurry

### DIFF
--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -73,9 +73,8 @@ export class BlockSwitcher extends Component {
 						disabled
 						className="editor-block-switcher__no-switcher-icon block-editor-block-switcher__no-switcher-icon"
 						label={ __( 'Block icon' ) }
-					>
-						<BlockIcon icon={ icon } showColors />
-					</IconButton>
+						icon={ <BlockIcon icon={ icon } showColors /> }
+					/>
 				</Toolbar>
 			);
 		}

--- a/packages/block-editor/src/components/block-switcher/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/block-switcher/test/__snapshots__/index.js.snap
@@ -5,13 +5,14 @@ exports[`BlockSwitcher should render disabled block switcher with multi block of
   <ForwardRef(IconButton)
     className="editor-block-switcher__no-switcher-icon block-editor-block-switcher__no-switcher-icon"
     disabled={true}
+    icon={
+      <BlockIcon
+        icon="layout"
+        showColors={true}
+      />
+    }
     label="Block icon"
-  >
-    <BlockIcon
-      icon="layout"
-      showColors={true}
-    />
-  </ForwardRef(IconButton)>
+  />
 </Toolbar>
 `;
 


### PR DESCRIPTION
## Description
Fixes #15629.

It looks like `IconButton` has a very unexpected logic for adding `has-text` class. It adds it when children prop is passed which was the case. However, an icon isn't really the text 🤷‍♂ 

## Before

When the block switcher is disabled, the block icon inside of it appears smaller than it should, resulting in some blurry icons on non-retina screens. Here's the Container block icon for instance, appearing at `20px` wide: 

![Screen Shot 2019-05-14 at 9 43 41 AM](https://user-images.githubusercontent.com/1202812/57702828-dd014f80-762c-11e9-906a-f9116e1e2e30.png)

For comparison, here's a non-disabled icon, which renders at the correct `24px` wide: 

![Screen Shot 2019-05-14 at 9 47 24 AM](https://user-images.githubusercontent.com/1202812/57703067-4bdea880-762d-11e9-8385-76c274ccd18f.png)
## Screenshots <!-- if applicable -->

## After 

![Screen Shot 2019-05-15 at 11 59 23](https://user-images.githubusercontent.com/699132/57767110-e7911700-7708-11e9-9659-5010de428b5f.png)
