### PR TITLE
ESLint: Copy no-restricted-syntax rules from ESLint plugin to config file

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-const { escapeRegExp, map } = require( 'lodash' );
+const { escapeRegExp } = require( 'lodash' );
 
 /**
  * Internal dependencies
@@ -36,6 +36,18 @@ module.exports = {
 			{
 				selector: 'CallExpression[callee.name="deprecated"] Property[key.name="version"][value.value=/' + majorMinorRegExp + '/]',
 				message: 'Deprecated functions must be removed before releasing this version.',
+			},
+			{
+				selector: 'CallExpression[callee.name=/^(__|_n|_nx|_x)$/]:not([arguments.0.type=/^Literal|BinaryExpression$/])',
+				message: 'Translate function arguments must be string literals.',
+			},
+			{
+				selector: 'CallExpression[callee.name=/^(_n|_nx|_x)$/]:not([arguments.1.type=/^Literal|BinaryExpression$/])',
+				message: 'Translate function arguments must be string literals.',
+			},
+			{
+				selector: 'CallExpression[callee.name=_nx]:not([arguments.3.type=/^Literal|BinaryExpression$/])',
+				message: 'Translate function arguments must be string literals.',
 			},
 			{
 				selector: 'CallExpression[callee.name=/^(__|_x|_n|_nx)$/] Literal[value=/\\.{3}/]',


### PR DESCRIPTION
## Description
As discussed in #15839, this PR copies the custom rules/options to the Gutenberg ESLint config.

## How has this been tested?

Create a file `test.js` with this content:

```js
const { __experimentalGetSettings } = wp.date;
const { __, _n, _nx, _x } = wp.i18n;

const foo_x = () => {};

const foo = 'bar';

/**
 * Should NOT flag
 */
__( 'Some text', 'text-domain' );
_n( 'Some text', 'Some texts', 42, 'text-domain' );
_nx( 'Some text', 'Some texts', 42, 'Some context', 'text-domain' );
_x( 'Some text', 'Some context', 'text-domain' );
const settings = __experimentalGetSettings();
foo_x();

/**
 * SHOULD flag
 */
__( foo, 'text-domain' );
_n( foo, 'Some texts', 42, 'text-domain' );
_nx( foo, 'Some texts', 42, 'Some context', 'text-domain' );
_x( foo, 'Some context', 'text-domain' );

_n( 'Some text', foo, 42, 'text-domain' );
_nx( 'Some texts', foo, 42, 'Some context', 'text-domain' );
_x( 'Some text', foo, 'text-domain' );

_nx( 'Some text', 'Some texts', 42, foo, 'text-domain' );
```

Then call:

```
./node_modules/.bin/eslint test.js
```

## Types of changes
Copy ESLint rules/options that are defined in the ESLint plugin, but overriden in the Gutenberg ESLint config.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
