### PR TITLE
[RNMobile] Show "add block here" placeholder when adding block from title

### DIFF
--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -226,11 +226,12 @@ export class BlockList extends Component {
 		return isUnmodifiedDefaultBlock( block );
 	}
 
-	renderItem( { item: clientId } ) {
-		const shouldReverseContent = this.isReplaceable( this.props.selectedBlock );
+	renderItem( { item: clientId, index } ) {
+		const shouldShowAddBlockSeparator = this.state.blockTypePickerVisible && ( this.props.isBlockSelected( clientId ) || ( index === 0 && this.props.isPostTitleSelected ) );
+		const shouldPutAddBlockSeparatorAboveBlock = this.isReplaceable( this.props.selectedBlock ) || this.props.isPostTitleSelected;
 
 		return (
-			<ReadableContentView reversed={ shouldReverseContent }>
+			<ReadableContentView reversed={ shouldPutAddBlockSeparatorAboveBlock }>
 				<BlockListBlock
 					key={ clientId }
 					showTitle={ false }
@@ -240,7 +241,7 @@ export class BlockList extends Component {
 					borderStyle={ this.blockHolderBorderStyle() }
 					focusedBorderColor={ styles.blockHolderFocused.borderColor }
 				/>
-				{ this.state.blockTypePickerVisible && this.props.isBlockSelected( clientId ) && this.renderAddBlockSeparator() }
+				{ shouldShowAddBlockSeparator && this.renderAddBlockSeparator() }
 			</ReadableContentView>
 		);
 	}


### PR DESCRIPTION
## Description
Fixes issue where the "add block here" indicator was not shown if the new block was being added while the post's title is selected.

## How has this been tested?
See [related mobile-gutenberg PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1219)

## Types of changes
Non-breaking change to fix a bug.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
