### PR TITLE
Show Preview button on mobile viewports

### DIFF
--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -36,14 +36,6 @@
 		}
 	}
 
-	.editor-post-switch-to-draft + .editor-post-preview {
-		display: none;
-
-		@include break-small {
-			display: inline-flex;
-		}
-	}
-
 	// Some browsers, most notably IE11, honor an older version of the flexbox spec
 	// which takes absolutely positioned items into account when calculating `space-between`.
 	// https://www.w3.org/TR/2012/WD-css3-flexbox-20120612/#abspos-flex-items

--- a/packages/editor/src/components/post-saved-state/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-saved-state/test/__snapshots__/index.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PostSavedState returns a switch to draft link if the post is published 1`] = `<WithSelect(WithDispatch(PostSwitchToDraftButton)) />`;
+exports[`PostSavedState returns a switch to draft link if the post is published 1`] = `<WithSelect(WithDispatch(WithViewportMatch(PostSwitchToDraftButton))) />`;
 
 exports[`PostSavedState should return Save button if edits to be saved 1`] = `
 <ForwardRef(Button)

--- a/packages/editor/src/components/post-switch-to-draft-button/index.js
+++ b/packages/editor/src/components/post-switch-to-draft-button/index.js
@@ -5,8 +5,15 @@ import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
+import { withViewportMatch } from '@wordpress/viewport';
 
-function PostSwitchToDraftButton( { isSaving, isPublished, isScheduled, onClick } ) {
+function PostSwitchToDraftButton( {
+	isSaving,
+	isPublished,
+	isScheduled,
+	onClick,
+	isMobileViewport,
+} ) {
 	if ( ! isPublished && ! isScheduled ) {
 		return null;
 	}
@@ -31,7 +38,7 @@ function PostSwitchToDraftButton( { isSaving, isPublished, isScheduled, onClick 
 			disabled={ isSaving }
 			isTertiary
 		>
-			{ __( 'Switch to Draft' ) }
+			{ isMobileViewport ? __( 'Draft' ) : __( 'Switch to Draft' ) }
 		</Button>
 	);
 }
@@ -54,5 +61,6 @@ export default compose( [
 			},
 		};
 	} ),
+	withViewportMatch( { isMobileViewport: '< small' } ),
 ] )( PostSwitchToDraftButton );
 


### PR DESCRIPTION
Fixes #8184.

![localhost_8888_wp-admin_post php_post=13 action=edit(iPhone 6_7_8)](https://user-images.githubusercontent.com/612155/60947986-4784f200-a335-11e9-98de-3245b1cfab17.png)

Displays the Preview button and renames _Switch to Draft_ to _Draft_ on mobile viewports. This allows mobile users to easily preview their published posts.

To test:

1. Create a new post
1. Click _Publish..._ and publish the post
1. On a mobile viewport, confirm that you now see a _Preview_ button