### PR TITLE
[docs] fix incorect prop name in KeyboardShortcuts

### DIFF
--- a/packages/components/src/keyboard-shortcuts/README.md
+++ b/packages/components/src/keyboard-shortcuts/README.md
@@ -54,7 +54,7 @@ __Note:__ The value of each shortcut should be a consistent function reference, 
 
 __Note:__ The `KeyboardShortcuts` component will not update to reflect a changed `shortcuts` prop. If you need to change shortcuts, mount a separate `KeyboardShortcuts` element, which can be achieved by assigning a unique `key` prop.
 
-## bindGlobal
+### bindGlobal
 
 By default, a callback will not be invoked if the key combination occurs in an editable field. Pass `bindGlobal` as `true` if the key events should be observed globally, including within editable fields.
 
@@ -63,9 +63,9 @@ By default, a callback will not be invoked if the key combination occurs in an e
 
 _Tip:_ If you need some but not all keyboard events to be observed globally, simply render two distinct `KeyboardShortcuts` elements, one with and one without the `bindGlobal` prop.
 
-## event
+### eventName
 
-By default, a callback is invoked in response to the `keydown` event. To override this, pass `event` with the name of a specific keyboard event.
+By default, a callback is invoked in response to the `keydown` event. To override this, pass `eventName` with the name of a specific keyboard event.
 
 - Type: `String`
 - Required: No

--- a/packages/components/src/keyboard-shortcuts/README.md
+++ b/packages/components/src/keyboard-shortcuts/README.md
@@ -48,7 +48,7 @@ Elements to render, upon whom key events are to be monitored.
 An object of shortcut bindings, where each key is a keyboard combination, the value of which is the callback to be invoked when the key combination is pressed.
 
 - Type: `Object`
-- Required: No
+- Required: Yes
 
 __Note:__ The value of each shortcut should be a consistent function reference, not an anonymous function. Otherwise, the callback will not be correctly unbound when the component unmounts.
 


### PR DESCRIPTION
This should be self-explanatory. Let me know if you have any questions.