### PR TITLE
Document and rename showSuggestionsOverride to something more sensible

### DIFF
--- a/packages/block-editor/src/components/url-input/README.md
+++ b/packages/block-editor/src/components/url-input/README.md
@@ -141,7 +141,7 @@ If you are not conditionally rendering this component set this property to `fals
 
 When hiding the URLInput using CSS (as is sometimes done for accessibility purposes), the suggestions can still be displayed. This is because they're rendered in a popover in a different part of the DOM, so any styles applied to the URLInput's container won't affect the popover.
 
-This prop allows the suggestions list to be progrmatically not rendered by passing a boolean—it can be `true` to make sure suggestions aren't rendered, or `false`/`undefined` to fall back to the default behaviour of showing suggestions when matching autocompletion items are found.
+This prop allows the suggestions list to be programmatically not rendered by passing a boolean—it can be `true` to make sure suggestions aren't rendered, or `false`/`undefined` to fall back to the default behaviour of showing suggestions when matching autocompletion items are found.
 
 ## Example
 

--- a/packages/block-editor/src/components/url-input/README.md
+++ b/packages/block-editor/src/components/url-input/README.md
@@ -135,6 +135,14 @@ If you are not conditionally rendering this component set this property to `fals
 
 *Optional.* Adds and optional class to the parent `div` that wraps the URLInput field and popover
 
+### `disableSuggestions: Boolean`
+
+*Optional.* Provides additional control over whether suggestions are disabled.
+
+When hiding the URLInput using CSS (as is sometimes done for accessibility purposes), the suggestions can still be displayed. This is because they're rendered in a popover in a different part of the DOM, so any styles applied to the URLInput's container won't affect the popover.
+
+This prop allows the suggestions list to be progrmatically not rendered by passing a boolean—it can be `true` to make sure suggestions aren't rendered, or `false`/`undefined` to fall back to the default behaviour of showing suggestions when matching autocompletion items are found.
+
 ## Example
 
 {% codetabs %}

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -223,9 +223,9 @@ class URLInput extends Component {
 		this.inputRef.current.focus();
 	}
 
-	static getDerivedStateFromProps( { showSuggestionsOverride }, { showSuggestions } ) {
+	static getDerivedStateFromProps( { disableSuggestions }, { showSuggestions } ) {
 		return {
-			showSuggestions: showSuggestionsOverride !== undefined ? showSuggestionsOverride : showSuggestions,
+			showSuggestions: disableSuggestions === true ? false : showSuggestions,
 		};
 	}
 

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -141,7 +141,7 @@ class ButtonEdit extends Component {
 						autoFocus={ false }
 						/* eslint-enable jsx-a11y/no-autofocus */
 						onChange={ ( value ) => setAttributes( { url: value } ) }
-						showSuggestionsOverride={ ! isSelected ? false : undefined }
+						disableSuggestions={ ! isSelected }
 						id={ linkId }
 						isFullWidth
 						hasBorder


### PR DESCRIPTION
## Description
I added a small contribution to #10128 to fix a problem when hiding the URLInput. It was pointed out in review comments that the name of the prop could be improved, and documentation should be added.

Now that #10128 has been merged, here's the follow up addressing those comments.

## How has this been tested?
1. Add a button block
2. Type in some text in the url input field that triggers the autocomplete suggestions to display
3. Press tab to tab out of the field

### Expected behaviour
The input is hidden due to the button block no longer being selected. The autocomplete suggestions are also hidden.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Code quality improvement (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
