### PR TITLE
[RN Native] Fix Video block crash on drawing on Android

### DIFF
--- a/packages/block-library/src/video/edit.native.js
+++ b/packages/block-library/src/video/edit.native.js
@@ -214,7 +214,7 @@ class VideoEdit extends React.Component {
 									{ showVideo && isURL( src ) &&
 										<Video
 											isSelected={ isSelected }
-											style={ [ videoStyle, { backgroundColor: 'black' } ] }
+											style={ videoStyle }
 											source={ { uri: src } }
 											paused={ true }
 											muted={ true }

--- a/packages/block-library/src/video/style.ios.scss
+++ b/packages/block-library/src/video/style.ios.scss
@@ -1,0 +1,8 @@
+// @format
+
+@import "./style.native.scss";
+
+.video {
+	background-color: #000;
+}
+

--- a/packages/block-library/src/video/style.native.scss
+++ b/packages/block-library/src/video/style.native.scss
@@ -1,7 +1,6 @@
 // @format
 
 .video {
-	background-color: $gray-lighten-30;
 	width: 100%;
 }
 


### PR DESCRIPTION
This PR does fix a crash that happens on Android when the video file upload finishes and the block tries to render the preview. Details are here:  https://github.com/wordpress-mobile/WordPress-Android/issues/9943

Companion PR for GB-mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1039

**To test Android**
- Start the wp-android app
- Add a video block to the editor and upload a video
- Wait until the upload ends
- The preview should be on the screen
- No crash should happen
- The bg color of the block is light grey

**To test on iOS**
- Start the wp-iOS app
- Add a video block to the editor and upload a video
- Wait until the upload ends
- The preview should be on the screen
- No crash should happen
- The bg color of the block is  black
