### PR TITLE
Allow inner block template options to wrap

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/style.scss
+++ b/packages/block-editor/src/components/inner-blocks/style.scss
@@ -39,18 +39,26 @@
 
 .block-editor-inner-blocks__template-picker-options.block-editor-inner-blocks__template-picker-options {
 	display: flex;
+	justify-content: center;
 	flex-direction: row;
-	flex-wrap: nowrap;
+	flex-wrap: wrap;
 	width: 100%;
-	margin: $grid-size-large 0;
+	margin: $grid-size-small 0;
 	list-style: none;
 
 	> li {
 		list-style: none;
-		flex-basis: 100%;
+		margin: $grid-size;
 		flex-shrink: 1;
-		margin: 0 $grid-size;
 		max-width: 100px;
+	}
+
+	.block-editor-inner-blocks__template-picker-option {
+		padding: $grid-size;
+	}
+
+	@include break-medium() {
+		flex-wrap: nowrap;
 	}
 }
 

--- a/packages/block-editor/src/components/inner-blocks/style.scss
+++ b/packages/block-editor/src/components/inner-blocks/style.scss
@@ -56,10 +56,6 @@
 	.block-editor-inner-blocks__template-picker-option {
 		padding: $grid-size;
 	}
-
-	@include break-medium() {
-		flex-wrap: nowrap;
-	}
 }
 
 .block-editor-inner-blocks__template-picker-option {


### PR DESCRIPTION
As noted in https://github.com/WordPress/gutenberg/pull/16255#discussion_r298853423, it appears that the InnerBlocks template options buttons get cut off on mobile, or at high levels of zoom. This PR allows template options to wrap, which fixes the mobile/zoom issue, and also allows for more flexibility in the number of template options presented. 

## Before Screenshots

![columns-responsive-before](https://user-images.githubusercontent.com/1202812/60441679-83a5ad80-9be5-11e9-81e4-5035920f9960.gif)

_Example with 10 items:_ 

<img width="731" alt="Screen Shot 2019-07-01 at 9 55 02 AM" src="https://user-images.githubusercontent.com/1202812/60442110-59082480-9be6-11e9-9baa-628e4ebb61ba.png">


## After Screenshots

![columns-responsive](https://user-images.githubusercontent.com/1202812/60441685-86080780-9be5-11e9-80c8-e4142f66b140.gif)

_Example with 10 items:_ 

<img width="620" alt="Screen Shot 2019-07-01 at 9 53 37 AM" src="https://user-images.githubusercontent.com/1202812/60442123-61605f80-9be6-11e9-83b3-d25372f72d7a.png">
