### PR TITLE
Update browserslist dependency to fix unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5146,44 +5146,36 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.4.1.tgz",
-			"integrity": "sha512-pEBxEXg7JwaakBXjATYw/D1YZh4QUSCX/Mnd/wnqSRPPSi1U39iDhDoKGoBUcraKdxDlrYqJxSI5nNvD+dWP2A==",
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.2.tgz",
+			"integrity": "sha512-2neU/V0giQy9h3XMPwLhEY3+Ao0uHSwHvU8Q1Ea6AgLVL1sXbX3dzPrJ8NWe5Hi4PoTkCYXOtVR9rfRLI0J/8Q==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30000929",
-				"electron-to-chromium": "^1.3.103",
-				"node-releases": "^1.1.3"
+				"caniuse-lite": "^1.0.30000974",
+				"electron-to-chromium": "^1.3.150",
+				"node-releases": "^1.1.23"
 			},
 			"dependencies": {
 				"caniuse-lite": {
-					"version": "1.0.30000929",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000929.tgz",
-					"integrity": "sha512-n2w1gPQSsYyorSVYqPMqbSaz1w7o9ZC8VhOEGI9T5MfGDzp7sbopQxG6GaQmYsaq13Xfx/mkxJUWC1Dz3oZfzw==",
-					"dev": true
-				},
-				"electron-to-chromium": {
-					"version": "1.3.103",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.103.tgz",
-					"integrity": "sha512-tObPqGmY9X8MUM8i3MEimYmbnLLf05/QV5gPlkR8MQ3Uj8G8B2govE1U4cQcBYtv3ymck9Y8cIOu4waoiykMZQ==",
+					"version": "1.0.30000974",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000974.tgz",
+					"integrity": "sha512-xc3rkNS/Zc3CmpMKuczWEdY2sZgx09BkAxfvkxlAEBTqcMHeL8QnPqhKse+5sRTi3nrw2pJwToD2WvKn1Uhvww==",
 					"dev": true
 				},
 				"node-releases": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.3.tgz",
-					"integrity": "sha512-6VrvH7z6jqqNFY200kdB6HdzkgM96Oaj9v3dqGfgp6mF+cHmU4wyQKZ2/WPDRVoR0Jz9KqbamaBN0ZhdUaysUQ==",
+					"version": "1.1.23",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.23.tgz",
+					"integrity": "sha512-uq1iL79YjfYC0WXoHbC/z28q/9pOl8kSHaXdWmAAc8No+bDwqkZbzIJz55g/MUsPgSGm9LZ7QSUbzTcH5tz47w==",
 					"dev": true,
 					"requires": {
 						"semver": "^5.3.0"
-					},
-					"dependencies": {
-						"semver": {
-							"version": "5.7.0",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-							"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-							"dev": true
-						}
 					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				}
 			}
 		},
@@ -8254,6 +8246,12 @@
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
 			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==",
+			"dev": true
+		},
+		"electron-to-chromium": {
+			"version": "1.3.155",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.155.tgz",
+			"integrity": "sha512-/ci/XgZG8jkLYOgOe3mpJY1onxPPTDY17y7scldhnSjjZqV6VvREG/LvwhRuV7BJbnENFfuDWZkSqlTh4x9ZjQ==",
 			"dev": true
 		},
 		"elegant-spinner": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
 		"@wordpress/scripts": "file:packages/scripts",
 		"babel-plugin-inline-json-import": "0.3.2",
 		"benchmark": "2.1.4",
-		"browserslist": "4.4.1",
+		"browserslist": "4.6.2",
 		"chalk": "2.4.1",
 		"commander": "2.20.0",
 		"concurrently": "3.5.0",


### PR DESCRIPTION
Right now the unit tests in master are broken because of a console log from an outdated dependency.