### PR TITLE
Block Editor: Partition attributes updates to avoid conflating meta and blocks attributes

### DIFF
--- a/packages/e2e-tests/specs/plugins/meta-attribute-block.test.js
+++ b/packages/e2e-tests/specs/plugins/meta-attribute-block.test.js
@@ -8,6 +8,7 @@ import {
 	getEditedPostContent,
 	insertBlock,
 	saveDraft,
+	pressKeyTimes,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Block with a meta attribute', () => {
@@ -25,7 +26,16 @@ describe( 'Block with a meta attribute', () => {
 
 	it( 'Should persist the meta attribute properly', async () => {
 		await insertBlock( 'Test Meta Attribute Block' );
-		await page.keyboard.type( 'Meta Value' );
+		await page.keyboard.type( 'Value' );
+
+		// Regression Test: Previously the caret would wrongly reset to the end
+		// of any input for meta-sourced attributes, due to syncing behavior of
+		// meta attribute updates.
+		//
+		// See: https://github.com/WordPress/gutenberg/issues/15739
+		await pressKeyTimes( 'ArrowLeft', 5 );
+		await page.keyboard.type( 'Meta ' );
+
 		await saveDraft();
 		await page.reload();
 


### PR DESCRIPTION
Fixes #15739 

This pull request seeks to resolve an issue where setting a new meta attribute value in a block can wrongfully displace the text caret selection.

**Implementation Notes:**

I consider this to be an incomplete but likely sufficient resolution to #15739. The issue occurs because a render of the block's `edit` occurs synchronously as a result of `updateBlockAttributes`. At this point in time the meta attributes have not yet updated, so the old value is used (more at https://github.com/WordPress/gutenberg/issues/15739#issuecomment-494822233). Arguably, it is not correct (or at least ineffective) to be calling `updateBlockAttributes` with new meta values, since the selector to generate a block's attributes will always ignore these ([source](https://github.com/WordPress/gutenberg/blob/27a6ead99b6ec38106c2b8696c74fe2a6e3d24d2/packages/block-editor/src/store/selectors.js#L154)). To that point, the changes here will avoid calling `updateBlockAttributes` with meta value updates, and avoid calling it altogether if the only attributes updates are meta value updates. The solution works because `updateBlockAttributes` is avoided, and thus the problematic intermediate render does not occur.

It is technically incomplete in that if a block were to call `setAttributes` with a mix of block attributes and meta attributes, a similar issue may occur. It is quite unlikely that a block would be implemented this way.

In any case, I'd like to see some improvements to this sort of "external" sourcing, which would be a larger task than I propose to resolve here. I will aim to submit a formal proposal for how it might work, informed on #15739 and previous issues #4989 and #2759. An inline code comment has been added to reflect this future work.

**Testing Instructions:**

An existing end-to-end test case has been adapted to reveal the failure from `master` resolved here. Verify that it passes:

```
npm run test-e2e packages/e2e-tests/specs/plugins/meta-attribute-block.test.js
```

Repeat Steps to Reproduce from #15739