### PR TITLE
Record selection changes in history (undo)

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -1028,8 +1028,19 @@ content reflected as an edit in state.
 _Parameters_
 
 -   _blocks_ `Array`: Array of blocks.
--   _selectionStart_ `Array`: Selection start object.
--   _selectionEnd_ `Array`: Selection end object.
+
+_Returns_
+
+-   `Object`: Action object.
+
+<a name="resetSelection" href="#resetSelection">#</a> **resetSelection**
+
+Returns an action object used in signalling that selection state should be
+reset to the specified selection.
+
+_Parameters_
+
+-   _selection_ `Array`: Selection.
 
 _Returns_
 

--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -691,7 +691,7 @@ _Returns_
 Returns true if the block corresponding to the specified client ID is
 currently selected but isn't the last of the selected blocks. Here "last"
 refers to the block sequence in the document, _not_ the sequence of
-multi-selection, which is why `state.blockSelection.end` isn't used.
+multi-selection, which is why `state.selectionEnd` isn't used.
 
 _Parameters_
 
@@ -1040,7 +1040,7 @@ reset to the specified selection.
 
 _Parameters_
 
--   _selection_ `Array`: Selection.
+-   _selection_ `Array<WPBlockSelection>`: The block selection start and end as a pair of `WPBlockSelection`.
 
 _Returns_
 

--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -1040,7 +1040,8 @@ reset to the specified selection.
 
 _Parameters_
 
--   _selection_ `Array<WPBlockSelection>`: The block selection start and end as a pair of `WPBlockSelection`.
+-   _selectionStart_ `WPBlockSelection`: The selection start.
+-   _selectionEnd_ `WPBlockSelection`: The selection end.
 
 _Returns_
 

--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -1028,6 +1028,8 @@ content reflected as an edit in state.
 _Parameters_
 
 -   _blocks_ `Array`: Array of blocks.
+-   _selectionStart_ `Array`: Selection start object.
+-   _selectionEnd_ `Array`: Selection end object.
 
 _Returns_
 

--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -358,21 +358,9 @@ _Returns_
 
 -   `Array`: Block list.
 
-<a name="getEditorSelectionEnd" href="#getEditorSelectionEnd">#</a> **getEditorSelectionEnd**
+<a name="getEditorSelection" href="#getEditorSelection">#</a> **getEditorSelection**
 
-Return the current selection end object.
-
-_Parameters_
-
--   _state_ `Object`: 
-
-_Returns_
-
--   `Array`: Selection end object.
-
-<a name="getEditorSelectionStart" href="#getEditorSelectionStart">#</a> **getEditorSelectionStart**
-
-Return the current selection start object.
+Return the current selection.
 
 _Parameters_
 
@@ -380,7 +368,7 @@ _Parameters_
 
 _Returns_
 
--   `Array`: Selection start object.
+-   `Array`: Selection.
 
 <a name="getEditorSettings" href="#getEditorSettings">#</a> **getEditorSettings**
 
@@ -1228,6 +1216,18 @@ _Parameters_
 
 -   _blocks_ `Array`: Block Array.
 -   _options_ `?Object`: Optional options.
+
+_Returns_
+
+-   `Object`: Action object
+
+<a name="resetEditorSelection" href="#resetEditorSelection">#</a> **resetEditorSelection**
+
+Returns an action object used to signal that the selection has been updated.
+
+_Parameters_
+
+-   _selection_ `Array`: Selection.
 
 _Returns_
 

--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -358,6 +358,30 @@ _Returns_
 
 -   `Array`: Block list.
 
+<a name="getEditorSelectionEnd" href="#getEditorSelectionEnd">#</a> **getEditorSelectionEnd**
+
+Return the current selection end object.
+
+_Parameters_
+
+-   _state_ `Object`: 
+
+_Returns_
+
+-   `Array`: Selection end object.
+
+<a name="getEditorSelectionStart" href="#getEditorSelectionStart">#</a> **getEditorSelectionStart**
+
+Return the current selection start object.
+
+_Parameters_
+
+-   _state_ `Object`: 
+
+_Returns_
+
+-   `Array`: Selection start object.
+
 <a name="getEditorSettings" href="#getEditorSettings">#</a> **getEditorSettings**
 
 Returns the post editor settings.

--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -368,7 +368,7 @@ _Parameters_
 
 _Returns_
 
--   `Array`: Selection.
+-   `Array<WPBlockSelection>`: The block selection start and end as a pair of `WPBlockSelection`.
 
 <a name="getEditorSettings" href="#getEditorSettings">#</a> **getEditorSettings**
 
@@ -1227,7 +1227,7 @@ Returns an action object used to signal that the selection has been updated.
 
 _Parameters_
 
--   _selection_ `Array`: Selection.
+-   _selection_ `Array<WPBlockSelection>`: The block selection start and end as a pair of `WPBlockSelection`.
 
 _Returns_
 

--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -358,9 +358,9 @@ _Returns_
 
 -   `Array`: Block list.
 
-<a name="getEditorSelection" href="#getEditorSelection">#</a> **getEditorSelection**
+<a name="getEditorSelectionEnd" href="#getEditorSelectionEnd">#</a> **getEditorSelectionEnd**
 
-Return the current selection.
+Return the current selection end.
 
 _Parameters_
 
@@ -368,7 +368,19 @@ _Parameters_
 
 _Returns_
 
--   `Array<WPBlockSelection>`: The block selection start and end as a pair of `WPBlockSelection`.
+-   `WPBlockSelection`: The selection end.
+
+<a name="getEditorSelectionStart" href="#getEditorSelectionStart">#</a> **getEditorSelectionStart**
+
+Return the current selection start.
+
+_Parameters_
+
+-   _state_ `Object`: 
+
+_Returns_
+
+-   `WPBlockSelection`: The selection start.
 
 <a name="getEditorSettings" href="#getEditorSettings">#</a> **getEditorSettings**
 
@@ -1227,7 +1239,8 @@ Returns an action object used to signal that the selection has been updated.
 
 _Parameters_
 
--   _selection_ `Array<WPBlockSelection>`: The block selection start and end as a pair of `WPBlockSelection`.
+-   _selectionStart_ `WPBlockSelection`: The selection start.
+-   _selectionEnd_ `WPBlockSelection`: The selection end.
 
 _Returns_
 

--- a/packages/block-editor/src/components/provider/README.md
+++ b/packages/block-editor/src/components/provider/README.md
@@ -12,6 +12,20 @@ BlockEditorProvider is a component which establishes a new block editing context
 
 The current array of blocks.
 
+### `selectionStart`
+
+* **Type:** `WPBlockSelection`
+* **Required** `no`
+
+The current selection start.
+
+### `selectionEnd`
+
+* **Type:** `WPBlockSelection`
+* **Required** `no`
+
+The current selection end.
+
 ### `onChange`
 
 * **Type:** `Function`
@@ -31,6 +45,13 @@ In the context of an editor, an example usage of this distinction is for managin
 * **Required** `no`
 
 A callback invoked when the blocks have been modified in a non-persistent manner. Contrasted with `onChange`, a "non-persistent" change is one which is part of a composed input. Any sequence of updates to the same block attribute are treated as non-persistent, except for the first.
+
+### `onChangeSelection`
+
+* **Type:** `Function`
+* **Required** `no`
+
+A callback invoked when the block selection has been modified.
 
 ### `children`
 

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -22,6 +22,8 @@ class BlockEditorProvider extends Component {
 			settings,
 			updateSettings,
 			value,
+			selectionStart,
+			selectionEnd,
 			resetBlocks,
 			registry,
 		} = this.props;
@@ -49,7 +51,7 @@ class BlockEditorProvider extends Component {
 			// subsequent renders.
 			this.isSyncingOutcomingValue = null;
 			this.isSyncingIncomingValue = value;
-			resetBlocks( value );
+			resetBlocks( value, selectionStart, selectionEnd );
 		}
 	}
 
@@ -78,6 +80,8 @@ class BlockEditorProvider extends Component {
 
 		const {
 			getBlocks,
+			getSelectionStart,
+			getSelectionEnd,
 			isLastBlockChangePersistent,
 			__unstableIsLastBlockChangeIgnored,
 		} = registry.select( 'core/block-editor' );
@@ -120,10 +124,13 @@ class BlockEditorProvider extends Component {
 				blocks = newBlocks;
 				isPersistent = newIsPersistent;
 
+				const selectionStart = getSelectionStart();
+				const selectionEnd = getSelectionEnd();
+
 				if ( isPersistent ) {
-					onChange( blocks );
+					onChange( blocks, selectionStart, selectionEnd );
 				} else {
-					onInput( blocks );
+					onInput( blocks, selectionStart, selectionEnd );
 				}
 			}
 		} );

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -22,9 +22,9 @@ class BlockEditorProvider extends Component {
 			settings,
 			updateSettings,
 			value,
-			selectionStart,
-			selectionEnd,
 			resetBlocks,
+			selection,
+			resetSelection,
 			registry,
 		} = this.props;
 
@@ -51,7 +51,8 @@ class BlockEditorProvider extends Component {
 			// subsequent renders.
 			this.isSyncingOutcomingValue = null;
 			this.isSyncingIncomingValue = value;
-			resetBlocks( value, selectionStart, selectionEnd );
+			resetBlocks( value );
+			resetSelection( selection );
 		}
 	}
 
@@ -93,6 +94,7 @@ class BlockEditorProvider extends Component {
 			const {
 				onChange,
 				onInput,
+				onChangeSelection,
 			} = this.props;
 
 			const newBlocks = getBlocks();
@@ -124,13 +126,16 @@ class BlockEditorProvider extends Component {
 				blocks = newBlocks;
 				isPersistent = newIsPersistent;
 
-				const selectionStart = getSelectionStart();
-				const selectionEnd = getSelectionEnd();
+				// Selection must be updated first, so it is recorded in history when the content change happens.
+				onChangeSelection( [
+					getSelectionStart(),
+					getSelectionEnd(),
+				] );
 
 				if ( isPersistent ) {
-					onChange( blocks, selectionStart, selectionEnd );
+					onChange( blocks );
 				} else {
-					onInput( blocks, selectionStart, selectionEnd );
+					onInput( blocks );
 				}
 			}
 		} );
@@ -149,11 +154,13 @@ export default compose( [
 		const {
 			updateSettings,
 			resetBlocks,
+			resetSelection,
 		} = dispatch( 'core/block-editor' );
 
 		return {
 			updateSettings,
 			resetBlocks,
+			resetSelection,
 		};
 	} ),
 ] )( BlockEditorProvider );

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -23,7 +23,8 @@ class BlockEditorProvider extends Component {
 			updateSettings,
 			value,
 			resetBlocks,
-			selection,
+			selectionStart,
+			selectionEnd,
 			resetSelection,
 			registry,
 		} = this.props;
@@ -52,7 +53,7 @@ class BlockEditorProvider extends Component {
 			this.isSyncingOutcomingValue = null;
 			this.isSyncingIncomingValue = value;
 			resetBlocks( value );
-			resetSelection( selection );
+			resetSelection( selectionStart, selectionEnd );
 		}
 	}
 
@@ -127,10 +128,12 @@ class BlockEditorProvider extends Component {
 				isPersistent = newIsPersistent;
 
 				// Selection must be updated first, so it is recorded in history when the content change happens.
-				onChangeSelection( [
-					getSelectionStart(),
-					getSelectionEnd(),
-				] );
+				if ( onChangeSelection ) {
+					onChangeSelection(
+						getSelectionStart(),
+						getSelectionEnd()
+					);
+				}
 
 				if ( isPersistent ) {
 					onChange( blocks );

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -53,7 +53,10 @@ class BlockEditorProvider extends Component {
 			this.isSyncingOutcomingValue = null;
 			this.isSyncingIncomingValue = value;
 			resetBlocks( value );
-			resetSelection( selectionStart, selectionEnd );
+
+			if ( selectionStart && selectionEnd ) {
+				resetSelection( selectionStart, selectionEnd );
+			}
 		}
 	}
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -49,10 +49,19 @@ export function resetBlocks( blocks ) {
 }
 
 /**
+ * @typedef {WPBlockSelection} A block selection object.
+ *
+ * @property {string} clientId     A block client ID.
+ * @property {string} attributeKey A block attribute key.
+ * @property {number} offset       A block attribute offset.
+ */
+
+/**
  * Returns an action object used in signalling that selection state should be
  * reset to the specified selection.
  *
- * @param {Array} selection Selection.
+ * @param {Array.<WPBlockSelection>} selection The block selection start and end
+ *                                             as a pair of `WPBlockSelection`.
  *
  * @return {Object} Action object.
  */

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -37,26 +37,22 @@ function* ensureDefaultBlock() {
  * reset to the specified array of blocks, taking precedence over any other
  * content reflected as an edit in state.
  *
- * @param {Array} blocks         Array of blocks.
- * @param {Array} selectionStart Selection start object.
- * @param {Array} selectionEnd   Selection end object.
+ * @param {Array} blocks Array of blocks.
  *
  * @return {Object} Action object.
  */
-export function resetBlocks( blocks, selectionStart, selectionEnd ) {
+export function resetBlocks( blocks ) {
 	return {
 		type: 'RESET_BLOCKS',
 		blocks,
-		selectionStart,
-		selectionEnd,
 	};
 }
 
 /**
  * Returns an action object used in signalling that selection state should be
- * reset to the specified selection object.
+ * reset to the specified selection.
  *
- * @param {Array} selection Selection object.
+ * @param {Array} selection Selection.
  *
  * @return {Object} Action object.
  */

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -53,6 +53,21 @@ export function resetBlocks( blocks, selectionStart, selectionEnd ) {
 }
 
 /**
+ * Returns an action object used in signalling that selection state should be
+ * reset to the specified selection object.
+ *
+ * @param {Array} selection Selection object.
+ *
+ * @return {Object} Action object.
+ */
+export function resetSelection( selection ) {
+	return {
+		type: 'RESET_SELECTION',
+		selection,
+	};
+}
+
+/**
  * Returns an action object used in signalling that blocks have been received.
  * Unlike resetBlocks, these should be appended to the existing known set, not
  * replacing.

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -37,14 +37,18 @@ function* ensureDefaultBlock() {
  * reset to the specified array of blocks, taking precedence over any other
  * content reflected as an edit in state.
  *
- * @param {Array} blocks Array of blocks.
+ * @param {Array} blocks         Array of blocks.
+ * @param {Array} selectionStart Selection start object.
+ * @param {Array} selectionEnd   Selection end object.
  *
  * @return {Object} Action object.
  */
-export function resetBlocks( blocks ) {
+export function resetBlocks( blocks, selectionStart, selectionEnd ) {
 	return {
 		type: 'RESET_BLOCKS',
 		blocks,
+		selectionStart,
+		selectionEnd,
 	};
 }
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -60,15 +60,16 @@ export function resetBlocks( blocks ) {
  * Returns an action object used in signalling that selection state should be
  * reset to the specified selection.
  *
- * @param {Array.<WPBlockSelection>} selection The block selection start and end
- *                                             as a pair of `WPBlockSelection`.
+ * @param {WPBlockSelection} selectionStart The selection start.
+ * @param {WPBlockSelection} selectionEnd   The selection end.
  *
  * @return {Object} Action object.
  */
-export function resetSelection( selection ) {
+export function resetSelection( selectionStart, selectionEnd ) {
 	return {
 		type: 'RESET_SELECTION',
-		selection,
+		selectionStart,
+		selectionEnd,
 	};
 }
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1005,7 +1005,7 @@ export function selectionStart( state = {}, action ) {
 				offset: action.startOffset,
 			};
 		case 'RESET_SELECTION':
-			return action.selection[ 0 ];
+			return action.selectionStart;
 		case 'MULTI_SELECT':
 			return { clientId: action.start };
 	}
@@ -1030,7 +1030,7 @@ export function selectionEnd( state = {}, action ) {
 				offset: action.endOffset,
 			};
 		case 'RESET_SELECTION':
-			return action.selection[ 1 ];
+			return action.selectionEnd;
 		case 'MULTI_SELECT':
 			return { clientId: action.end };
 	}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1076,16 +1076,22 @@ export function isSelectionEnabled( state = true, action ) {
 }
 
 /**
- * Reducer returning whether selection is enabled.
+ * Reducer returning the intial block selection.
+ *
+ * Currently this in only used to restore the selection after block deletion.
+ * This reducer should eventually be removed in favour of setting selection
+ * directly.
  *
  * @param {boolean} state  Current state.
  * @param {Object}  action Dispatched action.
  *
- * @return {boolean} Updated state.
+ * @return {?number} Initial position: -1 or undefined.
  */
 export function initialPosition( state, action ) {
 	if ( action.type === 'SELECT_BLOCK' ) {
 		return action.initialPosition;
+	} else if ( action.type === 'REMOVE_BLOCKS' ) {
+		return state;
 	}
 }
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -930,7 +930,7 @@ export function isCaretWithinFormattedText( state = false, action ) {
  *
  * @return {Object} Updated state.
  */
-function selection( state = {}, action ) {
+export function selection( state = {}, action ) {
 	switch ( action.type ) {
 		case 'CLEAR_SELECTED_BLOCK': {
 			if ( state.clientId ) {

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -981,6 +981,8 @@ function selection( state = {}, action ) {
 
 			return { clientId: blockToSelect.clientId };
 		}
+		case 'RESET_BLOCKS':
+			return {};
 	}
 
 	return state;

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1016,12 +1016,8 @@ export function blockSelection( state = { start: {}, end: {} }, action ) {
 					offset: action.endOffset,
 				},
 			};
-		case 'RESET_BLOCKS': {
-			const {
-				selectionStart: start = {},
-				selectionEnd: end = {},
-			} = action;
-
+		case 'RESET_SELECTION': {
+			const { selection: [ start = {}, end = {} ] } = action;
 			return { start, end };
 		}
 	}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -922,15 +922,6 @@ export function isCaretWithinFormattedText( state = false, action ) {
 	return state;
 }
 
-const BLOCK_SELECTION_EMPTY_OBJECT = {};
-const BLOCK_SELECTION_INITIAL_STATE = {
-	start: BLOCK_SELECTION_EMPTY_OBJECT,
-	end: BLOCK_SELECTION_EMPTY_OBJECT,
-	isMultiSelecting: false,
-	isEnabled: true,
-	initialPosition: null,
-};
-
 /**
  * Reducer returning the block selection's state.
  *
@@ -939,34 +930,18 @@ const BLOCK_SELECTION_INITIAL_STATE = {
  *
  * @return {Object} Updated state.
  */
-export function blockSelection( state = BLOCK_SELECTION_INITIAL_STATE, action ) {
+export function blockSelection( state = { start: {}, end: {} }, action ) {
 	switch ( action.type ) {
-		case 'CLEAR_SELECTED_BLOCK':
-			return BLOCK_SELECTION_INITIAL_STATE;
-		case 'START_MULTI_SELECT':
-			if ( state.isMultiSelecting ) {
-				return state;
+		case 'CLEAR_SELECTED_BLOCK': {
+			if ( state.start.clientId || state.end.clientId ) {
+				return { start: {}, end: {} };
 			}
 
-			return {
-				...state,
-				isMultiSelecting: true,
-				initialPosition: null,
-			};
-		case 'STOP_MULTI_SELECT':
-			if ( ! state.isMultiSelecting ) {
-				return state;
-			}
+			return state;
+		}
 
-			return {
-				...state,
-				isMultiSelecting: false,
-				initialPosition: null,
-			};
 		case 'MULTI_SELECT':
 			return {
-				...BLOCK_SELECTION_INITIAL_STATE,
-				isMultiSelecting: state.isMultiSelecting,
 				start: { clientId: action.start },
 				end: { clientId: action.end },
 			};
@@ -979,7 +954,6 @@ export function blockSelection( state = BLOCK_SELECTION_INITIAL_STATE, action ) 
 			}
 
 			return {
-				...BLOCK_SELECTION_INITIAL_STATE,
 				initialPosition: action.initialPosition,
 				start: { clientId: action.clientId },
 				end: { clientId: action.clientId },
@@ -988,7 +962,6 @@ export function blockSelection( state = BLOCK_SELECTION_INITIAL_STATE, action ) 
 		case 'INSERT_BLOCKS': {
 			if ( action.updateSelection ) {
 				return {
-					...BLOCK_SELECTION_INITIAL_STATE,
 					start: { clientId: action.blocks[ 0 ].clientId },
 					end: { clientId: action.blocks[ 0 ].clientId },
 				};
@@ -1005,7 +978,7 @@ export function blockSelection( state = BLOCK_SELECTION_INITIAL_STATE, action ) 
 				return state;
 			}
 
-			return BLOCK_SELECTION_INITIAL_STATE;
+			return { start: {}, end: {} };
 		case 'REPLACE_BLOCKS': {
 			if ( action.clientIds.indexOf( state.start.clientId ) === -1 ) {
 				return state;
@@ -1015,7 +988,7 @@ export function blockSelection( state = BLOCK_SELECTION_INITIAL_STATE, action ) 
 			const blockToSelect = action.blocks[ indexToSelect ];
 
 			if ( ! blockToSelect ) {
-				return BLOCK_SELECTION_INITIAL_STATE;
+				return { start: {}, end: {} };
 			}
 
 			if (
@@ -1026,19 +999,12 @@ export function blockSelection( state = BLOCK_SELECTION_INITIAL_STATE, action ) 
 			}
 
 			return {
-				...BLOCK_SELECTION_INITIAL_STATE,
 				start: { clientId: blockToSelect.clientId },
 				end: { clientId: blockToSelect.clientId },
 			};
 		}
-		case 'TOGGLE_SELECTION':
-			return {
-				...BLOCK_SELECTION_INITIAL_STATE,
-				isEnabled: action.isSelectionEnabled,
-			};
 		case 'SELECTION_CHANGE':
 			return {
-				...BLOCK_SELECTION_INITIAL_STATE,
 				start: {
 					clientId: action.clientId,
 					attributeKey: action.attributeKey,
@@ -1050,6 +1016,51 @@ export function blockSelection( state = BLOCK_SELECTION_INITIAL_STATE, action ) 
 					offset: action.endOffset,
 				},
 			};
+		case 'RESET_BLOCKS': {
+			const {
+				selectionStart: start = {},
+				selectionEnd: end = {},
+			} = action;
+
+			return { start, end };
+		}
+	}
+
+	return state;
+}
+
+/**
+ * Reducer returning whether the user is multi-selecting.
+ *
+ * @param {boolean} state  Current state.
+ * @param {Object}  action Dispatched action.
+ *
+ * @return {boolean} Updated state.
+ */
+export function isMultiSelecting( state = false, action ) {
+	switch ( action.type ) {
+		case 'START_MULTI_SELECT':
+			return true;
+
+		case 'STOP_MULTI_SELECT':
+			return false;
+	}
+
+	return state;
+}
+
+/**
+ * Reducer returning whether selection is enabled.
+ *
+ * @param {boolean} state  Current state.
+ * @param {Object}  action Dispatched action.
+ *
+ * @return {boolean} Updated state.
+ */
+export function isSelectionEnabled( state = true, action ) {
+	switch ( action.type ) {
+		case 'TOGGLE_SELECTION':
+			return action.isSelectionEnabled;
 	}
 
 	return state;
@@ -1256,6 +1267,8 @@ export default combineReducers( {
 	isTyping,
 	isCaretWithinFormattedText,
 	blockSelection,
+	isMultiSelecting,
+	isSelectionEnabled,
 	blocksMode,
 	blockListSettings,
 	insertionPoint,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -875,7 +875,7 @@ export function hasMultiSelection( state ) {
  * @return {boolean} True if multi-selecting, false if not.
  */
 export function isMultiSelecting( state ) {
-	return state.blockSelection.isMultiSelecting;
+	return state.isMultiSelecting;
 }
 
 /**
@@ -886,7 +886,7 @@ export function isMultiSelecting( state ) {
  * @return {boolean} True if it should be possible to multi-select blocks, false if multi-selection is disabled.
  */
 export function isSelectionEnabled( state ) {
-	return state.blockSelection.isEnabled;
+	return state.isSelectionEnabled;
 }
 
 /**

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -281,9 +281,9 @@ export function getBlockCount( state, rootClientId ) {
 /**
  * @typedef {WPBlockSelection} A block selection object.
  *
- * @property {string} clientId     The selected block client ID.
- * @property {string} attributeKey The selected block attribute key.
- * @property {number} offset       The selected block attribute offset.
+ * @property {string} clientId     A block client ID.
+ * @property {string} attributeKey A block attribute key.
+ * @property {number} offset       A block attribute offset.
  */
 
 /**
@@ -380,14 +380,11 @@ export function getSelectedBlockClientId( state ) {
 	const { selectionStart, selectionEnd } = state;
 	const { clientId } = selectionStart;
 
-	// We need to check the block exists because the current blockSelection
-	// reducer doesn't take into account when blocks are reset via undo. To be
-	// removed when that's fixed.
-	return (
-		clientId &&
-		clientId === selectionEnd.clientId &&
-		!! state.blocks.byClientId[ clientId ] ? clientId : null
-	);
+	if ( ! clientId || clientId !== selectionEnd.clientId ) {
+		return null;
+	}
+
+	return clientId;
 }
 
 /**

--- a/packages/block-editor/src/store/test/effects.js
+++ b/packages/block-editor/src/store/test/effects.js
@@ -107,12 +107,10 @@ describe( 'effects', () => {
 			};
 			const dispatch = jest.fn();
 			const getState = () => ( {
-				blockSelection: {
-					start: {
-						clientId: blockB.clientId,
-						attributeKey: 'content',
-						offset: 0,
-					},
+				selectionStart: {
+					clientId: blockB.clientId,
+					attributeKey: 'content',
+					offset: 0,
 				},
 			} );
 			handler( mergeBlocks( blockA.clientId, blockB.clientId ), { dispatch, getState } );
@@ -171,12 +169,10 @@ describe( 'effects', () => {
 			};
 			const dispatch = jest.fn();
 			const getState = () => ( {
-				blockSelection: {
-					start: {
-						clientId: blockB.clientId,
-						attributeKey: 'content',
-						offset: 0,
-					},
+				selectionStart: {
+					clientId: blockB.clientId,
+					attributeKey: 'content',
+					offset: 0,
 				},
 			} );
 			handler( mergeBlocks( blockA.clientId, blockB.clientId ), { dispatch, getState } );
@@ -238,12 +234,10 @@ describe( 'effects', () => {
 			};
 			const dispatch = jest.fn();
 			const getState = () => ( {
-				blockSelection: {
-					start: {
-						clientId: blockB.clientId,
-						attributeKey: 'content2',
-						offset: 0,
-					},
+				selectionStart: {
+					clientId: blockB.clientId,
+					attributeKey: 'content2',
+					offset: 0,
 				},
 			} );
 			handler( mergeBlocks( blockA.clientId, blockB.clientId ), { dispatch, getState } );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -12,6 +12,7 @@ import {
 	unregisterBlockType,
 	createBlock,
 } from '@wordpress/blocks';
+import { combineReducers } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -22,7 +23,9 @@ import {
 	blocks,
 	isTyping,
 	isCaretWithinFormattedText,
-	blockSelection,
+	selectionStart,
+	selectionEnd,
+	initialPosition,
 	isMultiSelecting,
 	preferences,
 	blocksMode,
@@ -31,6 +34,12 @@ import {
 	blockListSettings,
 	lastBlockAttributesChange,
 } from '../reducer';
+
+const blockSelection = combineReducers( {
+	start: selectionStart,
+	end: selectionEnd,
+	initialPosition,
+} );
 
 describe( 'state', () => {
 	describe( 'hasSameKeys()', () => {

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -1826,15 +1826,62 @@ describe( 'state', () => {
 				start: 'ribs',
 				end: 'chicken',
 			};
-			const start = selectionStart( undefined, action );
-			const end = selectionEnd( undefined, action );
+			const state1 = selectionStart( undefined, action );
+			const state2 = selectionEnd( undefined, action );
 
-			expect( start ).toEqual( { clientId: 'ribs' } );
-			expect( end ).toEqual( { clientId: 'chicken' } );
+			expect( state1 ).toEqual( { clientId: 'ribs' } );
+			expect( state2 ).toEqual( { clientId: 'chicken' } );
+		} );
+
+		it( 'should reset selection', () => {
+			const start = { clientId: 'a' };
+			const end = { clientId: 'b' };
+			const action = {
+				type: 'RESET_SELECTION',
+				selectionStart: start,
+				selectionEnd: end,
+			};
+			const state1 = selectionStart( undefined, action );
+			const state2 = selectionEnd( undefined, action );
+
+			expect( state1 ).toEqual( start );
+			expect( state2 ).toEqual( end );
+		} );
+
+		it( 'should change selection', () => {
+			const action = {
+				type: 'SELECTION_CHANGE',
+				clientId: 'a',
+				attributeKey: 'content',
+				startOffset: 1,
+				endOffset: 2,
+			};
+			const state1 = selectionStart( undefined, action );
+			const state2 = selectionEnd( undefined, action );
+
+			expect( state1 ).toEqual( {
+				clientId: 'a',
+				attributeKey: 'content',
+				offset: 1,
+			} );
+			expect( state2 ).toEqual( {
+				clientId: 'a',
+				attributeKey: 'content',
+				offset: 2,
+			} );
 		} );
 	} );
 
 	describe( 'selection()', () => {
+		it( 'should clear selection when resetting blocks', () => {
+			const original = deepFreeze( { clientId: 'a' } );
+			const state = selection( original, {
+				type: 'RESET_BLOCKS',
+			} );
+
+			expect( state ).toEqual( {} );
+		} );
+
 		it( 'should return with block clientId as selected', () => {
 			const state = selection( undefined, {
 				type: 'SELECT_BLOCK',

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -23,6 +23,7 @@ import {
 	isTyping,
 	isCaretWithinFormattedText,
 	blockSelection,
+	isMultiSelecting,
 	preferences,
 	blocksMode,
 	insertionPoint,
@@ -1798,8 +1799,6 @@ describe( 'state', () => {
 				start: { clientId: 'kumquat' },
 				end: { clientId: 'kumquat' },
 				initialPosition: -1,
-				isMultiSelecting: false,
-				isEnabled: true,
 			} );
 		} );
 
@@ -1814,9 +1813,6 @@ describe( 'state', () => {
 			expect( state ).toEqual( {
 				start: { clientId: 'ribs' },
 				end: { clientId: 'chicken' },
-				initialPosition: null,
-				isMultiSelecting: false,
-				isEnabled: true,
 			} );
 		} );
 
@@ -1831,70 +1827,22 @@ describe( 'state', () => {
 			expect( state ).toEqual( {
 				start: { clientId: 'ribs' },
 				end: { clientId: 'chicken' },
-				initialPosition: null,
-				isMultiSelecting: true,
-				isEnabled: true,
 			} );
 		} );
 
 		it( 'should start multi selection', () => {
-			const original = deepFreeze( { start: { clientId: 'ribs' }, end: { clientId: 'ribs' }, isMultiSelecting: false } );
-			const state = blockSelection( original, {
+			const state = isMultiSelecting( false, {
 				type: 'START_MULTI_SELECT',
 			} );
 
-			expect( state ).toEqual( {
-				start: { clientId: 'ribs' },
-				end: { clientId: 'ribs' },
-				initialPosition: null,
-				isMultiSelecting: true,
-			} );
+			expect( state ).toBe( true );
 		} );
-
-		it( 'should return same reference if already multi-selecting', () => {
-			const original = deepFreeze( { start: { clientId: 'ribs' }, end: { clientId: 'ribs' }, isMultiSelecting: true } );
-			const state = blockSelection( original, {
-				type: 'START_MULTI_SELECT',
-			} );
-
-			expect( state ).toBe( original );
-		} );
-
 		it( 'should end multi selection with selection', () => {
-			const original = deepFreeze( { start: { clientId: 'ribs' }, end: { clientId: 'chicken' }, isMultiSelecting: true } );
-			const state = blockSelection( original, {
+			const state = isMultiSelecting( true, {
 				type: 'STOP_MULTI_SELECT',
 			} );
 
-			expect( state ).toEqual( {
-				start: { clientId: 'ribs' },
-				end: { clientId: 'chicken' },
-				initialPosition: null,
-				isMultiSelecting: false,
-			} );
-		} );
-
-		it( 'should return same reference if already ended multi-selecting', () => {
-			const original = deepFreeze( { start: { clientId: 'ribs' }, end: { clientId: 'chicken' }, isMultiSelecting: false } );
-			const state = blockSelection( original, {
-				type: 'STOP_MULTI_SELECT',
-			} );
-
-			expect( state ).toBe( original );
-		} );
-
-		it( 'should end multi selection without selection', () => {
-			const original = deepFreeze( { start: { clientId: 'ribs' }, end: { clientId: 'ribs' }, isMultiSelecting: true } );
-			const state = blockSelection( original, {
-				type: 'STOP_MULTI_SELECT',
-			} );
-
-			expect( state ).toEqual( {
-				start: { clientId: 'ribs' },
-				end: { clientId: 'ribs' },
-				initialPosition: null,
-				isMultiSelecting: false,
-			} );
+			expect( state ).toBe( false );
 		} );
 
 		it( 'should not update the state if the block is already selected', () => {
@@ -1918,9 +1866,6 @@ describe( 'state', () => {
 			expect( state1 ).toEqual( {
 				start: {},
 				end: {},
-				initialPosition: null,
-				isMultiSelecting: false,
-				isEnabled: true,
 			} );
 		} );
 
@@ -1949,9 +1894,6 @@ describe( 'state', () => {
 			expect( state3 ).toEqual( {
 				start: { clientId: 'ribs' },
 				end: { clientId: 'ribs' },
-				initialPosition: null,
-				isMultiSelecting: false,
-				isEnabled: true,
 			} );
 		} );
 
@@ -1997,9 +1939,6 @@ describe( 'state', () => {
 			expect( state ).toEqual( {
 				start: { clientId: 'wings' },
 				end: { clientId: 'wings' },
-				initialPosition: null,
-				isEnabled: true,
-				isMultiSelecting: false,
 			} );
 		} );
 
@@ -2041,9 +1980,6 @@ describe( 'state', () => {
 			expect( state ).toEqual( {
 				start: { clientId: 'wings' },
 				end: { clientId: 'wings' },
-				initialPosition: null,
-				isMultiSelecting: false,
-				isEnabled: true,
 			} );
 		} );
 
@@ -2058,9 +1994,6 @@ describe( 'state', () => {
 			expect( state ).toEqual( {
 				start: {},
 				end: {},
-				initialPosition: null,
-				isMultiSelecting: false,
-				isEnabled: true,
 			} );
 		} );
 
@@ -2082,8 +2015,6 @@ describe( 'state', () => {
 			const original = deepFreeze( {
 				start: { clientId: 'chicken' },
 				end: { clientId: 'chicken' },
-				initialPosition: null,
-				isMultiSelecting: false,
 			} );
 			const state = blockSelection( original, {
 				type: 'REMOVE_BLOCKS',
@@ -2093,9 +2024,6 @@ describe( 'state', () => {
 			expect( state ).toEqual( {
 				start: {},
 				end: {},
-				initialPosition: null,
-				isMultiSelecting: false,
-				isEnabled: true,
 			} );
 		} );
 
@@ -2103,8 +2031,6 @@ describe( 'state', () => {
 			const original = deepFreeze( {
 				start: { clientId: 'chicken' },
 				end: { clientId: 'chicken' },
-				initialPosition: null,
-				isMultiSelecting: false,
 			} );
 			const state = blockSelection( original, {
 				type: 'REMOVE_BLOCKS',
@@ -2118,8 +2044,6 @@ describe( 'state', () => {
 			const original = deepFreeze( {
 				start: { clientId: 'chicken' },
 				end: { clientId: 'chicken' },
-				initialPosition: null,
-				isMultiSelecting: false,
 			} );
 			const newBlock = {
 				name: 'core/test-block',
@@ -2136,9 +2060,6 @@ describe( 'state', () => {
 			expect( state ).toEqual( {
 				start: { clientId: 'another-block' },
 				end: { clientId: 'another-block' },
-				initialPosition: null,
-				isMultiSelecting: false,
-				isEnabled: true,
 			} );
 		} );
 
@@ -2146,8 +2067,6 @@ describe( 'state', () => {
 			const original = deepFreeze( {
 				start: { clientId: 'chicken' },
 				end: { clientId: 'chicken' },
-				initialPosition: null,
-				isMultiSelecting: false,
 			} );
 			const newBlock = {
 				name: 'core/test-block',

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -524,10 +524,8 @@ describe( 'selectors', () => {
 	describe( 'hasSelectedBlock', () => {
 		it( 'should return false if no selection', () => {
 			const state = {
-				blockSelection: {
-					start: {},
-					end: {},
-				},
+				selectionStart: {},
+				selectionEnd: {},
 			};
 
 			expect( hasSelectedBlock( state ) ).toBe( false );
@@ -535,10 +533,8 @@ describe( 'selectors', () => {
 
 		it( 'should return false if multi-selection', () => {
 			const state = {
-				blockSelection: {
-					start: { clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' },
-					end: { clientId: '9db792c6-a25a-495d-adbd-97d56a4c4189' },
-				},
+				selectionStart: { clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' },
+				selectionEnd: { clientId: '9db792c6-a25a-495d-adbd-97d56a4c4189' },
 			};
 
 			expect( hasSelectedBlock( state ) ).toBe( false );
@@ -546,10 +542,8 @@ describe( 'selectors', () => {
 
 		it( 'should return true if singular selection', () => {
 			const state = {
-				blockSelection: {
-					start: { clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' },
-					end: { clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' },
-				},
+				selectionStart: { clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' },
+				selectionEnd: { clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' },
 			};
 
 			expect( hasSelectedBlock( state ) ).toBe( true );
@@ -604,7 +598,8 @@ describe( 'selectors', () => {
 	describe( 'getSelectedBlockClientId', () => {
 		it( 'should return null if no block is selected', () => {
 			const state = {
-				blockSelection: { start: {}, end: {} },
+				selectionStart: {},
+				selectionEnd: {},
 			};
 
 			expect( getSelectedBlockClientId( state ) ).toBe( null );
@@ -612,7 +607,8 @@ describe( 'selectors', () => {
 
 		it( 'should return null if there is multi selection', () => {
 			const state = {
-				blockSelection: { start: { clientId: 23 }, end: { clientId: 123 } },
+				selectionStart: { clientId: 23 },
+				selectionEnd: { clientId: 123 },
 			};
 
 			expect( getSelectedBlockClientId( state ) ).toBe( null );
@@ -627,7 +623,8 @@ describe( 'selectors', () => {
 						},
 					},
 				},
-				blockSelection: { start: { clientId: 23 }, end: { clientId: 23 } },
+				selectionStart: { clientId: 23 },
+				selectionEnd: { clientId: 23 },
 			};
 
 			expect( getSelectedBlockClientId( state ) ).toEqual( 23 );
@@ -656,7 +653,8 @@ describe( 'selectors', () => {
 						123: '',
 					},
 				},
-				blockSelection: { start: {}, end: {} },
+				selectionStart: {},
+				selectionEnd: {},
 			};
 
 			expect( getSelectedBlock( state ) ).toBe( null );
@@ -683,7 +681,8 @@ describe( 'selectors', () => {
 						23: '',
 					},
 				},
-				blockSelection: { start: { clientId: 23 }, end: { clientId: 123 } },
+				selectionStart: { clientId: 23 },
+				selectionEnd: { clientId: 123 },
 			};
 
 			expect( getSelectedBlock( state ) ).toBe( null );
@@ -713,7 +712,8 @@ describe( 'selectors', () => {
 						23: {},
 					},
 				},
-				blockSelection: { start: { clientId: 23 }, end: { clientId: 23 } },
+				selectionStart: { clientId: 23 },
+				selectionEnd: { clientId: 23 },
 			};
 
 			expect( getSelectedBlock( state ) ).toEqual( {
@@ -822,7 +822,8 @@ describe( 'selectors', () => {
 						23: '',
 					},
 				},
-				blockSelection: { start: {}, end: {} },
+				selectionStart: {},
+				selectionEnd: {},
 			};
 
 			expect( getSelectedBlockClientIds( state ) ).toEqual( [] );
@@ -842,7 +843,8 @@ describe( 'selectors', () => {
 						5: '',
 					},
 				},
-				blockSelection: { start: { clientId: 2 }, end: { clientId: 2 } },
+				selectionStart: { clientId: 2 },
+				selectionEnd: { clientId: 2 },
 			};
 
 			expect( getSelectedBlockClientIds( state ) ).toEqual( [ 2 ] );
@@ -862,7 +864,8 @@ describe( 'selectors', () => {
 						5: '',
 					},
 				},
-				blockSelection: { start: { clientId: 2 }, end: { clientId: 4 } },
+				selectionStart: { clientId: 2 },
+				selectionEnd: { clientId: 4 },
 			};
 
 			expect( getSelectedBlockClientIds( state ) ).toEqual( [ 4, 3, 2 ] );
@@ -887,7 +890,8 @@ describe( 'selectors', () => {
 						9: 4,
 					},
 				},
-				blockSelection: { start: { clientId: 7 }, end: { clientId: 9 } },
+				selectionStart: { clientId: 7 },
+				selectionEnd: { clientId: 9 },
 			};
 
 			expect( getSelectedBlockClientIds( state ) ).toEqual( [ 9, 8, 7 ] );
@@ -906,7 +910,8 @@ describe( 'selectors', () => {
 						123: '',
 					},
 				},
-				blockSelection: { start: {}, end: {} },
+				selectionStart: {},
+				selectionEnd: {},
 			};
 
 			expect( getMultiSelectedBlockClientIds( state ) ).toEqual( [] );
@@ -926,7 +931,8 @@ describe( 'selectors', () => {
 						5: '',
 					},
 				},
-				blockSelection: { start: { clientId: 2 }, end: { clientId: 4 } },
+				selectionStart: { clientId: 2 },
+				selectionEnd: { clientId: 4 },
 			};
 
 			expect( getMultiSelectedBlockClientIds( state ) ).toEqual( [ 4, 3, 2 ] );
@@ -951,7 +957,8 @@ describe( 'selectors', () => {
 						9: 4,
 					},
 				},
-				blockSelection: { start: { clientId: 7 }, end: { clientId: 9 } },
+				selectionStart: { clientId: 7 },
+				selectionEnd: { clientId: 9 },
 			};
 
 			expect( getMultiSelectedBlockClientIds( state ) ).toEqual( [ 9, 8, 7 ] );
@@ -967,7 +974,8 @@ describe( 'selectors', () => {
 					order: {},
 					parents: {},
 				},
-				blockSelection: { start: {}, end: {} },
+				selectionStart: {},
+				selectionEnd: {},
 			};
 
 			expect(
@@ -979,7 +987,8 @@ describe( 'selectors', () => {
 	describe( 'getMultiSelectedBlocksStartClientId', () => {
 		it( 'returns null if there is no multi selection', () => {
 			const state = {
-				blockSelection: { start: {}, end: {} },
+				selectionStart: {},
+				selectionEnd: {},
 			};
 
 			expect( getMultiSelectedBlocksStartClientId( state ) ).toBeNull();
@@ -987,7 +996,8 @@ describe( 'selectors', () => {
 
 		it( 'returns multi selection start', () => {
 			const state = {
-				blockSelection: { start: { clientId: 2 }, end: { clientId: 4 } },
+				selectionStart: { clientId: 2 },
+				selectionEnd: { clientId: 4 },
 			};
 
 			expect( getMultiSelectedBlocksStartClientId( state ) ).toBe( 2 );
@@ -997,7 +1007,8 @@ describe( 'selectors', () => {
 	describe( 'getMultiSelectedBlocksEndClientId', () => {
 		it( 'returns null if there is no multi selection', () => {
 			const state = {
-				blockSelection: { start: {}, end: {} },
+				selectionStart: {},
+				selectionEnd: {},
 			};
 
 			expect( getMultiSelectedBlocksEndClientId( state ) ).toBeNull();
@@ -1005,7 +1016,8 @@ describe( 'selectors', () => {
 
 		it( 'returns multi selection end', () => {
 			const state = {
-				blockSelection: { start: { clientId: 2 }, end: { clientId: 4 } },
+				selectionStart: { clientId: 2 },
+				selectionEnd: { clientId: 4 },
 			};
 
 			expect( getMultiSelectedBlocksEndClientId( state ) ).toBe( 4 );
@@ -1232,7 +1244,8 @@ describe( 'selectors', () => {
 	describe( 'isBlockSelected', () => {
 		it( 'should return true if the block is selected', () => {
 			const state = {
-				blockSelection: { start: { clientId: 123 }, end: { clientId: 123 } },
+				selectionStart: { clientId: 123 },
+				selectionEnd: { clientId: 123 },
 			};
 
 			expect( isBlockSelected( state, 123 ) ).toBe( true );
@@ -1240,7 +1253,8 @@ describe( 'selectors', () => {
 
 		it( 'should return false if a multi-selection range exists', () => {
 			const state = {
-				blockSelection: { start: { clientId: 123 }, end: { clientId: 124 } },
+				selectionStart: { clientId: 123 },
+				selectionEnd: { clientId: 124 },
 			};
 
 			expect( isBlockSelected( state, 123 ) ).toBe( false );
@@ -1248,7 +1262,8 @@ describe( 'selectors', () => {
 
 		it( 'should return false if the block is not selected', () => {
 			const state = {
-				blockSelection: { start: {}, end: {} },
+				selectionStart: {},
+				selectionEnd: {},
 			};
 
 			expect( isBlockSelected( state, 23 ) ).toBe( false );
@@ -1258,7 +1273,8 @@ describe( 'selectors', () => {
 	describe( 'hasSelectedInnerBlock', () => {
 		it( 'should return false if the selected block is a child of the given ClientId', () => {
 			const state = {
-				blockSelection: { start: { clientId: 5 }, end: { clientId: 5 } },
+				selectionStart: { clientId: 5 },
+				selectionEnd: { clientId: 5 },
 				blocks: {
 					order: {
 						4: [ 3, 2, 1 ],
@@ -1276,7 +1292,8 @@ describe( 'selectors', () => {
 
 		it( 'should return true if the selected block is a child of the given ClientId', () => {
 			const state = {
-				blockSelection: { start: { clientId: 3 }, end: { clientId: 3 } },
+				selectionStart: { clientId: 3 },
+				selectionEnd: { clientId: 3 },
 				blocks: {
 					order: {
 						4: [ 3, 2, 1 ],
@@ -1306,7 +1323,8 @@ describe( 'selectors', () => {
 						5: 6,
 					},
 				},
-				blockSelection: { start: { clientId: 2 }, end: { clientId: 4 } },
+				selectionStart: { clientId: 2 },
+				selectionEnd: { clientId: 4 },
 			};
 			expect( hasSelectedInnerBlock( state, 6 ) ).toBe( true );
 		} );
@@ -1325,7 +1343,8 @@ describe( 'selectors', () => {
 						5: 6,
 					},
 				},
-				blockSelection: { start: { clientId: 5 }, end: { clientId: 4 } },
+				selectionStart: { clientId: 5 },
+				selectionEnd: { clientId: 4 },
 			};
 			expect( hasSelectedInnerBlock( state, 3 ) ).toBe( false );
 		} );
@@ -1334,7 +1353,8 @@ describe( 'selectors', () => {
 	describe( 'isBlockWithinSelection', () => {
 		it( 'should return true if the block is selected but not the last', () => {
 			const state = {
-				blockSelection: { start: { clientId: 5 }, end: { clientId: 3 } },
+				selectionStart: { clientId: 5 },
+				selectionEnd: { clientId: 3 },
 				blocks: {
 					order: {
 						'': [ 5, 4, 3, 2, 1 ],
@@ -1354,7 +1374,8 @@ describe( 'selectors', () => {
 
 		it( 'should return false if the block is the last selected', () => {
 			const state = {
-				blockSelection: { start: { clientId: 5 }, end: { clientId: 3 } },
+				selectionStart: { clientId: 5 },
+				selectionEnd: { clientId: 3 },
 				blocks: {
 					order: {
 						'': [ 5, 4, 3, 2, 1 ],
@@ -1374,7 +1395,8 @@ describe( 'selectors', () => {
 
 		it( 'should return false if the block is not selected', () => {
 			const state = {
-				blockSelection: { start: { clientId: 5 }, end: { clientId: 3 } },
+				selectionStart: { clientId: 5 },
+				selectionEnd: { clientId: 3 },
 				blocks: {
 					order: {
 						'': [ 5, 4, 3, 2, 1 ],
@@ -1394,7 +1416,8 @@ describe( 'selectors', () => {
 
 		it( 'should return false if there is no selection', () => {
 			const state = {
-				blockSelection: { start: {}, end: {} },
+				selectionStart: {},
+				selectionEnd: {},
 				blocks: {
 					order: {
 						'': [ 5, 4, 3, 2, 1 ],
@@ -1416,10 +1439,8 @@ describe( 'selectors', () => {
 	describe( 'hasMultiSelection', () => {
 		it( 'should return false if no selection', () => {
 			const state = {
-				blockSelection: {
-					start: {},
-					end: {},
-				},
+				selectionStart: {},
+				selectionEnd: {},
 			};
 
 			expect( hasMultiSelection( state ) ).toBe( false );
@@ -1427,10 +1448,8 @@ describe( 'selectors', () => {
 
 		it( 'should return false if singular selection', () => {
 			const state = {
-				blockSelection: {
-					start: { clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' },
-					end: { clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' },
-				},
+				selectionStart: { clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' },
+				selectionEnd: { clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' },
 			};
 
 			expect( hasMultiSelection( state ) ).toBe( false );
@@ -1438,10 +1457,8 @@ describe( 'selectors', () => {
 
 		it( 'should return true if multi-selection', () => {
 			const state = {
-				blockSelection: {
-					start: { clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' },
-					end: { clientId: '9db792c6-a25a-495d-adbd-97d56a4c4189' },
-				},
+				selectionStart: { clientId: 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1' },
+				selectionEnd: { clientId: '9db792c6-a25a-495d-adbd-97d56a4c4189' },
 			};
 
 			expect( hasMultiSelection( state ) ).toBe( true );
@@ -1462,7 +1479,8 @@ describe( 'selectors', () => {
 					5: '',
 				},
 			},
-			blockSelection: { start: { clientId: 2 }, end: { clientId: 4 } },
+			selectionStart: { clientId: 2 },
+			selectionEnd: { clientId: 4 },
 		};
 
 		it( 'should return true if the block is multi selected', () => {
@@ -1488,7 +1506,8 @@ describe( 'selectors', () => {
 					5: '',
 				},
 			},
-			blockSelection: { start: { clientId: 2 }, end: { clientId: 4 } },
+			selectionStart: { clientId: 2 },
+			selectionEnd: { clientId: 4 },
 		};
 
 		it( 'should return true if the block is first in multi selection', () => {
@@ -1577,10 +1596,8 @@ describe( 'selectors', () => {
 	describe( 'getBlockInsertionPoint', () => {
 		it( 'should return the explicitly assigned insertion point', () => {
 			const state = {
-				blockSelection: {
-					start: { clientId: 'clientId2' },
-					end: { clientId: 'clientId2' },
-				},
+				selectionStart: { clientId: 'clientId2' },
+				selectionEnd: { clientId: 'clientId2' },
 				blocks: {
 					byClientId: {
 						clientId1: { clientId: 'clientId1' },
@@ -1614,10 +1631,8 @@ describe( 'selectors', () => {
 
 		it( 'should return an object for the selected block', () => {
 			const state = {
-				blockSelection: {
-					start: { clientId: 'clientId1' },
-					end: { clientId: 'clientId1' },
-				},
+				selectionStart: { clientId: 'clientId1' },
+				selectionEnd: { clientId: 'clientId1' },
 				blocks: {
 					byClientId: {
 						clientId1: { clientId: 'clientId1' },
@@ -1644,10 +1659,8 @@ describe( 'selectors', () => {
 
 		it( 'should return an object for the nested selected block', () => {
 			const state = {
-				blockSelection: {
-					start: { clientId: 'clientId2' },
-					end: { clientId: 'clientId2' },
-				},
+				selectionStart: { clientId: 'clientId2' },
+				selectionEnd: { clientId: 'clientId2' },
 				blocks: {
 					byClientId: {
 						clientId1: { clientId: 'clientId1' },
@@ -1678,10 +1691,8 @@ describe( 'selectors', () => {
 
 		it( 'should return an object for the last multi selected clientId', () => {
 			const state = {
-				blockSelection: {
-					start: { clientId: 'clientId1' },
-					end: { clientId: 'clientId2' },
-				},
+				selectionStart: { clientId: 'clientId1' },
+				selectionEnd: { clientId: 'clientId2' },
 				blocks: {
 					byClientId: {
 						clientId1: { clientId: 'clientId1' },
@@ -1712,10 +1723,8 @@ describe( 'selectors', () => {
 
 		it( 'should return an object for the last block if no selection', () => {
 			const state = {
-				blockSelection: {
-					start: {},
-					end: {},
-				},
+				selectionStart: {},
+				selectionEnd: {},
 				blocks: {
 					byClientId: {
 						clientId1: { clientId: 'clientId1' },

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -1559,9 +1559,7 @@ describe( 'selectors', () => {
 	describe( 'isSelectionEnabled', () => {
 		it( 'should return true if selection is enable', () => {
 			const state = {
-				blockSelection: {
-					isEnabled: true,
-				},
+				isSelectionEnabled: true,
 			};
 
 			expect( isSelectionEnabled( state ) ).toBe( true );
@@ -1569,9 +1567,7 @@ describe( 'selectors', () => {
 
 		it( 'should return false if selection is disabled', () => {
 			const state = {
-				blockSelection: {
-					isEnabled: false,
-				},
+				isSelectionEnabled: false,
 			};
 
 			expect( isSelectionEnabled( state ) ).toBe( false );

--- a/packages/e2e-tests/specs/undo.test.js
+++ b/packages/e2e-tests/specs/undo.test.js
@@ -24,12 +24,13 @@ const getSelection = async () => {
 
 		const editables = Array.from( document.querySelectorAll( '[contenteditable]' ) );
 		const editableIndex = editables.indexOf( document.activeElement );
+		const selection = window.getSelection();
 
-		if ( editableIndex === -1 ) {
+		if ( editableIndex === -1 || ! selection.rangeCount ) {
 			return { blockIndex };
 		}
 
-		const { startOffset, endOffset } = window.getSelection().getRangeAt( 0 );
+		const { startOffset, endOffset } = selection.getRangeAt( 0 );
 
 		return {
 			blockIndex,

--- a/packages/e2e-tests/specs/undo.test.js
+++ b/packages/e2e-tests/specs/undo.test.js
@@ -109,12 +109,7 @@ describe( 'undo', () => {
 
 		await pressKeyWithModifier( 'primary', 'z' ); // Undo 3rd block.
 
-		expect( await getSelection() ).toEqual( {
-			blockIndex: 2,
-			editableIndex: 1,
-			startOffset: 0,
-			endOffset: 0,
-		} );
+		expect( await getSelection() ).toEqual( {} );
 
 		await pressKeyWithModifier( 'primary', 'z' ); // Undo 2nd paragraph text.
 
@@ -127,12 +122,7 @@ describe( 'undo', () => {
 
 		await pressKeyWithModifier( 'primary', 'z' ); // Undo 2nd block.
 
-		expect( await getSelection() ).toEqual( {
-			blockIndex: 1,
-			editableIndex: 0,
-			startOffset: 0,
-			endOffset: 0,
-		} );
+		expect( await getSelection() ).toEqual( {} );
 
 		await pressKeyWithModifier( 'primary', 'z' ); // Undo 1st paragraph text.
 

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -142,6 +142,8 @@ class EditorProvider extends Component {
 			canUserUseUnfilteredHTML,
 			children,
 			blocks,
+			selectionStart,
+			selectionEnd,
 			resetEditorBlocks,
 			isReady,
 			settings,
@@ -166,6 +168,8 @@ class EditorProvider extends Component {
 				value={ blocks }
 				onInput={ resetEditorBlocksWithoutUndoLevel }
 				onChange={ resetEditorBlocks }
+				selectionStart={ selectionStart }
+				selectionEnd={ selectionEnd }
 				settings={ editorSettings }
 				useSubRegistry={ false }
 			>
@@ -184,6 +188,8 @@ export default compose( [
 			canUserUseUnfilteredHTML,
 			__unstableIsEditorReady: isEditorReady,
 			getEditorBlocks,
+			getEditorSelectionStart,
+			getEditorSelectionEnd,
 			__experimentalGetReusableBlocks,
 		} = select( 'core/editor' );
 		const { canUser } = select( 'core' );
@@ -192,6 +198,8 @@ export default compose( [
 			canUserUseUnfilteredHTML: canUserUseUnfilteredHTML(),
 			isReady: isEditorReady(),
 			blocks: getEditorBlocks(),
+			selectionStart: getEditorSelectionStart(),
+			selectionEnd: getEditorSelectionEnd(),
 			reusableBlocks: __experimentalGetReusableBlocks(),
 			hasUploadPermissions: defaultTo( canUser( 'create', 'media' ), true ),
 		};
@@ -210,11 +218,18 @@ export default compose( [
 			setupEditor,
 			updatePostLock,
 			createWarningNotice,
-			resetEditorBlocks,
+			resetEditorBlocks( blocks, selectionStart, selectionEnd ) {
+				resetEditorBlocks( blocks, {
+					selectionStart,
+					selectionEnd,
+				} );
+			},
 			updateEditorSettings,
-			resetEditorBlocksWithoutUndoLevel( blocks ) {
+			resetEditorBlocksWithoutUndoLevel( blocks, selectionStart, selectionEnd ) {
 				resetEditorBlocks( blocks, {
 					__unstableShouldCreateUndoLevel: false,
+					selectionStart,
+					selectionEnd,
 				} );
 			},
 			tearDownEditor: __experimentalTearDownEditor,

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -142,9 +142,9 @@ class EditorProvider extends Component {
 			canUserUseUnfilteredHTML,
 			children,
 			blocks,
-			selectionStart,
-			selectionEnd,
+			selection,
 			resetEditorBlocks,
+			resetEditorSelection,
 			isReady,
 			settings,
 			reusableBlocks,
@@ -168,8 +168,8 @@ class EditorProvider extends Component {
 				value={ blocks }
 				onInput={ resetEditorBlocksWithoutUndoLevel }
 				onChange={ resetEditorBlocks }
-				selectionStart={ selectionStart }
-				selectionEnd={ selectionEnd }
+				selection={ selection }
+				onChangeSelection={ resetEditorSelection }
 				settings={ editorSettings }
 				useSubRegistry={ false }
 			>
@@ -188,8 +188,7 @@ export default compose( [
 			canUserUseUnfilteredHTML,
 			__unstableIsEditorReady: isEditorReady,
 			getEditorBlocks,
-			getEditorSelectionStart,
-			getEditorSelectionEnd,
+			getEditorSelection,
 			__experimentalGetReusableBlocks,
 		} = select( 'core/editor' );
 		const { canUser } = select( 'core' );
@@ -198,8 +197,7 @@ export default compose( [
 			canUserUseUnfilteredHTML: canUserUseUnfilteredHTML(),
 			isReady: isEditorReady(),
 			blocks: getEditorBlocks(),
-			selectionStart: getEditorSelectionStart(),
-			selectionEnd: getEditorSelectionEnd(),
+			selection: getEditorSelection(),
 			reusableBlocks: __experimentalGetReusableBlocks(),
 			hasUploadPermissions: defaultTo( canUser( 'create', 'media' ), true ),
 		};
@@ -209,6 +207,7 @@ export default compose( [
 			setupEditor,
 			updatePostLock,
 			resetEditorBlocks,
+			resetEditorSelection,
 			updateEditorSettings,
 			__experimentalTearDownEditor,
 		} = dispatch( 'core/editor' );
@@ -218,12 +217,8 @@ export default compose( [
 			setupEditor,
 			updatePostLock,
 			createWarningNotice,
-			resetEditorBlocks( blocks, selectionStart, selectionEnd ) {
-				resetEditorBlocks( blocks, {
-					selectionStart,
-					selectionEnd,
-				} );
-			},
+			resetEditorBlocks,
+			resetEditorSelection,
 			updateEditorSettings,
 			resetEditorBlocksWithoutUndoLevel( blocks, selectionStart, selectionEnd ) {
 				resetEditorBlocks( blocks, {

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -142,7 +142,8 @@ class EditorProvider extends Component {
 			canUserUseUnfilteredHTML,
 			children,
 			blocks,
-			selection,
+			selectionStart,
+			selectionEnd,
 			resetEditorBlocks,
 			resetEditorSelection,
 			isReady,
@@ -168,7 +169,8 @@ class EditorProvider extends Component {
 				value={ blocks }
 				onInput={ resetEditorBlocksWithoutUndoLevel }
 				onChange={ resetEditorBlocks }
-				selection={ selection }
+				selectionStart={ selectionStart }
+				selectionEnd={ selectionEnd }
 				onChangeSelection={ resetEditorSelection }
 				settings={ editorSettings }
 				useSubRegistry={ false }
@@ -188,7 +190,8 @@ export default compose( [
 			canUserUseUnfilteredHTML,
 			__unstableIsEditorReady: isEditorReady,
 			getEditorBlocks,
-			getEditorSelection,
+			getEditorSelectionStart,
+			getEditorSelectionEnd,
 			__experimentalGetReusableBlocks,
 		} = select( 'core/editor' );
 		const { canUser } = select( 'core' );
@@ -197,7 +200,8 @@ export default compose( [
 			canUserUseUnfilteredHTML: canUserUseUnfilteredHTML(),
 			isReady: isEditorReady(),
 			blocks: getEditorBlocks(),
-			selection: getEditorSelection(),
+			selectionStart: getEditorSelectionStart(),
+			selectionEnd: getEditorSelectionEnd(),
 			reusableBlocks: __experimentalGetReusableBlocks(),
 			hasUploadPermissions: defaultTo( canUser( 'create', 'media' ), true ),
 		};
@@ -220,11 +224,9 @@ export default compose( [
 			resetEditorBlocks,
 			resetEditorSelection,
 			updateEditorSettings,
-			resetEditorBlocksWithoutUndoLevel( blocks, selectionStart, selectionEnd ) {
+			resetEditorBlocksWithoutUndoLevel( blocks ) {
 				resetEditorBlocks( blocks, {
 					__unstableShouldCreateUndoLevel: false,
-					selectionStart,
-					selectionEnd,
 				} );
 			},
 			tearDownEditor: __experimentalTearDownEditor,

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -961,7 +961,7 @@ export function* resetEditorBlocks( blocks, options = {} ) {
 /**
  * Returns an action object used to signal that the selection has been updated.
  *
- * @param {Object} selection Selection object.
+ * @param {Array} selection Selection.
  *
  * @return {Object} Action object
  */

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -943,10 +943,18 @@ export function* resetEditorBlocks( blocks, options = {} ) {
 		yield* resetLastBlockSourceDependencies( Array.from( updatedSources ) );
 	}
 
+	const {
+		selectionStart,
+		selectionEnd,
+		__unstableShouldCreateUndoLevel,
+	} = options;
+
 	return {
 		type: 'RESET_EDITOR_BLOCKS',
 		blocks: yield* getBlocksWithSourcedAttributes( blocks ),
-		shouldCreateUndoLevel: options.__unstableShouldCreateUndoLevel !== false,
+		selectionStart,
+		selectionEnd,
+		shouldCreateUndoLevel: __unstableShouldCreateUndoLevel !== false,
 	};
 }
 

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -943,25 +943,26 @@ export function* resetEditorBlocks( blocks, options = {} ) {
 		yield* resetLastBlockSourceDependencies( Array.from( updatedSources ) );
 	}
 
-	const {
-		selectionStart,
-		selectionEnd,
-		__unstableShouldCreateUndoLevel,
-	} = options;
-
 	return {
 		type: 'RESET_EDITOR_BLOCKS',
 		blocks: yield* getBlocksWithSourcedAttributes( blocks ),
-		selectionStart,
-		selectionEnd,
-		shouldCreateUndoLevel: __unstableShouldCreateUndoLevel !== false,
+		shouldCreateUndoLevel: options.__unstableShouldCreateUndoLevel !== false,
 	};
 }
 
 /**
+ * @typedef {WPBlockSelection} A block selection object.
+ *
+ * @property {string} clientId     A block client ID.
+ * @property {string} attributeKey A block attribute key.
+ * @property {number} offset       A block attribute offset.
+ */
+
+/**
  * Returns an action object used to signal that the selection has been updated.
  *
- * @param {Array} selection Selection.
+ * @param {Array.<WPBlockSelection>} selection The block selection start and end
+ *                                             as a pair of `WPBlockSelection`.
  *
  * @return {Object} Action object
  */

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -958,6 +958,20 @@ export function* resetEditorBlocks( blocks, options = {} ) {
 	};
 }
 
+/**
+ * Returns an action object used to signal that the selection has been updated.
+ *
+ * @param {Object} selection Selection object.
+ *
+ * @return {Object} Action object
+ */
+export function resetEditorSelection( selection ) {
+	return {
+		type: 'RESET_EDITOR_SELECTION',
+		selection,
+	};
+}
+
 /*
  * Returns an action object used in signalling that the post editor settings have been updated.
  *

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -961,15 +961,16 @@ export function* resetEditorBlocks( blocks, options = {} ) {
 /**
  * Returns an action object used to signal that the selection has been updated.
  *
- * @param {Array.<WPBlockSelection>} selection The block selection start and end
- *                                             as a pair of `WPBlockSelection`.
+ * @param {WPBlockSelection} selectionStart The selection start.
+ * @param {WPBlockSelection} selectionEnd   The selection end.
  *
  * @return {Object} Action object
  */
-export function resetEditorSelection( selection ) {
+export function resetEditorSelection( selectionStart, selectionEnd ) {
 	return {
 		type: 'RESET_EDITOR_SELECTION',
-		selection,
+		selectionStart,
+		selectionEnd,
 	};
 }
 

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -136,6 +136,7 @@ export const editor = flow( [
 		ignoreTypes: [
 			'RESET_POST',
 			'UPDATE_POST',
+			'RESET_EDITOR_SELECTION',
 		],
 		shouldOverwriteState,
 	} ),
@@ -155,6 +156,20 @@ export const editor = flow( [
 
 		return state;
 	} ),
+	selectionStart( state = {}, { type, selectionStart } ) {
+		if ( type === 'RESET_EDITOR_BLOCKS' && selectionStart !== state ) {
+			return selectionStart;
+		}
+
+		return state;
+	},
+	selectionEnd( state = {}, { type, selectionEnd } ) {
+		if ( type === 'RESET_EDITOR_BLOCKS' && selectionEnd !== state ) {
+			return selectionEnd;
+		}
+
+		return state;
+	},
 	edits( state = {}, action ) {
 		switch ( action.type ) {
 			case 'EDIT_POST':

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -156,16 +156,9 @@ export const editor = flow( [
 
 		return state;
 	} ),
-	selectionStart( state = {}, { type, selectionStart } ) {
-		if ( type === 'RESET_EDITOR_BLOCKS' && selectionStart !== state ) {
-			return selectionStart;
-		}
-
-		return state;
-	},
-	selectionEnd( state = {}, { type, selectionEnd } ) {
-		if ( type === 'RESET_EDITOR_BLOCKS' && selectionEnd !== state ) {
-			return selectionEnd;
+	selection( state = {}, { type, selection } ) {
+		if ( type === 'RESET_EDITOR_SELECTION' && selection !== state ) {
+			return selection;
 		}
 
 		return state;

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -116,12 +116,16 @@ export function shouldOverwriteState( action, previousAction ) {
 
 /**
  * Undoable reducer returning the editor post state, including blocks parsed
- * from current HTML markup.
+ * from current HTML markup, and including selection. It is important to store
+ * selection in this reducer so it can be restored when undoing or redoing
+ * changes.
  *
  * Handles the following state keys:
  *  - edits: an object describing changes to be made to the current post, in
  *           the format accepted by the WP REST API
  *  - blocks: post content blocks
+ *  - selectionStart: start of the post content blocks selection
+ *  - selectionEnd: end of the post content blocks selection
  *
  * @param {Object} state  Current state.
  * @param {Object} action Dispatched action.

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -156,12 +156,11 @@ export const editor = flow( [
 
 		return state;
 	} ),
-	selection( state = {}, { type, selection } ) {
-		if ( type === 'RESET_EDITOR_SELECTION' && selection !== state ) {
-			return selection;
-		}
-
-		return state;
+	selectionStart( state = {}, { type, selectionStart } ) {
+		return type === 'RESET_EDITOR_SELECTION' ? selectionStart : state;
+	},
+	selectionEnd( state = {}, { type, selectionEnd } ) {
+		return type === 'RESET_EDITOR_SELECTION' ? selectionEnd : state;
 	},
 	edits( state = {}, action ) {
 		switch ( action.type ) {

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1134,10 +1134,19 @@ export function getEditorBlocks( state ) {
 }
 
 /**
+ * @typedef {WPBlockSelection} A block selection object.
+ *
+ * @property {string} clientId     A block client ID.
+ * @property {string} attributeKey A block attribute key.
+ * @property {number} offset       A block attribute offset.
+ */
+
+/**
  * Return the current selection.
  *
  * @param {Object} state
- * @return {Array} Selection.
+ * @return {Array.<WPBlockSelection>} The block selection start and end as a
+ *                                    pair of `WPBlockSelection`.
  */
 export function getEditorSelection( state ) {
 	return state.editor.present.selection;

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1134,6 +1134,26 @@ export function getEditorBlocks( state ) {
 }
 
 /**
+ * Return the current selection start object.
+ *
+ * @param {Object} state
+ * @return {Array} Selection start object.
+ */
+export function getEditorSelectionStart( state ) {
+	return state.editor.present.selectionStart;
+}
+
+/**
+ * Return the current selection end object.
+ *
+ * @param {Object} state
+ * @return {Array} Selection end object.
+ */
+export function getEditorSelectionEnd( state ) {
+	return state.editor.present.selectionEnd;
+}
+
+/**
  * Is the editor ready
  *
  * @param {Object} state

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1134,23 +1134,13 @@ export function getEditorBlocks( state ) {
 }
 
 /**
- * Return the current selection start object.
+ * Return the current selection.
  *
  * @param {Object} state
- * @return {Array} Selection start object.
+ * @return {Array} Selection.
  */
-export function getEditorSelectionStart( state ) {
-	return state.editor.present.selectionStart;
-}
-
-/**
- * Return the current selection end object.
- *
- * @param {Object} state
- * @return {Array} Selection end object.
- */
-export function getEditorSelectionEnd( state ) {
-	return state.editor.present.selectionEnd;
+export function getEditorSelection( state ) {
+	return state.editor.present.selection;
 }
 
 /**

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1142,14 +1142,23 @@ export function getEditorBlocks( state ) {
  */
 
 /**
- * Return the current selection.
+ * Return the current selection start.
  *
  * @param {Object} state
- * @return {Array.<WPBlockSelection>} The block selection start and end as a
- *                                    pair of `WPBlockSelection`.
+ * @return {WPBlockSelection} The selection start.
  */
-export function getEditorSelection( state ) {
-	return state.editor.present.selection;
+export function getEditorSelectionStart( state ) {
+	return state.editor.present.selectionStart;
+}
+
+/**
+ * Return the current selection end.
+ *
+ * @param {Object} state
+ * @return {WPBlockSelection} The selection end.
+ */
+export function getEditorSelectionEnd( state ) {
+	return state.editor.present.selectionEnd;
 }
 
 /**

--- a/packages/editor/src/utils/with-history/index.js
+++ b/packages/editor/src/utils/with-history/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { overSome, includes, first, last, drop, dropRight } from 'lodash';
+import { includes, first, last, drop, dropRight } from 'lodash';
 
 /**
  * Default options for withHistory reducer enhancer. Refer to withHistory
@@ -36,12 +36,6 @@ const DEFAULT_OPTIONS = {
  */
 const withHistory = ( options = {} ) => ( reducer ) => {
 	options = { ...DEFAULT_OPTIONS, ...options };
-
-	// `ignoreTypes` is simply a convenience for `shouldOverwriteState`
-	options.shouldOverwriteState = overSome( [
-		options.shouldOverwriteState,
-		( action ) => includes( options.ignoreTypes, action.type ),
-	] );
 
 	const initialState = {
 		past: [],
@@ -120,9 +114,13 @@ const withHistory = ( options = {} ) => ( reducer ) => {
 		let lastActionToSubmit = previousAction;
 
 		if (
-			shouldCreateUndoLevel ||
-			! past.length ||
-			! shouldOverwriteState( action, previousAction )
+			// Ignored action should never create an undo level, regardless of
+			// whether there is already history or not.
+			! includes( options.ignoreTypes, action.type ) && (
+				shouldCreateUndoLevel ||
+				! past.length ||
+				! shouldOverwriteState( action, previousAction )
+			)
 		) {
 			nextPast = [ ...past, present ];
 			lastActionToSubmit = action;

--- a/packages/editor/src/utils/with-history/test/index.js
+++ b/packages/editor/src/utils/with-history/test/index.js
@@ -123,10 +123,10 @@ describe( 'withHistory', () => {
 		state = reducer( state, { type: 'INCREMENT' } );
 
 		expect( state ).toEqual( {
-			past: [ 0 ], // Needs at least one history
+			past: [],
 			present: 2,
 			future: [],
-			lastAction: { type: 'INCREMENT' },
+			lastAction: null,
 			shouldCreateUndoLevel: false,
 		} );
 	} );

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -485,8 +485,9 @@ class RichText extends Component {
 
 		this.value = this.valueToFormat( record );
 		this.record = record;
-		this.props.onChange( this.value );
+		// Selection must be updated first, so it is recorded in history when the content change happens.
 		this.props.onSelectionChange( start, end );
+		this.props.onChange( this.value );
 		this.setState( { activeFormats } );
 
 		if ( ! withoutHistory ) {


### PR DESCRIPTION
## Description

Creates selection reducers in `core/editor` to track selection within the `withHistory` reducer.

I've also split `isSelectionEnabled`, `isMultiSelecting`, and `initialPosition` out of the `blockSelection`, as these are not tied to the selection state. Since the reducer then didn't contain anything but the start and end of the selection, I flattened the structure to `state.selectionStart` and `state.selectionEnd`. The reducers ended up being much simpler.

The following gif shows the result after two times undo:

![undo-selection](https://user-images.githubusercontent.com/4710635/60721595-c2fa3400-9f2e-11e9-9925-9e6575f53dac.gif)

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
