### PR TITLE
WIP: Proof of concept to add an unschedule button to accompany the date picker

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-schedule/index.js
+++ b/packages/edit-post/src/components/sidebar/post-schedule/index.js
@@ -4,35 +4,80 @@
 import { __ } from '@wordpress/i18n';
 import { PanelRow, Dropdown, Button } from '@wordpress/components';
 import { PostSchedule as PostScheduleForm, PostScheduleLabel, PostScheduleCheck } from '@wordpress/editor';
+import { withSelect, withDispatch } from '@wordpress/data';
 
-export function PostSchedule() {
-	return (
-		<PostScheduleCheck>
-			<PanelRow className="edit-post-post-schedule">
-				<span>
-					{ __( 'Publish' ) }
-				</span>
-				<Dropdown
-					position="bottom left"
-					contentClassName="edit-post-post-schedule__dialog"
-					renderToggle={ ( { onToggle, isOpen } ) => (
-						<>
-							<Button
-								type="button"
-								className="edit-post-post-schedule__toggle"
-								onClick={ onToggle }
-								aria-expanded={ isOpen }
-								isLink
-							>
-								<PostScheduleLabel />
-							</Button>
-						</>
-					) }
-					renderContent={ () => <PostScheduleForm /> }
-				/>
-			</PanelRow>
-		</PostScheduleCheck>
-	);
+import { Component } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
+
+class PostSchedule extends Component {
+	constructor( props ) {
+		super( props );
+		this.unscheduleAction = this.unscheduleAction.bind( this );
+	}
+
+	unscheduleAction() {
+		this.props.editDate( this.props.modified );
+	}
+
+	render() {
+		return (
+			<PostScheduleCheck>
+				<PanelRow className="edit-post-post-schedule">
+					<span>
+						{ __( 'Publish' ) }
+					</span>
+					<Dropdown
+						position="bottom left"
+						contentClassName="edit-post-post-schedule__dialog"
+						renderToggle={ ( { onToggle, isOpen } ) => (
+							<>
+								<Button
+									type="button"
+									className="edit-post-post-schedule__toggle"
+									onClick={ onToggle }
+									aria-expanded={ isOpen }
+									isLink
+								>
+									<PostScheduleLabel />
+								</Button>
+							</>
+						) }
+						renderContent={ () => <PostScheduleForm /> }
+					/>
+				</PanelRow>
+				{ this.props.isScheduled === true &&
+					<PanelRow className="edit-post-post-unschedule">
+						<Button
+							isSmall
+							isDefault
+							onClick={ this.unscheduleAction }
+						>
+							{ __( 'Unschedule' ) }
+						</Button>
+					</PanelRow>
+				}
+			</PostScheduleCheck>
+		);
+	}
 }
+
+PostSchedule = compose( [
+	withSelect( ( select ) => {
+		return {
+			status: select( 'core/editor' ).getEditedPostAttribute( 'status' ),
+			date: select( 'core/editor' ).getEditedPostAttribute( 'date' ),
+			modified: select( 'core/editor' ).getEditedPostAttribute( 'modified' ),
+			isScheduled: select( 'core/editor' ).isEditedPostBeingScheduled(),
+		};
+	} ),
+	withDispatch( ( dispatch ) => {
+		const { editPost } = dispatch( 'core/editor' );
+		return {
+			editDate( date ) {
+				editPost( { date } );
+			},
+		};
+	} ),
+] )( PostSchedule );
 
 export default PostSchedule;

--- a/packages/edit-post/src/components/sidebar/post-schedule/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-schedule/style.scss
@@ -14,3 +14,9 @@
 		width: 270px;
 	}
 }
+
+.edit-post-post-unschedule {
+	margin-top: 0;
+	margin-top: 0.5em;
+	justify-content: flex-end;
+}

--- a/packages/editor/src/components/post-schedule/label.js
+++ b/packages/editor/src/components/post-schedule/label.js
@@ -5,17 +5,23 @@ import { __ } from '@wordpress/i18n';
 import { dateI18n, __experimentalGetSettings } from '@wordpress/date';
 import { withSelect } from '@wordpress/data';
 
-export function PostScheduleLabel( { date, isFloating } ) {
-	const settings = __experimentalGetSettings();
+import { Component } from '@wordpress/element';
 
-	return date && ! isFloating ?
-		dateI18n( settings.formats.datetimeAbbreviated, date ) :
-		__( 'Immediately' );
+class PostScheduleLabel extends Component {
+	render() {
+		const settings = __experimentalGetSettings();
+
+		if ( this.props.date && ! this.props.isFloating ) {
+			return dateI18n( settings.formats.datetimeAbbreviated, this.props.date );
+		}
+		return __( 'Immediately' );
+	}
 }
 
 export default withSelect( ( select ) => {
 	return {
 		date: select( 'core/editor' ).getEditedPostAttribute( 'date' ),
 		isFloating: select( 'core/editor' ).isEditedPostDateFloating(),
+		isScheduled: select( 'core/editor' ).isEditedPostBeingScheduled(),
 	};
 } )( PostScheduleLabel );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

This PR tests out the concept laid out by @karmatosed in https://github.com/WordPress/gutenberg/issues/12048#issuecomment-510052209 and adds an "unschedule" button to the post schedule panel in the sidebar.

The button sets the publishing date of the post to be the same as the modified date. However, when the post is saved, a new revision is made and the post gets scheduled in the past, which is not a desired functionality.

Note that this is an experimental PR and a work in progress, **so please do not merge**.

## How has this been tested?

Tests remain unchanged and would need to be amended or added before merging this PR.

## Screenshots <!-- if applicable -->

![Screenshot from 2019-07-12 22-54-11](https://user-images.githubusercontent.com/191583/61158032-17d21780-a4f8-11e9-8eaa-32e43c211ff7.png)


## Types of changes

Changes are concentrated on the `PostSchedule` component and other changes to the code were done to facilitate experimentation, may not be necessary and will be reverted.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
