### PR TITLE
Block Editor: Add missing dependencies to package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3731,6 +3731,7 @@
 				"@wordpress/blocks": "file:packages/blocks",
 				"@wordpress/components": "file:packages/components",
 				"@wordpress/compose": "file:packages/compose",
+				"@wordpress/core-data": "^2.4.0",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/dom": "file:packages/dom",
 				"@wordpress/element": "file:packages/element",
@@ -3747,11 +3748,25 @@
 				"classnames": "^2.2.5",
 				"dom-scroll-into-view": "^1.2.1",
 				"lodash": "^4.17.10",
+				"react-autosize-textarea": "^7.0.0",
 				"react-spring": "^8.0.19",
 				"redux-multi": "^0.1.12",
 				"refx": "^3.0.0",
 				"rememo": "^3.0.0",
-				"tinycolor2": "^1.4.1"
+				"tinycolor2": "^1.4.1",
+				"traverse": "^0.6.6"
+			},
+			"dependencies": {
+				"react-autosize-textarea": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-7.0.0.tgz",
+					"integrity": "sha512-rGQLpGUaELvzy3NKzp0kkcppaUtZTptsyR0PGuLotaJDjwRbT0DpD000yCzETpXseJQ/eMsyVGDDHXjXP93u8w==",
+					"requires": {
+						"autosize": "^4.0.2",
+						"line-height": "^0.3.1",
+						"prop-types": "^15.5.6"
+					}
+				}
 			}
 		},
 		"@wordpress/block-library": {
@@ -6767,7 +6782,7 @@
 							"dependencies": {
 								"minimist": {
 									"version": "1.2.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 									"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 									"dev": true,
 									"optional": true
@@ -11348,7 +11363,7 @@
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 							"dev": true,
 							"optional": true

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -28,6 +28,7 @@
 		"@wordpress/blocks": "file:../blocks",
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",
+		"@wordpress/core-data": "^2.4.0",
 		"@wordpress/data": "file:../data",
 		"@wordpress/dom": "file:../dom",
 		"@wordpress/element": "file:../element",
@@ -44,11 +45,13 @@
 		"classnames": "^2.2.5",
 		"dom-scroll-into-view": "^1.2.1",
 		"lodash": "^4.17.10",
+		"react-autosize-textarea": "^7.0.0",
 		"react-spring": "^8.0.19",
 		"redux-multi": "^0.1.12",
 		"refx": "^3.0.0",
 		"rememo": "^3.0.0",
-		"tinycolor2": "^1.4.1"
+		"tinycolor2": "^1.4.1",
+		"traverse": "^0.6.6"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
## Description
I'm using `@wordpress/block-editor` as a dependency for a Jetpack PR, https://github.com/Automattic/jetpack/pull/13070.

During build, webpack complained about a number of missing dependencies, which seems warranted:

- `@wordpress/core-data`: https://github.com/WordPress/gutenberg/blob/e82b7c6a6bb50f4ecb8a9ad51432cc4f5464d214/packages/block-editor/src/index.js#L5
- `react-autosize-textarea`: https://github.com/WordPress/gutenberg/blob/7964f381e07e06b2ac13698fd1465a4d0c16da1b/packages/block-editor/src/components/block-list/block-html.js#L5
- `traverse`: https://github.com/WordPress/gutenberg/blob/e82b7c6a6bb50f4ecb8a9ad51432cc4f5464d214/packages/block-editor/src/utils/transform-styles/traverse.js#L4

This PR is adding them to `block-editor`'s `package.json`

## How has this been tested?

(Doesn't really need testing since I'm just explicitly adding dependencies that were previously used implicitly.)


## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
