### PR TITLE
Remove: experimental status from blockEditor.transformStyles

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -387,6 +387,19 @@ _Type_
 
 -   `Object` 
 
+<a name="transformStyles" href="#transformStyles">#</a> **transformStyles**
+
+Applies a series of CSS rule transforms to wrap selectors inside a given class and/or rewrite URLs depending on the parameters passed.
+
+_Parameters_
+
+-   _styles_ `Array`: CSS rules.
+-   _wrapperClassName_ `string`: Wrapper Class Name.
+
+_Returns_
+
+-   `Array`: converted rules.
+
 <a name="URLInput" href="#URLInput">#</a> **URLInput**
 
 _Related_

--- a/packages/block-editor/src/utils/index.js
+++ b/packages/block-editor/src/utils/index.js
@@ -1,4 +1,1 @@
-/**
- * Internal dependencies
- */
-export { default as __experimentalTransformStyles } from './transform-styles';
+export { default as transformStyles } from './transform-styles';

--- a/packages/block-editor/src/utils/transform-styles/index.js
+++ b/packages/block-editor/src/utils/transform-styles/index.js
@@ -16,7 +16,7 @@ import urlRewrite from './transforms/url-rewrite';
 import wrap from './transforms/wrap';
 
 /**
- * Convert css rules.
+ * Applies a series of CSS rule transforms to wrap selectors inside a given class and/or rewrite URLs depending on the parameters passed.
  *
  * @param {Array} styles CSS rules.
  * @param {string} wrapperClassName Wrapper Class Name.

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -6,7 +6,7 @@ import { Component } from '@wordpress/element';
 import {
 	BlockControls,
 	PlainText,
-	__experimentalTransformStyles,
+	transformStyles,
 } from '@wordpress/block-editor';
 import { Disabled, SandBox } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
@@ -38,7 +38,7 @@ class HTMLEdit extends Component {
 
 		this.setState( { styles: [
 			defaultStyles,
-			...__experimentalTransformStyles( styles ),
+			...transformStyles( styles ),
 		] } );
 	}
 

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -11,7 +11,7 @@ import { compose } from '@wordpress/compose';
 import { Component } from '@wordpress/element';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { BlockEditorProvider, __experimentalTransformStyles } from '@wordpress/block-editor';
+import { BlockEditorProvider, transformStyles } from '@wordpress/block-editor';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -112,7 +112,7 @@ class EditorProvider extends Component {
 			return;
 		}
 
-		const updatedStyles = __experimentalTransformStyles( this.props.settings.styles, '.editor-styles-wrapper' );
+		const updatedStyles = transformStyles( this.props.settings.styles, '.editor-styles-wrapper' );
 
 		map( updatedStyles, ( updatedCSS ) => {
 			if ( updatedCSS ) {

--- a/packages/editor/src/index.js
+++ b/packages/editor/src/index.js
@@ -22,4 +22,4 @@ export { storeConfig } from './store';
 /*
  * Backward compatibility
  */
-export { __experimentalTransformStyles as transformStyles } from '@wordpress/block-editor';
+export { transformStyles } from '@wordpress/block-editor';


### PR DESCRIPTION
## Description
Follow up on https://github.com/WordPress/gutenberg/pull/15572.

Removes experimental status from blockEditor.transformStyles.

## How has this been tested?
I verified the HTML block still works as before.
I executed wp.blockEditor.transformStyles( [ { css: 'h1, b { color: red; }' } ], '.wp' );in the browser console and I verified the output was: [".wp h1,↵.wp b {↵color: red;↵}"].
