### PR TITLE
[RNMobile] Narrow down blur on unmount to replaceable only

### DIFF
--- a/packages/block-editor/src/components/block-edit/index.js
+++ b/packages/block-editor/src/components/block-edit/index.js
@@ -27,13 +27,13 @@ class BlockEdit extends Component {
 		);
 	}
 
-	propsToContext( name, isSelected, clientId, onFocus, onCaretVerticalPositionChange ) {
-		return { name, isSelected, clientId, onFocus, onCaretVerticalPositionChange };
+	propsToContext( name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, isReplaceable ) {
+		return { name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, isReplaceable };
 	}
 
 	render() {
-		const { name, isSelected, clientId, onFocus, onCaretVerticalPositionChange } = this.props;
-		const value = this.propsToContext( name, isSelected, clientId, onFocus, onCaretVerticalPositionChange );
+		const { name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, isReplaceable } = this.props;
+		const value = this.propsToContext( name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, isReplaceable );
 
 		return (
 			<BlockEditContextProvider value={ value }>

--- a/packages/block-editor/src/components/block-edit/index.js
+++ b/packages/block-editor/src/components/block-edit/index.js
@@ -27,13 +27,13 @@ class BlockEdit extends Component {
 		);
 	}
 
-	propsToContext( name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, unstableShouldBlurOnUnmount ) {
-		return { name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, unstableShouldBlurOnUnmount };
+	propsToContext( name, isSelected, clientId, onFocus, onCaretVerticalPositionChange ) {
+		return { name, isSelected, clientId, onFocus, onCaretVerticalPositionChange };
 	}
 
 	render() {
-		const { name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, unstableShouldBlurOnUnmount } = this.props;
-		const value = this.propsToContext( name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, unstableShouldBlurOnUnmount );
+		const { name, isSelected, clientId, onFocus, onCaretVerticalPositionChange } = this.props;
+		const value = this.propsToContext( name, isSelected, clientId, onFocus, onCaretVerticalPositionChange );
 
 		return (
 			<BlockEditContextProvider value={ value }>

--- a/packages/block-editor/src/components/block-edit/index.js
+++ b/packages/block-editor/src/components/block-edit/index.js
@@ -27,13 +27,13 @@ class BlockEdit extends Component {
 		);
 	}
 
-	propsToContext( name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, isReplaceable ) {
-		return { name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, isReplaceable };
+	propsToContext( name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, unstableShouldBlurOnUnmount ) {
+		return { name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, unstableShouldBlurOnUnmount };
 	}
 
 	render() {
-		const { name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, isReplaceable } = this.props;
-		const value = this.propsToContext( name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, isReplaceable );
+		const { name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, unstableShouldBlurOnUnmount } = this.props;
+		const value = this.propsToContext( name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, unstableShouldBlurOnUnmount );
 
 		return (
 			<BlockEditContextProvider value={ value }>

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -701,7 +701,7 @@ export class RichText extends Component {
 	}
 
 	componentWillUnmount() {
-		if ( this._editor.isFocused() && this.props.isReplaceable ) {
+		if ( this._editor.isFocused() && this.props.unstableShouldBlurOnUnmount ) {
 			this._editor.blur();
 		}
 	}
@@ -857,12 +857,12 @@ RichText.defaultProps = {
 
 const RichTextContainer = compose( [
 	withInstanceId,
-	withBlockEditContext( ( { clientId, onCaretVerticalPositionChange, isReplaceable, isSelected }, ownProps ) => {
+	withBlockEditContext( ( { clientId, onCaretVerticalPositionChange, unstableShouldBlurOnUnmount, isSelected }, ownProps ) => {
 		return {
 			clientId,
 			blockIsSelected: ownProps.isSelected !== undefined ? ownProps.isSelected : isSelected,
 			onCaretVerticalPositionChange,
-			isReplaceable,
+			unstableShouldBlurOnUnmount,
 		};
 	} ),
 	withSelect( ( select, {

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -702,7 +702,7 @@ export class RichText extends Component {
 
 	componentWillUnmount() {
 		if ( this._editor.isFocused() ) {
-			// this._editor.blur();
+			this._editor.blur();
 		}
 	}
 

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -701,7 +701,7 @@ export class RichText extends Component {
 	}
 
 	componentWillUnmount() {
-		if ( this._editor.isFocused() ) {
+		if ( this._editor.isFocused() && this.props.isReplaceable ) {
 			this._editor.blur();
 		}
 	}
@@ -857,11 +857,12 @@ RichText.defaultProps = {
 
 const RichTextContainer = compose( [
 	withInstanceId,
-	withBlockEditContext( ( { clientId, onCaretVerticalPositionChange, isSelected }, ownProps ) => {
+	withBlockEditContext( ( { clientId, onCaretVerticalPositionChange, isReplaceable, isSelected }, ownProps ) => {
 		return {
 			clientId,
 			blockIsSelected: ownProps.isSelected !== undefined ? ownProps.isSelected : isSelected,
 			onCaretVerticalPositionChange,
+			isReplaceable,
 		};
 	} ),
 	withSelect( ( select, {


### PR DESCRIPTION
## Description
Additional PR on top of https://github.com/WordPress/gutenberg/pull/16146, to add more conditions on when to do the blur-on-unmount for the RichText.

~In this case, we're passing the `isReplaceable` flag to the component via the Context, and do the blur-on-unmount only if the parent block is replaceable (in which case it won't have the chance the blur otherwise).~ Instead of passing it, the latest revision of this fix has the computation of the `shouldBlurOnUnmount` flag/prop right inside the `withSelect` HOC of the RichText.

(Embedding the description from #16146 for completeness):
In #15999 this behavior was changed to prevent the keyboard from disappearing
when you press Enter to create a new paragraph.

This worked in that case, but had the side effect of TextInputState still
thinking a dead view had focus, and causing a crash in some scenarios.

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1126

![Screen Recording 2019-06-13 at 09 17 45](https://user-images.githubusercontent.com/8739/59411812-69359c80-8dbc-11e9-98d4-d0aebaa7e233.gif)

To test:

1. Remove all the content
2. Insert an image
3. Remove the image
4. Ensure there's no crash

## Types of changes
Compute and pass `isReplaceable` to the editing context and use it in RichText to blur.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
