### PR TITLE
Plugin sorting via priority property in registerPlugin

### DIFF
--- a/packages/edit-post/src/components/sidebar/plugin-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-sidebar/index.js
@@ -133,6 +133,7 @@ export default compose(
 		return {
 			icon: ownProps.icon || context.icon,
 			sidebarName: `${ context.name }/${ ownProps.name }`,
+			priority: ownProps.priority || context.priority,
 		};
 	} ),
 	withSelect( ( select, { sidebarName } ) => {

--- a/packages/edit-post/src/components/sidebar/plugin-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-sidebar/index.js
@@ -1,0 +1,170 @@
+/**
+ * WordPress dependencies
+ */
+import { Button, Panel } from '@wordpress/components';
+import { withDispatch, withSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { withPluginContext } from '@wordpress/plugins';
+import { compose } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import PinnedPlugins from '../../header/pinned-plugins';
+import Sidebar from '../';
+import SidebarHeader from '../sidebar-header';
+
+function PluginSidebar( props ) {
+	const {
+		children,
+		className,
+		icon,
+		isActive,
+		isPinnable = true,
+		isPinned,
+		sidebarName,
+		title,
+		togglePin,
+		toggleSidebar,
+	} = props;
+
+	return (
+		<>
+			{ isPinnable && (
+				<PinnedPlugins>
+					{ isPinned && <Button
+						icon={ icon }
+						label={ title }
+						onClick={ toggleSidebar }
+						isPressed={ isActive }
+						aria-expanded={ isActive }
+					/> }
+				</PinnedPlugins>
+			) }
+			<Sidebar name={ sidebarName }>
+				<SidebarHeader
+					closeLabel={ __( 'Close plugin' ) }
+				>
+					<strong>{ title }</strong>
+					{ isPinnable && (
+						<Button
+							icon={ isPinned ? 'star-filled' : 'star-empty' }
+							label={ isPinned ? __( 'Unpin from toolbar' ) : __( 'Pin to toolbar' ) }
+							onClick={ togglePin }
+							isPressed={ isPinned }
+							aria-expanded={ isPinned }
+						/>
+					) }
+				</SidebarHeader>
+				<Panel className={ className }>
+					{ children }
+				</Panel>
+			</Sidebar>
+		</>
+	);
+}
+
+/**
+ * Renders a sidebar when activated. The contents within the `PluginSidebar` will appear as content within the sidebar.
+ * If you wish to display the sidebar, you can with use the `PluginSidebarMoreMenuItem` component or the `wp.data.dispatch` API:
+ *
+ * ```js
+ * wp.data.dispatch( 'core/edit-post' ).openGeneralSidebar( 'plugin-name/sidebar-name' );
+ * ```
+ *
+ * @see PluginSidebarMoreMenuItem
+ *
+ * @param {Object} props Element props.
+ * @param {string} props.name A string identifying the sidebar. Must be unique for every sidebar registered within the scope of your plugin.
+ * @param {string} [props.className] An optional class name added to the sidebar body.
+ * @param {string} props.title Title displayed at the top of the sidebar.
+ * @param {boolean} [props.isPinnable=true] Whether to allow to pin sidebar to toolbar.
+ * @param {WPBlockTypeIconRender} [props.icon=inherits from the plugin] The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered when the sidebar is pinned to toolbar.
+ *
+ * @example <caption>ES5</caption>
+ * ```js
+ * // Using ES5 syntax
+ * var __ = wp.i18n.__;
+ * var el = wp.element.createElement;
+ * var PanelBody = wp.components.PanelBody;
+ * var PluginSidebar = wp.editPost.PluginSidebar;
+ *
+ * function MyPluginSidebar() {
+ * 	return el(
+ * 			PluginSidebar,
+ * 			{
+ * 				name: 'my-sidebar',
+ * 				title: 'My sidebar title',
+ * 				icon: 'smiley',
+ * 			},
+ * 			el(
+ * 				PanelBody,
+ * 				{},
+ * 				__( 'My sidebar content' )
+ * 			)
+ * 	);
+ * }
+ * ```
+ *
+ * @example <caption>ESNext</caption>
+ * ```jsx
+ * // Using ESNext syntax
+ * const { __ } = wp.i18n;
+ * const { PanelBody } = wp.components;
+ * const { PluginSidebar } = wp.editPost;
+ *
+ * const MyPluginSidebar = () => (
+ * 	<PluginSidebar
+ * 		name="my-sidebar"
+ * 		title="My sidebar title"
+ * 		icon="smiley"
+ * 	>
+ * 		<PanelBody>
+ * 			{ __( 'My sidebar content' ) }
+ * 		</PanelBody>
+ * 	</PluginSidebar>
+ * );
+ * ```
+ *
+ * @return {WPComponent} Plugin sidebar component.
+ */
+export default compose(
+	withPluginContext( ( context, ownProps ) => {
+		return {
+			icon: ownProps.icon || context.icon,
+			sidebarName: `${ context.name }/${ ownProps.name }`,
+			priority: ownProps.priority || context.priority,
+		};
+	} ),
+	withSelect( ( select, { sidebarName } ) => {
+		const {
+			getActiveGeneralSidebarName,
+			isPluginItemPinned,
+		} = select( 'core/edit-post' );
+
+		return {
+			isActive: getActiveGeneralSidebarName() === sidebarName,
+			isPinned: isPluginItemPinned( sidebarName ),
+		};
+	} ),
+	withDispatch( ( dispatch, { isActive, sidebarName } ) => {
+		const {
+			closeGeneralSidebar,
+			openGeneralSidebar,
+			togglePinnedPluginItem,
+		} = dispatch( 'core/edit-post' );
+
+		return {
+			togglePin() {
+				togglePinnedPluginItem( sidebarName );
+			},
+			toggleSidebar() {
+				if ( isActive ) {
+					closeGeneralSidebar();
+				} else {
+					openGeneralSidebar( sidebarName );
+				}
+			},
+		};
+	} ),
+)( PluginSidebar );

--- a/packages/edit-post/src/components/sidebar/plugin-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-sidebar/index.js
@@ -133,7 +133,6 @@ export default compose(
 		return {
 			icon: ownProps.icon || context.icon,
 			sidebarName: `${ context.name }/${ ownProps.name }`,
-			priority: ownProps.priority || context.priority,
 		};
 	} ),
 	withSelect( ( select, { sidebarName } ) => {

--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -117,7 +117,11 @@ function Component() {
 registerPlugin( 'plugin-name', {
 	icon: moreIcon,
 	render: Component,
+<<<<<<< HEAD
 	scope: 'my-page',
+=======
+	priority: 5
+>>>>>>> 0950f3cb07 (Adds priority property to the settings object with a default of 10. Sorts the registered plugins by priority before rendering them in PluginArea)
 } );
 ```
 
@@ -141,7 +145,11 @@ const Component = () => (
 registerPlugin( 'plugin-name', {
 	icon: more,
 	render: Component,
+<<<<<<< HEAD
 	scope: 'my-page',
+=======
+	priority: 5
+>>>>>>> 0950f3cb07 (Adds priority property to the settings object with a default of 10. Sorts the registered plugins by priority before rendering them in PluginArea)
 } );
 ```
 

--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -118,10 +118,14 @@ registerPlugin( 'plugin-name', {
 	icon: moreIcon,
 	render: Component,
 <<<<<<< HEAD
+<<<<<<< HEAD
 	scope: 'my-page',
 =======
 	priority: 5
 >>>>>>> 0950f3cb07 (Adds priority property to the settings object with a default of 10. Sorts the registered plugins by priority before rendering them in PluginArea)
+=======
+	priority: 5
+>>>>>>> f5ea38a261 (Adds priority property to the settings object with a default of 10. Sorts the registered plugins by priority before rendering them in PluginArea)
 } );
 ```
 
@@ -146,17 +150,28 @@ registerPlugin( 'plugin-name', {
 	icon: more,
 	render: Component,
 <<<<<<< HEAD
+<<<<<<< HEAD
 	scope: 'my-page',
 =======
 	priority: 5
 >>>>>>> 0950f3cb07 (Adds priority property to the settings object with a default of 10. Sorts the registered plugins by priority before rendering them in PluginArea)
+=======
+	priority: 5
+>>>>>>> f5ea38a261 (Adds priority property to the settings object with a default of 10. Sorts the registered plugins by priority before rendering them in PluginArea)
 } );
 ```
 
 _Parameters_
 
 -   _name_ `string`: A string identifying the plugin. Must be unique across all registered plugins.
+<<<<<<< HEAD
 -   _settings_ `PluginSettings`: The settings for this plugin.
+=======
+-   _settings_ `Object`: The settings for this plugin.
+-   _settings.icon_ `(string|WPElement|Function)`: An icon to be shown in the UI. It can be a slug of the Dashicon, or an element (or function returning an element) if you choose to render your own SVG.
+-   _settings.render_ `Function`: A component containing the UI elements to be rendered.
+-   _settings.priority_ `number`: Allows for controlling the display order of this plugin. Default is 10.
+>>>>>>> f5ea38a261 (Adds priority property to the settings object with a default of 10. Sorts the registered plugins by priority before rendering them in PluginArea)
 
 _Returns_
 

--- a/packages/plugins/src/api/index.js
+++ b/packages/plugins/src/api/index.js
@@ -122,7 +122,6 @@ export function registerPlugin( name, settings ) {
 		console.error( 'Plugin names must be strings.' );
 		return null;
 	}
-
 	const { priority = 10 } = settings;
 	if (
 		priority !== 0 &&
@@ -154,7 +153,6 @@ export function registerPlugin( name, settings ) {
 		name,
 		icon: 'admin-plugins',
 		priority,
-		...settings,
 	};
 
 	doAction( 'plugins.pluginRegistered', settings, name );

--- a/packages/plugins/src/api/index.js
+++ b/packages/plugins/src/api/index.js
@@ -1,0 +1,222 @@
+/* eslint no-console: [ 'error', { allow: [ 'error' ] } ] */
+
+/**
+ * WordPress dependencies
+ */
+import { applyFilters, doAction } from '@wordpress/hooks';
+
+/**
+ * External dependencies
+ */
+import { isFunction } from 'lodash';
+
+/**
+ * Defined behavior of a plugin type.
+ *
+ * @typedef {Object} WPPlugin
+ *
+ * @property {string}                    name     A string identifying the plugin. Must be
+ *                                                unique across all registered plugins.
+ *                                                unique across all registered plugins.
+ * @property {string|WPElement|Function} icon     An icon to be shown in the UI. It can
+ *                                                be a slug of the Dashicon, or an element
+ *                                                (or function returning an element) if you
+ *                                                choose to render your own SVG.
+ * @property {Function}                  render   A component containing the UI elements
+ *                                                to be rendered.
+ * @property {number}                    priority Allows for controlling the display order of this plugin.
+ *                                                Default is 10.
+ */
+
+/**
+ * Plugin definitions keyed by plugin name.
+ *
+ * @type {Object.<string,WPPlugin>}
+ */
+const plugins = {};
+
+/**
+ * Registers a plugin to the editor.
+ *
+ * @param {string}   name     A string identifying the plugin.Must be
+ *                            unique across all registered plugins.
+ * @param {WPPlugin} settings The settings for this plugin.
+ *
+ * @example <caption>ES5</caption>
+ * ```js
+ * // Using ES5 syntax
+ * var el = wp.element.createElement;
+ * var Fragment = wp.element.Fragment;
+ * var PluginSidebar = wp.editPost.PluginSidebar;
+ * var PluginSidebarMoreMenuItem = wp.editPost.PluginSidebarMoreMenuItem;
+ * var registerPlugin = wp.plugins.registerPlugin;
+ *
+ * function Component() {
+ * 	return el(
+ * 		Fragment,
+ * 		{},
+ * 		el(
+ * 			PluginSidebarMoreMenuItem,
+ * 			{
+ * 				target: 'sidebar-name',
+ * 			},
+ * 			'My Sidebar'
+ * 		),
+ * 		el(
+ * 			PluginSidebar,
+ * 			{
+ * 				name: 'sidebar-name',
+ * 				title: 'My Sidebar',
+ * 			},
+ * 			'Content of the sidebar'
+ * 		)
+ * 	);
+ * }
+ * registerPlugin( 'plugin-name', {
+ * 	icon: 'smiley',
+ * 	render: Component,
+ * 	priority: 5
+ * } );
+ * ```
+ *
+ * @example <caption>ESNext</caption>
+ * ```js
+ * // Using ESNext syntax
+ * const { PluginSidebar, PluginSidebarMoreMenuItem } = wp.editPost;
+ * const { registerPlugin } = wp.plugins;
+ *
+ * const Component = () => (
+ * 	<>
+ * 		<PluginSidebarMoreMenuItem
+ * 			target="sidebar-name"
+ * 		>
+ * 			My Sidebar
+ * 		</PluginSidebarMoreMenuItem>
+ * 		<PluginSidebar
+ * 			name="sidebar-name"
+ * 			title="My Sidebar"
+ * 		>
+ * 			Content of the sidebar
+ * 		</PluginSidebar>
+ * 	</>
+ * );
+ *
+ * registerPlugin( 'plugin-name', {
+ * 	icon: 'smiley',
+ * 	render: Component,
+ * 	priority: 5
+ * } );
+ * ```
+ *
+ * @return {WPPlugin} The final plugin settings object.
+ */
+export function registerPlugin( name, settings ) {
+	if ( typeof settings !== 'object' ) {
+		console.error(
+			'No settings object provided!'
+		);
+		return null;
+	}
+	if ( typeof name !== 'string' ) {
+		console.error(
+			'Plugin names must be strings.'
+		);
+		return null;
+	}
+	if ( settings.priority && typeof settings.priority !== 'number' ) {
+		console.error(
+			'The "priority" property must be a number'
+		);
+		return null;
+	}
+	if ( ! /^[a-z][a-z0-9-]*$/.test( name ) ) {
+		console.error(
+			'Plugin names must include only lowercase alphanumeric characters or dashes, and start with a letter. Example: "my-plugin".'
+		);
+		return null;
+	}
+	if ( plugins[ name ] ) {
+		console.error(
+			`Plugin "${ name }" is already registered.`
+		);
+	}
+
+	settings = applyFilters( 'plugins.registerPlugin', settings, name );
+
+	if ( ! isFunction( settings.render ) ) {
+		console.error(
+			'The "render" property must be specified and must be a valid function.'
+		);
+		return null;
+	}
+
+	plugins[ name ] = {
+		name,
+		icon: 'admin-plugins',
+		priority: 10,
+		...settings,
+	};
+
+	doAction( 'plugins.pluginRegistered', settings, name );
+
+	return settings;
+}
+
+/**
+ * Unregisters a plugin by name.
+ *
+ * @param {string} name Plugin name.
+ *
+ * @example <caption>ES5</caption>
+ * ```js
+ * // Using ES5 syntax
+ * var unregisterPlugin = wp.plugins.unregisterPlugin;
+ *
+ * unregisterPlugin( 'plugin-name' );
+ * ```
+ *
+ * @example <caption>ESNext</caption>
+ * ```js
+ * // Using ESNext syntax
+ * const { unregisterPlugin } = wp.plugins;
+ *
+ * unregisterPlugin( 'plugin-name' );
+ * ```
+ *
+ * @return {?WPPlugin} The previous plugin settings object, if it has been
+ *                     successfully unregistered; otherwise `undefined`.
+ */
+export function unregisterPlugin( name ) {
+	if ( ! plugins[ name ] ) {
+		console.error(
+			'Plugin "' + name + '" is not registered.'
+		);
+		return;
+	}
+	const oldPlugin = plugins[ name ];
+	delete plugins[ name ];
+
+	doAction( 'plugins.pluginUnregistered', oldPlugin, name );
+
+	return oldPlugin;
+}
+
+/**
+ * Returns a registered plugin settings.
+ *
+ * @param {string} name Plugin name.
+ *
+ * @return {?WPPlugin} Plugin setting.
+ */
+export function getPlugin( name ) {
+	return plugins[ name ];
+}
+
+/**
+ * Returns all registered plugins.
+ *
+ * @return {WPPlugin[]} Plugin settings.
+ */
+export function getPlugins() {
+	return Object.values( plugins );
+}

--- a/packages/plugins/src/api/index.js
+++ b/packages/plugins/src/api/index.js
@@ -123,7 +123,6 @@ export function registerPlugin( name, settings ) {
 		);
 		return null;
 	}
-
 	const { priority = 10 } = settings;
 	if ( priority !== 0 && ( priority.length === 0 || typeof priority !== 'number' ) ) {
 		console.error(
@@ -156,7 +155,6 @@ export function registerPlugin( name, settings ) {
 		name,
 		icon: 'admin-plugins',
 		priority,
-		...settings,
 	};
 
 	doAction( 'plugins.pluginRegistered', settings, name );

--- a/packages/plugins/src/api/index.js
+++ b/packages/plugins/src/api/index.js
@@ -123,7 +123,9 @@ export function registerPlugin( name, settings ) {
 		);
 		return null;
 	}
-	if ( settings.priority && typeof settings.priority !== 'number' ) {
+
+	const { priority = 10 } = settings;
+	if ( priority !== 0 && ( priority.length === 0 || typeof priority !== 'number' ) ) {
 		console.error(
 			'The "priority" property must be a number'
 		);
@@ -153,7 +155,7 @@ export function registerPlugin( name, settings ) {
 	plugins[ name ] = {
 		name,
 		icon: 'admin-plugins',
-		priority: 10,
+		priority,
 		...settings,
 	};
 

--- a/packages/plugins/src/api/index.js
+++ b/packages/plugins/src/api/index.js
@@ -122,7 +122,12 @@ export function registerPlugin( name, settings ) {
 		console.error( 'Plugin names must be strings.' );
 		return null;
 	}
-	if ( settings.priority && typeof settings.priority !== 'number' ) {
+
+	const { priority = 10 } = settings;
+	if (
+		priority !== 0 &&
+		( priority.length === 0 || typeof priority !== 'number' )
+	) {
 		console.error( 'The "priority" property must be a number' );
 		return null;
 	}
@@ -148,7 +153,7 @@ export function registerPlugin( name, settings ) {
 	plugins[ name ] = {
 		name,
 		icon: 'admin-plugins',
-		priority: 10,
+		priority,
 		...settings,
 	};
 

--- a/packages/plugins/src/api/index.js
+++ b/packages/plugins/src/api/index.js
@@ -153,6 +153,7 @@ export function registerPlugin( name, settings ) {
 		name,
 		icon: 'admin-plugins',
 		priority,
+		...settings,
 	};
 
 	doAction( 'plugins.pluginRegistered', settings, name );

--- a/packages/plugins/src/api/index.js
+++ b/packages/plugins/src/api/index.js
@@ -124,7 +124,7 @@ export function registerPlugin( name, settings ) {
 		return null;
 	}
 	const { priority = 10 } = settings;
-	if ( priority !== 0 && ( priority.length === 0 || typeof priority !== 'number' ) ) {
+	if ( ! Number.isInteger( priority ) ) {
 		console.error(
 			'The "priority" property must be a number'
 		);

--- a/packages/plugins/src/api/index.js
+++ b/packages/plugins/src/api/index.js
@@ -123,10 +123,7 @@ export function registerPlugin( name, settings ) {
 		return null;
 	}
 	const { priority = 10 } = settings;
-	if (
-		priority !== 0 &&
-		( priority.length === 0 || typeof priority !== 'number' )
-	) {
+	if ( ! Number.isInteger( priority ) ) {
 		console.error( 'The "priority" property must be a number' );
 		return null;
 	}

--- a/packages/plugins/src/api/index.js
+++ b/packages/plugins/src/api/index.js
@@ -38,9 +38,12 @@ const plugins = {};
 /**
  * Registers a plugin to the editor.
  *
- * @param {string}   name     A string identifying the plugin.Must be
- *                            unique across all registered plugins.
- * @param {WPPlugin} settings The settings for this plugin.
+ * @param {string}                    name            A string identifying the plugin. Must be unique across all registered plugins.
+ * @param {Object}                    settings        The settings for this plugin.
+ * @param {string|WPElement|Function} settings.icon   An icon to be shown in the UI. It can be a slug of the Dashicon,
+ * or an element (or function returning an element) if you choose to render your own SVG.
+ * @param {Function}                  settings.render A component containing the UI elements to be rendered.
+ * @param {number}                       settings.priority Allows for controlling the display order of this plugin. Default is 10.
  *
  * @example <caption>ES5</caption>
  * ```js
@@ -112,22 +115,15 @@ const plugins = {};
  */
 export function registerPlugin( name, settings ) {
 	if ( typeof settings !== 'object' ) {
-		console.error(
-			'No settings object provided!'
-		);
+		console.error( 'No settings object provided!' );
 		return null;
 	}
 	if ( typeof name !== 'string' ) {
-		console.error(
-			'Plugin names must be strings.'
-		);
+		console.error( 'Plugin names must be strings.' );
 		return null;
 	}
-	const { priority = 10 } = settings;
-	if ( ! Number.isInteger( priority ) ) {
-		console.error(
-			'The "priority" property must be a number'
-		);
+	if ( settings.priority && typeof settings.priority !== 'number' ) {
+		console.error( 'The "priority" property must be a number' );
 		return null;
 	}
 	if ( ! /^[a-z][a-z0-9-]*$/.test( name ) ) {
@@ -137,9 +133,7 @@ export function registerPlugin( name, settings ) {
 		return null;
 	}
 	if ( plugins[ name ] ) {
-		console.error(
-			`Plugin "${ name }" is already registered.`
-		);
+		console.error( `Plugin "${ name }" is already registered.` );
 	}
 
 	settings = applyFilters( 'plugins.registerPlugin', settings, name );
@@ -154,7 +148,7 @@ export function registerPlugin( name, settings ) {
 	plugins[ name ] = {
 		name,
 		icon: 'admin-plugins',
-		priority,
+		priority: 10,
 		...settings,
 	};
 
@@ -189,9 +183,7 @@ export function registerPlugin( name, settings ) {
  */
 export function unregisterPlugin( name ) {
 	if ( ! plugins[ name ] ) {
-		console.error(
-			'Plugin "' + name + '" is not registered.'
-		);
+		console.error( 'Plugin "' + name + '" is not registered.' );
 		return;
 	}
 	const oldPlugin = plugins[ name ];

--- a/packages/plugins/src/api/index.js
+++ b/packages/plugins/src/api/index.js
@@ -155,6 +155,7 @@ export function registerPlugin( name, settings ) {
 		name,
 		icon: 'admin-plugins',
 		priority,
+		...settings,
 	};
 
 	doAction( 'plugins.pluginRegistered', settings, name );

--- a/packages/plugins/src/api/index.js
+++ b/packages/plugins/src/api/index.js
@@ -15,17 +15,18 @@ import { isFunction } from 'lodash';
  *
  * @typedef {Object} WPPlugin
  *
- * @property {string}                    name     A string identifying the plugin. Must be
- *                                                unique across all registered plugins.
- *                                                unique across all registered plugins.
- * @property {string|WPElement|Function} icon     An icon to be shown in the UI. It can
- *                                                be a slug of the Dashicon, or an element
- *                                                (or function returning an element) if you
- *                                                choose to render your own SVG.
- * @property {Function}                  render   A component containing the UI elements
- *                                                to be rendered.
- * @property {number}                    priority Allows for controlling the display order of this plugin.
- *                                                Default is 10.
+ * @property {string}                    name       A string identifying the plugin. Must be
+ *                                                  unique across all registered plugins.
+ * @property {string|WPElement|Function} [icon]     An icon to be shown in the UI. It can
+ *                                                  be a slug of the Dashicon, or an element
+ *                                                  (or function returning an element) if you
+ *                                                  choose to render your own SVG.
+ * @property {Function}                  render     A component containing the UI elements
+ *                                                  to be rendered.
+ * @property {string}                    [scope]    The optional scope to be used when rendering inside
+ *                                                  a plugin area. No scope by default.
+ * @property {number}                    [priority] Allows for controlling the display order of this
+ *                                                  plugin. Default is 10.
  */
 
 /**

--- a/packages/plugins/src/api/test/index.js
+++ b/packages/plugins/src/api/test/index.js
@@ -128,7 +128,9 @@ describe( 'getPlugins', () => {
 			render: () => {},
 			priority: '',
 		} );
-		expect( console ).toHaveErroredWith( 'The "priority" property must be a number' );
+		expect( console ).toHaveErroredWith(
+			'The "priority" property must be a number'
+		);
 	} );
 
 	it( 'fails to register a plugin with a priority set to boolean true', () => {
@@ -136,7 +138,9 @@ describe( 'getPlugins', () => {
 			render: () => {},
 			priority: true,
 		} );
-		expect( console ).toHaveErroredWith( 'The "priority" property must be a number' );
+		expect( console ).toHaveErroredWith(
+			'The "priority" property must be a number'
+		);
 	} );
 
 	it( 'fails to register a plugin with a priority set to boolean false', () => {
@@ -144,7 +148,9 @@ describe( 'getPlugins', () => {
 			render: () => {},
 			priority: false,
 		} );
-		expect( console ).toHaveErroredWith( 'The "priority" property must be a number' );
+		expect( console ).toHaveErroredWith(
+			'The "priority" property must be a number'
+		);
 	} );
 
 	it( 'fails to register a plugin with a priority set to an empty string', () => {

--- a/packages/plugins/src/api/test/index.js
+++ b/packages/plugins/src/api/test/index.js
@@ -24,6 +24,7 @@ describe( 'registerPlugin', () => {
 			name,
 			render: Component,
 			icon,
+			priority: 10,
 		} );
 	} );
 
@@ -120,5 +121,29 @@ describe( 'getPlugins', () => {
 		const scopedPlugins = getPlugins( scope );
 		expect( scopedPlugins ).toHaveLength( 1 );
 		expect( scopedPlugins[ 0 ].name ).toBe( 'scoped' );
+	} );
+
+	it( 'fails to register a plugin with a priority set to an empty string', () => {
+		registerPlugin( 'priority-as-string', {
+			render: () => {},
+			priority: '',
+		} );
+		expect( console ).toHaveErroredWith( 'The "priority" property must be a number' );
+	} );
+
+	it( 'fails to register a plugin with a priority set to boolean true', () => {
+		registerPlugin( 'priority-as-string', {
+			render: () => {},
+			priority: true,
+		} );
+		expect( console ).toHaveErroredWith( 'The "priority" property must be a number' );
+	} );
+
+	it( 'fails to register a plugin with a priority set to boolean false', () => {
+		registerPlugin( 'priority-as-string', {
+			render: () => {},
+			priority: false,
+		} );
+		expect( console ).toHaveErroredWith( 'The "priority" property must be a number' );
 	} );
 } );

--- a/packages/plugins/src/api/test/index.js
+++ b/packages/plugins/src/api/test/index.js
@@ -146,4 +146,28 @@ describe( 'getPlugins', () => {
 		} );
 		expect( console ).toHaveErroredWith( 'The "priority" property must be a number' );
 	} );
+
+	it( 'fails to register a plugin with a priority set to an empty string', () => {
+		registerPlugin( 'priority-as-string', {
+			render: () => {},
+			priority: '',
+		} );
+		expect( console ).toHaveErroredWith( 'The "priority" property must be a number' );
+	} );
+
+	it( 'fails to register a plugin with a priority set to boolean true', () => {
+		registerPlugin( 'priority-as-string', {
+			render: () => {},
+			priority: true,
+		} );
+		expect( console ).toHaveErroredWith( 'The "priority" property must be a number' );
+	} );
+
+	it( 'fails to register a plugin with a priority set to boolean false', () => {
+		registerPlugin( 'priority-as-string', {
+			render: () => {},
+			priority: false,
+		} );
+		expect( console ).toHaveErroredWith( 'The "priority" property must be a number' );
+	} );
 } );

--- a/packages/plugins/src/components/plugin-area/index.js
+++ b/packages/plugins/src/components/plugin-area/index.js
@@ -59,8 +59,8 @@ class PluginArea extends Component {
 	}
 
 	getCurrentPluginsState() {
-		const plugins = compose(
-			( list ) => map( list, ( { icon, name, render, priority } ) => {
+		return {
+			plugins: map( sortBy( getPlugins(), [ 'priority' ] ), ( { icon, name, render, priority } ) => {
 				return {
 					Plugin: render,
 					context: {

--- a/packages/plugins/src/components/plugin-area/index.js
+++ b/packages/plugins/src/components/plugin-area/index.js
@@ -59,8 +59,8 @@ class PluginArea extends Component {
 	}
 
 	getCurrentPluginsState() {
-		return {
-			plugins: map( sortBy( getPlugins(), [ 'priority' ] ), ( { icon, name, render, priority } ) => {
+		const plugins = compose(
+			( list ) => map( list, ( { icon, name, render, priority } ) => {
 				return {
 					Plugin: render,
 					context: {

--- a/packages/plugins/src/components/plugin-area/index.js
+++ b/packages/plugins/src/components/plugin-area/index.js
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+import { map, sortBy } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { addAction, removeAction } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { PluginContextProvider } from '../plugin-context';
+import { getPlugins } from '../../api';
+
+/**
+ * A component that renders all plugin fills in a hidden div.
+ *
+ * @example <caption>ES5</caption>
+ * ```js
+ * // Using ES5 syntax
+ * var el = wp.element.createElement;
+ * var PluginArea = wp.plugins.PluginArea;
+ *
+ * function Layout() {
+ * 	return el(
+ * 		'div',
+ * 		{},
+ * 		'Content of the page',
+ * 		PluginArea
+ * 	);
+ * }
+ * ```
+ *
+ * @example <caption>ESNext</caption>
+ * ```js
+ * // Using ESNext syntax
+ * const { PluginArea } = wp.plugins;
+ *
+ * const Layout = () => (
+ * 	<div>
+ * 		Content of the page
+ * 		<PluginArea />
+ * 	</div>
+ * );
+ * ```
+ *
+ * @return {WPComponent} The component to be rendered.
+ */
+class PluginArea extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.setPlugins = this.setPlugins.bind( this );
+		this.state = this.getCurrentPluginsState();
+	}
+
+	getCurrentPluginsState() {
+		return {
+			plugins: map( sortBy( getPlugins(), [ 'priority' ] ), ( { icon, name, render, priority } ) => {
+				return {
+					Plugin: render,
+					context: {
+						name,
+						icon,
+						priority,
+					},
+				};
+			} ),
+		};
+	}
+
+	componentDidMount() {
+		addAction( 'plugins.pluginRegistered', 'core/plugins/plugin-area/plugins-registered', this.setPlugins );
+		addAction( 'plugins.pluginUnregistered', 'core/plugins/plugin-area/plugins-unregistered', this.setPlugins );
+	}
+
+	componentWillUnmount() {
+		removeAction( 'plugins.pluginRegistered', 'core/plugins/plugin-area/plugins-registered' );
+		removeAction( 'plugins.pluginUnregistered', 'core/plugins/plugin-area/plugins-unregistered' );
+	}
+
+	setPlugins() {
+		this.setState( this.getCurrentPluginsState );
+	}
+
+	render() {
+		return (
+			<div style={ { display: 'none' } }>
+				{ map( this.state.plugins, ( { context, Plugin } ) => (
+					<PluginContextProvider
+						key={ context.name }
+						value={ context }
+					>
+						<Plugin />
+					</PluginContextProvider>
+				) ) }
+			</div>
+		);
+	}
+}
+
+export default PluginArea;

--- a/packages/plugins/src/components/plugin-area/index.js
+++ b/packages/plugins/src/components/plugin-area/index.js
@@ -60,9 +60,7 @@ class PluginArea extends Component {
 
 	getCurrentPluginsState() {
 		const plugins = compose(
-
-		return {
-			plugins: map( sortBy( getPlugins(), [ 'priority' ] ), ( { icon, name, render, priority } ) => {
+			( list ) => map( list, ( { icon, name, render, priority } ) => {
 				return {
 					Plugin: render,
 					context: {

--- a/packages/plugins/src/components/plugin-area/index.js
+++ b/packages/plugins/src/components/plugin-area/index.js
@@ -8,6 +8,7 @@ import { map, sortBy } from 'lodash';
  */
 import { Component } from '@wordpress/element';
 import { addAction, removeAction } from '@wordpress/hooks';
+import { compose } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -58,8 +59,8 @@ class PluginArea extends Component {
 	}
 
 	getCurrentPluginsState() {
-		return {
-			plugins: map( sortBy( getPlugins(), [ 'priority' ] ), ( { icon, name, render, priority } ) => {
+		const plugins = compose(
+			( list ) => map( list, ( { icon, name, render, priority } ) => {
 				return {
 					Plugin: render,
 					context: {
@@ -69,6 +70,11 @@ class PluginArea extends Component {
 					},
 				};
 			} ),
+			( list ) => sortBy( list, [ 'priority' ] ),
+		)( getPlugins() );
+
+		return {
+			plugins,
 		};
 	}
 

--- a/packages/plugins/src/components/plugin-area/index.js
+++ b/packages/plugins/src/components/plugin-area/index.js
@@ -60,7 +60,9 @@ class PluginArea extends Component {
 
 	getCurrentPluginsState() {
 		const plugins = compose(
-			( list ) => map( list, ( { icon, name, render, priority } ) => {
+
+		return {
+			plugins: map( sortBy( getPlugins(), [ 'priority' ] ), ( { icon, name, render, priority } ) => {
 				return {
 					Plugin: render,
 					context: {

--- a/packages/plugins/src/components/plugin-area/index.js
+++ b/packages/plugins/src/components/plugin-area/index.js
@@ -55,37 +55,72 @@ class PluginArea extends Component {
 		super( ...arguments );
 
 		this.setPlugins = this.setPlugins.bind( this );
+		this.memoizedContext = memoize( ( name, icon, priority ) => {
+			return {
+				name,
+				icon,
+				priority,
+			};
+		} );
 		this.state = this.getCurrentPluginsState();
 	}
 
 	getCurrentPluginsState() {
 		const plugins = compose(
-			( list ) => map( list, ( { icon, name, render, priority } ) => {
-				return {
-					Plugin: render,
-					context: {
-						name,
-						icon,
-						priority,
-					},
-				};
-			} ),
-			( list ) => sortBy( list, [ 'priority' ] ),
+			( list ) =>
+				map( list, ( { icon, name, render, priority } ) => {
+					return {
+						Plugin: render,
+						context: {
+							name,
+							icon,
+							priority,
+						},
+					};
+				} ),
+			( list ) => sortBy( list, [ 'priority' ] )
 		)( getPlugins() );
 
 		return {
-			plugins,
+			plugins: compose(
+				( list ) =>
+					map( list, ( { icon, name, render, priority } ) => {
+						return {
+							Plugin: render,
+							context: this.memoizedContext(
+								name,
+								icon,
+								priority
+							),
+						};
+					} ),
+				( list ) => sortBy( list, [ 'priority' ] )
+			)( getPlugins( this.props.scope ) ),
 		};
 	}
 
 	componentDidMount() {
-		addAction( 'plugins.pluginRegistered', 'core/plugins/plugin-area/plugins-registered', this.setPlugins );
-		addAction( 'plugins.pluginUnregistered', 'core/plugins/plugin-area/plugins-unregistered', this.setPlugins );
+		addAction(
+			'plugins.pluginRegistered',
+			'core/plugins/plugin-area/plugins-registered',
+			this.setPlugins
+		);
+		addAction(
+			'plugins.pluginUnregistered',
+			'core/plugins/plugin-area/plugins-unregistered',
+			this.setPlugins
+		);
 	}
 
 	componentWillUnmount() {
-		removeAction( 'plugins.pluginRegistered', 'core/plugins/plugin-area/plugins-registered' );
-		removeAction( 'plugins.pluginUnregistered', 'core/plugins/plugin-area/plugins-unregistered' );
+		removeAction(
+			'plugins.pluginRegistered',
+			'core/plugins/plugin-area/plugins-registered'
+		);
+		removeAction(
+			'plugins.pluginUnregistered',
+			'core/plugins/plugin-area/plugins-unregistered'
+		);
 	}
 
 	setPlugins() {

--- a/packages/plugins/src/components/plugin-context/index.js
+++ b/packages/plugins/src/components/plugin-context/index.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import { createContext } from '@wordpress/element';
+import { createHigherOrderComponent } from '@wordpress/compose';
+
+const { Consumer, Provider } = createContext( {
+	name: null,
+	icon: null,
+	priority: 10,
+} );
+
+export { Provider as PluginContextProvider };
+
+/**
+ * A Higher Order Component used to inject Plugin context to the
+ * wrapped component.
+ *
+ * @param {Function} mapContextToProps Function called on every context change,
+ *                                     expected to return object of props to
+ *                                     merge with the component's own props.
+ *
+ * @return {WPComponent} Enhanced component with injected context as props.
+ */
+export const withPluginContext = ( mapContextToProps ) => createHigherOrderComponent( ( OriginalComponent ) => {
+	return ( props ) => (
+		<Consumer>
+			{ ( context ) => (
+				<OriginalComponent
+					{ ...props }
+					{ ...mapContextToProps( context, props ) }
+				/>
+			) }
+		</Consumer>
+	);
+}, 'withPluginContext' );

--- a/packages/plugins/src/components/plugin-context/index.js
+++ b/packages/plugins/src/components/plugin-context/index.js
@@ -7,7 +7,7 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 const { Consumer, Provider } = createContext( {
 	name: null,
 	icon: null,
-	priority: null,
+	priority: 10,
 } );
 
 export { Provider as PluginContextProvider };

--- a/packages/plugins/src/components/plugin-context/index.js
+++ b/packages/plugins/src/components/plugin-context/index.js
@@ -7,7 +7,7 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 const { Consumer, Provider } = createContext( {
 	name: null,
 	icon: null,
-	priority: 10,
+	priority: null,
 } );
 
 export { Provider as PluginContextProvider };


### PR DESCRIPTION
## Description
As is stands now, there is no way to control the order of the items being rendered in Slots. This PR adds a new `priority` property to the settings object that is passed to `registerPlugin`. This property is optional and has a default value of 10. I chose 10 as that is the default priority for Hooks and familiar to most WordPress developers and so that we can move items ahead of the default position without using negative numbers.

The approach adds the `priority` property when the plugin is being registered and then uses `sortBy` to sort the plugins before they are rendered inside the `<PluginArea />` component.

## How has this been tested?
This has been tested locally and using the unit and e2e tests.

## Types of changes
New feature (non-breaking change which adds functionality) 


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
