### PR TITLE
Update onSplit method on RN blocks to the latest version.

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -93,13 +93,7 @@ export class RichText extends Component {
 		if ( this.multilineTag === 'li' ) {
 			this.multilineWrapperTags = [ 'ul', 'ol' ];
 		}
-
-		if ( this.props.onSplit ) {
-			this.onSplit = this.props.onSplit;
-		} else if ( this.props.unstableOnSplit ) {
-			this.onSplit = this.props.unstableOnSplit;
-		}
-
+		this.onSplit = this.onSplit.bind( this );
 		this.isIOS = Platform.OS === 'ios';
 		this.createRecord = this.createRecord.bind( this );
 		this.onChange = this.onChange.bind( this );
@@ -187,55 +181,61 @@ export class RichText extends Component {
 		};
 	}
 
-	/*
-	 * Splits the content at the location of the selection.
+	/**
+	 * Signals to the RichText owner that the block can be replaced with two
+	 * blocks as a result of splitting the block by pressing enter, or with
+	 * blocks as a result of splitting the block by pasting block content in the
+	 * instance.
 	 *
-	 * Replaces the content of the editor inside this element with the contents
-	 * before the selection. Sends the elements after the selection to the `onSplit`
-	 * handler.
-	 *
+	 * @param  {Object} record       The rich text value to split.
+	 * @param  {Array}  pastedBlocks The pasted blocks to insert, if any.
 	 */
-	splitContent( currentRecord, blocks = [], isPasted = false ) {
-		if ( ! this.onSplit ) {
+	onSplit( record, pastedBlocks = [] ) {
+		const {
+			onReplace,
+			onSplit,
+			__unstableOnSplitMiddle: onSplitMiddle,
+		} = this.props;
+
+		if ( ! onReplace || ! onSplit ) {
 			return;
 		}
 
-		// TODO : Fix the index position in AztecNative for Android
-		let [ before, after ] = split( currentRecord );
+		const blocks = [];
+		const [ before, after ] = split( record );
+		const hasPastedBlocks = pastedBlocks.length > 0;
 
-		// In case split occurs at the trailing or leading edge of the field,
-		// assume that the before/after values respectively reflect the current
-		// value. This also provides an opportunity for the parent component to
-		// determine whether the before/after value has changed using a trivial
-		//  strict equality operation.
-		if ( isEmpty( after ) && before.text.length === currentRecord.text.length ) {
-			before = currentRecord;
-		} else if ( isEmpty( before ) && after.text.length === currentRecord.text.length ) {
-			after = currentRecord;
+		// Create a block with the content before the caret if there's no pasted
+		// blocks, or if there are pasted blocks and the value is not empty.
+		// We do not want a leading empty block on paste, but we do if split
+		// with e.g. the enter key.
+		if ( ! hasPastedBlocks || ! isEmpty( before ) ) {
+			blocks.push( onSplit( this.valueToFormat( before ) ) );
 		}
 
-		// If pasting and the split would result in no content other than the
-		// pasted blocks, remove the before and after blocks.
-		if ( isPasted ) {
-			before = isEmpty( before ) ? null : before;
-			after = isEmpty( after ) ? null : after;
+		if ( hasPastedBlocks ) {
+			blocks.push( ...pastedBlocks );
+		} else if ( onSplitMiddle ) {
+			blocks.push( onSplitMiddle() );
 		}
 
-		if ( before ) {
-			before = this.valueToFormat( before );
+		// If there's pasted blocks, append a block with the content after the
+		// caret. Otherwise, do append and empty block if there is no
+		// `onSplitMiddle` prop, but if there is and the content is empty, the
+		// middle block is enough to set focus in.
+		if ( hasPastedBlocks || ! onSplitMiddle || ! isEmpty( after ) ) {
+			blocks.push( onSplit( this.valueToFormat( after ) ) );
 		}
 
-		if ( after ) {
-			after = this.valueToFormat( after );
-		}
-
+		// If there are pasted blocks, set the selection to the last one.
+		// Otherwise, set the selection to the second block.
+		const indexToSelect = hasPastedBlocks ? blocks.length - 1 : 1;
 		// The onSplit event can cause a content update event for this block.  Such event should
 		// definitely be processed by our native components, since they have no knowledge of
 		// how the split works.  Setting lastEventCount to undefined forces the native component to
 		// always update when provided with new content.
 		this.lastEventCount = undefined;
-
-		this.onSplit( before, after, ...blocks );
+		onReplace( blocks, indexToSelect );
 	}
 
 	valueToFormat( value ) {
@@ -364,7 +364,7 @@ export class RichText extends Component {
 				const insertedLineBreak = { ...insert( currentRecord, '\n' ) };
 				this.onFormatChangeForceChild( insertedLineBreak );
 			} else if ( this.onSplit && isEmptyLine( currentRecord ) ) {
-				this.splitContent( currentRecord );
+				this.onSplit( currentRecord );
 			} else {
 				this.needsSelectionUpdate = true;
 				const insertedLineSeparator = { ...insertLineSeparator( currentRecord ) };
@@ -375,7 +375,7 @@ export class RichText extends Component {
 			const insertedLineBreak = { ...insert( currentRecord, '\n' ) };
 			this.onFormatChangeForceChild( insertedLineBreak );
 		} else {
-			this.splitContent( currentRecord );
+			this.onSplit( currentRecord );
 		}
 		this.lastAztecEventType = 'input';
 	}
@@ -414,7 +414,6 @@ export class RichText extends Component {
 	 * @param {PasteEvent} event The paste event which wraps `nativeEvent`.
 	 */
 	onPaste( event ) {
-		const isPasted = true;
 		const { onSplit } = this.props;
 
 		const { pastedText, pastedHtml, files } = event.nativeEvent;
@@ -440,7 +439,7 @@ export class RichText extends Component {
 			if ( shouldReplace ) {
 				this.props.onReplace( content );
 			} else {
-				this.splitContent( currentRecord, content, isPasted );
+				this.onSplit( currentRecord, content );
 			}
 
 			return;
@@ -507,7 +506,7 @@ export class RichText extends Component {
 			if ( shouldReplace ) {
 				this.props.onReplace( pastedContent );
 			} else {
-				this.splitContent( currentRecord, pastedContent, isPasted );
+				this.onSplit( currentRecord, pastedContent );
 			}
 		}
 	}

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -609,13 +609,6 @@ export class RichText extends Component {
 		return value;
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.value !== this.value ) {
-			this.value = this.props.value;
-			this.lastEventCount = undefined;
-		}
-	}
-
 	forceSelectionUpdate( start, end ) {
 		if ( ! this.needsSelectionUpdate ) {
 			this.needsSelectionUpdate = true;
@@ -681,6 +674,10 @@ export class RichText extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
+		if ( this.props.value !== this.value ) {
+			this.value = this.props.value;
+			this.lastEventCount = undefined;
+		}
 		if ( this.props.isSelected && ! prevProps.isSelected ) {
 			this._editor.focus();
 			// Update selection props explicitly when component is selected as Aztec won't call onSelectionChange

--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -31,10 +31,10 @@ class HeadingEdit extends Component {
 	render() {
 		const {
 			attributes,
-			insertBlocksAfter,
 			setAttributes,
 			mergeBlocks,
 			style,
+			onReplace,
 		} = this.props;
 
 		const {
@@ -80,17 +80,18 @@ class HeadingEdit extends Component {
 					onBlur={ this.props.onBlur } // always assign onBlur as a props
 					onChange={ ( value ) => setAttributes( { content: value } ) }
 					onMerge={ mergeBlocks }
-					unstableOnSplit={
-						insertBlocksAfter ?
-							( before, after, ...blocks ) => {
-								setAttributes( { content: before } );
-								insertBlocksAfter( [
-									...blocks,
-									createBlock( 'core/paragraph', { content: after } ),
-								] );
-							} :
-							undefined
-					}
+					onSplit={ ( value ) => {
+						if ( ! value ) {
+							return createBlock( 'core/paragraph' );
+						}
+
+						return createBlock( 'core/heading', {
+							...attributes,
+							content: value,
+						} );
+					} }
+					onReplace={ onReplace }
+					onRemove={ () => onReplace( [] ) }
 					placeholder={ placeholder || __( 'Write heading…' ) }
 				/>
 			</View>

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -22,51 +22,7 @@ const name = 'core/paragraph';
 class ParagraphEdit extends Component {
 	constructor( props ) {
 		super( props );
-		this.splitBlock = this.splitBlock.bind( this );
 		this.onReplace = this.onReplace.bind( this );
-	}
-
-	/**
-	 * Split handler for RichText value, namely when content is pasted or the
-	 * user presses the Enter key.
-	 *
-	 * @param {?Array}     before Optional before value, to be used as content
-	 *                            in place of what exists currently for the
-	 *                            block. If undefined, the block is deleted.
-	 * @param {?Array}     after  Optional after value, to be appended in a new
-	 *                            paragraph block to the set of blocks passed
-	 *                            as spread.
-	 * @param {...WPBlock} blocks Optional blocks inserted between the before
-	 *                            and after value blocks.
-	 */
-	splitBlock( before, after, ...blocks ) {
-		const {
-			attributes,
-			insertBlocksAfter,
-			setAttributes,
-			onReplace,
-		} = this.props;
-
-		if ( after !== null ) {
-			// Append "After" content as a new paragraph block to the end of
-			// any other blocks being inserted after the current paragraph.
-			const newBlock = createBlock( name, { content: after } );
-			blocks.push( newBlock );
-		}
-
-		if ( blocks.length && insertBlocksAfter ) {
-			insertBlocksAfter( blocks );
-		}
-
-		const { content } = attributes;
-		if ( before === null ) {
-			onReplace( [] );
-		} else if ( content !== before ) {
-			// Only update content if it has in-fact changed. In case that user
-			// has created a new paragraph at end of an existing one, the value
-			// of before will be strictly equal to the current content.
-			setAttributes( { content: before } );
-		}
 	}
 
 	onReplace( blocks ) {

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -96,6 +96,7 @@ class ParagraphEdit extends Component {
 			attributes,
 			setAttributes,
 			mergeBlocks,
+			onReplace,
 			style,
 		} = this.props;
 
@@ -133,9 +134,19 @@ class ParagraphEdit extends Component {
 							content: nextContent,
 						} );
 					} }
-					onSplit={ this.splitBlock }
+					onSplit={ ( value ) => {
+						if ( ! value ) {
+							return createBlock( name );
+						}
+
+						return createBlock( name, {
+							...attributes,
+							content: value,
+						} );
+					} }
 					onMerge={ mergeBlocks }
-					onReplace={ this.onReplace }
+					onReplace={ onReplace }
+					onRemove={ onReplace ? () => onReplace( [] ) : undefined }
 					placeholder={ placeholder || __( 'Start writing…' ) }
 				/>
 			</View>


### PR DESCRIPTION

## Description
This commit updates the native richtext component to use the latest version of onSplit.
It also updates the custom paragraph and heading blocks to use the new onSplit.

## How has this been tested?
Use this PR on GB mobile to test: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1013

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
