### PR TITLE
proxied getEditorSettings in block-editor

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -352,7 +352,7 @@ Undocumented declaration.
 <a name="SETTINGS_DEFAULTS" href="#SETTINGS_DEFAULTS">#</a> **SETTINGS_DEFAULTS**
 
 The default editor settings
-```
+
  alignWide                     boolean       Enable/Disable Wide/Full Alignments
  availableLegacyWidgets        Array         Array of objects representing the legacy widgets available.
  colors                        Array         Palette colors
@@ -369,8 +369,7 @@ The default editor settings
  isRTL                         boolean       Whether the editor is in RTL mode
  bodyPlaceholder               string        Empty post placeholder
  titlePlaceholder              string        Empty title placeholder
- codeEditingEnabled            boolean       Whether or not the user can switch to the code editor 
-```
+ codeEditingEnabled            string        Whether or not the user can switch to the code editor
 
 <a name="SkipToSelectedBlock" href="#SkipToSelectedBlock">#</a> **SkipToSelectedBlock**
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -352,7 +352,7 @@ Undocumented declaration.
 <a name="SETTINGS_DEFAULTS" href="#SETTINGS_DEFAULTS">#</a> **SETTINGS_DEFAULTS**
 
 The default editor settings
-
+```
  alignWide                     boolean       Enable/Disable Wide/Full Alignments
  availableLegacyWidgets        Array         Array of objects representing the legacy widgets available.
  colors                        Array         Palette colors
@@ -369,6 +369,8 @@ The default editor settings
  isRTL                         boolean       Whether the editor is in RTL mode
  bodyPlaceholder               string        Empty post placeholder
  titlePlaceholder              string        Empty title placeholder
+ codeEditingEnabled            boolean       Whether or not the user can switch to the code editor 
+```
 
 <a name="SkipToSelectedBlock" href="#SkipToSelectedBlock">#</a> **SkipToSelectedBlock**
 

--- a/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
@@ -34,9 +34,9 @@ export function BlockModeToggle( { blockType, mode, onToggleMode, small = false,
 
 export default compose( [
 	withSelect( ( select, { clientId } ) => {
-		const { getBlock, getBlockMode } = select( 'core/block-editor' );
+		const { getBlock, getBlockMode, getEditorSettings } = select( 'core/block-editor' );
 		const block = getBlock( clientId );
-		const isCodeEditingEnabled = select( 'core/editor' ).getEditorSettings().codeEditingEnabled;
+		const isCodeEditingEnabled = getEditorSettings().codeEditingEnabled;
 
 		return {
 			mode: getBlockMode( clientId ),

--- a/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
@@ -34,9 +34,9 @@ export function BlockModeToggle( { blockType, mode, onToggleMode, small = false,
 
 export default compose( [
 	withSelect( ( select, { clientId } ) => {
-		const { getBlock, getBlockMode, getEditorSettings } = select( 'core/block-editor' );
+		const { getBlock, getBlockMode, getSettings } = select( 'core/block-editor' );
 		const block = getBlock( clientId );
-		const isCodeEditingEnabled = getEditorSettings().codeEditingEnabled;
+		const isCodeEditingEnabled = getSettings().codeEditingEnabled;
 
 		return {
 			mode: getBlockMode( clientId ),

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -138,9 +138,14 @@ export default compose( [
 			resetBlocks,
 		} = dispatch( 'core/block-editor' );
 
+		const {
+			getEditorSettings,
+		} = dispatch( 'core/editor' );
+
 		return {
 			updateSettings,
 			resetBlocks,
+			getEditorSettings,
 		};
 	} ),
 ] )( BlockEditorProvider );

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -138,14 +138,9 @@ export default compose( [
 			resetBlocks,
 		} = dispatch( 'core/block-editor' );
 
-		const {
-			getEditorSettings,
-		} = dispatch( 'core/editor' );
-
 		return {
 			updateSettings,
 			resetBlocks,
-			getEditorSettings,
 		};
 	} ),
 ] )( BlockEditorProvider );

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -26,6 +26,7 @@ export const PREFERENCES_DEFAULTS = {
  *  isRTL                         boolean       Whether the editor is in RTL mode
  *  bodyPlaceholder               string        Empty post placeholder
  *  titlePlaceholder              string        Empty title placeholder
+ *  codeEditingEnabled            string        Whether or not the user can switch to the code editor
  */
 export const SETTINGS_DEFAULTS = {
 	alignWide: false,

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -78,6 +78,7 @@ class EditorProvider extends Component {
 				'allowedBlockTypes',
 				'availableLegacyWidgets',
 				'bodyPlaceholder',
+				'codeEditingEnabled',
 				'colors',
 				'disableCustomColors',
 				'disableCustomFontSizes',


### PR DESCRIPTION
## Description
After #14932 was merged the block editor got coupled with the editor. This PR removes the coupling following @youknowriad 's suggestion by proxying the getEditorSettings from editor into block-editor:

[Link to original issue](https://github.com/WordPress/gutenberg/pull/14932/files/fdf452e366925f5ec103e94a2891d539e47903dd#r287278709)

## How has this been tested?
Tested locally, the original behaviour which introduced the problem is unchanged after the decoupling.