### PR TITLE
Update: scrollable component popover

### DIFF
--- a/packages/block-editor/src/components/block-preview/README.md
+++ b/packages/block-editor/src/components/block-preview/README.md
@@ -1,0 +1,24 @@
+BlockPreview
+============
+
+BlockPreview allows you to preview any arbitrary HTML and CSS content, with a perfectly scaled thumbnail.
+
+## Usage
+
+In a block's `edit` implementation, render `InnerBlocks`. Then, in the `save` implementation, render `InnerBlocks.Content`. This will be replaced automatically with the content of the nested blocks.
+
+```jsx
+<BlockPreviewContent
+	name={ name }
+	attributes={ {
+		...attributes,
+		className: styleClassName,
+	} }
+	innerBlocks={ block.innerBlocks }
+	srcWidth={ 400 }
+	srcHeight={ 300 }
+
+/>
+```
+
+_Note:_ `srcWidth` and `srcHeight` refer to the _unscaled dimensions of what you mean to preview. Think of the preview as a big sourc image, say 800x600 that's scaled down. So if the HTML you mean to preview looks good at 800x600, those are your source dimensionss. A calculated `transform: scale( ...  )` value will be assigned to the thumbnail, so that it fits your destination dimensions, which you set in CSS.

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -23,22 +23,41 @@ function BlockPreview( props ) {
 	return (
 		<div className="editor-block-preview block-editor-block-preview">
 			<div className="editor-block-preview__title block-editor-block-preview__title">{ __( 'Preview' ) }</div>
-			<BlockPreviewContent { ...props } />
+			<BlockPreviewContent { ...props } srcWidth={ 280 } srcHeight={ 300 } destWidth={ 280 } />
 		</div>
 	);
 }
 
-export function BlockPreviewContent( { name, attributes, innerBlocks, settings } ) {
+export function BlockPreviewContent( { name, attributes, innerBlocks, settings, srcWidth, srcHeight, destWidth } ) {
+	// Todo: It would be nice if destWidth could be calculated here, that's the only missing piece ot making this fully responsive.
+
+	// Calculate the scale factor necessary to size down the preview thumbnail.
+	const scale = Math.min( destWidth / srcWidth );
+	const previewDimensions = {
+		width: srcWidth ? srcWidth : 400 + 'px', // 400x300 is provided as a 4:3 aspect ratio fallback.
+		height: srcHeight ? srcHeight : 300 + 'px',
+		transform: 'scale(' + scale + ')',
+	};
+
+	// We use a top-padding to create a responsively sized element with the same aspect ratio as the preview.
+	// The preview is then absolutely positioned on top of this, creating a visual unit.
+	const aspectPadding = Math.round( srcHeight / srcWidth * 100 );
+	const previewAspect = {
+		paddingTop: aspectPadding + '%',
+	};
+
 	const block = createBlock( name, attributes, innerBlocks );
 	return (
-		<Disabled className="editor-block-preview__content block-editor-block-preview__content editor-styles-wrapper" aria-hidden>
-			<BlockEditorProvider
-				value={ [ block ] }
-				settings={ settings }
-			>
-				<BlockList />
-			</BlockEditorProvider>
-		</Disabled>
+		<div style={ previewAspect } className="editor-block-preview__container" aria-hidden>
+			<Disabled style={ previewDimensions } className="editor-block-preview__content block-editor-block-preview__content editor-styles-wrapper">
+				<BlockEditorProvider
+					value={ [ block ] }
+					settings={ settings }
+				>
+					<BlockList />
+				</BlockEditorProvider>
+			</Disabled>
+		</div>
 	);
 }
 

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -28,7 +28,7 @@ function BlockPreview( props ) {
 	return (
 		<div className="editor-block-preview block-editor-block-preview">
 			<div className="editor-block-preview__title block-editor-block-preview__title">{ __( 'Preview' ) }</div>
-			<BlockPreviewContent { ...props } srcWidth={ 560 } srcHeight={ 600 } />
+			<BlockPreviewContent { ...props } srcWidth={ 560 } srcHeight={ 700 } />
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -4,12 +4,11 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 import { Disabled } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
-import { useLayoutEffect, useState } from '@wordpress/element';
+import { useLayoutEffect, useState, createRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -32,15 +31,15 @@ function BlockPreview( props ) {
 		</div>
 	);
 }
-
-export function BlockPreviewContent( { name, attributes, innerBlocks, settings, srcWidth, srcHeight } = {} ) {
+// 400x300 is provided as a 4:3 aspect ratio fallback.
+export function BlockPreviewContent( { name, attributes, innerBlocks, settings, srcWidth = 400, srcHeight = 300 } = {} ) {
 	// Calculated the destination width.
-	const previewRef = React.createRef();
+	const previewRef = createRef();
 
 	// Fallback dimensions.
 	const [ previewDimensions, setPreviewDimensions ] = useState( {
-		width: 400,
-		height: 300,
+		width: srcWidth,
+		height: srcHeight,
 		transform: 'scale(1)',
 	} );
 
@@ -55,8 +54,8 @@ export function BlockPreviewContent( { name, attributes, innerBlocks, settings, 
 		const scale = Math.min( destWidth / srcWidth ) || 1;
 
 		setPreviewDimensions( {
-			width: srcWidth ? srcWidth : 400 + 'px', // 400x300 is provided as a 4:3 aspect ratio fallback.
-			height: srcHeight ? srcHeight : 300 + 'px',
+			width: srcWidth + 'px',
+			height: srcHeight + 'px',
 			transform: 'scale(' + scale + ')',
 		} );
 
@@ -66,7 +65,7 @@ export function BlockPreviewContent( { name, attributes, innerBlocks, settings, 
 		setPreviewAspect( {
 			paddingTop: aspectPadding + '%',
 		} );
-	}, [] );
+	}, [ srcHeight, srcWidth ] );
 
 	const block = createBlock( name, attributes, innerBlocks );
 	return (

--- a/packages/block-editor/src/components/block-preview/style.scss
+++ b/packages/block-editor/src/components/block-preview/style.scss
@@ -1,3 +1,4 @@
+// This is the preview that shows up to the right of the thumbnail when hovering.
 .block-editor-block-preview {
 	pointer-events: none;
 	padding: 10px;
@@ -14,33 +15,53 @@
 		font-family: $editor-font;
 
 		> div {
-			transform: scale(0.9);
-			transform-origin: center top;
 			font-family: $editor-font;
 		}
+	}
 
-		> div section {
-			height: auto;
-		}
-
-		> .reusable-block-indicator {
-			display: none;
-		}
+	.block-editor-block-preview__title {
+		margin-bottom: 10px;
+		color: $dark-gray-300;
 	}
 }
 
+// These rules ensure the preview scales smoothly regardless of the container size.
+.editor-block-preview__container {
+	// In the component, a top padding is provided as an inline style to provid an aspect-ratio.
+	// This positioning enables the content to sit on top of that padding to fit.
+	position: relative;
+}
+
 .block-editor-block-preview__content {
-	// Resetting the block editor paddings and margins
+	// This element receives inline styles for width, height, and transform-scale.
+	// Those inline styles are calculated to fit a perfect thumbnail.
+
+	// Position above the padding.
+	position: absolute;
+	top: 0;
+	left: 0;
+
+	// Important to set the origin.
+	transform-origin: top left;
+
+	// Resetting paddings, margins, and other.
+	text-align: initial;
+	margin: 0;
+	padding: 0;
+	overflow: visible;
+	min-height: auto;
+
 	.block-editor-block-list__layout,
 	.block-editor-block-list__block {
 		padding: 0;
 	}
+
 	.editor-block-list__block-edit [data-block] {
 		margin-top: 0;
 	}
-}
 
-.block-editor-block-preview__title {
-	margin-bottom: 10px;
-	color: $dark-gray-300;
+	.reusable-block-indicator,
+	.block-list-appender {
+		display: none;
+	}
 }

--- a/packages/block-editor/src/components/block-preview/style.scss
+++ b/packages/block-editor/src/components/block-preview/style.scss
@@ -30,6 +30,10 @@
 	// In the component, a top padding is provided as an inline style to provid an aspect-ratio.
 	// This positioning enables the content to sit on top of that padding to fit.
 	position: relative;
+
+	// The preview component measures the pixel width of this item, so as to calculate the scale factor.
+	// But without this baseline width, it collapses to 0.
+	width: 100%;
 }
 
 .block-editor-block-preview__content {

--- a/packages/block-editor/src/components/block-preview/style.scss
+++ b/packages/block-editor/src/components/block-preview/style.scss
@@ -34,6 +34,10 @@
 	// The preview component measures the pixel width of this item, so as to calculate the scale factor.
 	// But without this baseline width, it collapses to 0.
 	width: 100%;
+
+	// This ensures that content evne if it overlaps the preview container is properly clipped.
+	// This is mostly for previews that include arbitrary content.
+	overflow: hidden;
 }
 
 .block-editor-block-preview__content {

--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -133,7 +133,7 @@ function BlockStyles( {
 								innerBlocks={ block.innerBlocks }
 								srcWidth={ 400 }
 								srcHeight={ 300 }
-								destWidth={ 124 }
+
 							/>
 						</div>
 						<div className="editor-block-styles__item-label block-editor-block-styles__item-label">

--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -131,6 +131,9 @@ function BlockStyles( {
 									className: styleClassName,
 								} }
 								innerBlocks={ block.innerBlocks }
+								srcWidth={ 400 }
+								srcHeight={ 300 }
+								destWidth={ 124 }
 							/>
 						</div>
 						<div className="editor-block-styles__item-label block-editor-block-styles__item-label">

--- a/packages/block-editor/src/components/block-styles/style.scss
+++ b/packages/block-editor/src/components/block-styles/style.scss
@@ -27,29 +27,15 @@
 	}
 }
 
+// Show a little preview thumbnail for style variations.
 .block-editor-block-styles__item-preview {
 	outline: $border-width solid transparent; // Shown in Windows High Contrast mode.
-	border: 1px solid rgba($dark-gray-900, 0.2);
-	overflow: hidden;
 	padding: 0;
-	text-align: initial;
+	border: $border-width solid rgba($dark-gray-900, 0.2);
 	border-radius: $radius-round-rectangle;
 	display: flex;
-	height: 60px;
+	overflow: hidden;
 	background: $white;
-
-	// Actual preview contents.
-	.block-editor-block-preview__content {
-		transform: scale(0.7);
-		transform-origin: center center;
-		width: 100%;
-
-		// Unset some of the styles that might be inherited from the editor style.
-		margin: 0;
-		padding: 0;
-		overflow: visible;
-		min-height: auto;
-	}
 }
 
 .block-editor-block-styles__item-label {

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -127,38 +127,42 @@ export class BlockSwitcher extends Component {
 				} }
 				renderContent={ ( { onClose } ) => (
 					<>
-						{ hasBlockStyles &&
-							<PanelBody
-								title={ __( 'Block Styles' ) }
-								initialOpen
-							>
-								<BlockStyles
-									clientId={ blocks[ 0 ].clientId }
-									onSwitch={ onClose }
-									onHoverClassName={ this.onHoverClassName }
-								/>
-							</PanelBody>
-						}
-						{ possibleBlockTransformations.length !== 0 &&
-							<PanelBody
-								title={ __( 'Transform To:' ) }
-								initialOpen
-							>
-								<BlockTypesList
-									items={ possibleBlockTransformations.map( ( destinationBlockType ) => ( {
-										id: destinationBlockType.name,
-										icon: destinationBlockType.icon,
-										title: destinationBlockType.title,
-										hasChildBlocksWithInserterSupport: hasChildBlocksWithInserterSupport( destinationBlockType.name ),
-									} ) ) }
-									onSelect={ ( item ) => {
-										onTransform( blocks, item.id );
-										onClose();
-									} }
-								/>
-							</PanelBody>
-						}
+						{ ( hasBlockStyles || possibleBlockTransformations.length !== 0 ) &&
+							<div className="components-popover__container">
+								{ hasBlockStyles &&
+									<PanelBody
+										title={ __( 'Block Styles' ) }
+										initialOpen
+									>
+										<BlockStyles
+											clientId={ blocks[ 0 ].clientId }
+											onSwitch={ onClose }
+											onHoverClassName={ this.onHoverClassName }
+										/>
+									</PanelBody>
+								}
+								{ possibleBlockTransformations.length !== 0 &&
+									<PanelBody
+										title={ __( 'Transform To:' ) }
+										initialOpen
+									>
+										<BlockTypesList
+											items={ possibleBlockTransformations.map( ( destinationBlockType ) => ( {
+												id: destinationBlockType.name,
+												icon: destinationBlockType.icon,
+												title: destinationBlockType.title,
+												hasChildBlocksWithInserterSupport: hasChildBlocksWithInserterSupport( destinationBlockType.name ),
+											} ) ) }
+											onSelect={ ( item ) => {
+												onTransform( blocks, item.id );
+												onClose();
+											} }
+										/>
+									</PanelBody>
+								}
 
+							</div>
+						}
 						{ ( hoveredClassName !== null ) &&
 							<BlockPreview
 								name={ blocks[ 0 ].name }

--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -88,10 +88,12 @@
 		@include formatting-button-style__focus();
 	}
 }
-
+// we double the max-width for it to fit both the preview & content
+// but we keep the min width the same for the border to work.
 .components-popover:not(.is-mobile).block-editor-block-switcher__popover .components-popover__content {
 	min-width: 300px;
-	max-width: 340px;
+	max-width: calc(340px * 2);
+	max-height: 500px;
 }
 
 .block-editor-block-switcher__popover .components-popover__content {
@@ -99,15 +101,16 @@
 		position: relative;
 
 		.block-editor-block-preview {
-			border: $border-width solid $light-gray-500;
+			border-left: $border-width solid $light-gray-500;
 			box-shadow: $shadow-popover;
 			background: $white;
-			position: absolute;
-			left: 100%;
-			top: -1px;
-			bottom: -1px;
 			width: 300px;
 			height: auto;
+			// sticky helps us keep the preview at the top when scrolling
+			position: sticky;
+			align-self: stretch;
+			// for sticky to work we need top
+			top: 0;
 		}
 	}
 
@@ -123,11 +126,6 @@
 	.components-panel__body + .components-panel__body {
 		border-top: $border-width solid $light-gray-500;
 	}
-}
-
-.block-editor-block-switcher__popover:not(.is-mobile) > .components-popover__content {
-	// Reset overflow to allow showing the preview on the left once an item is hovered.
-	overflow-y: visible;
 }
 
 .block-editor-block-switcher__popover .block-editor-block-styles {

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -116,13 +116,8 @@
 			background-size: 100px 100%;
 			// Disable reason: This function call looks nicer when each argument is on its own line.
 			/* stylelint-disable */
-			background-image: linear-gradient(
-				-45deg,
-				theme(primary) 28%,
-				color(theme(primary) shade(30%)) 28%,
-				color(theme(primary) shade(30%)) 72%,
-				theme(primary) 72%
-			);
+			background-image:
+ linear-gradient(-45deg, theme(primary) 28%, color(theme(primary) shade(30%)) 28%, color(theme(primary) shade(30%)) 72%, theme(primary) 72%);
 			/* stylelint-enable */
 			border-color: color(theme(primary) shade(50%));
 		}

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -134,16 +134,21 @@ $arrow-size: 8px;
 }
 
 .components-popover__content {
-	box-shadow: $shadow-popover;
-	border: $border-width solid $light-gray-500;
-	background: $white;
 	height: 100%;
+	display: flex;
+	border: $border-width solid $light-gray-500;
 
 	.components-popover.is-mobile & {
 		height: calc(100% - #{ $panel-header-height });
 		border-top: 0;
 	}
-
+	.components-popover__container {
+		box-shadow: $shadow-popover;
+		background: $white;
+		min-width: 300px;
+		max-width: 340px;
+		width: 50%;
+	}
 	.components-popover:not(.is-mobile) & {
 		position: absolute;
 		height: auto;


### PR DESCRIPTION
closes following issues:
#10905
#16028

closes following PR:
#16113

it builds upon & fixes problems & review points in  #16113
fixes some issues with the component popover not having overflow scrolling when the list is long

it's basically a simple code refactor to factor in some review problems, it also adds flexbox support to the component to remove the need for `overflow: visible` and having problems with long lists of preview options.


![better-previews](https://user-images.githubusercontent.com/6165348/61594613-bc81e280-abe5-11e9-93cf-011b68e9a665.gif)
