### PR TITLE
Add alias for react-spring in webpack config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,6 +34,10 @@ module.exports = {
 				message: 'Path access on WordPress dependencies is not allowed.',
 			},
 			{
+				selector: 'ImportDeclaration[source.value=/^react-spring(?!\\u002Fweb\.cjs)/]',
+				message: 'The react-spring dependency must specify CommonJS bundle: react-spring/web.cjs',
+			},
+			{
 				selector: 'CallExpression[callee.name="deprecated"] Property[key.name="version"][value.value=/' + majorMinorRegExp + '/]',
 				message: 'Deprecated functions must be removed before releasing this version.',
 			},

--- a/packages/components/src/snackbar/list.js
+++ b/packages/components/src/snackbar/list.js
@@ -3,7 +3,7 @@
  */
 import classnames from 'classnames';
 import { omit, noop } from 'lodash';
-import { useTransition, animated } from 'react-spring';
+import { useTransition, animated } from 'react-spring/web.cjs';
 
 /**
  * WordPress dependencies

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -153,6 +153,7 @@ module.exports = {
 	],
 	resolve: {
 		alias: {
+			// Added for compatibility with IE.
 			'react-spring$': 'react-spring/web.cjs',
 		},
 	},

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -151,5 +151,10 @@ module.exports = {
 		] ),
 		new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),
 	],
+	resolve: {
+		alias: {
+			'react-spring$': 'react-spring/web.cjs',
+		},
+	},
 	devtool,
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -151,11 +151,5 @@ module.exports = {
 		] ),
 		new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),
 	],
-	resolve: {
-		alias: {
-			// Added for compatibility with IE.
-			'react-spring$': 'react-spring/web.cjs',
-		},
-	},
 	devtool,
 };


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Fixes #16194
Added an alias in webpack config for react-spring to fix incompatibility with Internet Explorer.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested locally on Internet Explorer, on Windows 7 and Windows 10. 

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
