### PR TITLE
Media flow component for media replace

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -320,6 +320,10 @@ _Related_
 
 -   <https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/media-placeholder/README.md>
 
+<a name="MediaReplaceFlow" href="#MediaReplaceFlow">#</a> **MediaReplaceFlow**
+
+Undocumented declaration.
+
 <a name="MediaUpload" href="#MediaUpload">#</a> **MediaUpload**
 
 _Related_

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -28,6 +28,7 @@ export { default as InnerBlocks } from './inner-blocks';
 export { default as InspectorAdvancedControls } from './inspector-advanced-controls';
 export { default as InspectorControls } from './inspector-controls';
 export { default as __experimentalLinkControl } from './link-control';
+export { default as MediaReplaceFlow } from './media-replace-flow';
 export { default as MediaPlaceholder } from './media-placeholder';
 export { default as MediaUpload } from './media-upload';
 export { default as MediaUploadCheck } from './media-upload/check';

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -72,7 +72,6 @@ const MediaReplaceFlow = (
 	const selectURL = ( newURL ) => {
 		onSelectURL( newURL );
 		setShowEditURLInput( false );
-		setShowURLInput( false );
 	};
 
 	const uploadFiles = ( event ) => {
@@ -90,8 +89,6 @@ const MediaReplaceFlow = (
 	};
 
 	const onClose = () => {
-		setShowEditURLInput( false );
-		setShowURLInput( false );
 		editMediaButtonRef.current.focus();
 	};
 

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -69,6 +69,12 @@ const MediaReplaceFlow = (
 		speak( __( 'The media file has been replaced' ) );
 	};
 
+	const selectURL = ( newURL ) => {
+		onSelectURL( newURL );
+		setShowEditURLInput( false );
+		setShowURLInput( false );
+	};
+
 	const uploadFiles = ( event ) => {
 		const files = event.target.files;
 		const setMedia = ( [ media ] ) => {
@@ -84,6 +90,8 @@ const MediaReplaceFlow = (
 	};
 
 	const onClose = () => {
+		setShowEditURLInput( false );
+		setShowURLInput( false );
 		editMediaButtonRef.current.focus();
 	};
 
@@ -109,8 +117,7 @@ const MediaReplaceFlow = (
 				onChangeInputValue={ ( url ) => ( setMediaURLValue( url ) ) }
 				onSubmit={ ( event ) => {
 					event.preventDefault();
-					onSelectURL( mediaURLValue );
-					setShowEditURLInput( ! showEditURLInput );
+					selectURL( mediaURLValue );
 					editMediaButtonRef.current.focus();
 				} }
 			/>

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -1,0 +1,199 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, createRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
+import {
+	FormFileUpload,
+	NavigableMenu,
+	MenuItem,
+	Toolbar,
+	Button,
+	Popover,
+	withNotices,
+} from '@wordpress/components';
+import {
+	LEFT,
+	RIGHT,
+	UP,
+	DOWN,
+	BACKSPACE,
+	ENTER,
+} from '@wordpress/keycodes';
+import { useSelect } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import MediaUpload from '../media-upload';
+import MediaUploadCheck from '../media-upload/check';
+import LinkEditor from '../url-popover/link-editor';
+import LinkViewer from '../url-popover/link-viewer';
+
+const MediaReplaceFlow = (
+	{
+		mediaURL,
+		allowedTypes,
+		accept,
+		onSelect,
+		onSelectURL,
+		onError,
+		name = __( 'Replace' ),
+	}
+) => {
+	const [ showURLInput, setShowURLInput ] = useState( false );
+	const [ showEditURLInput, setShowEditURLInput ] = useState( false );
+	const [ mediaURLValue, setMediaURLValue ] = useState( mediaURL );
+	const [ showMediaReplaceOptions, setShowMediaReplaceOptions ] = useState( false );
+	const mediaUpload = useSelect( ( select ) => {
+		return select( 'core/block-editor' ).getSettings().mediaUpload;
+	} );
+	const editMediaButtonRef = createRef();
+
+	const stopPropagation = ( event ) => {
+		event.stopPropagation();
+	};
+
+	const stopPropagationRelevantKeys = ( event ) => {
+		if ( [ LEFT, DOWN, RIGHT, UP, BACKSPACE, ENTER ].indexOf( event.keyCode ) > -1 ) {
+			// Stop the key event from propagating up to ObserveTyping.startTypingInTextField.
+			event.stopPropagation();
+		}
+	};
+
+	const selectMedia = ( media ) => {
+		onSelect( media );
+		setMediaURLValue( media.url );
+		speak( __( 'The media file has been replaced' ) );
+	};
+
+	const uploadFiles = ( event ) => {
+		const files = event.target.files;
+		const setMedia = ( [ media ] ) => {
+			setShowMediaReplaceOptions( false );
+			selectMedia( media );
+		};
+		mediaUpload( {
+			allowedTypes,
+			filesList: files,
+			onFileChange: setMedia,
+			onError,
+		} );
+	};
+
+	const onClose = () => {
+		editMediaButtonRef.current.focus();
+	};
+
+	const onClickOutside = () => ( setShowMediaReplaceOptions( false ) );
+
+	const openOnArrowDown = ( event ) => {
+		if ( event.keyCode === DOWN ) {
+			event.preventDefault();
+			event.stopPropagation();
+			event.target.click();
+		}
+	};
+
+	let urlInputUIContent;
+	if ( showEditURLInput ) {
+		urlInputUIContent = (
+			<LinkEditor
+				onKeyDown={ stopPropagationRelevantKeys }
+				onKeyPress={ stopPropagation }
+				value={ mediaURLValue }
+				isFullWidthInput={ true }
+				hasInputBorder={ true }
+				onChangeInputValue={ ( url ) => ( setMediaURLValue( url ) ) }
+				onSubmit={ ( event ) => {
+					event.preventDefault();
+					onSelectURL( mediaURLValue );
+					setShowEditURLInput( ! showEditURLInput );
+					editMediaButtonRef.current.focus();
+				} }
+			/>
+		);
+	} else {
+		urlInputUIContent = (
+			<LinkViewer
+				isFullWidth={ true }
+				className="editor-format-toolbar__link-container-content block-editor-format-toolbar__link-container-content"
+				url={ mediaURLValue }
+				onEditLinkClick={ () => ( setShowEditURLInput( ! showEditURLInput ) ) }
+			/>
+		);
+	}
+
+	return (
+		<MediaUpload
+			onSelect={ ( media ) => selectMedia( media ) }
+			onClose={ () => setShowMediaReplaceOptions( true ) }
+			allowedTypes={ allowedTypes }
+			render={ ( { open } ) => (
+				<Toolbar className={ 'media-replace-flow components-dropdown-menu' }>
+					<Button
+						ref={ editMediaButtonRef }
+						className={ 'components-icon-button components-dropdown-menu__toggle' }
+						onClick={ () => {
+							setShowMediaReplaceOptions( ! showMediaReplaceOptions );
+						} }
+						onKeyDown={ openOnArrowDown }
+					>
+						<span className="components-dropdown-menu__label" > { name } </span>
+						<span className="components-dropdown-menu__indicator" />
+					</Button>
+					{ showMediaReplaceOptions &&
+						<Popover
+							onClickOutside={ onClickOutside }
+							onClose={ onClose }
+							className={ 'media-replace-flow__options' }
+						>
+							<NavigableMenu>
+								<MenuItem
+									icon="admin-media"
+									onClick={ open }
+								>
+									{ __( 'Open Media Library' ) }
+								</MenuItem>
+								<MediaUploadCheck>
+									<FormFileUpload
+										onChange={ uploadFiles }
+										accept={ accept }
+										render={ ( { openFileDialog } ) => {
+											return (
+												<MenuItem
+													icon="upload"
+													onClick={ () => {
+														openFileDialog();
+													} }
+												>
+													{ __( 'Upload' ) }
+												</MenuItem>
+											);
+										} }
+									/>
+								</MediaUploadCheck>
+								<MenuItem
+									icon="admin-links"
+									onClick={ () => ( setShowURLInput( ! showURLInput ) ) }
+									aria-expanded={ showURLInput }
+								>
+									<div> { __( 'Insert from URL' ) } </div>
+								</MenuItem>
+							</NavigableMenu>
+							{ showURLInput && <div className="block-editor-media-flow__url-input">
+								{ urlInputUIContent }
+							</div> }
+						</Popover>
+					}
+				</Toolbar>
+			) }
+		/>
+	);
+};
+
+export default compose(
+	withNotices,
+)( MediaReplaceFlow );

--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -23,8 +23,9 @@
 
 		.components-external-link__icon {
 			position: absolute;
-			right: 50px;
-			bottom: 22px;
+			right: -4px;
+			bottom: 5px;
+			margin-right: 2px;
 		}
 
 		input {
@@ -34,9 +35,11 @@
 		}
 
 		.block-editor-url-popover__link-viewer-url {
-			padding-right: 10px;
+			padding-right: 15px;
 			padding-top: 3px;
-			max-width: 169px;
+			max-width: 179px;
+			position: relative;
+			margin-right: 0;
 		}
 
 		// Mimic toolbar component styles for the icons in this popover.
@@ -44,6 +47,7 @@
 			padding: 5px;
 			width: 40px;
 			height: 40px;
+			padding-left: 0;
 
 			> svg {
 				padding: 5px;

--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -1,0 +1,72 @@
+.media-replace-flow .components-dropdown-menu__indicator {
+	margin-left: 4px;
+
+	.components-dropdown-menu.media-flow_toolbar {
+		.components-dropdown-menu__label {
+			margin-right: 6px;
+			margin-left: 2px;
+		}
+	}
+}
+
+.media-replace-flow__options.components-popover:not(.is-mobile) {
+
+	.components-popover__content {
+		// this is a safari problem that shows scrollbars
+		// when display:flex and max-width are used together
+		overflow-x: hidden;
+	}
+
+	.block-editor-media-flow__url-input {
+
+		padding: 0 15px 10px 25px;
+
+		.components-external-link__icon {
+			position: absolute;
+			right: 50px;
+			bottom: 22px;
+		}
+
+		input {
+			max-width: 169px;
+			border: 1px solid $dark-gray-500;
+			border-radius: 4px;
+		}
+
+		.block-editor-url-popover__link-viewer-url {
+			padding-right: 10px;
+			padding-top: 3px;
+			max-width: 169px;
+		}
+
+		// Mimic toolbar component styles for the icons in this popover.
+		.components-icon-button {
+			padding: 5px;
+			width: 40px;
+			height: 40px;
+
+			> svg {
+				padding: 5px;
+				border-radius: $radius-round-rectangle;
+				height: 30px;
+				width: 30px;
+			}
+
+			&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover {
+				box-shadow: none;
+
+				> svg {
+					@include formatting-button-style__hover;
+				}
+			}
+
+			&:not(:disabled):focus {
+				box-shadow: none;
+
+				> svg {
+					@include formatting-button-style__focus;
+				}
+			}
+		}
+	}
+}

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -25,6 +25,7 @@
 @import "./components/inserter-with-shortcuts/style.scss";
 @import "./components/inserter/style.scss";
 @import "./components/inserter-list-item/style.scss";
+@import "./components/media-replace-flow/style.scss";
 @import "./components/media-placeholder/style.scss";
 @import "./components/multi-selection-inspector/style.scss";
 @import "./components/panel-color-settings/style.scss";

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -52,6 +52,7 @@ import {
 	InspectorControls,
 	InspectorAdvancedControls,
 	MediaPlaceholder,
+	MediaReplaceFlow,
 	URLPopover,
 	RichText,
 } from '@wordpress/block-editor';
@@ -64,13 +65,12 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { getPath } from '@wordpress/url';
 import { withViewportMatch } from '@wordpress/viewport';
-import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
  */
 import { createUpgradedEmbedBlock } from '../embed/util';
-import icon, { editImageIcon } from './icon';
+import icon from './icon';
 import ImageSize from './image-size';
 import { getUpdatedLinkTargetSettings, removeNewTabRel } from './utils';
 
@@ -265,7 +265,7 @@ const ImageURLInputUI = ( {
 };
 
 export class ImageEdit extends Component {
-	constructor( { attributes } ) {
+	constructor() {
 		super( ...arguments );
 		this.updateAlt = this.updateAlt.bind( this );
 		this.updateAlignment = this.updateAlignment.bind( this );
@@ -283,14 +283,12 @@ export class ImageEdit extends Component {
 		this.onSetNewTab = this.onSetNewTab.bind( this );
 		this.onSetTitle = this.onSetTitle.bind( this );
 		this.getFilename = this.getFilename.bind( this );
-		this.toggleIsEditing = this.toggleIsEditing.bind( this );
 		this.onUploadError = this.onUploadError.bind( this );
 		this.onImageError = this.onImageError.bind( this );
 		this.getLinkDestinations = this.getLinkDestinations.bind( this );
 
 		this.state = {
 			captionFocused: false,
-			isEditing: ! attributes.url,
 		};
 	}
 
@@ -314,7 +312,6 @@ export class ImageEdit extends Component {
 					allowedTypes: ALLOWED_MEDIA_TYPES,
 					onError: ( message ) => {
 						noticeOperations.createErrorNotice( message );
-						this.setState( { isEditing: true } );
 					},
 				} );
 			}
@@ -340,9 +337,6 @@ export class ImageEdit extends Component {
 		const { noticeOperations } = this.props;
 		noticeOperations.removeAllNotices();
 		noticeOperations.createErrorNotice( message );
-		this.setState( {
-			isEditing: true,
-		} );
 	}
 
 	onSelectImage( media ) {
@@ -356,10 +350,6 @@ export class ImageEdit extends Component {
 			} );
 			return;
 		}
-
-		this.setState( {
-			isEditing: false,
-		} );
 
 		const { id, url, alt, caption, linkDestination } = this.props.attributes;
 
@@ -411,10 +401,6 @@ export class ImageEdit extends Component {
 				sizeSlug: DEFAULT_SIZE_SLUG,
 			} );
 		}
-
-		this.setState( {
-			isEditing: false,
-		} );
 	}
 
 	onImageError( url ) {
@@ -552,24 +538,12 @@ export class ImageEdit extends Component {
 		];
 	}
 
-	toggleIsEditing() {
-		this.setState( {
-			isEditing: ! this.state.isEditing,
-		} );
-		if ( this.state.isEditing ) {
-			speak( __( 'You are now viewing the image in the image block.' ) );
-		} else {
-			speak( __( 'You are now editing the image in the image block.' ) );
-		}
-	}
-
 	getImageSizeOptions() {
 		const { imageSizes } = this.props;
 		return map( imageSizes, ( { name, slug } ) => ( { value: slug, label: name } ) );
 	}
 
 	render() {
-		const { isEditing } = this.state;
 		const {
 			attributes,
 			setAttributes,
@@ -607,48 +581,45 @@ export class ImageEdit extends Component {
 					value={ align }
 					onChange={ this.updateAlignment }
 				/>
+				{ url && <MediaReplaceFlow
+					mediaURL={ url }
+					allowedTypes={ ALLOWED_MEDIA_TYPES }
+					accept="image/*"
+					onSelect={ this.onSelectImage }
+					onSelectURL={ this.onSelectURL }
+					onError={ this.onUploadError }
+				/> }
 				{ url && (
-					<>
-						<ToolbarGroup>
-							<IconButton
-								className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': this.state.isEditing } ) }
-								label={ __( 'Edit image' ) }
-								aria-pressed={ this.state.isEditing }
-								onClick={ this.toggleIsEditing }
-								icon={ editImageIcon }
-							/>
-						</ToolbarGroup>
-						<ToolbarGroup>
-							<ImageURLInputUI
-								url={ href || '' }
-								onChangeUrl={ this.onSetHref }
-								mediaLinks={ this.getLinkDestinations() }
-								linkDestination={ linkDestination }
-								advancedOptions={
-									<>
-										<ToggleControl
-											label={ __( 'Open in New Tab' ) }
-											onChange={ this.onSetNewTab }
-											checked={ linkTarget === '_blank' } />
-										<TextControl
-											label={ __( 'Link Rel' ) }
-											value={ cleanRel || '' }
-											onChange={ this.onSetLinkRel }
-											onKeyPress={ stopPropagation }
-											onKeyDown={ stopPropagationRelevantKeys }
-										/>
-										<TextControl
-											label={ __( 'Link CSS Class' ) }
-											value={ linkClass || '' }
-											onKeyPress={ stopPropagation }
-											onKeyDown={ stopPropagationRelevantKeys }
-											onChange={ this.onSetLinkClass }
-										/>
-									</>
-								}
-							/>
-						</ToolbarGroup>
-					</>
+					<ToolbarGroup>
+						<ImageURLInputUI
+							url={ href || '' }
+							onChangeUrl={ this.onSetHref }
+							mediaLinks={ this.getLinkDestinations() }
+							linkDestination={ linkDestination }
+							advancedOptions={
+								<>
+									<ToggleControl
+										label={ __( 'Open in New Tab' ) }
+										onChange={ this.onSetNewTab }
+										checked={ linkTarget === '_blank' } />
+									<TextControl
+										label={ __( 'Link Rel' ) }
+										value={ cleanRel || '' }
+										onChange={ this.onSetLinkRel }
+										onKeyPress={ stopPropagation }
+										onKeyDown={ stopPropagationRelevantKeys }
+									/>
+									<TextControl
+										label={ __( 'Link CSS Class' ) }
+										value={ linkClass || '' }
+										onKeyPress={ stopPropagation }
+										onKeyDown={ stopPropagationRelevantKeys }
+										onChange={ this.onSetLinkClass }
+									/>
+								</>
+							}
+						/>
+					</ToolbarGroup>
 				) }
 			</BlockControls>
 		);
@@ -670,18 +641,16 @@ export class ImageEdit extends Component {
 				labels={ labels }
 				onSelect={ this.onSelectImage }
 				onSelectURL={ this.onSelectURL }
-				onDoubleClick={ this.toggleIsEditing }
-				onCancel={ !! url && this.toggleIsEditing }
 				notices={ noticeUI }
 				onError={ this.onUploadError }
 				accept="image/*"
 				allowedTypes={ ALLOWED_MEDIA_TYPES }
 				value={ { id, src } }
 				mediaPreview={ mediaPreview }
-				disableMediaButtons={ ! isEditing && url }
+				disableMediaButtons={ url }
 			/>
 		);
-		if ( isEditing || ! url ) {
+		if ( ! url ) {
 			return (
 				<>
 					{ controls }
@@ -832,7 +801,6 @@ export class ImageEdit extends Component {
 									<img
 										src={ url }
 										alt={ defaultedAlt }
-										onDoubleClick={ this.toggleIsEditing }
 										onClick={ this.onImageClick }
 										onError={ () => this.onImageError( url ) }
 									/>


### PR DESCRIPTION
## Description

Refactored following the suggestion from @youknowriad to no use DropDownMenu at all. Re implementing using a simple PopOver.

Closes #11952 

### Outstanding issues
- [x] Refactor so that no changes are applied to DropDownMenu
- [  ] Accessibility issues described by @enriquesanchez [here](https://github.com/WordPress/gutenberg/pull/16200#issuecomment-525502524)
- [x] The "Insert from URL" needs an aria-expanded attribute to communicate when the form is expanded/collapsed
- [x] When inserting / replacing media, the result of the action should be announced with a speak() message

![media-flow-new](https://user-images.githubusercontent.com/107534/65603102-bd503f80-dfad-11e9-9265-d25b290568f6.gif)


This component should be dropped in any media block 's toolbar and add the media edit functionality.

This component, in order to work, had a few hurdles to handle:

1. The is a z-index conflict that makes the suggestions from an url input appear below the popover when the popover is in a toolbar. The issue appears when the popover is displayed at the bottom and the problem is in `_z-index.scss` line 95, not sure what problem it solves there.

2. The `ObserveTyping` component needed `|| target.closest( '.components-popover' )` to determine the typing is in the toolbar. There was a condition but now that we have a popover in the toolbar I found no other solution than to look for the popover container. Not sure this is the best way though.

3. The `LinkEditor` component has some props forwarded to the `URLInput` it handles so we are able to show it with a border and full width.

4. The `DropdownMenu` component needed two new props:

- a `showLabel` prop that determines to show the label instead of the icon, when there is no icon
- an `onToggleHandler` prop which is a function that is called by `Dropdown` on `toggle`. This was the only solid way to have the `URLInput` hidden when the menu was closed and opened again.
- some style was added to have the arrow correctly spaced from the label as well

5. The `Toolbar` component passes down `showLabel` and `... otherProps` to `DropdownMenu` so we can set these in `MediaFlow`.





