### PR TITLE
Components: Speak Notice message

### DIFF
--- a/docs/designers-developers/developers/data/data-core-notices.md
+++ b/docs/designers-developers/developers/data/data-core-notices.md
@@ -65,7 +65,7 @@ _Returns_
 
 <a name="createNotice" href="#createNotice">#</a> **createNotice**
 
-Yields action objects used in signalling that a notice is to be created.
+Returns an action object used in signalling that a notice is to be created.
 
 _Parameters_
 
@@ -78,6 +78,10 @@ _Parameters_
 -   _options.type_ `[string]`: Type of notice, one of `default`, or `snackbar`.
 -   _options.speak_ `[boolean]`: Whether the notice content should be announced to screen readers.
 -   _options.actions_ `[Array<WPNoticeAction>]`: User actions to be presented with notice.
+
+_Returns_
+
+-   `Object`: Action object.
 
 <a name="createSuccessNotice" href="#createSuccessNotice">#</a> **createSuccessNotice**
 

--- a/packages/block-editor/src/components/contrast-checker/index.js
+++ b/packages/block-editor/src/components/contrast-checker/index.js
@@ -36,7 +36,11 @@ function ContrastCheckerMessage( {
 
 	return (
 		<div className="block-editor-contrast-checker">
-			<Notice status="warning" isDismissible={ false }>
+			<Notice
+				spokenMessage={ null }
+				status="warning"
+				isDismissible={ false }
+			>
 				{ msg }
 			</Notice>
 		</div>

--- a/packages/block-editor/src/components/contrast-checker/index.js
+++ b/packages/block-editor/src/components/contrast-checker/index.js
@@ -25,9 +25,15 @@ function ContrastCheckerMessage( {
 			: __(
 					'This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.'
 			  );
+
+	// Note: The `Notice` component can speak messages via its `spokenMessage`
+	// prop, but the contrast checker requires granular control over when the
+	// announcements are made. Notably, the message will be re-announced if a
+	// new color combination is selected and the contrast is still insufficient.
 	useEffect( () => {
 		speak( __( 'This color combination may be hard for people to read.' ) );
 	}, [ backgroundColor, textColor ] );
+
 	return (
 		<div className="block-editor-contrast-checker">
 			<Notice status="warning" isDismissible={ false }>

--- a/packages/block-editor/src/components/contrast-checker/test/index.js
+++ b/packages/block-editor/src/components/contrast-checker/test/index.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import { mount } from 'enzyme';
+import { render } from 'react-dom';
+import { act } from 'react-dom/test-utils';
 
 /**
  * WordPress dependencies
@@ -259,5 +261,31 @@ describe( 'ContrastChecker', () => {
 		).toBe(
 			'This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.'
 		);
+	} );
+
+	test( 'should re-announce if colors change, but still insufficient contrast', () => {
+		const appRoot = document.createElement( 'div' );
+
+		act( () => {
+			render(
+				<ContrastChecker
+					textColor={ textColor }
+					fallbackBackgroundColor={ textColor }
+				/>,
+				appRoot
+			);
+		} );
+
+		act( () => {
+			render(
+				<ContrastChecker
+					textColor={ backgroundColor }
+					fallbackBackgroundColor={ backgroundColor }
+				/>,
+				appRoot
+			);
+		} );
+
+		expect( speak ).toHaveBeenCalledTimes( 2 );
 	} );
 } );

--- a/packages/block-editor/src/components/contrast-checker/test/index.js
+++ b/packages/block-editor/src/components/contrast-checker/test/index.js
@@ -7,11 +7,14 @@ import { mount } from 'enzyme';
  * WordPress dependencies
  */
 import { Notice } from '@wordpress/components';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
  */
 import ContrastChecker from '../';
+
+jest.mock( '@wordpress/a11y', () => ( { speak: jest.fn() } ) );
 
 describe( 'ContrastChecker', () => {
 	const backgroundColor = '#ffffff';
@@ -21,6 +24,10 @@ describe( 'ContrastChecker', () => {
 	const fallbackTextColor = '#000';
 	const sameShade = '#666';
 	const colorWithTransparency = 'rgba(102,102,102,0.5)';
+
+	beforeEach( () => {
+		speak.mockReset();
+	} );
 
 	test( 'should render null when no colors are provided', () => {
 		expect( mount( <ContrastChecker /> ).html() ).toBeNull();
@@ -37,6 +44,7 @@ describe( 'ContrastChecker', () => {
 			/>
 		);
 
+		expect( speak ).not.toHaveBeenCalled();
 		expect( wrapper.html() ).toBeNull();
 	} );
 
@@ -51,6 +59,9 @@ describe( 'ContrastChecker', () => {
 			/>
 		);
 
+		expect( speak ).toHaveBeenCalledWith(
+			'This color combination may be hard for people to read.'
+		);
 		expect(
 			wrapper
 				.find( Notice )
@@ -72,6 +83,7 @@ describe( 'ContrastChecker', () => {
 			/>
 		);
 
+		expect( speak ).not.toHaveBeenCalled();
 		expect( wrapper.html() ).toBeNull();
 	} );
 
@@ -86,6 +98,7 @@ describe( 'ContrastChecker', () => {
 			/>
 		);
 
+		expect( speak ).not.toHaveBeenCalled();
 		expect( wrapper.html() ).toBeNull();
 	} );
 
@@ -102,6 +115,9 @@ describe( 'ContrastChecker', () => {
 			/>
 		);
 
+		expect( speak ).toHaveBeenCalledWith(
+			'This color combination may be hard for people to read.'
+		);
 		expect(
 			wrapper
 				.find( Notice )
@@ -121,6 +137,9 @@ describe( 'ContrastChecker', () => {
 			/>
 		);
 
+		expect( speak ).toHaveBeenCalledWith(
+			'This color combination may be hard for people to read.'
+		);
 		expect(
 			wrapperSmallText
 				.find( Notice )
@@ -150,6 +169,9 @@ describe( 'ContrastChecker', () => {
 			/>
 		);
 
+		expect( speak ).toHaveBeenCalledWith(
+			'This color combination may be hard for people to read.'
+		);
 		expect(
 			wrapperSmallFontSize
 				.find( Notice )
@@ -180,6 +202,7 @@ describe( 'ContrastChecker', () => {
 			/>
 		);
 
+		expect( speak ).not.toHaveBeenCalled();
 		expect( wrapper.html() ).toBeNull();
 
 		const wrapperNoLargeText = mount(
@@ -191,6 +214,9 @@ describe( 'ContrastChecker', () => {
 			/>
 		);
 
+		expect( speak ).toHaveBeenCalledWith(
+			'This color combination may be hard for people to read.'
+		);
 		expect(
 			wrapperNoLargeText
 				.find( Notice )
@@ -210,6 +236,7 @@ describe( 'ContrastChecker', () => {
 			/>
 		);
 
+		expect( speak ).not.toHaveBeenCalled();
 		expect( wrapper.html() ).toBeNull();
 	} );
 
@@ -221,6 +248,9 @@ describe( 'ContrastChecker', () => {
 			/>
 		);
 
+		expect( speak ).toHaveBeenCalledWith(
+			'This color combination may be hard for people to read.'
+		);
 		expect(
 			wrapper
 				.find( Notice )

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Enhancements
 
-- The `Notice` component will speak its message.
+- The `Notice` component will speak its message. With this new feature, a developer can control either the `spokenMessage` spoken message, or the `politeness` politeness level of the message.
 
 ### Bug Fixes
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Master
 
+### Enhancements
+
+- The `Notice` component will speak its message.
+
 ### Bug Fixes
 
 - Notice will assume a default status of 'info' if none is provided. This resolves an issue where the notice would be assigned a class name `is-undefined`. This was previously the effective default by styled appearance and should not be considered a breaking change in that regard.

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - The `Notice` component will speak its message. With this new feature, a developer can control either the `spokenMessage` spoken message, or the `politeness` politeness level of the message.
 - The `Snackbar` component will speak its message. With this new feature, a developer can control either the `spokenMessage` spoken message, or the `politeness` politeness level of the message.
+- A `Notice` `actions` member can now assign `isPrimary` to render a primary button action associated with a notice message.
 
 ### Bug Fixes
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Enhancements
 
 - The `Notice` component will speak its message. With this new feature, a developer can control either the `spokenMessage` spoken message, or the `politeness` politeness level of the message.
+- The `Snackbar` component will speak its message. With this new feature, a developer can control either the `spokenMessage` spoken message, or the `politeness` politeness level of the message.
 
 ### Bug Fixes
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### Bug Fixes
+
+- Notice will assume a default status of 'info' if none is provided. This resolves an issue where the notice would be assigned a class name `is-undefined`. This was previously the effective default by styled appearance and should not be considered a breaking change in that regard.
+
 ## 9.0.0 (2020-01-13)
 
 ### New Features

--- a/packages/components/src/notice/README.md
+++ b/packages/components/src/notice/README.md
@@ -101,7 +101,9 @@ The following props are used to control the behavior of the component.
 
 * `status`: (string) can be `warning` (yellow), `success` (green), `error` (red), or `info`. Defaults to `info`.
 * `onRemove`: function called when dismissing the notice
-* `role`: (string) One of role attributes relevant for live regions ([reference](https://www.w3.org/TR/wai-aria-1.1/#live_region_roles)). Defaults to a sensible default based on the notice status.
+* `politeness`: (string) A politeness level for the notice's spoken message. Should be provided as one of the valid options for [an `aria-live` attribute value](https://www.w3.org/TR/wai-aria-1.1/#aria-live). If not provided, a sensible default is used based on the notice status. Note that this value should be considered a suggestion; assistive technologies may override it based on internal heuristics.
+  * A value of `'assertive'` is to be used for important, and usually time-sensitive, information. It will interrupt anything else the screen reader is announcing in that moment.
+  * A value of `'polite'` is to be used for advisory information. It should not interrupt what the screen reader is announcing in that moment (the "speech queue") or interrupt the current task.
 * `isDismissible`: (boolean) defaults to true, whether the notice should be dismissible or not
 * `actions`: (array) an array of action objects. Each member object should contain a `label` and either a `url` link string or `onClick` callback function. A `className` property can be used to add custom classes to the button styles. By default, some classes are used (e.g: is-link or is-default) the default classes can be removed by setting property `noDefaultClasses` to `false`.
 

--- a/packages/components/src/notice/README.md
+++ b/packages/components/src/notice/README.md
@@ -97,10 +97,11 @@ const MyNotice = () => (
 
 #### Props
 
-The following props are used to control the display of the component.
+The following props are used to control the behavior of the component.
 
 * `status`: (string) can be `warning` (yellow), `success` (green), `error` (red), or `info`. Defaults to `info`.
 * `onRemove`: function called when dismissing the notice
+* `role`: (string) One of role attributes relevant for live regions ([reference](https://www.w3.org/TR/wai-aria-1.1/#live_region_roles)). Defaults to a sensible default based on the notice status.
 * `isDismissible`: (boolean) defaults to true, whether the notice should be dismissible or not
 * `actions`: (array) an array of action objects. Each member object should contain a `label` and either a `url` link string or `onClick` callback function. A `className` property can be used to add custom classes to the button styles. By default, some classes are used (e.g: is-link or is-default) the default classes can be removed by setting property `noDefaultClasses` to `false`.
 

--- a/packages/components/src/notice/README.md
+++ b/packages/components/src/notice/README.md
@@ -99,7 +99,7 @@ const MyNotice = () => (
 
 The following props are used to control the display of the component.
 
-* `status`: (string) can be `warning` (yellow), `success` (green), `error` (red).
+* `status`: (string) can be `warning` (yellow), `success` (green), `error` (red), or `info`. Defaults to `info`.
 * `onRemove`: function called when dismissing the notice
 * `isDismissible`: (boolean) defaults to true, whether the notice should be dismissible or not
 * `actions`: (array) an array of action objects. Each member object should contain a `label` and either a `url` link string or `onClick` callback function. A `className` property can be used to add custom classes to the button styles. By default, some classes are used (e.g: is-link or is-default) the default classes can be removed by setting property `noDefaultClasses` to `false`.

--- a/packages/components/src/notice/README.md
+++ b/packages/components/src/notice/README.md
@@ -99,6 +99,8 @@ const MyNotice = () => (
 
 The following props are used to control the behavior of the component.
 
+* `children`: (string) The displayed message of a notice. Also used as the spoken message for assistive technology, unless `spokenMessage` is provided as an alternative message.
+* `spokenMessage`: (string) Used to provide a custom spoken message in place of the `children` default.
 * `status`: (string) can be `warning` (yellow), `success` (green), `error` (red), or `info`. Defaults to `info`.
 * `onRemove`: function called when dismissing the notice
 * `politeness`: (string) A politeness level for the notice's spoken message. Should be provided as one of the valid options for [an `aria-live` attribute value](https://www.w3.org/TR/wai-aria-1.1/#aria-live). If not provided, a sensible default is used based on the notice status. Note that this value should be considered a suggestion; assistive technologies may override it based on internal heuristics.

--- a/packages/components/src/notice/README.md
+++ b/packages/components/src/notice/README.md
@@ -107,7 +107,7 @@ The following props are used to control the behavior of the component.
   * A value of `'assertive'` is to be used for important, and usually time-sensitive, information. It will interrupt anything else the screen reader is announcing in that moment.
   * A value of `'polite'` is to be used for advisory information. It should not interrupt what the screen reader is announcing in that moment (the "speech queue") or interrupt the current task.
 * `isDismissible`: (boolean) defaults to true, whether the notice should be dismissible or not
-* `actions`: (array) an array of action objects. Each member object should contain a `label` and either a `url` link string or `onClick` callback function. A `className` property can be used to add custom classes to the button styles. By default, some classes are used (e.g: is-link or is-default) the default classes can be removed by setting property `noDefaultClasses` to `false`.
+* `actions`: (array) an array of action objects. Each member object should contain a `label` and either a `url` link string or `onClick` callback function. A `className` property can be used to add custom classes to the button styles. The default appearance of the button is inferred based on whether `url` or `onClick` are provided, rendering the button as a link if appropriate. A `noDefaultClasses` property value of `true` will remove all default styling. You can denote a primary button action for a notice by assigning a `isPrimary` value of `true`.
 
 ## Related components
 

--- a/packages/components/src/notice/index.js
+++ b/packages/components/src/notice/index.js
@@ -93,6 +93,7 @@ function Notice( {
 						{
 							className: buttonCustomClasses,
 							label,
+							isPrimary,
 							noDefaultClasses = false,
 							onClick,
 							url,
@@ -103,6 +104,7 @@ function Notice( {
 							<Button
 								key={ index }
 								href={ url }
+								isPrimary={ isPrimary }
 								isSecondary={ ! noDefaultClasses && ! url }
 								isLink={ ! noDefaultClasses && !! url }
 								onClick={ url ? undefined : onClick }

--- a/packages/components/src/notice/index.js
+++ b/packages/components/src/notice/index.js
@@ -17,24 +17,23 @@ import { close } from '@wordpress/icons';
  */
 import { Button } from '../';
 
+/** @typedef {import('@wordpress/element').WPElement} WPElement */
+
 /**
  * Custom hook which announces the message with the given politeness, if a
  * valid message is provided.
  *
- * @param {string}               [message]  Message to announce.
+ * @param {string|WPElement}     [message]  Message to announce.
  * @param {'polite'|'assertive'} politeness Politeness to announce.
  */
 function useSpokenMessage( message, politeness ) {
+	const spokenMessage =
+		typeof message === 'string' ? message : renderToString( message );
+
 	useEffect( () => {
-		if ( ! message ) {
-			return;
+		if ( message ) {
+			speak( spokenMessage, politeness );
 		}
-
-		if ( typeof message !== 'string' ) {
-			message = renderToString( message );
-		}
-
-		speak( message, politeness );
 	}, [ message, politeness ] );
 }
 

--- a/packages/components/src/notice/index.js
+++ b/packages/components/src/notice/index.js
@@ -63,13 +63,14 @@ function Notice( {
 	className,
 	status = 'info',
 	children,
+	spokenMessage = children,
 	onRemove = noop,
 	isDismissible = true,
 	actions = [],
 	politeness = getDefaultPoliteness( status ),
 	__unstableHTML,
 } ) {
-	useSpokenMessage( children, politeness );
+	useSpokenMessage( spokenMessage, politeness );
 
 	const classes = classnames(
 		className,

--- a/packages/components/src/notice/index.js
+++ b/packages/components/src/notice/index.js
@@ -8,13 +8,57 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { RawHTML } from '@wordpress/element';
+import { RawHTML, useEffect, renderToString } from '@wordpress/element';
+import { speak } from '@wordpress/a11y';
 import { close } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import { Button } from '../';
+
+/**
+ * Custom hook which announces the message with the given politeness, if a
+ * valid message is provided.
+ *
+ * @param {?string} message    Message to announce.
+ * @param {string}  politeness Politeness in which to announce, one of 'polite'
+ *                             or 'assertive'.
+ */
+function useSpokenMessage( message, politeness ) {
+	useEffect( () => {
+		if ( ! message ) {
+			return;
+		}
+
+		if ( typeof message !== 'string' ) {
+			message = renderToString( message );
+		}
+
+		speak( message, politeness );
+	}, [ message, politeness ] );
+}
+
+/**
+ * Given a notice status, returns an assumed default equivalent role for the
+ * status. Defaults to 'alert'.
+ *
+ * @param {?string} status Notice status.
+ *
+ * @return {string} Notice role.
+ */
+function getDefaultRole( status ) {
+	switch ( status ) {
+		case 'success':
+		case 'warning':
+		case 'info':
+			return 'status';
+
+		case 'error':
+		default:
+			return 'alert';
+	}
+}
 
 function Notice( {
 	className,
@@ -23,8 +67,12 @@ function Notice( {
 	onRemove = noop,
 	isDismissible = true,
 	actions = [],
+	role = getDefaultRole( status ),
 	__unstableHTML,
 } ) {
+	const politeness = role === 'status' ? 'polite' : 'assertive';
+	useSpokenMessage( children, politeness );
+
 	const classes = classnames(
 		className,
 		'components-notice',

--- a/packages/components/src/notice/index.js
+++ b/packages/components/src/notice/index.js
@@ -18,7 +18,7 @@ import { Button } from '../';
 
 function Notice( {
 	className,
-	status,
+	status = 'info',
 	children,
 	onRemove = noop,
 	isDismissible = true,

--- a/packages/components/src/notice/index.js
+++ b/packages/components/src/notice/index.js
@@ -21,9 +21,8 @@ import { Button } from '../';
  * Custom hook which announces the message with the given politeness, if a
  * valid message is provided.
  *
- * @param {?string} message    Message to announce.
- * @param {string}  politeness Politeness in which to announce, one of 'polite'
- *                             or 'assertive'.
+ * @param {string}               [message]  Message to announce.
+ * @param {'polite'|'assertive'} politeness Politeness to announce.
  */
 function useSpokenMessage( message, politeness ) {
 	useEffect( () => {
@@ -40,23 +39,23 @@ function useSpokenMessage( message, politeness ) {
 }
 
 /**
- * Given a notice status, returns an assumed default equivalent role for the
- * status. Defaults to 'alert'.
+ * Given a notice status, returns an assumed default politeness for the status.
+ * Defaults to 'assertive'.
  *
- * @param {?string} status Notice status.
+ * @param {string} [status] Notice status.
  *
- * @return {string} Notice role.
+ * @return {'polite'|'assertive'} Notice politeness.
  */
-function getDefaultRole( status ) {
+function getDefaultPoliteness( status ) {
 	switch ( status ) {
 		case 'success':
 		case 'warning':
 		case 'info':
-			return 'status';
+			return 'polite';
 
 		case 'error':
 		default:
-			return 'alert';
+			return 'assertive';
 	}
 }
 
@@ -67,10 +66,9 @@ function Notice( {
 	onRemove = noop,
 	isDismissible = true,
 	actions = [],
-	role = getDefaultRole( status ),
+	politeness = getDefaultPoliteness( status ),
 	__unstableHTML,
 } ) {
-	const politeness = role === 'status' ? 'polite' : 'assertive';
 	useSpokenMessage( children, politeness );
 
 	const classes = classnames(

--- a/packages/components/src/notice/index.js
+++ b/packages/components/src/notice/index.js
@@ -31,10 +31,10 @@ function useSpokenMessage( message, politeness ) {
 		typeof message === 'string' ? message : renderToString( message );
 
 	useEffect( () => {
-		if ( message ) {
+		if ( spokenMessage ) {
 			speak( spokenMessage, politeness );
 		}
-	}, [ message, politeness ] );
+	}, [ spokenMessage, politeness ] );
 }
 
 /**

--- a/packages/components/src/notice/test/__snapshots__/index.js.snap
+++ b/packages/components/src/notice/test/__snapshots__/index.js.snap
@@ -14,7 +14,24 @@ exports[`Notice should match snapshot 1`] = `
       isLink={true}
       isSecondary={false}
     >
-      View
+      More information
+    </ForwardRef(Button)>
+    <ForwardRef(Button)
+      className="components-notice__action"
+      isLink={false}
+      isSecondary={true}
+      onClick={[Function]}
+    >
+      Cancel
+    </ForwardRef(Button)>
+    <ForwardRef(Button)
+      className="components-notice__action"
+      isLink={false}
+      isPrimary={true}
+      isSecondary={true}
+      onClick={[Function]}
+    >
+      Submit
     </ForwardRef(Button)>
   </div>
   <ForwardRef(Button)

--- a/packages/components/src/notice/test/index.js
+++ b/packages/components/src/notice/test/index.js
@@ -113,5 +113,20 @@ describe( 'Notice', () => {
 				'polite'
 			);
 		} );
+
+		it( 'should not re-speak an effectively equivalent element message', () => {
+			const tree = create(
+				<Notice>
+					With <em>emphasis</em> this time.
+				</Notice>
+			);
+			tree.update(
+				<Notice>
+					With <em>emphasis</em> this time.
+				</Notice>
+			);
+
+			expect( speak ).toHaveBeenCalledTimes( 1 );
+		} );
 	} );
 } );

--- a/packages/components/src/notice/test/index.js
+++ b/packages/components/src/notice/test/index.js
@@ -28,7 +28,11 @@ describe( 'Notice', () => {
 		renderer.render(
 			<Notice
 				status="success"
-				actions={ [ { label: 'View', url: 'https://example.com' } ] }
+				actions={ [
+					{ label: 'More information', url: 'https://example.com' },
+					{ label: 'Cancel', onClick() {} },
+					{ label: 'Submit', onClick() {}, isPrimary: true },
+				] }
 			>
 				Example
 			</Notice>

--- a/packages/components/src/notice/test/index.js
+++ b/packages/components/src/notice/test/index.js
@@ -61,12 +61,6 @@ describe( 'Notice', () => {
 	} );
 
 	describe( 'useSpokenMessage', () => {
-		// TODO: Current support for hooks in `react-test-renderer` is poor. In
-		// future versions, it should no longer be necessary to use `update` or
-		// the non-shallow renderer.
-		//
-		// See: https://github.com/facebook/react/issues/14050#issuecomment-447888631
-
 		it( 'should speak the given message', () => {
 			const tree = create( <Notice>FYI</Notice> );
 			tree.update();
@@ -74,23 +68,25 @@ describe( 'Notice', () => {
 			expect( speak ).toHaveBeenCalledWith( 'FYI', 'polite' );
 		} );
 
-		it( 'should speak the given message by explicit role', () => {
-			const tree = create( <Notice role="alert">Uh oh!</Notice> );
+		it( 'should speak the given message by explicit politeness', () => {
+			const tree = create(
+				<Notice politeness="assertive">Uh oh!</Notice>
+			);
 			tree.update();
 
 			expect( speak ).toHaveBeenCalledWith( 'Uh oh!', 'assertive' );
 		} );
 
-		it( 'should speak the given message by implicit role by status', () => {
+		it( 'should speak the given message by implicit politeness by status', () => {
 			const tree = create( <Notice status="error">Uh oh!</Notice> );
 			tree.update();
 
 			expect( speak ).toHaveBeenCalledWith( 'Uh oh!', 'assertive' );
 		} );
 
-		it( 'should speak the given message, preferring explicit to implicit roles', () => {
+		it( 'should speak the given message, preferring explicit to implicit politeness', () => {
 			const tree = create(
-				<Notice role="status" status="error">
+				<Notice politeness="polite" status="error">
 					No need to panic
 				</Notice>
 			);

--- a/packages/components/src/notice/test/index.js
+++ b/packages/components/src/notice/test/index.js
@@ -40,4 +40,15 @@ describe( 'Notice', () => {
 		expect( classes.contains( 'components-notice' ) ).toBe( true );
 		expect( classes.contains( 'is-dismissible' ) ).toBe( false );
 	} );
+
+	it( 'should default to info status', () => {
+		const renderer = new ShallowRenderer();
+
+		renderer.render( <Notice /> );
+
+		const classes = new TokenList(
+			renderer.getRenderOutput().props.className
+		);
+		expect( classes.contains( 'is-info' ) ).toBe( true );
+	} );
 } );

--- a/packages/components/src/notice/test/index.js
+++ b/packages/components/src/notice/test/index.js
@@ -2,18 +2,26 @@
  * External dependencies
  */
 import ShallowRenderer from 'react-test-renderer/shallow';
+import { create } from 'react-test-renderer';
 
 /**
  * WordPress dependencies
  */
 import TokenList from '@wordpress/token-list';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
  */
 import Notice from '../index';
 
+jest.mock( '@wordpress/a11y', () => ( { speak: jest.fn() } ) );
+
 describe( 'Notice', () => {
+	beforeEach( () => {
+		speak.mockReset();
+	} );
+
 	it( 'should match snapshot', () => {
 		const renderer = new ShallowRenderer();
 
@@ -50,5 +58,64 @@ describe( 'Notice', () => {
 			renderer.getRenderOutput().props.className
 		);
 		expect( classes.contains( 'is-info' ) ).toBe( true );
+	} );
+
+	describe( 'useSpokenMessage', () => {
+		// TODO: Current support for hooks in `react-test-renderer` is poor. In
+		// future versions, it should no longer be necessary to use `update` or
+		// the non-shallow renderer.
+		//
+		// See: https://github.com/facebook/react/issues/14050#issuecomment-447888631
+
+		it( 'should speak the given message', () => {
+			const tree = create( <Notice>FYI</Notice> );
+			tree.update();
+
+			expect( speak ).toHaveBeenCalledWith( 'FYI', 'polite' );
+		} );
+
+		it( 'should speak the given message by explicit role', () => {
+			const tree = create( <Notice role="alert">Uh oh!</Notice> );
+			tree.update();
+
+			expect( speak ).toHaveBeenCalledWith( 'Uh oh!', 'assertive' );
+		} );
+
+		it( 'should speak the given message by implicit role by status', () => {
+			const tree = create( <Notice status="error">Uh oh!</Notice> );
+			tree.update();
+
+			expect( speak ).toHaveBeenCalledWith( 'Uh oh!', 'assertive' );
+		} );
+
+		it( 'should speak the given message, preferring explicit to implicit roles', () => {
+			const tree = create(
+				<Notice role="status" status="error">
+					No need to panic
+				</Notice>
+			);
+			tree.update();
+
+			expect( speak ).toHaveBeenCalledWith(
+				'No need to panic',
+				'polite'
+			);
+		} );
+
+		it( 'should coerce a message to a string', () => {
+			// This test assumes that `@wordpress/a11y` is capable of handling
+			// markup strings appropriately.
+			const tree = create(
+				<Notice>
+					With <em>emphasis</em> this time.
+				</Notice>
+			);
+			tree.update();
+
+			expect( speak ).toHaveBeenCalledWith(
+				'With <em>emphasis</em> this time.',
+				'polite'
+			);
+		} );
 	} );
 } );

--- a/packages/components/src/snackbar/README.md
+++ b/packages/components/src/snackbar/README.md
@@ -40,6 +40,11 @@ const MySnackbarNotice = () => (
 
 The following props are used to control the display of the component.
 
+* `children`: (string) The displayed message of a notice. Also used as the spoken message for assistive technology, unless `spokenMessage` is provided as an alternative message.
+* `spokenMessage`: (string) Used to provide a custom spoken message in place of the `children` default.
+* `politeness`: (string) A politeness level for the notice's spoken message. Should be provided as one of the valid options for [an `aria-live` attribute value](https://www.w3.org/TR/wai-aria-1.1/#aria-live). Defaults to `"polite"`. Note that this value should be considered a suggestion; assistive technologies may override it based on internal heuristics.
+  * A value of `'assertive'` is to be used for important, and usually time-sensitive, information. It will interrupt anything else the screen reader is announcing in that moment.
+  * A value of `'polite'` is to be used for advisory information. It should not interrupt what the screen reader is announcing in that moment (the "speech queue") or interrupt the current task.
 * `onRemove`: function called when dismissing the notice.
 * `actions`: (array) an array of action objects. Each member object should contain a `label` and either a `url` link string or `onClick` callback function.
 

--- a/packages/components/src/snackbar/index.js
+++ b/packages/components/src/snackbar/index.js
@@ -19,24 +19,23 @@ import { Button } from '../';
 
 const NOTICE_TIMEOUT = 10000;
 
+/** @typedef {import('@wordpress/element').WPElement} WPElement */
+
 /**
  * Custom hook which announces the message with the given politeness, if a
  * valid message is provided.
  *
- * @param {string}               [message]  Message to announce.
+ * @param {string|WPElement}     [message]  Message to announce.
  * @param {'polite'|'assertive'} politeness Politeness to announce.
  */
 function useSpokenMessage( message, politeness ) {
+	const spokenMessage =
+		typeof message === 'string' ? message : renderToString( message );
+
 	useEffect( () => {
-		if ( ! message ) {
-			return;
+		if ( message ) {
+			speak( spokenMessage, politeness );
 		}
-
-		if ( typeof message !== 'string' ) {
-			message = renderToString( message );
-		}
-
-		speak( message, politeness );
 	}, [ message, politeness ] );
 }
 

--- a/packages/components/src/snackbar/index.js
+++ b/packages/components/src/snackbar/index.js
@@ -33,10 +33,10 @@ function useSpokenMessage( message, politeness ) {
 		typeof message === 'string' ? message : renderToString( message );
 
 	useEffect( () => {
-		if ( message ) {
+		if ( spokenMessage ) {
 			speak( spokenMessage, politeness );
 		}
-	}, [ message, politeness ] );
+	}, [ spokenMessage, politeness ] );
 }
 
 function Snackbar(

--- a/packages/components/src/snackbar/index.js
+++ b/packages/components/src/snackbar/index.js
@@ -7,7 +7,8 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useEffect, forwardRef } from '@wordpress/element';
+import { speak } from '@wordpress/a11y';
+import { useEffect, forwardRef, renderToString } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import warning from '@wordpress/warning';
 
@@ -18,10 +19,39 @@ import { Button } from '../';
 
 const NOTICE_TIMEOUT = 10000;
 
+/**
+ * Custom hook which announces the message with the given politeness, if a
+ * valid message is provided.
+ *
+ * @param {string}               [message]  Message to announce.
+ * @param {'polite'|'assertive'} politeness Politeness to announce.
+ */
+function useSpokenMessage( message, politeness ) {
+	useEffect( () => {
+		if ( ! message ) {
+			return;
+		}
+
+		if ( typeof message !== 'string' ) {
+			message = renderToString( message );
+		}
+
+		speak( message, politeness );
+	}, [ message, politeness ] );
+}
+
 function Snackbar(
-	{ className, children, actions = [], onRemove = noop },
+	{
+		className,
+		children,
+		spokenMessage = children,
+		politeness = 'polite',
+		actions = [],
+		onRemove = noop,
+	},
 	ref
 ) {
+	useSpokenMessage( spokenMessage, politeness );
 	useEffect( () => {
 		const timeoutHandle = setTimeout( () => {
 			onRemove();

--- a/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/cpt-locking.test.js
@@ -86,13 +86,13 @@ describe( 'cpt locking', () => {
 				'<!-- /wp:image -->'
 			);
 			await setPostContent( contentWithoutImage );
-			const VALIDATION_PARAGRAPH_SELECTOR =
-				'.editor-template-validation-notice .components-notice__content p';
-			await page.waitForSelector( VALIDATION_PARAGRAPH_SELECTOR );
+			const noticeContent = await page.waitForSelector(
+				'.editor-template-validation-notice .components-notice__content'
+			);
 			expect(
 				await page.evaluate(
-					( element ) => element.textContent,
-					await page.$( VALIDATION_PARAGRAPH_SELECTOR )
+					( _noticeContent ) => _noticeContent.firstChild.nodeValue,
+					noticeContent
 				)
 			).toEqual(
 				'The content of your post doesn’t match the template assigned to your post type.'

--- a/packages/editor/src/components/template-validation-notice/index.js
+++ b/packages/editor/src/components/template-validation-notice/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Notice, Button } from '@wordpress/components';
+import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
@@ -29,20 +29,21 @@ function TemplateValidationNotice( { isValid, ...props } ) {
 			className="editor-template-validation-notice"
 			isDismissible={ false }
 			status="warning"
+			actions={ [
+				{
+					label: __( 'Keep it as is' ),
+					onClick: props.resetTemplateValidity,
+				},
+				{
+					label: __( 'Reset the template' ),
+					onClick: confirmSynchronization,
+					isPrimary: true,
+				},
+			] }
 		>
-			<p>
-				{ __(
-					'The content of your post doesn’t match the template assigned to your post type.'
-				) }
-			</p>
-			<div>
-				<Button isSecondary onClick={ props.resetTemplateValidity }>
-					{ __( 'Keep it as is' ) }
-				</Button>
-				<Button onClick={ confirmSynchronization } isPrimary>
-					{ __( 'Reset the template' ) }
-				</Button>
-			</div>
+			{ __(
+				'The content of your post doesn’t match the template assigned to your post type.'
+			) }
 		</Notice>
 	);
 }

--- a/packages/notices/CHANGELOG.md
+++ b/packages/notices/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### Breaking Change
+
+- A notices message is no longer spoken as a result of notice creation, but rather by its display in the interface by its corresponding [`Notice` component](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/notice).
+
 ## 1.5.0 (2019-06-12)
 
 ### New Features

--- a/packages/notices/src/store/actions.js
+++ b/packages/notices/src/store/actions.js
@@ -20,7 +20,7 @@ import { DEFAULT_CONTEXT, DEFAULT_STATUS } from './constants';
  */
 
 /**
- * Yields action objects used in signalling that a notice is to be created.
+ * Returns an action object used in signalling that a notice is to be created.
  *
  * @param {string}                [status='info']              Notice status.
  * @param {string}                content                      Notice message.
@@ -40,12 +40,10 @@ import { DEFAULT_CONTEXT, DEFAULT_STATUS } from './constants';
  *                                                             readers.
  * @param {Array<WPNoticeAction>} [options.actions]            User actions to be
  *                                                             presented with notice.
+ *
+ * @return {Object} Action object.
  */
-export function* createNotice(
-	status = DEFAULT_STATUS,
-	content,
-	options = {}
-) {
+export function createNotice( status = DEFAULT_STATUS, content, options = {} ) {
 	const {
 		speak = true,
 		isDismissible = true,
@@ -61,21 +59,14 @@ export function* createNotice(
 	// supported, cast to a string.
 	content = String( content );
 
-	if ( speak ) {
-		yield {
-			type: 'SPEAK',
-			message: content,
-			ariaLive: type === 'snackbar' ? 'polite' : 'assertive',
-		};
-	}
-
-	yield {
+	return {
 		type: 'CREATE_NOTICE',
 		context,
 		notice: {
 			id,
 			status,
 			content,
+			spokenMessage: speak ? content : null,
 			__unstableHTML,
 			isDismissible,
 			actions,

--- a/packages/notices/src/store/index.js
+++ b/packages/notices/src/store/index.js
@@ -9,11 +9,9 @@ import { registerStore } from '@wordpress/data';
 import reducer from './reducer';
 import * as actions from './actions';
 import * as selectors from './selectors';
-import controls from './controls';
 
 export default registerStore( 'core/notices', {
 	reducer,
 	actions,
 	selectors,
-	controls,
 } );

--- a/packages/notices/src/store/selectors.js
+++ b/packages/notices/src/store/selectors.js
@@ -24,6 +24,8 @@ const DEFAULT_NOTICES = [];
  *                                      `info`, `error`, or `warning`. Defaults
  *                                      to `info`.
  * @property {string}  content          Notice message.
+ * @property {string}  spokenMessage    Audibly announced message text used by
+ *                                      assistive technologies.
  * @property {string}  __unstableHTML   Notice message as raw HTML. Intended to
  *                                      serve primarily for compatibility of
  *                                      server-rendered notices, and SHOULD NOT

--- a/packages/notices/src/store/test/actions.js
+++ b/packages/notices/src/store/test/actions.js
@@ -17,15 +17,10 @@ describe( 'actions', () => {
 		const status = 'status';
 		const content = 'my message';
 
-		it( 'yields actions when options is empty', () => {
+		it( 'returns an action when options is empty', () => {
 			const result = createNotice( status, content );
 
-			expect( result.next().value ).toMatchObject( {
-				type: 'SPEAK',
-				message: content,
-			} );
-
-			expect( result.next().value ).toMatchObject( {
+			expect( result ).toMatchObject( {
 				type: 'CREATE_NOTICE',
 				context: DEFAULT_CONTEXT,
 				notice: {
@@ -42,12 +37,7 @@ describe( 'actions', () => {
 		it( 'normalizes content to string', () => {
 			const result = createNotice( status, <strong>Hello</strong> );
 
-			expect( result.next().value ).toMatchObject( {
-				type: 'SPEAK',
-				message: expect.any( String ),
-			} );
-
-			expect( result.next().value ).toMatchObject( {
+			expect( result ).toMatchObject( {
 				type: 'CREATE_NOTICE',
 				context: DEFAULT_CONTEXT,
 				notice: {
@@ -61,7 +51,7 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		it( 'yields actions when options passed', () => {
+		it( 'returns an action when options passed', () => {
 			const context = 'foo';
 			const options = {
 				id,
@@ -71,18 +61,14 @@ describe( 'actions', () => {
 
 			const result = createNotice( status, content, options );
 
-			expect( result.next().value ).toMatchObject( {
-				type: 'SPEAK',
-				message: content,
-			} );
-
-			expect( result.next().value ).toEqual( {
+			expect( result ).toEqual( {
 				type: 'CREATE_NOTICE',
 				context,
 				notice: {
 					id,
 					status,
 					content,
+					spokenMessage: content,
 					isDismissible: false,
 					actions: [],
 					type: 'default',
@@ -90,7 +76,7 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		it( 'yields action when speak disabled', () => {
+		it( 'returns an action when speak disabled', () => {
 			const result = createNotice(
 				undefined,
 				'my <strong>message</strong>',
@@ -102,13 +88,14 @@ describe( 'actions', () => {
 				}
 			);
 
-			expect( result.next().value ).toEqual( {
+			expect( result ).toEqual( {
 				type: 'CREATE_NOTICE',
 				context: DEFAULT_CONTEXT,
 				notice: {
 					id,
 					status: DEFAULT_STATUS,
 					content: 'my <strong>message</strong>',
+					spokenMessage: null,
 					__unstableHTML: true,
 					isDismissible: false,
 					actions: [],
@@ -124,12 +111,7 @@ describe( 'actions', () => {
 
 			const result = createSuccessNotice( content );
 
-			expect( result.next().value ).toMatchObject( {
-				type: 'SPEAK',
-				message: content,
-			} );
-
-			expect( result.next().value ).toMatchObject( {
+			expect( result ).toMatchObject( {
 				type: 'CREATE_NOTICE',
 				context: DEFAULT_CONTEXT,
 				notice: {
@@ -149,12 +131,7 @@ describe( 'actions', () => {
 
 			const result = createInfoNotice( content );
 
-			expect( result.next().value ).toMatchObject( {
-				type: 'SPEAK',
-				message: content,
-			} );
-
-			expect( result.next().value ).toMatchObject( {
+			expect( result ).toMatchObject( {
 				type: 'CREATE_NOTICE',
 				context: DEFAULT_CONTEXT,
 				notice: {
@@ -174,12 +151,7 @@ describe( 'actions', () => {
 
 			const result = createErrorNotice( content );
 
-			expect( result.next().value ).toMatchObject( {
-				type: 'SPEAK',
-				message: content,
-			} );
-
-			expect( result.next().value ).toMatchObject( {
+			expect( result ).toMatchObject( {
 				type: 'CREATE_NOTICE',
 				context: DEFAULT_CONTEXT,
 				notice: {
@@ -199,12 +171,7 @@ describe( 'actions', () => {
 
 			const result = createWarningNotice( content );
 
-			expect( result.next().value ).toMatchObject( {
-				type: 'SPEAK',
-				message: content,
-			} );
-
-			expect( result.next().value ).toMatchObject( {
+			expect( result ).toMatchObject( {
 				type: 'CREATE_NOTICE',
 				context: DEFAULT_CONTEXT,
 				notice: {

--- a/packages/notices/src/store/test/reducer.js
+++ b/packages/notices/src/store/test/reducer.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import deepFreeze from 'deep-freeze';
-import { matchesProperty, find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,9 +11,6 @@ import { createNotice, removeNotice } from '../actions';
 import { getNotices } from '../selectors';
 import { DEFAULT_CONTEXT } from '../constants';
 
-const getYieldedOfType = ( generatorAction, type ) =>
-	find( Array.from( generatorAction ), matchesProperty( [ 'type' ], type ) );
-
 describe( 'reducer', () => {
 	it( 'should default to an empty object', () => {
 		const state = reducer( undefined, {} );
@@ -23,10 +19,7 @@ describe( 'reducer', () => {
 	} );
 
 	it( 'should track a notice', () => {
-		const action = getYieldedOfType(
-			createNotice( 'error', 'save error' ),
-			'CREATE_NOTICE'
-		);
+		const action = createNotice( 'error', 'save error' );
 		const state = reducer( undefined, action );
 
 		expect( state ).toEqual( {
@@ -34,6 +27,7 @@ describe( 'reducer', () => {
 				{
 					id: expect.any( String ),
 					content: 'save error',
+					spokenMessage: 'save error',
 					status: 'error',
 					isDismissible: true,
 					actions: [],
@@ -44,10 +38,9 @@ describe( 'reducer', () => {
 	} );
 
 	it( 'should track a notice by context', () => {
-		const action = getYieldedOfType(
-			createNotice( 'error', 'save error', { context: 'foo' } ),
-			'CREATE_NOTICE'
-		);
+		const action = createNotice( 'error', 'save error', {
+			context: 'foo',
+		} );
 		const state = reducer( undefined, action );
 
 		expect( state ).toEqual( {
@@ -55,6 +48,7 @@ describe( 'reducer', () => {
 				{
 					id: expect.any( String ),
 					content: 'save error',
+					spokenMessage: 'save error',
 					status: 'error',
 					isDismissible: true,
 					actions: [],
@@ -65,16 +59,10 @@ describe( 'reducer', () => {
 	} );
 
 	it( 'should track notices, respecting order by which they were created', () => {
-		let action = getYieldedOfType(
-			createNotice( 'error', 'save error' ),
-			'CREATE_NOTICE'
-		);
+		let action = createNotice( 'error', 'save error' );
 		const original = deepFreeze( reducer( undefined, action ) );
 
-		action = getYieldedOfType(
-			createNotice( 'success', 'successfully saved' ),
-			'CREATE_NOTICE'
-		);
+		action = createNotice( 'success', 'successfully saved' );
 		const state = reducer( original, action );
 
 		expect( state ).toEqual( {
@@ -82,6 +70,7 @@ describe( 'reducer', () => {
 				{
 					id: expect.any( String ),
 					content: 'save error',
+					spokenMessage: 'save error',
 					status: 'error',
 					isDismissible: true,
 					actions: [],
@@ -90,6 +79,7 @@ describe( 'reducer', () => {
 				{
 					id: expect.any( String ),
 					content: 'successfully saved',
+					spokenMessage: 'successfully saved',
 					status: 'success',
 					isDismissible: true,
 					actions: [],
@@ -100,10 +90,7 @@ describe( 'reducer', () => {
 	} );
 
 	it( 'should omit a removed notice', () => {
-		const action = getYieldedOfType(
-			createNotice( 'error', 'save error' ),
-			'CREATE_NOTICE'
-		);
+		const action = createNotice( 'error', 'save error' );
 		const original = deepFreeze( reducer( undefined, action ) );
 		const id = getNotices( original )[ 0 ].id;
 
@@ -115,10 +102,9 @@ describe( 'reducer', () => {
 	} );
 
 	it( 'should omit a removed notice by context', () => {
-		const action = getYieldedOfType(
-			createNotice( 'error', 'save error', { context: 'foo' } ),
-			'CREATE_NOTICE'
-		);
+		const action = createNotice( 'error', 'save error', {
+			context: 'foo',
+		} );
 		const original = deepFreeze( reducer( undefined, action ) );
 		const id = getNotices( original, 'foo' )[ 0 ].id;
 
@@ -130,10 +116,7 @@ describe( 'reducer', () => {
 	} );
 
 	it( 'should omit a removed notice across contexts', () => {
-		const action = getYieldedOfType(
-			createNotice( 'error', 'save error' ),
-			'CREATE_NOTICE'
-		);
+		const action = createNotice( 'error', 'save error' );
 		const original = deepFreeze( reducer( undefined, action ) );
 		const id = getNotices( original )[ 0 ].id;
 
@@ -143,16 +126,14 @@ describe( 'reducer', () => {
 	} );
 
 	it( 'should dedupe distinct ids, preferring new', () => {
-		let action = getYieldedOfType(
-			createNotice( 'error', 'save error (1)', { id: 'error-message' } ),
-			'CREATE_NOTICE'
-		);
+		let action = createNotice( 'error', 'save error (1)', {
+			id: 'error-message',
+		} );
 		const original = deepFreeze( reducer( undefined, action ) );
 
-		action = getYieldedOfType(
-			createNotice( 'error', 'save error (2)', { id: 'error-message' } ),
-			'CREATE_NOTICE'
-		);
+		action = createNotice( 'error', 'save error (2)', {
+			id: 'error-message',
+		} );
 		const state = reducer( original, action );
 
 		expect( state ).toEqual( {
@@ -160,6 +141,7 @@ describe( 'reducer', () => {
 				{
 					id: 'error-message',
 					content: 'save error (2)',
+					spokenMessage: 'save error (2)',
 					status: 'error',
 					isDismissible: true,
 					actions: [],


### PR DESCRIPTION
Fixes #9442
Closes #15708 
Related: #15594

This pull request seeks to move spoken message handling for notices from the notices store into the `Notice` component.

**Implementation notes:**

_**Update (2019-12-10):** The commentary in this section has since received feedback at https://github.com/WordPress/gutenberg/pull/15745#issuecomment-495912383 , with subsequent revisions summarized at https://github.com/WordPress/gutenberg/pull/15745#issuecomment-564250328_

I could use some accessibility feedback here. Per #9442, there's a recommendation to use the `role` attribute for notices affected by `withNotices`. It's unclear whether this is appropriate for all notices. The current implementation here preserves existing behavior so far as using `wp.a11y.speak`, but notices (both existing and from `withNotices`) will default to a politeness level corresponding to the status of the message (error messages as `'assertive'`, success messages as `'polite'`). From the reading of the [relevant roles](https://www.w3.org/TR/wai-aria-1.1/#alert), it doesn't seem like this must be a guaranteed 1-to-1 mapping (i.e. a success notice could be a time-sensitive, assertive message?), but is implemented instead as a sensible default. Notices can be configured to override this default by assigning `role="polite"` or `role="assertive"`. The role is not in-fact assigned to the rendered element, but its usage with `speak` is assumed to be a suitable equivalent behavior.

Feedback needed:

- Is the default behavior sensible?
- Is the actual behavior for `role` in not assigning the DOM attribute acceptable?
   - In my testing, assigning it to the element would cause a duplicate spoken message, if `speak` is also used.
- Would it be better to always use `role` and never `wp.a11y.speak`?
- Should `role` be exposed at all, or instead based entirely from `status`? Or always `'assertive'`?

**Testing instructions:**

Verify there are no regressions in the spoken messages of notices (example: published post "Post published!" notice).

Verify that notices mounted by `withNotices` (or ad hoc use of the `Notice` component) are spoken.