### PR TITLE
Block Library: Implement drag handles for columns resizing

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -809,7 +809,7 @@ export function blockSelection( state = BLOCK_SELECTION_INITIAL_STATE, action ) 
 		}
 		case 'TOGGLE_SELECTION':
 			return {
-				...BLOCK_SELECTION_INITIAL_STATE,
+				...state,
 				isEnabled: action.isSelectionEnabled,
 			};
 		case 'SELECTION_CHANGE':

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -1727,6 +1727,24 @@ describe( 'state', () => {
 			expect( state1 ).toBe( original );
 		} );
 
+		it( 'should maintain selection when toggling multi-selection', () => {
+			const original = deepFreeze( {
+				start: { clientId: 'ribs' },
+				end: { clientId: 'ribs' },
+			} );
+
+			const state = blockSelection( original, {
+				type: 'TOGGLE_SELECTION',
+				isSelectionEnabled: false,
+			} );
+
+			expect( state ).toEqual( {
+				start: { clientId: 'ribs' },
+				end: { clientId: 'ribs' },
+				isEnabled: false,
+			} );
+		} );
+
 		it( 'should unset multi selection', () => {
 			const original = deepFreeze( { start: { clientId: 'ribs' }, end: { clientId: 'chicken' } } );
 

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -34,6 +34,7 @@ import {
 	getRedistributedColumnWidths,
 	toWidthPrecision,
 } from './utils';
+import ColumnsResizer from './resizer';
 
 /**
  * Allowed blocks constant is passed to InnerBlocks precisely as specified here.
@@ -111,6 +112,8 @@ export function ColumnsEdit( {
 	updateAlignment,
 	updateColumns,
 	clientId,
+	isSelected,
+	toggleSelection,
 } ) {
 	const { verticalAlignment } = attributes;
 
@@ -175,6 +178,12 @@ export function ColumnsEdit( {
 					template={ count === 0 && ! forceUseTemplate ? null : template }
 					templateLock="all"
 					allowedBlocks={ ALLOWED_BLOCKS } />
+				{ isSelected && (
+					<ColumnsResizer
+						clientId={ clientId }
+						toggleSelection={ toggleSelection }
+					/>
+				) }
 			</div>
 		</>
 	);

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -33,95 +33,135 @@
 
 .wp-block-columns {
 	display: block;
+}
 
-	> .editor-inner-blocks > .editor-block-list__layout {
-		display: flex;
+.wp-block-columns > .editor-inner-blocks > .editor-block-list__layout,
+.wp-block-columns__resizer {
+	display: flex;
 
-		// Responsiveness: Allow wrapping on mobile.
-		flex-wrap: wrap;
+	// Responsiveness: Allow wrapping on mobile.
+	flex-wrap: wrap;
 
+	@include break-medium() {
+		flex-wrap: nowrap;
+	}
+	// Set full heights on Columns to enable vertical alignment preview
+	> [data-type="core/column"],
+	> [data-type="core/column"] > .editor-block-list__block-edit,
+	> [data-type="core/column"] > .editor-block-list__block-edit > div[data-block],
+	> [data-type="core/column"] > .editor-block-list__block-edit .block-core-columns,
+	> .wp-block-columns__resize-box {
+		@include flex-full-height();
+	}
+	// Adjust the individual column block.
+	> [data-type="core/column"],
+	.wp-block-columns__resize-box {
+
+		// On mobile, only a single column is shown, so match adjacent block paddings.
+		padding-left: 0;
+		padding-right: 0;
+		margin-left: -$block-padding;
+		margin-right: -$block-padding;
+
+		// Prevent the columns from growing wider than their distributed sizes.
+		min-width: 0;
+
+		// Prevent long unbroken words from overflowing.
+		word-break: break-word; // For back-compat.
+		overflow-wrap: break-word; // New standard.
+
+		// Responsiveness: Show at most one columns on mobile.
+		flex-basis: 100%;
+
+		// Beyond mobile, allow 2 columns.
+		@include break-small() {
+			flex-grow: 0;
+			margin-left: $block-padding;
+			margin-right: $block-padding;
+
+			// TODO: This is not viable, since it will cause overflow of the
+			// columns content, but is necessary as demonstration of the impact
+			// on browser flex distribution on assigned width disparities.
+			flex-shrink: 0;
+			flex-basis: 50%;
+		}
+
+		// Add space between columns. Themes can customize this if they wish to work differently.
+		// This has to match the same padding applied in style.scss.
+		// Only apply this beyond the mobile breakpoint, as there's only a single column on mobile.
+		@include break-small() {
+			&:nth-child(even) {
+				margin-left: calc(#{$grid-size-large * 2} + #{$block-padding});
+			}
+		}
+
+		// When columns are in a single row, add space before all except the first.
 		@include break-medium() {
-			flex-wrap: nowrap;
+			&:not(:first-child) {
+				margin-left: calc(#{$grid-size-large * 2} + #{$block-padding});
+			}
 		}
-		// Set full heights on Columns to enable vertical alignment preview
-		> [data-type="core/column"],
-		> [data-type="core/column"] > .editor-block-list__block-edit,
-		> [data-type="core/column"] > .editor-block-list__block-edit > div[data-block],
-		> [data-type="core/column"] > .editor-block-list__block-edit .block-core-columns {
-			@include flex-full-height();
-		}
-		// Adjust the individual column block.
-		> [data-type="core/column"] {
 
-			// On mobile, only a single column is shown, so match adjacent block paddings.
-			padding-left: 0;
-			padding-right: 0;
-			margin-left: -$block-padding;
-			margin-right: -$block-padding;
+		> .editor-block-list__block-edit {
+			margin-top: 0;
+			margin-bottom: 0;
 
-			// Prevent the columns from growing wider than their distributed sizes.
-			min-width: 0;
-
-			// Prevent long unbroken words from overflowing.
-			word-break: break-word; // For back-compat.
-			overflow-wrap: break-word; // New standard.
-
-			// Responsiveness: Show at most one columns on mobile.
-			flex-basis: 100%;
-
-			// Beyond mobile, allow 2 columns.
-			@include break-small() {
-				flex-basis: calc(50% - (#{$grid-size-large} + #{$block-padding * 2}));
-				flex-grow: 0;
-				margin-left: $block-padding;
-				margin-right: $block-padding;
+			// Remove Block "padding" so individual Column is flush with parent Columns
+			&::before {
+				left: 0;
+				right: 0;
 			}
 
-			// Add space between columns. Themes can customize this if they wish to work differently.
-			// This has to match the same padding applied in style.scss.
-			// Only apply this beyond the mobile breakpoint, as there's only a single column on mobile.
-			@include break-small() {
-				&:nth-child(even) {
-					margin-left: calc(#{$grid-size-large * 2} + #{$block-padding});
-				}
+			> .editor-block-contextual-toolbar {
+				margin-left: -$border-width;
 			}
 
-			// When columns are in a single row, add space before all except the first.
-			@include break-medium() {
-				&:not(:first-child) {
-					margin-left: calc(#{$grid-size-large * 2} + #{$block-padding});
-				}
-			}
-
-			> .editor-block-list__block-edit {
+			// Zero out margins.
+			> [data-block] {
 				margin-top: 0;
 				margin-bottom: 0;
+			}
 
-				// Remove Block "padding" so individual Column is flush with parent Columns
-				&::before {
-					left: 0;
-					right: 0;
-				}
-
-				> .editor-block-contextual-toolbar {
-					margin-left: -$border-width;
-				}
-
-				// Zero out margins.
-				> [data-block] {
-					margin-top: 0;
-					margin-bottom: 0;
-				}
-
-				// The Columns block is a flex-container, therefore it nullifies margin collapsing.
-				// Therefore, blocks inside this will appear to create a double margin.
-				// We compensate for this using negative margins.
-				> div > .block-core-columns > .editor-inner-blocks {
-					margin-top: -$default-block-margin;
-					margin-bottom: -$default-block-margin;
-				}
+			// The Columns block is a flex-container, therefore it nullifies margin collapsing.
+			// Therefore, blocks inside this will appear to create a double margin.
+			// We compensate for this using negative margins.
+			> div > .block-core-columns > .editor-inner-blocks {
+				margin-top: -$default-block-margin;
+				margin-bottom: -$default-block-margin;
 			}
 		}
+	}
+}
+
+.wp-block-columns__resizer {
+	display: none;
+
+	@include break-medium() {
+		display: flex;
+	}
+
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	pointer-events: none;
+}
+
+.wp-block-columns__resize-box {
+	.wp-block-columns__resizer.is-resizing &:not(.is-active) {
+		opacity: 0;
+	}
+
+	.wp-block-columns__resizer & {
+		// Reset natural flex-basis assigned above, deferring instead to the
+		// width assigned by ResizableBox.
+		flex-basis: auto;
+	}
+
+	.components-resizable-box__handle {
+		pointer-events: auto;
+		margin-right: #{-1 * ($grid-size-large + $block-padding)};
 	}
 }
 

--- a/packages/block-library/src/columns/resizer.js
+++ b/packages/block-library/src/columns/resizer.js
@@ -1,0 +1,106 @@
+/**
+ * External dependencies
+ */
+import { forEach, find, difference, over } from 'lodash';
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect, withDispatch } from '@wordpress/data';
+import { ResizableBox } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getEffectiveColumnWidth,
+	toWidthPrecision,
+	getTotalColumnsWidth,
+	getColumnWidths,
+	getAdjacentBlocks,
+	getRedistributedColumnWidths,
+} from './utils';
+
+function ColumnsResizer( {
+	clientId,
+	toggleSelection,
+	updateBlockAttributes,
+} ) {
+	const [ activeResizeClientId, setActiveResizeClientId ] = useState( null );
+
+	const { columns } = useSelect( ( select ) => ( {
+		columns: select( 'core/block-editor' ).getBlocks( clientId ),
+	} ), [ clientId ] );
+
+	const classes = classnames( 'wp-block-columns__resizer', {
+		'is-resizing': activeResizeClientId !== null,
+	} );
+
+	return (
+		<div className={ classes }>
+			{ columns.map( ( column, index ) => {
+				const width = getEffectiveColumnWidth( column, columns.length );
+
+				function onResizeStop( event, direction, element ) {
+					const nextWidth = toWidthPrecision( parseFloat( element.style.width ) );
+					const adjacentColumns = getAdjacentBlocks( columns, column.clientId );
+
+					// The occupied width is calculated as the sum of the new width
+					// and the total width of blocks _not_ in the adjacent set.
+					const occupiedWidth = nextWidth + getTotalColumnsWidth(
+						difference( columns, [
+							find( columns, { clientId: column.clientId } ),
+							...adjacentColumns,
+						] )
+					);
+
+					// Compute _all_ next column widths, in case the updated column
+					// is in the middle of a set of columns which don't yet have
+					// any explicit widths assigned (include updates to those not
+					// part of the adjacent blocks).
+					const nextColumnWidths = {
+						...getColumnWidths( columns, columns.length ),
+						[ column.clientId ]: nextWidth,
+						...getRedistributedColumnWidths( adjacentColumns, 100 - occupiedWidth, columns.length ),
+					};
+
+					forEach( nextColumnWidths, ( nextColumnWidth, columnClientId ) => {
+						updateBlockAttributes( columnClientId, { width: nextColumnWidth } );
+					} );
+				}
+
+				return (
+					<ResizableBox
+						key={ column.clientId }
+						enable={ {
+							right: index !== columns.length - 1,
+						} }
+						size={ { width: width + '%' } }
+						axis="x"
+						onResizeStart={ over( [
+							() => setActiveResizeClientId( column.clientId ),
+							() => toggleSelection( false ),
+						] ) }
+						onResizeStop={ over( [
+							() => setActiveResizeClientId( null ),
+							() => toggleSelection( true ),
+							onResizeStop,
+						] ) }
+						className={ classnames(
+							'wp-block-columns__resize-box',
+							'is-selected',
+							{ 'is-active': activeResizeClientId === column.clientId }
+						) }
+					/>
+				);
+			} ) }
+		</div>
+	);
+}
+
+export default withDispatch( ( dispatch ) => {
+	const { updateBlockAttributes } = dispatch( 'core/block-editor' );
+	return { updateBlockAttributes };
+} )( ColumnsResizer );


### PR DESCRIPTION
Closes #15659
~Cherry-picks 9688debafed0f717c3125311a454f0e08463f7bd from #15920~

This pull request seeks to enable columns resizing using draggable handles on the Columns block.

![columns-drag-resize](https://user-images.githubusercontent.com/1779930/58659177-574df700-82f0-11e9-8328-9d32c6002b50.gif)

_**Note:** This pull request is currently **in progress**._

**Progress notes:**

- The current implementation of columns margins are actually mathematically incorrect in most cases, due to the browser's distribution of widths from its flexbox styling. It became exceedingly obvious when implementing the drag handles, as the "intended" size (by visual placement at time of drag release) would not be reflected correctly.
   - Temporarily, I work around this by disabling flex resizing (`flex-grow: 0`, `flex-shrink: 0`), which obviously causes undesirable content overflow, but allows for verification of the attributes math and general behavior.
   - It might be possible to refactor the flex styling so that even if margins exist and the columns must shrink, they do so proportionally. In `master`, the implementation is off in part because the columns are imbalanced ([left-margins on all but the first column](https://github.com/WordPress/gutenberg/blob/c12859d12d87bb4194bec203531d2e7883c2bb9d/packages/block-library/src/columns/editor.scss#L92)).
   - cc @jasmussen in case you have advice here.
- This may be considered blocked by both #15660 and #7694, if the intention would be that these resizing controls are only available at the parent Columns block. Existing text controls for assigning width must be preserved (currently at Column inspector, presumably desired at Columns inspector).

**Implementation / Code Review Notes:**

Review with [white space changes hidden](https://user-images.githubusercontent.com/1779930/58659677-9466b900-82f1-11e9-99a5-9560b8371b7e.png) (`columns/editor.scss` are largely de-indentation).

~The changes from 9688debafed0f717c3125311a454f0e08463f7bd are temporary until #15920 to facilitate styling development.~ (#15920 was merged)

Much of the code from the resizer's `onResizeStop` callback is copied directly from [the implementation in the Column block](https://github.com/WordPress/gutenberg/blob/c12859d12d87bb4194bec203531d2e7883c2bb9d/packages/block-library/src/column/edit.js#L100-L132). I expect most of this could be consolidated back up to the Columns parent component, notably as part of #15660.

A change was included for blocks selection state handling of selection toggling. It's expected this was recently changed to an unexpected behavior. Without the revision, the Columns block becomes deselected when starting to use the drag handles. See also https://github.com/WordPress/gutenberg/pull/14640#discussion_r281802377 (cc @ellatrix).

**Testing Instructions:**

Verify that upon selecting a Columns block, you can see and use drag handles between columns. Verify across a multitude of columns in a block.

1. Navigate to Posts > Add New
2. Insert a Columns block
3. Press <kbd>ArrowUp</kbd> to select the parent Columns block
4. Note the drag resizer
5. Drag the resizer
6. Note that the Column blocks are resized upon drag release