### PR TITLE
Add table block column alignment

### DIFF
--- a/packages/block-editor/src/components/alignment-toolbar/index.js
+++ b/packages/block-editor/src/components/alignment-toolbar/index.js
@@ -27,7 +27,15 @@ const DEFAULT_ALIGNMENT_CONTROLS = [
 	},
 ];
 
-export function AlignmentToolbar( { value, onChange, alignmentControls = DEFAULT_ALIGNMENT_CONTROLS, isCollapsed = true } ) {
+export function AlignmentToolbar( props ) {
+	const {
+		value,
+		onChange,
+		alignmentControls = DEFAULT_ALIGNMENT_CONTROLS,
+		label = __( 'Change text alignment' ),
+		isCollapsed = true,
+	} = props;
+
 	function applyOrUnset( align ) {
 		return () => onChange( value === align ? undefined : align );
 	}
@@ -38,7 +46,7 @@ export function AlignmentToolbar( { value, onChange, alignmentControls = DEFAULT
 		<Toolbar
 			isCollapsed={ isCollapsed }
 			icon={ activeAlignment ? activeAlignment.icon : 'editor-alignleft' }
-			label={ __( 'Change text alignment' ) }
+			label={ label }
 			controls={ alignmentControls.map( ( control ) => {
 				const { align } = control;
 				const isActive = ( value === align );

--- a/packages/block-library/src/table/block.json
+++ b/packages/block-library/src/table/block.json
@@ -34,6 +34,11 @@
 							"type": "string",
 							"source": "attribute",
 							"attribute": "scope"
+						},
+						"align": {
+							"type": "string",
+							"source": "attribute",
+							"attribute": "data-align"
 						}
 					}
 				}
@@ -64,6 +69,11 @@
 							"type": "string",
 							"source": "attribute",
 							"attribute": "scope"
+						},
+						"align": {
+							"type": "string",
+							"source": "attribute",
+							"attribute": "data-align"
 						}
 					}
 				}
@@ -94,6 +104,11 @@
 							"type": "string",
 							"source": "attribute",
 							"attribute": "scope"
+						},
+						"align": {
+							"type": "string",
+							"source": "attribute",
+							"attribute": "data-align"
 						}
 					}
 				}

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -229,7 +229,7 @@ export class TableEdit extends Component {
 
 		const { attributes } = this.props;
 
-		return getCellAttribute( attributes, { ...selectedCell, attributeName: 'align' } );
+		return getCellAttribute( attributes, selectedCell, 'align' );
 	}
 
 	/**

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -14,6 +14,7 @@ import {
 	PanelColorSettings,
 	createCustomColorsHOC,
 	BlockIcon,
+	AlignmentToolbar,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import {
@@ -32,6 +33,8 @@ import {
 import {
 	createTable,
 	updateCellContent,
+	updateCellAttribute,
+	getCellAttribute,
 	insertRow,
 	deleteRow,
 	insertColumn,
@@ -61,6 +64,24 @@ const BACKGROUND_COLORS = [
 		color: '#fcf0ef',
 		name: 'Subtle pale pink',
 		slug: 'subtle-pale-pink',
+	},
+];
+
+const ALIGNMENT_CONTROLS = [
+	{
+		icon: 'editor-alignleft',
+		title: __( 'Align Column Left' ),
+		align: 'left',
+	},
+	{
+		icon: 'editor-aligncenter',
+		title: __( 'Align Column Center' ),
+		align: 'center',
+	},
+	{
+		icon: 'editor-alignright',
+		title: __( 'Align Column Right' ),
+		align: 'right',
 	},
 ];
 
@@ -164,6 +185,37 @@ export class TableEdit extends Component {
 			columnIndex,
 			content,
 		} ) );
+	}
+
+	onChangeCellAlignment( value ) {
+		const { selectedCell } = this.state;
+
+		if ( ! selectedCell ) {
+			return;
+		}
+
+		const { attributes, setAttributes } = this.props;
+		const { section, rowIndex, columnIndex } = selectedCell;
+
+		setAttributes( updateCellAttribute( attributes, {
+			section,
+			rowIndex,
+			columnIndex,
+			attributeName: 'align',
+			value,
+		} ) );
+	}
+
+	getCellAlignment() {
+		const { selectedCell } = this.state;
+
+		if ( ! selectedCell ) {
+			return;
+		}
+
+		const { attributes } = this.props;
+
+		return getCellAttribute( attributes, { ...selectedCell, attributeName: 'align' } );
 	}
 
 	/**
@@ -363,7 +415,7 @@ export class TableEdit extends Component {
 			<Tag>
 				{ rows.map( ( { cells }, rowIndex ) => (
 					<tr key={ rowIndex }>
-						{ cells.map( ( { content, tag: CellTag, scope }, columnIndex ) => {
+						{ cells.map( ( { content, tag: CellTag, scope, align }, columnIndex ) => {
 							const isSelected = selectedCell && (
 								type === selectedCell.section &&
 								rowIndex === selectedCell.rowIndex &&
@@ -376,7 +428,10 @@ export class TableEdit extends Component {
 								columnIndex,
 							};
 
-							const cellClasses = classnames( { 'is-selected': isSelected } );
+							const cellClasses = classnames( {
+								'is-selected': isSelected,
+								[ `has-text-align-${ align }` ]: align,
+							} );
 
 							return (
 								<CellTag
@@ -467,6 +522,12 @@ export class TableEdit extends Component {
 							controls={ this.getTableControls() }
 						/>
 					</Toolbar>
+					<AlignmentToolbar
+						alignmentControls={ ALIGNMENT_CONTROLS }
+						value={ this.getCellAlignment() }
+						onChange={ ( nextAlign ) => this.onChangeCellAlignment( nextAlign ) }
+						isCollapsed
+					/>
 				</BlockControls>
 				<InspectorControls>
 					<PanelBody title={ __( 'Table Settings' ) } className="blocks-table-settings">

--- a/packages/block-library/src/table/editor.scss
+++ b/packages/block-library/src/table/editor.scss
@@ -41,9 +41,19 @@
 
 	td.is-selected,
 	th.is-selected {
-		border-color: $blue-medium-500;
-		box-shadow: inset 0 0 0 1px $blue-medium-500;
-		border-style: double;
+		position: relative;
+
+		&::before {
+			content: "";
+			display: block;
+			position: absolute;
+			pointer-events: none;
+			top: -1px;
+			left: -1px;
+			right: -1px;
+			bottom: -1px;
+			border: 2px solid $blue-medium-500;
+		}
 	}
 
 	&__cell-content {

--- a/packages/block-library/src/table/editor.scss
+++ b/packages/block-library/src/table/editor.scss
@@ -41,19 +41,9 @@
 
 	td.is-selected,
 	th.is-selected {
-		position: relative;
-
-		&::before {
-			content: "";
-			display: block;
-			position: absolute;
-			pointer-events: none;
-			top: -1px;
-			left: -1px;
-			right: -1px;
-			bottom: -1px;
-			border: 2px solid $blue-medium-500;
-		}
+		border-color: $blue-medium-500;
+		box-shadow: inset 0 0 0 1px $blue-medium-500;
+		border-style: double;
 	}
 
 	&__cell-content {

--- a/packages/block-library/src/table/save.js
+++ b/packages/block-library/src/table/save.js
@@ -40,14 +40,22 @@ export default function save( { attributes } ) {
 			<Tag>
 				{ rows.map( ( { cells }, rowIndex ) => (
 					<tr key={ rowIndex }>
-						{ cells.map( ( { content, tag, scope }, cellIndex ) =>
-							<RichText.Content
-								tagName={ tag }
-								value={ content }
-								key={ cellIndex }
-								scope={ tag === 'th' ? scope : undefined }
-							/>
-						) }
+						{ cells.map( ( { content, tag, scope, align }, cellIndex ) => {
+							const cellClasses = classnames( {
+								[ `has-text-align-${ align }` ]: align,
+							} );
+
+							return (
+								<RichText.Content
+									className={ cellClasses ? cellClasses : undefined }
+									data-align={ align }
+									tagName={ tag }
+									value={ content }
+									key={ cellIndex }
+									scope={ tag === 'th' ? scope : undefined }
+								/>
+							);
+						} ) }
 					</tr>
 				) ) }
 			</Tag>

--- a/packages/block-library/src/table/state.js
+++ b/packages/block-library/src/table/state.js
@@ -49,20 +49,18 @@ export function getFirstRow( state ) {
 /**
  * Gets an attribute for a cell.
  *
- * @param {Object} state 			   	 Current table state.
- * @param {string} options.sectionName	 Section of the cell to update.
- * @param {number} options.rowIndex    	 Row index of the cell to update.
- * @param {number} options.columnIndex 	 Column index of the cell to update.
- * @param {number} options.attributeName The name of the attribute to get the value of.
+ * @param {Object} state 		 Current table state.
+ * @param {Object} cellLocation  The location of the cell
+ * @param {string} attributeName The name of the attribute to get the value of.
  *
  * @return {*} The attribute value.
  */
-export function getCellAttribute( state, {
-	sectionName,
-	rowIndex,
-	columnIndex,
-	attributeName,
-} ) {
+export function getCellAttribute( state, cellLocation, attributeName ) {
+	const {
+		sectionName,
+		rowIndex,
+		columnIndex,
+	} = cellLocation;
 	return get( state, [ sectionName, rowIndex, 'cells', columnIndex, attributeName ] );
 }
 
@@ -142,9 +140,9 @@ export function isCellSelected( cellLocation, selection ) {
 /**
  * Inserts a row in the table state.
  *
- * @param {Object} state                Current table state.
- * @param {string} options.sectionName  Section in which to insert the row.
- * @param {number} options.rowIndex     Row index at which to insert the row.
+ * @param {Object} state               Current table state.
+ * @param {string} options.sectionName Section in which to insert the row.
+ * @param {number} options.rowIndex    Row index at which to insert the row.
  *
  * @return {Object} New table state.
  */
@@ -154,7 +152,12 @@ export function insertRow( state, {
 	columnCount,
 } ) {
 	const firstRow = getFirstRow( state );
-	const cellCount = columnCount || get( firstRow, [ 'cells', 'length' ], 2 );
+	const cellCount = columnCount === undefined ? get( firstRow, [ 'cells', 'length' ] ) : columnCount;
+
+	// Bail early if the function cannot determine how many cells to add.
+	if ( ! cellCount ) {
+		return state;
+	}
 
 	return {
 		[ sectionName ]: [

--- a/packages/block-library/src/table/state.js
+++ b/packages/block-library/src/table/state.js
@@ -28,19 +28,21 @@ export function createTable( {
 /**
  * Updates cell content in the table state.
  *
- * @param {Object} state               Current table state.
- * @param {string} options.section     Section of the cell to update.
- * @param {number} options.rowIndex    Row index of the cell to update.
- * @param {number} options.columnIndex Column index of the cell to update.
- * @param {Array}  options.content     Content to set for the cell.
+ * @param {Object} state               	 Current table state.
+ * @param {string} options.section     	 Section of the cell to update.
+ * @param {number} options.rowIndex    	 Row index of the cell to update.
+ * @param {number} options.columnIndex 	 Column index of the cell to update.
+ * @param {number} options.attributeName The name of the attribute to update.
+ * @param {number} options.value 	   	 The value to update the attribute with.
  *
  * @return {Object} New table state.
  */
-export function updateCellContent( state, {
+export function updateCellAttribute( state, {
 	section,
 	rowIndex,
 	columnIndex,
-	content,
+	attributeName,
+	value,
 } ) {
 	return {
 		[ section ]: state[ section ].map( ( row, currentRowIndex ) => {
@@ -56,12 +58,50 @@ export function updateCellContent( state, {
 
 					return {
 						...cell,
-						content,
+						[ attributeName ]: value,
 					};
 				} ),
 			};
 		} ),
 	};
+}
+/**
+ * Gets an attribute for a cell.
+ *
+ * @param {Object} state 			   	 Current table state.
+ * @param {string} options.section     	 Section of the cell to update.
+ * @param {number} options.rowIndex    	 Row index of the cell to update.
+ * @param {number} options.columnIndex 	 Column index of the cell to update.
+ * @param {number} options.attributeName The name of the attribute to get the value of.
+ *
+ * @return {*} The attribute value.
+ */
+export function getCellAttribute( state, {
+	section,
+	rowIndex,
+	columnIndex,
+	attributeName,
+} ) {
+	return get( state, [ section, rowIndex, 'cells', columnIndex, attributeName ] );
+}
+
+/**
+ * Updates cell content in the table state.
+ *
+ * @param {Object} state               Current table state.
+ * @param {string} options.section     Section of the cell to update.
+ * @param {number} options.rowIndex    Row index of the cell to update.
+ * @param {number} options.columnIndex Column index of the cell to update.
+ * @param {Array}  options.content     Content to set for the cell.
+ *
+ * @return {Object} New table state.
+ */
+export function updateCellContent( state, { content: value, ...options } ) {
+	return updateCellAttribute( state, {
+		...options,
+		value,
+		attributeName: 'content',
+	} );
 }
 
 /**

--- a/packages/block-library/src/table/state.js
+++ b/packages/block-library/src/table/state.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import { times, get, mapValues, every } from 'lodash';
+import { times, get, mapValues, every, pick } from 'lodash';
+
+const INHERITED_COLUMN_ATTRIBUTES = [ 'align' ];
 
 /**
  * Creates a table state.
@@ -26,50 +28,29 @@ export function createTable( {
 }
 
 /**
- * Updates cell content in the table state.
+ * Returns the first row in the table.
  *
- * @param {Object} state               	 Current table state.
- * @param {string} options.section     	 Section of the cell to update.
- * @param {number} options.rowIndex    	 Row index of the cell to update.
- * @param {number} options.columnIndex 	 Column index of the cell to update.
- * @param {number} options.attributeName The name of the attribute to update.
- * @param {number} options.value 	   	 The value to update the attribute with.
+ * @param {Object} state Current table state.
  *
- * @return {Object} New table state.
+ * @return {Object} The first table row.
  */
-export function updateCellAttribute( state, {
-	section,
-	rowIndex,
-	columnIndex,
-	attributeName,
-	value,
-} ) {
-	return {
-		[ section ]: state[ section ].map( ( row, currentRowIndex ) => {
-			if ( currentRowIndex !== rowIndex ) {
-				return row;
-			}
-
-			return {
-				cells: row.cells.map( ( cell, currentColumnIndex ) => {
-					if ( currentColumnIndex !== columnIndex ) {
-						return cell;
-					}
-
-					return {
-						...cell,
-						[ attributeName ]: value,
-					};
-				} ),
-			};
-		} ),
-	};
+export function getFirstRow( state ) {
+	if ( ! isEmptyTableSection( state.head ) ) {
+		return state.head[ 0 ];
+	}
+	if ( ! isEmptyTableSection( state.body ) ) {
+		return state.body[ 0 ];
+	}
+	if ( ! isEmptyTableSection( state.foot ) ) {
+		return state.foot[ 0 ];
+	}
 }
+
 /**
  * Gets an attribute for a cell.
  *
  * @param {Object} state 			   	 Current table state.
- * @param {string} options.section     	 Section of the cell to update.
+ * @param {string} options.sectionName	 Section of the cell to update.
  * @param {number} options.rowIndex    	 Row index of the cell to update.
  * @param {number} options.columnIndex 	 Column index of the cell to update.
  * @param {number} options.attributeName The name of the attribute to get the value of.
@@ -77,59 +58,120 @@ export function updateCellAttribute( state, {
  * @return {*} The attribute value.
  */
 export function getCellAttribute( state, {
-	section,
+	sectionName,
 	rowIndex,
 	columnIndex,
 	attributeName,
 } ) {
-	return get( state, [ section, rowIndex, 'cells', columnIndex, attributeName ] );
+	return get( state, [ sectionName, rowIndex, 'cells', columnIndex, attributeName ] );
 }
 
 /**
- * Updates cell content in the table state.
+ * Returns updated cell attributes after applying the `updateCell` function to the selection.
  *
- * @param {Object} state               Current table state.
- * @param {string} options.section     Section of the cell to update.
- * @param {number} options.rowIndex    Row index of the cell to update.
- * @param {number} options.columnIndex Column index of the cell to update.
- * @param {Array}  options.content     Content to set for the cell.
+ * @param {Object}   state      The block attributes.
+ * @param {Object}   selection  The selection of cells to update.
+ * @param {Function} updateCell A function to update the selected cell attributes.
  *
- * @return {Object} New table state.
+ * @return {Object} New table state including the updated cells.
  */
-export function updateCellContent( state, { content: value, ...options } ) {
-	return updateCellAttribute( state, {
-		...options,
-		value,
-		attributeName: 'content',
+export function updateSelectedCell( state, selection, updateCell ) {
+	if ( ! selection ) {
+		return state;
+	}
+
+	const tableSections = pick( state, [ 'head', 'body', 'foot' ] );
+	const {
+		sectionName: selectionSectionName,
+		rowIndex: selectionRowIndex,
+	} = selection;
+
+	return mapValues( tableSections, ( section, sectionName ) => {
+		if ( selectionSectionName && selectionSectionName !== sectionName ) {
+			return section;
+		}
+
+		return section.map( ( row, rowIndex ) => {
+			if ( selectionRowIndex && selectionRowIndex !== rowIndex ) {
+				return row;
+			}
+
+			return {
+				cells: row.cells.map( ( cellAttributes, columnIndex ) => {
+					const cellLocation = {
+						sectionName,
+						columnIndex,
+						rowIndex,
+					};
+
+					if ( ! isCellSelected( cellLocation, selection ) ) {
+						return cellAttributes;
+					}
+
+					return updateCell( cellAttributes );
+				} ),
+			};
+		} );
 	} );
+}
+
+/**
+ * Returns whether the cell at `cellLocation` is included in the selection `selection`.
+ *
+ * @param {Object} cellLocation An object containing cell location properties.
+ * @param {Object} selection    An object containing selection properties.
+ *
+ * @return {boolean} True if the cell is selected, false otherwise.
+ */
+export function isCellSelected( cellLocation, selection ) {
+	if ( ! cellLocation || ! selection ) {
+		return false;
+	}
+
+	switch ( selection.type ) {
+		case 'column':
+			return selection.type === 'column' && cellLocation.columnIndex === selection.columnIndex;
+		case 'cell':
+			return selection.type === 'cell' &&
+				cellLocation.sectionName === selection.sectionName &&
+				cellLocation.columnIndex === selection.columnIndex &&
+				cellLocation.rowIndex === selection.rowIndex;
+	}
 }
 
 /**
  * Inserts a row in the table state.
  *
- * @param {Object} state            Current table state.
- * @param {string} options.section  Section in which to insert the row.
- * @param {number} options.rowIndex Row index at which to insert the row.
+ * @param {Object} state                Current table state.
+ * @param {string} options.sectionName  Section in which to insert the row.
+ * @param {number} options.rowIndex     Row index at which to insert the row.
  *
  * @return {Object} New table state.
  */
 export function insertRow( state, {
-	section,
+	sectionName,
 	rowIndex,
 	columnCount,
 } ) {
-	const cellCount = columnCount || state[ section ][ 0 ].cells.length;
+	const firstRow = getFirstRow( state );
+	const cellCount = columnCount || get( firstRow, [ 'cells', 'length' ], 2 );
 
 	return {
-		[ section ]: [
-			...state[ section ].slice( 0, rowIndex ),
+		[ sectionName ]: [
+			...state[ sectionName ].slice( 0, rowIndex ),
 			{
-				cells: times( cellCount, () => ( {
-					content: '',
-					tag: section === 'head' ? 'th' : 'td',
-				} ) ),
+				cells: times( cellCount, ( index ) => {
+					const firstCellInColumn = get( firstRow, [ 'cells', index ], {} );
+					const inheritedAttributes = pick( firstCellInColumn, INHERITED_COLUMN_ATTRIBUTES );
+
+					return {
+						...inheritedAttributes,
+						content: '',
+						tag: sectionName === 'head' ? 'th' : 'td',
+					};
+				} ),
 			},
-			...state[ section ].slice( rowIndex ),
+			...state[ sectionName ].slice( rowIndex ),
 		],
 	};
 }
@@ -137,18 +179,18 @@ export function insertRow( state, {
 /**
  * Deletes a row from the table state.
  *
- * @param {Object} state            Current table state.
- * @param {string} options.section  Section in which to delete the row.
- * @param {number} options.rowIndex Row index to delete.
+ * @param {Object} state               Current table state.
+ * @param {string} options.sectionName Section in which to delete the row.
+ * @param {number} options.rowIndex    Row index to delete.
  *
  * @return {Object} New table state.
  */
 export function deleteRow( state, {
-	section,
+	sectionName,
 	rowIndex,
 } ) {
 	return {
-		[ section ]: state[ section ].filter( ( row, index ) => index !== rowIndex ),
+		[ sectionName ]: state[ sectionName ].filter( ( row, index ) => index !== rowIndex ),
 	};
 }
 
@@ -156,7 +198,6 @@ export function deleteRow( state, {
  * Inserts a column in the table state.
  *
  * @param {Object} state               Current table state.
- * @param {string} options.section     Section in which to insert the column.
  * @param {number} options.columnIndex Column index at which to insert the column.
  *
  * @return {Object} New table state.
@@ -164,7 +205,9 @@ export function deleteRow( state, {
 export function insertColumn( state, {
 	columnIndex,
 } ) {
-	return mapValues( state, ( section, sectionName ) => {
+	const tableSections = pick( state, [ 'head', 'body', 'foot' ] );
+
+	return mapValues( tableSections, ( section, sectionName ) => {
 		// Bail early if the table section is empty.
 		if ( isEmptyTableSection( section ) ) {
 			return section;
@@ -195,7 +238,6 @@ export function insertColumn( state, {
  * Deletes a column from the table state.
  *
  * @param {Object} state               Current table state.
- * @param {string} options.section     Section in which to delete the column.
  * @param {number} options.columnIndex Column index to delete.
  *
  * @return {Object} New table state.
@@ -203,7 +245,9 @@ export function insertColumn( state, {
 export function deleteColumn( state, {
 	columnIndex,
 } ) {
-	return mapValues( state, ( section ) => {
+	const tableSections = pick( state, [ 'head', 'body', 'foot' ] );
+
+	return mapValues( tableSections, ( section ) => {
 		// Bail early if the table section is empty.
 		if ( isEmptyTableSection( section ) ) {
 			return section;
@@ -218,33 +262,33 @@ export function deleteColumn( state, {
 /**
  * Toggles the existance of a section.
  *
- * @param {Object} state   Current table state.
- * @param {string} section Name of the section to toggle.
+ * @param {Object} state       Current table state.
+ * @param {string} sectionName Name of the section to toggle.
  *
  * @return {Object} New table state.
  */
-export function toggleSection( state, section ) {
+export function toggleSection( state, sectionName ) {
 	// Section exists, replace it with an empty row to remove it.
-	if ( ! isEmptyTableSection( state[ section ] ) ) {
-		return { [ section ]: [] };
+	if ( ! isEmptyTableSection( state[ sectionName ] ) ) {
+		return { [ sectionName ]: [] };
 	}
 
 	// Get the length of the first row of the body to use when creating the header.
 	const columnCount = get( state, [ 'body', 0, 'cells', 'length' ], 1 );
 
 	// Section doesn't exist, insert an empty row to create the section.
-	return insertRow( state, { section, rowIndex: 0, columnCount } );
+	return insertRow( state, { sectionName, rowIndex: 0, columnCount } );
 }
 
 /**
  * Determines whether a table section is empty.
  *
- * @param {Object} sectionRows Table section state.
+ * @param {Object} section Table section state.
  *
  * @return {boolean} True if the table section is empty, false otherwise.
  */
-export function isEmptyTableSection( sectionRows ) {
-	return ! sectionRows || ! sectionRows.length || every( sectionRows, isEmptyRow );
+export function isEmptyTableSection( section ) {
+	return ! section || ! section.length || every( section, isEmptyRow );
 }
 
 /**

--- a/packages/block-library/src/table/test/state.js
+++ b/packages/block-library/src/table/test/state.js
@@ -163,12 +163,12 @@ describe( 'getFirstRow', () => {
 
 describe( 'getCellAttribute', () => {
 	it( 'should get the cell attribute', () => {
-		const state = getCellAttribute( tableWithAttribute, {
+		const cellLocation = {
 			sectionName: 'body',
 			rowIndex: 1,
 			columnIndex: 1,
-			attributeName: 'testAttr',
-		} );
+		};
+		const state = getCellAttribute( tableWithAttribute, cellLocation, 'testAttr' );
 
 		expect( state ).toBe( 'testVal' );
 	} );
@@ -368,6 +368,26 @@ describe( 'insertRow', () => {
 		};
 
 		expect( state ).toEqual( expected );
+	} );
+
+	it( 'should have no effect if `columnCount` is not provided and the table has no existing rows', () => {
+		const existingState = { body: {} };
+		const newState = insertRow( existingState, {
+			sectionName: 'body',
+			rowIndex: 0,
+		} );
+
+		expect( newState ).toBe( existingState );
+	} );
+
+	it( 'should have no effect if `columnCount` is `0`', () => {
+		const state = insertRow( tableWithHead, {
+			sectionName: 'head',
+			rowIndex: 1,
+			columnCount: 0,
+		} );
+
+		expect( state ).toBe( tableWithHead );
 	} );
 } );
 

--- a/packages/block-library/src/table/test/state.js
+++ b/packages/block-library/src/table/test/state.js
@@ -8,9 +8,8 @@ import deepFreeze from 'deep-freeze';
  */
 import {
 	createTable,
+	getFirstRow,
 	getCellAttribute,
-	updateCellAttribute,
-	updateCellContent,
 	insertRow,
 	deleteRow,
 	insertColumn,
@@ -18,6 +17,8 @@ import {
 	toggleSection,
 	isEmptyTableSection,
 	isEmptyRow,
+	isCellSelected,
+	updateSelectedCell,
 } from '../state';
 
 const table = deepFreeze( {
@@ -42,6 +43,32 @@ const table = deepFreeze( {
 				},
 				{
 					content: '',
+					tag: 'td',
+				},
+			],
+		},
+	],
+} );
+
+const tableWithHead = deepFreeze( {
+	head: [
+		{
+			cells: [
+				{
+					content: 'test',
+					tag: 'th',
+				},
+			],
+		},
+	],
+} );
+
+const tableWithFoot = deepFreeze( {
+	foot: [
+		{
+			cells: [
+				{
+					content: 'test',
 					tag: 'td',
 				},
 			],
@@ -116,10 +143,28 @@ describe( 'createTable', () => {
 	} );
 } );
 
+describe( 'getFirstRow', () => {
+	it( 'returns the first row in the head when the body is the first table section', () => {
+		expect( getFirstRow( tableWithHead ) ).toBe( tableWithHead.head[ 0 ] );
+	} );
+
+	it( 'returns the first row in the body when the body is the first table section', () => {
+		expect( getFirstRow( table ) ).toBe( table.body[ 0 ] );
+	} );
+
+	it( 'returns the first row in the foot when the body is the first table section', () => {
+		expect( getFirstRow( tableWithFoot ) ).toBe( tableWithFoot.foot[ 0 ] );
+	} );
+
+	it( 'returns `undefined` for an empty table', () => {
+		expect( getFirstRow( {} ) ).toBeUndefined();
+	} );
+} );
+
 describe( 'getCellAttribute', () => {
 	it( 'should get the cell attribute', () => {
 		const state = getCellAttribute( tableWithAttribute, {
-			section: 'body',
+			sectionName: 'body',
 			rowIndex: 1,
 			columnIndex: 1,
 			attributeName: 'testAttr',
@@ -129,37 +174,10 @@ describe( 'getCellAttribute', () => {
 	} );
 } );
 
-describe( 'updateCellAttribute', () => {
-	it( 'should update cell attribute', () => {
-		const state = updateCellAttribute( table, {
-			section: 'body',
-			rowIndex: 1,
-			columnIndex: 1,
-			attributeName: 'testAttr',
-			value: 'testVal',
-		} );
-
-		expect( state ).toEqual( tableWithAttribute );
-	} );
-} );
-
-describe( 'updateCellContent', () => {
-	it( 'should update cell content', () => {
-		const state = updateCellContent( table, {
-			section: 'body',
-			rowIndex: 1,
-			columnIndex: 1,
-			content: 'test',
-		} );
-
-		expect( state ).toEqual( tableWithContent );
-	} );
-} );
-
 describe( 'insertRow', () => {
 	it( 'should insert row', () => {
 		const state = insertRow( tableWithContent, {
-			section: 'body',
+			sectionName: 'body',
 			rowIndex: 2,
 		} );
 
@@ -209,7 +227,7 @@ describe( 'insertRow', () => {
 
 	it( 'allows the number of columns to be specified', () => {
 		const state = insertRow( tableWithContent, {
-			section: 'body',
+			sectionName: 'body',
 			rowIndex: 2,
 			columnCount: 4,
 		} );
@@ -266,11 +284,16 @@ describe( 'insertRow', () => {
 		expect( state ).toEqual( expected );
 	} );
 
-	it( 'adds `th` cells to the head', () => {
-		const tableWithHead = {
-			head: [
+	it( 'inherits the `align` property from the first cell in the column when adding a new row', () => {
+		const tableWithAlignment = {
+			body: [
 				{
 					cells: [
+						{
+							align: 'right',
+							content: 'test',
+							tag: 'th',
+						},
 						{
 							content: '',
 							tag: 'th',
@@ -280,8 +303,46 @@ describe( 'insertRow', () => {
 			],
 		};
 
+		const state = insertRow( tableWithAlignment, {
+			sectionName: 'body',
+			rowIndex: 1,
+		} );
+
+		expect( state ).toEqual( {
+			body: [
+				{
+					cells: [
+						{
+							align: 'right',
+							content: 'test',
+							tag: 'th',
+						},
+						{
+							content: '',
+							tag: 'th',
+						},
+					],
+				},
+				{
+					cells: [
+						{
+							align: 'right',
+							content: '',
+							tag: 'td',
+						},
+						{
+							content: '',
+							tag: 'td',
+						},
+					],
+				},
+			],
+		} );
+	} );
+
+	it( 'adds `th` cells to the head', () => {
 		const state = insertRow( tableWithHead, {
-			section: 'head',
+			sectionName: 'head',
 			rowIndex: 1,
 		} );
 
@@ -290,7 +351,7 @@ describe( 'insertRow', () => {
 				{
 					cells: [
 						{
-							content: '',
+							content: 'test',
 							tag: 'th',
 						},
 					],
@@ -312,19 +373,6 @@ describe( 'insertRow', () => {
 
 describe( 'insertColumn', () => {
 	it( 'inserts before existing content by default', () => {
-		const tableWithHead = {
-			head: [
-				{
-					cells: [
-						{
-							content: 'test',
-							tag: 'th',
-						},
-					],
-				},
-			],
-		};
-
 		const state = insertColumn( tableWithHead, {
 			columnIndex: 0,
 		} );
@@ -395,19 +443,6 @@ describe( 'insertColumn', () => {
 	} );
 
 	it( 'adds `th` cells to the head', () => {
-		const tableWithHead = {
-			head: [
-				{
-					cells: [
-						{
-							content: '',
-							tag: 'th',
-						},
-					],
-				},
-			],
-		};
-
 		const state = insertColumn( tableWithHead, {
 			columnIndex: 1,
 		} );
@@ -417,7 +452,7 @@ describe( 'insertColumn', () => {
 				{
 					cells: [
 						{
-							content: '',
+							content: 'test',
 							tag: 'th',
 						},
 						{
@@ -433,7 +468,7 @@ describe( 'insertColumn', () => {
 	} );
 
 	it( 'avoids adding cells to empty rows', () => {
-		const tableWithHead = {
+		const tableWithEmptyRow = {
 			head: [
 				{
 					cells: [
@@ -449,7 +484,7 @@ describe( 'insertColumn', () => {
 			],
 		};
 
-		const state = insertColumn( tableWithHead, {
+		const state = insertColumn( tableWithEmptyRow, {
 			columnIndex: 0,
 		} );
 
@@ -476,8 +511,8 @@ describe( 'insertColumn', () => {
 		expect( state ).toEqual( expected );
 	} );
 
-	it( 'adds cells across table sections that already have cells', () => {
-		const tableWithHead = {
+	it( 'adds cells across table sections that already have rows', () => {
+		const tableWithAllSections = {
 			head: [
 				{
 					cells: [
@@ -510,7 +545,7 @@ describe( 'insertColumn', () => {
 			],
 		};
 
-		const state = insertColumn( tableWithHead, {
+		const state = insertColumn( tableWithAllSections, {
 			columnIndex: 1,
 		} );
 
@@ -563,7 +598,7 @@ describe( 'insertColumn', () => {
 	} );
 
 	it( 'adds cells only to rows that have enough cells when rows have an unequal number of cells', () => {
-		const tableWithHead = {
+		const tableWithUnequalColumns = {
 			head: [
 				{
 					cells: [
@@ -604,7 +639,7 @@ describe( 'insertColumn', () => {
 			],
 		};
 
-		const state = insertColumn( tableWithHead, {
+		const state = insertColumn( tableWithUnequalColumns, {
 			columnIndex: 3,
 		} );
 
@@ -660,7 +695,7 @@ describe( 'insertColumn', () => {
 describe( 'deleteRow', () => {
 	it( 'should delete row', () => {
 		const state = deleteRow( tableWithContent, {
-			section: 'body',
+			sectionName: 'body',
 			rowIndex: 0,
 		} );
 
@@ -688,7 +723,6 @@ describe( 'deleteRow', () => {
 describe( 'deleteColumn', () => {
 	it( 'should delete column', () => {
 		const state = deleteColumn( tableWithContent, {
-			section: 'body',
 			columnIndex: 0,
 		} );
 
@@ -738,7 +772,6 @@ describe( 'deleteColumn', () => {
 			],
 		};
 		const state = deleteColumn( tableWithOneColumn, {
-			section: 'body',
 			columnIndex: 0,
 		} );
 
@@ -791,7 +824,6 @@ describe( 'deleteColumn', () => {
 			],
 		};
 		const state = deleteColumn( tableWithOneColumn, {
-			section: 'body',
 			columnIndex: 0,
 		} );
 
@@ -847,7 +879,6 @@ describe( 'deleteColumn', () => {
 		};
 
 		const state = deleteColumn( tableWithOneColumn, {
-			section: 'body',
 			columnIndex: 1,
 		} );
 
@@ -890,19 +921,6 @@ describe( 'deleteColumn', () => {
 
 describe( 'toggleSection', () => {
 	it( 'removes rows from the head section if the table already has them', () => {
-		const tableWithHead = {
-			head: [
-				{
-					cells: [
-						{
-							content: '',
-							tag: 'th',
-						},
-					],
-				},
-			],
-		};
-
 		const state = toggleSection( tableWithHead, 'head' );
 
 		const expected = {
@@ -913,11 +931,11 @@ describe( 'toggleSection', () => {
 	} );
 
 	it( 'adds a row to the head section if the table has none', () => {
-		const tableWithHead = {
+		const tableWithEmptyHead = {
 			head: [],
 		};
 
-		const state = toggleSection( tableWithHead, 'head' );
+		const state = toggleSection( tableWithEmptyHead, 'head' );
 
 		const expected = {
 			head: [
@@ -936,7 +954,7 @@ describe( 'toggleSection', () => {
 	} );
 
 	it( 'uses the number of cells in the first row of the body for the added table row', () => {
-		const tableWithHead = {
+		const tableWithEmptyHead = {
 			head: [],
 			body: [
 				{
@@ -958,7 +976,7 @@ describe( 'toggleSection', () => {
 			],
 		};
 
-		const state = toggleSection( tableWithHead, 'head' );
+		const state = toggleSection( tableWithEmptyHead, 'head' );
 
 		const expected = {
 			head: [
@@ -1053,5 +1071,124 @@ describe( 'isEmptyRow', () => {
 		};
 
 		expect( isEmptyRow( row ) ).toBe( false );
+	} );
+} );
+
+describe( 'isCellSelected', () => {
+	it( 'returns false when no cellLocation is provided', () => {
+		const tableSelection = { type: 'table' };
+
+		expect( isCellSelected( undefined, tableSelection ) ).toBe( false );
+	} );
+
+	it( 'returns false when no selection is provided', () => {
+		const cellLocation = { sectionName: 'head', columnIndex: 0, rowIndex: 0 };
+
+		expect( isCellSelected( cellLocation ) ).toBe( false );
+	} );
+
+	it( `considers only cells with the same columnIndex to be selected when the selection.type is 'column'`, () => {
+		// Valid locations and selections.
+		const headCellLocationA = { sectionName: 'head', columnIndex: 0, rowIndex: 0 };
+		const headCellLocationB = { sectionName: 'head', columnIndex: 0, rowIndex: 1 };
+		const bodyCellLocationA = { sectionName: 'body', columnIndex: 0, rowIndex: 0 };
+		const bodyCellLocationB = { sectionName: 'body', columnIndex: 0, rowIndex: 1 };
+		const footCellLocationA = { sectionName: 'foot', columnIndex: 0, rowIndex: 0 };
+		const footCellLocationB = { sectionName: 'foot', columnIndex: 0, rowIndex: 1 };
+		const columnSelection = { type: 'column', columnIndex: 0 };
+
+		// Invalid locations and selections.
+		const otherColumnCellLocationA = { sectionName: 'head', columnIndex: 1, rowIndex: 0 };
+		const otherColumnCellLocationB = { sectionName: 'body', columnIndex: 2, rowIndex: 0 };
+		const otherColumnCellLocationC = { sectionName: 'foot', columnIndex: 3, rowIndex: 0 };
+
+		expect( isCellSelected( headCellLocationA, columnSelection ) ).toBe( true );
+		expect( isCellSelected( headCellLocationB, columnSelection ) ).toBe( true );
+		expect( isCellSelected( bodyCellLocationA, columnSelection ) ).toBe( true );
+		expect( isCellSelected( bodyCellLocationB, columnSelection ) ).toBe( true );
+		expect( isCellSelected( footCellLocationA, columnSelection ) ).toBe( true );
+		expect( isCellSelected( footCellLocationB, columnSelection ) ).toBe( true );
+		expect( isCellSelected( otherColumnCellLocationA, columnSelection ) ).toBe( false );
+		expect( isCellSelected( otherColumnCellLocationB, columnSelection ) ).toBe( false );
+		expect( isCellSelected( otherColumnCellLocationC, columnSelection ) ).toBe( false );
+	} );
+
+	it( `considers only cells with the same section, columnIndex and rowIndex to be selected when the selection.type is 'cell'`, () => {
+		// Valid locations and selections.
+		const cellLocation = { sectionName: 'head', columnIndex: 0, rowIndex: 0 };
+		const cellSelection = { type: 'cell', sectionName: 'head', rowIndex: 0, columnIndex: 0 };
+
+		// Invalid locations and selections.
+		const otherColumnCellLocation = { sectionName: 'head', columnIndex: 1, rowIndex: 0 };
+		const otherRowCellLocation = { sectionName: 'head', columnIndex: 0, rowIndex: 1 };
+		const bodyCellLocation = { sectionName: 'body', columnIndex: 0, rowIndex: 0 };
+		const footCellLocation = { sectionName: 'foot', columnIndex: 0, rowIndex: 0 };
+
+		expect( isCellSelected( cellLocation, cellSelection ) ).toBe( true );
+		expect( isCellSelected( otherColumnCellLocation, cellSelection ) ).toBe( false );
+		expect( isCellSelected( otherRowCellLocation, cellSelection ) ).toBe( false );
+		expect( isCellSelected( bodyCellLocation, cellSelection ) ).toBe( false );
+		expect( isCellSelected( footCellLocation, cellSelection ) ).toBe( false );
+	} );
+} );
+
+describe( 'updateSelectedCell', () => {
+	it( 'returns an unchanged table state if there is no selection', () => {
+		const updated = updateSelectedCell( table, undefined, ( cell ) => ( { ...cell, content: 'test' } ) );
+		expect( table ).toEqual( updated );
+	} );
+
+	it( 'returns an unchanged table state if the selection is outside the bounds of the table', () => {
+		const cellSelection = { type: 'cell', sectionName: 'body', rowIndex: 100, columnIndex: 100 };
+		const updated = updateSelectedCell( table, cellSelection, ( cell ) => ( { ...cell, content: 'test' } ) );
+		expect( table ).toEqual( updated );
+	} );
+
+	it( 'updates only the individual cell when the selection type is `cell`', () => {
+		const cellSelection = { type: 'cell', sectionName: 'body', rowIndex: 0, columnIndex: 0 };
+		const updated = updateSelectedCell( table, cellSelection, ( cell ) => ( { ...cell, content: 'test' } ) );
+
+		expect( updated ).toEqual( {
+			body: [
+				{
+					cells: [
+						{
+							...table.body[ 0 ].cells[ 0 ],
+							content: 'test',
+						},
+						table.body[ 0 ].cells[ 1 ],
+					],
+				},
+				table.body[ 1 ],
+			],
+		} );
+	} );
+
+	it( 'updates every cell in the column when the selection type is `column`', () => {
+		const cellSelection = { type: 'column', columnIndex: 1 };
+		const updated = updateSelectedCell( table, cellSelection, ( cell ) => ( { ...cell, content: 'test' } ) );
+
+		expect( updated ).toEqual( {
+			body: [
+				{
+					cells: [
+						table.body[ 0 ].cells[ 0 ],
+						{
+							...table.body[ 0 ].cells[ 1 ],
+							content: 'test',
+						},
+					],
+				},
+				{
+					cells: [
+						table.body[ 1 ].cells[ 0 ],
+						{
+							...table.body[ 1 ].cells[ 1 ],
+							content: 'test',
+						},
+					],
+				},
+			],
+		} );
 	} );
 } );

--- a/packages/block-library/src/table/test/state.js
+++ b/packages/block-library/src/table/test/state.js
@@ -8,6 +8,8 @@ import deepFreeze from 'deep-freeze';
  */
 import {
 	createTable,
+	getCellAttribute,
+	updateCellAttribute,
 	updateCellContent,
 	insertRow,
 	deleteRow,
@@ -76,11 +78,68 @@ const tableWithContent = deepFreeze( {
 	],
 } );
 
+const tableWithAttribute = deepFreeze( {
+	body: [
+		{
+			cells: [
+				{
+					content: '',
+					tag: 'td',
+				},
+				{
+					content: '',
+					tag: 'td',
+				},
+			],
+		},
+		{
+			cells: [
+				{
+					content: '',
+					tag: 'td',
+				},
+				{
+					testAttr: 'testVal',
+					content: '',
+					tag: 'td',
+				},
+			],
+		},
+	],
+} );
+
 describe( 'createTable', () => {
 	it( 'should create a table', () => {
 		const state = createTable( { rowCount: 2, columnCount: 2 } );
 
 		expect( state ).toEqual( table );
+	} );
+} );
+
+describe( 'getCellAttribute', () => {
+	it( 'should get the cell attribute', () => {
+		const state = getCellAttribute( tableWithAttribute, {
+			section: 'body',
+			rowIndex: 1,
+			columnIndex: 1,
+			attributeName: 'testAttr',
+		} );
+
+		expect( state ).toBe( 'testVal' );
+	} );
+} );
+
+describe( 'updateCellAttribute', () => {
+	it( 'should update cell attribute', () => {
+		const state = updateCellAttribute( table, {
+			section: 'body',
+			rowIndex: 1,
+			columnIndex: 1,
+			attributeName: 'testAttr',
+			value: 'testVal',
+		} );
+
+		expect( state ).toEqual( tableWithAttribute );
 	} );
 } );
 

--- a/packages/e2e-tests/specs/blocks/__snapshots__/table.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/table.test.js.snap
@@ -12,9 +12,9 @@ exports[`Table allows adding and deleting columns across the table header, body 
 <!-- /wp:table -->"
 `;
 
-exports[`Table allows cells to be aligned 1`] = `
+exports[`Table allows columns to be aligned 1`] = `
 "<!-- wp:table -->
-<figure class=\\"wp-block-table\\"><table class=\\"\\"><tbody><tr><td>None</td><td class=\\"has-text-align-left\\" data-align=\\"left\\">To the left</td></tr><tr><td class=\\"has-text-align-center\\" data-align=\\"center\\">Centered</td><td class=\\"has-text-align-right\\" data-align=\\"right\\">To the right</td></tr></tbody></table></figure>
+<figure class=\\"wp-block-table\\"><table class=\\"\\"><tbody><tr><td>None</td><td class=\\"has-text-align-left\\" data-align=\\"left\\">To the left</td><td class=\\"has-text-align-center\\" data-align=\\"center\\">Centered</td><td class=\\"has-text-align-right\\" data-align=\\"right\\">Right aligned</td></tr><tr><td></td><td class=\\"has-text-align-left\\" data-align=\\"left\\"></td><td class=\\"has-text-align-center\\" data-align=\\"center\\"></td><td class=\\"has-text-align-right\\" data-align=\\"right\\"></td></tr></tbody></table></figure>
 <!-- /wp:table -->"
 `;
 

--- a/packages/e2e-tests/specs/blocks/__snapshots__/table.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/table.test.js.snap
@@ -12,6 +12,12 @@ exports[`Table allows adding and deleting columns across the table header, body 
 <!-- /wp:table -->"
 `;
 
+exports[`Table allows cells to be aligned 1`] = `
+"<!-- wp:table -->
+<figure class=\\"wp-block-table\\"><table class=\\"\\"><tbody><tr><td>None</td><td class=\\"has-text-align-left\\" data-align=\\"left\\">To the left</td></tr><tr><td class=\\"has-text-align-center\\" data-align=\\"center\\">Centered</td><td class=\\"has-text-align-right\\" data-align=\\"right\\">To the right</td></tr></tbody></table></figure>
+<!-- /wp:table -->"
+`;
+
 exports[`Table allows header and footer rows to be switched on and off 1`] = `
 "<!-- wp:table -->
 <figure class=\\"wp-block-table\\"><table class=\\"\\"><thead><tr><th>header</th><th></th></tr></thead><tbody><tr><td>body</td><td></td></tr><tr><td></td><td></td></tr></tbody><tfoot><tr><td>footer</td><td></td></tr></tfoot></table></figure>

--- a/packages/e2e-tests/specs/blocks/table.test.js
+++ b/packages/e2e-tests/specs/blocks/table.test.js
@@ -10,6 +10,17 @@ import {
 
 const createButtonSelector = "//div[@data-type='core/table']//button[text()='Create Table']";
 
+/**
+ * Utility function for changing the selected cell alignment.
+ *
+ * @param {string} align The alignment (one of 'left', 'center', or 'right').
+ */
+async function changeCellAlignment( align ) {
+	await clickBlockToolbarButton( 'Change Text Alignment' );
+	const alignButton = await page.$x( `//button[text()='Align text ${ align }']` );
+	await alignButton[ 0 ].click();
+}
+
 describe( 'Table', () => {
 	beforeEach( async () => {
 		await createNewPost();
@@ -29,22 +40,22 @@ describe( 'Table', () => {
 		await page.keyboard.press( 'Backspace' );
 		await page.keyboard.type( '5' );
 
-		// // Check for existence of the row count field.
+		// Check for existence of the row count field.
 		const rowCountLabel = await page.$x( "//div[@data-type='core/table']//label[text()='Row Count']" );
 		expect( rowCountLabel ).toHaveLength( 1 );
 
-		// // Modify the row count.
+		// Modify the row count.
 		await rowCountLabel[ 0 ].click();
 		const currentRowCount = await page.evaluate( () => document.activeElement.value );
 		expect( currentRowCount ).toBe( '2' );
 		await page.keyboard.press( 'Backspace' );
 		await page.keyboard.type( '10' );
 
-		// // Create the table.
+		// Create the table.
 		const createButton = await page.$x( createButtonSelector );
 		await createButton[ 0 ].click();
 
-		// // Expect the post content to have a correctly sized table.
+		// Expect the post content to have a correctly sized table.
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
@@ -152,6 +163,37 @@ describe( 'Table', () => {
 		await deleteColumnButton[ 0 ].click();
 
 		// Expect the table to have 2 columns across the header, body and footer.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'allows cells to be aligned', async () => {
+		await insertBlock( 'Table' );
+
+		// Create the table.
+		const createButton = await page.$x( createButtonSelector );
+		await createButton[ 0 ].click();
+
+		// Click the first cell and add some text. Don't align.
+		const cells = await page.$$( '.wp-block-table__cell-content' );
+		await cells[ 0 ].click();
+		await page.keyboard.type( 'None' );
+
+		// Click to the next cell and add some text. Align left.
+		await cells[ 1 ].click();
+		await page.keyboard.type( 'To the left' );
+		await changeCellAlignment( 'left' );
+
+		// Click the next cell and add some text. Align center.
+		await cells[ 2 ].click();
+		await page.keyboard.type( 'Centered' );
+		await changeCellAlignment( 'center' );
+
+		// Tab to the next cell and add some text. Align right.
+		await cells[ 3 ].click();
+		await page.keyboard.type( 'To the right' );
+		await changeCellAlignment( 'right' );
+
+		// Expect the post to have the correct written content inside the table.
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 } );

--- a/packages/e2e-tests/specs/blocks/table.test.js
+++ b/packages/e2e-tests/specs/blocks/table.test.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { capitalize } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -16,8 +21,8 @@ const createButtonSelector = "//div[@data-type='core/table']//button[text()='Cre
  * @param {string} align The alignment (one of 'left', 'center', or 'right').
  */
 async function changeCellAlignment( align ) {
-	await clickBlockToolbarButton( 'Change Text Alignment' );
-	const alignButton = await page.$x( `//button[text()='Align text ${ align }']` );
+	await clickBlockToolbarButton( 'Change column alignment' );
+	const alignButton = await page.$x( `//button[text()='Align Column ${ capitalize( align ) }']` );
 	await alignButton[ 0 ].click();
 }
 
@@ -166,12 +171,17 @@ describe( 'Table', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
-	it( 'allows cells to be aligned', async () => {
+	it( 'allows columns to be aligned', async () => {
 		await insertBlock( 'Table' );
 
+		const [ columnCountLabel ] = await page.$x( "//div[@data-type='core/table']//label[text()='Column Count']" );
+		await columnCountLabel.click();
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.type( '4' );
+
 		// Create the table.
-		const createButton = await page.$x( createButtonSelector );
-		await createButton[ 0 ].click();
+		const [ createButton ] = await page.$x( createButtonSelector );
+		await createButton.click();
 
 		// Click the first cell and add some text. Don't align.
 		const cells = await page.$$( '.wp-block-table__cell-content' );
@@ -190,7 +200,7 @@ describe( 'Table', () => {
 
 		// Tab to the next cell and add some text. Align right.
 		await cells[ 3 ].click();
-		await page.keyboard.type( 'To the right' );
+		await page.keyboard.type( 'Right aligned' );
 		await changeCellAlignment( 'right' );
 
 		// Expect the post to have the correct written content inside the table.


### PR DESCRIPTION
## Description
Adds column alignment options to the table block. Closes #15823

**Dev decisions**
Code-wise, the part where I've had to break from the norm is by using a `data-align` attribute to store the alignment value for a cell. This is because the cell attributes are deeply nested and sourced using a `query` matcher, so normal attributes can't be used.

Applying an alignment adds a class name and `data-align` attribute to each table cell in a column. There aren't many alternatives to this approach that I can think of, apart from using inline styles. `colgroup`/`col` elements don't support text align, so they're out of the question.

## How has this been tested?
Added unit and e2e tests.

Manual testing steps:
1. Add a table block to a post
2. Add some text to the first column of the table.
3. Ensure one of the cells in the first column is selected
4. From the toolbar try each of the column alignment options
5. Verify that text in the each cell in the column is aligned in the editor
6. Preview the post
7. Verify that the text is aligned when viewing the post.

## Screenshots <!-- if applicable -->
**Editor**
<img width="425" alt="Screen Shot 2019-07-30 at 10 46 50 am" src="https://user-images.githubusercontent.com/677833/62096810-7a2c6580-b2b7-11e9-9ed7-daa666eb7f99.png">

**Post**
<img width="466" alt="Screen Shot 2019-07-30 at 10 47 45 am" src="https://user-images.githubusercontent.com/677833/62096824-903a2600-b2b7-11e9-8b15-dac05e77d81b.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
