### PR TITLE
Update Tag Cloud copy when no terms are found

### DIFF
--- a/packages/block-library/src/tag-cloud/index.php
+++ b/packages/block-library/src/tag-cloud/index.php
@@ -30,7 +30,8 @@ function render_block_core_tag_cloud( $attributes ) {
 	$tag_cloud = wp_tag_cloud( $args );
 
 	if ( ! $tag_cloud ) {
-		$tag_cloud = esc_html( __( 'No terms to show.' ) );
+		$labels = get_taxonomy_labels( get_taxonomy( $attributes['taxonomy'] ) );
+		$tag_cloud = esc_html( sprintf( __( 'Your site doesn&#8217;t have any %s, so there&#8217;s nothing to display here at the moment.' ), strtolower( $labels->name ) ) );
 	}
 
 	return sprintf(


### PR DESCRIPTION
The current copy when you have no taxonomy terms is technical and unfriendly:

> No terms found.

Instead, let's make it a little easier to understand:

> Your site doesn’t have any tags, so there’s nothing to display here at the moment.

It updates based on the chosen taxonomy. Props @ryelle for writing the logic and @michelleweber for brainstorming copy with me.

## How has this been tested?
I've tested it with both core taxonomies, and new taxonomies provided by a plugin.

## Screenshots <!-- if applicable -->

Before:

![image](https://user-images.githubusercontent.com/2846578/59311382-1cd44a80-8c5e-11e9-90ef-517a173e7040.png)

After:

![image](https://user-images.githubusercontent.com/2846578/59311340-f6aeaa80-8c5d-11e9-9cfb-c7cb23e691cc.png)

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->

Fixes #13932.