### PR TITLE
[WIP] Expose forceIsDirty action for custom blocks with no content/attributes

### DIFF
--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -754,12 +754,12 @@ export function updateEditorSettings( settings ) {
 
 /**
  * Returns an action object used in signalling that editor is forced to dirty
- * state. This should only be used by custom blocks that have no attributes
+ * state. This should only be used by custom blocks that have no content, attributes
  * or meta fields to indicate dirty state to editor
  *
  * @return {Object} Action object.
  */
-export function forceEditorIsDirty( ) {
+export function __experimentalForceEditorIsDirty( ) {
 	return {
 		type: 'FORCE_EDITOR_IS_DIRTY',
 	};

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -753,15 +753,15 @@ export function updateEditorSettings( settings ) {
 }
 
 /**
- * Returns an action object used in signalling that a custom block
- * without attributes has changed.
- *
+ * Returns an action object used in signalling that editor is forced to dirty
+ * state. This should only be used by custom blocks that have no attributes
+ * or meta fields to indicate dirty state to editor
  *
  * @return {Object} Action object.
  */
-export function setAttributelessBlockHasChanged( ) {
+export function forceEditorIsDirty( ) {
 	return {
-		type: 'ATTRIBUTELESS_BLOCK_HAS_CHANGED',
+		type: 'FORCE_EDITOR_IS_DIRTY',
 	};
 }
 

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -753,6 +753,19 @@ export function updateEditorSettings( settings ) {
 }
 
 /**
+ * Returns an action object used in signalling that a custom block
+ * without attributes has changed.
+ *
+ *
+ * @return {Object} Action object.
+ */
+export function setAttributelessBlockHasChanged( ) {
+	return {
+		type: 'ATTRIBUTELESS_BLOCK_HAS_CHANGED',
+	};
+}
+
+/**
  * Backward compatibility
  */
 

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -155,6 +155,15 @@ export const editor = flow( [
 
 		return state;
 	} ),
+	forceIsDirty( state = false, action ) {
+		switch ( action.type ) {
+			case 'FORCE_EDITOR_IS_DIRTY':
+				return true;
+			case 'REQUEST_POST_UPDATE_SUCCESS':
+				return false;
+		}
+		return state;
+	},
 	edits( state = {}, action ) {
 		switch ( action.type ) {
 			case 'EDIT_POST':
@@ -583,25 +592,6 @@ export function editorSettings( state = EDITOR_SETTINGS_DEFAULTS, action ) {
 	return state;
 }
 
-/**
- * Reducer returning attributeless blocks state.
- *
- * @param {Object} state  Current state.
- * @param {Object} action Dispatched action.
- *
- * @return {Object} Updated state.
- */
-export function attributelessBlocks( state = {}, action ) {
-	switch ( action.type ) {
-		case 'ATTRIBUTELESS_BLOCK_HAS_CHANGED':
-			return { ...state, isDirty: true };
-		case 'REQUEST_POST_UPDATE_SUCCESS':
-			return { };
-	}
-
-	return state;
-}
-
 export default optimist( combineReducers( {
 	editor,
 	initialEdits,
@@ -615,5 +605,4 @@ export default optimist( combineReducers( {
 	postSavingLock,
 	isReady,
 	editorSettings,
-	attributelessBlocks,
 } ) );

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -583,6 +583,25 @@ export function editorSettings( state = EDITOR_SETTINGS_DEFAULTS, action ) {
 	return state;
 }
 
+/**
+ * Reducer returning attributeless blocks state.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function attributelessBlocks( state = {}, action ) {
+	switch ( action.type ) {
+		case 'ATTRIBUTELESS_BLOCK_HAS_CHANGED':
+			return { ...state, isDirty: true };
+		case 'REQUEST_POST_UPDATE_SUCCESS':
+			return { };
+	}
+
+	return state;
+}
+
 export default optimist( combineReducers( {
 	editor,
 	initialEdits,
@@ -596,4 +615,5 @@ export default optimist( combineReducers( {
 	postSavingLock,
 	isReady,
 	editorSettings,
+	attributelessBlocks,
 } ) );

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -94,7 +94,7 @@ export function isEditedPostNew( state ) {
 export function hasChangedContent( state ) {
 	return (
 		state.editor.present.blocks.isDirty ||
-		state.attributelessBlocks.isDirty ||
+		state.editor.present.forceIsDirty ||
 
 		// `edits` is intended to contain only values which are different from
 		// the saved post, so the mere presence of a property is an indicator

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -94,6 +94,7 @@ export function isEditedPostNew( state ) {
 export function hasChangedContent( state ) {
 	return (
 		state.editor.present.blocks.isDirty ||
+		state.attributelessBlocks.isDirty ||
 
 		// `edits` is intended to contain only values which are different from
 		// the saved post, so the mere presence of a property is an indicator


### PR DESCRIPTION
## Description

With the Full Site Editing project we have encountered an issue in that there is currently no way for a block that has no post content or attributes to signal to the the editor that it is in a dirty state and so enable the Update/Publish button.

As an example the FSE custom blocks for adding Site Title and Site Description are dynamic blocks whose source of truth is the Site Options API, so they store no attributes in the block content. We can independently handle the updating of content from the block to the API by hooking into the isSavingPost selectors, but need to somehow indicate to the editor that the block content has changed to allow the user to initiate a save.

A longer term solution is to have some site option specific attributes integrated into the editor, but some shorter term solutions to allow the FSE block development to move forward are outlined at paAmJe-tF-p2

This PR is one possible short term solution which is to allow custom blocks to dispatch a forceEditorIsDirty action, and to track this forced dirty state independently of the other editor isDirty tracking mechanisms.

## How has this been tested?
.... coming soon
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
.... coming soon

## Types of changes
.... coming soon
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
.... coming soon
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
