### PR TITLE
Added nofollow option for links

### DIFF
--- a/packages/e2e-tests/specs/__snapshots__/links.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/links.test.js.snap
@@ -53,3 +53,9 @@ exports[`Links should contain a label when it should open in a new tab 2`] = `
 <p>This is <a href=\\"http://wordpress.org\\">WordPress</a></p>
 <!-- /wp:paragraph -->"
 `;
+
+exports[`Links should contain a nofollow rel attribute when the option is selected 1`] = `
+"<!-- wp:paragraph -->
+<p>This is <a href=\\"http://w.org\\">WordPress</a></p>
+<!-- /wp:paragraph -->"
+`;

--- a/packages/e2e-tests/specs/__snapshots__/links.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/links.test.js.snap
@@ -44,7 +44,7 @@ exports[`Links can be removed 1`] = `
 
 exports[`Links should contain a label when it should open in a new tab 1`] = `
 "<!-- wp:paragraph -->
-<p>This is <a href=\\"http://w.org\\" target=\\"_blank\\" rel=\\"noreferrer noopener\\" aria-label=\\"WordPress (opens in a new tab)\\">WordPress</a></p>
+<p>This is <a href=\\"http://w.org\\" target=\\"_blank\\" aria-label=\\"WordPress (opens in a new tab)\\" rel=\\"noreferrer noopener\\">WordPress</a></p>
 <!-- /wp:paragraph -->"
 `;
 

--- a/packages/e2e-tests/specs/links.test.js
+++ b/packages/e2e-tests/specs/links.test.js
@@ -498,7 +498,9 @@ describe( 'Links', () => {
 		// Check the checkbox.
 		await page.keyboard.press( 'Space' );
 		// Navigate back to the input field.
-		await page.keyboard.press( 'Tab' );
+		await pressKeyWithModifier( 'shift', 'Tab' );
+		await pressKeyWithModifier( 'shift', 'Tab' );
+		await pressKeyWithModifier( 'shift', 'Tab' );
 		// Submit the form.
 		await page.keyboard.press( 'Enter' );
 
@@ -529,7 +531,7 @@ describe( 'Links', () => {
 		// Uncheck the checkbox.
 		await page.keyboard.press( 'Space' );
 		// Navigate back to the input field.
-		await page.keyboard.press( 'Tab' );
+		await pressKeyWithModifier( 'shift', 'Tab' );
 		// Submit the form.
 		await page.keyboard.press( 'Enter' );
 

--- a/packages/e2e-tests/specs/links.test.js
+++ b/packages/e2e-tests/specs/links.test.js
@@ -549,4 +549,33 @@ describe( 'Links', () => {
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should contain a nofollow rel attribute when the option is selected', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( 'This is WordPress' );
+		// Select "WordPress".
+		await pressKeyWithModifier( 'shiftAlt', 'ArrowLeft' );
+		await pressKeyWithModifier( 'primary', 'k' );
+		await waitForAutoFocus();
+		await page.keyboard.type( 'w.org' );
+		// Navigate to the settings toggle.
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+		// Open settings.
+		await page.keyboard.press( 'Space' );
+		// Navigate to the "No Follow" checkbox.
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+		// Check the checkbox.
+		await page.keyboard.press( 'Space' );
+		// Navigate back to the input field.
+		await pressKeyWithModifier( 'shift', 'Tab' );
+		await pressKeyWithModifier( 'shift', 'Tab' );
+		await pressKeyWithModifier( 'shift', 'Tab' );
+		await pressKeyWithModifier( 'shift', 'Tab' );
+		// Submit the form.
+		await page.keyboard.press( 'Enter' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );

--- a/packages/format-library/src/link/utils.js
+++ b/packages/format-library/src/link/utils.js
@@ -85,11 +85,12 @@ export function isValidHref( href ) {
  *
  * @param {string}  url              The href of the link.
  * @param {boolean} opensInNewWindow Whether this link will open in a new window.
+ * @param {boolean} noFollow         Whether this link will have a nofollow rel attribute.
  * @param {Object}  text             The text that is being hyperlinked.
  *
  * @return {Object} The final format object.
  */
-export function createLinkFormat( { url, opensInNewWindow, text } ) {
+export function createLinkFormat( { url, opensInNewWindow, noFollow, text } ) {
 	const format = {
 		type: 'core/link',
 		attributes: {
@@ -97,13 +98,24 @@ export function createLinkFormat( { url, opensInNewWindow, text } ) {
 		},
 	};
 
+	const relAttributes = [];
+
 	if ( opensInNewWindow ) {
 		// translators: accessibility label for external links, where the argument is the link text
 		const label = sprintf( __( '%s (opens in a new tab)' ), text );
 
 		format.attributes.target = '_blank';
-		format.attributes.rel = 'noreferrer noopener';
 		format.attributes[ 'aria-label' ] = label;
+
+		relAttributes.push( 'noreferrer noopener' );
+	}
+
+	if ( noFollow ) {
+		relAttributes.push( 'nofollow' );
+	}
+
+	if ( relAttributes.length > 0 ) {
+		format.attributes.rel = relAttributes.join( ' ' );
 	}
 
 	return format;


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Adds a "nofollow" option for links allowing the author to discourage search engines from following links.

This is an alternative for https://github.com/WordPress/gutenberg/pull/13190 which was overly complicated. Also because of https://github.com/WordPress/gutenberg/pull/13190#issuecomment-489580675.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Add a link in any block that allows it.
2. Enable the `No Follow` option. Save the post and see that a `rel="nofollow"` is added.
3. Enable the `Open in New Tab` option. Save the post and see that the links now has the `rel="noopener norefferer nofollow"` attribute, aside from the `aria-label` and `target` attributes that are also added by the `Open in New Tab` option.
4. Disable the `No Follow` option. See that the `nofollow` has been removed from the `rel` attribute.

## Screenshots <!-- if applicable -->
<img width="259" alt="Screenshot 2019-07-16 at 11 19 53" src="https://user-images.githubusercontent.com/5389513/61282468-a924e080-a7bb-11e9-904b-b9b517a65f95.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->

Fixes #13542