### PR TITLE
Code blocks should be editable after saving the post and reloading the editor

### DIFF
--- a/packages/block-library/src/code/block.json
+++ b/packages/block-library/src/code/block.json
@@ -4,7 +4,7 @@
 	"attributes": {
 		"content": {
 			"type": "string",
-			"source": "text",
+			"source": "html",
 			"selector": "code"
 		}
 	}

--- a/packages/block-library/src/code/index.js
+++ b/packages/block-library/src/code/index.js
@@ -23,13 +23,6 @@ export const settings = {
 	supports: {
 		html: false,
 	},
-	attributes: {
-		content: {
-			type: 'string',
-			source: 'html',
-			selector: 'pre code',
-		},
-	},
 	transforms,
 	edit,
 	save,

--- a/packages/block-library/src/code/index.js
+++ b/packages/block-library/src/code/index.js
@@ -23,6 +23,13 @@ export const settings = {
 	supports: {
 		html: false,
 	},
+	attributes: {
+		content: {
+			type: 'string',
+			source: 'html',
+			selector: 'pre code',
+		},
+	},
 	transforms,
 	edit,
 	save,

--- a/packages/block-library/src/code/test/utils.js
+++ b/packages/block-library/src/code/test/utils.js
@@ -38,6 +38,11 @@ describe( 'core/code', () => {
 			expect( text ).toBe( '&' );
 		} );
 
+		it( 'should unescape escaped less than and greater than characters', () => {
+			const text = unescape( '&lt;button&gt;Click&lt;/button>' );
+			expect( text ).toBe( '<button>Click</button>' );
+		} );
+
 		it( 'should unescape escaped opening square brackets', () => {
 			const text = unescape( '&#91;shortcode]&#91;/shortcode]' );
 			expect( text ).toBe( '[shortcode][/shortcode]' );

--- a/packages/block-library/src/code/utils.js
+++ b/packages/block-library/src/code/utils.js
@@ -12,7 +12,6 @@ import { flow } from 'lodash';
 export function escape( content ) {
 	return flow(
 		escapeAmpersands,
-		escapeTagDelimiters,
 		escapeOpeningSquareBrackets,
 		escapeProtocolInIsolatedUrls
 	)( content || '' );
@@ -54,18 +53,6 @@ function escapeAmpersands( content ) {
  */
 function unescapeAmpersands( content ) {
 	return content.replace( /&amp;/g, '&' );
-}
-
-/**
- * Returns the given content with all < and > characters converted into
- * their HTML entity counterparts: &lt; and &gt;
- *
- * @param {string}  content The content of a code block.
- * @return {string} The given content with all < and > characters converted
- *                  into their HTML entity counterparts: &lt; and &gt;
- */
-function escapeTagDelimiters( content ) {
-	return content.replace( /</g, '&lt;' ).replace( />/g, '&gt;' );
 }
 
 /**

--- a/packages/block-library/src/code/utils.js
+++ b/packages/block-library/src/code/utils.js
@@ -12,6 +12,7 @@ import { flow } from 'lodash';
 export function escape( content ) {
 	return flow(
 		escapeAmpersands,
+		escapeTagDelimiters,
 		escapeOpeningSquareBrackets,
 		escapeProtocolInIsolatedUrls
 	)( content || '' );
@@ -27,6 +28,7 @@ export function unescape( content ) {
 	return flow(
 		unescapeProtocolInIsolatedUrls,
 		unescapeOpeningSquareBrackets,
+		unescapeTagDelimiters,
 		unescapeAmpersands
 	)( content || '' );
 }
@@ -52,6 +54,30 @@ function escapeAmpersands( content ) {
  */
 function unescapeAmpersands( content ) {
 	return content.replace( /&amp;/g, '&' );
+}
+
+/**
+ * Returns the given content with all < and > characters converted into
+ * their HTML entity counterparts: &lt; and &gt;
+ *
+ * @param {string}  content The content of a code block.
+ * @return {string} The given content with all < and > characters converted
+ *                  into their HTML entity counterparts: &lt; and &gt;
+ */
+function escapeTagDelimiters( content ) {
+	return content.replace( /</g, '&lt;' ).replace( />/g, '&gt;' );
+}
+
+/**
+ * Returns the given content with all &lt; and &gt; HTML entities converted
+ * into < and >, respectively.
+ *
+ * @param {string}  content The content of a code block.
+ * @return {string} The given content with all &lt; and &gt; HTML entities
+ *                  converted into < and >, respectively
+ */
+function unescapeTagDelimiters( content ) {
+	return content.replace( /&lt;/g, '<' ).replace( /&gt;/g, '>' );
 }
 
 /**


### PR DESCRIPTION
## Description
See #13218.

## How has this been tested?
Created the block described in #13218.

## Types of changes
The PR solves the issue by making sure the content of a code block is pulled as HTML during the parsing process and escaping/unescaping tag delimiters (i.e. `<` and `>`) properly.

~Unfortunately, this seems to be (yet another) breaking change, as it requires `<` and `>` to be escaped before saving.~ **Edit:** 1ac7cfafd547231fe9920938f59c275e8bcbb97f prevents this PR from being a breaking change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
- [x] I've included developer documentation if appropriate.
