### PR TITLE
Improve placeholder text phrasing for media blocks

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -175,14 +175,14 @@ export class MediaPlaceholder extends Component {
 			const isVideo = isOneType && 'video' === allowedTypes[ 0 ];
 
 			if ( instructions === undefined && mediaUpload ) {
-				instructions = __( 'Drag a media file, upload a new one or select a file from your library.' );
+				instructions = __( 'Upload a media file or pick one from your media library.' );
 
 				if ( isAudio ) {
-					instructions = __( 'Drag an audio, upload a new one or select a file from your library.' );
+					instructions = __( 'Upload an audio file, pick one from your media library, or add one with a URL.' );
 				} else if ( isImage ) {
-					instructions = __( 'Drag an image, upload a new one or select a file from your library.' );
+					instructions = __( 'Upload an image file, pick one from your media library, or add one with a URL.' );
 				} else if ( isVideo ) {
-					instructions = __( 'Drag a video, upload a new one or select a file from your library.' );
+					instructions = __( 'Upload a video file, pick one from your media library, or add one with a URL.' );
 				}
 			}
 

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -243,7 +243,7 @@ class CoverEdit extends Component {
 						className={ className }
 						labels={ {
 							title: label,
-							instructions: __( 'Drag an image or a video, upload a new one or select a file from your library.' ),
+							instructions: __( 'Upload an image or video file, or pick one from your media library.' ),
 						} }
 						onSelect={ onSelectMedia }
 						accept="image/*,video/*"

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -161,7 +161,7 @@ class FileEdit extends Component {
 					icon={ <BlockIcon icon={ icon } /> }
 					labels={ {
 						title: __( 'File' ),
-						instructions: __( 'Drag a file, upload a new one or select a file from your library.' ),
+						instructions: __( 'Upload a file or pick one from your media library.' ),
 					} }
 					onSelect={ this.onSelectFile }
 					notices={ noticeUI }

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -408,7 +408,7 @@ class ImageEdit extends Component {
 		const src = isExternal ? url : undefined;
 		const labels = {
 			title: ! url ? __( 'Image' ) : __( 'Edit image' ),
-			instructions: __( 'Drag an image to upload, select a file from your library or add one from an URL.' ),
+			instructions: __( 'Upload an image, pick one from your media library, or add one with a URL.' ),
 		};
 		const mediaPreview = ( !! url && <img
 			alt={ __( 'Edit image' ) }


### PR DESCRIPTION
Closes #8409

This PR edits the placeholder text for the following blocks, cleaning up the sentence structure and phrasing. 

- Image
- Cover
- Audio
- Video
- File
- Media & Text

It uses the recommendations in the original ticket, but with some minor adjustments (from a DM with @michelleweber):

For when there's a URL option: 
> Upload a [type] file, pick one from your media library, or add one with a URL. 

For when there's no URL option: 
> Upload a [type] file or pick one from your media library. 

---

**Before:** 

![gutenberg test_wp-admin_post php_post=1 action=edit (1)](https://user-images.githubusercontent.com/1202812/59391375-f4fde900-8d28-11e9-81a0-6ee96a9d51af.png)

**After:** 

![gutenberg test_wp-admin_post php_post=1 action=edit](https://user-images.githubusercontent.com/1202812/59391164-596c7880-8d28-11e9-83b3-c7832c58a1f4.png)