### PR TITLE
i18n: Bump Tannin dependency to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2910,31 +2910,31 @@
 			}
 		},
 		"@tannin/compile": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.0.1.tgz",
-			"integrity": "sha512-ymd9icvnkQin8UG4eRU3+xBc7gqTn/Kv5+EMY3ALWVwIl6j/7McWbCkxB8MgU40UaHJk8kLCk06wiKszXLdXWQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.0.3.tgz",
+			"integrity": "sha512-OkPHvaM/hIHdSco3+ZO1hzkOtfEddn5a0veWft2aDLvKnbdj9VusiLKNdEE9by3hCZIIcb9aWF+iBorhfrQOfw==",
 			"requires": {
-				"@tannin/evaluate": "^1.0.0",
-				"@tannin/postfix": "^1.0.0"
+				"@tannin/evaluate": "^1.1.1",
+				"@tannin/postfix": "^1.0.2"
 			}
 		},
 		"@tannin/evaluate": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.0.0.tgz",
-			"integrity": "sha512-gO7YbJsD8sj5/nqUbFZv71Meu2++D9n4DZov/cWwp3YJbBwKShPlWwwlXr/0vz4vuxm/gys+3NiGbZkmhlXf0Q=="
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.1.1.tgz",
+			"integrity": "sha512-ALuSZHjrLHGnw0WxsHDHde74FJ2WW0Ck4rg3QBxFBCmxd6Wsac+e0HXfJ++Qion15LIOCmFhyVpWzawMgeBA8Q=="
 		},
 		"@tannin/plural-forms": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.0.1.tgz",
-			"integrity": "sha512-SXutT+XLbMOECvmWDBSqIOHhS5hzWG9875HCFGKYgp8ghGPrJ4HZ325Xc0hsRThdjgrWMEQixlbpWl4SXOQTig==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.0.3.tgz",
+			"integrity": "sha512-IUr9+FiCnzCiB9aRio3FVNR8TNL9SmX2zkV6tmfWWwSclX4uTCykoGsDhTGKK+sZnMrdPCTmb/OxbtGNdVyV4g==",
 			"requires": {
-				"@tannin/compile": "^1.0.0"
+				"@tannin/compile": "^1.0.3"
 			}
 		},
 		"@tannin/postfix": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.0.0.tgz",
-			"integrity": "sha512-59/mWwU7sXHfoU2kI3RcWRki2Jjbz5nEVJNBN4MUyIhPjXTebAcZqgsQACvlk+sjKVOTMEMHcrFrKQbaxz/1Dw=="
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.0.2.tgz",
+			"integrity": "sha512-Nggtk7/ljfNPpAX8CjxxLkMKuO6u2gH1ozmTvGclWF2pNcxTf6YGghYNYNWZRKrimXGhQ8yZqvAHep7h80K04g=="
 		},
 		"@types/babel__core": {
 			"version": "7.1.1",
@@ -3649,7 +3649,7 @@
 				"lodash": "^4.17.11",
 				"memize": "^1.0.5",
 				"sprintf-js": "^1.1.1",
-				"tannin": "^1.0.1"
+				"tannin": "^1.1.0"
 			}
 		},
 		"@wordpress/is-shallow-equal": {
@@ -21154,11 +21154,11 @@
 			}
 		},
 		"tannin": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/tannin/-/tannin-1.0.1.tgz",
-			"integrity": "sha512-dDtnwHQ63bS/Gz0ZLY+E+JCdRoTZkmoKDoC64y3hzAD2X2qrp8jSuWNUjtiYHA48mtj4Ens9xl4knAOm1t+rfQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/tannin/-/tannin-1.1.0.tgz",
+			"integrity": "sha512-LxhcXqpMHEOVeVKmuG5aCPPsTXFlO373vrWkqN7FSJBVLS6lFOAg8ZGzIyGhrOf7Ho3xB4jdGedY1gi/8J1FCA==",
 			"requires": {
-				"@tannin/plural-forms": "^1.0.0"
+				"@tannin/plural-forms": "^1.0.3"
 			}
 		},
 		"tapable": {

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -29,7 +29,7 @@
 		"lodash": "^4.17.11",
 		"memize": "^1.0.5",
 		"sprintf-js": "^1.1.1",
-		"tannin": "^1.0.1"
+		"tannin": "^1.1.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/i18n/src/index.js
+++ b/packages/i18n/src/index.js
@@ -13,7 +13,7 @@ import sprintfjs from 'sprintf-js';
  */
 const DEFAULT_LOCALE_DATA = {
 	'': {
-		plural_forms: 'plural=(n!=1)',
+		plural_forms: ( n ) => n === 1 ? 0 : 1,
 	},
 };
 


### PR DESCRIPTION
This pull request seeks to bump the Tannin dependency from 1.0.1 to 1.1.0 .

View CHANGELOGS:

- [`tannin`](https://github.com/aduth/tannin/blob/master/packages/tannin/CHANGELOG.md)
- [`@tannin/postfix`](https://github.com/aduth/tannin/blob/master/packages/postfix/CHANGELOG.md)
- [`@tannin/plural-forms`](https://github.com/aduth/tannin/blob/master/packages/plural-forms/CHANGELOG.md)
- [`@tannin/evaluate`](https://github.com/aduth/tannin/blob/master/packages/evaluate/CHANGELOG.md)
- [`@tannin/compile`](https://github.com/aduth/tannin/blob/master/packages/compile/CHANGELOG.md)

Notably, this includes a couple performance improvements:

- Accept `plural_forms` option as a function (https://github.com/aduth/tannin/commit/9825ad4ea9c5057c1111302cd9712f4800408b45). This is particularly useful for the "default" (untranslated) locale, to avoid parsing and computing plural forms using the default `'plural=(n!=1)'` plural expression.
- Optimize postfix evaluation arguments popping, avoiding `Array#splice` (https://github.com/aduth/tannin/commit/50cde556e318729242c33adc81c7f1e98054a469).

The performance impact is not expected to be dramatic (it largely affects plurals usage specifically, as singular strings are already optimized to bypass plural expression evaluation). That said, running `npm run test-performance` yields some improvement (~6ms reduction average time to type, from 103.4ms to 97.58ms).

**Testing Instructions:**

There should be no impact on localized strings. Test in both the default (English) locale and a translated (non-English) locale.