### PR TITLE
Try improving and standardizing the block styles focus + active states

### DIFF
--- a/assets/stylesheets/_mixins.scss
+++ b/assets/stylesheets/_mixins.scss
@@ -238,13 +238,31 @@
 	color: $dark-gray-900;
 }
 
-@mixin block-style__focus-active() {
+@mixin block-style__focus() {
 	color: $dark-gray-900;
-	box-shadow: 0 0 0 2px $blue-medium-500;
+	box-shadow: 0 0 0 1px $white, 0 0 0 3px $blue-medium-500;
 
 	// Windows High Contrast mode will show this outline, but not the box-shadow.
 	outline: 2px solid transparent;
 	outline-offset: -2px;
+}
+
+@mixin block-style__is-active() {
+	color: $dark-gray-900;
+	box-shadow: inset 0 0 0 2px $dark-gray-500;
+
+	// Windows High Contrast mode will show this outline, but not the box-shadow.
+	outline: 2px solid transparent;
+	outline-offset: -2px;
+}
+
+@mixin block-style__is-active-focus() {
+	color: $dark-gray-900;
+	box-shadow: 0 0 0 1px $white, 0 0 0 3px $blue-medium-500, inset 0 0 0 2px $dark-gray-500;
+
+	// Windows High Contrast mode will show this outline, but not the box-shadow.
+	outline: 4px solid transparent;
+	outline-offset: -4px;
 }
 
 /**

--- a/packages/block-editor/src/components/block-styles/style.scss
+++ b/packages/block-editor/src/components/block-styles/style.scss
@@ -11,19 +11,22 @@
 	cursor: pointer;
 	overflow: hidden;
 	border-radius: $radius-round-rectangle;
-	padding: $grid-size-small;
-
-	&.is-active {
-		@include block-style__focus-active();
-		box-shadow: 0 0 0 2px $dark-gray-500;
-	}
+	padding: $grid-size-small * 1.5;
 
 	&:focus {
-		@include block-style__focus-active();
+		@include block-style__focus();
 	}
 
 	&:hover {
 		@include block-style__hover;
+	}
+
+	&.is-active {
+		@include block-style__is-active();
+
+		&:focus {
+			@include block-style__is-active-focus();
+		}
 	}
 }
 

--- a/packages/block-editor/src/components/block-types-list/style.scss
+++ b/packages/block-editor/src/components/block-types-list/style.scss
@@ -1,6 +1,6 @@
 .block-editor-block-types-list {
 	list-style: none;
-	padding: 2px 0;
+	padding: 4px 0;
 	overflow: hidden;
 	display: flex;
 	flex-wrap: wrap;

--- a/packages/block-editor/src/components/inserter-list-item/style.scss
+++ b/packages/block-editor/src/components/inserter-list-item/style.scss
@@ -51,17 +51,24 @@
 		}
 
 		&:active,
-		&.is-active,
 		&:focus {
 			position: relative;
 
 			// Show the focus style in the icon inside instead.
 			outline: none;
-			@include block-style__focus-active();
+			@include block-style__focus();
 
 			.block-editor-block-types-list__item-icon,
 			.block-editor-block-types-list__item-title {
 				color: inherit;
+			}
+		}
+
+		&.is-active {
+			@include block-style__is-active();
+
+			&:focus {
+				@include block-style__is-active-focus();
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #15906. 

This PR adopts the proposal in https://github.com/WordPress/gutenberg/issues/15906#issuecomment-508129512 to make the focus state for the block styles buttons more accessible. With this change, the `is-active` and `:focus` states are differentiated by both size and color. The PR also rolls this change out to the `inserter-list-item` component, so that both are in sync. This may come in handy later on for #16283. 

The change in a few words: 

- The `is-active` gray border is moved _inside_ the active element. Minor padding adjustments are made to accommodate it.
- The `:focus` border is moved to the outside of the active element, and given a 1px white buffer zone, similar to our [Button block focus style](https://cloudup.com/cXG-6b5b1Fh). 

## Screenshots

**Before**

_Focus, `is-active`_:
<img width="298" alt="Screen Shot 2019-07-11 at 12 29 26 PM" src="https://user-images.githubusercontent.com/1202812/61069082-89677400-a3d9-11e9-9433-f44e961287fd.png">

_Focus and `is-active`_:
<img width="156" alt="Screen Shot 2019-07-11 at 12 31 39 PM" src="https://user-images.githubusercontent.com/1202812/61069031-70f75980-a3d9-11e9-9cb0-bd67adcdc07f.png">

**After**

_Focus, `is-active`_:
<img width="297" alt="Screen Shot 2019-07-11 at 12 30 50 PM" src="https://user-images.githubusercontent.com/1202812/61069094-8e2c2800-a3d9-11e9-87d3-20bb13d507fb.png">

_Focus and `is-active`_:
<img width="158" alt="Screen Shot 2019-07-11 at 12 31 09 PM" src="https://user-images.githubusercontent.com/1202812/61069026-6e94ff80-a3d9-11e9-86f1-e53dbf70bc6d.png">

## GIFs

**Before**

![focus-states-old](https://user-images.githubusercontent.com/1202812/61069132-a439e880-a3d9-11e9-85db-a55965a7e3c6.gif)

**After**

![focus-states-new](https://user-images.githubusercontent.com/1202812/61069139-a734d900-a3d9-11e9-9d59-1ca4b7941022.gif)
