### PR TITLE
Block Editor: Avoid default block insertion if no default block type

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -637,7 +637,13 @@ export function selectionChange( clientId, attributeKey, startOffset, endOffset 
  * @return {Object} Action object
  */
 export function insertDefaultBlock( attributes, rootClientId, index ) {
-	const block = createBlock( getDefaultBlockName(), attributes );
+	// Abort if there is no default block type (if it has been unregistered).
+	const defaultBlockName = getDefaultBlockName();
+	if ( ! defaultBlockName ) {
+		return;
+	}
+
+	const block = createBlock( defaultBlockName, attributes );
 
 	return insertBlock( block, index, rootClientId );
 }

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -131,7 +131,9 @@ export function* selectPreviousBlock( clientId ) {
 		clientId
 	);
 
-	yield selectBlock( previousBlockClientId, -1 );
+	if ( previousBlockClientId ) {
+		yield selectBlock( previousBlockClientId, -1 );
+	}
 }
 
 /**
@@ -147,7 +149,9 @@ export function* selectNextBlock( clientId ) {
 		clientId
 	);
 
-	yield selectBlock( nextBlockClientId );
+	if ( nextBlockClientId ) {
+		yield selectBlock( nextBlockClientId );
+	}
 }
 
 /**

--- a/packages/e2e-tests/specs/block-deletion.test.js
+++ b/packages/e2e-tests/specs/block-deletion.test.js
@@ -7,6 +7,7 @@ import {
 	createNewPost,
 	isInDefaultBlock,
 	pressKeyWithModifier,
+	insertBlock,
 } from '@wordpress/e2e-test-utils';
 
 const addThreeParagraphsToNewPost = async () => {
@@ -129,5 +130,35 @@ describe( 'deleting all blocks', () => {
 
 		// And focus is retained:
 		expect( await isInDefaultBlock() ).toBe( true );
+	} );
+
+	it( 'gracefully removes blocks when the default block is not available', async () => {
+		// Regression Test: Previously, removing a block would not clear
+		// selection state when there were no other blocks to select.
+		//
+		// See: https://github.com/WordPress/gutenberg/issues/15458
+		// See: https://github.com/WordPress/gutenberg/pull/15543
+		await createNewPost();
+
+		// Unregister default block type. This may happen if the editor is
+		// configured to not allow the default (paragraph) block type, either
+		// by plugin editor settings filtering or user block preferences.
+		await page.evaluate( () => {
+			const defaultBlockName = wp.data.select( 'core/blocks' ).getDefaultBlockName();
+			wp.data.dispatch( 'core/blocks' ).removeBlockTypes( defaultBlockName );
+		} );
+
+		// Add and remove a block.
+		await insertBlock( 'Image' );
+		await page.keyboard.press( 'Backspace' );
+
+		// Verify there is no selected block.
+		// TODO: There should be expectations around where focus is placed in
+		// this scenario. Currently, a focus loss occurs (not acceptable).
+		const selectedBlocksCount = await page.evaluate( () => {
+			return wp.data.select( 'core/block-editor' ).getSelectedBlockClientIds().length;
+		} );
+
+		expect( selectedBlocksCount ).toBe( 0 );
 	} );
 } );


### PR DESCRIPTION
Previously: https://github.com/WordPress/gutenberg/pull/15543#issuecomment-494577991
Cherry-picks 2f1a82f from #15543 (temporarily)

This pull request seeks to resolve an error which occurs when deleting the last of the blocks in a post, if there is no default block type.

**Implementation Notes:**

`getDefaultBlockName` is implemented to handle unregistrations, and thus we should be consistent to respect this nullable return type.

https://github.com/WordPress/gutenberg/blob/d15c484ce0172bba6f373ff5c62224cb71b9b208/packages/blocks/src/store/selectors.js#L76

https://github.com/WordPress/gutenberg/blob/d15c484ce0172bba6f373ff5c62224cb71b9b208/packages/blocks/src/store/reducer.js#L110-L114

**Testing Instructions:**

Verify no error when deleting all blocks if the default block type is disabled:

1. (Prerequisite) Remove the default block type:
   - `wp.data.dispatch( 'core/blocks' ).removeBlockTypes( wp.data.select( 'core/blocks' ).getDefaultBlockName() );`
2. Add an Image block
3. Delete the Image block
4. Ensure no errors are shown in the console