### PR TITLE
Update permalink panel text to be 'View [postType]' instead of 'Preview'

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-link/index.js
+++ b/packages/edit-post/src/components/sidebar/post-link/index.js
@@ -30,6 +30,7 @@ function PostLink( {
 	postTitle,
 	postSlug,
 	postID,
+	postTypeLabel,
 } ) {
 	const { prefix, suffix } = permalinkParts;
 	let prefixElement, postNameElement, suffixElement;
@@ -95,7 +96,7 @@ function PostLink( {
 				</div>
 			) }
 			<p className="edit-post-post-link__preview-label">
-				{ __( 'Preview' ) }
+				{ postTypeLabel || __( 'View Post' ) }
 			</p>
 			<ExternalLink
 				className="edit-post-post-link__link"
@@ -148,6 +149,7 @@ export default compose( [
 			postTitle: getEditedPostAttribute( 'title' ),
 			postSlug: getEditedPostAttribute( 'slug' ),
 			postID: id,
+			postTypeLabel: get( postType, [ 'labels', 'view_item' ] ),
 		};
 	} ),
 	ifCondition( ( { isEnabled, isNew, postLink, isViewable, permalinkParts } ) => {


### PR DESCRIPTION
## Description
Fixes #14206 by replacing the text "Preview" in the permalink panel of the document settings with "View X" where X is the post type being edited. Preview can cause some confusion as there is also a "Preview" button at the top of the settings that does something different (generates a preview) where this link is just the currently live page.

## How has this been tested?
Open a Post, see it now says "View Post"
![Post](https://user-images.githubusercontent.com/6653970/59109873-ddc79180-890b-11e9-917e-378fdc030c76.png)

Open a Page, see it now says "View Page"
![Page](https://user-images.githubusercontent.com/6653970/59109886-e750f980-890b-11e9-9215-975a310b76d8.png)

Enable Gutenberg's custom post type plugin, add a PublicQueryPublic custom post, see that it says "View PublicQueryPublic"
![CustomPost](https://user-images.githubusercontent.com/6653970/59109897-ec15ad80-890b-11e9-80b0-18a1ea299291.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->

