### PR TITLE
Fix h1 heading typo so h1 is same size as title

### DIFF
--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -36,7 +36,7 @@
 		}
 
 		// Match h1 heading.
-		font-size: 2.441em;
+		font-size: 2.44em;
 		font-weight: 600;
 
 		// Large text needs a 3:1 contrast ratio.


### PR DESCRIPTION
Fixes #11223. This is the smallest PR I've ever made. It's one character.

But it does fix a typo so the font size of the post title is the same as the h1.