### PR TITLE
Add option to add text color to specific text inside RichText

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10533,6 +10533,7 @@
 				"@babel/runtime": "^7.8.3",
 				"@wordpress/block-editor": "file:packages/block-editor",
 				"@wordpress/components": "file:packages/components",
+				"@wordpress/data": "file:packages/data",
 				"@wordpress/dom": "file:packages/dom",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/html-entities": "file:packages/html-entities",

--- a/packages/block-editor/src/components/rich-text/format-toolbar/index.js
+++ b/packages/block-editor/src/components/rich-text/format-toolbar/index.js
@@ -19,12 +19,14 @@ const FormatToolbar = () => {
 	return (
 		<div className="block-editor-format-toolbar">
 			<Toolbar>
-				{ [ 'bold', 'italic', 'link' ].map( ( format ) => (
-					<Slot
-						name={ `RichText.ToolbarControls.${ format }` }
-						key={ format }
-					/>
-				) ) }
+				{ [ 'bold', 'italic', 'link', 'text-color' ].map(
+					( format ) => (
+						<Slot
+							name={ `RichText.ToolbarControls.${ format }` }
+							key={ format }
+						/>
+					)
+				) }
 				<Slot name="RichText.ToolbarControls">
 					{ ( fills ) =>
 						fills.length !== 0 && (

--- a/packages/format-library/package.json
+++ b/packages/format-library/package.json
@@ -24,6 +24,7 @@
 		"@babel/runtime": "^7.8.3",
 		"@wordpress/block-editor": "file:../block-editor",
 		"@wordpress/components": "file:../components",
+		"@wordpress/data": "file:../data",
 		"@wordpress/dom": "file:../dom",
 		"@wordpress/element": "file:../element",
 		"@wordpress/html-entities": "file:../html-entities",

--- a/packages/format-library/src/default-formats.js
+++ b/packages/format-library/src/default-formats.js
@@ -8,5 +8,15 @@ import { italic } from './italic';
 import { link } from './link';
 import { strikethrough } from './strikethrough';
 import { underline } from './underline';
+import { textColor } from './text-color';
 
-export default [ bold, code, image, italic, link, strikethrough, underline ];
+export default [
+	bold,
+	code,
+	image,
+	italic,
+	link,
+	strikethrough,
+	underline,
+	textColor,
+];

--- a/packages/format-library/src/style.scss
+++ b/packages/format-library/src/style.scss
@@ -1,2 +1,3 @@
 @import "./image/style.scss";
 @import "./link/style.scss";
+@import "./text-color/style.scss";

--- a/packages/format-library/src/text-color/index.js
+++ b/packages/format-library/src/text-color/index.js
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { useCallback, useMemo, useState } from '@wordpress/element';
+import { RichTextToolbarButton } from '@wordpress/block-editor';
+import { Dashicon } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { default as InlineColorUI, getActiveColor } from './inline';
+
+const name = 'core/text-color';
+const title = __( 'Text Color' );
+
+const EMPTY_ARRAY = [];
+
+function TextColorEdit( { value, onChange, isActive, activeAttributes } ) {
+	const colors = useSelect( ( select ) => {
+		const { getSettings } = select( 'core/block-editor' );
+		if ( getSettings ) {
+			return get( getSettings(), [ 'colors' ], EMPTY_ARRAY );
+		}
+		return EMPTY_ARRAY;
+	} );
+	const [ isAddingColor, setIsAddingColor ] = useState( false );
+	const enableIsAddingColor = useCallback( () => setIsAddingColor( true ), [
+		setIsAddingColor,
+	] );
+	const disableIsAddingColor = useCallback( () => setIsAddingColor( false ), [
+		setIsAddingColor,
+	] );
+	const colorIndicatorStyle = useMemo( () => {
+		const activeColor = getActiveColor( name, value, colors );
+		if ( ! activeColor ) {
+			return undefined;
+		}
+		return {
+			backgroundColor: activeColor,
+		};
+	}, [ value, colors ] );
+	return (
+		<>
+			<RichTextToolbarButton
+				key={ isActive ? 'text-color' : 'text-color-not-active' }
+				className="format-library-text-color-button"
+				name={ isActive ? 'text-color' : undefined }
+				icon={
+					<>
+						<Dashicon icon="editor-textcolor" />
+						{ isActive && (
+							<span
+								className="format-library-text-color-button__indicator"
+								style={ colorIndicatorStyle }
+							/>
+						) }
+					</>
+				}
+				title={ title }
+				onClick={ enableIsAddingColor }
+			/>
+			{ isAddingColor && (
+				<InlineColorUI
+					name={ name }
+					addingColor={ isAddingColor }
+					onClose={ disableIsAddingColor }
+					isActive={ isActive }
+					activeAttributes={ activeAttributes }
+					value={ value }
+					onChange={ onChange }
+				/>
+			) }
+		</>
+	);
+}
+
+export const textColor = {
+	name,
+	title,
+	tagName: 'span',
+	className: 'has-inline-color',
+	attributes: {
+		style: 'style',
+		class: 'class',
+	},
+	edit: TextColorEdit,
+};

--- a/packages/format-library/src/text-color/inline.js
+++ b/packages/format-library/src/text-color/inline.js
@@ -1,0 +1,137 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { withSpokenMessages } from '@wordpress/components';
+import { getRectangleFromRange } from '@wordpress/dom';
+import {
+	applyFormat,
+	removeFormat,
+	getActiveFormat,
+} from '@wordpress/rich-text';
+import {
+	ColorPalette,
+	URLPopover,
+	getColorClassName,
+	getColorObjectByColorValue,
+	getColorObjectByAttributeValues,
+} from '@wordpress/block-editor';
+
+export function getActiveColor( formatName, formatValue, colors ) {
+	const activeColorFormat = getActiveFormat( formatValue, formatName );
+	if ( ! activeColorFormat ) {
+		return;
+	}
+	const styleColor = activeColorFormat.attributes.style;
+	if ( styleColor ) {
+		return styleColor.replace( new RegExp( `^color:\\s*` ), '' );
+	}
+	const currentClass = activeColorFormat.attributes.class;
+	if ( currentClass ) {
+		const colorSlug = currentClass.replace( /.*has-(.*?)-color.*/, '$1' );
+		return getColorObjectByAttributeValues( colors, colorSlug ).color;
+	}
+}
+
+const ColorPopoverAtLink = ( { isActive, addingColor, value, ...props } ) => {
+	const anchorRect = useMemo( () => {
+		const selection = window.getSelection();
+		const range =
+			selection.rangeCount > 0 ? selection.getRangeAt( 0 ) : null;
+		if ( ! range ) {
+			return;
+		}
+
+		if ( addingColor ) {
+			return getRectangleFromRange( range );
+		}
+
+		let element = range.startContainer;
+
+		// If the caret is right before the element, select the next element.
+		element = element.nextElementSibling || element;
+
+		while ( element.nodeType !== window.Node.ELEMENT_NODE ) {
+			element = element.parentNode;
+		}
+
+		const closest = element.closest( 'span' );
+		if ( closest ) {
+			return closest.getBoundingClientRect();
+		}
+	}, [ isActive, addingColor, value.start, value.end ] );
+
+	if ( ! anchorRect ) {
+		return null;
+	}
+
+	return <URLPopover anchorRect={ anchorRect } { ...props } />;
+};
+
+const ColorPicker = ( { name, value, onChange } ) => {
+	const colors = useSelect( ( select ) => {
+		const { getSettings } = select( 'core/block-editor' );
+		return get( getSettings(), [ 'colors' ], [] );
+	} );
+	const onColorChange = useCallback(
+		( color ) => {
+			if ( color ) {
+				const colorObject = getColorObjectByColorValue( colors, color );
+				onChange(
+					applyFormat( value, {
+						type: name,
+						attributes: colorObject
+							? {
+									class: getColorClassName(
+										'color',
+										colorObject.slug
+									),
+							  }
+							: {
+									style: `color:${ color }`,
+							  },
+					} )
+				);
+			} else {
+				onChange( removeFormat( value, name ) );
+			}
+		},
+		[ colors, onChange ]
+	);
+	const activeColor = useMemo( () => getActiveColor( name, value, colors ), [
+		name,
+		value,
+		colors,
+	] );
+
+	return <ColorPalette value={ activeColor } onChange={ onColorChange } />;
+};
+
+const InlineColorUI = ( {
+	name,
+	value,
+	onChange,
+	onClose,
+	isActive,
+	addingColor,
+} ) => {
+	return (
+		<ColorPopoverAtLink
+			value={ value }
+			isActive={ isActive }
+			addingColor={ addingColor }
+			onClose={ onClose }
+			className="components-inline-color-popover"
+		>
+			<ColorPicker name={ name } value={ value } onChange={ onChange } />
+		</ColorPopoverAtLink>
+	);
+};
+
+export default withSpokenMessages( InlineColorUI );

--- a/packages/format-library/src/text-color/style.scss
+++ b/packages/format-library/src/text-color/style.scss
@@ -1,0 +1,43 @@
+.components-inline-color__indicator {
+	position: absolute;
+	background: #000;
+	height: 3px;
+	width: 20px;
+	bottom: 6px;
+	left: auto;
+	right: auto;
+	margin: 0 5px;
+}
+
+.components-inline-color-popover {
+
+	.components-popover__content {
+		padding: 20px 18px;
+
+		.components-color-palette {
+			margin-top: 0.6rem;
+		}
+
+		.components-base-control__title {
+			display: block;
+			margin-bottom: 16px;
+			font-weight: 600;
+			color: #191e23;
+		}
+
+		.component-color-indicator {
+			vertical-align: text-bottom;
+		}
+	}
+}
+
+.format-library-text-color-button {
+	position: relative;
+}
+.format-library-text-color-button__indicator {
+	height: 4px;
+	width: 20px;
+	position: absolute;
+	bottom: 6px;
+	left: 8px;
+}


### PR DESCRIPTION
## Description
Add text color toolbar for https://github.com/WordPress/gutenberg/issues/15899 and https://github.com/WordPress/gutenberg/issues/13778

## How has this been tested?
Tested on Gutenberg 5.8.0 and WordPress 5.2.1

## Screenshots <!-- if applicable -->
![Screen Capture on 2019-06-06 at 12-42-34](https://user-images.githubusercontent.com/3365507/59007399-cbd8e680-8858-11e9-8f2b-c9e43dc8a883.gif)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
