### PR TITLE
Build: Skip downloading Chromium when building plugin's zip

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -99,7 +99,7 @@ done
 
 # Run the build.
 status "Installing dependencies... 📦"
-npm install
+PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install
 status "Generating build... 👷‍♀️"
 npm run build
 


### PR DESCRIPTION
## Description
This simple change should speed up the process of doing releases. It skips downloading Chromium which is only required when running e2e tests.

Before:
![Screen Shot 2019-05-29 at 12 46 59](https://user-images.githubusercontent.com/699132/58552833-9fe3b280-8213-11e9-95ed-1bc550a1a4aa.png)

After:
![Screen Shot 2019-05-29 at 13 14 19](https://user-images.githubusercontent.com/699132/58552862-affb9200-8213-11e9-9881-b3440c866d1f.png)


## Testing

`npm run package-plugin` or fork Gutenberg, change the `gitRepoOwner` in `bin/commander.js` constant to your handle and run `./bin/commander.js rc`.