### PR TITLE
Editor: Defer block validation until after source application

### DIFF
--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -1203,7 +1203,7 @@ Returns an action object used to signal that the blocks have been updated.
 _Parameters_
 
 -   _blocks_ `Array`: Block Array.
--   _options_ `?Object`: Optional options.
+-   _options_ `?WPEditorResetEditorBlocksActionOptions`: Optional options.
 
 _Returns_
 

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Master
 
+### New Features
+
+- `parse` now accepts an options object. Current options include the ability to disable default validation (`validate`).
+- New function: `validate`. Given a block or array of blocks, assigns the `isValid` property of each block corresponding to the validation result.
+
 ### Improvements
 
 - Omitting `attributes` or `keywords` settings will now stub default values (an empty object or empty array, respectively).

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -746,6 +746,16 @@ _Parameters_
 -   _slug_ `string`: Block category slug.
 -   _category_ `Object`: Object containing the category properties that should be updated.
 
+<a name="validate" href="#validate">#</a> **validate**
+
+Given a block or array of blocks, assigns the `isValid` property of each
+block corresponding to the validation result. This mutates the original
+array or object.
+
+_Parameters_
+
+-   _blocks_ `(WPBlock|Array<WPBlock>)`: Block or array of blocks to validate.
+
 <a name="withBlockContentContext" href="#withBlockContentContext">#</a> **withBlockContentContext**
 
 A Higher Order Component used to inject BlockContent using context to the

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -20,7 +20,10 @@ export {
 	getSaveElement,
 	getSaveContent,
 } from './serializer';
-export { isValidBlockContent } from './validation';
+export {
+	default as validate,
+	isValidBlockContent,
+} from './validation';
 export {
 	getCategories,
 	setCategories,

--- a/packages/blocks/src/api/test/parser.js
+++ b/packages/blocks/src/api/test/parser.js
@@ -8,6 +8,7 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import {
+	DEFAULT_PARSE_OPTIONS,
 	getBlockAttribute,
 	getBlockAttributes,
 	createBlockWithFallback,
@@ -671,7 +672,7 @@ describe( 'block parser', () => {
 				blockName: 'core/test-block',
 				innerHTML: 'Bananas',
 				attrs: { fruit: 'Bananas' },
-			} );
+			}, DEFAULT_PARSE_OPTIONS );
 			expect( block.name ).toEqual( 'core/test-block' );
 			expect( block.attributes ).toEqual( { fruit: 'Bananas' } );
 		} );
@@ -682,7 +683,7 @@ describe( 'block parser', () => {
 			const block = createBlockWithFallback( {
 				blockName: 'core/test-block',
 				innerHTML: '',
-			} );
+			}, DEFAULT_PARSE_OPTIONS );
 			expect( block.name ).toEqual( 'core/test-block' );
 			expect( block.attributes ).toEqual( {} );
 		} );
@@ -695,7 +696,7 @@ describe( 'block parser', () => {
 				blockName: 'core/test-block',
 				innerHTML: 'Bananas',
 				attrs: { fruit: 'Bananas' },
-			} );
+			}, DEFAULT_PARSE_OPTIONS );
 			expect( block.name ).toBe( 'core/unregistered-block' );
 			expect( block.attributes.content ).toContain( 'wp:test-block' );
 		} );
@@ -706,7 +707,7 @@ describe( 'block parser', () => {
 
 			const block = createBlockWithFallback( {
 				innerHTML: 'content',
-			} );
+			}, DEFAULT_PARSE_OPTIONS );
 			expect( block.name ).toEqual( 'core/freeform-block' );
 			expect( block.attributes ).toEqual( { content: '<p>content</p>' } );
 		} );
@@ -715,7 +716,7 @@ describe( 'block parser', () => {
 			const block = createBlockWithFallback( {
 				blockName: 'core/test-block',
 				innerHTML: '',
-			} );
+			}, DEFAULT_PARSE_OPTIONS );
 			expect( block ).toBeUndefined();
 		} );
 
@@ -749,7 +750,7 @@ describe( 'block parser', () => {
 				blockName: 'core/test-block',
 				innerHTML: '<span>Bananas</span>',
 				attrs: { fruit: 'Bananas' },
-			} );
+			}, DEFAULT_PARSE_OPTIONS );
 			expect( block.name ).toEqual( 'core/test-block' );
 			expect( block.attributes ).toEqual( { fruit: 'Big Bananas' } );
 			expect( block.isValid ).toBe( true );

--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import {
+import validate, {
 	isValidCharacterReference,
 	DecodeEntityParser,
 	getTextPiecesSplitOnWhitespace,
@@ -660,6 +660,50 @@ describe( 'validation', () => {
 			);
 
 			expect( isValid ).toBe( true );
+		} );
+	} );
+
+	describe( 'validate', () => {
+		it( 'returns undefined', () => {
+			registerBlockType( 'core/test-block', defaultBlockSettings );
+
+			const result = validate( [
+				{
+					name: 'core/test-block',
+					attributes: { fruit: 'Bananas' },
+					originalContent: 'Bananas',
+				},
+			] );
+
+			expect( result ).toBeUndefined();
+		} );
+
+		it( 'mutates the block with the validation result', () => {
+			registerBlockType( 'core/test-block', defaultBlockSettings );
+
+			const block = {
+				name: 'core/test-block',
+				attributes: { fruit: 'Bananas' },
+				originalContent: 'Bananas',
+			};
+
+			validate( block );
+
+			expect( block.isValid ).toBe( true );
+		} );
+
+		it( 'mutates the blocks array with the validation result', () => {
+			registerBlockType( 'core/test-block', defaultBlockSettings );
+
+			const block = {
+				name: 'core/test-block',
+				attributes: { fruit: 'Bananas' },
+				originalContent: 'Bananas',
+			};
+
+			validate( [ block ] );
+
+			expect( block.isValid ).toBe( true );
 		} );
 	} );
 } );

--- a/packages/blocks/src/api/validation.js
+++ b/packages/blocks/src/api/validation.js
@@ -9,6 +9,7 @@ import {
 	isEqual,
 	includes,
 	stubTrue,
+	castArray,
 } from 'lodash';
 
 /**
@@ -21,6 +22,7 @@ import { decodeEntities } from '@wordpress/html-entities';
  */
 import { getSaveContent } from './serializer';
 import { normalizeBlockType } from './utils';
+import { getBlockType } from './registration';
 
 /**
  * Globally matches any consecutive whitespace
@@ -648,4 +650,24 @@ export function isValidBlockContent( blockTypeOrName, attributes, originalBlockC
 	}
 
 	return isValid;
+}
+
+/**
+ * Given a block or array of blocks, assigns the `isValid` property of each
+ * block corresponding to the validation result. This mutates the original
+ * array or object.
+ *
+ * @param {(WPBlock|WPBlock[])} blocks Block or array of blocks to validate.
+ */
+export default function validate( blocks ) {
+	// Normalize value to array (support singular argument).
+	blocks = castArray( blocks );
+
+	for ( const block of blocks ) {
+		block.isValid = isValidBlockContent(
+			getBlockType( block.name ),
+			block.attributes,
+			block.originalContent
+		);
+	}
 }

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -99,8 +99,8 @@ export default compose( [
 				editPost( { content } );
 			},
 			onPersist( content ) {
-				const blocks = parse( content );
-				resetEditorBlocks( blocks );
+				const blocks = parse( content, { validate: false } );
+				resetEditorBlocks( blocks, { validate: true } );
 			},
 		};
 	} ),

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -195,7 +195,7 @@ export function* setupEditor( post, edits, template ) {
 		edits,
 		template,
 	};
-	yield resetEditorBlocks( blocks, { validate: true } );
+	yield resetEditorBlocks( blocks, { validate: ! isNewPost } );
 	yield setupEditorState( post );
 	yield* __experimentalSubscribeSources();
 }


### PR DESCRIPTION
Fixes #4989
Related: #16402, #16316

This pull request seeks to opt out of validation for the initial blocks parse, instead awaiting the application of sourced attributes. This allows, for example, meta attribute values to be applied such that validation can occur with expected results (see #4989).

**Testing Instructions:**

Ensure unit tests pass:

```
npm run test-unit
```

Verify that updating a block with an attribute sourced by a meta attribute and persisted to the block's markup (via `save`) is valid after saving and reloading the editor content.

Example plugin: https://gist.github.com/aduth/e44d104996277dd9d6b08edf403030c5