### PR TITLE
Fix: Playground build; Remove @babel/polyfill import from the playground

### DIFF
--- a/playground/src/index.js
+++ b/playground/src/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import '@babel/polyfill';
-
-/**
  * WordPress dependencies
  */
 import '@wordpress/editor'; // This shouldn't be necessary


### PR DESCRIPTION
## Description
Removes the @babel/polyfill import from the playground. The screen seems to work as expected without it, and with it, the build fails.
## How has this been tested?
I executed npm run playground:start
I verified the build was successful without errors, on master it failed.

Fixes #16082.