### PR TITLE
Fix rich image caption toolbar and focus

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -828,7 +828,7 @@ const RichTextContainer = compose( [
 		}
 		return {
 			clientId,
-			onFocus: onFocus,
+			onFocus,
 			onCaretVerticalPositionChange,
 		};
 	} ),

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -822,10 +822,18 @@ RichText.defaultProps = {
 const RichTextContainer = compose( [
 	withInstanceId,
 	withBlockEditContext( ( { clientId, onFocus, isSelected, onCaretVerticalPositionChange }, ownProps ) => {
+		// ownProps isSelected and onFocus has precedence over the block context
+		// So instances of RichText outside blocks can handle their own onFocus and send custom isSelected
+		if ( ownProps.isSelected !== undefined ) {
+			isSelected = ownProps.isSelected;
+		}
+		if ( ownProps.onFocus !== undefined ) {
+			onFocus = ownProps.onFocus;
+		}
 		return {
 			clientId,
 			isSelected,
-			onFocus: onFocus || ownProps.onFocus,
+			onFocus: onFocus,
 			onCaretVerticalPositionChange,
 		};
 	} ),

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -821,18 +821,13 @@ RichText.defaultProps = {
 
 const RichTextContainer = compose( [
 	withInstanceId,
-	withBlockEditContext( ( { clientId, onFocus, isSelected, onCaretVerticalPositionChange }, ownProps ) => {
-		// ownProps isSelected and onFocus has precedence over the block context
-		// So instances of RichText outside blocks can handle their own onFocus and send custom isSelected
-		if ( ownProps.isSelected !== undefined ) {
-			isSelected = ownProps.isSelected;
-		}
+	withBlockEditContext( ( { clientId, onFocus, onCaretVerticalPositionChange }, ownProps ) => {
+		// ownProps.onFocus needs precedence over the block edit context
 		if ( ownProps.onFocus !== undefined ) {
 			onFocus = ownProps.onFocus;
 		}
 		return {
 			clientId,
-			isSelected,
 			onFocus: onFocus,
 			onCaretVerticalPositionChange,
 		};


### PR DESCRIPTION
This PR fixes an issue with the new rich image caption where the edit image button and rich-text toolbar buttons were together in the toolbar, and the caption was autofocusing when the block was selected.

`gutenberg-mobile` side PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/987

To test:
- Run the example project
- Select the image block with image
  - Check that the caption is not auto-focused
  - Check that the tool bar only has the image edit button (pencil)
- Tap on the image
  - Check that nothing happens
- Tap on the caption field
  - Check that the caption is focused
  - Check that the toolbar now has the rich-text buttons
  - Check that the toolbar does not have the image edit button (pencil)
- Tap on the image again
  - Check that the caption is unfocused
  - Check that the toolbar has only the image edit button (pencil)
- Check for regressions:
  - Check that the list block is properly selected when is focused.
  - Check that the post title is properly selected when is focused. 