### PR TITLE
fix(shortcode): replace function should handle empty string callback return

### DIFF
--- a/packages/shortcode/src/index.js
+++ b/packages/shortcode/src/index.js
@@ -104,7 +104,7 @@ export function replace( tag, text, callback ) {
 
 			// Make sure to return any of the extra brackets if they weren't used to
 			// escape the shortcode.
-			return result ? left + result + right : match;
+			return result || result === '' ? left + result + right : match;
 		}
 	);
 }

--- a/packages/shortcode/src/test/index.js
+++ b/packages/shortcode/src/test/index.js
@@ -219,6 +219,30 @@ describe( 'shortcode', () => {
 			);
 			expect( result2 ).toBe( 'this has the [foo] shortcode' );
 		} );
+
+		it( 'should replace shortcode with a number', () => {
+			const result1 = replace( 'foo', 'hello [foo] world', () => 3 );
+			expect( result1 ).toBe( 'hello 3 world' );
+
+			const result2 = replace(
+				'foo',
+				'hello [foo bar=bar baz="baz" qux]delete me[/foo] world',
+				() => 4
+			);
+			expect( result2 ).toBe( 'hello 4 world' );
+		} );
+
+		it( 'should replace shortcode with an empty string', () => {
+			const result1 = replace( 'foo', 'hello [foo] world', () => '' );
+			expect( result1 ).toBe( 'hello  world' );
+
+			const result2 = replace(
+				'foo',
+				'hello [foo bar=bar baz="baz" qux]delete me[/foo] world',
+				() => ''
+			);
+			expect( result2 ).toBe( 'hello  world' );
+		} );
 	} );
 
 	describe( 'attrs', () => {


### PR DESCRIPTION
## Description

Currently, the `replace` function will not handle a callback that returns an empty string. This PR simply allows for that.

## How has this been tested?

Updated unit tests. All pass.

## Screenshots <!-- if applicable -->

N/A

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

(depending on the interpreter) either Bug fix or Feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->