### PR TITLE
[RNMobile] Simple View for video view on Android

### DIFF
--- a/packages/block-library/src/video/video-play-button.native.js
+++ b/packages/block-library/src/video/video-play-button.native.js
@@ -1,0 +1,30 @@
+/**
+ * WordPress dependencies
+ */
+import { Dashicon } from '@wordpress/components';
+
+/**
+ * External dependencies
+ */
+import { View, TouchableOpacity } from 'react-native';
+
+/**
+ * Internal dependencies
+ */
+import styles from './video-player.scss';
+
+export default ( props ) => {
+	const { isSelected, onPressPlay, style } = props;
+
+	return (
+		<TouchableOpacity disabled={ ! isSelected } onPress={ onPressPlay } style={ [ style, styles.overlay ] }>
+			<View style={ styles.playIcon }>
+				<Dashicon
+					icon={ 'controls-play' }
+					ariaPressed={ 'dashicon-active' }
+					size={ styles.playIcon.width }
+				/>
+			</View>
+		</TouchableOpacity>
+	);
+}

--- a/packages/block-library/src/video/video-player.android.js
+++ b/packages/block-library/src/video/video-player.android.js
@@ -1,0 +1,63 @@
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { Dashicon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * External dependencies
+ */
+import { View, Linking, Alert } from 'react-native';
+
+/**
+ * Internal dependencies
+ */
+import { default as VideoPlayButton } from './video-play-button';
+import styles from './video-player.scss';
+
+class Video extends Component {
+	constructor() {
+		super( ...arguments );
+		this.onPressPlay = this.onPressPlay.bind( this );
+	}
+
+	onPressPlay() {
+		const { source } = this.props;
+		if ( source && source.uri ) {
+			this.openURL( source.uri );
+		}
+	}
+
+	// Tries opening the URL outside of the app
+	openURL( url ) {
+		Linking.canOpenURL( url ).then( ( supported ) => {
+			if ( ! supported ) {
+				Alert.alert( __( 'Problem opening the video' ), __( 'No application can handle this request. Please install a Web browser.' ) );
+				window.console.warn( 'No application found that can open the video with URL: ' + url );
+			} else {
+				return Linking.openURL( url );
+			}
+		} ).catch( ( err ) => {
+			Alert.alert( __( 'Problem opening the video' ), __( 'An unknown error occurred. Please try again.' ) );
+			window.console.error( 'An error occurred while opening the video URL: ' + url, err );
+		} );
+	}
+
+	render() {
+		const { isSelected, style } = this.props;
+
+		return (
+			<View style={ styles.videoContainer }>
+				<View { ...this.props } />
+				<VideoPlayButton
+					style={ style }
+					isSelected={ isSelected }
+					onPressPlay={ this.onPressPlay }
+				/>
+			</View>
+		);
+	}
+}
+
+export default Video;

--- a/packages/block-library/src/video/video-player.ios.js
+++ b/packages/block-library/src/video/video-player.ios.js
@@ -8,18 +8,18 @@ import { __ } from '@wordpress/i18n';
 /**
  * External dependencies
  */
-import { View, TouchableOpacity, Platform, Linking, Alert } from 'react-native';
+import { View } from 'react-native';
 import { default as VideoPlayer } from 'react-native-video';
 
 /**
  * Internal dependencies
  */
+import { default as VideoPlayButton } from './video-play-button';
 import styles from './video-player.scss';
 
 class Video extends Component {
 	constructor() {
 		super( ...arguments );
-		this.isIOS = Platform.OS === 'ios';
 		this.state = {
 			isFullScreen: false,
 			videoContainerHeight: 0,
@@ -36,31 +36,9 @@ class Video extends Component {
 	}
 
 	onPressPlay() {
-		if ( this.isIOS ) {
-			if ( this.player ) {
-				this.player.presentFullscreenPlayer();
-			}
-		} else {
-			const { source } = this.props;
-			if ( source && source.uri ) {
-				this.openURL( source.uri );
-			}
+		if ( this.player ) {
+			this.player.presentFullscreenPlayer();
 		}
-	}
-
-	// Tries opening the URL outside of the app
-	openURL( url ) {
-		Linking.canOpenURL( url ).then( ( supported ) => {
-			if ( ! supported ) {
-				Alert.alert( __( 'Problem opening the video' ), __( 'No application can handle this request. Please install a Web browser.' ) );
-				window.console.warn( 'No application found that can open the video with URL: ' + url );
-			} else {
-				return Linking.openURL( url );
-			}
-		} ).catch( ( err ) => {
-			Alert.alert( __( 'Problem opening the video' ), __( 'An unknown error occurred. Please try again.' ) );
-			window.console.error( 'An error occurred while opening the video URL: ' + url, err );
-		} );
 	}
 
 	render() {
@@ -92,11 +70,11 @@ class Video extends Component {
 				{ showPlayButton &&
 				// If we add the play icon as a subview to VideoPlayer then react-native-video decides to show control buttons
 				// even if we set controls={ false }, so we are adding our play button as a sibling overlay view.
-				<TouchableOpacity disabled={ ! isSelected } onPress={ this.onPressPlay } style={ [ style, styles.overlay ] }>
-					<View style={ styles.playIcon }>
-						<Dashicon icon={ 'controls-play' } ariaPressed={ 'dashicon-active' } size={ styles.playIcon.width } />
-					</View>
-				</TouchableOpacity>
+				<VideoPlayButton
+					style={ style }
+					isSelected={ isSelected }
+					onPressPlay={ this.onPressPlay }
+				/>
 				}
 			</View>
 		);


### PR DESCRIPTION
## Description
Additional proposal on top of https://github.com/WordPress/gutenberg/pull/16089 that demotes the in-block video preview to a simple `View` instead of the full react-native-video view. This is a temporary workaround until some issues with the view overflowing its boundaries are fixed.

## How has this been tested?
Tested using https://github.com/wordpress-mobile/gutenberg-mobile/pull/1117

![simple-view-preview](https://user-images.githubusercontent.com/1032913/59392138-446f0400-8d7f-11e9-9c78-d050f0185ffe.gif)

## Types of changes
* Introduced the `VideoPlayButton` component to render the play button
* Introduced the `video-player.android.js` to implement the Android side of the video component, rendering a simple View instead of the proper video preview.
* Reduced the `video-player.native.js` module into `video-player.ios.js` to only hold the iOS side implementation

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
