### PR TITLE
ESLint: Explicitly unignore ESLint config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,5 @@ node_modules
 packages/e2e-tests/plugins
 vendor
 packages/block-serialization-spec-parser/parser.js
+
+!.eslintrc.js


### PR DESCRIPTION
## Description
ESLint, by default, does **not** lint the `.eslintrc.js` file.

This PR fixes that.

## How has this been tested?
Run this:

```
./node_modules/.bin/eslint .eslintrc.js
```

Without the new entry in the `.eslintignore` file, ESLint will report that it is ignoring the config file.

With the new entry, all is good (or not, which would mean issues with the contents of the file 😉).

## Types of changes
Unignore `.eslintrc.js` for ESLint.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
