### PR TITLE
Fix: Converting video shortcode results in empty block

### DIFF
--- a/packages/block-library/src/video/tranforms.js
+++ b/packages/block-library/src/video/tranforms.js
@@ -28,8 +28,8 @@ const transforms = {
 			attributes: {
 				src: {
 					type: 'string',
-					shortcode: ( { named: { src } } ) => {
-						return src;
+					shortcode: ( { named: { src, mp4, m4v, webm, ogv, flv } } ) => {
+						return src || mp4 || m4v || webm || ogv || flv;
 					},
 				},
 				poster: {


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/15869

The shortcode to video transform was not handling the file type shortcode attributes as a possible source so the video shortcodes ended up being transformed into an empty video block.

This PR  makes the transform handle all file type attributes documented in https://wordpress.org/support/article/video-shortcode/.

## How has this been tested?
I added a class block.
I used the insert media button to insert an mp4 video.
I used the covert to blocks option.
I verified the video block works as expected (on master it is converted to an empty video block).
