### PR TITLE
Fix: Gallery does not link to full size images

### DIFF
--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -13,6 +13,11 @@
 					"selector": "img",
 					"attribute": "src"
 				},
+				"fullUrl": {
+					"source": "attribute",
+					"selector": "img",
+					"attribute": "data-full-url"
+				},
 				"link": {
 					"source": "attribute",
 					"selector": "img",

--- a/packages/block-library/src/gallery/save.js
+++ b/packages/block-library/src/gallery/save.js
@@ -17,14 +17,23 @@ export default function save( { attributes } ) {
 
 				switch ( linkTo ) {
 					case 'media':
-						href = image.url;
+						href = image.fullUrl || image.url;
 						break;
 					case 'attachment':
 						href = image.link;
 						break;
 				}
 
-				const img = <img src={ image.url } alt={ image.alt } data-id={ image.id } data-link={ image.link } className={ image.id ? `wp-image-${ image.id }` : null } />;
+				const img = (
+					<img
+						src={ image.url }
+						alt={ image.alt }
+						data-id={ image.id }
+						data-full-url={ image.fullUrl }
+						data-link={ image.link }
+						className={ image.id ? `wp-image-${ image.id }` : null }
+					/>
+				);
 
 				return (
 					<li key={ image.id || image.url } className="blocks-gallery-item">

--- a/packages/block-library/src/gallery/shared.js
+++ b/packages/block-library/src/gallery/shared.js
@@ -10,5 +10,9 @@ export function defaultColumnsNumber( attributes ) {
 export const pickRelevantMediaFiles = ( image ) => {
 	const imageProps = pick( image, [ 'alt', 'id', 'link', 'caption' ] );
 	imageProps.url = get( image, [ 'sizes', 'large', 'url' ] ) || get( image, [ 'media_details', 'sizes', 'large', 'source_url' ] ) || image.url;
+	const fullUrl = get( image, [ 'sizes', 'full', 'url' ] ) || get( image, [ 'media_details', 'sizes', 'full', 'source_url' ] );
+	if ( fullUrl ) {
+		imageProps.fullUrl = fullUrl;
+	}
 	return imageProps;
 };


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/13398

Currently, when we select a link Media File for the gallery, each image links to large size, that size is one already being seen by the user, the correct link to use should be the full-size image.
Classic editor galleries use the full-size image, and the image block too.
This PR makes sure full-size images are used.

We are changing the save and attributes logic but we don't need to add a deprecation because we are still compatibility with the previous gallery.
That compatibility is ensured because when "link to" is set to "media file" and the fullUrl attribute is not set we fall back to the image URL the value that was previously used.


## How has this been tested?
I added some galleries I verified that when the "link to" option is set to "media file" the gallery links to full-size images.
I changed the galleries above to link to "attachment page" I saved and I reloaded the page, I changed "link to" to "media file" again. I verified the gallery still links to full-size images.
I created some galleries using Gutenberg master (including some galleries that link to "media file" ). I opened the post and verified there were no invalid blocks.

