### PR TITLE
Block Editor: Reimplement BlockEditorProvider using hooks

### DIFF
--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -1,139 +1,88 @@
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
-import { withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { useEffect, useRef } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import withRegistryProvider from './with-registry-provider';
 
-class BlockEditorProvider extends Component {
-	componentDidMount() {
-		this.props.updateSettings( this.props.settings );
-		this.props.resetBlocks( this.props.value );
-		this.attachChangeObserver( this.props.registry );
-	}
+function BlockEditorProvider( {
+	settings,
+	value,
+	children,
+	onChange = () => {},
+	onInput = () => {},
+} ) {
+	const { updateSettings, resetBlocks } = useDispatch( 'core/block-editor' );
 
-	componentDidUpdate( prevProps ) {
-		const {
-			settings,
-			updateSettings,
-			value,
-			resetBlocks,
-			registry,
-		} = this.props;
+	useEffect( () => {
+		updateSettings( settings );
+	}, [ settings ] );
 
-		if ( settings !== prevProps.settings ) {
-			updateSettings( settings );
-		}
-
-		if ( registry !== prevProps.registry ) {
-			this.attachChangeObserver( registry );
-		}
-
-		if ( this.isSyncingOutcomingValue ) {
-			this.isSyncingOutcomingValue = false;
-		} else if ( value !== prevProps.value ) {
-			this.isSyncingIncomingValue = true;
-			resetBlocks( value );
-		}
-	}
-
-	componentWillUnmount() {
-		if ( this.unsubscribe ) {
-			this.unsubscribe();
-		}
-	}
-
-	/**
-	 * Given a registry object, overrides the default dispatch behavior for the
-	 * `core/block-editor` store to interpret a state change and decide whether
-	 * we should call `onChange` or `onInput` depending on whether the change
-	 * is persistent or not.
-	 *
-	 * This needs to be done synchronously after state changes (instead of using
-	 * `componentDidUpdate`) in order to avoid batching these changes.
-	 *
-	 * @param {WPDataRegistry} registry     Registry from which block editor
-	 *                                      dispatch is to be overriden.
-	 */
-	attachChangeObserver( registry ) {
-		if ( this.unsubscribe ) {
-			this.unsubscribe();
-		}
-
+	const { blocks, isPersistent, isIgnored } = useSelect( ( select ) => {
 		const {
 			getBlocks,
 			isLastBlockChangePersistent,
 			__unstableIsLastBlockChangeIgnored,
-		} = registry.select( 'core/block-editor' );
-
-		let blocks = getBlocks();
-		let isPersistent = isLastBlockChangePersistent();
-
-		this.unsubscribe = registry.subscribe( () => {
-			const {
-				onChange,
-				onInput,
-			} = this.props;
-			const newBlocks = getBlocks();
-			const newIsPersistent = isLastBlockChangePersistent();
-			if (
-				newBlocks !== blocks && (
-					this.isSyncingIncomingValue ||
-					__unstableIsLastBlockChangeIgnored()
-				)
-			) {
-				this.isSyncingIncomingValue = false;
-				blocks = newBlocks;
-				isPersistent = newIsPersistent;
-				return;
-			}
-
-			if (
-				newBlocks !== blocks ||
-				// This happens when a previous input is explicitely marked as persistent.
-				( newIsPersistent && ! isPersistent )
-			) {
-				// When knowing the blocks value is changing, assign instance
-				// value to skip reset in subsequent `componentDidUpdate`.
-				if ( newBlocks !== blocks ) {
-					this.isSyncingOutcomingValue = true;
-				}
-
-				blocks = newBlocks;
-				isPersistent = newIsPersistent;
-
-				if ( isPersistent ) {
-					onChange( blocks );
-				} else {
-					onInput( blocks );
-				}
-			}
-		} );
-	}
-
-	render() {
-		const { children } = this.props;
-
-		return children;
-	}
-}
-
-export default compose( [
-	withRegistryProvider,
-	withDispatch( ( dispatch ) => {
-		const {
-			updateSettings,
-			resetBlocks,
-		} = dispatch( 'core/block-editor' );
+		} = select( 'core/block-editor' );
 
 		return {
-			updateSettings,
-			resetBlocks,
+			blocks: getBlocks(),
+			isPersistent: isLastBlockChangePersistent(),
+			isIgnored: __unstableIsLastBlockChangeIgnored(),
 		};
-	} ),
-] )( BlockEditorProvider );
+	} );
+
+	const previousBlocks = useRef( blocks );
+	const previousIsPersistent = useRef( isPersistent );
+	const isSyncingIncomingValue = useRef( false );
+	const isSyncingOutgoingValue = useRef( false );
+
+	useEffect( () => {
+		if (
+			blocks !== previousBlocks.current && (
+				isSyncingIncomingValue.current ||
+				isIgnored
+			)
+		) {
+			isSyncingIncomingValue.current = false;
+			previousBlocks.current = blocks;
+			previousIsPersistent.current = isPersistent;
+		} else if (
+			blocks !== previousBlocks.current ||
+			// This happens when a previous input is explicitely marked as persistent.
+			( isPersistent && ! previousIsPersistent.current )
+		) {
+			// When knowing the blocks value is changing, assign instance
+			// value to skip reset in subsequent `componentDidUpdate`.
+			if ( blocks !== previousBlocks.current ) {
+				isSyncingOutgoingValue.current = true;
+			}
+
+			previousBlocks.current = blocks;
+			previousIsPersistent.current = isPersistent;
+
+			if ( isPersistent ) {
+				onChange( blocks );
+			} else {
+				onInput( blocks );
+			}
+		}
+	}, [ blocks, isPersistent ] );
+
+	useEffect( () => {
+		if ( isSyncingOutgoingValue.current ) {
+			isSyncingOutgoingValue.current = false;
+		} else {
+			isSyncingIncomingValue.current = true;
+			resetBlocks( value );
+		}
+	}, [ value ] );
+
+	return children;
+}
+
+export default withRegistryProvider( BlockEditorProvider );

--- a/packages/block-editor/src/components/provider/with-registry-provider.js
+++ b/packages/block-editor/src/components/provider/with-registry-provider.js
@@ -14,7 +14,7 @@ import applyMiddlewares from '../../store/middlewares';
 const withRegistryProvider = createHigherOrderComponent( ( WrappedComponent ) => {
 	return withRegistry( ( { useSubRegistry = true, registry, ...props } ) => {
 		if ( ! useSubRegistry ) {
-			return <WrappedComponent registry={ registry } { ...props } />;
+			return <WrappedComponent { ...props } />;
 		}
 
 		const [ subRegistry, setSubRegistry ] = useState( null );
@@ -32,7 +32,7 @@ const withRegistryProvider = createHigherOrderComponent( ( WrappedComponent ) =>
 
 		return (
 			<RegistryProvider value={ subRegistry }>
-				<WrappedComponent registry={ subRegistry } { ...props } />
+				<WrappedComponent { ...props } />
 			</RegistryProvider>
 		);
 	} );


### PR DESCRIPTION
This pull request seeks to refactor the `BlockEditorProvider` component to use React hooks in order to sync blocks value as effects leveraging existing data hooks for value subscriptions.

The hope with this change was to simplify the logic flow, but I'd also hoped for some performance optimization to come from this simplification. However, it doesn't appear to have any benefit and in-fact has a minor negative impact (~106ms to 109ms average time to type via `npm run test-performance`). It's unclear to me why this would be the case. While I've not dug into it, I'm curious if `useSelect` is as performance-optimized as it can be in cases where a component renders for reasons other than state changes (i.e. does it call the mapping selector even though state hasn't changed?).

If the performance degradation cannot be resolved, I'm not sure whether it's worth moving forward with these changes.

If we do move forward with these changes, I think we could explore further flattening to reimplement the internal `withRegistryProvider` higher-order component as a hook.

**Testing Instructions:**

Verify there are no regressions in standard usage (particularly via blocks updates, reusable blocks, etc).