### PR TITLE
[Mobile] Merge hotfix v1.4.1 back to master

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -64,6 +64,14 @@ class ImageEdit extends React.Component {
 	componentDidMount() {
 		const { attributes, setAttributes } = this.props;
 
+		// This will warn when we have `id` defined, while `url` is undefined.
+		// This may help track this issue: https://github.com/wordpress-mobile/WordPress-Android/issues/9768
+		// where a cancelled image upload was resulting in a subsequent crash.
+		if ( attributes.id && ! attributes.url ) {
+			// eslint-disable-next-line no-console
+			console.warn( 'Attributes has id with no url.' );
+		}
+
 		if ( attributes.id && attributes.url && ! isURL( attributes.url ) ) {
 			if ( attributes.url.indexOf( 'file:' ) === 0 ) {
 				requestMediaImport( attributes.url, ( mediaId, mediaUri ) => {


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This PR merges the hotfix v1.4.1 (for this issue: https://github.com/wordpress-mobile/WordPress-Android/issues/9768) back to master.

**Note:** some of the changes for the hotfix are already in master, so this PR only brings in the `console.warn` to help track the issue, and some comments.

**Original (merged) PR:** https://github.com/WordPress/gutenberg/pull/15532/files
**Fix already in master:** https://github.com/WordPress/gutenberg/commit/295a381#diff-a61b3f346c11f42236eb2b1a783bf9bfR67

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested with steps here: https://github.com/wordpress-mobile/WordPress-Android/issues/9768#issuecomment-490852531.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
