### PR TITLE
Remove the use of popular plugins in e2e tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,39 +81,39 @@ jobs:
       script:
         - ./bin/run-wp-unit-tests.sh
 
-    - name: E2E tests (Admin with plugins) (1/4)
-      env: WP_VERSION=latest SCRIPT_DEBUG=false POPULAR_PLUGINS=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=
+    - name: E2E tests (Admin) (1/4)
+      env: WP_VERSION=latest SCRIPT_DEBUG=false PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=
       install:
         - ./bin/setup-travis-e2e-tests.sh
       script:
         - $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --listTests > ~/.jest-e2e-tests
         - $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 0' < ~/.jest-e2e-tests )
 
-    - name: E2E tests (Admin with plugins) (2/4)
-      env: WP_VERSION=latest SCRIPT_DEBUG=false POPULAR_PLUGINS=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=
+    - name: E2E tests (Admin) (2/4)
+      env: WP_VERSION=latest SCRIPT_DEBUG=false PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=
       install:
         - ./bin/setup-travis-e2e-tests.sh
       script:
         - $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --listTests > ~/.jest-e2e-tests
         - $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 1' < ~/.jest-e2e-tests )
 
-    - name: E2E tests (Admin with plugins) (3/4)
-      env: WP_VERSION=latest SCRIPT_DEBUG=false POPULAR_PLUGINS=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=
+    - name: E2E tests (Admin) (3/4)
+      env: WP_VERSION=latest SCRIPT_DEBUG=false PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=
       install:
         - ./bin/setup-travis-e2e-tests.sh
       script:
         - $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --listTests > ~/.jest-e2e-tests
         - $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 2' < ~/.jest-e2e-tests )
 
-    - name: E2E tests (Admin with plugins) (4/4)
-      env: WP_VERSION=latest SCRIPT_DEBUG=false POPULAR_PLUGINS=true PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=
+    - name: E2E tests (Admin) (4/4)
+      env: WP_VERSION=latest SCRIPT_DEBUG=false PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=
       install:
         - ./bin/setup-travis-e2e-tests.sh
       script:
         - $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --listTests > ~/.jest-e2e-tests
         - $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 3' < ~/.jest-e2e-tests )
 
-    - name: E2E tests (Author without plugins) (1/4)
+    - name: E2E tests (Author) (1/4)
       env: WP_VERSION=latest SCRIPT_DEBUG=false E2E_ROLE=author PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=
       install:
         - ./bin/setup-travis-e2e-tests.sh
@@ -121,7 +121,7 @@ jobs:
         - $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --listTests > ~/.jest-e2e-tests
         - $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 0' < ~/.jest-e2e-tests )
 
-    - name: E2E tests (Author without plugins) (2/4)
+    - name: E2E tests (Author) (2/4)
       env: WP_VERSION=latest SCRIPT_DEBUG=false E2E_ROLE=author PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=
       install:
         - ./bin/setup-travis-e2e-tests.sh
@@ -129,7 +129,7 @@ jobs:
         - $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --listTests > ~/.jest-e2e-tests
         - $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 1' < ~/.jest-e2e-tests )
 
-    - name: E2E tests (Author without plugins) (3/4)
+    - name: E2E tests (Author) (3/4)
       env: WP_VERSION=latest SCRIPT_DEBUG=false E2E_ROLE=author PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=
       install:
         - ./bin/setup-travis-e2e-tests.sh
@@ -137,7 +137,7 @@ jobs:
         - $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --listTests > ~/.jest-e2e-tests
         - $( npm bin )/wp-scripts test-e2e --config=./packages/e2e-tests/jest.config.js --cacheDirectory="$HOME/.jest-cache" --runTestsByPath $( awk 'NR % 4 == 2' < ~/.jest-e2e-tests )
 
-    - name: E2E tests (Author without plugins) (4/4)
+    - name: E2E tests (Author) (4/4)
       env: WP_VERSION=latest SCRIPT_DEBUG=false E2E_ROLE=author PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=
       install:
         - ./bin/setup-travis-e2e-tests.sh

--- a/bin/install-wordpress.sh
+++ b/bin/install-wordpress.sh
@@ -90,11 +90,6 @@ fi
 echo -e $(status_message "Activating Gutenberg...")
 docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI plugin activate gutenberg --quiet
 
-if [ "$POPULAR_PLUGINS" == "true" ]; then
-	echo -e $(status_message "Activating popular plugins...")
-	docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI plugin install advanced-custom-fields jetpack wpforms-lite --activate --quiet
-fi
-
 # Install a dummy favicon to avoid 404 errors.
 echo -e $(status_message "Installing a dummy favicon...")
 docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CONTAINER touch /var/www/html/favicon.ico

--- a/packages/e2e-tests/specs/block-transforms.test.js
+++ b/packages/e2e-tests/specs/block-transforms.test.js
@@ -94,13 +94,7 @@ const getTransformResult = async ( blockContent, transformName ) => {
 	return getEditedPostContent();
 };
 
-// Skipping all the tests when plugins are enabled
-// makes sure the tests are not executed, and no unused snapshots errors are thrown.
-const maybeDescribe = process.env.POPULAR_PLUGINS ?
-	describe.skip :
-	describe;
-
-maybeDescribe( 'Block transforms', () => {
+describe( 'Block transforms', () => {
 	const fileBasenames = getAvailableBlockFixturesBasenames();
 
 	const transformStructure = {};


### PR DESCRIPTION
This PR blocks #15770

These tests have been up for a long time now and didn't prove to be fruitful. Also, it's blocking us from adding warnings to the console as some plugins could trigger console messages.

While working on this, I also noticed that the e2e test jobs are splitted into 4 separate jobs per role. I assume this is an attempt to speedup the tests but I'd personally question whether it's achieving its purpose.

 - Travis don't always run the jobs in parallel (I know there are limits sometimes)
 - The big parts of these jobs is about setting up the environment which is common to all of them and splitting doesn't help here
 - It also obscures the jobs a little bit as someone unfamiliar the setup would wonder why there are so many jobs.

I don't think I will touch this in this PR but I'd love thoughts. A single job per user would be so much clearer.

Closes https://github.com/WordPress/gutenberg/issues/13038.