### PR TITLE
Vertically center default appender controls.

### DIFF
--- a/packages/block-editor/src/components/default-block-appender/style.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.scss
@@ -91,6 +91,9 @@
 	right: $grid-size; // Show to the right on mobile.
 
 	@include break-small {
+		display: flex;
+		align-items: center;
+		height: 100%;
 		left: -$block-side-ui-width - $block-padding - $block-side-ui-clearance;
 		right: auto;
 	}
@@ -124,7 +127,9 @@
 	z-index: z-index(".block-editor-inserter-with-shortcuts"); // Elevate above the sibling inserter.
 
 	@include break-small {
-		right: 0;
 		display: flex;
+		align-items: center;
+		height: 100%;
+		right: 0;
 	}
 }


### PR DESCRIPTION
Currently, the controls to the left and right of the default appender rely on the text being ~16px tall. This works well in themes where that's the case, but not so well in themes with larger text, like Twenty Nineteen. This PR vertically vertically aligns the appender controls so they more regularly fall in alignment with the text. 

Screens under 600px are unaffected by this PR. The inserter control doesn't quite line up there either, but it's less obvious because it only appears on hover, and mobile devices usually don't have that capability. 

I've tested in:

- The Gutenberg Starter theme (unstyled)
- Twenty Nineteen
- Twenty Seventeen
- Twenty Sixteen
- Twenty Fifteen

... and it seems to behave as expected. 

---

Here's Twenty Nineteen, which uses a 22px font size: 

**Before**

![before](https://user-images.githubusercontent.com/1202812/58508576-54bd9700-8162-11e9-8efb-8252b6d78059.jpg)

**After**

![after](https://user-images.githubusercontent.com/1202812/58508590-58e9b480-8162-11e9-835f-1b24717308b9.jpg)

---

Note that if a theme uses a super-large text size, and the text has to wrap on screens above 600px wide, the controls will now be centered vertically. I think this seems fine given the larger win here: 

**Before**

![Screen Shot 2019-05-28 at 3 57 41 PM](https://user-images.githubusercontent.com/1202812/58508134-5c307080-8161-11e9-9319-e473ce33108d.png)

**After**

![Screen Shot 2019-05-28 at 3 49 12 PM](https://user-images.githubusercontent.com/1202812/58508143-5fc3f780-8161-11e9-8b93-ac37bcd98236.png)