### PR TITLE
Ensure icons for image/video are SVG components

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -36,7 +36,7 @@ import { doAction, hasAction } from '@wordpress/hooks';
  */
 import styles from './styles.scss';
 import MediaUploadProgress from './media-upload-progress';
-import SvgIcon from './icon';
+import { SvgIcon } from './icon';
 import SvgIconRetry from './icon-retry';
 
 const LINK_DESTINATION_CUSTOM = 'custom';

--- a/packages/block-library/src/image/icon.js
+++ b/packages/block-library/src/image/icon.js
@@ -3,8 +3,8 @@
  */
 import { Path, SVG } from '@wordpress/components';
 
-function svg( props ) {
+export function SvgIcon( props ) {
 	return <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" { ...props }><Path d="M0,0h24v24H0V0z" fill="none" /><Path d="m19 5v14h-14v-14h14m0-2h-14c-1.1 0-2 0.9-2 2v14c0 1.1 0.9 2 2 2h14c1.1 0 2-0.9 2-2v-14c0-1.1-0.9-2-2-2z" /><Path d="m14.14 11.86l-3 3.87-2.14-2.59-3 3.86h12l-3.86-5.14z" /></SVG>;
 }
 
-export default svg;
+export default SvgIcon( {} );

--- a/packages/block-library/src/video/edit.native.js
+++ b/packages/block-library/src/video/edit.native.js
@@ -37,7 +37,7 @@ import { doAction, hasAction } from '@wordpress/hooks';
  */
 import MediaUploadProgress from '../image/media-upload-progress';
 import style from './style.scss';
-import SvgIcon from './icon';
+import { SvgIcon } from './icon';
 import SvgIconRetry from './icon-retry';
 
 const VIDEO_ASPECT_RATIO = 1.7;

--- a/packages/block-library/src/video/icon.js
+++ b/packages/block-library/src/video/icon.js
@@ -3,8 +3,8 @@
  */
 import { Path, SVG } from '@wordpress/components';
 
-function svg( props ) {
+export function SvgIcon( props ) {
 	return <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" { ...props }><Path fill="none" d="M0 0h24v24H0V0z" /><Path d="M4 6.47L5.76 10H20v8H4V6.47M22 4h-4l2 4h-3l-2-4h-2l2 4h-3l-2-4H8l2 4H7L5 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V4z" /></SVG>;
 }
 
-export default svg;
+export default SvgIcon( {} );


### PR DESCRIPTION
In #15551, these were changed to support passing props, but that also means
that when you pass the video icon to the `Icon` component, it won't inject the
right size, since it's not a SVG component.

Instead, we can export the new function to allow for a customizable icon, while
exporting the SVG component by default.

## How has this been tested?

Tested this through https://github.com/wordpress-mobile/gutenberg-mobile/pull/1036 by unregistering the video block, and viewing a post with videos in it.

## Screenshots <!-- if applicable -->

Before:

![IMG_723F87963C95-1](https://user-images.githubusercontent.com/8739/58473878-f97faa80-8149-11e9-89f3-d3ed1ae93e17.jpeg)

After:

![IMG_B8C8445DBCCD-1](https://user-images.githubusercontent.com/8739/58473864-f4226000-8149-11e9-9186-d20c404f322c.jpeg)


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->