### PR TITLE
[RN Mobile] Fix v1.6.0 crash when pasting on Title Block

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -675,12 +675,9 @@ export class RichText extends Component {
 
 	forceSelectionUpdate( start, end ) {
 		if ( ! this.needsSelectionUpdate ) {
-			if ( isNaN( start ) || isNaN( end ) ) {
-				return;
-			} 
 			this.needsSelectionUpdate = true;
-			this.selectionStart = start;
-			this.selectionEnd = end;
+			this.selectionStart = isNaN( start ) ? 0 : start;
+			this.selectionEnd = isNaN( end ) ? 0 : end;
 			this.forceUpdate();
 		}
 	}
@@ -800,7 +797,10 @@ export class RichText extends Component {
 		let selection = null;
 		if ( this.needsSelectionUpdate ) {
 			this.needsSelectionUpdate = false;
-			selection = { start: this.props.selectionStart, end: this.props.selectionEnd };
+			selection = { 
+				start: isNaN( this.props.selectionStart ) ? 0 : this.props.selectionStart,
+				end: isNaN( this.props.selectionEnd ) ? 0 : this.props.selectionEnd
+			};
 
 			// On AztecAndroid, setting the caret to an out-of-bounds position will crash the editor so, let's check for some cases.
 			if ( ! this.isIOS ) {

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -675,6 +675,9 @@ export class RichText extends Component {
 
 	forceSelectionUpdate( start, end ) {
 		if ( ! this.needsSelectionUpdate ) {
+			if ( isNaN( start ) || isNaN( end ) ) {
+				return;
+			} 
 			this.needsSelectionUpdate = true;
 			this.selectionStart = start;
 			this.selectionEnd = end;


### PR DESCRIPTION
This PR fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1092 by making sure the selection is valid before calling the update on the native layer (Aztec Wrapper).

Note: this does just fix the crash, but not the root cause of it.


GB-mobile side PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1098