### PR TITLE
Blocks: Fix error from tag source of non-matching selector

### DIFF
--- a/packages/blocks/src/api/parser.js
+++ b/packages/blocks/src/api/parser.js
@@ -238,7 +238,7 @@ export function matcherFromSource( sourceConfig ) {
 		case 'tag':
 			return flow( [
 				prop( sourceConfig.selector, 'nodeName' ),
-				( value ) => value.toLowerCase(),
+				( nodeName ) => nodeName ? nodeName.toLowerCase() : undefined,
 			] );
 		default:
 			// eslint-disable-next-line no-console

--- a/packages/blocks/src/api/test/parser.js
+++ b/packages/blocks/src/api/test/parser.js
@@ -286,7 +286,7 @@ describe( 'block parser', () => {
 		describe( 'source: tag', () => {
 			it( 'returns tag name of matching selector', () => {
 				const value = parseWithAttributeSchema(
-					'<div>',
+					'<div></div>',
 					{
 						source: 'tag',
 						selector: ':nth-child(1)',
@@ -298,7 +298,7 @@ describe( 'block parser', () => {
 
 			it( 'returns undefined when no element matches selector', () => {
 				const value = parseWithAttributeSchema(
-					'<div>',
+					'<div></div>',
 					{
 						source: 'tag',
 						selector: ':nth-child(2)',

--- a/packages/blocks/src/api/test/parser.js
+++ b/packages/blocks/src/api/test/parser.js
@@ -282,6 +282,32 @@ describe( 'block parser', () => {
 			);
 			expect( value ).toBe( false );
 		} );
+
+		describe( 'source: tag', () => {
+			it( 'returns tag name of matching selector', () => {
+				const value = parseWithAttributeSchema(
+					'<div>',
+					{
+						source: 'tag',
+						selector: ':nth-child(1)',
+					}
+				);
+
+				expect( value ).toBe( 'div' );
+			} );
+
+			it( 'returns undefined when no element matches selector', () => {
+				const value = parseWithAttributeSchema(
+					'<div>',
+					{
+						source: 'tag',
+						selector: ':nth-child(2)',
+					}
+				);
+
+				expect( value ).toBe( undefined );
+			} );
+		} );
 	} );
 
 	describe( 'getBlockAttribute', () => {


### PR DESCRIPTION
Observed by @dsifford in Slack ([link requires registration](https://make.wordpress.org/chat/)): https://wordpress.slack.com/archives/C02QB2JS7/p1561083541193400?thread_ts=1561050038.184100&cid=C02QB2JS7

This pull request seeks to resolve an issue where an error is thrown if an attribute is defined using the `'tag'` source, and there is no resulting element matching the given `selector`. With these changes, the parsed result will now yield `undefined` instead under these circumstances.

**Testing Instructions:**

Verify unit tests pass:

```
npm run test-unit packages/blocks/src/api/test/parser.js
```