### PR TITLE
[RNMobile] Native mobile release v1.9.0

### DIFF
--- a/packages/block-library/src/video/edit.native.js
+++ b/packages/block-library/src/video/edit.native.js
@@ -238,6 +238,7 @@ class VideoEdit extends React.Component {
 								value={ caption }
 								placeholder={ __( 'Write caption…' ) }
 								onChangeText={ ( newCaption ) => setAttributes( { caption: newCaption } ) }
+								onFocus={ this.props.onFocus }
 							/>
 						</View>
 					) }

--- a/packages/edit-post/src/index.native.js
+++ b/packages/edit-post/src/index.native.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { Platform } from 'react-native';
-
-/**
  * WordPress dependencies
  */
 import '@wordpress/core-data';
@@ -36,11 +31,6 @@ export function initializeEditor() {
 	// eslint-disable-next-line no-undef
 	if ( typeof __DEV__ === 'undefined' || ! __DEV__ ) {
 		unregisterBlockType( 'core/code' );
-
-		// Disable Video block except for iOS for now.
-		if ( Platform.OS !== 'ios' ) {
-			unregisterBlockType( 'core/video' );
-		}
 	}
 
 	blocksRegistered = true;


### PR DESCRIPTION
## Description
This PR tracks the release v1.9.0 of the native mobile app.

## How has this been tested?
Using this gutenberg-mobile side PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1216

## Types of changes
1. Enable the video block for android

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->
