### PR TITLE
Remove stray flexbox CSS that's no longer needed; closes #11566.

### DIFF
--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -119,9 +119,6 @@
 		}
 
 		.components-datetime__time-field {
-			align-self: center;
-			flex: 0 1 auto;
-			order: 1;
 
 			&.am-pm button {
 				font-size: 11px;


### PR DESCRIPTION
## Description
This removes three stray lines of flexbox CSS that were used for reordering date fields in the date picker component but now aren't needed. (These fields are now reordered using JS rather than CSS.) See #11566 for more discussion.

## How has this been tested?
Tested output in Firefox & Safari and everything seems as expected.

## Types of changes
More 🔴 than 💚!

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
