### PR TITLE
Fix spacer deselection after dragging

### DIFF
--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -12,7 +12,7 @@ import { InspectorControls } from '@wordpress/block-editor';
 import { BaseControl, PanelBody, ResizableBox } from '@wordpress/components';
 import { withInstanceId } from '@wordpress/compose';
 
-const SpacerEdit = ( { attributes, isSelected, setAttributes, toggleSelection, instanceId } ) => {
+const SpacerEdit = ( { attributes, isSelected, setAttributes, instanceId } ) => {
 	const { height } = attributes;
 	const id = `block-spacer-height-input-${ instanceId }`;
 	const [ inputHeightValue, setInputHeightValue ] = useState( height );
@@ -44,10 +44,6 @@ const SpacerEdit = ( { attributes, isSelected, setAttributes, toggleSelection, i
 						height: spacerHeight,
 					} );
 					setInputHeightValue( spacerHeight );
-					toggleSelection( true );
-				} }
-				onResizeStart={ () => {
-					toggleSelection( false );
 				} }
 			/>
 			<InspectorControls>

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -141,6 +141,21 @@ _Parameters_
 
 Disables Pre-publish checks.
 
+<a name="dragAndResize" href="#dragAndResize">#</a> **dragAndResize**
+
+Clicks an element, drags a particular distance and releases the mouse button.
+
+_Parameters_
+
+-   _element_ `Object`: The puppeteer element handle.
+-   _delta_ `number`: Object containing movement distances.
+-   _delta.x_ `number`: Horizontal distance to drag.
+-   _delta.y_ `number`: Vertical distance to drag.
+
+_Returns_
+
+-   `Promise`: Promise resolving when drag completes.
+
 <a name="enablePageDialogAccept" href="#enablePageDialogAccept">#</a> **enablePageDialogAccept**
 
 Enables even listener which accepts a page dialog which

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -148,7 +148,7 @@ Clicks an element, drags a particular distance and releases the mouse button.
 _Parameters_
 
 -   _element_ `Object`: The puppeteer element handle.
--   _delta_ `number`: Object containing movement distances.
+-   _delta_ `Object`: Object containing movement distances.
 -   _delta.x_ `number`: Horizontal distance to drag.
 -   _delta.y_ `number`: Vertical distance to drag.
 

--- a/packages/e2e-test-utils/src/drag-and-resize.js
+++ b/packages/e2e-test-utils/src/drag-and-resize.js
@@ -1,0 +1,26 @@
+/**
+ * Clicks an element, drags a particular distance and releases the mouse button.
+ *
+ * @param {Object} element The puppeteer element handle.
+ * @param {number} delta   Object containing movement distances.
+ * @param {number} delta.x Horizontal distance to drag.
+ * @param {number} delta.y Vertical distance to drag.
+ *
+ * @return {Promise} Promise resolving when drag completes.
+ */
+export async function dragAndResize( element, delta ) {
+	const {
+		x: elementX,
+		y: elementY,
+		width: elementWidth,
+		height: elementHeight,
+	} = await element.boundingBox();
+
+	const originX = elementX + ( elementWidth / 2 );
+	const originY = elementY + ( elementHeight / 2 );
+
+	await page.mouse.move( originX, originY );
+	await page.mouse.down();
+	await page.mouse.move( originX + delta.x, originY + delta.y );
+	await page.mouse.up();
+}

--- a/packages/e2e-test-utils/src/drag-and-resize.js
+++ b/packages/e2e-test-utils/src/drag-and-resize.js
@@ -2,7 +2,7 @@
  * Clicks an element, drags a particular distance and releases the mouse button.
  *
  * @param {Object} element The puppeteer element handle.
- * @param {number} delta   Object containing movement distances.
+ * @param {Object} delta   Object containing movement distances.
  * @param {number} delta.x Horizontal distance to drag.
  * @param {number} delta.y Vertical distance to drag.
  *

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -10,6 +10,7 @@ export { createNewPost } from './create-new-post';
 export { createURL } from './create-url';
 export { deactivatePlugin } from './deactivate-plugin';
 export { disablePrePublishChecks } from './disable-pre-publish-checks';
+export { dragAndResize } from './drag-and-resize';
 export { enablePageDialogAccept } from './enable-page-dialog-accept';
 export { enablePrePublishChecks } from './enable-pre-publish-checks';
 export { ensureSidebarOpened } from './ensure-sidebar-opened';

--- a/packages/e2e-tests/specs/blocks/__snapshots__/spacer.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/spacer.test.js.snap
@@ -6,7 +6,7 @@ exports[`Spacer can be created by typing "/spacer" 1`] = `
 <!-- /wp:spacer -->"
 `;
 
-exports[`Spacer can be resized using the drag handle and remains selected being dragged 1`] = `
+exports[`Spacer can be resized using the drag handle and remains selected after being dragged 1`] = `
 "<!-- wp:spacer {\\"height\\":150} -->
 <div style=\\"height:150px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
 <!-- /wp:spacer -->"

--- a/packages/e2e-tests/specs/blocks/__snapshots__/spacer.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/spacer.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Spacer can be created by typing "/spacer" 1`] = `
+"<!-- wp:spacer -->
+<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<!-- /wp:spacer -->"
+`;
+
+exports[`Spacer can be resized using the drag handle and remains selected being dragged 1`] = `
+"<!-- wp:spacer {\\"height\\":150} -->
+<div style=\\"height:150px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<!-- /wp:spacer -->"
+`;

--- a/packages/e2e-tests/specs/blocks/spacer.test.js
+++ b/packages/e2e-tests/specs/blocks/spacer.test.js
@@ -22,7 +22,7 @@ describe( 'Spacer', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
-	it( 'can be resized using the drag handle and remains selected being dragged', async () => {
+	it( 'can be resized using the drag handle and remains selected after being dragged', async () => {
 		// Create a spacer with the slash block shortcut.
 		await clickBlockAppender();
 		await page.keyboard.type( '/spacer' );

--- a/packages/e2e-tests/specs/blocks/spacer.test.js
+++ b/packages/e2e-tests/specs/blocks/spacer.test.js
@@ -5,34 +5,8 @@ import {
 	clickBlockAppender,
 	getEditedPostContent,
 	createNewPost,
+	dragAndResize,
 } from '@wordpress/e2e-test-utils';
-
-/**
- * Clicks an element, drags a particular distance and releases the mouse button.
- *
- * @param {Object} element The puppeteer element handle.
- * @param {number} delta   Object containing movement distances.
- * @param {number} delta.x Horizontal distance to drag.
- * @param {number} delta.y Vertical distance to drag.
- *
- * @return {Promise} Promise resolving when drag completes.
- */
-export async function dragAngDrop( element, delta ) {
-	const {
-		x: elementX,
-		y: elementY,
-		width: elementWidth,
-		height: elementHeight,
-	} = await element.boundingBox();
-
-	const originX = elementX + ( elementWidth / 2 );
-	const originY = elementY + ( elementHeight / 2 );
-
-	await page.mouse.move( originX, originY );
-	await page.mouse.down();
-	await page.mouse.move( originX + delta.x, originY + delta.y );
-	await page.mouse.up();
-}
 
 describe( 'Spacer', () => {
 	beforeEach( async () => {
@@ -55,8 +29,7 @@ describe( 'Spacer', () => {
 		await page.keyboard.press( 'Enter' );
 
 		const resizableHandle = await page.$( '.block-library-spacer__resize-container .components-resizable-box__handle' );
-		await dragAngDrop( resizableHandle, { x: 0, y: 50 } );
-
+		await dragAndResize( resizableHandle, { x: 0, y: 50 } );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 
 		const selectedSpacer = await page.$( '[data-type="core/spacer"].is-selected' );

--- a/packages/e2e-tests/specs/blocks/spacer.test.js
+++ b/packages/e2e-tests/specs/blocks/spacer.test.js
@@ -1,0 +1,65 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	clickBlockAppender,
+	getEditedPostContent,
+	createNewPost,
+} from '@wordpress/e2e-test-utils';
+
+/**
+ * Clicks an element, drags a particular distance and releases the mouse button.
+ *
+ * @param {Object} element The puppeteer element handle.
+ * @param {number} delta   Object containing movement distances.
+ * @param {number} delta.x Horizontal distance to drag.
+ * @param {number} delta.y Vertical distance to drag.
+ *
+ * @return {Promise} Promise resolving when drag completes.
+ */
+export async function dragAngDrop( element, delta ) {
+	const {
+		x: elementX,
+		y: elementY,
+		width: elementWidth,
+		height: elementHeight,
+	} = await element.boundingBox();
+
+	const originX = elementX + ( elementWidth / 2 );
+	const originY = elementY + ( elementHeight / 2 );
+
+	await page.mouse.move( originX, originY );
+	await page.mouse.down();
+	await page.mouse.move( originX + delta.x, originY + delta.y );
+	await page.mouse.up();
+}
+
+describe( 'Spacer', () => {
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	it( 'can be created by typing "/spacer"', async () => {
+		// Create a spacer with the slash block shortcut.
+		await clickBlockAppender();
+		await page.keyboard.type( '/spacer' );
+		await page.keyboard.press( 'Enter' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'can be resized using the drag handle and remains selected being dragged', async () => {
+		// Create a spacer with the slash block shortcut.
+		await clickBlockAppender();
+		await page.keyboard.type( '/spacer' );
+		await page.keyboard.press( 'Enter' );
+
+		const resizableHandle = await page.$( '.block-library-spacer__resize-container .components-resizable-box__handle' );
+		await dragAngDrop( resizableHandle, { x: 0, y: 50 } );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		const selectedSpacer = await page.$( '[data-type="core/spacer"].is-selected' );
+		expect( selectedSpacer ).not.toBe( null );
+	} );
+} );


### PR DESCRIPTION
## Description
Fixes a small issue with the spacer in `master` that seems to be a regression.

Fix required deleting some code, so seems like a win!

## How has this been tested?
Adds an e2e test so this never happens again 😈.

Manual steps to repro:
1. Add a spacer block. 
2. Click and drag the drag handle to resize the spacer block

Expected behaviour (what happens on this branch)
When releasing after resizing using the drag handle, the spacer block should remain selected.

Actual behaviour (what happens in `master`)
When releasing after resizing using the drag handle, the spacer block becomes deselected. The grey area denoting the size of the spacer becomes invisible, which can be confusing if the spacer is the last block.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
