### PR TITLE
Typewriter experience

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -423,7 +423,8 @@ _Returns_
 <a name="Typewriter" href="#Typewriter">#</a> **Typewriter**
 
 Ensures that the text selection keeps the same vertical distance from the
-viewport during keyboard events within this component.
+viewport during keyboard events within this component. The vertical distance
+can vary. It is the last clicked or scrolled to position.
 
 <a name="URLInput" href="#URLInput">#</a> **URLInput**
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -420,6 +420,11 @@ _Returns_
 
 -   `Array`: converted rules.
 
+<a name="Typewriter" href="#Typewriter">#</a> **Typewriter**
+
+Ensures that the text selection keeps the same vertical distance from the
+viewport during keyboard events within this component.
+
 <a name="URLInput" href="#URLInput">#</a> **URLInput**
 
 _Related_

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -263,6 +263,7 @@ export default compose( [
 			getMultiSelectedBlockClientIds,
 			hasMultiSelection,
 			getGlobalBlockCount,
+			isTyping,
 		} = select( 'core/block-editor' );
 
 		const { rootClientId } = ownProps;
@@ -276,7 +277,10 @@ export default compose( [
 			selectedBlockClientId: getSelectedBlockClientId(),
 			multiSelectedBlockClientIds: getMultiSelectedBlockClientIds(),
 			hasMultiSelection: hasMultiSelection(),
-			enableAnimation: getGlobalBlockCount() <= BLOCK_ANIMATION_THRESHOLD,
+			enableAnimation: (
+				! isTyping() &&
+				getGlobalBlockCount() <= BLOCK_ANIMATION_THRESHOLD
+			),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -59,6 +59,7 @@ export { default as NavigableToolbar } from './navigable-toolbar';
 export { default as ObserveTyping } from './observe-typing';
 export { default as PreserveScrollInReorder } from './preserve-scroll-in-reorder';
 export { default as SkipToSelectedBlock } from './skip-to-selected-block';
+export { default as Typewriter } from './typewriter';
 export { default as Warning } from './warning';
 export { default as WritingFlow } from './writing-flow';
 

--- a/packages/block-editor/src/components/typewriter/index.js
+++ b/packages/block-editor/src/components/typewriter/index.js
@@ -228,7 +228,8 @@ class Typewriter extends Component {
 
 /**
  * Ensures that the text selection keeps the same vertical distance from the
- * viewport during keyboard events within this component.
+ * viewport during keyboard events within this component. The vertical distance
+ * can vary. It is the last clicked or scrolled to position.
  */
 export default withSelect( ( select ) => {
 	const { getSelectedBlockClientId } = select( 'core/block-editor' );

--- a/packages/block-editor/src/components/typewriter/index.js
+++ b/packages/block-editor/src/components/typewriter/index.js
@@ -205,7 +205,7 @@ class Typewriter extends Component {
 		// There are some issues with Internet Explorer, which are probably not
 		// worth spending time on. Let's disable it.
 		if ( isIE ) {
-			return null;
+			return this.props.children;
 		}
 
 		// Disable reason: Wrapper itself is non-interactive, but must capture

--- a/packages/block-editor/src/components/typewriter/index.js
+++ b/packages/block-editor/src/components/typewriter/index.js
@@ -1,0 +1,155 @@
+/**
+ * External dependencies
+ */
+import { debounce } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Component, createRef } from '@wordpress/element';
+import { computeCaretRect, getScrollContainer } from '@wordpress/dom';
+import { withSelect } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+
+class Typewriter extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.ref = createRef();
+		this.onKeyDown = this.onKeyDown.bind( this );
+		this.onMouseDown = this.onMouseDown.bind( this );
+		this.onTouchStart = this.onTouchStart.bind( this );
+		this.maintainCaretPositionOnSelectionChange = this.maintainCaretPositionOnSelectionChange.bind( this );
+		this.computeCaretRectOnSelectionChange = this.computeCaretRectOnSelectionChange.bind( this );
+		this.maintainCaretPosition = this.maintainCaretPosition.bind( this );
+		this.computeCaretRect = this.computeCaretRect.bind( this );
+		this.debouncedComputeCaretRect = debounce( this.computeCaretRect, 100 );
+		this.isSelectionEligibleForScroll = this.isSelectionEligibleForScroll.bind( this );
+	}
+
+	componentDidMount() {
+		window.addEventListener( 'scroll', this.debouncedComputeCaretRect, true );
+		window.addEventListener( 'resize', this.debouncedComputeCaretRect, true );
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener( 'scroll', this.debouncedComputeCaretRect, true );
+		window.removeEventListener( 'resize', this.debouncedComputeCaretRect, true );
+		document.removeEventListener( 'selectionchange', this.maintainCaretPositionOnSelectionChange );
+		document.removeEventListener( 'selectionchange', this.computeCaretRectOnSelectionChange );
+		window.cancelAnimationFrame( this.rafId );
+		this.debouncedComputeCaretRect.cancel();
+	}
+
+	computeCaretRect() {
+		if ( this.isSelectionEligibleForScroll() ) {
+			this.caretRect = computeCaretRect();
+		}
+	}
+
+	maintainCaretPositionOnSelectionChange() {
+		document.removeEventListener( 'selectionchange', this.maintainCaretPositionOnSelectionChange );
+		this.maintainCaretPosition();
+	}
+
+	computeCaretRectOnSelectionChange() {
+		document.removeEventListener( 'selectionchange', this.computeCaretRectOnSelectionChange );
+		this.computeCaretRect();
+	}
+
+	isSelectionEligibleForScroll() {
+		return (
+			// There should be one and only one block selected.
+			this.props.selectedBlockClientId &&
+			// The component must contain the selection.
+			this.ref.current.contains( document.activeElement ) &&
+			// The active element must be contenteditable.
+			document.activeElement.isContentEditable
+		);
+	}
+
+	maintainCaretPosition() {
+		if ( ! this.caretRect ) {
+			this.computeCaretRect();
+			return;
+		}
+
+		if ( ! this.isSelectionEligibleForScroll() ) {
+			return;
+		}
+
+		const currentCaretRect = computeCaretRect();
+
+		if ( ! currentCaretRect ) {
+			return;
+		}
+
+		const diff = currentCaretRect.y - this.caretRect.y;
+
+		if ( diff === 0 ) {
+			return;
+		}
+
+		const scrollContainer = getScrollContainer( this.ref.current );
+
+		// The page must be scrollable.
+		if ( ! scrollContainer ) {
+			return;
+		}
+
+		// The scroll container may be different depending on the viewport
+		// width.
+		if ( scrollContainer === document.body ) {
+			window.scrollBy( 0, diff );
+		} else {
+			scrollContainer.scrollTop += diff;
+		}
+	}
+
+	onMouseDown() {
+		document.addEventListener( 'selectionchange', this.computeCaretRectOnSelectionChange );
+	}
+
+	onTouchStart() {
+		document.addEventListener( 'selectionchange', this.computeCaretRectOnSelectionChange );
+	}
+
+	onKeyDown() {
+		// Ensure the any remaining request is cancelled.
+		window.cancelAnimationFrame( this.rafId );
+		// Use an animation frame for a smooth result.
+		this.rafId = window.requestAnimationFrame( this.maintainCaretPosition );
+		// In rare cases, the selection is not updated before the animation
+		// frame. This selection change listener is a back up.
+		document.addEventListener( 'selectionchange', this.maintainCaretPositionOnSelectionChange );
+	}
+
+	render() {
+		// Disable reason: Wrapper itself is non-interactive, but must capture
+		// bubbling events from children to determine focus transition intents.
+		/* eslint-disable jsx-a11y/no-static-element-interactions */
+		return (
+			<div
+				ref={ this.ref }
+				onKeyDown={ this.onKeyDown }
+				onKeyUp={ this.onKeyUp }
+				onMouseDown={ this.onMouseDown }
+				onTouchStart={ this.onTouchStart }
+			>
+				{ this.props.children }
+			</div>
+		);
+		/* eslint-enable jsx-a11y/no-static-element-interactions */
+	}
+}
+
+/**
+ * Ensures that the text selection keeps the same vertical distance from the
+ * viewport during keyboard events within this component.
+ */
+export default compose( [
+	withSelect( ( select ) => {
+		const { getSelectedBlockClientId } = select( 'core/block-editor' );
+		return { selectedBlockClientId: getSelectedBlockClientId() };
+	} ),
+] )( Typewriter );

--- a/packages/block-editor/src/components/typewriter/index.js
+++ b/packages/block-editor/src/components/typewriter/index.js
@@ -135,9 +135,30 @@ class Typewriter extends Component {
 				return;
 			}
 
+			// Abort if the target scroll position would scroll the caret out of
+			// view.
+			if (
+				this.caretRect.y + this.caretRect.height > window.innerHeight ||
+				this.caretRect.y < 0
+			) {
+				return;
+			}
+
 			window.scrollBy( 0, diff );
 		} else {
 			if ( isLastEditableNode && scrollContainer.scrollTop === 0 ) {
+				return;
+			}
+
+			const scrollContainerRect = scrollContainer.getBoundingClientRect();
+
+			// Abort if the target scroll position would scroll the caret out of
+			// view.
+			if (
+				this.caretRect.y + this.caretRect.height >
+					scrollContainerRect.y + scrollContainer.clientHeight ||
+				this.caretRect.y < scrollContainerRect.y
+			) {
 				return;
 			}
 

--- a/packages/block-editor/src/components/typewriter/index.js
+++ b/packages/block-editor/src/components/typewriter/index.js
@@ -13,6 +13,7 @@ import { UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
 
 const isIE = window.navigator.userAgent.indexOf( 'Trident' ) !== -1;
 const arrowKeyCodes = new Set( [ UP, DOWN, LEFT, RIGHT ] );
+const initialTriggerPercentage = 0.75;
 
 class Typewriter extends Component {
 	constructor() {
@@ -123,6 +124,11 @@ class Typewriter extends Component {
 		const editableNodes = this.ref.current.querySelectorAll( '[contenteditable="true"]' );
 		const lastEditableNode = editableNodes[ editableNodes.length - 1 ];
 		const isLastEditableNode = lastEditableNode === document.activeElement;
+		const scrollContainerRect = scrollContainer.getBoundingClientRect();
+		const relativeScrollPosition = (
+			( this.caretRect.y - scrollContainerRect.y ) /
+			( window.innerHeight - scrollContainerRect.y )
+		);
 
 		// The scroll container may be different depending on the viewport
 		// width.
@@ -131,7 +137,11 @@ class Typewriter extends Component {
 		// The typewriter effect should not kick in until an empty page has been
 		// filled or the user scrolls intentionally down.
 		if ( scrollContainer === document.body ) {
-			if ( isLastEditableNode && window.scrollY === 0 ) {
+			if (
+				isLastEditableNode &&
+				window.scrollY === 0 &&
+				relativeScrollPosition < initialTriggerPercentage
+			) {
 				this.caretRect = currentCaretRect;
 				return;
 			}
@@ -148,12 +158,14 @@ class Typewriter extends Component {
 
 			window.scrollBy( 0, diff );
 		} else {
-			if ( isLastEditableNode && scrollContainer.scrollTop === 0 ) {
+			if (
+				isLastEditableNode &&
+				scrollContainer.scrollTop === 0 &&
+				relativeScrollPosition < initialTriggerPercentage
+			) {
 				this.caretRect = currentCaretRect;
 				return;
 			}
-
-			const scrollContainerRect = scrollContainer.getBoundingClientRect();
 
 			// Abort if the target scroll position would scroll the caret out of
 			// view.

--- a/packages/block-editor/src/components/typewriter/index.js
+++ b/packages/block-editor/src/components/typewriter/index.js
@@ -132,6 +132,7 @@ class Typewriter extends Component {
 		// filled or the user scrolls intentionally down.
 		if ( scrollContainer === document.body ) {
 			if ( isLastEditableNode && window.scrollY === 0 ) {
+				this.caretRect = currentCaretRect;
 				return;
 			}
 
@@ -141,12 +142,14 @@ class Typewriter extends Component {
 				this.caretRect.y + this.caretRect.height > window.innerHeight ||
 				this.caretRect.y < 0
 			) {
+				this.caretRect = currentCaretRect;
 				return;
 			}
 
 			window.scrollBy( 0, diff );
 		} else {
 			if ( isLastEditableNode && scrollContainer.scrollTop === 0 ) {
+				this.caretRect = currentCaretRect;
 				return;
 			}
 
@@ -159,6 +162,7 @@ class Typewriter extends Component {
 					scrollContainerRect.y + scrollContainer.clientHeight ||
 				this.caretRect.y < scrollContainerRect.y
 			) {
+				this.caretRect = currentCaretRect;
 				return;
 			}
 

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -404,7 +404,7 @@ class WritingFlow extends Component {
 					aria-hidden
 					tabIndex={ -1 }
 					onClick={ this.focusLastTextField }
-					className="wp-block editor-writing-flow__click-redirect block-editor-writing-flow__click-redirect"
+					className="editor-writing-flow__click-redirect block-editor-writing-flow__click-redirect"
 				/>
 			</div>
 		);

--- a/packages/block-editor/src/components/writing-flow/style.scss
+++ b/packages/block-editor/src/components/writing-flow/style.scss
@@ -1,10 +1,8 @@
 .block-editor-writing-flow {
-	height: 100%;
 	display: flex;
 	flex-direction: column;
 }
 
 .block-editor-writing-flow__click-redirect {
-	flex-basis: 100%;
 	cursor: text;
 }

--- a/packages/e2e-tests/specs/typewriter.test.js
+++ b/packages/e2e-tests/specs/typewriter.test.js
@@ -1,0 +1,126 @@
+/**
+ * WordPress dependencies
+ */
+import { createNewPost } from '@wordpress/e2e-test-utils';
+
+describe( 'TypeWriter', () => {
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	const expectScrollPositionToBe = async ( expectedScrollPosition ) => {
+		const currentScrollPosition = await page.evaluate( () =>
+			wp.dom.computeCaretRect().y
+		);
+		const diff = Math.abs( currentScrollPosition - expectedScrollPosition );
+
+		// Allow the scroll position to be 1px off.
+		expect( diff ).toBeLessThanOrEqual( 1 );
+	};
+
+	it( 'should maintain caret position', async () => {
+		// Create first block.
+		await page.keyboard.press( 'Enter' );
+
+		const initialPosition = await page.evaluate( () =>
+			wp.dom.computeCaretRect().y
+		);
+
+		// The page shouldn't be scrolled when it's being filled.
+		await page.keyboard.press( 'Enter' );
+
+		expect( await page.evaluate( () =>
+			wp.dom.computeCaretRect().y
+		) ).toBeGreaterThan( initialPosition );
+
+		// Create blocks until the browser scroll the page.
+		while ( await page.evaluate( () =>
+			wp.dom.getScrollContainer( document.activeElement ).scrollTop === 0
+		) ) {
+			await page.keyboard.press( 'Enter' );
+		}
+
+		// Debounce time for the scroll event listener.
+		// eslint-disable-next-line no-restricted-syntax
+		await page.waitFor( 100 );
+
+		const newPosition = await page.evaluate( () =>
+			wp.dom.computeCaretRect().y
+		);
+
+		// Now the scroll position should be maintained.
+		await page.keyboard.press( 'Enter' );
+
+		await expectScrollPositionToBe( newPosition );
+
+		// Type until the text wraps.
+		while ( await page.evaluate( () =>
+			document.activeElement.clientHeight <=
+			parseInt( getComputedStyle( document.activeElement ).lineHeight, 10 )
+		) ) {
+			await page.keyboard.type( 'a' );
+		}
+
+		await expectScrollPositionToBe( newPosition );
+
+		// Pressing backspace will reposition the caret to the previous line.
+		// Scroll position should be adjusted again.
+		await page.keyboard.press( 'Backspace' );
+
+		await expectScrollPositionToBe( newPosition );
+
+		// Should reset scroll position to maintain.
+		await page.keyboard.press( 'ArrowUp' );
+
+		const positionAfterArrowUp = await page.evaluate( () =>
+			wp.dom.computeCaretRect().y
+		);
+
+		expect( positionAfterArrowUp ).toBeLessThan( newPosition );
+
+		// Should be scrolled to new position.
+		await page.keyboard.press( 'Enter' );
+
+		await expectScrollPositionToBe( positionAfterArrowUp );
+	} );
+
+	it( 'should maintain caret position after scroll', async () => {
+		// Create first block.
+		await page.keyboard.press( 'Enter' );
+
+		await page.evaluate( () =>
+			wp.dom.getScrollContainer( document.activeElement ).scrollTop = 1
+		);
+
+		// Debounce time for the scroll event listener.
+		// eslint-disable-next-line no-restricted-syntax
+		await page.waitFor( 100 );
+
+		const initialPosition = await page.evaluate( () =>
+			wp.dom.computeCaretRect().y
+		);
+
+		// Should maintain scroll position.
+		await page.keyboard.press( 'Enter' );
+
+		await expectScrollPositionToBe( initialPosition );
+	} );
+
+	it( 'should maintain caret position after leaving last editable', async () => {
+		// Create first block.
+		await page.keyboard.press( 'Enter' );
+		// Create second block.
+		await page.keyboard.press( 'Enter' );
+		// Move to first block.
+		await page.keyboard.press( 'ArrowUp' );
+
+		const initialPosition = await page.evaluate( () =>
+			wp.dom.computeCaretRect().y
+		);
+
+		// Should maintain scroll position.
+		await page.keyboard.press( 'Enter' );
+
+		await expectScrollPositionToBe( initialPosition );
+	} );
+} );

--- a/packages/e2e-tests/specs/typewriter.test.js
+++ b/packages/e2e-tests/specs/typewriter.test.js
@@ -35,10 +35,6 @@ describe( 'TypeWriter', () => {
 			await page.keyboard.press( 'Enter' );
 		}
 
-		// Debounce time for the scroll event listener.
-		// eslint-disable-next-line no-restricted-syntax
-		await page.waitFor( 100 );
-
 		const newPosition = await getCaretPosition();
 
 		// Now the scroll position should be maintained.
@@ -82,10 +78,6 @@ describe( 'TypeWriter', () => {
 		await page.evaluate( () =>
 			wp.dom.getScrollContainer( document.activeElement ).scrollTop = 1
 		);
-
-		// Debounce time for the scroll event listener.
-		// eslint-disable-next-line no-restricted-syntax
-		await page.waitFor( 100 );
 
 		const initialPosition = await getCaretPosition();
 
@@ -137,10 +129,6 @@ describe( 'TypeWriter', () => {
 		// Should scroll the caret back into view (preserve browser behaviour).
 		await page.keyboard.type( 'a' );
 
-		// Debounce time for the scroll event listener.
-		// eslint-disable-next-line no-restricted-syntax
-		await page.waitFor( 100 );
-
 		const newBottomPosition = await getCaretPosition();
 
 		expect( newBottomPosition ).toBeLessThan( bottomPostition );
@@ -167,10 +155,6 @@ describe( 'TypeWriter', () => {
 
 		// Should scroll the caret back into view (preserve browser behaviour).
 		await page.keyboard.type( 'a' );
-
-		// Debounce time for the scroll event listener.
-		// eslint-disable-next-line no-restricted-syntax
-		await page.waitFor( 100 );
 
 		const newTopPosition = await getCaretPosition();
 

--- a/packages/e2e-tests/specs/typewriter.test.js
+++ b/packages/e2e-tests/specs/typewriter.test.js
@@ -8,32 +8,27 @@ describe( 'TypeWriter', () => {
 		await createNewPost();
 	} );
 
-	const expectScrollPositionToBe = async ( expectedScrollPosition ) => {
-		const currentScrollPosition = await page.evaluate( () =>
-			wp.dom.computeCaretRect().y
-		);
-		const diff = Math.abs( currentScrollPosition - expectedScrollPosition );
+	const getCaretPosition = async () =>
+		await page.evaluate( () => wp.dom.computeCaretRect().y );
 
-		// Allow the scroll position to be 1px off.
-		expect( diff ).toBeLessThanOrEqual( 1 );
-	};
+	// Allow the scroll position to be 1px off.
+	const BUFFER = 1;
+
+	const getDiff = async ( caretPosition ) =>
+		Math.abs( await getCaretPosition() - caretPosition );
 
 	it( 'should maintain caret position', async () => {
 		// Create first block.
 		await page.keyboard.press( 'Enter' );
 
-		const initialPosition = await page.evaluate( () =>
-			wp.dom.computeCaretRect().y
-		);
+		const initialPosition = await getCaretPosition();
 
 		// The page shouldn't be scrolled when it's being filled.
 		await page.keyboard.press( 'Enter' );
 
-		expect( await page.evaluate( () =>
-			wp.dom.computeCaretRect().y
-		) ).toBeGreaterThan( initialPosition );
+		expect( await getCaretPosition() ).toBeGreaterThan( initialPosition );
 
-		// Create blocks until the browser scroll the page.
+		// Create blocks until the the typewriter effect kicks in.
 		while ( await page.evaluate( () =>
 			wp.dom.getScrollContainer( document.activeElement ).scrollTop === 0
 		) ) {
@@ -44,14 +39,12 @@ describe( 'TypeWriter', () => {
 		// eslint-disable-next-line no-restricted-syntax
 		await page.waitFor( 100 );
 
-		const newPosition = await page.evaluate( () =>
-			wp.dom.computeCaretRect().y
-		);
+		const newPosition = await getCaretPosition();
 
 		// Now the scroll position should be maintained.
 		await page.keyboard.press( 'Enter' );
 
-		await expectScrollPositionToBe( newPosition );
+		expect( await getDiff( newPosition ) ).toBeLessThanOrEqual( BUFFER );
 
 		// Type until the text wraps.
 		while ( await page.evaluate( () =>
@@ -61,27 +54,25 @@ describe( 'TypeWriter', () => {
 			await page.keyboard.type( 'a' );
 		}
 
-		await expectScrollPositionToBe( newPosition );
+		expect( await getDiff( newPosition ) ).toBeLessThanOrEqual( BUFFER );
 
 		// Pressing backspace will reposition the caret to the previous line.
 		// Scroll position should be adjusted again.
 		await page.keyboard.press( 'Backspace' );
 
-		await expectScrollPositionToBe( newPosition );
+		expect( await getDiff( newPosition ) ).toBeLessThanOrEqual( BUFFER );
 
 		// Should reset scroll position to maintain.
 		await page.keyboard.press( 'ArrowUp' );
 
-		const positionAfterArrowUp = await page.evaluate( () =>
-			wp.dom.computeCaretRect().y
-		);
+		const positionAfterArrowUp = await getCaretPosition();
 
 		expect( positionAfterArrowUp ).toBeLessThan( newPosition );
 
 		// Should be scrolled to new position.
 		await page.keyboard.press( 'Enter' );
 
-		await expectScrollPositionToBe( positionAfterArrowUp );
+		expect( await getDiff( positionAfterArrowUp ) ).toBeLessThanOrEqual( BUFFER );
 	} );
 
 	it( 'should maintain caret position after scroll', async () => {
@@ -96,14 +87,12 @@ describe( 'TypeWriter', () => {
 		// eslint-disable-next-line no-restricted-syntax
 		await page.waitFor( 100 );
 
-		const initialPosition = await page.evaluate( () =>
-			wp.dom.computeCaretRect().y
-		);
+		const initialPosition = await getCaretPosition();
 
 		// Should maintain scroll position.
 		await page.keyboard.press( 'Enter' );
 
-		await expectScrollPositionToBe( initialPosition );
+		expect( await getDiff( initialPosition ) ).toBeLessThanOrEqual( BUFFER );
 	} );
 
 	it( 'should maintain caret position after leaving last editable', async () => {
@@ -114,13 +103,82 @@ describe( 'TypeWriter', () => {
 		// Move to first block.
 		await page.keyboard.press( 'ArrowUp' );
 
-		const initialPosition = await page.evaluate( () =>
-			wp.dom.computeCaretRect().y
-		);
+		const initialPosition = await getCaretPosition();
 
 		// Should maintain scroll position.
 		await page.keyboard.press( 'Enter' );
 
-		await expectScrollPositionToBe( initialPosition );
+		expect( await getDiff( initialPosition ) ).toBeLessThanOrEqual( BUFFER );
+	} );
+
+	it( 'should scroll caret into view from the top', async () => {
+		// Create first block.
+		await page.keyboard.press( 'Enter' );
+
+		let count = 0;
+
+		// Create blocks until the the typewriter effect kicks in.
+		while ( await page.evaluate( () =>
+			wp.dom.getScrollContainer( document.activeElement ).scrollTop === 0
+		) ) {
+			await page.keyboard.press( 'Enter' );
+			count++;
+		}
+
+		// Scroll the active element to the very bottom of the scroll container,
+		// then scroll 20px down, so the caret is partially hidden.
+		await page.evaluate( () => {
+			document.activeElement.scrollIntoView( false );
+			wp.dom.getScrollContainer( document.activeElement ).scrollTop -= 20;
+		} );
+
+		const bottomPostition = await getCaretPosition();
+
+		// Should scroll the caret back into view (preserve browser behaviour).
+		await page.keyboard.type( 'a' );
+
+		// Debounce time for the scroll event listener.
+		// eslint-disable-next-line no-restricted-syntax
+		await page.waitFor( 100 );
+
+		const newBottomPosition = await getCaretPosition();
+
+		expect( newBottomPosition ).toBeLessThan( bottomPostition );
+
+		// Should maintain new caret position.
+		await page.keyboard.press( 'Enter' );
+
+		expect( await getDiff( newBottomPosition ) ).toBeLessThanOrEqual( BUFFER );
+
+		await page.keyboard.press( 'Backspace' );
+
+		while ( count-- ) {
+			await page.keyboard.press( 'ArrowUp' );
+		}
+
+		// Scroll the active element to the very top of the scroll container,
+		// then scroll 10px down, so the caret is partially hidden.
+		await page.evaluate( () => {
+			document.activeElement.scrollIntoView();
+			wp.dom.getScrollContainer( document.activeElement ).scrollTop += 20;
+		} );
+
+		const topPostition = await getCaretPosition();
+
+		// Should scroll the caret back into view (preserve browser behaviour).
+		await page.keyboard.type( 'a' );
+
+		// Debounce time for the scroll event listener.
+		// eslint-disable-next-line no-restricted-syntax
+		await page.waitFor( 100 );
+
+		const newTopPosition = await getCaretPosition();
+
+		expect( newTopPosition ).toBeGreaterThan( topPostition );
+
+		// Should maintain new caret position.
+		await page.keyboard.press( 'Enter' );
+
+		expect( await getDiff( newTopPosition ) ).toBeLessThanOrEqual( BUFFER );
 	} );
 } );

--- a/packages/e2e-tests/specs/writing-flow.test.js
+++ b/packages/e2e-tests/specs/writing-flow.test.js
@@ -422,4 +422,46 @@ describe( 'Writing Flow', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should maintain caret position', async () => {
+		// Create first block.
+		await page.keyboard.press( 'Enter' );
+
+		// Create blocks until the page is scrollable.
+		while ( await page.evaluate( () =>
+			! wp.dom.getScrollContainer( document.activeElement )
+		) ) {
+			await page.keyboard.press( 'Enter' );
+		}
+
+		const initialPosition = await page.evaluate( () =>
+			wp.dom.computeCaretRect().y
+		);
+
+		await page.keyboard.press( 'Enter' );
+
+		expect( await page.evaluate( () =>
+			wp.dom.computeCaretRect().y
+		) ).toBe( initialPosition );
+
+		// Type until the text wraps.
+		while ( await page.evaluate( () =>
+			document.activeElement.clientHeight <=
+			parseInt( getComputedStyle( document.activeElement ).lineHeight, 10 )
+		) ) {
+			await page.keyboard.type( 'a' );
+		}
+
+		expect( await page.evaluate( () =>
+			wp.dom.computeCaretRect().y
+		) ).toBe( initialPosition );
+
+		// Pressing backspace will reposition the caret to the previous line.
+		// Scroll position should be adjusted again.
+		await page.keyboard.press( 'Backspace' );
+
+		expect( await page.evaluate( () =>
+			wp.dom.computeCaretRect().y
+		) ).toBe( initialPosition );
+	} );
 } );

--- a/packages/e2e-tests/specs/writing-flow.test.js
+++ b/packages/e2e-tests/specs/writing-flow.test.js
@@ -422,46 +422,4 @@ describe( 'Writing Flow', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
-
-	it( 'should maintain caret position', async () => {
-		// Create first block.
-		await page.keyboard.press( 'Enter' );
-
-		// Create blocks until the page is scrollable.
-		while ( await page.evaluate( () =>
-			! wp.dom.getScrollContainer( document.activeElement )
-		) ) {
-			await page.keyboard.press( 'Enter' );
-		}
-
-		const initialPosition = await page.evaluate( () =>
-			wp.dom.computeCaretRect().y
-		);
-
-		await page.keyboard.press( 'Enter' );
-
-		expect( await page.evaluate( () =>
-			wp.dom.computeCaretRect().y
-		) ).toBe( initialPosition );
-
-		// Type until the text wraps.
-		while ( await page.evaluate( () =>
-			document.activeElement.clientHeight <=
-			parseInt( getComputedStyle( document.activeElement ).lineHeight, 10 )
-		) ) {
-			await page.keyboard.type( 'a' );
-		}
-
-		expect( await page.evaluate( () =>
-			wp.dom.computeCaretRect().y
-		) ).toBe( initialPosition );
-
-		// Pressing backspace will reposition the caret to the previous line.
-		// Scroll position should be adjusted again.
-		await page.keyboard.press( 'Backspace' );
-
-		expect( await page.evaluate( () =>
-			wp.dom.computeCaretRect().y
-		) ).toBe( initialPosition );
-	} );
 } );

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -62,6 +62,7 @@ function Layout( {
 	const className = classnames( 'edit-post-layout', {
 		'is-sidebar-opened': sidebarIsOpened,
 		'has-fixed-toolbar': hasFixedToolbar,
+		'has-metaboxes': hasActiveMetaboxes,
 	} );
 
 	const publishLandmarkProps = {

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -7,6 +7,7 @@ import {
 } from '@wordpress/editor';
 import {
 	WritingFlow,
+	Typewriter,
 	ObserveTyping,
 	BlockList,
 	CopyHandler,
@@ -27,14 +28,16 @@ function VisualEditor() {
 		<BlockSelectionClearer className="edit-post-visual-editor editor-styles-wrapper">
 			<VisualEditorGlobalKeyboardShortcuts />
 			<MultiSelectScrollIntoView />
-			<WritingFlow>
-				<ObserveTyping>
-					<CopyHandler>
-						<PostTitle />
-						<BlockList />
-					</CopyHandler>
-				</ObserveTyping>
-			</WritingFlow>
+			<Typewriter>
+				<WritingFlow>
+					<ObserveTyping>
+						<CopyHandler>
+							<PostTitle />
+							<BlockList />
+						</CopyHandler>
+					</ObserveTyping>
+				</WritingFlow>
+			</Typewriter>
 			<__experimentalBlockSettingsMenuFirstItem>
 				{ ( { onClose } ) => <BlockInspectorButton onClick={ onClose } /> }
 			</__experimentalBlockSettingsMenuFirstItem>

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -1,6 +1,6 @@
 .edit-post-visual-editor {
 	position: relative;
-	padding: 50px 0;
+	padding-top: 50px;
 
 	& .components-button {
 		font-family: $default-font;
@@ -8,11 +8,9 @@
 }
 
 .edit-post-visual-editor .block-editor-writing-flow__click-redirect {
-	// Collapse to minimum height of 50px, to fully occupy editor bottom pad.
-	height: 50px;
+	// Allow the page to be scrolled with the last block in the middle.
+	height: 50vh;
 	width: 100%;
-	// Offset for: Visual editor padding, block (default appender) margin.
-	margin: #{ -1 * $block-spacing } auto -50px;
 }
 
 // The base width of blocks

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -13,6 +13,11 @@
 	width: 100%;
 }
 
+// Hide the extra space when there are metaboxes.
+.has-metaboxes .edit-post-visual-editor .block-editor-writing-flow__click-redirect {
+	height: 0;
+}
+
 // The base width of blocks
 .edit-post-visual-editor .block-editor-block-list__block {
 	margin-left: auto;


### PR DESCRIPTION
## Description

This change maintains the caret (insertion point) position while the user is typing.

Text wrapping and `Enter`.

![typewriter](https://user-images.githubusercontent.com/4710635/60810989-9d6b6580-a18e-11e9-8012-8b895f99b2f4.gif)

iOS (there's still movement, but MUCH better). Apologies, Simulator doesn't correctly set the correct keyboard layout...

![m-type](https://user-images.githubusercontent.com/4710635/60814748-7fa1fe80-a196-11e9-8b46-ddea24a1f88b.gif)


## How has this been tested?

Make sure there is enough content so that the page is scrollable.

On various devices test:

* `Enter`
* `Shift+Enter`
* `Backspace`
* Text wrapping (when text wraps to a new line, the position should update).

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
