### PR TITLE
Re-enable Video block on Android after Android X migration

### DIFF
--- a/packages/edit-post/src/index.native.js
+++ b/packages/edit-post/src/index.native.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { Platform } from 'react-native';
-
-/**
  * WordPress dependencies
  */
 import '@wordpress/core-data';
@@ -27,11 +22,6 @@ export function initializeEditor() {
 	// eslint-disable-next-line no-undef
 	if ( typeof __DEV__ === 'undefined' || ! __DEV__ ) {
 		unregisterBlockType( 'core/code' );
-
-		// Disable Video block except for iOS for now.
-		if ( Platform.OS !== 'ios' ) {
-			unregisterBlockType( 'core/video' );
-		}
 	}
 }
 


### PR DESCRIPTION
This PR re-enables the Video block on Android. 

Companion Mobile Gutenberg PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1150


Video block was disabled right before 1.7 version of gb-mobile, since there were issues with the Android implementation. https://github.com/WordPress/gutenberg/pull/16149