### PR TITLE
[Mobile]Open video/quote/more blocks to public

### DIFF
--- a/packages/edit-post/src/index.native.js
+++ b/packages/edit-post/src/index.native.js
@@ -22,9 +22,6 @@ export function initializeEditor() {
 	// eslint-disable-next-line no-undef
 	if ( typeof __DEV__ === 'undefined' || ! __DEV__ ) {
 		unregisterBlockType( 'core/code' );
-		unregisterBlockType( 'core/more' );
-		unregisterBlockType( 'core/video' );
-		unregisterBlockType( 'core/quote' );
 	}
 }
 

--- a/packages/edit-post/src/index.native.js
+++ b/packages/edit-post/src/index.native.js
@@ -18,7 +18,7 @@ export function initializeEditor() {
 	// register and setup blocks
 	registerCoreBlocks();
 
-	// disable Code and More blocks for the release
+	// disable Code block for the release
 	// eslint-disable-next-line no-undef
 	if ( typeof __DEV__ === 'undefined' || ! __DEV__ ) {
 		unregisterBlockType( 'core/code' );


### PR DESCRIPTION
## Description

This PR makes video/quote/more blocks publicly available

## How has this been tested?

Tested with steps on gutenberg mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1094

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
