### PR TITLE
docs(components/higher-order/with-spoken-messages): fix issue in example code

### DIFF
--- a/packages/components/src/higher-order/with-spoken-messages/README.md
+++ b/packages/components/src/higher-order/with-spoken-messages/README.md
@@ -7,8 +7,8 @@ import { withSpokenMessages, Button } from '@wordpress/components';
 
 const MyComponentWithSpokenMessages = withSpokenMessages( ( { speak, debouncedSpeak } ) => (
 	<div>
-		<Button isDefault onClick={ speak( 'Spoken message' ) }>Speak</Button>
-		<Button isDefault onClick={ debouncedSpeak( 'Delayed message' ) }>Debounced Speak</Button>
+		<Button isDefault onClick={ () => speak( 'Spoken message' ) }>Speak</Button>
+		<Button isDefault onClick={ () => debouncedSpeak( 'Delayed message' ) }>Debounced Speak</Button>
 	</div>
 ) );
 ```


### PR DESCRIPTION
## Description

This PR simply fixes the example in `with-spoken-messages`. The `onClick` prop should be a function.

## How has this been tested?

N/A

## Screenshots <!-- if applicable -->

N/A

## Types of changes

Docs

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->