### PR TITLE
Fix: change featured image size to medium #15842

### DIFF
--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -31,7 +31,7 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 
 	let mediaWidth, mediaHeight, mediaSourceUrl;
 	if ( media ) {
-		const mediaSize = applyFilters( 'editor.PostFeaturedImage.imageSize', 'post-thumbnail', media.id, currentPostId );
+		const mediaSize = applyFilters( 'editor.PostFeaturedImage.imageSize', 'medium', media.id, currentPostId );
 		if ( has( media, [ 'media_details', 'sizes', mediaSize ] ) ) {
 			mediaWidth = media.media_details.sizes[ mediaSize ].width;
 			mediaHeight = media.media_details.sizes[ mediaSize ].height;


### PR DESCRIPTION
## Description
sets the default image size used in the editor for the featured image to `medium` since post-thumbnail doesn't exists and it fallback to full creating performance issues, see issue #15842 

## How has this been tested?
1. Create a Post
2. Add a Featured image in a large size e.g. 2000px wide
3. Right-click on the image and choose "open image in new window"
4. You can see the image in full size.



## Types of changes
bug fix

## Checklist:
- [ x] My code is tested.
- [ x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
