### PR TITLE
Show custom fields option only if post type supports it

### DIFF
--- a/packages/edit-post/src/components/options-modal/meta-boxes-section.js
+++ b/packages/edit-post/src/components/options-modal/meta-boxes-section.js
@@ -15,10 +15,9 @@ import { withSelect } from '@wordpress/data';
 import Section from './section';
 import { EnableCustomFieldsOption, EnablePanelOption } from './options';
 
-export function MetaBoxesSection( { metaBoxes, postType, ...sectionProps } ) {
+export function MetaBoxesSection( { metaBoxes, supportsCustomFields, ...sectionProps } ) {
 	// The 'Custom Fields' meta box is a special case that we handle separately.
 	const thirdPartyMetaBoxes = filter( metaBoxes, ( { id } ) => id !== 'postcustom' );
-	const supportsCustomFields = get( postType, [ 'supports', 'custom-fields' ], false );
 
 	if ( ! supportsCustomFields && thirdPartyMetaBoxes.length === 0 ) {
 		return null;
@@ -38,9 +37,10 @@ export default withSelect( ( select ) => {
 	const { getPostType } = select( 'core' );
 	const { getEditedPostAttribute } = select( 'core/editor' );
 	const { getAllMetaBoxes } = select( 'core/edit-post' );
+	const postType = getPostType( getEditedPostAttribute( 'type' ) );
 
 	return {
 		metaBoxes: getAllMetaBoxes(),
-		postType: getPostType( getEditedPostAttribute( 'type' ) ),
+		supportsCustomFields: get( postType, [ 'supports', 'custom-fields' ], false ),
 	};
 } )( MetaBoxesSection );

--- a/packages/edit-post/src/components/options-modal/meta-boxes-section.js
+++ b/packages/edit-post/src/components/options-modal/meta-boxes-section.js
@@ -18,7 +18,6 @@ import { EnableCustomFieldsOption, EnablePanelOption } from './options';
 export function MetaBoxesSection( { metaBoxes, postType, ...sectionProps } ) {
 	// The 'Custom Fields' meta box is a special case that we handle separately.
 	const thirdPartyMetaBoxes = filter( metaBoxes, ( { id } ) => id !== 'postcustom' );
-
 	const supportsCustomFields = get( postType, [ 'supports', 'custom-fields' ], false );
 
 	if ( ! supportsCustomFields && thirdPartyMetaBoxes.length === 0 ) {

--- a/packages/edit-post/src/components/options-modal/test/meta-boxes-section.js
+++ b/packages/edit-post/src/components/options-modal/test/meta-boxes-section.js
@@ -12,7 +12,7 @@ describe( 'MetaBoxesSection', () => {
 	it( 'does not render if there are no options', () => {
 		const wrapper = shallow(
 			<MetaBoxesSection
-				areCustomFieldsRegistered={ false }
+				supportsCustomFields={ false }
 				metaBoxes={ [ { id: 'postcustom', title: 'This should not render' } ] }
 			/>
 		);
@@ -23,7 +23,7 @@ describe( 'MetaBoxesSection', () => {
 		const wrapper = shallow(
 			<MetaBoxesSection
 				title="Advanced Panels"
-				areCustomFieldsRegistered
+				supportsCustomFields
 				metaBoxes={ [ { id: 'postcustom', title: 'This should not render' } ] }
 			/>
 		);
@@ -34,7 +34,7 @@ describe( 'MetaBoxesSection', () => {
 		const wrapper = shallow(
 			<MetaBoxesSection
 				title="Advanced Panels"
-				areCustomFieldsRegistered={ false }
+				supportsCustomFields={ false }
 				metaBoxes={ [
 					{ id: 'postcustom', title: 'This should not render' },
 					{ id: 'test1', title: 'Meta Box 1' },
@@ -49,7 +49,7 @@ describe( 'MetaBoxesSection', () => {
 		const wrapper = shallow(
 			<MetaBoxesSection
 				title="Advanced Panels"
-				areCustomFieldsRegistered
+				supportsCustomFields
 				metaBoxes={ [
 					{ id: 'postcustom', title: 'This should not render' },
 					{ id: 'test1', title: 'Meta Box 1' },


### PR DESCRIPTION
## Description
Fixes #16333 
The custom field option should only be visible, if the post type supports this feature. The old solution doesn't work anymore, because `enableCustomFields ` has now a default value `false` (added in #14082).
So this new solution checks the supports array of the post type for the value `custom-fields`.

## How has this been tested?
Register a post type without custom field support, so the option should be hidden. If you add the custom fields support, the option should be visible.
```php
function register_custom_post_types() {
	register_post_type('test', [
		'labels' => [
			'name' => __('test'),
		],
		'public' => true,
		'supports' => [
			'title',
			'editor',
			// 'custom-fields',
		],
		'show_in_rest' => true,
	]);
}
add_action('init', 'register_custom_post_types');

```

## Screenshot
![Bildschirmfoto 2019-06-27 um 21 48 31](https://user-images.githubusercontent.com/695201/60296052-81153080-9925-11e9-8b94-d33f8411c2c0.png)
