### PR TITLE
[Mobile] native mobile release v1.5.1

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -749,8 +749,8 @@ export class RichText extends Component {
 					// So, skip forcing it, let Aztec just do its best and just log the fact.
 					console.warn( 'RichText value will be trimmed for spaces! Avoiding setting the caret position manually.' );
 					selection = null;
-				} else if ( this.props.selectionStart > record.text.length || this.props.selectionEnd > record.text.length) {
-					console.warn( 'Oops, selection will land outside the text, skipping setting it...');
+				} else if ( this.props.selectionStart > record.text.length || this.props.selectionEnd > record.text.length ) {
+					console.warn( 'Oops, selection will land outside the text, skipping setting it...' );
 					selection = null;
 				}
 			}

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -821,12 +821,16 @@ RichText.defaultProps = {
 
 const RichTextContainer = compose( [
 	withInstanceId,
-	withBlockEditContext( ( { clientId, onFocus, onCaretVerticalPositionChange }, ownProps ) => {
-		// ownProps.onFocus needs precedence over the block edit context
+	withBlockEditContext( ( { clientId, onFocus, onCaretVerticalPositionChange, isSelected }, ownProps ) => {
+		// ownProps.onFocus and isSelected needs precedence over the block edit context
+		if ( ownProps.isSelected !== undefined ) {
+			isSelected = ownProps.isSelected;
+		}
 		if ( ownProps.onFocus !== undefined ) {
 			onFocus = ownProps.onFocus;
 		}
 		return {
+			isSelected,
 			clientId,
 			onFocus,
 			onCaretVerticalPositionChange,

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -821,11 +821,14 @@ RichText.defaultProps = {
 
 const RichTextContainer = compose( [
 	withInstanceId,
-	withBlockEditContext( ( { clientId, onFocus, isSelected, onCaretVerticalPositionChange }, ownProps ) => {
+	withBlockEditContext( ( { clientId, onFocus, onCaretVerticalPositionChange }, ownProps ) => {
+		// ownProps.onFocus needs precedence over the block edit context
+		if ( ownProps.onFocus !== undefined ) {
+			onFocus = ownProps.onFocus;
+		}
 		return {
 			clientId,
-			isSelected,
-			onFocus: onFocus || ownProps.onFocus,
+			onFocus,
 			onCaretVerticalPositionChange,
 		};
 	} ),

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -737,16 +737,22 @@ export class RichText extends Component {
 		let selection = null;
 		if ( this.needsSelectionUpdate ) {
 			this.needsSelectionUpdate = false;
+			selection = { start: this.props.selectionStart, end: this.props.selectionEnd };
 
-			// Aztec performs some html text cleanup while parsing it so, its internal representation gets out-of-sync with the
-			// representation of the format-lib on the RN side. We need to avoid trying to set the caret position because it may
-			// be outside the text bounds and crash Aztec, at least on Android.
-			if ( ! this.isIOS && this.willTrimSpaces( html ) ) {
-				// the html will get trimmed by the cleaning up functions in Aztec and caret position will get out-of-sync.
-				// So, skip forcing it, let Aztec just do its best and just log the fact.
-				console.warn( 'RichText value will be trimmed for spaces! Avoiding setting the caret position manually.' );
-			} else {
-				selection = { start: this.props.selectionStart, end: this.props.selectionEnd };
+			// On AztecAndroid, setting the caret to an out-of-bounds position will crash the editor so, let's check for some cases.
+			if ( ! this.isIOS ) {
+				// Aztec performs some html text cleanup while parsing it so, its internal representation gets out-of-sync with the
+				// representation of the format-lib on the RN side. We need to avoid trying to set the caret position because it may
+				// be outside the text bounds and crash Aztec, at least on Android.
+				if ( this.willTrimSpaces( html ) ) {
+					// the html will get trimmed by the cleaning up functions in Aztec and caret position will get out-of-sync.
+					// So, skip forcing it, let Aztec just do its best and just log the fact.
+					console.warn( 'RichText value will be trimmed for spaces! Avoiding setting the caret position manually.' );
+					selection = null;
+				} else if ( this.props.selectionStart > record.text.length || this.props.selectionEnd > record.text.length) {
+					console.warn( 'Oops, selection will land outside the text, skipping setting it...');
+					selection = null;
+				}
 			}
 		}
 


### PR DESCRIPTION
## Description
PR to add a fix for an undo issue happening in the v1.5.0 release of mobile gutenberg. Related issue: https://github.com/wordpress-mobile/gutenberg-mobile/issues/1001

This PR includes the 8160f88, 0e05d0c commits too, which have already been merged to master via https://github.com/WordPress/gutenberg/pull/15703.

### Note: this is a hotfix style PR and we should not use its merged state in the mobile side release, otherwise more GB commits will be brought in. So, we'll tag and use the hash of the 7631bb1 commit but not the one that will be created after merging this PR to master.

## How has this been tested?
Using this gutenberg-mobile side PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1002

## Types of changes
Inhibit setting the caret position if the position is larger than the text size.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
