### PR TITLE
Framework: Update download link for Docker Desktop

### DIFF
--- a/bin/install-docker.sh
+++ b/bin/install-docker.sh
@@ -10,7 +10,7 @@ set -e
 
 # Check that Docker is installed.
 if ! command_exists "docker"; then
-	echo -e $(error_message "Docker doesn't seem to be installed. Please head on over to the Docker site to download it: $(action_format "https://www.docker.com/community-edition#/download")")
+	echo -e $(error_message "Docker doesn't seem to be installed. Please head on over to the Docker site to download it: $(action_format "https://www.docker.com/products/docker-desktop")")
 	exit 1
 fi
 


### PR DESCRIPTION
Relevant Slack conversation ([link requires registration](https://make.wordpress.org/chat/)): https://wordpress.slack.com/archives/C02QB2JS7/p1559322698064000

This pull request seeks to update the download link for Docker which is displayed in the environment setup script when Docker is not installed. The previous like is now "Not Found", likely due to recent renaming of the Docker Community product to Docker Desktop.

- Old: https://www.docker.com/community-edition#/download
- New: https://www.docker.com/products/docker-desktop