### PR TITLE
Add support for disabled drop down items in SelectControl

### DIFF
--- a/packages/block-library/src/tag-cloud/edit.js
+++ b/packages/block-library/src/tag-cloud/edit.js
@@ -34,6 +34,7 @@ class TagCloudEdit extends Component {
 		const selectOption = {
 			label: __( '- Select -' ),
 			value: '',
+			disabled: true,
 		};
 		const taxonomyOptions = map( taxonomies, ( taxonomy ) => {
 			return {

--- a/packages/components/src/select-control/README.md
+++ b/packages/components/src/select-control/README.md
@@ -107,6 +107,7 @@ Render a user interface to select multiple users from a list.
             value={ this.state.users } // e.g: value = [ 'a', 'c' ]
             onChange={ ( users ) => { this.setState( { users } ) } }
             options={ [
+                { value: null, label: 'Select a User', disabled: true },
                 { value: 'a', label: 'User A' },
                 { value: 'b', label: 'User B' },
                 { value: 'c', label: 'User c' },
@@ -114,7 +115,6 @@ Render a user interface to select multiple users from a list.
         />
 
 ### Props
-
 
 - The set of props accepted by the component will be specified below.
 - Props not included in this set will be applied to the select element.
@@ -144,6 +144,7 @@ If this property is added, multiple values can be selected. The value passed sho
 An array of objects containing the following properties:
 - `label`: (string) The label to be shown to the user.
 - `value`: (Object) The internal value used to choose the selected value. This is also the value passed to onChange when the option is selected.
+- `disabled`: (boolean) Whether or not the option should have the disabled attribute.
 - Type: `Array`
 - Required: No
 

--- a/packages/components/src/select-control/index.js
+++ b/packages/components/src/select-control/index.js
@@ -51,6 +51,7 @@ function SelectControl( {
 					<option
 						key={ `${ option.label }-${ option.value }-${ index }` }
 						value={ option.value }
+						disabled={ option.disabled }
 					>
 						{ option.label }
 					</option>


### PR DESCRIPTION
## Description

Fixes #11270. Adds support for marking options within a `SelectControl` as 'disabled', which translates to the `disabled` attribute being added to the HTML `option` element.

## How Has This Been Tested?

1. Added the Tag Cloud block to a new post
2. Observed that the "Taxonomy" sidebar setting included a "- Select -" option that could be selected.
3. Applied the patch and ran the build
4. Repeated step 1
5. Observed that the "- Select -" option is now disabled

## Screenshots (jpeg or gifs if applicable):

Before:
![tag-cloud-before](https://user-images.githubusercontent.com/136342/58864457-a5764800-86ac-11e9-819c-3a771002bf92.png)

After:
![tag-cloud-after](https://user-images.githubusercontent.com/136342/58864459-a7400b80-86ac-11e9-90f6-f5ac7da54029.png)


## Types of changes

This changes improves an existing component and updates one use of that component to demonstrate how it can be used.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.