### PR TITLE
Add logic to prevent ungroup option when there are no inner blocks

### DIFF
--- a/packages/e2e-tests/specs/block-grouping.test.js
+++ b/packages/e2e-tests/specs/block-grouping.test.js
@@ -102,6 +102,13 @@ describe( 'Block Grouping', () => {
 
 			expect( await getEditedPostContent() ).toMatchSnapshot();
 		} );
+
+		it( 'does not allow ungrouping a group block that has no children', async () => {
+			await insertBlock( 'Group' );
+			await clickBlockToolbarButton( 'More options' );
+			const ungroupButtons = await page.$x( '//button[text()="Ungroup"]' );
+			expect( ungroupButtons ).toHaveLength( 0 );
+		} );
 	} );
 
 	describe( 'Container Block availability', () => {

--- a/packages/editor/src/components/convert-to-group-buttons/convert-button.js
+++ b/packages/editor/src/components/convert-to-group-buttons/convert-button.js
@@ -72,8 +72,8 @@ export default compose( [
 			! isSingleContainerBlock
 		);
 
-		// Do we have a single Group Block selected?
-		const isUngroupable = isSingleContainerBlock;
+		// Do we have a single Group Block selected and does that group have inner blocks?
+		const isUngroupable = isSingleContainerBlock && !! blocksSelection[ 0 ].innerBlocks.length;
 
 		return {
 			isGroupable,


### PR DESCRIPTION
## Description
Prevents the ungroup option being displayed in the options menu when a group block has no inner blocks.

## How has this been tested?
Added an e2e test

**Manual testing:**
1. Add a group block
2. Open the block more menu

**Actual behaviour (`master`)**
The ungroup option is visible, and when clicked does nothing

**Expected behaviour ( this branch )**
The ungroup option is not visible.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
