### PR TITLE
[Mobile] Disable Video block on Android for v1.7.0 release

### DIFF
--- a/packages/edit-post/src/index.native.js
+++ b/packages/edit-post/src/index.native.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { Platform } from 'react-native';
+
+/**
  * WordPress dependencies
  */
 import '@wordpress/core-data';
@@ -23,8 +28,8 @@ export function initializeEditor() {
 	if ( typeof __DEV__ === 'undefined' || ! __DEV__ ) {
 		unregisterBlockType( 'core/code' );
 
-		// Disable Video block on Android for now.
-		if ( platform.OS === 'android' ) {
+		// Disable Video block except for iOS for now.
+		if ( Platform.OS !== 'ios' ) {
 			unregisterBlockType( 'core/video' );
 		}
 	}

--- a/packages/edit-post/src/index.native.js
+++ b/packages/edit-post/src/index.native.js
@@ -22,6 +22,11 @@ export function initializeEditor() {
 	// eslint-disable-next-line no-undef
 	if ( typeof __DEV__ === 'undefined' || ! __DEV__ ) {
 		unregisterBlockType( 'core/code' );
+
+		// Disable Video block on Android for now.
+		if ( platform.OS === 'android' ) {
+			unregisterBlockType( 'core/video' );
+		}
 	}
 }
 


### PR DESCRIPTION
## Description
This PR disables the Video block on Android.

Companion Mobile Gutenberg PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1127

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
