### PR TITLE
Add end to end test embed inside block with locking all.

### DIFF
--- a/packages/e2e-tests/plugins/inner-blocks-locking-all-embed.php
+++ b/packages/e2e-tests/plugins/inner-blocks-locking-all-embed.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test InnerBlocks Locking All Embed
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-inner-blocks-locking-all-embed
+ */
+
+/**
+ * Registers a custom script for the plugin.
+ */
+function enqueue_container_without_paragraph_plugin_script() {
+	wp_enqueue_script(
+		'gutenberg-test-inner-blocks-locking-all-embed',
+		plugins_url( 'inner-blocks-locking-all-embed/index.js', __FILE__ ),
+		array(
+			'wp-blocks',
+			'wp-element',
+			'wp-block-editor',
+			'wp-i18n',
+		),
+		filemtime( plugin_dir_path( __FILE__ ) . 'inner-blocks-locking-all-embed/index.js' ),
+		true
+	);
+}
+
+add_action( 'init', 'enqueue_container_without_paragraph_plugin_script' );

--- a/packages/e2e-tests/plugins/inner-blocks-locking-all-embed/index.js
+++ b/packages/e2e-tests/plugins/inner-blocks-locking-all-embed/index.js
@@ -1,0 +1,35 @@
+( function() {
+	var registerBlockType = wp.blocks.registerBlockType;
+	var el = wp.element.createElement;
+	var InnerBlocks = wp.blockEditor.InnerBlocks;
+	var __ = wp.i18n.__;
+	var TEMPLATE = [
+		[ 'core/paragraph', {
+			fontSize: 'large',
+			content: __( 'Content…' ),
+		} ],
+		[ 'core/embed' ],
+	];
+
+	var save = function() {
+		return el( InnerBlocks.Content );
+	};
+
+	registerBlockType( 'test/test-inner-blocks-locking-all-embed', {
+		title: 'Test Inner Blocks Locking All Embed',
+		icon: 'cart',
+		category: 'common',
+
+		edit: function( props ) {
+			return el(
+				InnerBlocks,
+				{
+					template: TEMPLATE,
+					templateLock: 'all',
+				}
+			);
+		},
+
+		save,
+	} );
+} )();

--- a/packages/e2e-tests/specs/embedding.test.js
+++ b/packages/e2e-tests/specs/embedding.test.js
@@ -3,15 +3,15 @@
  */
 import {
 	clickBlockAppender,
-	createNewPost,
-	createEmbeddingMatcher,
-	createURLMatcher,
-	setUpResponseMocking,
-	createJSONResponse,
-	getEditedPostContent,
 	clickButton,
+	createEmbeddingMatcher,
+	createJSONResponse,
+	createNewPost,
+	createURLMatcher,
+	getEditedPostContent,
 	insertBlock,
 	publishPost,
+	setUpResponseMocking,
 } from '@wordpress/e2e-test-utils';
 
 const MOCK_EMBED_WORDPRESS_SUCCESS_RESPONSE = {

--- a/packages/e2e-tests/specs/plugins/innerblocks-locking-all-embed.js
+++ b/packages/e2e-tests/specs/plugins/innerblocks-locking-all-embed.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	activatePlugin,
+	createNewPost,
+	deactivatePlugin,
+	insertBlock,
+} from '@wordpress/e2e-test-utils';
+
+describe( 'Embed block inside a locked all parent', () => {
+	beforeAll( async () => {
+		await activatePlugin( 'gutenberg-test-innerblocks-locking-all-embed' );
+	} );
+
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	afterAll( async () => {
+		await deactivatePlugin( 'gutenberg-test-innerblocks-locking-all-embed' );
+	} );
+
+	it( 'embed block should be able to embed external content', async () => {
+		await insertBlock( 'Test Inner Blocks Locking All Embed' );
+		const embedInputSelector = '.components-placeholder__input[aria-label="Embed URL"]';
+		await page.waitForSelector( embedInputSelector );
+		await page.click( embedInputSelector );
+		// This URL should not have a trailing slash.
+		await page.keyboard.type( 'https://twitter.com/WordPress' );
+		await page.keyboard.press( 'Enter' );
+		// The twitter block should appear correctly.
+		await page.waitForSelector( 'figure.wp-block-embed' );
+	} );
+} );


### PR DESCRIPTION
## Description
Adds an end 2 end test for the issue fixed in https://github.com/WordPress/gutenberg/pull/15866.

## How has this been tested?
I checked the end 2 end tests pass.
I reverted https://github.com/WordPress/gutenberg/pull/15866 and I verified the end to end tests fail.
