### PR TITLE
[RNMobile] Release v1.6.1

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -676,8 +676,8 @@ export class RichText extends Component {
 	forceSelectionUpdate( start, end ) {
 		if ( ! this.needsSelectionUpdate ) {
 			this.needsSelectionUpdate = true;
-			this.selectionStart = start;
-			this.selectionEnd = end;
+			this.selectionStart = isNaN( start ) ? 0 : start;
+			this.selectionEnd = isNaN( end ) ? 0 : end;
 			this.forceUpdate();
 		}
 	}
@@ -797,7 +797,10 @@ export class RichText extends Component {
 		let selection = null;
 		if ( this.needsSelectionUpdate ) {
 			this.needsSelectionUpdate = false;
-			selection = { start: this.props.selectionStart, end: this.props.selectionEnd };
+			selection = { 
+				start: isNaN( this.props.selectionStart ) ? 0 : this.props.selectionStart,
+				end: isNaN( this.props.selectionEnd ) ? 0 : this.props.selectionEnd
+			};
 
 			// On AztecAndroid, setting the caret to an out-of-bounds position will crash the editor so, let's check for some cases.
 			if ( ! this.isIOS ) {

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -36,7 +36,7 @@ import { doAction, hasAction } from '@wordpress/hooks';
  */
 import styles from './styles.scss';
 import MediaUploadProgress from './media-upload-progress';
-import SvgIcon from './icon';
+import { SvgIcon } from './icon';
 import SvgIconRetry from './icon-retry';
 
 const LINK_DESTINATION_CUSTOM = 'custom';

--- a/packages/block-library/src/image/icon.js
+++ b/packages/block-library/src/image/icon.js
@@ -3,8 +3,8 @@
  */
 import { Path, SVG } from '@wordpress/components';
 
-function svg( props ) {
+export function SvgIcon( props ) {
 	return <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" { ...props }><Path d="M0,0h24v24H0V0z" fill="none" /><Path d="m19 5v14h-14v-14h14m0-2h-14c-1.1 0-2 0.9-2 2v14c0 1.1 0.9 2 2 2h14c1.1 0 2-0.9 2-2v-14c0-1.1-0.9-2-2-2z" /><Path d="m14.14 11.86l-3 3.87-2.14-2.59-3 3.86h12l-3.86-5.14z" /></SVG>;
 }
 
-export default svg;
+export default SvgIcon( {} );

--- a/packages/block-library/src/video/edit.native.js
+++ b/packages/block-library/src/video/edit.native.js
@@ -37,7 +37,7 @@ import { doAction, hasAction } from '@wordpress/hooks';
  */
 import MediaUploadProgress from '../image/media-upload-progress';
 import style from './style.scss';
-import SvgIcon from './icon';
+import { SvgIcon } from './icon';
 import SvgIconRetry from './icon-retry';
 
 const VIDEO_ASPECT_RATIO = 1.7;

--- a/packages/block-library/src/video/icon.js
+++ b/packages/block-library/src/video/icon.js
@@ -3,8 +3,8 @@
  */
 import { Path, SVG } from '@wordpress/components';
 
-function svg( props ) {
+export function SvgIcon( props ) {
 	return <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" { ...props }><Path fill="none" d="M0 0h24v24H0V0z" /><Path d="M4 6.47L5.76 10H20v8H4V6.47M22 4h-4l2 4h-3l-2-4h-2l2 4h-3l-2-4H8l2 4H7L5 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V4z" /></SVG>;
 }
 
-export default svg;
+export default SvgIcon( {} );


### PR DESCRIPTION
This PR tracks the release v1.6.1 of the native mobile app.

We will not merge this one actually since the code it includes is about a fix that doesn't happen on current gutenberg-mobile `develop`. Also, it includes code from v1.6.0 that [was not mergeable either](https://github.com/WordPress/gutenberg/pull/16108).