### PR TITLE
Serializer:  Fix Invariant error related to hooks

### DIFF
--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -35,7 +35,9 @@ import {
 	startsWith,
 	kebabCase,
 	isPlainObject,
+	noop,
 } from 'lodash';
+import { __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED } from 'react';
 
 /**
  * WordPress dependencies
@@ -53,6 +55,20 @@ import {
 import RawHTML from './raw-html';
 
 const { Provider, Consumer } = createContext();
+
+const Dispatcher = {
+	readContext: noop,
+	useContext: noop,
+	useMemo: noop,
+	useReducer: () => [],
+	useRef: () => ( { current: '' } ),
+	useState: () => [],
+	useLayoutEffect: noop,
+	useCallback: noop,
+	useImperativeHandle: noop,
+	useEffect: noop,
+	useDebugValue: noop,
+};
 
 /**
  * Valid attribute types.
@@ -396,8 +412,14 @@ export function renderElement( element, context, legacyContext = {} ) {
 			if ( type.prototype && typeof type.prototype.render === 'function' ) {
 				return renderComponent( type, props, context, legacyContext );
 			}
-
-			return renderElement( type( props, legacyContext ), context, legacyContext );
+			const prevDispatcher = __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentDispatcher;
+			__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentDispatcher.current = Dispatcher;
+			const value = renderElement( type( props, legacyContext ),
+				context,
+				legacyContext
+			);
+			__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentDispatcher = prevDispatcher;
+			return value;
 	}
 
 	switch ( type && type.$$typeof ) {


### PR DESCRIPTION
## Description

This is an error that currently doesn't seem to be surfacing anywhere in the interface for users but was spotted by @aduth when testing #13879 against the work merged in from #15737 (introducing `useSelect` and implemented in `withSelect).

For his tests he was doing something like this in the console:

```js
ExampleComponent = wp.data.withSelect( () => ( {} ) )( () => wp.element.createElement( 'div', null, 'Howdy There' ) );
wp.element.renderToString( wp.element.createElement( ExampleComponent ) );
```

This produced the error:

> Uncaught Invariant Violation: Hooks can only be called inside the body of a function component.

This was troubleshot for a few minutes [in slack](https://wordpress.slack.com/archives/C5UNMSU4R/p1559078065122300) and taking cues from some of the things uncovered there I spent some time trying out a few things and ended up with this rough pull which allows for `renderToString` to run without errors for the above code snippet (producing the expected `<div>Howdy There</div>` output).  However, I don't think this is the solution we'll roll with (won't we need hooks to actually run?).  I decided to throw this pull up anyways and it can be iterated on with ideas for solving.

Note:

- I did try feeding the actual hooks to the monkey patched `Dispatcher` but that resulted in recursion errors (try it and you'll see). Actual error is `Uncaught RangeError: Maximum call stack size exceeded`
- I'm not very familiar with React internals so this is a bit of a shot in the dark at resolving this issue.
- I'm kinda surprised this isn't surfacing in any interface or e2e testing problems (yet)... kinda makes me wonder if there's something different about reproducing this in the console with the test string.
