### PR TITLE
Add deprecated call to wp.components.ServerSideRender; Remove some missed wp.components.ServerSideRender usages.

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -282,9 +282,17 @@ function gutenberg_register_scripts_and_styles() {
 			"\n",
 			array(
 				'( function() {',
-				'	if ( wp && wp.components && wp.serverSideRender && ! wp.components.ServerSideRender ) {',
-				'		wp.components.ServerSideRender = wp.serverSideRender;',
-				'	};',
+				'	if ( wp && wp.components && wp.serverSideRender ) {',
+				'		wp.components.ServerSideRender = wp.element.forwardRef( function( props, ref ) {',
+				'			wp.deprecated( \'wp.components.ServerSideRender\', {',
+				'				alternative: \'wp.serverSideRender\',',
+				'			} );',
+				'			return wp.element.createElement(',
+				'				wp.serverSideRender,',
+				'				Object.assign( { ref: ref }, props )',
+				'			);',
+				'		} );',
+				'	}',
 				'} )();',
 			)
 		)

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -275,29 +275,6 @@ function gutenberg_register_scripts_and_styles() {
 		)
 	);
 
-	// Add back compatibility for calls to wp.components.ServerSideRender.
-	wp_add_inline_script(
-		'wp-server-side-render',
-		implode(
-			"\n",
-			array(
-				'( function() {',
-				'	if ( wp && wp.components && wp.serverSideRender ) {',
-				'		wp.components.ServerSideRender = wp.element.forwardRef( function( props, ref ) {',
-				'			wp.deprecated( \'wp.components.ServerSideRender\', {',
-				'				alternative: \'wp.serverSideRender\',',
-				'			} );',
-				'			return wp.element.createElement(',
-				'				wp.serverSideRender,',
-				'				Object.assign( { ref: ref }, props )',
-				'			);',
-				'		} );',
-				'	}',
-				'} )();',
-			)
-		)
-	);
-
 	// Editor Styles.
 	// This empty stylesheet is defined to ensure backward compatibility.
 	gutenberg_override_style( 'wp-blocks', false );

--- a/package-lock.json
+++ b/package-lock.json
@@ -5218,6 +5218,7 @@
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/components": "file:packages/components",
 				"@wordpress/data": "file:packages/data",
+				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/url": "file:packages/url",

--- a/packages/server-side-render/package.json
+++ b/packages/server-side-render/package.json
@@ -26,6 +26,7 @@
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/components": "file:../components",
 		"@wordpress/data": "file:../data",
+		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/url": "file:../url",

--- a/packages/server-side-render/src/index.js
+++ b/packages/server-side-render/src/index.js
@@ -1,8 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { useMemo } from '@wordpress/element';
+import { useMemo, forwardRef } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -14,7 +15,7 @@ import ServerSideRender from './server-side-render';
  */
 const EMPTY_OBJECT = {};
 
-export default withSelect(
+const ExportedServerSideRender = withSelect(
 	( select ) => {
 		const coreEditorSelect = select( 'core/editor' );
 		if ( coreEditorSelect ) {
@@ -44,3 +45,16 @@ export default withSelect(
 		);
 	}
 );
+
+if ( window && window.wp && window.wp.components ) {
+	window.wp.components.ServerSideRender = forwardRef( ( props, ref ) => {
+		deprecated( 'wp.components.ServerSideRender', {
+			alternative: 'wp.serverSideRender',
+		} );
+		return (
+			<ExportedServerSideRender { ...props } ref={ ref } />
+		);
+	} );
+}
+
+export default ExportedServerSideRender;


### PR DESCRIPTION
## Description
Follow up from https://github.com/WordPress/gutenberg/pull/15635.

In https://github.com/WordPress/gutenberg/pull/15635 we kept the back-compatibility for usages of wp.components.ServerSideRender but we did not implement a deprecated call.

This PR adds the missing deprecated call.

## How has this been tested?
I changed the archives block to use ServerSideRender from wp.components.
I verified the block works as expected, but a deprecated warning is thrown in the browser console.