### PR TITLE
Makes cleanForSlug more robust when receiving falsy values. 

### DIFF
--- a/packages/editor/src/utils/test/url.js
+++ b/packages/editor/src/utils/test/url.js
@@ -7,4 +7,13 @@ describe( 'cleanForSlug()', () => {
 	it( 'Should return string prepared for use as url slug', () => {
 		expect( cleanForSlug( ' /Déjà_vu. ' ) ).toBe( 'deja-vu' );
 	} );
+
+	it( 'Should return an empty string for missing argument', () => {
+		expect( cleanForSlug() ).toBe( '' );
+	} );
+
+	it( 'Should return an empty string for falsy argument', () => {
+		expect( cleanForSlug(null) ).toBe( '' );
+	} );
+
 } );

--- a/packages/editor/src/utils/test/url.js
+++ b/packages/editor/src/utils/test/url.js
@@ -13,7 +13,6 @@ describe( 'cleanForSlug()', () => {
 	} );
 
 	it( 'Should return an empty string for falsy argument', () => {
-		expect( cleanForSlug(null) ).toBe( '' );
+		expect( cleanForSlug( null ) ).toBe( '' );
 	} );
-
 } );

--- a/packages/editor/src/utils/url.js
+++ b/packages/editor/src/utils/url.js
@@ -39,5 +39,8 @@ export function getWPAdminURL( page, query ) {
  * @return {string} Processed string
  */
 export function cleanForSlug( string ) {
+	if ( ! string ) {
+		return;
+	}
 	return toLower( deburr( trim( string.replace( /[\s\./_]+/g, '-' ), '-' ) ) );
 }

--- a/packages/editor/src/utils/url.js
+++ b/packages/editor/src/utils/url.js
@@ -40,7 +40,7 @@ export function getWPAdminURL( page, query ) {
  */
 export function cleanForSlug( string ) {
 	if ( ! string ) {
-		return;
+		return '';
 	}
 	return toLower( deburr( trim( string.replace( /[\s\./_]+/g, '-' ), '-' ) ) );
 }


### PR DESCRIPTION
## Description
Fixes https://core.trac.wordpress.org/ticket/47216

Currently, cleanForSlug is used a few times with the assumption that it'll return a falsy value for a falsy input (see [post-link](https://github.com/WordPress/gutenberg/blob/2ab29100b413feb4932cbd576c9e7a9bde31c18e/packages/edit-post/src/components/sidebar/post-link/index.js#L36) or [post-permalink](https://github.com/WordPress/gutenberg/blob/54bae98f51dd4a12d68022ff1a2806253d18fefa/packages/editor/src/components/post-permalink/index.js#L81)) but it crashes as it assumes the argument to be string.

## How has this been tested?
I ran this change in a local WordPress instance with the testing procedure outlined in the [WordPress issue](https://core.trac.wordpress.org/ticket/47216).

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
