### PR TITLE
change unit to e2e tests in parts of scripts package  README

### DIFF
--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -236,9 +236,9 @@ _Example:_
 
 This is how you execute those scripts using the presented setup:
 
-* `npm run test:e2e` - runs all unit tests.
-* `npm run test:e2e:help` - prints all available options to configure unit tests runner.
-* `npm run test-e2e -- --puppeteer-interactive` - runs all unit tests interactively.
+* `npm run test:e2e` - runs all e2e tests.
+* `npm run test:e2e:help` - prints all available options to configure e2e test runner.
+* `npm run test-e2e -- --puppeteer-interactive` - runs all e2e tests interactively.
 * `npm run test-e2e FILE_NAME -- --puppeteer-interactive ` - runs one test file interactively.
 * `npm run test-e2e:watch -- --puppeteer-interactive` - runs all tests interactively and watch for changes.
 


### PR DESCRIPTION
## Description
I changed where the README for @wordpress/scripts refers to e2e tests as unit tests.

Fixes #16264.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
