### PR TITLE
Remove focus from RichText when unmounting

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -702,7 +702,7 @@ export class RichText extends Component {
 
 	componentWillUnmount() {
 		if ( this._editor.isFocused() ) {
-			// this._editor.blur();
+			this._editor.blur();
 		}
 	}
 


### PR DESCRIPTION
In #15999 this behavior was changed to prevent the keyboard from disappearing
when you press Enter to create a new paragraph.

This worked in that case, but had the side effect of TextInputState still
thinking a dead view had focus, and causing a crash in some scenarios.

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1126

![Screen Recording 2019-06-13 at 09 17 45](https://user-images.githubusercontent.com/8739/59411812-69359c80-8dbc-11e9-98d4-d0aebaa7e233.gif)

To test:

1. Remove all the content
2. Insert an image
3. Remove the image
4. Ensure there's no crash