### PR TITLE
Fix: Show pre publish panel items for contributors

### DIFF
--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -56,11 +56,11 @@ function PostPublishPanelPrepublish( {
 					] }>
 						<PostSchedule />
 					</PanelBody>
-					<MaybePostFormatPanel />
-					<MaybeTagsPanel />
-					{ children }
 				</>
 			) }
+			<MaybePostFormatPanel />
+			<MaybeTagsPanel />
+			{ children }
 		</div>
 	);
 }


### PR DESCRIPTION
## Description
Fix: https://github.com/WordPress/gutenberg/issues/16198

We were not showing the pre-publish panel items added by the plugins, the tags, and the format suggestion to contributors.

This PR fixes that problem.


## How has this been tested?
As a contributor user:
I pressed the publish button to open the pre-publish panel.
I verified Post visibility and post schedule don't appear.
I verified the panel with a suggestion to add tags appears if no tags were selected before.
I verified the panel with a suggestion to add a format appears (if the theme supports post formats e.g: 2014, and if the post respects the format e.g.: contains just an image).
I pasted the following content on the browser console:
```
(
    function() {
        var PluginPrePublishPanel = wp.editPost.PluginPrePublishPanel;
        var registerPlugin = wp.plugins.registerPlugin;

        function Component() {
            return wp.element.createElement(
                PluginPrePublishPanel,
                {   
                    className: 'my-plugin-publish-panel',
                    title: 'Panel title',
                    initialOpen: true,
                },  
                'Panel content'
            );  
        }

        registerPlugin( 'my-plugin', {
          render: Component,
        });
    }
)();
```

I verified a new panel appears in the pre-publish panel.


I repeated the same actions as an admin user, and I verified the result was the same, excluding the fact that the admin has post visibility and post schedule panels.
