### PR TITLE
Provide margins to Latest Posts excerpts

### DIFF
--- a/packages/block-library/src/latest-posts/editor.scss
+++ b/packages/block-library/src/latest-posts/editor.scss
@@ -4,6 +4,16 @@
 		padding-left: 0;
 	}
 }
-.wp-block-latest-posts li a > div {
-	display: inline;
+
+.wp-block-latest-posts {
+
+	li a > div {
+		display: inline;
+	}
+
+	.wp-block-latest-posts__post-excerpt,
+	.wp-block-latest-posts__post-full-content {
+		margin-top: $grid-size;
+		margin-bottom: $grid-size-large;
+	}
 }

--- a/packages/block-library/src/latest-posts/editor.scss
+++ b/packages/block-library/src/latest-posts/editor.scss
@@ -8,8 +8,3 @@
 .wp-block-latest-posts li a > div {
 	display: inline;
 }
-
-.wp-block-latest-posts__post-excerpt {
-	margin-top: $grid-size;
-	margin-bottom: $grid-size-large;
-}

--- a/packages/block-library/src/latest-posts/editor.scss
+++ b/packages/block-library/src/latest-posts/editor.scss
@@ -5,14 +5,11 @@
 	}
 }
 
-.wp-block-latest-posts {
+.wp-block-latest-posts li a > div {
+	display: inline;
+}
 
-	li a > div {
-		display: inline;
-	}
-
-	.wp-block-latest-posts__post-excerpt {
-		margin-top: $grid-size;
-		margin-bottom: $grid-size-large;
-	}
+.wp-block-latest-posts__post-excerpt {
+	margin-top: $grid-size;
+	margin-bottom: $grid-size-large;
 }

--- a/packages/block-library/src/latest-posts/editor.scss
+++ b/packages/block-library/src/latest-posts/editor.scss
@@ -11,8 +11,7 @@
 		display: inline;
 	}
 
-	.wp-block-latest-posts__post-excerpt,
-	.wp-block-latest-posts__post-full-content {
+	.wp-block-latest-posts__post-excerpt {
 		margin-top: $grid-size;
 		margin-bottom: $grid-size-large;
 	}

--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -35,3 +35,8 @@
 	color: $dark-gray-300;
 	font-size: $default-font-size;
 }
+
+.wp-block-latest-posts__post-excerpt {
+	margin-top: $grid-size;
+	margin-bottom: $grid-size-large;
+}


### PR DESCRIPTION
_Addresses part of #15722._

#14627 added the option for users to display post excerpts and full content to posts within the Latest Posts block. It did not include any styles for that content. This means that excerpts will generally bump up against each other like so: 

![gutenberg test_wp-admin_post php_post=1 action=edit (2)](https://user-images.githubusercontent.com/1202812/58126442-f849fd00-7be0-11e9-8586-2f80327a9b2e.png)

This PR adds some top and bottom margin to the excerpt to prevent this visual issue: 

![gutenberg test_wp-admin_post php_post=1 action=edit (3)](https://user-images.githubusercontent.com/1202812/58126466-06981900-7be1-11e9-9082-a8badbce755c.png)

The style is entered into `editor.scss` so that it's visible in the editor, and to themes that opt-in to opinionated styles. If there's an appetite for it, this could alternatively be included in `style.scss` instead, so that the margin is supplied by default in all themes. I'm all for that, but figured we can have a discussion here first. 
