### PR TITLE
Fix: Embeds crash when nested inside a block with locking

### DIFF
--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -42,12 +42,14 @@ export function getEmbedEditComponent( title, icon, responsive = true ) {
 
 		handleIncomingPreview() {
 			this.setMergedAttributes();
-			const upgradedBlock = createUpgradedEmbedBlock(
-				this.props,
-				this.getMergedAttributes()
-			);
-			if ( upgradedBlock ) {
-				this.props.onReplace( upgradedBlock );
+			if ( this.props.onReplace ) {
+				const upgradedBlock = createUpgradedEmbedBlock(
+					this.props,
+					this.getMergedAttributes()
+				);
+				if ( upgradedBlock ) {
+					this.props.onReplace( upgradedBlock );
+				}
 			}
 		}
 


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/13887

Embed block did not check for onReplace function existence and called it unconditionally.
This PR updates the embed block to check for the onReplace availability.

## How has this been tested?
I added the test block available at https://gist.github.com/jorgefilipecosta/16f16cc264c8e4e24f93236de5685436.
I tried to embed a youtube video in the nested block.
I verified no crash happened and the video appeared.
