### PR TITLE
Correct default appender icon transition jump in Safari

### DIFF
--- a/packages/block-editor/src/components/default-block-appender/style.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.scss
@@ -32,6 +32,7 @@
 	.block-editor-inserter__toggle:not([aria-expanded="true"]) {
 		opacity: 0;
 		transition: opacity 0.2s;
+		will-change: opacity;
 	}
 
 	&:hover {


### PR DESCRIPTION
As noted in #15868, when hovering over the default appender icon to the left of the text field, Safari renders a tiny position jump: 

![broken](https://user-images.githubusercontent.com/1202812/58567034-99e3d680-81ff-11e9-8f0e-fff97d52255a.gif)

This is likely because the browser tries to shift the animation from the CPU to the GPU, mid-animation. 😕 By providing `will-change: opacity` (the newer version of the traditional `translateZ(0)` hack to fix this), we can tell the browser to render the animation using the GPU right from the start, and avoid this issue:

![fixed](https://user-images.githubusercontent.com/1202812/58567039-9c463080-81ff-11e9-91af-1268244d46bc.gif)

The docs for `will-change` recommend [removing this after the animation happens](https://drafts.csswg.org/css-will-change/#dont-waste), but I haven't been able to sort out a way to get that working here. 