### PR TITLE
ESLint Plugin: Fix rule selectors

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Bug Fix
 
-- Fixed custom regular expression for the `no-restricted-syntax` rule. [#15839](https://github.com/WordPress/gutenberg/pull/15839)
+- Fixed custom regular expression for the `no-restricted-syntax` rule enforcing translate function arguments. [#15839](https://github.com/WordPress/gutenberg/pull/15839).
+- Fixed arguments checking of `_nx` for the `no-restricted-syntax` rule enforcing translate function arguments. [#15839](https://github.com/WordPress/gutenberg/pull/15839).
 
 ## 2.2.0 (2019-05-21)
 

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### Bug Fix
+
+- Fixed custom regular expression for the `no-restricted-syntax` rule. [#15839](https://github.com/WordPress/gutenberg/pull/15839)
+
 ## 2.2.0 (2019-05-21)
 
 ### New Features

--- a/packages/eslint-plugin/configs/custom.js
+++ b/packages/eslint-plugin/configs/custom.js
@@ -11,11 +11,11 @@ module.exports = {
 		'no-restricted-syntax': [
 			'error',
 			{
-				selector: 'CallExpression[callee.name=/^__|_n|_x$/]:not([arguments.0.type=/^Literal|BinaryExpression$/])',
+				selector: 'CallExpression[callee.name=/^(__|_n|_x)$/]:not([arguments.0.type=/^Literal|BinaryExpression$/])',
 				message: 'Translate function arguments must be string literals.',
 			},
 			{
-				selector: 'CallExpression[callee.name=/^_n|_x$/]:not([arguments.1.type=/^Literal|BinaryExpression$/])',
+				selector: 'CallExpression[callee.name=/^(_n|_x)$/]:not([arguments.1.type=/^Literal|BinaryExpression$/])',
 				message: 'Translate function arguments must be string literals.',
 			},
 			{

--- a/packages/eslint-plugin/configs/custom.js
+++ b/packages/eslint-plugin/configs/custom.js
@@ -11,15 +11,15 @@ module.exports = {
 		'no-restricted-syntax': [
 			'error',
 			{
-				selector: 'CallExpression[callee.name=/^(__|_n|_x)$/]:not([arguments.0.type=/^Literal|BinaryExpression$/])',
+				selector: 'CallExpression[callee.name=/^(__|_n|_nx|_x)$/]:not([arguments.0.type=/^Literal|BinaryExpression$/])',
 				message: 'Translate function arguments must be string literals.',
 			},
 			{
-				selector: 'CallExpression[callee.name=/^(_n|_x)$/]:not([arguments.1.type=/^Literal|BinaryExpression$/])',
+				selector: 'CallExpression[callee.name=/^(_n|_nx|_x)$/]:not([arguments.1.type=/^Literal|BinaryExpression$/])',
 				message: 'Translate function arguments must be string literals.',
 			},
 			{
-				selector: 'CallExpression[callee.name=_nx]:not([arguments.2.type=/^Literal|BinaryExpression$/])',
+				selector: 'CallExpression[callee.name=_nx]:not([arguments.3.type=/^Literal|BinaryExpression$/])',
 				message: 'Translate function arguments must be string literals.',
 			},
 		],


### PR DESCRIPTION
## Description

The two (regular expression) selectors of the custom `no-restricted-syntax` rule in `eslint-plugin` are broken.

For example, the first regular expression, `^__|_n|_x$`, is equivalent to the following list of patterns:

* `^__`
* `_n`
* `_x$`

Obviously, what the author had in mind, however, is this list:

* `^__$`
* `^_n$`
* `^_x$`

Because of the broken rule, my call to `__experimentalGetSettings` (imported from `wp.date`/`@wordpress/date`) got flagged; it matches the `^__` pattern/option.

Also, calling the fictional function `foo_x()` would also flag up, as it matches the last pattern/option, `_x$`.

In addition to the above bugs, the two selectors shuold also account for `_nx`, which is currently only tested for the third (i.e., index `2`) argument, which is yet another error. It should be checked for indexes `0`, `1` and `3`, that is: `single`, `plural` and `context` (not `number`).

## How has this been tested?
Run ESLint with the old and with the new rule on this code:

```js
const { __experimentalGetSettings } = wp.date;
const { __, _n, _nx, _x } = wp.i18n;

const foo_x = () => {};

const foo = 'bar';

/**
 * Should NOT flag
 */
__( 'Some text', 'text-domain' );
_n( 'Some text', 'Some texts', 42, 'text-domain' );
_nx( 'Some text', 'Some texts', 42, 'Some context', 'text-domain' );
_x( 'Some text', 'Some context', 'text-domain' );
const settings = __experimentalGetSettings();
foo_x();

/**
 * SHOULD flag
 */
__( foo, 'text-domain' );
_n( foo, 'Some texts', 42, 'text-domain' );
_nx( foo, 'Some texts', 42, 'Some context', 'text-domain' );
_x( foo, 'Some context', 'text-domain' );

_n( 'Some text', foo, 42, 'text-domain' );
_nx( 'Some texts', foo, 42, 'Some context', 'text-domain' );
_x( 'Some text', foo, 'text-domain' );

_nx( 'Some text', 'Some texts', 42, foo, 'text-domain' );
```

## Types of changes
Fix several issues with ESLint rule selectors. Most of them have to do with the regular expressions, one issue is an incorrect argument index.

By the way, I decided to go with `_nx` as new sub-pattern/option, and not make `_n` be `_nx?` or so. Both for cinsistency and better readability.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
