### PR TITLE
Update re-resizable dependency to the last version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3381,7 +3381,7 @@
 				"memize": "^1.0.5",
 				"moment": "^2.22.1",
 				"mousetrap": "^1.6.2",
-				"re-resizable": "^4.7.1",
+				"re-resizable": "^5.0.1",
 				"react-click-outside": "^3.0.0",
 				"react-dates": "^17.1.1",
 				"react-spring": "^8.0.20",
@@ -9374,6 +9374,11 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
+		},
+		"fast-memoize": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.1.tgz",
+			"integrity": "sha512-xdmw296PCL01tMOXx9mdJSmWY29jQgxyuZdq0rEHMu+Tpe1eOEtCycoG6chzlcrWsNgpZP7oL8RiQr7+G6Bl6g=="
 		},
 		"fastparse": {
 			"version": "1.1.2",
@@ -18366,9 +18371,12 @@
 			}
 		},
 		"re-resizable": {
-			"version": "4.7.1",
-			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-4.7.1.tgz",
-			"integrity": "sha512-pLJkPbZCe+3ml+9Q15z+R69qYZDsluj0KwrdFb8kSNaqDzYAveDUblf7voHH9hNTdKIiIvP8iIdGFFKSgffVaQ=="
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-5.0.1.tgz",
+			"integrity": "sha512-Iy8v5li7bhNBDxCN1DbA4l6G2Hk8NCZtcExoI1D+5pfvKyQcH8LH2P5h3DGoEfHhs0uyyRC1Qx8bHBomfrmxgA==",
+			"requires": {
+				"fast-memoize": "^2.5.1"
+			}
 		},
 		"react": {
 			"version": "16.8.4",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -40,7 +40,7 @@
 		"memize": "^1.0.5",
 		"moment": "^2.22.1",
 		"mousetrap": "^1.6.2",
-		"re-resizable": "^4.7.1",
+		"re-resizable": "^5.0.1",
 		"react-click-outside": "^3.0.0",
 		"react-dates": "^17.1.1",
 		"react-spring": "^8.0.20",

--- a/packages/components/src/resizable-box/index.js
+++ b/packages/components/src/resizable-box/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import ReResizableBox from 're-resizable';
+import { Resizable } from 're-resizable';
 
 function ResizableBox( { className, ...props } ) {
 	// Removes the inline styles in the drag handles.
@@ -20,7 +20,7 @@ function ResizableBox( { className, ...props } ) {
 	const cornerHandleClassName = 'components-resizable-box__corner-handle';
 
 	return (
-		<ReResizableBox
+		<Resizable
 			className={ classnames(
 				'components-resizable-box__container',
 				className,


### PR DESCRIPTION
This seems to fix the issues related to the Media & Text block causing the editor to only show half of the canvas.

This issue was also seen with the columns and image blocks, not sure if this fixes these as well.

closes #14652

 