### PR TITLE
Fix: When adding a button block, Button receives focus first #15859

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -131,6 +131,7 @@ class ButtonEdit extends Component {
 						<URLInput
 							value={ url }
 							/* eslint-disable jsx-a11y/no-autofocus */
+							// Disable Reason: The rule is meant to prevent enabling auto-focus, not disabling it.
 							autoFocus={ false }
 							/* eslint-enable jsx-a11y/no-autofocus */
 							onChange={ ( value ) => setAttributes( { url: value } ) }

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -130,6 +130,9 @@ class ButtonEdit extends Component {
 						<Dashicon icon="admin-links" />
 						<URLInput
 							value={ url }
+							/* eslint-disable jsx-a11y/no-autofocus */
+							autoFocus={ false }
+							/* eslint-enable jsx-a11y/no-autofocus */
 							onChange={ ( value ) => setAttributes( { url: value } ) }
 						/>
 						<IconButton icon="editor-break" label={ __( 'Apply' ) } type="submit" />

--- a/packages/e2e-tests/specs/blocks/__snapshots__/button.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/button.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Button can jump focus back & forth 1`] = `
 "<!-- wp:button -->
-<div class=\\"wp-block-button\\"><a class=\\"wp-block-button__link\\" href=\\"https://wordpress.org\\">WordPress.org</a></div>
+<div class=\\"wp-block-button\\"><a class=\\"wp-block-button__link\\" href=\\"https://wordpress.org\\">WordPress</a></div>
 <!-- /wp:button -->"
 `;
 

--- a/packages/e2e-tests/specs/blocks/__snapshots__/button.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/button.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Button can jump focus back & forth 1`] = `
+"<!-- wp:button -->
+<div class=\\"wp-block-button\\"><a class=\\"wp-block-button__link\\" href=\\"https://wordpress.org\\">WordPress.org</a></div>
+<!-- /wp:button -->"
+`;
+
+exports[`Button has focus on button content 1`] = `
+"<!-- wp:button -->
+<div class=\\"wp-block-button\\"><a class=\\"wp-block-button__link\\">Content</a></div>
+<!-- /wp:button -->"
+`;

--- a/packages/e2e-tests/specs/blocks/button.test.js
+++ b/packages/e2e-tests/specs/blocks/button.test.js
@@ -5,7 +5,6 @@ import {
 	insertBlock,
 	getEditedPostContent,
 	createNewPost,
-	pressKeyWithModifier,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Button', () => {
@@ -25,9 +24,6 @@ describe( 'Button', () => {
 		await page.keyboard.type( 'WordPress' );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.type( 'https://wordpress.org' );
-		await pressKeyWithModifier( 'shift', 'Tab' );
-		await pressKeyWithModifier( 'alt', 'ArrowRight' );
-		await page.keyboard.type( '.org' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );

--- a/packages/e2e-tests/specs/blocks/button.test.js
+++ b/packages/e2e-tests/specs/blocks/button.test.js
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	insertBlock,
+	getEditedPostContent,
+	createNewPost,
+	pressKeyWithModifier,
+} from '@wordpress/e2e-test-utils';
+
+describe( 'Button', () => {
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	it( 'has focus on button content', async () => {
+		await insertBlock( 'Button' );
+		await page.keyboard.type( 'Content' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'can jump focus back & forth', async () => {
+		await insertBlock( 'Button' );
+		await page.keyboard.type( 'WordPress' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.type( 'https://wordpress.org' );
+		await pressKeyWithModifier( 'shift', 'Tab' );
+		await pressKeyWithModifier( 'alt', 'ArrowRight' );
+		await page.keyboard.type( '.org' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
## Description
This pull request fixes issue #15859 
When adding a button block, the URL Input field receives focus first, even though it's the second editable text field displayed to users.
this pull fixes it by adding `autoFocus={ false }` to `URLInput` component inside the `Button/edit.js`


## How has this been tested?
Testing by creating a button in the editor, have all test pass on local

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
