### PR TITLE
Make capitalization of block names consistent per #16118

### DIFF
--- a/docs/designers-developers/designers/block-design.md
+++ b/docs/designers-developers/designers/block-design.md
@@ -25,7 +25,7 @@ Each Settings Sidebar comes with an "Advanced" section by default. This area hou
 
 ## Setup state vs. live preview state
 
-Setup states, sometimes referred to as "placeholders", can be used to walk users through an initial process before showing the live preview state of the block. The setup process gathers information from the user that is needed to render the block. A block’s setup state is indicated with a grey background to provide clear differentiation for the user. Not all blocks have setup states — for example, the paragraph block.
+Setup states, sometimes referred to as "placeholders", can be used to walk users through an initial process before showing the live preview state of the block. The setup process gathers information from the user that is needed to render the block. A block’s setup state is indicated with a grey background to provide clear differentiation for the user. Not all blocks have setup states — for example, the Paragraph block.
 
 ![An example of a gallery block’s setup state on a grey background](https://make.wordpress.org/design/files/2018/12/gallery-setup.png)
 
@@ -108,7 +108,7 @@ Do not put controls that are essential to the block in the sidebar, or the block
 
 The “Block” tab of the Settings Sidebar can contain additional block options and configuration. Keep in mind that a user can dismiss the sidebar and never use it. You should not put critical options in the Sidebar.
 
-![A screenshot of the paragraph block's advanced settings in the sidebar](https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/designers/assets/advanced-settings-do.png)
+![A screenshot of the Paragraph block's advanced settings in the sidebar](https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/designers/assets/advanced-settings-do.png)
 **Do:**
 Because the Drop Cap feature is not necessary for the basic operation of the block, you can put it to the Block tab as optional configuration.
 
@@ -126,9 +126,9 @@ To demonstrate some of these practices, here are a few annotated examples of def
 
 ### Paragraph
 
-The most basic unit of the editor. The paragraph block is a simple input field.
+The most basic unit of the editor. The Paragraph block is a simple input field.
 
-![Paragraph Block](https://cldup.com/HVJe5bGZ8H-3000x3000.png)
+![Paragraph block](https://cldup.com/HVJe5bGZ8H-3000x3000.png)
 
 ### Placeholder:
 
@@ -144,7 +144,7 @@ The most basic unit of the editor. The paragraph block is a simple input field.
 
 Basic image block.
 
-![Image Block Placeholder](https://cldup.com/w6FNywNsj1-3000x3000.png)
+![Image block placeholder](https://cldup.com/w6FNywNsj1-3000x3000.png)
 
 ### Placeholder:
 

--- a/docs/designers-developers/developers/block-api/block-annotations.md
+++ b/docs/designers-developers/developers/block-api/block-annotations.md
@@ -32,7 +32,7 @@ All available properties can be found in the API documentation of the `addAnnota
 
 The property `richTextIdentifier` is the identifier of the RichText instance the annotation applies to. This is necessary because blocks may have multiple rich text instances that are used to manage data for different attributes, so you need to pass this in order to highlight text within the correct one.
 
-For example the paragraph block only has a single RichText instance, with the identifer `content`. The quote block type has 2 RichText instances, so if you wish to highlight text in the citation, you need to pass `citation` as the `richTextIdentifier` when adding an annotation. To target the quote content, you need to use the identifier `value`. Refer to the source code of the block type to find the correct identifier.
+For example the Paragraph block only has a single RichText instance, with the identifer `content`. The quote block type has 2 RichText instances, so if you wish to highlight text in the citation, you need to pass `citation` as the `richTextIdentifier` when adding an annotation. To target the quote content, you need to use the identifier `value`. Refer to the source code of the block type to find the correct identifier.
 
 ## Block annotation
 

--- a/docs/designers-developers/developers/block-api/block-deprecation.md
+++ b/docs/designers-developers/developers/block-api/block-deprecation.md
@@ -275,6 +275,6 @@ registerBlockType( 'gutenberg/block-with-deprecated-version', {
 ```
 {% end %}
 
-In the example above we updated the block to use an inner paragraph block with a title instead of a title attribute.
+In the example above we updated the block to use an inner Paragraph block with a title instead of a title attribute.
 
 *Above are example cases of block deprecation. For more, real-world examples, check for deprecations in the [core block library](/packages/block-library/src/README.md). Core blocks have been updated across releases and contain simple and complex deprecations.*

--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -174,7 +174,7 @@ attributes: {
 
 Transforms provide rules for what a block can be transformed from and what it can be transformed to. A block can be transformed from another block, a shortcode, a regular expression, a file or a raw DOM node.
 
-For example, a paragraph block can be transformed into a heading block. This uses the `createBlock` function from the [`wp-blocks` package](/packages/blocks/README.md#createBlock)
+For example, a Paragraph block can be transformed into a Heading block. This uses the `createBlock` function from the [`wp-blocks` package](/packages/blocks/README.md#createBlock)
 
 {% codetabs %}
 {% ES5 %}
@@ -274,7 +274,7 @@ transforms: {
 ```
 {% end %}
 
-A block can also be transformed into another block type. For example, a heading block can be transformed into a paragraph block.
+A block can also be transformed into another block type. For example, a Heading block can be transformed into a Paragraph block.
 
 {% codetabs %}
 {% ES5 %}
@@ -345,7 +345,7 @@ transforms: {
 {% end %}
 
 
-A block with innerBlocks can also be transformed from and to another block with innerBlocks.
+A block with InnerBlocks can also be transformed from and to another block with InnerBlocks.
 
 {% codetabs %}
 {% ES5 %}
@@ -478,7 +478,7 @@ transforms: {
 ```
 {% end %}
 
-A prefix transform is a transform that will be applied if the user prefixes some text in e.g. the paragraph block with a given pattern and a trailing space.
+A prefix transform is a transform that will be applied if the user prefixes some text in e.g. the Paragraph block with a given pattern and a trailing space.
 
 {% codetabs %}
 {% ES5 %}

--- a/docs/designers-developers/developers/tutorials/block-tutorial/block-controls-toolbar-and-sidebar.md
+++ b/docs/designers-developers/developers/tutorials/block-tutorial/block-controls-toolbar-and-sidebar.md
@@ -4,7 +4,7 @@ To simplify block customization and ensure a consistent experience for users, th
 
 ## Block Toolbar
 
-![Screenshot of the rich text toolbar applied to a paragraph block inside the block editor](https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/assets/toolbar-text.png)
+![Screenshot of the rich text toolbar applied to a Paragraph block inside the block editor](https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/assets/toolbar-text.png)
 
 When the user selects a block, a number of control buttons may be shown in a toolbar above the selected block. Some of these block-level controls are included automatically if the editor is able to transform the block to another type, or if the focused element is a RichText component.
 
@@ -167,7 +167,7 @@ Note that `BlockControls` is only visible when the block is currently selected a
 
 ## Inspector
 
-![Screenshot of the inspector panel focused on the settings for a paragraph block](https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/assets/inspector.png)
+![Screenshot of the inspector panel focused on the settings for a Paragraph block](https://raw.githubusercontent.com/WordPress/gutenberg/master/docs/designers-developers/assets/inspector.png)
 
 The Settings Sidebar is used to display less-often-used settings or settings that require more screen space. The Settings Sidebar should be used for **block-level settings only**.
 

--- a/docs/designers-developers/developers/tutorials/format-api/2-toolbar-button.md
+++ b/docs/designers-developers/developers/tutorials/format-api/2-toolbar-button.md
@@ -40,7 +40,7 @@ You may also want to check that upon clicking the button the `toggle format` mes
 
 By default, the button is rendered on every rich text toolbar (image captions, buttons, paragraphs, etc).
 It is possible to render the button only on blocks of a certain type by using `wp.data.withSelect` together with `wp.compose.ifCondition`.
-The following sample code renders the previously shown button only on paragraph blocks:
+The following sample code renders the previously shown button only on Paragraph blocks:
 
 ```js
 ( function( wp ) {

--- a/docs/designers-developers/developers/tutorials/metabox/meta-block-4-use-data.md
+++ b/docs/designers-developers/developers/tutorials/metabox/meta-block-4-use-data.md
@@ -20,7 +20,7 @@ add_filter( 'the_content', 'myguten_content_filter' );
 
 ## Use Post Meta in Block
 
-You can also use the post meta data in other blocks. For this example the data is loaded at the end of every paragraph block when it is rendered, ie. shown to the user. You can replace this for any core or custom block types as needed.
+You can also use the post meta data in other blocks. For this example the data is loaded at the end of every Paragraph block when it is rendered, ie. shown to the user. You can replace this for any core or custom block types as needed.
 
 In PHP, use the [register_block_type](https://developer.wordpress.org/reference/functions/register_block_type/) function to set a callback when the block is rendered to include the meta value.
 

--- a/docs/designers-developers/key-concepts.md
+++ b/docs/designers-developers/key-concepts.md
@@ -18,7 +18,7 @@ Blocks can be static or dynamic. Static blocks contain rendered content and an o
 
 Each block contains Attributes or configuration settings, which can be sourced from raw HTML in the content, via meta or other customizable origins.
 
-The Paragraph is the default Block. Instead of a new line upon typing return on a keyboard, try to think of it as an empty paragraph block (type / to trigger an autocompleting Slash Inserter -- /image will pull up Images as well as Instagram embeds).
+The Paragraph is the default block. Instead of a new line upon typing return on a keyboard, try to think of it as an empty Paragraph block (type / to trigger an autocompleting Slash Inserter -- /image will pull up Images as well as Instagram embeds).
 
 Users insert new blocks by clicking the plus button for the Block Inserter, typing / for the Slash Inserter or typing return for a blank Paragraph block.
 


### PR DESCRIPTION
## Description

Adjust the capitalization of block names to match the standard per #16118 that state block names should be something like "Paragraph block" 

Note: this is not an exhaustive search of all block names referenced across the documentation. This pass was mostly just on the Paragraph block in /docs directory.

## Types of changes

Documentation
