### PR TITLE
[RNMobile] Disable video, quote blocks but for development

### DIFF
--- a/packages/edit-post/src/index.native.js
+++ b/packages/edit-post/src/index.native.js
@@ -23,6 +23,8 @@ export function initializeEditor() {
 	if ( typeof __DEV__ === 'undefined' || ! __DEV__ ) {
 		unregisterBlockType( 'core/code' );
 		unregisterBlockType( 'core/more' );
+		unregisterBlockType( 'core/video' );
+		unregisterBlockType( 'core/quote' );
 	}
 }
 


### PR DESCRIPTION
## Description
This PR puts the video, quote blocks back into "dev" mode only, hiding them from the release build of native mobile. We found some issues (see [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/11786#issuecomment-496228819), [here](https://github.com/wordpress-mobile/WordPress-Android/pull/9941#issuecomment-496226624)) so, disabling them to work on them some more.

## How has this been tested?
By running `yarn ios --configuration Release` and noticing that the video, quote blocks are indeed not offered in the Inserter.

Here's the gutenberg-mobile PR that will adopt this change: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1036

## Types of changes
Unregistering the `core/video`, `core/quote` blocks unless we're in `__DEV__` mode.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
