### PR TITLE
docs(components/text-control): Fix incorrectly documented "value" prop

### DIFF
--- a/packages/components/src/text-control/README.md
+++ b/packages/components/src/text-control/README.md
@@ -96,7 +96,7 @@ Type of the input element to render. Defaults to "text".
 #### value
 The current value of the input.
 
-- Type: `Number`
+- Type: `String | Number`
 - Required: Yes
 
 #### className


### PR DESCRIPTION
## Description

Should be pretty self-explanatory. Let me know if you have any questions/comments.

## How has this been tested?

N/A

## Screenshots <!-- if applicable -->

N/A

## Types of changes

Docs

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->