### PR TITLE
Add: Simple way to register block styles.

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Block registration functions.
+ * Block and style registration functions.
  *
  * @package gutenberg
  */
@@ -45,3 +45,76 @@ function gutenberg_reregister_core_block_types() {
 	}
 }
 add_action( 'init', 'gutenberg_reregister_core_block_types' );
+
+/**
+ * Registers a new block style.
+ *
+ * @param string $block_name       Block type name including namespace.
+ * @param array  $style_properties Array containing the properties of the style name, label, style (name of the stylesheet to be enqueued), inline_style (string containing the CSS to be added).
+ *
+ * @return boolean True if the block style was registered with success and false otherwise.
+ */
+function register_block_style( $block_name, $style_properties ) {
+	return WP_Block_Styles_Registry::get_instance()->register( $block_name, $style_properties );
+}
+
+/**
+ * Unregisters a block style.
+ *
+ * @param string $block_name       Block type name including namespace.
+ * @param array  $block_style_name Block style name.
+ *
+ * @return boolean True if the block style was unregistered with success and false otherwise.
+ */
+function unregister_block_style( $block_name, $block_style_name ) {
+	return WP_Block_Styles_Registry::get_instance()->unregister( $block_name, $block_style_name );
+}
+
+/**
+ * Function responsible for enqueuing the styles required for block styles functionality on the editor and on the frontend.
+ */
+function enqueue_block_styles_assets() {
+	$block_styles = WP_Block_Styles_Registry::get_instance()->get_all_registered();
+
+	foreach ( $block_styles as $styles ) {
+		foreach ( $styles as $style_properties ) {
+			if ( isset( $style_properties['style_handle'] ) ) {
+				wp_enqueue_style( $style_properties['style_handle'] );
+			}
+			if ( isset( $style_properties['inline_style'] ) ) {
+				wp_add_inline_style( 'wp-block-library', $style_properties['inline_style'] );
+			}
+		}
+	}
+}
+add_action( 'enqueue_block_assets', 'enqueue_block_styles_assets', 30 );
+
+/**
+ * Function responsible for enqueuing the assets required for block styles functionality on the editor.
+ */
+function enqueue_editor_block_styles_assets() {
+	$block_styles = WP_Block_Styles_Registry::get_instance()->get_all_registered();
+
+	$register_script_lines = array( '( function() {' );
+	foreach ( $block_styles as $block_name => $styles ) {
+		foreach ( $styles as $style_properties ) {
+			$register_script_lines[] = sprintf(
+				'	wp.blocks.registerBlockStyle( \'%s\', %s );',
+				$block_name,
+				wp_json_encode(
+					array(
+						'name'  => $style_properties['name'],
+						'label' => $style_properties['label'],
+					)
+				)
+			);
+		}
+	}
+	$register_script_lines[] = '} )();';
+	$inline_script           = implode( "\n", $register_script_lines );
+
+	wp_register_script( 'wp-block-styles', false, array( 'wp-blocks' ), true, true );
+	wp_add_inline_script( 'wp-block-styles', $inline_script );
+	wp_enqueue_script( 'wp-block-styles' );
+}
+add_action( 'enqueue_block_editor_assets', 'enqueue_editor_block_styles_assets' );

--- a/lib/class-wp-block-styles-registry.php
+++ b/lib/class-wp-block-styles-registry.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Blocks API: WP_Block_Styles_Registry class
+ *
+ * @package Gutenberg
+ * @since 6.2.0
+ */
+
+/**
+ * Class used for interacting with block styles.
+ *
+ * @since 6.2.0
+ */
+final class WP_Block_Styles_Registry {
+	/**
+	 * Registered block styles, as `$block_name => $block_style_name => $block_style_properties` multidimensional arrays.
+	 *
+	 * @since 6.2.0
+	 * @var array
+	 */
+	private $registered_block_styles = array();
+
+	/**
+	 * Container for the main instance of the class.
+	 *
+	 * @since 6.2.0
+	 * @var WP_Block_Styles_Registry|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Registers a block style.
+	 *
+	 * @since 6.2.0
+	 *
+	 * @param string $block_name       Block type name including namespace.
+	 * @param array  $style_properties Array containing the properties of the style name, label, style (name of the stylesheet to be enqueued), inline_style (string containing the CSS to be added).
+	 *
+	 * @return boolean True if the block style was registered with success and false otherwise.
+	 */
+	public function register( $block_name, $style_properties ) {
+
+		if ( ! isset( $block_name ) || ! is_string( $block_name ) ) {
+			$message = __( 'Block name name must be a string.', 'gutenberg' );
+			_doing_it_wrong( __METHOD__, $message, '6.2.0' );
+			return false;
+		}
+
+		if ( ! isset( $style_properties['name'] ) || ! is_string( $style_properties['name'] ) ) {
+			$message = __( 'Block style name must be a string.', 'gutenberg' );
+			_doing_it_wrong( __METHOD__, $message, '6.2.0' );
+			return false;
+		}
+
+		$block_style_name = $style_properties['name'];
+
+		if ( ! isset( $this->registered_block_styles[ $block_name ] ) ) {
+			$this->registered_block_styles[ $block_name ] = array();
+		}
+		$this->registered_block_styles[ $block_name ][ $block_style_name ] = $style_properties;
+
+		return true;
+	}
+
+	/**
+	 * Unregisters a block style.
+	 *
+	 * @param string $block_name       Block type name including namespace.
+	 * @param array  $block_style_name Block style name.
+	 *
+	 * @return boolean True if the block style was unregistered with success and false otherwise.
+	 */
+	public function unregister( $block_name, $block_style_name ) {
+		if ( ! $this->is_registered( $block_name, $block_style_name ) ) {
+			/* translators: 1: block name, 2: block style name */
+			$message = sprintf( __( 'Block "%1$s" does not contain a style named "%2$s.".', 'gutenberg' ), $block_name, $block_style_name );
+			_doing_it_wrong( __METHOD__, $message, '6.2.0' );
+			return false;
+		}
+
+		unset( $this->registered_block_styles[ $block_name ][ $block_style_name ] );
+
+		return true;
+	}
+
+	/**
+	 * Retrieves an array containing the properties of a registered block style.
+	 *
+	 * @since 6.2.0
+	 *
+	 * @param string $block_name       Block type name including namespace.
+	 * @param array  $block_style_name Block style name.
+	 *
+	 * @return array Registered block style properties.
+	 */
+	public function get_registered( $block_name, $block_style_name ) {
+		if ( ! $this->is_registered( $block_name, $block_style_name ) ) {
+			return null;
+		}
+
+		return $this->registered_block_styles[ $block_name ][ $block_style_name ];
+	}
+
+	/**
+	 * Retrieves all registered block styles.
+	 *
+	 * @since 6.2.0
+	 *
+	 * @return array Array of arrays containing the registered block styles properties grouped per block, and per style.
+	 */
+	public function get_all_registered() {
+		return $this->registered_block_styles;
+	}
+
+	/**
+	 * Retrieves registered block styles for a specific block.
+	 *
+	 * @since 6.2.0
+	 *
+	 * @param string $block_name Block type name including namespace.
+	 *
+	 * @return array Array whose keys are block style names and whose value are block style properties.
+	 */
+	public function get_registered_styles_for_block( $block_name ) {
+		if ( isset( $this->registered_block_styles[ $block_name ] ) ) {
+			return $this->registered_block_styles[ $block_name ];
+		}
+		return array();
+	}
+
+	/**
+	 * Checks if a block style is registered.
+	 *
+	 * @since 6.2.0
+	 *
+	 * @param string $block_name       Block type name including namespace.
+	 * @param array  $block_style_name Block style name.
+	 *
+	 * @return bool True if the block style is registered, false otherwise.
+	 */
+	public function is_registered( $block_name, $block_style_name ) {
+		return isset( $this->registered_block_styles[ $block_name ][ $block_style_name ] );
+	}
+
+	/**
+	 * Utility method to retrieve the main instance of the class.
+	 *
+	 * The instance will be created if it does not exist yet.
+	 *
+	 * @since 6.2.0
+	 *
+	 * @return WP_Block_Styles_Registry The main instance.
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+}

--- a/lib/load.php
+++ b/lib/load.php
@@ -29,6 +29,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 }
 
 require dirname( __FILE__ ) . '/compat.php';
+require dirname( __FILE__ ) . '/class-wp-block-styles-registry.php';
 require dirname( __FILE__ ) . '/blocks.php';
 require dirname( __FILE__ ) . '/client-assets.php';
 require dirname( __FILE__ ) . '/demo.php';


### PR DESCRIPTION
## Description
Part of: https://github.com/WordPress/gutenberg/issues/7551

This PR adds a simple mechanism for theme and plugin developers to register block styles using only PHP function calls to abstract the existing JavaScript mechanism.

## How has this been tested?
I added the following code to the functions.php file of the active theme:
```
add_action(
	'enqueue_block_assets',
	function() {
		wp_register_style( 'myguten-style', get_template_directory_uri() . '/custom-style.css' );
	}
);

register_block_style(
	'core/quote',
	array(
		'name'         => 'fancy-quote',
		'label'        => 'Fancy Quote',
		'style_handle' => 'myguten-style',
	)
);

register_block_style(
	'core/quote',
	array(
		'name'         => 'not-fancy-quote',
		'label'        => 'Not Fancy Quote',
		'inline_style' => '.wp-block-quote.is-style-not-fancy-quote { color: blue; }',
	)
);

register_block_style(
	'core/quote',
	array(
		'name'         => 'unregistered-fancy-quote',
		'label'        => 'Unregistered Fancy Quote',
		'inline_style' => '.wp-block-quote.is-style-unregistered-fancy-quote { color: orange; }',
	)
);
unregister_block_style( 'core/quote', 'unregistered-fancy-quote' );
```

I created a custom-style.css file in the theme directory with the following contents:
```
.wp-block-quote.is-style-fancy-quote {
	color: tomato;
}
```

I loaded the block editor; I verified quote block has Fancy Quote and Not Fancy Quote, and both styles are correctly applied to the editor and the frontend.