### PR TITLE
[RNMobile] Fix pasting text on Post Title

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -358,7 +358,6 @@ export class RichText extends Component {
 
 	// eslint-disable-next-line no-unused-vars
 	onEnter( event ) {
-		let { onEnter } = this.props;
 		if ( this.props.onEnter ) {
 			this.props.onEnter();
 			return;

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -358,6 +358,12 @@ export class RichText extends Component {
 
 	// eslint-disable-next-line no-unused-vars
 	onEnter( event ) {
+		let { onEnter } = this.props;
+		if ( this.props.onEnter ) {
+			this.props.onEnter();
+			return;
+		}
+
 		this.lastEventCount = event.nativeEvent.eventCount;
 		this.comesFromAztec = true;
 		this.firedAfterTextChanged = event.nativeEvent.firedAfterTextChanged;

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -102,7 +102,7 @@ class PostTitle extends Component {
 					placeholder={ decodedPlaceholder }
 					value={ title }
 					onSplit={ () => { } }
-					onReplace={ this.props.onEnterPress }
+					onEnter={ this.props.onEnterPress }
 					disableEditingMenu={ true }
 					setRef={ ( ref ) => {
 						this.titleViewRef = ref;


### PR DESCRIPTION
fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1099

This PR fixes an issue where pasting text on post title was behaving as pressing Enter key when the title field is empty.
Pasting send an event to `onReplace`, that was wired directly to `onEnterPress`.

This PR fixes the issue by adding an `onEnter` prop to `RichText`, adding the ability to handle custom onEnter handling when needed.

This PR does **NOT** fix pasting multi-paragraph text. I investigated multi-paragraph pasting and it will take some effort and discussion. I think the best would be to not use RichText on PostTitle, but let's have this discussion on another ticket.

`gutenberg-mobile` side PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1123

To test:
- Run the demo app.
- Select the Post Title field.
- Delete its current content.
- Paste some text inside the empty Post Title.
- Check that paste works as expected.
- Press Enter.
- Check that it creates a new block and it gets focused as expected.