### PR TITLE
[RNMobile] Native mobile release v1.8.0

### DIFF
--- a/packages/block-editor/src/components/block-list/block-mobile-toolbar.native.js
+++ b/packages/block-editor/src/components/block-list/block-mobile-toolbar.native.js
@@ -55,15 +55,12 @@ export default compose(
 			order: getBlockIndex( clientId ),
 		};
 	} ),
-	withDispatch( ( dispatch, { clientId, rootClientId, onDelete } ) => {
+	withDispatch( ( dispatch, { clientId, rootClientId } ) => {
 		const { removeBlock } = dispatch( 'core/block-editor' );
 		return {
-			onDelete() {
+			onDelete: () => {
 				Keyboard.dismiss();
 				removeBlock( clientId, rootClientId );
-				if ( onDelete ) {
-					onDelete( clientId );
-				}
 			},
 		};
 	} ),

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -8,7 +8,6 @@ import {
 	mediaUploadSync,
 	requestImageFailedRetryDialog,
 	requestImageUploadCancelDialog,
-	requestImageUploadCancel,
 } from 'react-native-gutenberg-bridge';
 import { isEmpty } from 'lodash';
 
@@ -31,6 +30,7 @@ import {
 } from '@wordpress/block-editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { isURL } from '@wordpress/url';
+import { doAction, hasAction } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -92,8 +92,9 @@ class ImageEdit extends React.Component {
 	}
 
 	componentWillUnmount() {
-		if ( this.state.isUploadInProgress ) {
-			requestImageUploadCancel( this.props.attributes.id );
+		// this action will only exist if the user pressed the trash button on the block holder
+		if ( hasAction( 'blocks.onRemoveBlockCheckUpload' ) && this.state.isUploadInProgress ) {
+			doAction( 'blocks.onRemoveBlockCheckUpload', this.props.attributes.id );
 		}
 	}
 

--- a/packages/block-library/src/video/edit.native.js
+++ b/packages/block-library/src/video/edit.native.js
@@ -11,7 +11,6 @@ import {
 	mediaUploadSync,
 	requestImageFailedRetryDialog,
 	requestImageUploadCancelDialog,
-	requestImageUploadCancel,
 } from 'react-native-gutenberg-bridge';
 
 /**
@@ -32,6 +31,7 @@ import {
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { isURL } from '@wordpress/url';
+import { doAction, hasAction } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -70,8 +70,9 @@ class VideoEdit extends React.Component {
 	}
 
 	componentWillUnmount() {
-		if ( this.state.isUploadInProgress ) {
-			requestImageUploadCancel( this.props.attributes.id );
+		// this action will only exist if the user pressed the trash button on the block holder
+		if ( hasAction( 'blocks.onRemoveBlockCheckUpload' ) && this.state.isUploadInProgress ) {
+			doAction( 'blocks.onRemoveBlockCheckUpload', this.props.attributes.id );
 		}
 	}
 

--- a/packages/edit-post/src/index.native.js
+++ b/packages/edit-post/src/index.native.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { Platform } from 'react-native';
+
+/**
  * WordPress dependencies
  */
 import '@wordpress/core-data';
@@ -24,6 +29,11 @@ export function initializeEditor() {
 	// eslint-disable-next-line no-undef
 	if ( typeof __DEV__ === 'undefined' || ! __DEV__ ) {
 		unregisterBlockType( 'core/code' );
+
+		// Disable Video block except for iOS for now.
+		if ( Platform.OS !== 'ios' ) {
+			unregisterBlockType( 'core/video' );
+		}
 	}
 }
 


### PR DESCRIPTION
## Description
This PR tracks the release v1.8.0 of the native mobile app.

## How has this been tested?
Using this gutenberg-mobile side PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1172

## Types of changes
1. Disable the video block for ios

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
