### PR TITLE
Add overlayColor class name to cover blocks editor markup (#15897)

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -256,6 +256,7 @@ class CoverEdit extends Component {
 				'is-dark-theme': this.state.isDark,
 				'has-background-dim': dimRatio !== 0,
 				'has-parallax': hasParallax,
+				[ overlayColor.class ]: overlayColor.class,
 			}
 		);
 


### PR DESCRIPTION
## Description

Added the overlayColor class name to the block markup when rendered in the editor. Same as the block does in the view function from before. See #15897

## How has this been tested?

Ran the local development environment and verified that the class gets added in the editor.

## Types of changes

New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
