### PR TITLE
Add minimum and maximum gallery columns attribute

### DIFF
--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -46,7 +46,9 @@
 			"default": [ ]
 		},
 		"columns": {
-			"type": "number"
+			"type": "number",
+			"minimum": 1,
+			"maximum": 8
 		},
 		"caption": {
 			"type": "string",


### PR DESCRIPTION
Make it clearer when define the gallery block, min/max and default values.