### PR TITLE
Data: Implement preferences persistence using user settings

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -24,3 +24,39 @@ function gutenberg_safe_style_css_column_flex_basis( $attr ) {
 	return $attr;
 }
 add_filter( 'safe_style_css', 'gutenberg_safe_style_css_column_flex_basis' );
+
+/**
+ * Adds an inline script to augment the default persistence method for data to
+ * use WordPress client user settings.
+ *
+ * @since 5.8.0
+ */
+function gutenberg_settings_cookie_persistence() {
+	// Ensure `utils` is a dependency, which makes available `userSettings`,
+	// `getUserSetting`, and `setUserSettings` window globals.
+	$data_script = wp_scripts()->query( 'wp-data', 'registered' );
+	if ( ! in_array( 'utils', $data_script->deps ) ) {
+		$data_script->deps[] = 'utils';
+	}
+
+	wp_add_inline_script(
+		'wp-data',
+		"
+( function() {
+	wp.data.use( wp.data.plugins.persistence, {
+		storage: {
+			getItem: function() {
+				return (
+					window.getUserSetting( 'dataState' ) ||
+					localStorage.getItem( 'WP_DATA_USER_' + window.userSettings.uid )
+				);
+			},
+			setItem: function( key, value ) {
+				window.setUserSetting( 'dataState', value );
+			}
+		}
+	} );
+} )();"
+	);
+}
+add_action( 'admin_enqueue_scripts', 'gutenberg_settings_cookie_persistence' );


### PR DESCRIPTION
Closes #15105

This pull request seeks to explore a (likely non-viable) approach for preferences persistence, leveraging the [user settings cookie](https://developer.wordpress.org/reference/functions/get_all_user_settings/), existing [`utils` script methods](https://github.com/WordPress/WordPress/blob/master/wp-includes/js/utils.js) for operating on this cookie, and [substitute storage implementation](https://github.com/WordPress/gutenberg/tree/master/packages/data/src/plugins/persistence#storage) for the data persistence plugin.

Problems:

- `setUserSettings` explicitly forbids (and removes) non-ASCII characters from values, so storing a stringified JSON blob is not directly feasible ([source](https://github.com/WordPress/WordPress/blob/aaa3e181a0cc212d4943953cb1c5390483d342dc/wp-includes/js/utils.js#L156-L158))
   - Technically, we could bypass this by assigning directly to the cookie
- Per above, cookie storage limits are quite small. It varies by browser, but is apparently roughly considered capped at 4kb ([reference](https://stackoverflow.com/a/4604212)). Anecdotally, my own data persistence preference as a string sizes about 1kb. This obviously does not account for (a) other user settings and (b) future growth.

For this reason, it may not be advisable to consider the cookie for storage, though there is an appeal in trying to reuse an existing feature targeted at an identical goal (client-side UI settings).

Alternative considerations will continue to be proposed in and linking to #14512.