### PR TITLE
API Fetch: refresh nonces as soon as they expire, then fetch again

### DIFF
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -129,6 +129,10 @@ function gutenberg_pre_init() {
 	require_once dirname( __FILE__ ) . '/lib/load.php';
 }
 
-add_action( 'wp_ajax_gutenberg_rest_nonce', function() {
+/**
+ * Outputs a WP REST API nonce.
+ */
+function gutenberg_rest_nonce() {
 	exit( wp_create_nonce( 'wp_rest' ) );
-} );
+}
+add_action( 'wp_ajax_gutenberg_rest_nonce', 'gutenberg_rest_nonce' );

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -128,3 +128,8 @@ function gutenberg_pre_init() {
 
 	require_once dirname( __FILE__ ) . '/lib/load.php';
 }
+
+add_action( 'wp_ajax_gutenberg_rest_nonce', function() {
+	echo wp_create_nonce( 'wp_rest' );
+	die;
+} );

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -130,6 +130,5 @@ function gutenberg_pre_init() {
 }
 
 add_action( 'wp_ajax_gutenberg_rest_nonce', function() {
-	echo wp_create_nonce( 'wp_rest' );
-	die;
+	exit( wp_create_nonce( 'wp_rest' ) );
 } );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -246,25 +246,11 @@ function gutenberg_register_scripts_and_styles() {
 	wp_add_inline_script(
 		'wp-api-fetch',
 		sprintf(
-			implode(
-				"\n",
-				array(
-					'( function() {',
-					'	var nonceMiddleware = wp.apiFetch.createNonceMiddleware( "%s" );',
-					'	wp.apiFetch.use( nonceMiddleware );',
-					'	wp.hooks.addAction(',
-					'		"heartbeat.tick",',
-					'		"core/api-fetch/create-nonce-middleware",',
-					'		function( response ) {',
-					'			if ( response[ "rest_nonce" ] ) {',
-					'				nonceMiddleware.nonce = response[ "rest_nonce" ];',
-					'			}',
-					'		}',
-					'	)',
-					'} )();',
-				)
-			),
-			( wp_installing() && ! is_multisite() ) ? '' : wp_create_nonce( 'wp_rest' )
+			'wp.apiFetch.nonceMiddleware = wp.apiFetch.createNonceMiddleware( "%s" );' .
+			'wp.apiFetch.use( wp.apiFetch.nonceMiddleware );' .
+			'wp.apiFetch.nonceEndpoint = "%s";',
+			( wp_installing() && ! is_multisite() ) ? '' : wp_create_nonce( 'wp_rest' ),
+			admin_url( 'admin-ajax.php?action=gutenberg_rest_nonce' )
 		),
 		'after'
 	);

--- a/packages/e2e-tests/plugins/nonce.php
+++ b/packages/e2e-tests/plugins/nonce.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Plugin Name: Gutenberg Test Plugin, Nonce
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-plugin-nonce
+ */
+
+add_filter( 'nonce_life', function () {
+	return 5;
+} );

--- a/packages/e2e-tests/plugins/nonce.php
+++ b/packages/e2e-tests/plugins/nonce.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Plugin Name: Gutenberg Test Plugin, Nonce
  * Plugin URI: https://github.com/WordPress/gutenberg
@@ -8,6 +7,10 @@
  * @package gutenberg-test-plugin-nonce
  */
 
-add_filter( 'nonce_life', function () {
+/**
+ * Returns the nonce life time.
+ */
+function gutenberg_test_plugin_nonce_life() {
 	return 5;
-} );
+}
+add_filter( 'nonce_life', 'gutenberg_test_plugin_nonce_life' );

--- a/packages/e2e-tests/specs/plugins/nonce.test.js
+++ b/packages/e2e-tests/specs/plugins/nonce.test.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	activatePlugin,
+	createNewPost,
+	deactivatePlugin,
+	saveDraft,
+} from '@wordpress/e2e-test-utils';
+
+describe( 'Nonce', () => {
+	beforeAll( async () => {
+		await activatePlugin( 'gutenberg-test-plugin-nonce' );
+	} );
+
+	afterAll( async () => {
+		await deactivatePlugin( 'gutenberg-test-plugin-nonce' );
+	} );
+
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	it( 'should refresh when expired', async () => {
+		await page.keyboard.press( 'Enter' );
+		// eslint-disable-next-line no-restricted-syntax
+		await page.waitFor( 5000 );
+		await page.keyboard.type( 'test' );
+		// `saveDraft` waits for saving to be successful, so this test would
+		// timeout if it's not.
+		await saveDraft();
+		// We expect a 403 status once.
+		expect( console ).toHaveErrored();
+	} );
+} );


### PR DESCRIPTION
## Description

Currently, nonces are refresh through the Heartbeat API, but it requires a valid nonce. When you leave a post open and come back to it the next day (during which time the heartbeat may have stopped), the nonce cannot be refreshed.

Since a simple authenticated request is enough to get a new nonce elsewhere (like a full page reload), we can just create an endpoint with `admin-ajax.php` to get a new nonce. We CANNOT use the REST API itself because of CORS, but we can create a separate endpoint without CORS.

I updated the API Fetch package to refresh a nonce when the REST API sends a nonce error code. Once a new nonce is obtained, the request is remade. The user wouldn't notice a thing. :)

Notice that with this technique, the nonce lifetime could even be **reduced** for increased security, without affecting the user experience!

## How has this been tested?

Install the e2e test plugin that sets the nonce lifetime to 5 seconds. Create a new post. Wait 5 seconds, then add some text and try to save. Saving should work. Open the console and notice that there is one 403 status error logged.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
