### PR TITLE
Editor: Add sessionStorage autosave mechanism

### DIFF
--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -481,27 +481,6 @@ _Related_
 
 -   getPreviousBlockClientId in core/block-editor store.
 
-<a name="getReferenceByDistinctEdits" href="#getReferenceByDistinctEdits">#</a> **getReferenceByDistinctEdits**
-
-Returns a new reference when edited values have changed. This is useful in
-inferring where an edit has been made between states by comparison of the
-return values using strict equality.
-
-_Usage_
-
-    const hasEditOccurred = (
-       getReferenceByDistinctEdits( beforeState ) !==
-       getReferenceByDistinctEdits( afterState )
-    );
-
-_Parameters_
-
--   _state_ `Object`: Editor state.
-
-_Returns_
-
--   `*`: A value whose reference will change only when an edit occurs.
-
 <a name="getSelectedBlock" href="#getSelectedBlock">#</a> **getSelectedBlock**
 
 _Related_

--- a/docs/designers-developers/developers/data/data-core.md
+++ b/docs/designers-developers/developers/data/data-core.md
@@ -246,6 +246,27 @@ _Returns_
 
 -   `?Object`: The edit.
 
+<a name="getReferenceByDistinctEdits" href="#getReferenceByDistinctEdits">#</a> **getReferenceByDistinctEdits**
+
+Returns a new reference when edited values have changed. This is useful in
+inferring where an edit has been made between states by comparison of the
+return values using strict equality.
+
+_Usage_
+
+    const hasEditOccurred = (
+       getReferenceByDistinctEdits( beforeState ) !==
+       getReferenceByDistinctEdits( afterState )
+    );
+
+_Parameters_
+
+-   _state_ `Object`: Editor state.
+
+_Returns_
+
+-   `*`: A value whose reference will change only when an edit occurs.
+
 <a name="getThemeSupports" href="#getThemeSupports">#</a> **getThemeSupports**
 
 Return theme supports data in the index.

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -457,6 +457,27 @@ _Returns_
 
 -   `?Object`: The edit.
 
+<a name="getReferenceByDistinctEdits" href="#getReferenceByDistinctEdits">#</a> **getReferenceByDistinctEdits**
+
+Returns a new reference when edited values have changed. This is useful in
+inferring where an edit has been made between states by comparison of the
+return values using strict equality.
+
+_Usage_
+
+    const hasEditOccurred = (
+       getReferenceByDistinctEdits( beforeState ) !==
+       getReferenceByDistinctEdits( afterState )
+    );
+
+_Parameters_
+
+-   _state_ `Object`: Editor state.
+
+_Returns_
+
+-   `*`: A value whose reference will change only when an edit occurs.
+
 <a name="getThemeSupports" href="#getThemeSupports">#</a> **getThemeSupports**
 
 Return theme supports data in the index.

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -478,3 +478,26 @@ export function getAutosave( state, postType, postId, authorId ) {
 export const hasFetchedAutosaves = createRegistrySelector( ( select ) => ( state, postType, postId ) => {
 	return select( REDUCER_KEY ).hasFinishedResolution( 'getAutosaves', [ postType, postId ] );
 } );
+
+/**
+ * Returns a new reference when edited values have changed. This is useful in
+ * inferring where an edit has been made between states by comparison of the
+ * return values using strict equality.
+ *
+ * @example
+ *
+ * ```
+ * const hasEditOccurred = (
+ *    getReferenceByDistinctEdits( beforeState ) !==
+ *    getReferenceByDistinctEdits( afterState )
+ * );
+ * ```
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {*} A value whose reference will change only when an edit occurs.
+ */
+export const getReferenceByDistinctEdits = createSelector(
+	() => [],
+	( state ) => [ state.undo.length, state.undo.offset ],
+);

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -309,9 +309,9 @@ describe( 'getReferenceByDistinctEdits', () => {
 
 	describe( 'when using undo', () => {
 		it( 'should return referentially different values across changing states', () => {
-			const beforeState = { undo: [ {} ] };
+			const beforeState = { undo: [ {}, {} ] };
 			beforeState.undo.offset = 1;
-			const afterState = { undo: [ {} ] };
+			const afterState = { undo: [ {}, {} ] };
 			afterState.undo.offset = 0;
 			expect( getReferenceByDistinctEdits( beforeState ) ).not.toBe( getReferenceByDistinctEdits( afterState ) );
 		} );

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -15,6 +15,7 @@ import {
 	getAutosave,
 	getAutosaves,
 	getCurrentUser,
+	getReferenceByDistinctEdits,
 } from '../selectors';
 
 describe( 'getEntityRecord', () => {
@@ -275,3 +276,45 @@ describe( 'getCurrentUser', () => {
 		expect( getCurrentUser( state ) ).toEqual( currentUser );
 	} );
 } );
+
+describe( 'getReferenceByDistinctEdits', () => {
+	it( 'should return referentially equal values across empty states', () => {
+		const state = { undo: [] };
+		expect( getReferenceByDistinctEdits( state ) ).toBe( getReferenceByDistinctEdits( state ) );
+
+		const beforeState = { undo: [] };
+		const afterState = { undo: [] };
+		expect( getReferenceByDistinctEdits( beforeState ) ).toBe( getReferenceByDistinctEdits( afterState ) );
+	} );
+
+	it( 'should return referentially equal values across unchanging non-empty state', () => {
+		const undoStates = [ {} ];
+		const state = { undo: undoStates };
+		expect( getReferenceByDistinctEdits( state ) ).toBe( getReferenceByDistinctEdits( state ) );
+
+		const beforeState = { undo: undoStates };
+		const afterState = { undo: undoStates };
+		expect( getReferenceByDistinctEdits( beforeState ) ).toBe( getReferenceByDistinctEdits( afterState ) );
+	} );
+
+	describe( 'when adding edits', () => {
+		it( 'should return referentially different values across changing states', () => {
+			const beforeState = { undo: [ {} ] };
+			beforeState.undo.offset = 0;
+			const afterState = { undo: [ {}, {} ] };
+			afterState.undo.offset = 1;
+			expect( getReferenceByDistinctEdits( beforeState ) ).not.toBe( getReferenceByDistinctEdits( afterState ) );
+		} );
+	} );
+
+	describe( 'when using undo', () => {
+		it( 'should return referentially different values across changing states', () => {
+			const beforeState = { undo: [ {} ] };
+			beforeState.undo.offset = 1;
+			const afterState = { undo: [ {} ] };
+			afterState.undo.offset = 0;
+			expect( getReferenceByDistinctEdits( beforeState ) ).not.toBe( getReferenceByDistinctEdits( afterState ) );
+		} );
+	} );
+} );
+

--- a/packages/e2e-tests/specs/autosave.test.js
+++ b/packages/e2e-tests/specs/autosave.test.js
@@ -8,7 +8,8 @@ import {
 	pressKeyWithModifier,
 } from '@wordpress/e2e-test-utils';
 
-const AUTOSAVE_INTERVAL_SECONDS = 15;
+// Constant to override editor preference
+const AUTOSAVE_INTERVAL_SECONDS = 5;
 
 async function saveDraftWithKeyboard() {
 	return pressKeyWithModifier( 'primary', 's' );
@@ -36,6 +37,13 @@ async function getCurrentPostId() {
 	);
 }
 
+async function setLocalAutosaveInterval( value ) {
+	return page.evaluate( ( _value ) => {
+		window.wp.data.dispatch( 'core/edit-post' )
+			.__experimentalUpdateLocalAutosaveInterval( _value );
+	}, value );
+}
+
 function wrapParagraph( text ) {
 	return `<!-- wp:paragraph -->
 <p>${ text }</p>
@@ -46,6 +54,7 @@ describe( 'autosave', () => {
 	beforeEach( async () => {
 		await clearSessionStorage();
 		await createNewPost();
+		await setLocalAutosaveInterval( AUTOSAVE_INTERVAL_SECONDS );
 	} );
 
 	it( 'should save to sessionStorage', async () => {

--- a/packages/e2e-tests/specs/autosave.test.js
+++ b/packages/e2e-tests/specs/autosave.test.js
@@ -1,0 +1,98 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	clickBlockAppender,
+	createNewPost,
+	getEditedPostContent,
+	pressKeyWithModifier,
+} from '@wordpress/e2e-test-utils';
+
+const AUTOSAVE_INTERVAL_SECONDS = 15;
+
+async function saveDraftWithKeyboard() {
+	return pressKeyWithModifier( 'primary', 's' );
+}
+
+async function sleep( durationInSeconds ) {
+	return new Promise( ( resolve ) =>
+		setTimeout( resolve, durationInSeconds * 1000 ) );
+}
+
+async function clearSessionStorage() {
+	await page.evaluate( () => window.sessionStorage.clear() );
+}
+
+async function readSessionStorageAutosave( postId ) {
+	return page.evaluate(
+		( key ) => window.sessionStorage.getItem( key ),
+		`wp-autosave-block-editor-post-${ postId }`
+	);
+}
+
+async function getCurrentPostId() {
+	return page.evaluate(
+		() => window.wp.data.select( 'core/editor' ).getCurrentPostId()
+	);
+}
+
+function wrapParagraph( text ) {
+	return `<!-- wp:paragraph -->
+<p>${ text }</p>
+<!-- /wp:paragraph -->`;
+}
+
+describe( 'autosave', () => {
+	beforeEach( async () => {
+		await clearSessionStorage();
+		await createNewPost();
+	} );
+
+	it( 'should save to sessionStorage', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'before save' );
+		await saveDraftWithKeyboard();
+		await page.keyboard.type( ' after save' );
+
+		// Wait long enough for local autosave to kick in
+		await sleep( AUTOSAVE_INTERVAL_SECONDS + 1 );
+
+		const id = await getCurrentPostId();
+		const autosave = await readSessionStorageAutosave( id );
+		const { content } = JSON.parse( autosave );
+		expect( content ).toBe( wrapParagraph( 'before save after save' ) );
+
+		// Test throttling by scattering typing
+		await page.keyboard.type( ' 1' );
+		await sleep( AUTOSAVE_INTERVAL_SECONDS - 4 );
+		await page.keyboard.type( '2' );
+		await sleep( 2 );
+		await page.keyboard.type( '3' );
+		await sleep( 2 );
+
+		const newAutosave = await readSessionStorageAutosave( id );
+		expect( JSON.parse( newAutosave ).content ).toBe( wrapParagraph( 'before save after save 123' ) );
+	} );
+
+	it( 'should recover from sessionStorage', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'before save' );
+		await saveDraftWithKeyboard();
+		await page.keyboard.type( ' after save' );
+
+		// Reload without saving on the server
+		await sleep( AUTOSAVE_INTERVAL_SECONDS + 1 );
+		await page.reload();
+
+		const notice = await page.$eval( '.components-notice__content', ( element ) => element.innerText );
+		expect( notice ).toContain( 'The backup of this post in your browser is different from the version below.' );
+
+		expect( await getEditedPostContent() ).toEqual( wrapParagraph( 'before save' ) );
+		await page.click( '.components-notice__action' );
+		expect( await getEditedPostContent() ).toEqual( wrapParagraph( 'before save after save' ) );
+	} );
+
+	afterAll( async () => {
+		await clearSessionStorage();
+	} );
+} );

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -17,6 +17,7 @@ import { __ } from '@wordpress/i18n';
 import { PreserveScrollInReorder } from '@wordpress/block-editor';
 import {
 	AutosaveMonitor,
+	LocalAutosaveMonitor,
 	UnsavedChangesWarning,
 	EditorNotices,
 	PostPublishPanel,
@@ -77,6 +78,7 @@ function Layout( {
 			<BrowserURL />
 			<UnsavedChangesWarning />
 			<AutosaveMonitor />
+			<LocalAutosaveMonitor />
 			<Header />
 			<div
 				className="edit-post-layout__content"

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -42,6 +42,7 @@ class Editor extends Component {
 		hiddenBlockTypes,
 		blockTypes,
 		preferredStyleVariations,
+		__experimentalLocalAutosaveInterval,
 		updatePreferredStyleVariations,
 	) {
 		settings = {
@@ -53,6 +54,7 @@ class Editor extends Component {
 			hasFixedToolbar,
 			focusMode,
 			showInserterHelpPanel,
+			__experimentalLocalAutosaveInterval,
 		};
 
 		// Omit hidden block types if exists and non-empty.
@@ -77,7 +79,6 @@ class Editor extends Component {
 
 	render() {
 		const {
-			preferredStyleVariations,
 			settings,
 			hasFixedToolbar,
 			focusMode,
@@ -87,6 +88,8 @@ class Editor extends Component {
 			onError,
 			hiddenBlockTypes,
 			blockTypes,
+			preferredStyleVariations,
+			__experimentalLocalAutosaveInterval,
 			showInserterHelpPanel,
 			updatePreferredStyleVariations,
 			...props
@@ -104,6 +107,7 @@ class Editor extends Component {
 			hiddenBlockTypes,
 			blockTypes,
 			preferredStyleVariations,
+			__experimentalLocalAutosaveInterval,
 			updatePreferredStyleVariations,
 		);
 
@@ -148,6 +152,7 @@ export default compose( [
 			preferredStyleVariations: getPreference( 'preferredStyleVariations' ),
 			hiddenBlockTypes: getPreference( 'hiddenBlockTypes' ),
 			blockTypes: getBlockTypes(),
+			__experimentalLocalAutosaveInterval: getPreference( 'localAutosaveInterval' ),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -196,6 +196,13 @@ export function updatePreferredStyleVariations( blockName, blockStyle ) {
 	};
 }
 
+export function __experimentalUpdateLocalAutosaveInterval( interval ) {
+	return {
+		type: 'UPDATE_LOCAL_AUTOSAVE_INTERVAL',
+		interval,
+	};
+}
+
 /**
  * Returns an action object used in signalling that block types by the given
  * name(s) should be shown.

--- a/packages/edit-post/src/store/defaults.js
+++ b/packages/edit-post/src/store/defaults.js
@@ -13,4 +13,5 @@ export const PREFERENCES_DEFAULTS = {
 	pinnedPluginItems: {},
 	hiddenBlockTypes: [],
 	preferredStyleVariations: {},
+	localAutosaveInterval: 15,
 };

--- a/packages/edit-post/src/store/reducer.js
+++ b/packages/edit-post/src/store/reducer.js
@@ -153,6 +153,14 @@ export const preferences = flow( [
 		}
 		return state;
 	},
+	localAutosaveInterval( state, action ) {
+		switch ( action.type ) {
+			case 'UPDATE_LOCAL_AUTOSAVE_INTERVAL':
+				return action.interval;
+		}
+
+		return state;
+	},
 } );
 
 /**

--- a/packages/editor/src/components/autosave-monitor/index.js
+++ b/packages/editor/src/components/autosave-monitor/index.js
@@ -42,11 +42,24 @@ export class AutosaveMonitor extends Component {
 	}
 
 	toggleTimer( isPendingSave ) {
-		clearTimeout( this.pendingSave );
-		const { interval } = this.props;
-		if ( isPendingSave ) {
+		const { interval, shouldThrottle = false } = this.props;
+
+		// By default, AutosaveMonitor will wait for a pause in editing before
+		// autosaving. In other words, its action is "debounced".
+		//
+		// The `shouldThrottle` props allows overriding this behaviour, thus
+		// making the autosave action "throttled".
+		if ( ! shouldThrottle ) {
+			clearTimeout( this.pendingSave );
+			delete this.pendingSave;
+		}
+
+		if ( isPendingSave && ! ( shouldThrottle && this.pendingSave ) ) {
 			this.pendingSave = setTimeout(
-				() => this.props.autosave(),
+				() => {
+					this.props.autosave();
+					delete this.pendingSave;
+				},
 				interval * 1000
 			);
 		}

--- a/packages/editor/src/components/autosave-monitor/index.js
+++ b/packages/editor/src/components/autosave-monitor/index.js
@@ -43,11 +43,11 @@ export class AutosaveMonitor extends Component {
 
 	toggleTimer( isPendingSave ) {
 		clearTimeout( this.pendingSave );
-		const { autosaveInterval } = this.props;
+		const { interval } = this.props;
 		if ( isPendingSave ) {
 			this.pendingSave = setTimeout(
 				() => this.props.autosave(),
-				autosaveInterval * 1000
+				interval * 1000
 			);
 		}
 	}
@@ -58,25 +58,29 @@ export class AutosaveMonitor extends Component {
 }
 
 export default compose( [
-	withSelect( ( select ) => {
+	withSelect( ( select, ownProps ) => {
 		const {
 			isEditedPostDirty,
 			isEditedPostAutosaveable,
 			getReferenceByDistinctEdits,
 			isAutosavingPost,
+			getEditorSettings,
 		} = select( 'core/editor' );
 
-		const { autosaveInterval } = select( 'core/editor' ).getEditorSettings();
+		const { interval = getEditorSettings().autosaveInterval } = ownProps;
 
 		return {
 			isDirty: isEditedPostDirty(),
 			isAutosaveable: isEditedPostAutosaveable(),
 			editsReference: getReferenceByDistinctEdits(),
 			isAutosaving: isAutosavingPost(),
-			autosaveInterval,
+			interval,
 		};
 	} ),
-	withDispatch( ( dispatch ) => ( {
-		autosave: dispatch( 'core/editor' ).autosave,
+	withDispatch( ( dispatch, ownProps ) => ( {
+		autosave() {
+			const { autosave = dispatch( 'core/editor' ).autosave } = ownProps;
+			autosave();
+		},
 	} ) ),
 ] )( AutosaveMonitor );

--- a/packages/editor/src/components/autosave-monitor/index.js
+++ b/packages/editor/src/components/autosave-monitor/index.js
@@ -49,7 +49,7 @@ export class AutosaveMonitor extends Component {
 		//
 		// The `shouldThrottle` props allows overriding this behaviour, thus
 		// making the autosave action "throttled".
-		if ( ! shouldThrottle ) {
+		if ( ! shouldThrottle && this.pendingSave ) {
 			clearTimeout( this.pendingSave );
 			delete this.pendingSave;
 		}

--- a/packages/editor/src/components/autosave-monitor/index.js
+++ b/packages/editor/src/components/autosave-monitor/index.js
@@ -60,9 +60,12 @@ export class AutosaveMonitor extends Component {
 export default compose( [
 	withSelect( ( select, ownProps ) => {
 		const {
+			getReferenceByDistinctEdits,
+		} = select( 'core' );
+
+		const {
 			isEditedPostDirty,
 			isEditedPostAutosaveable,
-			getReferenceByDistinctEdits,
 			isAutosavingPost,
 			getEditorSettings,
 		} = select( 'core/editor' );

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -14,6 +14,7 @@ export { default as EditorHistoryRedo } from './editor-history/redo';
 export { default as EditorHistoryUndo } from './editor-history/undo';
 export { default as EditorNotices } from './editor-notices';
 export { default as ErrorBoundary } from './error-boundary';
+export { default as LocalAutosaveMonitor } from './local-autosave-monitor';
 export { default as PageAttributesCheck } from './page-attributes/check';
 export { default as PageAttributesOrder } from './page-attributes/order';
 export { default as PageAttributesParent } from './page-attributes/parent';

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { once } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+import { ifCondition } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import AutosaveMonitor from '../autosave-monitor';
+
+const AUTOSAVE_INTERVAL_SECONDS = 15;
+
+const hasLocalStorageSupport = once( () => {
+	try {
+		// Private Browsing in Safari 10 and earlier will throw an error when
+		// attempting to set into localStorage. The test here is intentional in
+		// causing a thrown error as condition for using fallback object storage.
+		window.localStorage.setItem( '__wpEditorTestLocalStorage', '' );
+		window.localStorage.removeItem( '__wpEditorTestLocalStorage' );
+		return true;
+	} catch ( error ) {
+		return false;
+	}
+} );
+
+function LocalAutosaveMonitor() {
+	const {
+		postId,
+		getEditedPostAttribute,
+	} = useSelect( ( select ) => ( {
+		postId: select( 'core/editor' ).getCurrentPostId(),
+		getEditedPostAttribute: select( 'core/editor' ).getEditedPostAttribute,
+	} ) );
+
+	const autosave = useCallback( () => {
+		window.localStorage.setItem( 'post_' + postId, JSON.stringify( {
+			post_title: getEditedPostAttribute( 'title' ),
+			content: getEditedPostAttribute( 'content' ),
+			excerpt: getEditedPostAttribute( 'excerpt' ),
+		} ) );
+	}, [ postId, getEditedPostAttribute ] );
+
+	return (
+		<AutosaveMonitor
+			interval={ AUTOSAVE_INTERVAL_SECONDS }
+			autosave={ autosave }
+		/>
+	);
+}
+
+export default ifCondition( hasLocalStorageSupport )( LocalAutosaveMonitor );

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -27,16 +27,16 @@ const AUTOSAVE_INTERVAL_SECONDS = 15;
 
 /**
  * Function which returns true if the current environment supports browser
- * localStorage, or false otherwise. The result of this function is cached and
+ * sessionStorage, or false otherwise. The result of this function is cached and
  * reused in subsequent invocations.
  */
-const hasLocalStorageSupport = once( () => {
+const hasSessionStorageSupport = once( () => {
 	try {
 		// Private Browsing in Safari 10 and earlier will throw an error when
-		// attempting to set into localStorage. The test here is intentional in
+		// attempting to set into sessionStorage. The test here is intentional in
 		// causing a thrown error as condition bailing from local autosave.
-		window.localStorage.setItem( '__wpEditorTestLocalStorage', '' );
-		window.localStorage.removeItem( '__wpEditorTestLocalStorage' );
+		window.sessionStorage.setItem( '__wpEditorTestSessionStorage', '' );
+		window.sessionStorage.removeItem( '__wpEditorTestSessionStorage' );
 		return true;
 	} catch ( error ) {
 		return false;
@@ -75,7 +75,7 @@ function useAutosaveCallback() {
 	} ) );
 
 	return useCallback( () => {
-		window.localStorage.setItem( 'post_' + postId, JSON.stringify( {
+		window.sessionStorage.setItem( postKey( postId ), JSON.stringify( {
 			post_title: getEditedPostAttribute( 'title' ),
 			content: getEditedPostAttribute( 'content' ),
 			excerpt: getEditedPostAttribute( 'excerpt' ),
@@ -100,7 +100,7 @@ function useAutosaveNotice() {
 	const { editPost, resetEditorBlocks } = useDispatch( 'core/editor' );
 
 	useEffect( () => {
-		let autosave = window.localStorage.getItem( 'post_' + postId );
+		let autosave = window.sessionStorage.getItem( postKey( postId ) );
 		if ( ! autosave ) {
 			return;
 		}
@@ -116,14 +116,14 @@ function useAutosaveNotice() {
 		const edits = { title, content, excerpt };
 
 		// Only display a notice if there is a difference between what has been
-		// saved and that which is stored in localStorage.
+		// saved and that which is stored in sessionStorage.
 		const hasDifference = Object.keys( edits ).some( ( key ) => {
 			return edits[ key ] !== getEditedPostAttribute( key );
 		} );
 
 		if ( ! hasDifference ) {
 			// If there is no difference, it can be safely ejected from storage.
-			window.localStorage.removeItem( 'post_' + postId );
+			window.sessionStorage.removeItem( postKey( postId ) );
 
 			return;
 		}
@@ -162,7 +162,7 @@ function useAutosavePurge() {
 
 	useEffect( () => {
 		if ( lastDidSave.current !== true && didSave ) {
-			window.localStorage.removeItem( 'post_' + postId );
+			window.sessionStorage.removeItem( postKey( postId ) );
 		}
 
 		lastDidSave.current = didSave;
@@ -182,4 +182,4 @@ function LocalAutosaveMonitor() {
 	);
 }
 
-export default ifCondition( hasLocalStorageSupport )( LocalAutosaveMonitor );
+export default ifCondition( hasSessionStorageSupport )( LocalAutosaveMonitor );

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -49,7 +49,7 @@ const hasLocalStorageSupport = once( () => {
  *
  * @return {Function} Callback function.
  */
-function useAutosaveSaveCallback() {
+function useAutosaveCallback() {
 	const {
 		postId,
 		getEditedPostAttribute,
@@ -154,7 +154,7 @@ function useAutosavePurge() {
 }
 
 function LocalAutosaveMonitor() {
-	const autosave = useAutosaveSaveCallback();
+	const autosave = useAutosaveCallback();
 	useAutosaveNotice();
 	useAutosavePurge();
 

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -1,22 +1,35 @@
 /**
  * External dependencies
  */
-import { once } from 'lodash';
+import { once, pickBy, negate, isUndefined, uniqueId, omit } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { useCallback } from '@wordpress/element';
+import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { ifCondition } from '@wordpress/compose';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { parse } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import AutosaveMonitor from '../autosave-monitor';
 
+/**
+ * Time interval at which local autosave should occur after a change, in
+ * seconds.
+ *
+ * @var {number}
+ */
 const AUTOSAVE_INTERVAL_SECONDS = 15;
 
+/**
+ * Function which returns true if the current environment supports browser
+ * localStorage, or false otherwise. The result of this function is cached and
+ * reused in subsequent invocations.
+ */
 const hasLocalStorageSupport = once( () => {
 	try {
 		// Private Browsing in Safari 10 and earlier will throw an error when
@@ -30,7 +43,13 @@ const hasLocalStorageSupport = once( () => {
 	}
 } );
 
-function LocalAutosaveMonitor() {
+/**
+ * Custom hook which returns a callback function to be invoked when a local
+ * autosave should occur.
+ *
+ * @return {Function} Callback function.
+ */
+function useAutosaveSaveCallback() {
 	const {
 		postId,
 		getEditedPostAttribute,
@@ -39,13 +58,105 @@ function LocalAutosaveMonitor() {
 		getEditedPostAttribute: select( 'core/editor' ).getEditedPostAttribute,
 	} ) );
 
-	const autosave = useCallback( () => {
+	return useCallback( () => {
 		window.localStorage.setItem( 'post_' + postId, JSON.stringify( {
 			post_title: getEditedPostAttribute( 'title' ),
 			content: getEditedPostAttribute( 'content' ),
 			excerpt: getEditedPostAttribute( 'excerpt' ),
 		} ) );
 	}, [ postId, getEditedPostAttribute ] );
+}
+
+/**
+ * Custom hook which manages the creation of a notice prompting the user to
+ * restore a local autosave, if one exists.
+ */
+function useAutosaveNotice() {
+	const {
+		postId,
+		getEditedPostAttribute,
+	} = useSelect( ( select ) => ( {
+		postId: select( 'core/editor' ).getCurrentPostId(),
+		getEditedPostAttribute: select( 'core/editor' ).getEditedPostAttribute,
+	} ) );
+
+	const { createWarningNotice, removeNotice } = useDispatch( 'core/notices' );
+	const { editPost, resetEditorBlocks } = useDispatch( 'core/editor' );
+
+	useEffect( () => {
+		let autosave = window.localStorage.getItem( 'post_' + postId );
+		if ( ! autosave ) {
+			return;
+		}
+
+		try {
+			autosave = JSON.parse( autosave );
+		} catch ( error ) {
+			// Not usable if it can't be parsed.
+			return;
+		}
+
+		const { post_title: title, content, excerpt } = autosave;
+		const edits = pickBy( { title, content, excerpt }, negate( isUndefined ) );
+
+		// Only display a notice if there is a difference between what has been
+		// saved and that which is stored in localStorage.
+		const hasDifference = Object.keys( edits ).some( ( key ) => {
+			return edits[ key ] !== getEditedPostAttribute( key );
+		} );
+
+		if ( ! hasDifference ) {
+			// If there is no difference, it can be safely ejected from storage.
+			window.localStorage.removeItem( 'post_' + postId );
+
+			return;
+		}
+
+		const noticeId = uniqueId( 'wpEditorAutosaveRestore' );
+
+		createWarningNotice( __( 'The backup of this post in your browser is different from the version below.' ), {
+			id: noticeId,
+			actions: [
+				{
+					label: __( 'Restore the backup' ),
+					onClick() {
+						editPost( omit( edits, [ 'content' ] ) );
+						resetEditorBlocks( parse( edits.content ) );
+						removeNotice( noticeId );
+					},
+				},
+			],
+		} );
+	}, [ postId ] );
+}
+
+/**
+ * Custom hook which ejects a local autosave after a successful save occurs.
+ */
+function useAutosavePurge() {
+	const {
+		postId,
+		didSave,
+	} = useSelect( ( select ) => ( {
+		postId: select( 'core/editor' ).getCurrentPostId(),
+		didSave: select( 'core/editor' ).didPostSaveRequestSucceed(),
+	} ) );
+
+	const lastDidSave = useRef( didSave );
+
+	useEffect( () => {
+		if ( lastDidSave.current !== true && didSave ) {
+			window.localStorage.removeItem( 'post_' + postId );
+		}
+
+		lastDidSave.current = didSave;
+	}, [ didSave ] );
+}
+
+function LocalAutosaveMonitor() {
+	const autosave = useAutosaveSaveCallback();
+	useAutosaveNotice();
+	useAutosavePurge();
 
 	return (
 		<AutosaveMonitor

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -20,14 +20,6 @@ import AutosaveMonitor from '../autosave-monitor';
 const requestIdleCallback = window.requestIdleCallback ? window.requestIdleCallback : window.requestAnimationFrame;
 
 /**
- * Time interval at which local autosave should occur after a change, in
- * seconds.
- *
- * @var {number}
- */
-const AUTOSAVE_INTERVAL_SECONDS = 15;
-
-/**
  * Function which returns true if the current environment supports browser
  * sessionStorage, or false otherwise. The result of this function is cached and
  * reused in subsequent invocations.
@@ -179,9 +171,14 @@ function LocalAutosaveMonitor() {
 	useAutosaveNotice();
 	useAutosavePurge();
 
+	const { localAutosaveInterval } = useSelect( ( select ) => ( {
+		localAutosaveInterval: select( 'core/editor' )
+			.getEditorSettings().__experimentalLocalAutosaveInterval,
+	} ) );
+
 	return (
 		<AutosaveMonitor
-			interval={ AUTOSAVE_INTERVAL_SECONDS }
+			interval={ localAutosaveInterval }
 			autosave={ autosave }
 			shouldThrottle
 		/>

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -157,21 +157,21 @@ function useAutosaveNotice() {
 function useAutosavePurge() {
 	const {
 		postId,
-		didSave,
+		isDirty,
 	} = useSelect( ( select ) => ( {
 		postId: select( 'core/editor' ).getCurrentPostId(),
-		didSave: select( 'core/editor' ).didPostSaveRequestSucceed(),
+		isDirty: select( 'core/editor' ).isEditedPostDirty(),
 	} ) );
 
-	const lastDidSave = useRef( didSave );
+	const lastIsDirty = useRef( isDirty );
 
 	useEffect( () => {
-		if ( lastDidSave.current !== true && didSave ) {
+		if ( lastIsDirty.current && ! isDirty ) {
 			window.sessionStorage.removeItem( postKey( postId ) );
 		}
 
-		lastDidSave.current = didSave;
-	}, [ didSave ] );
+		lastIsDirty.current = isDirty;
+	}, [ isDirty ] );
 }
 
 function LocalAutosaveMonitor() {

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -183,6 +183,7 @@ function LocalAutosaveMonitor() {
 		<AutosaveMonitor
 			interval={ AUTOSAVE_INTERVAL_SECONDS }
 			autosave={ autosave }
+			shouldThrottle
 		/>
 	);
 }

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -17,6 +17,8 @@ import { parse } from '@wordpress/blocks';
  */
 import AutosaveMonitor from '../autosave-monitor';
 
+const requestIdleCallback = window.requestIdleCallback ? window.requestIdleCallback : window.requestAnimationFrame;
+
 /**
  * Time interval at which local autosave should occur after a change, in
  * seconds.
@@ -75,11 +77,14 @@ function useAutosaveCallback() {
 	} ) );
 
 	return useCallback( () => {
-		window.sessionStorage.setItem( postKey( postId ), JSON.stringify( {
-			post_title: getEditedPostAttribute( 'title' ),
-			content: getEditedPostAttribute( 'content' ),
-			excerpt: getEditedPostAttribute( 'excerpt' ),
-		} ) );
+		const saveToSessionStorage = () => {
+			window.sessionStorage.setItem( postKey( postId ), JSON.stringify( {
+				post_title: getEditedPostAttribute( 'title' ),
+				content: getEditedPostAttribute( 'content' ),
+				excerpt: getEditedPostAttribute( 'excerpt' ),
+			} ) );
+		};
+		requestIdleCallback( saveToSessionStorage );
 	}, [ postId, getEditedPostAttribute ] );
 }
 

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -44,6 +44,22 @@ const hasLocalStorageSupport = once( () => {
 } );
 
 /**
+ * Function returning a sessionStorage key to set or retrieve a given post's
+ * automatic session backup.
+ *
+ * Keys are crucially prefixed with 'wp-autosave-' so that wp-login.php's
+ * `loggedout` handler can clear sessionStorage of any user-private content.
+ *
+ * @see https://github.com/WordPress/wordpress-develop/blob/6dad32d2aed47e6c0cf2aee8410645f6d7aba6bd/src/wp-login.php#L103
+ *
+ * @param {string} postId  Post ID.
+ * @return {string}        sessionStorage key
+ */
+function postKey( postId ) {
+	return `wp-autosave-block-editor-post-${ postId }`;
+}
+
+/**
  * Custom hook which returns a callback function to be invoked when a local
  * autosave should occur.
  *

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -21,7 +21,7 @@ const hasLocalStorageSupport = once( () => {
 	try {
 		// Private Browsing in Safari 10 and earlier will throw an error when
 		// attempting to set into localStorage. The test here is intentional in
-		// causing a thrown error as condition for using fallback object storage.
+		// causing a thrown error as condition bailing from local autosave.
 		window.localStorage.setItem( '__wpEditorTestLocalStorage', '' );
 		window.localStorage.removeItem( '__wpEditorTestLocalStorage' );
 		return true;

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { once, pickBy, negate, isUndefined, uniqueId, omit } from 'lodash';
+import { once, uniqueId, omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -97,7 +97,7 @@ function useAutosaveNotice() {
 		}
 
 		const { post_title: title, content, excerpt } = autosave;
-		const edits = pickBy( { title, content, excerpt }, negate( isUndefined ) );
+		const edits = { title, content, excerpt };
 
 		// Only display a notice if there is a difference between what has been
 		// saved and that which is stored in localStorage.

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -85,7 +85,7 @@ function useAutosaveCallback() {
 			} ) );
 		};
 		requestIdleCallback( saveToSessionStorage );
-	}, [ postId, getEditedPostAttribute ] );
+	}, [ postId ] );
 }
 
 /**

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -231,29 +231,6 @@ export const getPostEdits = createRegistrySelector( ( select ) => ( state ) => {
 } );
 
 /**
- * Returns a new reference when edited values have changed. This is useful in
- * inferring where an edit has been made between states by comparison of the
- * return values using strict equality.
- *
- * @example
- *
- * ```
- * const hasEditOccurred = (
- *    getReferenceByDistinctEdits( beforeState ) !==
- *    getReferenceByDistinctEdits( afterState )
- * );
- * ```
- *
- * @param {Object} state Editor state.
- *
- * @return {*} A value whose reference will change only when an edit occurs.
- */
-export const getReferenceByDistinctEdits = createSelector(
-	() => [],
-	( state ) => [ state.editor ],
-);
-
-/**
  * Returns an attribute value of the saved post.
  *
  * @param {Object} state         Global application state.

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -130,7 +130,6 @@ const {
 	getCurrentPostRevisionsCount,
 	getCurrentPostType,
 	getPostEdits,
-	getReferenceByDistinctEdits,
 	getEditedPostVisibility,
 	isCurrentPostPending,
 	isCurrentPostPublished,
@@ -776,21 +775,6 @@ describe( 'selectors', () => {
 			};
 
 			expect( getPostEdits( state ) ).toEqual( { title: 'werga' } );
-		} );
-	} );
-
-	describe( 'getReferenceByDistinctEdits', () => {
-		it( 'should return referentially equal values across unchanging state', () => {
-			const state = { editor: {} };
-
-			expect( getReferenceByDistinctEdits( state ) ).toBe( getReferenceByDistinctEdits( state ) );
-		} );
-
-		it( 'should return referentially unequal values across changing state', () => {
-			const beforeState = { editor: {} };
-			const afterState = { editor: {} };
-
-			expect( getReferenceByDistinctEdits( beforeState ) ).not.toBe( getReferenceByDistinctEdits( afterState ) );
 		} );
 	} );
 


### PR DESCRIPTION
Closes #7367
Related: #6322

_Some edits by @mcsf_

This pull request seeks to implement periodic ~localStorage~ sessionStorage autosave backups for posts. It reuses and extends the behavior of the existing server-persisted autosave component, leveraging sessionStorage when available to save data on a more frequent basis.

![backup](https://user-images.githubusercontent.com/1779930/61158816-1688f680-a4c8-11e9-9d64-088206e276db.gif)

**Implementation notes:**

~This was designed to be compatible with localStorage backup mechanism implemented in the classic editor (WordPress 4.9.x and older), hence the selection of the localStorage key `'post_' + postId`.~

This influenced the choice to not use the existing [data persistence behavior](https://github.com/WordPress/gutenberg/tree/master/packages/data/src/plugins/persistence), along with a desire to avoid creating saves until the interval has elapsed (vs. on every state change).

Even with the delay, we may want to explore using [`requestIdleCallback`](https://developers.google.com/web/updates/2015/08/using-requestidlecallback) in addition to the timeout interval, since serialization can be a very non-performant operation, depending on the size of the post.

**Testing Instructions:**

The autosaves occur every 15 seconds after the last change has occurred. Verify that upon waiting this duration and reloading the page (dismissing the prompt), you see a restore option to restore the title, content, and excerpt of the post you had been working on.

Verify that the prompt is not shown if you proceed to make edits to the post and save (regardless of whether you choose to restore or dismiss the notice).

**Checklist:** (Added 2019-08-30)

- [x] Always run the autosave procedure every 15 seconds, not 15 seconds after the last change
- ~Still try to save to storage only if a change has actually occurred~
- [x] Explore whether requestIdleCallback is a reasonable improvement to avoid blocking operation
- [x] Add some more through inline code documention (e.g. lastDidSave)
- [x] Convert to use sessionStorage as a way to avoid accumulating storage and potential for lingering storage from other users
- ~Should confirm that this data is in-fact purged upon logging out, or that an equivalent measure is taken to avoid access by other users even within the same storage~
- [x] Fix `useAutosavePurge`, per https://github.com/WordPress/gutenberg/pull/16490#discussion_r324427512