### PR TITLE
Fix adding/deleting table columns across sections

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -1,4 +1,10 @@
-## ## 2.6.0 (2019-06-12)
+## Master (unreleased)
+
+### Bug Fixes
+
+- Fixed insertion of columns in the table block, which now inserts columns for all table sections ([#16410](https://github.com/WordPress/gutenberg/pull/16410))
+
+## 2.6.0 (2019-06-12)
 
 - Fixed an issue with creating upgraded embed blocks that are not registered ([#15883](https://github.com/WordPress/gutenberg/issues/15883)).
 

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -37,6 +37,7 @@ import {
 	insertColumn,
 	deleteColumn,
 	toggleSection,
+	isEmptyTableSection,
 } from './state';
 import icon from './icon';
 
@@ -241,11 +242,10 @@ export class TableEdit extends Component {
 		}
 
 		const { attributes, setAttributes } = this.props;
-		const { section, columnIndex } = selectedCell;
+		const { columnIndex } = selectedCell;
 
 		this.setState( { selectedCell: null } );
 		setAttributes( insertColumn( attributes, {
-			section,
 			columnIndex: columnIndex + delta,
 		} ) );
 	}
@@ -352,7 +352,7 @@ export class TableEdit extends Component {
 	 * @return {Object} React element for the section.
 	 */
 	renderSection( { type, rows } ) {
-		if ( ! rows.length ) {
+		if ( isEmptyTableSection( rows ) ) {
 			return null;
 		}
 
@@ -416,7 +416,7 @@ export class TableEdit extends Component {
 		} = this.props;
 		const { initialRowCount, initialColumnCount } = this.state;
 		const { hasFixedLayout, head, body, foot } = attributes;
-		const isEmpty = ! head.length && ! body.length && ! foot.length;
+		const isEmpty = isEmptyTableSection( head ) && isEmptyTableSection( body ) && isEmptyTableSection( foot );
 		const Section = this.renderSection;
 
 		if ( isEmpty ) {

--- a/packages/block-library/src/table/state.js
+++ b/packages/block-library/src/table/state.js
@@ -161,14 +161,18 @@ export function insertColumn( state, {
  * @return {Object} New table state.
  */
 export function deleteColumn( state, {
-	section,
 	columnIndex,
 } ) {
-	return {
-		[ section ]: state[ section ].map( ( row ) => ( {
-			cells: row.cells.filter( ( cell, index ) => index !== columnIndex ),
-		} ) ).filter( ( row ) => row.cells.length ),
-	};
+	return mapValues( state, ( section ) => {
+		// Bail early if the table section is empty.
+		if ( isEmptyTableSection( section ) ) {
+			return section;
+		}
+
+		return section.map( ( row ) => ( {
+			cells: row.cells.length >= columnIndex ? row.cells.filter( ( cell, index ) => index !== columnIndex ) : row.cells,
+		} ) ).filter( ( row ) => row.cells.length );
+	} );
 }
 
 /**

--- a/packages/block-library/src/table/test/state.js
+++ b/packages/block-library/src/table/test/state.js
@@ -689,6 +689,144 @@ describe( 'deleteColumn', () => {
 
 		expect( state ).toEqual( expected );
 	} );
+
+	it( 'deletes columns across table sections', () => {
+		const tableWithOneColumn = {
+			head: [
+				{
+					cells: [
+						{
+							content: '',
+							tag: 'th',
+						},
+					],
+				},
+			],
+			body: [
+				{
+					cells: [
+						{
+							content: '',
+							tag: 'td',
+						},
+					],
+				},
+				{
+					cells: [
+						{
+							content: 'test',
+							tag: 'td',
+						},
+					],
+				},
+			],
+			foot: [
+				{
+					cells: [
+						{
+							content: '',
+							tag: 'td',
+						},
+					],
+				},
+			],
+		};
+		const state = deleteColumn( tableWithOneColumn, {
+			section: 'body',
+			columnIndex: 0,
+		} );
+
+		const expected = {
+			head: [],
+			body: [],
+			foot: [],
+		};
+
+		expect( state ).toEqual( expected );
+	} );
+
+	it( 'deletes columns across table sections when there are missing columns', () => {
+		const tableWithOneColumn = {
+			head: [
+				{
+					cells: [
+						{
+							content: '',
+							tag: 'th',
+						},
+						{
+							content: '',
+							tag: 'th',
+						},
+					],
+				},
+			],
+			body: [
+				{
+					cells: [
+						{
+							content: '',
+							tag: 'td',
+						},
+					],
+				},
+			],
+			foot: [
+				{
+					cells: [
+						{
+							content: '',
+							tag: 'td',
+						},
+						{
+							content: '',
+							tag: 'td',
+						},
+					],
+				},
+			],
+		};
+
+		const state = deleteColumn( tableWithOneColumn, {
+			section: 'body',
+			columnIndex: 1,
+		} );
+
+		const expected = {
+			head: [
+				{
+					cells: [
+						{
+							content: '',
+							tag: 'th',
+						},
+					],
+				},
+			],
+			body: [
+				{
+					cells: [
+						{
+							content: '',
+							tag: 'td',
+						},
+					],
+				},
+			],
+			foot: [
+				{
+					cells: [
+						{
+							content: '',
+							tag: 'td',
+						},
+					],
+				},
+			],
+		};
+
+		expect( state ).toEqual( expected );
+	} );
 } );
 
 describe( 'toggleSection', () => {

--- a/packages/e2e-tests/specs/blocks/__snapshots__/table.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/table.test.js.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Table allows adding and deleting columns across the table header, body and footer 1`] = `
+"<!-- wp:table -->
+<table class=\\"wp-block-table\\"><thead><tr><th></th><th></th></tr></thead><tbody><tr><td></td><td></td></tr><tr><td></td><td></td></tr></tbody><tfoot><tr><td></td><td></td></tr></tfoot></table>
+<!-- /wp:table -->"
+`;
+
+exports[`Table allows adding and deleting columns across the table header, body and footer 2`] = `
+"<!-- wp:table -->
+<table class=\\"wp-block-table\\"><thead><tr><th></th></tr></thead><tbody><tr><td></td></tr><tr><td></td></tr></tbody><tfoot><tr><td></td></tr></tfoot></table>
+<!-- /wp:table -->"
+`;
+
 exports[`Table allows header and footer rows to be switched on and off 1`] = `
 "<!-- wp:table -->
 <table class=\\"wp-block-table\\"><thead><tr><th>header</th><th></th></tr></thead><tbody><tr><td>body</td><td></td></tr><tr><td></td><td></td></tr></tbody><tfoot><tr><td>footer</td><td></td></tr></tfoot></table>

--- a/packages/e2e-tests/specs/blocks/table.test.js
+++ b/packages/e2e-tests/specs/blocks/table.test.js
@@ -1,7 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { createNewPost, insertBlock, getEditedPostContent } from '@wordpress/e2e-test-utils';
+import {
+	clickBlockToolbarButton,
+	createNewPost,
+	getEditedPostContent,
+	insertBlock,
+} from '@wordpress/e2e-test-utils';
 
 const createButtonSelector = "//div[@data-type='core/table']//button[text()='Create Table']";
 
@@ -113,6 +118,38 @@ describe( 'Table', () => {
 		await footerSwitch[ 0 ].click();
 
 		// Expect the table to have only a body with written content.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'allows adding and deleting columns across the table header, body and footer', async () => {
+		await insertBlock( 'Table' );
+
+		// Create the table.
+		const createButton = await page.$x( createButtonSelector );
+		await createButton[ 0 ].click();
+
+		// Toggle on the switches and add some content.
+		const headerSwitch = await page.$x( "//label[text()='Header section']" );
+		const footerSwitch = await page.$x( "//label[text()='Footer section']" );
+		await headerSwitch[ 0 ].click();
+		await footerSwitch[ 0 ].click();
+
+		// Add a column.
+		await clickBlockToolbarButton( 'Edit table' );
+		const addColumnAfterButton = await page.$x( "//button[text()='Add Column After']" );
+		await addColumnAfterButton[ 0 ].click();
+
+		// Expect the table to have 3 columns across the header, body and footer.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await page.click( '.wp-block-table__cell-content' );
+
+		// Delete a column.
+		await clickBlockToolbarButton( 'Edit table' );
+		const deleteColumnButton = await page.$x( "//button[text()='Delete Column']" );
+		await deleteColumnButton[ 0 ].click();
+
+		// Expect the table to have 2 columns across the header, body and footer.
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
## Description
Fixes #16046

Ensures adding table cells/columns results in cells being added across table sections (in the header, body and footer)..

## How has this been tested?
- Added unit tests
- Added e2e tests

**Manual Testing steps**
1. Navigate to Posts > Add New
2. Insert a Table block
3. Choose Column/Row Count and press "Create Table" (specific values do not matter)
4. Toggle "Header section" in the Block Inspector "Table Settings" sidebar
5. Select a cell in the table
6. From the "Edit Table" Block Toolbar menu, select "Add Column Before" or "Add Column After"
7. Note that the last column does not include cells under its header
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
