### PR TITLE
[RNMobile] Fix crash when deleting all content of RichText based block

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -396,7 +396,6 @@ export class RichText extends Component {
 		if ( start === 0 && end !== 0 && end >= value.text.length ) {
 			newValue = remove( value, start, end );
 			this.props.onChange( newValue );
-			this.forceSelectionUpdate( 0, 0 );
 			return;
 		}
 


### PR DESCRIPTION
`forceSelectionUpdate` definition was removed, but there was still this one line calling it.

To test:
- Test remove all content from: (test on both Android and iOS)
  - Heading block
  - Paragraph block
  - List block
  - Quote block