### PR TITLE
Track the parent block to optimize hierarchy selectors

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -447,7 +447,7 @@ const withBlockParents = ( reducer ) => ( state = {}, action ) => {
 		case 'REPLACE_BLOCKS':
 			newState.parents = {
 				...omit( newState.parents, getAllPreviousChildren( action.clientIds ) ),
-				...mapBlockParents( action.blocks, state[ action.clientIds[ 0 ] ] ),
+				...mapBlockParents( action.blocks, state.parents[ action.clientIds[ 0 ] ] ),
 			};
 			break;
 		case 'REMOVE_BLOCKS':

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -64,13 +64,11 @@ function mapBlockOrder( blocks, rootClientId = '' ) {
  * @return {Object} Block order map object.
  */
 function mapBlockParents( blocks, rootClientId = '' ) {
-	const result = {};
-	blocks.forEach( ( block ) => {
-		result[ block.clientId ] = rootClientId;
-		Object.assign( result, mapBlockParents( block.innerBlocks, block.clientId ) );
-	} );
-
-	return result;
+	return blocks.reduce( ( result, block ) => Object.assign(
+		result,
+		{ [ block.clientId ]: rootClientId },
+		mapBlockParents( block.innerBlocks, block.clientId )
+	), {} );
 }
 
 /**
@@ -680,8 +678,8 @@ export const blocks = flow(
 		return state;
 	},
 
-	// This is the opposite of the order property.
-	//  It's duplicated data used for performance reasons.
+	// While technically redundant data as the inverse of `order`, it serves as
+	// an optimization for the selectors which derive the ancestry of a block.
 	parents( state = {}, action ) {
 		switch ( action.type ) {
 			case 'RESET_BLOCKS':

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -303,12 +303,14 @@ const withInnerBlocksRemoveCascade = ( reducer ) => ( state, action ) => {
 			case 'REMOVE_BLOCKS':
 				action = {
 					...action,
+					type: 'REMOVE_BLOCKS_AUGMENTED_WITH_CHILDREN',
 					removedClientIds: getAllChildren( action.clientIds ),
 				};
 				break;
 			case 'REPLACE_BLOCKS':
 				action = {
 					...action,
+					type: 'REPLACE_BLOCKS_AUGMENTED_WITH_CHILDREN',
 					replacedClientIds: getAllChildren( action.clientIds ),
 				};
 				break;
@@ -478,7 +480,7 @@ export const blocks = flow(
 					...getFlattenedBlocksWithoutAttributes( action.blocks ),
 				};
 
-			case 'REPLACE_BLOCKS':
+			case 'REPLACE_BLOCKS_AUGMENTED_WITH_CHILDREN':
 				if ( ! action.blocks ) {
 					return state;
 				}
@@ -488,7 +490,7 @@ export const blocks = flow(
 					...getFlattenedBlocksWithoutAttributes( action.blocks ),
 				};
 
-			case 'REMOVE_BLOCKS':
+			case 'REMOVE_BLOCKS_AUGMENTED_WITH_CHILDREN':
 				return omit( state, action.removedClientIds );
 		}
 
@@ -554,7 +556,7 @@ export const blocks = flow(
 					...getFlattenedBlockAttributes( action.blocks ),
 				};
 
-			case 'REPLACE_BLOCKS':
+			case 'REPLACE_BLOCKS_AUGMENTED_WITH_CHILDREN':
 				if ( ! action.blocks ) {
 					return state;
 				}
@@ -564,7 +566,7 @@ export const blocks = flow(
 					...getFlattenedBlockAttributes( action.blocks ),
 				};
 
-			case 'REMOVE_BLOCKS':
+			case 'REMOVE_BLOCKS_AUGMENTED_WITH_CHILDREN':
 				return omit( state, action.removedClientIds );
 		}
 
@@ -652,7 +654,7 @@ export const blocks = flow(
 				};
 			}
 
-			case 'REPLACE_BLOCKS': {
+			case 'REPLACE_BLOCKS_AUGMENTED_WITH_CHILDREN': {
 				const { clientIds } = action;
 				if ( ! action.blocks ) {
 					return state;
@@ -685,7 +687,7 @@ export const blocks = flow(
 				] )( state );
 			}
 
-			case 'REMOVE_BLOCKS':
+			case 'REMOVE_BLOCKS_AUGMENTED_WITH_CHILDREN':
 				return flow( [
 					// Remove inner block ordering for removed blocks
 					( nextState ) => omit( nextState, action.removedClientIds ),
@@ -726,13 +728,13 @@ export const blocks = flow(
 				};
 			}
 
-			case 'REPLACE_BLOCKS':
+			case 'REPLACE_BLOCKS_AUGMENTED_WITH_CHILDREN':
 				return {
 					...omit( state, action.replacedClientIds ),
 					...mapBlockParents( action.blocks, state[ action.clientIds[ 0 ] ] ),
 				};
 
-			case 'REMOVE_BLOCKS':
+			case 'REMOVE_BLOCKS_AUGMENTED_WITH_CHILDREN':
 				return omit( state, action.removedClientIds );
 		}
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -282,15 +282,19 @@ function withIgnoredBlockChange( reducer ) {
  */
 const withInnerBlocksRemoveCascade = ( reducer ) => ( state, action ) => {
 	const getAllChildren = ( clientIds ) => {
-		const result = [ ...clientIds ];
-
-		// For each removed client ID, include its inner blocks to remove,
-		// recursing into those so long as inner blocks exist.
+		let result = clientIds;
 		for ( let i = 0; i < result.length; i++ ) {
-			if ( state.order[ result[ i ] ] ) {
-				result.push( ...state.order[ result[ i ] ] );
+			if ( ! state.order[ result[ i ] ] ) {
+				continue;
 			}
+
+			if ( result === clientIds ) {
+				result = [ ...result ];
+			}
+
+			result.push( ...state.order[ result[ i ] ] );
 		}
+
 		return result;
 	};
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -458,22 +458,11 @@ export function getSelectedBlock( state ) {
  *
  * @return {?string} Root client ID, if exists
  */
-export const getBlockRootClientId = createSelector(
-	( state, clientId ) => {
-		const { order } = state.blocks;
-
-		for ( const rootClientId in order ) {
-			if ( includes( order[ rootClientId ], clientId ) ) {
-				return rootClientId;
-			}
-		}
-
-		return null;
-	},
-	( state ) => [
-		state.blocks.order,
-	]
-);
+export const getBlockRootClientId = ( state, clientId ) => {
+	return state.blocks.parents[ clientId ] !== undefined ?
+		state.blocks.parents[ clientId ] :
+		null;
+};
 
 /**
  * Given a block client ID, returns the root of the hierarchy from which the block is nested, return the block itself for root level blocks.
@@ -483,21 +472,15 @@ export const getBlockRootClientId = createSelector(
  *
  * @return {string} Root client ID
  */
-export const getBlockHierarchyRootClientId = createSelector(
-	( state, clientId ) => {
-		let rootClientId = clientId;
-		let current = clientId;
-		while ( rootClientId ) {
-			current = rootClientId;
-			rootClientId = getBlockRootClientId( state, current );
-		}
-
-		return current;
-	},
-	( state ) => [
-		state.blocks.order,
-	]
-);
+export const getBlockHierarchyRootClientId = ( state, clientId ) => {
+	let current = clientId;
+	let parent;
+	do {
+		parent = current;
+		current = state.blocks.parents[ current ];
+	} while ( current );
+	return parent;
+};
 
 /**
  * Returns the client ID of the block adjacent one at the given reference

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -458,11 +458,11 @@ export function getSelectedBlock( state ) {
  *
  * @return {?string} Root client ID, if exists
  */
-export const getBlockRootClientId = ( state, clientId ) => {
+export function getBlockRootClientId( state, clientId ) {
 	return state.blocks.parents[ clientId ] !== undefined ?
 		state.blocks.parents[ clientId ] :
 		null;
-};
+}
 
 /**
  * Given a block client ID, returns the root of the hierarchy from which the block is nested, return the block itself for root level blocks.
@@ -472,7 +472,7 @@ export const getBlockRootClientId = ( state, clientId ) => {
  *
  * @return {string} Root client ID
  */
-export const getBlockHierarchyRootClientId = ( state, clientId ) => {
+export function getBlockHierarchyRootClientId( state, clientId ) {
 	let current = clientId;
 	let parent;
 	do {
@@ -480,7 +480,7 @@ export const getBlockHierarchyRootClientId = ( state, clientId ) => {
 		current = state.blocks.parents[ current ];
 	} while ( current );
 	return parent;
-};
+}
 
 /**
  * Returns the client ID of the block adjacent one at the given reference

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -193,27 +193,31 @@ describe( 'state', () => {
 			it( 'can replace a child block', () => {
 				const existingState = deepFreeze( {
 					byClientId: {
-						clicken: {
+						chicken: {
 							clientId: 'chicken',
 							name: 'core/test-parent-block',
 							isValid: true,
 						},
-						'clicken-child': {
+						'chicken-child': {
 							clientId: 'chicken-child',
 							name: 'core/test-child-block',
 							isValid: true,
 						},
 					},
 					attributes: {
-						clicken: {},
-						'clicken-child': {
+						chicken: {},
+						'chicken-child': {
 							attr: true,
 						},
 					},
 					order: {
-						'': [ 'clicken' ],
-						clicken: [ 'clicken-child' ],
-						'clicken-child': [],
+						'': [ 'chicken' ],
+						chicken: [ 'chicken-child' ],
+						'chicken-child': [],
+					},
+					parents: {
+						chicken: '',
+						'chicken-child': 'chicken',
 					},
 				} );
 
@@ -226,7 +230,7 @@ describe( 'state', () => {
 
 				const action = {
 					type: 'REPLACE_INNER_BLOCKS',
-					rootClientId: 'clicken',
+					rootClientId: 'chicken',
 					blocks: [ newChildBlock ],
 				};
 
@@ -236,7 +240,7 @@ describe( 'state', () => {
 					isPersistentChange: true,
 					isIgnoredChange: false,
 					byClientId: {
-						clicken: {
+						chicken: {
 							clientId: 'chicken',
 							name: 'core/test-parent-block',
 							isValid: true,
@@ -248,16 +252,20 @@ describe( 'state', () => {
 						},
 					},
 					attributes: {
-						clicken: {},
+						chicken: {},
 						[ newChildBlockId ]: {
 							attr: false,
 							attr2: 'perfect',
 						},
 					},
 					order: {
-						'': [ 'clicken' ],
-						clicken: [ newChildBlockId ],
+						'': [ 'chicken' ],
+						chicken: [ newChildBlockId ],
 						[ newChildBlockId ]: [],
+					},
+					parents: {
+						[ newChildBlockId ]: 'chicken',
+						chicken: '',
 					},
 				} );
 			} );
@@ -265,18 +273,21 @@ describe( 'state', () => {
 			it( 'can insert a child block', () => {
 				const existingState = deepFreeze( {
 					byClientId: {
-						clicken: {
+						chicken: {
 							clientId: 'chicken',
 							name: 'core/test-parent-block',
 							isValid: true,
 						},
 					},
 					attributes: {
-						clicken: {},
+						chicken: {},
 					},
 					order: {
-						'': [ 'clicken' ],
-						clicken: [],
+						'': [ 'chicken' ],
+						chicken: [],
+					},
+					parents: {
+						chicken: '',
 					},
 				} );
 
@@ -289,7 +300,7 @@ describe( 'state', () => {
 
 				const action = {
 					type: 'REPLACE_INNER_BLOCKS',
-					rootClientId: 'clicken',
+					rootClientId: 'chicken',
 					blocks: [ newChildBlock ],
 				};
 
@@ -299,7 +310,7 @@ describe( 'state', () => {
 					isPersistentChange: true,
 					isIgnoredChange: false,
 					byClientId: {
-						clicken: {
+						chicken: {
 							clientId: 'chicken',
 							name: 'core/test-parent-block',
 							isValid: true,
@@ -311,16 +322,20 @@ describe( 'state', () => {
 						},
 					},
 					attributes: {
-						clicken: {},
+						chicken: {},
 						[ newChildBlockId ]: {
 							attr: false,
 							attr2: 'perfect',
 						},
 					},
 					order: {
-						'': [ 'clicken' ],
-						clicken: [ newChildBlockId ],
+						'': [ 'chicken' ],
+						chicken: [ newChildBlockId ],
 						[ newChildBlockId ]: [],
+					},
+					parents: {
+						[ newChildBlockId ]: 'chicken',
+						chicken: '',
 					},
 				} );
 			} );
@@ -328,36 +343,41 @@ describe( 'state', () => {
 			it( 'can replace multiple child blocks', () => {
 				const existingState = deepFreeze( {
 					byClientId: {
-						clicken: {
+						chicken: {
 							clientId: 'chicken',
 							name: 'core/test-parent-block',
 							isValid: true,
 						},
-						'clicken-child': {
+						'chicken-child': {
 							clientId: 'chicken-child',
 							name: 'core/test-child-block',
 							isValid: true,
 						},
-						'clicken-child-2': {
+						'chicken-child-2': {
 							clientId: 'chicken-child',
 							name: 'core/test-child-block',
 							isValid: true,
 						},
 					},
 					attributes: {
-						clicken: {},
-						'clicken-child': {
+						chicken: {},
+						'chicken-child': {
 							attr: true,
 						},
-						'clicken-child-2': {
+						'chicken-child-2': {
 							attr2: 'ok',
 						},
 					},
 					order: {
-						'': [ 'clicken' ],
-						clicken: [ 'clicken-child', 'clicken-child-2' ],
-						'clicken-child': [],
-						'clicken-child-2': [],
+						'': [ 'chicken' ],
+						chicken: [ 'chicken-child', 'chicken-child-2' ],
+						'chicken-child': [],
+						'chicken-child-2': [],
+					},
+					parents: {
+						chicken: '',
+						'chicken-child': 'chicken',
+						'chicken-child-2': 'chicken',
 					},
 				} );
 
@@ -381,7 +401,7 @@ describe( 'state', () => {
 
 				const action = {
 					type: 'REPLACE_INNER_BLOCKS',
-					rootClientId: 'clicken',
+					rootClientId: 'chicken',
 					blocks: [ newChildBlock1, newChildBlock2, newChildBlock3 ],
 				};
 
@@ -391,7 +411,7 @@ describe( 'state', () => {
 					isPersistentChange: true,
 					isIgnoredChange: false,
 					byClientId: {
-						clicken: {
+						chicken: {
 							clientId: 'chicken',
 							name: 'core/test-parent-block',
 							isValid: true,
@@ -413,7 +433,7 @@ describe( 'state', () => {
 						},
 					},
 					attributes: {
-						clicken: {},
+						chicken: {},
 						[ newChildBlockId1 ]: {
 							attr: false,
 							attr2: 'perfect',
@@ -427,11 +447,17 @@ describe( 'state', () => {
 						},
 					},
 					order: {
-						'': [ 'clicken' ],
-						clicken: [ newChildBlockId1, newChildBlockId2, newChildBlockId3 ],
+						'': [ 'chicken' ],
+						chicken: [ newChildBlockId1, newChildBlockId2, newChildBlockId3 ],
 						[ newChildBlockId1 ]: [],
 						[ newChildBlockId2 ]: [],
 						[ newChildBlockId3 ]: [],
+					},
+					parents: {
+						chicken: '',
+						[ newChildBlockId1 ]: 'chicken',
+						[ newChildBlockId2 ]: 'chicken',
+						[ newChildBlockId3 ]: 'chicken',
 					},
 				} );
 			} );
@@ -439,32 +465,37 @@ describe( 'state', () => {
 			it( 'can replace a child block that has other children', () => {
 				const existingState = deepFreeze( {
 					byClientId: {
-						clicken: {
+						chicken: {
 							clientId: 'chicken',
 							name: 'core/test-parent-block',
 							isValid: true,
 						},
-						'clicken-child': {
+						'chicken-child': {
 							clientId: 'chicken-child',
 							name: 'core/test-child-block',
 							isValid: true,
 						},
-						'clicken-grand-child': {
+						'chicken-grand-child': {
 							clientId: 'chicken-child',
 							name: 'core/test-block',
 							isValid: true,
 						},
 					},
 					attributes: {
-						clicken: {},
-						'clicken-child': {},
-						'clicken-grand-child': {},
+						chicken: {},
+						'chicken-child': {},
+						'chicken-grand-child': {},
 					},
 					order: {
-						'': [ 'clicken' ],
-						clicken: [ 'clicken-child' ],
-						'clicken-child': [ 'clicken-grand-child' ],
-						'clicken-grand-child': [],
+						'': [ 'chicken' ],
+						chicken: [ 'chicken-child' ],
+						'chicken-child': [ 'chicken-grand-child' ],
+						'chicken-grand-child': [],
+					},
+					parents: {
+						chicken: '',
+						'chicken-child': 'chicken',
+						'chicken-grand-child': 'chicken-cchild',
 					},
 				} );
 
@@ -474,7 +505,7 @@ describe( 'state', () => {
 
 				const action = {
 					type: 'REPLACE_INNER_BLOCKS',
-					rootClientId: 'clicken',
+					rootClientId: 'chicken',
 					blocks: [ newChildBlock ],
 				};
 
@@ -484,7 +515,7 @@ describe( 'state', () => {
 					isPersistentChange: true,
 					isIgnoredChange: false,
 					byClientId: {
-						clicken: {
+						chicken: {
 							clientId: 'chicken',
 							name: 'core/test-parent-block',
 							isValid: true,
@@ -496,13 +527,17 @@ describe( 'state', () => {
 						},
 					},
 					attributes: {
-						clicken: {},
+						chicken: {},
 						[ newChildBlockId ]: {},
 					},
 					order: {
-						'': [ 'clicken' ],
-						clicken: [ newChildBlockId ],
+						'': [ 'chicken' ],
+						chicken: [ newChildBlockId ],
 						[ newChildBlockId ]: [],
+					},
+					parents: {
+						chicken: '',
+						[ newChildBlockId ]: 'chicken',
 					},
 				} );
 			} );
@@ -515,6 +550,7 @@ describe( 'state', () => {
 				byClientId: {},
 				attributes: {},
 				order: {},
+				parents: {},
 				isPersistentChange: true,
 				isIgnoredChange: false,
 			} );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -495,7 +495,7 @@ describe( 'state', () => {
 					parents: {
 						chicken: '',
 						'chicken-child': 'chicken',
-						'chicken-grand-child': 'chicken-cchild',
+						'chicken-grand-child': 'chicken-child',
 					},
 				} );
 
@@ -648,6 +648,47 @@ describe( 'state', () => {
 				'': [ 'wings' ],
 				wings: [],
 			} );
+			expect( state.parents ).toEqual( {
+				wings: '',
+			} );
+		} );
+		it( 'should replace the block and remove references to its inner blocks', () => {
+			const original = blocks( undefined, {
+				type: 'RESET_BLOCKS',
+				blocks: [ {
+					clientId: 'chicken',
+					name: 'core/test-block',
+					attributes: {},
+					innerBlocks: [
+						{
+							clientId: 'child',
+							name: 'core/test-block',
+							attributes: {},
+							innerBlocks: [],
+						},
+					],
+				} ],
+			} );
+			const state = blocks( original, {
+				type: 'REPLACE_BLOCKS',
+				clientIds: [ 'chicken' ],
+				blocks: [ {
+					clientId: 'wings',
+					name: 'core/freeform',
+					innerBlocks: [],
+				} ],
+			} );
+
+			// This is commented because we have a memory leak in the byClientId and order reduces
+			// When removing blocks with innerBlocks.
+			// expect( Object.keys( state.byClientId ) ).toHaveLength( 1 );
+			// expect( state.order ).toEqual( {
+			// 	 '': [ 'wings' ],
+			//	 wings: [],
+			// } );
+			expect( state.parents ).toEqual( {
+				wings: '',
+			} );
 		} );
 
 		it( 'should replace the nested block', () => {
@@ -669,6 +710,10 @@ describe( 'state', () => {
 				'': [ wrapperBlock.clientId ],
 				[ wrapperBlock.clientId ]: [ replacementBlock.clientId ],
 				[ replacementBlock.clientId ]: [],
+			} );
+			expect( state.parents ).toEqual( {
+				[ wrapperBlock.clientId ]: '',
+				[ replacementBlock.clientId ]: wrapperBlock.clientId,
 			} );
 		} );
 
@@ -1060,6 +1105,9 @@ describe( 'state', () => {
 
 			expect( state.order[ '' ] ).toEqual( [ 'ribs' ] );
 			expect( state.order ).not.toHaveProperty( 'chicken' );
+			expect( state.parents ).toEqual( {
+				ribs: '',
+			} );
 			expect( state.byClientId ).toEqual( {
 				ribs: {
 					clientId: 'ribs',
@@ -1099,6 +1147,9 @@ describe( 'state', () => {
 			expect( state.order[ '' ] ).toEqual( [ 'ribs' ] );
 			expect( state.order ).not.toHaveProperty( 'chicken' );
 			expect( state.order ).not.toHaveProperty( 'veggies' );
+			expect( state.parents ).toEqual( {
+				ribs: '',
+			} );
 			expect( state.byClientId ).toEqual( {
 				ribs: {
 					clientId: 'ribs',
@@ -1131,6 +1182,7 @@ describe( 'state', () => {
 			expect( state.order ).toEqual( {
 				'': [],
 			} );
+			expect( state.parents ).toEqual( {} );
 		} );
 
 		it( 'should insert at the specified index', () => {

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -679,13 +679,11 @@ describe( 'state', () => {
 				} ],
 			} );
 
-			// This is commented because we have a memory leak in the byClientId and order reduces
-			// When removing blocks with innerBlocks.
-			// expect( Object.keys( state.byClientId ) ).toHaveLength( 1 );
-			// expect( state.order ).toEqual( {
-			// 	 '': [ 'wings' ],
-			//	 wings: [],
-			// } );
+			expect( Object.keys( state.byClientId ) ).toHaveLength( 1 );
+			expect( state.order ).toEqual( {
+				'': [ 'wings' ],
+				wings: [],
+			} );
 			expect( state.parents ).toEqual( {
 				wings: '',
 			} );

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -156,6 +156,9 @@ describe( 'selectors', () => {
 						'': rootOrder,
 						123: rootBlockOrder,
 					},
+					parents: {
+						123: '',
+					},
 				},
 			};
 
@@ -170,6 +173,9 @@ describe( 'selectors', () => {
 					order: {
 						'': rootOrder,
 						123: rootBlockOrder,
+					},
+					parents: {
+						123: '',
 					},
 				},
 			};
@@ -192,6 +198,9 @@ describe( 'selectors', () => {
 						'': rootOrder,
 						123: [],
 					},
+					parents: {
+						123: '',
+					},
 				},
 			};
 
@@ -209,6 +218,10 @@ describe( 'selectors', () => {
 						'': rootOrder,
 						123: [ 456 ],
 						456: [],
+					},
+					parents: {
+						123: '',
+						456: 123,
 					},
 				},
 			};
@@ -239,6 +252,10 @@ describe( 'selectors', () => {
 						123: rootBlockOrder,
 						456: childBlockOrder,
 					},
+					parents: {
+						123: '',
+						456: 123,
+					},
 				},
 			};
 
@@ -256,6 +273,10 @@ describe( 'selectors', () => {
 						'': rootOrder,
 						123: rootBlockOrder,
 						456: childBlockOrder,
+					},
+					parents: {
+						123: '',
+						456: 123,
 					},
 				},
 			};
@@ -284,6 +305,10 @@ describe( 'selectors', () => {
 						123: rootBlockOrder,
 						456: childBlockOrder,
 					},
+					parents: {
+						123: '',
+						456: 123,
+					},
 				},
 			};
 
@@ -301,6 +326,10 @@ describe( 'selectors', () => {
 						'': rootOrder,
 						123: rootBlockOrder,
 						456: childBlockOrder,
+					},
+					parents: {
+						123: '',
+						456: 123,
 					},
 				},
 			};
@@ -335,6 +364,11 @@ describe( 'selectors', () => {
 						456: childBlockOrder,
 						789: grandChildBlockOrder,
 					},
+					parents: {
+						123: '',
+						456: 123,
+						789: 456,
+					},
 				},
 			};
 
@@ -356,6 +390,11 @@ describe( 'selectors', () => {
 						456: childBlockOrder,
 						789: grandChildBlockOrder,
 					},
+					parents: {
+						123: '',
+						456: 123,
+						789: 456,
+					},
 				},
 			};
 
@@ -372,6 +411,7 @@ describe( 'selectors', () => {
 					byClientId: {},
 					attributes: {},
 					order: {},
+					parents: {},
 				},
 			};
 
@@ -396,6 +436,9 @@ describe( 'selectors', () => {
 						'': [ 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' ],
 						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': [],
 					},
+					parents: {
+						'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1': '',
+					},
 				},
 			};
 
@@ -419,6 +462,9 @@ describe( 'selectors', () => {
 						'': [ 123 ],
 						123: [],
 					},
+					parents: {
+						123: '',
+					},
 				},
 			};
 
@@ -436,6 +482,7 @@ describe( 'selectors', () => {
 					byClientId: {},
 					attributes: {},
 					order: {},
+					parents: {},
 				},
 			};
 
@@ -457,6 +504,10 @@ describe( 'selectors', () => {
 						'': [ 123 ],
 						123: [ 456 ],
 						456: [],
+					},
+					parents: {
+						123: '',
+						456: 123,
 					},
 				},
 			};
@@ -507,6 +558,9 @@ describe( 'selectors', () => {
 						'': [ 123 ],
 						123: [],
 					},
+					parents: {
+						123: '',
+					},
 				},
 			};
 
@@ -537,6 +591,10 @@ describe( 'selectors', () => {
 					},
 					order: {
 						'': [ 123, 23 ],
+					},
+					parents: {
+						123: '',
+						23: '',
 					},
 				},
 			};
@@ -602,6 +660,20 @@ describe( 'selectors', () => {
 						'uuid-24': [ 'uuid-26', 'uuid-28' ],
 						'uuid-26': [ ],
 						'uuid-28': [ 'uuid-30' ],
+					},
+					parents: {
+						'uuid-6': '',
+						'uuid-8': '',
+						'uuid-10': '',
+						'uuid-22': '',
+						'uuid-12': 'uuid-10',
+						'uuid-14': 'uuid-10',
+						'uuid-16': 'uuid-12',
+						'uuid-18': 'uuid-14',
+						'uuid-24': 'uuid-18',
+						'uuid-26': 'uuid-24',
+						'uuid-28': 'uuid-24',
+						'uuid-30': 'uuid-28',
 					},
 				},
 			};
@@ -673,6 +745,20 @@ describe( 'selectors', () => {
 						'uuid-26': [ ],
 						'uuid-28': [ 'uuid-30' ],
 					},
+					parents: {
+						'uuid-6': '',
+						'uuid-8': '',
+						'uuid-10': '',
+						'uuid-22': '',
+						'uuid-12': 'uuid-10',
+						'uuid-14': 'uuid-10',
+						'uuid-16': 'uuid-12',
+						'uuid-18': 'uuid-14',
+						'uuid-24': 'uuid-18',
+						'uuid-26': 'uuid-24',
+						'uuid-28': 'uuid-24',
+						'uuid-30': 'uuid-28',
+					},
 				},
 			};
 			expect( getClientIdsWithDescendants( state ) ).toEqual( [
@@ -729,6 +815,11 @@ describe( 'selectors', () => {
 					order: {
 						'': [ 123 ],
 						123: [ 456, 789 ],
+					},
+					parents: {
+						123: '',
+						456: 123,
+						789: 123,
 					},
 				},
 			};
@@ -788,6 +879,10 @@ describe( 'selectors', () => {
 				order: {
 					'': [ 123, 456 ],
 				},
+				parents: {
+					123: '',
+					456: '',
+				},
 			},
 		};
 
@@ -805,6 +900,7 @@ describe( 'selectors', () => {
 					byClientId: {},
 					attributes: {},
 					order: {},
+					parents: {},
 				},
 			};
 			expect( getGlobalBlockCount( emptyState ) ).toBe( 0 );
@@ -862,6 +958,10 @@ describe( 'selectors', () => {
 						23: [],
 						123: [],
 					},
+					parents: {
+						23: '',
+						123: '',
+					},
 				},
 				blockSelection: { start: {}, end: {} },
 			};
@@ -884,6 +984,10 @@ describe( 'selectors', () => {
 						'': [ 23, 123 ],
 						23: [],
 						123: [],
+					},
+					parents: {
+						123: '',
+						23: '',
 					},
 				},
 				blockSelection: { start: { clientId: 23 }, end: { clientId: 123 } },
@@ -908,6 +1012,10 @@ describe( 'selectors', () => {
 						23: [],
 						123: [],
 					},
+					parents: {
+						123: '',
+						23: '',
+					},
 				},
 				blockSelection: { start: { clientId: 23 }, end: { clientId: 23 } },
 			};
@@ -926,6 +1034,7 @@ describe( 'selectors', () => {
 			const state = {
 				blocks: {
 					order: {},
+					parents: {},
 				},
 			};
 
@@ -939,10 +1048,16 @@ describe( 'selectors', () => {
 						'': [ 123, 23 ],
 						123: [ 456, 56 ],
 					},
+					parents: {
+						123: '',
+						23: '',
+						456: 123,
+						56: 123,
+					},
 				},
 			};
 
-			expect( getBlockRootClientId( state, 56 ) ).toBe( '123' );
+			expect( getBlockRootClientId( state, 56 ) ).toBe( 123 );
 		} );
 	} );
 
@@ -951,6 +1066,7 @@ describe( 'selectors', () => {
 			const state = {
 				blocks: {
 					order: {},
+					parents: {},
 				},
 			};
 
@@ -964,10 +1080,16 @@ describe( 'selectors', () => {
 						'': [ 123, 23 ],
 						123: [ 456, 56 ],
 					},
+					parents: {
+						123: '',
+						23: '',
+						456: 123,
+						56: 123,
+					},
 				},
 			};
 
-			expect( getBlockHierarchyRootClientId( state, 56 ) ).toBe( '123' );
+			expect( getBlockHierarchyRootClientId( state, 56 ) ).toBe( 123 );
 		} );
 
 		it( 'should return the top level root ClientId relative the block ClientId', () => {
@@ -978,10 +1100,17 @@ describe( 'selectors', () => {
 						123: [ '456', '56' ],
 						56: [ '12' ],
 					},
+					parents: {
+						123: '',
+						23: '',
+						456: 123,
+						56: 123,
+						12: 56,
+					},
 				},
 			};
 
-			expect( getBlockHierarchyRootClientId( state, '12' ) ).toBe( '123' );
+			expect( getBlockHierarchyRootClientId( state, '12' ) ).toBe( 123 );
 		} );
 	} );
 
@@ -991,6 +1120,10 @@ describe( 'selectors', () => {
 				blocks: {
 					order: {
 						'': [ 123, 23 ],
+					},
+					parents: {
+						123: '',
+						23: '',
 					},
 				},
 				blockSelection: { start: {}, end: {} },
@@ -1005,6 +1138,13 @@ describe( 'selectors', () => {
 					order: {
 						'': [ 5, 4, 3, 2, 1 ],
 					},
+					parents: {
+						1: '',
+						2: '',
+						3: '',
+						4: '',
+						5: '',
+					},
 				},
 				blockSelection: { start: { clientId: 2 }, end: { clientId: 2 } },
 			};
@@ -1017,6 +1157,13 @@ describe( 'selectors', () => {
 				blocks: {
 					order: {
 						'': [ 5, 4, 3, 2, 1 ],
+					},
+					parents: {
+						1: '',
+						2: '',
+						3: '',
+						4: '',
+						5: '',
 					},
 				},
 				blockSelection: { start: { clientId: 2 }, end: { clientId: 4 } },
@@ -1031,6 +1178,17 @@ describe( 'selectors', () => {
 					order: {
 						'': [ 5, 4, 3, 2, 1 ],
 						4: [ 9, 8, 7, 6 ],
+					},
+					parents: {
+						1: '',
+						2: '',
+						3: '',
+						4: '',
+						5: '',
+						6: 4,
+						7: 4,
+						8: 4,
+						9: 4,
 					},
 				},
 				blockSelection: { start: { clientId: 7 }, end: { clientId: 9 } },
@@ -1047,6 +1205,10 @@ describe( 'selectors', () => {
 					order: {
 						'': [ 123, 23 ],
 					},
+					parents: {
+						23: '',
+						123: '',
+					},
 				},
 				blockSelection: { start: {}, end: {} },
 			};
@@ -1059,6 +1221,13 @@ describe( 'selectors', () => {
 				blocks: {
 					order: {
 						'': [ 5, 4, 3, 2, 1 ],
+					},
+					parents: {
+						1: '',
+						2: '',
+						3: '',
+						4: '',
+						5: '',
 					},
 				},
 				blockSelection: { start: { clientId: 2 }, end: { clientId: 4 } },
@@ -1073,6 +1242,17 @@ describe( 'selectors', () => {
 					order: {
 						'': [ 5, 4, 3, 2, 1 ],
 						4: [ 9, 8, 7, 6 ],
+					},
+					parents: {
+						1: '',
+						2: '',
+						3: '',
+						4: '',
+						5: '',
+						6: 4,
+						7: 4,
+						8: 4,
+						9: 4,
 					},
 				},
 				blockSelection: { start: { clientId: 7 }, end: { clientId: 9 } },
@@ -1089,6 +1269,7 @@ describe( 'selectors', () => {
 					byClientId: {},
 					attributes: {},
 					order: {},
+					parents: {},
 				},
 				blockSelection: { start: {}, end: {} },
 			};
@@ -1142,6 +1323,10 @@ describe( 'selectors', () => {
 					order: {
 						'': [ 123, 23 ],
 					},
+					parents: {
+						23: '',
+						123: '',
+					},
 				},
 			};
 
@@ -1154,6 +1339,11 @@ describe( 'selectors', () => {
 					order: {
 						'': [ 123, 23 ],
 						123: [ 456 ],
+					},
+					parents: {
+						23: '',
+						123: '',
+						456: 123,
 					},
 				},
 			};
@@ -1169,6 +1359,10 @@ describe( 'selectors', () => {
 					order: {
 						'': [ 123, 23 ],
 					},
+					parents: {
+						23: '',
+						123: '',
+					},
 				},
 			};
 
@@ -1181,6 +1375,12 @@ describe( 'selectors', () => {
 					order: {
 						'': [ 123, 23 ],
 						123: [ 456, 56 ],
+					},
+					parents: {
+						23: '',
+						123: '',
+						56: 123,
+						456: 123,
 					},
 				},
 			};
@@ -1196,6 +1396,10 @@ describe( 'selectors', () => {
 					order: {
 						'': [ 123, 23 ],
 					},
+					parents: {
+						23: '',
+						123: '',
+					},
 				},
 			};
 
@@ -1209,6 +1413,12 @@ describe( 'selectors', () => {
 						'': [ 123, 23 ],
 						123: [ 456, 56 ],
 					},
+					parents: {
+						23: '',
+						123: '',
+						456: 123,
+						56: 123,
+					},
 				},
 			};
 
@@ -1220,6 +1430,10 @@ describe( 'selectors', () => {
 				blocks: {
 					order: {
 						'': [ 123, 23 ],
+					},
+					parents: {
+						23: '',
+						123: '',
 					},
 				},
 			};
@@ -1233,6 +1447,12 @@ describe( 'selectors', () => {
 					order: {
 						'': [ 123, 23 ],
 						123: [ 456, 56 ],
+					},
+					parents: {
+						23: '',
+						123: '',
+						456: 123,
+						56: 123,
 					},
 				},
 			};
@@ -1248,6 +1468,10 @@ describe( 'selectors', () => {
 					order: {
 						'': [ 123, 23 ],
 					},
+					parents: {
+						23: '',
+						123: '',
+					},
 				},
 			};
 
@@ -1261,6 +1485,12 @@ describe( 'selectors', () => {
 						'': [ 123, 23 ],
 						123: [ 456, 56 ],
 					},
+					parents: {
+						23: '',
+						123: '',
+						456: 123,
+						56: 123,
+					},
 				},
 			};
 
@@ -1272,6 +1502,10 @@ describe( 'selectors', () => {
 				blocks: {
 					order: {
 						'': [ 123, 23 ],
+					},
+					parents: {
+						23: '',
+						123: '',
 					},
 				},
 			};
@@ -1285,6 +1519,12 @@ describe( 'selectors', () => {
 					order: {
 						'': [ 123, 23 ],
 						123: [ 456, 56 ],
+					},
+					parents: {
+						23: '',
+						123: '',
+						456: 123,
+						56: 123,
 					},
 				},
 			};
@@ -1327,6 +1567,11 @@ describe( 'selectors', () => {
 					order: {
 						4: [ 3, 2, 1 ],
 					},
+					parents: {
+						1: 4,
+						2: 4,
+						3: 4,
+					},
 				},
 			};
 
@@ -1340,6 +1585,11 @@ describe( 'selectors', () => {
 					order: {
 						4: [ 3, 2, 1 ],
 					},
+					parents: {
+						1: 4,
+						2: 4,
+						3: 4,
+					},
 				},
 			};
 
@@ -1351,6 +1601,13 @@ describe( 'selectors', () => {
 				blocks: {
 					order: {
 						6: [ 5, 4, 3, 2, 1 ],
+					},
+					parents: {
+						1: 6,
+						2: 6,
+						3: 6,
+						4: 6,
+						5: 6,
 					},
 				},
 				blockSelection: { start: { clientId: 2 }, end: { clientId: 4 } },
@@ -1364,6 +1621,12 @@ describe( 'selectors', () => {
 					order: {
 						3: [ 2, 1 ],
 						6: [ 5, 4 ],
+					},
+					parents: {
+						1: 3,
+						2: 3,
+						4: 6,
+						5: 6,
 					},
 				},
 				blockSelection: { start: { clientId: 5 }, end: { clientId: 4 } },
@@ -1380,6 +1643,13 @@ describe( 'selectors', () => {
 					order: {
 						'': [ 5, 4, 3, 2, 1 ],
 					},
+					parents: {
+						1: '',
+						2: '',
+						3: '',
+						4: '',
+						5: '',
+					},
 				},
 			};
 
@@ -1392,6 +1662,13 @@ describe( 'selectors', () => {
 				blocks: {
 					order: {
 						'': [ 5, 4, 3, 2, 1 ],
+					},
+					parents: {
+						1: '',
+						2: '',
+						3: '',
+						4: '',
+						5: '',
 					},
 				},
 			};
@@ -1406,6 +1683,13 @@ describe( 'selectors', () => {
 					order: {
 						'': [ 5, 4, 3, 2, 1 ],
 					},
+					parents: {
+						1: '',
+						2: '',
+						3: '',
+						4: '',
+						5: '',
+					},
 				},
 			};
 
@@ -1418,6 +1702,13 @@ describe( 'selectors', () => {
 				blocks: {
 					order: {
 						'': [ 5, 4, 3, 2, 1 ],
+					},
+					parents: {
+						1: '',
+						2: '',
+						3: '',
+						4: '',
+						5: '',
 					},
 				},
 			};
@@ -1467,6 +1758,13 @@ describe( 'selectors', () => {
 				order: {
 					'': [ 5, 4, 3, 2, 1 ],
 				},
+				parents: {
+					1: '',
+					2: '',
+					3: '',
+					4: '',
+					5: '',
+				},
 			},
 			blockSelection: { start: { clientId: 2 }, end: { clientId: 4 } },
 		};
@@ -1485,6 +1783,13 @@ describe( 'selectors', () => {
 			blocks: {
 				order: {
 					'': [ 5, 4, 3, 2, 1 ],
+				},
+				parents: {
+					1: '',
+					2: '',
+					3: '',
+					4: '',
+					5: '',
 				},
 			},
 			blockSelection: { start: { clientId: 2 }, end: { clientId: 4 } },
@@ -1598,6 +1903,10 @@ describe( 'selectors', () => {
 						clientId1: [ 'clientId2' ],
 						clientId2: [],
 					},
+					parents: {
+						clientId1: '',
+						clientId2: 'clientId1',
+					},
 				},
 				insertionPoint: {
 					rootClientId: undefined,
@@ -1627,6 +1936,9 @@ describe( 'selectors', () => {
 					order: {
 						'': [ 'clientId1' ],
 						clientId1: [],
+					},
+					parents: {
+						clientId1: '',
 					},
 				},
 				insertionPoint: null,
@@ -1658,6 +1970,10 @@ describe( 'selectors', () => {
 						clientId1: [ 'clientId2' ],
 						clientId2: [],
 					},
+					parents: {
+						clientId1: '',
+						clientId2: 'clientId1',
+					},
 				},
 				insertionPoint: null,
 			};
@@ -1688,6 +2004,10 @@ describe( 'selectors', () => {
 						clientId1: [],
 						clientId2: [],
 					},
+					parents: {
+						clientId1: '',
+						clientId2: '',
+					},
 				},
 				insertionPoint: null,
 			};
@@ -1717,6 +2037,10 @@ describe( 'selectors', () => {
 						'': [ 'clientId1', 'clientId2' ],
 						clientId1: [],
 						clientId2: [],
+					},
+					parents: {
+						clientId1: '',
+						clientId2: '',
 					},
 				},
 				insertionPoint: null,
@@ -1921,6 +2245,7 @@ describe( 'selectors', () => {
 						block1: {},
 					},
 					order: {},
+					parents: {},
 				},
 				settings: {
 					__experimentalReusableBlocks: [
@@ -1991,6 +2316,9 @@ describe( 'selectors', () => {
 					order: {
 						'': [ 'block1ref' ],
 					},
+					parents: {
+						block1ref: '',
+					},
 				},
 				settings: {
 					__experimentalReusableBlocks: [
@@ -2051,6 +2379,11 @@ describe( 'selectors', () => {
 						referredBlock2: [ 'childReferredBlock2' ],
 						childReferredBlock2: [ 'grandchildReferredBlock2' ],
 					},
+					parents: {
+						block2ref: '',
+						childReferredBlock2: 'referredBlock2',
+						grandchildReferredBlock2: 'childReferredBlock2',
+					},
 				},
 
 				settings: {
@@ -2094,6 +2427,7 @@ describe( 'selectors', () => {
 						block2: {},
 					},
 					order: {},
+					parents: {},
 				},
 				settings: {
 					__experimentalReusableBlocks: [
@@ -2136,6 +2470,10 @@ describe( 'selectors', () => {
 					},
 					order: {
 						'': [ 'block3', 'block4' ],
+					},
+					parents: {
+						block3: '',
+						block4: '',
 					},
 				},
 				settings: {
@@ -2214,6 +2552,7 @@ describe( 'selectors', () => {
 					byClientId: {},
 					attributes: {},
 					order: {},
+					parents: {},
 				},
 				preferences: {
 					insertUsage: {},
@@ -2232,6 +2571,7 @@ describe( 'selectors', () => {
 					byClientId: {},
 					attributes: {},
 					order: {},
+					parents: {},
 				},
 				preferences: {
 					insertUsage: {
@@ -2258,6 +2598,9 @@ describe( 'selectors', () => {
 					},
 					order: {
 						'': [ 'block1' ],
+					},
+					parents: {
+						block1: '',
 					},
 				},
 				preferences: {

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -1070,47 +1070,47 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getBlockHierarchyRootClientId( state, 56 ) ).toBe( 56 );
+			expect( getBlockHierarchyRootClientId( state, '56' ) ).toBe( '56' );
 		} );
 
 		it( 'should return root ClientId relative the block ClientId', () => {
 			const state = {
 				blocks: {
 					order: {
-						'': [ 123, 23 ],
-						123: [ 456, 56 ],
+						'': [ 'a', 'b' ],
+						a: [ 'c', 'd' ],
 					},
 					parents: {
-						123: '',
-						23: '',
-						456: 123,
-						56: 123,
+						a: '',
+						b: '',
+						c: 'a',
+						d: 'a',
 					},
 				},
 			};
 
-			expect( getBlockHierarchyRootClientId( state, 56 ) ).toBe( 123 );
+			expect( getBlockHierarchyRootClientId( state, 'c' ) ).toBe( 'a' );
 		} );
 
 		it( 'should return the top level root ClientId relative the block ClientId', () => {
 			const state = {
 				blocks: {
 					order: {
-						'': [ '123', '23' ],
-						123: [ '456', '56' ],
-						56: [ '12' ],
+						'': [ 'a', 'b' ],
+						a: [ 'c', 'd' ],
+						d: [ 'e' ],
 					},
 					parents: {
-						123: '',
-						23: '',
-						456: 123,
-						56: 123,
-						12: 56,
+						a: '',
+						b: '',
+						c: 'a',
+						d: 'a',
+						e: 'd',
 					},
 				},
 			};
 
-			expect( getBlockHierarchyRootClientId( state, '12' ) ).toBe( 123 );
+			expect( getBlockHierarchyRootClientId( state, 'e' ) ).toBe( 'a' );
 		} );
 	} );
 


### PR DESCRIPTION
Extracted from #16368

This PR tracks the parent of a block in the "blocks.parents" state tree in the reducer to optimizer the performance of some block editor selectors.

On its own, this PR doesn't seem to have a huge impact on performance bit it's a good step towards #16368 