### PR TITLE
Fix default featured image size

### DIFF
--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -31,12 +31,21 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 
 	let mediaWidth, mediaHeight, mediaSourceUrl;
 	if ( media ) {
-		const mediaSize = applyFilters( 'editor.PostFeaturedImage.imageSize', 'thumbnail', media.id, currentPostId );
+		const mediaSize = applyFilters( 'editor.PostFeaturedImage.imageSize', 'post-thumbnail', media.id, currentPostId );
+		const fallbackMediaSize = applyFilters( 'editor.PostFeaturedImage.fallbackImageSize', 'thumbnail', media.id, currentPostId );
+
 		if ( has( media, [ 'media_details', 'sizes', mediaSize ] ) ) {
+			// use mediaSize when available
 			mediaWidth = media.media_details.sizes[ mediaSize ].width;
 			mediaHeight = media.media_details.sizes[ mediaSize ].height;
 			mediaSourceUrl = media.media_details.sizes[ mediaSize ].source_url;
+		} else if ( has( media, [ 'media_details', 'sizes', fallbackMediaSize ] ) ) {
+			// use fallbackMediaSize when mediaSize is not available
+			mediaWidth = media.media_details.sizes[ fallbackMediaSize ].width;
+			mediaHeight = media.media_details.sizes[ fallbackMediaSize ].height;
+			mediaSourceUrl = media.media_details.sizes[ fallbackMediaSize ].source_url;
 		} else {
+			// use full image size when mediaFallbackSize and mediaSize are not available
 			mediaWidth = media.media_details.width;
 			mediaHeight = media.media_details.height;
 			mediaSourceUrl = media.source_url;

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -31,7 +31,7 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 
 	let mediaWidth, mediaHeight, mediaSourceUrl;
 	if ( media ) {
-		const mediaSize = applyFilters( 'editor.PostFeaturedImage.imageSize', 'post-thumbnail', media.id, currentPostId );
+		const mediaSize = applyFilters( 'editor.PostFeaturedImage.imageSize', 'thumbnail', media.id, currentPostId );
 		if ( has( media, [ 'media_details', 'sizes', mediaSize ] ) ) {
 			mediaWidth = media.media_details.sizes[ mediaSize ].width;
 			mediaHeight = media.media_details.sizes[ mediaSize ].height;

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -32,23 +32,25 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 	let mediaWidth, mediaHeight, mediaSourceUrl;
 	if ( media ) {
 		const mediaSize = applyFilters( 'editor.PostFeaturedImage.imageSize', 'post-thumbnail', media.id, currentPostId );
-		const fallbackMediaSize = applyFilters( 'editor.PostFeaturedImage.fallbackImageSize', 'thumbnail', media.id, currentPostId );
-
 		if ( has( media, [ 'media_details', 'sizes', mediaSize ] ) ) {
 			// use mediaSize when available
 			mediaWidth = media.media_details.sizes[ mediaSize ].width;
 			mediaHeight = media.media_details.sizes[ mediaSize ].height;
 			mediaSourceUrl = media.media_details.sizes[ mediaSize ].source_url;
-		} else if ( has( media, [ 'media_details', 'sizes', fallbackMediaSize ] ) ) {
-			// use fallbackMediaSize when mediaSize is not available
-			mediaWidth = media.media_details.sizes[ fallbackMediaSize ].width;
-			mediaHeight = media.media_details.sizes[ fallbackMediaSize ].height;
-			mediaSourceUrl = media.media_details.sizes[ fallbackMediaSize ].source_url;
 		} else {
-			// use full image size when mediaFallbackSize and mediaSize are not available
-			mediaWidth = media.media_details.width;
-			mediaHeight = media.media_details.height;
-			mediaSourceUrl = media.source_url;
+			// get fallbackMediaSize if mediaSize is not available
+			const fallbackMediaSize = applyFilters( 'editor.PostFeaturedImage.imageSize', 'thumbnail', media.id, currentPostId );
+			if ( has( media, [ 'media_details', 'sizes', fallbackMediaSize ] ) ) {
+				// use fallbackMediaSize when mediaSize is not available
+				mediaWidth = media.media_details.sizes[ fallbackMediaSize ].width;
+				mediaHeight = media.media_details.sizes[ fallbackMediaSize ].height;
+				mediaSourceUrl = media.media_details.sizes[ fallbackMediaSize ].source_url;
+			} else {
+				// use full image size when mediaFallbackSize and mediaSize are not available
+				mediaWidth = media.media_details.width;
+				mediaHeight = media.media_details.height;
+				mediaSourceUrl = media.source_url;
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
Fixed the default image sizes used for featured images displayed in the editor:
Fixes: #15842, #14084


## How has this been tested?
Verified with a linter on my local environment.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
