### PR TITLE
Chore Update phpcs config to test php 5.6 compatibility instead of 5.2

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -3,7 +3,7 @@
 	<description>Sniffs for WordPress plugins, with minor modifications for Gutenberg</description>
 
 	<rule ref="PHPCompatibility"/>
-	<config name="testVersion" value="5.2-"/>
+	<config name="testVersion" value="5.6-"/>
 
 	<rule ref="WordPress-Core"/>
 	<rule ref="WordPress-Docs"/>


### PR DESCRIPTION
## Description
This changes phpcs to verify compatibility against 5.6 instead of PHP 5.2.
It was extracted from https://github.com/WordPress/gutenberg/pull/16356 and it is required to merge that PR.