### PR TITLE
use theme color for all shadows for focus state in primary button

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -90,7 +90,7 @@
 			box-shadow:
 				inset 0 -1px 0 color(theme(button) shade(50%)),
 				0 0 0 1px $white,
-				0 0 0 3px color(theme(button) shade(50%));
+				0 0 0 3px color(theme(button) shade(5%));
 		}
 
 		&:active:enabled {

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -90,7 +90,7 @@
 			box-shadow:
 				inset 0 -1px 0 color(theme(button) shade(50%)),
 				0 0 0 1px $white,
-				0 0 0 3px $blue-medium-focus;
+				0 0 0 3px color(theme(button) shade(50%));
 		}
 
 		&:active:enabled {


### PR DESCRIPTION
## Description
Use the PostCSS-provided theme colors consistently in button component stylesheet. This ensures that when the button's color is overridden (admin themes, or custom PostCSS) the focus rect is based on the `button` color :)

## How has this been tested?
I have briefly tested this by making the same change in this package in my project's `node_modules` (!). 

## Screenshots
After :
<img width="630" alt="Screen Shot 2019-06-25 at 3 28 00 PM" src="https://user-images.githubusercontent.com/4167300/60067228-ec140b00-975d-11e9-8150-f926b12c7528.png">

Before:
<img width="629" alt="Screen Shot 2019-06-25 at 3 30 09 PM" src="https://user-images.githubusercontent.com/4167300/60067368-5dec5480-975e-11e9-9ab0-17ca561721ce.png">



## Types of changes
- Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
