### PR TITLE
Build Tooling: Avoid Docker container automatic restart

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
 
   wordpress:
     image: wordpress
-    restart: always
     ports:
       - 8888:80
     environment:
@@ -24,7 +23,6 @@ services:
 
   cli:
     image: wordpress:cli
-    restart: always
     user: xfs
     volumes:
       - wordpress_data:/var/www/html
@@ -35,14 +33,12 @@ services:
 
   mysql:
     image: mysql:5.7
-    restart: always
     environment:
       MYSQL_ROOT_PASSWORD: example
       MYSQL_DATABASE: wordpress_test
 
   wordpress_phpunit:
     image: chriszarate/wordpress-phpunit
-    restart: always
     environment:
       PHPUNIT_DB_HOST: mysql
     volumes:
@@ -53,13 +49,11 @@ services:
 
   composer:
     image: composer
-    restart: always
     volumes:
       - .:/app
 
   wordpress_e2e_tests:
     image: wordpress
-    restart: always
     ports:
       - 8889:80
     environment:
@@ -80,7 +74,6 @@ services:
 
   cli_e2e_tests:
     image: wordpress:cli
-    restart: always
     user: xfs
     volumes:
       - wordpress_e2e_tests_data:/var/www/html


### PR DESCRIPTION
Previously: #14638

This pull request seeks to remove `restart: always` configurations from all container configurations in `docker-compose.yml`. Specifically, the `wordpress:cli` and `composer` containers are not typically intended to be "kept up" and are instead mostly used for one-off commands. The `restart` directive will cause the containers to restart infinitely. While there may potentially be some benefit in keeping this configuration for other containers, I'm not convinced it's necessary, and it may be more worthwhile for unexpected halts to be surfaced more prominently than to be restarted automatically.

**Testing Instructions:**

1. `docker-compose stop && docker-compose up -d`
2. Verify that when executing `docker container ls`, you do not see any containers with a status "Restarting".