### PR TITLE
Reset the current branch before changing branches when releasing Gutenberg

### DIFF
--- a/bin/commander.js
+++ b/bin/commander.js
@@ -265,8 +265,8 @@ async function releasePluginRC() {
 			abortMessage
 		);
 		await simpleGit.fetch();
-		await simpleGit.checkout( 'master' );
 		await simpleGit.reset( 'hard' );
+		await simpleGit.checkout( 'master' );
 		await simpleGit.pull( 'origin', 'master' );
 		await simpleGit.raw( [ 'cherry-pick', commitHash ] );
 		await simpleGit.push( 'origin', 'master' );


### PR DESCRIPTION
When releasing the Gutenberg 5.8 RC1, I had an error at the end of the process (see the end of the recording https://asciinema.org/a/prYW5WryI9AfFUbFYZjAtJtuv )

npm install can create dirtiness in the `package-lock.json` file and the repo wasn't reset at the right moment. This fixes it.