### PR TITLE
Editor: Run block-editor's setup before editor's so that settings are available for parse-time validation.

### DIFF
--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -130,9 +130,9 @@ class BlockEditorProvider extends Component {
 	}
 
 	render() {
-		const { children } = this.props;
+		const { isReady, children } = this.props;
 
-		return children;
+		return isReady && children;
 	}
 }
 

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -41,35 +41,12 @@ const fetchLinkSuggestions = async ( search ) => {
 };
 
 class EditorProvider extends Component {
-	constructor( props ) {
+	constructor() {
 		super( ...arguments );
 
 		this.getBlockEditorSettings = memize( this.getBlockEditorSettings, {
 			maxSize: 1,
 		} );
-
-		// Assume that we don't need to initialize in the case of an error recovery.
-		if ( props.recovery ) {
-			return;
-		}
-
-		props.updatePostLock( props.settings.postLock );
-		props.setupEditor( props.post, props.initialEdits, props.settings.template );
-
-		if ( props.settings.autosave ) {
-			props.createWarningNotice(
-				__( 'There is an autosave of this post that is more recent than the version below.' ),
-				{
-					id: 'autosave-exists',
-					actions: [
-						{
-							label: __( 'View the autosave' ),
-							url: props.settings.autosave.editLink,
-						},
-					],
-				}
-			);
-		}
 	}
 
 	getBlockEditorSettings(
@@ -108,6 +85,29 @@ class EditorProvider extends Component {
 	}
 
 	componentDidMount() {
+		// Assume that we don't need to initialize in the case of an error recovery.
+		if ( this.props.recovery ) {
+			return;
+		}
+
+		this.props.updatePostLock( this.props.settings.postLock );
+		this.props.setupEditor( this.props.post, this.props.initialEdits, this.props.settings.template );
+
+		if ( this.props.settings.autosave ) {
+			this.props.createWarningNotice(
+				__( 'There is an autosave of this post that is more recent than the version below.' ),
+				{
+					id: 'autosave-exists',
+					actions: [
+						{
+							label: __( 'View the autosave' ),
+							url: this.props.settings.autosave.editLink,
+						},
+					],
+				}
+			);
+		}
+
 		this.props.updateEditorSettings( this.props.settings );
 
 		if ( ! this.props.settings.styles ) {
@@ -148,10 +148,6 @@ class EditorProvider extends Component {
 			hasUploadPermissions,
 		} = this.props;
 
-		if ( ! isReady ) {
-			return null;
-		}
-
 		const editorSettings = this.getBlockEditorSettings(
 			settings,
 			reusableBlocks,
@@ -166,6 +162,7 @@ class EditorProvider extends Component {
 				onChange={ resetEditorBlocks }
 				settings={ editorSettings }
 				useSubRegistry={ false }
+				isReady={ isReady }
 			>
 				{ children }
 				<ReusableBlocksButtons />


### PR DESCRIPTION
Fixes #16429

## Description

Validation runs during parsing when `EditorProvider` is **constructed**, but needs to use settings, e.g. colors, which are first set when `BlockEditorProvider` is **mounted**.

Either moving validation out of the parsing step or moving `EditorProvider` constructor setup side effects into `componentDidMount` would fix this (because `componentDidMount` runs children => parent).

We should do the latter anyways, in preparation for the next version of React, so this PR takes that route.

## How has this been tested?

It was verified that a page with a pullquote block using the `primary` color from settings is no longer failing validation.

## Types of Changes

*Bug Fix:* Setup editor and block-editor in the right order so that settings like colors are available during parse-time block validation.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
- [x] I've included developer documentation if appropriate.
