### PR TITLE
Fix: Block icon on the block switcher may become unreadable.

### DIFF
--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -23,7 +23,6 @@
 // When the block switcher does not have any transformations, we show it but as disabled.
 // The background and opacity change helps make the icon legible, despite being disabled.
 .components-button.block-editor-block-switcher__no-switcher-icon:disabled {
-	background: $light-gray-200;
 	border-radius: 0;
 	opacity: 0.84;
 
@@ -32,6 +31,7 @@
 	// and should be overridden when disabled.
 	.block-editor-block-icon.has-colors {
 		color: $dark-gray-500 !important;
+		background: $light-gray-200 !important;
 	}
 }
 


### PR DESCRIPTION
## Description
We were forcing a color change on the icon in cases where there were no available items on the block switcher, but we were not forcing a background color change -- this may make the icon totally invisible. If we force a color chnage we should also force a background color change.

Related: https://github.com/WordPress/gutenberg/issues/16349



## How has this been tested?
I disabled the group block on the block manager so the group transform is not available.
I pasted the following code on the browser console:
```
( function() {
	var registerBlockType = wp.blocks.registerBlockType;
	var el = wp.element.createElement;

	registerBlockType( 'test/block', {
		title: 'Test Block',
		icon: { background: '#555d66', foreground: "#fff", src: 'warning' },
		category: 'common',

		edit: function( props ) {
			return el( 'div', { style: { outline: '1px solid gray', padding: 5 } },
                el( 'span', {}, 'My test block' ),
			);
		},

		save: function( props ) {
			return el( 'div', { style: { outline: '1px solid gray', padding: 5 } },
                el( 'span', {}, 'My test block' ),x
			);
		},
	} );
} )();
```
I inserted the 'Test Block' block, and I verified its icon is visible.


## Screenshots <!-- if applicable -->
Before:
<img width="1286" alt="Screenshot 2019-07-02 at 11 43 39" src="https://user-images.githubusercontent.com/11271197/60507155-6ba25c80-9cbf-11e9-9658-a314e64ef9c3.png">

After:
<img width="1357" alt="Screenshot 2019-07-02 at 11 44 13" src="https://user-images.githubusercontent.com/11271197/60507135-61805e00-9cbf-11e9-8ac5-83656007e6bc.png">

