### PR TITLE
Blocks: Remove unused asType internal parser utility

### DIFF
--- a/packages/blocks/src/api/parser.js
+++ b/packages/blocks/src/api/parser.js
@@ -170,45 +170,6 @@ export function isAmbiguousStringSource( attributeSchema ) {
 }
 
 /**
- * Returns value coerced to the specified JSON schema type string.
- *
- * @see http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.25
- *
- * @param {*}      value Original value.
- * @param {string} type  Type to coerce.
- *
- * @return {*} Coerced value.
- */
-export function asType( value, type ) {
-	switch ( type ) {
-		case 'string':
-			return String( value );
-
-		case 'boolean':
-			return Boolean( value );
-
-		case 'object':
-			return Object( value );
-
-		case 'null':
-			return null;
-
-		case 'array':
-			if ( Array.isArray( value ) ) {
-				return value;
-			}
-
-			return Array.from( value );
-
-		case 'integer':
-		case 'number':
-			return Number( value );
-	}
-
-	return value;
-}
-
-/**
  * Returns an hpq matcher given a source object.
  *
  * @param {Object} sourceConfig Attribute Source object.

--- a/packages/blocks/src/api/test/parser.js
+++ b/packages/blocks/src/api/test/parser.js
@@ -10,7 +10,6 @@ import deepFreeze from 'deep-freeze';
 import {
 	getBlockAttribute,
 	getBlockAttributes,
-	asType,
 	createBlockWithFallback,
 	getMigratedBlock,
 	default as parsePegjs,
@@ -101,44 +100,6 @@ describe( 'block parser', () => {
 
 			expect( originalMatcher( node ) ).toBe( 'disabled' );
 			expect( enhancedMatcher( node ) ).toBe( true );
-		} );
-	} );
-
-	describe( 'asType()', () => {
-		it( 'gracefully handles undefined type', () => {
-			expect( asType( 5 ) ).toBe( 5 );
-		} );
-
-		it( 'gracefully handles unhandled type', () => {
-			expect( asType( 5, '__UNHANDLED__' ) ).toBe( 5 );
-		} );
-
-		it( 'returns expected coerced values', () => {
-			const arr = [];
-			const obj = {};
-
-			expect( asType( '5', 'string' ) ).toBe( '5' );
-			expect( asType( 5, 'string' ) ).toBe( '5' );
-
-			expect( asType( 5, 'integer' ) ).toBe( 5 );
-			expect( asType( '5', 'integer' ) ).toBe( 5 );
-
-			expect( asType( 5, 'number' ) ).toBe( 5 );
-			expect( asType( '5', 'number' ) ).toBe( 5 );
-
-			expect( asType( true, 'boolean' ) ).toBe( true );
-			expect( asType( false, 'boolean' ) ).toBe( false );
-			expect( asType( '5', 'boolean' ) ).toBe( true );
-			expect( asType( 0, 'boolean' ) ).toBe( false );
-
-			expect( asType( null, 'null' ) ).toBe( null );
-			expect( asType( 0, 'null' ) ).toBe( null );
-
-			expect( asType( arr, 'array' ) ).toBe( arr );
-			expect( asType( new Set( [ 1, 2, 3 ] ), 'array' ) ).toEqual( [ 1, 2, 3 ] );
-
-			expect( asType( obj, 'object' ) ).toBe( obj );
-			expect( asType( {}, 'object' ) ).toEqual( {} );
 		} );
 	} );
 


### PR DESCRIPTION
Previously: #10388, #10952

This pull request seeks to remove an unused `asType` function defined in the blocks parser. Previously, this was used to coerce attribute values to the type given by the attribute schema. This was later removed by a combination of #10388 and #10952, and the function is currently otherwise unused.

**Testing Instructions:**

Verify unit tests pass:

```
npm run test-unit
```

Ensure there are no lingering references to `asType`.