### PR TITLE
Block Library: Move Column resizing to Columns

### DIFF
--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { forEach, find, difference } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -11,31 +10,16 @@ import {
 	InnerBlocks,
 	BlockControls,
 	BlockVerticalAlignmentToolbar,
-	InspectorControls,
 } from '@wordpress/block-editor';
-import { PanelBody, RangeControl } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
-import { __ } from '@wordpress/i18n';
-
-/**
- * Internal dependencies
- */
-import {
-	toWidthPrecision,
-	getTotalColumnsWidth,
-	getColumnWidths,
-	getAdjacentBlocks,
-	getRedistributedColumnWidths,
-} from '../columns/utils';
 
 function ColumnEdit( {
 	attributes,
 	updateAlignment,
-	updateWidth,
 	hasChildBlocks,
 } ) {
-	const { verticalAlignment, width } = attributes;
+	const { verticalAlignment } = attributes;
 
 	const classes = classnames( 'block-core-columns', {
 		[ `is-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
@@ -49,19 +33,6 @@ function ColumnEdit( {
 					value={ verticalAlignment }
 				/>
 			</BlockControls>
-			<InspectorControls>
-				<PanelBody title={ __( 'Column Settings' ) }>
-					<RangeControl
-						label={ __( 'Percentage width' ) }
-						value={ width || '' }
-						onChange={ updateWidth }
-						min={ 0 }
-						max={ 100 }
-						required
-						allowReset
-					/>
-				</PanelBody>
-			</InspectorControls>
 			<InnerBlocks
 				templateLock={ false }
 				renderAppender={ (
@@ -96,39 +67,6 @@ export default compose(
 				// Reset Parent Columns Block
 				const rootClientId = getBlockRootClientId( clientId );
 				updateBlockAttributes( rootClientId, { verticalAlignment: null } );
-			},
-			updateWidth( width ) {
-				const { clientId } = ownProps;
-				const { updateBlockAttributes } = dispatch( 'core/block-editor' );
-				const { getBlockRootClientId, getBlocks } = registry.select( 'core/block-editor' );
-
-				// Constrain or expand siblings to account for gain or loss of
-				// total columns area.
-				const columns = getBlocks( getBlockRootClientId( clientId ) );
-				const adjacentColumns = getAdjacentBlocks( columns, clientId );
-
-				// The occupied width is calculated as the sum of the new width
-				// and the total width of blocks _not_ in the adjacent set.
-				const occupiedWidth = width + getTotalColumnsWidth(
-					difference( columns, [
-						find( columns, { clientId } ),
-						...adjacentColumns,
-					] )
-				);
-
-				// Compute _all_ next column widths, in case the updated column
-				// is in the middle of a set of columns which don't yet have
-				// any explicit widths assigned (include updates to those not
-				// part of the adjacent blocks).
-				const nextColumnWidths = {
-					...getColumnWidths( columns, columns.length ),
-					[ clientId ]: toWidthPrecision( width ),
-					...getRedistributedColumnWidths( adjacentColumns, 100 - occupiedWidth, columns.length ),
-				};
-
-				forEach( nextColumnWidths, ( nextColumnWidth, columnClientId ) => {
-					updateBlockAttributes( columnClientId, { width: nextColumnWidth } );
-				} );
 			},
 		};
 	} )

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -174,3 +174,11 @@ div.block-core-columns.is-vertically-aligned-bottom {
 	left: 0;
 	right: 0;
 }
+
+.wp-block-columns__column-settings-column {
+	legend {
+		font-weight: bold;
+		padding: 0;
+		margin-bottom: $grid-size-small;
+	}
+}


### PR DESCRIPTION
Closes #15660

This pull request seeks to move management of the individual Column widths to be managed at the Columns wrapper. The goal here, in combination with #16024 and toward #7694, is to eliminate the "Column" block as a necessary stop for user interaction.

![resize](https://user-images.githubusercontent.com/1779930/59217409-e0d0b500-8b8b-11e9-8340-330ba3fa6e53.gif)

**Accessibility Notes:**

The current implementation renders a `fieldset` for each column. At the moment, there is only the width field within these groups. However, as part of #7694, it will be necessary to incorporate column vertical alignment into the Columns sidebar as well. With each column possibly having multiple fields to manage in the block inspector, the fieldset grouping felt appropriate. Guidance here would be appreciated.

**Implementation Notes:**

The implementation of the widths assignment is ported directly from the Column block, with minor adaptation to receive `clientId` as an argument of the function.

This nicely allows for a re-consolidation of the width sizing utility functions (previously, the "Column" block implementation penetrated the block abstraction into the implementation of the "Columns" block).

**Testing Instructions:**

Repeat testing instructions from #15499, managing column width from the Columns block instead of the Column block.