### PR TITLE
[Mobile] PlainText based on RCTAztecView.

### DIFF
--- a/packages/block-editor/src/components/plain-text/index.native.js
+++ b/packages/block-editor/src/components/plain-text/index.native.js
@@ -107,7 +107,6 @@ export default class PlainText extends Component {
 				onFocus={ this.props.onFocus }
 				onBlur={ this.props.onBlur }
 				fontFamily={ this.props.fontFamily || ( styles[ 'block-editor-plain-text' ].fontFamily ) }
-
 				style={ {
 					minHeight: this.state.height,
 				} }
@@ -120,7 +119,7 @@ export default class PlainText extends Component {
 				onContentSizeChange={ this.onContentSizeChange }
 				onSelectionChange={ this.onSelectionChangeFromAztec }
 				maxImagesWidth={ 200 }
-				isMultiline={ true }
+				isMultiline={ this.props.multiline }
 			/>
 		);
 	}

--- a/packages/block-editor/src/components/plain-text/index.native.js
+++ b/packages/block-editor/src/components/plain-text/index.native.js
@@ -2,11 +2,15 @@
  * External dependencies
  */
 import { TextInput, Platform } from 'react-native';
+import RCTAztecView from 'react-native-aztec';
 
 /**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
+import { withInstanceId, compose } from '@wordpress/compose';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { withBlockEditContext } from '../block-edit/context';
 
 /**
  * Internal dependencies
@@ -16,19 +20,36 @@ import styles from './style.scss';
 export default class PlainText extends Component {
 	constructor() {
 		super( ...arguments );
-		this.isIOS = Platform.OS === 'ios';
+
+		this.onContentSizeChange = this.onContentSizeChange.bind( this );
+		this.onChange = this.onChange.bind( this );
+		this.onSelectionChangeFromAztec = this.onSelectionChangeFromAztec.bind( this );
+
+		this.selection = {
+			start: 0,
+			end:0,
+		}
+
+		this.state = {
+			height: 0,
+		};
 	}
 
 	componentDidMount() {
-		// if isSelected is true, we should request the focus on this TextInput
-		if ( ( this._input.isFocused() === false ) && ( this._input.props.isSelected === true ) ) {
+		if ( ( this._input.isFocused() === false ) && ( this.props.isSelected === true ) ) {
 			this.focus();
 		}
 	}
 
 	componentDidUpdate( prevProps ) {
-		if ( ! this.props.isSelected && prevProps.isSelected && this.isIOS ) {
-			this._input.blur();
+		if ( this.props.isSelected === prevProps.isSelected ) {
+			return;
+		}
+
+		if ( this.props.isSelected ) {
+			this.focus();
+		} else {
+			this.blur();
 		}
 	}
 
@@ -36,21 +57,70 @@ export default class PlainText extends Component {
 		this._input.focus();
 	}
 
+	blur() {
+		this._input.blur();
+	}
+
+	onChange( event ) {
+		const value = event.nativeEvent.plainText;
+		this.props.onChange( value );
+	}
+
+	onPaste( event ) {
+
+	}
+
+	/*
+	* Handles any case where the content of the AztecRN instance has changed in size
+	*/
+	onContentSizeChange( contentSize ) {
+		const height = contentSize.height;
+		this.setState( { height } );
+	}
+
+	onSelectionChangeFromAztec( start, end ) {
+		const realStart = Math.min( start, end );
+		const realEnd = Math.max( start, end );
+
+		if ( this.start !== realStart || this.end !== realEnd ) {
+			this.setSelection( realStart, realEnd );
+		}
+	}
+
+	setSelection( start, end ) {
+		this.selection = {
+			start, 
+			end,
+		}
+	}
+
 	render() {
+		let minHeight = styles[ 'block-editor-plain-text' ].minHeight;
+
 		return (
-			<TextInput
+			<RCTAztecView
 				{ ...this.props }
-				ref={ ( x ) => this._input = x }
-				className={ [ styles[ 'block-editor-plain-text' ], this.props.className ] }
-				onChange={ ( event ) => {
-					this.props.onChange( event.nativeEvent.text );
+				ref={ ( ref ) => {
+					this._input = ref;
 				} }
-				onFocus={ this.props.onFocus } // always assign onFocus as a props
-				onBlur={ this.props.onBlur } // always assign onBlur as a props
+				className={ [ styles[ 'block-editor-plain-text' ], this.props.className ] }
+				onFocus={ this.props.onFocus }
+				onBlur={ this.props.onBlur }
 				fontFamily={ this.props.fontFamily || ( styles[ 'block-editor-plain-text' ].fontFamily ) }
-				fontSize={ this.props.fontSize }
-				fontWeight={ this.props.fontWeight }
-				fontStyle={ this.props.fontStyle }
+
+				style={ {
+					minHeight: this.state.height,
+				} }
+				plainText={ {
+					text: this.props.value,
+					selection: this.selection,
+				} }
+				onChange={ this.onChange }
+				onPaste={ this.onPaste }
+				onContentSizeChange={ this.onContentSizeChange }
+				onSelectionChange={ this.onSelectionChangeFromAztec }
+				maxImagesWidth={ 200 }
+				isMultiline={ true }
 			/>
 		);
 	}

--- a/packages/block-editor/src/components/plain-text/index.native.js
+++ b/packages/block-editor/src/components/plain-text/index.native.js
@@ -68,13 +68,15 @@ export default class PlainText extends Component {
 		this._input.blur();
 	}
 
-	onChange( event ) {
-		const value = event.nativeEvent.plainText;
+	onChange( { nativeEvent } ) {
+		const value = nativeEvent.plainText;
+		this.lastEventCount = nativeEvent.eventCount;
 		this.props.onChange( value );
 	}
 
 	onPaste( { nativeEvent } ) {
 		const finalRecord = this.insertPastedText( nativeEvent.pastedText );
+		this.lastEventCount = undefined;
 		this.setSelection( finalRecord.start, finalRecord.end );
 		this.props.onChange( finalRecord.text );
 	}
@@ -112,7 +114,11 @@ export default class PlainText extends Component {
 	}
 
 	render() {
-		let minHeight = styles[ 'block-editor-plain-text' ].minHeight;
+		const textEvent = {
+			text: this.props.value,
+			eventCount: this.lastEventCount,
+			selection: this.selection,
+		}
 
 		return (
 			<RCTAztecView
@@ -124,13 +130,8 @@ export default class PlainText extends Component {
 				onFocus={ this.props.onFocus }
 				onBlur={ this.props.onBlur }
 				fontFamily={ this.props.fontFamily || ( styles[ 'block-editor-plain-text' ].fontFamily ) }
-				style={ {
-					minHeight: this.state.height,
-				} }
-				plainText={ {
-					text: this.props.value,
-					selection: this.selection,
-				} }
+				style={ { minHeight: this.state.height } }
+				plainText={ textEvent }
 				onChange={ this.onChange }
 				onPaste={ this.onPaste }
 				onContentSizeChange={ this.onContentSizeChange }

--- a/packages/block-editor/src/components/plain-text/style.native.scss
+++ b/packages/block-editor/src/components/plain-text/style.native.scss
@@ -2,9 +2,8 @@
 .block-editor-plain-text {
 	font-family: $default-regular-font;
 	box-shadow: none;
-
+	min-height: $min-height-paragraph;
 	border-width: 0;
-
 	padding: 0;
 	margin: 0;
 }

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -8,7 +8,7 @@ import { isEmpty } from 'lodash';
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { RichText } from '@wordpress/block-editor';
+import { PlainText } from '@wordpress/block-editor';
 import { decodeEntities } from '@wordpress/html-entities';
 import { withDispatch } from '@wordpress/data';
 import { withFocusOutside } from '@wordpress/components';
@@ -86,11 +86,10 @@ class PostTitle extends Component {
 						)
 				}
 			>
-				<RichText
+				<PlainText
 					tagName={ 'p' }
-					rootTagsToEliminate={ [ 'strong' ] }
-					unstableOnFocus={ this.onSelect }
-					onBlur={ this.props.onBlur } // always assign onBlur as a props
+					onFocus={ this.onSelect }
+					onBlur={ this.props.onBlur }
 					multiline={ false }
 					style={ style }
 					fontSize={ 24 }
@@ -101,14 +100,11 @@ class PostTitle extends Component {
 					} }
 					placeholder={ decodedPlaceholder }
 					value={ title }
-					onSplit={ () => { } }
 					onEnter={ this.props.onEnterPress }
-					disableEditingMenu={ true }
 					setRef={ ( ref ) => {
 						this.titleViewRef = ref;
 					} }
-				>
-				</RichText>
+				/>
 			</View>
 		);
 	}


### PR DESCRIPTION
This PR changes the implementation of `PlainText` to use `RCTAztecView` instead of `TextInput`.

This allow us to have more control over the events like `onEnter`, `onPaste`, `onBackspace` etc... while avoiding adding custom code to `RichText`.

`PlainText` is used on Mobile and Web to power the `Code Block`. 

This PR also implements `PlainText` on `PostTitle` too, fixing this issues:
https://github.com/wordpress-mobile/gutenberg-mobile/issues/1124
https://github.com/wordpress-mobile/gutenberg-mobile/issues/1033

This change needed a change on the iOS Native Side, and will need to be reproduce on Android if we decide to go with this solution.

- [x] Refactor PlainText to use RCTAztecView.
- [x] Check that Code block works properly.
- [x] Refactor PostTitle to use PlainText.
- [x] Make sure pasting single paragraph text works properly.
- [x] Make sure pasting multi-paragraph block works properly.
- [x] Make sure that Enter key works properly in both single line (PostTitle) and multiline (Code block) configurations.
- [ ] Fix placeholder styles.
- [ ] Fix hide keyboard button on PostTitle.
- [ ] Unit Tests