### PR TITLE
docs(block-editor/components/inspector-controls): fix image path

### DIFF
--- a/packages/block-editor/src/components/inspector-controls/README.md
+++ b/packages/block-editor/src/components/inspector-controls/README.md
@@ -1,6 +1,6 @@
 # Inspector Controls
 
-<img src="https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/blocks/inspector.png" with="281" height="527" alt="inspector">
+<img src="https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/assets/inspector.png" with="281" height="527" alt="inspector">
 
 Inspector Controls appear in the post settings sidebar when a block is being edited. The controls appear in both HTML and visual editing modes, and thus should contain settings that affect the entire block.
 


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This PR simply fixes the image path.

https://github.com/WordPress/gutenberg/tree/master/packages/block-editor/src/components/inspector-controls

`docs/blocks/inspector.png` ⇒ `docs/designers-developers/assets/inspector.png`


### History
- https://github.com/WordPress/gutenberg/pull/11817
  - `docs/blocks/inspector.png` ⇒ `docs/designers-developers/developers/tutorials/block-tutorial/inspector.png`
- https://github.com/WordPress/gutenberg/pull/12745
  - `docs/designers-developers/developers/tutorials/block-tutorial/inspector.png` ⇒ `docs/designers-developers/assets/inspector.png`

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
N/A

## Screenshots <!-- if applicable -->
### Before fix
![before](https://raw.githubusercontent.com/technote-space/screenshots/master/gutenberg/201906131508.png)

### After fix
![after](https://raw.githubusercontent.com/technote-space/screenshots/master/gutenberg/201906131519.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Docs

