### PR TITLE
Fix `npm run docs:build` on Windows environments

### DIFF
--- a/bin/update-readmes.js
+++ b/bin/update-readmes.js
@@ -1,5 +1,6 @@
-#!/usr/bin/env node
-
+/**
+ * Node dependencies.
+ */
 const { join } = require( 'path' );
 const spawnSync = require( 'child_process' ).spawnSync;
 

--- a/docs/tool/index.js
+++ b/docs/tool/index.js
@@ -3,7 +3,7 @@
  */
 const fs = require( 'fs' );
 const { join } = require( 'path' );
-const { execSync } = require( 'child_process' );
+const { execFileSync } = require( 'child_process' );
 const path = require( 'path' );
 
 /**
@@ -15,7 +15,7 @@ const tocFileInput = path.resolve( __dirname, '../toc.json' );
 const manifestOutput = path.resolve( __dirname, '../manifest-devhub.json' );
 
 // Update data files from code
-execSync( join( __dirname, 'update-data.js' ) );
+execFileSync( 'node', [ join( __dirname, 'update-data.js' ) ] );
 
 // Process TOC file and generate manifest handbook
 fs.writeFileSync( manifestOutput, JSON.stringify( getRootManifest( tocFileInput ), undefined, '\t' ) );

--- a/docs/tool/update-data.js
+++ b/docs/tool/update-data.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 const { join } = require( 'path' );
 const spawnSync = require( 'child_process' ).spawnSync;
 

--- a/docs/tool/update-data.js
+++ b/docs/tool/update-data.js
@@ -1,3 +1,6 @@
+/**
+ * Node dependencies.
+ */
 const { join } = require( 'path' );
 const spawnSync = require( 'child_process' ).spawnSync;
 

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
 		"predev": "npm run check-engines",
 		"dev": "npm run build:packages && concurrently \"wp-scripts start\" \"npm run dev:packages\"",
 		"dev:packages": "node ./bin/packages/watch.js",
-		"docs:build": "node ./docs/tool && node ./bin/update-readmes",
+		"docs:build": "node ./docs/tool/index.js && node ./bin/update-readmes.js",
 		"fixtures:clean": "rimraf \"packages/e2e-tests/fixtures/blocks/*.+(json|serialized.html)\"",
 		"fixtures:server-registered": "docker-compose run -w /var/www/html/wp-content/plugins/gutenberg --rm wordpress ./bin/get-server-blocks.php > test/integration/full-content/server-registered.json",
 		"fixtures:generate": "npm run fixtures:server-registered && cross-env GENERATE_MISSING_FIXTURES=y npm run test-unit",

--- a/package.json
+++ b/package.json
@@ -224,10 +224,10 @@
 			"wp-scripts lint-js"
 		],
 		"{docs/{toc.json,tool/*.js},packages/{*/README.md,*/src/{actions,selectors}.js,components/src/*/**/README.md}}": [
-			"node ./docs/tool"
+			"node ./docs/tool/index.js"
 		],
 		"packages/**/*.js": [
-			"node ./bin/update-readmes"
+			"node ./bin/update-readmes.js"
 		]
 	}
 }

--- a/packages/docgen/CHANGELOG.md
+++ b/packages/docgen/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.1 (Unreleased)
+
+### Bug Fixes
+
+- Docblocks with CRLF endings are now parsed correctly.
+
 ## 1.2.0 (2019-05-21)
 
 ### Enhancement

--- a/packages/docgen/src/get-jsdoc-from-token.js
+++ b/packages/docgen/src/get-jsdoc-from-token.js
@@ -20,7 +20,7 @@ const getTypeAsString = require( './get-type-as-string' );
 module.exports = function( token ) {
 	let jsdoc;
 	const comments = getLeadingComments( token );
-	if ( comments && comments.startsWith( '*\n' ) ) {
+	if ( comments && /^\*\r?\n/.test( comments ) ) {
 		jsdoc = doctrine.parse( comments, {
 			unwrap: true,
 			recoverable: true,


### PR DESCRIPTION
Windows environments do not support shebang (#!) scripts. This caused `npm run docs:build` to error when running it on Windows, see https://github.com/WordPress/gutenberg/pull/15956#issuecomment-498259445.

The fix is to run `node docs/tool/update-data.js` instead of running `./docs/tool/update-data.js`.

I tested this by starting a Windows environment in VirtualBox, installing Node.js, downloading Gutenberg, and then running:

```
npm install
npm run docs:build
```

The command exited without error.