### PR TITLE
Fix: Block Movers disappear on middle breakpoints for full/wide blocks.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -456,7 +456,7 @@
 		@include break-mobile() {
 			.block-editor-block-toolbar {
 				/*!rtl:begin:ignore*/
-				left: $block-side-ui-width * 3;
+				left: $block-side-ui-width * 3 + ($grid-size-small * 1.5);
 				/*!rtl:end:ignore*/
 			}
 		}

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -439,19 +439,6 @@
 			float: left;
 		}
 
-		// Hide mover until wide breakpoints, or it might be covered by toolbar
-		&.is-multi-selected > .block-editor-block-mover,
-		> .block-editor-block-list__block-edit > .block-editor-block-mover {
-			display: none;
-		}
-
-		@include break-wide() {
-			&.is-multi-selected > .block-editor-block-mover,
-			> .block-editor-block-list__block-edit > .block-editor-block-mover {
-				display: block;
-			}
-		}
-
 		// Beyond the mobile breakpoint, wide images stretch outside of the column.
 		// To center the toolbar, we make it inline-flex so the toolbar is not full-wide.
 		@include break-small () {
@@ -463,6 +450,23 @@
 		// If the block movers are visible, push the breadcrumb down to make room for them.
 		.block-editor-block-mover.is-visible + .block-editor-block-list__breadcrumb {
 			top: (-$block-padding - $block-left-border-width - ($grid-size-small / 2));
+		}
+
+		// Align block toolbar to floated content.
+		@include break-mobile() {
+			.block-editor-block-toolbar {
+				/*!rtl:begin:ignore*/
+				left: $block-side-ui-width * 3;
+				/*!rtl:end:ignore*/
+			}
+		}
+
+		@include break-xlarge() {
+			.block-editor-block-toolbar {
+				/*!rtl:begin:ignore*/
+				left: $block-padding;
+				/*!rtl:end:ignore*/
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
Fix: https://github.com/WordPress/gutenberg/issues/16564

We had a rule to hide block mover until wide breakpoints, because otherwise it may be covered by the block toolbar. This rule caused a bug where the mover was not seen at all between mobile and wide breakpoints.
This PR removes this rule and to fix the problem where the toolbar covers the movers adds a rule to the toolbar that guarantees there is always space in the left for the movers.


## How has this been tested?
I added an image block.
I set the block to full alignment.
I resized the screen from 500px until 1300 px and verified the movers were always shown and not covered by the toolbar.
I repeated the test for wide alignment.

## Screenshots <!-- if applicable -->
![Jul-14-2019 13-21-12](https://user-images.githubusercontent.com/11271197/61183624-6b994980-a63b-11e9-9105-6794a243e578.gif)