### PR TITLE
Block Editor: Maintain selection when multi-selection toggled

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -809,7 +809,7 @@ export function blockSelection( state = BLOCK_SELECTION_INITIAL_STATE, action ) 
 		}
 		case 'TOGGLE_SELECTION':
 			return {
-				...BLOCK_SELECTION_INITIAL_STATE,
+				...state,
 				isEnabled: action.isSelectionEnabled,
 			};
 		case 'SELECTION_CHANGE':

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -699,6 +699,27 @@ export function isCaretWithinFormattedText( state = false, action ) {
 }
 
 const BLOCK_SELECTION_EMPTY_OBJECT = {};
+
+/**
+ * Initial state object for block selection.
+ *
+ * @property {Object}  start            Block anchor from which the selection
+ *                                      begins.
+ * @property {Object}  end              Block extent to which the selection
+ *                                      ends.
+ * @property {boolean} isMultiSelecting Flag representing whether a multi-
+ *                                      selection interaction is in progress.
+ * @property {boolean} isEnabled        Flag representing whether multi-
+ *                                      selection is currently allowed.
+ * @property {number?} initialPosition  For a changed selection, the position
+ *                                      at which the caret should be placed.
+ *                                      Either null (default position) or -1
+ *                                      (at the end of the block).
+ *
+ * @typedef {WPBlockSelectionState}
+ *
+ * @type {Object}
+ */
 const BLOCK_SELECTION_INITIAL_STATE = {
 	start: BLOCK_SELECTION_EMPTY_OBJECT,
 	end: BLOCK_SELECTION_EMPTY_OBJECT,
@@ -710,10 +731,10 @@ const BLOCK_SELECTION_INITIAL_STATE = {
 /**
  * Reducer returning the block selection's state.
  *
- * @param {Object} state  Current state.
+ * @param {WPBlockSelectionState} state  Current state.
  * @param {Object} action Dispatched action.
  *
- * @return {Object} Updated state.
+ * @return {WPBlockSelectionState} Updated state.
  */
 export function blockSelection( state = BLOCK_SELECTION_INITIAL_STATE, action ) {
 	switch ( action.type ) {

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -811,6 +811,9 @@ export function blockSelection( state = BLOCK_SELECTION_INITIAL_STATE, action ) 
 			return {
 				...state,
 				isEnabled: action.isSelectionEnabled,
+				isMultiSelecting: action.isSelectionEnabled ?
+					state.isMultiSelecting :
+					false,
 			};
 		case 'SELECTION_CHANGE':
 			return {

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -1727,6 +1727,24 @@ describe( 'state', () => {
 			expect( state1 ).toBe( original );
 		} );
 
+		it( 'should maintain selection when toggling multi-selection', () => {
+			const original = deepFreeze( {
+				start: { clientId: 'ribs' },
+				end: { clientId: 'ribs' },
+			} );
+
+			const state = blockSelection( original, {
+				type: 'TOGGLE_SELECTION',
+				isSelectionEnabled: false,
+			} );
+
+			expect( state ).toEqual( {
+				start: { clientId: 'ribs' },
+				end: { clientId: 'ribs' },
+				isEnabled: false,
+			} );
+		} );
+
 		it( 'should unset multi selection', () => {
 			const original = deepFreeze( { start: { clientId: 'ribs' }, end: { clientId: 'chicken' } } );
 

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -1731,6 +1731,27 @@ describe( 'state', () => {
 			const original = deepFreeze( {
 				start: { clientId: 'ribs' },
 				end: { clientId: 'ribs' },
+				isMultiSelecting: false,
+			} );
+
+			const state = blockSelection( original, {
+				type: 'TOGGLE_SELECTION',
+				isSelectionEnabled: false,
+			} );
+
+			expect( state ).toEqual( {
+				start: { clientId: 'ribs' },
+				end: { clientId: 'ribs' },
+				isMultiSelecting: false,
+				isEnabled: false,
+			} );
+		} );
+
+		it( 'should cancel multi-selection when disabling multi-selection', () => {
+			const original = deepFreeze( {
+				start: { clientId: 'ribs' },
+				end: { clientId: 'ribs' },
+				isMultiSelecting: true,
 			} );
 
 			const state = blockSelection( original, {
@@ -1742,6 +1763,29 @@ describe( 'state', () => {
 				start: { clientId: 'ribs' },
 				end: { clientId: 'ribs' },
 				isEnabled: false,
+				isMultiSelecting: false,
+			} );
+		} );
+
+		it( 'should preserve multi-selection when enabling multi-selection', () => {
+			[ true, false ].forEach( ( isMultiSelecting ) => {
+				const original = deepFreeze( {
+					start: { clientId: 'ribs' },
+					end: { clientId: 'ribs' },
+					isMultiSelecting,
+				} );
+
+				const state = blockSelection( original, {
+					type: 'TOGGLE_SELECTION',
+					isSelectionEnabled: true,
+				} );
+
+				expect( state ).toEqual( {
+					start: { clientId: 'ribs' },
+					end: { clientId: 'ribs' },
+					isEnabled: true,
+					isMultiSelecting,
+				} );
 			} );
 		} );
 


### PR DESCRIPTION
Extracted from #15927 
Previously: https://github.com/WordPress/gutenberg/pull/14640#discussion_r281802377

This pull request seeks to revise the behavior of the selection reducer to persist selected block through (multi-)selection toggling. Without these changes, an image will become unselected when resizing it, or as in #15927, the Columns block would become unselected when resizing columns.

**Testing Instructions:**

Verify that resizing an image does not unselect the block.

1. Navigate to Posts > Add New
2. Insert an image block
3. Select an image from the media library
4. Resize the image
5. Note that the image block is still selected