### PR TITLE
Block Library: Implement pass-through behavior for Column block

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -400,6 +400,15 @@ function BlockListBlock( {
 		className
 	);
 
+	// By default, a block is focusable, which enables it to be set as the
+	// selected block when the user interacts within its content. Through
+	// assignment of its wrapper props, however, a block can opt-out of this
+	// behavior to effectively treat the block as a "pass-through", one which
+	// is not intended to be directly selected under normal circumstances.
+	// Often this occurs in the context of deep block nesting, where focus
+	// selection instead occurs by one of the ancestor blocks.
+	let isFocusable = true;
+
 	// Determine whether the block has props to apply to the wrapper.
 	let blockWrapperProps = wrapperProps;
 	if ( blockType.getEditWrapperProps ) {
@@ -407,6 +416,11 @@ function BlockListBlock( {
 			...blockWrapperProps,
 			...blockType.getEditWrapperProps( attributes ),
 		};
+
+		isFocusable = ! ( 'tabIndex' in blockWrapperProps ) || (
+			isFinite( blockWrapperProps.tabIndex ) &&
+			Number( blockWrapperProps.tabIndex ) !== '-1'
+		);
 	}
 	const blockElementId = `block-${ clientId }`;
 
@@ -452,7 +466,7 @@ function BlockListBlock( {
 			className={ wrapperClassName }
 			data-type={ name }
 			onTouchStart={ onTouchStart }
-			onFocus={ onFocus }
+			onFocus={ isFocusable ? onFocus : null }
 			onClick={ onTouchStop }
 			onKeyDown={ deleteOrInsertAfterWrapper }
 			tabIndex="0"

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -419,7 +419,7 @@ function BlockListBlock( {
 
 		isFocusable = ! ( 'tabIndex' in blockWrapperProps ) || (
 			isFinite( blockWrapperProps.tabIndex ) &&
-			Number( blockWrapperProps.tabIndex ) !== '-1'
+			Number( blockWrapperProps.tabIndex ) !== -1
 		);
 	}
 	const blockElementId = `block-${ clientId }`;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -316,6 +316,16 @@
 		}
 	}
 
+	// Disable clickthrough overlay for blocks which aren't focusable, since
+	// overlay depends on dismissal by selection. This effectively treats the
+	// block as a "pass-through", one which is not intended to be selected
+	// through standard focus interactions.
+	&[tabindex="-1"],
+	&:not([tabindex]) {
+		> .block-editor-block-list__block-edit .block-editor-inner-blocks.has-overlay::after {
+			display: none;
+		}
+	}
 
 	// Alignments
 	&[data-align="left"],

--- a/packages/block-library/src/column/index.js
+++ b/packages/block-library/src/column/index.js
@@ -27,13 +27,20 @@ export const settings = {
 	},
 	getEditWrapperProps( attributes ) {
 		const { width } = attributes;
+
+		// A column should act as a "pass-through", meaning that it cannot be
+		// selected by typical focus interactions. A block becomes selected by
+		// virtue of its focus handler, and by nullifying its tabIndex, it will
+		// no longer handle focus events.
+		const props = { tabIndex: undefined };
+
 		if ( Number.isFinite( width ) ) {
-			return {
-				style: {
-					flexBasis: width + '%',
-				},
+			props.style = {
+				flexBasis: width + '%',
 			};
 		}
+
+		return props;
 	},
 	edit,
 	save,


### PR DESCRIPTION
Related: #15927 
Closes #7694
Partially addresses #15660

This pull request seeks to implement a "pass-through" behavior for blocks.

It is implemented as two parts:

- Anticipate wrapper props which disable a block's ability to be focused by bypassing the default selection behavior (allow the event to propagate to an assumed ancestor).
- Assign as a prop of the Column block wrapper to disable focus in Column block.

With these changes, it should become impossible to select a Column block either by clicking on it, or by using arrow keys to navigate blocks. It is technically still possible to select a Column block via the Block Navigation menu. I don't personally have an issue with this, since the block is technically still present, and the primary motivation is in solving the usability problems around standard selection interactions (which this achieves).

**_Blocked:_** While this pull request is considered complete so far as implementing the pass-through behavior, it would need to be merged only in combination with a separate pull request which would recreate the existing Column attributes customizations of widths and vertical alignment assignment. My plan is to create separate pull requests for these distinct efforts, and merge them all at once only when they have each been approved.

**Testing Instructions:**

Verify that click and arrow key navigation to a Column block is not possible, but that otherwise behaviors are unaffected:

- Click-through behavior implemented in #15537 
- Columns selection
- Selection of blocks within a Column
- "Focus" selection of various block types (e.g. Paragraph, Image, Code blocks each have distinct selection behaviors worth validating)