### PR TITLE
Fix/add check for null in gutenberg is block editor function

### DIFF
--- a/lib/widgets.php
+++ b/lib/widgets.php
@@ -17,7 +17,7 @@ function gutenberg_is_block_editor() {
 		return false;
 	}
 	$screen = get_current_screen();
-	return $screen->is_block_editor() || 'gutenberg_page_gutenberg-widgets' === $screen->id;
+	return ! empty( $screen ) && ( $screen->is_block_editor() || 'gutenberg_page_gutenberg-widgets' === $screen->id );
 }
 
 /**


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This pull request addresses #16199. Adds a null check in the `gutenberg_is_block_editor` function so that we can avoid unexpected errors.

## How has this been tested?
We are using the mailpoet plugin which utilizes wp_iframe (where this error is occuring). I added this check and the plugin works like it should now.

## Types of changes
<!-- What types of changes does your code introduce?  -->
A very small quick fix to avoid a unexpected 500 error.

Fixes #16199.