### PR TITLE
Fix: Don't render drop zone bellow the default block appender

### DIFF
--- a/packages/block-editor/src/components/block-drop-zone/index.js
+++ b/packages/block-editor/src/components/block-drop-zone/index.js
@@ -58,7 +58,7 @@ class BlockDropZone extends Component {
 		const { clientId, rootClientId, getBlockIndex } = this.props;
 		if ( clientId !== undefined ) {
 			const index = getBlockIndex( clientId, rootClientId );
-			return position.y === 'top' ? index : index + 1;
+			return ( position && position.y === 'top' ) ? index : index + 1;
 		}
 	}
 
@@ -111,10 +111,12 @@ class BlockDropZone extends Component {
 	}
 
 	render() {
-		const { isLockedAll, index } = this.props;
+		const { isLockedAll } = this.props;
 		if ( isLockedAll ) {
 			return null;
 		}
+
+		const index = this.getInsertIndex();
 		const isAppender = index === undefined;
 
 		return (

--- a/packages/block-editor/src/components/block-drop-zone/style.scss
+++ b/packages/block-editor/src/components/block-drop-zone/style.scss
@@ -8,16 +8,20 @@
 		display: none;
 	}
 
-	&.is-close-to-bottom {
+	&.is-close-to-bottom,
+	&.is-close-to-top {
 		background: none;
+	}
+
+	&.is-close-to-top {
+		border-top: 3px solid theme(primary);
+	}
+
+	&.is-close-to-bottom {
 		border-bottom: 3px solid theme(primary);
 	}
 
-	&.is-close-to-top,
-	&.is-appender.is-close-to-top,
-	&.is-appender.is-close-to-bottom {
-		background: none;
-		border-top: 3px solid theme(primary);
+	&.is-appender.is-active.is-dragging-over-document {
 		border-bottom: none;
 	}
 }


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/9824

Currently, if we drag a block or a file above the default block appender we see the visual feedback that it is possible to drag it below the appender, we should not have that visual feedback.

I think we had some logic to handle the appender case. We added a flag `isAppender = index === undefined;` that would then add a class. But the index was never passed to the component and so the flag was always true. The CSS of the class was also not working as expected.

This PR fixes the isAppender flag/class computation and fixes the CSS to make sure when isAppender class is present only the top drop feedback border is visible.

## How has this been tested?
I tried to drag & drop blocks and files in the editor and verified things still work as expected.
I created some paragraphs. I added an HTML block at the end, I noticed the default block appender appeared after the HTML block I tried to drop a file above the default block appender and I verified the visual drop feedback only appeared on the top of the default block appender.
