### PR TITLE
Correct text zoom issue in the Content Structure popover

### DIFF
--- a/packages/editor/src/components/table-of-contents/style.scss
+++ b/packages/editor/src/components/table-of-contents/style.scss
@@ -29,12 +29,17 @@
 }
 
 .table-of-contents__count {
-	width: 25%;
+	flex-basis: 25%;
 	display: flex;
 	flex-direction: column;
 	font-size: $default-font-size;
 	color: $dark-gray-300;
+	padding-right: $grid-size;
 	margin-bottom: 0;
+
+	&:last-child {
+		padding-right: 0;
+	}
 }
 
 .table-of-contents__number,


### PR DESCRIPTION
Fixes #15357. 

As noted in the issue, text in the Content Structure popover currently overlaps when using the browser's text zoom feature. This PR switches the fixed percentage width to use the somewhat more flexible`flex-basis` instead. It also adds a tiny bit of spacing in between each item.

---

**Before**

_Viewed at 100%_
<img width="390" alt="Screen Shot 2019-06-04 at 2 51 11 PM" src="https://user-images.githubusercontent.com/1202812/58905812-a45b1000-86d8-11e9-8db6-ea6e2657d6af.png">

_Viewed at 200%_
<img width="389" alt="Screen Shot 2019-06-04 at 2 50 57 PM" src="https://user-images.githubusercontent.com/1202812/58905836-b2a92c00-86d8-11e9-800f-ad731b855d29.png">

---

**After**

_Viewed at 100% (No changes)_

<img width="389" alt="Screen Shot 2019-06-04 at 2 49 43 PM" src="https://user-images.githubusercontent.com/1202812/58905863-bf2d8480-86d8-11e9-8d54-580cb43e7748.png">

_Viewed at 200%_

<img width="388" alt="Screen Shot 2019-06-04 at 2 50 20 PM" src="https://user-images.githubusercontent.com/1202812/58905882-c5bbfc00-86d8-11e9-8e06-88648116fa97.png">