### PR TITLE
Scripts: Fix naming conventions for function containing CLI keyword

### DIFF
--- a/packages/scripts/bin/wp-scripts.js
+++ b/packages/scripts/bin/wp-scripts.js
@@ -3,8 +3,8 @@
 /**
  * Internal dependencies
  */
-const { getCliArgs, spawnScript } = require( '../utils' );
+const { getArgsFromCLI, spawnScript } = require( '../utils' );
 
-const [ scriptName, ...nodesArgs ] = getCliArgs();
+const [ scriptName, ...nodesArgs ] = getArgsFromCLI();
 
 spawnScript( scriptName, nodesArgs );

--- a/packages/scripts/scripts/check-engines.js
+++ b/packages/scripts/scripts/check-engines.js
@@ -8,16 +8,16 @@ const { sync: resolveBin } = require( 'resolve-bin' );
  * Internal dependencies
  */
 const {
-	getCliArgs,
-	hasCliArg,
+	getArgsFromCLI,
+	hasArgInCLI,
 } = require( '../utils' );
 
-const args = getCliArgs();
+const args = getArgsFromCLI();
 
-const hasConfig = hasCliArg( '--package' ) ||
-	hasCliArg( '--node' ) ||
-	hasCliArg( '--npm' ) ||
-	hasCliArg( '--yarn' );
+const hasConfig = hasArgInCLI( '--package' ) ||
+	hasArgInCLI( '--node' ) ||
+	hasArgInCLI( '--npm' ) ||
+	hasArgInCLI( '--yarn' );
 const config = ! hasConfig ?
 	[
 		'--node', '>=10.0.0',

--- a/packages/scripts/scripts/check-licenses.js
+++ b/packages/scripts/scripts/check-licenses.js
@@ -9,7 +9,7 @@ const chalk = require( 'chalk' );
 /**
  * Internal dependencies
  */
-const { getCliArg, hasCliArg } = require( '../utils' );
+const { getArgFromCLI, hasArgInCLI } = require( '../utils' );
 
 /*
  * WARNING: Changes to this file may inadvertently cause us to distribute code that
@@ -22,11 +22,11 @@ const { getCliArg, hasCliArg } = require( '../utils' );
 
 const ERROR = chalk.reset.inverse.bold.red( ' ERROR ' );
 
-const prod = hasCliArg( '--prod' ) || hasCliArg( '--production' );
-const dev = hasCliArg( '--dev' ) || hasCliArg( '--development' );
-const gpl2 = hasCliArg( '--gpl2' );
-const ignored = hasCliArg( '--ignore' ) ?
-	getCliArg( '--ignore' )
+const prod = hasArgInCLI( '--prod' ) || hasArgInCLI( '--production' );
+const dev = hasArgInCLI( '--dev' ) || hasArgInCLI( '--development' );
+const gpl2 = hasArgInCLI( '--gpl2' );
+const ignored = hasArgInCLI( '--ignore' ) ?
+	getArgFromCLI( '--ignore' )
 		// "--ignore=a, b" -> "[ 'a', ' b' ]"
 		.split( ',' )
 		// "[ 'a', ' b' ]" -> "[ 'a', 'b' ]"

--- a/packages/scripts/scripts/lint-js.js
+++ b/packages/scripts/scripts/lint-js.js
@@ -9,20 +9,20 @@ const { sync: resolveBin } = require( 'resolve-bin' );
  */
 const {
 	fromConfigRoot,
-	getCliArgs,
-	hasCliArg,
-	hasFileInCliArgs,
+	getArgsFromCLI,
+	hasArgInCLI,
+	hasFileArgInCLI,
 	hasPackageProp,
 	hasProjectFile,
 } = require( '../utils' );
 
-const args = getCliArgs();
+const args = getArgsFromCLI();
 
-const defaultFilesArgs = hasFileInCliArgs() ? [] : [ '.' ];
+const defaultFilesArgs = hasFileArgInCLI() ? [] : [ '.' ];
 
 // See: https://eslint.org/docs/user-guide/configuring#using-configuration-files-1.
-const hasLintConfig = hasCliArg( '-c' ) ||
-	hasCliArg( '--config' ) ||
+const hasLintConfig = hasArgInCLI( '-c' ) ||
+	hasArgInCLI( '--config' ) ||
 	hasProjectFile( '.eslintrc.js' ) ||
 	hasProjectFile( '.eslintrc.yaml' ) ||
 	hasProjectFile( '.eslintrc.yml' ) ||
@@ -38,7 +38,7 @@ const defaultConfigArgs = ! hasLintConfig ?
 	[];
 
 // See: https://eslint.org/docs/user-guide/configuring#ignoring-files-and-directories.
-const hasIgnoredFiles = hasCliArg( '--ignore-path' ) ||
+const hasIgnoredFiles = hasArgInCLI( '--ignore-path' ) ||
 	hasProjectFile( '.eslintignore' );
 
 const defaultIgnoreArgs = ! hasIgnoredFiles ?

--- a/packages/scripts/scripts/lint-pkg-json.js
+++ b/packages/scripts/scripts/lint-pkg-json.js
@@ -9,20 +9,20 @@ const { sync: resolveBin } = require( 'resolve-bin' );
  */
 const {
 	fromConfigRoot,
-	getCliArgs,
-	hasCliArg,
-	hasFileInCliArgs,
+	getArgsFromCLI,
+	hasArgInCLI,
+	hasFileArgInCLI,
 	hasProjectFile,
 	hasPackageProp,
 } = require( '../utils' );
 
-const args = getCliArgs();
+const args = getArgsFromCLI();
 
-const defaultFilesArgs = hasFileInCliArgs() ? [] : [ '.' ];
+const defaultFilesArgs = hasFileArgInCLI() ? [] : [ '.' ];
 
 // See: https://github.com/tclindner/npm-package-json-lint/wiki/configuration#configuration.
-const hasLintConfig = hasCliArg( '-c' ) ||
-	hasCliArg( '--configFile' ) ||
+const hasLintConfig = hasArgInCLI( '-c' ) ||
+	hasArgInCLI( '--configFile' ) ||
 	hasProjectFile( '.npmpackagejsonlintrc.json' ) ||
 	hasProjectFile( 'npmpackagejsonlint.config.js' ) ||
 	hasPackageProp( 'npmPackageJsonLintConfig' );
@@ -32,7 +32,7 @@ const defaultConfigArgs = ! hasLintConfig ?
 	[];
 
 // See: https://github.com/tclindner/npm-package-json-lint/#cli-commands-and-configuration.
-const hasIgnoredFiles = hasCliArg( '--ignorePath' ) ||
+const hasIgnoredFiles = hasArgInCLI( '--ignorePath' ) ||
 	hasProjectFile( '.npmpackagejsonlintignore' );
 
 const defaultIgnoreArgs = ! hasIgnoredFiles ?

--- a/packages/scripts/scripts/lint-style.js
+++ b/packages/scripts/scripts/lint-style.js
@@ -9,19 +9,19 @@ const { sync: resolveBin } = require( 'resolve-bin' );
  */
 const {
 	fromConfigRoot,
-	getCliArgs,
-	hasCliArg,
-	hasFileInCliArgs,
+	getArgsFromCLI,
+	hasArgInCLI,
+	hasFileArgInCLI,
 	hasProjectFile,
 	hasPackageProp,
 } = require( '../utils' );
 
-const args = getCliArgs();
+const args = getArgsFromCLI();
 
-const defaultFilesArgs = hasFileInCliArgs() ? [] : [ '**/*.{css,scss}' ];
+const defaultFilesArgs = hasFileArgInCLI() ? [] : [ '**/*.{css,scss}' ];
 
 // See: https://github.com/stylelint/stylelint/blob/master/docs/user-guide/configuration.md#loading-the-configuration-object.
-const hasLintConfig = hasCliArg( '--config' ) ||
+const hasLintConfig = hasArgInCLI( '--config' ) ||
 	hasProjectFile( '.stylelintrc' ) ||
 	hasProjectFile( '.stylelintrc.js' ) ||
 	hasProjectFile( '.stylelintrc.json' ) ||
@@ -35,7 +35,7 @@ const defaultConfigArgs = ! hasLintConfig ?
 	[];
 
 // See: https://github.com/stylelint/stylelint/blob/master/docs/user-guide/configuration.md#stylelintignore.
-const hasIgnoredFiles = hasCliArg( '--ignore-path' ) ||
+const hasIgnoredFiles = hasArgInCLI( '--ignore-path' ) ||
 	hasProjectFile( '.stylelintignore' );
 
 const defaultIgnoreArgs = ! hasIgnoredFiles ?

--- a/packages/scripts/scripts/test-e2e.js
+++ b/packages/scripts/scripts/test-e2e.js
@@ -19,9 +19,9 @@ const jest = require( 'jest' );
  */
 const {
 	fromConfigRoot,
-	getCliArg,
-	getCliArgs,
-	hasCliArg,
+	getArgFromCLI,
+	getArgsFromCLI,
+	hasArgInCLI,
 	hasProjectFile,
 	hasJestConfig,
 } = require( '../utils' );
@@ -37,15 +37,15 @@ const config = ! hasJestConfig() ?
 	[ '--config', JSON.stringify( require( fromConfigRoot( 'jest-e2e.config.js' ) ) ) ] :
 	[];
 
-const hasRunInBand = hasCliArg( '--runInBand' ) ||
-	hasCliArg( '-i' );
+const hasRunInBand = hasArgInCLI( '--runInBand' ) ||
+	hasArgInCLI( '-i' );
 const runInBand = ! hasRunInBand ?
 	[ '--runInBand' ] :
 	[];
 
-if ( hasCliArg( '--puppeteer-interactive' ) ) {
+if ( hasArgInCLI( '--puppeteer-interactive' ) ) {
 	process.env.PUPPETEER_HEADLESS = 'false';
-	process.env.PUPPETEER_SLOWMO = getCliArg( '--puppeteer-slowmo' ) || 80;
+	process.env.PUPPETEER_SLOWMO = getArgFromCLI( '--puppeteer-slowmo' ) || 80;
 }
 
 const configsMapping = {
@@ -55,11 +55,11 @@ const configsMapping = {
 };
 
 Object.entries( configsMapping ).forEach( ( [ envKey, argName ] ) => {
-	if ( hasCliArg( argName ) ) {
-		process.env[ envKey ] = getCliArg( argName );
+	if ( hasArgInCLI( argName ) ) {
+		process.env[ envKey ] = getArgFromCLI( argName );
 	}
 } );
 
 const cleanUpPrefixes = [ '--puppeteer-', '--wordpress-' ];
 
-jest.run( [ ...config, ...runInBand, ...getCliArgs( cleanUpPrefixes ) ] );
+jest.run( [ ...config, ...runInBand, ...getArgsFromCLI( cleanUpPrefixes ) ] );

--- a/packages/scripts/scripts/test-unit-jest.js
+++ b/packages/scripts/scripts/test-unit-jest.js
@@ -19,7 +19,7 @@ const jest = require( 'jest' );
  */
 const {
 	fromConfigRoot,
-	getCliArgs,
+	getArgsFromCLI,
 	hasJestConfig,
 } = require( '../utils' );
 
@@ -27,4 +27,4 @@ const config = ! hasJestConfig() ?
 	[ '--config', JSON.stringify( require( fromConfigRoot( 'jest-unit.config.js' ) ) ) ] :
 	[];
 
-jest.run( [ ...config, ...getCliArgs() ] );
+jest.run( [ ...config, ...getArgsFromCLI() ] );

--- a/packages/scripts/utils/cli.js
+++ b/packages/scripts/utils/cli.js
@@ -13,11 +13,11 @@ const {
 } = require( './file' );
 const {
 	exit,
-	getCliArgs,
+	getArgsFromCLI,
 } = require( './process' );
 
-const getCliArg = ( arg ) => {
-	for ( const cliArg of getCliArgs() ) {
+const getArgFromCLI = ( arg ) => {
+	for ( const cliArg of getArgsFromCLI() ) {
 		const [ name, value ] = cliArg.split( '=' );
 		if ( name === arg ) {
 			return value || null;
@@ -25,9 +25,9 @@ const getCliArg = ( arg ) => {
 	}
 };
 
-const hasCliArg = ( arg ) => getCliArg( arg ) !== undefined;
+const hasArgInCLI = ( arg ) => getArgFromCLI( arg ) !== undefined;
 
-const hasFileInCliArgs = () => minimist( getCliArgs() )._.length > 0;
+const hasFileArgInCLI = () => minimist( getArgsFromCLI() )._.length > 0;
 
 const handleSignal = ( signal ) => {
 	if ( signal === 'SIGKILL' ) {
@@ -81,9 +81,9 @@ const spawnScript = ( scriptName, args = [] ) => {
 };
 
 module.exports = {
-	getCliArg,
-	getCliArgs,
-	hasCliArg,
-	hasFileInCliArgs,
+	getArgFromCLI,
+	getArgsFromCLI,
+	hasArgInCLI,
+	hasFileArgInCLI,
 	spawnScript,
 };

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-const { hasCliArg, getCliArgs } = require( './cli' );
+const { hasArgInCLI, getArgsFromCLI } = require( './cli' );
 const { fromConfigRoot, hasProjectFile } = require( './file' );
 const { hasPackageProp } = require( './package' );
 
@@ -12,18 +12,18 @@ const hasBabelConfig = () =>
 	hasPackageProp( 'babel' );
 
 const hasJestConfig = () =>
-	hasCliArg( '-c' ) ||
-	hasCliArg( '--config' ) ||
+	hasArgInCLI( '-c' ) ||
+	hasArgInCLI( '--config' ) ||
 	hasProjectFile( 'jest.config.js' ) ||
 	hasProjectFile( 'jest.config.json' ) ||
 	hasPackageProp( 'jest' );
 
-const hasWebpackConfig = () => hasCliArg( '--config' ) ||
+const hasWebpackConfig = () => hasArgInCLI( '--config' ) ||
 	hasProjectFile( 'webpack.config.js' ) ||
 	hasProjectFile( 'webpack.config.babel.js' );
 
 const getWebpackArgs = ( additionalArgs = [] ) => {
-	const webpackArgs = getCliArgs();
+	const webpackArgs = getArgsFromCLI();
 	if ( ! hasWebpackConfig() ) {
 		webpackArgs.push( '--config', fromConfigRoot( 'webpack.config.js' ) );
 	}

--- a/packages/scripts/utils/index.js
+++ b/packages/scripts/utils/index.js
@@ -2,10 +2,10 @@
  * Internal dependencies
  */
 const {
-	getCliArg,
-	getCliArgs,
-	hasCliArg,
-	hasFileInCliArgs,
+	getArgFromCLI,
+	getArgsFromCLI,
+	hasArgInCLI,
+	hasFileArgInCLI,
 	spawnScript,
 } = require( './cli' );
 const {
@@ -27,12 +27,12 @@ const {
 module.exports = {
 	camelCaseDash,
 	fromConfigRoot,
-	getCliArg,
-	getCliArgs,
+	getArgFromCLI,
+	getArgsFromCLI,
 	getWebpackArgs,
 	hasBabelConfig,
-	hasCliArg,
-	hasFileInCliArgs,
+	hasArgInCLI,
+	hasFileArgInCLI,
 	hasJestConfig,
 	hasPackageProp,
 	hasProjectFile,

--- a/packages/scripts/utils/process.js
+++ b/packages/scripts/utils/process.js
@@ -1,4 +1,4 @@
-const getCliArgs = ( excludePrefixes ) => {
+const getArgsFromCLI = ( excludePrefixes ) => {
 	const args = process.argv.slice( 2 );
 	if ( excludePrefixes ) {
 		return args.filter( ( arg ) => {
@@ -10,6 +10,6 @@ const getCliArgs = ( excludePrefixes ) => {
 
 module.exports = {
 	exit: process.exit,
-	getCliArgs,
+	getArgsFromCLI,
 	getCurrentWorkingDirectory: process.cwd,
 };

--- a/packages/scripts/utils/test/index.js
+++ b/packages/scripts/utils/test/index.js
@@ -7,7 +7,7 @@ import crossSpawn from 'cross-spawn';
  * Internal dependencies
  */
 import {
-	hasCliArg,
+	hasArgInCLI,
 	hasProjectFile,
 	spawnScript,
 } from '../';
@@ -16,7 +16,7 @@ import {
 } from '../package';
 import {
 	exit as exitMock,
-	getCliArgs as getCliArgsMock,
+	getArgsFromCLI as getArgsFromCLIMock,
 } from '../process';
 
 jest.mock( '../package', () => {
@@ -30,7 +30,7 @@ jest.mock( '../process', () => {
 	const module = require.requireActual( '../process' );
 
 	jest.spyOn( module, 'exit' );
-	jest.spyOn( module, 'getCliArgs' );
+	jest.spyOn( module, 'getArgsFromCLI' );
 
 	return module;
 } );
@@ -38,29 +38,29 @@ jest.mock( '../process', () => {
 describe( 'utils', () => {
 	const crossSpawnMock = jest.spyOn( crossSpawn, 'sync' );
 
-	describe( 'hasCliArg', () => {
+	describe( 'hasArgInCLI', () => {
 		beforeAll( () => {
-			getCliArgsMock.mockReturnValue( [ '-a', '--b', '--config=test' ] );
+			getArgsFromCLIMock.mockReturnValue( [ '-a', '--b', '--config=test' ] );
 		} );
 
 		afterAll( () => {
-			getCliArgsMock.mockReset();
+			getArgsFromCLIMock.mockReset();
 		} );
 
 		test( 'should return false when no args passed', () => {
-			getCliArgsMock.mockReturnValueOnce( [] );
+			getArgsFromCLIMock.mockReturnValueOnce( [] );
 
-			expect( hasCliArg( '--no-args' ) ).toBe( false );
+			expect( hasArgInCLI( '--no-args' ) ).toBe( false );
 		} );
 
 		test( 'should return false when checking for unrecognized arg', () => {
-			expect( hasCliArg( '--non-existent' ) ).toBe( false );
+			expect( hasArgInCLI( '--non-existent' ) ).toBe( false );
 		} );
 
 		test( 'should return true when CLI arg found', () => {
-			expect( hasCliArg( '-a' ) ).toBe( true );
-			expect( hasCliArg( '--b' ) ).toBe( true );
-			expect( hasCliArg( '--config' ) ).toBe( true );
+			expect( hasArgInCLI( '-a' ) ).toBe( true );
+			expect( hasArgInCLI( '--b' ) ).toBe( true );
+			expect( hasArgInCLI( '--config' ) ).toBe( true );
 		} );
 	} );
 


### PR DESCRIPTION
## Description
Addressed the issue found by @aduth in https://github.com/WordPress/gutenberg/pull/16079#discussion_r292443060:
> This function is technically not named correctly in accordance with naming guidelines. It should be `hasFileInCLIArgs` (["CLI" is an acronym](https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/#abbreviations-and-acronyms)).

Function names which this PR updates:
- `getCliArg` -> `getArgFromCLI`
- `getCliArgs` -> `getArgsFromCLI`
- `hasCliArg`  -> `hasArgInCLI`
- `hasFileInCliArgs ` -> `hasFileArgInCLI`