### PR TITLE
Adds check for attributes in block settings

### DIFF
--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { assign } from 'lodash';
+import { assign, has } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -33,6 +33,10 @@ const ANCHOR_REGEX = /[\s#]/g;
  * @return {Object} Filtered block settings.
  */
 export function addAttribute( settings ) {
+	// allow blocks to specify their own attribute definition with default values if needed.
+	if ( has( settings.attributes, [ 'anchor', 'type' ] ) ) {
+		return settings;
+	}
 	if ( hasBlockSupport( settings, 'anchor' ) ) {
 		// Use Lodash's assign to gracefully handle if attributes are undefined
 		settings.attributes = assign( settings.attributes, {

--- a/packages/block-editor/src/hooks/test/anchor.js
+++ b/packages/block-editor/src/hooks/test/anchor.js
@@ -49,11 +49,12 @@ describe( 'anchor', () => {
 				attributes: {
 					anchor: {
 						type: 'string',
+						default: 'testAnchor',
 					},
 				},
 			} );
 
-			expect( settings.attributes.anchor ).not.toHaveProperty( 'source' );
+			expect( settings.attributes.anchor ).toEqual( { type: 'string', default: 'testAnchor' } );
 		} );
 	} );
 

--- a/packages/block-editor/src/hooks/test/anchor.js
+++ b/packages/block-editor/src/hooks/test/anchor.js
@@ -39,6 +39,22 @@ describe( 'anchor', () => {
 
 			expect( settings.attributes ).toHaveProperty( 'anchor' );
 		} );
+
+		it( 'should not override attributes defined in settings', () => {
+			const settings = registerBlockType( {
+				...blockSettings,
+				supports: {
+					anchor: true,
+				},
+				attributes: {
+					anchor: {
+						type: 'string',
+					},
+				},
+			} );
+
+			expect( settings.attributes.anchor ).not.toHaveProperty( 'source' );
+		} );
 	} );
 
 	describe( 'addSaveProps', () => {


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Fixes #15240

Anchor attributes in settings were being overridden by defaults in `addAttribute` function. This adds check for settings attributes and returns those if they exist.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

* Ran unit tests.
* Tested locally with a custom block: defined anchor attributes for it and checked with redux dev tools whether they appeared in `core/blocks` state (they did).
* Added a new unit test to check that settings are not overridden.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
