### PR TITLE
Remove merged files from phpcs config

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -35,10 +35,6 @@
 	<exclude-pattern>./packages/block-serialization-spec-parser/parser.php</exclude-pattern>
 	<exclude-pattern>./build</exclude-pattern>
 
-	<rule ref="PHPCompatibility.PHP.NewKeywords.t_namespaceFound">
-		<exclude-pattern>lib/class-wp-rest-block-renderer-controller.php</exclude-pattern>
-		<exclude-pattern>lib/class-wp-rest-search-controller.php</exclude-pattern>
-	</rule>
 	<!-- These special comments are markers for the build process -->
 	<rule ref="Squiz.Commenting.InlineComment.WrongStyle">
 		<exclude-pattern>gutenberg.php</exclude-pattern>


### PR DESCRIPTION
## Description
The files `class-wp-rest-block-renderer-controller.php` and `class-wp-rest-search-controller.php` were merged into core, so we don't need the exclude in the phpcs config anymore.