### PR TITLE
Remove editor dependency from the block library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9593,7 +9593,6 @@
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/date": "file:packages/date",
 				"@wordpress/deprecated": "file:packages/deprecated",
-				"@wordpress/editor": "file:packages/editor",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/escape-html": "file:packages/escape-html",
 				"@wordpress/i18n": "file:packages/i18n",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -37,7 +37,6 @@
 		"@wordpress/data": "file:../data",
 		"@wordpress/date": "file:../date",
 		"@wordpress/deprecated": "file:../deprecated",
-		"@wordpress/editor": "file:../editor",
 		"@wordpress/element": "file:../element",
 		"@wordpress/escape-html": "file:../escape-html",
 		"@wordpress/i18n": "file:../i18n",

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -3,7 +3,6 @@
  */
 import '@wordpress/core-data';
 import '@wordpress/block-editor';
-import '@wordpress/editor';
 import {
 	registerBlockType,
 	setDefaultBlockName,


### PR DESCRIPTION
## Description
The block library does not depend directly on the editor module so we should remove this dependency.

This PR should not be merged yet because the widgets screen starts breaking because of 3 things:
The calendar depends on the editor store and should be resilient against it not being present.
The RichText depends on editor store to check if the user can use unfiltered HTML this checks should be moved to the block editor.
The reusable blocks depend on the editor, not sure yet of the best solution.

