### PR TITLE
Allow defining the default style at runtime

### DIFF
--- a/packages/blocks/src/store/actions.js
+++ b/packages/blocks/src/store/actions.js
@@ -64,6 +64,22 @@ export function removeBlockStyles( blockName, styleNames ) {
 }
 
 /**
+ * Return an action object used to set the default block style.
+ *
+ * @param {string} blockName Block name.
+ * @param {string} styleName Block style name to be used as default.
+ *
+ * @return {Object} Action object.
+ */
+export function setDefaultBlockStyle( blockName, styleName ) {
+	return {
+		type: 'SET_DEFAULT_BLOCK_STYLE',
+		blockName,
+		styleName,
+	};
+}
+
+/**
  * Returns an action object used to set the default block name.
  *
  * @param {string} name Block name.

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -92,6 +92,13 @@ export function blockStyles( state = {}, action ) {
 					( style ) => action.styleNames.indexOf( style.name ) === -1,
 				),
 			};
+		case 'SET_DEFAULT_BLOCK_STYLE':
+			return {
+				...state,
+				[ action.blockName ]: get( state, action.blockName ).map(
+					( style ) => ( { ...style, isDefault: style.name === action.styleName } )
+				),
+			};
 	}
 
 	return state;

--- a/packages/blocks/src/store/test/reducer.js
+++ b/packages/blocks/src/store/test/reducer.js
@@ -133,6 +133,28 @@ describe( 'blockStyles', () => {
 			],
 		} );
 	} );
+
+	it( 'should set default styles', () => {
+		const original = { 'core/list': [
+			{ name: 'default', label: 'Default', isDefault: true },
+			{ name: 'none', label: 'None', isDefault: false },
+			{ name: 'checkbox', label: 'Checkbox' },
+		] };
+
+		const newState = blockStyles( original, {
+			type: 'SET_DEFAULT_BLOCK_STYLE',
+			blockName: 'core/list',
+			styleName: 'none',
+		} );
+
+		expect( newState ).toEqual( {
+			'core/list': [
+				{ name: 'default', label: 'Default', isDefault: false },
+				{ name: 'none', label: 'None', isDefault: true },
+				{ name: 'checkbox', label: 'Checkbox', isDefault: false },
+			],
+		} );
+	} );
 } );
 
 describe( 'defaultBlockName', () => {


### PR DESCRIPTION
As part of improving the block style variations https://github.com/WordPress/gutenberg/issues/7551 we need the ability to set the default style at runtime.

This PR adds the `setDefaultBlockStyle` low-level primitive.

## Testing

Execute `npm run test-unit`.

1. Compile this branch: `npm install && npm run dev`.
2. Open the block editor and add a quote block.
3. Open the InspectorControl and note that the default style is "default".
4. Open the developer console and execute: `wp.data.dispatch( 'core/block' ).setDefaultBlockStyle( 'core/quote', 'large' )`.
5. Add a new quote block.
6. Open the InspectorControl and note that the default style is the `large` one.

So far, the new block doesn't reflect the `large` style. The reason is that the CSS classes for default block styles don't get applied to the block until the user specifically clicks the style. Because the style class `is-style-large` is not applied, the CSS for the block is still the initial default style, not the one defined at runtime.
