### PR TITLE
Warning Message: Prevent Themes Accidentally Overriding Styles

### DIFF
--- a/packages/block-editor/src/components/warning/style.scss
+++ b/packages/block-editor/src/components/warning/style.scss
@@ -23,7 +23,8 @@
 		}
 	}
 
-	.block-editor-warning__message {
+	.block-editor-warning__message,
+	.block-editor-warning__message p {
 		line-height: $default-line-height;
 		font-family: $default-font;
 		font-size: $default-font-size;


### PR DESCRIPTION
## Description
Along with the current selector (the text inside might not always use a `p` tag), this adds the slightly more specific `p` selector to the warning message. This prevents themes overriding it. 

Themes often intend to try to be specific enough to provide readers an accurate perception of the content when published, but unlike the rest of the editor, these warning messages aren't published and are only accessible in the editor.

_I feel hesitant to use a universal selector here, but that's probably another alternative. This mainly affects `p` tags, so I think it's best to just target that in addition._

## How has this been tested?
Verified through the browser development tools that this is enough to override themes inadvertently touching the warning message.

## Screenshots <!-- if applicable -->

**Before:**

<img width="864" alt="Screenshot 2019-07-10 at 15 30 04" src="https://user-images.githubusercontent.com/43215253/60977735-e571c000-a327-11e9-9af7-8a7eb1234f92.png">

**After:**

<img width="868" alt="Screenshot 2019-07-10 at 15 30 19" src="https://user-images.githubusercontent.com/43215253/60977705-d854d100-a327-11e9-930e-35540261c807.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) --> Bug fix for some themes

## Checklist:
- ✅ My code is tested.
- ✅My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- ✅ My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- ✅ My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- ❌ I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
