### PR TITLE
Avoid a console warning when running performance tests

### DIFF
--- a/packages/e2e-tests/specs/performance.test.js
+++ b/packages/e2e-tests/specs/performance.test.js
@@ -34,7 +34,7 @@ describe( 'Performance', () => {
 				}
 			} );
 
-			dispatch( 'core/editor' ).resetBlocks( blocks );
+			dispatch( 'core/block-editor' ).resetBlocks( blocks );
 		}, html );
 		await saveDraft();
 


### PR DESCRIPTION
We were using a deprecated API triggering a console warning.

**Testing instructions**

- run `npm run test-performance`
- the job should not show an error.