### PR TITLE
Try making the Inserter category icons grayscale.

### DIFF
--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -117,6 +117,7 @@
 
 .components-panel__icon {
 	color: $dark-gray-500;
+	filter: grayscale(1);
 	margin: -2px 0 -2px 6px;
 }
 

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -117,7 +117,7 @@
 
 .components-panel__icon {
 	color: $dark-gray-500;
-	filter: grayscale(1);
+	filter: grayscale(1) !important;
 	margin: -2px 0 -2px 6px;
 }
 


### PR DESCRIPTION
## Description
Fixes #14180. There's a concern that the full-color icons cause more cognitive load than they do help. While the primary desire is to remove them fully, I'm trying out the secondary option of just making them grayscale. This will minimize their brightness, but still allow them to help guide the user to that section of blocks. 

## How has this been tested?
Locally.

## Screenshots

**BEFORE**

![Screen Shot 2019-06-13 at 10 02 39 AM](https://user-images.githubusercontent.com/617986/59453673-3c39b780-8dc5-11e9-921a-c7a22529e4d9.png)

**AFTER**

![grayscale](https://user-images.githubusercontent.com/617986/59453697-4360c580-8dc5-11e9-9804-1cf643972b67.png)


## Types of changes
Minor CSS filter added to the icon.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
