### PR TITLE
Bring consistency to block toolbar for text blocks

### DIFF
--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -61,19 +61,18 @@ function HeadingEdit( {
 	return (
 		<>
 			<BlockControls>
-				<HeadingToolbar minLevel={ 2 } maxLevel={ 5 } selectedLevel={ level } onChange={ ( newLevel ) => setAttributes( { level: newLevel } ) } />
+				<HeadingToolbar minLevel={ 1 } maxLevel={ 7 } selectedLevel={ level } onChange={ ( newLevel ) => setAttributes( { level: newLevel } ) } />
+				<AlignmentToolbar
+					value={ align }
+					onChange={ ( nextAlign ) => {
+						setAttributes( { align: nextAlign } );
+					} }
+				/>
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Heading Settings' ) }>
 					<p>{ __( 'Level' ) }</p>
 					<HeadingToolbar minLevel={ 1 } maxLevel={ 7 } selectedLevel={ level } onChange={ ( newLevel ) => setAttributes( { level: newLevel } ) } />
-					<p>{ __( 'Text Alignment' ) }</p>
-					<AlignmentToolbar
-						value={ align }
-						onChange={ ( nextAlign ) => {
-							setAttributes( { align: nextAlign } );
-						} }
-					/>
 				</PanelBody>
 				<HeadingColorUI
 					setTextColor={ setTextColor }

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -61,7 +61,13 @@ function HeadingEdit( {
 	return (
 		<>
 			<BlockControls>
-				<HeadingToolbar minLevel={ 1 } maxLevel={ 7 } selectedLevel={ level } onChange={ ( newLevel ) => setAttributes( { level: newLevel } ) } />
+				<HeadingToolbar
+					isCollapsed
+					minLevel={ 1 }
+					maxLevel={ 7 }
+					selectedLevel={ level }
+					onChange={ ( newLevel ) => setAttributes( { level: newLevel } ) }
+				/>
 				<AlignmentToolbar
 					value={ align }
 					onChange={ ( nextAlign ) => {

--- a/packages/block-library/src/heading/heading-toolbar.js
+++ b/packages/block-library/src/heading/heading-toolbar.js
@@ -23,9 +23,14 @@ class HeadingToolbar extends Component {
 	}
 
 	render() {
-		const { minLevel, maxLevel, selectedLevel, onChange } = this.props;
+		const { isCollapsed, minLevel, maxLevel, selectedLevel, onChange } = this.props;
+
 		return (
-			<Toolbar controls={ range( minLevel, maxLevel ).map( ( index ) => this.createLevelControl( index, selectedLevel, onChange ) ) } />
+			<Toolbar
+				controls={ range( minLevel, maxLevel ).map( ( index ) => this.createLevelControl( index, selectedLevel, onChange ) ) }
+				icon="heading"
+				isCollapsed={ isCollapsed }
+			/>
 		);
 	}
 }

--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -2,6 +2,9 @@
 	"name": "core/list",
 	"category": "common",
 	"attributes": {
+		"align": {
+			"type": "string"
+		},
 		"ordered": {
 			"type": "boolean",
 			"default": false

--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -3,7 +3,11 @@
  */
 import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
-import { RichText } from '@wordpress/block-editor';
+import {
+	AlignmentToolbar,
+	BlockControls,
+	RichText,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -17,24 +21,38 @@ export default function ListEdit( {
 	onReplace,
 	className,
 } ) {
-	const { ordered, values } = attributes;
+	const { align, ordered, values } = attributes;
 
 	return (
-		<RichText
-			identifier="values"
-			multiline="li"
-			tagName={ ordered ? 'ol' : 'ul' }
-			onChange={ ( nextValues ) => setAttributes( { values: nextValues } ) }
-			value={ values }
-			wrapperClassName="block-library-list"
-			className={ className }
-			placeholder={ __( 'Write list…' ) }
-			onMerge={ mergeBlocks }
-			onSplit={ ( value ) => createBlock( name, { ordered, values: value } ) }
-			__unstableOnSplitMiddle={ () => createBlock( 'core/paragraph' ) }
-			onReplace={ onReplace }
-			onRemove={ () => onReplace( [] ) }
-			onTagNameChange={ ( tag ) => setAttributes( { ordered: tag === 'ol' } ) }
-		/>
+		<>
+			<BlockControls>
+				<AlignmentToolbar
+					value={ align }
+					onChange={ ( nextAlign ) => {
+						setAttributes( { align: nextAlign } );
+					} }
+				/>
+			</BlockControls>
+			<RichText
+				identifier="values"
+				multiline="li"
+				tagName={ ordered ? 'ol' : 'ul' }
+				onChange={ ( nextValues ) => setAttributes( { values: nextValues } ) }
+				value={ values }
+				wrapperClassName="block-library-list"
+				className={ className }
+				placeholder={ __( 'Write list…' ) }
+				onMerge={ mergeBlocks }
+				onSplit={ ( value ) => createBlock( name, { ordered, values: value } ) }
+				__unstableOnSplitMiddle={ () => createBlock( 'core/paragraph' ) }
+				onReplace={ onReplace }
+				onRemove={ () => onReplace( [] ) }
+				onTagNameChange={ ( tag ) => setAttributes( { ordered: tag === 'ol' } ) }
+				style={ {
+					textAlign: align,
+					listStylePosition: 'inside',
+				} }
+			/>
+		</>
 	);
 }

--- a/packages/block-library/src/list/save.js
+++ b/packages/block-library/src/list/save.js
@@ -4,10 +4,14 @@
 import { RichText } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { ordered, values } = attributes;
+	const { align, ordered, values } = attributes;
 	const tagName = ordered ? 'ol' : 'ul';
+	const styles = {
+		textAlign: align,
+		listStylePosition: 'inside',
+	};
 
 	return (
-		<RichText.Content tagName={ tagName } value={ values } multiline="li" />
+		<RichText.Content tagName={ tagName } style={ styles } value={ values } multiline="li" />
 	);
 }

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -153,10 +153,12 @@
 }
 
 .has-text-align-left {
+	/*rtl:ignore*/
 	text-align: left;
 }
 
 .has-text-align-right {
+	/*rtl:ignore*/
 	text-align: right;
 }
 


### PR DESCRIPTION
## Description
Closes #15096.

Right now the toolbar across text blocks change a fair bit, and in the case of the heading block, it's not possible to set the alignment unless you open the sidebar. Let's simplify and unify that:

![Screenshot 2019-04-22 at 08 05 00](https://user-images.githubusercontent.com/1204802/56485782-af196700-64d5-11e9-8b8c-ae5da4366485.png)

A toolbar for text-blocks consists of these elements and in this order:

1. The block switcher. This doubles as a block type indicator, even when a block has no transformations.
2. An optional "level selector". For headings, this lets you select the level of the heading. For the list block, this lets you pick between the type of list.
3. Text alignments. This one can collapse. 
4. Inline formatting. Don't put any buttons here that apply on the block level, it's inline-only.
5. More menu.

A few other details in this mockup:

- The More menu button has been made thinner, as the vertical icon affords this.
- The dropdown triangle buttons have been made thinner as well. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

**It's still work in progress. I just wanted to document where we are at the moment.**

![Screen Shot 2019-06-03 at 15 26 31](https://user-images.githubusercontent.com/699132/58805335-29302600-8614-11e9-83c7-62d00ac6b2ab.png)
![Screen Shot 2019-06-03 at 15 26 43](https://user-images.githubusercontent.com/699132/58805336-29302600-8614-11e9-9575-f0aeb2c71db3.png)
![Screen Shot 2019-06-03 at 15 27 17](https://user-images.githubusercontent.com/699132/58805337-29c8bc80-8614-11e9-96f4-7b79ddfa62b3.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
