### PR TITLE
Editor: Operate on template CPT posts and add a default template with post title and content blocks.

### DIFF
--- a/lib/load.php
+++ b/lib/load.php
@@ -30,6 +30,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 
 require dirname( __FILE__ ) . '/compat.php';
 require dirname( __FILE__ ) . '/blocks.php';
+require dirname( __FILE__ ) . '/templates.php';
 require dirname( __FILE__ ) . '/client-assets.php';
 require dirname( __FILE__ ) . '/demo.php';
 require dirname( __FILE__ ) . '/widgets.php';

--- a/lib/templates.php
+++ b/lib/templates.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Register Gutenberg core block editor templates.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Registers Gutenberg core block editor templates.
+ */
+function gutenberg_register_templates() {
+	$post_post_type_object                = get_post_type_object( 'post' );
+	$post_post_type_object->template      = array(
+		array( 'core/post-title' ),
+	);
+	$post_post_type_object->template_lock = 'insert';
+}
+add_action( 'init', 'gutenberg_register_templates' );

--- a/lib/templates.php
+++ b/lib/templates.php
@@ -12,6 +12,7 @@ function gutenberg_register_templates() {
 	$post_post_type_object                = get_post_type_object( 'post' );
 	$post_post_type_object->template      = array(
 		array( 'core/post-title' ),
+		array( 'core/post-content', array(), array( array( 'core/paragraph' ) ) ),
 	);
 	$post_post_type_object->template_lock = 'insert';
 }

--- a/lib/templates.php
+++ b/lib/templates.php
@@ -9,11 +9,39 @@
  * Registers Gutenberg core block editor templates.
  */
 function gutenberg_register_templates() {
-	$post_post_type_object                = get_post_type_object( 'post' );
-	$post_post_type_object->template      = array(
-		array( 'core/post-title' ),
-		array( 'core/post-content', array(), array( array( 'core/paragraph' ) ) ),
+	register_post_type(
+		'wp_template',
+		array(
+			'labels'       => array(
+				'name' => __( 'Templates', 'gutenberg' ),
+			),
+			'show_in_rest' => true,
+		)
 	);
-	$post_post_type_object->template_lock = 'insert';
+
+	$template_query = new WP_Query(
+		array(
+			'post_type' => 'wp_template',
+			'name'      => 'single-post',
+		)
+	);
+
+	$template;
+	if ( ! $template_query->have_posts() ) {
+		$template_id = wp_insert_post(
+			array(
+				'post_type'    => 'wp_template',
+				'post_name'    => 'single-post',
+				'post_content' => '<!-- wp:post-title /--><!-- wp:post-content --><!-- wp:paragraph --><p></p><!-- /wp:paragraph --><!-- /wp:post-content -->',
+			)
+		);
+		$template    = get_post( $template_id );
+	} else {
+		$template = $template_query->get_posts();
+		$template = $template[0];
+	}
+
+	$post_type_object           = get_post_type_object( 'post' );
+	$post_type_object->template = $template;
 }
 add_action( 'init', 'gutenberg_register_templates' );

--- a/lib/templates.php
+++ b/lib/templates.php
@@ -41,6 +41,12 @@ function gutenberg_register_templates() {
 		$template = $template[0];
 	}
 
+	if ( isset( $_GET['gutenberg-demo'] ) ) {
+		ob_start();
+		include gutenberg_dir_path() . 'post-content.php';
+		$template->post_content = ob_get_clean();
+	}
+
 	$post_type_object           = get_post_type_object( 'post' );
 	$post_type_object->template = $template;
 }

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -262,9 +262,12 @@ export default compose( [
 			getMultiSelectedBlockClientIds,
 			hasMultiSelection,
 			getGlobalBlockCount,
+			getFirstAncestorWithZoomSupport,
 		} = select( 'core/block-editor' );
+		const selectedBlockClientId = getSelectedBlockClientId();
+		const zoomedBlockId = getFirstAncestorWithZoomSupport( selectedBlockClientId );
 
-		const { rootClientId } = ownProps;
+		const rootClientId = ownProps.rootClientId || zoomedBlockId;
 
 		return {
 			blockClientIds: getBlockOrder( rootClientId ),
@@ -272,7 +275,7 @@ export default compose( [
 			selectionEnd: getMultiSelectedBlocksEndClientId(),
 			isSelectionEnabled: isSelectionEnabled(),
 			isMultiSelecting: isMultiSelecting(),
-			selectedBlockClientId: getSelectedBlockClientId(),
+			selectedBlockClientId,
 			multiSelectedBlockClientIds: getMultiSelectedBlockClientIds(),
 			hasMultiSelection: hasMultiSelection(),
 			enableAnimation: getGlobalBlockCount() <= BLOCK_ANIMATION_THRESHOLD,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1405,3 +1405,38 @@ export function __experimentalGetLastBlockAttributeChanges( state ) {
 function getReusableBlocks( state ) {
 	return get( state, [ 'settings', '__experimentalReusableBlocks' ], EMPTY_ARRAY );
 }
+
+/**
+ * Returns the first ancestor of the specified block, that supports zoom.
+ * Returns null if there isn't one.
+ *
+ * @param {Object} state    Editor state.
+ * @param {string} clientId The block's client ID.
+ *
+ * @return {?string} The zoom supporting ancestor's client ID or null if there isn't one.
+ */
+export const getFirstAncestorWithZoomSupport = createSelector(
+	( state, clientId ) => {
+		let ancestorClientId = clientId;
+		while ( ancestorClientId ) {
+			const blockName = getBlockName( state, ancestorClientId );
+			if ( ! blockName ) {
+				return null;
+			}
+
+			const blockType = getBlockType( blockName );
+			if ( ! blockType ) {
+				return null;
+			}
+
+			if ( hasBlockSupport( blockType, 'zoom', false ) ) {
+				return ancestorClientId;
+			}
+
+			ancestorClientId = getBlockRootClientId( state, ancestorClientId );
+		}
+
+		return ancestorClientId;
+	},
+	( state ) => [ state.blocks.byClientId, getBlockTypes(), state.blocks.parents ]
+);

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -62,6 +62,9 @@ import * as tagCloud from './tag-cloud';
 
 import * as classic from './classic';
 
+// Top-level template blocks.
+import * as postTitle from './post-title';
+
 /**
  * Function to register core blocks provided by the block editor.
  *
@@ -124,6 +127,9 @@ export const registerCoreBlocks = () => {
 		textColumns,
 		verse,
 		video,
+
+		// Register top-level template blocks.
+		postTitle,
 	].forEach( ( block ) => {
 		if ( ! block ) {
 			return;

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -64,6 +64,7 @@ import * as classic from './classic';
 
 // Top-level template blocks.
 import * as postTitle from './post-title';
+import * as postContent from './post-content';
 
 /**
  * Function to register core blocks provided by the block editor.
@@ -130,6 +131,7 @@ export const registerCoreBlocks = () => {
 
 		// Register top-level template blocks.
 		postTitle,
+		postContent,
 	].forEach( ( block ) => {
 		if ( ! block ) {
 			return;

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -1,0 +1,4 @@
+{
+	"name": "core/post-content",
+	"category": "common"
+}

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -1,4 +1,5 @@
 {
 	"name": "core/post-content",
-	"category": "common"
+	"category": "common",
+	"multiple": false
 }

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -1,5 +1,8 @@
 {
 	"name": "core/post-content",
 	"category": "common",
-	"multiple": false
+	"supports": {
+		"multiple": false,
+		"zoom": true
+	}
 }

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+
+export default function PostContentEdit() {
+	return <InnerBlocks templateLock={ false } />;
+}

--- a/packages/block-library/src/post-content/index.js
+++ b/packages/block-library/src/post-content/index.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './edit';
+
+const { name } = metadata;
+
+export { metadata, name };
+
+export const settings = {
+	title: __( 'Post Content' ),
+	edit,
+};

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -1,0 +1,9 @@
+{
+	"name": "core/post-title",
+	"category": "common",
+	"attributes": {
+		"title": {
+			"type": "string"
+		}
+	}
+}

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -3,7 +3,9 @@
 	"category": "common",
 	"attributes": {
 		"title": {
-			"type": "string"
+			"type": "string",
+			"source": "post",
+			"attribute": "title"
 		}
 	}
 }

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -1,0 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * WordPress dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+
+export default function PostTitleEdit( {
+	attributes: { title },
+	setAttributes,
+} ) {
+	return (
+		<RichText
+			value={ title }
+			onChange={ ( value ) => setAttributes( { title: value } ) }
+			tagName="h1"
+			placeholder={ __( 'Title' ) }
+			formattingControls={ [] }
+		/>
+	);
+}

--- a/packages/block-library/src/post-title/index.js
+++ b/packages/block-library/src/post-title/index.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './edit';
+
+const { name } = metadata;
+
+export { metadata, name };
+
+export const settings = {
+	title: __( 'Post Title' ),
+	edit,
+};

--- a/packages/blocks/src/api/templates.js
+++ b/packages/blocks/src/api/templates.js
@@ -54,7 +54,10 @@ export function synchronizeBlocksWithTemplate( blocks = [], template ) {
 		return blocks;
 	}
 
-	return map( template, ( { name, attributes, innerBlocks: innerBlocksTemplate }, index ) => {
+	return map( template, ( templateBlock, index ) => {
+		const [ name, attributes, innerBlocksTemplate ] = Array.isArray( templateBlock ) ?
+			templateBlock :
+			[ templateBlock.name, templateBlock.attributes, templateBlock.innerBlocksTemplate ];
 		const block = blocks[ index ];
 
 		if ( block && block.name === name ) {

--- a/packages/blocks/src/api/templates.js
+++ b/packages/blocks/src/api/templates.js
@@ -55,14 +55,21 @@ export function synchronizeBlocksWithTemplate( blocks = [], template ) {
 	}
 
 	return map( template, ( templateBlock, index ) => {
-		const [ name, attributes, innerBlocksTemplate ] = Array.isArray( templateBlock ) ?
+		const [ name, attributes, _innerBlocksTemplate ] = Array.isArray( templateBlock ) ?
 			templateBlock :
-			[ templateBlock.name, templateBlock.attributes, templateBlock.innerBlocksTemplate ];
+			[ templateBlock.name, templateBlock.attributes, templateBlock.innerBlocks ];
 		const block = blocks[ index ];
+		let innerBlocksTemplate = _innerBlocksTemplate;
 
-		if ( block && block.name === name ) {
-			const innerBlocks = synchronizeBlocksWithTemplate( block.innerBlocks, innerBlocksTemplate );
-			return { ...block, innerBlocks };
+		if ( block ) {
+			if ( block.name === name ) {
+				const innerBlocks = synchronizeBlocksWithTemplate( block.innerBlocks, innerBlocksTemplate );
+				return { ...block, innerBlocks };
+			}
+
+			if ( 'core/post-content' === name ) {
+				innerBlocksTemplate = blocks;
+			}
 		}
 
 		// To support old templates that were using the "children" format

--- a/packages/blocks/src/api/templates.js
+++ b/packages/blocks/src/api/templates.js
@@ -54,7 +54,7 @@ export function synchronizeBlocksWithTemplate( blocks = [], template ) {
 		return blocks;
 	}
 
-	return map( template, ( [ name, attributes, innerBlocksTemplate ], index ) => {
+	return map( template, ( { name, attributes, innerBlocks: innerBlocksTemplate }, index ) => {
 		const block = blocks[ index ];
 
 		if ( block && block.name === name ) {

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -1,10 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	PostTitle,
-	VisualEditorGlobalKeyboardShortcuts,
-} from '@wordpress/editor';
+import { VisualEditorGlobalKeyboardShortcuts } from '@wordpress/editor';
 import {
 	WritingFlow,
 	ObserveTyping,
@@ -30,7 +27,6 @@ function VisualEditor() {
 			<WritingFlow>
 				<ObserveTyping>
 					<CopyHandler>
-						<PostTitle />
 						<BlockList />
 					</CopyHandler>
 				</ObserveTyping>

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -12,6 +12,7 @@ import { dispatch, select, apiFetch } from '@wordpress/data-controls';
 import {
 	parse,
 	synchronizeBlocksWithTemplate,
+	serialize,
 } from '@wordpress/blocks';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 
@@ -487,7 +488,8 @@ export function* savePost( options = {} ) {
 				content: editedPostContent,
 			},
 		} );
-		editedPostContent = '';
+		const postContentBlock = ( yield select( STORE_KEY, 'getBlocksForSerialization' ) ).find( ( block ) => block.name === 'core/post-content' );
+		editedPostContent = postContentBlock ? serialize( postContentBlock.innerBlocks ) : '';
 	}
 
 	let toSend = {

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -172,7 +172,10 @@ export function* setupEditor( post, edits, template ) {
 
 	// Apply a template for new posts only, if exists.
 	if ( template ) {
-		blocks = synchronizeBlocksWithTemplate( blocks, parse( template.post_content ) );
+		blocks = synchronizeBlocksWithTemplate(
+			blocks,
+			template.post_content ? parse( template.post_content ) : template
+		);
 	}
 
 	yield resetPost( post );
@@ -480,7 +483,7 @@ export function* savePost( options = {} ) {
 	);
 
 	const template = ( yield select( STORE_KEY, 'getEditorSettings' ) ).template;
-	if ( template ) {
+	if ( template && template.post_content ) {
 		yield apiFetch( {
 			path: `/wp/v2/${ template.post_type }/${ template.ID }`,
 			method: 'PUT',

--- a/packages/editor/src/store/block-sources/index.js
+++ b/packages/editor/src/store/block-sources/index.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import * as post from './post';
 import * as meta from './meta';
 
-export { meta };
+export { post, meta };

--- a/packages/editor/src/store/block-sources/post.js
+++ b/packages/editor/src/store/block-sources/post.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { get, set } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { select } from '@wordpress/data-controls';
+
+/**
+ * Internal dependencies
+ */
+import { editPost } from '../actions';
+import { EDIT_MERGE_PROPERTIES } from '../constants';
+
+export function* getDependencies() {
+	return {
+		post: yield select( 'core/editor', 'getCurrentPost' ),
+		content: yield select( 'core/editor', 'getEditedPostContent' ),
+		edits: yield select( 'core/editor', 'getPostEdits' ),
+	};
+}
+
+export function apply( { attribute }, { post, content, edits } ) {
+	if ( 'content' === attribute ) {
+		return content;
+	}
+
+	if ( undefined === get( edits, attribute ) ) {
+		return get( post, attribute );
+	}
+
+	if ( EDIT_MERGE_PROPERTIES.has( attribute ) ) {
+		return {
+			...get( post, attribute ),
+			...get( edits, attribute ),
+		};
+	}
+
+	return get( edits, attribute );
+}
+
+export function* update( { attribute }, value ) {
+	yield editPost( set( {}, attribute, value ) );
+}

--- a/post-content.php
+++ b/post-content.php
@@ -6,6 +6,8 @@
  */
 
 ?>
+<!-- wp:post-title /-->
+<!-- wp:post-content -->
 <!-- wp:cover {"url":"https://cldup.com/Fz-ASbo2s3.jpg","className":"alignwide"} -->
 <div class="wp-block-cover has-background-dim alignwide" style="background-image:url(https://cldup.com/Fz-ASbo2s3.jpg)"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
 <p style="text-align:center" class="has-large-font-size"><?php _e( 'Of Mountains &amp; Printing Presses', 'gutenberg' ); ?></p>
@@ -184,3 +186,4 @@ https://vimeo.com/22439234
 <!-- wp:paragraph {"align":"center"} -->
 <p style="text-align:center">👋</p>
 <!-- /wp:paragraph -->
+<!-- /wp:post-content -->


### PR DESCRIPTION
cc @youknowriad 

Closes #16281

## Description

This PR builds on @aduth 's work on #16402 to add backwards compatible support for making the editor operate on and persist to template CPT posts instead of the actual edited post.

It adds a single, default, editable template to the "post" post type which contains a new post-title block, which persists to the edited post's title, followed by a new post-content block, which persists to the edited post's `post_content`. Note that this post-content block produces no markup on `save` so that the template only stores the location of `post-content` relative to the other blocks in the template. When the template is rendered by a theme, either explicitly or dynamically like in #4659, a render callback for the block could fill in the viewed post's content.

Future work will be needed to allow users or theme authors to create a template hierarchy and apply them to specific posts.

## How has this been tested?

Posts were edited and saved and it was verified that the template updated correctly when making changes outside of the post-content block, as well as the title for the post-title block, and the content for the post-content block.

## Screenshots

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/19157096/60903807-9f3d3380-a237-11e9-84fb-bc627a09dac7.gif)

## Types of Changes

*New Feature:* Operate on template CPT posts and add a default template with post title and content blocks.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
- [ ] I've included developer documentation if appropriate.
