### PR TITLE
Docs: Add title attribute to PluginDocumentSettingPanel example

### DIFF
--- a/packages/edit-post/README.md
+++ b/packages/edit-post/README.md
@@ -118,6 +118,7 @@ function MyDocumentSettingPlugin() {
 		PluginDocumentSettingPanel,
 		{
 			className: 'my-document-setting-plugin',
+			title: 'My Panel',
 		},
 		__( 'My Document Setting Panel' )
 	);
@@ -134,7 +135,7 @@ const { registerPlugin } = wp.plugins;
 const { PluginDocumentSettingPanel } = wp.editPost;
 
 const MyDocumentSettingTest = () => (
-		<PluginDocumentSettingPanel className="my-document-setting-plugin">
+		<PluginDocumentSettingPanel className="my-document-setting-plugin" title="My Panel">
 		<p>My Document Setting Panel</p>
 	</PluginDocumentSettingPanel>
 );

--- a/packages/edit-post/src/components/sidebar/plugin-document-setting-panel/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-document-setting-panel/index.js
@@ -53,6 +53,7 @@ const PluginDocumentSettingFill = ( { isEnabled, opened, onToggle, className, ti
  * 		PluginDocumentSettingPanel,
  * 		{
  * 			className: 'my-document-setting-plugin',
+ * 			title: 'My Panel',
  * 		},
  * 		__( 'My Document Setting Panel' )
  * 	);
@@ -70,7 +71,7 @@ const PluginDocumentSettingFill = ( { isEnabled, opened, onToggle, className, ti
  * const { PluginDocumentSettingPanel } = wp.editPost;
  *
  * const MyDocumentSettingTest = () => (
- * 		<PluginDocumentSettingPanel className="my-document-setting-plugin">
+ * 		<PluginDocumentSettingPanel className="my-document-setting-plugin" title="My Panel">
  *			<p>My Document Setting Panel</p>
  *		</PluginDocumentSettingPanel>
  *	);


### PR DESCRIPTION
## Description
Adds title attributes to the new `PluginDocumentSettingPanel` [examples](https://developer.wordpress.org/block-editor/packages/packages-edit-post/#PluginDocumentSettingPanel. ): 
If we don't have a title the panel is not visible.

Before:
![before](https://user-images.githubusercontent.com/695201/61039565-499b8f00-a3cf-11e9-8664-f3dedad41767.png)

After:
![after](https://user-images.githubusercontent.com/695201/61039567-499b8f00-a3cf-11e9-8a46-f17b258a922a.png)
