### PR TITLE
Ignore the wordpress directory in stylelint.

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,1 @@
+wordpress


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
While working in `localwpdev` mode in local environment, `npm run lint-css` does not ignore `wordpress` directory which works as a volume for the docker containers.

It throws errors as below:
```
[2] wordpress/wp-content/themes/twentynineteen/sass/site/primary/_comments.scss
[2]   87:25  ✖  Unexpected whitespace before ")"   function-parentheses-space-inside
[2]  174:22  ✖  Expected a leading zero            number-leading-zero
[2]  174:68  ✖  Unexpected whitespace before ")"   function-parentheses-space-inside
[2]  229:24  ✖  Unexpected whitespace after "("    function-parentheses-space-inside
[2]  229:41  ✖  Unexpected whitespace before ")"   function-parentheses-space-inside
[2]  235:48  ✖  Expected a leading zero            number-leading-zero
[2]  242:11  ✖  Unexpected named color "white"     color-named
[2]  369:21  ✖  Unexpected whitespace after "("    function-parentheses-space-inside
[2]  369:25  ✖  Unexpected whitespace before ")"   function-parentheses-space-inside
[2]  370:20  ✖  Expected a leading zero            number-leading-zero
[2]
[2] wordpress/wp-content/themes/twentynineteen/sass/site/primary/_posts-and-pages.scss
[2]   11:11  ✖  Expected a leading zero                         number-leading-zero
[2]  144:6   ✖  Expected double colon pseudo-element notation   selector-pseudo-element-colon-notation
[2]  149:15  ✖  Expected a leading zero                         number-leading-zero
[2]  162:5   ✖  Expected double colon pseudo-element notation   selector-pseudo-element-colon-notation
[2]  163:5   ✖  Expected double colon pseudo-element notation   selector-pseudo-element-colon-notation
[2]  168:12  ✖  Expected newline after ";"                      declaration-block-semicolon-newline-after
[2]  201:5   ✖  Expected double colon pseudo-element notation   selector-pseudo-element-colon-notation
[2]
[2] npm
[2]  ERR! code ELIFECYCLE
[2] npm
[2]  ERR! errno 2
[2] npm
[2]  ERR! gutenberg@5.9.2 lint-css: `wp-scripts lint-style '**/*.scss'`
[2] npm ERR! Exit status 2
[2] npm ERR!
[2] npm ERR! Failed at the gutenberg@5.9.2 lint-css script.
[2] npm ERR!
[2]  This is probably not a problem with npm. There is likely additional logging output above.
[2]
[2] npm ERR! A complete log of this run can be found in:
[2] npm ERR!     /Users/udit.desai/.npm/_logs/2019-06-22T07_11_57_444Z-debug.log
[2] npm run lint-css exited with code 2
```

`wordpress` directory should not be scanned and ignored for the linting purpose.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Running `npm run lint-css` in local environment does not report those errors anymore.
<!-- Include details of your testing environment, tests ran to see how -->
- Local Environment: MacOS
<!-- your change affects other areas of the code, etc. -->
- This is only affected in linting the source code. No behavior change is expected.

## Screenshots <!-- if applicable -->
<img width="717" alt="Screen Shot 2019-06-22 at 17 21 14" src="https://user-images.githubusercontent.com/2236554/59960848-30ab6680-9512-11e9-8fcf-1339c646ce05.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
- Introduced `.stylelintignore` file at the project root and added `wordpress` directory in it to ignore.
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
