### PR TITLE
Data: Persistence: Run persistence subscriber on idle callback

### DIFF
--- a/packages/data/src/plugins/persistence/index.js
+++ b/packages/data/src/plugins/persistence/index.js
@@ -64,7 +64,7 @@ export const withLazySameState = ( reducer ) => ( state, action ) => {
  * @return {Function} Callback proxy, invoking the callback when available.
  */
 export const withIdleCallback = ( () => {
-	if ( 'requestIdleCallback' in window ) {
+	if ( typeof window !== 'undefined' && 'requestIdleCallback' in window ) {
 		return window.requestIdleCallback;
 	}
 

--- a/packages/data/src/plugins/persistence/index.js
+++ b/packages/data/src/plugins/persistence/index.js
@@ -7,6 +7,7 @@ import { merge, isPlainObject, get, has } from 'lodash';
  * Internal dependencies
  */
 import defaultStorage from './storage/default';
+import withIdleCallback from './with-idle-callback';
 import { combineReducers } from '../../';
 
 /** @typedef {import('../../registry').WPDataRegistry} WPDataRegistry */
@@ -53,23 +54,6 @@ export const withLazySameState = ( reducer ) => ( state, action ) => {
 
 	return reducer( state, action );
 };
-
-/**
- * Returns a function which accepts a callback and, when called, invokes the
- * callback at the earliest free moment, using `requestIdleCallback` if
- * available, falling back to `setTimeout`.
- *
- * @param {Function} callback Callback to invoke.
- *
- * @return {Function} Callback proxy, invoking the callback when available.
- */
-export const withIdleCallback = ( () => {
-	if ( typeof window !== 'undefined' && 'requestIdleCallback' in window ) {
-		return window.requestIdleCallback;
-	}
-
-	return ( callback ) => setTimeout( callback, 0 );
-} )();
 
 /**
  * Creates a persistence interface, exposing getter and setter methods (`get`

--- a/packages/data/src/plugins/persistence/with-idle-callback.js
+++ b/packages/data/src/plugins/persistence/with-idle-callback.js
@@ -1,0 +1,12 @@
+/**
+ * A function which accepts a callback, calling the callback at the earliest
+ * free moment, using `requestIdleCallback` if available, falling back to
+ * `setTimeout`.
+ *
+ * @type {(callback:()=>void)=>void}
+ */
+const withIdleCallback = typeof window !== 'undefined' && 'requestIdleCallback' in window ?
+	( callback ) => void window.requestIdleCallback( () => callback() ) :
+	( callback ) => void setTimeout( callback, 0 );
+
+export default withIdleCallback;


### PR DESCRIPTION
This pull request seeks to optimize the implementation of the data persistence plugin to occur asynchronously in response to a state change only at the earliest idle opportunity. Persistence should occur after a state change, but does not need to occur immediately / synchronously. By deferring the work, we lessen the total workload necessary for each state change.

_Work in Progress:_

- [x] The unit tests still need to be updated for the changed behavior.
- [x] Measure performance impact

**Testing Instructions:**

Ensure unit tests pass:

```
npm run test-unit
```

Verify that changes in preferences (e.g. top toolbar option) persist across page reloads.