### PR TITLE
Fix: Move the "View Posts..." anchor out of the role=toolbar section in the header

### DIFF
--- a/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
@@ -4,11 +4,11 @@
 	display: none;
 
 	@include break-medium() {
-		display: block;
+		display: flex;
 		border-top: 0;
 		border-bottom: 0;
 		border-left: 0;
-		margin: -9px 10px -9px -10px;
+		margin: -9px 10px -8px -10px;
 		padding: 9px 10px;
 	}
 }

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -18,11 +18,6 @@ import {
 	EditorHistoryUndo,
 } from '@wordpress/editor';
 
-/**
- * Internal dependencies
- */
-import FullscreenModeClose from '../fullscreen-mode-close';
-
 function HeaderToolbar( { hasFixedToolbar, isLargeViewport, showInserter, isTextModeEnabled } ) {
 	const toolbarAriaLabel = hasFixedToolbar ?
 		/* translators: accessibility text for the editor toolbar when Top Toolbar is on */
@@ -35,7 +30,6 @@ function HeaderToolbar( { hasFixedToolbar, isLargeViewport, showInserter, isText
 			className="edit-post-header-toolbar"
 			aria-label={ toolbarAriaLabel }
 		>
-			<FullscreenModeClose />
 			<div>
 				<Inserter disabled={ ! showInserter } position="bottom right" />
 				<DotTip tipId="core/editor.inserter">

--- a/packages/edit-post/src/components/header/index.js
+++ b/packages/edit-post/src/components/header/index.js
@@ -14,11 +14,12 @@ import { DotTip } from '@wordpress/nux';
 /**
  * Internal dependencies
  */
-import MoreMenu from './more-menu';
+import FullscreenModeClose from './fullscreen-mode-close';
 import HeaderToolbar from './header-toolbar';
+import MoreMenu from './more-menu';
 import PinnedPlugins from './pinned-plugins';
-import shortcuts from '../../keyboard-shortcuts';
 import PostPublishButtonOrToggle from './post-publish-button-or-toggle';
+import shortcuts from '../../keyboard-shortcuts';
 
 function Header( {
 	closeGeneralSidebar,
@@ -38,7 +39,10 @@ function Header( {
 			className="edit-post-header"
 			tabIndex="-1"
 		>
-			<HeaderToolbar />
+			<div className="edit-post-header__toolbar">
+				<FullscreenModeClose />
+				<HeaderToolbar />
+			</div>
 			<div className="edit-post-header__settings">
 				{ ! isPublishSidebarOpened && (
 					// This button isn't completely hidden by the publish sidebar.

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -59,6 +59,10 @@
 
 @include editor-left(".edit-post-header");
 
+.edit-post-header__toolbar {
+	display: flex;
+}
+
 .edit-post-header__settings {
 	display: inline-flex;
 	align-items: center;


### PR DESCRIPTION
## Description
Partially fixes #15331.

> Screenshot from full report:
> 
> ![image](https://user-images.githubusercontent.com/2846578/57185582-404bee80-6e83-11e9-8cec-9d123bc0c4ff.png)

> Keyboard-only users who enter the Editor Top Bar must Tab from button to
button. Although this is manageable when there's a small number of
buttons, the group of buttons is given the role of toolbar, whose
purpose (besides grouping related controls) is to lessen the number of
Tab stops keyboard users must make to navigate past widgets.

This PR follows the recommendation:

> Move the "View Posts..." anchor out of the `role=toolbar` section,
> so the toolbar only has `<button>` children.

## Testing

Enabled Fullscreen Mode through More Menu item. Ensure that the header looks like before and `View Posts` anchor is outside of the toolbar.

## Screenshots <!-- if applicable -->

![Screen Shot 2019-05-17 at 09 56 37](https://user-images.githubusercontent.com/699132/57912257-27333c80-788a-11e9-8c43-cab268194f88.png)
![Screen Shot 2019-05-17 at 09 57 03](https://user-images.githubusercontent.com/699132/57912258-27cbd300-788a-11e9-955b-0faa9c05f962.png)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
