### PR TITLE
[Mobile] Fix insert list block focus

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -821,12 +821,16 @@ RichText.defaultProps = {
 
 const RichTextContainer = compose( [
 	withInstanceId,
-	withBlockEditContext( ( { clientId, onFocus, onCaretVerticalPositionChange }, ownProps ) => {
-		// ownProps.onFocus needs precedence over the block edit context
+	withBlockEditContext( ( { clientId, onFocus, onCaretVerticalPositionChange, isSelected }, ownProps ) => {
+		// ownProps.onFocus and isSelected needs precedence over the block edit context
+		if ( ownProps.isSelected !== undefined ) {
+			isSelected = ownProps.isSelected;
+		}
 		if ( ownProps.onFocus !== undefined ) {
 			onFocus = ownProps.onFocus;
 		}
 		return {
+			isSelected,
 			clientId,
 			onFocus,
 			onCaretVerticalPositionChange,


### PR DESCRIPTION
This PR fixes a regression introduced by https://github.com/WordPress/gutenberg/pull/15685 where inserting a new list block, that block was not automatically focused.

`gutenberg-mobile` side PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/994

To test:
- Check the test cases from: https://github.com/WordPress/gutenberg/pull/15685
- Check that a new list block is automatically focused