### PR TITLE
Update HTML anchor explaination text

### DIFF
--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -7,7 +7,7 @@ import { assign, has } from 'lodash';
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
-import { TextControl } from '@wordpress/components';
+import { TextControl, ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { hasBlockSupport } from '@wordpress/blocks';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -71,7 +71,16 @@ export const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) =>
 					<InspectorAdvancedControls>
 						<TextControl
 							label={ __( 'HTML Anchor' ) }
-							help={ __( 'Anchors lets you link directly to a section on a page.' ) }
+							help={ (
+							    <>
+							        { __( 'Enter a word or two — without spaces — to make a unique web address just for this heading, called an "anchor." Then, you’ll be able link directly to this section of your page.' ) }
+							        <div className="components-placeholder__learn-more">
+							            <ExternalLink href={ __( 'https://wordpress.org/support/article/#/' ) }>
+							                { __( 'Learn more about anchors' ) }
+							            </ExternalLink>
+							        </div>
+							    </>
+							) }
 							value={ props.attributes.anchor || '' }
 							onChange={ ( nextValue ) => {
 								nextValue = nextValue.replace( ANCHOR_REGEX, '-' );

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -73,7 +73,9 @@ export const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) =>
 							label={ __( 'HTML Anchor' ) }
 							help={ (
 								<>
-								{ __( 'Enter a word or two — without spaces — to make a unique web address just for this heading, called an "anchor." Then, you’ll be able link directly to this section of your page.' ) }
+								<p>
+									{ __( 'Enter a word or two — without spaces — to make a unique web address just for this heading, called an "anchor." Then, you’ll be able link directly to this section of your page.' ) }
+								</p>
 								<div className="components-base-control__learn-more">
 									<ExternalLink href={ __( 'https://wordpress.org/support/article/#/' ) }>
 										{ __( 'Learn more about anchors' ) }

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -76,11 +76,11 @@ export const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) =>
 									<p>
 										{ __( 'Enter a word or two — without spaces — to make a unique web address just for this heading, called an "anchor." Then, you\'ll be able link directly to this section of your page.' ) }
 									</p>
-									<div className="components-base-control__learn-more">
+									<p className="components-base-control__learn-more">
 										<ExternalLink href={ __( 'https://wordpress.org/support/article/#/' ) }>
 											{ __( 'Learn more about anchors' ) }
 										</ExternalLink>
-									</div>
+									</p>
 								</>
 							) }
 							value={ props.attributes.anchor || '' }

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -70,17 +70,15 @@ export const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) =>
 					<BlockEdit { ...props } />
 					<InspectorAdvancedControls>
 						<TextControl
+							className="html-anchor-control"
 							label={ __( 'HTML Anchor' ) }
 							help={ (
 								<>
-									<p>
-										{ __( 'Enter a word or two — without spaces — to make a unique web address just for this heading, called an “anchor.” Then, you’ll be able to link directly to this section of your page.' ) }
-									</p>
-									<p>
-										<ExternalLink href={ __( 'https://wordpress.org/support/article/#/' ) }>
-											{ __( 'Learn more about anchors' ) }
-										</ExternalLink>
-									</p>
+									{ __( 'Enter a word or two — without spaces — to make a unique web address just for this heading, called an “anchor.” Then, you’ll be able to link directly to this section of your page.' ) }
+
+									<ExternalLink href={ __( 'https://wordpress.org/support/article/#/' ) }>
+										{ __( 'Learn more about anchors' ) }
+									</ExternalLink>
 								</>
 							) }
 							value={ props.attributes.anchor || '' }

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -76,7 +76,7 @@ export const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) =>
 								<>
 									{ __( 'Enter a word or two — without spaces — to make a unique web address just for this heading, called an “anchor.” Then, you’ll be able to link directly to this section of your page.' ) }
 
-									<ExternalLink href={ __( 'https://wordpress.org/support/article/page-jumps/' ) }>
+									<ExternalLink href={ 'https://wordpress.org/support/article/page-jumps/' }>
 										{ __( 'Learn more about anchors' ) }
 									</ExternalLink>
 								</>

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -72,14 +72,14 @@ export const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) =>
 						<TextControl
 							label={ __( 'HTML Anchor' ) }
 							help={ (
-							    <>
-							        { __( 'Enter a word or two — without spaces — to make a unique web address just for this heading, called an "anchor." Then, you’ll be able link directly to this section of your page.' ) }
-							        <div className="components-placeholder__learn-more">
-							            <ExternalLink href={ __( 'https://wordpress.org/support/article/#/' ) }>
-							                { __( 'Learn more about anchors' ) }
-							            </ExternalLink>
-							        </div>
-							    </>
+								<>
+								{ __( 'Enter a word or two — without spaces — to make a unique web address just for this heading, called an "anchor." Then, you’ll be able link directly to this section of your page.' ) }
+								<div className="components-base-control__learn-more">
+									<ExternalLink href={ __( 'https://wordpress.org/support/article/#/' ) }>
+										{ __( 'Learn more about anchors' ) }
+									</ExternalLink>
+								</div>
+								</>
 							) }
 							value={ props.attributes.anchor || '' }
 							onChange={ ( nextValue ) => {

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -74,7 +74,7 @@ export const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) =>
 							help={ (
 								<>
 									<p>
-										{ __( 'Enter a word or two — without spaces — to make a unique web address just for this heading, called an "anchor." Then, you\'ll be able link directly to this section of your page.' ) }
+										{ __( 'Enter a word or two — without spaces — to make a unique web address just for this heading, called an “anchor.” Then, you’ll be able to link directly to this section of your page.' ) }
 									</p>
 									<p className="components-base-control__learn-more">
 										<ExternalLink href={ __( 'https://wordpress.org/support/article/#/' ) }>

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -76,7 +76,7 @@ export const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) =>
 									<p>
 										{ __( 'Enter a word or two — without spaces — to make a unique web address just for this heading, called an “anchor.” Then, you’ll be able to link directly to this section of your page.' ) }
 									</p>
-									<p className="components-base-control__learn-more">
+									<p>
 										<ExternalLink href={ __( 'https://wordpress.org/support/article/#/' ) }>
 											{ __( 'Learn more about anchors' ) }
 										</ExternalLink>

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -73,14 +73,14 @@ export const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) =>
 							label={ __( 'HTML Anchor' ) }
 							help={ (
 								<>
-								<p>
-									{ __( 'Enter a word or two — without spaces — to make a unique web address just for this heading, called an "anchor." Then, you’ll be able link directly to this section of your page.' ) }
-								</p>
-								<div className="components-base-control__learn-more">
-									<ExternalLink href={ __( 'https://wordpress.org/support/article/#/' ) }>
-										{ __( 'Learn more about anchors' ) }
-									</ExternalLink>
-								</div>
+									<p>
+										{ __( 'Enter a word or two — without spaces — to make a unique web address just for this heading, called an "anchor." Then, you’ll be able link directly to this section of your page.' ) }
+									</p>
+									<div className="components-base-control__learn-more">
+										<ExternalLink href={ __( 'https://wordpress.org/support/article/#/' ) }>
+											{ __( 'Learn more about anchors' ) }
+										</ExternalLink>
+									</div>
 								</>
 							) }
 							value={ props.attributes.anchor || '' }

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -76,7 +76,7 @@ export const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) =>
 								<>
 									{ __( 'Enter a word or two — without spaces — to make a unique web address just for this heading, called an “anchor.” Then, you’ll be able to link directly to this section of your page.' ) }
 
-									<ExternalLink href={ __( 'https://wordpress.org/support/article/#/' ) }>
+									<ExternalLink href={ __( 'https://wordpress.org/support/article/page-jumps/' ) }>
 										{ __( 'Learn more about anchors' ) }
 									</ExternalLink>
 								</>

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -74,7 +74,7 @@ export const withInspectorControl = createHigherOrderComponent( ( BlockEdit ) =>
 							help={ (
 								<>
 									<p>
-										{ __( 'Enter a word or two — without spaces — to make a unique web address just for this heading, called an "anchor." Then, you’ll be able link directly to this section of your page.' ) }
+										{ __( 'Enter a word or two — without spaces — to make a unique web address just for this heading, called an "anchor." Then, you\'ll be able link directly to this section of your page.' ) }
 									</p>
 									<div className="components-base-control__learn-more">
 										<ExternalLink href={ __( 'https://wordpress.org/support/article/#/' ) }>

--- a/packages/block-editor/src/hooks/anchor.scss
+++ b/packages/block-editor/src/hooks/anchor.scss
@@ -1,0 +1,4 @@
+.html-anchor-control .components-external-link {
+	display: block;
+	margin-top: $grid-size;
+}

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -32,3 +32,4 @@
 @import "./components/url-popover/style.scss";
 @import "./components/warning/style.scss";
 @import "./components/writing-flow/style.scss";
+@import "./hooks/anchor.scss";


### PR DESCRIPTION
## Description
The HTML anchor text was unclear to anyone who didn't already know what HTML anchors are. This PR updates that text to be more user friendly, with copy written by @michelleweber. 

See #15306.

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/2846578/59399432-d9a2d600-8d48-11e9-8d9b-1976a82da3c8.png)

After:
![image](https://user-images.githubusercontent.com/2846578/59401069-63a16d80-8d4e-11e9-8160-e8ac0c61572e.png)

## Issues
- ~I'd like to add 1em of space between paragraphs, but there's currently no CSS file for adding new styles to this section. How should I approach this?~ Okay, this is fixed, but... now there are p's indented into p's. 
- We don't have any HelpHub documentation on HTML anchors, as far as I can tell, which stops us from being able to link to anything right now. WordPress.com has really great docs on this; maybe we could copy them over? https://en.support.wordpress.com/splitting-content/page-jumps/. Is there someone I can ping about this?

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
