### PR TITLE
Run registerBlockType hook over deprecated settings

### DIFF
--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -59,7 +59,7 @@ Extending blocks can involve more than just providing alternative styles, in thi
 
 #### `blocks.registerBlockType`
 
-Used to filter the block settings. It receives the block settings and the name of the block the registered block as arguments.
+Used to filter the block settings. It receives the block settings and the name of the block the registered block as arguments. Since v6.1.0 this filter is also applied to each of a block's deprecated settings.
 
 _Example:_
 

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### Bug Fixes
+
+- The `'blocks.registerBlockType'` filter is now applied to each of a block's deprecated settings as well as the block's main settings. Ensures `supports` settings like `anchor` work for deprecations.
+
 ## 6.3.0 (2019-05-21)
 
 ### New Feature

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -99,6 +99,11 @@ export function registerBlockType( name, settings ) {
 	}
 
 	settings = applyFilters( 'blocks.registerBlockType', settings, name );
+
+	if ( settings.deprecated ) {
+		settings.deprecated = settings.deprecated.map( ( deprecation ) => applyFilters( 'blocks.registerBlockType', deprecation, name ) );
+	}
+
 	if ( ! isPlainObject( settings ) ) {
 		console.error(
 			'Block settings must be a valid object.'

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -337,6 +337,42 @@ describe( 'blocks', () => {
 				expect( console ).toHaveErroredWith( 'Block settings must be a valid object.' );
 				expect( block ).toBeUndefined();
 			} );
+
+			it( 'should apply the blocks.registerBlockType filter to each of the deprecated settings as well as the main block settings', () => {
+				const blockSettingsWithDeprecations = {
+					...defaultBlockSettings,
+					deprecated: [
+						{
+							save() {
+								return 1;
+							},
+						},
+						{
+							save() {
+								return 2;
+							},
+						},
+					],
+				};
+
+				addFilter( 'blocks.registerBlockType', 'core/blocks/without-title', ( settings ) => {
+					return {
+						...settings,
+						attributes: {
+							...settings.attributes,
+							id: {
+								type: 'string',
+							},
+						},
+					};
+				} );
+
+				const block = registerBlockType( 'my-plugin/fancy-block-13', blockSettingsWithDeprecations );
+
+				expect( block.attributes.id ).toEqual( { type: 'string' } );
+				expect( block.deprecated[ 0 ].attributes.id ).toEqual( { type: 'string' } );
+				expect( block.deprecated[ 1 ].attributes.id ).toEqual( { type: 'string' } );
+			} );
 		} );
 	} );
 

--- a/packages/e2e-tests/fixtures/blocks/core__group__deprecated.html
+++ b/packages/e2e-tests/fixtures/blocks/core__group__deprecated.html
@@ -1,5 +1,5 @@
 <!-- wp:group {"backgroundColor":"lighter-blue","align":"full"} -->
-<div class="wp-block-group alignfull has-lighter-blue-background-color has-background">
+<div class="wp-block-group alignfull has-lighter-blue-background-color has-background" id="test-id">
 	<!-- wp:paragraph -->
 	<p>test</p>
 	<!-- /wp:paragraph -->

--- a/packages/e2e-tests/fixtures/blocks/core__group__deprecated.json
+++ b/packages/e2e-tests/fixtures/blocks/core__group__deprecated.json
@@ -5,7 +5,7 @@
         "isValid": true,
         "attributes": {
             "backgroundColor": "lighter-blue",
-            "className": "alignfull"
+            "align": "full"
         },
         "innerBlocks": [
             {

--- a/packages/e2e-tests/fixtures/blocks/core__group__deprecated.json
+++ b/packages/e2e-tests/fixtures/blocks/core__group__deprecated.json
@@ -5,7 +5,8 @@
         "isValid": true,
         "attributes": {
             "backgroundColor": "lighter-blue",
-            "align": "full"
+            "align": "full",
+            "anchor": "test-id"
         },
         "innerBlocks": [
             {
@@ -20,6 +21,6 @@
                 "originalContent": "<p>test</p>"
             }
         ],
-        "originalContent": "<div class=\"wp-block-group alignfull has-lighter-blue-background-color has-background\">\n\t\n</div>"
+        "originalContent": "<div class=\"wp-block-group alignfull has-lighter-blue-background-color has-background\" id=\"test-id\">\n\t\n</div>"
     }
 ]

--- a/packages/e2e-tests/fixtures/blocks/core__group__deprecated.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__group__deprecated.parsed.json
@@ -16,9 +16,9 @@
                 ]
             }
         ],
-        "innerHTML": "\n<div class=\"wp-block-group alignfull has-lighter-blue-background-color has-background\">\n\t\n</div>\n",
+        "innerHTML": "\n<div class=\"wp-block-group alignfull has-lighter-blue-background-color has-background\" id=\"test-id\">\n\t\n</div>\n",
         "innerContent": [
-            "\n<div class=\"wp-block-group alignfull has-lighter-blue-background-color has-background\">\n\t",
+            "\n<div class=\"wp-block-group alignfull has-lighter-blue-background-color has-background\" id=\"test-id\">\n\t",
             null,
             "\n</div>\n"
         ]

--- a/packages/e2e-tests/fixtures/blocks/core__group__deprecated.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__group__deprecated.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:group {"backgroundColor":"lighter-blue","align":"full"} -->
-<div class="wp-block-group alignfull has-lighter-blue-background-color has-background"><div class="wp-block-group__inner-container"><!-- wp:paragraph -->
+<div class="wp-block-group alignfull has-lighter-blue-background-color has-background" id="test-id"><div class="wp-block-group__inner-container"><!-- wp:paragraph -->
 <p>test</p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:group -->

--- a/packages/e2e-tests/fixtures/blocks/core__group__deprecated.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__group__deprecated.serialized.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"backgroundColor":"lighter-blue","className":"alignfull"} -->
-<div class="wp-block-group has-lighter-blue-background-color has-background alignfull"><div class="wp-block-group__inner-container"><!-- wp:paragraph -->
+<!-- wp:group {"backgroundColor":"lighter-blue","align":"full"} -->
+<div class="wp-block-group alignfull has-lighter-blue-background-color has-background"><div class="wp-block-group__inner-container"><!-- wp:paragraph -->
 <p>test</p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:group -->


### PR DESCRIPTION
## Description
Alternative attempt to fix #16328. Unfinished and unlikely to be the right fix, but this PR should hopefully generate some discussion about the right way to fix the issue.

**Background**
After some digging into the above issue, I discovered that the `supports` settings for blocks relies on the `registerBlockType` filter. This filter adds an extra `anchor` attribute to blocks that support anchors.

Unfortunately the `registerBlockType` filter only runs on the main block settings, not deprecated block settings. When falling back to an older deprecation the attribute is not present and is never sourced from the HTML. In the case reported in the related issue, this caused a validation issue.

Other `supports` settings (e.g. align) also don't work with deprecations, but don't cause validation issues since `data-` attributes are ignored by the validator.

The fix here is to also run the `registerBlockType` filter over each object in the deprecation array.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
