### PR TITLE
RichText: fix inline toolbar position

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -112,8 +112,10 @@ function RichTextWraper( {
 							<FormatToolbar />
 						</BlockFormatControls>
 					) }
-					{ inlineToolbar && (
-						<IsolatedEventContainer>
+					{ isSelected && inlineToolbar && (
+						<IsolatedEventContainer
+							className="editor-rich-text__inline-toolbar block-editor-rich-text__inline-toolbar"
+						>
 							<FormatToolbar />
 						</IsolatedEventContainer>
 					) }


### PR DESCRIPTION
## Description

Correction after #15212.
See https://github.com/WordPress/gutenberg/pull/16295#issuecomment-505843106.

This PR restores inline toolbar positioning.

## How has this been tested?

Insert an image block, focus caption, ensure inline toolbar is positioned correctly.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
