### PR TITLE
Blocks: Include pre-filter settings in block type registration deprecation filter applications.

### DIFF
--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -1,0 +1,7 @@
+export const DEPRECATED_ENTRY_KEYS = [
+	'attributes',
+	'supports',
+	'save',
+	'migrate',
+	'isEligible',
+];

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -1,3 +1,8 @@
+/**
+ * Array of valid keys in a block type settings deprecation object.
+ *
+ * @type {string[]}
+ */
 export const DEPRECATED_ENTRY_KEYS = [
 	'attributes',
 	'supports',

--- a/packages/blocks/src/api/parser.js
+++ b/packages/blocks/src/api/parser.js
@@ -24,6 +24,7 @@ import { isValidBlockContent } from './validation';
 import { getCommentDelimitedContent } from './serializer';
 import { attr, html, text, query, node, children, prop } from './matchers';
 import { normalizeBlockType } from './utils';
+import { DEPRECATED_ENTRY_KEYS } from './constants';
 
 /**
  * Sources which are guaranteed to return a string value.
@@ -324,7 +325,7 @@ export function getMigratedBlock( block, parsedAttributes ) {
 		// parsing are not considered in the deprecated block type by default,
 		// and must be explicitly provided.
 		const deprecatedBlockType = Object.assign(
-			omit( blockType, [ 'attributes', 'save', 'supports' ] ),
+			omit( blockType, DEPRECATED_ENTRY_KEYS ),
 			deprecatedDefinitions[ i ]
 		);
 

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -143,7 +143,7 @@ export function registerBlockType( name, settings ) {
 		return;
 	}
 
-	const preFilterSettings = settings;
+	const preFilterSettings = { ...settings };
 	settings = applyFilters( 'blocks.registerBlockType', settings, name );
 
 	if ( settings.deprecated ) {

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -84,14 +84,14 @@ import { DEPRECATED_ENTRY_KEYS } from './constants';
  *
  * @type {Object}
  */
-const DEFAULT_BLOCK_TYPE_SETTINGS = {
+export const DEFAULT_BLOCK_TYPE_SETTINGS = {
 	icon: 'block-default',
 	attributes: {},
 	keywords: [],
 	save: () => null,
 };
 
-let serverSideBlockDefinitions = {};
+export let serverSideBlockDefinitions = {};
 
 /**
  * Sets the server side block definition of blocks.

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -5,6 +5,8 @@
  */
 import {
 	get,
+	omit,
+	pick,
 	isFunction,
 	isPlainObject,
 	some,
@@ -20,6 +22,7 @@ import { select, dispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import { isValidIcon, normalizeIconObject } from './utils';
+import { DEPRECATED_ENTRY_KEYS } from './constants';
 
 /**
  * Render behavior of a block type icon; one of a Dashicon slug, an element,
@@ -140,10 +143,23 @@ export function registerBlockType( name, settings ) {
 		return;
 	}
 
+	const preFilterSettings = settings;
 	settings = applyFilters( 'blocks.registerBlockType', settings, name );
 
 	if ( settings.deprecated ) {
-		settings.deprecated = settings.deprecated.map( ( deprecation ) => applyFilters( 'blocks.registerBlockType', deprecation, name ) );
+		settings.deprecated = settings.deprecated.map( ( deprecation ) =>
+			pick(
+				applyFilters(
+					'blocks.registerBlockType',
+					{
+						...omit( preFilterSettings, DEPRECATED_ENTRY_KEYS ),
+						...deprecation,
+					},
+					name
+				),
+				DEPRECATED_ENTRY_KEYS
+			)
+		);
 	}
 
 	if ( ! isPlainObject( settings ) ) {

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -148,10 +148,15 @@ export function registerBlockType( name, settings ) {
 
 	if ( settings.deprecated ) {
 		settings.deprecated = settings.deprecated.map( ( deprecation ) =>
-			pick(
+			pick( // Only keep valid deprecation keys.
 				applyFilters(
 					'blocks.registerBlockType',
+					// Merge deprecation keys with pre-filter settings
+					// so that filters that depend on specific keys being
+					// present don't fail.
 					{
+						// Omit deprecation keys here so that deprecations
+						// can opt out of specific keys like "supports".
 						...omit( preFilterSettings, DEPRECATED_ENTRY_KEYS ),
 						...deprecation,
 					},

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { noop, omit, pick } from 'lodash';
+import { noop, get, omit, pick } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -29,7 +29,9 @@ import {
 	getBlockSupport,
 	hasBlockSupport,
 	isReusableBlock,
+	serverSideBlockDefinitions,
 	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase
+	DEFAULT_BLOCK_TYPE_SETTINGS,
 } from '../registration';
 import { DEPRECATED_ENTRY_KEYS } from '../constants';
 
@@ -397,8 +399,15 @@ describe( 'blocks', () => {
 					// settings with deprecation keys omitted and the deprecation entry.
 					if ( i > 0 ) {
 						expect( settings ).toEqual( {
-							name,
-							...omit( blockSettingsWithDeprecations, DEPRECATED_ENTRY_KEYS ),
+							...omit(
+								{
+									name,
+									...DEFAULT_BLOCK_TYPE_SETTINGS,
+									...get( serverSideBlockDefinitions, name ),
+									...blockSettingsWithDeprecations,
+								},
+								DEPRECATED_ENTRY_KEYS
+							),
 							...blockSettingsWithDeprecations.deprecated[ i - 1 ],
 						} );
 					}

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
+import { noop, omit, pick } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -31,6 +31,7 @@ import {
 	isReusableBlock,
 	unstable__bootstrapServerSideBlockDefinitions, // eslint-disable-line camelcase
 } from '../registration';
+import { DEPRECATED_ENTRY_KEYS } from '../constants';
 
 describe( 'blocks', () => {
 	const defaultBlockSettings = { save: noop, category: 'common', title: 'block title' };
@@ -373,6 +374,7 @@ describe( 'blocks', () => {
 			} );
 
 			it( 'should apply the blocks.registerBlockType filter to each of the deprecated settings as well as the main block settings', () => {
+				const name = 'my-plugin/fancy-block-13';
 				const blockSettingsWithDeprecations = {
 					...defaultBlockSettings,
 					deprecated: [
@@ -389,7 +391,19 @@ describe( 'blocks', () => {
 					],
 				};
 
+				let i = 0;
 				addFilter( 'blocks.registerBlockType', 'core/blocks/without-title', ( settings ) => {
+					// Verify that for deprecations, the filter is called with a merge of pre-filter
+					// settings with deprecation keys omitted and the deprecation entry.
+					if ( i > 0 ) {
+						expect( settings ).toEqual( {
+							name,
+							...omit( blockSettingsWithDeprecations, DEPRECATED_ENTRY_KEYS ),
+							...blockSettingsWithDeprecations.deprecated[ i - 1 ],
+						} );
+					}
+					i++;
+
 					return {
 						...settings,
 						attributes: {
@@ -401,11 +415,14 @@ describe( 'blocks', () => {
 					};
 				} );
 
-				const block = registerBlockType( 'my-plugin/fancy-block-13', blockSettingsWithDeprecations );
+				const block = registerBlockType( name, blockSettingsWithDeprecations );
 
 				expect( block.attributes.id ).toEqual( { type: 'string' } );
-				expect( block.deprecated[ 0 ].attributes.id ).toEqual( { type: 'string' } );
-				expect( block.deprecated[ 1 ].attributes.id ).toEqual( { type: 'string' } );
+				block.deprecated.forEach( ( deprecation ) => {
+					expect( deprecation.attributes.id ).toEqual( { type: 'string' } );
+					// Verify that the deprecation's keys are a subset of deprecation keys.
+					expect( deprecation ).toEqual( pick( deprecation, DEPRECATED_ENTRY_KEYS ) );
+				} );
 			} );
 		} );
 	} );


### PR DESCRIPTION
Fixes https://meta.trac.wordpress.org/ticket/4597

## Description

PR #16348 created errors for plugins that have block type registration filters in which they expect properties not present in a deprecation entry.

A specific example of this is:

https://github.com/Automattic/jetpack/blob/4c63a49fc0139c3296248e09ee69dedb537e024f/extensions/blocks/videopress/editor

Which expects `settings.edit` to exist and throws an error that hangs the editor on a white screen.

## How has this been tested?

Tests for the new functionality were added in the block type registration tests.

Test suites were ran and they all passed.

## Types of Changes

*Bug Fix:* Include pre-filter settings in block type registration deprecation filter applications to avoid uncaught errors. 

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
- [x] I've included developer documentation if appropriate.
