### PR TITLE
Add support for dropdown container to be inline-block (#8559)

### DIFF
--- a/packages/components/src/dropdown/README.md
+++ b/packages/components/src/dropdown/README.md
@@ -10,11 +10,12 @@ and uses render props to render the button and the content.
 ```jsx
 import { Button, Dropdown } from '@wordpress/components';
 
-const MyDropdown = () => (
+export const MyDropdown = () => (
 	<Dropdown
 		className="my-container-class-name"
 		contentClassName="my-popover-content-classname"
 		position="bottom right"
+		isInline={ true }
 		renderToggle={ ( { isOpen, onToggle } ) => (
 			<Button isPrimary onClick={ onToggle } aria-expanded={ isOpen }>
 				Toggle Popover!
@@ -91,7 +92,7 @@ Opt-in prop to show popovers fullscreen on mobile, pass `false` in this prop to 
  - Type: `String`
  - Required: No
  
- ### focusOnMount
+### focusOnMount
  
  By default, the *first tabblable element* in the popover will receive focus when it mounts. This is the same as setting `focusOnMount` to `"firstElement"`. If you want to focus the container instead, you can set `focusOnMount` to `"container"`.
  
@@ -101,10 +102,18 @@ Opt-in prop to show popovers fullscreen on mobile, pass `false` in this prop to 
  - Required: No
  - Default: `"firstElement"`
 
- ### popoverProps
+### popoverProps
  
 Properties of popoverProps object will be passed as props to the `Popover` component.
 Use this o object to access properties/feature if the `Popover` component that are not already exposed in the `Dropdown`component, e.g.: the hability to have the popover without an arrow. 
  
  - Type: `Object`
  - Required: No
+
+### isInline
+ 
+A flag that sets the dropdown container to display as an `inline-block` element
+ 
+ - Type: `Boolean`
+ - Required: No
+ - Default: `false`

--- a/packages/components/src/dropdown/index.js
+++ b/packages/components/src/dropdown/index.js
@@ -4,6 +4,11 @@
 import { Component, createRef } from '@wordpress/element';
 
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * Internal dependencies
  */
 import Popover from '../popover';
@@ -75,12 +80,14 @@ class Dropdown extends Component {
 			headerTitle,
 			focusOnMount,
 			popoverProps,
+			isInline,
 		} = this.props;
 
 		const args = { isOpen, onToggle: this.toggle, onClose: this.close };
+		const containerClasses = classnames( className, { [ `components-dropdown__inline` ]: isInline } );
 
 		return (
-			<div className={ className } ref={ this.containerRef }>
+			<div className={ containerClasses } ref={ this.containerRef }>
 				{ renderToggle( args ) }
 				{ isOpen && (
 					<Popover

--- a/packages/components/src/dropdown/style.scss
+++ b/packages/components/src/dropdown/style.scss
@@ -1,0 +1,3 @@
+.components-dropdown__inline {
+	display: inline-block;
+}

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -12,6 +12,7 @@
 @import "./disabled/style.scss";
 @import "./draggable/style.scss";
 @import "./drop-zone/style.scss";
+@import "./dropdown/style.scss";
 @import "./dropdown-menu/style.scss";
 @import "./external-link/style.scss";
 @import "./focal-point-picker/style.scss";


### PR DESCRIPTION
## Description
This change adds a prop to the `Dropdown` component that allows a user to set the containing element to display `inline-block`. This allows the popover to appear centered relative to its trigger in instances outside of the Gutenberg context.  

## How has this been tested?
Tested in the Gutenberg playground and passes respective unit tests.

## Screenshots <!-- if applicable -->
_Before_
![Screen Recording 2019-07-09 at 05 37 PM](https://user-images.githubusercontent.com/5375500/60925260-29ee5480-a271-11e9-938a-8ac34fa25a2d.gif)

_After_
![Screen Recording 2019-07-09 at 05 36 PM](https://user-images.githubusercontent.com/5375500/60925265-2eb30880-a271-11e9-847c-0c06196b392c.gif)

## Types of changes
Fixes #8559

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
