### PR TITLE
Update type specifiers in validation logging

### DIFF
--- a/packages/blocks/src/api/validation.js
+++ b/packages/blocks/src/api/validation.js
@@ -431,7 +431,7 @@ export function isEqualTagAttributePairs( actual, expected ) {
 	// avoids us needing to check both attributes sets, since if A has any keys
 	// which do not exist in B, we know the sets to be different.
 	if ( actual.length !== expected.length ) {
-		log.warning( 'Expected attributes %o, instead saw %o.', expected, actual );
+		log.warning( 'Expected attributes %j, instead saw %j.', expected, actual );
 		return false;
 	}
 
@@ -573,13 +573,13 @@ export function isEquivalentHTML( actual, expected ) {
 
 		// Inequal if exhausted all expected tokens
 		if ( ! expectedToken ) {
-			log.warning( 'Expected end of content, instead saw %o.', actualToken );
+			log.warning( 'Expected end of content, instead saw %j.', actualToken );
 			return false;
 		}
 
 		// Inequal if next non-whitespace token of each set are not same type
 		if ( actualToken.type !== expectedToken.type ) {
-			log.warning( 'Expected token of type `%s` (%o), instead saw `%s` (%o).', expectedToken.type, expectedToken, actualToken.type, actualToken );
+			log.warning( 'Expected token of type `%s` (%j), instead saw `%s` (%j).', expectedToken.type, expectedToken, actualToken.type, actualToken );
 			return false;
 		}
 
@@ -606,7 +606,7 @@ export function isEquivalentHTML( actual, expected ) {
 	if ( ( expectedToken = getNextNonWhitespaceToken( expectedTokens ) ) ) {
 		// If any non-whitespace tokens remain in expected token set, this
 		// indicates inequality
-		log.warning( 'Expected %o, instead saw end of content.', expectedToken );
+		log.warning( 'Expected %j, instead saw end of content.', expectedToken );
 		return false;
 	}
 


### PR DESCRIPTION
## Description
Noticed while debugging a validation issue with a full-content test I'm working on. The warning logged had some incorrect formatting.

I was receiving the following error, which I initially found confusing:
```
"Expected attributes 0, instead saw 0."
```

I tracked this down to the line of code:
```js
log.warning( 'Expected attributes %o, instead saw %o.', expected, actual );
```

According to the sprintf-js docs, `%o` is for an octal, so that explains the zeros. This PR changes the instances of `%o` to `%j`, which the library says will output a json representation of the parameter.

Tested and I received a better error, still not perfect, but an improvement:
```
["Expected attributes [], instead saw [[\"scope\",\"col\",true]]."]
```

I imagine this came about because of an update to the library or change of library used for those messages.

## How has this been tested?
Detailed above. I reproduced by creating a validation error in one of the full-content tests (adding an attribute that wasn't produced in the save content), and then regenerating the fixtures. Jest will output the error in the terminal.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
