### PR TITLE
Add improved "Group" and "Ungroup" icons

### DIFF
--- a/packages/block-library/src/group/icon.js
+++ b/packages/block-library/src/group/icon.js
@@ -4,5 +4,5 @@
 import { Path, SVG } from '@wordpress/components';
 
 export default (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><Path d="M19 12h-2v3h-3v2h5v-5zM7 9h3V7H5v5h2V9zm14-6H3c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16.01H3V4.99h18v14.02z" /><Path d="M0 0h24v24H0z" fill="none" /></SVG>
+	<SVG width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill-rule="evenodd" clip-rule="evenodd" d="M9 8a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v4a1 1 0 0 1-1 1h-1v3a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1v-4a1 1 0 0 1 1-1h1V8zm2 3h4V9h-4v2zm2 2H9v2h4v-2z" /><Path fill-rule="evenodd" clip-rule="evenodd" d="M2 4.732A2 2 0 1 1 4.732 2h14.536A2 2 0 1 1 22 4.732v14.536A2 2 0 1 1 19.268 22H4.732A2 2 0 1 1 2 19.268V4.732zM4.732 4h14.536c.175.304.428.557.732.732v14.536a2.01 2.01 0 0 0-.732.732H4.732A2.01 2.01 0 0 0 4 19.268V4.732A2.01 2.01 0 0 0 4.732 4z" /></SVG>
 );

--- a/packages/editor/src/components/convert-to-group-buttons/icons.js
+++ b/packages/editor/src/components/convert-to-group-buttons/icons.js
@@ -3,17 +3,11 @@
  */
 import { Icon, SVG, Path } from '@wordpress/components';
 
-const GroupSVG = <SVG width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-	<Path fillRule="evenodd" clipRule="evenodd" d="M10 4H18C19.1 4 20 4.9 20 6V14C20 15.1 19.1 16 18 16H10C8.9 16 8 15.1 8 14V6C8 4.9 8.9 4 10 4ZM10 14H18V6H10V14Z" />
-	<Path d="M6 8C4.9 8 4 8.9 4 10V18C4 19.1 4.9 20 6 20H14C15.1 20 16 19.1 16 18H6V8Z" />
-</SVG>;
+const GroupSVG = <SVG width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><Path fill-rule="evenodd" clip-rule="evenodd" d="M8 5a1 1 0 0 0-1 1v3H6a1 1 0 0 0-1 1v4a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1v-3h1a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1H8zm3 6H7v2h4v-2zM9 9V7h4v2H9z" /><Path fill-rule="evenodd" clip-rule="evenodd" d="M1 3a2 2 0 0 0 1 1.732v10.536A2 2 0 1 0 4.732 18h10.536A2 2 0 1 0 18 15.268V4.732A2 2 0 1 0 15.268 2H4.732A2 2 0 0 0 1 3zm14.268 1H4.732A2.01 2.01 0 0 1 4 4.732v10.536c.304.175.557.428.732.732h10.536a2.01 2.01 0 0 1 .732-.732V4.732A2.01 2.01 0 0 1 15.268 4z" /></SVG>;
 
 export const Group = <Icon icon={ GroupSVG } />;
 
-const UngroupSVG = <SVG width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-	<Path fillRule="evenodd" clipRule="evenodd" d="M12 2H20C21.1 2 22 2.9 22 4V12C22 13.1 21.1 14 20 14H12C10.9 14 10 13.1 10 12V4C10 2.9 10.9 2 12 2ZM12 12H20V4H12V12Z" />
-	<Path d="M4 10H8V12H4V20H12V16H14V20C14 21.1 13.1 22 12 22H4C2.9 22 2 21.1 2 20V12C2 10.9 2.9 10 4 10Z" />
-</SVG>;
+const UngroupSVG = <SVG width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><Path fill-rule="evenodd" clip-rule="evenodd" d="M9 2H15C16.1 2 17 2.9 17 4V7C17 8.1 16.1 9 15 9H9C7.9 9 7 8.1 7 7V4C7 2.9 7.9 2 9 2ZM9 7H15V4H9V7Z" /><Path fill-rule="evenodd" clip-rule="evenodd" d="M5 11H11C12.1 11 13 11.9 13 13V16C13 17.1 12.1 18 11 18H5C3.9 18 3 17.1 3 16V13C3 11.9 3.9 11 5 11ZM5 16H11V13H5V16Z" /></SVG>;
 
 export const Ungroup = <Icon icon={ UngroupSVG } />;
 


### PR DESCRIPTION
Closes #15602. Followup from #14908. 

This PR replaces the Group and Ungroup icons with those decided on in https://github.com/WordPress/gutenberg/issues/15602#issuecomment-497697933. It replaces both the action icons in the ellipsis menu, and also the Group block icon itself for consistency. 

**Screenshots**

<img width="657" alt="Screen Shot 2019-06-05 at 8 32 56 AM" src="https://user-images.githubusercontent.com/1202812/58956939-94d9d680-876d-11e9-8eaa-a40655b3c121.png">

<img width="650" alt="Screen Shot 2019-06-05 at 8 32 33 AM" src="https://user-images.githubusercontent.com/1202812/58956940-94d9d680-876d-11e9-98e4-08b28429b64b.png">


<img width="628" alt="Screen Shot 2019-06-05 at 8 30 26 AM" src="https://user-images.githubusercontent.com/1202812/58956925-8d1a3200-876d-11e9-85b3-c864d5fcf95c.png">

<img width="639" alt="Screen Shot 2019-06-05 at 8 41 21 AM" src="https://user-images.githubusercontent.com/1202812/58956995-b6d35900-876d-11e9-82f4-f2a647374380.png">
