### PR TITLE
i18n: Merge similar translation strings - file errors

### DIFF
--- a/packages/editor/src/utils/media-upload/media-upload.js
+++ b/packages/editor/src/utils/media-upload/media-upload.js
@@ -152,7 +152,7 @@ export async function mediaUpload( {
 		if ( mediaFile.size <= 0 ) {
 			triggerError( {
 				code: 'EMPTY_FILE',
-				message: __( 'This file is empty.' ),
+				message: __( 'This file is empty. Please try another.' ),
 				file: mediaFile,
 			} );
 			continue;


### PR DESCRIPTION
## Description

Merge [similar translation strings](https://translate.wordpress.org/projects/wp/dev/he/default/?filters%5Bterm%5D=This+file&filters%5Buser_login%5D=&filters%5Bstatus%5D=current_or_waiting_or_fuzzy_or_untranslated&filter=Filter&sort%5Bby%5D=original&sort%5Bhow%5D=asc).

Moved here from: https://core.trac.wordpress.org/ticket/47277#comment:2

## Screenshots <!-- if applicable -->

![47277](https://user-images.githubusercontent.com/576623/57769438-8c662100-7716-11e9-868c-e5cfd976d7b9.png)

## Types of changes
Translation string change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
