### PR TITLE
Data: Create registry selector with self-contained registry proxying

### DIFF
--- a/packages/data/src/factory.js
+++ b/packages/data/src/factory.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import defaultRegistry from './default-registry';
+
+/**
  * Mark a selector as a registry selector.
  *
  * @param {function} registrySelector Function receiving a registry object and returning a state selector.
@@ -6,9 +11,25 @@
  * @return {function} marked registry selector.
  */
 export function createRegistrySelector( registrySelector ) {
-	registrySelector.isRegistrySelector = true;
+	const selector = ( ...args ) => registrySelector( selector.registry.select )( ...args );
 
-	return registrySelector;
+	/**
+	 * Flag indicating to selector registration mapping that the selector should
+	 * be mapped as a registry selector.
+	 *
+	 * @type {boolean}
+	 */
+	selector.isRegistrySelector = true;
+
+	/**
+	 * Registry on which to call `select`, stubbed for non-standard usage to
+	 * use the default registry.
+	 *
+	 * @type {WPDataRegistry}
+	 */
+	selector.registry = defaultRegistry;
+
+	return selector;
 }
 
 /**

--- a/packages/data/src/factory.js
+++ b/packages/data/src/factory.js
@@ -4,6 +4,10 @@
 import defaultRegistry from './default-registry';
 
 /**
+ * @typedef {import('./registry').WPDataRegistry} WPDataRegistry
+ */
+
+/**
  * Mark a selector as a registry selector.
  *
  * @param {function} registrySelector Function receiving a registry object and returning a state selector.

--- a/packages/data/src/namespace-store/index.js
+++ b/packages/data/src/namespace-store/index.js
@@ -148,12 +148,10 @@ function createReduxStore( key, options, registry ) {
 /**
  * Maps selectors to a store.
  *
- * @param {Object}         selectors Selectors to register. Keys will be used as
- *                                   the public facing API. Selectors will get
- *                                   passed the state as first argument.
- * @param {Object}         store     The store to which the selectors should be
- *                                   mapped.
- * @param {WPDataRegistry} registry  Registry reference.
+ * @param {Object} selectors Selectors to register. Keys will be used as the
+ *                           public facing API. Selectors will get passed the
+ *                           state as first argument.
+ * @param {Object} store     The store to which the selectors should be mapped.
  *
  * @return {Object} Selectors mapped to the provided store.
  */

--- a/packages/data/src/namespace-store/index.js
+++ b/packages/data/src/namespace-store/index.js
@@ -51,16 +51,12 @@ export default function createNamespace( key, options, registry ) {
 		...mapValues( metadataSelectors, ( selector ) => ( state, ...args ) => selector( state.metadata, ...args ) ),
 		...mapValues( options.selectors, ( selector ) => {
 			if ( selector.isRegistrySelector ) {
-				const mappedSelector = ( reg ) => ( state, ...args ) => {
-					return selector( reg )( state.root, ...args );
-				};
-				mappedSelector.isRegistrySelector = selector.isRegistrySelector;
-				return mappedSelector;
+				selector.registry = registry;
 			}
 
 			return ( state, ...args ) => selector( state.root, ...args );
 		} ),
-	}, store, registry );
+	}, store );
 	if ( options.resolvers ) {
 		const result = mapResolvers( options.resolvers, selectors, store );
 		resolvers = result.resolvers;
@@ -161,12 +157,8 @@ function createReduxStore( key, options, registry ) {
  *
  * @return {Object} Selectors mapped to the provided store.
  */
-function mapSelectors( selectors, store, registry ) {
-	const createStateSelector = ( registeredSelector ) => {
-		const registrySelector = registeredSelector.isRegistrySelector ?
-			registeredSelector( registry.select ) :
-			registeredSelector;
-
+function mapSelectors( selectors, store ) {
+	const createStateSelector = ( registrySelector ) => {
 		const selector = function runSelector() {
 			// This function is an optimized implementation of:
 			//

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -464,6 +464,38 @@ describe( 'createRegistry', () => {
 
 			expect( registry.select( 'reducer2' ).selector2() ).toEqual( 'result1' );
 		} );
+
+		it( 'should run the registry selector from a non-registry selector', () => {
+			const selector1 = () => 'result1';
+			const selector2 = createRegistrySelector( ( select ) => () =>
+				select( 'reducer1' ).selector1()
+			);
+			const selector3 = () => selector2();
+			registry.registerStore( 'reducer1', {
+				reducer: () => 'state1',
+				selectors: {
+					selector1,
+				},
+			} );
+			registry.registerStore( 'reducer2', {
+				reducer: () => 'state1',
+				selectors: {
+					selector2,
+					selector3,
+				},
+			} );
+
+			expect( registry.select( 'reducer2' ).selector3() ).toEqual( 'result1' );
+		} );
+
+		it( 'gracefully stubs select on selector calls', () => {
+			const selector = createRegistrySelector( ( select ) => () => select );
+
+			const maybeSelect = selector();
+
+			expect( maybeSelect ).toEqual( expect.any( Function ) );
+			expect( maybeSelect() ).toEqual( expect.any( Object ) );
+		} );
 	} );
 
 	describe( 'subscribe', () => {

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -44,7 +44,7 @@ const {
 	isCurrentPostScheduled,
 	isEditedPostPublishable,
 	isEditedPostSaveable,
-	isEditedPostAutosaveable: isEditedPostAutosaveableRegistrySelector,
+	isEditedPostAutosaveable: _isEditedPostAutosaveableRegistrySelector,
 	isEditedPostEmpty,
 	isEditedPostBeingScheduled,
 	isEditedPostDateFloating,
@@ -71,9 +71,14 @@ const {
 
 describe( 'selectors', () => {
 	let cachedSelectors;
+	let isEditedPostAutosaveableRegistrySelector;
 
 	beforeAll( () => {
 		cachedSelectors = filter( selectors, ( selector ) => selector.clear );
+		isEditedPostAutosaveableRegistrySelector = ( select ) => {
+			_isEditedPostAutosaveableRegistrySelector.registry = { select };
+			return _isEditedPostAutosaveableRegistrySelector;
+		};
 	} );
 
 	beforeEach( () => {


### PR DESCRIPTION
Extracted from #16761

This pull request seeks to resolve an issue where calling a registry selector from a non-registry selector will produce an unexpected value, since the function returned by `createRegistrySelector` was the higher-order function expecting the registry as argument, not the underlying selector. With the changes here, a non-registry selector can call a registry selector as if it were any standard selector. The registry is automatically provided by the "current" registry in the mapping of selectors during store registration.

**Testing Instructions:**

Ensure unit tests pass:

```
npm run test-unit
```