### PR TITLE
Add callbacks to ServerSideRenderer to handle failures with custom renderers

### DIFF
--- a/packages/server-side-render/CHANGELOG.md
+++ b/packages/server-side-render/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Master
+
+### Feature
+- Add `EmptyResponsePlaceholder`, `ErrorResponsePlaceholder` and `LoadingResponsePlaceholder` render props for parent components to swap out alternate placeholders for the various states (see https://github.com/WordPress/gutenberg/pull/16512).
+
 ## 1.0.0 (2019-06-12)
 
 ### Initial Release

--- a/packages/server-side-render/README.md
+++ b/packages/server-side-render/README.md
@@ -55,6 +55,25 @@ E.g: `{ post_id: 12 }`.
 - Type: `Object`
 - Required: No
 
+### EmptyResponsePlaceholder
+
+This is a [render prop](https://reactjs.org/docs/render-props.html). When the api response is empty, the value of this prop is rendered. The render prop will receive the value of the api response as well as all props passed into `ServerSideRenderer`.
+- Type: `WPElement`
+- Required: No
+
+### ErrorResponsePlaceholder
+
+This is a [render prop](https://reactjs.org/docs/render-props.html). When the api response is an error, the value of this prop is rendered. The render prop will receive the value of the api response as well as all props passed into `ServerSideRenderer`.
+- Type: `WPElement`
+- Required: No
+
+### LoadingResponsePlaceholder
+
+This is a [render prop](https://reactjs.org/docs/render-props.html). While the request is being processed (loading state), the value of this prop is rendered. The render prop will receive the value of the api response as well as all props passed into `ServerSideRenderer`.
+- Type: `WPElement`
+- Required: No
+
+
 ## Usage
 
 Render core/archives preview.

--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -83,33 +83,14 @@ export class ServerSideRender extends Component {
 
 	render() {
 		const response = this.state.response;
-		const { className, onEmptyResponse, onErrorResponse, onNullResponse } = this.props;
+		const { className, EmptyResponsePlaceholder, ErrorResponsePlaceholder, NullResponsePlaceholder } = this.props;
+
 		if ( response === '' ) {
-			return !! onEmptyResponse ? onEmptyResponse( this ) : (
-				<Placeholder
-					className={ className }
-				>
-					{ __( 'Block rendered as empty.' ) }
-				</Placeholder>
-			);
+			return EmptyResponsePlaceholder( this.props, response );
 		} else if ( ! response ) {
-			return !! onNullResponse ? onNullResponse( this ) : (
-				<Placeholder
-					className={ className }
-				>
-					<Spinner />
-				</Placeholder>
-			);
+			return NullResponsePlaceholder( this.props, response );
 		} else if ( response.error ) {
-			// translators: %s: error message describing the problem
-			const errorMessage = sprintf( __( 'Error loading block: %s' ), response.errorMsg );
-			return !! onErrorResponse ? onErrorResponse( this, errorMessage ) : (
-				<Placeholder
-					className={ className }
-				>
-					{ errorMessage }
-				</Placeholder>
-			);
+			return ErrorResponsePlaceholder( this.props, response );
 		}
 
 		return (
@@ -122,5 +103,40 @@ export class ServerSideRender extends Component {
 		);
 	}
 }
+
+ServerSideRender.defaultProps = {
+	EmptyResponsePlaceholder: ( props ) => {
+		const { className } = props;
+		return (
+			<Placeholder
+				className={ className }
+			>
+				{ __( 'Block rendered as empty.' ) }
+			</Placeholder>
+		);
+	},
+	ErrorResponsePlaceholder: ( props, response ) => {
+		// translators: %s: error message describing the problem
+		const errorMessage = sprintf( __( 'Error loading block: %s' ), response.errorMsg );
+		const { className } = props;
+		return (
+			<Placeholder
+				className={ className }
+			>
+				{ errorMessage }
+			</Placeholder>
+		);
+	},
+	NullResponsePlaceholder: ( props ) => {
+		const { className } = props;
+		return (
+			<Placeholder
+				className={ className }
+			>
+				<Spinner />
+			</Placeholder>
+		);
+	},
+};
 
 export default ServerSideRender;

--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -59,7 +59,7 @@ export class ServerSideRender extends Component {
 		if ( null !== this.state.response ) {
 			this.setState( { response: null } );
 		}
-		const { block, attributes = null, urlQueryArgs = {} } = props;
+		const { block, attributes = null, urlQueryArgs = {}, fetchComplete } = props;
 
 		const path = rendererPath( block, attributes, urlQueryArgs );
 		// Store the latest fetch request so that when we process it, we can
@@ -77,6 +77,9 @@ export class ServerSideRender extends Component {
 						errorMsg: error.message,
 					} } );
 				}
+			} )
+			.finally( () => {
+				fetchComplete( this );
 			} );
 		return fetchRequest;
 	}
@@ -137,6 +140,7 @@ ServerSideRender.defaultProps = {
 			</Placeholder>
 		);
 	},
+	fetchComplete: () => {},
 };
 
 export default ServerSideRender;

--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -83,14 +83,14 @@ export class ServerSideRender extends Component {
 
 	render() {
 		const response = this.state.response;
-		const { className, EmptyResponsePlaceholder, ErrorResponsePlaceholder, LoadingResponsePlaceholder } = this.props;
+		const { className, emptyResponsePlaceholder, errorResponsePlaceholder, loadingResponsePlaceholder } = this.props;
 
 		if ( response === '' ) {
-			return EmptyResponsePlaceholder( this.props, response );
+			return emptyResponsePlaceholder( this.props, response );
 		} else if ( ! response ) {
-			return LoadingResponsePlaceholder( this.props, response );
+			return loadingResponsePlaceholder( this.props, response );
 		} else if ( response.error ) {
-			return ErrorResponsePlaceholder( this.props, response );
+			return errorResponsePlaceholder( this.props, response );
 		}
 
 		return (
@@ -105,7 +105,7 @@ export class ServerSideRender extends Component {
 }
 
 ServerSideRender.defaultProps = {
-	EmptyResponsePlaceholder: ( props ) => {
+	emptyResponsePlaceholder: ( props ) => {
 		const { className } = props;
 		return (
 			<Placeholder
@@ -115,7 +115,7 @@ ServerSideRender.defaultProps = {
 			</Placeholder>
 		);
 	},
-	ErrorResponsePlaceholder: ( props, response ) => {
+	errorResponsePlaceholder: ( props, response ) => {
 		// translators: %s: error message describing the problem
 		const errorMessage = sprintf( __( 'Error loading block: %s' ), response.errorMsg );
 		const { className } = props;
@@ -127,7 +127,7 @@ ServerSideRender.defaultProps = {
 			</Placeholder>
 		);
 	},
-	LoadingResponsePlaceholder: ( props ) => {
+	loadingResponsePlaceholder: ( props ) => {
 		const { className } = props;
 		return (
 			<Placeholder

--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -83,12 +83,12 @@ export class ServerSideRender extends Component {
 
 	render() {
 		const response = this.state.response;
-		const { className, EmptyResponsePlaceholder, ErrorResponsePlaceholder, NullResponsePlaceholder } = this.props;
+		const { className, EmptyResponsePlaceholder, ErrorResponsePlaceholder, LoadingResponsePlaceholder } = this.props;
 
 		if ( response === '' ) {
 			return EmptyResponsePlaceholder( this.props, response );
 		} else if ( ! response ) {
-			return NullResponsePlaceholder( this.props, response );
+			return LoadingResponsePlaceholder( this.props, response );
 		} else if ( response.error ) {
 			return ErrorResponsePlaceholder( this.props, response );
 		}
@@ -127,7 +127,7 @@ ServerSideRender.defaultProps = {
 			</Placeholder>
 		);
 	},
-	NullResponsePlaceholder: ( props ) => {
+	LoadingResponsePlaceholder: ( props ) => {
 		const { className } = props;
 		return (
 			<Placeholder

--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -83,14 +83,20 @@ export class ServerSideRender extends Component {
 
 	render() {
 		const response = this.state.response;
-		const { className, emptyResponsePlaceholder, errorResponsePlaceholder, loadingResponsePlaceholder } = this.props;
+		const { className, EmptyResponsePlaceholder, ErrorResponsePlaceholder, LoadingResponsePlaceholder } = this.props;
 
 		if ( response === '' ) {
-			return emptyResponsePlaceholder( this.props, response );
+			return (
+				<EmptyResponsePlaceholder response={ response } { ...this.props } />
+			);
 		} else if ( ! response ) {
-			return loadingResponsePlaceholder( this.props, response );
+			return (
+				<LoadingResponsePlaceholder response={ response } { ...this.props } />
+			);
 		} else if ( response.error ) {
-			return errorResponsePlaceholder( this.props, response );
+			return (
+				<ErrorResponsePlaceholder response={ response } { ...this.props } />
+			);
 		}
 
 		return (
@@ -105,20 +111,16 @@ export class ServerSideRender extends Component {
 }
 
 ServerSideRender.defaultProps = {
-	emptyResponsePlaceholder: ( props ) => {
-		const { className } = props;
-		return (
-			<Placeholder
-				className={ className }
-			>
-				{ __( 'Block rendered as empty.' ) }
-			</Placeholder>
-		);
-	},
-	errorResponsePlaceholder: ( props, response ) => {
+	EmptyResponsePlaceholder: ( { className } ) => (
+		<Placeholder
+			className={ className }
+		>
+			{ __( 'Block rendered as empty.' ) + className }
+		</Placeholder>
+	),
+	ErrorResponsePlaceholder: ( { response, className } ) => {
 		// translators: %s: error message describing the problem
 		const errorMessage = sprintf( __( 'Error loading block: %s' ), response.errorMsg );
-		const { className } = props;
 		return (
 			<Placeholder
 				className={ className }
@@ -127,8 +129,7 @@ ServerSideRender.defaultProps = {
 			</Placeholder>
 		);
 	},
-	loadingResponsePlaceholder: ( props ) => {
-		const { className } = props;
+	LoadingResponsePlaceholder: ( { className } ) => {
 		return (
 			<Placeholder
 				className={ className }

--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -83,9 +83,9 @@ export class ServerSideRender extends Component {
 
 	render() {
 		const response = this.state.response;
-		const { className } = this.props;
+		const { className, onEmptyResponse, onErrorResponse, onNullResponse } = this.props;
 		if ( response === '' ) {
-			return (
+			return !! onEmptyResponse ? onEmptyResponse( this ) : (
 				<Placeholder
 					className={ className }
 				>
@@ -93,7 +93,7 @@ export class ServerSideRender extends Component {
 				</Placeholder>
 			);
 		} else if ( ! response ) {
-			return (
+			return !! onNullResponse ? onNullResponse( this ) : (
 				<Placeholder
 					className={ className }
 				>
@@ -103,7 +103,7 @@ export class ServerSideRender extends Component {
 		} else if ( response.error ) {
 			// translators: %s: error message describing the problem
 			const errorMessage = sprintf( __( 'Error loading block: %s' ), response.errorMsg );
-			return (
+			return !! onErrorResponse ? onErrorResponse( this, errorMessage ) : (
 				<Placeholder
 					className={ className }
 				>

--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -59,7 +59,7 @@ export class ServerSideRender extends Component {
 		if ( null !== this.state.response ) {
 			this.setState( { response: null } );
 		}
-		const { block, attributes = null, urlQueryArgs = {}, fetchComplete } = props;
+		const { block, attributes = null, urlQueryArgs = {} } = props;
 
 		const path = rendererPath( block, attributes, urlQueryArgs );
 		// Store the latest fetch request so that when we process it, we can
@@ -77,9 +77,6 @@ export class ServerSideRender extends Component {
 						errorMsg: error.message,
 					} } );
 				}
-			} )
-			.finally( () => {
-				fetchComplete( this );
 			} );
 		return fetchRequest;
 	}
@@ -140,7 +137,6 @@ ServerSideRender.defaultProps = {
 			</Placeholder>
 		);
 	},
-	fetchComplete: () => {},
 };
 
 export default ServerSideRender;


### PR DESCRIPTION
## Description
Added 3 optional callbacks to the `ServerSideRender` component so that consumers can change what is displayed based on the result. These include:

- ~~`onEmptyResponse`~~ -> emptyResponsePlaceholder
- ~~`onErrorResponse`~~ -> errorResponsePlaceholder
- ~~`onNullResponse`~~ -> loadingResponsePlaceholder

## How has this been tested?
Testing this with my own code/callback function.

```jsx
<ServerSideRender block={ name } attributes={ attributes } emptyResponsePlaceholder={ this.emptyResponsePlaceholder } />
```

And my callback:

```
	emptyResponsePlaceholder() {
		return (
			<Placeholder
				icon="category"
				label={ __( 'Products by Category', 'woo-gutenberg-products-block' ) }
				className="wc-block-products-grid wc-block-products-category"
			>
				{ __( 'No products were found that matched your selection.', 'woo-gutenberg-products-block' ) }
			</Placeholder>
		);
	}
```

## Screenshots

The above example let's me render this when my block renderer returns empty content:

![Edit Post ‹ local wordpress test — WordPress 2019-07-10 16-27-25](https://user-images.githubusercontent.com/90977/60982246-a8a9c700-a32f-11e9-8ee7-11305c63b5f2.png)

The default state is left alone if you don't pass a callback:

![Edit Post ‹ local wordpress test — WordPress 2019-07-10 16-29-16](https://user-images.githubusercontent.com/90977/60982373-e870ae80-a32f-11e9-98f8-aed8d31e77ea.png)

## Types of changes
This adds some non-required props to `<ServerSideRender>` so it shouldn't impact existing code.

## Checklist:
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
