### PR TITLE
Scripts: Fix default use of lint-js file patterns

### DIFF
--- a/packages/block-editor/src/components/media-upload/test/index.native.js
+++ b/packages/block-editor/src/components/media-upload/test/index.native.js
@@ -52,7 +52,7 @@ describe( 'MediaUpload component', () => {
 				);
 			} } />
 		);
-		expect( wrapper.find( 'Picker' ).length ).toEqual( 1 );
+		expect( wrapper.find( 'Picker' ) ).toHaveLength( 1 );
 	} );
 
 	it( 'shows right media capture option for media type', () => {
@@ -68,7 +68,7 @@ describe( 'MediaUpload component', () => {
 						);
 					} } />
 			);
-			expect( wrapper.find( 'Picker' ).props().options.filter( ( item ) => item.label === expectedOption ).length ).toEqual( 1 );
+			expect( wrapper.find( 'Picker' ).props().options.filter( ( item ) => item.label === expectedOption ) ).toHaveLength( 1 );
 		};
 		expectOptionForMediaType( MEDIA_TYPE_IMAGE, OPTION_TAKE_PHOTO );
 		expectOptionForMediaType( MEDIA_TYPE_VIDEO, OPTION_TAKE_VIDEO );

--- a/packages/block-editor/src/components/rich-text/test/index.native.js
+++ b/packages/block-editor/src/components/rich-text/test/index.native.js
@@ -32,11 +32,11 @@ describe( 'RichText Native', () => {
 
 	describe( 'Adds new line on Enter', () => {
 		let newValue;
-		const wrapper = shallow( <RichText 
+		const wrapper = shallow( <RichText
 			rootTagsToEliminate={ [ 'p' ] }
-			value={ "" }
+			value=""
 			onChange={ ( value ) => {
-				newValue = value
+				newValue = value;
 			} }
 			formatTypes={ [] }
 			onSelectionChange={ jest.fn() }
@@ -45,12 +45,12 @@ describe( 'RichText Native', () => {
 		const event = {
 			nativeEvent: {
 				eventCount: 0,
-			}
+			},
 		};
-		wrapper.instance().onEnter(event);
+		wrapper.instance().onEnter( event );
 
 		it( ' Adds <br> tag to content after pressing Enter key', () => {
-			expect( newValue ).toEqual( "<br>" );
-		});
+			expect( newValue ).toEqual( '<br>' );
+		} );
 	} );
 } );

--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -18,9 +18,7 @@ import { createBlock } from '@wordpress/blocks';
 
 const HeadingEdit = ( {
 	attributes,
-	isSelected,
 	mergeBlocks,
-	onBlur,
 	onFocus,
 	onReplace,
 	setAttributes,

--- a/packages/block-library/src/video/video-player.android.js
+++ b/packages/block-library/src/video/video-player.android.js
@@ -19,7 +19,7 @@ const Video = ( props ) => {
 				// We are using built-in player controls becasue manually
 				// calling presentFullscreenPlayer() is not working for android
 				controls={ isSelected }
-				muted={ !isSelected }
+				muted={ ! isSelected }
 			/>
 		</View>
 	);

--- a/packages/scripts/scripts/lint-js.js
+++ b/packages/scripts/scripts/lint-js.js
@@ -18,7 +18,7 @@ const {
 
 const args = getCliArgs();
 
-const defaultFilesArgs = ! hasFileInCliArgs ? [ '.' ] : [];
+const defaultFilesArgs = hasFileInCliArgs() ? [] : [ '.' ];
 
 // See: https://eslint.org/docs/user-guide/configuring#using-configuration-files-1.
 const hasLintConfig = hasCliArg( '-c' ) ||

--- a/packages/scripts/scripts/lint-pkg-json.js
+++ b/packages/scripts/scripts/lint-pkg-json.js
@@ -41,7 +41,7 @@ const defaultIgnoreArgs = ! hasIgnoredFiles ?
 
 const result = spawn(
 	resolveBin( 'npm-package-json-lint', { executable: 'npmPkgJsonLint' } ),
-	[ ...defaultConfigArgs, ...defaultIgnoreArgs, ...args, defaultFilesArgs ],
+	[ ...defaultConfigArgs, ...defaultIgnoreArgs, ...args, ...defaultFilesArgs ],
 	{ stdio: 'inherit' }
 );
 

--- a/packages/scripts/scripts/lint-pkg-json.js
+++ b/packages/scripts/scripts/lint-pkg-json.js
@@ -18,7 +18,7 @@ const {
 
 const args = getCliArgs();
 
-const defaultFilesArgs = ! hasFileInCliArgs ? [ '.' ] : [];
+const defaultFilesArgs = hasFileInCliArgs() ? [] : [ '.' ];
 
 // See: https://github.com/tclindner/npm-package-json-lint/wiki/configuration#configuration.
 const hasLintConfig = hasCliArg( '-c' ) ||

--- a/packages/scripts/scripts/lint-style.js
+++ b/packages/scripts/scripts/lint-style.js
@@ -18,7 +18,7 @@ const {
 
 const args = getCliArgs();
 
-const defaultFilesArgs = ! hasFileInCliArgs ? [ '**/*.{css,scss}' ] : [];
+const defaultFilesArgs = hasFileInCliArgs() ? [] : [ '**/*.{css,scss}' ];
 
 // See: https://github.com/stylelint/stylelint/blob/master/docs/user-guide/configuration.md#loading-the-configuration-object.
 const hasLintConfig = hasCliArg( '--config' ) ||


### PR DESCRIPTION
Issue introduced in: #15890 

This pull request seeks to resolve an issue where the `lint-js` script does not work in default usage. Without these changes, running `npm run lint-js` will output ESLint's default usage instructions.

```
> gutenberg@5.9.0-rc.1 lint-js /Users/andrew/Documents/Code/vvv/www/editor/htdocs/wp-content/plugins/gutenberg
> wp-scripts lint-js

eslint [options] file.js [file.js] [dir]

Basic configuration:
  --no-eslintrc                Disable use of configuration from .eslintrc.*
  -c, --config path::String    Use this configuration, overriding .eslintrc.* config options if present
...
```

As [mentioned by @gziolo in Slack](https://wordpress.slack.com/archives/C02QB2JS7/p1560196701311000?thread_ts=1560190925.308400&cid=C02QB2JS7), the `hasFileInCliArgs` utility should be called as a function. These changes are included here.

Further, as mentioned at , there appears to be an issue with the implementation of `lint-pkg-json.js` which would have prevented the default file arguments from being included correctly in the spread array of arguments. This has been resolved in 92ed212.

**Testing Instructions:**

Verify `npm run lint-js` works as expected.

_*WARNING:*_ In my testing, I am encountering issues with memory exhaustion which I can't yet explain. Based on my understanding of these errors, it may be scanning recursively or folders which it is not expecting to. I am unable yet to understand why this would be happening now as a result of #15890 (or even also #15977).