### PR TITLE
Match the primary button disabled state to Core's color contrast

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -80,6 +80,11 @@
 			background: color(theme(button) shade(5%));
 			border-color: color(theme(button) shade(50%));
 			color: $white;
+			/* Keep the disabled text color when focused */
+			&:disabled,
+			&[aria-disabled="true"] {
+				color: color(theme(button) tint(40%));
+			}
 		}
 
 		&:hover {

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -102,8 +102,8 @@
 
 		&:disabled,
 		&[aria-disabled="true"] {
-			color: color(theme(button) tint(30%));
-			background: color(theme(button) shade(30%));
+			color: color(theme(button) tint(50%));
+			background: color(theme(button) tint(5%));
 			border-color: color(theme(button) shade(20%));
 			box-shadow: none;
 			text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.1);
@@ -171,7 +171,7 @@
 	&:disabled,
 	&[aria-disabled="true"] {
 		cursor: default;
-		opacity: 0.3;
+		//opacity: 0.3;
 	}
 
 	&:focus:not(:disabled) {

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -110,6 +110,14 @@
 			box-shadow: none;
 			text-shadow: none;
 
+			// This specificity is needed to override alternate color schemes in WP-Admin.
+			&.is-button,
+			&.is-button:hover,
+			&:active:enabled {
+				box-shadow: none;
+				text-shadow: none;
+			}
+
 			&:focus:enabled {
 				color: color(theme(button) tint(40%));
 				border-color: color(theme(button) shade(7%));

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -80,15 +80,6 @@
 			background: color(theme(button) shade(5%));
 			border-color: color(theme(button) shade(50%));
 			color: $white;
-			/* Keep the disabled text color when focused */
-			&:disabled,
-			&[aria-disabled="true"] {
-				border-color: color(theme(button) shade(7%));
-				box-shadow:
-					0 0 0 1px $white,
-					0 0 0 3px $blue-medium-focus;
-				color: color(theme(button) tint(40%));
-			}
 		}
 
 		&:hover {
@@ -118,6 +109,14 @@
 			border-color: color(theme(button) shade(7%));
 			box-shadow: none;
 			text-shadow: none;
+
+			&:focus:enabled {
+				color: color(theme(button) tint(40%));
+				border-color: color(theme(button) shade(7%));
+				box-shadow:
+					0 0 0 1px $white,
+					0 0 0 3px $blue-medium-focus;
+			}
 		}
 
 		&.is-busy,

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -83,6 +83,10 @@
 			/* Keep the disabled text color when focused */
 			&:disabled,
 			&[aria-disabled="true"] {
+				border-color: color(theme(button) shade(7%));
+				box-shadow:
+					0 0 0 1px $white,
+					0 0 0 3px $blue-medium-focus;
 				color: color(theme(button) tint(40%));
 			}
 		}

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -106,7 +106,7 @@
 			background: color(theme(button));
 			border-color: color(theme(button) shade(7%));
 			box-shadow: none;
-			text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.1);
+			text-shadow: none;
 		}
 
 		&.is-busy,

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -101,7 +101,9 @@
 		}
 
 		&:disabled,
-		&[aria-disabled="true"] {
+		&:disabled:active:enabled,
+		&[aria-disabled="true"],
+		&[aria-disabled="true"]:active:enabled {
 			color: color(theme(button) tint(40%));
 			background: color(theme(button));
 			border-color: color(theme(button) shade(7%));

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -102,9 +102,9 @@
 
 		&:disabled,
 		&[aria-disabled="true"] {
-			color: color(theme(button) tint(50%));
-			background: color(theme(button) tint(5%));
-			border-color: color(theme(button) shade(20%));
+			color: color(theme(button) tint(40%));
+			background: color(theme(button));
+			border-color: color(theme(button) shade(7%));
 			box-shadow: none;
 			text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.1);
 		}

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -171,7 +171,6 @@
 	&:disabled,
 	&[aria-disabled="true"] {
 		cursor: default;
-		//opacity: 0.3;
 	}
 
 	&:focus:not(:disabled) {


### PR DESCRIPTION
## Description
See #15280. This fixes the primary button's disabled view to match Core's primary disabled buttons. It should help the a11y issue raised in #15280.

Oh, it also fixes the default button state to match Core's too.

## How has this been tested?
Locally.

## Screenshots

**BEFORE**

![Screen Shot 2019-06-11 at 6 00 47 PM](https://user-images.githubusercontent.com/617986/59316352-de955600-8c72-11e9-8000-b902f9e3dd97.png)

**AFTER**

![Screen Shot 2019-06-11 at 5 53 45 PM](https://user-images.githubusercontent.com/617986/59316360-e81ebe00-8c72-11e9-8d3e-cffd891b6435.png)


## Types of changes
Minor CSS changes tweaking shade and tints of disabled buttons.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
