### PR TITLE
Fix link to InnerBlocks

### DIFF
--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -520,7 +520,7 @@ transforms: {
 
 * **Type:** `Array`
 
-Blocks are able to be inserted into blocks that use [`InnerBlocks`](/packages/block-editor/src/components/inner-blocks/README.md) as nested content. Sometimes it is useful to restrict a block so that it is only available as a nested block. For example, you might want to allow an 'Add to Cart' block to only be available within a 'Product' block.
+Blocks are able to be inserted into blocks that use [`InnerBlocks`](https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/inner-blocks/README.md) as nested content. Sometimes it is useful to restrict a block so that it is only available as a nested block. For example, you might want to allow an 'Add to Cart' block to only be available within a 'Product' block.
 
 Setting `parent` lets a block require that it is only available when nested within the specified blocks.
 


### PR DESCRIPTION
## Description

The link to InnerBlocks [on this page](https://developer.wordpress.org/block-editor/developers/block-api/block-registration/) is not working. 

The link in the source goes to: `/packages/block-editor/src/components/inner-blocks/README.md`
when published gets translated to: `https://developer.wordpress.org/block-editor/designers-developers/developers/packages/packages-block-editor/src/components/inner-blocks/` which is invalid.

The actual page should be https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/inner-blocks/README.md

I don't really know how to link it properly, so this PR just uses the full Github link

## Types of changes

Documentation.
