### PR TITLE
RSS block: Remove PHP 5.2 compatibility code

### DIFF
--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -20,10 +20,6 @@ function render_block_core_rss( $attributes ) {
 	}
 
 	if ( ! $rss->get_item_quantity() ) {
-		// PHP 5.2 compatibility. See: http://simplepie.org/wiki/faq/i_m_getting_memory_leaks.
-		$rss->__destruct();
-		unset( $rss );
-
 		return '<div class="components-placeholder"><div class="notice notice-error">' . __( 'An error has occurred, which probably means the feed is down. Try again later.' ) . '</div></div>';
 	}
 
@@ -96,13 +92,7 @@ function render_block_core_rss( $attributes ) {
 		$class .= ' ' . $attributes['className'];
 	}
 
-	$list_items_markup = "<ul class='{$class}'>{$list_items}</ul>";
-
-	// PHP 5.2 compatibility. See: http://simplepie.org/wiki/faq/i_m_getting_memory_leaks.
-	$rss->__destruct();
-	unset( $rss );
-
-	return $list_items_markup;
+	return "<ul class='{$class}'>{$list_items}</ul>";
 }
 
 /**


### PR DESCRIPTION
## Description
This PR removes PHP 5.2 compatibility code from the RSS widget.

Before we merge we have to require min. WordPress 5.2.