### PR TITLE
[wip] Update/image block alignment

### DIFF
--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -62,6 +62,9 @@
 			"source": "attribute",
 			"selector": "figure > a",
 			"attribute": "target"
+		},
+		"fullScreen": {
+			"type": "boolean"
 		}
 	}
 }

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -280,6 +280,7 @@ export class ImageEdit extends Component {
 		this.onSetNewTab = this.onSetNewTab.bind( this );
 		this.getFilename = this.getFilename.bind( this );
 		this.toggleIsEditing = this.toggleIsEditing.bind( this );
+		this.toggleFullScreen = this.toggleFullScreen.bind( this );
 		this.onUploadError = this.onUploadError.bind( this );
 		this.onImageError = this.onImageError.bind( this );
 		this.getLinkDestinations = this.getLinkDestinations.bind( this );
@@ -287,6 +288,7 @@ export class ImageEdit extends Component {
 		this.state = {
 			captionFocused: false,
 			isEditing: ! attributes.url,
+			fullScreen: attributes.fullScreen,
 		};
 	}
 
@@ -535,6 +537,16 @@ export class ImageEdit extends Component {
 		];
 	}
 
+	toggleFullScreen() {
+		this.setState( {
+			fullScreen: ! this.state.fullScreen,
+		} );
+
+		this.props.setAttributes( {
+			fullScreen: ! this.state.fullScreen,
+		} );
+	}
+
 	toggleIsEditing() {
 		this.setState( {
 			isEditing: ! this.state.isEditing,
@@ -564,6 +576,7 @@ export class ImageEdit extends Component {
 			toggleSelection,
 			isRTL,
 		} = this.props;
+
 		const {
 			url,
 			alt,
@@ -588,6 +601,16 @@ export class ImageEdit extends Component {
 					value={ align }
 					onChange={ this.updateAlignment }
 				/>
+				{
+					<Toolbar>
+						<IconButton
+							className={ classnames( 'components-icon-button components-toolbar__control', { 'is-active': this.state.fullScreen } ) }
+							icon="editor-expand"
+							label={ __( 'Full screen' ) }
+							onClick={ this.toggleFullScreen }
+						/>
+					</Toolbar>
+				}
 				{ url && (
 					<>
 						<Toolbar>

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -113,6 +113,15 @@
 	}
 }
 
+
+[data-type="core/image"][data-full-screen="true"] {
+	figure img {
+		height: 100vh;
+		min-height: 100vh;
+		width: auto;
+	}
+}
+
 // This is similar to above but for resized unfloated images only, where the markup is different.
 [data-type="core/image"] .block-editor-block-list__block-edit figure.is-resized {
 	margin: 0;

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -4,6 +4,11 @@
 import { __ } from '@wordpress/i18n';
 
 /**
+ * External dependencies
+ */
+import { includes } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import deprecated from './deprecated';
@@ -14,6 +19,8 @@ import save from './save';
 import transforms from './transforms';
 
 const { name } = metadata;
+
+const ALL_ALIGNMENTS = [ 'left', 'center', 'right', 'wide', 'full' ];
 
 export { metadata, name };
 
@@ -27,9 +34,14 @@ export const settings = {
 	],
 	transforms,
 	getEditWrapperProps( attributes ) {
-		const { align, width } = attributes;
-		if ( 'left' === align || 'center' === align || 'right' === align || 'wide' === align || 'full' === align ) {
-			return { 'data-align': align, 'data-resized': !! width };
+		const { align, width, fullScreen } = attributes;
+
+		if ( includes( ALL_ALIGNMENTS, align ) ) {
+			return {
+				'data-align': align,
+				'data-resized': !! width,
+				'data-full-screen': fullScreen ? 'true' : 'false',
+			};
 		}
 	},
 	edit,

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -22,12 +22,14 @@ export default function save( { attributes } ) {
 		id,
 		linkTarget,
 		sizeSlug,
+		fullScreen,
 	} = attributes;
 
 	const classes = classnames( {
 		[ `align${ align }` ]: align,
 		[ `size-${ sizeSlug }` ]: sizeSlug,
 		'is-resized': width || height,
+		'full-screen': fullScreen,
 	} );
 
 	const image = (
@@ -56,7 +58,7 @@ export default function save( { attributes } ) {
 		</>
 	);
 
-	if ( 'left' === align || 'right' === align || 'center' === align ) {
+	if ( 'left' === align || 'right' === align || 'center' === align || fullScreen ) {
 		return (
 			<div>
 				<figure className={ classes }>

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -18,6 +18,11 @@
 		width: 100%;
 	}
 
+	.full-screen img {
+		height: 100vh;
+		min-height: 100vh;
+	}
+
 	// This resets the intrinsic margin on the figure in non-floated, wide, and full-wide alignments.
 	margin-left: 0;
 	margin-right: 0;

--- a/packages/block-library/src/image/transforms.js
+++ b/packages/block-library/src/image/transforms.js
@@ -45,7 +45,7 @@ function getFirstAnchorAttributeFormHTML( html, attributeName ) {
 const imageSchema = {
 	img: {
 		attributes: [ 'src', 'alt' ],
-		classes: [ 'alignleft', 'aligncenter', 'alignright', 'alignnone', /^wp-image-\d+$/ ],
+		classes: [ 'alignleft', 'aligncenter', 'alignright', 'alignnone', /^wp-image-\d+$/, 'full-screen' ],
 	},
 };
 


### PR DESCRIPTION
## Description
This PR adds a new button to the toolbar for the `core/image` block

It tries to tackle https://github.com/WordPress/gutenberg/issues/16385 

https://cloudup.com/corIGmn7AsB