### PR TITLE
Update/16128 add attribute types documentation

### DIFF
--- a/docs/designers-developers/developers/block-api/block-attributes.md
+++ b/docs/designers-developers/developers/block-api/block-attributes.md
@@ -43,7 +43,6 @@ Accepted values in the `type` field of an `attribute` MUST be one of the followi
 * number
 * string
 * integer
-	- Matches any number with a zero fractional part
 
 See [WordPress's REST API documentation](https://developer.wordpress.org/rest-api/extending-the-rest-api/schema/) for additional details.
 

--- a/docs/designers-developers/developers/block-api/block-attributes.md
+++ b/docs/designers-developers/developers/block-api/block-attributes.md
@@ -45,6 +45,8 @@ Accepted values in the `type` field of an `attribute` MUST be one of the followi
 * integer
 	- Matches any number with a zero fractional part
 
+Additional details are found in the documentation for Wordpress's REST API [here](https://developer.wordpress.org/rest-api/extending-the-rest-api/schema/).
+
 ### `text`
 
 Use `text` to extract the inner text from markup.

--- a/docs/designers-developers/developers/block-api/block-attributes.md
+++ b/docs/designers-developers/developers/block-api/block-attributes.md
@@ -45,7 +45,7 @@ Accepted values in the `type` field of an `attribute` MUST be one of the followi
 * integer
 	- Matches any number with a zero fractional part
 
-Additional details are found in the documentation for Wordpress's REST API [here](https://developer.wordpress.org/rest-api/extending-the-rest-api/schema/).
+See [WordPress's REST API documentation](https://developer.wordpress.org/rest-api/extending-the-rest-api/schema/) for additional details.
 
 ### `text`
 

--- a/docs/designers-developers/developers/block-api/block-attributes.md
+++ b/docs/designers-developers/developers/block-api/block-attributes.md
@@ -32,6 +32,7 @@ _Example_: Extract the `src` attribute from an image found in the block's markup
 }
 // { "url": "https://lorempixel.com/1200/800/" }
 ```
+
 #### `attribute` Type Validation
 
 Accepted values in the `type` field of an `attribute` MUST be one of the following:

--- a/docs/designers-developers/developers/block-api/block-attributes.md
+++ b/docs/designers-developers/developers/block-api/block-attributes.md
@@ -32,6 +32,18 @@ _Example_: Extract the `src` attribute from an image found in the block's markup
 }
 // { "url": "https://lorempixel.com/1200/800/" }
 ```
+#### `attribute` Type Validation
+
+Accepted values in the `type` field of an `attribute` MUST be one of the following:
+
+* null
+* boolean
+* object
+* array
+* number
+* string
+* integer
+	- Matches any number with a zero fractional part
 
 ### `text`
 


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Fixes #16128 . Added accepted attribute types for the Blocks API, including a link to the Wordpress REST API documentation for clarification. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Ran changes in docs through Visual Studio Code's markdown preview testing.

Changes should not affect any other code, as it was purely an addition to documentation. No existing documentation was altered.

## Screenshots <!-- if applicable -->


## Types of changes
<!-- What types of changes does your code introduce?  -->
Only a change in documentation, as clarification was requested through #16128 .

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
