### PR TITLE
Remove background color text from heading; Fix end to end tests;

### DIFF
--- a/packages/e2e-tests/specs/blocks/__snapshots__/heading.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/heading.test.js.snap
@@ -13,26 +13,14 @@ exports[`Heading can be created by prefixing number sign and a space 1`] = `
 `;
 
 exports[`Heading it should correctly apply custom colors 1`] = `
-"<!-- wp:heading {\\"level\\":3,\\"customBackgroundColor\\":\\"#ab4567\\"} -->
-<h3 class=\\"has-background\\" style=\\"background-color:#ab4567\\">Heading</h3>
-<!-- /wp:heading -->"
-`;
-
-exports[`Heading it should correctly apply custom colors 2`] = `
-"<!-- wp:heading {\\"level\\":3,\\"customTextColor\\":\\"#181717\\",\\"customBackgroundColor\\":\\"#ab4567\\"} -->
-<h3 class=\\"has-background\\" style=\\"background-color:#ab4567;color:#181717\\">Heading</h3>
+"<!-- wp:heading {\\"level\\":3,\\"customTextColor\\":\\"#181717\\"} -->
+<h3 style=\\"color:#181717\\">Heading</h3>
 <!-- /wp:heading -->"
 `;
 
 exports[`Heading it should correctly apply named colors 1`] = `
-"<!-- wp:heading {\\"backgroundColor\\":\\"primary\\"} -->
-<h2 class=\\"has-background has-primary-background-color\\">Heading</h2>
-<!-- /wp:heading -->"
-`;
-
-exports[`Heading it should correctly apply named colors 2`] = `
-"<!-- wp:heading {\\"textColor\\":\\"white\\",\\"backgroundColor\\":\\"primary\\"} -->
-<h2 class=\\"has-background has-white-color has-primary-background-color\\">Heading</h2>
+"<!-- wp:heading {\\"textColor\\":\\"white\\"} -->
+<h2 class=\\"has-white-color\\">Heading</h2>
 <!-- /wp:heading -->"
 `;
 

--- a/packages/e2e-tests/specs/blocks/heading.test.js
+++ b/packages/e2e-tests/specs/blocks/heading.test.js
@@ -9,10 +9,8 @@ import {
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Heading', () => {
-	const BACKGROUND_COLOR_TEXT = 'Background Color';
 	const TEXT_COLOR_TEXT = 'Text Color';
 	const CUSTOM_COLOR_TEXT = 'Custom Color';
-	const BACKGROUND_COLOR_UI_X_SELECTOR = `//div[./span[contains(text(),'${ BACKGROUND_COLOR_TEXT }')]]`;
 	const TEXT_COLOR_UI_X_SELECTOR = `//div[./span[contains(text(),'${ TEXT_COLOR_TEXT }')]]`;
 	const CUSTOM_COLOR_BUTTON_X_SELECTOR = `//button[contains(text(),'${ CUSTOM_COLOR_TEXT }')]`;
 	const COLOR_INPUT_FIELD_SELECTOR = '.components-color-palette__picker .components-text-control__input';
@@ -60,16 +58,6 @@ describe( 'Heading', () => {
 		await page.keyboard.type( '### Heading' );
 		const [ colorPanelToggle ] = await page.$x( COLOR_PANEL_TOGGLE_X_SELECTOR );
 		await colorPanelToggle.click();
-		const [ customBackgroundColorButton ] = await page.$x(
-			`${ BACKGROUND_COLOR_UI_X_SELECTOR }${ CUSTOM_COLOR_BUTTON_X_SELECTOR }`
-		);
-		await customBackgroundColorButton.click();
-		await page.click( COLOR_INPUT_FIELD_SELECTOR );
-		await pressKeyWithModifier( 'primary', 'A' );
-		await page.keyboard.type( '#ab4567' );
-		await page.click( '.wp-block-heading' );
-		await page.waitForSelector( '.component-color-indicator[aria-label="(background color: #ab4567)"]' );
-		expect( await getEditedPostContent() ).toMatchSnapshot();
 
 		const [ customTextColorButton ] = await page.$x(
 			`${ TEXT_COLOR_UI_X_SELECTOR }${ CUSTOM_COLOR_BUTTON_X_SELECTOR }`
@@ -88,12 +76,6 @@ describe( 'Heading', () => {
 		await page.keyboard.type( '## Heading' );
 		const [ colorPanelToggle ] = await page.$x( COLOR_PANEL_TOGGLE_X_SELECTOR );
 		await colorPanelToggle.click();
-		const primaryColorButtonSelector = `${ BACKGROUND_COLOR_UI_X_SELECTOR }//button[@aria-label='Color: Primary']`;
-		const [ primaryColorButton ] = await page.$x( primaryColorButtonSelector );
-		await primaryColorButton.click();
-		await page.click( '.wp-block-heading' );
-		await page.waitForXPath( `${ primaryColorButtonSelector }[@aria-pressed='true']` );
-		expect( await getEditedPostContent() ).toMatchSnapshot();
 
 		const whiteColorButtonSelector = `${ TEXT_COLOR_UI_X_SELECTOR }//button[@aria-label='Color: White']`;
 		const [ whiteColorButton ] = await page.$x( whiteColorButtonSelector );


### PR DESCRIPTION
## Description
Background colors were removed from the heading.
https://github.com/WordPress/gutenberg/pull/15784 was created when background colors still existed, meanwhile that PR was merged and that made the end 2 end tests fail.
CI tests were passing in that PR because at the time it was created background colors were still part of the editor.

## How has this been tested?
I verified end to end tests are passing.
