### PR TITLE
Add native version of BlockMobileToolbar (Ported from gutenberg-mobile)

### DIFF
--- a/packages/block-editor/src/components/block-list/block-mobile-toolbar.native.js
+++ b/packages/block-editor/src/components/block-list/block-mobile-toolbar.native.js
@@ -31,7 +31,7 @@ const BlockMobileToolbar = ( {
 		<InspectorControls.Slot />
 
 		<ToolbarButton
-			label={
+			title={
 				sprintf(
 					/* translators: accessibility text. %s: current block position (number). */
 					__( 'Remove block at row %s' ),

--- a/packages/block-editor/src/components/block-list/block-mobile-toolbar.native.js
+++ b/packages/block-editor/src/components/block-list/block-mobile-toolbar.native.js
@@ -38,12 +38,15 @@ const BlockMobileToolbar = ( {
 );
 
 export default compose(
-	withDispatch( ( dispatch, { clientId, rootClientId } ) => {
+	withDispatch( ( dispatch, { clientId, rootClientId, onDelete } ) => {
 		const { removeBlock } = dispatch( 'core/block-editor' );
 		return {
-			onDelete: () => {
+			onDelete() {
 				Keyboard.dismiss();
 				removeBlock( clientId, rootClientId );
+				if ( onDelete ) {
+					onDelete( clientId );
+				}
 			},
 		};
 	} ),

--- a/packages/block-editor/src/components/block-list/block-mobile-toolbar.native.js
+++ b/packages/block-editor/src/components/block-list/block-mobile-toolbar.native.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { Keyboard, View } from 'react-native';
+
+/**
+ * WordPress dependencies
+ */
+import { ToolbarButton } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import styles from './block-mobile-toolbar.scss';
+import BlockMover from '../block-mover';
+import InspectorControls from '../inspector-controls';
+
+const BlockMobileToolbar = ( {
+	clientId,
+	onDelete,
+} ) => (
+	<View style={ styles.toolbar }>
+		<BlockMover clientIds={ [ clientId ] } />
+
+		<View style={ styles.spacer } />
+
+		<InspectorControls.Slot />
+
+		<ToolbarButton
+			label={ __( 'Remove' ) }
+			onClick={ onDelete }
+			icon="trash"
+		/>
+	</View>
+);
+
+export default compose(
+	withDispatch( ( dispatch, { clientId, rootClientId } ) => {
+		const { removeBlock } = dispatch( 'core/block-editor' );
+		return {
+			onDelete: () => {
+				Keyboard.dismiss();
+				removeBlock( clientId, rootClientId );
+			},
+		};
+	} ),
+)( BlockMobileToolbar );

--- a/packages/block-editor/src/components/block-list/block-mobile-toolbar.native.js
+++ b/packages/block-editor/src/components/block-list/block-mobile-toolbar.native.js
@@ -7,8 +7,8 @@ import { Keyboard, View } from 'react-native';
  * WordPress dependencies
  */
 import { ToolbarButton } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { withDispatch } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
 /**
@@ -21,6 +21,7 @@ import InspectorControls from '../inspector-controls';
 const BlockMobileToolbar = ( {
 	clientId,
 	onDelete,
+	order,
 } ) => (
 	<View style={ styles.toolbar }>
 		<BlockMover clientIds={ [ clientId ] } />
@@ -30,14 +31,30 @@ const BlockMobileToolbar = ( {
 		<InspectorControls.Slot />
 
 		<ToolbarButton
-			label={ __( 'Remove' ) }
+			label={
+				sprintf(
+					/* translators: accessibility text. %s: current block position (number). */
+					__( 'Remove block at row %s' ),
+					order + 1
+				)
+			}
 			onClick={ onDelete }
 			icon="trash"
+			extraProps={ { hint: __( 'Double tap to remove the block' ) } }
 		/>
 	</View>
 );
 
 export default compose(
+	withSelect( ( select, { clientId } ) => {
+		const {
+			getBlockIndex,
+		} = select( 'core/block-editor' );
+
+		return {
+			order: getBlockIndex( clientId ),
+		};
+	} ),
 	withDispatch( ( dispatch, { clientId, rootClientId, onDelete } ) => {
 		const { removeBlock } = dispatch( 'core/block-editor' );
 		return {

--- a/packages/block-editor/src/components/block-list/block-mobile-toolbar.native.scss
+++ b/packages/block-editor/src/components/block-list/block-mobile-toolbar.native.scss
@@ -1,0 +1,11 @@
+.toolbar {
+	flex-direction: row;
+	height: 44px;
+	align-items: flex-start;
+	margin-left: 2px;
+	margin-right: 2px;
+}
+
+.spacer {
+	flex-grow: 1;
+}

--- a/packages/block-editor/src/components/block-mover/index.native.js
+++ b/packages/block-editor/src/components/block-mover/index.native.js
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import { first, last, partial, castArray } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { ToolbarButton } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { withInstanceId, compose } from '@wordpress/compose';
+
+const BlockMover = ( {
+	isFirst,
+	isLast,
+	onMoveDown,
+	onMoveUp,
+} ) => (
+	<>
+		<ToolbarButton
+			accessibilityLabel={ __( 'Move up' ) }
+			label={ __( 'Move up' ) }
+			isDisabled={ isFirst }
+			onClick={ onMoveUp }
+			icon="arrow-up-alt"
+		/>
+
+		<ToolbarButton
+			label={ __( 'Move down' ) }
+			isDisabled={ isLast }
+			onClick={ onMoveDown }
+			icon="arrow-down-alt"
+		/>
+	</>
+);
+
+export default compose(
+	withSelect( ( select, { clientIds } ) => {
+		const { getBlockIndex, getBlockRootClientId, getBlockOrder } = select( 'core/block-editor' );
+		const normalizedClientIds = castArray( clientIds );
+		const firstClientId = first( normalizedClientIds );
+		const rootClientId = getBlockRootClientId( first( normalizedClientIds ) );
+		const blockOrder = getBlockOrder( rootClientId );
+		const firstIndex = getBlockIndex( firstClientId, rootClientId );
+		const lastIndex = getBlockIndex( last( normalizedClientIds ), rootClientId );
+
+		return {
+			isFirst: firstIndex === 0,
+			isLast: lastIndex === blockOrder.length - 1,
+		};
+	} ),
+	withDispatch( ( dispatch, { clientIds, rootClientId } ) => {
+		const { moveBlocksDown, moveBlocksUp } = dispatch( 'core/block-editor' );
+		return {
+			onMoveDown: partial( moveBlocksDown, clientIds, rootClientId ),
+			onMoveUp: partial( moveBlocksUp, clientIds, rootClientId ),
+		};
+	} ),
+	withInstanceId,
+)( BlockMover );

--- a/packages/block-editor/src/components/block-mover/index.native.js
+++ b/packages/block-editor/src/components/block-mover/index.native.js
@@ -7,7 +7,7 @@ import { first, last, partial, castArray } from 'lodash';
  * WordPress dependencies
  */
 import { ToolbarButton } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { withInstanceId, compose } from '@wordpress/compose';
 
@@ -16,21 +16,40 @@ const BlockMover = ( {
 	isLast,
 	onMoveDown,
 	onMoveUp,
+	firstIndex,
+	lastIndex,
 } ) => (
 	<>
 		<ToolbarButton
-			accessibilityLabel={ __( 'Move up' ) }
-			label={ __( 'Move up' ) }
+			label={ ! isFirst ?
+				sprintf(
+					/* translators: accessibility text. %1: current block position (number). %2: next block position (number) */
+					__( 'Move block up from row %1$s to row %2$s' ),
+					firstIndex + 1,
+					firstIndex
+				) :
+				__( 'Move block up' )
+			}
 			isDisabled={ isFirst }
 			onClick={ onMoveUp }
 			icon="arrow-up-alt"
+			extraProps={ { hint: __( 'Double tap to move the block up' ) } }
 		/>
 
 		<ToolbarButton
-			label={ __( 'Move down' ) }
+			label={ ! isLast ?
+				sprintf(
+					/* translators: accessibility text. %1: current block position (number). %2: next block position (number) */
+					__( 'Move block down from row %1$s to row %2$s' ),
+					lastIndex + 1,
+					lastIndex
+				) :
+				__( 'Move block down' )
+			}
 			isDisabled={ isLast }
 			onClick={ onMoveDown }
 			icon="arrow-down-alt"
+			extraProps={ { hint: __( 'Double tap to move the block down' ) } }
 		/>
 	</>
 );
@@ -46,6 +65,8 @@ export default compose(
 		const lastIndex = getBlockIndex( last( normalizedClientIds ), rootClientId );
 
 		return {
+			firstIndex,
+			lastIndex,
 			isFirst: firstIndex === 0,
 			isLast: lastIndex === blockOrder.length - 1,
 		};

--- a/packages/block-editor/src/components/block-mover/index.native.js
+++ b/packages/block-editor/src/components/block-mover/index.native.js
@@ -17,7 +17,6 @@ const BlockMover = ( {
 	onMoveDown,
 	onMoveUp,
 	firstIndex,
-	lastIndex,
 } ) => (
 	<>
 		<ToolbarButton
@@ -41,8 +40,8 @@ const BlockMover = ( {
 				sprintf(
 					/* translators: accessibility text. %1: current block position (number). %2: next block position (number) */
 					__( 'Move block down from row %1$s to row %2$s' ),
-					lastIndex + 1,
-					lastIndex
+					firstIndex + 1,
+					firstIndex + 2
 				) :
 				__( 'Move block down' )
 			}
@@ -66,7 +65,6 @@ export default compose(
 
 		return {
 			firstIndex,
-			lastIndex,
 			isFirst: firstIndex === 0,
 			isLast: lastIndex === blockOrder.length - 1,
 		};

--- a/packages/block-editor/src/components/block-mover/index.native.js
+++ b/packages/block-editor/src/components/block-mover/index.native.js
@@ -21,7 +21,7 @@ const BlockMover = ( {
 } ) => (
 	<>
 		<ToolbarButton
-			label={ ! isFirst ?
+			title={ ! isFirst ?
 				sprintf(
 					/* translators: accessibility text. %1: current block position (number). %2: next block position (number) */
 					__( 'Move block up from row %1$s to row %2$s' ),
@@ -37,7 +37,7 @@ const BlockMover = ( {
 		/>
 
 		<ToolbarButton
-			label={ ! isLast ?
+			title={ ! isLast ?
 				sprintf(
 					/* translators: accessibility text. %1: current block position (number). %2: next block position (number) */
 					__( 'Move block down from row %1$s to row %2$s' ),

--- a/packages/block-editor/src/components/index.native.js
+++ b/packages/block-editor/src/components/index.native.js
@@ -19,6 +19,8 @@ export { default as URLInput } from './url-input';
 export { default as BlockInvalidWarning } from './block-list/block-invalid-warning';
 
 // Content Related Components
+export { default as BlockMobileToolbar } from './block-list/block-mobile-toolbar';
+export { default as BlockMover } from './block-mover';
 export { default as BlockToolbar } from './block-toolbar';
 export { default as DefaultBlockAppender } from './default-block-appender';
 export { default as Inserter } from './inserter';

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -8,6 +8,7 @@ import {
 	mediaUploadSync,
 	requestImageFailedRetryDialog,
 	requestImageUploadCancelDialog,
+	requestImageUploadCancel,
 } from 'react-native-gutenberg-bridge';
 import { isEmpty } from 'lodash';
 
@@ -30,7 +31,6 @@ import {
 } from '@wordpress/block-editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { isURL } from '@wordpress/url';
-import { doAction, hasAction } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -92,9 +92,8 @@ class ImageEdit extends React.Component {
 	}
 
 	componentWillUnmount() {
-		// this action will only exist if the user pressed the trash button on the block holder
-		if ( hasAction( 'blocks.onRemoveBlockCheckUpload' ) && this.state.isUploadInProgress ) {
-			doAction( 'blocks.onRemoveBlockCheckUpload', this.props.attributes.id );
+		if ( this.state.isUploadInProgress ) {
+			requestImageUploadCancel( this.props.attributes.id );
 		}
 	}
 

--- a/packages/block-library/src/video/edit.native.js
+++ b/packages/block-library/src/video/edit.native.js
@@ -11,6 +11,7 @@ import {
 	mediaUploadSync,
 	requestImageFailedRetryDialog,
 	requestImageUploadCancelDialog,
+	requestImageUploadCancel,
 } from 'react-native-gutenberg-bridge';
 
 /**
@@ -31,7 +32,6 @@ import {
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { isURL } from '@wordpress/url';
-import { doAction, hasAction } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -70,9 +70,8 @@ class VideoEdit extends React.Component {
 	}
 
 	componentWillUnmount() {
-		// this action will only exist if the user pressed the trash button on the block holder
-		if ( hasAction( 'blocks.onRemoveBlockCheckUpload' ) && this.state.isUploadInProgress ) {
-			doAction( 'blocks.onRemoveBlockCheckUpload', this.props.attributes.id );
+		if ( this.state.isUploadInProgress ) {
+			requestImageUploadCancel( this.props.attributes.id );
 		}
 	}
 


### PR DESCRIPTION
## Description
This is step 4 of wordpress-mobile/gutenberg-mobile#958
This PR ports the gutenberg-mobile InlineToolbar to gutenberg as the BlockMobileToolbar component inside @wordpress/block-editor.
This is needed to implement Inner blocks for mobile native. You can follow the progress of the port here wordpress-mobile/gutenberg-mobile#958

## How has this been tested?
https://github.com/wordpress-mobile/gutenberg-mobile/pull/1133

## Types of changes
Adds native support for a block editor component

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
