### PR TITLE
Fix issue #15652

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 
 - Fixed display of reset button when using RangeControl `allowReset` prop.
+- Fixed minutes field of `DateTimePicker` missed '0' before single digit values.
 
 ## 7.3.0 (2019-04-16)
 

--- a/packages/components/src/date-time/time.js
+++ b/packages/components/src/date-time/time.js
@@ -189,7 +189,8 @@ class TimePicker extends Component {
 	}
 
 	onChangeMinutes( event ) {
-		this.setState( { minutes: event.target.value } );
+		const minutes = event.target.value;
+		this.setState( { minutes: ( '0' + minutes ).slice( -2 ) } );
 	}
 
 	renderMonth( month ) {

--- a/packages/components/src/date-time/time.js
+++ b/packages/components/src/date-time/time.js
@@ -190,7 +190,9 @@ class TimePicker extends Component {
 
 	onChangeMinutes( event ) {
 		const minutes = event.target.value;
-		this.setState( { minutes: ( '0' + minutes ).slice( -2 ) } );
+		this.setState( {
+			minutes: ( minutes === '' ) ? '' : ( '0' + minutes ).slice( -2 ),
+		} );
 	}
 
 	renderMonth( month ) {


### PR DESCRIPTION
## Description
Fix this issue using the approach suggested by @aduth by formatting the minutes value when assigning its state.

Fixes: https://github.com/WordPress/gutenberg/issues/15652

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
