### PR TITLE
[RNMobile] Blur post title any time another block is selected

### DIFF
--- a/packages/edit-post/src/components/visual-editor/index.native.js
+++ b/packages/edit-post/src/components/visual-editor/index.native.js
@@ -26,8 +26,8 @@ class VisualEditor extends Component {
 		};
 	}
 
-	static getDerivedStateFromProps( props, state ) {
-		if ( props.isAnyBlockSelected && state.isPostTitleSelected ) {
+	static getDerivedStateFromProps( props ) {
+		if ( props.isAnyBlockSelected ) {
 			return { isPostTitleSelected: false };
 		}
 		return null;

--- a/packages/edit-post/src/components/visual-editor/index.native.js
+++ b/packages/edit-post/src/components/visual-editor/index.native.js
@@ -26,6 +26,13 @@ class VisualEditor extends Component {
 		};
 	}
 
+	static getDerivedStateFromProps( props, state ) {
+		if ( props.isAnyBlockSelected && state.isPostTitleSelected ) {
+			return { isPostTitleSelected: false };
+		}
+		return null;
+	}
+
 	onPostTitleSelect() {
 		this.setState( { isPostTitleSelected: true } );
 		this.props.clearSelectedBlock();
@@ -87,6 +94,7 @@ class VisualEditor extends Component {
 					rootViewHeight={ rootViewHeight }
 					safeAreaBottomInset={ safeAreaBottomInset }
 					isPostTitleSelected={ this.state.isPostTitleSelected }
+					onBlockTypeSelected={ this.onPostTitleUnselect }
 				/>
 			</BlockEditorProvider>
 		);
@@ -100,9 +108,12 @@ export default compose( [
 			getEditedPostAttribute,
 		} = select( 'core/editor' );
 
+		const { getSelectedBlockClientId } = select( 'core/block-editor' );
+
 		return {
 			blocks: getEditorBlocks(),
 			title: getEditedPostAttribute( 'title' ),
+			isAnyBlockSelected: !! getSelectedBlockClientId(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/editor/src/components/post-title/index.native.js
+++ b/packages/editor/src/components/post-title/index.native.js
@@ -22,12 +22,6 @@ import { pasteHandler } from '@wordpress/blocks';
 import styles from './style.scss';
 
 class PostTitle extends Component {
-	constructor() {
-		super( ...arguments );
-
-		this.titleViewRef = null;
-	}
-
 	componentDidMount() {
 		if ( this.props.innerRef ) {
 			this.props.innerRef( this );
@@ -39,10 +33,7 @@ class PostTitle extends Component {
 	}
 
 	focus() {
-		if ( this.titleViewRef ) {
-			this.titleViewRef.focus();
-			this.props.onSelect();
-		}
+		this.props.onSelect();
 	}
 
 	render() {
@@ -91,10 +82,8 @@ class PostTitle extends Component {
 					onSelectionChange={ () => { } }
 					onEnter={ this.props.onEnterPress }
 					disableEditingMenu={ true }
-					setRef={ ( ref ) => {
-						this.titleViewRef = ref;
-					} }
 					__unstablePasteHandler={ pasteHandler }
+					__unstableIsSelected={ this.props.isSelected }
 				>
 				</RichText>
 			</View>


### PR DESCRIPTION
## Description
This is a bug-fix that updates the post-title to not be selected if another block is selected. Additional description and testing steps are included in the [related gutenberg-mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1231).

## Checklist:
- [X] My code is tested.
- [X]  My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
