### PR TITLE
Make sure $label_markup is always defined.

### DIFF
--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -15,7 +15,8 @@
 function render_block_core_search( $attributes ) {
 	static $instance_id = 0;
 
-	$input_id = 'wp-block-search__input-' . ++$instance_id;
+	$input_id     = 'wp-block-search__input-' . ++$instance_id;
+	$label_markup = '';
 
 	if ( ! empty( $attributes['label'] ) ) {
 		$label_markup = sprintf(


### PR DESCRIPTION
Fixes #16188.

## Description
Since `$label_markup` in `render_block_core_search()` is [defined conditionally](https://core.trac.wordpress.org/browser/tags/5.2.1/src/wp-includes/blocks/search.php?marks=20-26#L15), it causes a PHP notice if there's no label provided.

Making sure that the variable is always defined fixes the issue.

## Screenshots
![Screenshot of the PHP notice](https://cldup.com/ypr58TgAx7.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
