### PR TITLE
Mobile app crashes when the user merges two blocks

### DIFF
--- a/packages/blocks/src/api/index.native.js
+++ b/packages/blocks/src/api/index.native.js
@@ -1,4 +1,5 @@
 export {
+	cloneBlock,
 	createBlock,
 	switchToBlockType,
 } from './factory';


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/1202

gutenberg-mobile PR : https://github.com/wordpress-mobile/gutenberg-mobile/pull/1203