### PR TITLE
Add missing file entry for util.js

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.1 (2019-05-21)
+
+### Bug Fixes
+
+- Fix missing file entry for `util.js` in `package.json`
+
 ## 1.0.0 (2019-05-21)
 
 ### New Feature

--- a/packages/dependency-extraction-webpack-plugin/package.json
+++ b/packages/dependency-extraction-webpack-plugin/package.json
@@ -19,7 +19,8 @@
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
 	"files": [
-		"index.js"
+		"index.js",
+		"util.js"
 	],
 	"main": "index.js",
 	"dependencies": {


### PR DESCRIPTION
## Description
Updates the `files` entry in `package.json` for the `@wordpress/dependency-extraction-webpack-plugin-files` package. Because of the missing entry the file is currently not included in the published release, which means it's kinda broken.

Slack discussion: https://wordpress.slack.com/archives/C02QB2JS7/p1558448690100500

## How has this been tested?
Apply patch, run `wp-scripts build` smoothly without issues.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
