### PR TITLE
Placeholder instructions: Make texts more consistent

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -415,7 +415,7 @@ class ImageEdit extends Component {
 		const src = isExternal ? url : undefined;
 		const labels = {
 			title: ! url ? __( 'Image' ) : __( 'Edit image' ),
-			instructions: __( 'Upload an image, pick one from your media library, or add one with a URL.' ),
+			instructions: __( 'Upload an image file, pick one from your media library, or add one with a URL.' ),
 		};
 		const mediaPreview = ( !! url && <img
 			alt={ __( 'Edit image' ) }


### PR DESCRIPTION
## Description
The placeholder text for media should be in this structure
>For when there's a URL option:
Upload a [type] file, pick one from your media library, or add one with a URL.

See #16135

This PR adds the word 'file' to the string, so that this string is consistent with the media-placeholder component.