### PR TITLE
Remove @wordpress/format-library dependency from edit-post

### DIFF
--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -33,7 +33,6 @@
 		"@wordpress/data": "file:../data",
 		"@wordpress/editor": "file:../editor",
 		"@wordpress/element": "file:../element",
-		"@wordpress/format-library": "file:../format-library",
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/keycodes": "file:../keycodes",


### PR DESCRIPTION
## Description
The edit-post does not use the format-library package. The package is loaded by core and calls the correct mechanism to register the formats being used but the edit-post package does not directly depend on format-library.

## How has this been tested?
I checked the formats still work as expected.
