### PR TITLE
Add timezone to PostSchedule date

### DIFF
--- a/packages/e2e-tests/specs/datepicker.test.js
+++ b/packages/e2e-tests/specs/datepicker.test.js
@@ -33,7 +33,7 @@ describe( 'Datepicker', () => {
 			( dateLabel ) => dateLabel.textContent
 		);
 
-		expect( publishingDate ).toMatch( /[A-Za-z]{3} \d{1,2}, \d{4} \d{1,2}:\d{2} [ap]m/ );
+		expect( publishingDate ).toMatch( /[A-Za-z]{3} \d{1,2}, \d{4} \d{1,2}:\d{2} [ap]m [A-Z]{3}/ );
 	} );
 
 	it( 'should show the publishing date if the date is in the future', async () => {
@@ -53,7 +53,7 @@ describe( 'Datepicker', () => {
 		);
 
 		expect( publishingDate ).not.toEqual( 'Immediately' );
-		// The expected date format will be "Sep 26, 2018 11:52 pm".
-		expect( publishingDate ).toMatch( /[A-Za-z]{3} \d{1,2}, \d{4} \d{1,2}:\d{2} [ap]m/ );
+		// The expected date format will be "Sep 26, 2018 11:52 pm UTC".
+		expect( publishingDate ).toMatch( /[A-Za-z]{3} \d{1,2}, \d{4} \d{1,2}:\d{2} [ap]m [A-Z]{3}/ );
 	} );
 } );

--- a/packages/editor/src/components/post-schedule/label.js
+++ b/packages/editor/src/components/post-schedule/label.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { dateI18n, __experimentalGetSettings } from '@wordpress/date';
+import { dateI18n } from '@wordpress/date';
 import { withSelect } from '@wordpress/data';
 
 export function PostScheduleLabel( { date, isFloating } ) {


### PR DESCRIPTION
## Description

Fixes #15673

Changes date time format shown in post including the timezone. This is particularly helpful for multi-user sites where the author may not be in the same timezone the site is set in. By showing the timezone in the date, it shows the user what the scheduled time the post will be published.

## How has this been tested?

- Create a new post 
- Schedule for a future time
- View date displayed and confirm it shows the timezone

## Screenshots 

![Screenshot from 2019-07-01 13-26-43](https://user-images.githubusercontent.com/45363/60464605-eb6af100-9c03-11e9-85e9-2bde73c20d94.png)


## Types of changes

Removes the settings format and replaces with a date format that includes the timezone. The setting inside the date format package is equally hard-coded and not from wp-admin settings configuration.

It makes sense to me to hard-code the setting closer to the usage, I'm open to alternatives, issue #15673 highlights a couple of different solutions considered but did not receive any feedback.


## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
