### PR TITLE
Allow changing Block attributes dynamically in InnerBlocks template.

### DIFF
--- a/packages/blocks/src/api/templates.js
+++ b/packages/blocks/src/api/templates.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { every, map, get, mapValues, isArray, omitBy } from 'lodash';
+import { every, map, get, mapValues, isArray } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -69,11 +69,7 @@ export function synchronizeBlocksWithTemplate( blocks = [], template ) {
 				// either the template is given without any block attributes (this means the template doesn't care about the content).
 				! attributes ||
 				// or the attributes are same as what is given in the template.
-				isShallowEqual(
-					// ignore falsy attributes from the template.
-					omitBy( attributes, ( attr ) => ! attr ),
-					block.attributes
-				)
+				isShallowEqual( attributes, block.attributes )
 			)
 		) {
 			const innerBlocks = synchronizeBlocksWithTemplate( block.innerBlocks, innerBlocksTemplate );

--- a/packages/blocks/src/api/templates.js
+++ b/packages/blocks/src/api/templates.js
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
-import { every, map, get, mapValues, isArray } from 'lodash';
+import { every, map, get, mapValues, isArray, omitBy } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { renderToString } from '@wordpress/element';
+import isShallowEqual from '@wordpress/is-shallow-equal';
 
 /**
  * Internal dependencies
@@ -57,7 +58,24 @@ export function synchronizeBlocksWithTemplate( blocks = [], template ) {
 	return map( template, ( [ name, attributes, innerBlocksTemplate ], index ) => {
 		const block = blocks[ index ];
 
-		if ( block && block.name === name ) {
+		// Return the same block,
+		if (
+			// if block exists,
+			block &&
+			// and the name of the block is same,
+			block.name === name &&
+			// and
+			(
+				// either the template is given without any block attributes (this means the template doesn't care about the content).
+				! attributes ||
+				// or the attributes are same as what is given in the template.
+				isShallowEqual(
+					// ignore falsy attributes from the template.
+					omitBy( attributes, ( attr ) => ! attr ),
+					block.attributes
+				)
+			)
+		) {
 			const innerBlocks = synchronizeBlocksWithTemplate( block.innerBlocks, innerBlocksTemplate );
 			return { ...block, innerBlocks };
 		}

--- a/packages/blocks/src/api/test/templates.js
+++ b/packages/blocks/src/api/test/templates.js
@@ -193,21 +193,12 @@ describe( 'templates', () => {
 						attr2: 200,
 					},
 				],
-				[
-					'core/test-block-with-attrs',
-					{
-						attr1: 'attr1 - 3',
-						// falsy attributes from the template, will be ignored.
-						attr2: undefined,
-					},
-				],
 			];
 
 			const block1 = createBlock( 'core/test-block-with-attrs' );
 			const block2 = createBlock( 'core/test-block-with-attrs', { attr1: 'attr1', attr2: 100 } );
 			const block3 = createBlock( 'core/test-block-with-attrs', { attr1: 'attr1 - 2.1', attr2: 201 } );
-			const block4 = createBlock( 'core/test-block-with-attrs', { attr1: 'attr1 - 3' } );
-			const blockList = [ block1, block2, block3, block4 ];
+			const blockList = [ block1, block2, block3 ];
 
 			expect( synchronizeBlocksWithTemplate( blockList, template ) ).toMatchObject( [
 				block1,
@@ -216,7 +207,6 @@ describe( 'templates', () => {
 					name: 'core/test-block-with-attrs',
 					attributes: { attr1: 'attr1 - 2', attr2: 200 },
 				},
-				block4,
 			] );
 		} );
 

--- a/packages/blocks/src/api/test/templates.js
+++ b/packages/blocks/src/api/test/templates.js
@@ -36,6 +36,16 @@ describe( 'templates', () => {
 			category: 'common',
 			title: 'test block',
 		} );
+
+		registerBlockType( 'core/test-block-with-attrs', {
+			attributes: {
+				attr1: { type: 'string' },
+				attr2: { type: 'number' },
+			},
+			save: noop,
+			category: 'common',
+			title: 'test block',
+		} );
 	} );
 
 	describe( 'doBlocksMatchTemplate', () => {
@@ -163,6 +173,50 @@ describe( 'templates', () => {
 				block1,
 				{ name: 'core/test-block-2' },
 				{ name: 'core/test-block-2' },
+			] );
+		} );
+
+		it( 'should replace blocks if block attributes are not matched', () => {
+			const template = [
+				[ 'core/test-block-with-attrs' ],
+				[
+					'core/test-block-with-attrs',
+					{
+						attr1: 'attr1',
+						attr2: 100,
+					},
+				],
+				[
+					'core/test-block-with-attrs',
+					{
+						attr1: 'attr1 - 2',
+						attr2: 200,
+					},
+				],
+				[
+					'core/test-block-with-attrs',
+					{
+						attr1: 'attr1 - 3',
+						// falsy attributes from the template, will be ignored.
+						attr2: undefined,
+					},
+				],
+			];
+
+			const block1 = createBlock( 'core/test-block-with-attrs' );
+			const block2 = createBlock( 'core/test-block-with-attrs', { attr1: 'attr1', attr2: 100 } );
+			const block3 = createBlock( 'core/test-block-with-attrs', { attr1: 'attr1 - 2.1', attr2: 201 } );
+			const block4 = createBlock( 'core/test-block-with-attrs', { attr1: 'attr1 - 3' } );
+			const blockList = [ block1, block2, block3, block4 ];
+
+			expect( synchronizeBlocksWithTemplate( blockList, template ) ).toMatchObject( [
+				block1,
+				block2,
+				{
+					name: 'core/test-block-with-attrs',
+					attributes: { attr1: 'attr1 - 2', attr2: 200 },
+				},
+				block4,
 			] );
 		} );
 


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
`<InnerBlocks>` doesn't seem to respect dynamic changes in its template while re-rendering the component. It stays on its initial state when it's rendered for the first time. Then on wards, if the block attributes in the template are changed, it does not update them in the blocks within.

On further investigation, it was found that `<InnerBlocks>` component only synchronizes its block with the given template, when `templateLock === 'all'`.

And further `synchronizeBlocksWithTemplate` method from `@wordpress/blocks` package only re-creates the block, if the order of that block is changed in the given template. [Check here](https://github.com/WordPress/gutenberg/blob/master/packages/blocks/src/api/templates.js#L60)

So if a consumer compoent of `<InnerBlocks />` is passing a dynamic template where the attributes (such as content, placeholder etc.) are changing in the template, then those changes won't ever come into effect. The `<InnerBlocks />` will always render the template correctly first time. Not subsequently.

I've created an example block where I'm creating the same use-case and it's not working as expected in the `master` branch of Gutenberg. [Example](https://github.com/desaiuditd/dynamic-template-inner-block/blob/master/src/block/preview.js#L23)

This PR fixes the issue.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- I've added unit tests to support my use-case.
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- My change may also affect `<BlockList>` component or Group Blocks. Not really sure at this stage, as I've not thoroughly tested other components. However, I'm trusting the unit tests at the moment. Happy to dive deep, if needed.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
- Code change in the Blocks API function - `synchronizeBlocksWithTemplate` to allow dynamic templates in the `<InnerBlocks>` component.
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
- At this state, this seems like a new feature, because currently `<InnerBlocks>` doesn't allow changing the templates dynamically.
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
- I don't believe, this is a breaking change. I've tried to cover all the possibilities around that function based on the existing unit tests. But bear with my ignorance here.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
