### PR TITLE
Fix: Allow dropping blocks into blocks with button block appender

### DIFF
--- a/packages/block-editor/src/components/button-block-appender/index.js
+++ b/packages/block-editor/src/components/button-block-appender/index.js
@@ -12,25 +12,29 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import BlockDropZone from '../block-drop-zone';
 import Inserter from '../inserter';
 
 function ButtonBlockAppender( { rootClientId, className } ) {
 	return (
-		<Inserter
-			rootClientId={ rootClientId }
-			renderToggle={ ( { onToggle, disabled, isOpen } ) => (
-				<Button
-					className={ classnames( className, 'block-editor-button-block-appender' ) }
-					onClick={ onToggle }
-					aria-expanded={ isOpen }
-					disabled={ disabled }
-				>
-					<span className="screen-reader-text">{ __( 'Add Block' ) }</span>
-					<Icon icon="insert" />
-				</Button>
-			) }
-			isAppender
-		/>
+		<>
+			<BlockDropZone rootClientId={ rootClientId } />
+			<Inserter
+				rootClientId={ rootClientId }
+				renderToggle={ ( { onToggle, disabled, isOpen } ) => (
+					<Button
+						className={ classnames( className, 'block-editor-button-block-appender' ) }
+						onClick={ onToggle }
+						aria-expanded={ isOpen }
+						disabled={ disabled }
+					>
+						<span className="screen-reader-text">{ __( 'Add Block' ) }</span>
+						<Icon icon="insert" />
+					</Button>
+				) }
+				isAppender
+			/>
+		</>
 	);
 }
 


### PR DESCRIPTION
## Description
With the recent addition of the button block appender for Column and Group blocks it's no longer possible to drag a block when there is appender displayed. To work around it, you have to add any block using the appender first. This PR fixes it.

## How has this been tested?
Add both Column and Group block to the existing post. Try to drag and drop any block and observer the block button appender being replaced with the selected block.

## Screenshots <!-- if applicable -->

This is how it works with changes applied:

![drop-block-button-appender](https://user-images.githubusercontent.com/699132/57933168-d38e1680-78bc-11e9-80cd-46d2aaff7a01.gif)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->