### PR TITLE
Interpolate Component Experiment #1

### DIFF
--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -138,6 +138,39 @@ _Returns_
 
 -   `WPElement`: Element.
 
+<a name="createInterpolateElement" href="#createInterpolateElement">#</a> **createInterpolateElement**
+
+This function creates an interpolated element from a passed in string with
+specific tags matching how the string should be converted to an element via
+the conversion map value.
+
+_Usage_
+
+For example, for the given string:
+
+"This is a \<span%1>string\</span%1> with \<a%1>a link\</a%1>, a self-closing
+%1$s tag and a plain value %2$s"
+
+You would have something like this as the conversionMap value:
+
+```js
+[
+    [ 'span%1', { tag: CustomComponent, props: {}, hasChildren: true } ],
+    [ 'a%1', { tag: 'a', props: { href: 'https://github.com' }, hasChildren: true } ],
+    [ '%1$s', { tag: CustomComponentB, props: {}, hasChildren: false } ],
+    [ '%2$s', { value: 'custom value' } ]
+]
+```
+
+_Parameters_
+
+-   _interpolatedString_ `string`: The interpolation string to be parsed.
+-   _conversionMap_ `Array<Array>`: The map used to convert the string to a react element.
+
+_Returns_
+
+-   `Element`: A react element.
+
 <a name="createPortal" href="#createPortal">#</a> **createPortal**
 
 Creates a portal into which a component can be rendered.
@@ -188,6 +221,31 @@ _Returns_
 <a name="Fragment" href="#Fragment">#</a> **Fragment**
 
 A component which renders its children without any wrapping element.
+
+<a name="Interpolate" href="#Interpolate">#</a> **Interpolate**
+
+A component that allows for easier interpolation of values.
+
+This is useful for dynamic type string-like elements with embedded components
+and values.
+
+_Usage_
+
+```js
+const MyComponent = ( { url } ) => {
+  return <Interpolate foo={ 'bar' } >
+      This is a string with a <a href={ url }>linked <em>item</em></a> and a custom value: %%foo%%
+  </Interpolate>;
+}
+```
+
+_Parameters_
+
+-   _props_ `Object`: 
+
+_Returns_
+
+-   `WPElement`: An element.
 
 <a name="isEmptyElement" href="#isEmptyElement">#</a> **isEmptyElement**
 

--- a/packages/element/src/components/index.js
+++ b/packages/element/src/components/index.js
@@ -1,0 +1,1 @@
+export * from './interpolate';

--- a/packages/element/src/components/interpolate/index.js
+++ b/packages/element/src/components/interpolate/index.js
@@ -1,0 +1,2 @@
+export { default as Interpolate } from './interpolate';
+export { createInterpolateElement } from './utils';

--- a/packages/element/src/components/interpolate/interpolate.js
+++ b/packages/element/src/components/interpolate/interpolate.js
@@ -1,0 +1,37 @@
+/**
+ * Internal dependencies
+ */
+import {
+	createInterpolateString,
+	createInterpolateElement,
+	getInterpolateMap,
+} from './utils';
+
+/**
+ * A component that allows for easier interpolation of values.
+ *
+ * This is useful for dynamic type string-like elements with embedded components
+ * and values.
+ *
+ * @example
+ *
+ * ```js
+ * const MyComponent = ( { url } ) => {
+ *   return <Interpolate foo={ 'bar' } >
+ *       This is a string with a <a href={ url }>linked <em>item</em></a> and a custom value: %%foo%%
+ *   </Interpolate>;
+ * }
+ * ```
+ *
+ * @param {Object} props
+ * @return {WPElement} An element.
+ * @constructor
+ */
+const Interpolate = ( props ) => {
+	return createInterpolateElement(
+		createInterpolateString( props.children, props ),
+		getInterpolateMap(),
+	);
+};
+
+export default Interpolate;

--- a/packages/element/src/components/interpolate/test/__snapshots__/interpolate.js.snap
+++ b/packages/element/src/components/interpolate/test/__snapshots__/interpolate.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Interpolate renders expected result from component 1`] = `
+Array [
+  "This is an awesome cheeseburger ",
+  "and fries",
+  "! Go ",
+  <a
+    href="https://example.org"
+  >
+    here
+  </a>,
+  " to eat at the ",
+  "bar",
+  ".",
+]
+`;

--- a/packages/element/src/components/interpolate/test/interpolate.js
+++ b/packages/element/src/components/interpolate/test/interpolate.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import TestRenderer from 'react-test-renderer';
+
+/**
+ * Internal dependencies
+ */
+import Interpolate from '../interpolate';
+
+describe( 'Interpolate', () => {
+	it( 'renders expected result from component', () => {
+		const TestComponent = () => {
+			const image = <img alt={ 'An test' } src={ '/file' } />;
+			const url = 'https://example.org';
+			return <Interpolate
+				extra={ 'and fries' }
+				foo={ 'bar' }
+				image={ image }
+			>
+				This is an awesome cheeseburger %%extra%%! Go <a href={ url }>here</a> to eat at the %%foo%%.
+			</Interpolate>;
+		};
+		const tree = TestRenderer
+			.create( <TestComponent /> )
+			.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
+} );

--- a/packages/element/src/components/interpolate/utils/create-interpolate-element.js
+++ b/packages/element/src/components/interpolate/utils/create-interpolate-element.js
@@ -1,0 +1,190 @@
+/**
+ * Internal dependencies
+ */
+import { getTagsFromSearchString } from './tag-tokens';
+import { getTokenCount, resetTokenCount } from './token-count';
+import { createElement, Fragment, isValidElement } from '../../../react';
+
+/**
+ * External dependencies
+ */
+import { escapeRegExp } from 'lodash';
+
+const getHasPropValue = ( config ) => !! config.value;
+const getHasChildren = ( config ) => !! config.hasChildren;
+
+/**
+ * Generates and returns the regular expression for the given arguments.
+ *
+ * @param {string}  searchString  The search string serving as the base for the
+ *                                expression.
+ * @param {boolean} hasChildren   Whether the interpolation item has children.
+ * @param {boolean} hasPropValue  Whether the interpolation item represents a
+ *                                prop value.
+ *
+ * @return {RegExp}  The generated regular expression.
+ */
+const getRegEx = ( searchString, hasChildren, hasPropValue ) => {
+	let pattern;
+	const [ openTag, closeTag, selfClosingTag ] = getTagsFromSearchString( searchString );
+	if ( hasChildren ) {
+		pattern = escapeRegExp( openTag ) + '(.*)' + escapeRegExp( closeTag );
+	} else if ( hasPropValue ) {
+		pattern = escapeRegExp( searchString );
+	} else {
+		pattern = escapeRegExp( selfClosingTag );
+	}
+	return new RegExp( pattern );
+};
+
+/**
+ * Generates and returns the regular expression used for splitting a string
+ *
+ * @param {string} searchString  The search string serving as the base for the
+ *                               expression.
+ *
+ * @return {RegExp}  The generated regular expression
+ */
+const getSplitRegEx = ( searchString ) => new RegExp( '(' + escapeRegExp( searchString ) + ')' );
+
+/**
+ * Generates a String.prototype.match value for the incoming arguments.
+ *
+ * @param {string} interpolatedString  The string the match is performed on.
+ * @param {string} searchString				 The string used as the base for the
+ *                                     search
+ * @param {Object} conversionConfig    The configuration object for the
+ *                                     interpolation being performed.
+ *
+ * @return {Array|null}	An array if there is a match or null if not.
+ */
+const getMatchFromString = (
+	interpolatedString,
+	searchString,
+	conversionConfig
+) => {
+	const regEx = getRegEx(
+		searchString,
+		getHasChildren( conversionConfig ),
+		getHasPropValue( conversionConfig )
+	);
+	return interpolatedString.match( regEx );
+};
+
+/**
+ * Used to recursively create elements from the interpolation string using the
+ * conversion map.
+ *
+ * @param {string} potentialElement  The interpolation string (or fragment)
+ *                                   being processed.
+ * @param {Array[]}conversionMap     The interpolation map used for converting
+ *                                   the string to a react element.
+ *
+ * @return {Element|string|Array}  A react element, string or array.
+ */
+const recursiveCreateElement = ( potentialElement, conversionMap ) => {
+	/**
+	 * If the conversion map is not a valid array or empty then just return the
+	 * element.
+	 */
+	if ( ! Array.isArray( conversionMap ) || ! conversionMap.length ) {
+		return potentialElement;
+	}
+	const [ mapItem ] = conversionMap.slice( 0, 1 );
+	const [ searchString, conversionConfig ] = mapItem;
+	let keyIndex;
+
+	/**
+	 * This short circuits the process if the conversion map has an invalid config.
+	 */
+	if ( ! searchString || ! conversionConfig ) {
+		return potentialElement;
+	}
+
+	const match = getMatchFromString(
+		potentialElement,
+		searchString,
+		conversionConfig
+	);
+
+	// if there is no match for this string, then that means it is not an element
+	// so just return as is to be used as a direct child.
+	if ( match === null ) {
+		return potentialElement;
+	}
+
+	// if the full match returned equals the potential element, then we know
+	// we can create the element and restart the conversion on any children if
+	// necessary.
+	if ( match[ 0 ] === potentialElement ) {
+		// remove this item from the conversion map because it's no longer needed.
+		conversionMap.shift();
+
+		if ( getHasPropValue( conversionConfig ) ) {
+			// if value is a react element, then need to wrap in Fragment with a key
+			// to prevent key warnings.
+			if ( isValidElement( conversionConfig.value ) ) {
+				keyIndex = getTokenCount( 'key' );
+				return <Fragment key={ keyIndex }>{ conversionConfig.value }</Fragment>;
+			}
+			return conversionConfig.value;
+		}
+		keyIndex = getTokenCount( 'key' );
+		return getHasChildren( conversionConfig ) ?
+			createElement(
+				conversionConfig.tag,
+				{ ...conversionConfig.props, key: keyIndex },
+				recursiveCreateElement( match[ 1 ], conversionMap )
+			) :
+			createElement(
+				conversionConfig.tag,
+				{ ...conversionConfig.props, key: keyIndex }
+			);
+	}
+
+	// still here, so we need to split on the full match and loop through each
+	return potentialElement.split( getSplitRegEx( match[ 0 ] ) )
+		.filter( ( value ) => !! value )
+		.flatMap( ( element ) => {
+			return recursiveCreateElement( element, conversionMap );
+		} );
+};
+
+/**
+ * This function creates an interpolated element from a passed in string with
+ * specific tags matching how the string should be converted to an element via
+ * the conversion map value.
+ *
+ * @example
+ * For example, for the given string:
+ *
+ * "This is a <span%1>string</span%1> with <a%1>a link</a%1>, a self-closing
+ * %1$s tag and a plain value %2$s"
+ *
+ * You would have something like this as the conversionMap value:
+ *
+ * ```js
+ * [
+ *     [ 'span%1', { tag: CustomComponent, props: {}, hasChildren: true } ],
+ *     [ 'a%1', { tag: 'a', props: { href: 'https://github.com' }, hasChildren: true } ],
+ *     [ '%1$s', { tag: CustomComponentB, props: {}, hasChildren: false } ],
+ *     [ '%2$s', { value: 'custom value' } ]
+ * ]
+ * ```
+ *
+ * @param {string}  interpolatedString  The interpolation string to be parsed.
+ * @param {Array[]} conversionMap       The map used to convert the string to
+ *                                      a react element.
+ *
+ * @return {Element}  A react element.
+ */
+const createInterpolateElement = ( interpolatedString, conversionMap ) => {
+	resetTokenCount();
+	return createElement(
+		Fragment,
+		{},
+		recursiveCreateElement( interpolatedString, conversionMap )
+	);
+};
+
+export default createInterpolateElement;

--- a/packages/element/src/components/interpolate/utils/create-interpolate-string.js
+++ b/packages/element/src/components/interpolate/utils/create-interpolate-string.js
@@ -1,0 +1,244 @@
+/**
+ * Internal dependencies
+ */
+import { isValidElement, Fragment } from '../../../react';
+import { getTags, getFormatToken } from './tag-tokens';
+import { resetTokenCount } from './token-count';
+import {
+	addPropValueToInterpolateMap,
+	resetInterpolateMap,
+	addElementToInterpolateMap,
+} from './interpolate-map';
+
+const VARIABLE_PROPS_PATTERN = /%%(.*)%%/;
+
+/**
+ * Returns whether the provided node value has children.
+ *
+ * @param {Object} node
+ *
+ * @return {boolean}  If true, then the provided value has children.
+ */
+const hasChildren = ( node ) => {
+	if ( ! node ) {
+		return false;
+	}
+	return node &&
+		( !! node.children || !! ( node.props && node.props.children ) );
+};
+
+/**
+ * Function converting the provided element to a string.
+ *
+ * @param {*}      element
+ * @param {Object} mainProps  The main props from the the wrapping component
+ *
+ * @todo Might need to implement handling for non-supported element types.
+ *
+ * @return {string} The element represented as a string.
+ */
+const convertElementToString = ( element, mainProps = {} ) => {
+	if ( Array.isArray( element ) ) {
+		return convertChildrenToString( element, mainProps );
+	}
+
+	switch ( typeof element ) {
+		case 'string':
+			return convertStringElement( element, mainProps );
+		case 'number':
+			return element.toString();
+	}
+
+	if ( ! isValidElement( element ) ) {
+		return '';
+	}
+
+	const { type, props } = element;
+
+	// if Fragment, then do children
+	if ( type === Fragment ) {
+		return convertChildrenToString( props.children, mainProps );
+	}
+
+	switch ( typeof type ) {
+		// native element
+		case 'string':
+			return convertNativeComponentToString( type, props, mainProps );
+		case 'function':
+			// custom element which will not get drilled down into.
+			return convertCustomComponentToString( type, props, mainProps );
+	}
+};
+
+/**
+ * Receives "children" and processes to convert to a string.
+ *
+ * @param {*}      children  Children may be an array or a string.
+ * @param {Object} mainProps The props object passed through from the main
+ *                           component wrapper.
+ * @return {string} The final rendered string.
+ */
+const convertChildrenToString = ( children, mainProps ) => {
+	let result = '';
+
+	if ( ! Array.isArray( children ) ) {
+		result += convertElementToString( children, mainProps );
+		return result;
+	}
+
+	for ( let i = 0; i < children.length; i++ ) {
+		const child = children[ i ];
+		result += convertElementToString( child, mainProps );
+	}
+
+	return result;
+};
+
+/**
+ * Converts an element that is a string.
+ *
+ * This handles processing potential embedded special prop value tags (%%tag%%)
+ * in the string
+ *
+ * @param {string}  element
+ * @param {Object}  mainProps  The props object passed through from the main
+ *                             component wrapper.
+ * @return {string} The final string value.
+ */
+const convertStringElement = ( element, mainProps ) => {
+	// replace any dynamic values %%something%% with a sprintf style placeholder
+	const splitString = element.split( new RegExp( '(%%.*%%)' ) );
+	if ( splitString.length === 1 ) {
+		return element;
+	}
+	return convertElementToString(
+		splitString.flatMap( ( value ) => {
+			const match = value.match( VARIABLE_PROPS_PATTERN );
+			if ( Array.isArray( match ) ) {
+				if ( match.length > 1 && typeof match[ 1 ] !== 'undefined' ) {
+					value = getFormatToken( 'sprintf' );
+					if ( typeof mainProps[ match[ 1 ] ] === 'undefined' ) {
+						//@todo throw invariant warning here instead and just return the token
+						throw new Error( 'main props does not have a value for the token' );
+					}
+					addPropValueToInterpolateMap( value, mainProps[ match[ 1 ] ] );
+				}
+			}
+			return value;
+		} ),
+		mainProps
+	);
+};
+
+/**
+ * Converts an element that is a custom component to a string representation
+ *
+ * A common use-case will be to create interpolation strings for translators.
+ * Since translators might not realize a custom component should not be
+ * translated, this uses variants of the `<span>` tag as placeholders as those
+ * will be more universally recognized as html content that should not be
+ * touched.
+ *
+ * @param {WPElement} type       The custom type to be converted.
+ * @param {Object}    props      The props on the component being converted.
+ * @param {Object}    mainProps  The props object passed through from the main
+ *                               component wrapper
+ *
+ * @return {string}  The final string value
+ */
+const convertCustomComponentToString = ( type, props, mainProps ) => {
+	const withChildren = hasChildren( props );
+	if ( withChildren ) {
+		const [ searchString, openTag, closeTag ] = getTags( 'span' );
+		addElementToInterpolateMap(
+			searchString,
+			type,
+			{ ...props, children: '' },
+			withChildren
+		);
+		return openTag + convertElementToString( props.children, mainProps ) + closeTag;
+	}
+
+	// self closing tag so let's just use a sprintf format token for this component
+	const token = getFormatToken();
+	addElementToInterpolateMap(
+		token,
+		type,
+		props,
+		false,
+	);
+	return token;
+};
+
+/**
+ * Converts a native html element to a string representation.
+ *
+ * @param {string} type
+ * @param {Object} props
+ * @param {Object} mainProps  The props object passed through from the main
+ *                            component wrapper
+ *
+ * @return {string} The final string value
+ */
+const convertNativeComponentToString = ( type, props, mainProps ) => {
+	const withChildren = hasChildren( props );
+	const [ searchString, openTag, closeTag, selfClosingTag ] = getTags( type );
+	addElementToInterpolateMap(
+		searchString,
+		type,
+		{ ...props, children: '' },
+		withChildren
+	);
+	return withChildren ?
+		openTag + convertElementToString( props.children, mainProps ) + closeTag :
+		selfClosingTag;
+};
+
+/**
+ * Receives an element and converts it to a string representation for interpolate
+ * logic.
+ *
+ * This is a companion to `createInterpolateElement`. The string prepped here
+ * along with the map generated during the conversion and exposed on
+ * `getInterpolateMap` can be fed to `createInterpolateElement` to create the
+ * React Element.
+ *
+ * The following conversions are performed as a part of the process:
+ *
+ * - Native elements (<a>, <p>, <strong> etc) are represented in the string
+ *   tokenized by the count in the string.
+ * - Custom components are represented in the string by a tokenized `<span>`
+ *   element. Self closing components are represented by a sprintf type format
+ *   token.
+ * - `%%tag%%` type strings are converted to sprintf type format tokens but the
+ *   `tag` must be a prop key on main props passed in to this function.  So for
+ *   example, if the token was `%%special%%` then it's expected that
+ *   `mainProps.special` would exist.  This allows for substituting dynamic
+ *   values at runtime.
+ *
+ * @example
+ *
+ * The following JSX expression:
+ *
+ * This is a string with a special value: %%special%%. There is also a
+ * <a href={ url }>link with <em>emphasis</em></a>. Finally, <a href={ url2 }>
+ * another link with a <CustomComponent>custom component</CustomComponent></a>
+ *
+ * Would be converted to:
+ *
+ * 'This is a string with a special value: %1$s. There is also a <a%1>link
+ * with <em%1>emphasis</em%1></a%1>. Finally, <a%2>another link with a
+ * <span%1>custom component</span%1></a%2>'
+ *
+ * @param {WPElement} element   The element to convert.
+ * @param {Object}    mainProps The main props from the wrapping component.
+ *
+ * @return {string}   The converted string
+ */
+const createInterpolateString = ( element, mainProps ) => {
+	resetTokenCount();
+	resetInterpolateMap();
+	return convertElementToString( element, mainProps );
+};
+
+export default createInterpolateString;

--- a/packages/element/src/components/interpolate/utils/index.js
+++ b/packages/element/src/components/interpolate/utils/index.js
@@ -1,0 +1,5 @@
+export { default as createInterpolateString } from './create-interpolate-string';
+export { default as createInterpolateElement } from './create-interpolate-element';
+export * from './interpolate-map';
+export * from './tag-tokens';
+export * from './token-count';

--- a/packages/element/src/components/interpolate/utils/interpolate-map.js
+++ b/packages/element/src/components/interpolate/utils/interpolate-map.js
@@ -1,0 +1,89 @@
+/**
+ * An ordered array that describes the replacements that should be made on a
+ * translated string.
+ *
+ * Example, given a string with:
+ *
+ * 'This is a <strong%1>string</strong%1> with
+ * <a%1><em%1>emphasized</em%1>link</a%1> and a <span%1>custom
+ * component</span%1> along with a custom value of %1$d'
+ *
+ * The translation replace map for the above might be something like this.
+ *
+ * ```js
+ * const interpolationMap = [
+ * 	[ 'strong%1', { tag: 'strong', props: {}, hasChildren: true } ],
+ * 	[ 'a%1', { tag: 'a', props: {}, hasChildren: true } ],
+ * 	[ 'em%1', { tag: 'em', props: {}, hasChildren: false } ],
+ * 	[ 'span%1', { tag: CustomComponent, props: {} hasChildren: true } ],
+ * 	[ '%1$d', { value: 10 } ]
+ * ]
+ * ```
+ *
+ * @type {Array}  An ordered map of values describing the interpolation.
+ */
+let interpolateMap = [];
+
+/**
+ * Adds a prop value to the interpolate map.
+ *
+ * Prop value is a value that is replaced on a sprintf like token; `%1$s`.
+ *
+ * @param {string} searchString  The search string for what will be replaced by
+ *                               the value.
+ * @param {*}      value
+ */
+const addPropValueToInterpolateMap = ( searchString, value ) => {
+	interpolateMap.push( [
+		searchString,
+		{ value },
+	] );
+};
+
+/**
+ * Returns the current interpolate map.
+ *
+ * @return {Array}  The current interpolate map
+ */
+const getInterpolateMap = () => interpolateMap;
+
+/**
+ * Resets the current interpolate map.
+ */
+const resetInterpolateMap = () => {
+	interpolateMap = [];
+};
+
+/**
+ * Adds element related values to the interpolate map.
+ *
+ * These are used to construct a react element when replacing what is
+ * represented as the search string in the interpolation string.
+ *
+ * @param {string}           searchString  The token part used for generating
+ *                                         the search regex.
+ * @param {string|Component} tag           Either the native tag or a react
+ *                                         component.
+ * @param {Object}           props         The props to pass to the generated
+ *                                         component.
+ * @param {boolean}          hasChildren   Whether this component has children
+ *                                         (which will be parsed from the
+ *                                         interpolation string)
+ */
+const addElementToInterpolateMap = ( searchString, tag, props, hasChildren ) => {
+	interpolateMap.push( [
+		searchString,
+		{
+			tag,
+			props,
+			hasChildren,
+		},
+	] );
+};
+
+export {
+	addPropValueToInterpolateMap,
+	getInterpolateMap,
+	resetInterpolateMap,
+	addElementToInterpolateMap,
+};

--- a/packages/element/src/components/interpolate/utils/tag-tokens.js
+++ b/packages/element/src/components/interpolate/utils/tag-tokens.js
@@ -1,0 +1,71 @@
+/**
+ * Internal dependencies
+ */
+import { getTokenCount } from './token-count';
+
+/**
+ * Returns a sprintf like string token (eg %1$s) incrementing the numeral
+ * each time it's called.
+ *
+ * Note: to reset the count, you must call `resetTokenCount`.
+ *
+ * @return {string}  A sprintf like token.
+ */
+const getFormatToken = () => {
+	return '%' + getTokenCount( 'sprintf' ) + '$s';
+};
+
+/**
+ * Generates and returns tags to use for the provided type.
+ *
+ * - search string for the given tag type (i.e. `a%1`), with an incremented
+ *   numeral each time this is called.
+ * - open tag for the given tag type (eg. <a%1>)
+ * - close tag for the given tag type (eg. </a%1>)
+ * - self-closing tag for the given tag type (eg. <a%1/>)
+ *
+ * @param {string} type
+ * @return { string[] } A tuple-like construct. See description for returned values.
+ */
+const getTags = ( type ) => {
+	const searchString = type + '%' + getTokenCount( type );
+	return [
+		searchString,
+		...getTagsFromSearchString( searchString ),
+	];
+};
+
+/**
+ * The same as `getTags` except it receives the search string for generating the
+ * tags and thus does only returns the tags.
+ *
+ * @example
+ *
+ * If you provide `something` as the search string, this will return:
+ *
+ * ```js
+ * const tags = getTagsFromSearchString( 'something' );
+ * const tagsAre = tags === [
+ *     '<something>',
+ *     '</something>',
+ *     '<something/>',
+ * ];
+ * ```
+ *
+ * @param {string} searchString  Something like `<a%1>`.
+ *
+ * @return {string[]} The generated tags for the search string.
+ */
+const getTagsFromSearchString = ( searchString ) => {
+	return [
+		`<${ searchString }>`,
+		`</${ searchString }>`,
+		`<${ searchString }/>`,
+	];
+};
+
+export {
+	getFormatToken,
+	getTags,
+	getTagsFromSearchString,
+};

--- a/packages/element/src/components/interpolate/utils/test/create-interpolate-element.js
+++ b/packages/element/src/components/interpolate/utils/test/create-interpolate-element.js
@@ -1,0 +1,209 @@
+/**
+ * Internal dependencies
+ */
+import { createElement, Fragment } from '../../../../react';
+import createInterpolateElement from '../create-interpolate-element';
+
+describe( 'createInterpolateElement', () => {
+	it( 'returns same string when there is no conversion map', () => {
+		const testString = 'This is a string';
+		expect(
+			createInterpolateElement( testString, [] )
+		).toEqual( <Fragment>This is a string</Fragment> );
+	} );
+	it( 'returns same string when there are no tokens in the string', () => {
+		const testString = 'This is a string';
+		expect(
+			createInterpolateElement(
+				testString,
+				[ [ '%1$s', { value: 10 } ] ]
+			)
+		).toEqual( <Fragment>{ testString }</Fragment> );
+	} );
+	it( 'returns same string when there is an invalid conversion map', () => {
+		const testString = 'This is a %1$s string';
+		expect(
+			createInterpolateElement(
+				testString,
+				[ '%1$s', { value: 10 } ],
+			)
+		).toEqual( <Fragment>{ testString }</Fragment> );
+	} );
+	it( 'returns same string when there is an invalid token in the string', () => {
+		const testString = 'This is a %1$s string';
+		expect(
+			createInterpolateElement(
+				testString,
+				[ [ '%2$s', { value: 20 } ] ]
+			)
+		).toEqual( <Fragment>{ testString }</Fragment> );
+	} );
+	it( 'returns expected react element for non nested components', () => {
+		const testString = 'This is a string with <a%1>a link</a%1>.';
+		const expectedElement = createElement(
+			Fragment,
+			{},
+			[
+				'This is a string with ',
+				createElement(
+					'a',
+					{ href: 'https://github.com', className: 'some_class', key: 1 },
+					'a link'
+				),
+				'.',
+			]
+		);
+		expect( createInterpolateElement(
+			testString,
+			[
+				[
+					'a%1',
+					{
+						tag: 'a',
+						props: { href: 'https://github.com', className: 'some_class' },
+						hasChildren: true,
+					},
+				],
+			]
+		) ).toEqual( expectedElement );
+	} );
+	it( 'returns expected react element for nested components', () => {
+		const testString = 'This is a <a1>string that is <em1>linked</em1></a1>.';
+		const expectedElement = createElement(
+			Fragment,
+			{},
+			[
+				'This is a ',
+				createElement(
+					'a',
+					{ key: 1 },
+					[
+						'string that is ',
+						createElement(
+							'em',
+							{ key: 2 },
+							'linked'
+						),
+					]
+				),
+				'.',
+			]
+		);
+		expect( createInterpolateElement(
+			testString,
+			[
+				[ 'a1', { tag: 'a', props: {}, hasChildren: true } ],
+				[ 'em1', { tag: 'em', props: {}, hasChildren: true } ],
+			]
+		) ).toEqual( expectedElement );
+	} );
+	it( 'returns a value for a prop value type token replacement', () => {
+		const testString = 'This is a string with a value token: %1$s';
+		const expectedElement = createElement(
+			Fragment,
+			{},
+			[
+				'This is a string with a value token: ',
+				10,
+			]
+		);
+		expect( createInterpolateElement(
+			testString,
+			[ [ '%1$s', { value: 10 } ] ],
+		) ).toEqual( expectedElement );
+	} );
+	it( 'returns expected output for a custom component with children ' +
+		'replacement', () => {
+		const TestComponent = ( props ) => {
+			return <div { ...props } >{ props.children }</div>;
+		};
+		const testString = 'This is a string with a <span1>Custom Component</span1>';
+		const expectedElement = createElement(
+			Fragment,
+			{},
+			[
+				'This is a string with a ',
+				createElement(
+					TestComponent,
+					{ key: 1 },
+					'Custom Component'
+				),
+			]
+		);
+		expect( createInterpolateElement(
+			testString,
+			[
+				[ 'span1', { tag: TestComponent, props: {}, hasChildren: true } ],
+			]
+		) ).toEqual( expectedElement );
+	} );
+	it( 'returns expected output for self closing custom component', () => {
+		const TestComponent = ( props ) => {
+			return <div { ...props } />;
+		};
+		const testString = 'This is a string with a self closing custom component: <span1/>';
+		const expectedElement = createElement(
+			Fragment,
+			{},
+			[
+				'This is a string with a self closing custom component: ',
+				createElement(
+					TestComponent,
+					{ key: 1 }
+				),
+			]
+		);
+		expect( createInterpolateElement(
+			testString,
+			[
+				[ 'span1', { tag: TestComponent, props: {}, hasChildren: false } ],
+			]
+		) ).toEqual( expectedElement );
+	} );
+	it( 'returns expected output for complex replacement', () => {
+		const TestComponent = ( props ) => {
+			return <div { ...props } />;
+		};
+		const testString = 'This is a complex string having a %1$s value, with ' +
+			'a <a1>nested <em1>%2$s</em1> link</a1> and value: %3$s';
+		const expectedElement = createElement(
+			Fragment,
+			{},
+			[
+				'This is a complex string having a ',
+				'concrete',
+				' value, with a ',
+				createElement(
+					'a',
+					{ key: 1 },
+					[
+						'nested ',
+						createElement(
+							'em',
+							{ key: 2 },
+							'value'
+						),
+						' link',
+					]
+				),
+				' and value: ',
+				createElement(
+					Fragment,
+					{ key: 3 },
+					<TestComponent />,
+				),
+			]
+		);
+		expect( JSON.stringify( createInterpolateElement(
+			testString,
+			[
+				[ '%1$s', { value: 'concrete' } ],
+				[ 'a1', { tag: 'a', props: {}, hasChildren: true } ],
+				[ 'em1', { tag: 'em', props: {}, hasChildren: true } ],
+				[ '%2$s', { value: 'value' } ],
+				[ '%3$s', { value: <TestComponent /> } ],
+			]
+		) ) ).toEqual( JSON.stringify( expectedElement ) );
+	} );
+	// test complex multi types replacements.
+} );

--- a/packages/element/src/components/interpolate/utils/test/create-interpolate-string.js
+++ b/packages/element/src/components/interpolate/utils/test/create-interpolate-string.js
@@ -1,0 +1,79 @@
+/**
+ * Internal dependencies
+ */
+import { Fragment } from '../../../../react';
+import createInterpolateString from '../create-interpolate-string';
+
+describe( 'createInterpolateString', () => {
+	// test converting native component with children to string
+	test( 'converting native component with children to string', () => {
+		const testElement = <Fragment>This is a string <a href={ 'https://exmaple.org' }>with a link</a></Fragment>;
+		const expectedString = 'This is a string <a%1>with a link</a%1>';
+		expect( createInterpolateString( testElement, {} ) )
+			.toEqual( expectedString );
+	} );
+	test( 'converting value token without defined prop for it', () => {
+		const testElement = <Fragment>This is a %%special%% value</Fragment>;
+		const test = () => createInterpolateString( testElement, {} );
+		expect( test ).toThrowError();
+	} );
+	test( 'converting value token with defined prop for it', () => {
+		const testElement = <Fragment>This is a %%special%% value.</Fragment>;
+		const expectedString = 'This is a %1$s value.';
+		expect( createInterpolateString( testElement, { special: 'super great' } ) )
+			.toEqual( expectedString );
+	} );
+	test( 'converting custom component with children to string', () => {
+		const TestComponent = ( props ) => <div { ...props }>{ props.children }</div>;
+		const testElement = <Fragment>This is a string with a <TestComponent>test component</TestComponent>.</Fragment>;
+		const expectedString = 'This is a string with a <span%1>test component</span%1>.';
+		expect( createInterpolateString( testElement, {} ) )
+			.toEqual( expectedString );
+	} );
+	test( 'converting nested native components', () => {
+		const testElement = <Fragment>
+			This is a <a href={ 'https://example.org' }>link with some <em>emphasis</em></a>
+		</Fragment>;
+		const expectedString = 'This is a <a%1>link with some <em%1>emphasis</em%1></a%1>';
+		expect( createInterpolateString( testElement, {} ) )
+			.toEqual( expectedString );
+	} );
+	test( 'converting nested native + custom component with child', () => {
+		const TestComponent = ( props ) => <div { ...props }>{ props.children }</div>;
+		const testElement = <Fragment>
+				This is a <div>nested div with a <TestComponent>nested custom component</TestComponent></div>.
+		</Fragment>;
+		const expectedString = 'This is a <div%1>nested div with a <span%1>nested ' +
+			'custom component</span%1></div%1>.';
+		expect( createInterpolateString( testElement, {} ) )
+			.toEqual( expectedString );
+	} );
+	test( 'converting self-closing native component', () => {
+		const testElement = <Fragment>This is a <br /></Fragment>;
+		const expectedString = 'This is a <br%1/>';
+		expect( createInterpolateString( testElement, {} ) )
+			.toEqual( expectedString );
+	} );
+	test( 'converting self-closing custom component', () => {
+		const TestComponent = ( props ) => <div { ...props } />;
+		const testElement = <Fragment>This is a <TestComponent /></Fragment>;
+		const expectedString = 'This is a %1$s';
+		expect( createInterpolateString( testElement, {} ) )
+			.toEqual( expectedString );
+	} );
+	test( 'converting complex element conversion', () => {
+		const TestComponent = ( props ) => <div { ...props } />;
+		const testElement = <Fragment>
+			A string with %%tokens%%, a <TestComponent /> and <a href={ 'http://example.org' }>some <em>%%special^value%%</em></a>. Also <a href={ 'https://example.org' }>another <strong>link</strong></a>.
+		</Fragment>;
+		const expectedString = 'A string with %1$s, a %2$s and <a%1>some ' +
+			'<em%1>%3$s</em%1></a%1>. Also <a%2>another <strong%1>link</strong%1>' +
+			'</a%2>.';
+		expect( createInterpolateString(
+			testElement,
+			{
+				tokens: 10,
+				'special^value': 'cheeseburger',
+			} ) ).toEqual( expectedString );
+	} );
+} );

--- a/packages/element/src/components/interpolate/utils/token-count.js
+++ b/packages/element/src/components/interpolate/utils/token-count.js
@@ -1,0 +1,25 @@
+let tokenCount = {};
+
+const updateTokenCount = ( type ) => {
+	if ( typeof tokenCount[ type ] === 'undefined' ) {
+		tokenCount[ type ] = 0;
+	}
+	tokenCount[ type ]++;
+};
+
+const getTokenCount = ( type ) => {
+	if ( typeof tokenCount[ type ] === 'undefined' ) {
+		tokenCount[ type ] = 0;
+	}
+	updateTokenCount( type );
+	return tokenCount[ type ];
+};
+
+const resetTokenCount = () => {
+	tokenCount = {};
+};
+
+export {
+	getTokenCount,
+	resetTokenCount,
+};

--- a/packages/element/src/index.js
+++ b/packages/element/src/index.js
@@ -1,3 +1,4 @@
+export * from './components';
 export * from './react';
 export * from './react-platform';
 export * from './utils';

--- a/packages/element/src/utils.js
+++ b/packages/element/src/utils.js
@@ -24,3 +24,4 @@ export const isEmptyElement = ( element ) => {
 
 	return ! element;
 };
+


### PR DESCRIPTION
## Description

This is the initial experiment prompted by #9846.

In progress towards solving the problem posed in #9846, this pull was created with the following goals in mind:

* [ ] expose a simple api for wrapping react elements that could be easily localized.
* [ ] re-use as much of the current i18n tools as possible (extraction, pluralization etc) (recognizing that there still may be _some_ work needed)
* [ ] expose a utility that can have purpose beyond string localization
* [ ] expose an api that doesn't require a build process for developers in the WordPress ecosystem that want to use interpolation for localizable strings.
* [ ] Translateable strings should retain context for translators.

In this pull:

### Introduction of `createInterpolateElement`.

This function works similarly to `createElement` in exposing an api for creating a WordPress (React) element.  

It accepts two arguments:

| Argument | Type | description |
|---------| ----------| ------------|
| interpolatedString| string | The interpolation string to be parsed.  This can be wrapped with i18n functions.
| conversionMap | Array[] | The map used to convert the string to a react element.

Example:

```jsx
const MyCustomComponent = ( { url } ) => {
	return createInterpolateComponent(
		__( 'This is a <span%1>string</span%1> with <a%1>a link</a%1>, a self-closing %1$s component and a plain value: %2$s' ),
		[
			[ 'span%1', { tag: CustomComponent, props: {}, hasChildren: true } ],
			[ 'a%1', { tag: 'a', props: { href: url }, hasChildren: true } ],
			[ '%1$s', { tag: CustomComponentB, props: {}, hasChildren: false } ],
			[ '%2$s', { value: 'custom value' } ],
		]
	);
};
```

The function returns this as the equivalent:

```jsx
import { __ } from '@wordpress/i18n';
import { createInterpolateComponent, createElement } from '@wordpress/element';
import { CustomComponent, CustomComponentB } from './custom-components';

const MyCustomComponent = ( { url } ) => {
	return createElement(
		Fragment,
		{},
		[
			'This is a ',
			createElement(
				CustomComponent,
				{ key: 1 },
				'string'
			),
			' with ',
			createElement(
				'a',
				{ key: 2, href: url },
				'a link'
			),
			', a self-closing ',
			createElement(
				CustomComponentB,
				{ key: 3 },
			),
			' component and a plain value: ',
			createElement(
				Fragment,
				{ key: 4 },
				'custom value'
			),
		],
	);
};
```

This allows for usage _immediately_ wherever interpolation is needed for translated strings.

Some notes:

Tags can be virtually anything, but for the purpose of localization it's recommended to use something that provides context for translators.

The conversion map is expected to be an array of configuration elements ordered by how the tags appear in the interpolation string.  Each element in the array is expected to have two values:

- The first value is the tag that that will be matched in the string.
- The second value is either a component configuration object with `tag`, `props`, and `hasChildren` keys, or a "prop value" type object with `value` as the key.  The former is similar to the arguments for `wp.element.createElement` except rather then the third being an array of children, it is simply a boolean indicating whether the given tag represents an element with children.  This is because children are extracted _from the_ interpolation string rather than being predefined and may be nested elements.  The latter simply signals that the given search string is a straight replacement with the given value.

This api is a bit verbose and could be prone to human error, however it solves the majority of the issues with the current problem out of the box and allows for immediate use.

### `Interpolate` component

This component is currently a _demonstration_ of how an easier api _could_ be exposed to developers for writing interpolation type components.

#### Usage:

Here's an example of how it could be used (using the same string as our example):

```jsx
const MyCustomComponent = ( { url } ) => {
	return <Interpolate custom={ 'custom value' }>
		This is a <CustomComponent>string</CustomComponent> with <a href={ url }>a link</a>, a self-closing <CustomComponentB /> component and a plain value: %%custom%%
	</Interpolate>
};
```

This will result in the same element as described in the previous example.  Note the differences:

- The content can be written more naturally using familiar api.
- Dynamic values that should be evaluated at runtime are indicated via special `%%value%%` syntax and the `value` should correspond to the name of the prop defined on the `Interpolate` tag.  The format of this syntax is negotiable but for the sake of this pull I used something that should be fairly straightforward.

**Internally**, `Interpolate` calls `createInterpolateElement` and uses the new function, `createInterpolateString` to generate the interpolation string from the element.  The created string for this example is the same as what was fed into `createInterpolateElement` in the previous example.  Currently in the code this is not localized but this gives an example of how it _could_ be so that `Interpolate` could be a suitable friendlier api for this use-case.

## Next steps

I've mostly submitted this pull to demonstrate what I think will be a good path to go forward with in solving #9846.  Here's some next steps to keep momentum:

* [ ] Evaluate this approach.  What works well? what needs changed?
* [ ] I think at a minimum `createInterpolateElement` seems to best fit as an export on `@wordpress/element` however it's arguable whether `Interpolate` should live here also or be exported from `@wordpress/i18n`.  Typical usage will likely be for i18n so it'd probably be better to put `Interpolate` there.
* [ ] Naming wise, I think it might be better for the _component_ to be named something like `<Translate>` or something like that.  Feasibly in the future it could serve as the mechanism (via context hooks) for live language switching.
* [ ] The component currently doesn't localize or account for singular/plural form.  I think the api described in #9846 for that would be suitable (have `Translate.Singular` and `Translate.Plural`) and should be fairly trivial to detect and implement.  For actual localization, I think the best method would be to write a babel plugin that translates `<Translate>{ children }</Translate>` to use `createInterpolateElement` with the appropriate `wp.i18n` function  wrapping the interpolationString argument on the _built_ code.  That would allow all existing string extraction methods to "just" work against built code as before.

There's probably some other thoughts I've missed here, I'll add them as I remember, but for now I think this is ready for initial feedback, review and direction.  It is not in mergeable state _yet_ , however we _could_ decide to extract `createInterpolateElement` into its own pull as it _could_ be released as is for a good interim solution.

## How has this been tested?

There are unit tests covering the public api and demonstrating expected behaviour.

## Types of changes

This is a new feature introduced to solve problems outlined in #9846

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
