### PR TITLE
Editor: Create own sub-registry in default EditorProvider use

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -375,6 +375,18 @@ The default editor settings
 
 Undocumented declaration.
 
+<a name="storeConfig" href="#storeConfig">#</a> **storeConfig**
+
+Block editor data store configuration.
+
+_Related_
+
+-   <https://github.com/WordPress/gutenberg/blob/master/packages/data/README.md#registerStore>
+
+_Type_
+
+-   `Object` 
+
 <a name="URLInput" href="#URLInput">#</a> **URLInput**
 
 _Related_

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -14,5 +14,5 @@ import './hooks';
 
 export * from './components';
 export * from './utils';
-
+export { storeConfig } from './store';
 export { SETTINGS_DEFAULTS } from './store/defaults';

--- a/packages/block-editor/src/store/index.js
+++ b/packages/block-editor/src/store/index.js
@@ -17,6 +17,13 @@ import controls from './controls';
  */
 const MODULE_KEY = 'core/block-editor';
 
+/**
+ * Block editor data store configuration.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/master/packages/data/README.md#registerStore
+ *
+ * @type {Object}
+ */
 export const storeConfig = {
 	reducer,
 	selectors,

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -91,6 +91,7 @@ class Editor extends Component {
 					settings={ editorSettings }
 					post={ post }
 					initialEdits={ initialEdits }
+					useSubRegistry={ false }
 					{ ...props }
 				>
 					<ErrorBoundary onError={ onError }>

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -19,6 +19,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 /**
  * Internal dependencies
  */
+import withRegistryProvider from './with-registry-provider';
 import { mediaUpload } from '../../utils';
 import ReusableBlocksButtons from '../reusable-blocks-buttons';
 
@@ -165,6 +166,7 @@ class EditorProvider extends Component {
 }
 
 export default compose( [
+	withRegistryProvider,
 	withSelect( ( select ) => {
 		const {
 			__unstableIsEditorReady: isEditorReady,

--- a/packages/editor/src/components/provider/with-registry-provider.js
+++ b/packages/editor/src/components/provider/with-registry-provider.js
@@ -1,0 +1,46 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+import { withRegistry, createRegistry, RegistryProvider } from '@wordpress/data';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { storeConfig as blockEditorStoreConfig } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { storeConfig } from '../../store';
+import applyMiddlewares from '../../store/middlewares';
+
+const withRegistryProvider = createHigherOrderComponent(
+	( WrappedComponent ) => withRegistry( ( props ) => {
+		const { useSubRegistry = true, registry, ...additionalProps } = props;
+		if ( ! useSubRegistry ) {
+			return <WrappedComponent { ...additionalProps } />;
+		}
+
+		const [ subRegistry, setSubRegistry ] = useState( null );
+		useEffect( () => {
+			const newRegistry = createRegistry( {
+				'core/block-editor': blockEditorStoreConfig,
+			}, registry );
+			const store = newRegistry.registerStore( 'core/editor', storeConfig );
+			// This should be removed after the refactoring of the effects to controls.
+			applyMiddlewares( store );
+			setSubRegistry( newRegistry );
+		}, [ registry ] );
+
+		if ( ! subRegistry ) {
+			return null;
+		}
+
+		return (
+			<RegistryProvider value={ subRegistry }>
+				<WrappedComponent { ...additionalProps } />
+			</RegistryProvider>
+		);
+	} ),
+	'withRegistryProvider'
+);
+
+export default withRegistryProvider;

--- a/packages/editor/src/index.js
+++ b/packages/editor/src/index.js
@@ -17,6 +17,7 @@ import './hooks';
 
 export * from './components';
 export * from './utils';
+export { storeConfig } from './store';
 
 /*
  * Backward compatibility

--- a/packages/editor/src/store/index.js
+++ b/packages/editor/src/store/index.js
@@ -13,11 +13,22 @@ import * as selectors from './selectors';
 import * as actions from './actions';
 import { STORE_KEY } from './constants';
 
-const store = registerStore( STORE_KEY, {
+/**
+ * Post editor data store configuration.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/master/packages/data/README.md#registerStore
+ *
+ * @type {Object}
+ */
+export const storeConfig = {
 	reducer,
 	selectors,
 	actions,
 	controls,
+};
+
+const store = registerStore( STORE_KEY, {
+	...storeConfig,
 	persist: [ 'preferences' ],
 } );
 applyMiddlewares( store );


### PR DESCRIPTION
Extracted from #14715
Related: #14678, #14367

This pull request seeks to introduce automated sub-registry creation for the `EditorProvider` component. It is identical in purpose and in implementation to the `BlockEditorProvider` enhancements merged in #14678.

This will bring consistency in editor creation, where #14715 proposes to reimplement reusable blocks using its own rendering of `EditorProvider` to leverage both the blocks-editing behaviors of `@wordpress/block-editor`, and the post lifecycle management of `@wordpress/editor`.

**Implementation Notes:**

This introduces API changes to `@wordpress/editor` and `@wordpress/block-editor` in the form of exposing their respective base data store configurations. For additional context, this was explored and discussed previously in https://github.com/WordPress/gutenberg/pull/14367#discussion_r266969822 .

**Testing Instructions:**

There should be no regressions in standard use of the editor.

You may place a breakpoint at any code within `@wordpress/editor` which has access to the registry to confirm there is no effective difference in reference between `master` and this branch, since sub-registries should only be created when not at the top-level.

```
registry.select === wp.data.select
```