### PR TITLE
Fix: Block manager doesn't respect allowed_block_types hook

### DIFF
--- a/packages/e2e-tests/specs/plugins/allowed-blocks.test.js
+++ b/packages/e2e-tests/specs/plugins/allowed-blocks.test.js
@@ -38,4 +38,29 @@ describe( 'Allowed Blocks Filter', () => {
 		) )[ 0 ];
 		expect( galleryBlockButton ).toBeUndefined();
 	} );
+
+	it( 'should remove not allowed blocks from the block manager', async () => {
+		const BLOCK_LABEL_SELECTOR = '.edit-post-manage-blocks-modal__checklist-item .components-checkbox-control__label';
+		await page.click(
+			'.edit-post-more-menu [aria-label="More tools & options"]'
+		);
+		const [ button ] = await page.$x(
+			`//button[contains(text(), 'Block Manager')]`
+		);
+		await button.click( 'button' );
+
+		await page.waitForSelector( BLOCK_LABEL_SELECTOR );
+		const blocks = await page.evaluate(
+			( selector ) => {
+				return Array.from( document.querySelectorAll( selector ) ).map(
+					( element ) => ( ( element.innerText || '' ).trim() )
+				).sort();
+			},
+			BLOCK_LABEL_SELECTOR
+		);
+		expect( blocks ).toEqual( [
+			'Image',
+			'Paragraph',
+		] );
+	} );
 } );

--- a/packages/edit-post/src/components/edit-post-settings/index.js
+++ b/packages/edit-post/src/components/edit-post-settings/index.js
@@ -1,0 +1,7 @@
+/**
+ * WordPress dependencies
+ */
+import { createContext } from '@wordpress/element';
+
+const EditPostSettings = createContext( {} );
+export default EditPostSettings;

--- a/packages/edit-post/src/components/manage-blocks-modal/category.js
+++ b/packages/edit-post/src/components/manage-blocks-modal/category.js
@@ -1,11 +1,12 @@
 /**
  * External dependencies
  */
-import { without, map } from 'lodash';
+import { includes, map, without } from 'lodash';
 
 /**
  * WordPress dependencies
  */
+import { useContext, useMemo } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose, withInstanceId } from '@wordpress/compose';
 import { CheckboxControl } from '@wordpress/components';
@@ -14,6 +15,7 @@ import { CheckboxControl } from '@wordpress/components';
  * Internal dependencies
  */
 import BlockTypesChecklist from './checklist';
+import EditPostSettings from '../edit-post-settings';
 
 function BlockManagerCategory( {
 	instanceId,
@@ -23,6 +25,17 @@ function BlockManagerCategory( {
 	toggleVisible,
 	toggleAllVisible,
 } ) {
+	const settings = useContext( EditPostSettings );
+	const { allowedBlockTypes } = settings;
+	blockTypes = useMemo( () => {
+		if ( allowedBlockTypes === true ) {
+			return blockTypes;
+		}
+		return blockTypes.filter( ( { name } ) => {
+			return includes( allowedBlockTypes || [], name );
+		} );
+	} );
+
 	if ( ! blockTypes.length ) {
 		return null;
 	}

--- a/packages/edit-post/src/components/manage-blocks-modal/category.js
+++ b/packages/edit-post/src/components/manage-blocks-modal/category.js
@@ -27,27 +27,30 @@ function BlockManagerCategory( {
 } ) {
 	const settings = useContext( EditPostSettings );
 	const { allowedBlockTypes } = settings;
-	blockTypes = useMemo( () => {
-		if ( allowedBlockTypes === true ) {
-			return blockTypes;
-		}
-		return blockTypes.filter( ( { name } ) => {
-			return includes( allowedBlockTypes || [], name );
-		} );
-	} );
+	const filteredBlockTypes = useMemo(
+		() => {
+			if ( allowedBlockTypes === true ) {
+				return blockTypes;
+			}
+			return blockTypes.filter( ( { name } ) => {
+				return includes( allowedBlockTypes || [], name );
+			} );
+		},
+		[ allowedBlockTypes, blockTypes ]
+	);
 
-	if ( ! blockTypes.length ) {
+	if ( ! filteredBlockTypes.length ) {
 		return null;
 	}
 
 	const checkedBlockNames = without(
-		map( blockTypes, 'name' ),
+		map( filteredBlockTypes, 'name' ),
 		...hiddenBlockTypes
 	);
 
 	const titleId = 'edit-post-manage-blocks-modal__category-title-' + instanceId;
 
-	const isAllChecked = checkedBlockNames.length === blockTypes.length;
+	const isAllChecked = checkedBlockNames.length === filteredBlockTypes.length;
 
 	let ariaChecked;
 	if ( isAllChecked ) {
@@ -72,7 +75,7 @@ function BlockManagerCategory( {
 				label={ <span id={ titleId }>{ category.title }</span> }
 			/>
 			<BlockTypesChecklist
-				blockTypes={ blockTypes }
+				blockTypes={ filteredBlockTypes }
 				value={ checkedBlockNames }
 				onItemChange={ toggleVisible }
 			/>

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -22,6 +22,7 @@ import {
 import preventEventDiscovery from './prevent-event-discovery';
 import Layout from './components/layout';
 import EditorInitialization from './components/editor-initialization';
+import EditPostSettings from './components/edit-post-settings';
 
 class Editor extends Component {
 	constructor() {
@@ -93,24 +94,26 @@ class Editor extends Component {
 
 		return (
 			<StrictMode>
-				<SlotFillProvider>
-					<DropZoneProvider>
-						<EditorProvider
-							settings={ editorSettings }
-							post={ post }
-							initialEdits={ initialEdits }
-							useSubRegistry={ false }
-							{ ...props }
-						>
-							<ErrorBoundary onError={ onError }>
-								<EditorInitialization postId={ postId } />
-								<Layout />
-								<KeyboardShortcuts shortcuts={ preventEventDiscovery } />
-							</ErrorBoundary>
-							<PostLockedModal />
-						</EditorProvider>
-					</DropZoneProvider>
-				</SlotFillProvider>
+				<EditPostSettings.Provider value={ settings }>
+					<SlotFillProvider>
+						<DropZoneProvider>
+							<EditorProvider
+								settings={ editorSettings }
+								post={ post }
+								initialEdits={ initialEdits }
+								useSubRegistry={ false }
+								{ ...props }
+							>
+								<ErrorBoundary onError={ onError }>
+									<EditorInitialization postId={ postId } />
+									<Layout />
+									<KeyboardShortcuts shortcuts={ preventEventDiscovery } />
+								</ErrorBoundary>
+								<PostLockedModal />
+							</EditorProvider>
+						</DropZoneProvider>
+					</SlotFillProvider>
+				</EditPostSettings.Provider>
 			</StrictMode>
 		);
 	}


### PR DESCRIPTION
## Description
Fix: https://github.com/WordPress/gutenberg/issues/15598

Currently, the block manager shows blocks that are not allowed by the allowed_block_types filter.
This PR fixes this problem by removing hiding these blocks from the block manager. The user should not notice the existence of blocks not allowed by the allowed_block_types so not showing them in the block manager seems the best approach.


## How has this been tested?
I tested these changes without applying any filter, and things worked exactly as before.
I added the following code to functions.php of the currently enabled theme:
```php
function whitelistBlocks( $allowed ) {
	$allowed = [
		'core/image',
		'core/gallery',
		'core/list',
		'core/button',
		'core/columns',
		'core/column',
		'core-embed/youtube',
		'core-embed/vimeo',
		'core/separator',
		'core/text-columns',
		'core/heading',
		'core/subhead',
		'core/block',
		'core/shortcode',
	];
	return $allowed;
}

add_filter( 'allowed_block_types', 'whitelistBlocks' );
```
I verified only blocks that are returned by whitelistBlocks are part of the block manager; all other blocks don't appear at all.