### PR TITLE
Move post permalink to beneath title on mobile.

### DIFF
--- a/packages/editor/src/components/post-permalink/style.scss
+++ b/packages/editor/src/components/post-permalink/style.scss
@@ -56,7 +56,7 @@
 	color: $dark-gray-200;
 	text-decoration: underline;
 	margin-right: 10px;
-	width: 100%;
+	flex-grow: 1;
 	overflow: hidden;
 	position: relative;
 	white-space: nowrap;

--- a/packages/editor/src/components/post-permalink/style.scss
+++ b/packages/editor/src/components/post-permalink/style.scss
@@ -1,8 +1,9 @@
 .editor-post-permalink {
 	display: inline-flex;
 	align-items: center;
+	flex-wrap: wrap;
 	background: $white;
-	padding: 5px;
+	padding: $grid-size $grid-size 0;
 	font-family: $default-font;
 	font-size: $default-font-size;
 	height: 40px;
@@ -25,11 +26,21 @@
 	// Put toolbar snugly to edge on mobile.
 	margin-left: -$block-padding - $border-width; // This hides the border off the edge of the screen.
 	margin-right: -$block-padding - $border-width;
+	@include break-mobile() {
+		padding: $grid-size-small;
+	}
 	@include break-small() {
 		margin-left: -$border-width;
 		margin-right: -$border-width;
 	}
+	// Increase specificity to override margins set on label element.
+	&.editor-post-permalink > * {
+		margin-bottom: $grid-size;
 
+		@include break-mobile() {
+			margin-bottom: 0;
+		}
+	}
 	button {
 		// Prevent button shrinking in IE11 when other items have a 100% flex basis.
 		// This should be safe to apply in all browsers because we don't want these

--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -113,12 +113,22 @@
 	top: -2px;
 	width: calc(100% - #{$block-left-border-width});
 
+	> * {
+		margin-top: $grid-size-small;
+		margin-bottom: $grid-size-small;
+	}
+
 	@include break-mobile() {
 		position: absolute;
 		top: -$block-toolbar-height + $border-width + $border-width + 1px; // Shift this element upward the same height as the block toolbar, minus the border size
 		right: 0;
 		flex-wrap: nowrap;
 		width: auto;
+
+		> * {
+			margin-top: 0;
+			margin-bottom: 0;
+		}
 	}
 	@include break-small() {
 		left: $block-side-ui-clearance;

--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -106,13 +106,14 @@
 .editor-post-title .editor-post-permalink {
 	font-size: $default-font-size;
 	color: $dark-gray-900;
-	position: absolute;
-	top: -$block-toolbar-height + $border-width + $border-width + 1px; // Shift this element upward the same height as the block toolbar, minus the border size
-	left: 0;
-	right: 0;
+	flex-wrap: wrap;
+	height: auto;
 
-	@include break-small() {
+	@include break-mobile() {
+		position: absolute;
+		top: -$block-toolbar-height + $border-width + $border-width + 1px; // Shift this element upward the same height as the block toolbar, minus the border size
 		left: $block-side-ui-clearance;
 		right: $block-side-ui-clearance;
+		flex-wrap: nowrap;
 	}
 }

--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -108,12 +108,20 @@
 	color: $dark-gray-900;
 	flex-wrap: wrap;
 	height: auto;
+	position: relative;
+	left: $block-left-border-width;
+	top: -2px;
+	width: calc(100% - #{$block-left-border-width});
 
 	@include break-mobile() {
 		position: absolute;
 		top: -$block-toolbar-height + $border-width + $border-width + 1px; // Shift this element upward the same height as the block toolbar, minus the border size
+		right: 0;
+		flex-wrap: nowrap;
+		width: auto;
+	}
+	@include break-small() {
 		left: $block-side-ui-clearance;
 		right: $block-side-ui-clearance;
-		flex-wrap: nowrap;
 	}
 }

--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -106,17 +106,11 @@
 .editor-post-title .editor-post-permalink {
 	font-size: $default-font-size;
 	color: $dark-gray-900;
-	flex-wrap: wrap;
 	height: auto;
 	position: relative;
 	left: $block-left-border-width;
 	top: -2px;
 	width: calc(100% - #{$block-left-border-width});
-
-	> * {
-		margin-top: $grid-size-small;
-		margin-bottom: $grid-size-small;
-	}
 
 	@include break-mobile() {
 		position: absolute;
@@ -124,11 +118,6 @@
 		right: 0;
 		flex-wrap: nowrap;
 		width: auto;
-
-		> * {
-			margin-top: 0;
-			margin-bottom: 0;
-		}
 	}
 	@include break-small() {
 		left: $block-side-ui-clearance;


### PR DESCRIPTION
## Description

Un-positioned post permalink in the editor title block for smallest breakpoint, so it flows below the title and its contents can wrap without breaking layout. On larger breakpoints it is still absolutely positioned.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Manually tested at different widths and zoom levels on Chrome, Safari (Mac) and IE (Windows 7).

## Screenshots <!-- if applicable -->

<img width="967" alt="Screen Shot 2019-06-25 at 3 30 37 pm" src="https://user-images.githubusercontent.com/8096000/60078050-89773b00-976e-11e9-89bd-aea2620838b4.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
 Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
