### PR TITLE
Scripts: Ignore linting files located in build folders by default

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### New Features
+
+- The `lint-js`, `lint-pkg-json` and `lint-style` commands ignore now files located in `build` and `node_modules` folders by default ([15977](https://github.com/WordPress/gutenberg/pull/15977)).
+
 ## 3.2.0 (2019-05-21)
 
 ### New Feature

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -123,6 +123,9 @@ This is how you execute the script with presented setup:
 
 * `npm run lint:js` - lints JavaScript files in the entire project's directories.
 
+
+By default, files located in `build` and `node_modules` folders are ignored.
+
 #### Advanced information
 
 It uses [eslint](https://eslint.org/) with the set of recommended rules defined in [@wordpress/eslint-plugin](https://www.npmjs.com/package/@wordpress/eslint-plugin) npm package. You can override default rules with your own as described in [eslint docs](https://eslint.org/docs/rules/). Learn more in the [Advanced Usage](#advanced-usage) section.
@@ -145,6 +148,8 @@ This is how you execute those scripts using the presented setup:
 
 * `npm run lint:pkg-json` - lints `package.json` file in the project's root folder.
 
+By default, files located in `build` and `node_modules` folders are ignored.
+
 #### Advanced information
 
 It uses [npm-package-json-lint](https://www.npmjs.com/package/npm-package-json-lint) with the set of recommended rules defined in [@wordpress/npm-package-json-lint-config](https://www.npmjs.com/package/@wordpress/npm-package-json-lint-config) npm package. You can override default rules with your own as described in [npm-package-json-lint wiki](https://github.com/tclindner/npm-package-json-lint/wiki). Learn more in the [Advanced Usage](#advanced-usage) section.
@@ -166,6 +171,8 @@ _Example:_
 This is how you execute the script with presented setup:
 
 * `npm run lint:css` - lints CSS files in the whole project's directory.
+
+By default, files located in `build` and `node_modules` folders are ignored.
 
 #### Advanced information
 

--- a/packages/scripts/config/.eslintignore
+++ b/packages/scripts/config/.eslintignore
@@ -1,0 +1,2 @@
+build
+node_modules

--- a/packages/scripts/config/.npmpackagejsonlintignore
+++ b/packages/scripts/config/.npmpackagejsonlintignore
@@ -1,0 +1,3 @@
+# By default, all `node_modules` are ignored.
+
+build

--- a/packages/scripts/config/.stylelintignore
+++ b/packages/scripts/config/.stylelintignore
@@ -1,0 +1,3 @@
+# By default, all `node_modules` are ignored.
+
+build

--- a/packages/scripts/scripts/lint-js.js
+++ b/packages/scripts/scripts/lint-js.js
@@ -17,6 +17,7 @@ const {
 
 const args = getCliArgs();
 
+// See: https://eslint.org/docs/user-guide/configuring#using-configuration-files-1.
 const hasLintConfig = hasCliArg( '-c' ) ||
 	hasCliArg( '--config' ) ||
 	hasProjectFile( '.eslintrc.js' ) ||
@@ -33,9 +34,17 @@ const config = ! hasLintConfig ?
 	[ '--no-eslintrc', '--config', fromConfigRoot( '.eslintrc.js' ) ] :
 	[];
 
+// See: https://eslint.org/docs/user-guide/configuring#ignoring-files-and-directories.
+const hasIgnoredFiles = hasCliArg( '--ignore-path' ) ||
+	hasProjectFile( '.eslintignore' );
+
+const defaultIgnoreArgs = ! hasIgnoredFiles ?
+	[ '--ignore-path', fromConfigRoot( '.eslintignore' ) ] :
+	[];
+
 const result = spawn(
 	resolveBin( 'eslint' ),
-	[ ...config, ...args ],
+	[ ...config, ...defaultIgnoreArgs, ...args ],
 	{ stdio: 'inherit' }
 );
 

--- a/packages/scripts/scripts/lint-pkg-json.js
+++ b/packages/scripts/scripts/lint-pkg-json.js
@@ -17,6 +17,7 @@ const {
 
 const args = getCliArgs();
 
+// See: https://github.com/tclindner/npm-package-json-lint/wiki/configuration#configuration.
 const hasLintConfig = hasCliArg( '-c' ) ||
 	hasCliArg( '--configFile' ) ||
 	hasProjectFile( '.npmpackagejsonlintrc.json' ) ||
@@ -27,9 +28,17 @@ const config = ! hasLintConfig ?
 	[ '--configFile', fromConfigRoot( 'npmpackagejsonlint.json' ) ] :
 	[];
 
+// See: https://github.com/tclindner/npm-package-json-lint/#cli-commands-and-configuration.
+const hasIgnoredFiles = hasCliArg( '--ignorePath' ) ||
+	hasProjectFile( '.npmpackagejsonlintignore' );
+
+const defaultIgnoreArgs = ! hasIgnoredFiles ?
+	[ '--ignorePath', fromConfigRoot( '.npmpackagejsonlintignore' ) ] :
+	[];
+
 const result = spawn(
 	resolveBin( 'npm-package-json-lint', { executable: 'npmPkgJsonLint' } ),
-	[ ...config, ...args ],
+	[ ...config, ...defaultIgnoreArgs, ...args ],
 	{ stdio: 'inherit' }
 );
 

--- a/packages/scripts/scripts/lint-style.js
+++ b/packages/scripts/scripts/lint-style.js
@@ -17,7 +17,8 @@ const {
 
 const args = getCliArgs();
 
-const hasStylelintConfig = hasCliArg( '--config' ) ||
+// See: https://github.com/stylelint/stylelint/blob/master/docs/user-guide/configuration.md#loading-the-configuration-object.
+const hasLintConfig = hasCliArg( '--config' ) ||
 	hasProjectFile( '.stylelintrc' ) ||
 	hasProjectFile( '.stylelintrc.js' ) ||
 	hasProjectFile( '.stylelintrc.json' ) ||
@@ -26,13 +27,21 @@ const hasStylelintConfig = hasCliArg( '--config' ) ||
 	hasProjectFile( '.stylelint.config.js' ) ||
 	hasPackageProp( 'stylelint' );
 
-const config = ! hasStylelintConfig ?
+const config = ! hasLintConfig ?
 	[ '--config', fromConfigRoot( '.stylelintrc.json' ) ] :
+	[];
+
+// See: https://github.com/stylelint/stylelint/blob/master/docs/user-guide/configuration.md#stylelintignore.
+const hasIgnoredFiles = hasCliArg( '--ignore-path' ) ||
+	hasProjectFile( '.stylelintignore' );
+
+const defaultIgnoreArgs = ! hasIgnoredFiles ?
+	[ '--ignore-path', fromConfigRoot( '.stylelintignore' ) ] :
 	[];
 
 const result = spawn(
 	resolveBin( 'stylelint' ),
-	[ ...config, ...args ],
+	[ ...config, ...defaultIgnoreArgs, ...args ],
 	{ stdio: 'inherit' }
 );
 


### PR DESCRIPTION
## Description
Closes #15407.

It should give very good defaults with the related proposal #15890 which provides defaults for file pattern matching.

> **Describe the bug**
> 
> Running the JS linter will lint the `build/` folder, resulting in hundreds of errors because it's minified, etc.
> When using `wp-scripts` to build blocks or other plugins that use `wp.element`, `wp.component`, etc. [For example](https://github.com/iandunn/quick-navigation-interface/tree/4ff42c2).> 
> **Expected behavior**
> 
> The `build/` folder should be ignored by the linter config.

This PR ensures that by default all files located in `build` and `node_modules` folders are ignored when using `wp-scripts` for all 3 types of linter:
- `lint-js`
- `lint-pkg-json`
- `lint-style`

## How has this been tested?

This is quite difficult to test without publishing to npm. I personally tested it with Gutenberg repository by playing with configuration files. This is how you can run commands:

* `npx wp-scripts lint-js .`
* `npx wp-scripts lint-pkg-json .`
* `npx wp-scripts lint-style '**/*.scss'`

I deleted `.eslintignore` from the root folder of Gutenberg and played with defaults:
- `packages/scripts/config/.eslintignore`
- `packages/scripts/config/.npmpackagejsonlintignore`
- `packages/scripts/config/.stylelintignore`

I had to add some linting errors in random files to ensure it all works.

Then I reverted changes in those config files and copied them to the root folder. I tried again to modify those config files in the root folder running all commands again.

I also ensured that when I add violations to files inside `build` or `node_modules` nested subfolder, those errors are ignored.