### PR TITLE
Framework: Bump Lodash dependencies to 4.17.14

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -439,6 +439,13 @@ function gutenberg_register_vendor_scripts() {
 		'https://unpkg.com/react-dom@16.8.4/umd/react-dom' . $react_suffix . '.js',
 		array( 'react' )
 	);
+
+	// TODO: This is necessarily only so long as core ships with v4.17.11, and
+	// can be removed at such time a newer version is available.
+	gutenberg_register_vendor_script(
+		'lodash',
+		'https://unpkg.com/lodash@4.17.14/lodash' . $suffix . '.js'
+	);
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -3669,7 +3669,7 @@
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/rich-text": "file:packages/rich-text",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.14",
 				"rememo": "^3.0.0",
 				"uuid": "^3.3.2"
 			}
@@ -3698,7 +3698,7 @@
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"gettext-parser": "^1.3.1",
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.14"
 			}
 		},
 		"@wordpress/babel-preset-default": {
@@ -3776,7 +3776,7 @@
 				"@wordpress/viewport": "file:packages/viewport",
 				"classnames": "^2.2.5",
 				"fast-average-color": "4.3.0",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.14",
 				"memize": "^1.0.5",
 				"url": "^0.11.0"
 			}
@@ -3810,7 +3810,7 @@
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/shortcode": "file:packages/shortcode",
 				"hpq": "^1.3.0",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.14",
 				"rememo": "^3.0.0",
 				"showdown": "^1.8.6",
 				"simple-html-tokenizer": "^0.5.7",
@@ -3840,7 +3840,7 @@
 				"clipboard": "^2.0.1",
 				"diff": "^3.5.0",
 				"dom-scroll-into-view": "^1.2.1",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.14",
 				"memize": "^1.0.5",
 				"moment": "^2.22.1",
 				"mousetrap": "^1.6.2",
@@ -3859,7 +3859,7 @@
 				"@babel/runtime": "^7.4.4",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.14"
 			}
 		},
 		"@wordpress/core-data": {
@@ -3871,7 +3871,7 @@
 				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/url": "file:packages/url",
 				"equivalent-key-map": "^0.2.2",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.14",
 				"rememo": "^3.0.0"
 			}
 		},
@@ -3894,7 +3894,7 @@
 				"@wordpress/redux-routine": "file:packages/redux-routine",
 				"equivalent-key-map": "^0.2.2",
 				"is-promise": "^2.1.0",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.14",
 				"redux": "^4.0.0",
 				"turbo-combine-reducers": "^1.0.2"
 			}
@@ -3944,7 +3944,7 @@
 			"version": "file:packages/dom",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.14"
 			}
 		},
 		"@wordpress/dom-ready": {
@@ -3960,7 +3960,7 @@
 				"@babel/runtime": "^7.4.4",
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"@wordpress/url": "file:packages/url",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.14",
 				"node-fetch": "^1.7.3"
 			}
 		},
@@ -3973,7 +3973,7 @@
 				"@wordpress/jest-puppeteer-axe": "file:packages/jest-puppeteer-axe",
 				"@wordpress/scripts": "file:packages/scripts",
 				"expect-puppeteer": "^4.0.0",
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.14"
 			}
 		},
 		"@wordpress/edit-post": {
@@ -3999,7 +3999,7 @@
 				"@wordpress/url": "file:packages/url",
 				"@wordpress/viewport": "file:packages/viewport",
 				"classnames": "^2.2.5",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.14",
 				"refx": "^3.0.0"
 			}
 		},
@@ -4042,7 +4042,7 @@
 				"@wordpress/wordcount": "file:packages/wordcount",
 				"classnames": "^2.2.5",
 				"inherits": "^2.0.3",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.14",
 				"memize": "^1.0.5",
 				"react-autosize-textarea": "^3.0.2",
 				"redux-optimist": "^1.0.0",
@@ -4056,7 +4056,7 @@
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"@wordpress/escape-html": "file:packages/escape-html",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.14",
 				"react": "^16.8.4",
 				"react-dom": "^16.8.4"
 			}
@@ -4110,7 +4110,7 @@
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"gettext-parser": "^1.3.1",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.14",
 				"memize": "^1.0.5",
 				"sprintf-js": "^1.1.1",
 				"tannin": "^1.1.0"
@@ -4128,7 +4128,7 @@
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"jest-matcher-utils": "^24.7.0",
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.14"
 			}
 		},
 		"@wordpress/jest-preset-default": {
@@ -4154,14 +4154,14 @@
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"@wordpress/i18n": "file:packages/i18n",
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.14"
 			}
 		},
 		"@wordpress/library-export-default-webpack-plugin": {
 			"version": "file:packages/library-export-default-webpack-plugin",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.14",
 				"webpack-sources": "^1.1.0"
 			}
 		},
@@ -4174,7 +4174,7 @@
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/i18n": "file:packages/i18n",
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.14"
 			}
 		},
 		"@wordpress/media-utils": {
@@ -4185,7 +4185,7 @@
 				"@wordpress/blob": "file:packages/blob",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/i18n": "file:packages/i18n",
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.14"
 			}
 		},
 		"@wordpress/notices": {
@@ -4194,7 +4194,7 @@
 				"@babel/runtime": "^7.4.4",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/data": "file:packages/data",
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.14"
 			}
 		},
 		"@wordpress/npm-package-json-lint-config": {
@@ -4210,7 +4210,7 @@
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/i18n": "file:packages/i18n",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.14",
 				"rememo": "^3.0.0"
 			}
 		},
@@ -4221,7 +4221,7 @@
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.14"
 			}
 		},
 		"@wordpress/postcss-themes": {
@@ -4261,7 +4261,7 @@
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"classnames": "^2.2.5",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.14",
 				"memize": "^1.0.5",
 				"rememo": "^3.0.0"
 			}
@@ -4307,14 +4307,14 @@
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/url": "file:packages/url",
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.14"
 			}
 		},
 		"@wordpress/shortcode": {
 			"version": "file:packages/shortcode",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.14",
 				"memize": "^1.0.5"
 			}
 		},
@@ -4322,7 +4322,7 @@
 			"version": "file:packages/token-list",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.14"
 			}
 		},
 		"@wordpress/url": {
@@ -4339,14 +4339,14 @@
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/element": "file:packages/element",
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.14"
 			}
 		},
 		"@wordpress/wordcount": {
 			"version": "file:packages/wordcount",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.14"
 			}
 		},
 		"JSONStream": {
@@ -15316,9 +15316,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.11",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+			"version": "4.17.14",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+			"integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
 		},
 		"lodash._reinterpolate": {
 			"version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17131,9 +17131,9 @@
 			}
 		},
 		"mixin-deep": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+			"integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
 			"dev": true,
 			"requires": {
 				"for-in": "^1.0.2",
@@ -22666,9 +22666,9 @@
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 		},
 		"set-value": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+			"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
@@ -24878,38 +24878,15 @@
 			}
 		},
 		"union-value": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+			"integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
 			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"get-value": "^2.0.6",
 				"is-extendable": "^0.1.1",
-				"set-value": "^0.4.3"
-			},
-			"dependencies": {
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
-					"requires": {
-						"is-extendable": "^0.1.0"
-					}
-				},
-				"set-value": {
-					"version": "0.4.3",
-					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-extendable": "^0.1.1",
-						"is-plain-object": "^2.0.1",
-						"to-object-path": "^0.3.0"
-					}
-				}
+				"set-value": "^2.0.1"
 			}
 		},
 		"uniq": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6384,7 +6384,8 @@
 						"ansi-regex": {
 							"version": "2.1.1",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"aproba": {
 							"version": "1.2.0",
@@ -6405,12 +6406,14 @@
 						"balanced-match": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -6425,17 +6428,20 @@
 						"code-point-at": {
 							"version": "1.1.0",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -6552,7 +6558,8 @@
 						"inherits": {
 							"version": "2.0.3",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -6564,6 +6571,7 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -6578,6 +6586,7 @@
 							"version": "3.0.4",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
@@ -6585,12 +6594,14 @@
 						"minimist": {
 							"version": "0.0.8",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"minipass": {
 							"version": "2.3.5",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
 								"yallist": "^3.0.0"
@@ -6609,6 +6620,7 @@
 							"version": "0.5.1",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
@@ -6689,7 +6701,8 @@
 						"number-is-nan": {
 							"version": "1.0.1",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -6701,6 +6714,7 @@
 							"version": "1.4.0",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -6787,7 +6801,8 @@
 						"safe-buffer": {
 							"version": "5.1.2",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -6823,6 +6838,7 @@
 							"version": "1.0.2",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -6842,6 +6858,7 @@
 							"version": "3.0.1",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -6885,12 +6902,14 @@
 						"wrappy": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"yallist": {
 							"version": "3.0.3",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						}
 					}
 				},
@@ -10946,7 +10965,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -10967,12 +10987,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -10987,17 +11009,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -11114,7 +11139,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -11126,6 +11152,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -11140,6 +11167,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -11147,12 +11175,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -11171,6 +11201,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -11251,7 +11282,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -11263,6 +11295,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -11349,7 +11382,8 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -11385,6 +11419,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -11404,6 +11439,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -11447,12 +11483,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
 		"jsdom": "11.12.0",
 		"lerna": "3.14.1",
 		"lint-staged": "8.1.5",
-		"lodash": "4.17.11",
+		"lodash": "4.17.14",
 		"make-dir": "3.0.0",
 		"metro-react-native-babel-preset": "0.55.0",
 		"metro-react-native-babel-transformer": "0.55.0",

--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -26,7 +26,7 @@
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/rich-text": "file:../rich-text",
-		"lodash": "^4.17.11",
+		"lodash": "^4.17.14",
 		"rememo": "^3.0.0",
 		"uuid": "^3.3.2"
 	},

--- a/packages/babel-plugin-makepot/package.json
+++ b/packages/babel-plugin-makepot/package.json
@@ -31,7 +31,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
 		"gettext-parser": "^1.3.1",
-		"lodash": "^4.17.11"
+		"lodash": "^4.17.14"
 	},
 	"peerDependencies": {
 		"@babel/core": "^7.0.0"

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -40,7 +40,7 @@
 		"@wordpress/viewport": "file:../viewport",
 		"classnames": "^2.2.5",
 		"fast-average-color": "4.3.0",
-		"lodash": "^4.17.11",
+		"lodash": "^4.17.14",
 		"memize": "^1.0.5",
 		"url": "^0.11.0"
 	},

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -35,7 +35,7 @@
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/shortcode": "file:../shortcode",
 		"hpq": "^1.3.0",
-		"lodash": "^4.17.11",
+		"lodash": "^4.17.14",
 		"rememo": "^3.0.0",
 		"showdown": "^1.8.6",
 		"simple-html-tokenizer": "^0.5.7",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -36,7 +36,7 @@
 		"clipboard": "^2.0.1",
 		"diff": "^3.5.0",
 		"dom-scroll-into-view": "^1.2.1",
-		"lodash": "^4.17.11",
+		"lodash": "^4.17.14",
 		"memize": "^1.0.5",
 		"moment": "^2.22.1",
 		"mousetrap": "^1.6.2",

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -25,7 +25,7 @@
 		"@babel/runtime": "^7.4.4",
 		"@wordpress/element": "file:../element",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
-		"lodash": "^4.17.11"
+		"lodash": "^4.17.14"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -28,7 +28,7 @@
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/url": "file:../url",
 		"equivalent-key-map": "^0.2.2",
-		"lodash": "^4.17.11",
+		"lodash": "^4.17.14",
 		"rememo": "^3.0.0"
 	},
 	"publishConfig": {

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -31,7 +31,7 @@
 		"@wordpress/redux-routine": "file:../redux-routine",
 		"equivalent-key-map": "^0.2.2",
 		"is-promise": "^2.1.0",
-		"lodash": "^4.17.11",
+		"lodash": "^4.17.14",
 		"redux": "^4.0.0",
 		"turbo-combine-reducers": "^1.0.2"
 	},

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -23,7 +23,7 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
-		"lodash": "^4.17.11"
+		"lodash": "^4.17.14"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/e2e-test-utils/package.json
+++ b/packages/e2e-test-utils/package.json
@@ -31,7 +31,7 @@
 		"@babel/runtime": "^7.4.4",
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/url": "file:../url",
-		"lodash": "^4.17.11",
+		"lodash": "^4.17.14",
 		"node-fetch": "^1.7.3"
 	},
 	"peerDependencies": {

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -27,7 +27,7 @@
 		"@wordpress/jest-puppeteer-axe": "file:../jest-puppeteer-axe",
 		"@wordpress/scripts": "file:../scripts",
 		"expect-puppeteer": "^4.0.0",
-		"lodash": "^4.17.11"
+		"lodash": "^4.17.14"
 	},
 	"peerDependencies": {
 		"jest": ">=24",

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -41,7 +41,7 @@
 		"@wordpress/url": "file:../url",
 		"@wordpress/viewport": "file:../viewport",
 		"classnames": "^2.2.5",
-		"lodash": "^4.17.11",
+		"lodash": "^4.17.14",
 		"refx": "^3.0.0"
 	},
 	"publishConfig": {

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -46,7 +46,7 @@
 		"@wordpress/wordcount": "file:../wordcount",
 		"classnames": "^2.2.5",
 		"inherits": "^2.0.3",
-		"lodash": "^4.17.11",
+		"lodash": "^4.17.14",
 		"memize": "^1.0.5",
 		"react-autosize-textarea": "^3.0.2",
 		"redux-optimist": "^1.0.0",

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -24,7 +24,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
 		"@wordpress/escape-html": "file:../escape-html",
-		"lodash": "^4.17.11",
+		"lodash": "^4.17.14",
 		"react": "^16.8.4",
 		"react-dom": "^16.8.4"
 	},

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -26,7 +26,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
 		"gettext-parser": "^1.3.1",
-		"lodash": "^4.17.11",
+		"lodash": "^4.17.14",
 		"memize": "^1.0.5",
 		"sprintf-js": "^1.1.1",
 		"tannin": "^1.1.0"

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -31,7 +31,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
 		"jest-matcher-utils": "^24.7.0",
-		"lodash": "^4.17.11"
+		"lodash": "^4.17.14"
 	},
 	"peerDependencies": {
 		"jest": ">=24"

--- a/packages/keycodes/package.json
+++ b/packages/keycodes/package.json
@@ -23,7 +23,7 @@
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
 		"@wordpress/i18n": "file:../i18n",
-		"lodash": "^4.17.11"
+		"lodash": "^4.17.14"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/library-export-default-webpack-plugin/package.json
+++ b/packages/library-export-default-webpack-plugin/package.json
@@ -26,7 +26,7 @@
 	],
 	"main": "index.js",
 	"dependencies": {
-		"lodash": "^4.17.11",
+		"lodash": "^4.17.14",
 		"webpack-sources": "^1.1.0"
 	},
 	"peerDependencies": {

--- a/packages/list-reusable-blocks/package.json
+++ b/packages/list-reusable-blocks/package.json
@@ -26,7 +26,7 @@
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
-		"lodash": "^4.17.11"
+		"lodash": "^4.17.14"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/media-utils/package.json
+++ b/packages/media-utils/package.json
@@ -27,7 +27,7 @@
 		"@wordpress/blob": "file:../blob",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
-		"lodash": "^4.17.11"
+		"lodash": "^4.17.14"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/notices/package.json
+++ b/packages/notices/package.json
@@ -24,7 +24,7 @@
 		"@babel/runtime": "^7.4.4",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/data": "file:../data",
-		"lodash": "^4.17.11"
+		"lodash": "^4.17.14"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/nux/package.json
+++ b/packages/nux/package.json
@@ -27,7 +27,7 @@
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
-		"lodash": "^4.17.11",
+		"lodash": "^4.17.14",
 		"rememo": "^3.0.0"
 	},
 	"publishConfig": {

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -25,7 +25,7 @@
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",
-		"lodash": "^4.17.11"
+		"lodash": "^4.17.14"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -32,7 +32,7 @@
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/keycodes": "file:../keycodes",
 		"classnames": "^2.2.5",
-		"lodash": "^4.17.11",
+		"lodash": "^4.17.14",
 		"memize": "^1.0.5",
 		"rememo": "^3.0.0"
 	},

--- a/packages/server-side-render/package.json
+++ b/packages/server-side-render/package.json
@@ -29,7 +29,7 @@
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/url": "file:../url",
-		"lodash": "^4.17.11"
+		"lodash": "^4.17.14"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/shortcode/package.json
+++ b/packages/shortcode/package.json
@@ -22,7 +22,7 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
-		"lodash": "^4.17.11",
+		"lodash": "^4.17.14",
 		"memize": "^1.0.5"
 	},
 	"publishConfig": {

--- a/packages/token-list/package.json
+++ b/packages/token-list/package.json
@@ -21,7 +21,7 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
-		"lodash": "^4.17.11"
+		"lodash": "^4.17.14"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -25,7 +25,7 @@
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",
-		"lodash": "^4.17.11"
+		"lodash": "^4.17.14"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/wordcount/package.json
+++ b/packages/wordcount/package.json
@@ -22,7 +22,7 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
-		"lodash": "^4.17.11"
+		"lodash": "^4.17.14"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
This pull request seeks to bump Lodash from `4.17.11` to `4.17.14`, for all included packages, and pinned for all dependencies which depend on Lodash. It includes a script override for the default-registered copy shipped with WordPress.

**Testing Instructions:**

Verify there are no warning messages or local changes after running `npm install`.

Verify the editor loads correctly, and that running `lodash.VERSION` in your browser developer tools yields a value of `4.17.14`.