### PR TITLE
WIP: Add table block caption positioning

### DIFF
--- a/packages/block-library/src/table/block.json
+++ b/packages/block-library/src/table/block.json
@@ -9,6 +9,12 @@
 		"backgroundColor": {
 			"type": "string"
 		},
+		"caption": {
+			"type": "string",
+			"source": "html",
+			"selector": "caption",
+			"default": ""
+		},
 		"head": {
 			"type": "array",
 			"default": [],

--- a/packages/block-library/src/table/block.json
+++ b/packages/block-library/src/table/block.json
@@ -15,6 +15,10 @@
 			"selector": "caption",
 			"default": ""
 		},
+		"captionPosition": {
+			"type": "string",
+			"default": "top"
+		},
 		"head": {
 			"type": "array",
 			"default": [],

--- a/packages/block-library/src/table/caption-bottom-icon.js
+++ b/packages/block-library/src/table/caption-bottom-icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+export default (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewbox="20 20 0 0" width="20" height="20"><Path fillRule="evenodd" clipRule="evenodd" d="M13 7l-3 3-3-3h2V2h2v5h2zM2 14v-2h16v2H2zm2 4v-2h12v2H4z" /></SVG>
+);

--- a/packages/block-library/src/table/caption-top-icon.js
+++ b/packages/block-library/src/table/caption-top-icon.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+export default (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewbox="20 20 0 0" width="20" height="20" ><Path fill-rule="evenodd" clip-rule="evenodd" d="M2 2h16v2H2V2zm2 4h12v2H4V6zm3 7l3-3 3 3h-2v5H9v-5H7z" /></SVG>
+);

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -414,9 +414,11 @@ export class TableEdit extends Component {
 			className,
 			backgroundColor,
 			setBackgroundColor,
+			setAttributes,
+			isSelected,
 		} = this.props;
 		const { initialRowCount, initialColumnCount } = this.state;
-		const { hasFixedLayout, head, body, foot } = attributes;
+		const { hasFixedLayout, caption, head, body, foot } = attributes;
 		const isEmpty = isEmptyTableSection( head ) && isEmptyTableSection( body ) && isEmptyTableSection( foot );
 		const Section = this.renderSection;
 
@@ -501,10 +503,27 @@ export class TableEdit extends Component {
 				</InspectorControls>
 				<figure className={ className }>
 					<table className={ tableClasses }>
+						{ /* Caption is specified as visibly hidden. This allows the caption to be
+						read by a screenreader, but remain editable using a RichText outside the table.
+						Specifying a key forces react to replace the caption element,
+						ensure the up-to-date caption is read by voiceover in chrome */ }
+						<caption className="screen-reader-text" key={ caption }>{ caption }</caption>
 						<Section type="head" rows={ head } />
 						<Section type="body" rows={ body } />
 						<Section type="foot" rows={ foot } />
 					</table>
+					<RichText
+						className={ classnames( 'wp-block-table__caption-content', {
+							'is-visible': isSelected || caption,
+						} ) }
+						tagName="div"
+						placeholder={ __( 'Write caption…' ) }
+						value={ caption }
+						onChange={ ( value ) => setAttributes( { caption: value } ) }
+						// Deselect the selected table cell when the caption is focused.
+						unstableOnFocus={ () => this.setState( { selectedCell: null } ) }
+						inlineToolbar
+					/>
 				</figure>
 			</>
 		);

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -481,7 +481,7 @@ export class TableEdit extends Component {
 					isCaptionSelected: true,
 				} ) }
 				// Only show inlineToolbar when caption is at the bottom,
-				// otherwise it's overlaped by the main block toolbar.
+				// otherwise it's overlapped by the main block toolbar.
 				inlineToolbar={ isCaptionBottom }
 			/>
 		);

--- a/packages/block-library/src/table/editor.scss
+++ b/packages/block-library/src/table/editor.scss
@@ -49,16 +49,35 @@
 	&__cell-content {
 		padding: 0.5em;
 	}
+
 	// Extra specificity to override default Placeholder styles.
 	&__placeholder-form.wp-block-table__placeholder-form {
 		text-align: left;
 		align-items: center;
 	}
+
 	&__placeholder-input {
 		width: 100px;
 	}
+
 	&__placeholder-button {
 		min-width: 100px;
 		justify-content: center;
+	}
+
+	&__caption-content {
+		overflow: hidden;
+		height: 0;
+		margin: 0.5em 0 0;
+
+		&.is-visible {
+			overflow: auto;
+			height: auto;
+
+			// The following rules are specified under the `.is-visible` selector
+			// as it helps introduce specificity and override conflicting styles.
+			margin: 0.5em 0 0;
+			@include caption-style-theme();
+		}
 	}
 }

--- a/packages/block-library/src/table/editor.scss
+++ b/packages/block-library/src/table/editor.scss
@@ -68,15 +68,21 @@
 	&__caption-content {
 		overflow: hidden;
 		height: 0;
-		margin: 0.5em 0 0;
+
+		&.is-position-top {
+			margin: 0 0 0.5em;
+		}
+
+		&.is-position-bottom {
+			margin: 1em 0 0;
+		}
 
 		&.is-visible {
 			overflow: auto;
 			height: auto;
 
-			// The following rules are specified under the `.is-visible` selector
+			// The following rule is specified under the `.is-visible` selector
 			// as it helps introduce specificity and override conflicting styles.
-			margin: 0.5em 0 0;
 			@include caption-style-theme();
 		}
 	}

--- a/packages/block-library/src/table/save.js
+++ b/packages/block-library/src/table/save.js
@@ -15,6 +15,7 @@ export default function save( { attributes } ) {
 		body,
 		foot,
 		backgroundColor,
+		caption,
 	} = attributes;
 	const isEmpty = ! head.length && ! body.length && ! foot.length;
 
@@ -57,6 +58,7 @@ export default function save( { attributes } ) {
 	return (
 		<figure>
 			<table className={ classes }>
+				{ ! RichText.isEmpty( caption ) && <RichText.Content tagName="caption" value={ caption } /> }
 				<Section type="head" rows={ head } />
 				<Section type="body" rows={ body } />
 				<Section type="foot" rows={ foot } />

--- a/packages/block-library/src/table/save.js
+++ b/packages/block-library/src/table/save.js
@@ -16,6 +16,7 @@ export default function save( { attributes } ) {
 		foot,
 		backgroundColor,
 		caption,
+		captionPosition,
 	} = attributes;
 	const isEmpty = ! head.length && ! body.length && ! foot.length;
 
@@ -28,6 +29,7 @@ export default function save( { attributes } ) {
 	const classes = classnames( backgroundClass, {
 		'has-fixed-layout': hasFixedLayout,
 		'has-background': !! backgroundClass,
+		'has-bottom-caption': captionPosition === 'bottom',
 	} );
 
 	const Section = ( { type, rows } ) => {

--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -39,6 +39,10 @@
 		}
 	}
 
+	.has-bottom-caption {
+		caption-side: bottom;
+	}
+
 	.has-subtle-light-gray-background-color {
 		background-color: $subtle-light-gray;
 	}

--- a/packages/block-library/src/table/theme.scss
+++ b/packages/block-library/src/table/theme.scss
@@ -7,4 +7,10 @@
 		border: 1px solid;
 		word-break: normal;
 	}
+
+	caption {
+		caption-side: bottom;
+		margin-top: 0.5em;
+		@include caption-style-theme();
+	}
 }

--- a/packages/block-library/src/table/theme.scss
+++ b/packages/block-library/src/table/theme.scss
@@ -9,8 +9,11 @@
 	}
 
 	caption {
-		caption-side: bottom;
-		margin-top: 0.5em;
+		margin-bottom: 0.5em;
 		@include caption-style-theme();
+	}
+
+	&.has-bottom-caption caption {
+		margin-top: 0.5em;
 	}
 }

--- a/packages/e2e-tests/specs/blocks/__snapshots__/table.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/table.test.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Table allows a caption to be added 1`] = `
+"<!-- wp:table -->
+<table class=\\"wp-block-table\\"><caption>Caption!</caption><tbody><tr><td></td><td></td></tr><tr><td></td><td></td></tr></tbody></table>
+<!-- /wp:table -->"
+`;
+
 exports[`Table allows adding and deleting columns across the table header, body and footer 1`] = `
 "<!-- wp:table -->
 <figure class=\\"wp-block-table\\"><table class=\\"\\"><thead><tr><th></th><th></th></tr></thead><tbody><tr><td></td><td></td></tr><tr><td></td><td></td></tr></tbody><tfoot><tr><td></td><td></td></tr></tfoot></table></figure>

--- a/packages/e2e-tests/specs/blocks/__snapshots__/table.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/table.test.js.snap
@@ -1,8 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Table allows a caption to be added 1`] = `
+exports[`Table allows a caption to be added and supports positioning the caption below the table 1`] = `
 "<!-- wp:table -->
 <table class=\\"wp-block-table\\"><caption>Caption!</caption><tbody><tr><td></td><td></td></tr><tr><td></td><td></td></tr></tbody></table>
+<!-- /wp:table -->"
+`;
+
+exports[`Table allows a caption to be added and supports positioning the caption below the table 2`] = `
+"<!-- wp:table {\\"captionPosition\\":\\"bottom\\"} -->
+<table class=\\"wp-block-table has-bottom-caption\\"><caption>Caption!</caption><tbody><tr><td></td><td></td></tr><tr><td></td><td></td></tr></tbody></table>
 <!-- /wp:table -->"
 `;
 

--- a/packages/e2e-tests/specs/blocks/table.test.js
+++ b/packages/e2e-tests/specs/blocks/table.test.js
@@ -152,4 +152,19 @@ describe( 'Table', () => {
 		// Expect the table to have 2 columns across the header, body and footer.
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'allows a caption to be added', async () => {
+		await insertBlock( 'Table' );
+
+		// Create the table.
+		const createButton = await page.$x( createButtonSelector );
+		await createButton[ 0 ].click();
+
+		// Click the first cell and add some text.
+		await page.click( '.wp-block-table__caption-content' );
+		await page.keyboard.type( 'Caption!' );
+
+		// Expect the post to have the correct written content inside the table.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );

--- a/packages/e2e-tests/specs/blocks/table.test.js
+++ b/packages/e2e-tests/specs/blocks/table.test.js
@@ -153,7 +153,7 @@ describe( 'Table', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
-	it( 'allows a caption to be added', async () => {
+	it( 'allows a caption to be added and supports positioning the caption below the table', async () => {
 		await insertBlock( 'Table' );
 
 		// Create the table.
@@ -164,7 +164,15 @@ describe( 'Table', () => {
 		await page.click( '.wp-block-table__caption-content' );
 		await page.keyboard.type( 'Caption!' );
 
-		// Expect the post to have the correct written content inside the table.
+		// Expect the post to have the correct table caption.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		// Toggle the position of the caption.
+		await clickBlockToolbarButton( 'Edit table' );
+		const captionPositioningButton = await page.$x( "//button[text()='Show Caption Below Table']" );
+		await captionPositioningButton[ 0 ].click();
+
+		// Expect the caption to be below the table (an additional classname should be added to the table).
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
## Description
Initially, this was implemented as part of https://github.com/WordPress/gutenberg/pull/15554, but I've decided to reduce the scope of that PR to give it more of a chance of shipping, and split the positioning part into its own PR.

Description TBC

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
