### PR TITLE
Spacer block: Add clear:both; to clear any floats around it

### DIFF
--- a/packages/block-library/src/spacer/editor.scss
+++ b/packages/block-library/src/spacer/editor.scss
@@ -3,5 +3,6 @@
 }
 
 .block-library-spacer__resize-container {
+	clear: both;
 	margin-bottom: $default-block-margin;
 }

--- a/packages/block-library/src/spacer/style.scss
+++ b/packages/block-library/src/spacer/style.scss
@@ -1,0 +1,3 @@
+.wp-block-spacer {
+	clear: both;
+}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -24,6 +24,7 @@
 @import "./text-columns/style.scss";
 @import "./verse/style.scss";
 @import "./video/style.scss";
+@import "./spacer/style.scss";
 
 // The following selectors have increased specificity (using the :root prefix)
 // to assure colors take effect over another base class color, mainly to let

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -19,12 +19,12 @@
 @import "./rss/style.scss";
 @import "./search/style.scss";
 @import "./separator/style.scss";
+@import "./spacer/style.scss";
 @import "./subhead/style.scss";
 @import "./table/style.scss";
 @import "./text-columns/style.scss";
 @import "./verse/style.scss";
 @import "./video/style.scss";
-@import "./spacer/style.scss";
 
 // The following selectors have increased specificity (using the :root prefix)
 // to assure colors take effect over another base class color, mainly to let


### PR DESCRIPTION
Fixes #15099. Adds a `clear:both;` to the Spacer block so that it clears any floated blocks and functions as a Spacer block should.

## How has this been tested?
Locally.

## Screenshots 

**Current result adding Spacer block under floated images**

![Screen Shot 2019-05-28 at 8 15 03 PM](https://user-images.githubusercontent.com/617986/58526849-4d5bb500-8185-11e9-956a-90fdff50f666.png)

**Proposed result adding Spacer block that clears floats**

![Screen Shot 2019-05-28 at 8 03 37 PM](https://user-images.githubusercontent.com/617986/58526869-5e0c2b00-8185-11e9-85cf-53e529ce5f4c.png)


## Types of changes
Added minor CSS. I tested under various use cases.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
