### PR TITLE
Legacy widget: Remove custom class

### DIFF
--- a/packages/block-library/src/legacy-widget/index.js
+++ b/packages/block-library/src/legacy-widget/index.js
@@ -18,6 +18,7 @@ export const settings = {
 	category: 'widgets',
 	supports: {
 		html: false,
+		customClassName: false,
 	},
 	edit,
 };

--- a/packages/block-library/src/legacy-widget/index.php
+++ b/packages/block-library/src/legacy-widget/index.php
@@ -60,9 +60,6 @@ function register_block_core_legacy_widget() {
 		'core/legacy-widget',
 		array(
 			'attributes'      => array(
-				'className'        => array(
-					'type' => 'string',
-				),
 				'identifier'       => array(
 					'type' => 'string',
 				),


### PR DESCRIPTION
## Description
For the legacy widget block we just render the widget and don't wrap it into an element. Widgets don't support custom classes, so it's not possible to add a class to widget. So we should remove the custom class feature from this block.

Fixes: #14495

## How has this been tested?
Add a legacy widget block with the custom class attribute:
`<!-- wp:legacy-widget {"className":"my-custom-class","identifier":"WP_Widget_Pages","instance":{"title":"Hello world","sortby":"post_title","exclude":""},"isCallbackWidget":false} /-->`

Save the post, if you reload the post it should be gone and the block should render.
`<!-- wp:legacy-widget {"identifier":"WP_Widget_Pages","instance":{"title":"Hello world","sortby":"post_title","exclude":""},"isCallbackWidget":false} /-->`