### PR TITLE
[RNMobile] Fix for extra BR tag on Title field on Android

### DIFF
--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { View } from 'react-native';
+import { View, Platform } from 'react-native';
 import { isEmpty } from 'lodash';
 
 /**
@@ -31,6 +31,8 @@ class PostTitle extends Component {
 		this.state = {
 			isSelected: false,
 		};
+
+		this.isIOS = Platform.OS === 'ios';
 	}
 
 	componentDidMount() {
@@ -96,6 +98,10 @@ class PostTitle extends Component {
 					fontSize={ 24 }
 					fontWeight={ 'bold' }
 					onChange={ ( value ) => {
+						if ( ! this.isIOS ) {
+							const extraBRTagRegexp = RegExp( '<br>$', 'gim' );
+							value = value.replace( extraBRTagRegexp, '' );
+						}
 						this.props.onUpdate( value );
 					} }
 					placeholder={ decodedPlaceholder }

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { View, Platform } from 'react-native';
+import { View } from 'react-native';
 import { isEmpty } from 'lodash';
 
 /**
@@ -31,8 +31,6 @@ class PostTitle extends Component {
 		this.state = {
 			isSelected: false,
 		};
-
-		this.isIOS = Platform.OS === 'ios';
 	}
 
 	componentDidMount() {
@@ -97,11 +95,8 @@ class PostTitle extends Component {
 					style={ style }
 					fontSize={ 24 }
 					fontWeight={ 'bold' }
+					deleteEnter={ true }
 					onChange={ ( value ) => {
-						if ( ! this.isIOS ) {
-							const extraBRTagRegexp = RegExp( '<br>$', 'gim' );
-							value = value.replace( extraBRTagRegexp, '' );
-						}
 						this.props.onUpdate( value );
 					} }
 					placeholder={ decodedPlaceholder }


### PR DESCRIPTION
This PR is a fix for https://github.com/wordpress-mobile/gutenberg-mobile/issues/1078  _(Pressing enter on the title creates a BR tag)_
It does set the proper props to instruct AztecWrapper on Android to remove the new line char ( converted to BR on HTML ) when Enter.key is pressed on the keyboard.

GB-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1095