### PR TITLE
adds nofollow and blank target

### DIFF
--- a/packages/block-library/src/navigation-menu-item/block.json
+++ b/packages/block-library/src/navigation-menu-item/block.json
@@ -8,6 +8,10 @@
 		"destination": {
 			"type": "string"
 		},
+		"rel": {
+			"type": "string",
+			"default": ""
+		},
 		"nofollow": {
 			"type": "boolean",
 			"default": false

--- a/packages/block-library/src/navigation-menu-item/edit.js
+++ b/packages/block-library/src/navigation-menu-item/edit.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { invoke } from 'lodash';
+import classnames from 'classnames/dedupe';
 
 /**
  * WordPress dependencies
@@ -39,13 +40,30 @@ function NavigationMenuItemEdit( {
 	setAttributes,
 } ) {
 	const plainTextRef = useRef( null );
-	const onEditLableClicked = useCallback(
+	const onEditLabelClicked = useCallback(
 		( onClose ) => () => {
 			onClose();
 			invoke( plainTextRef, [ 'current', 'textarea', 'focus' ] );
 		},
 		[ plainTextRef ]
 	);
+
+	const setTarget = ( opensInNewTab ) => {
+		const { rel } = attributes;
+
+		const updatedRel = classnames( rel, { noopener: opensInNewTab, noreferrer: opensInNewTab } );
+
+		setAttributes( { opensInNewTab, rel: updatedRel } );
+	};
+
+	const setNofollow = ( nofollow ) => {
+		const { rel } = attributes;
+
+		const updatedRel = classnames( rel, { nofollow } );
+
+		setAttributes( { nofollow, rel: updatedRel } );
+	};
+
 	let content;
 	if ( isSelected ) {
 		content = (
@@ -74,7 +92,7 @@ function NavigationMenuItemEdit( {
 						<MenuItemActions
 							clientId={ clientId }
 							destination={ attributes.destination }
-							onEditLableClicked={ onEditLableClicked( onClose ) }
+							onEditLableClicked={ onEditLabelClicked( onClose ) }
 						/>
 					) }
 				/>
@@ -83,6 +101,7 @@ function NavigationMenuItemEdit( {
 	} else {
 		content = attributes.label;
 	}
+
 	return (
 		<Fragment>
 			<InspectorControls>
@@ -91,9 +110,7 @@ function NavigationMenuItemEdit( {
 				>
 					<ToggleControl
 						checked={ attributes.opensInNewTab }
-						onChange={ ( opensInNewTab ) => {
-							setAttributes( { opensInNewTab } );
-						} }
+						onChange={ setTarget }
 						label={ __( 'Open in new tab' ) }
 					/>
 					<TextareaControl
@@ -117,9 +134,7 @@ function NavigationMenuItemEdit( {
 					/>
 					<ToggleControl
 						checked={ attributes.nofollow }
-						onChange={ ( nofollow ) => {
-							setAttributes( { nofollow } );
-						} }
+						onChange={ setNofollow }
 						label={ __( 'Add nofollow to menu item' ) }
 						help={ (
 							<Fragment>

--- a/packages/block-library/src/navigation-menu-item/save.js
+++ b/packages/block-library/src/navigation-menu-item/save.js
@@ -2,7 +2,7 @@ export default function save( { attributes } ) {
 	return (
 		<a
 			href={ attributes.destination }
-			rel={ attributes.nofollow && 'nofollow' }
+			rel={ attributes.rel }
 			title={ attributes.title }
 			target={ attributes.opensInNewTab && '_blank' }
 		>


### PR DESCRIPTION
## Description
Closes #16636 

## How has this been tested?
Tested locally.

## Screenshots <!-- if applicable -->

## Types of changes
Added two functions that handle the rel and target attributes accordingly. I used classnames as a tokenizer for lack of a better option, but I believe classnames works for `rel` just as well as for `class`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->