### PR TITLE
Add new block indicator should show in place of empty block instead of below it

### DIFF
--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -214,10 +214,10 @@ export class BlockList extends Component {
 	}
 
 	renderItem( { item: clientId } ) {
-		const reversedContent = this.isReplaceable( this.props.selectedBlock );
+		const shouldReverseContent = this.isReplaceable( this.props.selectedBlock );
 
 		return (
-			<ReadableContentView reversed={ reversedContent }>
+			<ReadableContentView reversed={ shouldReverseContent }>
 				<BlockListBlock
 					key={ clientId }
 					showTitle={ false }

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -32,6 +32,7 @@ export class BlockList extends Component {
 		super( ...arguments );
 
 		this.renderItem = this.renderItem.bind( this );
+		this.renderAddBlockSeparator = this.renderAddBlockSeparator.bind( this );
 		this.shouldFlatListPreventAutomaticScroll = this.shouldFlatListPreventAutomaticScroll.bind( this );
 		this.renderDefaultBlockAppender = this.renderDefaultBlockAppender.bind( this );
 		this.onBlockTypeSelected = this.onBlockTypeSelected.bind( this );
@@ -213,8 +214,10 @@ export class BlockList extends Component {
 	}
 
 	renderItem( { item: clientId } ) {
+		const reversedContent = this.isReplaceable( this.props.selectedBlock );
+
 		return (
-			<ReadableContentView>
+			<ReadableContentView reversed={ reversedContent }>
 				<BlockListBlock
 					key={ clientId }
 					showTitle={ false }
@@ -224,14 +227,18 @@ export class BlockList extends Component {
 					borderStyle={ this.blockHolderBorderStyle() }
 					focusedBorderColor={ styles.blockHolderFocused.borderColor }
 				/>
-				{ this.state.blockTypePickerVisible && this.props.isBlockSelected( clientId ) && (
-					<View style={ styles.containerStyleAddHere } >
-						<View style={ styles.lineStyleAddHere }></View>
-						<Text style={ styles.labelStyleAddHere } >{ __( 'ADD BLOCK HERE' ) }</Text>
-						<View style={ styles.lineStyleAddHere }></View>
-					</View>
-				) }
+				{ this.state.blockTypePickerVisible && this.props.isBlockSelected( clientId ) && this.renderAddBlockSeparator() }
 			</ReadableContentView>
+		);
+	}
+
+	renderAddBlockSeparator() {
+		return (
+			<View style={ styles.containerStyleAddHere } >
+				<View style={ styles.lineStyleAddHere }></View>
+				<Text style={ styles.labelStyleAddHere } >{ __( 'ADD BLOCK HERE' ) }</Text>
+				<View style={ styles.lineStyleAddHere }></View>
+			</View>
 		);
 	}
 

--- a/packages/components/src/mobile/readable-content-view/index.native.js
+++ b/packages/components/src/mobile/readable-content-view/index.native.js
@@ -8,9 +8,9 @@ import { View, Dimensions } from 'react-native';
  */
 import styles from './style.scss';
 
-const ReadableContentView = ( { children } ) => (
+const ReadableContentView = ( { reversed, children } ) => (
 	<View style={ styles.container } >
-		<View style={ styles.centeredContent } >
+		<View style={ reversed ? styles.reversedCenteredContent : styles.centeredContent } >
 			{ children }
 		</View>
 	</View>

--- a/packages/components/src/mobile/readable-content-view/style.native.scss
+++ b/packages/components/src/mobile/readable-content-view/style.native.scss
@@ -6,3 +6,9 @@
 	width: 100%;
 	max-width: 580;
 }
+
+.reversedCenteredContent {
+	flex-direction: column-reverse;
+	width: 100%;
+	max-width: 580;
+}


### PR DESCRIPTION
Fixes : https://github.com/wordpress-mobile/gutenberg-mobile/issues/1165

To test:

1. Open new Post
2. Open block inserter 

Result: Add Block Here should show above block

3. Put some words into Block
4. Open block inserter 

Result: Add Block Here should show below block

![ezgif com-video-to-gif (4)](https://user-images.githubusercontent.com/28219092/60060817-71e17900-96c0-11e9-9f37-2b8ab1e7f68d.gif)
