### PR TITLE
[Mobile] Insert new block below post title if post title is selected

### DIFF
--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -40,6 +40,7 @@ export class BlockList extends Component {
 		this.keyboardDidHide = this.keyboardDidHide.bind( this );
 		this.onCaretVerticalPositionChange = this.onCaretVerticalPositionChange.bind( this );
 		this.scrollViewInnerRef = this.scrollViewInnerRef.bind( this );
+		this.getNewBlockInsertionIndex = this.getNewBlockInsertionIndex.bind( this );
 
 		this.state = {
 			blockTypePickerVisible: false,
@@ -69,10 +70,20 @@ export class BlockList extends Component {
 			// do replace here
 			this.props.replaceBlock( this.props.selectedBlockClientId, newBlock );
 		} else {
-			const indexAfterSelected = this.props.selectedBlockOrder + 1;
-			const insertionIndex = indexAfterSelected || this.props.blockCount;
-			this.props.insertBlock( newBlock, insertionIndex );
+			this.props.insertBlock( newBlock, this.getNewBlockInsertionIndex() );
 		}
+	}
+
+	getNewBlockInsertionIndex() {
+		if ( this.props.isPostTitleSelected ) {
+			// if post title selected, insert at top of post
+			return 0;
+		} else if ( this.props.selectedBlockOrder === -1 ) {
+			// if no block selected, insert at end of post
+			return this.blockCount;
+		}
+		// insert after selected block
+		return this.props.selectedBlockOrder + 1;
 	}
 
 	blockHolderBorderStyle() {

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -80,7 +80,7 @@ export class BlockList extends Component {
 			return 0;
 		} else if ( this.props.selectedBlockOrder === -1 ) {
 			// if no block selected, insert at end of post
-			return this.blockCount;
+			return this.props.blockCount;
 		}
 		// insert after selected block
 		return this.props.selectedBlockOrder + 1;

--- a/packages/edit-post/src/components/visual-editor/index.native.js
+++ b/packages/edit-post/src/components/visual-editor/index.native.js
@@ -15,6 +15,26 @@ import { ReadableContentView } from '@wordpress/components';
 import styles from './style.scss';
 
 class VisualEditor extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.onPostTitleSelect = this.onPostTitleSelect.bind( this );
+		this.onPostTitleUnselect = this.onPostTitleUnselect.bind( this );
+
+		this.state = {
+			isPostTitleSelected: false,
+		};
+	}
+
+	onPostTitleSelect() {
+		this.setState( { isPostTitleSelected: true } );
+		this.props.clearSelectedBlock();
+	}
+
+	onPostTitleUnselect() {
+		this.setState( { isPostTitleSelected: false } );
+	}
+
 	renderHeader() {
 		const {
 			editTitle,
@@ -28,6 +48,9 @@ class VisualEditor extends Component {
 					innerRef={ setTitleRef }
 					title={ title }
 					onUpdate={ editTitle }
+					onSelect={ this.onPostTitleSelect }
+					onUnselect={ this.onPostTitleUnselect }
+					isSelected={ this.state.isPostTitleSelected }
 					placeholder={ __( 'Add title' ) }
 					borderStyle={
 						this.props.isFullyBordered ?
@@ -63,6 +86,7 @@ class VisualEditor extends Component {
 					isFullyBordered={ isFullyBordered }
 					rootViewHeight={ rootViewHeight }
 					safeAreaBottomInset={ safeAreaBottomInset }
+					isPostTitleSelected={ this.state.isPostTitleSelected }
 				/>
 			</BlockEditorProvider>
 		);
@@ -87,7 +111,10 @@ export default compose( [
 			resetEditorBlocks,
 		} = dispatch( 'core/editor' );
 
+		const { clearSelectedBlock } = dispatch( 'core/block-editor' );
+
 		return {
+			clearSelectedBlock,
 			editTitle( title ) {
 				editPost( { title } );
 			},

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -25,13 +25,7 @@ class PostTitle extends Component {
 	constructor() {
 		super( ...arguments );
 
-		this.onSelect = this.onSelect.bind( this );
-		this.onUnselect = this.onUnselect.bind( this );
 		this.titleViewRef = null;
-
-		this.state = {
-			isSelected: false,
-		};
 	}
 
 	componentDidMount() {
@@ -41,23 +35,14 @@ class PostTitle extends Component {
 	}
 
 	handleFocusOutside() {
-		this.onUnselect();
+		this.props.onUnselect();
 	}
 
 	focus() {
 		if ( this.titleViewRef ) {
 			this.titleViewRef.focus();
-			this.setState( { isSelected: true } );
+			this.props.onSelect();
 		}
-	}
-
-	onSelect() {
-		this.setState( { isSelected: true } );
-		this.props.clearSelectedBlock();
-	}
-
-	onUnselect() {
-		this.setState( { isSelected: false } );
 	}
 
 	render() {
@@ -70,12 +55,12 @@ class PostTitle extends Component {
 		} = this.props;
 
 		const decodedPlaceholder = decodeEntities( placeholder );
-		const borderColor = this.state.isSelected ? focusedBorderColor : 'transparent';
+		const borderColor = this.props.isSelected ? focusedBorderColor : 'transparent';
 
 		return (
 			<View
 				style={ [ styles.titleContainer, borderStyle, { borderColor } ] }
-				accessible={ ! this.state.isSelected }
+				accessible={ ! this.props.isSelected }
 				accessibilityLabel={
 					isEmpty( title ) ?
 						/* translators: accessibility text. empty post title. */
@@ -90,7 +75,7 @@ class PostTitle extends Component {
 				<RichText
 					tagName={ 'p' }
 					rootTagsToEliminate={ [ 'strong' ] }
-					unstableOnFocus={ this.onSelect }
+					unstableOnFocus={ this.props.onSelect }
 					onBlur={ this.props.onBlur } // always assign onBlur as a props
 					multiline={ false }
 					style={ style }
@@ -125,7 +110,6 @@ const applyWithDispatch = withDispatch( ( dispatch ) => {
 
 	const {
 		insertDefaultBlock,
-		clearSelectedBlock,
 	} = dispatch( 'core/block-editor' );
 
 	return {
@@ -134,7 +118,6 @@ const applyWithDispatch = withDispatch( ( dispatch ) => {
 		},
 		onUndo: undo,
 		onRedo: redo,
-		clearSelectedBlock,
 	};
 } );
 


### PR DESCRIPTION
For mobile, this changes the behavior when the user selects a post's title and inserts a block. Previously, the new block would be inserted at the bottom of the post (this will remain the behavior on web). This PR changes this so that on mobile the new block will be inserted at the top of the post immediately before the title.

Before | After
------------ | -------------
![before mp4](https://user-images.githubusercontent.com/4656348/60605569-c4d5c300-9d87-11e9-8c0b-af5b9a4e1bce.gif) | ![after mp4](https://user-images.githubusercontent.com/4656348/60605586-ce5f2b00-9d87-11e9-9833-1a4a2566dff8.gif)

## How has this been tested?
See [related `mobile-gutenberg` PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1201)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

The starting point for determining the insertion location for a new block is the index of the currently selected block. If either (a) the post's Title was currently selected, or (b) nothing in the post was selected, the value for the index of the selected block will be `-1`. The insertion index was then incremented and, if that resulted in an `indexAfterSelected` value of `0`, the block would be inserted at the end of the post instead (`indexAfterSelected || this.props.blockCount`). As a result, if either the post's Title was selected or no block was selected, a new block would be inserted at the end of the post. Otherwise, the block would be inserted immediately after the currently selected block.

This PR seeks to 
1. Change the behavior when the post's Title is selected (insert the new block at the beginning of the post);
2. Maintain the current behavior in the case where no blocks are selected (insert the new block at the end of the post); and
3. Maintain the current behavior in the case where a block is selected (insert the new black after the selected block).

It does this by lifting the state of whether the post title is selected out of the `post-title` component to the `visual-editor` component so that it can be shared with the `block-list` component, which handles inserting newly added blocks. 

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
  
