### PR TITLE
Date/Time picker: ensure hour/minute fields are always shown left to right

### DIFF
--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -135,8 +135,11 @@
 
 		.components-datetime__time-field {
 
-			/*rtl:ignore*/
-			direction: ltr;
+			&-time {
+				/*rtl:ignore*/
+				direction: ltr;
+			}
+
 
 			&.am-pm button {
 				font-size: 11px;

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -135,6 +135,9 @@
 
 		.components-datetime__time-field {
 
+			/*rtl:ignore*/
+			direction: ltr;
+
 			&.am-pm button {
 				font-size: 11px;
 				font-weight: 600;


### PR DESCRIPTION
Fix an issue where right to left languages showed the hour and minute fields reversed, with the minutes on the left instead of the hours.

Fixes https://github.com/WordPress/gutenberg/issues/16373.

## Description
CSS change: set the `direction` for the `.components-datetime__time-field` class.

## How has this been tested?
Published a post after setting my profile to use Hebrew.

Verified the hour field shown to the left of the minute field.

## Screenshots <!-- if applicable -->
After this PR, my post published at 8:44am shows correctly in an RTL language: 
![image](https://user-images.githubusercontent.com/2676022/60454193-76da8700-9bf0-11e9-8b14-74ea5f0d778f.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

CSS: set the time field order to ltr regardless of page direction.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
