### PR TITLE
Paste: Plain text disguised as HTML should come out in blocks

### DIFF
--- a/test/integration/blocks-raw-handling.spec.js
+++ b/test/integration/blocks-raw-handling.spec.js
@@ -232,6 +232,7 @@ describe( 'Blocks raw handling', () => {
 	describe( 'pasteHandler', () => {
 		[
 			'plain',
+			'plain-like',
 			'classic',
 			'apple',
 			'google-docs',

--- a/test/integration/fixtures/plain-in.html
+++ b/test/integration/fixtures/plain-in.html
@@ -1,1 +1,8 @@
-test<br>test<br><br>test<br>
+Paragraph 1
+
+Paragraph 2
+•	List item 1
+•	List item 2
+•	List item 3
+
+Paragraph 3

--- a/test/integration/fixtures/plain-like-in.html
+++ b/test/integration/fixtures/plain-like-in.html
@@ -1,0 +1,1 @@
+test<br>test<br><br>test<br>

--- a/test/integration/fixtures/plain-like-out.html
+++ b/test/integration/fixtures/plain-like-out.html
@@ -1,0 +1,7 @@
+<!-- wp:paragraph -->
+<p>test<br>test</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>test<br></p>
+<!-- /wp:paragraph -->

--- a/test/integration/fixtures/plain-out.html
+++ b/test/integration/fixtures/plain-out.html
@@ -1,7 +1,0 @@
-<!-- wp:paragraph -->
-<p>test<br>test</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p>test<br></p>
-<!-- /wp:paragraph -->


### PR DESCRIPTION
## Description

Aims to fix #9759 as good as we can.

I just added a test case for now where you can see pasted plain text disguised as HTML comes out as inline text. We can at least parse this into paragraph blocks at double line breaks.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
