### PR TITLE
Always show side inserter on the last empty paragraph

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -344,6 +344,7 @@ function BlockListBlock( {
 
 				// If the block is selected and we're typing the block should not appear.
 				// Empty paragraph blocks should always show up as unselected.
+				const showInserterShortcuts = ( isSelected || isHovered ) && isEmptyDefaultBlock && isValid;
 				const showEmptyBlockSideInserter = ( isSelected || isHovered || isLast ) && isEmptyDefaultBlock && isValid;
 				const shouldAppearSelected =
 					! isFocusMode &&
@@ -538,24 +539,24 @@ function BlockListBlock( {
 								{ !! hasError && <BlockCrashWarning /> }
 							</IgnoreNestedEvents>
 						</div>
+						{ showInserterShortcuts && (
+							<div className="editor-block-list__side-inserter block-editor-block-list__side-inserter">
+								<InserterWithShortcuts
+									clientId={ clientId }
+									rootClientId={ rootClientId }
+									onToggle={ selectOnOpen }
+								/>
+							</div>
+						) }
 						{ showEmptyBlockSideInserter && (
-							<>
-								<div className="editor-block-list__side-inserter block-editor-block-list__side-inserter">
-									<InserterWithShortcuts
-										clientId={ clientId }
-										rootClientId={ rootClientId }
-										onToggle={ selectOnOpen }
-									/>
-								</div>
-								<div className="editor-block-list__empty-block-inserter block-editor-block-list__empty-block-inserter">
-									<Inserter
-										position="top right"
-										onToggle={ selectOnOpen }
-										rootClientId={ rootClientId }
-										clientId={ clientId }
-									/>
-								</div>
-							</>
+							<div className="editor-block-list__empty-block-inserter block-editor-block-list__empty-block-inserter">
+								<Inserter
+									position="top right"
+									onToggle={ selectOnOpen }
+									rootClientId={ rootClientId }
+									clientId={ clientId }
+								/>
+							</div>
 						) }
 					</IgnoreNestedEvents>
 				);
@@ -642,7 +643,6 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 		mergeBlocks,
 		replaceBlocks,
 		toggleSelection,
-
 	} = dispatch( 'core/block-editor' );
 
 	return {

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -79,6 +79,7 @@ function BlockListBlock( {
 	className,
 	name,
 	isValid,
+	isLast,
 	attributes,
 	initialPosition,
 	wrapperProps,
@@ -343,8 +344,7 @@ function BlockListBlock( {
 
 				// If the block is selected and we're typing the block should not appear.
 				// Empty paragraph blocks should always show up as unselected.
-				const showEmptyBlockSideInserter =
-					( isSelected || isHovered ) && isEmptyDefaultBlock && isValid;
+				const showEmptyBlockSideInserter = ( isSelected || isHovered || isLast ) && isEmptyDefaultBlock && isValid;
 				const shouldAppearSelected =
 					! isFocusMode &&
 					! showEmptyBlockSideInserter &&
@@ -580,6 +580,8 @@ const applyWithSelect = withSelect(
 			getSettings,
 			hasSelectedInnerBlock,
 			getTemplateLock,
+			getBlockIndex,
+			getBlockOrder,
 			__unstableGetBlockWithoutInnerBlocks,
 		} = select( 'core/block-editor' );
 		const block = __unstableGetBlockWithoutInnerBlocks( clientId );
@@ -587,6 +589,8 @@ const applyWithSelect = withSelect(
 		const { hasFixedToolbar, focusMode } = getSettings();
 		const templateLock = getTemplateLock( rootClientId );
 		const isParentOfSelectedBlock = hasSelectedInnerBlock( clientId, true );
+		const index = getBlockIndex( clientId, rootClientId );
+		const blockOrder = getBlockOrder( rootClientId );
 
 		// The fallback to `{}` is a temporary fix.
 		// This function should never be called when a block is not present in the state.
@@ -611,6 +615,7 @@ const applyWithSelect = withSelect(
 			isLocked: !! templateLock,
 			isFocusMode: focusMode && isLargeViewport,
 			hasFixedToolbar: hasFixedToolbar && isLargeViewport,
+			isLast: index === blockOrder.length - 1,
 
 			// Users of the editor.BlockListBlock filter used to be able to access the block prop
 			// Ideally these blocks would rely on the clientId prop only.

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -274,13 +274,11 @@
 	}
 
 	// Appender
-	&.is-typing .block-editor-block-list__empty-block-inserter,
 	&.is-typing .block-editor-block-list__side-inserter {
 		opacity: 0;
 		animation: none;
 	}
 
-	.block-editor-block-list__empty-block-inserter,
 	.block-editor-block-list__side-inserter {
 		@include edit-post__fade-in-animation;
 	}

--- a/packages/block-editor/src/components/default-block-appender/style.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.scss
@@ -29,21 +29,9 @@
 		}
 	}
 
-	// Don't show the inserter until mousing over.
-	.block-editor-inserter__toggle:not([aria-expanded="true"]) {
-		opacity: 0;
-		transition: opacity 0.2s;
-		@include reduce-motion("transition");
-		will-change: opacity;
-	}
-
 	&:hover {
 		.block-editor-inserter-with-shortcuts {
 			@include edit-post__fade-in-animation;
-		}
-
-		.block-editor-inserter__toggle {
-			opacity: 1;
 		}
 	}
 


### PR DESCRIPTION
This is a proposal to try to tweak the block inserter visibility. Some feedback suggest that it's not always clear how to add blocks/content.

in this PR, I'm trying to give more visibility to the side block inserter on the last paragraph of the post content. Also when focusing "empty paragraphs", we always show the inserter.
