### PR TITLE
Correct position of the "Remove Featured Image" button on small screens. 

### DIFF
--- a/packages/editor/src/components/post-featured-image/style.scss
+++ b/packages/editor/src/components/post-featured-image/style.scss
@@ -5,10 +5,10 @@
 		margin: 0;
 	}
 
-	// Space consecutive buttons evenly.
+	// Stack consecutive buttons.
 	.components-button + .components-button {
+		display: block;
 		margin-top: 1em;
-		margin-right: 8px;
 	}
 
 	// This keeps images at their intrinsic size (eg. a 50px


### PR DESCRIPTION
Addresses part of #15853.

On small screens, the "Remove Featured Image" link is placed next to the "Replace Image" button. It doesn't line up correctly. Rather than rewrite that area to make that work, I'd suggest we just place the "Remove Featured Image" link on its own line, just like we do in the desktop sidebar.

---

**Before** 

<img width="375" alt="Screen Shot 2019-05-30 at 4 50 14 PM" src="https://user-images.githubusercontent.com/1202812/58663685-04c60800-82fb-11e9-8590-97821f584f4d.png">

---

**After**

<img width="374" alt="Screen Shot 2019-05-30 at 4 47 42 PM" src="https://user-images.githubusercontent.com/1202812/58663624-e3fdb280-82fa-11e9-8c1b-4863dd86b303.png">
