### PR TITLE
useReducedMotion: Guard process usage

### DIFF
--- a/packages/compose/src/hooks/use-reduced-motion/index.js
+++ b/packages/compose/src/hooks/use-reduced-motion/index.js
@@ -11,12 +11,22 @@ import useMediaQuery from '../use-media-query';
 const IS_IE = window.navigator.userAgent.indexOf( 'Trident' ) >= 0;
 
 /**
+ * Force reduced motion behavior at build time
+ *
+ * @type {boolean}
+ */
+const FORCE_REDUCED_MOTION =
+	typeof process === 'object' &&
+	typeof process.env === 'object' &&
+	!! process.env.FORCE_REDUCED_MOTION;
+
+/**
  * Hook returning whether the user has a preference for reduced motion.
  *
  * @return {boolean} Reduced motion preference value.
  */
 const useReducedMotion =
-	process.env.FORCE_REDUCED_MOTION || IS_IE ?
+	FORCE_REDUCED_MOTION || IS_IE ?
 		() => true :
 		() => useMediaQuery( '(prefers-reduced-motion: reduce)' );
 

--- a/packages/compose/src/hooks/use-reduced-motion/index.js
+++ b/packages/compose/src/hooks/use-reduced-motion/index.js
@@ -16,6 +16,11 @@ const IS_IE = window.navigator.userAgent.indexOf( 'Trident' ) >= 0;
  * @type {boolean}
  */
 let FORCE_REDUCED_MOTION = false;
+
+// Prefer the try/catch to allow bundlers to replace `process.env.FORCE_REDUCED_MOTION` completely.
+// Checks like `typeof process === 'object' && …` will be safe, but may short-circuit if a bundler
+// has replaced `process.env.FORCE_REDUCED_MOTION` with `true`, but `window.process`
+// remains undefined.
 try {
 	FORCE_REDUCED_MOTION = !! process.env.FORCE_REDUCED_MOTION;
 } catch ( err ) {}

--- a/packages/compose/src/hooks/use-reduced-motion/index.js
+++ b/packages/compose/src/hooks/use-reduced-motion/index.js
@@ -15,10 +15,10 @@ const IS_IE = window.navigator.userAgent.indexOf( 'Trident' ) >= 0;
  *
  * @type {boolean}
  */
-const FORCE_REDUCED_MOTION =
-	typeof process === 'object' &&
-	typeof process.env === 'object' &&
-	!! process.env.FORCE_REDUCED_MOTION;
+let FORCE_REDUCED_MOTION = false;
+try {
+	FORCE_REDUCED_MOTION = !! process.env.FORCE_REDUCED_MOTION;
+} catch ( err ) {}
 
 /**
  * Hook returning whether the user has a preference for reduced motion.


### PR DESCRIPTION
## Description

The `useReducedMotion` hook provided by `@wordpress/compose` has unguarded usage of the `process` global:

https://github.com/WordPress/gutenberg/blob/6ef0222b152408e640b8d519236f885e166c5a41/packages/compose/src/hooks/use-reduced-motion/index.js#L19

`process` is not a global variable in the browser. Depending on the way this code is bundled, it may work well at runtime, or it may error when the `useReducedMotion` module is evaluated.

In `webpack`, this is is controlled by the [`node` configuration option](https://webpack.js.org/configuration/node#node). If you attempt to bundle a project like the following:

```js
// webpack.config.js
module.exports = { node: false };

// src/index.js (entrypoint)
import { useReducedMotion } from '@wordpress/compose';
```

An error will be thrown at runtime when the script is evaluated:

```
Uncaught ReferenceError: process is not defined
    at Module.<anonymous> (main.js:38)
    at n (main.js:1)
    at main.js:1
    at main.js:1
```

## How has this been tested?

Local testing by manipulating the installed module in a minimal test repo.

## Types of changes

Bug fix - Unprotected `process` global usage could throw runtime errors when. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
