### PR TITLE
Build Tooling: Use "full" `npm install` for Build Artifacts Travis task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,11 @@ jobs:
 
     - name: Build artifacts
       install:
-        - npm ci
+        # A "full" install is executed, since `npm ci` does not always exit
+        # with an error status code if the lock file is inaccurate.
+        #
+        # See: https://github.com/WordPress/gutenberg/issues/16157
+        - npm install
       script:
         - npm run check-local-changes
 


### PR DESCRIPTION
Related: #16157

This pull request seeks to change to the install step for the Travis "Build artifacts" task to use `npm install` instead of `npm ci`. The purpose of this task is to capture local changes occurring as the result of `npm install` (or `npm run docs:build`), typically in the form of an unsynced `package-lock.json` file. Historically, this test has often resulted in false negatives, due to issues with `npm ci` described in #16157.

**Testing Instructions:**

These changes impact only Travis configuration. The "Build artifacts" test case in particular should continue to pass. If necessary, we can demonstrate it capturing intended errors with a temporary commit to the branch.