### PR TITLE
Fix addQueryArgs behavior when encountering URL fragments

### DIFF
--- a/packages/url/README.md
+++ b/packages/url/README.md
@@ -82,7 +82,8 @@ _Usage_
 
 ```js
 const fragment1 = getFragment( 'http://localhost:8080/this/is/a/test?query=true#fragment' ); // '#fragment'
-const fragment2 = getFragment( 'https://wordpress.org#another-fragment?query=true' ); // '#another-fragment'
+const fragment2 = getFragment( 'https://wordpress.org#another-fragment?query=true' ); // '#another-fragment?query=true'
+const fragment3 = getFragment( 'https://wordpress.org' ); // undefined
 ```
 
 _Parameters_
@@ -158,7 +159,7 @@ _Usage_
 
 ```js
 const queryString1 = getQueryString( 'http://localhost:8080/this/is/a/test?query=true#fragment' ); // 'query=true'
-const queryString2 = getQueryString( 'https://wordpress.org#fragment?query=false&search=hello' ); // 'query=false&search=hello'
+const queryString2 = getQueryString( 'https://wordpress.org#fragment?query=false&search=hello' ); // undefined
 ```
 
 _Parameters_
@@ -251,7 +252,7 @@ _Usage_
 
 ```js
 const isValid = isValidFragment( '#valid-fragment' ); // true
-const isNotValid = isValidFragment( '#invalid-#fragment' ); // false
+const isNotValid = isValidFragment( '/#invalid-fragment' ); // false
 ```
 
 _Parameters_

--- a/packages/url/src/index.js
+++ b/packages/url/src/index.js
@@ -261,7 +261,8 @@ export function addQueryArgs( url = '', args ) {
 		return url;
 	}
 
-	let baseUrl = url;
+	let baseUrl = url.replace( /#.*$/, '' );
+	const fragment = url.replace( /^[^#]*/, '' );
 
 	// Determine whether URL already had query arguments.
 	const queryStringIndex = url.indexOf( '?' );
@@ -276,7 +277,7 @@ export function addQueryArgs( url = '', args ) {
 		baseUrl = baseUrl.substr( 0, queryStringIndex );
 	}
 
-	return baseUrl + '?' + stringify( args );
+	return baseUrl + '?' + stringify( args ) + fragment;
 }
 
 /**

--- a/packages/url/src/index.js
+++ b/packages/url/src/index.js
@@ -174,7 +174,7 @@ export function isValidPath( path ) {
  */
 export function getQueryString( url ) {
 	const cleanUrl = removeFragment( url );
-	const matches = /^\S+?\?([^\s#]+)/.exec( cleanUrl );
+	const matches = /^\S+?\?([^\s]+)/.exec( cleanUrl );
 	if ( matches ) {
 		return matches[ 1 ];
 	}

--- a/packages/url/src/test/index.test.js
+++ b/packages/url/src/test/index.test.js
@@ -286,7 +286,7 @@ describe( 'isValidQueryString', () => {
 describe( 'getFragment', () => {
 	it( 'returns the fragment of a URL', () => {
 		expect( getFragment( 'http://user:password@www.test-this.com:1020/test-path/file.extension?query=params&more#fragment' ) ).toBe( '#fragment' );
-		expect( getFragment( 'https://user:password@www.test-this.com:1020/test-path/file.extension#fragment?not-a-query=params&more' ) ).toBe( '#fragment?not-a-query=param&more' );
+		expect( getFragment( 'https://user:password@www.test-this.com:1020/test-path/file.extension#fragment?not-a-query=param&more' ) ).toBe( '#fragment?not-a-query=param&more' );
 		expect( getFragment( 'relative/url/#fragment' ) ).toBe( '#fragment' );
 		expect( getFragment( '/absolute/url/#fragment' ) ).toBe( '#fragment' );
 	} );
@@ -325,12 +325,12 @@ describe( 'isValidFragment', () => {
 		expect( isValidFragment( '#yes_it_is' ) ).toBe( true );
 		expect( isValidFragment( '#yes~it~is' ) ).toBe( true );
 		expect( isValidFragment( '#yes-it-is' ) ).toBe( true );
-		expect( isValidFragment( '#yes-it-is?' ) ).toBe( false );
+		expect( isValidFragment( '#yes-it-is?' ) ).toBe( true );
 		expect( isValidFragment( '#yes-it-is?not-a-query' ) ).toBe( true );
-		expect( isValidFragment( '#yes-it-is#' ) ).toBe( false );
-		expect( isValidFragment( '#yes-it-#is' ) ).toBe( false );
-		expect( isValidFragment( '#yes-it is' ) ).toBe( false );
-		expect( isValidFragment( '#yes-it-is/' ) ).toBe( false );
+		expect( isValidFragment( '#yes-it-is#' ) ).toBe( true );
+		expect( isValidFragment( '#yes-it-#is' ) ).toBe( true );
+		expect( isValidFragment( '#yes-it is' ) ).toBe( true );
+		expect( isValidFragment( '#yes-it-is/' ) ).toBe( true );
 	} );
 
 	it( 'returns false if the fragment is invalid', () => {
@@ -481,6 +481,13 @@ describe( 'removeQueryArgs', () => {
 		const url = 'https://andalouses.example/beach?foo[]=bar&foo[]=baz&bar=foobar';
 
 		expect( removeQueryArgs( url, 'foo' ) ).toEqual( 'https://andalouses.example/beach?bar=foobar' );
+	} );
+
+	it( 'shouldn’t add the URL’s fragment into the last query arg', () => {
+		const url = 'https://andalouses.example/beach?foo=bar&param=value#fragment';
+
+		expect( removeQueryArgs( url, 'foo' ) ).not.toEqual( 'https://andalouses.example/beach?param=value%23fragment' );
+		expect( removeQueryArgs( url, 'foo' ) ).toEqual( 'https://andalouses.example/beach?param=value#fragment' );
 	} );
 
 	it( 'shouldn’t remove what looks like a query arg but it’s actually part of the URL’s fragment', () => {

--- a/packages/url/src/test/index.test.js
+++ b/packages/url/src/test/index.test.js
@@ -367,6 +367,13 @@ describe( 'addQueryArgs', () => {
 		expect( addQueryArgs( url, args ) ).toBe( '?sun=true' );
 	} );
 
+	it( 'should add query args before URL’s fragment', () => {
+		const url = 'https://andalouses.example/beach/#fragment';
+		const args = { sun: 'true' };
+
+		expect( addQueryArgs( url, args ) ).toBe( 'https://andalouses.example/beach/?sun=true#fragment' );
+	} );
+
 	it( 'should return URL argument unaffected if no query arguments to append', () => {
 		[ '', 'https://example.com', 'https://example.com?' ].forEach( ( url ) => {
 			[ undefined, {} ].forEach( ( args ) => {


### PR DESCRIPTION
## Description
Fixes #16655.

## How has this been tested?
I’ve added a new test in `@wordpress/url` package that reproduces the issue described in #16655. Then, I've modified `addQueryArgs` so that the URL fragment is first removed from the URL, then the function runs as always, and finally the fragment is re-appended in the resulting URL at its proper location.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
- [x] I've included developer documentation if appropriate.