### PR TITLE
Adds an is-busy state to the save button of the widgets page

### DIFF
--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -1,12 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { compose } from '@wordpress/compose';
-import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { withDispatch } from '@wordpress/data';
 
-function Header( { saveWidgetAreas } ) {
+/**
+ * Internal dependencies
+ */
+import SaveButton from '../save-button';
+
+function Header() {
 	return (
 		<div
 			className="edit-widgets-header"
@@ -19,20 +21,10 @@ function Header( { saveWidgetAreas } ) {
 			</h1>
 
 			<div className="edit-widgets-header__actions">
-				<Button isPrimary isLarge onClick={ saveWidgetAreas }>
-					{ __( 'Update' ) }
-				</Button>
+				<SaveButton />
 			</div>
 		</div>
 	);
 }
 
-export default compose( [
-	withDispatch( ( dispatch ) => {
-		const { saveWidgetAreas } = dispatch( 'core/edit-widgets' );
-		return {
-			saveWidgetAreas,
-		};
-	} ),
-] )( Header );
-
+export default Header;

--- a/packages/edit-widgets/src/components/save-button/index.js
+++ b/packages/edit-widgets/src/components/save-button/index.js
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useDispatch } from '@wordpress/data';
+import { useState, useCallback } from '@wordpress/element';
+
+function SaveButton() {
+	const [ isSaving, setIsSaving ] = useState( false );
+	const { saveWidgetAreas } = useDispatch( 'core/edit-widgets' );
+	const onClick = useCallback( async () => {
+		setIsSaving( true );
+		await saveWidgetAreas();
+		setIsSaving( false );
+	}, [] );
+
+	return (
+		<Button
+			isPrimary
+			isLarge
+			isBusy={ isSaving }
+			aria-disabled={ isSaving }
+			onClick={ isSaving ? undefined : onClick }
+		>
+			{ __( 'Update' ) }
+		</Button>
+	);
+}
+
+export default SaveButton;


### PR DESCRIPTION
This PR just updates the save button of the widgets screen to apply the `is-busy` and `aria-disabled` states when the widgets are being saved.

I also extracted the button to its own component. Notice that the design of the busy state is not great at the moment but this is not specific to the widgets screen and is tracked separately.

I also wanted to add "snackbar notifications" to the save success action but decided to that separately?