### PR TITLE
Docs: Fix typo in sanitize_title()

### DIFF
--- a/packages/editor/src/utils/url.js
+++ b/packages/editor/src/utils/url.js
@@ -25,7 +25,7 @@ export function getWPAdminURL( page, query ) {
 /**
  * Performs some basic cleanup of a string for use as a post slug
  *
- * This replicates some of what santize_title() does in WordPress core, but
+ * This replicates some of what sanitize_title() does in WordPress core, but
  * is only designed to approximate what the slug will be.
  *
  * Converts whitespace, periods, forward slashes and underscores to hyphens.


### PR DESCRIPTION
## Description
Adds an i to `santize_title()` --> `sanitize_title()`