### PR TITLE
Add instructions for test file location

### DIFF
--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -255,7 +255,7 @@ It uses [Jest](https://jestjs.io/) behind the scenes and you are able to use all
 
 _Alias_: `test-unit-jest`
 
-Launches the unit test runner. Writing tests can be done using the [Jest API](https://jestjs.io/docs/en/api).
+Launches the unit test runner. Writing tests can be done using the [Jest API](https://jestjs.io/docs/en/api). You can place tests files inside of the `/src` directory. Test filenames should end with `.test.js`. For example, if testing a component called `Tacos` you would name your test file `Tacos.test.js`.
 
 _Example:_
 


### PR DESCRIPTION
## Description
Where to put test files when using @wordpress/scripts` for unit testing is documented. I assumed and was correct that it was the default setting in Jest. This should be explicit.

## How has this been tested?
It worked in the plugin I'm working on :)


## Types of changes
Updated readme.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
