### PR TITLE
[RNMobile] iOS Image block caption multiline fix

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -365,7 +365,7 @@ export class RichText extends Component {
 				const insertedLineSeparator = { ...insertLineSeparator( currentRecord ) };
 				this.onFormatChange( insertedLineSeparator );
 			}
-		} else if ( event.shiftKey || ! this.onSplit ) {
+		} else if ( event.shiftKey || ! onSplit ) {
 			this.needsSelectionUpdate = true;
 			const insertedLineBreak = { ...insert( currentRecord, '\n' ) };
 			this.onFormatChange( insertedLineBreak );

--- a/packages/block-editor/src/components/rich-text/test/index.native.js
+++ b/packages/block-editor/src/components/rich-text/test/index.native.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
  * Internal dependencies
  */
 import { RichText } from '../index';
@@ -23,5 +28,29 @@ describe( 'RichText Native', () => {
 			const html = '<p><b>Hello</b> <strong>Hello</strong> WorldWorld!</p>';
 			expect( richText.willTrimSpaces( html ) ).toBe( false );
 		} );
+	} );
+
+	describe( 'Adds new line on Enter', () => {
+		let newValue;
+		const wrapper = shallow( <RichText 
+			rootTagsToEliminate={ [ 'p' ] }
+			value={ "" }
+			onChange={ ( value ) => {
+				newValue = value
+			} }
+			formatTypes={ [] }
+			onSelectionChange={ jest.fn() }
+		/> );
+
+		const event = {
+			nativeEvent: {
+				eventCount: 0,
+			}
+		};
+		wrapper.instance().onEnter(event);
+
+		it( ' Adds <br> tag to content after pressing Enter key', () => {
+			expect( newValue ).toEqual( "<br>" );
+		});
 	} );
 } );


### PR DESCRIPTION
This PR fixes an issue on iOS where pressing Enter on a Image Block's caption field, it won't do anything.

It should append a `<br>` tag and create a new line.

`gutenberg-mobile` side PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1107

To test:
- Run the example project.
- Select the Image block with content.
- Write something in the caption field.
- Press enter,
- Check that a new line is created.
- Switch to HTML mode.
- Check that the new line was created by appending a `<br>` tag.