### PR TITLE
Restored code removed in c64faf4

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -933,7 +933,11 @@ export class RichText extends Component {
 	formatToValue( value ) {
 		// Handle deprecated `children` and `node` sources.
 		if ( Array.isArray( value ) ) {
-			value = children.toHTML( value );
+			return create( {
+				html: children.toHTML( value ),
+				multilineTag: this.multilineTag,
+				multilineWrapperTags: this.multilineWrapperTags,
+			} );
 		}
 
 		if ( this.props.format === 'string' ) {


### PR DESCRIPTION
Hopefully fixes #16092

## Description

Restored lines removed in commit [c64faf4](https://github.com/wordpress/gutenberg/commit/c64faf4902dfeda9eb33301b12b4214da854d101) to fix issue described in #16092.

## How has this been tested?

Manually tested using code that worked as expected with Gutenberg `v5.4.0` and the example given in #16092.

## Types of changes

Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
