### PR TITLE
Add Editor and Layout in @wordpress/edit-post (Ported from Gutenberg Mobile)

### DIFF
--- a/packages/edit-post/src/components/layout/index.native.js
+++ b/packages/edit-post/src/components/layout/index.native.js
@@ -1,0 +1,129 @@
+/**
+ * External dependencies
+ */
+import { SafeAreaView } from 'react-native';
+import SafeArea from 'react-native-safe-area';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { withSelect } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+import { HTMLTextInput, ReadableContentView } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import styles from './style.scss';
+import VisualEditor from '../visual-editor';
+
+class Layout extends Component {
+	_isMounted: boolean;
+
+	constructor() {
+		super( ...arguments );
+
+		this.onSafeAreaInsetsUpdate = this.onSafeAreaInsetsUpdate.bind( this );
+		this.onRootViewLayout = this.onRootViewLayout.bind( this );
+
+		this.state = {
+			rootViewHeight: 0,
+			safeAreaBottomInset: 0,
+			isFullyBordered: true,
+		};
+
+		SafeArea.getSafeAreaInsetsForRootView().then( this.onSafeAreaInsetsUpdate );
+	}
+
+	componentDidMount() {
+		this._isMounted = true;
+		SafeArea.addEventListener( 'safeAreaInsetsForRootViewDidChange', this.onSafeAreaInsetsUpdate );
+	}
+
+	componentWillUnmount() {
+		SafeArea.removeEventListener( 'safeAreaInsetsForRootViewDidChange', this.onSafeAreaInsetsUpdate );
+		this._isMounted = false;
+	}
+
+	onSafeAreaInsetsUpdate( result ) {
+		const { safeAreaInsets } = result;
+		if ( this._isMounted && this.state.safeAreaBottomInset !== safeAreaInsets.bottom ) {
+			this.setState( { safeAreaBottomInset: safeAreaInsets.bottom } );
+		}
+	}
+
+	onRootViewLayout( event ) {
+		if ( this._isMounted ) {
+			this.setHeightState( event );
+			this.setBorderStyleState();
+		}
+	}
+
+	setHeightState( event ) {
+		const { height } = event.nativeEvent.layout;
+		this.setState( { rootViewHeight: height }, this.props.onNativeEditorDidLayout );
+	}
+
+	setBorderStyleState() {
+		const isFullyBordered = ReadableContentView.isContentMaxWidth();
+		if ( isFullyBordered !== this.state.isFullyBordered ) {
+			this.setState( { isFullyBordered } );
+		}
+	}
+
+	renderHTML() {
+		return (
+			<HTMLTextInput
+				parentHeight={ this.state.rootViewHeight }
+			/>
+		);
+	}
+
+	renderVisual() {
+		const {
+			isReady,
+		} = this.props;
+
+		if ( ! isReady ) {
+			return null;
+		}
+
+		return (
+			<VisualEditor
+				isFullyBordered={ this.state.isFullyBordered }
+				rootViewHeight={ this.state.rootViewHeight }
+				safeAreaBottomInset={ this.state.safeAreaBottomInset }
+				setTitleRef={ this.props.setTitleRef }
+			/>
+		);
+	}
+
+	render() {
+		const {
+			mode,
+		} = this.props;
+
+		return (
+			<SafeAreaView style={ styles.container } onLayout={ this.onRootViewLayout }>
+				{ mode === 'text' ? this.renderHTML() : this.renderVisual() }
+			</SafeAreaView>
+		);
+	}
+}
+
+export default compose( [
+	withSelect( ( select ) => {
+		const {
+			__unstableIsEditorReady: isEditorReady,
+		} = select( 'core/editor' );
+		const {
+			getEditorMode,
+		} = select( 'core/edit-post' );
+
+		return {
+			isReady: isEditorReady(),
+			mode: getEditorMode(),
+		};
+	} ),
+] )( Layout );

--- a/packages/edit-post/src/components/layout/index.native.js
+++ b/packages/edit-post/src/components/layout/index.native.js
@@ -19,8 +19,6 @@ import styles from './style.scss';
 import VisualEditor from '../visual-editor';
 
 class Layout extends Component {
-	_isMounted: boolean;
-
 	constructor() {
 		super( ...arguments );
 

--- a/packages/edit-post/src/components/layout/style.native.scss
+++ b/packages/edit-post/src/components/layout/style.native.scss
@@ -1,0 +1,6 @@
+
+.container {
+	flex: 1;
+	justify-content: flex-start;
+	background-color: #fff;
+}

--- a/packages/edit-post/src/editor.native.js
+++ b/packages/edit-post/src/editor.native.js
@@ -1,0 +1,207 @@
+/** @flow
+ * @format */
+
+/**
+ * External dependencies
+ */
+import RNReactNativeGutenbergBridge, {
+	subscribeParentGetHtml,
+	subscribeParentToggleHTMLMode,
+	subscribeUpdateHtml,
+	subscribeSetFocusOnTitle,
+	subscribeSetTitle,
+	sendNativeEditorDidLayout,
+} from 'react-native-gutenberg-bridge';
+import { isEmpty } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { parse, serialize, getUnregisteredTypeHandlerName } from '@wordpress/blocks';
+import { withDispatch, withSelect } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import Layout from './components/layout';
+
+class Editor extends Component {
+	constructor( props ) {
+		super( ...arguments );
+
+		this.setTitleRef = this.setTitleRef.bind( this );
+
+		// TODO: use EditorProvider instead
+		this.post = props.post || {
+			id: 1,
+			title: {
+				raw: props.initialTitle,
+			},
+			content: {
+				raw: props.initialHtml || '',
+			},
+			type: 'draft',
+		};
+
+		props.setupEditor( this.post );
+
+		// make sure the post content is in sync with gutenberg store
+		// to avoid marking the post as modified when simply loaded
+		// For now, let's assume: serialize( parse( html ) ) !== html
+		this.post.content.raw = serialize( props.getEditorBlocks() );
+
+		if ( props.initialHtmlModeEnabled && props.mode === 'visual' ) {
+			// enable html mode if the initial mode the parent wants it but we're not already in it
+			this.toggleMode();
+		}
+	}
+
+	componentDidMount() {
+		this.subscriptionParentGetHtml = subscribeParentGetHtml( () => {
+			this.serializeToNativeAction();
+		} );
+
+		this.subscriptionParentToggleHTMLMode = subscribeParentToggleHTMLMode( () => {
+			this.toggleMode();
+		} );
+
+		this.subscriptionParentSetTitle = subscribeSetTitle( ( payload ) => {
+			this.props.editTitle( payload.title );
+		} );
+
+		this.subscriptionParentUpdateHtml = subscribeUpdateHtml( ( payload ) => {
+			this.updateHtmlAction( payload.html );
+		} );
+
+		this.subscriptionParentSetFocusOnTitle = subscribeSetFocusOnTitle( () => {
+			if ( this.postTitleRef ) {
+				this.postTitleRef.focus();
+			}
+		} );
+	}
+
+	componentWillUnmount() {
+		if ( this.subscriptionParentGetHtml ) {
+			this.subscriptionParentGetHtml.remove();
+		}
+
+		if ( this.subscriptionParentToggleHTMLMode ) {
+			this.subscriptionParentToggleHTMLMode.remove();
+		}
+
+		if ( this.subscriptionParentSetTitle ) {
+			this.subscriptionParentSetTitle.remove();
+		}
+
+		if ( this.subscriptionParentUpdateHtml ) {
+			this.subscriptionParentUpdateHtml.remove();
+		}
+
+		if ( this.subscriptionParentSetFocusOnTitle ) {
+			this.subscriptionParentSetFocusOnTitle.remove();
+		}
+	}
+
+	serializeToNativeAction() {
+		if ( this.props.mode === 'text' ) {
+			this.updateHtmlAction( this.props.getEditedPostContent() );
+		}
+
+		const html = serialize( this.props.getEditorBlocks() );
+		const title = this.props.getEditedPostAttribute( 'title' );
+
+		const hasChanges = title !== this.post.title.raw || html !== this.post.content.raw;
+
+		RNReactNativeGutenbergBridge.provideToNative_Html( html, title, hasChanges );
+
+		if ( hasChanges ) {
+			this.post.title.raw = title;
+			this.post.content.raw = html;
+		}
+	}
+
+	updateHtmlAction( html ) {
+		const parsed = parse( html );
+		this.props.resetEditorBlocksWithoutUndoLevel( parsed );
+	}
+
+	toggleMode() {
+		const { mode, switchMode } = this.props;
+		// refresh html content first
+		this.serializeToNativeAction();
+		switchMode( mode === 'visual' ? 'text' : 'visual' );
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( ! prevProps.isReady && this.props.isReady ) {
+			const blocks = this.props.getEditorBlocks();
+			const isUnsupportedBlock = ( { name } ) => name === getUnregisteredTypeHandlerName();
+			const unsupportedBlocks = blocks.filter( isUnsupportedBlock );
+			const hasUnsupportedBlocks = ! isEmpty( unsupportedBlocks );
+
+			RNReactNativeGutenbergBridge.editorDidMount( hasUnsupportedBlocks );
+		}
+	}
+
+	setTitleRef( titleRef ) {
+		this.postTitleRef = titleRef;
+	}
+
+	render() {
+		return (
+			<Layout
+				setTitleRef={ this.setTitleRef }
+				onNativeEditorDidLayout={ sendNativeEditorDidLayout }
+			/>
+		);
+	}
+}
+
+export default compose( [
+	withSelect( ( select ) => {
+		const {
+			__unstableIsEditorReady: isEditorReady,
+			getEditorBlocks,
+			getEditedPostAttribute,
+			getEditedPostContent,
+		} = select( 'core/editor' );
+		const {
+			getEditorMode,
+		} = select( 'core/edit-post' );
+
+		return {
+			mode: getEditorMode(),
+			isReady: isEditorReady(),
+			getEditorBlocks,
+			getEditedPostAttribute,
+			getEditedPostContent,
+		};
+	} ),
+	withDispatch( ( dispatch ) => {
+		const {
+			editPost,
+			setupEditor,
+			resetEditorBlocks,
+		} = dispatch( 'core/editor' );
+		const {
+			switchEditorMode,
+		} = dispatch( 'core/edit-post' );
+
+		return {
+			editTitle( title ) {
+				editPost( { title } );
+			},
+			resetEditorBlocksWithoutUndoLevel( blocks ) {
+				resetEditorBlocks( blocks, {
+					__unstableShouldCreateUndoLevel: false,
+				} );
+			},
+			setupEditor,
+			switchMode( mode ) {
+				switchEditorMode( mode );
+			},
+		};
+	} ),
+] )( Editor );

--- a/packages/edit-post/src/editor.native.js
+++ b/packages/edit-post/src/editor.native.js
@@ -1,6 +1,3 @@
-/** @flow
- * @format */
-
 /**
  * External dependencies
  */

--- a/packages/edit-post/src/index.native.js
+++ b/packages/edit-post/src/index.native.js
@@ -2,21 +2,28 @@
  * WordPress dependencies
  */
 import '@wordpress/core-data';
+import '@wordpress/block-editor';
+import '@wordpress/editor';
 import '@wordpress/notices';
 import { registerCoreBlocks } from '@wordpress/block-library';
 import { unregisterBlockType } from '@wordpress/blocks';
+import '@wordpress/format-library';
 
 /**
  * Internal dependencies
  */
 import './store';
 
-export { default as VisualEditor } from './components/visual-editor';
+let blocksRegistered = false;
 
 /**
  * Initializes the Editor.
  */
 export function initializeEditor() {
+	if ( blocksRegistered ) {
+		return;
+	}
+
 	// register and setup blocks
 	registerCoreBlocks();
 
@@ -25,5 +32,8 @@ export function initializeEditor() {
 	if ( typeof __DEV__ === 'undefined' || ! __DEV__ ) {
 		unregisterBlockType( 'core/code' );
 	}
+
+	blocksRegistered = true;
 }
 
+export { default as Editor } from './editor';

--- a/packages/edit-post/src/test/editor.native.js
+++ b/packages/edit-post/src/test/editor.native.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import renderer from 'react-test-renderer';
+import RNReactNativeGutenbergBridge from 'react-native-gutenberg-bridge';
+
+/**
+ * WordPress dependencies
+ */
+import { registerCoreBlocks } from '@wordpress/block-library';
+
+/**
+ * Internal dependencies
+ */
+import '../store';
+import Editor from '../editor';
+
+const unsupportedBlock = `
+<!-- wp:notablock -->
+<p>Not supported</p>
+<!-- /wp:notablock -->
+`;
+
+describe( 'Editor', () => {
+	beforeAll( registerCoreBlocks );
+
+	it( 'detects unsupported block and sends hasUnsupportedBlocks true to native', () => {
+		RNReactNativeGutenbergBridge.editorDidMount = jest.fn();
+
+		const appContainer = renderEditorWith( unsupportedBlock );
+		appContainer.unmount();
+
+		expect( RNReactNativeGutenbergBridge.editorDidMount ).toHaveBeenCalledTimes( 1 );
+		expect( RNReactNativeGutenbergBridge.editorDidMount ).toHaveBeenCalledWith( true );
+	} );
+} );
+
+// Utilities
+const renderEditorWith = ( content ) => {
+	return renderer.create(
+		<Editor
+			initialHtml={ content }
+			initialHtmlModeEnabled={ false }
+			initialTitle={ '' }
+		/>
+	);
+};


### PR DESCRIPTION
## Description
This is step 8b of wordpress-mobile/gutenberg-mobile#958
This PR ports the gutenberg-mobile AppContainer and MainScreen to gutenberg as the Editor and Layout components inside `@wordpress/edit-post`.
This is not needed to implement Inner blocks for mobile native but is a nice improvement which will help port the remaining of our code to gutenberg.

## How has this been tested?
GB Mobile PR https://github.com/wordpress-mobile/gutenberg-mobile/pull/1171

## Types of changes
Adds native support for Editor and Layout

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
