### PR TITLE
Fix disabled menu item button styles

### DIFF
--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -106,4 +106,13 @@
 			padding-left: 0.5rem;
 		}
 	}
+
+	.components-dropdown-menu__menu-item,
+	.components-menu-item,
+	.components-menu-item__button {
+		&:disabled,
+		&[aria-disabled="true"] {
+			opacity: 0.3;
+		}
+	}
 }

--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -108,7 +108,6 @@
 	}
 
 	.components-dropdown-menu__menu-item,
-	.components-menu-item,
 	.components-menu-item__button {
 		&:disabled,
 		&[aria-disabled="true"] {


### PR DESCRIPTION
## Description
This is a small fix for a visual regression introduced in #16103.

In that PR an opacity of 0.3 that was applied to any disabled button was removed. This caused disabled menu items to no longer appear disabled. This screenshot shows a menu with some enabled and some disabled menu items when that opacity is no longer present:

![Screen Shot 2019-07-15 at 11 33 55 am](https://user-images.githubusercontent.com/677833/61194516-7d8af300-a6f4-11e9-9f52-2494fc097451.png)

This PR reintroduces that opacity style, but only for menu items:
![Screen Shot 2019-07-15 at 11 36 45 am](https://user-images.githubusercontent.com/677833/61194571-e5413e00-a6f4-11e9-82c0-c3a36f6c3be4.png)


## How has this been tested?
1. Add a table block to a post
2. Without selecting a cell, click on the edit toolbar button on the edit toolbar

#### Expected (in this branch)
Buttons in the dropdown menu appear greyed out.

#### Actual (in master)
Buttons in the dropdown menu appear active, but cannot be clicked on or interacted with

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
