### PR TITLE
Project management: Fix milestone version selection when RC is included in version

### DIFF
--- a/.github/actions/milestone-it/entrypoint.sh
+++ b/.github/actions/milestone-it/entrypoint.sh
@@ -29,7 +29,7 @@ minor=${parts[1]}
 
 # 3. Determine next milestone.
 
-if [ minor == '9' ]; then
+if [[ $minor == 9* ]]; then
 	major=$((major+1))
 	minor="0"
 else


### PR DESCRIPTION
## Description
The current version of the plugin is `5.9-rc.1`. This causes that `Milestone it` action creates [Gutenberg 5.10](https://github.com/WordPress/gutenberg/milestone/101) milestone where it should create `Gutenberg 6.0`. I fixed manually some of the latest PRs merged to be assigned to the correct milestone but we need to fix in in the actions as well.