### PR TITLE
Update Group block transform snapshots

### DIFF
--- a/packages/e2e-tests/specs/__snapshots__/block-grouping.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/block-grouping.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Block Grouping Group creation creates a group from multiple blocks of different types via block transforms 1`] = `
 "<!-- wp:group -->
-<div class=\\"wp-block-group\\"><!-- wp:heading -->
+<div class=\\"wp-block-group\\"><div class=\\"wp-block-group__inner-container\\"><!-- wp:heading -->
 <h2>Group Heading</h2>
 <!-- /wp:heading -->
 
@@ -12,13 +12,13 @@ exports[`Block Grouping Group creation creates a group from multiple blocks of d
 
 <!-- wp:paragraph -->
 <p>Some paragraph</p>
-<!-- /wp:paragraph --></div>
+<!-- /wp:paragraph --></div></div>
 <!-- /wp:group -->"
 `;
 
 exports[`Block Grouping Group creation creates a group from multiple blocks of the same type via block transforms 1`] = `
 "<!-- wp:group -->
-<div class=\\"wp-block-group\\"><!-- wp:paragraph -->
+<div class=\\"wp-block-group\\"><div class=\\"wp-block-group__inner-container\\"><!-- wp:paragraph -->
 <p>First Paragraph</p>
 <!-- /wp:paragraph -->
 
@@ -28,13 +28,13 @@ exports[`Block Grouping Group creation creates a group from multiple blocks of t
 
 <!-- wp:paragraph -->
 <p>Third Paragraph</p>
-<!-- /wp:paragraph --></div>
+<!-- /wp:paragraph --></div></div>
 <!-- /wp:group -->"
 `;
 
 exports[`Block Grouping Group creation creates a group from multiple blocks of the same type via options toolbar 1`] = `
 "<!-- wp:group -->
-<div class=\\"wp-block-group\\"><!-- wp:paragraph -->
+<div class=\\"wp-block-group\\"><div class=\\"wp-block-group__inner-container\\"><!-- wp:paragraph -->
 <p>First Paragraph</p>
 <!-- /wp:paragraph -->
 
@@ -44,13 +44,13 @@ exports[`Block Grouping Group creation creates a group from multiple blocks of t
 
 <!-- wp:paragraph -->
 <p>Third Paragraph</p>
-<!-- /wp:paragraph --></div>
+<!-- /wp:paragraph --></div></div>
 <!-- /wp:group -->"
 `;
 
 exports[`Block Grouping Group creation groups and ungroups multiple blocks of different types via options toolbar 1`] = `
 "<!-- wp:group -->
-<div class=\\"wp-block-group\\"><!-- wp:heading -->
+<div class=\\"wp-block-group\\"><div class=\\"wp-block-group__inner-container\\"><!-- wp:heading -->
 <h2>Group Heading</h2>
 <!-- /wp:heading -->
 
@@ -60,7 +60,7 @@ exports[`Block Grouping Group creation groups and ungroups multiple blocks of di
 
 <!-- wp:paragraph -->
 <p>Some paragraph</p>
-<!-- /wp:paragraph --></div>
+<!-- /wp:paragraph --></div></div>
 <!-- /wp:group -->"
 `;
 
@@ -80,7 +80,7 @@ exports[`Block Grouping Group creation groups and ungroups multiple blocks of di
 
 exports[`Block Grouping Preserving selected blocks attributes preserves width alignment settings of selected blocks 1`] = `
 "<!-- wp:group {\\"align\\":\\"full\\"} -->
-<div class=\\"wp-block-group alignfull\\"><!-- wp:heading -->
+<div class=\\"wp-block-group alignfull\\"><div class=\\"wp-block-group__inner-container\\"><!-- wp:heading -->
 <h2>Group Heading</h2>
 <!-- /wp:heading -->
 
@@ -94,6 +94,6 @@ exports[`Block Grouping Preserving selected blocks attributes preserves width al
 
 <!-- wp:paragraph -->
 <p>Some paragraph</p>
-<!-- /wp:paragraph --></div>
+<!-- /wp:paragraph --></div></div>
 <!-- /wp:group -->"
 `;

--- a/packages/e2e-tests/specs/__snapshots__/block-transforms.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/block-transforms.test.js.snap
@@ -98,9 +98,9 @@ exports[`Block transforms correctly transform block Image in fixture core__image
 
 exports[`Block transforms correctly transform block Image in fixture core__image into the Group block 1`] = `
 "<!-- wp:group -->
-<div class=\\"wp-block-group\\"><!-- wp:image -->
+<div class=\\"wp-block-group\\"><div class=\\"wp-block-group__inner-container\\"><!-- wp:image -->
 <figure class=\\"wp-block-image\\"><img src=\\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\\" alt=\\"\\"/></figure>
-<!-- /wp:image --></div>
+<!-- /wp:image --></div></div>
 <!-- /wp:group -->"
 `;
 
@@ -362,9 +362,9 @@ exports[`Block transforms correctly transform block Media & Text in fixture core
 
 exports[`Block transforms correctly transform block Paragraph in fixture core__paragraph__align-right into the Group block 1`] = `
 "<!-- wp:group -->
-<div class=\\"wp-block-group\\"><!-- wp:paragraph {\\"align\\":\\"right\\"} -->
+<div class=\\"wp-block-group\\"><div class=\\"wp-block-group__inner-container\\"><!-- wp:paragraph {\\"align\\":\\"right\\"} -->
 <p style=\\"text-align:right\\">... like this one, which is separate from the above and right aligned.</p>
-<!-- /wp:paragraph --></div>
+<!-- /wp:paragraph --></div></div>
 <!-- /wp:group -->"
 `;
 


### PR DESCRIPTION
Fixes some snapshots that errored after #15210 was merged into `master`. 

The tests are related to grouping/ungrouping actions, which weren't synced up with that PR when it last had its tests run. 