### PR TITLE
Remove "Change Permalinks" button when permalink is not editable

### DIFF
--- a/packages/editor/src/components/post-permalink/index.js
+++ b/packages/editor/src/components/post-permalink/index.js
@@ -18,7 +18,7 @@ import { safeDecodeURI, safeDecodeURIComponent } from '@wordpress/url';
  * Internal dependencies
  */
 import PostPermalinkEditor from './editor.js';
-import { getWPAdminURL, cleanForSlug } from '../../utils/url';
+import { cleanForSlug } from '../../utils/url';
 
 class PostPermalink extends Component {
 	constructor() {
@@ -120,18 +120,6 @@ class PostPermalink extends Component {
 						onClick={ () => this.setState( { isEditingPermalink: true } ) }
 					>
 						{ __( 'Edit' ) }
-					</Button>
-				}
-
-				{ ! isEditable &&
-					<Button
-						className="editor-post-permalink__change"
-						isLarge
-						href={ getWPAdminURL( 'options-permalink.php' ) }
-						onClick={ this.addVisibilityCheck }
-						target="_blank"
-					>
-						{ __( 'Change Permalinks' ) }
 					</Button>
 				}
 			</div>


### PR DESCRIPTION
## Description
Fix: https://github.com/WordPress/gutenberg/issues/12498

When we are editing a page that is the homepage of a website, the Permalink UI shows a Change Permalinks button that links to the settings page allowing the user to change the site-wide permalink structure. Given that the user pressed a link on a specific page, the user may not be aware a site-wide change is being applied.
This PR follows @mapk suggestion and removes the button.

## How has this been tested?
I created a new page published it.
I went to the customizer, I selected "Homepage Settings" section, I set the page created on the previous step as the Homepage.
I opened the page in the editor and I verified 'Change Permalinks' was not available in the permalink editor.