### PR TITLE
Custom Fields option: Add confirmation step

### DIFF
--- a/packages/e2e-tests/specs/preview.test.js
+++ b/packages/e2e-tests/specs/preview.test.js
@@ -70,8 +70,10 @@ async function toggleCustomFieldsOption( shouldBeChecked ) {
 	);
 
 	if ( isChecked !== shouldBeChecked ) {
-		const navigationCompleted = page.waitForNavigation();
 		await checkboxHandle.click();
+		const [ saveButton ] = await page.$x( '//button[text()="Save & Reload"]' );
+		const navigationCompleted = page.waitForNavigation();
+		saveButton.click();
 		await navigationCompleted;
 		return;
 	}

--- a/packages/e2e-tests/specs/preview.test.js
+++ b/packages/e2e-tests/specs/preview.test.js
@@ -71,7 +71,7 @@ async function toggleCustomFieldsOption( shouldBeChecked ) {
 
 	if ( isChecked !== shouldBeChecked ) {
 		await checkboxHandle.click();
-		const [ saveButton ] = await page.$x( '//button[text()="Save & Reload"]' );
+		const [ saveButton ] = await page.$x( shouldBeChecked ? '//button[text()="Enable & Reload"]' : '//button[text()="Disable & Reload"]' );
 		const navigationCompleted = page.waitForNavigation();
 		saveButton.click();
 		await navigationCompleted;

--- a/packages/edit-post/src/components/options-modal/options/base.js
+++ b/packages/edit-post/src/components/options-modal/options/base.js
@@ -3,14 +3,16 @@
  */
 import { CheckboxControl } from '@wordpress/components';
 
-function BaseOption( { label, isChecked, onChange } ) {
+function BaseOption( { label, isChecked, onChange, children } ) {
 	return (
-		<CheckboxControl
-			className="edit-post-options-modal__option"
-			label={ label }
-			checked={ isChecked }
-			onChange={ onChange }
-		/>
+		<div className="edit-post-options-modal__option">
+			<CheckboxControl
+				label={ label }
+				checked={ isChecked }
+				onChange={ onChange }
+			/>
+			{ children }
+		</div>
 	);
 }
 

--- a/packages/edit-post/src/components/options-modal/options/enable-custom-fields.js
+++ b/packages/edit-post/src/components/options-modal/options/enable-custom-fields.js
@@ -15,11 +15,12 @@ export function CustomFieldsConfirmation() {
 	const [ isReloading, setIsReloading ] = useState( false );
 
 	return (
-		<div className="edit-post-options-modal__custom-fields-confirmation">
+		<>
 			<p className="edit-post-options-modal__custom-fields-confirmation-message">
 				{ __( 'Page reload is required for this change.' ) }
 			</p>
 			<Button
+				className="edit-post-options-modal__custom-fields-confirmation-button"
 				isDefault
 				isBusy={ isReloading }
 				disabled={ isReloading }
@@ -30,7 +31,7 @@ export function CustomFieldsConfirmation() {
 			>
 				{ __( 'Save & Reload' ) }
 			</Button>
-		</div>
+		</>
 	);
 }
 

--- a/packages/edit-post/src/components/options-modal/options/enable-custom-fields.js
+++ b/packages/edit-post/src/components/options-modal/options/enable-custom-fields.js
@@ -3,7 +3,7 @@
  */
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Notice, Button } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 
 /**
@@ -16,9 +16,9 @@ export function CustomFieldsConfirmation() {
 
 	return (
 		<div className="edit-post-options-modal__custom-fields-confirmation">
-			<Notice status="warning" isDismissible={ false }>
+			<p className="edit-post-options-modal__custom-fields-confirmation-message">
 				{ __( 'Page reload is required for this change.' ) }
-			</Notice>
+			</p>
 			<Button
 				isDefault
 				isBusy={ isReloading }

--- a/packages/edit-post/src/components/options-modal/options/enable-custom-fields.js
+++ b/packages/edit-post/src/components/options-modal/options/enable-custom-fields.js
@@ -1,7 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Notice, Button } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 
 /**
@@ -9,39 +11,43 @@ import { withSelect } from '@wordpress/data';
  */
 import BaseOption from './base';
 
-export class EnableCustomFieldsOption extends Component {
-	constructor( { isChecked } ) {
-		super( ...arguments );
+export function CustomFieldsConfirmation() {
+	const [ isReloading, setIsReloading ] = useState( false );
 
-		this.toggleCustomFields = this.toggleCustomFields.bind( this );
+	return (
+		<div className="edit-post-options-modal__custom-fields-confirmation">
+			<Notice status="warning" isDismissible={ false }>
+				{ __( 'Page reload is required for this change.' ) }
+			</Notice>
+			<Button
+				isDefault
+				isBusy={ isReloading }
+				disabled={ isReloading }
+				onClick={ () => {
+					setIsReloading( true );
+					document.getElementById( 'toggle-custom-fields-form' ).submit();
+				} }
+			>
+				{ __( 'Save & Reload' ) }
+			</Button>
+		</div>
+	);
+}
 
-		this.state = { isChecked };
-	}
+export function EnableCustomFieldsOption( { label, areCustomFieldsEnabled } ) {
+	const [ isChecked, setIsChecked ] = useState( areCustomFieldsEnabled );
 
-	toggleCustomFields() {
-		// Submit a hidden form which triggers the toggle_custom_fields admin action.
-		// This action will toggle the setting and reload the editor with the meta box
-		// assets included on the page.
-		document.getElementById( 'toggle-custom-fields-form' ).submit();
-
-		// Make it look like something happened while the page reloads.
-		this.setState( { isChecked: ! this.props.isChecked } );
-	}
-
-	render() {
-		const { label } = this.props;
-		const { isChecked } = this.state;
-
-		return (
-			<BaseOption
-				label={ label }
-				isChecked={ isChecked }
-				onChange={ this.toggleCustomFields }
-			/>
-		);
-	}
+	return (
+		<BaseOption
+			label={ label }
+			isChecked={ isChecked }
+			onChange={ ( nextIsChecked ) => setIsChecked( nextIsChecked ) }
+		>
+			{ isChecked !== areCustomFieldsEnabled && <CustomFieldsConfirmation /> }
+		</BaseOption>
+	);
 }
 
 export default withSelect( ( select ) => ( {
-	isChecked: !! select( 'core/editor' ).getEditorSettings().enableCustomFields,
+	areCustomFieldsEnabled: !! select( 'core/editor' ).getEditorSettings().enableCustomFields,
 } ) )( EnableCustomFieldsOption );

--- a/packages/edit-post/src/components/options-modal/options/enable-custom-fields.js
+++ b/packages/edit-post/src/components/options-modal/options/enable-custom-fields.js
@@ -11,7 +11,7 @@ import { withSelect } from '@wordpress/data';
  */
 import BaseOption from './base';
 
-export function CustomFieldsConfirmation( { nextState } ) {
+export function CustomFieldsConfirmation( { willEnable } ) {
 	const [ isReloading, setIsReloading ] = useState( false );
 
 	return (
@@ -29,7 +29,7 @@ export function CustomFieldsConfirmation( { nextState } ) {
 					document.getElementById( 'toggle-custom-fields-form' ).submit();
 				} }
 			>
-				{ nextState ? __( 'Enable & Reload' ) : __( 'Disable & Reload' ) }
+				{ willEnable ? __( 'Enable & Reload' ) : __( 'Disable & Reload' ) }
 			</Button>
 		</>
 	);
@@ -44,7 +44,7 @@ export function EnableCustomFieldsOption( { label, areCustomFieldsEnabled } ) {
 			isChecked={ isChecked }
 			onChange={ setIsChecked }
 		>
-			{ isChecked !== areCustomFieldsEnabled && <CustomFieldsConfirmation nextState={ isChecked } /> }
+			{ isChecked !== areCustomFieldsEnabled && <CustomFieldsConfirmation willEnable={ isChecked } /> }
 		</BaseOption>
 	);
 }

--- a/packages/edit-post/src/components/options-modal/options/enable-custom-fields.js
+++ b/packages/edit-post/src/components/options-modal/options/enable-custom-fields.js
@@ -17,7 +17,7 @@ export function CustomFieldsConfirmation() {
 	return (
 		<>
 			<p className="edit-post-options-modal__custom-fields-confirmation-message">
-				{ __( 'Page reload is required for this change.' ) }
+				{ __( 'A page reload is required for this change.' ) }
 			</p>
 			<Button
 				className="edit-post-options-modal__custom-fields-confirmation-button"

--- a/packages/edit-post/src/components/options-modal/options/enable-custom-fields.js
+++ b/packages/edit-post/src/components/options-modal/options/enable-custom-fields.js
@@ -29,7 +29,7 @@ export function CustomFieldsConfirmation( { nextState } ) {
 					document.getElementById( 'toggle-custom-fields-form' ).submit();
 				} }
 			>
-				{ nextState === true ? __( 'Enable & Reload' ) : __( 'Disable & Reload' ) }
+				{ nextState ? __( 'Enable & Reload' ) : __( 'Disable & Reload' ) }
 			</Button>
 		</>
 	);

--- a/packages/edit-post/src/components/options-modal/options/enable-custom-fields.js
+++ b/packages/edit-post/src/components/options-modal/options/enable-custom-fields.js
@@ -11,7 +11,7 @@ import { withSelect } from '@wordpress/data';
  */
 import BaseOption from './base';
 
-export function CustomFieldsConfirmation() {
+export function CustomFieldsConfirmation( { nextState } ) {
 	const [ isReloading, setIsReloading ] = useState( false );
 
 	return (
@@ -29,7 +29,7 @@ export function CustomFieldsConfirmation() {
 					document.getElementById( 'toggle-custom-fields-form' ).submit();
 				} }
 			>
-				{ __( 'Save & Reload' ) }
+				{ nextState === true ? __( 'Enable & Reload' ) : __( 'Disable & Reload' ) }
 			</Button>
 		</>
 	);
@@ -44,7 +44,7 @@ export function EnableCustomFieldsOption( { label, areCustomFieldsEnabled } ) {
 			isChecked={ isChecked }
 			onChange={ setIsChecked }
 		>
-			{ isChecked !== areCustomFieldsEnabled && <CustomFieldsConfirmation /> }
+			{ isChecked !== areCustomFieldsEnabled && <CustomFieldsConfirmation nextState={ isChecked } /> }
 		</BaseOption>
 	);
 }

--- a/packages/edit-post/src/components/options-modal/options/enable-custom-fields.js
+++ b/packages/edit-post/src/components/options-modal/options/enable-custom-fields.js
@@ -17,7 +17,7 @@ export function CustomFieldsConfirmation( { nextState } ) {
 	return (
 		<>
 			<p className="edit-post-options-modal__custom-fields-confirmation-message">
-				{ __( 'A page reload is required for this change.' ) }
+				{ __( 'A page reload is required for this change. Make sure your content is saved before reloading.' ) }
 			</p>
 			<Button
 				className="edit-post-options-modal__custom-fields-confirmation-button"

--- a/packages/edit-post/src/components/options-modal/options/enable-custom-fields.js
+++ b/packages/edit-post/src/components/options-modal/options/enable-custom-fields.js
@@ -42,7 +42,7 @@ export function EnableCustomFieldsOption( { label, areCustomFieldsEnabled } ) {
 		<BaseOption
 			label={ label }
 			isChecked={ isChecked }
-			onChange={ ( nextIsChecked ) => setIsChecked( nextIsChecked ) }
+			onChange={ setIsChecked }
 		>
 			{ isChecked !== areCustomFieldsEnabled && <CustomFieldsConfirmation /> }
 		</BaseOption>

--- a/packages/edit-post/src/components/options-modal/options/test/__snapshots__/enable-custom-fields.js.snap
+++ b/packages/edit-post/src/components/options-modal/options/test/__snapshots__/enable-custom-fields.js.snap
@@ -27,15 +27,11 @@ exports[`EnableCustomFieldsOption renders a checked checkbox and a confirmation 
   <div
     className="edit-post-options-modal__custom-fields-confirmation"
   >
-    <div
-      className="components-notice is-warning"
+    <p
+      className="edit-post-options-modal__custom-fields-confirmation-message"
     >
-      <div
-        className="components-notice__content"
-      >
-        Page reload is required for this change.
-      </div>
-    </div>
+      Page reload is required for this change.
+    </p>
     <button
       className="components-button is-button is-default"
       disabled={false}
@@ -102,15 +98,11 @@ exports[`EnableCustomFieldsOption renders an unchecked checkbox and a confirmati
   <div
     className="edit-post-options-modal__custom-fields-confirmation"
   >
-    <div
-      className="components-notice is-warning"
+    <p
+      className="edit-post-options-modal__custom-fields-confirmation-message"
     >
-      <div
-        className="components-notice__content"
-      >
-        Page reload is required for this change.
-      </div>
-    </div>
+      Page reload is required for this change.
+    </p>
     <button
       className="components-button is-button is-default"
       disabled={false}

--- a/packages/edit-post/src/components/options-modal/options/test/__snapshots__/enable-custom-fields.js.snap
+++ b/packages/edit-post/src/components/options-modal/options/test/__snapshots__/enable-custom-fields.js.snap
@@ -1,17 +1,151 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EnableCustomFieldsOption renders properly when checked 1`] = `
-<BaseOption
-  isChecked={true}
-  label="Custom Fields"
-  onChange={[Function]}
-/>
+exports[`EnableCustomFieldsOption renders a checked checkbox and a confirmation message when toggled on 1`] = `
+<div
+  className="edit-post-options-modal__option"
+>
+  <div
+    className="components-base-control"
+  >
+    <div
+      className="components-base-control__field"
+    >
+      <input
+        checked={true}
+        className="components-checkbox-control__input"
+        id="inspector-checkbox-control-3"
+        onChange={[Function]}
+        type="checkbox"
+        value="1"
+      />
+      <label
+        className="components-checkbox-control__label"
+        htmlFor="inspector-checkbox-control-3"
+      />
+    </div>
+  </div>
+  <div
+    className="edit-post-options-modal__custom-fields-confirmation"
+  >
+    <div
+      className="components-notice is-warning"
+    >
+      <div
+        className="components-notice__content"
+      >
+        Page reload is required for this change.
+      </div>
+    </div>
+    <button
+      className="components-button is-button is-default"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      Save & Reload
+    </button>
+  </div>
+</div>
 `;
 
-exports[`EnableCustomFieldsOption renders properly when unchecked 1`] = `
-<BaseOption
-  isChecked={false}
-  label="Custom Fields"
-  onChange={[Function]}
-/>
+exports[`EnableCustomFieldsOption renders a checked checkbox when custom fields are enabled 1`] = `
+<div
+  className="edit-post-options-modal__option"
+>
+  <div
+    className="components-base-control"
+  >
+    <div
+      className="components-base-control__field"
+    >
+      <input
+        checked={true}
+        className="components-checkbox-control__input"
+        id="inspector-checkbox-control-0"
+        onChange={[Function]}
+        type="checkbox"
+        value="1"
+      />
+      <label
+        className="components-checkbox-control__label"
+        htmlFor="inspector-checkbox-control-0"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EnableCustomFieldsOption renders an unchecked checkbox and a confirmation message when toggled off 1`] = `
+<div
+  className="edit-post-options-modal__option"
+>
+  <div
+    className="components-base-control"
+  >
+    <div
+      className="components-base-control__field"
+    >
+      <input
+        checked={false}
+        className="components-checkbox-control__input"
+        id="inspector-checkbox-control-2"
+        onChange={[Function]}
+        type="checkbox"
+        value="1"
+      />
+      <label
+        className="components-checkbox-control__label"
+        htmlFor="inspector-checkbox-control-2"
+      />
+    </div>
+  </div>
+  <div
+    className="edit-post-options-modal__custom-fields-confirmation"
+  >
+    <div
+      className="components-notice is-warning"
+    >
+      <div
+        className="components-notice__content"
+      >
+        Page reload is required for this change.
+      </div>
+    </div>
+    <button
+      className="components-button is-button is-default"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      Save & Reload
+    </button>
+  </div>
+</div>
+`;
+
+exports[`EnableCustomFieldsOption renders an unchecked checkbox when custom fields are disabled 1`] = `
+<div
+  className="edit-post-options-modal__option"
+>
+  <div
+    className="components-base-control"
+  >
+    <div
+      className="components-base-control__field"
+    >
+      <input
+        checked={false}
+        className="components-checkbox-control__input"
+        id="inspector-checkbox-control-1"
+        onChange={[Function]}
+        type="checkbox"
+        value="1"
+      />
+      <label
+        className="components-checkbox-control__label"
+        htmlFor="inspector-checkbox-control-1"
+      />
+    </div>
+  </div>
+</div>
 `;

--- a/packages/edit-post/src/components/options-modal/options/test/__snapshots__/enable-custom-fields.js.snap
+++ b/packages/edit-post/src/components/options-modal/options/test/__snapshots__/enable-custom-fields.js.snap
@@ -24,23 +24,19 @@ exports[`EnableCustomFieldsOption renders a checked checkbox and a confirmation 
       />
     </div>
   </div>
-  <div
-    className="edit-post-options-modal__custom-fields-confirmation"
+  <p
+    className="edit-post-options-modal__custom-fields-confirmation-message"
   >
-    <p
-      className="edit-post-options-modal__custom-fields-confirmation-message"
-    >
-      Page reload is required for this change.
-    </p>
-    <button
-      className="components-button is-button is-default"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      Save & Reload
-    </button>
-  </div>
+    Page reload is required for this change.
+  </p>
+  <button
+    className="components-button edit-post-options-modal__custom-fields-confirmation-button is-button is-default"
+    disabled={false}
+    onClick={[Function]}
+    type="button"
+  >
+    Save & Reload
+  </button>
 </div>
 `;
 
@@ -95,23 +91,19 @@ exports[`EnableCustomFieldsOption renders an unchecked checkbox and a confirmati
       />
     </div>
   </div>
-  <div
-    className="edit-post-options-modal__custom-fields-confirmation"
+  <p
+    className="edit-post-options-modal__custom-fields-confirmation-message"
   >
-    <p
-      className="edit-post-options-modal__custom-fields-confirmation-message"
-    >
-      Page reload is required for this change.
-    </p>
-    <button
-      className="components-button is-button is-default"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      Save & Reload
-    </button>
-  </div>
+    Page reload is required for this change.
+  </p>
+  <button
+    className="components-button edit-post-options-modal__custom-fields-confirmation-button is-button is-default"
+    disabled={false}
+    onClick={[Function]}
+    type="button"
+  >
+    Save & Reload
+  </button>
 </div>
 `;
 

--- a/packages/edit-post/src/components/options-modal/options/test/__snapshots__/enable-custom-fields.js.snap
+++ b/packages/edit-post/src/components/options-modal/options/test/__snapshots__/enable-custom-fields.js.snap
@@ -27,7 +27,7 @@ exports[`EnableCustomFieldsOption renders a checked checkbox and a confirmation 
   <p
     className="edit-post-options-modal__custom-fields-confirmation-message"
   >
-    Page reload is required for this change.
+    A page reload is required for this change. Make sure your content is saved before reloading.
   </p>
   <button
     className="components-button edit-post-options-modal__custom-fields-confirmation-button is-button is-default"
@@ -35,7 +35,7 @@ exports[`EnableCustomFieldsOption renders a checked checkbox and a confirmation 
     onClick={[Function]}
     type="button"
   >
-    Save & Reload
+    Enable & Reload
   </button>
 </div>
 `;
@@ -94,7 +94,7 @@ exports[`EnableCustomFieldsOption renders an unchecked checkbox and a confirmati
   <p
     className="edit-post-options-modal__custom-fields-confirmation-message"
   >
-    Page reload is required for this change.
+    A page reload is required for this change. Make sure your content is saved before reloading.
   </p>
   <button
     className="components-button edit-post-options-modal__custom-fields-confirmation-button is-button is-default"
@@ -102,7 +102,7 @@ exports[`EnableCustomFieldsOption renders an unchecked checkbox and a confirmati
     onClick={[Function]}
     type="button"
   >
-    Save & Reload
+    Disable & Reload
   </button>
 </div>
 `;

--- a/packages/edit-post/src/components/options-modal/options/test/enable-custom-fields.js
+++ b/packages/edit-post/src/components/options-modal/options/test/enable-custom-fields.js
@@ -1,62 +1,63 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import { default as TestRenderer, act } from 'react-test-renderer';
+
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import { EnableCustomFieldsOption } from '../enable-custom-fields';
+import { EnableCustomFieldsOption, CustomFieldsConfirmation } from '../enable-custom-fields';
+import BaseOption from '../base';
 
 describe( 'EnableCustomFieldsOption', () => {
-	it( 'renders properly when checked', () => {
-		const wrapper = shallow( <EnableCustomFieldsOption label="Custom Fields" isChecked /> );
-		expect( wrapper ).toMatchSnapshot();
+	it( 'renders a checked checkbox when custom fields are enabled', () => {
+		const renderer = TestRenderer.create( <EnableCustomFieldsOption areCustomFieldsEnabled /> );
+		expect( renderer ).toMatchSnapshot();
 	} );
 
-	it( 'can be unchecked', () => {
+	it( 'renders an unchecked checkbox when custom fields are disabled', () => {
+		const renderer = TestRenderer.create(
+			<EnableCustomFieldsOption areCustomFieldsEnabled={ false } />
+		);
+		expect( renderer ).toMatchSnapshot();
+	} );
+
+	it( 'renders an unchecked checkbox and a confirmation message when toggled off', () => {
+		const renderer = new TestRenderer.create( <EnableCustomFieldsOption areCustomFieldsEnabled /> );
+		act( () => {
+			renderer.root.findByType( BaseOption ).props.onChange( false );
+		} );
+		expect( renderer ).toMatchSnapshot();
+	} );
+
+	it( 'renders a checked checkbox and a confirmation message when toggled on', () => {
+		const renderer = new TestRenderer.create(
+			<EnableCustomFieldsOption areCustomFieldsEnabled={ false } />
+		);
+		act( () => {
+			renderer.root.findByType( BaseOption ).props.onChange( true );
+		} );
+		expect( renderer ).toMatchSnapshot();
+	} );
+} );
+
+describe( 'CustomFieldsConfirmation', () => {
+	it( 'submits the toggle-custom-fields-form', () => {
 		const submit = jest.fn();
 		const getElementById = jest.spyOn( document, 'getElementById' ).mockImplementation( () => ( {
 			submit,
 		} ) );
 
-		const wrapper = shallow( <EnableCustomFieldsOption label="Custom Fields" isChecked /> );
+		const renderer = new TestRenderer.create( <CustomFieldsConfirmation /> );
+		act( () => {
+			renderer.root.findByType( Button ).props.onClick();
+		} );
 
-		expect( wrapper.prop( 'isChecked' ) ).toBe( true );
-
-		wrapper.prop( 'onChange' )();
-		wrapper.update();
-
-		expect( wrapper.prop( 'isChecked' ) ).toBe( false );
-		expect( getElementById ).toHaveBeenCalledWith( 'toggle-custom-fields-form' );
-		expect( submit ).toHaveBeenCalled();
-
-		getElementById.mockRestore();
-	} );
-
-	it( 'renders properly when unchecked', () => {
-		const wrapper = shallow(
-			<EnableCustomFieldsOption label="Custom Fields" isChecked={ false } />
-		);
-		expect( wrapper ).toMatchSnapshot();
-	} );
-
-	it( 'can be checked', () => {
-		const submit = jest.fn();
-		const getElementById = jest.spyOn( document, 'getElementById' ).mockImplementation( () => ( {
-			submit,
-		} ) );
-
-		const wrapper = shallow(
-			<EnableCustomFieldsOption label="Custom Fields" isChecked={ false } />
-		);
-
-		expect( wrapper.prop( 'isChecked' ) ).toBe( false );
-
-		wrapper.prop( 'onChange' )();
-		wrapper.update();
-
-		expect( wrapper.prop( 'isChecked' ) ).toBe( true );
 		expect( getElementById ).toHaveBeenCalledWith( 'toggle-custom-fields-form' );
 		expect( submit ).toHaveBeenCalled();
 

--- a/packages/edit-post/src/components/options-modal/style.scss
+++ b/packages/edit-post/src/components/options-modal/style.scss
@@ -27,10 +27,12 @@
 		}
 	}
 
-	&__custom-fields-confirmation {
-		&-message,
-		.components-button {
-			margin: 0 0 0.6rem;
+	&__custom-fields-confirmation-message,
+	&__custom-fields-confirmation-button {
+		margin: 0 0 0.6rem 48px;
+
+		@include break-medium() {
+			margin-left: 38px;
 		}
 	}
 }

--- a/packages/edit-post/src/components/options-modal/style.scss
+++ b/packages/edit-post/src/components/options-modal/style.scss
@@ -28,19 +28,9 @@
 	}
 
 	&__custom-fields-confirmation {
-		margin-left: 48px;
-
-		@include break-medium() {
-			margin-left: 38px;
-		}
-
-		.components-notice,
+		&-message,
 		.components-button {
-			margin: 0.2rem 0;
-		}
-
-		.components-notice__content {
-			margin: 0;
+			margin: 0 0 0.6rem;
 		}
 	}
 }

--- a/packages/edit-post/src/components/options-modal/style.scss
+++ b/packages/edit-post/src/components/options-modal/style.scss
@@ -21,13 +21,26 @@
 			margin: 0;
 		}
 
-		&.components-base-control + &.components-base-control {
-			margin-bottom: 0;
-		}
-
 		.components-checkbox-control__label {
 			flex-grow: 1;
 			padding: 0.6rem 0 0.6rem 10px;
+		}
+	}
+
+	&__custom-fields-confirmation {
+		margin-left: 48px;
+
+		@include break-medium() {
+			margin-left: 38px;
+		}
+
+		.components-notice,
+		.components-button {
+			margin: 0.2rem 0;
+		}
+
+		.components-notice__content {
+			margin: 0;
 		}
 	}
 }

--- a/packages/edit-post/src/components/options-modal/style.scss
+++ b/packages/edit-post/src/components/options-modal/style.scss
@@ -34,5 +34,8 @@
 		@include break-medium() {
 			margin-left: 38px;
 		}
+		@include break-small() {
+			max-width: 300px;
+		}
 	}
 }


### PR DESCRIPTION
Fixes #15320.

"Custom Fields" in Options modal requires a full page reload in order to toggle the option. Currently, this happens instantly after clicking the checkbox. 

This PR changes the flow to add an inline confirmation step:

see the latest version https://github.com/WordPress/gutenberg/pull/15688#issuecomment-515697517