### PR TITLE
Edit Widgets: Don't run Customizer setup on every preview refresh.

### DIFF
--- a/packages/edit-widgets/src/components/customizer-edit-widgets-initializer/sync-customizer.js
+++ b/packages/edit-widgets/src/components/customizer-edit-widgets-initializer/sync-customizer.js
@@ -78,9 +78,19 @@ const updateSettingInputValue = throttle( ( nextWidgetAreas ) => {
 
 // Check that all the necessary globals are present.
 if ( window.wp && window.wp.customize && window.wp.data ) {
+	let ran = false;
 	// Wait for the Customizer to finish bootstrapping.
 	window.wp.customize.bind( 'ready', () =>
 		window.wp.customize.previewer.bind( 'ready', () => {
+			// The Customizer will call this on every preview refresh,
+			// but we only want to run it once to avoid running another
+			// store setup that would set changeset edits and save
+			// widget blocks unintentionally.
+			if ( ran ) {
+				return;
+			}
+			ran = true;
+
 			// Try to parse a previous changeset from the hidden input.
 			let widgetAreas;
 			try {


### PR DESCRIPTION
cc @jorgefilipecosta 

Fixes #16538 

## Description

The Customizer runs the `preview-ready` event that was being used to sync the store with Changeset data on every preview refresh. This meant that changing any setting that triggered a refresh would convert all sidebars to block widget areas, because on subsequent calls, the handler would see the newly loaded data as different and add it to the widget blocks Changeset entry.

This was an issue because block widget areas break legacy widget editing when Gutenberg is disabled and the conversion to widget blocks here was not explicit.

## How has this been tested?

The steps in #16538 were followed and everything worked as expected.

## Types of Changes

*Bug Fix:* Don't run Customizer setup on every preview refresh to avoid implicitly saving sidebars as block widget areas.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
- [x] I've included developer documentation if appropriate.
