### PR TITLE
Bail early in createUpgradedEmbedBlock for invalid block types

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Master
+
+- Fixed an issue with creating upgraded embed blocks that are not registered ([#15883](https://github.com/WordPress/gutenberg/issues/15883)).
+
 ## 2.5.0 (2019-05-21)
 
 - Add vertical alignment controls to Columns Block ([#13899](https://github.com/WordPress/gutenberg/pull/13899/)).

--- a/packages/block-library/src/embed/test/index.js
+++ b/packages/block-library/src/embed/test/index.js
@@ -4,10 +4,15 @@
 import { render } from 'enzyme';
 
 /**
+ * WordPress dependencies
+ */
+import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
+
+/**
  * Internal dependencies
  */
 import { getEmbedEditComponent } from '../edit';
-import { findBlock, getClassNames } from '../util';
+import { findBlock, getClassNames, createUpgradedEmbedBlock } from '../util';
 
 describe( 'core/embed', () => {
 	test( 'block edit matches snapshot', () => {
@@ -43,5 +48,30 @@ describe( 'core/embed', () => {
 		const html = '<iframe height="9" width="16"></iframe>';
 		const expected = 'lovely';
 		expect( getClassNames( html, 'lovely wp-embed-aspect-16-9 wp-has-aspect-ratio', false ) ).toEqual( expected );
+	} );
+
+	test( 'createUpgradedEmbedBlock bails early when block type does not exist', () => {
+		const youtubeURL = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+
+		expect( createUpgradedEmbedBlock( { attributes: { url: youtubeURL } }, {} ) ).toBeUndefined();
+	} );
+
+	test( 'createUpgradedEmbedBlock returns a YouTube embed block when given a YouTube URL', () => {
+		const youtubeURL = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+
+		registerBlockType(
+			'core-embed/youtube',
+			{
+				title: 'YouTube',
+				category: 'embed',
+			}
+		);
+
+		const result = createUpgradedEmbedBlock( { attributes: { url: youtubeURL } }, {} );
+
+		unregisterBlockType( 'core-embed/youtube' );
+
+		expect( result ).not.toBeUndefined();
+		expect( result.name ).toBe( 'core-embed/youtube' );
 	} );
 } );

--- a/packages/block-library/src/embed/util.js
+++ b/packages/block-library/src/embed/util.js
@@ -15,7 +15,7 @@ import memoize from 'memize';
  * WordPress dependencies
  */
 import { renderToString } from '@wordpress/element';
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, getBlockType } from '@wordpress/blocks';
 
 /**
  * Returns true if any of the regular expressions match the URL.
@@ -81,6 +81,10 @@ export const createUpgradedEmbedBlock = ( props, attributesFromPreview ) => {
 	}
 
 	const matchingBlock = findBlock( url );
+
+	if ( ! getBlockType( matchingBlock ) ) {
+		return;
+	}
 
 	// WordPress blocks can work on multiple sites, and so don't have patterns,
 	// so if we're in a WordPress block, assume the user has chosen it for a WordPress URL.


### PR DESCRIPTION
## Description

Fixes #15883.

Patches `createUpgradedEmbedBlock` by checking whether the block type is valid before trying to create the actual block.

## How has this been tested?
Added some new tests 💪 

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
