### PR TITLE
Project Management: Update Milestone It reference date

### DIFF
--- a/.github/actions/milestone-it/entrypoint.sh
+++ b/.github/actions/milestone-it/entrypoint.sh
@@ -1,7 +1,21 @@
 #!/bin/bash
 set -e
 
-# 1. Proceed only when merge occurs to `master` base branch.
+# 1. Proceed only when acting on a merge action on the master branch.
+
+action=$(jq -r '.action' $GITHUB_EVENT_PATH)
+
+if [ "$action" != 'closed' ]; then
+	echo "Action '$action' not a close action. Aborting."
+	exit 78;
+fi
+
+merged=$(jq -r '.pull_request.merged' $GITHUB_EVENT_PATH)
+
+if [ "$merged" != 'true' ]; then
+	echo "Pull request closed without merge. Aborting."
+	exit 78;
+fi
 
 base=$(jq -r '.pull_request.base.ref' $GITHUB_EVENT_PATH)
 

--- a/.github/actions/milestone-it/entrypoint.sh
+++ b/.github/actions/milestone-it/entrypoint.sh
@@ -71,7 +71,7 @@ milestone="Gutenberg $major.$minor"
 
 reference_major=5
 reference_minor=0
-reference_date=1549238400
+reference_date=1564358400
 num_versions_elapsed=$(((major-reference_major)*10+(minor-reference_minor)))
 weeks=$((num_versions_elapsed*2))
 due=$(date -u --iso-8601=seconds -d "$(date -d @$(echo $reference_date)) + $(echo $weeks) weeks")

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -3,13 +3,7 @@ workflow "Milestone merged pull requests" {
   resolves = ["Milestone It"]
 }
 
-action "Filter merged" {
-  uses = "actions/bin/filter@3c0b4f0e63ea54ea5df2914b4fabf383368cd0da"
-  args = "merged true"
-}
-
 action "Milestone It" {
   uses = "./.github/actions/milestone-it"
-  needs = ["Filter merged"]
   secrets = ["GITHUB_TOKEN"]
 }


### PR DESCRIPTION
This pull request seeks to:

- Update the "Milestone It" reference date per July 22 delayed release
  - Since the next milestone date is calculated based on a two-week release cycle, this delay must be accounted for by manually updating the reference date
   - Ideally we can improve this further by referencing the due date of the previous milestone / current release. This will require more work to implement, since there is no easy way to search for a milestone from GitHub's milestone API without paginating results.
- Embed the merge action filtering into the custom Milestone It script
   - It is hoped this may improve reliability for inadvertent cancellations we have been seeing at this stage of the GitHub action workflow