### PR TITLE
Fix: Popover positions on the widget screen

### DIFF
--- a/packages/edit-widgets/src/components/layout/index.js
+++ b/packages/edit-widgets/src/components/layout/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { navigateRegions } from '@wordpress/components';
+import { navigateRegions, Popover, SlotFillProvider } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -14,7 +14,7 @@ import Notices from '../notices';
 
 function Layout( { blockEditorSettings } ) {
 	return (
-		<>
+		<SlotFillProvider>
 			<Header />
 			<Sidebar />
 			<Notices />
@@ -28,7 +28,8 @@ function Layout( { blockEditorSettings } ) {
 					blockEditorSettings={ blockEditorSettings }
 				/>
 			</div>
-		</>
+			<Popover.Slot />
+		</SlotFillProvider>
 	);
 }
 


### PR DESCRIPTION
## Description
This PR adds the Popover slot to the widget screen inside BlockEditorProvider as we do in the playground.
This allows the Popovers to appear in the correct position.

I'm not very convinced of this change. We are adding a Popover slot per BlockEditorProvider is it ok to do that and have the same slot multiple times on a page? I guess we will need something similar for slots like the block toolbar.

I tried another approach besides this one: Adding the PopOver slot in the layout of the widget screen as we do for edit-post. That did not work as the slot was not found. I think that the slot was not found because <SlotFillProvider> is only used inside the block editor. So the Slot usage is outside of SlotFillProvider descendants. In edit post that also seems to be the case, so why things work as expected there?

I also tried removing SlotFillProvider from the block editor and using it in the widget screen layout level with PopOver.slot as a direct child. That also fixed the popover position problem, but when I selected a paragraph from another widget area the paragraph that was previously selected gets double formatting controls. To test this we need to cherry pick https://github.com/WordPress/gutenberg/pull/15948.

## How has this been tested?
I went to the widget screen.
I added a paragraph, I opened block settings, I verified the popover with the menu appears on the right position.
