### PR TITLE
Fix using the classic block in nested contexts

### DIFF
--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -639,6 +639,7 @@ Takes a block or set of blocks and returns the serialized post content.
 _Parameters_
 
 -   _blocks_ `Array`: Block(s) to serialize.
+-   _options_ `Object`: Serialization options.
 
 _Returns_
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -639,7 +639,7 @@ Takes a block or set of blocks and returns the serialized post content.
 _Parameters_
 
 -   _blocks_ `Array`: Block(s) to serialize.
--   _options_ `Object`: Serialization options.
+-   _options_ `WPBlockSerializationOptions`: Serialization options.
 
 _Returns_
 

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -255,17 +255,18 @@ export function getCommentDelimitedContent( rawBlockName, attributes, content ) 
  * Returns the content of a block, including comment delimiters, determining
  * serialized attributes and content form from the current state of the block.
  *
- * @param {Object} block Block instance.
+ * @param {Object} block   Block instance.
+ * @param {Object} options Serialization options.
  *
  * @return {string} Serialized block.
  */
-export function serializeBlock( block ) {
+export function serializeBlock( block, { isNested = false } = {} ) {
 	const blockName = block.name;
 	const saveContent = getBlockContent( block );
 
-	switch ( blockName ) {
-		case getFreeformContentHandlerName():
-		case getUnregisteredTypeHandlerName():
+	switch ( true ) {
+		case ! isNested && blockName === getFreeformContentHandlerName():
+		case blockName === getUnregisteredTypeHandlerName():
 			return saveContent;
 
 		default: {
@@ -280,9 +281,12 @@ export function serializeBlock( block ) {
  * Takes a block or set of blocks and returns the serialized post content.
  *
  * @param {Array} blocks Block(s) to serialize.
+ * @param {Object} options Serialization options.
  *
  * @return {string} The post content.
  */
-export default function serialize( blocks ) {
-	return castArray( blocks ).map( serializeBlock ).join( '\n\n' );
+export default function serialize( blocks, options ) {
+	return castArray( blocks )
+		.map( ( block ) => serializeBlock( block, options ) )
+		.join( '\n\n' );
 }

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -22,6 +22,12 @@ import { normalizeBlockType } from './utils';
 import BlockContentProvider from '../block-content-provider';
 
 /**
+ * @typedef {Object} WPBlockSerializationOptions Serialization Options.
+ *
+ * @property {boolean} isInnerBlocks Whether we are serializing inner blocks.
+ */
+
+/**
  * Returns the block's default classname from its name.
  *
  * @param {string} blockName The block name.
@@ -255,33 +261,32 @@ export function getCommentDelimitedContent( rawBlockName, attributes, content ) 
  * Returns the content of a block, including comment delimiters, determining
  * serialized attributes and content form from the current state of the block.
  *
- * @param {Object} block   Block instance.
- * @param {Object} options Serialization options.
+ * @param {Object}                      block   Block instance.
+ * @param {WPBlockSerializationOptions} options Serialization options.
  *
  * @return {string} Serialized block.
  */
-export function serializeBlock( block, { isNested = false } = {} ) {
+export function serializeBlock( block, { isInnerBlocks = false } = {} ) {
 	const blockName = block.name;
 	const saveContent = getBlockContent( block );
 
-	switch ( true ) {
-		case ! isNested && blockName === getFreeformContentHandlerName():
-		case blockName === getUnregisteredTypeHandlerName():
-			return saveContent;
-
-		default: {
-			const blockType = getBlockType( blockName );
-			const saveAttributes = getCommentAttributes( blockType, block.attributes );
-			return getCommentDelimitedContent( blockName, saveAttributes, saveContent );
-		}
+	if (
+		( blockName === getUnregisteredTypeHandlerName() ) ||
+		( ! isInnerBlocks && blockName === getFreeformContentHandlerName() )
+	) {
+		return saveContent;
 	}
+
+	const blockType = getBlockType( blockName );
+	const saveAttributes = getCommentAttributes( blockType, block.attributes );
+	return getCommentDelimitedContent( blockName, saveAttributes, saveContent );
 }
 
 /**
  * Takes a block or set of blocks and returns the serialized post content.
  *
- * @param {Array} blocks Block(s) to serialize.
- * @param {Object} options Serialization options.
+ * @param {Array}                       blocks  Block(s) to serialize.
+ * @param {WPBlockSerializationOptions} options Serialization options.
  *
  * @return {string} The post content.
  */

--- a/packages/blocks/src/api/test/serializer.js
+++ b/packages/blocks/src/api/test/serializer.js
@@ -257,7 +257,7 @@ describe( 'block serializer', () => {
 			setFreeformContentHandlerName( 'core/freeform-block' );
 			const block = createBlock( 'core/freeform-block', { fruit: 'Bananas' } );
 
-			const content = serializeBlock( block, { isNested: true } );
+			const content = serializeBlock( block, { isInnerBlocks: true } );
 
 			expect( content ).toBe(
 				'<!-- wp:freeform-block {\"fruit\":\"Bananas\"} -->\n' +

--- a/packages/blocks/src/api/test/serializer.js
+++ b/packages/blocks/src/api/test/serializer.js
@@ -243,6 +243,28 @@ describe( 'block serializer', () => {
 
 			expect( content ).toBe( 'Bananas' );
 		} );
+		it( 'serializes the freeform content fallback block with comment delimiters in nested context', () => {
+			registerBlockType( 'core/freeform-block', {
+				category: 'common',
+				title: 'freeform block',
+				attributes: {
+					fruit: {
+						type: 'string',
+					},
+				},
+				save: ( { attributes } ) => attributes.fruit,
+			} );
+			setFreeformContentHandlerName( 'core/freeform-block' );
+			const block = createBlock( 'core/freeform-block', { fruit: 'Bananas' } );
+
+			const content = serializeBlock( block, { isNested: true } );
+
+			expect( content ).toBe(
+				'<!-- wp:freeform-block {\"fruit\":\"Bananas\"} -->\n' +
+				'Bananas\n' +
+				'<!-- /wp:freeform-block -->'
+			);
+		} );
 		it( 'serializes the unregistered fallback block without comment delimiters', () => {
 			registerBlockType( 'core/unregistered-block', {
 				category: 'common',

--- a/packages/blocks/src/block-content-provider/index.js
+++ b/packages/blocks/src/block-content-provider/index.js
@@ -31,7 +31,7 @@ const { Consumer, Provider } = createContext( () => {} );
 const BlockContentProvider = ( { children, innerBlocks } ) => {
 	const BlockContent = () => {
 		// Value is an array of blocks, so defer to block serializer
-		const html = serialize( innerBlocks, { isNested: true } );
+		const html = serialize( innerBlocks, { isInnerBlocks: true } );
 
 		// Use special-cased raw HTML tag to avoid default escaping
 		return <RawHTML>{ html }</RawHTML>;

--- a/packages/blocks/src/block-content-provider/index.js
+++ b/packages/blocks/src/block-content-provider/index.js
@@ -31,7 +31,7 @@ const { Consumer, Provider } = createContext( () => {} );
 const BlockContentProvider = ( { children, innerBlocks } ) => {
 	const BlockContent = () => {
 		// Value is an array of blocks, so defer to block serializer
-		const html = serialize( innerBlocks );
+		const html = serialize( innerBlocks, { isNested: true } );
 
 		// Use special-cased raw HTML tag to avoid default escaping
 		return <RawHTML>{ html }</RawHTML>;


### PR DESCRIPTION
At the root level, the classic block omits its delimiters in order to support posts written with alternative editors. In nested contexts though, the classic editor should be rendered with delimiters otherwise the parser won't be able to reparse the post properly.

closes #13187

**Testing instructions**

 - Use a classic block in a columns block
 - Save and refresh
 - Everything should work as intended.