### PR TITLE
Adds grouping supports opt out for blocks

### DIFF
--- a/packages/block-library/src/column/index.js
+++ b/packages/block-library/src/column/index.js
@@ -24,6 +24,7 @@ export const settings = {
 		inserter: false,
 		reusable: false,
 		html: false,
+		grouping: false,
 	},
 	getEditWrapperProps( attributes ) {
 		const { width } = attributes;


### PR DESCRIPTION
## Description
Closes https://github.com/WordPress/gutenberg/issues/16416

Certain types of Blocks should not be groupable. A good example is the single `column` Block.

This PR adds the `groupable` `supports` flag to Blocks. Setting this to `false` means that a given Block cannot be grouped.

If a Block is not groupable but it is part of a selection which includes other blocks that _are_ groupable then a group is formed from those blocks which are groupable only, leaving ungroupable blocks untouched.

Still todo:

- [ ] Hide Grouping Menu options from unsupported Blocks
- [ ] Work out where to set the `supports` defaults for all blocks

## How has this been tested?

* Add a Columns block with 3 cols
* Select more than 1 single column blocks - attempt to Group.
* See that no Grouping actually happens.

* Experiment by setting the `core/paragraph` to be ungroupable. 
* Create a heading, paragraph and quote block.
* Create a group from all 3 blocks - see only Heading and Quote are included in the Group. 
* Revert change to paragraph.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
