### PR TITLE
Copy All Content button: Hide if is no content

### DIFF
--- a/packages/edit-post/src/plugins/copy-content-menu-item/index.js
+++ b/packages/edit-post/src/plugins/copy-content-menu-item/index.js
@@ -8,27 +8,29 @@ import { withState, compose } from '@wordpress/compose';
 
 function CopyContentMenuItem( { createNotice, editedPostContent, hasCopied, setState } ) {
 	return (
-		<ClipboardButton
-			text={ editedPostContent }
-			role="menuitem"
-			className="components-menu-item__button"
-			onCopy={ () => {
-				setState( { hasCopied: true } );
-				createNotice(
-					'info',
-					'All content copied.',
-					{
-						isDismissible: true,
-						type: 'snackbar',
-					}
-				);
-			} }
-			onFinishCopy={ () => setState( { hasCopied: false } ) }
-		>
-			{ hasCopied ?
-				__( 'Copied!' ) :
-				__( 'Copy All Content' ) }
-		</ClipboardButton>
+		editedPostContent.length > 0 && (
+			<ClipboardButton
+				text={ editedPostContent }
+				role="menuitem"
+				className="components-menu-item__button"
+				onCopy={ () => {
+					setState( { hasCopied: true } );
+					createNotice(
+						'info',
+						'All content copied.',
+						{
+							isDismissible: true,
+							type: 'snackbar',
+						}
+					);
+				} }
+				onFinishCopy={ () => setState( { hasCopied: false } ) }
+			>
+				{ hasCopied ?
+					__( 'Copied!' ) :
+					__( 'Copy All Content' ) }
+			</ClipboardButton>
+		)
 	);
 }
 


### PR DESCRIPTION
## Description
The "Copy All Content" button should not be visible if there is no content.

Fixes #15500

![hide-copy-button](https://user-images.githubusercontent.com/695201/60114890-05748180-9775-11e9-8b17-115210432e12.gif)
