### PR TITLE
Fix issue with inconsistent nesting appender

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -530,8 +530,8 @@
 		margin: 0 $block-padding;
 	}
 
-	// Hide appender shortcuts in nested blocks
-	// This essentially duplicates the mobile styles for the appender component
+	// Hide appender shortcuts in nested blocks.
+	// This essentially duplicates the mobile styles for the appender component.
 	// It would be nice to be able to use element queries in that component instead https://github.com/tomhodgins/element-queries-spec
 	.block-editor-block-list__layout {
 		.block-editor-inserter-with-shortcuts {
@@ -544,6 +544,38 @@
 			right: $grid-size;
 		}
 	}
+}
+
+
+/**
+ * Styles that affect inner-block containers (nested blocks).
+ */
+
+// Hide trailing appender for non-empty blocks, until selected.
+.block-editor-inner-blocks {
+	.block-editor-block-list__block + .block-list-appender {
+		display: none;
+
+		// When a parent container is selected, show the appender.
+		.is-selected & {
+			display: block;
+		}
+	}
+
+	// When a child of a parent is selected, show the adjacent appender.
+	.block-editor-block-list__block.is-selected + .block-list-appender {
+		display: block;
+	}
+
+	/* @todo:
+	The two rules above can be simplified & combined when https://github.com/WordPress/gutenberg/pull/14961 is merged,
+	into the following:
+
+	.is-selected &,
+	.has-child-selected & {
+		display: block;
+	}
+	*/
 }
 
 


### PR DESCRIPTION
Fixes #16221.

This PR intends to fix a visual regression that happened as a result of some consistency work done to the trailing appender.

The trailing appender is the one that sits at the end of the document to allow you to easily add new content. It usually sits after any block that isn't a paragraph. The consistency work brought this to nesting containers as well. But the side effect is that if you have a single list block inside a group block, the appender is permanently visible all the time, even if probably it shouldn't be. The net result is that the unselected editing canvas is no longer representative of the end result.

This PR changes that, so the trailing appender is only visible when a parent or adjacent block is selected. It's not the be-all end-all solution, as it might make sense to look into more holistic changes to when the appender is visible. But it does fix the immediate visual regression.

Here's a list block inside a group block, **before**:

![listbefore](https://user-images.githubusercontent.com/1204802/60792345-d2af8d80-a165-11e9-9afc-9cefdac1be07.gif)

Here's after:

![list after](https://user-images.githubusercontent.com/1204802/60792351-d511e780-a165-11e9-8aad-1bc06f818289.gif)

Here's a columns block with an image, **before**:

![colsbefore](https://user-images.githubusercontent.com/1204802/60792367-dd6a2280-a165-11e9-9c3e-65bda671cf53.gif)

Here's after:

![colsafter](https://user-images.githubusercontent.com/1204802/60792375-e0651300-a165-11e9-9180-83648aa66ebe.gif)

I intentionally left in a ToDo that can either be removed once #14961 is merged, or in a future patch. 