### PR TITLE
Fix missing closing tag for RegistryConsumer example

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -398,7 +398,7 @@ You can read more about the react context api here:
 
 _Usage_
 
-````js
+```js
 const {
   RegistryProvider,
   RegistryConsumer,
@@ -419,6 +419,7 @@ const App = ( { props } ) => {
     </RegistryConsumer>
   </RegistryProvider>
 }
+```
 
 <a name="RegistryProvider" href="#RegistryProvider">#</a> **RegistryProvider**
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -398,7 +398,7 @@ You can read more about the react context api here:
 
 _Usage_
 
-````js
+```js
 const {
   RegistryProvider,
   RegistryConsumer,
@@ -419,6 +419,7 @@ const App = ( { props } ) => {
     </RegistryConsumer>
   </RegistryProvider>
 }
+```
 
 <a name="RegistryProvider" href="#RegistryProvider">#</a> **RegistryProvider**
 
@@ -434,13 +435,13 @@ Given the name of a registered store, returns an object of the store's selectors
 The selector functions are been pre-bound to pass the current state automatically.
 As a consumer, you need only pass arguments of the selector, if applicable.
 
-*Usage*
+_Usage_
 
 ```js
 const { select } = wp.data;
 
 select( 'my-shop' ).getPrice( 'hammer' );
-````
+```
 
 _Parameters_
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -398,7 +398,7 @@ You can read more about the react context api here:
 
 _Usage_
 
-```js
+````js
 const {
   RegistryProvider,
   RegistryConsumer,
@@ -419,7 +419,6 @@ const App = ( { props } ) => {
     </RegistryConsumer>
   </RegistryProvider>
 }
-```
 
 <a name="RegistryProvider" href="#RegistryProvider">#</a> **RegistryProvider**
 

--- a/packages/data/src/components/registry-provider/context.js
+++ b/packages/data/src/components/registry-provider/context.js
@@ -41,6 +41,7 @@ const { Consumer, Provider } = Context;
  *     </RegistryConsumer>
  *   </RegistryProvider>
  * }
+ * ```
  */
 export const RegistryConsumer = Consumer;
 


### PR DESCRIPTION
The code block for https://github.com/WordPress/gutenberg/tree/b354644/packages/data#RegistryConsumer is missing the closing backticks.