### PR TITLE
Project Management: Merge lib and REST controllers CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -82,8 +82,7 @@
 /packages/block-editor/src/components/rich-text @youknowriad @aduth @ellatrix @jorgefilipecosta @daniloercoli @sergioestevao
 
 # PHP
-/lib                                            @youknowriad @gziolo @aduth
-*-controller.php                                @youknowriad @gziolo @aduth @timothybjacobs
+/lib                                            @youknowriad @gziolo @aduth @timothybjacobs
 
 # Native (Unowned)
 *.native.js                                     @ghost


### PR DESCRIPTION
Previously: #15215

For reasons currently outside my understanding, the `*-controller.php` CODEOWNERS entry is not correctly matching. For the pull request #15651, which includes the file `lib/class-wp-rest-widget-areas-controller.php`, it should have been expected that @TimothyBJacobs was assigned as reviewer by code ownership.

https://github.com/WordPress/gutenberg/blob/761543e9f092e04fcdbb32c1d99afd8fb3d11624/.github/CODEOWNERS#L86

Reference: https://help.github.com/en/articles/about-code-owners

CODEOWNERS should prefer last-match, and follows gitignore syntax. It's possible the convention here is incorrect, though variations tested locally against [`git check-ignore`](https://git-scm.com/docs/git-check-ignore) don't appear to make any difference. Suggestions welcome here. I suspect it is a matter of either (a) nested directories or (b) wildcard placement.

From the pull request #15651, there are also people _not_ expected to be assigned as code owner reviewers (@noisysocks, @nerrad) based on the files changed. It may be that earlier versions of the branch included revisions to files outside this directory (it was rebased a number of times).

The text "code owners" in the screenshot:

![image](https://user-images.githubusercontent.com/1779930/58656716-c9bbd880-82ea-11e9-8eb8-8b2dff844eb1.png)

..is linked to: https://github.com/WordPress/gutenberg/blob/761543e9f092e04fcdbb32c1d99afd8fb3d11624/.github/CODEOWNERS#L85

For this reason, we can assume that at least `/lib` should be working as expected. Until this can be correctly diagnosed, @TimothyBJacobs has agreed to be included as code owner for `/lib`.