### PR TITLE
Docs: Change register_meta to register_post_meta

### DIFF
--- a/docs/designers-developers/developers/block-api/block-attributes.md
+++ b/docs/designers-developers/developers/block-api/block-attributes.md
@@ -172,7 +172,7 @@ By default, a meta field will be excluded from a post object's meta. This can be
 
 ```php
 function gutenberg_my_block_init() {
-	register_meta( 'post', 'author', array(
+	register_post_meta( 'post', 'author', array(
 		'show_in_rest' => true,
 	) );
 }
@@ -184,11 +184,11 @@ Furthermore, be aware that WordPress defaults to:
 - not treating a meta datum as being unique, instead returning an array of values;
 - treating that datum as a string.
 
-If either behavior is not desired, the same `register_meta` call can be complemented with the `single` and/or `type` parameters as follows:
+If either behavior is not desired, the same `register_post_meta` call can be complemented with the `single` and/or `type` parameters as follows:
 
 ```php
 function gutenberg_my_block_init() {
-	register_meta( 'post', 'author_count', array(
+	register_post_meta( 'post', 'author_count', array(
 		'show_in_rest' => true,
 		'single' => true,
 		'type' => 'integer',

--- a/docs/designers-developers/developers/tutorials/metabox/meta-block-2-register-meta.md
+++ b/docs/designers-developers/developers/tutorials/metabox/meta-block-2-register-meta.md
@@ -2,7 +2,7 @@
 
 A post meta field is a WordPress object used to store extra data about a post. You need to first register a new meta field prior to use. See Managing [Post Metadata](https://developer.wordpress.org/plugins/metadata/managing-post-metadata/) to learn more about post meta.
 
-When registering the field, note the `show_in_rest` parameter. This ensures the data will be included in the REST API, which the block editor uses to load and save meta data. See the [`register_meta`](https://developer.wordpress.org/reference/functions/register_meta/) function definition for extra information.
+When registering the field, note the `show_in_rest` parameter. This ensures the data will be included in the REST API, which the block editor uses to load and save meta data. See the [`register_post_meta`](https://developer.wordpress.org/reference/functions/register_post_meta/) function definition for extra information.
 
 To register the field, create a PHP plugin file called `myguten-meta-block.php` including:
 
@@ -13,20 +13,20 @@ To register the field, create a PHP plugin file called `myguten-meta-block.php` 
  */
 
 // register custom meta tag field
-function myguten_register_meta() {
-	register_meta( 'post', 'myguten_meta_block_field', array(
+function myguten_register_post_meta() {
+	register_post_meta( 'post', 'myguten_meta_block_field', array(
 		'show_in_rest' => true,
 		'single' => true,
 		'type' => 'string',
 	) );
 }
-add_action( 'init', 'myguten_register_meta' );
+add_action( 'init', 'myguten_register_post_meta' );
 ```
 
-**Note:** If the meta key name starts with an underscore WordPress considers it a protected field. Editing this field requires passing a permission check, which is set as the `auth_callback` in the `register_meta` function. Here is an example:
+**Note:** If the meta key name starts with an underscore WordPress considers it a protected field. Editing this field requires passing a permission check, which is set as the `auth_callback` in the `register_post_meta` function. Here is an example:
 
 ```php
-register_meta( 'post', '_myguten_protected_key', array(
+register_post_meta( 'post', '_myguten_protected_key', array(
 	'show_in_rest' => true,
 	'single' => true,
 	'type' => 'string',

--- a/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-3-register-meta.md
+++ b/docs/designers-developers/developers/tutorials/sidebar-tutorial/plugin-sidebar-3-register-meta.md
@@ -1,11 +1,11 @@
 # Register the Meta Field
 
-To work with fields in the `post_meta` table, WordPress has a function called [register_meta](https://developer.wordpress.org/reference/functions/register_meta/). You're going to use it to register a new field called `sidebar_plugin_meta_block_field`, which will be a single string. Note that this field needs to be available through the [REST API](https://developer.wordpress.org/rest-api/) because that's how the block editor access data.
+To work with fields in the `post_meta` table, WordPress has a function called [register_post_meta](https://developer.wordpress.org/reference/functions/register_post_meta/). You're going to use it to register a new field called `sidebar_plugin_meta_block_field`, which will be a single string. Note that this field needs to be available through the [REST API](https://developer.wordpress.org/rest-api/) because that's how the block editor access data.
 
 Add this to the PHP code, within the `init` callback function:
 
 ```php
-register_meta( 'post', 'sidebar_plugin_meta_block_field', array(
+register_post_meta( 'post', 'sidebar_plugin_meta_block_field', array(
 	'show_in_rest' => true,
 	'single' => true,
 	'type' => 'string',
@@ -18,4 +18,4 @@ To make sure the field has been loaded, query the block editor [internal data st
 wp.data.select( 'core/editor' ).getCurrentPost().meta;
 ```
 
-Before adding the `register_meta` function to the plugin, this code returns a void array, because WordPress hasn't been told to load any meta field yet. After registering the field, the same code will return an object containing the registered meta field you registered.
+Before adding the `register_post_meta` function to the plugin, this code returns a void array, because WordPress hasn't been told to load any meta field yet. After registering the field, the same code will return an object containing the registered meta field you registered.


### PR DESCRIPTION
## Description
Changes the function `register_meta` to `register_post_meta` (added in WP 4.9.8) in the docs. This function is more specific and intuitive for developers. Fore more details see #16025

Fixes #16025