### PR TITLE
[RNMobile] Native mobile release v1.7.0

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -13,6 +13,9 @@ import memize from 'memize';
 /**
  * WordPress dependencies
  */
+import {
+	isUnmodifiedDefaultBlock,
+} from '@wordpress/blocks';
 import { Component, RawHTML } from '@wordpress/element';
 import { withInstanceId, compose } from '@wordpress/compose';
 import { BlockFormatControls } from '@wordpress/block-editor';
@@ -701,8 +704,8 @@ export class RichText extends Component {
 	}
 
 	componentWillUnmount() {
-		if ( this._editor.isFocused() ) {
-			// this._editor.blur();
+		if ( this._editor.isFocused() && this.props.shouldBlurOnUnmount ) {
+			this._editor.blur();
 		}
 	}
 
@@ -875,6 +878,7 @@ const RichTextContainer = compose( [
 		const {
 			getSelectionStart,
 			getSelectionEnd,
+			__unstableGetBlockWithoutInnerBlocks,
 		} = select( 'core/block-editor' );
 
 		const selectionStart = getSelectionStart();
@@ -887,12 +891,19 @@ const RichTextContainer = compose( [
 			);
 		}
 
+		// If the block of this RichText is unmodified then it's a candidate for replacing when adding a new block.
+		// In order to fix https://github.com/wordpress-mobile/gutenberg-mobile/issues/1126, let's blur on unmount in that case.
+		// This apparently assumes functionality the BlockHlder actually 
+		const block = clientId && __unstableGetBlockWithoutInnerBlocks( clientId );
+		const shouldBlurOnUnmount = block && isSelected && isUnmodifiedDefaultBlock( block );
+
 		return {
 			formatTypes: getFormatTypes(),
 			selectionStart: isSelected ? selectionStart.offset : undefined,
 			selectionEnd: isSelected ? selectionEnd.offset : undefined,
 			isSelected,
 			blockIsSelected,
+			shouldBlurOnUnmount,
 		};
 	} ),
 	withDispatch( ( dispatch, {

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -37,7 +37,7 @@ import { BACKSPACE } from '@wordpress/keycodes';
 import {
 	children,
 	isUnmodifiedDefaultBlock,
-	pasteHandler
+	pasteHandler,
 } from '@wordpress/blocks';
 import { isURL } from '@wordpress/url';
 

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -13,9 +13,6 @@ import memize from 'memize';
 /**
  * WordPress dependencies
  */
-import {
-	isUnmodifiedDefaultBlock,
-} from '@wordpress/blocks';
 import { Component, RawHTML } from '@wordpress/element';
 import { withInstanceId, compose } from '@wordpress/compose';
 import { BlockFormatControls } from '@wordpress/block-editor';
@@ -37,7 +34,11 @@ import {
 } from '@wordpress/rich-text';
 import { decodeEntities } from '@wordpress/html-entities';
 import { BACKSPACE } from '@wordpress/keycodes';
-import { pasteHandler, children } from '@wordpress/blocks';
+import {
+	children,
+	isUnmodifiedDefaultBlock,
+	pasteHandler
+} from '@wordpress/blocks';
 import { isURL } from '@wordpress/url';
 
 /**

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -894,7 +894,7 @@ const RichTextContainer = compose( [
 
 		// If the block of this RichText is unmodified then it's a candidate for replacing when adding a new block.
 		// In order to fix https://github.com/wordpress-mobile/gutenberg-mobile/issues/1126, let's blur on unmount in that case.
-		// This apparently assumes functionality the BlockHlder actually 
+		// This apparently assumes functionality the BlockHlder actually
 		const block = clientId && __unstableGetBlockWithoutInnerBlocks( clientId );
 		const shouldBlurOnUnmount = block && isSelected && isUnmodifiedDefaultBlock( block );
 

--- a/packages/edit-post/src/index.native.js
+++ b/packages/edit-post/src/index.native.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { Platform } from 'react-native';
+
+/**
  * WordPress dependencies
  */
 import '@wordpress/core-data';
@@ -22,6 +27,11 @@ export function initializeEditor() {
 	// eslint-disable-next-line no-undef
 	if ( typeof __DEV__ === 'undefined' || ! __DEV__ ) {
 		unregisterBlockType( 'core/code' );
+
+		// Disable Video block except for iOS for now.
+		if ( Platform.OS !== 'ios' ) {
+			unregisterBlockType( 'core/video' );
+		}
 	}
 }
 


### PR DESCRIPTION
## Description
This PR tracks the release v1.7.0 of the native mobile app.

## How has this been tested?
Using this gutenberg-mobile side PR: wordpress-mobile/gutenberg-mobile#1116

## Types of changes
1. Puts the video block behind the __DEV__ flag on Android, making it available only in the development builds

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
