### PR TITLE
Update the post schedule label to correctly reflect the date and time display settings

### DIFF
--- a/packages/editor/src/components/post-schedule/label.js
+++ b/packages/editor/src/components/post-schedule/label.js
@@ -9,7 +9,7 @@ export function PostScheduleLabel( { date, isFloating } ) {
 	const settings = __experimentalGetSettings();
 
 	return date && ! isFloating ?
-		dateI18n( settings.formats.datetimeAbbreviated, date ) :
+		dateI18n( `${ settings.formats.date } ${ settings.formats.time }`, date ) :
 		__( 'Immediately' );
 }
 


### PR DESCRIPTION
## Description
Fixes #15654. 

Updates the post schedule label to correctly reflect a user's date and time display preferences. This was previously using the "datetimeAbbreviated" format, which is not updated when a user changes their date/time settings.

Additionally, now if a user specifies a custom date or time format, it will be correctly reflected in the publish date.

An alternative to this approach would be to update the functionality that is setting the settings.formats.date and settings.formats.time to correctly set the time in settings.formats.datetime, and settings.formats.datetimeAbbreviated. 

I opted for my approach over this because it will also pass through any totally custom date or time setting. Also, because I couldn't for the life of me find where settings.formats.time was getting updated when the site settings were updated. 

If the other approach is preferred, I would be happy to revisit.  Someone would just need to point me in the right direction for where those get set. It looks like it used to be in lib/client-assets.php but got removed [here](https://github.com/WordPress/gutenberg/commit/f7b002d284ff1a08bc257c5dc41303a7f532789f?diff=split#diff-620130744b6b73b822a3df609671d930L190)

## How has this been tested?
*For 24 hour time*
Change time settings to use 24h time. (Settings > General > Time Format > H:i)
Create a post.
Schedule for any time past 12:00. (ie, 13:25).
Close popover by clicking outside.
Publish date now correctly lists 12:25

*For custom date/time settings*
Change date/time settings to use something custom:
(Settings > General > Time Format > G:i)
(Settings > General > Date Format > d-m-Y)
Create a post.
Schedule for any time before 12:00. (ie, 1:25).
Close popover by clicking outside.
Publish date now correctly display custom format of 21-05-2019 01:25

## Screenshots
*24 hour time*
![24 Hour Format](https://user-images.githubusercontent.com/6653970/58115149-73061e80-7bc7-11e9-8c98-e661142be848.gif)

*Custom date/time settings*
![Custom date and time](https://user-images.githubusercontent.com/6653970/58115181-82856780-7bc7-11e9-915b-0180fbafae0b.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
