### PR TITLE
Update documentation for consistent Settings Sidebar terminology

### DIFF
--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -42,7 +42,7 @@ title: __( 'Book' )
 
 * **Type:** `String`
 
-This is a short description for your block, which can be translated with our translation functions. This will be shown in the block settings sidebar.
+This is a short description for your block, which can be translated with our translation functions. This will be shown in the Block Tab in the Settings Sidebar.
 
 ```js
 description: __( 'Block showing a Book card.' )

--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -42,7 +42,7 @@ title: __( 'Book' )
 
 * **Type:** `String`
 
-This is a short description for your block, which can be translated with our translation functions. This will be shown in the block inspector.
+This is a short description for your block, which can be translated with our translation functions. This will be shown in the block settings sidebar.
 
 ```js
 description: __( 'Block showing a Book card.' )

--- a/docs/designers-developers/glossary.md
+++ b/docs/designers-developers/glossary.md
@@ -29,7 +29,7 @@
 <dd>A type of block where the content of which may change and cannot be determined at the time of saving a post, instead calculated any time the post is shown on the front of a site. These blocks may save fallback content or no content at all in their JavaScript implementation, instead deferring to a PHP block implementation for runtime rendering.</dd>
 
 <dt>Inspector</dt>
-<dd>Deprecated term. See Settings Sidebar</dd>
+<dd>Deprecated term. See Settings Sidebar.</dd>
 
 <dt>Post settings</dt>
 <dd>A sidebar region containing metadata fields for the post, including scheduling, visibility, terms, and featured image.</dd>

--- a/docs/designers-developers/glossary.md
+++ b/docs/designers-developers/glossary.md
@@ -29,7 +29,7 @@
 <dd>A type of block where the content of which may change and cannot be determined at the time of saving a post, instead calculated any time the post is shown on the front of a site. These blocks may save fallback content or no content at all in their JavaScript implementation, instead deferring to a PHP block implementation for runtime rendering.</dd>
 
 <dt>Inspector</dt>
-<dd>A block settings region shown in place of the post settings when a block is selected. Fields may be shown here to allow the user to customize the selected block.</dd>
+<dd>Deprecated term. See Settings Sidebar</dd>
 
 <dt>Post settings</dt>
 <dd>A sidebar region containing metadata fields for the post, including scheduling, visibility, terms, and featured image.</dd>
@@ -40,8 +40,8 @@
 <dt>Reusable block</dt>
 <dd>A block that is saved and then can be shared as a reusable, repeatable piece of content.</dd>
 
-<dt>Sidebar</dt>
-<dd>The panel on the right which contains the document and block settings. The sidebar is toggled using the Settings gear icon.</dd>
+<dt>Settings Sidebar</dt>
+<dd>The panel on the right that contains the document and block settings. The sidebar is toggled using the Settings gear icon. Block settings are shown when a block is selected, otherwise document settings are shown.</dd>
 
 <dt>Serialization</dt>
 <dd>The process of converting a block's attributes object into HTML markup, which occurs each time a block is edited.</dd>

--- a/docs/designers-developers/glossary.md
+++ b/docs/designers-developers/glossary.md
@@ -29,7 +29,7 @@
 <dd>A type of block where the content of which may change and cannot be determined at the time of saving a post, instead calculated any time the post is shown on the front of a site. These blocks may save fallback content or no content at all in their JavaScript implementation, instead deferring to a PHP block implementation for runtime rendering.</dd>
 
 <dt>Inspector</dt>
-<dd>Deprecated term. See Settings Sidebar.</dd>
+<dd>Deprecated term. See <a href="#settings-sidebar">Settings Sidebar.</a></dd>
 
 <dt>Post settings</dt>
 <dd>A sidebar region containing metadata fields for the post, including scheduling, visibility, terms, and featured image.</dd>
@@ -40,7 +40,7 @@
 <dt>Reusable block</dt>
 <dd>A block that is saved and then can be shared as a reusable, repeatable piece of content.</dd>
 
-<dt>Settings Sidebar</dt>
+<dt id="settings-sidebar">Settings Sidebar</dt>
 <dd>The panel on the right that contains the document and block settings. The sidebar is toggled using the Settings gear icon. Block settings are shown when a block is selected, otherwise document settings are shown.</dd>
 
 <dt>Serialization</dt>


### PR DESCRIPTION
## Description

Follow up on #16138 updating documentation in glossary and block registration to use the Settings Sidebar terminology instead of Inspector. This is consistent with the Designer Reference.

## Types of changes

Documentation changes.

