### PR TITLE
Registers the core/group Block as the default block for handling "grouping" interactions

### DIFF
--- a/docs/designers-developers/developers/data/data-core-blocks.md
+++ b/docs/designers-developers/developers/data/data-core-blocks.md
@@ -110,7 +110,7 @@ _Returns_
 
 <a name="getGroupingBlockName" href="#getGroupingBlockName">#</a> **getGroupingBlockName**
 
-Returns the name of the block for handling unregistered blocks.
+Returns the name of the block for handling the grouping of blocks.
 
 _Parameters_
 
@@ -118,7 +118,7 @@ _Parameters_
 
 _Returns_
 
--   `?string`: Name of the block for handling unregistered blocks.
+-   `?string`: Name of the block for handling grouping blocks.
 
 <a name="getUnregisteredFallbackBlockName" href="#getUnregisteredFallbackBlockName">#</a> **getUnregisteredFallbackBlockName**
 

--- a/docs/designers-developers/developers/data/data-core-blocks.md
+++ b/docs/designers-developers/developers/data/data-core-blocks.md
@@ -110,7 +110,7 @@ _Returns_
 
 <a name="getGroupingBlockName" href="#getGroupingBlockName">#</a> **getGroupingBlockName**
 
-Returns the name of the block for handling the grouping of blocks.
+Returns the name of the block for handling unregistered blocks.
 
 _Parameters_
 
@@ -118,7 +118,7 @@ _Parameters_
 
 _Returns_
 
--   `?string`: Name of the block for handling grouping blocks.
+-   `?string`: Name of the block for handling unregistered blocks.
 
 <a name="getUnregisteredFallbackBlockName" href="#getUnregisteredFallbackBlockName">#</a> **getUnregisteredFallbackBlockName**
 

--- a/docs/designers-developers/developers/data/data-core-blocks.md
+++ b/docs/designers-developers/developers/data/data-core-blocks.md
@@ -108,6 +108,18 @@ _Returns_
 
 -   `?string`: Name of the block for handling non-block content.
 
+<a name="getGroupingBlockName" href="#getGroupingBlockName">#</a> **getGroupingBlockName**
+
+Returns the name of the block for handling unregistered blocks.
+
+_Parameters_
+
+-   _state_ `Object`: Data state.
+
+_Returns_
+
+-   `?string`: Name of the block for handling unregistered blocks.
+
 <a name="getUnregisteredFallbackBlockName" href="#getUnregisteredFallbackBlockName">#</a> **getUnregisteredFallbackBlockName**
 
 Returns the name of the block for handling unregistered blocks.
@@ -261,6 +273,20 @@ _Returns_
 
 Returns an action object used to set the name of the block used as a fallback
 for non-block content.
+
+_Parameters_
+
+-   _name_ `string`: Block name.
+
+_Returns_
+
+-   `Object`: Action object.
+
+<a name="setGroupingBlockName" href="#setGroupingBlockName">#</a> **setGroupingBlockName**
+
+Returns an action object used to set the name of the block used
+when grouping other blocks
+eg: in "Group/Ungroup" interactions
 
 _Parameters_
 

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -9,6 +9,7 @@ import {
 	setDefaultBlockName,
 	setFreeformContentHandlerName,
 	setUnregisteredTypeHandlerName,
+	setGroupingBlockName,
 	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase
 } from '@wordpress/blocks';
 
@@ -135,4 +136,8 @@ export const registerCoreBlocks = () => {
 		setFreeformContentHandlerName( classic.name );
 	}
 	setUnregisteredTypeHandlerName( missing.name );
+
+	if ( group ) {
+		setGroupingBlockName( group.name );
+	}
 };

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -670,7 +670,7 @@ _Parameters_
 
 <a name="setGroupingBlockName" href="#setGroupingBlockName">#</a> **setGroupingBlockName**
 
-Assigns the grouping block name.
+Assigns name of block for handling block grouping interactions.
 
 _Parameters_
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -372,6 +372,15 @@ _Returns_
 
 -   `?string`: Blog name.
 
+<a name="getGroupingBlockName" href="#getGroupingBlockName">#</a> **getGroupingBlockName**
+
+Retrieves name of block used for handling grouping interactions, or undefined if no
+handler has been defined.
+
+_Returns_
+
+-   `?string`: Blog name.
+
 <a name="getPhrasingContentSchema" href="#getPhrasingContentSchema">#</a> **getPhrasingContentSchema**
 
 Get schema of possible paths for phrasing content.
@@ -667,6 +676,14 @@ Assigns name of block handling unregistered block types.
 _Parameters_
 
 -   _blockName_ `string`: Block name.
+
+<a name="setGroupingBlockName" href="#setGroupingBlockName">#</a> **setGroupingBlockName**
+
+Assigns the name of the block used in grouping interactions.
+
+_Parameters_
+
+-   _name_ `string`: Block name.
 
 <a name="switchToBlockType" href="#switchToBlockType">#</a> **switchToBlockType**
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -370,15 +370,15 @@ handler has been defined.
 
 _Returns_
 
--   `?string`: Blog name.
+-   `?string`: Block name.
 
 <a name="getGroupingBlockName" href="#getGroupingBlockName">#</a> **getGroupingBlockName**
 
-Retrieves name of block used for handling grouping interactions
+Retrieves name of block used for handling grouping interactions.
 
 _Returns_
 
--   `?string`: Blog name.
+-   `?string`: Block name.
 
 <a name="getPhrasingContentSchema" href="#getPhrasingContentSchema">#</a> **getPhrasingContentSchema**
 
@@ -442,7 +442,7 @@ handler has been defined.
 
 _Returns_
 
--   `?string`: Blog name.
+-   `?string`: Block name.
 
 <a name="hasBlockSupport" href="#hasBlockSupport">#</a> **hasBlockSupport**
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -374,8 +374,7 @@ _Returns_
 
 <a name="getGroupingBlockName" href="#getGroupingBlockName">#</a> **getGroupingBlockName**
 
-Retrieves name of block used for handling grouping interactions, or undefined if no
-handler has been defined.
+Retrieves name of block used for handling grouping interactions
 
 _Returns_
 
@@ -669,6 +668,14 @@ _Parameters_
 
 -   _blockName_ `string`: Block name.
 
+<a name="setGroupingBlockName" href="#setGroupingBlockName">#</a> **setGroupingBlockName**
+
+Assigns the grouping block name.
+
+_Parameters_
+
+-   _name_ `string`: Block name.
+
 <a name="setUnregisteredTypeHandlerName" href="#setUnregisteredTypeHandlerName">#</a> **setUnregisteredTypeHandlerName**
 
 Assigns name of block handling unregistered block types.
@@ -676,14 +683,6 @@ Assigns name of block handling unregistered block types.
 _Parameters_
 
 -   _blockName_ `string`: Block name.
-
-<a name="setGroupingBlockName" href="#setGroupingBlockName">#</a> **setGroupingBlockName**
-
-Assigns the name of the block used in grouping interactions.
-
-_Parameters_
-
--   _name_ `string`: Block name.
 
 <a name="switchToBlockType" href="#switchToBlockType">#</a> **switchToBlockType**
 

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -35,6 +35,8 @@ export {
 	getUnregisteredTypeHandlerName,
 	setDefaultBlockName,
 	getDefaultBlockName,
+	setGroupingBlockName,
+	getGroupingBlockName,
 	getBlockType,
 	getBlockTypes,
 	getBlockSupport,

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -193,16 +193,16 @@ export function setFreeformContentHandlerName( blockName ) {
  * Retrieves name of block handling non-block content, or undefined if no
  * handler has been defined.
  *
- * @return {?string} Blog name.
+ * @return {?string} Block name.
  */
 export function getFreeformContentHandlerName() {
 	return select( 'core/blocks' ).getFreeformFallbackBlockName();
 }
 
 /**
- * Retrieves name of block used for handling grouping interactions
+ * Retrieves name of block used for handling grouping interactions.
  *
- * @return {?string} Blog name.
+ * @return {?string} Block name.
  */
 export function getGroupingBlockName() {
 	return select( 'core/blocks' ).getGroupingBlockName();
@@ -221,7 +221,7 @@ export function setUnregisteredTypeHandlerName( blockName ) {
  * Retrieves name of block handling unregistered block types, or undefined if no
  * handler has been defined.
  *
- * @return {?string} Blog name.
+ * @return {?string} Block name.
  */
 export function getUnregisteredTypeHandlerName() {
 	return select( 'core/blocks' ).getUnregisteredFallbackBlockName();

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -200,6 +200,15 @@ export function getFreeformContentHandlerName() {
 }
 
 /**
+ * Retrieves name of block used for handling grouping interactions
+ *
+ * @return {?string} Blog name.
+ */
+export function getGroupingBlockName() {
+	return select( 'core/blocks' ).getGroupingBlockName();
+}
+
+/**
  * Assigns name of block handling unregistered block types.
  *
  * @param {string} blockName Block name.
@@ -225,6 +234,15 @@ export function getUnregisteredTypeHandlerName() {
  */
 export function setDefaultBlockName( name ) {
 	dispatch( 'core/blocks' ).setDefaultBlockName( name );
+}
+
+/**
+ * Assigns the grouping block name.
+ *
+ * @param {string} name Block name.
+ */
+export function setGroupingBlockName( name ) {
+	dispatch( 'core/blocks' ).setGroupingBlockName( name );
 }
 
 /**

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -237,7 +237,7 @@ export function setDefaultBlockName( name ) {
 }
 
 /**
- * Assigns the grouping block name.
+ * Assigns name of block for handling block grouping interactions.
  *
  * @param {string} name Block name.
  */

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -22,6 +22,8 @@ import {
 	getUnregisteredTypeHandlerName,
 	setDefaultBlockName,
 	getDefaultBlockName,
+	getGroupingBlockName,
+	setGroupingBlockName,
 	getBlockType,
 	getBlockTypes,
 	getBlockSupport,
@@ -412,6 +414,20 @@ describe( 'blocks', () => {
 	describe( 'getDefaultBlockName()', () => {
 		it( 'defaults to undefined', () => {
 			expect( getDefaultBlockName() ).toBeNull();
+		} );
+	} );
+
+	describe( 'getGroupingBlockName()', () => {
+		it( 'defaults to undefined', () => {
+			expect( getGroupingBlockName() ).toBeNull();
+		} );
+	} );
+
+	describe( 'setGroupingBlockName()', () => {
+		it( 'assigns default block name', () => {
+			setGroupingBlockName( 'core/test-block' );
+
+			expect( getGroupingBlockName() ).toBe( 'core/test-block' );
 		} );
 	} );
 

--- a/packages/blocks/src/store/actions.js
+++ b/packages/blocks/src/store/actions.js
@@ -108,6 +108,22 @@ export function setUnregisteredFallbackBlockName( name ) {
 }
 
 /**
+ * Returns an action object used to set the name of the block used
+ * when grouping other blocks
+ * eg: in "Group/Ungroup" interactions
+ *
+ * @param {string} name Block name.
+ *
+ * @return {Object} Action object.
+ */
+export function setGroupingBlockName( name ) {
+	return {
+		type: 'SET_GROUPING_BLOCK_NAME',
+		name,
+	};
+}
+
+/**
  * Returns an action object used to set block categories.
  *
  * @param {Object[]} categories Block categories.

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -124,6 +124,7 @@ export function createBlockNameSetterReducer( setActionType ) {
 export const defaultBlockName = createBlockNameSetterReducer( 'SET_DEFAULT_BLOCK_NAME' );
 export const freeformFallbackBlockName = createBlockNameSetterReducer( 'SET_FREEFORM_FALLBACK_BLOCK_NAME' );
 export const unregisteredFallbackBlockName = createBlockNameSetterReducer( 'SET_UNREGISTERED_FALLBACK_BLOCK_NAME' );
+export const groupingBlockName = createBlockNameSetterReducer( 'SET_GROUPING_BLOCK_NAME' );
 
 /**
  * Reducer managing the categories
@@ -164,5 +165,6 @@ export default combineReducers( {
 	defaultBlockName,
 	freeformFallbackBlockName,
 	unregisteredFallbackBlockName,
+	groupingBlockName,
 	categories,
 } );

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -102,6 +102,17 @@ export function getUnregisteredFallbackBlockName( state ) {
 }
 
 /**
+ * Returns the name of the block for handling unregistered blocks.
+ *
+ * @param {Object} state Data state.
+ *
+ * @return {string?} Name of the block for handling unregistered blocks.
+ */
+export function getGroupingBlockName( state ) {
+	return state.groupingBlockName;
+}
+
+/**
  * Returns an array with the child blocks of a given block.
  *
  * @param {Object} state     Data state.

--- a/packages/blocks/src/store/test/reducer.js
+++ b/packages/blocks/src/store/test/reducer.js
@@ -13,6 +13,7 @@ import {
 	defaultBlockName,
 	freeformFallbackBlockName,
 	unregisteredFallbackBlockName,
+	groupingBlockName,
 	DEFAULT_CATEGORIES,
 } from '../reducer';
 
@@ -177,6 +178,30 @@ describe( 'freeformFallbackBlockName', () => {
 		const state = freeformFallbackBlockName( 'core/code', {
 			type: 'REMOVE_BLOCK_TYPES',
 			names: [ 'core/code' ],
+		} );
+
+		expect( state ).toBeNull();
+	} );
+} );
+
+describe( 'groupingBlockName', () => {
+	it( 'should return null as default state', () => {
+		expect( groupingBlockName( undefined, {} ) ).toBeNull();
+	} );
+
+	it( 'should set the grouping block name', () => {
+		const state = groupingBlockName( null, {
+			type: 'SET_GROUPING_BLOCK_NAME',
+			name: 'core/group',
+		} );
+
+		expect( state ).toBe( 'core/group' );
+	} );
+
+	it( 'should reset the group fallback block name', () => {
+		const state = groupingBlockName( 'core/group', {
+			type: 'REMOVE_BLOCK_TYPES',
+			names: [ 'core/group' ],
 		} );
 
 		expect( state ).toBeNull();

--- a/packages/blocks/src/store/test/selectors.js
+++ b/packages/blocks/src/store/test/selectors.js
@@ -4,6 +4,7 @@
 import {
 	getChildBlockNames,
 	isMatchingSearchTerm,
+	getGroupingBlockName,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -197,6 +198,16 @@ describe( 'selectors', () => {
 
 				expect( result ).toBe( true );
 			} );
+		} );
+	} );
+
+	describe( 'getGroupingBlockName', () => {
+		it( 'returns the grouping block name from state', () => {
+			const state = {
+				groupingBlockName: 'core/group',
+			};
+
+			expect( getGroupingBlockName( state ) ).toEqual( 'core/group' );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Description
Adds the ability to assign the `core/group` block as the block used in "grouping" interactions which will be introduced in https://github.com/WordPress/gutenberg/pull/14908.

Please see the related PR for context. Once the Grouping PR is shipped then (if acceptable) I will look to land this PR. Lastly, in a final PR I will update the logic around grouping interactions to utilise the block registered for grouping.

## How has this been tested?
Needs a test plan...

## Types of changes
New feature (non-breaking change which adds functionality) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
