### PR TITLE
Correct the front-end class name for the latest posts excerpt

### DIFF
--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -59,7 +59,7 @@ function render_block_core_latest_posts( $attributes ) {
 			$trimmed_excerpt = esc_html( wp_trim_words( $post_excerpt, $excerpt_length, ' &hellip; ' ) );
 
 			$list_items_markup .= sprintf(
-				'<div class="wp-block-latest-posts____post-excerpt">%1$s',
+				'<div class="wp-block-latest-posts__post-excerpt">%1$s',
 				$trimmed_excerpt
 			);
 


### PR DESCRIPTION
The front-end class name added in #14627 for the latest posts excerpt is `wp-block-latest-posts____post-excerpt`.

The use of four underscores here does not match our usual style, and I think it may be a typo anyway — [the class used in the editor only uses two underscores](https://github.com/WordPress/gutenberg/blob/8960509d97f72bf4bee68e1513a6c3fd3b0d446e/packages/block-library/src/latest-posts/edit.js#L218). 

This PR just changes the front end classname to `wp-block-latest-posts__post-excerpt` so it follows the usual class name pattern, and so the frontend and editor classnames match. 