### PR TITLE
Fix focusing on video block

### DIFF
--- a/packages/block-library/src/video/edit.native.js
+++ b/packages/block-library/src/video/edit.native.js
@@ -238,6 +238,7 @@ class VideoEdit extends React.Component {
 								value={ caption }
 								placeholder={ __( 'Write caption…' ) }
 								onChangeText={ ( newCaption ) => setAttributes( { caption: newCaption } ) }
+								onFocus={ this.props.onFocus }
 							/>
 						</View>
 					) }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1220

## Description
The bug was a focus issue, making sure we call onFocus when the video block caption is focused fixes it.

## Testing Instructions
Boot the demo app, edit a video block caption, switch to a richtext component in another block, switch back to the video block caption, you should not see rich text formatting options in the toolbar

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
