### PR TITLE
Build: Add type module commonjs to the corresponding packages

### DIFF
--- a/bin/packages/get-packages.js
+++ b/bin/packages/get-packages.js
@@ -25,6 +25,21 @@ function isDirectory( file ) {
 }
 
 /**
+ * Returns true if the given packages has type "module".
+ *
+ * @see https://medium.com/@nodejs/announcing-a-new-experimental-modules-1be8d2d6c2ff
+ *
+ * @param {string} file Packages directory file.
+ *
+ * @return {boolean} Whether file is a directory.
+ */
+function isModuleType( file ) {
+	const { type = 'module' } = require( path.resolve( PACKAGES_DIR, file, 'package.json' ) );
+
+	return type === 'module';
+}
+
+/**
  * Filter predicate, returning true if the given base file name is to be
  * included in the build.
  *
@@ -32,7 +47,7 @@ function isDirectory( file ) {
  *
  * @return {boolean} Whether to include file in build.
  */
-const filterPackages = overEvery( isDirectory );
+const filterPackages = overEvery( isDirectory, isModuleType );
 
 /**
  * Returns the absolute path of all WordPress packages

--- a/packages/babel-plugin-import-jsx-pragma/package.json
+++ b/packages/babel-plugin-import-jsx-pragma/package.json
@@ -26,6 +26,7 @@
 	"files": [
 		"index.js"
 	],
+	"type": "commonjs",
 	"main": "index.js",
 	"peerDependencies": {
 		"@babel/core": "^7.0.0"

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -25,6 +25,7 @@
 	"files": [
 		"index.js"
 	],
+	"type": "commonjs",
 	"main": "index.js",
 	"dependencies": {
 		"@babel/core": "^7.4.4",

--- a/packages/block-serialization-spec-parser/package.json
+++ b/packages/block-serialization-spec-parser/package.json
@@ -19,6 +19,7 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
+	"type": "commonjs",
 	"main": "parser.js",
 	"dependencies": {
 		"pegjs": "^0.10.0"

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -21,6 +21,10 @@
 	"engines": {
 		"node": ">=8"
 	},
+	"files": [
+		"index.js"
+	],
+	"type": "commonjs",
 	"main": "index.js",
 	"publishConfig": {
 		"access": "public"

--- a/packages/custom-templated-path-webpack-plugin/package.json
+++ b/packages/custom-templated-path-webpack-plugin/package.json
@@ -24,6 +24,8 @@
 	"files": [
 		"index.js"
 	],
+	"type": "commonjs",
+	"main": "index.js",
 	"dependencies": {
 		"escape-string-regexp": "^1.0.5"
 	},

--- a/packages/dependency-extraction-webpack-plugin/package.json
+++ b/packages/dependency-extraction-webpack-plugin/package.json
@@ -22,6 +22,7 @@
 		"index.js",
 		"util.js"
 	],
+	"type": "commonjs",
 	"main": "index.js",
 	"dependencies": {
 		"webpack": "^4.8.3",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -17,6 +17,14 @@
 	"bugs": {
 		"url": "https://github.com/WordPress/gutenberg/issues"
 	},
+	"files": [
+		"configs",
+		"docs",
+		"rules",
+		"index.js"
+	],
+	"type": "commonjs",
+	"main": "index.js",
 	"dependencies": {
 		"babel-eslint": "^10.0.1",
 		"eslint-plugin-jsx-a11y": "^6.2.1",

--- a/packages/is-shallow-equal/package.json
+++ b/packages/is-shallow-equal/package.json
@@ -21,8 +21,10 @@
 	},
 	"files": [
 		"arrays.js",
+		"index.js",
 		"objects.js"
 	],
+	"type": "commonjs",
 	"main": "index.js",
 	"dependencies": {
 		"@babel/runtime": "^7.4.4"

--- a/packages/jest-preset-default/package.json
+++ b/packages/jest-preset-default/package.json
@@ -26,8 +26,10 @@
 	},
 	"files": [
 		"scripts",
+		"index.js",
 		"jest-preset.json"
 	],
+	"type": "commonjs",
 	"main": "index.js",
 	"dependencies": {
 		"@wordpress/jest-console": "file:../jest-console",

--- a/packages/library-export-default-webpack-plugin/package.json
+++ b/packages/library-export-default-webpack-plugin/package.json
@@ -24,6 +24,8 @@
 	"files": [
 		"index.js"
 	],
+	"type": "commonjs",
+	"main": "index.js",
 	"dependencies": {
 		"lodash": "^4.17.11",
 		"webpack-sources": "^1.1.0"

--- a/packages/npm-package-json-lint-config/CHANGELOG.md
+++ b/packages/npm-package-json-lint-config/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### New Feature
+
+- Added `type` to the order of preferred properties. 
+
 ## 1.2.0 (2019-03-06)
 
 ### Internal

--- a/packages/npm-package-json-lint-config/index.js
+++ b/packages/npm-package-json-lint-config/index.js
@@ -53,6 +53,7 @@ const defaultConfig = {
 				'engines',
 				'directories',
 				'files',
+				'type',
 				'main',
 				'module',
 				'bin',

--- a/packages/npm-package-json-lint-config/package.json
+++ b/packages/npm-package-json-lint-config/package.json
@@ -21,6 +21,10 @@
 	"engines": {
 		"node": ">=8"
 	},
+	"files": [
+		"index.js"
+	],
+	"type": "commonjs",
 	"main": "index.js",
 	"peerDependencies": {
 		"npm-package-json-lint": ">=3.6.0"

--- a/packages/postcss-themes/package.json
+++ b/packages/postcss-themes/package.json
@@ -27,6 +27,7 @@
 	"files": [
 		"index.js"
 	],
+	"type": "commonjs",
 	"main": "index.js",
 	"dependencies": {
 		"autoprefixer": "^9.4.5",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -28,6 +28,7 @@
 		"scripts",
 		"utils"
 	],
+	"type": "commonjs",
 	"bin": {
 		"wp-scripts": "./bin/wp-scripts.js"
 	},


### PR DESCRIPTION
## Description

There was announced [a new --experimental-modules](https://medium.com/@nodejs/announcing-a-new-experimental-modules-1be8d2d6c2ff) support for Node. It contains also `package.json` “type” field:

> Add “type”: “module” to the package.json for your project, and Node.js will treat all .js files in your project as ES modules.
> 
> If some of your project’s files use CommonJS and you can’t convert your entire project all at once, you can either rename those files to use the .cjs extension or put them in a subfolder containing a package.json with { “type”: “commonjs” }, under which all .js files are treated as CommonJS.
> 
> For any file that Node.js tries to load, it will look for a package.json in that file’s folder, then that file’s parent folder and so on upwards until it reaches the root of the volume. This is similar to how Babel searches for .babelrc files. This new approach allows Node.js to use package.json for package-level metadata and configuration, similar to how it is already used by Babel and other tools.

This PR marks all packages which contain `commonjs` syntax with its corresponding type. 

This allows us to use a more predictable way to filter out packages which don't need to be processed with Babel. It will also make it possible to use `src` subfolder in packages which don't need to transpiled.

## How has this been tested?
* `npm run dev`
* `npm run build`

## Future considerations

This probably will have to be revisited once Node enables full support for modules. However, I don't think it's going to happen any time soon. 