### PR TITLE
Fix: Image block does not retain the dimensions when opening the media library

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -261,7 +261,7 @@ const ImageURLInputUI = ( {
 	);
 };
 
-class ImageEdit extends Component {
+export class ImageEdit extends Component {
 	constructor( { attributes } ) {
 		super( ...arguments );
 		this.updateAlt = this.updateAlt.bind( this );
@@ -357,11 +357,23 @@ class ImageEdit extends Component {
 			isEditing: false,
 		} );
 
+		const { id, url } = this.props.attributes;
+		let additionalAttributes;
+		// Reset the dimension attributes if changing to a different image.
+		if ( ! media.id || media.id !== id ) {
+			additionalAttributes = {
+				width: undefined,
+				height: undefined,
+				sizeSlug: DEFAULT_SIZE_SLUG,
+			};
+		} else {
+			// Keep the same url when selecting the same file, so "Image Size" option is not changed.
+			additionalAttributes = { url };
+		}
+
 		this.props.setAttributes( {
 			...pickRelevantMediaFiles( media ),
-			width: undefined,
-			height: undefined,
-			sizeSlug: DEFAULT_SIZE_SLUG,
+			...additionalAttributes,
 		} );
 	}
 

--- a/packages/block-library/src/image/test/edit.js
+++ b/packages/block-library/src/image/test/edit.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import TestRenderer from 'react-test-renderer';
+
+/**
+ * Internal dependencies
+ */
+import { ImageEdit } from '../edit';
+
+describe( 'core/image/edit', () => {
+	describe( 'onSelectImage', () => {
+		test( 'should reset dimensions when changing the image and keep them on selecting the same image', () => {
+			const attributes = {
+				id: 1,
+				url: 'http://www.example.com/myimage.jpeg',
+				alt: 'alt1',
+			};
+			const setAttributes = jest.fn( () => {} );
+			const testRenderer = TestRenderer.create(
+				<ImageEdit attributes={ attributes } setAttributes={ setAttributes } />
+			);
+			const instance = testRenderer.getInstance();
+
+			instance.onSelectImage( {
+				id: 1,
+				url: 'http://www.example.com/myimage.jpeg',
+				alt: 'alt2',
+			} );
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				id: 1,
+				url: 'http://www.example.com/myimage.jpeg',
+				alt: 'alt2',
+			} );
+			instance.onSelectImage( {
+				id: 2,
+				url: 'http://www.example.com/myimage.jpeg',
+				alt: 'alt2',
+			} );
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				id: 2,
+				url: 'http://www.example.com/myimage.jpeg',
+				alt: 'alt2',
+				sizeSlug: 'large',
+				width: undefined,
+				height: undefined,
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/9737

Currently, in the image block, if we open the media library and we select the same image the "Image Size" (URL) and the dimensions are reset.
It seems after the upload some users may first select the desired size and then open the media library to change the media object itself (and not just the block) and add alt, description, etc. Doing this resets the choose image size. This PR fixes that problem.


## How has this been tested?
I upload an image, I changed the dimensions using the resizer. I pressed the change image button, I opened the media library and I changed the caption of the image. I verified the new caption was applied and the dimensions were kept.
I repeated the test but instead of changing dimensions I changed the "Image Size" option of the image to "Full Image".

