### PR TITLE
Build Tooling: Wait for MySQL availability before install

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -117,6 +117,13 @@ install_db() {
 	mysql --user="$DB_USER" --password="$DB_PASS"$EXTRA --execute "CREATE DATABASE IF NOT EXISTS $DB_NAME;"
 }
 
+# Wait for MySQL availability before proceeding with installation
+echo -en $(status_message "Attempting to connect to MySQL...")
+while ! mysqladmin ping -h"$DB_HOST" --silent; do
+	echo -n '.'
+	sleep 2
+done
+
 install_wp
 install_test_suite
 install_db


### PR DESCRIPTION
This pull request seeks to resolve an issue where Travis builds may fail in the "PHP unit tests (Docker)" task. The issue is caused by a race condition which can occur when the MySQL container is not given sufficient time to initialize before the WordPress test procedure begins. This can cause errors to occur when the database is unavailable and refuses connections.

The changes here resolve this issue by waiting for the MySQL host to be available to receive connections before proceeding with the installation procedure.

**Testing Instructions:**

Verify the Travis build passes, and that the logs of the "PHP unit tests (Docker)" are sensible and include the expected PHP test cases result.