### PR TITLE
Framework: Consolidate Docker commands in site installation

### DIFF
--- a/bin/install-wordpress.sh
+++ b/bin/install-wordpress.sh
@@ -64,13 +64,8 @@ fi
 
 # Make sure the uploads and upgrade folders exist and we have permissions to add files.
 echo -e $(status_message "Ensuring that files can be uploaded...")
-docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CONTAINER chmod 767 /var/www/html/wp-content/plugins
-docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CONTAINER chmod 767 /var/www/html/wp-config.php
-docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CONTAINER chmod 767 /var/www/html/wp-settings.php
-docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CONTAINER mkdir -p /var/www/html/wp-content/uploads
-docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CONTAINER chmod -v 767 /var/www/html/wp-content/uploads
-docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CONTAINER mkdir -p /var/www/html/wp-content/upgrade
-docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CONTAINER chmod 767 /var/www/html/wp-content/upgrade
+docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CONTAINER mkdir -p /var/www/html/wp-content/uploads /var/www/html/wp-content/upgrade
+docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CONTAINER chmod 767 /var/www/html/wp-content/plugins /var/www/html/wp-config.php /var/www/html/wp-settings.php /var/www/html/wp-content/uploads /var/www/html/wp-content/upgrade
 
 CURRENT_WP_VERSION=$(docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run -T --rm $CLI core version)
 echo -e $(status_message "Current WordPress version: $CURRENT_WP_VERSION...")
@@ -97,9 +92,7 @@ docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI plugin activate 
 
 if [ "$POPULAR_PLUGINS" == "true" ]; then
 	echo -e $(status_message "Activating popular plugins...")
-	docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI plugin install advanced-custom-fields --activate --quiet
-	docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI plugin install jetpack --activate --quiet
-	docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI plugin install wpforms-lite --activate --quiet
+	docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI plugin install advanced-custom-fields jetpack wpforms-lite --activate --quiet
 fi
 
 # Install a dummy favicon to avoid 404 errors.


### PR DESCRIPTION
Related: #15159

This pull request seeks to update `bin/install-wordpress.sh` in an effort to reduce the number of individual `docker-compose` commands where consolidation is straight-forward.

Each of the affected commands supports multiple arguments:

- `mkdir` : https://linux.die.net/man/1/mkdir
- `chmod` : https://linux.die.net/man/1/chmod
- `wp plugin install` : https://developer.wordpress.org/cli/commands/plugin/install/

Proposed benefit: Anecdotally, each `docker-compose` command takes upwards of seconds to run, thus encouraging that we reduce the number in the install script. This will shorten build times for Travis and setup times for local end-to-end test runs and environment setups. Additional Docker improvements are proposed at #15159. This will likely have a more minimal impact, but is most trivial to implement.

**Testing Instructions:**

Verify fresh Docker environments setups for end-to-end tests (and optionally local development).

https://github.com/WordPress/gutenberg/blob/master/docs/contributors/getting-started.md#local-environment

Verify Travis build passes.