### PR TITLE
Update developer contributions link on build files notice

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -89,7 +89,7 @@ function gutenberg_wordpress_version_notice() {
  */
 function gutenberg_build_files_notice() {
 	echo '<div class="error"><p>';
-	_e( 'Gutenberg development mode requires files to be built. Run <code>npm install</code> to install dependencies, <code>npm run build</code> to build the files or <code>npm run dev</code> to build the files and watch for changes. Read the <a href="https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTING.md">contributing</a> file for more information.', 'gutenberg' );
+	_e( 'Gutenberg development mode requires files to be built. Run <code>npm install</code> to install dependencies, <code>npm run build</code> to build the files or <code>npm run dev</code> to build the files and watch for changes. Read the <a href="https://github.com/WordPress/gutenberg/blob/master/docs/contributors/getting-started.md">contributing</a> file for more information.', 'gutenberg' );
 	echo '</p></div>';
 }
 


### PR DESCRIPTION
## Description

Update developer contributions link on the Gutenberg build files notice on wp-admin (usually seen on first login).

This is to reflect the changes made in https://github.com/WordPress/gutenberg/pull/15187 - where the developer contributions file was moved.

## How has this been tested?

- Build Gutenberg afresh and when logging in on the wp-admin for the first time, you should see the `gutenberg_build_files_notice` notice at the top. The `contributing` link should be the [new one](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/getting-started.md).

## Screenshots <!-- if applicable -->

<img width="1535" alt="Screenshot 2019-05-17 at 14 38 32" src="https://user-images.githubusercontent.com/18581859/57918404-59599400-78b4-11e9-8d6a-6d22e5f1d0b0.png">

## Types of changes

- Documentation changes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
