### PR TITLE
Don't show theme blocks on post content

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -48,3 +48,24 @@ function gutenberg_reregister_core_block_types() {
 	}
 }
 add_action( 'init', 'gutenberg_reregister_core_block_types' );
+
+/**
+ * Adds new block categories needed by the Gutenberg plugin.
+ *
+ * @param array $categories Array of block categories.
+ *
+ * @return array Array of block categories plus the new categories added.
+ */
+function gutenberg_block_categories( $categories ) {
+	return array_merge(
+		$categories,
+		array(
+			array(
+				'slug'  => 'theme',
+				'title' => __( 'Theme Blocks' ),
+				'icon'  => null,
+			),
+		)
+	);
+}
+add_filter( 'block_categories', 'gutenberg_block_categories' );

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/post-content",
-	"category": "common",
+	"category": "theme",
 	"supports": {
 		"multiple": false
 	}

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -2,7 +2,18 @@
  * WordPress dependencies
  */
 import { InnerBlocks } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
 
 export default function PostContentEdit() {
-	return <InnerBlocks templateLock={ false } />;
+	const allowedBlocks = useSelect( ( select ) => {
+		return select( 'core/blocks' ).getBlockTypes().filter(
+			( { category } ) => category !== 'theme'
+		).map( ( { name } ) => name );
+	} );
+	return (
+		<InnerBlocks
+			templateLock={ false }
+			allowedBlocks={ allowedBlocks }
+		/>
+	);
 }

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "core/post-title",
-	"category": "common",
+	"category": "theme",
 	"attributes": {
 		"title": {
 			"type": "string",

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -28,6 +28,7 @@ export const DEFAULT_CATEGORIES = [
 	{ slug: 'layout', title: __( 'Layout Elements' ) },
 	{ slug: 'widgets', title: __( 'Widgets' ) },
 	{ slug: 'embed', title: __( 'Embeds' ) },
+	{ slug: 'theme', title: __( 'Theme Blocks' ) },
 	{ slug: 'reusable', title: __( 'Reusable Blocks' ) },
 ];
 


### PR DESCRIPTION
## Description
This is a simple PR that implements functionality to not show theme blocks in the post content.
We are also creating a new category that contains all theme blocks (post title and post content for now).

## How has this been tested?
I selected a block inside the post content block, I verified post title and post content don't appear on the inserter.
At the template level outside post content the theme blocks still appear.
