### PR TITLE
Documentation: Clarify block conventions

### DIFF
--- a/docs/designers-developers/designers/block-design.md
+++ b/docs/designers-developers/designers/block-design.md
@@ -74,7 +74,9 @@ Avoid long, multi-line block names.
 
 ### Block Description
 
-Every block should include a description attribute in the [registerBlockType function](/docs/designers-developers/developers/block-api/block-registration/). The description will display in the Settings sidebar and should explain your block's function clearly.
+Every block should include a description that clearly explains the block's function. The description will display in the Settings Sidebar.
+
+You can add a description by using the description attribute in the [registerBlockType function](/docs/designers-developers/developers/block-api/block-registration/). 
 
 Stick to a single imperative sentence with an action + subject format. Examples:
 

--- a/docs/designers-developers/designers/block-design.md
+++ b/docs/designers-developers/designers/block-design.md
@@ -52,9 +52,15 @@ In most cases, a block’s setup state is only shown once and then further custo
 
 ## Do's and Don'ts
 
-### Blocks
+### Block Identification
 
 A block should have a straightforward, short name so users can easily find it in the Block Library. A block named "YouTube" is easy to find and understand. The same block, named "Embedded Video (YouTube)", would be less clear and harder to find in the Block Library.
+
+When referring to a block in documentation or UI, use title case for the block title, and lowercase for the "block" descriptor. For example:
+
+- Paragraph block
+- Latest Posts block
+- Media & Text block
 
 Blocks should have an identifying icon, ideally using a single color. Try to avoid using the same icon used by an existing block. The core block icons are based on [Material Design Icons](https://material.io/tools/icons/). Look to that icon set, or to [Dashicons](https://developer.wordpress.org/resource/dashicons/) for style inspiration.
 

--- a/docs/designers-developers/designers/block-design.md
+++ b/docs/designers-developers/designers/block-design.md
@@ -74,7 +74,13 @@ Avoid long, multi-line block names.
 
 ### Block Description
 
-Every block should include a description in the “Block” tab of the Settings sidebar. This description should explain your block's function clearly. Keep it to a single sentence.
+Every block should include a description in the “Block” tab of the Settings sidebar. This description should explain your block's function clearly.
+
+Stick to a single imperative sentence with an action + subject format. Examples:
+
+- Start with the building block of all narrative.
+- Introduce new sections and organize content to help visitors (and search engines) understand the structure of your content.
+- Create a bulleted or numbered list.
 
 ![A screenshot of a short block description](https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/designers/assets/block-descriptions-do.png)
 **Do:**

--- a/docs/designers-developers/designers/block-design.md
+++ b/docs/designers-developers/designers/block-design.md
@@ -74,7 +74,7 @@ Avoid long, multi-line block names.
 
 ### Block Description
 
-Every block should include a description in the “Block” tab of the Settings sidebar. This description should explain your block's function clearly.
+Every block should include a description attribute in the [registerBlockType function](/docs/designers-developers/developers/block-api/block-registration/). The description will display in the Settings sidebar and should explain your block's function clearly.
 
 Stick to a single imperative sentence with an action + subject format. Examples:
 


### PR DESCRIPTION
In response to confusion in #16118 and #16002, this introduces two small documentation changes to be more explicit about the conventions we follow:

- Naming conventions when referring to blocks in documentation or elsewhere in the UI.
- The verb + subject format used for block descriptions.

I tried to be as clear and succinct as possible here, but I'm natually wordy (and I think examples are probably extremely helpful here). If there are bits we can clarify or trim down, happy to revise!