### PR TITLE
Table column and row selection

### DIFF
--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -41,6 +41,8 @@ import {
 	toggleSection,
 	isEmptyTableSection,
 	isCellInMultiSelection,
+	isRowSelected,
+	isColumnSelected,
 	getCellAbove,
 	getCellBelow,
 	getCellToRight,
@@ -409,15 +411,20 @@ export class TableEdit extends Component {
 								>
 									{ showBlockSelectionControls && rowIndex === 0 && columnIndex === 0 && (
 										<IconButton
-											className="wp-block-table__table-selection-button"
+											className={ classnames( 'wp-block-table__table-selection-button', {
+												'is-selected': isInMultiCellSelection && selection.type === 'table',
+											} ) }
 											label={ __( 'Select all' ) }
 											icon="grid-view"
 											onClick={ () => this.setState( { selection: { type: 'table' } } ) }
+											aria-pressed={ isInMultiCellSelection && selection.type === 'table' }
 										/>
 									) }
 									{ columnIndex === 0 && (
 										<IconButton
-											className="wp-block-table__row-selection-button"
+											className={ classnames( 'wp-block-table__row-selection-button', {
+												'is-selected': isInMultiCellSelection && isRowSelected( cellLocation, selection ),
+											} ) }
 											label={ __( 'Select row' ) }
 											icon="arrow-right"
 											onClick={ () => this.setState( {
@@ -427,11 +434,14 @@ export class TableEdit extends Component {
 													rowIndex,
 												},
 											} ) }
+											aria-pressed={ isInMultiCellSelection && isRowSelected( cellLocation, selection ) }
 										/>
 									) }
 									{ showBlockSelectionControls && rowIndex === 0 && (
 										<IconButton
-											className="wp-block-table__column-selection-button"
+											className={ classnames( 'wp-block-table__column-selection-button', {
+												'is-selected': isInMultiCellSelection && isColumnSelected( cellLocation, selection ),
+											} ) }
 											label={ __( 'Select column' ) }
 											icon="arrow-down"
 											onClick={ () => this.setState( {
@@ -440,6 +450,7 @@ export class TableEdit extends Component {
 													columnIndex,
 												},
 											} ) }
+											aria-pressed={ isInMultiCellSelection && isColumnSelected( cellLocation, selection ) }
 										/>
 									) }
 									<RichText

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -323,8 +323,8 @@ export class TableEdit extends Component {
 	getTableControls() {
 		const { selection } = this.state;
 
-		const canPerformRowOperations = selection && includes( selection.type, [ 'cell', 'row' ] );
-		const canPerformColumnOperations = selection && includes( selection.type, [ 'cell', 'column' ] );
+		const canPerformRowOperations = selection && includes( [ 'cell', 'row' ], selection.type );
+		const canPerformColumnOperations = selection && includes( [ 'cell', 'column' ], selection.type );
 
 		return [
 			{

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { includes } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -93,9 +94,6 @@ export class TableEdit extends Component {
 		this.onDeleteColumn = this.onDeleteColumn.bind( this );
 		this.onToggleHeaderSection = this.onToggleHeaderSection.bind( this );
 		this.onToggleFooterSection = this.onToggleFooterSection.bind( this );
-		this.onSelectTable = this.onSelectTable.bind( this );
-		this.onSelectRow = this.onSelectRow.bind( this );
-		this.onSelectColumn = this.onSelectColumn.bind( this );
 		this.getMultiSelectionClasses = this.getMultiSelectionClasses.bind( this );
 
 		this.state = {
@@ -291,33 +289,6 @@ export class TableEdit extends Component {
 		setAttributes( deleteColumn( attributes, { section, columnIndex } ) );
 	}
 
-	onSelectTable() {
-		this.setState( {
-			selection: {
-				type: 'table',
-			},
-		} );
-	}
-
-	onSelectColumn( columnIndex ) {
-		this.setState( {
-			selection: {
-				type: 'column',
-				columnIndex,
-			},
-		} );
-	}
-
-	onSelectRow( section, rowIndex ) {
-		this.setState( {
-			selection: {
-				type: 'row',
-				section,
-				rowIndex,
-			},
-		} );
-	}
-
 	getMultiSelectionClasses( cellLocation, selection ) {
 		const { attributes } = this.props;
 
@@ -352,41 +323,44 @@ export class TableEdit extends Component {
 	getTableControls() {
 		const { selection } = this.state;
 
+		const canPerformRowOperations = selection && includes( selection.type, [ 'cell', 'row' ] );
+		const canPerformColumnOperations = selection && includes( selection.type, [ 'cell', 'column' ] );
+
 		return [
 			{
 				icon: 'table-row-before',
 				title: __( 'Add Row Before' ),
-				isDisabled: ! selection,
+				isDisabled: ! canPerformRowOperations,
 				onClick: this.onInsertRowBefore,
 			},
 			{
 				icon: 'table-row-after',
 				title: __( 'Add Row After' ),
-				isDisabled: ! selection,
+				isDisabled: ! canPerformRowOperations,
 				onClick: this.onInsertRowAfter,
 			},
 			{
 				icon: 'table-row-delete',
 				title: __( 'Delete Row' ),
-				isDisabled: ! selection,
+				isDisabled: ! canPerformRowOperations,
 				onClick: this.onDeleteRow,
 			},
 			{
 				icon: 'table-col-before',
 				title: __( 'Add Column Before' ),
-				isDisabled: ! selection,
+				isDisabled: ! canPerformColumnOperations,
 				onClick: this.onInsertColumnBefore,
 			},
 			{
 				icon: 'table-col-after',
 				title: __( 'Add Column After' ),
-				isDisabled: ! selection,
+				isDisabled: ! canPerformColumnOperations,
 				onClick: this.onInsertColumnAfter,
 			},
 			{
 				icon: 'table-col-delete',
 				title: __( 'Delete Column' ),
-				isDisabled: ! selection,
+				isDisabled: ! canPerformColumnOperations,
 				onClick: this.onDeleteColumn,
 			},
 		];
@@ -438,7 +412,7 @@ export class TableEdit extends Component {
 											className="wp-block-table__table-selection-button"
 											label={ __( 'Select all' ) }
 											icon="grid-view"
-											onClick={ this.onSelectTable }
+											onClick={ () => this.setState( { selection: { type: 'table' } } ) }
 										/>
 									) }
 									{ columnIndex === 0 && (
@@ -446,7 +420,13 @@ export class TableEdit extends Component {
 											className="wp-block-table__row-selection-button"
 											label={ __( 'Select row' ) }
 											icon="arrow-right"
-											onClick={ () => this.onSelectRow( section, rowIndex ) }
+											onClick={ () => this.setState( {
+												selection: {
+													type: 'row',
+													section,
+													rowIndex,
+												},
+											} ) }
 										/>
 									) }
 									{ showBlockSelectionControls && rowIndex === 0 && (
@@ -454,7 +434,12 @@ export class TableEdit extends Component {
 											className="wp-block-table__column-selection-button"
 											label={ __( 'Select column' ) }
 											icon="arrow-down"
-											onClick={ () => this.onSelectColumn( columnIndex ) }
+											onClick={ () => this.setState( {
+												selection: {
+													type: 'column',
+													columnIndex,
+												},
+											} ) }
 										/>
 									) }
 									<RichText
@@ -463,9 +448,7 @@ export class TableEdit extends Component {
 										onChange={ this.onChange }
 										unstableOnFocus={ this.createOnFocus( {
 											type: 'cell',
-											section,
-											rowIndex,
-											columnIndex,
+											...cellLocation,
 										} ) }
 									/>
 								</CellTag>

--- a/packages/block-library/src/table/editor.scss
+++ b/packages/block-library/src/table/editor.scss
@@ -29,36 +29,107 @@
 	// Remove default <figure> style.
 	margin: 0;
 
+	// Pad the container so that table/column/row selection buttons have adequate space.
+	padding: 20px 0 0 20px;
+	width: 100%;
+
 	table {
 		border-collapse: collapse;
 	}
 
 	td,
 	th {
+		position: relative;
 		padding: 0;
 		border: $border-width solid;
-	}
 
-	td.is-selected,
-	th.is-selected {
-		border-color: $blue-medium-500;
-		box-shadow: inset 0 0 0 1px $blue-medium-500;
-		border-style: double;
+		&.is-selected-cell,
+		&.is-in-selected-range {
+			&::before {
+				content: "";
+				display: block;
+				position: absolute;
+				pointer-events: none;
+				top: -1px;
+				left: -1px;
+				right: -1px;
+				bottom: -1px;
+				border: 3px solid $blue-medium-500;
+			}
+		}
+
+		&.is-in-selected-range {
+			&::before {
+				border-width: 0;
+			}
+			&.is-range-selection-top {
+				&::before {
+					border-top-width: 3px;
+				}
+			}
+			&.is-range-selection-right {
+				&::before {
+					border-right-width: 3px;
+				}
+			}
+			&.is-range-selection-bottom {
+				&::before {
+					border-bottom-width: 3px;
+				}
+			}
+			&.is-range-selection-left {
+				&::before {
+					border-left-width: 3px;
+				}
+			}
+		}
+
 	}
 
 	&__cell-content {
 		padding: 0.5em;
 	}
+
 	// Extra specificity to override default Placeholder styles.
 	&__placeholder-form.wp-block-table__placeholder-form {
 		text-align: left;
 		align-items: center;
 	}
+
 	&__placeholder-input {
 		width: 100px;
 	}
+
 	&__placeholder-button {
 		min-width: 100px;
 		justify-content: center;
+	}
+
+	&__table-selection-button {
+		position: absolute;
+		top: -31px;
+		left: -31px;
+		width: 30px;
+		height: 30px;
+	}
+
+	&__row-selection-button {
+		position: absolute;
+		top: 0;
+		left: -31px;
+		width: 30px;
+		height: 100%;
+	}
+
+	&__column-selection-button {
+		position: absolute;
+		top: -31px;
+		left: 0;
+		width: 100%;
+		height: 30px;
+
+		.dashicon {
+			margin: 0 auto;
+		}
 	}
 }

--- a/packages/block-library/src/table/editor.scss
+++ b/packages/block-library/src/table/editor.scss
@@ -44,7 +44,7 @@
 		border: $border-width solid;
 
 		&.is-selected-cell,
-		&.is-in-selected-range {
+		&.is-multi-selected {
 			&::before {
 				content: "";
 				display: block;
@@ -58,26 +58,30 @@
 			}
 		}
 
-		&.is-in-selected-range {
+		&.is-multi-selected {
 			&::before {
 				border-width: 0;
 			}
-			&.is-range-selection-top {
+
+			&.is-multi-selection-top-edge {
 				&::before {
 					border-top-width: 3px;
 				}
 			}
-			&.is-range-selection-right {
+
+			&.is-multi-selection-right-edge {
 				&::before {
 					border-right-width: 3px;
 				}
 			}
-			&.is-range-selection-bottom {
+
+			&.is-multi-selection-bottom-edge {
 				&::before {
 					border-bottom-width: 3px;
 				}
 			}
-			&.is-range-selection-left {
+
+			&.is-multi-selection-left-edge {
 				&::before {
 					border-left-width: 3px;
 				}

--- a/packages/block-library/src/table/editor.scss
+++ b/packages/block-library/src/table/editor.scss
@@ -26,11 +26,9 @@
 
 
 .wp-block-table {
-	// Remove default <figure> style.
-	margin: 0;
-
 	// Pad the container so that table/column/row selection buttons have adequate space.
-	padding: 20px 0 0 20px;
+	margin: -8px 0 0 -8px;
+	padding: 30px 0 0 30px;
 	width: 100%;
 
 	table {
@@ -109,8 +107,21 @@
 		justify-content: center;
 	}
 
-	&__table-selection-button {
+	&__table-selection-button,
+	&__row-selection-button,
+	&__column-selection-button {
 		position: absolute;
+
+		// Ensure the icon is centered, even when the button is very narrow.
+		padding: 0;
+		justify-content: center;
+
+		.dashicon {
+			margin: 0 auto;
+		}
+	}
+
+	&__table-selection-button {
 		top: -31px;
 		left: -31px;
 		width: 30px;
@@ -118,7 +129,6 @@
 	}
 
 	&__row-selection-button {
-		position: absolute;
 		top: 0;
 		left: -31px;
 		width: 30px;
@@ -126,14 +136,9 @@
 	}
 
 	&__column-selection-button {
-		position: absolute;
 		top: -31px;
 		left: 0;
 		width: 100%;
 		height: 30px;
-
-		.dashicon {
-			margin: 0 auto;
-		}
 	}
 }

--- a/packages/block-library/src/table/editor.scss
+++ b/packages/block-library/src/table/editor.scss
@@ -111,10 +111,19 @@
 	&__row-selection-button,
 	&__column-selection-button {
 		position: absolute;
+		border-radius: 0;
 
 		// Ensure the icon is centered, even when the button is very narrow.
 		padding: 0;
 		justify-content: center;
+
+		&.is-selected,
+		&.is-selected:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover,
+		&.is-selected:focus,
+		&.is-selected:not(:disabled):not([aria-disabled="true"]):not(.is-default):active {
+			background: $blue-medium-500;
+			color: $white;
+		}
 
 		.dashicon {
 			margin: 0 auto;

--- a/packages/block-library/src/table/editor.scss
+++ b/packages/block-library/src/table/editor.scss
@@ -41,8 +41,7 @@
 		padding: 0;
 		border: $border-width solid;
 
-		&.is-selected-cell,
-		&.is-multi-selected {
+		&.is-selected {
 			&::before {
 				content: "";
 				display: block;
@@ -56,30 +55,30 @@
 			}
 		}
 
-		&.is-multi-selected {
+		&.is-multi-cell-selection {
 			&::before {
 				border-width: 0;
 			}
 
-			&.is-multi-selection-top-edge {
+			&.is-selection-top-edge {
 				&::before {
 					border-top-width: 3px;
 				}
 			}
 
-			&.is-multi-selection-right-edge {
+			&.is-selection-right-edge {
 				&::before {
 					border-right-width: 3px;
 				}
 			}
 
-			&.is-multi-selection-bottom-edge {
+			&.is-selection-bottom-edge {
 				&::before {
 					border-bottom-width: 3px;
 				}
 			}
 
-			&.is-multi-selection-left-edge {
+			&.is-selection-left-edge {
 				&::before {
 					border-left-width: 3px;
 				}

--- a/packages/block-library/src/table/editor.scss
+++ b/packages/block-library/src/table/editor.scss
@@ -57,7 +57,7 @@
 
 		&.is-multi-cell-selection {
 			&::before {
-				border-width: 0;
+				border-width: 1px;
 			}
 
 			&.is-selection-top-edge {

--- a/packages/block-library/src/table/state.js
+++ b/packages/block-library/src/table/state.js
@@ -3,6 +3,12 @@
  */
 import { times, get, mapValues, every } from 'lodash';
 
+const SECTION_INDEX = {
+	head: 0,
+	body: 1,
+	foot: 2,
+};
+
 /**
  * Creates a table state.
  *
@@ -216,4 +222,121 @@ export function isEmptyTableSection( sectionRows ) {
  */
 export function isEmptyRow( row ) {
 	return ! ( row.cells && row.cells.length );
+}
+
+export function isAxisInSelectionRange( selection, axisIndex, axisName ) {// Compute the selection at axis level.
+	const fromAxisIndex = selection.from[ axisName ];
+	const toAxisIndex = selection.to[ axisName ];
+
+	return fromAxisIndex <= axisIndex && toAxisIndex >= axisIndex;
+}
+
+export function isCellInSelectionRange( selection, section, rowIndex, columnIndex ) {
+	if ( ! selection || selection.type !== 'range' ) {
+		return false;
+	}
+
+	const cellSectionIndex = SECTION_INDEX[ section ];
+	const fromSectionIndex = SECTION_INDEX[ selection.from.section ];
+	const toSectionIndex = SECTION_INDEX[ selection.to.section ];
+
+	// Return early if section is not within the range.
+	if ( fromSectionIndex > cellSectionIndex || toSectionIndex < cellSectionIndex ) {
+		return false;
+	}
+
+	// All rows in the body have selected cells if the selection
+	// start is in the head and the selection end is in the foot.
+	const allRowsInSectionHaveSelection = fromSectionIndex < cellSectionIndex && toSectionIndex > cellSectionIndex;
+
+	// Compute individual cell selection.
+	const isRowSelected = allRowsInSectionHaveSelection || isAxisInSelectionRange( selection, rowIndex, 'rowIndex' );
+	const isColumnSelected = isAxisInSelectionRange( selection, columnIndex, 'columnIndex' );
+
+	return isRowSelected && isColumnSelected;
+}
+
+export function isStartOfSelectionRange( selection, section, axisIndex, axisName ) {
+	// The row is not the start of a selection if it's in a different section.
+	if ( axisName === 'rowIndex' && section !== selection.from.section ) {
+		return false;
+	}
+
+	return selection.from[ axisName ] === axisIndex;
+}
+
+export function isEndOfSelectionRange( selection, section, axisIndex, axisName ) {
+	// The row is not the end of a selection if it's in a different section.
+	if ( axisName === 'rowIndex' && section !== selection.to.section ) {
+		return false;
+	}
+
+	return selection.to[ axisName ] === axisIndex;
+}
+
+export function isTopOfSelectionRange( selection, section, rowIndex ) {
+	return isStartOfSelectionRange( selection, section, rowIndex, 'rowIndex' );
+}
+
+export function isLeftOfSelectionRange( selection, section, columnIndex ) {
+	return isStartOfSelectionRange( selection, section, columnIndex, 'columnIndex' );
+}
+
+export function isBottomOfSelectionRange( selection, section, rowIndex ) {
+	return isEndOfSelectionRange( selection, section, rowIndex, 'rowIndex' );
+}
+
+export function isRightOfSelectionRange( selection, section, columnIndex ) {
+	return isEndOfSelectionRange( selection, section, columnIndex, 'columnIndex' );
+}
+
+export function getVerticalSelectionRangeStart( state, columnIndex = 0 ) {
+	const {
+		head,
+	} = state;
+	const isEmptyHead = isEmptyTableSection( head );
+
+	return {
+		section: isEmptyHead ? 'body' : 'head',
+		rowIndex: 0,
+		columnIndex,
+	};
+}
+
+export function getVerticalSelectionRangeEnd( state, columnIndex ) {
+	const {
+		body,
+		foot,
+	} = state;
+	const isEmptyFoot = isEmptyTableSection( foot );
+
+	const rows = isEmptyFoot ? body : foot;
+
+	if ( columnIndex === undefined ) {
+		columnIndex = isEmptyFoot ? rows[ 0 ].cells.length - 1 : rows[ 0 ].cells.length - 1;
+	}
+
+	return {
+		section: isEmptyFoot ? 'body' : 'foot',
+		rowIndex: isEmptyFoot ? rows.length - 1 : rows.length - 1,
+		columnIndex,
+	};
+}
+
+export function getHorizontalSelectionRangeStart( state, section, rowIndex ) {
+	return {
+		section,
+		rowIndex,
+		columnIndex: 0,
+	};
+}
+
+export function getHorizontalSelectionRangeEnd( state, section, rowIndex ) {
+	const rows = state[ section ];
+
+	return {
+		section,
+		rowIndex,
+		columnIndex: rows[ 0 ].cells.length - 1,
+	};
 }

--- a/packages/block-library/src/table/state.js
+++ b/packages/block-library/src/table/state.js
@@ -219,54 +219,74 @@ export function isEmptyRow( row ) {
 }
 
 /**
- * Determines if a cell is within a multi-cell selection.
+ * Determines if a cell is selected.
  *
- * @param {Object} cellLocation The cell to check
- * @param {Object} selection    The selection data
+ * @param {Object} cellLocation The cell to check.
+ * @param {Object} selection    The selection data.
  *
  * @return {boolean} True if the cell is within a selection, false otherwise.
  */
-export function isCellInMultiSelection( cellLocation, selection ) {
+export function isCellSelected( cellLocation, selection ) {
 	if ( ! cellLocation || ! selection ) {
 		return false;
 	}
 
 	switch ( selection.type ) {
+		case 'cell':
+			return hasSingleCellSelection( cellLocation, selection );
 		case 'table':
 			return true;
 		case 'row':
-			return isRowSelected( cellLocation, selection );
+			return hasRowSelection( cellLocation, selection );
 		case 'column':
-			return isColumnSelected( cellLocation, selection );
-		case 'cell':
-			return false;
+			return hasColumnSelection( cellLocation, selection );
 	}
+}
+
+/**
+ * Determines if a cell is the single cell selected.
+ *
+ * @param {Object} cellLocation The cell to check.
+ * @param {Object} selection    The selection data.
+ *
+ * @return {boolean} True if the cell is within a selection, false otherwise.
+ */
+export function hasSingleCellSelection( cellLocation, selection ) {
+	if ( ! cellLocation || ! selection ) {
+		return false;
+	}
+	return selection.type === 'cell' &&
+		cellLocation.section === selection.section &&
+		cellLocation.columnIndex === selection.columnIndex &&
+		cellLocation.rowIndex === selection.rowIndex;
 }
 
 /**
  * Determines if a cell is within a row selection.
  *
- * @param {Object} cellLocation The cell to check
- * @param {Object} selection    The selection data
+ * @param {Object} cellLocation The cell to check.
+ * @param {Object} selection    The selection data.
  *
  * @return {boolean} True if the cell is within a selection, false otherwise.
  */
-export function isRowSelected( cellLocation, selection ) {
+export function hasRowSelection( cellLocation, selection ) {
 	if ( ! cellLocation || ! selection ) {
 		return false;
 	}
-	return selection.type === 'row' && cellLocation.section === selection.section && cellLocation.rowIndex === selection.rowIndex;
+	return selection.type === 'row' &&
+		cellLocation.section === selection.section &&
+		cellLocation.rowIndex === selection.rowIndex;
 }
 
 /**
  * Determines if a cell is within a column selection.
  *
- * @param {Object} cellLocation The cell to check
- * @param {Object} selection    The selection data
+ * @param {Object} cellLocation The cell to check.
+ * @param {Object} selection    The selection data.
  *
  * @return {boolean} True if the cell is within a selection, false otherwise.
  */
-export function isColumnSelected( cellLocation, selection ) {
+export function hasColumnSelection( cellLocation, selection ) {
 	if ( ! cellLocation || ! selection ) {
 		return false;
 	}

--- a/packages/block-library/src/table/state.js
+++ b/packages/block-library/src/table/state.js
@@ -311,34 +311,34 @@ export function getCellAbove( state, cellLocation ) {
 		return;
 	}
 
+	let sectionNameForRowAbove, previousRowIndex;
+
 	// Handle getting the cell from the next section.
 	if ( isFirstRow ) {
-		const previousSectionName = sectionName === 'foot' ? 'body' : 'head';
-		const previousSection = state[ previousSectionName ];
+		sectionNameForRowAbove = sectionName === 'foot' ? 'body' : 'head';
+		const previousSection = state[ sectionNameForRowAbove ];
 
 		// There is no previous section, return undefined early.
 		if ( isEmptyTableSection( previousSection ) ) {
 			return;
 		}
 
-		// The previous section doesn't have as many columns, return undefined early.
-		const columnCount = previousSection[ 0 ].cells.length;
-		if ( columnIndex > columnCount - 1 ) {
-			return;
-		}
+		previousRowIndex = previousSection.length - 1;
+	} else {
+		sectionNameForRowAbove = sectionName;
+		previousRowIndex = rowIndex - 1;
+	}
 
-		const lastRowOfPreviousSection = previousSection.length - 1;
-
-		return {
-			section: previousSectionName,
-			rowIndex: lastRowOfPreviousSection,
-			columnIndex,
-		};
+	// The row above doesn't have as many columns, return undefined early.
+	const columnCountForRowAbove = state[ sectionNameForRowAbove ][ previousRowIndex ].cells.length;
+	if ( columnIndex > columnCountForRowAbove - 1 ) {
+		return;
 	}
 
 	return {
-		...cellLocation,
-		rowIndex: rowIndex - 1,
+		section: sectionNameForRowAbove,
+		rowIndex: previousRowIndex,
+		columnIndex,
 	};
 }
 
@@ -362,32 +362,34 @@ export function getCellBelow( state, cellLocation ) {
 		return;
 	}
 
+	let sectionNameForRowBelow, nextRowIndex;
+
 	// Handle getting the cell from the next section.
 	if ( isLastRow ) {
-		const nextSectionName = sectionName === 'head' ? 'body' : 'foot';
-		const nextSection = state[ nextSectionName ];
+		sectionNameForRowBelow = sectionName === 'head' ? 'body' : 'foot';
+		const nextSection = state[ sectionNameForRowBelow ];
 
 		// There is no next section, return undefined early.
 		if ( isEmptyTableSection( nextSection ) ) {
 			return;
 		}
 
-		// The next section doesn't have as many columns, return undefined early.
-		const columnCount = nextSection[ 0 ].cells.length;
-		if ( columnIndex > columnCount - 1 ) {
-			return;
-		}
+		nextRowIndex = 0;
+	} else {
+		sectionNameForRowBelow = sectionName;
+		nextRowIndex = rowIndex + 1;
+	}
 
-		return {
-			section: nextSectionName,
-			rowIndex: 0,
-			columnIndex,
-		};
+	// The row above doesn't have as many columns, return undefined early.
+	const columnCountForRowBelow = state[ sectionNameForRowBelow ][ nextRowIndex ].cells.length;
+	if ( columnIndex > columnCountForRowBelow - 1 ) {
+		return;
 	}
 
 	return {
-		...cellLocation,
-		rowIndex: rowIndex + 1,
+		section: sectionNameForRowBelow,
+		rowIndex: nextRowIndex,
+		columnIndex,
 	};
 }
 

--- a/packages/block-library/src/table/state.js
+++ b/packages/block-library/src/table/state.js
@@ -1,13 +1,7 @@
 /**
  * External dependencies
  */
-import { times, get, mapValues, every, includes } from 'lodash';
-
-const MULTI_SELECTION_TYPES = [
-	'table',
-	'column',
-	'row',
-];
+import { times, get, mapValues, every } from 'lodash';
 
 /**
  * Creates a table state.
@@ -230,10 +224,10 @@ export function isEmptyRow( row ) {
  * @param {Object} cellLocation The cell to check
  * @param {Object} selection    The selection data
  *
- * @return {boolean} True if the cell is within a seleciton, false otherwise.
+ * @return {boolean} True if the cell is within a selection, false otherwise.
  */
 export function isCellInMultiSelection( cellLocation, selection ) {
-	if ( ! cellLocation || ! selection || includes( selection.type, MULTI_SELECTION_TYPES ) ) {
+	if ( ! cellLocation || ! selection ) {
 		return false;
 	}
 
@@ -241,10 +235,42 @@ export function isCellInMultiSelection( cellLocation, selection ) {
 		case 'table':
 			return true;
 		case 'row':
-			return cellLocation.section === selection.section && cellLocation.rowIndex === selection.rowIndex;
+			return isRowSelected( cellLocation, selection );
 		case 'column':
-			return cellLocation.columnIndex === selection.columnIndex;
+			return isColumnSelected( cellLocation, selection );
+		case 'cell':
+			return false;
 	}
+}
+
+/**
+ * Determines if a cell is within a row selection.
+ *
+ * @param {Object} cellLocation The cell to check
+ * @param {Object} selection    The selection data
+ *
+ * @return {boolean} True if the cell is within a selection, false otherwise.
+ */
+export function isRowSelected( cellLocation, selection ) {
+	if ( ! cellLocation || ! selection ) {
+		return false;
+	}
+	return selection.type === 'row' && cellLocation.section === selection.section && cellLocation.rowIndex === selection.rowIndex;
+}
+
+/**
+ * Determines if a cell is within a column selection.
+ *
+ * @param {Object} cellLocation The cell to check
+ * @param {Object} selection    The selection data
+ *
+ * @return {boolean} True if the cell is within a selection, false otherwise.
+ */
+export function isColumnSelected( cellLocation, selection ) {
+	if ( ! cellLocation || ! selection ) {
+		return false;
+	}
+	return selection.type === 'column' && cellLocation.columnIndex === selection.columnIndex;
 }
 
 /**

--- a/packages/block-library/src/table/test/state.js
+++ b/packages/block-library/src/table/test/state.js
@@ -16,7 +16,72 @@ import {
 	toggleSection,
 	isEmptyTableSection,
 	isEmptyRow,
+	isCellSelected,
+	hasSingleCellSelection,
+	hasRowSelection,
+	hasColumnSelection,
+	getCellAbove,
+	getCellBelow,
+	getCellToLeft,
+	getCellToRight,
 } from '../state';
+
+const tableWithHeadAndFoot = deepFreeze( {
+	head: [
+		{
+			cells: [
+				{
+					content: '',
+					tag: 'th',
+				},
+				{
+					content: '',
+					tag: 'th',
+				},
+			],
+		},
+	],
+	body: [
+		{
+			cells: [
+				{
+					content: '',
+					tag: 'td',
+				},
+				{
+					content: '',
+					tag: 'td',
+				},
+			],
+		},
+		{
+			cells: [
+				{
+					content: '',
+					tag: 'td',
+				},
+				{
+					content: '',
+					tag: 'td',
+				},
+			],
+		},
+	],
+	foot: [
+		{
+			cells: [
+				{
+					content: '',
+					tag: 'td',
+				},
+				{
+					content: '',
+					tag: 'td',
+				},
+			],
+		},
+	],
+} );
 
 const table = deepFreeze( {
 	body: [
@@ -994,5 +1059,311 @@ describe( 'isEmptyRow', () => {
 		};
 
 		expect( isEmptyRow( row ) ).toBe( false );
+	} );
+} );
+
+describe( 'isCellSelected', () => {
+	it( 'returns false when no cellLocation is provided', () => {
+		const tableSelection = { type: 'table' };
+
+		expect( isCellSelected( undefined, tableSelection ) ).toBe( false );
+	} );
+
+	it( 'returns false when no selection is provided', () => {
+		const cellLocation = { section: 'head', columnIndex: 0, rowIndex: 0 };
+
+		expect( isCellSelected( cellLocation ) ).toBe( false );
+	} );
+
+	it( `considers every cell selected when the selection.type is 'table'`, () => {
+		const headCellLocationA = { section: 'head', columnIndex: 0, rowIndex: 0 };
+		const headCellLocationB = { section: 'head', columnIndex: 999, rowIndex: 999 };
+		const bodyCellLocationA = { section: 'body', columnIndex: 0, rowIndex: 0 };
+		const bodyCellLocationB = { section: 'body', columnIndex: 999, rowIndex: 999 };
+		const footCellLocationA = { section: 'foot', columnIndex: 0, rowIndex: 0 };
+		const footCellLocationB = { section: 'foot', columnIndex: 999, rowIndex: 999 };
+		const tableSelection = { type: 'table' };
+
+		expect( isCellSelected( headCellLocationA, tableSelection ) ).toBe( true );
+		expect( isCellSelected( headCellLocationB, tableSelection ) ).toBe( true );
+		expect( isCellSelected( bodyCellLocationA, tableSelection ) ).toBe( true );
+		expect( isCellSelected( bodyCellLocationB, tableSelection ) ).toBe( true );
+		expect( isCellSelected( footCellLocationA, tableSelection ) ).toBe( true );
+		expect( isCellSelected( footCellLocationB, tableSelection ) ).toBe( true );
+	} );
+
+	it( `considers only cells with the same columnIndex to be selected when the selection.type is 'column'`, () => {
+		// Valid locations and selections.
+		const headCellLocationA = { section: 'head', columnIndex: 0, rowIndex: 0 };
+		const headCellLocationB = { section: 'head', columnIndex: 0, rowIndex: 1 };
+		const bodyCellLocationA = { section: 'body', columnIndex: 0, rowIndex: 0 };
+		const bodyCellLocationB = { section: 'body', columnIndex: 0, rowIndex: 1 };
+		const footCellLocationA = { section: 'foot', columnIndex: 0, rowIndex: 0 };
+		const footCellLocationB = { section: 'foot', columnIndex: 0, rowIndex: 1 };
+		const columnSelection = { type: 'column', columnIndex: 0 };
+
+		// Invalid locations and selections.
+		const otherColumnCellLocationA = { section: 'head', columnIndex: 1, rowIndex: 0 };
+		const otherColumnCellLocationB = { section: 'body', columnIndex: 2, rowIndex: 0 };
+		const otherColumnCellLocationC = { section: 'foot', columnIndex: 3, rowIndex: 0 };
+
+		expect( isCellSelected( headCellLocationA, columnSelection ) ).toBe( true );
+		expect( isCellSelected( headCellLocationB, columnSelection ) ).toBe( true );
+		expect( isCellSelected( bodyCellLocationA, columnSelection ) ).toBe( true );
+		expect( isCellSelected( bodyCellLocationB, columnSelection ) ).toBe( true );
+		expect( isCellSelected( footCellLocationA, columnSelection ) ).toBe( true );
+		expect( isCellSelected( footCellLocationB, columnSelection ) ).toBe( true );
+		expect( isCellSelected( otherColumnCellLocationA, columnSelection ) ).toBe( false );
+		expect( isCellSelected( otherColumnCellLocationB, columnSelection ) ).toBe( false );
+		expect( isCellSelected( otherColumnCellLocationC, columnSelection ) ).toBe( false );
+	} );
+
+	it( `considers only cells with the same section and rowIndex to be selected when the selection.type is 'row'`, () => {
+		const headCellLocationA = { section: 'head', columnIndex: 0, rowIndex: 0 };
+		const headCellLocationB = { section: 'head', columnIndex: 1, rowIndex: 0 };
+		const otherSectionCellLocation = { section: 'body', columnIndex: 0, rowIndex: 0 };
+		const otherRowCellLocation = { section: 'head', columnIndex: 0, rowIndex: 1 };
+		const rowSelection = { type: 'row', section: 'head', rowIndex: 0 };
+
+		expect( isCellSelected( headCellLocationA, rowSelection ) ).toBe( true );
+		expect( isCellSelected( headCellLocationB, rowSelection ) ).toBe( true );
+		expect( isCellSelected( otherSectionCellLocation, rowSelection ) ).toBe( false );
+		expect( isCellSelected( otherRowCellLocation, rowSelection ) ).toBe( false );
+	} );
+
+	it( `considers only cells with the same section, columnIndex and rowIndex to be selected when the selection.type is 'cell'`, () => {
+		// Valid locations and selections.
+		const cellLocation = { section: 'head', columnIndex: 0, rowIndex: 0 };
+		const cellSelection = { type: 'cell', section: 'head', rowIndex: 0, columnIndex: 0 };
+
+		// Invalid locations and selections.
+		const otherColumnCellLocation = { section: 'head', columnIndex: 1, rowIndex: 0 };
+		const otherRowCellLocation = { section: 'head', columnIndex: 0, rowIndex: 1 };
+		const bodyCellLocation = { section: 'body', columnIndex: 0, rowIndex: 0 };
+		const footCellLocation = { section: 'foot', columnIndex: 0, rowIndex: 0 };
+
+		expect( isCellSelected( cellLocation, cellSelection ) ).toBe( true );
+		expect( isCellSelected( otherColumnCellLocation, cellSelection ) ).toBe( false );
+		expect( isCellSelected( otherRowCellLocation, cellSelection ) ).toBe( false );
+		expect( isCellSelected( bodyCellLocation, cellSelection ) ).toBe( false );
+		expect( isCellSelected( footCellLocation, cellSelection ) ).toBe( false );
+	} );
+} );
+
+describe( 'hasSingleCellSelection', () => {
+	it( 'returns false when no cellLocation is provided', () => {
+		const cellSelection = { type: 'cell', section: 'head', rowIndex: 0, columnIndex: 0 };
+
+		expect( hasSingleCellSelection( undefined, cellSelection ) ).toBe( false );
+	} );
+
+	it( 'returns false when no selection is provided', () => {
+		const cellLocation = { section: 'head', columnIndex: 0, rowIndex: 0 };
+
+		expect( hasSingleCellSelection( cellLocation ) ).toBe( false );
+	} );
+
+	it( `considers only cells with the same section, columnIndex and rowIndex as the selection to be selected, and the selection type must be 'cell'`, () => {
+		// Valid locations and selections.
+		const cellLocation = { section: 'head', columnIndex: 0, rowIndex: 0 };
+		const cellSelection = { type: 'cell', section: 'head', rowIndex: 0, columnIndex: 0 };
+
+		// Invalid locations and selections.
+		const otherColumnCellLocation = { section: 'head', columnIndex: 1, rowIndex: 0 };
+		const otherRowCellLocation = { section: 'head', columnIndex: 0, rowIndex: 1 };
+		const bodyCellLocation = { section: 'body', columnIndex: 0, rowIndex: 0 };
+		const footCellLocation = { section: 'foot', columnIndex: 0, rowIndex: 0 };
+		const tableSelection = { type: 'table' };
+		const columnSelection = { type: 'column', columnIndex: 0 };
+		const rowSelection = { type: 'row', section: 'head', rowIndex: 0 };
+
+		expect( hasSingleCellSelection( cellLocation, cellSelection ) ).toBe( true );
+		expect( hasSingleCellSelection( otherColumnCellLocation, cellSelection ) ).toBe( false );
+		expect( hasSingleCellSelection( otherRowCellLocation, cellSelection ) ).toBe( false );
+		expect( hasSingleCellSelection( bodyCellLocation, cellSelection ) ).toBe( false );
+		expect( hasSingleCellSelection( footCellLocation, cellSelection ) ).toBe( false );
+		expect( hasSingleCellSelection( cellLocation, tableSelection ) ).toBe( false );
+		expect( hasSingleCellSelection( cellLocation, columnSelection ) ).toBe( false );
+		expect( hasSingleCellSelection( cellLocation, rowSelection ) ).toBe( false );
+	} );
+} );
+
+describe( 'hasRowSelection', () => {
+	it( 'returns false when no cellLocation is provided', () => {
+		const rowSelection = { type: 'row', section: 'head', rowIndex: 0 };
+
+		expect( hasRowSelection( undefined, rowSelection ) ).toBe( false );
+	} );
+
+	it( 'returns false when no selection is provided', () => {
+		const rowLocation = { section: 'head', rowIndex: 0 };
+
+		expect( hasRowSelection( rowLocation ) ).toBe( false );
+	} );
+
+	it( `considers only rows with the same section and rowIndex as the selection to be selected, and the selection type must be 'row'`, () => {
+		// Valid locations and selections.
+		const rowLocationA = { section: 'head', rowIndex: 0 };
+		const rowSelection = { type: 'row', section: 'head', rowIndex: 0 };
+
+		// Invalid locations and selections.
+		const otherRowLocation = { section: 'head', rowIndex: 1 };
+		const bodyCellLocation = { section: 'body', rowIndex: 0 };
+		const footCellLocation = { section: 'foot', rowIndex: 0 };
+		const cellSelection = { type: 'cell', section: 'head', rowIndex: 0, columnIndex: 0 };
+		const tableSelection = { type: 'table' };
+		const columnSelection = { type: 'column', columnIndex: 0 };
+
+		expect( hasRowSelection( rowLocationA, rowSelection ) ).toBe( true );
+		expect( hasRowSelection( otherRowLocation, rowSelection ) ).toBe( false );
+		expect( hasRowSelection( bodyCellLocation, rowSelection ) ).toBe( false );
+		expect( hasRowSelection( footCellLocation, rowSelection ) ).toBe( false );
+		expect( hasRowSelection( rowLocationA, tableSelection ) ).toBe( false );
+		expect( hasRowSelection( rowLocationA, columnSelection ) ).toBe( false );
+		expect( hasRowSelection( rowLocationA, cellSelection ) ).toBe( false );
+	} );
+} );
+
+describe( 'hasColumnSelection', () => {
+	it( 'returns false when no cellLocation is provided', () => {
+		const columnSelection = { type: 'column', columnIndex: 0 };
+
+		expect( hasColumnSelection( undefined, columnSelection ) ).toBe( false );
+	} );
+
+	it( 'returns false when no selection is provided', () => {
+		const columnLocation = { columnIndex: 0 };
+
+		expect( hasColumnSelection( columnLocation ) ).toBe( false );
+	} );
+
+	it( `considers only cells with the same section and columnIndex as the selection to be selected, and the selection type must be 'column'`, () => {
+		// Valid locations and selections.
+		const columnLocationHead = { section: 'head', columnIndex: 0 };
+		const columnLocationBody = { section: 'body', columnIndex: 0 };
+		const columnLocationFoot = { section: 'foot', columnIndex: 0 };
+		const columnSelection = { type: 'column', columnIndex: 0 };
+
+		// Invalid locations and selections.
+		const otherColumnLocation = { section: 'head', columnIndex: 1 };
+		const tableSelection = { type: 'table' };
+		const rowSelection = { type: 'row', section: 'head', rowIndex: 0 };
+		const cellSelection = { type: 'cell', section: 'head', columnIndex: 0, rowIndex: 0 };
+
+		expect( hasColumnSelection( columnLocationHead, columnSelection ) ).toBe( true );
+		expect( hasColumnSelection( columnLocationBody, columnSelection ) ).toBe( true );
+		expect( hasColumnSelection( columnLocationFoot, columnSelection ) ).toBe( true );
+		expect( hasColumnSelection( otherColumnLocation, columnSelection ) ).toBe( false );
+		expect( hasColumnSelection( columnLocationHead, tableSelection ) ).toBe( false );
+		expect( hasColumnSelection( columnLocationHead, rowSelection ) ).toBe( false );
+		expect( hasColumnSelection( columnLocationHead, cellSelection ) ).toBe( false );
+	} );
+} );
+
+describe( 'getCellAbove', () => {
+	it( `returns undefined for the first row of 'head' section`, () => {
+		const cellLocation = { section: 'head', rowIndex: 0, columnIndex: 0 };
+		expect( getCellAbove( tableWithHeadAndFoot, cellLocation ) ).toBeUndefined();
+	} );
+
+	it( `returns undefined for the first row of 'body' section if the 'head' section is empty`, () => {
+		const cellLocation = { section: 'body', rowIndex: 0, columnIndex: 0 };
+		expect( getCellAbove( table, cellLocation ) ).toBeUndefined();
+	} );
+
+	it( `returns undefined if the row above does not have as many cells`, () => {
+		const cellLocation = { section: 'body', rowIndex: 1, columnIndex: 2 };
+		expect( getCellAbove( table, cellLocation ) ).toBeUndefined();
+	} );
+
+	it( `returns the location for the row above in the same section when that row exists`, () => {
+		const cellLocation = { section: 'body', rowIndex: 1, columnIndex: 0 };
+		expect( getCellAbove( table, cellLocation ) ).toEqual( { section: 'body', rowIndex: 0, columnIndex: 0 } );
+	} );
+
+	it( `returns the location for the row above in the previous section when that row exists`, () => {
+		const bodyCellLocation = { section: 'body', rowIndex: 0, columnIndex: 0 };
+		const footCellLocation = { section: 'foot', rowIndex: 0, columnIndex: 0 };
+
+		expect( getCellAbove( tableWithHeadAndFoot, bodyCellLocation ) ).toEqual( {
+			section: 'head',
+			rowIndex: 0,
+			columnIndex: 0,
+		} );
+		expect( getCellAbove( tableWithHeadAndFoot, footCellLocation ) ).toEqual( {
+			section: 'body',
+			rowIndex: 1,
+			columnIndex: 0,
+		} );
+	} );
+} );
+
+describe( 'getCellBelow', () => {
+	it( `returns undefined for the last row of 'foot' section`, () => {
+		const cellLocation = { section: 'foot', rowIndex: 0, columnIndex: 0 };
+		expect( getCellBelow( tableWithHeadAndFoot, cellLocation ) ).toBeUndefined();
+	} );
+
+	it( `returns undefined for the last row of 'body' section if the 'foot' section is empty`, () => {
+		const cellLocation = { section: 'body', rowIndex: 1, columnIndex: 0 };
+		expect( getCellBelow( table, cellLocation ) ).toBeUndefined();
+	} );
+
+	it( `returns undefined if the row below does not have as many cells`, () => {
+		const cellLocation = { section: 'body', rowIndex: 0, columnIndex: 2 };
+		expect( getCellBelow( table, cellLocation ) ).toBeUndefined();
+	} );
+
+	it( `returns the location for the row below in the same section when that row exists`, () => {
+		const cellLocation = { section: 'body', rowIndex: 0, columnIndex: 0 };
+		expect( getCellBelow( table, cellLocation ) ).toEqual( { section: 'body', rowIndex: 1, columnIndex: 0 } );
+	} );
+
+	it( `returns the location for the row below in the next section when that row exists`, () => {
+		const bodyCellLocation = { section: 'head', rowIndex: 0, columnIndex: 0 };
+		expect( getCellBelow( tableWithHeadAndFoot, bodyCellLocation ) ).toEqual( {
+			section: 'body',
+			rowIndex: 0,
+			columnIndex: 0,
+		} );
+
+		const footCellLocation = { section: 'body', rowIndex: 1, columnIndex: 0 };
+		expect( getCellBelow( tableWithHeadAndFoot, footCellLocation ) ).toEqual( {
+			section: 'foot',
+			rowIndex: 0,
+			columnIndex: 0,
+		} );
+	} );
+} );
+
+describe( 'getCellToRight', () => {
+	it( 'returns undefined if there is no cell to the right', () => {
+		const cellLocation = { section: 'body', rowIndex: 0, columnIndex: 1 };
+		expect( getCellToRight( table, cellLocation ) ).toBeUndefined();
+	} );
+
+	it( 'returns the location of the cell to the right if it exists', () => {
+		const cellLocation = { section: 'body', rowIndex: 0, columnIndex: 0 };
+		expect( getCellToRight( table, cellLocation ) ).toEqual( {
+			section: 'body',
+			rowIndex: 0,
+			columnIndex: 1,
+		} );
+	} );
+} );
+
+describe( 'getCellToLeft', () => {
+	it( 'returns undefined if there is no cell to the left', () => {
+		const cellLocation = { section: 'body', rowIndex: 0, columnIndex: 0 };
+		expect( getCellToLeft( cellLocation ) ).toBeUndefined();
+	} );
+
+	it( 'returns the location of the cell to the left if it exists', () => {
+		const cellLocation = { section: 'body', rowIndex: 0, columnIndex: 1 };
+		expect( getCellToLeft( cellLocation ) ).toEqual( {
+			section: 'body',
+			rowIndex: 0,
+			columnIndex: 0,
+		} );
 	} );
 } );


### PR DESCRIPTION
Status: This is blocked by https://github.com/WordPress/gutenberg/pull/17084, better keyboard nav is required for accessibility of the column/row selection buttons in this PR

## Description
Closes #16294

This is an early exploration of adding buttons for selecting entire table/columns/rows in the table block.

At the moment I'm trying a few different approaches. In the current version, while you can select columns/rows or the entire table, you can't actually do anything with the selection. 😁

Update: you can now insert columns/rows before/after the selected columns/rows.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
![table-select](https://user-images.githubusercontent.com/677833/61121426-c44cd300-a4d1-11e9-9a21-9968e4a3eb4c.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
