### PR TITLE
Cherry-pick commits meant to land in WP 5.2.2

### DIFF
--- a/packages/e2e-tests/specs/plugins/cpt-locking.test.js
+++ b/packages/e2e-tests/specs/plugins/cpt-locking.test.js
@@ -8,6 +8,7 @@ import {
 	deactivatePlugin,
 	getEditedPostContent,
 	insertBlock,
+	setPostContent,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'cpt locking', () => {
@@ -57,6 +58,20 @@ describe( 'cpt locking', () => {
 			expect(
 				await page.$( 'button[aria-label="Move up"]' )
 			).toBeNull();
+		} );
+
+		it( 'should show invalid template notice if the blocks do not match the templte', async () => {
+			const content = await getEditedPostContent();
+			const [ , contentWithoutImage ] = content.split( '<!-- /wp:image -->' );
+			await setPostContent( contentWithoutImage );
+			const VALIDATION_PARAGRAPH_SELECTOR = '.editor-template-validation-notice .components-notice__content p';
+			await page.waitForSelector( VALIDATION_PARAGRAPH_SELECTOR );
+			expect(
+				await page.evaluate(
+					( element ) => element.textContent,
+					await page.$( VALIDATION_PARAGRAPH_SELECTOR )
+				)
+			).toEqual( 'The content of your post doesn’t match the template assigned to your post type.' );
 		} );
 	} );
 

--- a/packages/e2e-tests/specs/plugins/meta-attribute-block.test.js
+++ b/packages/e2e-tests/specs/plugins/meta-attribute-block.test.js
@@ -8,6 +8,7 @@ import {
 	getEditedPostContent,
 	insertBlock,
 	saveDraft,
+	pressKeyTimes,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Block with a meta attribute', () => {
@@ -25,7 +26,16 @@ describe( 'Block with a meta attribute', () => {
 
 	it( 'Should persist the meta attribute properly', async () => {
 		await insertBlock( 'Test Meta Attribute Block' );
-		await page.keyboard.type( 'Meta Value' );
+		await page.keyboard.type( 'Value' );
+
+		// Regression Test: Previously the caret would wrongly reset to the end
+		// of any input for meta-sourced attributes, due to syncing behavior of
+		// meta attribute updates.
+		//
+		// See: https://github.com/WordPress/gutenberg/issues/15739
+		await pressKeyTimes( 'ArrowLeft', 5 );
+		await page.keyboard.type( 'Meta ' );
+
 		await saveDraft();
 		await page.reload();
 

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -69,6 +69,7 @@ class EditorProvider extends Component {
 				'isRTL',
 				'maxWidth',
 				'styles',
+				'template',
 				'templateLock',
 				'titlePlaceholder',
 			] ),


### PR DESCRIPTION
Patches backported:

 - https://github.com/WordPress/gutenberg/pull/15418 Fix the template validation notice
 - https://github.com/WordPress/gutenberg/pull/15781 Fix for focus jumps when typing in meta attributes