### PR TITLE
Fix: Alt and caption text written on images while the image was temporary is deleted.

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -8,6 +8,7 @@ import {
 	isEmpty,
 	map,
 	last,
+	omit,
 	pick,
 } from 'lodash';
 
@@ -295,7 +296,6 @@ export class ImageEdit extends Component {
 			attributes,
 			mediaUpload,
 			noticeOperations,
-			setAttributes,
 		} = this.props;
 		const { id, url = '' } = attributes;
 
@@ -306,7 +306,7 @@ export class ImageEdit extends Component {
 				mediaUpload( {
 					filesList: [ file ],
 					onFileChange: ( [ image ] ) => {
-						setAttributes( pickRelevantMediaFiles( image ) );
+						this.onSelectImage( image );
 					},
 					allowedTypes: ALLOWED_MEDIA_TYPES,
 					onError: ( message ) => {
@@ -357,7 +357,21 @@ export class ImageEdit extends Component {
 			isEditing: false,
 		} );
 
-		const { id, url } = this.props.attributes;
+		const { id, url, alt, caption } = this.props.attributes;
+
+		let mediaAttributes = pickRelevantMediaFiles( media );
+
+		// If the current image is temporary but an alt or caption text was meanwhile written by the user,
+		// make sure the text is not overwritten.
+		if ( isTemporaryImage( id, url ) ) {
+			if ( alt ) {
+				mediaAttributes = omit( mediaAttributes, [ 'alt' ] );
+			}
+			if ( caption ) {
+				mediaAttributes = omit( mediaAttributes, [ 'caption' ] );
+			}
+		}
+
 		let additionalAttributes;
 		// Reset the dimension attributes if changing to a different image.
 		if ( ! media.id || media.id !== id ) {
@@ -372,7 +386,7 @@ export class ImageEdit extends Component {
 		}
 
 		this.props.setAttributes( {
-			...pickRelevantMediaFiles( media ),
+			...mediaAttributes,
 			...additionalAttributes,
 		} );
 	}


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/12202, https://github.com/WordPress/gutenberg/issues/16746

Currently, the image alt text written while the image is temporary (points to a blob URL) is deleted as soon as the upload finishes.

This PR fixes the problem.
Alt attribute is not set when the upload is complete if the current image is temporary and an alt already exists.

## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
(to make the upload slow I used chrome dev tools network throttling) 
I added an image block, I pressed the upload button, while the image is uploading I wrote some alt text. I verified that the al text was persisted when the upload finished.
I repeated the same test but instead of adding an image block I drag&dropped an image directly to the editor.
I added an image I wrote some alt text. I drag & dropped another image to replace the current image, I waited for the upload to complete and I verified the alt text was removed.