### PR TITLE
Set link text color and link underline from JS

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -797,7 +797,7 @@ export class RichText extends Component {
 						...style,
 						minHeight: Math.max( minHeight, this.state.height ),
 					} }
-					text={ { text: html, eventCount: this.lastEventCount, selection } }
+					text={ { text: html, eventCount: this.lastEventCount, selection, linkTextColor: styles[ 'block-editor-rich-text' ].textDecorationColor } }
 					placeholder={ this.props.placeholder }
 					placeholderTextColor={ this.props.placeholderTextColor || styles[ 'block-editor-rich-text' ].textDecorationColor }
 					deleteEnter={ this.props.deleteEnter }


### PR DESCRIPTION
It is Android update for PR : https://github.com/WordPress/gutenberg/pull/16016

Corresponding `gutenberg-mobile` PR : https://github.com/wordpress-mobile/gutenberg-mobile/pull/1101