### PR TITLE
Update increase tooltip selector specificity

### DIFF
--- a/packages/components/src/tooltip/style.scss
+++ b/packages/components/src/tooltip/style.scss
@@ -12,6 +12,10 @@
 	&.is-bottom::after {
 		border-bottom-color: $dark-gray-900;
 	}
+
+	&:not(.is-mobile) .components-popover__content {
+		min-width: 0;
+	}
 }
 
 .components-tooltip .components-popover__content {
@@ -21,10 +25,6 @@
 	color: $white;
 	white-space: nowrap;
 	text-align: center;
-}
-
-.components-tooltip:not(.is-mobile) .components-popover__content {
-	min-width: 0;
 }
 
 .components-tooltip__shortcut {


### PR DESCRIPTION
## Description
Fix: https://github.com/WordPress/gutenberg/issues/6681
The popover uses a min widget of 270px the tooltip needs to overwrite that style the rule to overwrite the popover style in the tooltip had the same specificity has the one on the popover. This only works because the code order is favorable and we had problems related to that in the past.
This PR just increases the tooltip rule specificity so we are not dependent on code order.
More details can be checked on the issue.

## How has this been tested?
I verified the tooltips and popovers still work as expected.
