### PR TITLE
Docs: Add example of passing global `fetch` params to `apiFetch`.

### DIFF
--- a/packages/api-fetch/README.md
+++ b/packages/api-fetch/README.md
@@ -63,6 +63,20 @@ apiFetch.use( ( options, next ) => {
 } );
 ```
 
+Using global `fetch` options like `method`:
+
+```js
+apiFetch( { url, data, method: 'POST' } ).then( data => {
+	newState = { foo: data.foo };
+} ).catch( error => {
+	newState = { error };
+	console.error( `My Plugin error: ${newState.error}` );
+} ).finally( () => {
+	newState.loading = false;
+	this.setstate( newState );
+} );
+```
+
 ### Built-in middlewares
 
 The `api-fetch` package provides built-in middlewares you can use to provide a `nonce` and a custom `rootURL`.

--- a/packages/api-fetch/README.md
+++ b/packages/api-fetch/README.md
@@ -63,12 +63,15 @@ apiFetch.use( ( options, next ) => {
 } );
 ```
 
-Using global `fetch` options like `method`:
+Making a request to a 3rd party server using `url` instead of `path`, and using global `fetch` options like `method`:
 
 ```js
+const url = `https://api.example.org/v1/example?key=${ apiKey }`;
+const data = { foo: bar };
 let newState = {};
+
 apiFetch( { url, data, method: 'POST' } ).then( data => {
-	newState = { foo: data.foo };
+	newState = { bax: data.quix };
 } ).catch( error => {
 	newState = { error };
 	console.error( `My Plugin error: ${newState.error}` );

--- a/packages/api-fetch/README.md
+++ b/packages/api-fetch/README.md
@@ -66,6 +66,7 @@ apiFetch.use( ( options, next ) => {
 Using global `fetch` options like `method`:
 
 ```js
+let newState = {};
 apiFetch( { url, data, method: 'POST' } ).then( data => {
 	newState = { foo: data.foo };
 } ).catch( error => {
@@ -73,7 +74,7 @@ apiFetch( { url, data, method: 'POST' } ).then( data => {
 	console.error( `My Plugin error: ${newState.error}` );
 } ).finally( () => {
 	newState.loading = false;
-	this.setstate( newState );
+	this.setState( newState );
 } );
 ```
 


### PR DESCRIPTION
Previously the ability to pass `fetch` params was only mentioned in passing, but doing that will be a common use case for plugin developers. Having an explicit example will make it obvious, and save people time.