### PR TITLE
Make calendar block resilient against editor module not being present

### DIFF
--- a/packages/block-library/src/calendar/edit.js
+++ b/packages/block-library/src/calendar/edit.js
@@ -61,9 +61,13 @@ class CalendarEdit extends Component {
 }
 
 export default withSelect( ( select ) => {
+	const coreEditorSelect = select( 'core/editor' );
+	if ( ! coreEditorSelect ) {
+		return;
+	}
 	const {
 		getEditedPostAttribute,
-	} = select( 'core/editor' );
+	} = coreEditorSelect;
 	const postType = getEditedPostAttribute( 'type' );
 	// Dates are used to overwrite year and month used on the calendar.
 	// This overwrite should only happen for 'post' post types.


### PR DESCRIPTION
## Description
The block should not assume the editor store is available.

## How has this been tested?
I added a calendar block to one of the widget areas.
I switched to this branch and cherry-picked https://github.com/WordPress/gutenberg/pull/16160.
I verified the calendar block still works. I go to branch https://github.com/WordPress/gutenberg/pull/16160 without these changes the block crashes.