### PR TITLE
Make sure no div elements get in the content of quotes.

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -299,12 +299,23 @@ export class RichText extends Component {
 				result = this.removeRootTag( element, result );
 			} );
 		}
+
+		if ( this.props.tagsToEliminate ) {
+			this.props.tagsToEliminate.forEach( ( element ) => {
+				result = this.removeTag( element, result );
+			} );
+		}
 		return result;
 	}
 
 	removeRootTag( tag, html ) {
 		const openingTagRegexp = RegExp( '^<' + tag + '>', 'gim' );
 		const closingTagRegexp = RegExp( '</' + tag + '>$', 'gim' );
+		return html.replace( openingTagRegexp, '' ).replace( closingTagRegexp, '' );
+	}
+	removeTag( tag, html ) {
+		const openingTagRegexp = RegExp( '<' + tag + '>', 'gim' );
+		const closingTagRegexp = RegExp( '</' + tag + '>', 'gim' );
 		return html.replace( openingTagRegexp, '' ).replace( closingTagRegexp, '' );
 	}
 

--- a/packages/components/src/primitives/block-quotation/index.native.js
+++ b/packages/components/src/primitives/block-quotation/index.native.js
@@ -17,7 +17,7 @@ export const BlockQuotation = ( props ) => {
 			return cloneElement( child, { style: styles.wpBlockQuoteCitation } );
 		}
 		if ( child && child.props.identifier === 'value' ) {
-			return cloneElement( child, { rootTagsToEliminate: [ 'div' ] } );
+			return cloneElement( child, { tagsToEliminate: [ 'div' ] } );
 		}
 		return child;
 	} );

--- a/packages/components/src/primitives/block-quotation/index.native.js
+++ b/packages/components/src/primitives/block-quotation/index.native.js
@@ -16,6 +16,9 @@ export const BlockQuotation = ( props ) => {
 		if ( child && child.props.identifier === 'citation' ) {
 			return cloneElement( child, { style: styles.wpBlockQuoteCitation } );
 		}
+		if ( child && child.props.identifier === 'value' ) {
+			return cloneElement( child, { rootTagsToEliminate: [ 'div' ] } );
+		}
 		return child;
 	} );
 	return (


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This PR makes sure that no `div` elements gets in the content of the quote block in mobile

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

This can be test using this GB-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1110

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
