### PR TITLE
Add option for themes to configure block styles

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -677,3 +677,22 @@ function gutenberg_extend_block_editor_preload_paths( $preload_paths, $post ) {
 	return $preload_paths;
 }
 add_filter( 'block_editor_preload_paths', 'gutenberg_extend_block_editor_preload_paths', 10, 2 );
+
+
+/**
+ * Extends block editor settings to include themeAutoApplyStyles.
+ * This option allows themes to set the default style applied in a block.
+ *
+ * @param array $settings Default editor settings.
+ *
+ * @return array Filtered editor settings.
+ */
+function gutenberg_add_auto_apply_block_styles_setting( $settings ) {
+	$auto_apply_styles = current( (array) get_theme_support( 'editor-default-block-styles' ) );
+	if ( false !== $auto_apply_styles ) {
+		$settings['themeAutoApplyStyles'] = $auto_apply_styles;
+	}
+	return $settings;
+}
+
+add_filter( 'block_editor_settings', 'gutenberg_add_auto_apply_block_styles_setting' );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -680,19 +680,19 @@ add_filter( 'block_editor_preload_paths', 'gutenberg_extend_block_editor_preload
 
 
 /**
- * Extends block editor settings to include themeAutoApplyStyles.
+ * Extends block editor settings to include __experimentalPreferredBlockStyles.
  * This option allows themes to set the default style applied in a block.
  *
  * @param array $settings Default editor settings.
  *
  * @return array Filtered editor settings.
  */
-function gutenberg_add_auto_apply_block_styles_setting( $settings ) {
-	$auto_apply_styles = current( (array) get_theme_support( 'editor-default-block-styles' ) );
-	if ( false !== $auto_apply_styles ) {
-		$settings['themeAutoApplyStyles'] = $auto_apply_styles;
+function gutenberg_add_preferred_block_styles_setting( $settings ) {
+	$preferred_block_styles = current( (array) get_theme_support( 'editor-preferred-block-styles' ) );
+	if ( false !== $preferred_block_styles ) {
+		$settings['__experimentalPreferredBlockStyles'] = $preferred_block_styles;
 	}
 	return $settings;
 }
 
-add_filter( 'block_editor_settings', 'gutenberg_add_auto_apply_block_styles_setting' );
+add_filter( 'block_editor_settings', 'gutenberg_add_preferred_block_styles_setting' );

--- a/packages/block-editor/src/components/default-style-picker/index.js
+++ b/packages/block-editor/src/components/default-style-picker/index.js
@@ -36,10 +36,7 @@ export default function DefaultStylePicker( { blockName } ) {
 		[ blockName ]
 	);
 	const selectOptions = useMemo(
-		() => ( [
-			{ label: __( 'Not set' ), value: '' },
-			...styles.map( ( { label, name } ) => ( { label, value: name } ) ),
-		] ),
+		() => styles.map( ( { label, name } ) => ( { label, value: name } ) ),
 		[ styles ],
 	);
 	const selectOnChange = useCallback(

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -49,7 +49,7 @@ class Editor extends Component {
 			...settings,
 			__experimentalPreferredStyleVariations: {
 				value: {
-					...( settings.themeAutoApplyStyles || {} ),
+					...( settings.__experimentalPreferredBlockStyles || {} ),
 					...preferredStyleVariations,
 				},
 				onChange: updatePreferredStyleVariations,

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -48,7 +48,10 @@ class Editor extends Component {
 		settings = {
 			...settings,
 			__experimentalPreferredStyleVariations: {
-				value: preferredStyleVariations,
+				value: {
+					...( settings.themeAutoApplyStyles || {} ),
+					...preferredStyleVariations,
+				},
 				onChange: updatePreferredStyleVariations,
 			},
 			hasFixedToolbar,


### PR DESCRIPTION
## Description
Depends on: https://github.com/WordPress/gutenberg/pull/16465

This PR extends the work done in https://github.com/WordPress/gutenberg/pull/16465 . to allow themes to set the default styles applied to a block.

## How has this been tested?
I went to functions.php of the currently enabled theme.
I pasted the following code:
```
function setup_default_block_styles() {
	add_theme_support(
		'editor-default-block-styless',
		array(
			'core/quote'     => 'large',
			'core/pullquote' => 'solid-color',
		)
	);
}

add_action( 'after_setup_theme', 'setup_default_block_styles' );
```
I created a new quote and a new pullquote I verified the default styles were large and solid color respectively.
