### PR TITLE
Adds a cache key to the blocks reducer in order to optimize the getBlock selector

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -80,24 +80,6 @@ _Returns_
 
 -   `number`: Number of blocks in the post.
 
-<a name="getBlockDependantsCacheBust" href="#getBlockDependantsCacheBust">#</a> **getBlockDependantsCacheBust**
-
-Returns a new reference when the inner blocks of a given block client ID
-change. This is used exclusively as a memoized selector dependant, relying
-on this selector's shared return value and recursively those of its inner
-blocks defined as dependencies. This abuses mechanics of the selector
-memoization to return from the original selector function only when
-dependants change.
-
-_Parameters_
-
--   _state_ `Object`: Editor state.
--   _clientId_ `string`: Block client ID.
-
-_Returns_
-
--   `*`: A value whose reference will change only when inner blocks of the given block client ID change.
-
 <a name="getBlockHierarchyRootClientId" href="#getBlockHierarchyRootClientId">#</a> **getBlockHierarchyRootClientId**
 
 Given a block client ID, returns the root of the hierarchy from which the block is nested, return the block itself for root level blocks.

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -219,6 +219,19 @@ const withPostMetaUpdateCacheReset = ( reducer ) => ( state, action ) => {
 };
 
 /**
+ * Utility returning an object with an empty object value for each key.
+ *
+ * @param {Array} objectKeys Keys to fill.
+ * @return {Object} Object filled with empty object as values for each clientId.
+ */
+const fillKeysWithEmptyObject = ( objectKeys ) => {
+	return objectKeys.reduce( ( result, key ) => {
+		result[ key ] = {};
+		return result;
+	}, {} );
+};
+
+/**
  * Higher-order reducer intended to compute a cache key for each block in the post.
  * A new instance of the cache key (empty object) is created each time the block object
  * needs to be refreshed (for any change in the block or its children).
@@ -235,7 +248,7 @@ const withBlockCache = ( reducer ) => ( state = {}, action ) => {
 	}
 	newState.cache = state.cache ? state.cache : {};
 
-	const addParentBlocks = ( clientIds ) => {
+	const getBlocksWithParentsClientIds = ( clientIds ) => {
 		return clientIds.reduce( ( result, clientId ) => {
 			let current = clientId;
 			do {
@@ -244,13 +257,6 @@ const withBlockCache = ( reducer ) => ( state = {}, action ) => {
 			} while ( current );
 			return result;
 		}, [] );
-	};
-
-	const fillKeysWithEmptyObject = ( clientIds ) => {
-		return clientIds.reduce( ( result, key ) => {
-			result[ key ] = {};
-			return result;
-		}, {} );
 	};
 
 	switch ( action.type ) {
@@ -266,7 +272,7 @@ const withBlockCache = ( reducer ) => ( state = {}, action ) => {
 			newState.cache = {
 				...newState.cache,
 				...fillKeysWithEmptyObject(
-					addParentBlocks( updatedBlockUids ),
+					getBlocksWithParentsClientIds( updatedBlockUids ),
 				),
 			};
 			break;
@@ -276,7 +282,7 @@ const withBlockCache = ( reducer ) => ( state = {}, action ) => {
 			newState.cache = {
 				...newState.cache,
 				...fillKeysWithEmptyObject(
-					addParentBlocks( [ action.clientId ] ),
+					getBlocksWithParentsClientIds( [ action.clientId ] ),
 				),
 			};
 			break;
@@ -284,7 +290,7 @@ const withBlockCache = ( reducer ) => ( state = {}, action ) => {
 			newState.cache = {
 				...omit( newState.cache, action.replacedClientIds ),
 				...fillKeysWithEmptyObject(
-					addParentBlocks( keys( flattenBlocks( action.blocks ) ) ),
+					getBlocksWithParentsClientIds( keys( flattenBlocks( action.blocks ) ) ),
 				),
 			};
 			break;
@@ -292,7 +298,7 @@ const withBlockCache = ( reducer ) => ( state = {}, action ) => {
 			newState.cache = {
 				...omit( newState.cache, action.removedClientIds ),
 				...fillKeysWithEmptyObject(
-					difference( addParentBlocks( action.clientIds ), action.clientIds ),
+					difference( getBlocksWithParentsClientIds( action.clientIds ), action.clientIds ),
 				),
 			};
 			break;
@@ -307,7 +313,7 @@ const withBlockCache = ( reducer ) => ( state = {}, action ) => {
 			newState.cache = {
 				...newState.cache,
 				...fillKeysWithEmptyObject(
-					addParentBlocks( updatedBlockUids )
+					getBlocksWithParentsClientIds( updatedBlockUids )
 				),
 			};
 			break;
@@ -321,7 +327,7 @@ const withBlockCache = ( reducer ) => ( state = {}, action ) => {
 			newState.cache = {
 				...newState.cache,
 				...fillKeysWithEmptyObject(
-					addParentBlocks( updatedBlockUids )
+					getBlocksWithParentsClientIds( updatedBlockUids )
 				),
 			};
 			break;
@@ -334,7 +340,7 @@ const withBlockCache = ( reducer ) => ( state = {}, action ) => {
 			newState.cache = {
 				...newState.cache,
 				...fillKeysWithEmptyObject(
-					addParentBlocks( updatedBlockUids )
+					getBlocksWithParentsClientIds( updatedBlockUids )
 				),
 			};
 		}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -426,6 +426,69 @@ const withSaveReusableBlock = ( reducer ) => ( state, action ) => {
 	return reducer( state, action );
 };
 
+// While technically redundant data as the inverse of `order`, it serves as
+// an optimization for the selectors which derive the ancestry of a block.
+const withBlockParents = ( reducer ) => ( state = {}, action ) => {
+	const newState = reducer( state, action );
+	if ( newState === state ) {
+		return newState;
+	}
+	newState.parents = newState.parents ? newState.parents : {};
+
+	const getAllPreviousChildren = ( clientIds ) => {
+		let children = [];
+		clientIds.forEach( ( clientId ) => {
+			children = children.concat( state.order[ clientId ] );
+		} );
+		return children.length ?
+			clientIds.concat( getAllPreviousChildren( children ) ) :
+			clientIds;
+	};
+
+	switch ( action.type ) {
+		case 'RESET_BLOCKS':
+			newState.parents = mapBlockParents( action.blocks );
+			break;
+		case 'RECEIVE_BLOCKS':
+			newState.parents = {
+				...newState.parents,
+				...mapBlockParents( action.blocks ),
+			};
+			break;
+		case 'INSERT_BLOCKS':
+			newState.parents = {
+				...newState.parents,
+				...mapBlockParents( action.blocks, action.rootClientId || '' ),
+			};
+			break;
+		case 'MOVE_BLOCK_TO_POSITION': {
+			newState.parents = {
+				...newState.parents,
+				[ action.clientId ]: action.toRootClientId || '',
+			};
+			break;
+		}
+		case 'REPLACE_BLOCKS':
+			newState.parents = {
+				...omit( newState.parents, getAllPreviousChildren( action.clientIds ) ),
+				...mapBlockParents( action.blocks, state[ action.clientIds[ 0 ] ] ),
+			};
+			break;
+		case 'REMOVE_BLOCKS':
+			newState.parents = omit( newState.parents, getAllPreviousChildren( action.clientIds ) );
+			break;
+		case 'REPLACE_INNER_BLOCKS':
+			newState.parents = {
+				// Inner blocks removed should be omitted from the state
+				...omit( newState.parents, getAllPreviousChildren( state.order[ action.rootClientId ] ) ),
+				...mapBlockParents( action.blocks, action.rootClientId ),
+			};
+			break;
+	}
+
+	return newState;
+};
+
 /**
  * Reducer returning the blocks state.
  *
@@ -438,6 +501,7 @@ export const blocks = flow(
 	combineReducers,
 	withInnerBlocksRemoveCascade,
 	withReplaceInnerBlocks, // needs to be after withInnerBlocksRemoveCascade
+	withBlockParents,
 	withBlockReset,
 	withSaveReusableBlock,
 	withPersistentBlockChange,

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -294,7 +294,6 @@ const withInnerBlocksRemoveCascade = ( reducer ) => ( state, action ) => {
 
 			result.push( ...state.order[ result[ i ] ] );
 		}
-
 		return result;
 	};
 
@@ -426,69 +425,6 @@ const withSaveReusableBlock = ( reducer ) => ( state, action ) => {
 	return reducer( state, action );
 };
 
-// While technically redundant data as the inverse of `order`, it serves as
-// an optimization for the selectors which derive the ancestry of a block.
-const withBlockParents = ( reducer ) => ( state = {}, action ) => {
-	const newState = reducer( state, action );
-	if ( newState === state ) {
-		return newState;
-	}
-	newState.parents = newState.parents ? newState.parents : {};
-
-	const getAllPreviousChildren = ( clientIds ) => {
-		let children = [];
-		clientIds.forEach( ( clientId ) => {
-			children = children.concat( state.order[ clientId ] );
-		} );
-		return children.length ?
-			clientIds.concat( getAllPreviousChildren( children ) ) :
-			clientIds;
-	};
-
-	switch ( action.type ) {
-		case 'RESET_BLOCKS':
-			newState.parents = mapBlockParents( action.blocks );
-			break;
-		case 'RECEIVE_BLOCKS':
-			newState.parents = {
-				...newState.parents,
-				...mapBlockParents( action.blocks ),
-			};
-			break;
-		case 'INSERT_BLOCKS':
-			newState.parents = {
-				...newState.parents,
-				...mapBlockParents( action.blocks, action.rootClientId || '' ),
-			};
-			break;
-		case 'MOVE_BLOCK_TO_POSITION': {
-			newState.parents = {
-				...newState.parents,
-				[ action.clientId ]: action.toRootClientId || '',
-			};
-			break;
-		}
-		case 'REPLACE_BLOCKS':
-			newState.parents = {
-				...omit( newState.parents, getAllPreviousChildren( action.clientIds ) ),
-				...mapBlockParents( action.blocks, state.parents[ action.clientIds[ 0 ] ] ),
-			};
-			break;
-		case 'REMOVE_BLOCKS':
-			newState.parents = omit( newState.parents, getAllPreviousChildren( action.clientIds ) );
-			break;
-		case 'REPLACE_INNER_BLOCKS':
-			newState.parents = {
-				// Inner blocks removed should be omitted from the state
-				...omit( newState.parents, getAllPreviousChildren( state.order[ action.rootClientId ] ) ),
-				...mapBlockParents( action.blocks, action.rootClientId ),
-			};
-			break;
-	}
-
-	return newState;
-};
-
 /**
  * Reducer returning the blocks state.
  *
@@ -501,7 +437,6 @@ export const blocks = flow(
 	combineReducers,
 	withInnerBlocksRemoveCascade,
 	withReplaceInnerBlocks, // needs to be after withInnerBlocksRemoveCascade
-	withBlockParents,
 	withBlockReset,
 	withSaveReusableBlock,
 	withPersistentBlockChange,

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -471,7 +471,7 @@ const withBlockParents = ( reducer ) => ( state = {}, action ) => {
 		case 'REPLACE_BLOCKS':
 			newState.parents = {
 				...omit( newState.parents, getAllPreviousChildren( action.clientIds ) ),
-				...mapBlockParents( action.blocks, state[ action.clientIds[ 0 ] ] ),
+				...mapBlockParents( action.blocks, state.parents[ action.clientIds[ 0 ] ] ),
 			};
 			break;
 		case 'REMOVE_BLOCKS':

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -205,8 +205,8 @@ export function isUpdatingSameBlockAttribute( action, lastAction ) {
  */
 const withPostMetaUpdateCacheReset = ( reducer ) => ( state, action ) => {
 	const newState = reducer( state, action );
-	const previousMetaValues = get( state, [ 'settings', '__experimentalMetaSource', 'value' ] );
-	const nextMetaValues = get( newState, [ 'settings', '__experimentalMetaSource', 'value' ] );
+	const previousMetaValues = get( state.settings.__experimentalMetaSource, [ 'value' ] );
+	const nextMetaValues = get( newState.settings.__experimentalMetaSource, [ 'value' ] );
 	// If post meta values change, reset the cache key for all blocks
 	if ( previousMetaValues !== nextMetaValues ) {
 		newState.blocks = {
@@ -229,7 +229,6 @@ const withPostMetaUpdateCacheReset = ( reducer ) => ( state, action ) => {
  */
 const withBlockCache = ( reducer ) => ( state = {}, action ) => {
 	const newState = reducer( state, action );
-	const previousParents = state.parents;
 
 	if ( newState === state ) {
 		return state;
@@ -237,21 +236,20 @@ const withBlockCache = ( reducer ) => ( state = {}, action ) => {
 	newState.cache = state.cache ? state.cache : {};
 
 	const addParentBlocks = ( clientIds ) => {
-		const result = [];
-		clientIds.forEach( ( clientId ) => {
+		return clientIds.reduce( ( result, clientId ) => {
 			let current = clientId;
 			do {
 				result.push( current );
-				current = previousParents[ current ];
+				current = state.parents[ current ];
 			} while ( current );
-		} );
-		return result;
+			return result;
+		}, [] );
 	};
 
 	const fillKeysWithEmptyObject = ( clientIds ) => {
-		return clientIds.reduce( ( ret, key ) => {
-			ret[ key ] = {};
-			return ret;
+		return clientIds.reduce( ( result, key ) => {
+			result[ key ] = {};
+			return result;
 		}, {} );
 	};
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -286,7 +286,7 @@ const withBlockCache = ( reducer ) => ( state = {}, action ) => {
 				),
 			};
 			break;
-		case 'REPLACE_BLOCKS':
+		case 'REPLACE_BLOCKS_AUGMENTED_WITH_CHILDREN':
 			newState.cache = {
 				...omit( newState.cache, action.replacedClientIds ),
 				...fillKeysWithEmptyObject(
@@ -294,7 +294,7 @@ const withBlockCache = ( reducer ) => ( state = {}, action ) => {
 				),
 			};
 			break;
-		case 'REMOVE_BLOCKS':
+		case 'REMOVE_BLOCKS_AUGMENTED_WITH_CHILDREN':
 			newState.cache = {
 				...omit( newState.cache, action.removedClientIds ),
 				...fillKeysWithEmptyObject(

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -205,7 +205,7 @@ export function isUpdatingSameBlockAttribute( action, lastAction ) {
  */
 const withPostMetaUpdateCacheReset = ( reducer ) => ( state, action ) => {
 	const newState = reducer( state, action );
-	const previousMetaValues = get( state.settings.__experimentalMetaSource, [ 'value' ] );
+	const previousMetaValues = get( state, [ 'settings', '__experimentalMetaSource', 'value' ] );
 	const nextMetaValues = get( newState.settings.__experimentalMetaSource, [ 'value' ] );
 	// If post meta values change, reset the cache key for all blocks
 	if ( previousMetaValues !== nextMetaValues ) {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -73,28 +73,6 @@ const EMPTY_ARRAY = [];
 const EMPTY_OBJECT = {};
 
 /**
- * Returns a new reference when the inner blocks of a given block client ID
- * change. This is used exclusively as a memoized selector dependant, relying
- * on this selector's shared return value and recursively those of its inner
- * blocks defined as dependencies. This abuses mechanics of the selector
- * memoization to return from the original selector function only when
- * dependants change.
- *
- * @param {Object} state    Editor state.
- * @param {string} clientId Block client ID.
- *
- * @return {*} A value whose reference will change only when inner blocks of
- *             the given block client ID change.
- */
-export const getBlockDependantsCacheBust = createSelector(
-	() => [],
-	( state, clientId ) => map(
-		getBlockOrder( state, clientId ),
-		( innerBlockClientId ) => getBlock( state, innerBlockClientId ),
-	),
-);
-
-/**
  * Returns a block's name given its client ID, or null if no block exists with
  * the client ID.
  *
@@ -192,8 +170,7 @@ export const getBlock = createSelector(
 		};
 	},
 	( state, clientId ) => [
-		...getBlockAttributes.getDependants( state, clientId ),
-		getBlockDependantsCacheBust( state, clientId ),
+		state.blocks.cache[ clientId ],
 	]
 );
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -170,6 +170,11 @@ export const getBlock = createSelector(
 		};
 	},
 	( state, clientId ) => [
+		// Normally, we'd have both  `getBlockAttributes` dependancies and
+		// `getBlocks` (children) dependancies here but for performance reasons
+		// we use a denormalized cache key computed in the reducer that takes both
+		// the attributes and inner blocks into account. The value of the cache key
+		// is being changed whenever one of these dependencies is out of date.
 		state.blocks.cache[ clientId ],
 	]
 );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -219,6 +219,10 @@ describe( 'state', () => {
 						chicken: '',
 						'chicken-child': 'chicken',
 					},
+					cache: {
+						chicken: {},
+						'chicken-child': {},
+					},
 				} );
 
 				const newChildBlock = createBlock( 'core/test-child-block', {
@@ -267,7 +271,12 @@ describe( 'state', () => {
 						[ newChildBlockId ]: 'chicken',
 						chicken: '',
 					},
+					cache: {
+						chicken: {},
+						[ newChildBlockId ]: {},
+					},
 				} );
+				expect( state.cache.chicken ).not.toBe( existingState.cache.chicken );
 			} );
 
 			it( 'can insert a child block', () => {
@@ -289,6 +298,9 @@ describe( 'state', () => {
 					parents: {
 						chicken: '',
 					},
+					cache: {
+						chicken: {},
+					},
 				} );
 
 				const newChildBlock = createBlock( 'core/test-child-block', {
@@ -337,7 +349,12 @@ describe( 'state', () => {
 						[ newChildBlockId ]: 'chicken',
 						chicken: '',
 					},
+					cache: {
+						chicken: {},
+						[ newChildBlockId ]: {},
+					},
 				} );
+				expect( state.cache.chicken ).not.toBe( existingState.cache.chicken );
 			} );
 
 			it( 'can replace multiple child blocks', () => {
@@ -378,6 +395,11 @@ describe( 'state', () => {
 						chicken: '',
 						'chicken-child': 'chicken',
 						'chicken-child-2': 'chicken',
+					},
+					cache: {
+						chicken: {},
+						'chicken-child': {},
+						'chicken-child-2': {},
 					},
 				} );
 
@@ -459,6 +481,12 @@ describe( 'state', () => {
 						[ newChildBlockId2 ]: 'chicken',
 						[ newChildBlockId3 ]: 'chicken',
 					},
+					cache: {
+						chicken: {},
+						[ newChildBlockId1 ]: {},
+						[ newChildBlockId2 ]: {},
+						[ newChildBlockId3 ]: {},
+					},
 				} );
 			} );
 
@@ -496,6 +524,11 @@ describe( 'state', () => {
 						chicken: '',
 						'chicken-child': 'chicken',
 						'chicken-grand-child': 'chicken-child',
+					},
+					cache: {
+						chicken: {},
+						'chicken-child': {},
+						'chicken-grand-child': {},
 					},
 				} );
 
@@ -539,7 +572,14 @@ describe( 'state', () => {
 						chicken: '',
 						[ newChildBlockId ]: 'chicken',
 					},
+					cache: {
+						chicken: {},
+						[ newChildBlockId ]: {},
+					},
 				} );
+
+				// the cache key of the parent should be updated
+				expect( existingState.cache.chicken ).not.toBe( state.cache.chicken );
 			} );
 		} );
 
@@ -553,6 +593,7 @@ describe( 'state', () => {
 				parents: {},
 				isPersistentChange: true,
 				isIgnoredChange: false,
+				cache: {},
 			} );
 		} );
 
@@ -572,6 +613,9 @@ describe( 'state', () => {
 					'': [ 'bananas' ],
 					bananas: [],
 				} );
+				expect( state.cache ).toEqual( {
+					bananas: {},
+				} );
 			} );
 		} );
 
@@ -590,6 +634,10 @@ describe( 'state', () => {
 				'': [ 'bananas' ],
 				apples: [],
 				bananas: [ 'apples' ],
+			} );
+			expect( state.cache ).toEqual( {
+				bananas: {},
+				apples: {},
 			} );
 		} );
 
@@ -619,6 +667,12 @@ describe( 'state', () => {
 				chicken: [],
 				ribs: [],
 			} );
+			expect( state.cache ).toEqual( {
+				chicken: {},
+				ribs: {},
+			} );
+			// The cache key is the same because the block has not been modified.
+			expect( original.cache.chicken ).toBe( state.cache.chicken );
 		} );
 
 		it( 'should replace the block', () => {
@@ -650,6 +704,9 @@ describe( 'state', () => {
 			} );
 			expect( state.parents ).toEqual( {
 				wings: '',
+			} );
+			expect( state.cache ).toEqual( {
+				wings: {},
 			} );
 		} );
 		it( 'should replace the block and remove references to its inner blocks', () => {
@@ -687,6 +744,9 @@ describe( 'state', () => {
 			expect( state.parents ).toEqual( {
 				wings: '',
 			} );
+			expect( state.cache ).toEqual( {
+				wings: {},
+			} );
 		} );
 
 		it( 'should replace the nested block', () => {
@@ -712,6 +772,10 @@ describe( 'state', () => {
 			expect( state.parents ).toEqual( {
 				[ wrapperBlock.clientId ]: '',
 				[ replacementBlock.clientId ]: wrapperBlock.clientId,
+			} );
+			expect( state.cache ).toEqual( {
+				[ wrapperBlock.clientId ]: {},
+				[ replacementBlock.clientId ]: {},
 			} );
 		} );
 
@@ -743,6 +807,10 @@ describe( 'state', () => {
 				'': [ 'chicken' ],
 				chicken: [],
 			} );
+			expect( replacedState.cache ).toEqual( {
+				chicken: {},
+			} );
+			expect( originalState.cache.chicken ).not.toBe( replacedState.cache.chicken );
 
 			const nestedBlock = {
 				clientId: 'chicken',
@@ -808,6 +876,11 @@ describe( 'state', () => {
 			expect( state.attributes.chicken ).toEqual( {
 				content: 'ribs',
 			} );
+
+			expect( state.cache ).toEqual( {
+				chicken: {},
+			} );
+			expect( state.cache.chicken ).not.toBe( original.cache.chicken );
 		} );
 
 		it( 'should update the reusable block reference if the temporary id is swapped', () => {
@@ -839,6 +912,10 @@ describe( 'state', () => {
 			expect( state.attributes.chicken ).toEqual( {
 				ref: 3,
 			} );
+			expect( state.cache ).toEqual( {
+				chicken: {},
+			} );
+			expect( state.cache.chicken ).not.toBe( original.cache.chicken );
 		} );
 
 		it( 'should move the block up', () => {
@@ -862,6 +939,8 @@ describe( 'state', () => {
 			} );
 
 			expect( state.order[ '' ] ).toEqual( [ 'ribs', 'chicken' ] );
+			expect( state.cache.ribs ).toBe( original.cache.ribs );
+			expect( state.cache.chicken ).toBe( original.cache.chicken );
 		} );
 
 		it( 'should move the nested block up', () => {
@@ -884,6 +963,9 @@ describe( 'state', () => {
 				[ movedBlock.clientId ]: [],
 				[ siblingBlock.clientId ]: [],
 			} );
+			expect( state.cache[ wrapperBlock.clientId ] ).not.toBe( original.cache[ wrapperBlock.clientId ] );
+			expect( state.cache[ movedBlock.clientId ] ).toBe( original.cache[ movedBlock.clientId ] );
+			expect( state.cache[ siblingBlock.clientId ] ).toBe( original.cache[ siblingBlock.clientId ] );
 		} );
 
 		it( 'should move multiple blocks up', () => {
@@ -1113,6 +1195,9 @@ describe( 'state', () => {
 				},
 			} );
 			expect( state.attributes ).toEqual( {
+				ribs: {},
+			} );
+			expect( state.cache ).toEqual( {
 				ribs: {},
 			} );
 		} );
@@ -1607,7 +1692,8 @@ describe( 'state', () => {
 
 			describe( 'isIgnoredChange', () => {
 				it( 'should consider received blocks as ignored change', () => {
-					const state = blocks( undefined, {
+					const resetState = blocks( undefined, { type: 'random action' } );
+					const state = blocks( resetState, {
 						type: 'RECEIVE_BLOCKS',
 						blocks: [ {
 							clientId: 'kumquat',

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -19,7 +19,6 @@ import { RawHTML } from '@wordpress/element';
 import * as selectors from '../selectors';
 
 const {
-	getBlockDependantsCacheBust,
 	getBlockName,
 	getBlock,
 	getBlocks,
@@ -136,274 +135,6 @@ describe( 'selectors', () => {
 		setFreeformContentHandlerName( undefined );
 	} );
 
-	describe( 'getBlockDependantsCacheBust', () => {
-		const rootBlock = { clientId: 123, name: 'core/paragraph' };
-		const rootBlockAttributes = {};
-		const rootOrder = [ 123 ];
-
-		it( 'returns an unchanging reference', () => {
-			const rootBlockOrder = [];
-
-			const state = {
-				blocks: {
-					byClientId: {
-						123: rootBlock,
-					},
-					attributes: {
-						123: rootBlockAttributes,
-					},
-					order: {
-						'': rootOrder,
-						123: rootBlockOrder,
-					},
-					parents: {
-						123: '',
-					},
-				},
-			};
-
-			const nextState = {
-				blocks: {
-					byClientId: {
-						123: rootBlock,
-					},
-					attributes: {
-						123: rootBlockAttributes,
-					},
-					order: {
-						'': rootOrder,
-						123: rootBlockOrder,
-					},
-					parents: {
-						123: '',
-					},
-				},
-			};
-
-			expect(
-				getBlockDependantsCacheBust( state, 123 )
-			).toBe( getBlockDependantsCacheBust( nextState, 123 ) );
-		} );
-
-		it( 'returns a new reference on added inner block', () => {
-			const state = {
-				blocks: {
-					byClientId: {
-						123: rootBlock,
-					},
-					attributes: {
-						123: rootBlockAttributes,
-					},
-					order: {
-						'': rootOrder,
-						123: [],
-					},
-					parents: {
-						123: '',
-					},
-				},
-			};
-
-			const nextState = {
-				blocks: {
-					byClientId: {
-						123: rootBlock,
-						456: { clientId: 456, name: 'core/paragraph' },
-					},
-					attributes: {
-						123: rootBlockAttributes,
-						456: {},
-					},
-					order: {
-						'': rootOrder,
-						123: [ 456 ],
-						456: [],
-					},
-					parents: {
-						123: '',
-						456: 123,
-					},
-				},
-			};
-
-			expect(
-				getBlockDependantsCacheBust( state, 123 )
-			).not.toBe( getBlockDependantsCacheBust( nextState, 123 ) );
-		} );
-
-		it( 'returns an unchanging reference on unchanging inner block', () => {
-			const rootBlockOrder = [ 456 ];
-			const childBlock = { clientId: 456, name: 'core/paragraph' };
-			const childBlockAttributes = {};
-			const childBlockOrder = [];
-
-			const state = {
-				blocks: {
-					byClientId: {
-						123: rootBlock,
-						456: childBlock,
-					},
-					attributes: {
-						123: rootBlockAttributes,
-						456: childBlockAttributes,
-					},
-					order: {
-						'': rootOrder,
-						123: rootBlockOrder,
-						456: childBlockOrder,
-					},
-					parents: {
-						123: '',
-						456: 123,
-					},
-				},
-			};
-
-			const nextState = {
-				blocks: {
-					byClientId: {
-						123: rootBlock,
-						456: childBlock,
-					},
-					attributes: {
-						123: rootBlockAttributes,
-						456: childBlockAttributes,
-					},
-					order: {
-						'': rootOrder,
-						123: rootBlockOrder,
-						456: childBlockOrder,
-					},
-					parents: {
-						123: '',
-						456: 123,
-					},
-				},
-			};
-
-			expect(
-				getBlockDependantsCacheBust( state, 123 )
-			).toBe( getBlockDependantsCacheBust( nextState, 123 ) );
-		} );
-
-		it( 'returns a new reference on updated inner block', () => {
-			const rootBlockOrder = [ 456 ];
-			const childBlockOrder = [];
-
-			const state = {
-				blocks: {
-					byClientId: {
-						123: rootBlock,
-						456: { clientId: 456, name: 'core/paragraph' },
-					},
-					attributes: {
-						123: rootBlockAttributes,
-						456: {},
-					},
-					order: {
-						'': rootOrder,
-						123: rootBlockOrder,
-						456: childBlockOrder,
-					},
-					parents: {
-						123: '',
-						456: 123,
-					},
-				},
-			};
-
-			const nextState = {
-				blocks: {
-					byClientId: {
-						123: rootBlock,
-						456: { clientId: 456, name: 'core/paragraph' },
-					},
-					attributes: {
-						123: rootBlockAttributes,
-						456: { content: [ 'foo' ] },
-					},
-					order: {
-						'': rootOrder,
-						123: rootBlockOrder,
-						456: childBlockOrder,
-					},
-					parents: {
-						123: '',
-						456: 123,
-					},
-				},
-			};
-
-			expect(
-				getBlockDependantsCacheBust( state, 123 )
-			).not.toBe( getBlockDependantsCacheBust( nextState, 123 ) );
-		} );
-
-		it( 'returns a new reference on updated grandchild inner block', () => {
-			const rootBlockOrder = [ 456 ];
-			const childBlock = { clientId: 456, name: 'core/paragraph' };
-			const childBlockAttributes = {};
-			const childBlockOrder = [ 789 ];
-			const grandChildBlockOrder = [];
-
-			const state = {
-				blocks: {
-					byClientId: {
-						123: rootBlock,
-						456: childBlock,
-						789: { clientId: 789, name: 'core/paragraph' },
-					},
-					attributes: {
-						123: rootBlockAttributes,
-						456: childBlockAttributes,
-						789: {},
-					},
-					order: {
-						'': rootOrder,
-						123: rootBlockOrder,
-						456: childBlockOrder,
-						789: grandChildBlockOrder,
-					},
-					parents: {
-						123: '',
-						456: 123,
-						789: 456,
-					},
-				},
-			};
-
-			const nextState = {
-				blocks: {
-					byClientId: {
-						123: rootBlock,
-						456: childBlock,
-						789: { clientId: 789, name: 'core/paragraph' },
-					},
-					attributes: {
-						123: rootBlockAttributes,
-						456: childBlockAttributes,
-						789: { content: [ 'foo' ] },
-					},
-					order: {
-						'': rootOrder,
-						123: rootBlockOrder,
-						456: childBlockOrder,
-						789: grandChildBlockOrder,
-					},
-					parents: {
-						123: '',
-						456: 123,
-						789: 456,
-					},
-				},
-			};
-
-			expect(
-				getBlockDependantsCacheBust( state, 123 )
-			).not.toBe( getBlockDependantsCacheBust( nextState, 123 ) );
-		} );
-	} );
-
 	describe( 'getBlockName', () => {
 		it( 'returns null if no block by clientId', () => {
 			const state = {
@@ -465,6 +196,9 @@ describe( 'selectors', () => {
 					parents: {
 						123: '',
 					},
+					cache: {
+						123: {},
+					},
 				},
 			};
 
@@ -483,6 +217,7 @@ describe( 'selectors', () => {
 					attributes: {},
 					order: {},
 					parents: {},
+					cache: {},
 				},
 			};
 
@@ -508,6 +243,10 @@ describe( 'selectors', () => {
 					parents: {
 						123: '',
 						456: 123,
+					},
+					cache: {
+						123: {},
+						456: {},
 					},
 				},
 			};
@@ -561,6 +300,9 @@ describe( 'selectors', () => {
 					parents: {
 						123: '',
 					},
+					cache: {
+						123: {},
+					},
 				},
 			};
 
@@ -595,6 +337,10 @@ describe( 'selectors', () => {
 					parents: {
 						123: '',
 						23: '',
+					},
+					cache: {
+						123: {},
+						23: {},
 					},
 				},
 			};
@@ -1015,6 +761,9 @@ describe( 'selectors', () => {
 					parents: {
 						123: '',
 						23: '',
+					},
+					cache: {
+						23: {},
 					},
 				},
 				blockSelection: { start: { clientId: 23 }, end: { clientId: 23 } },
@@ -2246,6 +1995,7 @@ describe( 'selectors', () => {
 					},
 					order: {},
 					parents: {},
+					cache: {},
 				},
 				settings: {
 					__experimentalReusableBlocks: [
@@ -2319,6 +2069,9 @@ describe( 'selectors', () => {
 					parents: {
 						block1ref: '',
 					},
+					cache: {
+						block1ref: {},
+					},
 				},
 				settings: {
 					__experimentalReusableBlocks: [
@@ -2384,6 +2137,11 @@ describe( 'selectors', () => {
 						childReferredBlock2: 'referredBlock2',
 						grandchildReferredBlock2: 'childReferredBlock2',
 					},
+					cache: {
+						block2ref: {},
+						childReferredBlock2: {},
+						grandchildReferredBlock2: {},
+					},
 				},
 
 				settings: {
@@ -2428,6 +2186,7 @@ describe( 'selectors', () => {
 					},
 					order: {},
 					parents: {},
+					cache: {},
 				},
 				settings: {
 					__experimentalReusableBlocks: [
@@ -2474,6 +2233,12 @@ describe( 'selectors', () => {
 					parents: {
 						block3: '',
 						block4: '',
+					},
+					cache: {
+						block1: {},
+						block2: {},
+						block3: {},
+						block4: {},
 					},
 				},
 				settings: {
@@ -2534,6 +2299,9 @@ describe( 'selectors', () => {
 					order: {
 						'': [ 'block1' ],
 					},
+					cache: {
+						block1: {},
+					},
 				},
 				preferences: {
 					insertUsage: {},
@@ -2553,6 +2321,7 @@ describe( 'selectors', () => {
 					attributes: {},
 					order: {},
 					parents: {},
+					cache: {},
 				},
 				preferences: {
 					insertUsage: {},
@@ -2572,6 +2341,7 @@ describe( 'selectors', () => {
 					attributes: {},
 					order: {},
 					parents: {},
+					cache: {},
 				},
 				preferences: {
 					insertUsage: {
@@ -2601,6 +2371,9 @@ describe( 'selectors', () => {
 					},
 					parents: {
 						block1: '',
+					},
+					cache: {
+						block1: {},
 					},
 				},
 				preferences: {


### PR DESCRIPTION
Extracted from #16368 
Blocked by #16392

The getBlock selector is the bottleneck in terms of performance in the editor when the number of blocks increase. This PR adds a cache key to the reducer which let us drop the expensive `getBlockDependantsCacheBust`