### PR TITLE
Edit Post: Remove SlotFillProvider as rendered by block editor

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -1,8 +1,10 @@
-## 2.2.0 (2019-06-12)
+## Master
 
 ### Breaking Changes
 
-- `BlockEditorProvider` no longer renders a wrapping `SlotFillProvider` (from `@wordpress/components`). For custom block editors, you should render your own as wrapping the `BlockEditorProvider`. A future release will include a new `BlockEditor` component for simple, standard usage. `BlockEditorProvider` will serve the simple purpose of establishing its own context for block editors.
+- `BlockEditorProvider` no longer renders a wrapping `SlotFillProvider` or `DropZoneProvider` (from `@wordpress/components`). For custom block editors, you should render your own as wrapping the `BlockEditorProvider`. A future release will include a new `BlockEditor` component for simple, standard usage. `BlockEditorProvider` will serve the simple purpose of establishing its own context for block editors.
+
+## 2.2.0 (2019-06-12)
 
 ### Internal
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 2.2.0 (2019-06-12)
 
+### Breaking Changes
+
+- `BlockEditorProvider` no longer renders a wrapping `SlotFillProvider` (from `@wordpress/components`). For custom block editors, you should render your own as wrapping the `BlockEditorProvider`. A future release will include a new `BlockEditor` component for simple, standard usage. `BlockEditorProvider` will serve the simple purpose of establishing its own context for block editors.
+
 ### Internal
 
 - Refactored `BlockSettingsMenu` to use `DropdownMenu` from `@wordpress/components`.

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { DropZoneProvider, SlotFillProvider } from '@wordpress/components';
+import { DropZoneProvider } from '@wordpress/components';
 import { withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
@@ -121,11 +121,9 @@ class BlockEditorProvider extends Component {
 		const { children } = this.props;
 
 		return (
-			<SlotFillProvider>
-				<DropZoneProvider>
-					{ children }
-				</DropZoneProvider>
-			</SlotFillProvider>
+			<DropZoneProvider>
+				{ children }
+			</DropZoneProvider>
 		);
 	}
 }

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { DropZoneProvider } from '@wordpress/components';
 import { withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
@@ -120,11 +119,7 @@ class BlockEditorProvider extends Component {
 	render() {
 		const { children } = this.props;
 
-		return (
-			<DropZoneProvider>
-				{ children }
-			</DropZoneProvider>
-		);
+		return children;
 	}
 }
 

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -10,7 +10,7 @@ import { size, map, without } from 'lodash';
 import { withSelect } from '@wordpress/data';
 import { EditorProvider, ErrorBoundary, PostLockedModal } from '@wordpress/editor';
 import { StrictMode, Component } from '@wordpress/element';
-import { KeyboardShortcuts } from '@wordpress/components';
+import { KeyboardShortcuts, SlotFillProvider } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -87,19 +87,21 @@ class Editor extends Component {
 
 		return (
 			<StrictMode>
-				<EditorProvider
-					settings={ editorSettings }
-					post={ post }
-					initialEdits={ initialEdits }
-					useSubRegistry={ false }
-					{ ...props }
-				>
-					<ErrorBoundary onError={ onError }>
-						<Layout />
-						<KeyboardShortcuts shortcuts={ preventEventDiscovery } />
-					</ErrorBoundary>
-					<PostLockedModal />
-				</EditorProvider>
+				<SlotFillProvider>
+					<EditorProvider
+						settings={ editorSettings }
+						post={ post }
+						initialEdits={ initialEdits }
+						useSubRegistry={ false }
+						{ ...props }
+					>
+						<ErrorBoundary onError={ onError }>
+							<Layout />
+							<KeyboardShortcuts shortcuts={ preventEventDiscovery } />
+						</ErrorBoundary>
+						<PostLockedModal />
+					</EditorProvider>
+				</SlotFillProvider>
 			</StrictMode>
 		);
 	}

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -10,7 +10,11 @@ import { size, map, without } from 'lodash';
 import { withSelect } from '@wordpress/data';
 import { EditorProvider, ErrorBoundary, PostLockedModal } from '@wordpress/editor';
 import { StrictMode, Component } from '@wordpress/element';
-import { KeyboardShortcuts, SlotFillProvider } from '@wordpress/components';
+import {
+	KeyboardShortcuts,
+	SlotFillProvider,
+	DropZoneProvider,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -88,19 +92,21 @@ class Editor extends Component {
 		return (
 			<StrictMode>
 				<SlotFillProvider>
-					<EditorProvider
-						settings={ editorSettings }
-						post={ post }
-						initialEdits={ initialEdits }
-						useSubRegistry={ false }
-						{ ...props }
-					>
-						<ErrorBoundary onError={ onError }>
-							<Layout />
-							<KeyboardShortcuts shortcuts={ preventEventDiscovery } />
-						</ErrorBoundary>
-						<PostLockedModal />
-					</EditorProvider>
+					<DropZoneProvider>
+						<EditorProvider
+							settings={ editorSettings }
+							post={ post }
+							initialEdits={ initialEdits }
+							useSubRegistry={ false }
+							{ ...props }
+						>
+							<ErrorBoundary onError={ onError }>
+								<Layout />
+								<KeyboardShortcuts shortcuts={ preventEventDiscovery } />
+							</ErrorBoundary>
+							<PostLockedModal />
+						</EditorProvider>
+					</DropZoneProvider>
 				</SlotFillProvider>
 			</StrictMode>
 		);

--- a/playground/src/index.js
+++ b/playground/src/index.js
@@ -10,7 +10,7 @@ import {
 	WritingFlow,
 	ObserveTyping,
 } from '@wordpress/block-editor';
-import { Popover } from '@wordpress/components';
+import { Popover, SlotFillProvider } from '@wordpress/components';
 import { registerCoreBlocks } from '@wordpress/block-library';
 import '@wordpress/format-library';
 
@@ -37,20 +37,22 @@ function App() {
 				<h1 className="playground__logo">Gutenberg Playground</h1>
 			</div>
 			<div className="playground__body">
-				<BlockEditorProvider
-					value={ blocks }
-					onInput={ updateBlocks }
-					onChange={ updateBlocks }
-				>
-					<div className="editor-styles-wrapper">
-						<WritingFlow>
-							<ObserveTyping>
-								<BlockList />
-							</ObserveTyping>
-						</WritingFlow>
-					</div>
-					<Popover.Slot />
-				</BlockEditorProvider>
+				<SlotFillProvider>
+					<BlockEditorProvider
+						value={ blocks }
+						onInput={ updateBlocks }
+						onChange={ updateBlocks }
+					>
+						<div className="editor-styles-wrapper">
+							<WritingFlow>
+								<ObserveTyping>
+									<BlockList />
+								</ObserveTyping>
+							</WritingFlow>
+						</div>
+						<Popover.Slot />
+					</BlockEditorProvider>
+				</SlotFillProvider>
 			</div>
 		</Fragment>
 	);

--- a/playground/src/index.js
+++ b/playground/src/index.js
@@ -10,7 +10,11 @@ import {
 	WritingFlow,
 	ObserveTyping,
 } from '@wordpress/block-editor';
-import { Popover, SlotFillProvider } from '@wordpress/components';
+import {
+	Popover,
+	SlotFillProvider,
+	DropZoneProvider,
+} from '@wordpress/components';
 import { registerCoreBlocks } from '@wordpress/block-library';
 import '@wordpress/format-library';
 
@@ -38,20 +42,22 @@ function App() {
 			</div>
 			<div className="playground__body">
 				<SlotFillProvider>
-					<BlockEditorProvider
-						value={ blocks }
-						onInput={ updateBlocks }
-						onChange={ updateBlocks }
-					>
-						<div className="editor-styles-wrapper">
-							<WritingFlow>
-								<ObserveTyping>
-									<BlockList />
-								</ObserveTyping>
-							</WritingFlow>
-						</div>
-						<Popover.Slot />
-					</BlockEditorProvider>
+					<DropZoneProvider>
+						<BlockEditorProvider
+							value={ blocks }
+							onInput={ updateBlocks }
+							onChange={ updateBlocks }
+						>
+							<div className="editor-styles-wrapper">
+								<WritingFlow>
+									<ObserveTyping>
+										<BlockList />
+									</ObserveTyping>
+								</WritingFlow>
+							</div>
+							<Popover.Slot />
+						</BlockEditorProvider>
+					</DropZoneProvider>
 				</SlotFillProvider>
 			</div>
 		</Fragment>


### PR DESCRIPTION
Extracted from #14715 
Unblocks #15949 

This pull request cherry-picks the ade6069 commit from #14715. This is necessary both for the reusable blocks embedded editor refactor, and for the custom widgets integration of block editor. Currently, because the BlockEditorProvider component renders the context provider for Slot/Fill, it is not possible to render slots outside the editor. This prevents block inspector rendering as in the #14715 refactoring and Popover rendering as in #15949.

It may be the case that we want to expose a component with "easy" bundled behavior, but it should still be possible to opt out of behaviors in advanced use cases like described above.

#14715 proposes additional enhancements to Slot/Fill behavior to allow whitelisted "proxying" to allow layered Fill capturing. It's not relevant for this pull request, but noteworthy for context.

**Testing Instructions:**

Verify there are no regressions in Slot/Fill (block inspector, block toolbar, popovers, etc).