### PR TITLE
Re-enable the menu item hover state on small screens

### DIFF
--- a/packages/components/src/menu-item/style.scss
+++ b/packages/components/src/menu-item/style.scss
@@ -19,11 +19,7 @@
 	}
 
 	&:hover:not(:disabled):not([aria-disabled="true"]) {
-		// Disable hover style on mobile to prevent odd scroll behaviour.
-		// See: https://github.com/WordPress/gutenberg/pull/10333
-		@include break-medium() {
-			@include menu-style__hover;
-		}
+		@include menu-style__hover;
 
 		.components-menu-item__shortcut {
 			color: $dark-gray-600;


### PR DESCRIPTION
Fixes #12262. Reverses a change made in #10333. 

As discussed in https://github.com/WordPress/gutenberg/issues/12262#issuecomment-493276550, this PR turns on the menu-item hover state for all breakpoints. 

There should be no visible difference from `master` if a touch-enabled user presses on a menu item, but unlike `master`,  the hover states will be activated if that user presses them and scrolls the viewport. This isn't ideal, but  but as discussed in #12262, this may be an okay tradeoff. If we merge this, we may want to reopen #10320 to keep tracking this issue. 

**GIF:** 

![hover-2](https://user-images.githubusercontent.com/1202812/59466088-410c6480-8de1-11e9-9458-8ecc482432e0.gif)
![hover](https://user-images.githubusercontent.com/1202812/59466090-410c6480-8de1-11e9-936f-c017f978d1ed.gif)