### PR TITLE
 Scripts: Document and simplify changing file entry and output of build scripts

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### New Features
+
+- The `build` and `start` commands supports simplified syntax for multiple entry points: `wp-scripts build entry-one.js entry-two.js` ([15982](https://github.com/WordPress/gutenberg/pull/15982)).
+
 ## 3.3.0 (2019-06-12)
 
 ### New Features

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -49,7 +49,8 @@ _Example:_
 ```json
 {
 	"scripts": {
-		"build": "wp-scripts build"
+		"build": "wp-scripts build",
+		"build:custom": "wp-scripts build entry-one.js entry-two.js --output-path=custom"
 	}
 }
 ```
@@ -57,6 +58,7 @@ _Example:_
 This is how you execute the script with presented setup:
 
 * `npm run build` - builds the code for production.
+* `npm run build:custom` - builds the code for production with two entry points and a custom output folder. Paths for custom entry points are relative to the project root.
 
 #### Advanced information
 
@@ -198,7 +200,8 @@ _Example:_
 ```json
 {
 	"scripts": {
-		"start": "wp-scripts start"
+		"start": "wp-scripts start",
+		"start:custom": "wp-scripts start entry-one.js entry-two.js --output-path=custom"
 	}
 }
 ```
@@ -206,6 +209,7 @@ _Example:_
 This is how you execute the script with presented setup:
 
 * `npm start` - starts the build for development.
+* `npm run start:custom` - starts the build for development which contains two entry points and a custom output folder. Paths for custom entry points are relative to the project root.
 
 #### Advanced information
 

--- a/packages/scripts/utils/cli.js
+++ b/packages/scripts/utils/cli.js
@@ -27,7 +27,9 @@ const getArgFromCLI = ( arg ) => {
 
 const hasArgInCLI = ( arg ) => getArgFromCLI( arg ) !== undefined;
 
-const hasFileArgInCLI = () => minimist( getArgsFromCLI() )._.length > 0;
+const getFileArgsFromCLI = () => minimist( getArgsFromCLI() )._;
+
+const hasFileArgInCLI = () => getFileArgsFromCLI().length > 0;
 
 const handleSignal = ( signal ) => {
 	if ( signal === 'SIGKILL' ) {
@@ -83,6 +85,7 @@ const spawnScript = ( scriptName, args = [] ) => {
 module.exports = {
 	getArgFromCLI,
 	getArgsFromCLI,
+	getFileArgsFromCLI,
 	hasArgInCLI,
 	hasFileArgInCLI,
 	spawnScript,

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -1,7 +1,12 @@
 /**
+ * External dependencies
+ */
+const { basename } = require( 'path' );
+
+/**
  * Internal dependencies
  */
-const { hasArgInCLI, getArgsFromCLI } = require( './cli' );
+const { getArgsFromCLI, getFileArgsFromCLI, hasArgInCLI, hasFileArgInCLI } = require( './cli' );
 const { fromConfigRoot, hasProjectFile } = require( './file' );
 const { hasPackageProp } = require( './package' );
 
@@ -22,12 +27,57 @@ const hasWebpackConfig = () => hasArgInCLI( '--config' ) ||
 	hasProjectFile( 'webpack.config.js' ) ||
 	hasProjectFile( 'webpack.config.babel.js' );
 
+/**
+ * Converts CLI arguments to the format which webpack understands.
+ * It allows to optionally pass some additional webpack CLI arguments.
+ *
+ * @see https://webpack.js.org/api/cli/#usage-with-config-file
+ *
+ * @param {?Array} additionalArgs The list of additional CLI arguments.
+ *
+ * @return {Array} The list of CLI arguments to pass to webpack CLI.
+ */
 const getWebpackArgs = ( additionalArgs = [] ) => {
-	const webpackArgs = getArgsFromCLI();
+	let webpackArgs = getArgsFromCLI();
+
+	const hasWebpackOutputOption = hasArgInCLI( '-o' ) || hasArgInCLI( '--output' );
+	if ( hasFileArgInCLI() && ! hasWebpackOutputOption ) {
+		/**
+		 * Converts a path to the entry format supported by webpack, e.g.:
+		 * `./entry-one.js` -> `entry-one=./entry-one.js`
+		 * `entry-two.js` -> `entry-two=./entry-two.js`
+		 *
+		 * @param {string} path The path provided.
+		 *
+		 * @return {string} The entry format supported by webpack.
+		 */
+		const pathToEntry = ( path ) => {
+			const entry = basename( path, '.js' );
+
+			if ( ! path.startsWith( './' ) ) {
+				path = './' + path;
+			}
+
+			return [ entry, path ].join( '=' );
+		};
+
+		// The following handles the support for multiple entry points in webpack, e.g.:
+		// `wp-scripts build one.js custom=./two.js` -> `webpack one=./one.js custom=./two.js`
+		webpackArgs = webpackArgs.map( ( cliArg ) => {
+			if ( getFileArgsFromCLI().includes( cliArg ) && ! cliArg.includes( '=' ) ) {
+				return pathToEntry( cliArg );
+			}
+
+			return cliArg;
+		} );
+	}
+
 	if ( ! hasWebpackConfig() ) {
 		webpackArgs.push( '--config', fromConfigRoot( 'webpack.config.js' ) );
 	}
+
 	webpackArgs.push( ...additionalArgs );
+
 	return webpackArgs;
 };
 

--- a/packages/scripts/utils/index.js
+++ b/packages/scripts/utils/index.js
@@ -4,6 +4,7 @@
 const {
 	getArgFromCLI,
 	getArgsFromCLI,
+	getFileArgsFromCLI,
 	hasArgInCLI,
 	hasFileArgInCLI,
 	spawnScript,
@@ -29,6 +30,7 @@ module.exports = {
 	fromConfigRoot,
 	getArgFromCLI,
 	getArgsFromCLI,
+	getFileArgsFromCLI,
 	getWebpackArgs,
 	hasBabelConfig,
 	hasArgInCLI,


### PR DESCRIPTION
## Description
Closes #14891.

The `build` and `start` commands supports simplified syntax for multiple entry points:
```shell
$ npx wp-scripts build entry-one.js entry-two.js --output-path=dist
```

In fact, you could call:
```shell
$ npx wp-scripts build entry-one=./entry-one.js entry-two=./entry-two.js --output-path=dist
```
as of today to achieve the same but it might take some time to experiment to discover it.

This proposal makes public API less tied to webpack and gives a way to map it to another tool in the future. In addition, it makes it simple to provide entry points by doing all the mapping behind the scenes.

## Testing

### Two entry points in `src` folder built into `build` folder

Create two JS files in `src` folder:
- `entry-one.js`
- `entry-two.js`

```shell
 $ npx wp-scripts build src/entry-one.js src/entry-two.js
```

This should output four files:
 - `build/entry-one.js`
 - `build/entry-one.deps.json`
 - `build/entry-two.js`
 - `build/entry-two.deps.json`

### Custom entry points and custom output folder

Create two JS files in the root folder:
- `entry-one.js`
- `entry-two.js`

```shell
 $ npx wp-scripts build entry-one.js entry-two.js --output-path=dist
```

This should output four files:
 - `dist/entry-one.js`
 - `dist/entry-one.deps.json`
 - `dist/entry-two.js`
 - `dist/entry-two.deps.json`