### PR TITLE
Builld Tooling: Skip Chromium download in Travis by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ jobs:
         - ./bin/run-wp-unit-tests.sh
 
     - name: E2E tests (Admin with plugins) (1/4)
-      env: WP_VERSION=latest SCRIPT_DEBUG=false POPULAR_PLUGINS=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=false
+      env: WP_VERSION=latest SCRIPT_DEBUG=false POPULAR_PLUGINS=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=
       install:
         - ./bin/setup-local-env.sh
       script:
@@ -99,7 +99,7 @@ jobs:
         - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 0' < ~/.jest-e2e-tests )
 
     - name: E2E tests (Admin with plugins) (2/4)
-      env: WP_VERSION=latest SCRIPT_DEBUG=false POPULAR_PLUGINS=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=false
+      env: WP_VERSION=latest SCRIPT_DEBUG=false POPULAR_PLUGINS=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=
       install:
         - ./bin/setup-local-env.sh
       script:
@@ -108,7 +108,7 @@ jobs:
         - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 1' < ~/.jest-e2e-tests )
 
     - name: E2E tests (Admin with plugins) (3/4)
-      env: WP_VERSION=latest SCRIPT_DEBUG=false POPULAR_PLUGINS=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=false
+      env: WP_VERSION=latest SCRIPT_DEBUG=false POPULAR_PLUGINS=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=
       install:
         - ./bin/setup-local-env.sh
       script:
@@ -117,7 +117,7 @@ jobs:
         - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 2' < ~/.jest-e2e-tests )
 
     - name: E2E tests (Admin with plugins) (4/4)
-      env: WP_VERSION=latest SCRIPT_DEBUG=false POPULAR_PLUGINS=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=false
+      env: WP_VERSION=latest SCRIPT_DEBUG=false POPULAR_PLUGINS=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=
       install:
         - ./bin/setup-local-env.sh
       script:
@@ -126,7 +126,7 @@ jobs:
         - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 3' < ~/.jest-e2e-tests )
 
     - name: E2E tests (Author without plugins) (1/4)
-      env: WP_VERSION=latest SCRIPT_DEBUG=false E2E_ROLE=author PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=false
+      env: WP_VERSION=latest SCRIPT_DEBUG=false E2E_ROLE=author PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=
       install:
         - ./bin/setup-local-env.sh
       script:
@@ -135,7 +135,7 @@ jobs:
         - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 0' < ~/.jest-e2e-tests )
 
     - name: E2E tests (Author without plugins) (2/4)
-      env: WP_VERSION=latest SCRIPT_DEBUG=false E2E_ROLE=author PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=false
+      env: WP_VERSION=latest SCRIPT_DEBUG=false E2E_ROLE=author PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=
       install:
         - ./bin/setup-local-env.sh
       script:
@@ -144,7 +144,7 @@ jobs:
         - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 1' < ~/.jest-e2e-tests )
 
     - name: E2E tests (Author without plugins) (3/4)
-      env: WP_VERSION=latest SCRIPT_DEBUG=false E2E_ROLE=author PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=false
+      env: WP_VERSION=latest SCRIPT_DEBUG=false E2E_ROLE=author PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=
       install:
         - ./bin/setup-local-env.sh
       script:
@@ -153,7 +153,7 @@ jobs:
         - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 2' < ~/.jest-e2e-tests )
 
     - name: E2E tests (Author without plugins) (4/4)
-      env: WP_VERSION=latest SCRIPT_DEBUG=false E2E_ROLE=author PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=false
+      env: WP_VERSION=latest SCRIPT_DEBUG=false E2E_ROLE=author PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=
       install:
         - ./bin/setup-local-env.sh
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ branches:
 before_install:
   - nvm install
 
+env: PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+
 jobs:
   include:
     - name: Lint
@@ -88,7 +90,7 @@ jobs:
         - ./bin/run-wp-unit-tests.sh
 
     - name: E2E tests (Admin with plugins) (1/4)
-      env: WP_VERSION=latest SCRIPT_DEBUG=false POPULAR_PLUGINS=true
+      env: WP_VERSION=latest SCRIPT_DEBUG=false POPULAR_PLUGINS=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=false
       install:
         - ./bin/setup-local-env.sh
       script:
@@ -97,7 +99,7 @@ jobs:
         - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 0' < ~/.jest-e2e-tests )
 
     - name: E2E tests (Admin with plugins) (2/4)
-      env: WP_VERSION=latest SCRIPT_DEBUG=false POPULAR_PLUGINS=true
+      env: WP_VERSION=latest SCRIPT_DEBUG=false POPULAR_PLUGINS=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=false
       install:
         - ./bin/setup-local-env.sh
       script:
@@ -106,7 +108,7 @@ jobs:
         - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 1' < ~/.jest-e2e-tests )
 
     - name: E2E tests (Admin with plugins) (3/4)
-      env: WP_VERSION=latest SCRIPT_DEBUG=false POPULAR_PLUGINS=true
+      env: WP_VERSION=latest SCRIPT_DEBUG=false POPULAR_PLUGINS=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=false
       install:
         - ./bin/setup-local-env.sh
       script:
@@ -115,7 +117,7 @@ jobs:
         - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 2' < ~/.jest-e2e-tests )
 
     - name: E2E tests (Admin with plugins) (4/4)
-      env: WP_VERSION=latest SCRIPT_DEBUG=false POPULAR_PLUGINS=true
+      env: WP_VERSION=latest SCRIPT_DEBUG=false POPULAR_PLUGINS=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=false
       install:
         - ./bin/setup-local-env.sh
       script:
@@ -124,7 +126,7 @@ jobs:
         - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 3' < ~/.jest-e2e-tests )
 
     - name: E2E tests (Author without plugins) (1/4)
-      env: WP_VERSION=latest SCRIPT_DEBUG=false E2E_ROLE=author
+      env: WP_VERSION=latest SCRIPT_DEBUG=false E2E_ROLE=author PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=false
       install:
         - ./bin/setup-local-env.sh
       script:
@@ -133,7 +135,7 @@ jobs:
         - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 0' < ~/.jest-e2e-tests )
 
     - name: E2E tests (Author without plugins) (2/4)
-      env: WP_VERSION=latest SCRIPT_DEBUG=false E2E_ROLE=author
+      env: WP_VERSION=latest SCRIPT_DEBUG=false E2E_ROLE=author PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=false
       install:
         - ./bin/setup-local-env.sh
       script:
@@ -142,7 +144,7 @@ jobs:
         - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 1' < ~/.jest-e2e-tests )
 
     - name: E2E tests (Author without plugins) (3/4)
-      env: WP_VERSION=latest SCRIPT_DEBUG=false E2E_ROLE=author
+      env: WP_VERSION=latest SCRIPT_DEBUG=false E2E_ROLE=author PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=false
       install:
         - ./bin/setup-local-env.sh
       script:
@@ -151,7 +153,7 @@ jobs:
         - npm run test-e2e -- --ci --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 2' < ~/.jest-e2e-tests )
 
     - name: E2E tests (Author without plugins) (4/4)
-      env: WP_VERSION=latest SCRIPT_DEBUG=false E2E_ROLE=author
+      env: WP_VERSION=latest SCRIPT_DEBUG=false E2E_ROLE=author PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=false
       install:
         - ./bin/setup-local-env.sh
       script:


### PR DESCRIPTION
Related: #15667, #15159

This pull request seeks to skip Puppeteer's Chromium download in all Travis tasks except end-to-end containers. The proposed benefit is to help reduce the build time in non-end-to-end tasks, since the Chromium download can be time-consuming with its large size, and is unnecessary.

It may be possible to revert this optimization if and when a more general solution proposed in #15667 is implemented.

**Testing Instructions:**

Verify the Travis build passes.