### PR TITLE
Fix: DatePicker missing focus on datepicker #15929

### DIFF
--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -63,7 +63,7 @@
 		&:focus {
 			outline: 2px solid transparent;
 			border: 2px solid theme(primary);
-			border-radius: 50px;
+			border-radius: 50%;
 
 		}
 	}

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -47,11 +47,25 @@
 		font-size: $default-font-size;
 	}
 
+	// Seperate borders so that border respect border radius
+	.CalendarMonth_table {
+		border-collapse: separate;
+		border-spacing: 1px;
+	}
+
 	.CalendarDay {
 		font-size: $default-font-size;
-		border: 1px solid transparent;
+		border: 2px solid transparent;
 		border-radius: $radius-round;
 		text-align: center;
+		transition: border 100ms linear, background 100ms linear;
+
+		&:focus {
+			outline: 2px solid transparent;
+			border: 2px solid theme(primary);
+			border-radius: 50px;
+
+		}
 	}
 
 	.CalendarDay__selected {
@@ -59,6 +73,11 @@
 
 		&:hover {
 			background: color(theme(primary) shade(15%));
+		}
+
+		&:focus {
+			background: color(theme(primary) shade(15%));
+			border-color: transparent;
 		}
 	}
 

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -61,8 +61,10 @@
 		transition: border 100ms linear, background 100ms linear;
 
 		&:focus {
-			outline: 2px solid transparent;
 			border: 2px solid theme(primary);
+			// Windows' High Contrast mode will show this outline
+			outline: 2px solid transparent;
+			outline-offset: -2px;
 			border-radius: 50%;
 
 		}
@@ -76,7 +78,9 @@
 		}
 
 		&:focus {
-			background: color(theme(primary) shade(15%));
+			// we can't use border to create a ring, and a shadow with a border is not
+			// crisp, so we hide the border and create a double shadow
+			box-shadow: inset 0 0 0 1px $white, inset 0 0 0 2px theme(primary);
 			border-color: transparent;
 		}
 	}


### PR DESCRIPTION
closes #15929

## Description
add border to days on focus, also darken the selected day background color on focus

## How has this been tested?
- open editor
- select publish date or any component that use datePicker
- tab your way around days

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/6165348/58796892-62599d80-85f6-11e9-90a4-022ad62f80cb.png)

## Types of changes
Bug fix

## Checklist:
- [x ] My code is tested.
- [x ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
