### PR TITLE
Try adding some additional padding to the modal component. 

### DIFF
--- a/assets/stylesheets/_variables.scss
+++ b/assets/stylesheets/_variables.scss
@@ -19,6 +19,7 @@ $mobile-text-min-font-size: 16px; // Any font size below 16px will cause Mobile 
 $grid-size-small: 4px;
 $grid-size: 8px;
 $grid-size-large: 16px;
+$grid-size-xlarge: 24px;
 
 // Widths, heights & dimensions
 $panel-padding: 16px;

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -61,7 +61,7 @@
 .components-modal__header {
 	box-sizing: border-box;
 	border-bottom: $border-width solid $light-gray-500;
-	padding: 0 $grid-size-large;
+	padding: 0 ($grid-size * 3);
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
@@ -71,7 +71,7 @@
 	position: sticky;
 	top: 0;
 	z-index: z-index(".components-modal__header");
-	margin: 0 -#{ $grid-size-large } $grid-size-large;
+	margin: 0 -#{ $grid-size * 3 } #{ $grid-size * 3 };
 
 	// Rules inside this query are only run by Microsoft Edge.
 	// Edge has bugs around position: sticky;, so it needs a separate top rule.
@@ -114,7 +114,7 @@
 .components-modal__content {
 	box-sizing: border-box;
 	height: 100%;
-	padding: 0 $grid-size-large $grid-size-large;
+	padding: 0 ($grid-size * 3) ($grid-size * 3);
 
 	// Rules inside this query are only run by Microsoft Edge.
 	// This is a companion top padding to the fixed rule in line 77.

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -61,7 +61,7 @@
 .components-modal__header {
 	box-sizing: border-box;
 	border-bottom: $border-width solid $light-gray-500;
-	padding: 0 ($grid-size * 3);
+	padding: 0 $grid-size-xlarge;
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
@@ -71,7 +71,7 @@
 	position: sticky;
 	top: 0;
 	z-index: z-index(".components-modal__header");
-	margin: 0 -#{ $grid-size * 3 } #{ $grid-size * 3 };
+	margin: 0 -#{$grid-size-xlarge} $grid-size-xlarge;
 
 	// Rules inside this query are only run by Microsoft Edge.
 	// Edge has bugs around position: sticky;, so it needs a separate top rule.
@@ -114,7 +114,7 @@
 .components-modal__content {
 	box-sizing: border-box;
 	height: 100%;
-	padding: 0 ($grid-size * 3) ($grid-size * 3);
+	padding: 0 $grid-size-xlarge $grid-size-xlarge;
 
 	// Rules inside this query are only run by Microsoft Edge.
 	// This is a companion top padding to the fixed rule in line 77.

--- a/packages/edit-post/src/components/manage-blocks-modal/style.scss
+++ b/packages/edit-post/src/components/manage-blocks-modal/style.scss
@@ -109,9 +109,9 @@
 .edit-post-manage-blocks-modal__results {
 	height: 100%;
 	overflow: auto;
-	margin-left: -1 * $grid-size-large;
-	margin-right: -1 * $grid-size-large;
-	padding-left: $grid-size-large;
-	padding-right: $grid-size-large;
+	margin-left: -3 * $grid-size;
+	margin-right: -3 * $grid-size;
+	padding-left: $grid-size * 3;
+	padding-right: $grid-size * 3;
 	border-top: $border-width solid $light-gray-500;
 }

--- a/packages/edit-post/src/components/manage-blocks-modal/style.scss
+++ b/packages/edit-post/src/components/manage-blocks-modal/style.scss
@@ -109,9 +109,9 @@
 .edit-post-manage-blocks-modal__results {
 	height: 100%;
 	overflow: auto;
-	margin-left: -3 * $grid-size;
-	margin-right: -3 * $grid-size;
-	padding-left: $grid-size * 3;
-	padding-right: $grid-size * 3;
+	margin-left: -$grid-size-xlarge;
+	margin-right: -$grid-size-xlarge;
+	padding-left: $grid-size-xlarge;
+	padding-right: $grid-size-xlarge;
 	border-top: $border-width solid $light-gray-500;
 }


### PR DESCRIPTION
The modal component currently has `16px` of padding all the way around it. This is fine, but it does leave things feeling a little closed in. This PR updates that from `16px` to `24px` instead. This is more padding than we typically use around these sorts of containers, but I think the extra breathing room makes the modals feel a lot more comfortable. 

**Before:**

<img width="387" alt="Screen Shot 2019-07-19 at 3 52 18 PM" src="https://user-images.githubusercontent.com/1202812/61561558-4cd0f380-aa3d-11e9-8bd2-c62cc58c08d6.png">

<img width="506" alt="Screen Shot 2019-07-19 at 3 46 28 PM" src="https://user-images.githubusercontent.com/1202812/61561573-5195a780-aa3d-11e9-9782-4f09c2135582.png">

<img width="391" alt="Screen Shot 2019-07-19 at 3 46 13 PM" src="https://user-images.githubusercontent.com/1202812/61561578-55c1c500-aa3d-11e9-8c21-d3e7f1fccd77.png">

**After**

<img width="396" alt="Screen Shot 2019-07-19 at 3 52 01 PM" src="https://user-images.githubusercontent.com/1202812/61561600-640fe100-aa3d-11e9-91a6-7ca7f48d0a3c.png">

<img width="527" alt="Screen Shot 2019-07-19 at 3 43 36 PM" src="https://user-images.githubusercontent.com/1202812/61561606-683bfe80-aa3d-11e9-9ce6-f83217ffd8ed.png">

<img width="399" alt="Screen Shot 2019-07-19 at 3 43 17 PM" src="https://user-images.githubusercontent.com/1202812/61561614-6a9e5880-aa3d-11e9-8eca-c30cbdbefb19.png">
