### PR TITLE
docs(components/toggle-control): clarify that onChange is not required

### DIFF
--- a/packages/components/src/toggle-control/README.md
+++ b/packages/components/src/toggle-control/README.md
@@ -53,7 +53,7 @@ If no value is passed the toggle will be unchecked.
 A function that receives the checked state (boolean) as input.
 
 - Type: `function`
-- Required: Yes
+- Required: No
 
 ### className
 


### PR DESCRIPTION
## Description

Per discussion in Slack with @gziolo, this adjustment to the docs reflects the fact that `onChange` is not required if the user intends the component to be an "uncontrolled" component.

Let me know if you have any further questions/comments.

## How has this been tested?

N/A

## Screenshots <!-- if applicable -->

N/A

## Types of changes

Docs

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->