### PR TITLE
docs(components/autocomplete): prune outdated props and function params from README.md

### DIFF
--- a/packages/components/src/autocomplete/README.md
+++ b/packages/components/src/autocomplete/README.md
@@ -76,13 +76,6 @@ There are currently two supported actions:
 * "insert-at-caret" - Insert the `value` into the text (the default completion action).
 * "replace" - Replace the current block with the block specified in the `value` property.
 
-#### allowNode
-
-A function that takes a text node and returns a boolean indicating whether the completer should be considered for that node.
-
-- Type: `Function`
-- Required: No
-
 #### allowContext
 
 A function that takes a Range before and a Range after the autocomplete trigger and query text and returns a boolean indicating whether the completer should be considered for that context.

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -89,7 +89,6 @@ import withSpokenMessages from '../higher-order/with-spoken-messages';
 /**
  * @callback FnGetOptionCompletion
  * @param {CompleterOption} value the value of the completer option.
- * @param {Range} range the nodes included in the autocomplete trigger and query.
  * @param {String} query the text value of the autocomplete query.
  *
  * @returns {(OptionCompletion|OptionCompletionValue)} the completion for the given option. If an

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -69,10 +69,10 @@ import withSpokenMessages from '../higher-order/with-spoken-messages';
 
 /**
  * @callback FnAllowContext
- * @param {Range} before the range before the auto complete trigger and query.
- * @param {Range} after the range after the autocomplete trigger and query.
+ * @param {string} before the string before the auto complete trigger and query.
+ * @param {string} after  the string after the autocomplete trigger and query.
  *
- * @returns {boolean} true if the completer can handle these ranges.
+ * @returns {boolean} true if the completer can handle.
  */
 
 /**

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -61,13 +61,6 @@ import withSpokenMessages from '../higher-order/with-spoken-messages';
  */
 
 /**
- * @callback FnAllowNode
- * @param {Node} textNode check if the completer can handle this text node.
- *
- * @returns {boolean} true if the completer can handle this text node.
- */
-
-/**
  * @callback FnAllowContext
  * @param {string} before the string before the auto complete trigger and query.
  * @param {string} after  the string after the autocomplete trigger and query.
@@ -105,7 +98,6 @@ import withSpokenMessages from '../higher-order/with-spoken-messages';
  * @property {?FnGetOptionKeywords} getOptionKeywords get the keywords for a given option.
  * @property {?FnIsOptionDisabled} isOptionDisabled get whether or not the given option is disabled.
  * @property {FnGetOptionLabel} getOptionLabel get the label for a given option.
- * @property {?FnAllowNode} allowNode filter the allowed text nodes in the autocomplete.
  * @property {?FnAllowContext} allowContext filter the context under which the autocomplete activates.
  * @property {FnGetOptionCompletion} getOptionCompletion get the completion associated with a given option.
  */


### PR DESCRIPTION
## Description

This PR simply prunes out outdated stuff from the autocomplete README and inline documentation.

Should be fairly self-explanatory.

## How has this been tested?

N/A

## Screenshots <!-- if applicable -->

N/A

## Types of changes

Documentation

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->