### PR TITLE
Project Management: Milestone It: Read version from master branch package.json

### DIFF
--- a/.github/actions/milestone-it/entrypoint.sh
+++ b/.github/actions/milestone-it/entrypoint.sh
@@ -16,7 +16,7 @@ current_milestone=$(
 
 if [ "$current_milestone" != 'null' ]; then
 	echo 'Milestone already applied. Aborting.'
-	exit 1;
+	exit 78;
 fi
 
 # 2. Read current version.

--- a/.github/actions/milestone-it/entrypoint.sh
+++ b/.github/actions/milestone-it/entrypoint.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
 set -e
 
-# 1. Determine if milestone already exists (don't replace one which has already
+# 1. Proceed only when merge occurs to `master` base branch.
+
+base=$(jq -r '.pull_request.base.ref' $GITHUB_EVENT_PATH)
+
+if [ "$base" != 'master' ]; then
+	echo 'Milestones apply only to master merge. Aborting.'
+	exit 78;
+fi
+
+# 2. Determine if milestone already exists (don't replace one which has already
 #    been assigned).
 
 pr=$(jq -r '.number' $GITHUB_EVENT_PATH)
@@ -19,7 +28,7 @@ if [ "$current_milestone" != 'null' ]; then
 	exit 78;
 fi
 
-# 2. Read current version.
+# 3. Read current version.
 
 version=$(git show master:package.json | jq -r '.version')
 
@@ -27,7 +36,7 @@ IFS='.' read -ra parts <<< "$version"
 major=${parts[0]}
 minor=${parts[1]}
 
-# 3. Determine next milestone.
+# 4. Determine next milestone.
 
 if [[ $minor == 9* ]]; then
 	major=$((major+1))
@@ -38,7 +47,7 @@ fi
 
 milestone="Gutenberg $major.$minor"
 
-# 4. Calculate next milestone due date, using a static reference of an earlier
+# 5. Calculate next milestone due date, using a static reference of an earlier
 #    release (v5.0) as a reference point for the biweekly release schedule.
 
 reference_major=5
@@ -48,7 +57,7 @@ num_versions_elapsed=$(((major-reference_major)*10+(minor-reference_minor)))
 weeks=$((num_versions_elapsed*2))
 due=$(date -u --iso-8601=seconds -d "$(date -d @$(echo $reference_date)) + $(echo $weeks) weeks")
 
-# 5. Create milestone. This may fail for duplicates, which is expected and
+# 6. Create milestone. This may fail for duplicates, which is expected and
 #    ignored.
 
 curl \
@@ -59,7 +68,7 @@ curl \
 	-d "{\"title\":\"$milestone\",\"due_on\":\"$due\",\"description\":\"Tasks to be included in the $milestone plugin release.\"}" \
 	"https://api.github.com/repos/$GITHUB_REPOSITORY/milestones" > /dev/null
 
-# 6. Find milestone number. This could be improved to allow for non-open status
+# 7. Find milestone number. This could be improved to allow for non-open status
 #    or paginated results.
 
 number=$(
@@ -70,7 +79,7 @@ number=$(
 		| jq ".[] | select(.title == \"$milestone\") | .number"
 )
 
-# 7. Assign pull request to milestone.
+# 8. Assign pull request to milestone.
 
 curl \
 	--silent \

--- a/.github/actions/milestone-it/entrypoint.sh
+++ b/.github/actions/milestone-it/entrypoint.sh
@@ -21,7 +21,7 @@ fi
 
 # 2. Read current version.
 
-version=$(jq -r '.version' package.json)
+version=$(git show master:package.json | jq -r '.version')
 
 IFS='.' read -ra parts <<< "$version"
 major=${parts[0]}


### PR DESCRIPTION
This pull request seeks to improve the Milestone It custom GitHub action to ensure that the version read from `package.json` is that of the master branch, not the "current" branch of the pull request being merged. Since the branch of a pull request which has been merged may be stale, the version may not reflect the next release. The version should always be derived based on the `master` branch at the time of the merge.

In the course of implementing this, a few other necessary changes were made:

- Milestones should only be applied when a pull request is merged to the master branch. This restriction did not exist previously, so it was possible branches merged to other non-master branches would have a milestone applied.
- Changed "Skip" exits to use a neutral status code ([documentation](https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#exit-codes-and-statuses))