### PR TITLE
Configure Babel to target your current version of Node with Jest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3713,7 +3713,8 @@
 				"@babel/preset-env": "^7.4.4",
 				"@babel/runtime": "^7.4.4",
 				"@wordpress/babel-plugin-import-jsx-pragma": "file:packages/babel-plugin-import-jsx-pragma",
-				"@wordpress/browserslist-config": "file:packages/browserslist-config"
+				"@wordpress/browserslist-config": "file:packages/browserslist-config",
+				"core-js": "^3.1.4"
 			}
 		},
 		"@wordpress/blob": {
@@ -4276,6 +4277,7 @@
 				"@wordpress/eslint-plugin": "file:packages/eslint-plugin",
 				"@wordpress/jest-preset-default": "file:packages/jest-preset-default",
 				"@wordpress/npm-package-json-lint-config": "file:packages/npm-package-json-lint-config",
+				"babel-jest": "^24.7.1",
 				"babel-loader": "^8.0.5",
 				"chalk": "^2.4.1",
 				"check-node-version": "^3.1.1",
@@ -8138,58 +8140,34 @@
 			}
 		},
 		"core-js": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.1.tgz",
-			"integrity": "sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
+			"integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ==",
 			"dev": true
 		},
 		"core-js-compat": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.0.1.tgz",
-			"integrity": "sha512-2pC3e+Ht/1/gD7Sim/sqzvRplMiRnFQVlPpDVaHtY9l7zZP7knamr3VRD6NyGfHd84MrDC0tAM9ulNxYMW0T3g==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.4.tgz",
+			"integrity": "sha512-Z5zbO9f1d0YrJdoaQhphVAnKPimX92D6z8lCGphH89MNRxlL1prI9ExJPqVwP0/kgkQCv8c4GJGT8X16yUncOg==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.5.4",
-				"core-js": "3.0.1",
-				"core-js-pure": "3.0.1",
-				"semver": "^6.0.0"
+				"browserslist": "^4.6.2",
+				"core-js-pure": "3.1.4",
+				"semver": "^6.1.1"
 			},
 			"dependencies": {
-				"browserslist": {
-					"version": "4.5.5",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.5.tgz",
-					"integrity": "sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==",
-					"dev": true,
-					"requires": {
-						"caniuse-lite": "^1.0.30000960",
-						"electron-to-chromium": "^1.3.124",
-						"node-releases": "^1.1.14"
-					}
-				},
-				"caniuse-lite": {
-					"version": "1.0.30000963",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000963.tgz",
-					"integrity": "sha512-n4HUiullc7Lw0LyzpeLa2ffP8KxFBGdxqD/8G3bSL6oB758hZ2UE2CVK+tQN958tJIi0/tfpjAc67aAtoHgnrQ==",
-					"dev": true
-				},
-				"electron-to-chromium": {
-					"version": "1.3.125",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.125.tgz",
-					"integrity": "sha512-XxowpqQxJ4nDwUXHtVtmEhRqBpm2OnjBomZmZtHD0d2Eo0244+Ojezhk3sD/MBSSe2nxCdGQFRXHIsf/LUTL9A==",
-					"dev": true
-				},
 				"semver": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
-					"integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==",
+					"version": "6.1.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.2.tgz",
+					"integrity": "sha512-z4PqiCpomGtWj8633oeAdXm1Kn1W++3T8epkZYnwiVgIYIJ0QHszhInYSJTYxebByQH7KVCEAn8R9duzZW2PhQ==",
 					"dev": true
 				}
 			}
 		},
 		"core-js-pure": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.0.1.tgz",
-			"integrity": "sha512-mSxeQ6IghKW3MoyF4cz19GJ1cMm7761ON+WObSyLfTu/Jn3x7w4NwNFnrZxgl4MTSvYYepVLNuRtlB4loMwJ5g==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.1.4.tgz",
+			"integrity": "sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA==",
 			"dev": true
 		},
 		"core-util-is": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
 		"commander": "2.20.0",
 		"concurrently": "3.5.0",
 		"copy-webpack-plugin": "4.5.2",
-		"core-js": "3.0.1",
 		"cross-env": "3.2.4",
 		"cssnano": "4.1.10",
 		"deep-freeze": "0.0.1",

--- a/packages/babel-preset-default/CHANGELOG.md
+++ b/packages/babel-preset-default/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Master
+
+### Bug Fixes
+
+- Configure Babel to target your current version of Node as described in [Jest docs](https://jestjs.io/docs/en/getting-started#using-babel).
+- Added missing [core-js](https://www.npmjs.com/package/core-js) dependency ([#16259](https://github.com/WordPress/gutenberg/pull/16259)).
+
 ## 4.2.0 (2019-05-21)
 
 ### New Features

--- a/packages/babel-preset-default/index.js
+++ b/packages/babel-preset-default/index.js
@@ -18,8 +18,9 @@ module.exports = function( api ) {
 		const opts = {};
 
 		if ( isTestEnv ) {
-			opts.useBuiltIns = 'usage';
-			opts.corejs = 3;
+			opts.targets = {
+				node: 'current',
+			};
 		} else {
 			opts.modules = false;
 			opts.targets = {

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -35,7 +35,8 @@
 		"@babel/preset-env": "^7.4.4",
 		"@babel/runtime": "^7.4.4",
 		"@wordpress/babel-plugin-import-jsx-pragma": "file:../babel-plugin-import-jsx-pragma",
-		"@wordpress/browserslist-config": "file:../browserslist-config"
+		"@wordpress/browserslist-config": "file:../browserslist-config",
+		"core-js": "^3.1.4"
 	},
 	"peerDependencies": {
 		"@babel/core": "^7.0.0"

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - The `build` and `start` commands supports simplified syntax for multiple entry points: `wp-scripts build entry-one.js entry-two.js` ([15982](https://github.com/WordPress/gutenberg/pull/15982)).
 
+### Bug Fix
+
+- Added missing [babel-jest](https://www.npmjs.com/package/babel-jest) dependency ([#16259](https://github.com/WordPress/gutenberg/pull/16259)).
+
 ## 3.3.0 (2019-06-12)
 
 ### New Features

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -37,6 +37,7 @@
 		"@wordpress/eslint-plugin": "file:../eslint-plugin",
 		"@wordpress/jest-preset-default": "file:../jest-preset-default",
 		"@wordpress/npm-package-json-lint-config": "file:../npm-package-json-lint-config",
+		"babel-jest": "^24.7.1",
 		"babel-loader": "^8.0.5",
 		"chalk": "^2.4.1",
 		"check-node-version": "^3.1.1",


### PR DESCRIPTION
## Description
It aims to fix the issue raised by @youknowriad in https://github.com/WordPress/wordpress-develop/pull/69#discussion_r295793603.

Fixes #16262.

> `@wordpress/babel-preset-default` `babel-jest` and `core-js` dependencies are required to make sure we can use "import" and ESnext features while writing tests, I think this should be absorbed by `@wordpress/scripts`

This PR adds the missing `babel-jest` dependency and tries to update Babel config to remove the need for `core-js` but it seems like it's not working as intended.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
