### PR TITLE
Add  @daniloercoli and @sergioestevao as RichText CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -77,9 +77,9 @@
 /packages/plugins                               @youknowriad @gziolo @aduth @adamsilverstein
 
 # Rich Text
-/packages/format-library                        @youknowriad @aduth @ellatrix @jorgefilipecosta
-/packages/rich-text                             @youknowriad @aduth @ellatrix @jorgefilipecosta
-/packages/block-editor/src/components/rich-text @youknowriad @aduth @ellatrix @jorgefilipecosta
+/packages/format-library                        @youknowriad @aduth @ellatrix @jorgefilipecosta @daniloercoli @sergioestevao
+/packages/rich-text                             @youknowriad @aduth @ellatrix @jorgefilipecosta @daniloercoli @sergioestevao
+/packages/block-editor/src/components/rich-text @youknowriad @aduth @ellatrix @jorgefilipecosta @daniloercoli @sergioestevao
 
 # PHP
 /lib                                            @youknowriad @gziolo @aduth


### PR DESCRIPTION
As mentioned on the last editor chat, let's make sure we have one
representative of each mobile platform keeping notified of changes to RichText.

https://make.wordpress.org/core/2019/05/15/editor-chat-summary-may-15/
