### PR TITLE
Scope the data-block CSS selector.

### DIFF
--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -49,7 +49,7 @@
 
 // Provide every block with a default base margin. This margin provides a consistent spacing
 // between blocks in the editor.
-[data-block] {
+.editor-styles-wrapper [data-block] {
 	margin-top: $default-block-margin;
 	margin-bottom: $default-block-margin;
 }


### PR DESCRIPTION
## Description
This PR seeks to better scope the `[data-block]` CSS selector after #15465.

The new margins used in this selector rule can break other (external) components, for example `Draft.js`.

/Cc @jasmussen @m-e-h I'd greatly appreciate your review, thanks!

Fixes #15465 