### PR TITLE
Block API: Add parse options to specify custom source handling

### DIFF
--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -244,6 +244,7 @@ _Parameters_
 -   _blockTypeOrName_ `(string|Object)`: Block type or name.
 -   _innerHTML_ `string`: Raw block content.
 -   _attributes_ `?Object`: Known block attributes (from delimiters).
+-   _parseOptions_ `WPBlocksParseOptions`: Parser options.
 
 _Returns_
 

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -59,7 +59,11 @@ export function* setupEditor( post, edits, template ) {
 		content = post.content.raw;
 	}
 
-	let blocks = parse( content );
+	let blocks = parse( content, {
+		sources: {
+			meta: ( schema ) => post.meta[ schema.meta ],
+		},
+	} );
 
 	// Apply a template for new posts only, if exists.
 	const isNewPost = post.status === 'auto-draft';


### PR DESCRIPTION
Related: #16282, #5077
Fixes #4989

This pull request seeks to explore a small part of proper handling of custom sources as part of the parse stage of editor initialization. Specifically, the changes here are alone sufficient to resolve the issue described in #4989. With these changes, a new options object can be passed with `wp.blocks.parse` to control behavior of the attributes derivation. Unlike #5077, this is exposed as part of the top-level API rather than as a hooks filtering. Hooks could still serve this purpose, but as of latest consideration are being discouraged, and could work unpredictably in nested editor environments.

**In-Progress Notes:**

- [ ] Needs unit tests
- [ ] There is another direct `parse` which occurs in the code editor ([source](https://github.com/WordPress/gutenberg/blob/89a8ac90b714e747bf57cf7e7deb16705357564c/packages/editor/src/components/post-text-editor/index.js#L102-L103)) which should be consolidated

Effectively, I'm not too committed to the direction here, and am opening to solicit some early feedback in considering whether to continue as a solution.