### PR TITLE
Packages: Refactor Common Block Code

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - `BlockEditorProvider` no longer renders a wrapping `SlotFillProvider` or `DropZoneProvider` (from `@wordpress/components`). For custom block editors, you should render your own as wrapping the `BlockEditorProvider`. A future release will include a new `BlockEditor` component for simple, standard usage. `BlockEditorProvider` will serve the simple purpose of establishing its own context for block editors.
 
+### New Features
+
+- Added the `useAttributePicker` hook to abstract away common block code and used it to refactor the color higher order components. They are now written with the new exported hooks, `useColors` and `useCustomColors`.
+
 ## 2.2.0 (2019-06-12)
 
 ### Internal

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### New Features
 
-- Added the `useAttributePicker` hook to abstract away common block code and used it to refactor the color higher order components. They are now written with the new exported hooks, `useColors` and `useCustomColors`.
+- Added the `useAttributePicker` hook to abstract away common block code and used it to refactor the color and font size higher order components. They are now written with the new exported hooks, `useColors`, `useCustomColors`, and `useFontSizes`.
 
 ## 2.2.0 (2019-06-12)
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -498,7 +498,7 @@ const MyColorfulComponent = () => {
 	// _.isEqual(
 	// 	{ ...CUSTOM_COLORS[ 0 ], class: 'has-red-background-color' },
 	// 	backgroundColor
-	//	);
+	// );
 	// setBackgroundColor( '#000000' );
 	// _.isEqual( { color: '#000000' }, backgroundColor );
 	//...
@@ -513,6 +513,56 @@ _Parameters_
 _Returns_
 
 -   `Object`: The object with color objects and color setters.
+
+<a name="useFontSizes" href="#useFontSizes">#</a> **useFontSizes**
+
+A hook that returns an object with font size objects and font size
+block attribute setters for a given list of font size names.
+It uses the font size object list from the editor's settings as a palette.
+
+_Usage_
+
+Calling it with a font size name `"paragraphFontSize"` will return an object
+with a font size object `paragraphFontSize`, and a function `setParagraphFontSize`.
+`setParagraphFontSize` can be called with any font size value. If the value
+equals the `size` property of an object in the `fontSizes` list from the editor's settings,
+`paragraphFontSize` will be set to that object merged with a custom
+`class` property. If it's not, it will be set to a custom object
+with just a `size` property set to the value.
+
+```jsx
+// const FONT_SIZES = [
+// 	{
+// 		name: 'Small',
+// 		size: 13,
+// 		slug: 'small',
+// 	},
+// 	// ...
+// ];
+// _.isEqual( FONT_SIZES, select( 'core/block-editor' ).getSettings().fontSizes );
+
+const MyFontSizeableComponent = () => {
+	const { paragraphFontSize, setParagraphFontSize } = useFontSizes( [
+		'paragraphFontSize',
+	] );
+
+	// setParagraphFontSize( 13 );
+	// _.isEqual(
+	// 	{ ...FONT_SIZES[ 0 ], class: 'has-small-font-size' },
+	// 	paragraphFontSize
+	// );
+	// setParagraphFontSize( 14 );
+	// _.isEqual( { size: 14 }, paragraphFontSize );
+};
+```
+
+_Parameters_
+
+-   _fontSizeNames_ `Array<string>`: The list of font size names.
+
+_Returns_
+
+-   `Object`: The object with font size objects and font size setters.
 
 <a name="Warning" href="#Warning">#</a> **Warning**
 
@@ -552,7 +602,7 @@ font size value retrieval, and font size change handling.
 
 _Parameters_
 
--   _args_ `...(object|string)`: The arguments should all be strings Each string contains the font size attribute name e.g: 'fontSize'.
+-   _fontSizeNames_ `...string`: The arguments should all be strings. Each string contains the font size attribute name e.g.: 'fontSize'.
 
 _Returns_
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -90,6 +90,10 @@ Undocumented declaration.
 
 Undocumented declaration.
 
+<a name="BlockEditContextProvider" href="#BlockEditContextProvider">#</a> **BlockEditContextProvider**
+
+Undocumented declaration.
+
 <a name="BlockEditorKeyboardShortcuts" href="#BlockEditorKeyboardShortcuts">#</a> **BlockEditorKeyboardShortcuts**
 
 Undocumented declaration.
@@ -404,6 +408,111 @@ _Related_
 _Related_
 
 -   <https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/url-popover/README.md>
+
+<a name="useAttributePicker" href="#useAttributePicker">#</a> **useAttributePicker**
+
+Low level hook that takes an options object that has a list of attributes to manage, values that they can be set to,
+and functions for customizing how values are compared, saved, and returned. It also handles setting attributes to
+custom values and provides an easy way to bind utilities.
+It returns an object with mapped attributes, attribute setters, and bound utilities.
+It can be used to write hooks like `useColors`.
+
+_Related_
+
+-   [useColors](/packages/block-editor/README.md#useColors)
+
+_Parameters_
+
+-   _attributePickerOptions_ `Object`: The options object.
+-   _attributePickerOptions.names_ `Array<string>`: The list of attributes to manage.
+-   _attributePickerOptions.valuesEnum_ `Array<*>`: The list of values attributes can be set to. Setting an attribute to a custom value not on this list will set the attribute's value to `undefined` and the corresponding `custom${ upperFirst( name ) }` attribute to the custom value.
+-   _attributePickerOptions.findEnumValue_ `[Function]`: Function for comparing an enum value to the value passed to the setter, when looking for the value in the enum. Defaults to shallow comparison.
+-   _attributePickerOptions.mapEnumValue_ `[Function]`: Function for mapping the enum value found with `findEnumValue` before saving it, if found. Otherwise, the value is assumed to be custom and saved as is.
+-   _attributePickerOptions.findAndMapEnumValueDeps_ `[Array<*>]`: List of items that, if they fail a shallow equality test, will cause new setters to be returned. Useful if your `findEnumValue` or `mapEnumValue` have closures.
+-   _attributePickerOptions.mapAttribute_ `[Function]`: Function for mapping attributes before returning them, called with the attribute's or custom attribute's value and the name.
+-   _attributePickerOptions.mapAttributeDeps_ `[Array<*>]`: List of items that, if they fail a shallow equality test, will cause attributes to be mapped again. Useful if your `mapAttribute` has closures.
+-   _attributePickerOptions.utilsToBind_ `[undefined]`: Object with functions to bind to `valuesEnum` and merge into the returned object. Useful for utilities that need to be bound.
+-   _attributePickerOptions.utilsToBindDeps_ `[Array<*>]`: List of items that, if they fail a shallow equality test, will cause `utilsToBind` to be bound again. Useful if any of your utils has closures.
+
+_Returns_
+
+-   `Object`: The object with mapped attributes and attribute setters.
+
+<a name="useColors" href="#useColors">#</a> **useColors**
+
+Like `useCustomColors`, but uses the color palette from
+the editor's settings.
+
+_Related_
+
+-   [useCustomColors](/packages/block-editor/README.md#useCustomColors)
+
+_Usage_
+
+```jsx
+const MyColorfulComponent = () => {
+	const { backgroundColor, setBackgroundColor } = useColors( [
+		'backgroundColor',
+	] );
+
+	//...
+};
+```
+
+_Parameters_
+
+-   _colorTypes_ `Array<(Object|string)>`: The color types passed to `useCustomColors`.
+
+_Returns_
+
+-   `Object`: The object with color objects and color setters.
+
+<a name="useCustomColors" href="#useCustomColors">#</a> **useCustomColors**
+
+A hook that returns an object with color objects and color
+block attribute setters for a given list of color types and
+a custom color palette.
+
+_Usage_
+
+Calling it with a color type `"backgroundColor"` will return an object
+with a color object `backgroundColor`, and a function `setBackgroundColor`.
+`setBackgroundColor` can be called with any color value. If the value
+equals the `color` property of an object in the `colorPalette`,
+`backgroundColor` will be set to that object merged with a custom
+`class` property. If it's not, it will be set to a custom object
+with just a `color` property set to the value.
+
+```jsx
+const CUSTOM_COLORS = [
+	{ name: 'Red', slug: 'red', color: '#ff0000' },
+	{ name: 'Blue', slug: 'blue', color: '#0000ff' },
+];
+
+const MyColorfulComponent = () => {
+	const { backgroundColor, setBackgroundColor } = useCustomColors(
+		[ 'backgroundColor' ],
+		CUSTOM_COLORS
+	);
+	// setBackgroundColor( '#ff0000' );
+	// _.isEqual(
+	// 	{ ...CUSTOM_COLORS[ 0 ], class: 'has-red-background-color' },
+	// 	backgroundColor
+	//	);
+	// setBackgroundColor( '#000000' );
+	// _.isEqual( { color: '#000000' }, backgroundColor );
+	//...
+};
+```
+
+_Parameters_
+
+-   _colorTypes_ `Array<(Object|string)>`: The arguments can be strings or objects. If the argument is an object, it should contain the color attribute name as key and the color context as value. If the argument is a string, the value should be the color attribute name, the color context is computed by applying a kebab case transform to the value. Color context represents the context/place where the color is going to be used. The class name of the color is generated using 'has' followed by the color name and ending with the color context all in kebab case e.g: has-green-background-color.
+-   _colorPalette_ `Array<Object>`: The array of color objects (name, slug, color, etc... ).
+
+_Returns_
+
+-   `Object`: The object with color objects and color setters.
 
 <a name="Warning" href="#Warning">#</a> **Warning**
 

--- a/packages/block-editor/src/components/block-controls/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/block-controls/test/__snapshots__/index.js.snap
@@ -4,11 +4,13 @@ exports[`BlockControls should render a dynamic toolbar of controls 1`] = `
 <ContextProvider
   value={
     Object {
+      "attributes": undefined,
       "clientId": undefined,
       "isSelected": true,
       "name": undefined,
       "onCaretVerticalPositionChange": undefined,
       "onFocus": undefined,
+      "setAttributes": undefined,
     }
   }
 >

--- a/packages/block-editor/src/components/block-edit/context.js
+++ b/packages/block-editor/src/components/block-edit/context.js
@@ -6,18 +6,22 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { createContext } from '@wordpress/element';
+import { createContext, useContext } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
 
-const { Consumer, Provider } = createContext( {
+export const Context = createContext( {
 	name: '',
 	isSelected: false,
 	focusedElement: null,
 	setFocusedElement: noop,
 	clientId: null,
 } );
+const { Consumer, Provider } = Context;
 
 export { Provider as BlockEditContextProvider };
+export function useBlockEditContext() {
+	return useContext( Context );
+}
 
 /**
  * A Higher Order Component used to inject BlockEdit context to the

--- a/packages/block-editor/src/components/block-edit/index.js
+++ b/packages/block-editor/src/components/block-edit/index.js
@@ -14,7 +14,7 @@ import { Component } from '@wordpress/element';
 import Edit from './edit';
 import { BlockEditContextProvider } from './context';
 
-class BlockEdit extends Component {
+export default class BlockEdit extends Component {
 	constructor() {
 		super( ...arguments );
 
@@ -27,13 +27,13 @@ class BlockEdit extends Component {
 		);
 	}
 
-	propsToContext( name, isSelected, clientId, onFocus, onCaretVerticalPositionChange ) {
-		return { name, isSelected, clientId, onFocus, onCaretVerticalPositionChange };
+	propsToContext( name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, attributes, setAttributes ) {
+		return { name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, attributes, setAttributes };
 	}
 
 	render() {
-		const { name, isSelected, clientId, onFocus, onCaretVerticalPositionChange } = this.props;
-		const value = this.propsToContext( name, isSelected, clientId, onFocus, onCaretVerticalPositionChange );
+		const { name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, attributes, setAttributes } = this.props;
+		const value = this.propsToContext( name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, attributes, setAttributes );
 
 		return (
 			<BlockEditContextProvider value={ value }>
@@ -43,4 +43,5 @@ class BlockEdit extends Component {
 	}
 }
 
-export default BlockEdit;
+export { BlockEditContextProvider };
+export { default as useAttributePicker } from './use-attribute-picker';

--- a/packages/block-editor/src/components/block-edit/use-attribute-picker.js
+++ b/packages/block-editor/src/components/block-edit/use-attribute-picker.js
@@ -1,0 +1,138 @@
+/**
+ * External dependencies
+ */
+import { upperFirst } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { useShallowCompareDep, useDeepCompareDep } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { useBlockEditContext } from './context';
+
+/**
+ * Low level hook that takes an options object that has a list of attributes to manage, values that they can be set to,
+ * and functions for customizing how values are compared, saved, and returned. It also handles setting attributes to
+ * custom values and provides an easy way to bind utilities.
+ * It returns an object with mapped attributes, attribute setters, and bound utilities.
+ * It can be used to write hooks like `useColors`.
+ *
+ * @see [useColors](/packages/block-editor/README.md#useColors)
+ *
+ * @param {Object}                 attributePickerOptions                           The options object.
+ *
+ * @param {string[]}               attributePickerOptions.names                     The list of attributes to manage.
+ *
+ * @param {*[]}                    attributePickerOptions.valuesEnum                The list of values attributes can be set to.
+ *                                                                                   Setting an attribute to a custom value not on
+ *                                                                                   this list will set the attribute's value to
+ *                                                                                   `undefined` and the corresponding `custom${ upperFirst( name ) }`
+ *                                                                                   attribute to the custom value.
+ *
+ * @param {Function}               [attributePickerOptions.findEnumValue]           Function for comparing an enum value to the
+ *                                                                                   value passed to the setter, when looking for
+ *                                                                                   the value in the enum. Defaults to shallow comparison.
+ *
+ * @param {Function}               [attributePickerOptions.mapEnumValue]            Function for mapping the enum value found with
+ *                                                                                   `findEnumValue` before saving it, if found.
+ *                                                                                   Otherwise, the value is assumed to be custom and saved as is.
+ *
+ * @param {*[]}                    [attributePickerOptions.findAndMapEnumValueDeps] List of items that, if they fail a shallow equality test, will
+ *                                                                                   cause new setters to be returned. Useful if your `findEnumValue` or `mapEnumValue` have closures.
+ *
+ * @param {Function}               [attributePickerOptions.mapAttribute]            Function for mapping attributes before returning them, called
+ *                                                                                   with the attribute's or custom attribute's value and the name.
+ *
+ * @param {*[]}                    [attributePickerOptions.mapAttributeDeps]        List of items that, if they fail a shallow equality test, will
+ *                                                                                   cause attributes to be mapped again. Useful if your `mapAttribute` has closures.
+ *
+ * @param {{ string: Function }}   [attributePickerOptions.utilsToBind]             Object with functions to bind to `valuesEnum` and merge into the
+ *                                                                                   returned object. Useful for utilities that need to be bound.
+ *
+ * @param {*[]}                    [attributePickerOptions.utilsToBindDeps]         List of items that, if they fail a shallow equality test, will
+ *                                                                                   cause `utilsToBind` to be bound again. Useful if any of your utils has closures.
+ *
+ * @return {Object} The object with mapped attributes and attribute setters.
+ */
+export default function useAttributePicker( {
+	names,
+	valuesEnum,
+
+	findEnumValue = ( enumValue, newValue ) => enumValue === newValue,
+	mapEnumValue = ( enumValue ) => enumValue,
+	findAndMapEnumValueDeps = [],
+
+	mapAttribute = ( mappedEnumValueOrCustomValue ) => mappedEnumValueOrCustomValue,
+	mapAttributeDeps = [],
+
+	utilsToBind = {},
+	utilsToBindDeps = [],
+} ) {
+	const { setAttributes, attributes } = useBlockEditContext();
+	const namesDep = useShallowCompareDep( names );
+	const valuesEnumDep = useDeepCompareDep( valuesEnum );
+
+	const setters = useMemo(
+		() =>
+			names.map( ( name ) => ( newValue ) => {
+				const foundEnumValue = valuesEnum.find( ( enumValue ) =>
+					findEnumValue( enumValue, newValue )
+				);
+				const mappedValue = foundEnumValue && mapEnumValue( foundEnumValue );
+
+				setAttributes( {
+					[ name ]: mappedValue ? mappedValue : undefined,
+					[ `custom${ upperFirst( name ) }` ]: mappedValue ? undefined : newValue,
+				} );
+			} ),
+		[ namesDep, valuesEnumDep, ...findAndMapEnumValueDeps ]
+	);
+
+	const mappedAttributes = useMemo(
+		() =>
+			names.map( ( name ) =>
+				mapAttribute(
+					attributes[ name ] || attributes[ `custom${ upperFirst( name ) }` ],
+					name
+				)
+			),
+		[
+			namesDep,
+			valuesEnumDep,
+			useDeepCompareDep(
+				names.map(
+					( name ) => attributes[ name ] || attributes[ `custom${ upperFirst( name ) }` ]
+				)
+			),
+			...mapAttributeDeps,
+		]
+	);
+
+	const utils = useMemo(
+		() =>
+			Object.keys( utilsToBind ).reduce( ( utilsAccumulator, utilName ) => {
+				utilsAccumulator[ utilName ] = utilsToBind[ utilName ].bind(
+					null,
+					valuesEnum
+				);
+				return utilsAccumulator;
+			}, {} ),
+		[ valuesEnumDep, useShallowCompareDep( utilsToBind ), ...utilsToBindDeps ]
+	);
+
+	return useMemo(
+		() => ( {
+			...names.reduce( ( attributePicker, name, i ) => {
+				attributePicker[ `set${ upperFirst( name ) }` ] = setters[ i ];
+				attributePicker[ name ] = mappedAttributes[ i ];
+				return attributePicker;
+			}, {} ),
+			utils,
+		} ),
+		[ setters, mappedAttributes, utils ]
+	);
+}

--- a/packages/block-editor/src/components/colors/index.js
+++ b/packages/block-editor/src/components/colors/index.js
@@ -3,7 +3,5 @@ export {
 	getColorObjectByAttributeValues,
 	getColorObjectByColorValue,
 } from './utils';
-export {
-	createCustomColorsHOC,
-	default as withColors,
-} from './with-colors';
+export { default as useColors, useCustomColors } from './use-colors';
+export { createCustomColorsHOC, default as withColors } from './with-colors';

--- a/packages/block-editor/src/components/colors/test/__snapshots__/with-colors.js.snap
+++ b/packages/block-editor/src/components/colors/test/__snapshots__/with-colors.js.snap
@@ -1,23 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`createCustomColorsHOC provides the the wrapped component with color values and setter functions as props 1`] = `
-<Component
-  attributes={
-    Object {
-      "backgroundColor": null,
-    }
-  }
-  backgroundColor={
-    Object {
-      "class": undefined,
-      "color": undefined,
-    }
-  }
-  colorUtils={
-    Object {
-      "getMostReadableColor": [Function],
-    }
-  }
-  setBackgroundColor={[Function]}
-/>
+<WithCustomColors(Component)>
+  <Component>
+    <Component
+      backgroundColor={
+        Object {
+          "class": undefined,
+          "color": undefined,
+        }
+      }
+      colorUtils={
+        Object {
+          "getMostReadableColor": [Function],
+        }
+      }
+      setBackgroundColor={[Function]}
+    >
+      <div />
+    </Component>
+  </Component>
+</WithCustomColors(Component)>
 `;

--- a/packages/block-editor/src/components/colors/test/with-colors.js
+++ b/packages/block-editor/src/components/colors/test/with-colors.js
@@ -1,11 +1,12 @@
 /**
  * External dependencies
  */
-import { shallow, mount } from 'enzyme';
+import { mount } from 'enzyme';
 
 /**
  * Internal dependencies
  */
+import { BlockEditContextProvider } from '../../block-edit';
 import { createCustomColorsHOC } from '../with-colors';
 
 describe( 'createCustomColorsHOC', () => {
@@ -15,11 +16,15 @@ describe( 'createCustomColorsHOC', () => {
 			<div />
 		) );
 
-		const wrapper = shallow(
-			<EnhancedComponent attributes={ { backgroundColor: null } } />
+		const wrapper = mount(
+			<BlockEditContextProvider
+				value={ { attributes: { backgroundColor: null } } }
+			>
+				<EnhancedComponent />
+			</BlockEditContextProvider>
 		);
 
-		expect( wrapper.dive() ).toMatchSnapshot();
+		expect( wrapper ).toMatchSnapshot();
 	} );
 
 	it( 'setting the color to a value in the provided custom color array updated the backgroundColor attribute', () => {
@@ -31,7 +36,11 @@ describe( 'createCustomColorsHOC', () => {
 		const setAttributes = jest.fn();
 
 		const wrapper = mount(
-			<EnhancedComponent attributes={ { backgroundColor: null } } setAttributes={ setAttributes } />
+			<BlockEditContextProvider
+				value={ { attributes: { backgroundColor: null }, setAttributes } }
+			>
+				<EnhancedComponent />
+			</BlockEditContextProvider>
 		);
 
 		wrapper.find( 'button' ).simulate( 'click' );
@@ -47,7 +56,11 @@ describe( 'createCustomColorsHOC', () => {
 		const setAttributes = jest.fn();
 
 		const wrapper = mount(
-			<EnhancedComponent attributes={ { backgroundColor: null } } setAttributes={ setAttributes } />
+			<BlockEditContextProvider
+				value={ { attributes: { backgroundColor: null }, setAttributes } }
+			>
+				<EnhancedComponent />
+			</BlockEditContextProvider>
 		);
 
 		wrapper.find( 'button' ).simulate( 'click' );

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -1,0 +1,140 @@
+/**
+ * External dependencies
+ */
+import { kebabCase } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useAttributePicker } from '../block-edit';
+import { getMostReadableColor } from './utils';
+
+/**
+ * A hook that returns an object with color objects and color
+ * block attribute setters for a given list of color types and
+ * a custom color palette.
+ *
+ * @example
+ * Calling it with a color type `"backgroundColor"` will return an object
+ * with a color object `backgroundColor`, and a function `setBackgroundColor`.
+ * `setBackgroundColor` can be called with any color value. If the value
+ * equals the `color` property of an object in the `colorPalette`,
+ * `backgroundColor` will be set to that object merged with a custom
+ * `class` property. If it's not, it will be set to a custom object
+ * with just a `color` property set to the value.
+ *
+ * ```jsx
+ * const CUSTOM_COLORS = [
+ * 	{ name: 'Red', slug: 'red', color: '#ff0000' },
+ * 	{ name: 'Blue', slug: 'blue', color: '#0000ff' },
+ * ];
+ *
+ * const MyColorfulComponent = () => {
+ * 	const { backgroundColor, setBackgroundColor } = useCustomColors(
+ * 		[ 'backgroundColor' ],
+ * 		CUSTOM_COLORS
+ * 	);
+ * 	// setBackgroundColor( '#ff0000' );
+ * 	// _.isEqual(
+ * 	// 	{ ...CUSTOM_COLORS[ 0 ], class: 'has-red-background-color' },
+ * 	// 	backgroundColor
+ * 	//	);
+ * 	// setBackgroundColor( '#000000' );
+ * 	// _.isEqual( { color: '#000000' }, backgroundColor );
+ * 	//...
+ * };
+ * ```
+ *
+ * @param {(Object|string)[]} colorTypes The arguments can be strings or objects. If the argument is an object,
+ *                                        it should contain the color attribute name as key and the color context as value.
+ *                                        If the argument is a string, the value should be the color attribute name,
+ *                                        the color context is computed by applying a kebab case transform to the value.
+ *                                        Color context represents the context/place where the color is going to be used.
+ *                                        The class name of the color is generated using 'has' followed by the color name
+ *                                        and ending with the color context all in kebab case e.g: has-green-background-color.
+ *
+ * @param {Object[]} colorPalette The array of color objects (name, slug, color, etc... ).
+ *
+ * @return {Object} The object with color objects and color setters.
+ */
+export function useCustomColors( colorTypes, colorPalette ) {
+	const attributePicker = useAttributePicker( {
+		names: colorTypes.flatMap( ( colorType ) =>
+			typeof colorType === 'string' ? colorType : Object.keys( colorType )
+		),
+		valuesEnum: colorPalette,
+
+		findEnumValue: ( colorPaletteObject, newColorValue ) =>
+			colorPaletteObject.color === newColorValue,
+		mapEnumValue: ( colorPaletteObject ) => colorPaletteObject.slug,
+
+		mapAttribute: ( colorSlugOrCustomValue, name ) => {
+			const foundColorPaletteObject = colorPalette.find(
+				( colorPaletteObject ) => colorPaletteObject.slug === colorSlugOrCustomValue
+			) || { color: colorSlugOrCustomValue };
+
+			let colorClass;
+			if ( foundColorPaletteObject.slug ) {
+				const foundColorType = colorTypes.find( ( colorType ) =>
+					typeof colorType === 'string' ?
+						colorType === name :
+						Object.keys( colorType ).some( ( key ) => key === name )
+				);
+				const colorContextName =
+					typeof foundColorType === 'string' ?
+						foundColorType :
+						Object.entries( foundColorType ).find( ( entry ) => entry[ 0 ] === name )[ 1 ];
+
+				colorClass = `has-${ kebabCase(
+					foundColorPaletteObject.slug
+				) }-${ kebabCase( colorContextName ) }`;
+			}
+
+			return {
+				...foundColorPaletteObject,
+				class: colorClass,
+			};
+		},
+
+		utilsToBind: { getMostReadableColor },
+	} );
+	attributePicker.colorUtils = attributePicker.utils;
+	delete attributePicker.utils;
+
+	return attributePicker;
+}
+
+/**
+ * Like `useCustomColors`, but uses the color palette from
+ * the editor's settings.
+ *
+ * @see [useCustomColors](/packages/block-editor/README.md#useCustomColors)
+ *
+ * @example
+ * ```jsx
+ * const MyColorfulComponent = () => {
+ * 	const { backgroundColor, setBackgroundColor } = useColors( [
+ * 		'backgroundColor',
+ * 	] );
+ *
+ * 	//...
+ * };
+ * ```
+ *
+ * @param {(Object|string)[]} colorTypes The color types passed to `useCustomColors`.
+ *
+ * @return {Object} The object with color objects and color setters.
+ */
+export default function useColors( colorTypes ) {
+	const colorPalette = useSelect(
+		( select ) => select( 'core/block-editor' ).getSettings().colors || [],
+		[]
+	);
+
+	return useCustomColors( colorTypes, colorPalette );
+}

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -43,7 +43,7 @@ import { getMostReadableColor } from './utils';
  * 	// _.isEqual(
  * 	// 	{ ...CUSTOM_COLORS[ 0 ], class: 'has-red-background-color' },
  * 	// 	backgroundColor
- * 	//	);
+ * 	// );
  * 	// setBackgroundColor( '#000000' );
  * 	// _.isEqual( { color: '#000000' }, backgroundColor );
  * 	//...

--- a/packages/block-editor/src/components/colors/with-colors.js
+++ b/packages/block-editor/src/components/colors/with-colors.js
@@ -1,148 +1,12 @@
 /**
- * External dependencies
- */
-import { get, isString, kebabCase, reduce, upperFirst } from 'lodash';
-
-/**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
-import { withSelect } from '@wordpress/data';
-import { compose, createHigherOrderComponent } from '@wordpress/compose';
+import { createHigherOrderComponentWithMergeProps } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
-import { getColorClassName, getColorObjectByColorValue, getColorObjectByAttributeValues, getMostReadableColor } from './utils';
-
-const DEFAULT_COLORS = [];
-
-/**
- * Higher order component factory for injecting the `colorsArray` argument as
- * the colors prop in the `withCustomColors` HOC.
- *
- * @param {Array} colorsArray An array of color objects.
- *
- * @return {function} The higher order component.
- */
-const withCustomColorPalette = ( colorsArray ) => createHigherOrderComponent( ( WrappedComponent ) => ( props ) => (
-	<WrappedComponent { ...props } colors={ colorsArray } />
-), 'withCustomColorPalette' );
-
-/**
- * Higher order component factory for injecting the editor colors as the
- * `colors` prop in the `withColors` HOC.
- *
- * @return {function} The higher order component.
- */
-const withEditorColorPalette = () => withSelect( ( select ) => {
-	const settings = select( 'core/block-editor' ).getSettings();
-	return {
-		colors: get( settings, [ 'colors' ], DEFAULT_COLORS ),
-	};
-} );
-
-/**
- * Helper function used with `createHigherOrderComponent` to create
- * higher order components for managing color logic.
- *
- * @param {Array}    colorTypes       An array of color types (e.g. 'backgroundColor, borderColor).
- * @param {Function} withColorPalette A HOC for injecting the 'colors' prop into the WrappedComponent.
- *
- * @return {Component} The component that can be used as a HOC.
- */
-function createColorHOC( colorTypes, withColorPalette ) {
-	const colorMap = reduce( colorTypes, ( colorObject, colorType ) => {
-		return {
-			...colorObject,
-			...( isString( colorType ) ? { [ colorType ]: kebabCase( colorType ) } : colorType ),
-		};
-	}, {} );
-
-	return compose( [
-		withColorPalette,
-		( WrappedComponent ) => {
-			return class extends Component {
-				constructor( props ) {
-					super( props );
-
-					this.setters = this.createSetters();
-					this.colorUtils = {
-						getMostReadableColor: this.getMostReadableColor.bind( this ),
-					};
-
-					this.state = {};
-				}
-
-				getMostReadableColor( colorValue ) {
-					const { colors } = this.props;
-					return getMostReadableColor( colors, colorValue );
-				}
-
-				createSetters() {
-					return reduce( colorMap, ( settersAccumulator, colorContext, colorAttributeName ) => {
-						const upperFirstColorAttributeName = upperFirst( colorAttributeName );
-						const customColorAttributeName = `custom${ upperFirstColorAttributeName }`;
-						settersAccumulator[ `set${ upperFirstColorAttributeName }` ] =
-							this.createSetColor( colorAttributeName, customColorAttributeName );
-						return settersAccumulator;
-					}, {} );
-				}
-
-				createSetColor( colorAttributeName, customColorAttributeName ) {
-					return ( colorValue ) => {
-						const colorObject = getColorObjectByColorValue( this.props.colors, colorValue );
-						this.props.setAttributes( {
-							[ colorAttributeName ]: colorObject && colorObject.slug ? colorObject.slug : undefined,
-							[ customColorAttributeName ]: colorObject && colorObject.slug ? undefined : colorValue,
-						} );
-					};
-				}
-
-				static getDerivedStateFromProps( { attributes, colors }, previousState ) {
-					return reduce( colorMap, ( newState, colorContext, colorAttributeName ) => {
-						const colorObject = getColorObjectByAttributeValues(
-							colors,
-							attributes[ colorAttributeName ],
-							attributes[ `custom${ upperFirst( colorAttributeName ) }` ],
-						);
-
-						const previousColorObject = previousState[ colorAttributeName ];
-						const previousColor = get( previousColorObject, [ 'color' ] );
-						/**
-						* The "and previousColorObject" condition checks that a previous color object was already computed.
-						* At the start previousColorObject and colorValue are both equal to undefined
-						* bus as previousColorObject does not exist we should compute the object.
-						*/
-						if ( previousColor === colorObject.color && previousColorObject ) {
-							newState[ colorAttributeName ] = previousColorObject;
-						} else {
-							newState[ colorAttributeName ] = {
-								...colorObject,
-								class: getColorClassName( colorContext, colorObject.slug ),
-							};
-						}
-						return newState;
-					}, {} );
-				}
-
-				render() {
-					return (
-						<WrappedComponent
-							{ ...{
-								...this.props,
-								colors: undefined,
-								...this.state,
-								...this.setters,
-								colorUtils: this.colorUtils,
-							} }
-						/>
-					);
-				}
-			};
-		},
-	] );
-}
+import useColors, { useCustomColors } from './use-colors';
 
 /**
  * A higher-order component factory for creating a 'withCustomColors' HOC, which handles color logic
@@ -167,10 +31,11 @@ function createColorHOC( colorTypes, withColorPalette ) {
  * @return {Function} Higher-order component.
  */
 export function createCustomColorsHOC( colorsArray ) {
-	return ( ...colorTypes ) => {
-		const withColorPalette = withCustomColorPalette( colorsArray );
-		return createHigherOrderComponent( createColorHOC( colorTypes, withColorPalette ), 'withCustomColors' );
-	};
+	return ( ...colorTypes ) =>
+		createHigherOrderComponentWithMergeProps(
+			() => useCustomColors( colorTypes, colorsArray ),
+			'withCustomColors'
+		);
 }
 
 /**
@@ -198,6 +63,8 @@ export function createCustomColorsHOC( colorsArray ) {
  * @return {Function} Higher-order component.
  */
 export default function withColors( ...colorTypes ) {
-	const withColorPalette = withEditorColorPalette();
-	return createHigherOrderComponent( createColorHOC( colorTypes, withColorPalette ), 'withColors' );
+	return createHigherOrderComponentWithMergeProps(
+		() => useColors( colorTypes ),
+		'withColors'
+	);
 }

--- a/packages/block-editor/src/components/font-sizes/index.js
+++ b/packages/block-editor/src/components/font-sizes/index.js
@@ -1,3 +1,4 @@
 export { getFontSize, getFontSizeClass } from './utils';
 export { default as FontSizePicker } from './font-size-picker';
+export { default as useFontSizes } from './use-font-sizes';
 export { default as withFontSizes } from './with-font-sizes';

--- a/packages/block-editor/src/components/font-sizes/use-font-sizes.js
+++ b/packages/block-editor/src/components/font-sizes/use-font-sizes.js
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import { kebabCase } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useAttributePicker } from '../block-edit';
+
+/**
+ * A hook that returns an object with font size objects and font size
+ * block attribute setters for a given list of font size names.
+ * It uses the font size object list from the editor's settings as a palette.
+ *
+ * @example
+ * Calling it with a font size name `"paragraphFontSize"` will return an object
+ * with a font size object `paragraphFontSize`, and a function `setParagraphFontSize`.
+ * `setParagraphFontSize` can be called with any font size value. If the value
+ * equals the `size` property of an object in the `fontSizes` list from the editor's settings,
+ * `paragraphFontSize` will be set to that object merged with a custom
+ * `class` property. If it's not, it will be set to a custom object
+ * with just a `size` property set to the value.
+ *
+ * ```jsx
+ * // const FONT_SIZES = [
+ * // 	{
+ * // 		name: 'Small',
+ * // 		size: 13,
+ * // 		slug: 'small',
+ * // 	},
+ * // 	// ...
+ * // ];
+ * // _.isEqual( FONT_SIZES, select( 'core/block-editor' ).getSettings().fontSizes );
+ *
+ * const MyFontSizeableComponent = () => {
+ * 	const { paragraphFontSize, setParagraphFontSize } = useFontSizes( [
+ * 		'paragraphFontSize',
+ * 	] );
+ *
+ * 	// setParagraphFontSize( 13 );
+ * 	// _.isEqual(
+ * 	// 	{ ...FONT_SIZES[ 0 ], class: 'has-small-font-size' },
+ * 	// 	paragraphFontSize
+ * 	// );
+ * 	// setParagraphFontSize( 14 );
+ * 	// _.isEqual( { size: 14 }, paragraphFontSize );
+ * };
+ * ```
+ *
+ * @param {string[]} fontSizeNames The list of font size names.
+ *
+ * @return {Object} The object with font size objects and font size setters.
+ */
+export default function useFontSizes( fontSizeNames ) {
+	const fontSizes = useSelect(
+		( select ) => select( 'core/block-editor' ).getSettings().fontSizes || [],
+		[]
+	);
+
+	return useAttributePicker( {
+		names: fontSizeNames,
+		valuesEnum: fontSizes,
+
+		findEnumValue: ( fontSizeObject, newFontSizeValue ) =>
+			fontSizeObject.size === newFontSizeValue,
+		mapEnumValue: ( fontSizeObject ) => fontSizeObject.slug,
+
+		mapAttribute: ( fontSizeSlugOrCustomValue ) => {
+			const foundFontSizeObject = fontSizes.find(
+				( fontSizeObject ) => fontSizeObject.slug === fontSizeSlugOrCustomValue
+			) || { size: fontSizeSlugOrCustomValue };
+
+			return {
+				...foundFontSizeObject,
+				class:
+					foundFontSizeObject.slug &&
+					`has-${ kebabCase( foundFontSizeObject.slug ) }-font-size`,
+			};
+		},
+	} );
+}

--- a/packages/block-editor/src/components/font-sizes/with-font-sizes.js
+++ b/packages/block-editor/src/components/font-sizes/with-font-sizes.js
@@ -1,134 +1,25 @@
 /**
- * External dependencies
- */
-import { find, pickBy, reduce, some, upperFirst } from 'lodash';
-
-/**
  * WordPress dependencies
  */
-import { createHigherOrderComponent, compose } from '@wordpress/compose';
-import { Component } from '@wordpress/element';
-import { withSelect } from '@wordpress/data';
+import { createHigherOrderComponentWithMergeProps } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
-import { getFontSize, getFontSizeClass } from './utils';
+import useFontSizes from './use-font-sizes';
 
 /**
  * Higher-order component, which handles font size logic for class generation,
  * font size value retrieval, and font size change handling.
  *
- * @param {...(object|string)} args The arguments should all be strings
- *                                  Each string contains the font size attribute name e.g: 'fontSize'.
+ * @param {...string} fontSizeNames The arguments should all be strings.
+ *                                   Each string contains the font size attribute name e.g.: 'fontSize'.
  *
  * @return {Function} Higher-order component.
  */
-export default ( ...fontSizeNames ) => {
-	/*
-	* Computes an object whose key is the font size attribute name as passed in the array,
-	* and the value is the custom font size attribute name.
-	* Custom font size is automatically compted by appending custom followed by the font size attribute name in with the first letter capitalized.
-	*/
-	const fontSizeAttributeNames = reduce( fontSizeNames, ( fontSizeAttributeNamesAccumulator, fontSizeAttributeName ) => {
-		fontSizeAttributeNamesAccumulator[ fontSizeAttributeName ] = `custom${ upperFirst( fontSizeAttributeName ) }`;
-		return fontSizeAttributeNamesAccumulator;
-	}, {} );
-
-	return createHigherOrderComponent(
-		compose( [
-			withSelect( ( select ) => {
-				const { fontSizes } = select( 'core/block-editor' ).getSettings();
-				return {
-					fontSizes,
-				};
-			} ),
-			( WrappedComponent ) => {
-				return class extends Component {
-					constructor( props ) {
-						super( props );
-
-						this.setters = this.createSetters();
-
-						this.state = {};
-					}
-
-					createSetters() {
-						return reduce( fontSizeAttributeNames, ( settersAccumulator, customFontSizeAttributeName, fontSizeAttributeName ) => {
-							const upperFirstFontSizeAttributeName = upperFirst( fontSizeAttributeName );
-							settersAccumulator[ `set${ upperFirstFontSizeAttributeName }` ] =
-								this.createSetFontSize( fontSizeAttributeName, customFontSizeAttributeName );
-							return settersAccumulator;
-						}, {} );
-					}
-
-					createSetFontSize( fontSizeAttributeName, customFontSizeAttributeName ) {
-						return ( fontSizeValue ) => {
-							const fontSizeObject = find( this.props.fontSizes, { size: fontSizeValue } );
-							this.props.setAttributes( {
-								[ fontSizeAttributeName ]: fontSizeObject && fontSizeObject.slug ? fontSizeObject.slug : undefined,
-								[ customFontSizeAttributeName ]: fontSizeObject && fontSizeObject.slug ? undefined : fontSizeValue,
-							} );
-						};
-					}
-
-					static getDerivedStateFromProps( { attributes, fontSizes }, previousState ) {
-						const didAttributesChange = ( customFontSizeAttributeName, fontSizeAttributeName ) => {
-							if ( previousState[ fontSizeAttributeName ] ) {
-								// if new font size is name compare with the previous slug
-								if ( attributes[ fontSizeAttributeName ] ) {
-									return attributes[ fontSizeAttributeName ] !== previousState[ fontSizeAttributeName ].slug;
-								}
-								// if font size is not named, update when the font size value changes.
-								return previousState[ fontSizeAttributeName ].size !== attributes[ customFontSizeAttributeName ];
-							}
-							// in this case we need to build the font size object
-							return true;
-						};
-
-						if ( ! some( fontSizeAttributeNames, didAttributesChange ) ) {
-							return null;
-						}
-
-						const newState = reduce(
-							pickBy( fontSizeAttributeNames, didAttributesChange ),
-							( newStateAccumulator, customFontSizeAttributeName, fontSizeAttributeName ) => {
-								const fontSizeAttributeValue = attributes[ fontSizeAttributeName ];
-								const fontSizeObject = getFontSize(
-									fontSizes,
-									fontSizeAttributeValue,
-									attributes[ customFontSizeAttributeName ]
-								);
-								newStateAccumulator[ fontSizeAttributeName ] = {
-									...fontSizeObject,
-									class: getFontSizeClass( fontSizeAttributeValue ),
-								};
-								return newStateAccumulator;
-							},
-							{}
-						);
-
-						return {
-							...previousState,
-							...newState,
-						};
-					}
-
-					render() {
-						return (
-							<WrappedComponent
-								{ ...{
-									...this.props,
-									fontSizes: undefined,
-									...this.state,
-									...this.setters,
-								} }
-							/>
-						);
-					}
-				};
-			},
-		] ),
+export default function withFontSizes( ...fontSizeNames ) {
+	return createHigherOrderComponentWithMergeProps(
+		() => useFontSizes( fontSizeNames ),
 		'withFontSizes'
 	);
-};
+}

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -2,6 +2,7 @@
  * Block Creation Components
  */
 
+export * from './block-edit';
 export * from './colors';
 export * from './font-sizes';
 export { default as AlignmentToolbar } from './alignment-toolbar';

--- a/packages/compose/CHANGELOG.md
+++ b/packages/compose/CHANGELOG.md
@@ -1,8 +1,15 @@
+## Master
+
+### New Features
+
+- Add `createHigherOrderComponentWithMergeProps` for making it easier to make higher order components from hooks.
+- Add the `useCustomCompareDep`, `useShallowCompareDep`, and `useDeepCompareDep` hooks for making it easier to use non-primitives in hooks dependency arrays.
+
 ## 3.4.0 (2019-06-12)
 
 ### New Features
 
-- Add the `useMediaQuery` and `useReducedMotion` hooks. 
+- Add the `useMediaQuery` and `useReducedMotion` hooks.
 
 ## 3.0.0 (2018-11-15)
 
@@ -28,4 +35,4 @@
 
 ### Breaking Change
 
-- Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)).  If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.
+- Change how required built-ins are polyfilled with Babel 7 ([#9171](https://github.com/WordPress/gutenberg/pull/9171)). If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods.

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -80,17 +80,33 @@ _Returns_
 
 <a name="createHigherOrderComponent" href="#createHigherOrderComponent">#</a> **createHigherOrderComponent**
 
-Given a function mapping a component to an enhanced component and modifier
+Given a function mapping a component to an enhanced component, and a modifier
 name, returns the enhanced component augmented with a generated displayName.
 
 _Parameters_
 
 -   _mapComponentToEnhancedComponent_ `Function`: Function mapping component to enhanced component.
--   _modifierName_ `string`: Seed name from which to generated display name.
+-   _modifierName_ `string`: Seed name from which to generate display name.
 
 _Returns_
 
 -   `WPComponent`: Component class with generated display name assigned.
+
+<a name="createHigherOrderComponentWithMergeProps" href="#createHigherOrderComponentWithMergeProps">#</a> **createHigherOrderComponentWithMergeProps**
+
+Given a function that returns an object, and a modifier
+name, returns an enhanced pure component that calls
+the function and merges the returned object into its props.
+This is useful for making higher order components from hooks.
+
+_Parameters_
+
+-   _getMergeProps_ `Function`: Function that returns the object to merge into props.
+-   _modifierName_ `string`: Seed name from which to generate display name.
+
+_Returns_
+
+-   `WPComponent`: Component class, with generated display name assigned, that merges the result of `getMergeProps` with its own props.
 
 <a name="ifCondition" href="#ifCondition">#</a> **ifCondition**
 
@@ -119,6 +135,48 @@ _Returns_
 
 -   `WPComponent`: Component class with generated display name assigned.
 
+<a name="useCustomCompareDep" href="#useCustomCompareDep">#</a> **useCustomCompareDep**
+
+Takes a value to be used as a dependency in a hooks dependency array
+and a custom compare function and memoizes the value for as long
+as the compare function dictates that it hasn't changed. This
+lets you use non-primitives in hooks dependency arrays.
+
+_Usage_
+
+```js
+useMemo( expensiveComputation, [ useCustomCompareDep( mutableObject, _.isEqual ) ] );
+```
+
+_Parameters_
+
+-   _value_ `*`: Value to memoize.
+-   _compare_ `Function`: Custom compare function for diffing `value`.
+
+_Returns_
+
+-   `*`: The memoized `value`.
+
+<a name="useDeepCompareDep" href="#useDeepCompareDep">#</a> **useDeepCompareDep**
+
+Takes a value to be used as a dependency in a hooks dependency array
+and memoizes it for as long as it is deeply unchanged.
+This lets you use non-primitives in hooks dependency arrays.
+
+_Usage_
+
+```js
+useMemo( expensiveComputation, [ useDeepCompareDep( deeplyMutableObject ) ] );
+```
+
+_Parameters_
+
+-   _value_ `*`: Value to memoize.
+
+_Returns_
+
+-   `*`: The memoized `value`.
+
 <a name="useMediaQuery" href="#useMediaQuery">#</a> **useMediaQuery**
 
 Runs a media query and returns its value when it changes.
@@ -138,6 +196,26 @@ Hook returning whether the user has a preference for reduced motion.
 _Returns_
 
 -   `boolean`: Reduced motion preference value.
+
+<a name="useShallowCompareDep" href="#useShallowCompareDep">#</a> **useShallowCompareDep**
+
+Takes a value to be used as a dependency in a hooks dependency array
+and memoizes it for as long as it is shallowly unchanged.
+This lets you use non-primitives in hooks dependency arrays.
+
+_Usage_
+
+```js
+useMemo( expensiveComputation, [ useShallowCompareDep( shallowlyMutableObject ) ] );
+```
+
+_Parameters_
+
+-   _value_ `*`: Value to memoize.
+
+_Returns_
+
+-   `*`: The memoized `value`.
 
 <a name="withGlobalEvents" href="#withGlobalEvents">#</a> **withGlobalEvents**
 

--- a/packages/compose/src/hooks/use-custom-compare-dep/index.js
+++ b/packages/compose/src/hooks/use-custom-compare-dep/index.js
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+import { isEqual } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { useRef } from '@wordpress/element';
+import isShallowEqual from '@wordpress/is-shallow-equal';
+
+/**
+ * Takes a value to be used as a dependency in a hooks dependency array
+ * and a custom compare function and memoizes the value for as long
+ * as the compare function dictates that it hasn't changed. This
+ * lets you use non-primitives in hooks dependency arrays.
+ *
+ * @example
+ * ```js
+ * useMemo( expensiveComputation, [ useCustomCompareDep( mutableObject, _.isEqual ) ] );
+ * ```
+ *
+ * @param {*}        value   Value to memoize.
+ *
+ * @param {Function} compare Custom compare function for diffing `value`.
+ *
+ * @return {*} The memoized `value`.
+ */
+export default function useCustomCompareDep( value, compare ) {
+	const ref = useRef();
+
+	if ( ! compare( value, ref.current ) ) {
+		ref.current = value;
+	}
+
+	return ref.current;
+}
+
+/**
+ * Takes a value to be used as a dependency in a hooks dependency array
+ * and memoizes it for as long as it is shallowly unchanged.
+ * This lets you use non-primitives in hooks dependency arrays.
+ *
+ * @example
+ * ```js
+ * useMemo( expensiveComputation, [ useShallowCompareDep( shallowlyMutableObject ) ] );
+ * ```
+ *
+ * @param {*} value Value to memoize.
+ *
+ * @return {*} The memoized `value`.
+ */
+export function useShallowCompareDep( value ) {
+	return useCustomCompareDep( value, isShallowEqual );
+}
+
+/**
+ * Takes a value to be used as a dependency in a hooks dependency array
+ * and memoizes it for as long as it is deeply unchanged.
+ * This lets you use non-primitives in hooks dependency arrays.
+ *
+ * @example
+ * ```js
+ * useMemo( expensiveComputation, [ useDeepCompareDep( deeplyMutableObject ) ] );
+ * ```
+ *
+ * @param {*} value Value to memoize.
+ *
+ * @return {*} The memoized `value`.
+ */
+export function useDeepCompareDep( value ) {
+	return useCustomCompareDep( value, isEqual );
+}

--- a/packages/compose/src/index.js
+++ b/packages/compose/src/index.js
@@ -4,7 +4,10 @@
 import { flowRight } from 'lodash';
 
 // Utils
-export { default as createHigherOrderComponent } from './utils/create-higher-order-component';
+export {
+	default as createHigherOrderComponent,
+	createHigherOrderComponentWithMergeProps,
+} from './utils/create-higher-order-component';
 
 /**
  * Composes multiple higher-order components into a single higher-order component. Performs right-to-left function
@@ -25,5 +28,10 @@ export { default as withSafeTimeout } from './higher-order/with-safe-timeout';
 export { default as withState } from './higher-order/with-state';
 
 // Hooks
+export {
+	default as useCustomCompareDep,
+	useShallowCompareDep,
+	useDeepCompareDep,
+} from './hooks/use-custom-compare-dep';
 export { default as useMediaQuery } from './hooks/use-media-query';
 export { default as useReducedMotion } from './hooks/use-reduced-motion';

--- a/packages/compose/src/utils/create-higher-order-component/index.js
+++ b/packages/compose/src/utils/create-higher-order-component/index.js
@@ -4,17 +4,22 @@
 import { camelCase, upperFirst } from 'lodash';
 
 /**
- * Given a function mapping a component to an enhanced component and modifier
+ * Internal dependencies
+ */
+import pure from '../../higher-order/pure';
+
+/**
+ * Given a function mapping a component to an enhanced component, and a modifier
  * name, returns the enhanced component augmented with a generated displayName.
  *
  * @param {Function} mapComponentToEnhancedComponent Function mapping component
- *                                                   to enhanced component.
+ *                                                    to enhanced component.
  * @param {string}   modifierName                    Seed name from which to
- *                                                   generated display name.
+ *                                                    generate display name.
  *
  * @return {WPComponent} Component class with generated display name assigned.
  */
-function createHigherOrderComponent( mapComponentToEnhancedComponent, modifierName ) {
+export default function createHigherOrderComponent( mapComponentToEnhancedComponent, modifierName ) {
 	return ( OriginalComponent ) => {
 		const EnhancedComponent = mapComponentToEnhancedComponent( OriginalComponent );
 		const { displayName = OriginalComponent.name || 'Component' } = OriginalComponent;
@@ -24,4 +29,28 @@ function createHigherOrderComponent( mapComponentToEnhancedComponent, modifierNa
 	};
 }
 
-export default createHigherOrderComponent;
+/**
+ * Given a function that returns an object, and a modifier
+ * name, returns an enhanced pure component that calls
+ * the function and merges the returned object into its props.
+ * This is useful for making higher order components from hooks.
+ *
+ * @param {Function} getMergeProps Function that returns the object to merge into props.
+ *
+ * @param {string}   modifierName  Seed name from which to generate display name.
+ *
+ * @return {WPComponent} Component class, with generated display name assigned, that
+ *                        merges the result of `getMergeProps` with its own props.
+ */
+export function createHigherOrderComponentWithMergeProps(
+	getMergeProps,
+	modifierName
+) {
+	return createHigherOrderComponent(
+		( WrappedComponent ) =>
+			pure( ( ownProps ) => (
+				<WrappedComponent { ...ownProps } { ...getMergeProps( ownProps ) } />
+			) ),
+		modifierName
+	);
+}


### PR DESCRIPTION
cc @youknowriad 

Relates to #15450

## Description

This PR begins to explore a new way to share **Common Block Code** using React hooks.

*In `@wordpress/block-editor`:*

It introduces a low level hook, `useAttributePicker`, that is very flexible and can be easily used to build higher level hooks like `useColor` and `useCustomColor` which replaced the previous implementation of `withColors` and `createCustomColorsHOC` with a fraction of the code.

***use-colors.js***

```js
export function useCustomColors( colorTypes, colorPalette ) {
	const attributePicker = useAttributePicker( {
		names: colorTypes.flatMap( ( colorType ) =>
			typeof colorType === 'string' ? colorType : Object.keys( colorType )
		),
		valuesEnum: colorPalette,

		findEnumValue: ( colorPaletteObject, newColorValue ) =>
			colorPaletteObject.color === newColorValue,
		mapEnumValue: ( colorPaletteObject ) => colorPaletteObject.slug,

		mapAttribute: ( colorSlugOrCustomValue, name ) => {
			const foundColorPaletteObject = colorPalette.find(
				( colorPaletteObject ) => colorPaletteObject.slug === colorSlugOrCustomValue
			) || { color: colorSlugOrCustomValue };

			let colorClass;
			if ( foundColorPaletteObject.slug ) {
				const foundColorType = colorTypes.find( ( colorType ) =>
					typeof colorType === 'string' ?
						colorType === name :
						Object.keys( colorType ).some( ( key ) => key === name )
				);
				const colorContextName =
					typeof foundColorType === 'string' ?
						foundColorType :
						Object.entries( foundColorType ).find( ( entry ) => entry[ 0 ] === name )[ 1 ];

				colorClass = `has-${ kebabCase(
					foundColorPaletteObject.slug
				) }-${ kebabCase( colorContextName ) }`;
			}

			return {
				...foundColorPaletteObject,
				class: colorClass,
			};
		},

		utilsToBind: { getMostReadableColor },
	} );
	attributePicker.colorUtils = attributePicker.utils;
	delete attributePicker.utils;

	return attributePicker;
}

export default function useColors( colorTypes ) {
	const colorPalette = useSelect(
		( select ) => select( 'core/block-editor' ).getSettings().colors || [],
		[]
	);

	return useCustomColors( colorTypes, colorPalette );
}
```

***with-colors.js***

```js
export default function withColors( ...colorTypes ) {
	return createHigherOrderComponentWithMergeProps(
		() => useColors( colorTypes ),
		'withColors'
	);
}
```

*In `@wordpress/compose`:*

It adds `createHigherOrderComponentWithMergeProps` (shown above) for making it easier to make higher order components from hooks. This will become a more and more common pattern as we replace the implementation of more and more HOCs with their hooks counterparts.

It also adds the `useCustomCompareDep`, `useShallowCompareDep`, and `useDeepCompareDep` hooks for making it easier to use non-primitives in hooks dependency arrays. This was needed for `useAttributePicker`.

E.g.

```js
useMemo( expensiveComputation, [ useDeepCompareDep( deeplyMutableObject ) ] );
```

### Updates

- https://github.com/WordPress/gutenberg/pull/16229#issuecomment-504158703

## How has this been tested?

All of the tests suites succeeded, but new unit tests have to be written for the new functions once consensus on the APIs is reached.

## Types of Changes

### New Features

- Add the `useAttributePicker` hook to abstract away common block code and use it to refactor the color and font size higher order components. They are now written with the new exported hooks, `useColors`, `useCustomColors`, and `useFontSizes`.
- Add `createHigherOrderComponentWithMergeProps` for making it easier to make higher order components from hooks.
- Add the `useCustomCompareDep`, `useShallowCompareDep`, and `useDeepCompareDep` hooks for making it easier to use non-primitives in hooks dependency arrays.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
- [x] I've included developer documentation if appropriate.
