### PR TITLE
chore: Remove duplicate switch cases in packages/block-editor/src/store/reducer.js

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -587,6 +587,7 @@ export const blocks = flow(
 				return getFlattenedBlocksWithoutAttributes( action.blocks );
 
 			case 'RECEIVE_BLOCKS':
+			case 'INSERT_BLOCKS':
 				return {
 					...state,
 					...getFlattenedBlocksWithoutAttributes( action.blocks ),
@@ -612,12 +613,6 @@ export const blocks = flow(
 					},
 				};
 
-			case 'INSERT_BLOCKS':
-				return {
-					...state,
-					...getFlattenedBlocksWithoutAttributes( action.blocks ),
-				};
-
 			case 'REPLACE_BLOCKS_AUGMENTED_WITH_CHILDREN':
 				if ( ! action.blocks ) {
 					return state;
@@ -641,6 +636,7 @@ export const blocks = flow(
 				return getFlattenedBlockAttributes( action.blocks );
 
 			case 'RECEIVE_BLOCKS':
+			case 'INSERT_BLOCKS':
 				return {
 					...state,
 					...getFlattenedBlockAttributes( action.blocks ),
@@ -686,12 +682,6 @@ export const blocks = flow(
 				return {
 					...state,
 					[ action.clientId ]: nextAttributes,
-				};
-
-			case 'INSERT_BLOCKS':
-				return {
-					...state,
-					...getFlattenedBlockAttributes( action.blocks ),
 				};
 
 			case 'REPLACE_BLOCKS_AUGMENTED_WITH_CHILDREN':


### PR DESCRIPTION
I noticed while navigating the code, that the code to handle RECEIVE_BLOCKS and INSERT_BLOCKS was the same, so this PR's just collapses the switch cases.



## How has this been tested?
Verified the automated tests pass.
Did smoke tests to block insertion.
