### PR TITLE
Remove usage of select editor from the block editor module

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -353,23 +353,24 @@ Undocumented declaration.
 
 The default editor settings
 
- alignWide                     boolean       Enable/Disable Wide/Full Alignments
- availableLegacyWidgets        Array         Array of objects representing the legacy widgets available.
- colors                        Array         Palette colors
- disableCustomColors           boolean       Whether or not the custom colors are disabled
- fontSizes                     Array         Available font sizes
- disableCustomFontSizes        boolean       Whether or not the custom font sizes are disabled
- imageSizes                    Array         Available image sizes
- maxWidth                      number        Max width to constraint resizing
- allowedBlockTypes             boolean|Array Allowed block types
- hasFixedToolbar               boolean       Whether or not the editor toolbar is fixed
- hasPermissionsToManageWidgets boolean       Whether or not the user is able to manage widgets.
- focusMode                     boolean       Whether the focus mode is enabled or not
- styles                        Array         Editor Styles
- isRTL                         boolean       Whether the editor is in RTL mode
- bodyPlaceholder               string        Empty post placeholder
- titlePlaceholder              string        Empty title placeholder
- codeEditingEnabled            string        Whether or not the user can switch to the code editor
+ alignWide                              boolean       Enable/Disable Wide/Full Alignments
+ availableLegacyWidgets                 Array         Array of objects representing the legacy widgets available.
+ colors                                 Array         Palette colors
+ disableCustomColors                    boolean       Whether or not the custom colors are disabled
+ fontSizes                              Array         Available font sizes
+ disableCustomFontSizes                 boolean       Whether or not the custom font sizes are disabled
+ imageSizes                             Array         Available image sizes
+ maxWidth                               number        Max width to constraint resizing
+ allowedBlockTypes                      boolean|Array Allowed block types
+ hasFixedToolbar                        boolean       Whether or not the editor toolbar is fixed
+ hasPermissionsToManageWidgets          boolean       Whether or not the user is able to manage widgets.
+ focusMode                              boolean       Whether the focus mode is enabled or not
+ styles                                 Array         Editor Styles
+ isRTL                                  boolean       Whether the editor is in RTL mode
+ bodyPlaceholder                        string        Empty post placeholder
+ titlePlaceholder                       string        Empty title placeholder
+ codeEditingEnabled                     string        Whether or not the user can switch to the code editor
+ \_\_experimentalCanUserUseUnfilteredHTML string        Whether the user should be able to use unfiltered HTML or the HTML should be filtered e.g., to remove elements considered insecure like iframes.
 
 <a name="SkipToSelectedBlock" href="#SkipToSelectedBlock">#</a> **SkipToSelectedBlock**
 

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -135,17 +135,16 @@ const RichTextContainer = compose( [
 		identifier = instanceId,
 		isSelected,
 	} ) => {
-		// This should probably be moved to the block editor settings.
-		const { canUserUseUnfilteredHTML } = select( 'core/editor' );
 		const {
 			isCaretWithinFormattedText,
 			getSelectionStart,
 			getSelectionEnd,
+			getSettings,
 		} = select( 'core/block-editor' );
 
 		const selectionStart = getSelectionStart();
 		const selectionEnd = getSelectionEnd();
-
+		const { __experimentalCanUserUseUnfilteredHTML } = getSettings();
 		if ( isSelected === undefined ) {
 			isSelected = (
 				selectionStart.clientId === clientId &&
@@ -154,7 +153,7 @@ const RichTextContainer = compose( [
 		}
 
 		return {
-			canUserUseUnfilteredHTML: canUserUseUnfilteredHTML(),
+			canUserUseUnfilteredHTML: __experimentalCanUserUseUnfilteredHTML,
 			isCaretWithinFormattedText: isCaretWithinFormattedText(),
 			selectionStart: isSelected ? selectionStart.offset : undefined,
 			selectionEnd: isSelected ? selectionEnd.offset : undefined,

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -10,23 +10,24 @@ export const PREFERENCES_DEFAULTS = {
 /**
  * The default editor settings
  *
- *  alignWide                     boolean       Enable/Disable Wide/Full Alignments
- *  availableLegacyWidgets        Array         Array of objects representing the legacy widgets available.
- *  colors                        Array         Palette colors
- *  disableCustomColors           boolean       Whether or not the custom colors are disabled
- *  fontSizes                     Array         Available font sizes
- *  disableCustomFontSizes        boolean       Whether or not the custom font sizes are disabled
- *  imageSizes                    Array         Available image sizes
- *  maxWidth                      number        Max width to constraint resizing
- *  allowedBlockTypes             boolean|Array Allowed block types
- *  hasFixedToolbar               boolean       Whether or not the editor toolbar is fixed
- *  hasPermissionsToManageWidgets boolean       Whether or not the user is able to manage widgets.
- *  focusMode                     boolean       Whether the focus mode is enabled or not
- *  styles                        Array         Editor Styles
- *  isRTL                         boolean       Whether the editor is in RTL mode
- *  bodyPlaceholder               string        Empty post placeholder
- *  titlePlaceholder              string        Empty title placeholder
- *  codeEditingEnabled            string        Whether or not the user can switch to the code editor
+ *  alignWide                              boolean       Enable/Disable Wide/Full Alignments
+ *  availableLegacyWidgets                 Array         Array of objects representing the legacy widgets available.
+ *  colors                                 Array         Palette colors
+ *  disableCustomColors                    boolean       Whether or not the custom colors are disabled
+ *  fontSizes                              Array         Available font sizes
+ *  disableCustomFontSizes                 boolean       Whether or not the custom font sizes are disabled
+ *  imageSizes                             Array         Available image sizes
+ *  maxWidth                               number        Max width to constraint resizing
+ *  allowedBlockTypes                      boolean|Array Allowed block types
+ *  hasFixedToolbar                        boolean       Whether or not the editor toolbar is fixed
+ *  hasPermissionsToManageWidgets          boolean       Whether or not the user is able to manage widgets.
+ *  focusMode                              boolean       Whether the focus mode is enabled or not
+ *  styles                                 Array         Editor Styles
+ *  isRTL                                  boolean       Whether the editor is in RTL mode
+ *  bodyPlaceholder                        string        Empty post placeholder
+ *  titlePlaceholder                       string        Empty title placeholder
+ *  codeEditingEnabled                     string        Whether or not the user can switch to the code editor
+ *  __experimentalCanUserUseUnfilteredHTML string        Whether the user should be able to use unfiltered HTML or the HTML should be filtered e.g., to remove elements considered insecure like iframes.
  */
 export const SETTINGS_DEFAULTS = {
 	alignWide: false,
@@ -137,5 +138,6 @@ export const SETTINGS_DEFAULTS = {
 
 	availableLegacyWidgets: {},
 	hasPermissionsToManageWidgets: false,
+	__experimentalCanUserUseUnfilteredHTML: false,
 };
 

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -72,7 +72,14 @@ class EditorProvider extends Component {
 		}
 	}
 
-	getBlockEditorSettings( settings, meta, onMetaChange, reusableBlocks, hasUploadPermissions ) {
+	getBlockEditorSettings(
+		settings,
+		meta,
+		onMetaChange,
+		reusableBlocks,
+		hasUploadPermissions,
+		canUserUseUnfilteredHTML
+	) {
 		return {
 			...pick( settings, [
 				'alignWide',
@@ -102,6 +109,7 @@ class EditorProvider extends Component {
 			__experimentalReusableBlocks: reusableBlocks,
 			__experimentalMediaUpload: hasUploadPermissions ? mediaUpload : undefined,
 			__experimentalFetchLinkSuggestions: fetchLinkSuggestions,
+			__experimentalCanUserUseUnfilteredHTML: canUserUseUnfilteredHTML,
 		};
 	}
 
@@ -131,6 +139,7 @@ class EditorProvider extends Component {
 
 	render() {
 		const {
+			canUserUseUnfilteredHTML,
 			children,
 			blocks,
 			resetEditorBlocks,
@@ -148,7 +157,12 @@ class EditorProvider extends Component {
 		}
 
 		const editorSettings = this.getBlockEditorSettings(
-			settings, meta, onMetaChange, reusableBlocks, hasUploadPermissions
+			settings,
+			meta,
+			onMetaChange,
+			reusableBlocks,
+			hasUploadPermissions,
+			canUserUseUnfilteredHTML
 		);
 
 		return (
@@ -171,6 +185,7 @@ export default compose( [
 	withRegistryProvider,
 	withSelect( ( select ) => {
 		const {
+			canUserUseUnfilteredHTML,
 			__unstableIsEditorReady: isEditorReady,
 			getEditorBlocks,
 			getEditedPostAttribute,
@@ -179,6 +194,7 @@ export default compose( [
 		const { canUser } = select( 'core' );
 
 		return {
+			canUserUseUnfilteredHTML: canUserUseUnfilteredHTML(),
 			isReady: isEditorReady(),
 			blocks: getEditorBlocks(),
 			meta: getEditedPostAttribute( 'meta' ),


### PR DESCRIPTION
## Description
The block editor performed a select to the core/editor store, this causes problems when the editor store is not available e.g. in the widget screen after we merge https://github.com/WordPress/gutenberg/pull/16160.

This PR refactors to code to use a block editor setting instead of the editor store.

## How has this been tested?
With an admin rule, I pasted the following in a paragraph: `<iframe src="httt://www.wordpress.org/" />`. I verified an HTML block with the iframe was created.
With a contributor rule I pasted the same code I verified an HTML block with the iframe was not created. 

