### PR TITLE
Slimmer top/bottom spacing inside notices

### DIFF
--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -28,7 +28,7 @@
 }
 
 .components-notice__content {
-	margin: 1em #{ $icon-button-size-small + $border-width } 1em 0;
+	margin: $grid-size-small #{ $icon-button-size-small + $border-width } $grid-size-small 0;
 }
 
 .components-notice__action.components-button {

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -63,4 +63,9 @@
 	// The notice should never be wider than the viewport, or the close button might be hidden. Especially relevant at high zoom levels. Related to https://core.trac.wordpress.org/ticket/47603#ticket.
 	max-width: 100vw;
 	z-index: z-index(".components-notice-list");
+
+	.components-notice__content {
+		margin-top: $grid-size;
+		margin-bottom: $grid-size;
+	}
 }


### PR DESCRIPTION
Currently, our Notice component ships with `1em` of padding on the top and bottom of the content area: 

<img width="269" alt="Screen Shot 2019-07-15 at 8 16 25 AM" src="https://user-images.githubusercontent.com/1202812/61215427-dba9dd00-a6d8-11e9-82a0-d0d115794f3b.png">

This results in a lot of extra room on the top and bottom of the text: 

<img width="277" alt="Screen Shot 2019-07-15 at 8 11 25 AM" src="https://user-images.githubusercontent.com/1202812/61215450-f0867080-a6d8-11e9-8a1b-21d6c3c68fad.png">

This PR changes that spacing to `$grid-size-small`, to balance it out with the spacing on the sides, and to align to our standard spacing increments, instead of `1em`: 

<img width="276" alt="Screen Shot 2019-07-15 at 8 12 57 AM" src="https://user-images.githubusercontent.com/1202812/61215502-157ae380-a6d9-11e9-8d43-ddae83764b87.png">
