### PR TITLE
Fix aspect ratio typo and recalculate padding in embed block CSS

### DIFF
--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -64,7 +64,7 @@
 		}
 
 		&.wp-embed-aspect-9-16 .wp-block-embed__wrapper::before {
-			padding-top: 177.77%; // 16 / 9 * 100
+			padding-top: 177.78%; // 16 / 9 * 100
 		}
 
 		&.wp-embed-aspect-1-2 .wp-block-embed__wrapper::before {

--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -63,8 +63,8 @@
 			padding-top: 100%; // 1 / 1 * 100
 		}
 
-		&.wp-embed-aspect-9-6 .wp-block-embed__wrapper::before {
-			padding-top: 66.66%; // 6 / 9 * 100
+		&.wp-embed-aspect-9-16 .wp-block-embed__wrapper::before {
+			padding-top: 177.77%; // 16 / 9 * 100
 		}
 
 		&.wp-embed-aspect-1-2 .wp-block-embed__wrapper::before {


### PR DESCRIPTION
## Description
As discussed with @jasmussen [here](https://github.com/WordPress/gutenberg/issues/10109#issuecomment-511013409), there is a typo in the selector for the 9:16 aspect ratio. The ratio is listed accurately here:

https://github.com/WordPress/gutenberg/blob/429558ad320c55e3e8b5236dfb6ce139fa3a7d25/packages/block-library/src/embed/style.scss#L19-L26

But here it has been changed to 9:6:

https://github.com/WordPress/gutenberg/blob/429558ad320c55e3e8b5236dfb6ce139fa3a7d25/packages/block-library/src/embed/style.scss#L66-L68

Given that aspect ratios are sorted in ascending order by the required top padding, it appears the second code excerpt should be:

```scss
&.wp-embed-aspect-9-16 .wp-block-embed__wrapper::before {
	padding-top: 177.77%; // 16 / 9 * 100
}
```

This pull request fixes the typo and recalculates the value for `padding-top`.

I considered whether the intention could be to use 9:6 as an aspect ratio in addition to 9:16, but presumably that would have been listed as 3:2, so I believe 9:16 was the intended aspect ratio all along.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
