### PR TITLE
PluginPostPublishPanel uses icon and inherits from registerPlugin

### DIFF
--- a/packages/edit-post/README.md
+++ b/packages/edit-post/README.md
@@ -261,6 +261,7 @@ _Parameters_
 -   _props.className_ `[string]`: An optional class name added to the panel.
 -   _props.title_ `[string]`: Title displayed at the top of the panel.
 -   _props.initialOpen_ `[boolean]`: Whether to have the panel initially opened. When no title is provided it is always opened.
+-   _props.icon_ `[(string|Element)]`: The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered when the sidebar is pinned to toolbar.
 
 _Returns_
 

--- a/packages/edit-post/src/components/sidebar/plugin-post-publish-panel/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-post-publish-panel/index.js
@@ -1,10 +1,24 @@
 /**
  * WordPress dependencies
  */
+import { compose } from '@wordpress/compose';
+import { withPluginContext } from '@wordpress/plugins';
 import { createSlotFill, PanelBody } from '@wordpress/components';
 
 const { Fill, Slot } = createSlotFill( 'PluginPostPublishPanel' );
 
+const PluginPostPublishPanelFill = ( { children, className, title, initialOpen = false, icon } ) => (
+	<Fill>
+		<PanelBody
+			className={ className }
+			initialOpen={ initialOpen || ! title }
+			title={ title }
+			icon={ icon }
+		>
+			{ children }
+		</PanelBody>
+	</Fill>
+);
 /**
  * Renders provided content to the post-publish panel in the publish flow
  * (side panel that opens after a user publishes the post).
@@ -13,6 +27,7 @@ const { Fill, Slot } = createSlotFill( 'PluginPostPublishPanel' );
  * @param {string} [props.className] An optional class name added to the panel.
  * @param {string} [props.title] Title displayed at the top of the panel.
  * @param {boolean} [props.initialOpen=false] Whether to have the panel initially opened. When no title is provided it is always opened.
+ * @param {string|Element} [props.icon=inherits from the plugin] The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered when the sidebar is pinned to toolbar.
  *
  * @example <caption>ES5</caption>
  * ```js
@@ -52,17 +67,14 @@ const { Fill, Slot } = createSlotFill( 'PluginPostPublishPanel' );
  *
  * @return {WPElement} The WPElement to be rendered.
  */
-const PluginPostPublishPanel = ( { children, className, title, initialOpen = false } ) => (
-	<Fill>
-		<PanelBody
-			className={ className }
-			initialOpen={ initialOpen || ! title }
-			title={ title }
-		>
-			{ children }
-		</PanelBody>
-	</Fill>
-);
+
+const PluginPostPublishPanel = compose(
+	withPluginContext( ( context, ownProps ) => {
+		return {
+			icon: ownProps.icon || context.icon,
+		};
+	} ),
+)( PluginPostPublishPanelFill );
 
 PluginPostPublishPanel.Slot = Slot;
 


### PR DESCRIPTION
## Description
This PR updates the PluginPostPublishPanel SlotFill to accept an `icon` or inherit from `registerPlugin()`

## Screenshots
![post-publish-panel](https://user-images.githubusercontent.com/1259027/60475533-c7300400-9c45-11e9-9f01-9c23471f7fe2.png)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
