### PR TITLE
Add: Format library to the widget screen.

### DIFF
--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -68,6 +68,8 @@ function gutenberg_widgets_init( $hook ) {
 		'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( get_block_editor_server_block_settings() ) . ');'
 	);
 	wp_enqueue_script( 'wp-edit-widgets' );
+	wp_enqueue_script( 'wp-format-library' );
 	wp_enqueue_style( 'wp-edit-widgets' );
+	wp_enqueue_style( 'wp-format-library' );
 }
 add_action( 'admin_enqueue_scripts', 'gutenberg_widgets_init' );


### PR DESCRIPTION
## Description
The PR just adds the missing format library to the widget screen.

## How has this been tested?
I went to the widget block editor.
I added a paragraph and I verified I could see and use the format options e.g: Bold.
