### PR TITLE
Add global Inserter to the widget screen

### DIFF
--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -2,10 +2,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { NavigableMenu } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
+import Inserter from '../inserter';
 import SaveButton from '../save-button';
 
 function Header() {
@@ -16,10 +18,12 @@ function Header() {
 			aria-label={ __( 'Widgets screen top bar' ) }
 			tabIndex="-1"
 		>
+			<NavigableMenu>
+				<Inserter.Slot />
+			</NavigableMenu>
 			<h1 className="edit-widgets-header__title">
 				{ __( 'Block Areas' ) } { __( '(experimental)' ) }
 			</h1>
-
 			<div className="edit-widgets-header__actions">
 				<SaveButton />
 			</div>

--- a/packages/edit-widgets/src/components/inserter/index.js
+++ b/packages/edit-widgets/src/components/inserter/index.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { createSlotFill } from '@wordpress/components';
+
+const { Fill: BlockInserterFill, Slot: BlockInserterSlot } = createSlotFill( 'EditWidgetsInserter' );
+
+const Inserter = BlockInserterFill;
+
+Inserter.Slot = function() {
+	return (
+		<BlockInserterSlot bubblesVirtually />
+	);
+};
+
+export default Inserter;

--- a/packages/edit-widgets/src/components/widget-area/index.js
+++ b/packages/edit-widgets/src/components/widget-area/index.js
@@ -14,6 +14,7 @@ import {
 	BlockInspector,
 	BlockEditorProvider,
 	BlockList,
+	Inserter as BlockInserter,
 	WritingFlow,
 	ObserveTyping,
 } from '@wordpress/block-editor';
@@ -24,6 +25,7 @@ import { withDispatch, withSelect } from '@wordpress/data';
  */
 import Sidebar from '../sidebar';
 import SelectionObserver from './selection-observer';
+import Inserter from '../inserter';
 
 function getBlockEditorSettings( blockEditorSettings, hasUploadPermissions ) {
 	if ( ! hasUploadPermissions ) {
@@ -68,6 +70,11 @@ function WidgetArea( {
 					onChange={ updateBlocks }
 					settings={ settings }
 				>
+					{ isSelectedArea && (
+						<Inserter>
+							<BlockInserter />
+						</Inserter>
+					) }
 					<SelectionObserver
 						isSelectedArea={ isSelectedArea }
 						onBlockSelected={ onBlockSelected }


### PR DESCRIPTION
## Description
This PR adds a global inserter to the widget screen.

## How has this been tested?
I used a theme with multiple widget areas (Twenty Fourteen).
I added some blocks in each widget area.
I used the global block inserter and verified the global inserter always inserts the block after the last selected block in the correct widget area.
