### PR TITLE
[RNMobile] Replace use of deprecated componentWillReceiveProps in ImageEdit

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -98,12 +98,12 @@ class ImageEdit extends React.Component {
 		}
 	}
 
-	componentWillReceiveProps( nextProps ) {
+	static getDerivedStateFromProps( props, state ) {
 		// Avoid a UI flicker in the toolbar by insuring that isCaptionSelected
 		// is updated immediately any time the isSelected prop becomes false
-		this.setState( ( state ) => ( {
-			isCaptionSelected: nextProps.isSelected && state.isCaptionSelected,
-		} ) );
+		return {
+			isCaptionSelected: props.isSelected && state.isCaptionSelected,
+		};
 	}
 
 	onImagePressed() {


### PR DESCRIPTION
## Description
For mobile, replaces the native image component's use of the deprecated `componentWillReceiveProps` component lifecycle method in order to remove a warning. Additional detail, including testing directions, can be found in the [related gutenberg-mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1228).

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
