### PR TITLE
Switched to regular function in shortcode replace callback

### DIFF
--- a/packages/shortcode/src/index.js
+++ b/packages/shortcode/src/index.js
@@ -90,7 +90,7 @@ export function next( tag, text, index = 0 ) {
  * @return {string} Text with shortcodes replaced.
  */
 export function replace( tag, text, callback ) {
-	return text.replace( regexp( tag ), ( match, left, $3, attrs, slash, content, closing, right ) => {
+	return text.replace( regexp( tag ), function( match, left, $3, attrs, slash, content, closing, right ) {
 		// If both extra brackets exist, the shortcode has been properly
 		// escaped.
 		if ( left === '[' && right === ']' ) {

--- a/packages/shortcode/src/test/index.js
+++ b/packages/shortcode/src/test/index.js
@@ -90,6 +90,13 @@ describe( 'shortcode', () => {
 			expect( result2 ).toBe( 'this has the bar shortcode' );
 		} );
 
+		it( 'should replace the shortcode with data from an attribute', () => {
+			const result1 = replace( 'foo', 'this [foo param="replacement text"] came from a shortcode attribute', ( match ) => {
+				return match.attrs.named.param || '';
+			} );
+			expect( result1 ).toBe( 'this replacement text came from a shortcode attribute' );
+		} );
+
 		it( 'should not replace the shortcode when it does not match', () => {
 			const result1 = replace( 'bar', 'this has the [foo] shortcode', () => 'bar' );
 			expect( result1 ).toBe( 'this has the [foo] shortcode' );


### PR DESCRIPTION
## Description
Arrow functions have no `arguments` array, so the `arguments` passed to `fromMatch` within the `string.replace` callback are from the parent context. As such, `shortcode.replace` doesn't work correctly. By switching from an arrow function to a regular function, `arguments` contains arguments from the correct function, allowing `fromMatch` to work correctly.

## How has this been tested?
This has been tested manually via a node REPL as well as adding an additional test case.

## Types of changes
This is not a breaking change, but rather fixes a bug in an existing function to allow it to work as intended.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->