### PR TITLE
Visible focus and active styles for Windows high contrast mode

### DIFF
--- a/assets/stylesheets/_mixins.scss
+++ b/assets/stylesheets/_mixins.scss
@@ -143,7 +143,6 @@
 
 	// Windows High Contrast mode will show this outline, but not the box-shadow.
 	outline: 2px solid transparent;
-	outline-offset: -2px;
 }
 
 // Switch.
@@ -173,7 +172,6 @@
 
 	// Windows High Contrast mode will show this outline, but not the box-shadow.
 	outline: 2px solid transparent;
-	outline-offset: -2px;
 }
 
 // Tabs, Inputs, Square buttons.
@@ -192,7 +190,6 @@
 
 	// Windows High Contrast mode will show this outline, but not the box-shadow.
 	outline: 2px solid transparent;
-	outline-offset: -2px;
 }
 
 // Square buttons.
@@ -244,7 +241,6 @@
 
 	// Windows High Contrast mode will show this outline, but not the box-shadow.
 	outline: 2px solid transparent;
-	outline-offset: -2px;
 }
 
 @mixin block-style__is-active() {

--- a/packages/block-editor/src/components/inserter-list-item/style.scss
+++ b/packages/block-editor/src/components/inserter-list-item/style.scss
@@ -53,7 +53,7 @@
 		&:active,
 		&:focus {
 			position: relative;
-			@include block-style__focus-active();
+			@include block-style__focus();
 
 			.block-editor-block-types-list__item-icon,
 			.block-editor-block-types-list__item-title {

--- a/packages/block-editor/src/components/inserter-list-item/style.scss
+++ b/packages/block-editor/src/components/inserter-list-item/style.scss
@@ -53,10 +53,7 @@
 		&:active,
 		&:focus {
 			position: relative;
-
-			// Show the focus style in the icon inside instead.
-			outline: none;
-			@include block-style__focus();
+			@include block-style__focus-active();
 
 			.block-editor-block-types-list__item-icon,
 			.block-editor-block-types-list__item-title {

--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -61,12 +61,14 @@ $color-palette-circle-spacing: 14px;
 	&::after {
 		content: "";
 		position: absolute;
-		top: 0;
-		left: 0;
-		bottom: 0;
-		right: 0;
+		top: -1px;
+		left: -1px;
+		bottom: -1px;
+		right: -1px;
 		border-radius: $radius-round;
 		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+		// Show a thin circular outline in Windows high contrast mode, otherwise the button is invisible.
+		border: 1px solid transparent;
 	}
 
 	&:focus {

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -67,8 +67,7 @@
 		top: 20px;
 
 		&:focus {
-			border-color: $blue-medium-focus;
-			box-shadow: 0 0 0 1px $blue-medium-focus;
+			@include input-style__focus();
 		}
 	}
 

--- a/packages/components/src/toolbar-button/style.scss
+++ b/packages/components/src/toolbar-button/style.scss
@@ -69,6 +69,18 @@
 	// Focus style
 	&:not(:disabled):focus > svg {
 		@include formatting-button-style__focus;
+		// Remove outline from SVG to apply on focused element - see below.
+		outline: 0;
+	}
+
+	// Microsoft Edge in high contrast mode only displays outlines on focused elements, not their children.
+	&:not(:disabled).is-active {
+		outline: 1px dotted transparent;
+		outline-offset: -2px;
+	}
+	// Microsoft Edge in high contrast mode only displays outlines on focused elements, not their children.
+	&:not(:disabled):focus {
+		outline: 2px solid transparent;
 	}
 }
 


### PR DESCRIPTION
## Description

Removed the negative `outline-offset`s that were making outlines hard to see;
Added focus outline for calendar buttons (the ones for navigating from month to month);
Added thin outline for color picker buttons to be visible;
Added thin dotted outlines for active states in toolbar. (Would appreciate design input on this - settled for dotted because a thin solid outline was hard to tell apart from the toolbar outline itself - see attached screenshots.)

## How has this been tested?

Tested locally on Windows 10 set to high contrast mode, with Edge, IE and Firefox.
Used keyboard to tab through several blocks as well as the Block and Document sections of the sidebar.

## Screenshots <!-- if applicable -->

![color_settings_hc](https://user-images.githubusercontent.com/8096000/61094246-b2e3d680-a491-11e9-90e9-f8da38fccaac.png)

Toolbar on Edge:

![toolbar_Edge](https://user-images.githubusercontent.com/8096000/61094256-c131f280-a491-11e9-8dcc-0a752eb0a5b5.png)

Toolbar on Firefox:

![toolbar_Firefox](https://user-images.githubusercontent.com/8096000/61094264-ca22c400-a491-11e9-8560-2a8bddd4c7fc.png)

Toolbar on IE:

![toolbar_IE](https://user-images.githubusercontent.com/8096000/61094270-d0b13b80-a491-11e9-8ad1-98cf41446821.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
