### PR TITLE
Add support for watching block.json files when running `npm run dev`

### DIFF
--- a/bin/packages/build-worker.js
+++ b/bin/packages/build-worker.js
@@ -140,6 +140,21 @@ const BUILD_TASK_BY_EXTENSION = {
 			] );
 		}
 	},
+
+	async '.json'( file ) {
+		// Currently, only building block library block.json files is supported.
+		// See https://github.com/WordPress/gutenberg/issues/16104 for further info.
+		if ( ! /block-library.*block\.json$/.test( file ) ) {
+			return;
+		}
+
+		// The block.json file is inlined into the block's index.js when building.
+		// The following code rebuilds the index.js relative to the block.json so
+		// that this inlining happens again.
+		const blockIndexFile = file.replace( 'block.json', 'index.js' );
+		const task = BUILD_TASK_BY_EXTENSION[ '.js' ];
+		await task( blockIndexFile );
+	},
 };
 
 module.exports = async ( file, callback ) => {

--- a/bin/packages/build-worker.js
+++ b/bin/packages/build-worker.js
@@ -140,21 +140,6 @@ const BUILD_TASK_BY_EXTENSION = {
 			] );
 		}
 	},
-
-	async '.json'( file ) {
-		// Currently, only building block library block.json files is supported.
-		// See https://github.com/WordPress/gutenberg/issues/16104 for further info.
-		if ( ! /block-library.*block\.json$/.test( file ) ) {
-			return;
-		}
-
-		// The block.json file is inlined into the block's index.js when building.
-		// The following code rebuilds the index.js relative to the block.json so
-		// that this inlining happens again.
-		const blockIndexFile = file.replace( 'block.json', 'index.js' );
-		const task = BUILD_TASK_BY_EXTENSION[ '.js' ];
-		await task( blockIndexFile );
-	},
 };
 
 module.exports = async ( file, callback ) => {

--- a/bin/packages/build.js
+++ b/bin/packages/build.js
@@ -95,8 +95,7 @@ function createBlockJsonEntryTransform() {
 			}
 
 			blocks.add( blockName );
-			const entries = await glob( path.resolve( PACKAGES_DIR, 'block-library/src/', blockName, 'index.js' ) );
-			entries.forEach( ( entry ) => this.push( entry ) );
+			this.push( file.replace( 'block.json', 'index.js' ) );
 			callback();
 		},
 	} );

--- a/bin/packages/build.js
+++ b/bin/packages/build.js
@@ -64,6 +64,14 @@ function createStyleEntryTransform() {
 	} );
 }
 
+/**
+ * Returns a stream transform which maps an individual block.json to the
+ * index.js that imports it. Presently, babel resolves the import of json
+ * files by inlining them as a JavaScript primitive in the importing file.
+ * This transform ensures the importing file is rebuilt.
+ *
+ * @return {Transform} Stream transform instance.
+ */
 function createBlockJsonEntryTransform() {
 	const blocks = new Set;
 

--- a/bin/packages/build.js
+++ b/bin/packages/build.js
@@ -78,7 +78,7 @@ function createBlockJsonEntryTransform() {
 	return new Transform( {
 		objectMode: true,
 		async transform( file, encoding, callback ) {
-			const matches = /block-library\/src\/(.*)\/block.json$/.exec( file );
+			const matches = /block-library[\/\\]src[\/\\](.*)[\/\\]block.json$/.exec( file );
 			const blockName = matches ? matches[ 1 ] : undefined;
 
 			// Only block.json files in the block-library folder are subject to this transform.


### PR DESCRIPTION
## Description
Fixes #16104

This is quite a simplistic fix, but gets the job done!

The lowdown is that currently, block.json content is inlined into the index.js file its imported from when babel builds the files. The watch task currently doesn't work, firstly as the `build-worker` file had no task specified for building a json file. Secondly, such a task would have to rebuild the index.js relative to the block.json so that the inlined json is replaced when rebuilding.

This PR adds a new task that checks whether the file is a block.json file, and if so rebuilds the relative index.js file. It'll only handle block.json files in the block-library package, but helps solve a problem for most devs working on core blocks.

## How has this been tested?
1. Run npm run dev
2. Load the editor and add an empty paragraph block, save the post
3. In the paragraph block's block.json, change the content attributes default to something else like "Hello, world!"
4. Observe in the console that a webpack rebuild is triggered
5. Reload the editor and click on the paragraph block you added earlier

On this branch:
The paragraph block contains the default defined in step 3, demonstrating that the watch task worked.

When running npm run dev against master:
The paragraph block isn't updated with its new default

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
