### PR TITLE
Add back important clarification doc for `withDispatch` removed in #15896

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -684,6 +684,10 @@ const SaleButton = withDispatch( ( dispatch, ownProps, { select } ) => {
 //  <SaleButton>Start Sale!</SaleButton>
 ```
 
+_Note:_ It is important that the `mapDispatchToProps` function always
+returns an object with the same keys. For example, it should not contain
+conditions under which a different value would be returned.
+
 _Parameters_
 
 -   _mapDispatchToProps_ `Function`: A function of returning an object of prop names where value is a dispatch-bound action creator, or a function to be called with the component's props and returning an action creator.

--- a/packages/data/src/components/with-dispatch/index.js
+++ b/packages/data/src/components/with-dispatch/index.js
@@ -81,6 +81,10 @@ import { useDispatchWithMap } from '../use-dispatch';
  * //  <SaleButton>Start Sale!</SaleButton>
  * ```
  *
+ * _Note:_ It is important that the `mapDispatchToProps` function always
+ * returns an object with the same keys. For example, it should not contain
+ * conditions under which a different value would be returned.
+ *
  * @return {Component} Enhanced component with merged dispatcher props.
  */
 const withDispatch = ( mapDispatchToProps ) => createHigherOrderComponent(


### PR DESCRIPTION
## Description
As per [this comment](https://github.com/WordPress/gutenberg/pull/15896#discussion_r290450424) this pull adds back in some important clarification docs for `withDispatch` and the shape of the object returned from `mapDispatchToProps`.

This is a documentation only change so no impact on existing code and no testing needed.
