### PR TITLE
Support forwardRef components in save functions

### DIFF
--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -49,10 +49,14 @@ import {
 	createContext,
 	Fragment,
 	StrictMode,
+	forwardRef,
 } from './react';
 import RawHTML from './raw-html';
 
 const { Provider, Consumer } = createContext();
+const ForwardRef = forwardRef( () => {
+	return null;
+} );
 
 /**
  * Valid attribute types.
@@ -406,6 +410,9 @@ export function renderElement( element, context, legacyContext = {} ) {
 
 		case Consumer.$$typeof:
 			return renderElement( props.children( context || type._currentValue ), context, legacyContext );
+
+		case ForwardRef.$$typeof:
+			return renderElement( type.render( props ), context, legacyContext );
 	}
 
 	return '';

--- a/packages/element/src/test/serialize.js
+++ b/packages/element/src/test/serialize.js
@@ -12,6 +12,7 @@ import {
 	createElement,
 	Fragment,
 	StrictMode,
+	forwardRef,
 } from '../react';
 import RawHTML from '../raw-html';
 import serialize, {
@@ -81,6 +82,20 @@ describe( 'serialize()', () => {
 		expect( result ).toBe(
 			'FunctionComponent: Hello!' +
 			'ClassComponent: Hello!'
+		);
+	} );
+
+	it( 'should render with forwardRef', () => {
+		const ForwardedComponent = forwardRef( () => {
+			return <div>test</div>;
+		} );
+
+		const result = serialize(
+			<ForwardedComponent />
+		);
+
+		expect( result ).toBe(
+			'<div>test</div>'
 		);
 	} );
 


### PR DESCRIPTION
Closes #16167

It seems like we only fixed half of the issue. The components are now properly deprecated but it also seems that our custom serializer doesn't support forwarded components.

**Testing instructions**

 - Check using `editor` instead of `block-editor` in the save function of the group block
 - The group block should persist properly.