### PR TITLE
Merging blocks: clone blocks to safely insert selection tracking character

### DIFF
--- a/packages/block-editor/src/store/test/effects.js
+++ b/packages/block-editor/src/store/test/effects.js
@@ -93,11 +93,13 @@ describe( 'effects', () => {
 				clientId: 'chicken',
 				name: 'core/test-block',
 				attributes: { content: 'chicken' },
+				innerBlocks: [],
 			};
 			const blockB = {
 				clientId: 'ribs',
 				name: 'core/test-block',
 				attributes: { content: 'ribs' },
+				innerBlocks: [],
 			};
 			selectors.getBlock = ( state, clientId ) => {
 				return blockA.clientId === clientId ? blockA : blockB;
@@ -155,11 +157,13 @@ describe( 'effects', () => {
 				clientId: 'chicken',
 				name: 'core/test-block',
 				attributes: { content: 'chicken' },
+				innerBlocks: [],
 			};
 			const blockB = {
 				clientId: 'ribs',
 				name: 'core/test-block-2',
 				attributes: { content: 'ribs' },
+				innerBlocks: [],
 			};
 			selectors.getBlock = ( state, clientId ) => {
 				return blockA.clientId === clientId ? blockA : blockB;
@@ -220,11 +224,13 @@ describe( 'effects', () => {
 				clientId: 'chicken',
 				name: 'core/test-block',
 				attributes: { content: 'chicken' },
+				innerBlocks: [],
 			};
 			const blockB = {
 				clientId: 'ribs',
 				name: 'core/test-block-2',
 				attributes: { content2: 'ribs' },
+				innerBlocks: [],
 			};
 			selectors.getBlock = ( state, clientId ) => {
 				return blockA.clientId === clientId ? blockA : blockB;

--- a/packages/block-editor/src/store/test/effects.js
+++ b/packages/block-editor/src/store/test/effects.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { noop } from 'lodash';
+import deepFreeze from 'deep-freeze';
 
 /**
  * WordPress dependencies
@@ -55,14 +56,14 @@ describe( 'effects', () => {
 
 		it( 'should only focus the blockA if the blockA has no merge function', () => {
 			registerBlockType( 'core/test-block', defaultBlockSettings );
-			const blockA = {
+			const blockA = deepFreeze( {
 				clientId: 'chicken',
 				name: 'core/test-block',
-			};
-			const blockB = {
+			} );
+			const blockB = deepFreeze( {
 				clientId: 'ribs',
 				name: 'core/test-block',
-			};
+			} );
 			selectors.getBlock = ( state, clientId ) => {
 				return blockA.clientId === clientId ? blockA : blockB;
 			};
@@ -89,18 +90,18 @@ describe( 'effects', () => {
 				category: 'common',
 				title: 'test block',
 			} );
-			const blockA = {
+			const blockA = deepFreeze( {
 				clientId: 'chicken',
 				name: 'core/test-block',
 				attributes: { content: 'chicken' },
 				innerBlocks: [],
-			};
-			const blockB = {
+			} );
+			const blockB = deepFreeze( {
 				clientId: 'ribs',
 				name: 'core/test-block',
 				attributes: { content: 'ribs' },
 				innerBlocks: [],
-			};
+			} );
 			selectors.getBlock = ( state, clientId ) => {
 				return blockA.clientId === clientId ? blockA : blockB;
 			};
@@ -153,18 +154,18 @@ describe( 'effects', () => {
 				title: 'test block',
 			} );
 			registerBlockType( 'core/test-block-2', defaultBlockSettings );
-			const blockA = {
+			const blockA = deepFreeze( {
 				clientId: 'chicken',
 				name: 'core/test-block',
 				attributes: { content: 'chicken' },
 				innerBlocks: [],
-			};
-			const blockB = {
+			} );
+			const blockB = deepFreeze( {
 				clientId: 'ribs',
 				name: 'core/test-block-2',
 				attributes: { content: 'ribs' },
 				innerBlocks: [],
-			};
+			} );
 			selectors.getBlock = ( state, clientId ) => {
 				return blockA.clientId === clientId ? blockA : blockB;
 			};
@@ -220,18 +221,18 @@ describe( 'effects', () => {
 				category: 'common',
 				title: 'test block 2',
 			} );
-			const blockA = {
+			const blockA = deepFreeze( {
 				clientId: 'chicken',
 				name: 'core/test-block',
 				attributes: { content: 'chicken' },
 				innerBlocks: [],
-			};
-			const blockB = {
+			} );
+			const blockB = deepFreeze( {
 				clientId: 'ribs',
 				name: 'core/test-block-2',
 				attributes: { content2: 'ribs' },
 				innerBlocks: [],
-			};
+			} );
 			selectors.getBlock = ( state, clientId ) => {
 				return blockA.clientId === clientId ? blockA : blockB;
 			};


### PR DESCRIPTION
## Description

* The selection tracking character shouldn't be inserted when the merge effect returns early (e.g. no block transformation).
* Only insert the selection tracking character when we are sure that there is text selection.

Might fix https://github.com/wordpress-mobile/WordPress-iOS/issues/11950?

## How has this been tested?

Insert a list and a heading. Try to merge the heading with list. Select something else. Ensure that no space is added before the heading text. In master, some whitespace is added.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
