### PR TITLE
Try fixing Heading block validation errors on native

### DIFF
--- a/packages/block-library/src/heading/deprecated.js
+++ b/packages/block-library/src/heading/deprecated.js
@@ -73,6 +73,11 @@ const deprecated = [
 				/>
 			);
 		},
+		isEligible( { style } ) {
+			if ( style && style.textAlign ) {
+				return true;
+			}
+		},
 	},
 ];
 


### PR DESCRIPTION
## Description
This is a WIP. I'm trying to fix the block validation errors we're seeing on Gutenberg RN. Also experimenting with (auto?-)migration

```
Block validation: Block validation failed for `core/heading` ({name: "core/heading", save: ƒ, category: "common", attributes: {…}, title: "Heading", …}).

Content generated by `save` function:

<h2 class="has-text-align-left">Meet your new best friends, Blocks</h2>

Content retrieved from post body:

<h2 style="text-align:left">Meet your new best friends, Blocks</h2>
```

## How has this been tested?
TBD

## Types of changes
React Native

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
