### PR TITLE
Fix group block deprecation

### DIFF
--- a/packages/block-library/src/group/deprecated.js
+++ b/packages/block-library/src/group/deprecated.js
@@ -18,6 +18,12 @@ const deprecated = [
 			customBackgroundColor: {
 				type: 'string',
 			},
+			anchor: {
+				type: 'string',
+				source: 'attribute',
+				attribute: 'id',
+				selector: '*',
+			},
 		},
 		supports: {
 			align: [ 'wide', 'full' ],

--- a/packages/e2e-tests/fixtures/blocks/core__group__deprecated.html
+++ b/packages/e2e-tests/fixtures/blocks/core__group__deprecated.html
@@ -1,5 +1,5 @@
 <!-- wp:group {"backgroundColor":"lighter-blue","align":"full"} -->
-<div class="wp-block-group alignfull has-lighter-blue-background-color has-background">
+<div class="wp-block-group alignfull has-lighter-blue-background-color has-background" id="test-anchor">
 	<!-- wp:paragraph -->
 	<p>test</p>
 	<!-- /wp:paragraph -->

--- a/packages/e2e-tests/fixtures/blocks/core__group__deprecated.json
+++ b/packages/e2e-tests/fixtures/blocks/core__group__deprecated.json
@@ -5,6 +5,7 @@
         "isValid": true,
         "attributes": {
             "backgroundColor": "lighter-blue",
+            "anchor": "test-anchor",
             "className": "alignfull"
         },
         "innerBlocks": [
@@ -20,6 +21,6 @@
                 "originalContent": "<p>test</p>"
             }
         ],
-        "originalContent": "<div class=\"wp-block-group alignfull has-lighter-blue-background-color has-background\">\n\t\n</div>"
+        "originalContent": "<div class=\"wp-block-group alignfull has-lighter-blue-background-color has-background\" id=\"test-anchor\">\n\t\n</div>"
     }
 ]

--- a/packages/e2e-tests/fixtures/blocks/core__group__deprecated.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__group__deprecated.parsed.json
@@ -16,9 +16,9 @@
                 ]
             }
         ],
-        "innerHTML": "\n<div class=\"wp-block-group alignfull has-lighter-blue-background-color has-background\">\n\t\n</div>\n",
+        "innerHTML": "\n<div class=\"wp-block-group alignfull has-lighter-blue-background-color has-background\" id=\"test-anchor\">\n\t\n</div>\n",
         "innerContent": [
-            "\n<div class=\"wp-block-group alignfull has-lighter-blue-background-color has-background\">\n\t",
+            "\n<div class=\"wp-block-group alignfull has-lighter-blue-background-color has-background\" id=\"test-anchor\">\n\t",
             null,
             "\n</div>\n"
         ]

--- a/packages/e2e-tests/fixtures/blocks/core__group__deprecated.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__group__deprecated.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:group {"backgroundColor":"lighter-blue","className":"alignfull"} -->
-<div class="wp-block-group has-lighter-blue-background-color has-background alignfull"><div class="wp-block-group__inner-container"><!-- wp:paragraph -->
+<div class="wp-block-group has-lighter-blue-background-color has-background alignfull" id="test-anchor"><div class="wp-block-group__inner-container"><!-- wp:paragraph -->
 <p>test</p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:group -->


### PR DESCRIPTION
## Description
Fixes #16328. Ensures the deprecation for the group block won't trigger a validation error when an id is defined on a matching group.

## How has this been tested?
Updated integration tests

**Manual Testing**
1. Checkout Gutenberg 5.9.0
2. Create a post
3. Add a group block and give that group block an ID (using the *Advanced* section in the sidebar).
4. Save the post
5. Checkout this branch
6. Load the post

**Expected Behaviour (this branch)**
The group block continues to work

**Actual Behaviour ( currently in `master`)**
The group block causes a validation error.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
