### PR TITLE
Media+Text block: Remove `break-all` styling 

### DIFF
--- a/packages/block-library/src/media-text/editor.scss
+++ b/packages/block-library/src/media-text/editor.scss
@@ -3,7 +3,6 @@
 		"media-text-media media-text-content"
 		"resizer resizer";
 	align-items: center;
-	word-break: break-all;
 }
 
 .wp-block-media-text.has-media-on-the-right {


### PR DESCRIPTION
Fixes #15870. Removes the from the editor.scss file allowing it to break at the word.

## Description
In Firefox, the content of this block would break in the middle of a word. It shouldn't.

## How has this been tested?
Tested locally.

## Screenshots 

![mediatext-fix](https://user-images.githubusercontent.com/617986/58518713-2a210d80-8165-11e9-901a-6b432b1d68f5.gif)


## Types of changes
Minor CSS change.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
