### PR TITLE
Docs: Fix 404 link in filters document

### DIFF
--- a/docs/designers-developers/developers/filters/README.md
+++ b/docs/designers-developers/developers/filters/README.md
@@ -4,4 +4,4 @@
 
 There are two types of hooks: [Actions](https://developer.wordpress.org/plugins/hooks/actions/) and [Filters](https://developer.wordpress.org/plugins/hooks/filters/). In addition to PHP actions and filters, WordPress also provides a mechanism for registering and executing hooks in JavaScript. This functionality is also available on npm as the [@wordpress/hooks](https://www.npmjs.com/package/@wordpress/hooks) package, for general purpose use.
 
-You can also learn more about both APIs: [PHP](https://codex.wordpress.org/Plugin_API/) and [JavaScript](/packages/tree/master/packages/hooks).
+You can also learn more about both APIs: [PHP](https://codex.wordpress.org/Plugin_API/) and [JavaScript](https://developer.wordpress.org/block-editor/packages/packages-hooks/).

--- a/docs/designers-developers/developers/filters/README.md
+++ b/docs/designers-developers/developers/filters/README.md
@@ -4,4 +4,4 @@
 
 There are two types of hooks: [Actions](https://developer.wordpress.org/plugins/hooks/actions/) and [Filters](https://developer.wordpress.org/plugins/hooks/filters/). In addition to PHP actions and filters, WordPress also provides a mechanism for registering and executing hooks in JavaScript. This functionality is also available on npm as the [@wordpress/hooks](https://www.npmjs.com/package/@wordpress/hooks) package, for general purpose use.
 
-You can also learn more about both APIs: [PHP](https://codex.wordpress.org/Plugin_API/) and [JavaScript](https://developer.wordpress.org/block-editor/packages/packages-hooks/).
+You can also learn more about both APIs: [PHP](https://codex.wordpress.org/Plugin_API/) and [JavaScript](/packages/hooks/README.md).


### PR DESCRIPTION
Fix 404 link which is reported bug in following link.

Closes https://github.com/WordPress/gutenberg/issues/15834

## Description
I have added [@wordpress/hooks](https://developer.wordpress.org/block-editor/packages/packages-hooks/) for javascript hook and filter.