### PR TITLE
fix(components/tab-panel): improve className safety by using 'classnames'

### DIFF
--- a/packages/components/src/tab-panel/README.md
+++ b/packages/components/src/tab-panel/README.md
@@ -114,15 +114,15 @@ The function called when a tab has been selected. It is passed the `tabName` as 
 
 #### tabs
 
-A list of tabs where each tab is defined by an object with the following fields:
+An array of objects containing the following properties:
 
-1. name: String. Defines the key for the tab
-2. title: String. Defines the translated text for the tab
-3. className: String. Defines the class to put on the tab.
+- `name`: `(string)` Defines the key for the tab.
+- `title`:`(string)` Defines the translated text for the tab.
+- `className`:`(string)` Optional. Defines the class to put on the tab.
 
-Other fields may be added to the object and accessed from the child function if desired.
+>> **Note:** Other fields may be added to the object and accessed from the child function if desired.
 
-- Type: Array
+- Type: `Array`
 - Required: Yes
 
 #### activeClass

--- a/packages/components/src/tab-panel/index.js
+++ b/packages/components/src/tab-panel/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { partial, noop, find } from 'lodash';
 
 /**
@@ -74,7 +75,7 @@ class TabPanel extends Component {
 					className="components-tab-panel__tabs"
 				>
 					{ tabs.map( ( tab ) => (
-						<TabButton className={ `${ tab.className } ${ tab.name === selected ? activeClass : '' }` }
+						<TabButton className={ classnames( tab.className, { [ activeClass ]: tab.name === selected } ) }
 							tabId={ instanceId + '-' + tab.name }
 							aria-controls={ instanceId + '-' + tab.name + '-view' }
 							selected={ tab.name === selected }


### PR DESCRIPTION
Let me know if you have any questions or if I missed something.

## Description

This PR does two things:
1. Improves safety of the interpolation of className for `tab`s (currently the string `undefined` will show up if the `tab` doesn't have the `className` property defined).
2. Relaxes the strictness and makes the `className` property of `tab` optional.


## How has this been tested?

Yes. All tests still pass fine.

## Screenshots <!-- if applicable -->

N/A

## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->