### PR TITLE
Project Management: Assign issues 'fixed' by a PR to the author of th…

### DIFF
--- a/.github/actions/assign-fixed-issues/Dockerfile
+++ b/.github/actions/assign-fixed-issues/Dockerfile
@@ -1,0 +1,18 @@
+FROM debian:stable-slim
+
+LABEL "name"="Assign Fixed Issues"
+LABEL "maintainer"="The WordPress Contributors"
+LABEL "version"="1.0.0"
+
+LABEL "com.github.actions.name"="Assign Fixed Issues"
+LABEL "com.github.actions.description"="Assigns the issues fixed by a pull request to the author of that pull request"
+LABEL "com.github.actions.icon"="flag"
+LABEL "com.github.actions.color"="green"
+
+RUN apt-get update && \
+	apt-get install --no-install-recommends -y jq curl ca-certificates && \
+	apt-get clean -y
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/.github/actions/assign-fixed-issues/entrypoint.sh
+++ b/.github/actions/assign-fixed-issues/entrypoint.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e
+
+# 1. Find the issues that this PR 'fixes'.
+
+issues=$(
+	jq -r '.pull_request.body' $GITHUB_EVENT_PATH | perl -nle 'print $1 while /
+		(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)
+		:?
+		\ +
+		(?:\#?|https?:\/\/github\.com\/WordPress\/gutenberg\/issues\/)
+		(\d+)
+	/igx'
+)
+
+if [ -z "$issues" ]; then
+	echo "Pull request does not 'fix' any issues. Aborting."
+	exit 78
+fi
+
+# 2. Grab the author of the PR.
+
+author=$(jq -r '.pull_request.user.login' $GITHUB_EVENT_PATH)
+
+# 3. Loop through each 'fixed' issue.
+
+for issue in $issues; do
+
+	# 3a. Add the author as an asignee to the issue. This fails if the author is
+	#     already assigned, which is expected and ignored.
+
+	curl \
+		--silent \
+		-X POST \
+		-H "Authorization: token $GITHUB_TOKEN" \
+		-H "Content-Type: application/json" \
+		-d "{\"assignees\":[\"$author\"]}" \
+		"https://api.github.com/repos/$GITHUB_REPOSITORY/issues/$issue/assignees" > /dev/null
+
+	# 3b. Label the issue as 'In Progress'. This fails if the label is already
+	#     applied, which is expected and ignored.
+
+	curl \
+		--silent \
+		-X POST \
+		-H "Authorization: token $GITHUB_TOKEN" \
+		-H "Content-Type: application/json" \
+		-d '{"labels":["[Status] In Progress"]}' \
+		"https://api.github.com/repos/$GITHUB_REPOSITORY/issues/$issue/labels" > /dev/null
+
+done

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -13,3 +13,19 @@ action "Milestone It" {
   needs = ["Filter merged"]
   secrets = ["GITHUB_TOKEN"]
 }
+
+workflow "Assign fixed issues when pull request opened" {
+  on = "pull_request"
+  resolves = ["Assign Fixed Issues"]
+}
+
+action "Filter opened" {
+  uses = "actions/bin/filter@0dbb077f64d0ec1068a644d25c71b1db66148a24"
+  args = "action opened"
+}
+
+action "Assign Fixed Issues" {
+  uses = "./.github/actions/assign-fixed-issues"
+  needs = ["Filter opened"]
+  secrets = ["GITHUB_TOKEN"]
+}


### PR DESCRIPTION
Adds a GitHub Action which, when a pull request is opened, searches the pull request description for 'Fixes #XXXX'  and, for each found issue:

- Adds the author of the pull request as an assignee.
- Adds the `[Status] In Progress` label.

#### Testing

I'm unable to test this on GitHub because my personal GitHub account doesn't have access to GitHub Actions. 

I tested it locally by:

1. Generate a [personal access token](https://github.com/settings/tokens) with the `public_repo` permission.
2. Create a mock [pull request event](https://developer.github.com/v3/activity/events/types/#pullrequestevent) and save it as `event.json`:  

```json
{
  "pull_request": {
    "body": "Lorem ipsum etc etc. Fixes #1.\nCloses 2",
	"user": {
	  "login": "noisysocks"
	}
  }
}
```
3. Run the action, replacing `INSERT_TOKEN_HERE` with the token generated above:  

  ```sh
docker build .github/actions/assign-fixed-issues/ -t assign-fixed-issues
docker run -v `pwd`:`pwd` -w `pwd` -e GITHUB_EVENT_PATH=event.json -e GITHUB_TOKEN=INSERT_TOKEN_HERE -e GITHUB_REPOSITORY=noisysocks/gutenberg -it assign-fixed-issues
```