### PR TITLE
PHPCS: Use strict comparisons

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -628,7 +628,7 @@ function gutenberg_extend_block_editor_preload_paths( $preload_paths, $post ) {
 		$rest_base      = ! empty( $post_type_object->rest_base ) ? $post_type_object->rest_base : $post_type_object->name;
 		$autosaves_path = sprintf( '/wp/v2/%s/%d/autosaves?context=edit', $rest_base, $post->ID );
 
-		if ( ! in_array( $autosaves_path, $preload_paths ) ) {
+		if ( ! in_array( $autosaves_path, $preload_paths, true ) ) {
 			$preload_paths[] = $autosaves_path;
 		}
 	}
@@ -644,7 +644,7 @@ function gutenberg_extend_block_editor_preload_paths( $preload_paths, $post ) {
 	 */
 	$blocks_path = array( '/wp/v2/blocks', 'OPTIONS' );
 
-	if ( ! in_array( $blocks_path, $preload_paths ) ) {
+	if ( ! in_array( $blocks_path, $preload_paths, true ) ) {
 		$preload_paths[] = $blocks_path;
 	}
 

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -51,7 +51,7 @@ function render_block_core_latest_posts( $attributes ) {
 		}
 
 		if ( isset( $attributes['displayPostContent'] ) && $attributes['displayPostContent']
-			&& isset( $attributes['displayPostContentRadio'] ) && 'excerpt' == $attributes['displayPostContentRadio'] ) {
+			&& isset( $attributes['displayPostContentRadio'] ) && 'excerpt' === $attributes['displayPostContentRadio'] ) {
 			$post_excerpt = $post->post_excerpt;
 			if ( ! ( $post_excerpt ) ) {
 				$post_excerpt = $post->post_content;
@@ -77,7 +77,7 @@ function render_block_core_latest_posts( $attributes ) {
 		}
 
 		if ( isset( $attributes['displayPostContent'] ) && $attributes['displayPostContent']
-			&& isset( $attributes['displayPostContentRadio'] ) && 'full_post' == $attributes['displayPostContentRadio'] ) {
+			&& isset( $attributes['displayPostContentRadio'] ) && 'full_post' === $attributes['displayPostContentRadio'] ) {
 			$list_items_markup .= sprintf(
 				'<div class="wp-block-latest-posts__post-full-content">%1$s</div>',
 				wp_kses_post( html_entity_decode( $post->post_content, ENT_QUOTES, get_option( 'blog_charset' ) ) )

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -69,7 +69,7 @@ function render_block_core_rss( $attributes ) {
 			$excerpt = esc_attr( wp_trim_words( $excerpt, $attributes['excerptLength'], ' [&hellip;]' ) );
 
 			// Change existing [...] to [&hellip;].
-			if ( '[...]' == substr( $excerpt, -5 ) ) {
+			if ( '[...]' === substr( $excerpt, -5 ) ) {
 				$excerpt = substr( $excerpt, 0, -5 ) . '[&hellip;]';
 			}
 


### PR DESCRIPTION
## Description
>Rule: Unless absolutely necessary, loose comparisons should not be used, as their behaviour can be misleading.

- Use strict comparisons `===`  instead of `==`.
- Use `in_array()` with `strict` parameter