### PR TITLE
Document the disabled prop for Button

### DIFF
--- a/packages/components/src/button/README.md
+++ b/packages/components/src/button/README.md
@@ -122,6 +122,8 @@ const MyButton = () => (
 
 The presence of a `href` prop determines whether an `anchor` element is rendered instead of a `button`.
 
+Props not included in this set will be applied to the `a` or `button` element.
+
 Name | Type | Default | Description
 --- | --- | --- | ---
 `disabled` | `bool` | `false` | Whether the button is disabled. If `true`, this will force a `button` element to be rendered.

--- a/packages/components/src/button/README.md
+++ b/packages/components/src/button/README.md
@@ -124,6 +124,7 @@ The presence of a `href` prop determines whether an `anchor` element is rendered
 
 Name | Type | Default | Description
 --- | --- | --- | ---
+`disabled` | `bool` | `false` | Whether the button is disabled.
 `href` | `string` | `undefined` | If provided, renders `a` instead of `button`.
 `isDefault` | `bool` | `false` | Renders a default button style.
 `isPrimary` | `bool` | `false` | Renders a primary button style.

--- a/packages/components/src/button/README.md
+++ b/packages/components/src/button/README.md
@@ -124,7 +124,7 @@ The presence of a `href` prop determines whether an `anchor` element is rendered
 
 Name | Type | Default | Description
 --- | --- | --- | ---
-`disabled` | `bool` | `false` | Whether the button is disabled.
+`disabled` | `bool` | `false` | Whether the button is disabled. If `true`, this will force a `button` element to be rendered.
 `href` | `string` | `undefined` | If provided, renders `a` instead of `button`.
 `isDefault` | `bool` | `false` | Renders a default button style.
 `isPrimary` | `bool` | `false` | Renders a primary button style.


### PR DESCRIPTION
I noticed `Button` is missing documentation for the `disabled` prop, which is actually supported.