### PR TITLE
Make Drop Cap alignment-aware

### DIFF
--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -58,7 +58,7 @@ class ParagraphBlock extends Component {
 	}
 
 	getDropCapHelp( checked ) {
-		return checked ? __( 'Showing large initial letter.' ) : __( 'Toggle to show a large initial letter.' );
+		return checked ? __( 'Showing large initial letter. Drop Cap is hidden when text is not aligned with reading direction.' ) : __( 'Toggle to show a large initial letter.' );
 	}
 
 	render() {
@@ -87,6 +87,8 @@ class ParagraphBlock extends Component {
 			placeholder,
 			direction,
 		} = attributes;
+
+		const showDropCap = align === undefined || align === ( isRTL ? 'right' : 'left' );
 
 		return (
 			<>
@@ -162,7 +164,7 @@ class ParagraphBlock extends Component {
 					className={ classnames( 'wp-block-paragraph', className, {
 						'has-text-color': textColor.color,
 						'has-background': backgroundColor.color,
-						'has-drop-cap': dropCap,
+						'has-drop-cap': showDropCap && dropCap,
 						[ backgroundColor.class ]: backgroundColor.class,
 						[ textColor.class ]: textColor.class,
 						[ fontSize.class ]: fontSize.class,


### PR DESCRIPTION
Alternate approach to #15066. Hides drop cap when the text is not aligned with the direction of reading.

Fixes #11756.

## Description
Added a variable to determine whether the drop cap should be shown, besides the user selection.
True when text is not aligned or aligned with directions of reading. False otherwise.

Added an explanatory sentence to the help section.

## How has this been tested?
Local environment, created a paragraph with a sentence, enabled Drop Cap, played with alignment options.

## Types of changes
Bug fix for #11756.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
