### PR TITLE
Fix: Image resizer does not work if only one dimension is changed

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -675,12 +675,10 @@ class ImageEdit extends Component {
 								<>
 									{ getInspectorControls( imageWidth, imageHeight ) }
 									<ResizableBox
-										size={
-											width && height ? {
-												width,
-												height,
-											} : undefined
-										}
+										size={ {
+											width,
+											height,
+										} }
 										minWidth={ minWidth }
 										maxWidth={ maxWidthBuffer }
 										minHeight={ minHeight }


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/12278

Image sizes were only applied to the editor if both width and height were set. This PR applies the sizes even if just one of the dimensions is set.

## How has this been tested?
I added an image, I went to the image dimensions setting, I changed the width by writing a new number. I verified the new dimension was applied. On master, nothing happens until the height is also set, but the attribute is changed anyway and when we view the post on the frontend the dimension is applied.

