### PR TITLE
Editor: Resolve Publish button busy state styling regression

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,9 +1,12 @@
-## Next release
+## Master
 
 ### New Features
 
 - Added a new `popoverProps` prop to the `Dropdown` component which allows users of the `Dropdown` component to pass props directly to the `PopOver` component.
 
+### Bug Fixes
+
+- The `Button` component will no longer assign default styling (`is-default` class) when explicitly assigned as primary (the `isPrimary` prop). This should resolve potential conflicts affecting a combination of `isPrimary`, `isDefault`, and `isLarge` / `isSmall`, where the busy animation would appear with incorrect coloring.
 
 ## 8.0.0 (2019-06-12)
 

--- a/packages/components/src/button/index.js
+++ b/packages/components/src/button/index.js
@@ -28,7 +28,7 @@ export function Button( props, ref ) {
 
 	const classes = classnames( 'components-button', className, {
 		'is-button': isDefault || isPrimary || isLarge || isSmall,
-		'is-default': ! isPrimary && ( isDefault || isLarge || isSmall ),
+		'is-default': isDefault || ( ! isPrimary && ( isLarge || isSmall ) ),
 		'is-primary': isPrimary,
 		'is-large': isLarge,
 		'is-small': isSmall,

--- a/packages/components/src/button/index.js
+++ b/packages/components/src/button/index.js
@@ -28,7 +28,7 @@ export function Button( props, ref ) {
 
 	const classes = classnames( 'components-button', className, {
 		'is-button': isDefault || isPrimary || isLarge || isSmall,
-		'is-default': isDefault || isLarge || isSmall,
+		'is-default': ! isPrimary && ( isDefault || isLarge || isSmall ),
 		'is-primary': isPrimary,
 		'is-large': isLarge,
 		'is-small': isSmall,

--- a/packages/components/src/button/test/index.js
+++ b/packages/components/src/button/test/index.js
@@ -27,14 +27,14 @@ describe( 'Button', () => {
 			expect( button.type() ).toBe( 'button' );
 		} );
 
-		it( 'should render a button element with button-primary class', () => {
+		it( 'should render a button element with is-primary class', () => {
 			const button = shallow( <Button isPrimary /> );
 			expect( button.hasClass( 'is-large' ) ).toBe( false );
 			expect( button.hasClass( 'is-primary' ) ).toBe( true );
 			expect( button.hasClass( 'is-button' ) ).toBe( true );
 		} );
 
-		it( 'should render a button element with button-large class', () => {
+		it( 'should render a button element with is-large class', () => {
 			const button = shallow( <Button isLarge /> );
 			expect( button.hasClass( 'is-large' ) ).toBe( true );
 			expect( button.hasClass( 'is-default' ) ).toBe( true );
@@ -42,7 +42,12 @@ describe( 'Button', () => {
 			expect( button.hasClass( 'is-primary' ) ).toBe( false );
 		} );
 
-		it( 'should render a button element with button-small class', () => {
+		it( 'should render a button element without is-default if primary', () => {
+			const button = shallow( <Button isPrimary isLarge /> );
+			expect( button.hasClass( 'is-default' ) ).toBe( false );
+		} );
+
+		it( 'should render a button element with is-small class', () => {
 			const button = shallow( <Button isSmall /> );
 			expect( button.hasClass( 'is-default' ) ).toBe( true );
 			expect( button.hasClass( 'is-button' ) ).toBe( true );

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -92,7 +92,6 @@ export class PostPublishButton extends Component {
 			'aria-disabled': isButtonDisabled,
 			className: 'editor-post-publish-button',
 			isBusy: isSaving && isPublished,
-			isLarge: true,
 			isPrimary: true,
 			onClick: onClickButton,
 		};


### PR DESCRIPTION
Fixes #15029

This pull request seeks to resolve an issue where the Publish button (or any busy, disabled button) would display with incorrect styling.

Before|After
---|---
![Before](https://user-images.githubusercontent.com/1779930/60188246-f89b7080-97fc-11e9-83ae-6f85b85b571a.png)|![After](https://user-images.githubusercontent.com/1779930/60188292-06e98c80-97fd-11e9-89f6-cca9e0923d57.png)

**Implementation Notes:**

There are two separate changes which independently resolve the issue, but which together help reduce redundancy and assure broader applicability:

- A button should not be assigned `is-default` styling if it is is a primary button, since the "default" styling is the gray background (which primary styling is intended to supersede)
- The publish button does not need large styling (which is how `is-default` was applied) because all style properties of `is-large` ([source](https://github.com/WordPress/gutenberg/blob/f4d5d500630e44e4f2b0cb160fed7c0ca2ee353a/packages/components/src/button/style.scss#L191-L195)) are substituted in post editor header styles ([[1]](https://github.com/WordPress/gutenberg/blob/f4d5d500630e44e4f2b0cb160fed7c0ca2ee353a/packages/edit-post/src/components/header/style.scss#L95-L96), [[2]](https://github.com/WordPress/gutenberg/blob/f4d5d500630e44e4f2b0cb160fed7c0ca2ee353a/packages/edit-post/src/components/header/style.scss#L112-L116)). This also ensures consistency with the "Toggle" variant of the same button, which already doesn't apply `isLarge` and, aside from text of the button is intended to appear visually identical.

**Testing Instructions:**

Verify that upon Publishing a post, the intermediate state of the save request displays as shown in the "After" screenshot above.