### PR TITLE
Add circle-crop variation to Image block.

### DIFF
--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -24,6 +24,10 @@ export const settings = {
 	keywords: [
 		'img', // "img" is not translated as it is intended to reflect the HTML <img> tag.
 		__( 'photo' ),
+	],
+	styles: [
+		{ name: 'default', label: _x( 'Default', 'block style' ), isDefault: true },
+		{ name: 'circle-crop', label: _x( 'Circle Crop', 'block style' ) },
 	],
 	transforms,
 	getEditWrapperProps( attributes ) {

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -27,7 +27,7 @@ export const settings = {
 	],
 	styles: [
 		{ name: 'default', label: _x( 'Default', 'block style' ), isDefault: true },
-		{ name: 'circle-crop', label: _x( 'Circle Crop', 'block style' ) },
+		{ name: 'circle-mask', label: _x( 'Circle Mask', 'block style' ) },
 	],
 	transforms,
 	getEditWrapperProps( attributes ) {

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -65,4 +65,17 @@
 	// We use an absolute pixel to prevent the oval shape that a value of 50% would give
 	// to rectangular images. A pill-shape is better than otherwise.
 	border-radius: 9999px;
+
+	// If a browser supports it, we will switch to using a circular SVG mask.
+	// The stylelint override is necessary to use the SVG inline here.
+	@supports (mask-image: none) or (-webkit-mask-image: none) {
+		/* stylelint-disable */
+		mask-image: url('data:image/svg+xml;utf8,<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="50"/></svg>');
+		/* stylelint-enable */
+		mask-mode: alpha;
+		mask-repeat: no-repeat;
+		mask-size: contain;
+		mask-position: center;
+		border-radius: none;
+	}
 }

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -59,3 +59,10 @@
 		margin-right: auto;
 	}
 }
+
+// Variations
+.is-style-circle-crop img {
+	// We use an absolute pixel to prevent the oval shape that a value of 50% would give
+	// to rectangular images. A pill-shape is better than otherwise.
+	border-radius: 9999px;
+}

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -61,7 +61,7 @@
 }
 
 // Variations
-.is-style-circle-crop img {
+.is-style-circle-mask img {
 	// We use an absolute pixel to prevent the oval shape that a value of 50% would give
 	// to rectangular images. A pill-shape is better than otherwise.
 	border-radius: 9999px;

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -177,7 +177,7 @@ figcaption {
 // Apply some base styles to blocks that need them.
 img {
 	max-width: 100%;
-	height: auto;
+	//height: auto;
 }
 
 iframe {

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -177,7 +177,7 @@ figcaption {
 // Apply some base styles to blocks that need them.
 img {
 	max-width: 100%;
-	//height: auto;
+	height: auto;
 }
 
 iframe {


### PR DESCRIPTION
Props @phpbits for the technical implementation.

This PR adds a variation to the Image block, "Circle Crop". What that means is you can choose a style variation for the image, which rounds all 4 corners. When this is appliedto a square image, that means a perfect circle. When it is applied to a rectangle, it means a pill-shape.

In past attempts to fix this, it was either an oval crop, or it required a large refactor to be able to make a rectangular image into a square, in CSS only. But with @phpbits clever trick — using a pixel value for the border radius — the we can actually implement this in a simple way that is still visually appealing even for rectangles.

GIF:

![circle crop](https://user-images.githubusercontent.com/1204802/60871367-dbba6080-a232-11e9-9714-321af933c1ce.gif)

---

On a separate note, I did look into sort of a "hack" to create perfect circles from rectangular images. Since you can manually type in the dimensions of an image in the block inspector, you can _force_ a square image even from a rectangle. If you combine that with `object-fit: cover;`, it means that the image won't be stretched. 

However, every modern WordPress theme has the following CSS bundled along, to make images responsive:

```
img {
	max-width: 100%;
	height: auto;
}
```

This reminded me that unless the width of the image is fluid, it won't scale to mobile. So the hack unfortunately won't work. 