### PR TITLE
Try: Make the modal overlay scrim darker

### DIFF
--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -5,7 +5,7 @@
 	right: 0;
 	bottom: 0;
 	left: 0;
-	background-color: rgba($white, 0.4);
+	background-color: rgba($black, 0.7);
 	z-index: z-index(".components-modal__screen-overlay");
 
 	// This animates the appearance of the white background.


### PR DESCRIPTION
Over in https://github.com/WordPress/gutenberg/issues/7602#issuecomment-497833635, I noticed @afercia bring up the point that the [scrim](https://material.io/design/environment/surfaces.html#attributes) (also known as the color overlay) behind the modal is inconsistent with the color used throughout WP-Admin. This is true — you'll notice that the Media modal brings up a dark background, whereas other modals use the white background. 

I know this has been [discussed in the past](https://github.com/WordPress/gutenberg/pull/6261#issuecomment-392518245), but now that some time has passed I'm wondering if we'd be open to reconsidering? 

The purpose of the scrim is to de-emphasise distracting elements of the screen and focus attention on an important area (in this case, the modal). Darkening the scrim helps fulfill this purpose more effectively by increasing the contrast between the important area and the rest of the page. This seems like a simple change that'd benefit everyone. 

For the PR here, I've swapped out the white with black, and adjusted the opacity to match the color used in the media modal's scrim. 

**Before:** 

![gutenberg test_wp-admin_post php_post=1 action=edit(iPad) (1)](https://user-images.githubusercontent.com/1202812/58823829-9d64cc80-8608-11e9-88b8-fb39f68f0867.png)

**After:**

![gutenberg test_wp-admin_post php_post=1 action=edit(iPad)](https://user-images.githubusercontent.com/1202812/58823819-96d65500-8608-11e9-8d74-cbb6a72e86c3.png)