### PR TITLE
Copy All Content button: remove text change (Copied!)

### DIFF
--- a/packages/edit-post/src/plugins/copy-content-menu-item/index.js
+++ b/packages/edit-post/src/plugins/copy-content-menu-item/index.js
@@ -4,16 +4,15 @@
 import { ClipboardButton } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { withState, compose } from '@wordpress/compose';
+import { compose } from '@wordpress/compose';
 
-function CopyContentMenuItem( { createNotice, editedPostContent, hasCopied, setState } ) {
+function CopyContentMenuItem( { createNotice, editedPostContent } ) {
 	return (
 		<ClipboardButton
 			text={ editedPostContent }
 			role="menuitem"
 			className="components-menu-item__button"
 			onCopy={ () => {
-				setState( { hasCopied: true } );
 				createNotice(
 					'info',
 					'All content copied.',
@@ -23,11 +22,8 @@ function CopyContentMenuItem( { createNotice, editedPostContent, hasCopied, setS
 					}
 				);
 			} }
-			onFinishCopy={ () => setState( { hasCopied: false } ) }
 		>
-			{ hasCopied ?
-				__( 'Copied!' ) :
-				__( 'Copy All Content' ) }
+			{ __( 'Copy All Content' ) }
 		</ClipboardButton>
 	);
 }
@@ -45,5 +41,4 @@ export default compose(
 			createNotice,
 		};
 	} ),
-	withState( { hasCopied: false } )
 )( CopyContentMenuItem );


### PR DESCRIPTION
## Description
As mentioned in #15500, the text of the "Copy All Content" button should not change dynamically to "Copied!". We now have a snackbar notice, so we don't need this feedback anymore.

![copied-button](https://user-images.githubusercontent.com/695201/60114857-f8579280-9774-11e9-99be-4b9286a05fa7.gif)

