### PR TITLE
Block API: Downgrade `convert` API to experimental

### DIFF
--- a/packages/block-library/src/group/index.js
+++ b/packages/block-library/src/group/index.js
@@ -33,7 +33,7 @@ export const settings = {
 				type: 'block',
 				isMultiBlock: true,
 				blocks: [ '*' ],
-				convert( blocks ) {
+				__experimentalConvert( blocks ) {
 					// Avoid transforming a single `core/group` Block
 					if ( blocks.length === 1 && blocks[ 0 ].name === 'core/group' ) {
 						return;

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Added a default implementation for `save` setting in `registerBlockType` which saves no markup in the post content.
 - Added wildcard block transforms which allows for transforming all/any blocks in another block.
-- Added `convert()` method option to `transforms` definition. It receives complete block object(s) as it's argument(s). It is now preferred over the older `transform()` (note that `transform()` is still fully supported).
 
 ## 6.1.0 (2019-03-06)
 

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -404,16 +404,16 @@ export function switchToBlockType( blocks, name ) {
 	let transformationResults;
 
 	if ( transformation.isMultiBlock ) {
-		if ( has( transformation, 'convert' ) ) {
-			transformationResults = transformation.convert( blocksArray );
+		if ( has( transformation, '__experimentalConvert' ) ) {
+			transformationResults = transformation.__experimentalConvert( blocksArray );
 		} else {
 			transformationResults = transformation.transform(
 				blocksArray.map( ( currentBlock ) => currentBlock.attributes ),
 				blocksArray.map( ( currentBlock ) => currentBlock.innerBlocks ),
 			);
 		}
-	} else if ( has( transformation, 'convert' ) ) {
-		transformationResults = transformation.convert( firstBlock );
+	} else if ( has( transformation, '__experimentalConvert' ) ) {
+		transformationResults = transformation.__experimentalConvert( firstBlock );
 	} else {
 		transformationResults = transformation.transform( firstBlock.attributes, firstBlock.innerBlocks );
 	}

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -1301,7 +1301,7 @@ describe( 'block factory', () => {
 			expect( transformedBlocks[ 1 ].innerBlocks[ 0 ].attributes.value ).toBe( 'after1' );
 		} );
 
-		it( 'should pass entire block object(s) to the "convert" method if defined', () => {
+		it( 'should pass entire block object(s) to the "__experimentalConvert" method if defined', () => {
 			registerBlockType( 'core/test-group-block', {
 				attributes: {
 					value: {
@@ -1313,7 +1313,7 @@ describe( 'block factory', () => {
 						type: 'block',
 						blocks: [ '*' ],
 						isMultiBlock: true,
-						convert( blocks ) {
+						__experimentalConvert( blocks ) {
 							const groupInnerBlocks = blocks.map( ( { name, attributes, innerBlocks } ) => {
 								return createBlock( name, attributes, innerBlocks );
 							} );
@@ -1343,7 +1343,7 @@ describe( 'block factory', () => {
 			expect( transformedBlocks[ 0 ].innerBlocks ).toHaveLength( numOfBlocksToGroup );
 		} );
 
-		it( 'should prefer "convert" method over "transform" method when running a transformation', () => {
+		it( 'should prefer "__experimentalConvert" method over "transform" method when running a transformation', () => {
 			const convertSpy = jest.fn( ( blocks ) => {
 				const groupInnerBlocks = blocks.map( ( { name, attributes, innerBlocks } ) => {
 					return createBlock( name, attributes, innerBlocks );
@@ -1364,7 +1364,7 @@ describe( 'block factory', () => {
 						type: 'block',
 						blocks: [ '*' ],
 						isMultiBlock: true,
-						convert: convertSpy,
+						__experimentalConvert: convertSpy,
 						transform: transformSpy,
 					} ],
 				},


### PR DESCRIPTION
Related: #15972, #14908 

This pull request seeks to rename the `convert` transform function introduced in #14908 to be marked as experimental ([see relevant documentation](https://github.com/WordPress/gutenberg/blob/master/docs/contributors/coding-guidelines.md#experimental-and-unstable-apis)), pending further consideration for how it be named or implemented.

**Testing Instructions:**

Repeat Testing Instructions from #14908, verifying no regressions in the behavior of block grouping / ungrouping.