### PR TITLE
Experiment with live Drag&Drop

### DIFF
--- a/packages/components/src/drop-zone/provider.js
+++ b/packages/components/src/drop-zone/provider.js
@@ -185,7 +185,27 @@ class DropZoneProvider extends Component {
 			position,
 		};
 		if ( ! isShallowEqual( newState, this.state ) ) {
-			this.setState( newState );
+			this.setState( newState, () => {
+				const dz = this.dropZones[ this.state.hoveredDropZone ];
+				if ( dz ) {
+					switch ( dragEventType ) {
+						case 'file':
+							dz.onFilesDrop(
+								[ ...event.dataTransfer.files ],
+								position
+							);
+							break;
+						case 'html':
+							dz.onHTMLDrop(
+								event.dataTransfer.getData( 'text/html' ),
+								position
+							);
+							break;
+						case 'default':
+							dz.onDrop( event, position );
+					}
+				}
+			} );
 		}
 	}
 


### PR DESCRIPTION
This PR seeks to experiment with _live_ Drag&Drop, meaning that blocks are moved to the new position during dragging, not when dropping.

## Tasks 

Mechanics:

- Move block on dragging
- Make it stable. Right now requires dexterity around blocks with a low height.

Visuals:

- Drag image: make it opaque? use elevation? etc
- Drop affordances: remove the blue line? etc
