### PR TITLE
Fix issue where the toolbar can be hidden for the block after a wide aligned image

### DIFF
--- a/packages/block-editor/src/components/block-list/moving-animation.js
+++ b/packages/block-editor/src/components/block-list/moving-animation.js
@@ -43,7 +43,9 @@ function useMovingAnimation( ref, isSelected, enableAnimation, triggerAnimationO
 			x: previous ? previous.left - destination.left : 0,
 			y: previous ? previous.top - destination.top : 0,
 		};
-		ref.current.style.transform = `translate3d(${ newTransform.x }px,${ newTransform.y }px,0)`;
+		ref.current.style.transform = newTransform.x === 0 && newTransform.y === 0 ?
+			undefined :
+			`translate3d(${ newTransform.x }px,${ newTransform.y }px,0)`;
 		setResetAnimation( true );
 		setTransform( newTransform );
 	}, [ triggerAnimationOnChange ] );


### PR DESCRIPTION
closes #16519

**Testing instructions**

 - Insert a full aligned image
 - Insert a paragraph after the image
 - The paragraph's toolbar should not be cropped.