### PR TITLE
Build Tooling: Remove WebpackRTLPlugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2572,87 +2572,6 @@
 				"physical-cpu-count": "^2.0.0"
 			}
 		},
-		"@romainberger/css-diff": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@romainberger/css-diff/-/css-diff-1.0.3.tgz",
-			"integrity": "sha1-ztOHU11PQqQqwf4TwJ3pf1rhNEw=",
-			"dev": true,
-			"requires": {
-				"lodash.merge": "^4.4.0",
-				"postcss": "^5.0.21"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-							"dev": true
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-					"dev": true
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"dev": true,
-					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"dev": true,
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
-				}
-			}
-		},
 		"@samverschueren/stream-to-observable": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
@@ -5120,12 +5039,6 @@
 				"lodash.uniq": "^4.5.0"
 			}
 		},
-		"caniuse-db": {
-			"version": "1.0.30000871",
-			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000871.tgz",
-			"integrity": "sha1-8ZlcH+MYkmSadgWVeoDJJRhCPU0=",
-			"dev": true
-		},
 		"caniuse-lite": {
 			"version": "1.0.30000957",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000957.tgz",
@@ -5877,57 +5790,6 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
-		"clap": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
-			"integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
-			"dev": true,
-			"requires": {
-				"chalk": "^1.1.3"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
-				}
-			}
-		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -6190,17 +6052,6 @@
 			"dev": true,
 			"requires": {
 				"color-name": "^1.0.0"
-			}
-		},
-		"colormin": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
-			"integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
-			"dev": true,
-			"requires": {
-				"color": "^0.11.0",
-				"css-color-names": "0.0.4",
-				"has": "^1.0.1"
 			}
 		},
 		"colors": {
@@ -7742,12 +7593,6 @@
 				}
 			}
 		},
-		"defined": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
-			"dev": true
-		},
 		"del": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
@@ -8077,12 +7922,6 @@
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
 			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==",
-			"dev": true
-		},
-		"electron-to-chromium": {
-			"version": "1.3.52",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.52.tgz",
-			"integrity": "sha1-0tnxJwuko7lnuDHEDvcftNmrXOA=",
 			"dev": true
 		},
 		"elegant-spinner": {
@@ -9473,12 +9312,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
 			"integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
-			"dev": true
-		},
-		"flatten": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
-			"integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
 			"dev": true
 		},
 		"flush-write-stream": {
@@ -13824,12 +13657,6 @@
 			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
 			"dev": true
 		},
-		"lodash.merge": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-			"integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
-			"dev": true
-		},
 		"lodash.set": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
@@ -14186,12 +14013,6 @@
 			"requires": {
 				"escape-string-regexp": "^1.0.4"
 			}
-		},
-		"math-expression-evaluator": {
-			"version": "1.2.17",
-			"resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
-			"integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw=",
-			"dev": true
 		},
 		"mathml-tag-names": {
 			"version": "2.1.0",
@@ -16854,167 +16675,6 @@
 				"postcss": "^7.0.0"
 			}
 		},
-		"postcss-discard-unused": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
-			"integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
-			"dev": true,
-			"requires": {
-				"postcss": "^5.0.14",
-				"uniqs": "^2.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-							"dev": true
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-					"dev": true
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"dev": true,
-					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"dev": true,
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
-				}
-			}
-		},
-		"postcss-filter-plugins": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.3.tgz",
-			"integrity": "sha512-T53GVFsdinJhgwm7rg1BzbeBRomOg9y5MBVhGcsV0CxurUdVj1UlPdKtn7aqYA/c/QVkzKMjq2bSV5dKG5+AwQ==",
-			"dev": true,
-			"requires": {
-				"postcss": "^5.0.4"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-							"dev": true
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-					"dev": true
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"dev": true,
-					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"dev": true,
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
-				}
-			}
-		},
 		"postcss-html": {
 			"version": "0.36.0",
 			"resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.36.0.tgz",
@@ -17244,88 +16904,6 @@
 			"resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
 			"integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=",
 			"dev": true
-		},
-		"postcss-merge-idents": {
-			"version": "2.1.7",
-			"resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
-			"integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
-			"dev": true,
-			"requires": {
-				"has": "^1.0.1",
-				"postcss": "^5.0.10",
-				"postcss-value-parser": "^3.1.1"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-							"dev": true
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-					"dev": true
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"dev": true,
-					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"dev": true,
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
-				}
-			}
 		},
 		"postcss-merge-longhand": {
 			"version": "4.0.11",
@@ -17658,87 +17236,6 @@
 				"postcss-value-parser": "^3.0.0"
 			}
 		},
-		"postcss-reduce-idents": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
-			"integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
-			"dev": true,
-			"requires": {
-				"postcss": "^5.0.4",
-				"postcss-value-parser": "^3.0.2"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-							"dev": true
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-					"dev": true
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"dev": true,
-					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"dev": true,
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
-				}
-			}
-		},
 		"postcss-reduce-initial": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-4.0.3.tgz",
@@ -17817,17 +17314,6 @@
 				"postcss": "^7.0.0"
 			}
 		},
-		"postcss-selector-parser": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
-			"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
-			"dev": true,
-			"requires": {
-				"flatten": "^1.0.2",
-				"indexes-of": "^1.0.1",
-				"uniq": "^1.0.1"
-			}
-		},
 		"postcss-svgo": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-4.0.2.tgz",
@@ -17862,88 +17348,6 @@
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
 			"integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
 			"dev": true
-		},
-		"postcss-zindex": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
-			"integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
-			"dev": true,
-			"requires": {
-				"has": "^1.0.1",
-				"postcss": "^5.0.4",
-				"uniqs": "^2.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-							"dev": true
-						}
-					}
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-					"dev": true
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"dev": true,
-					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"dev": true,
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
-				}
-			}
 		},
 		"posthtml": {
 			"version": "0.11.3",
@@ -17998,12 +17402,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-			"dev": true
-		},
-		"prepend-http": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
 			"dev": true
 		},
 		"pretty-format": {
@@ -18251,16 +17649,6 @@
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
 			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-		},
-		"query-string": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-			"integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-			"dev": true,
-			"requires": {
-				"object-assign": "^4.1.0",
-				"strict-uri-encode": "^1.0.0"
-			}
 		},
 		"querystring": {
 			"version": "0.2.0",
@@ -18680,42 +18068,6 @@
 			"requires": {
 				"indent-string": "^3.0.0",
 				"strip-indent": "^2.0.0"
-			}
-		},
-		"reduce-css-calc": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
-			"integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
-			"dev": true,
-			"requires": {
-				"balanced-match": "^0.4.2",
-				"math-expression-evaluator": "^1.2.14",
-				"reduce-function-call": "^1.0.1"
-			},
-			"dependencies": {
-				"balanced-match": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-					"dev": true
-				}
-			}
-		},
-		"reduce-function-call": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
-			"integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
-			"dev": true,
-			"requires": {
-				"balanced-match": "^0.4.2"
-			},
-			"dependencies": {
-				"balanced-match": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-					"dev": true
-				}
 			}
 		},
 		"redux": {
@@ -20465,12 +19817,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
 			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-			"dev": true
-		},
-		"strict-uri-encode": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
 			"dev": true
 		},
 		"string-argv": {
@@ -22717,477 +22063,6 @@
 				"tiny-lr": "^1.1.1"
 			}
 		},
-		"webpack-rtl-plugin": {
-			"version": "github:yoavf/webpack-rtl-plugin#fc5a2f20dd99fde8f86f297844aefde601780fa3",
-			"from": "github:yoavf/webpack-rtl-plugin#develop",
-			"dev": true,
-			"requires": {
-				"@romainberger/css-diff": "^1.0.3",
-				"async": "^2.0.0-rc.6",
-				"cssnano": "^3.7.1",
-				"postcss": "^5.0.21",
-				"rtlcss": "^2.0.4",
-				"webpack-sources": "^0.1.2"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"autoprefixer": {
-					"version": "6.7.7",
-					"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
-					"integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
-					"dev": true,
-					"requires": {
-						"browserslist": "^1.7.6",
-						"caniuse-db": "^1.0.30000634",
-						"normalize-range": "^0.1.2",
-						"num2fraction": "^1.2.2",
-						"postcss": "^5.2.16",
-						"postcss-value-parser": "^3.2.3"
-					}
-				},
-				"browserslist": {
-					"version": "1.7.7",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
-					"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-					"dev": true,
-					"requires": {
-						"caniuse-db": "^1.0.30000639",
-						"electron-to-chromium": "^1.2.7"
-					}
-				},
-				"caniuse-api": {
-					"version": "1.6.1",
-					"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
-					"integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
-					"dev": true,
-					"requires": {
-						"browserslist": "^1.3.6",
-						"caniuse-db": "^1.0.30000529",
-						"lodash.memoize": "^4.1.2",
-						"lodash.uniq": "^4.5.0"
-					}
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-							"dev": true
-						}
-					}
-				},
-				"coa": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
-					"integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
-					"dev": true,
-					"requires": {
-						"q": "^1.1.2"
-					}
-				},
-				"colors": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-					"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-					"dev": true
-				},
-				"cssnano": {
-					"version": "3.10.0",
-					"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
-					"integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
-					"dev": true,
-					"requires": {
-						"autoprefixer": "^6.3.1",
-						"decamelize": "^1.1.2",
-						"defined": "^1.0.0",
-						"has": "^1.0.1",
-						"object-assign": "^4.0.1",
-						"postcss": "^5.0.14",
-						"postcss-calc": "^5.2.0",
-						"postcss-colormin": "^2.1.8",
-						"postcss-convert-values": "^2.3.4",
-						"postcss-discard-comments": "^2.0.4",
-						"postcss-discard-duplicates": "^2.0.1",
-						"postcss-discard-empty": "^2.0.1",
-						"postcss-discard-overridden": "^0.1.1",
-						"postcss-discard-unused": "^2.2.1",
-						"postcss-filter-plugins": "^2.0.0",
-						"postcss-merge-idents": "^2.1.5",
-						"postcss-merge-longhand": "^2.0.1",
-						"postcss-merge-rules": "^2.0.3",
-						"postcss-minify-font-values": "^1.0.2",
-						"postcss-minify-gradients": "^1.0.1",
-						"postcss-minify-params": "^1.0.4",
-						"postcss-minify-selectors": "^2.0.4",
-						"postcss-normalize-charset": "^1.1.0",
-						"postcss-normalize-url": "^3.0.7",
-						"postcss-ordered-values": "^2.1.0",
-						"postcss-reduce-idents": "^2.2.2",
-						"postcss-reduce-initial": "^1.0.0",
-						"postcss-reduce-transforms": "^1.0.3",
-						"postcss-svgo": "^2.1.1",
-						"postcss-unique-selectors": "^2.0.2",
-						"postcss-value-parser": "^3.2.3",
-						"postcss-zindex": "^2.0.1"
-					}
-				},
-				"csso": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
-					"integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
-					"dev": true,
-					"requires": {
-						"clap": "^1.0.9",
-						"source-map": "^0.5.3"
-					}
-				},
-				"esprima": {
-					"version": "2.7.3",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-					"dev": true
-				},
-				"is-svg": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
-					"integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
-					"dev": true,
-					"requires": {
-						"html-comment-regex": "^1.1.0"
-					}
-				},
-				"js-yaml": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
-					"integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
-					"dev": true,
-					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^2.6.0"
-					}
-				},
-				"normalize-url": {
-					"version": "1.9.1",
-					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
-					"integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
-					"dev": true,
-					"requires": {
-						"object-assign": "^4.0.1",
-						"prepend-http": "^1.0.0",
-						"query-string": "^4.1.0",
-						"sort-keys": "^1.0.0"
-					}
-				},
-				"postcss": {
-					"version": "5.2.18",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-					"dev": true,
-					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
-					}
-				},
-				"postcss-calc": {
-					"version": "5.3.1",
-					"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
-					"integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
-					"dev": true,
-					"requires": {
-						"postcss": "^5.0.2",
-						"postcss-message-helpers": "^2.0.0",
-						"reduce-css-calc": "^1.2.6"
-					}
-				},
-				"postcss-colormin": {
-					"version": "2.2.2",
-					"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
-					"integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
-					"dev": true,
-					"requires": {
-						"colormin": "^1.0.5",
-						"postcss": "^5.0.13",
-						"postcss-value-parser": "^3.2.3"
-					}
-				},
-				"postcss-convert-values": {
-					"version": "2.6.1",
-					"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
-					"integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
-					"dev": true,
-					"requires": {
-						"postcss": "^5.0.11",
-						"postcss-value-parser": "^3.1.2"
-					}
-				},
-				"postcss-discard-comments": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
-					"integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
-					"dev": true,
-					"requires": {
-						"postcss": "^5.0.14"
-					}
-				},
-				"postcss-discard-duplicates": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
-					"integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
-					"dev": true,
-					"requires": {
-						"postcss": "^5.0.4"
-					}
-				},
-				"postcss-discard-empty": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
-					"integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
-					"dev": true,
-					"requires": {
-						"postcss": "^5.0.14"
-					}
-				},
-				"postcss-discard-overridden": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
-					"integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
-					"dev": true,
-					"requires": {
-						"postcss": "^5.0.16"
-					}
-				},
-				"postcss-merge-longhand": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
-					"integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
-					"dev": true,
-					"requires": {
-						"postcss": "^5.0.4"
-					}
-				},
-				"postcss-merge-rules": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
-					"integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
-					"dev": true,
-					"requires": {
-						"browserslist": "^1.5.2",
-						"caniuse-api": "^1.5.2",
-						"postcss": "^5.0.4",
-						"postcss-selector-parser": "^2.2.2",
-						"vendors": "^1.0.0"
-					}
-				},
-				"postcss-minify-font-values": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
-					"integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
-					"dev": true,
-					"requires": {
-						"object-assign": "^4.0.1",
-						"postcss": "^5.0.4",
-						"postcss-value-parser": "^3.0.2"
-					}
-				},
-				"postcss-minify-gradients": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
-					"integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
-					"dev": true,
-					"requires": {
-						"postcss": "^5.0.12",
-						"postcss-value-parser": "^3.3.0"
-					}
-				},
-				"postcss-minify-params": {
-					"version": "1.2.2",
-					"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
-					"integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
-					"dev": true,
-					"requires": {
-						"alphanum-sort": "^1.0.1",
-						"postcss": "^5.0.2",
-						"postcss-value-parser": "^3.0.2",
-						"uniqs": "^2.0.0"
-					}
-				},
-				"postcss-minify-selectors": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
-					"integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
-					"dev": true,
-					"requires": {
-						"alphanum-sort": "^1.0.2",
-						"has": "^1.0.1",
-						"postcss": "^5.0.14",
-						"postcss-selector-parser": "^2.0.0"
-					}
-				},
-				"postcss-normalize-charset": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
-					"integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
-					"dev": true,
-					"requires": {
-						"postcss": "^5.0.5"
-					}
-				},
-				"postcss-normalize-url": {
-					"version": "3.0.8",
-					"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
-					"integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
-					"dev": true,
-					"requires": {
-						"is-absolute-url": "^2.0.0",
-						"normalize-url": "^1.4.0",
-						"postcss": "^5.0.14",
-						"postcss-value-parser": "^3.2.3"
-					}
-				},
-				"postcss-ordered-values": {
-					"version": "2.2.3",
-					"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
-					"integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
-					"dev": true,
-					"requires": {
-						"postcss": "^5.0.4",
-						"postcss-value-parser": "^3.0.1"
-					}
-				},
-				"postcss-reduce-initial": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
-					"integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
-					"dev": true,
-					"requires": {
-						"postcss": "^5.0.4"
-					}
-				},
-				"postcss-reduce-transforms": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
-					"integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
-					"dev": true,
-					"requires": {
-						"has": "^1.0.1",
-						"postcss": "^5.0.8",
-						"postcss-value-parser": "^3.0.1"
-					}
-				},
-				"postcss-svgo": {
-					"version": "2.1.6",
-					"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
-					"integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
-					"dev": true,
-					"requires": {
-						"is-svg": "^2.0.0",
-						"postcss": "^5.0.14",
-						"postcss-value-parser": "^3.2.3",
-						"svgo": "^0.7.0"
-					}
-				},
-				"postcss-unique-selectors": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
-					"integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
-					"dev": true,
-					"requires": {
-						"alphanum-sort": "^1.0.1",
-						"postcss": "^5.0.4",
-						"uniqs": "^2.0.0"
-					}
-				},
-				"sort-keys": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
-					"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-					"dev": true,
-					"requires": {
-						"is-plain-obj": "^1.0.0"
-					}
-				},
-				"source-list-map": {
-					"version": "0.1.8",
-					"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
-					"integrity": "sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY=",
-					"dev": true
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"dev": true,
-					"requires": {
-						"has-flag": "^1.0.0"
-					}
-				},
-				"svgo": {
-					"version": "0.7.2",
-					"resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
-					"integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
-					"dev": true,
-					"requires": {
-						"coa": "~1.0.1",
-						"colors": "~1.1.2",
-						"csso": "~2.3.1",
-						"js-yaml": "~3.7.0",
-						"mkdirp": "~0.5.1",
-						"sax": "~1.2.1",
-						"whet.extend": "~0.9.9"
-					}
-				},
-				"webpack-sources": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.5.tgz",
-					"integrity": "sha1-qh86vw8NdNtxEcQOUAuE+WZkB1A=",
-					"dev": true,
-					"requires": {
-						"source-list-map": "~0.1.7",
-						"source-map": "~0.5.3"
-					}
-				}
-			}
-		},
 		"webpack-sources": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
@@ -23260,12 +22135,6 @@
 				"tr46": "^1.0.1",
 				"webidl-conversions": "^4.0.2"
 			}
-		},
-		"whet.extend": {
-			"version": "0.9.9",
-			"resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
-			"integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=",
-			"dev": true
 		},
 		"which": {
 			"version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -121,8 +121,7 @@
 		"sprintf-js": "1.1.1",
 		"stylelint-config-wordpress": "13.1.0",
 		"uuid": "3.3.2",
-		"webpack": "4.8.3",
-		"webpack-rtl-plugin": "github:yoavf/webpack-rtl-plugin#develop"
+		"webpack": "4.8.3"
 	},
 	"npmPackageJsonLintConfig": {
 		"extends": "@wordpress/npm-package-json-lint-config",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 const { DefinePlugin } = require( 'webpack' );
-const WebpackRTLPlugin = require( 'webpack-rtl-plugin' );
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 const postcss = require( 'postcss' );
 const { get, escapeRegExp } = require( 'lodash' );
@@ -46,11 +45,6 @@ module.exports = {
 			// Inject the `GUTENBERG_PHASE` global, used for feature flagging.
 			// eslint-disable-next-line @wordpress/gutenberg-phase
 			'process.env.GUTENBERG_PHASE': JSON.stringify( parseInt( process.env.npm_package_config_GUTENBERG_PHASE, 10 ) || 1 ),
-		} ),
-		// Create RTL files with a -rtl suffix
-		new WebpackRTLPlugin( {
-			suffix: '-rtl',
-			minify: defaultConfig.mode === 'production' ? { safe: true } : false,
 		} ),
 		new CustomTemplatedPathPlugin( {
 			basename( path, data ) {


### PR DESCRIPTION
Closes #15146 

This pull request seeks to remove the `WebpackRTLPlugin`. The plugin is no longer necessary, as there is otherwise RTL CSS generated through the packages build script. The Webpack build configuration is only responsible for copying these built files:

https://github.com/WordPress/gutenberg/blob/d08dcd89fd83cdcd0f899b3df8c4a0d4565976bd/webpack.config.js#L85-L107

The plugin is also slated to become broken due to removed deprecations with Webpack 5.x , and would otherwise need to be updated.

**Testing Instructions:**

Verify there are no regressions in the CSS RTL output from the build.

cc @yoavf 