### PR TITLE
Fixes a renamed function in the block-editor component readme

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -56,7 +56,7 @@ In the example above, there's no registered block type, in order to use the bloc
 ```js
 import { registerCoreBlocks } from '@wordpress/block-library';
 
-registerCoreBlockTypes();
+registerCoreBlocks();
 
 // Make sure to load the block stylesheets too
 // import '@wordpress/block-library/build-style/style.css';


### PR DESCRIPTION
## Description

the import for registerCoreBlocks was changed but the function call hadn't, this PR fixes the example