### PR TITLE
Fix/image overlaps control

### DIFF
--- a/assets/stylesheets/_z-index.scss
+++ b/assets/stylesheets/_z-index.scss
@@ -19,7 +19,7 @@ $z-layers: (
 	".components-modal__header": 10,
 	".edit-post-meta-boxes-area.is-loading::before": 1,
 	".edit-post-meta-boxes-area .spinner": 5,
-	".block-editor-block-contextual-toolbar": 21,
+	".block-editor-block-contextual-toolbar": 81,
 	".components-popover__close": 5,
 	".block-editor-block-list__insertion-point": 6,
 	".block-editor-inserter-with-shortcuts": 5,


### PR DESCRIPTION
closes issue #15923
## Description
increase block editor contextual toolbar z index so that floated images don't overlap it

## How has this been tested?
see #15923 for a way to reintroduce and then click on image to test

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/6165348/58807436-f71cc500-860f-11e9-94e9-1ab68d2df7ea.png)


## Types of changes
bug fix

## Checklist:
- [x ] My code is tested.
- [x ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
