### PR TITLE
[RNMobile] Update Video caption placeholder color to match other placeholder text styles

### DIFF
--- a/packages/block-library/src/video/edit.native.js
+++ b/packages/block-library/src/video/edit.native.js
@@ -237,6 +237,7 @@ class VideoEdit extends React.Component {
 								underlineColorAndroid="transparent"
 								value={ caption }
 								placeholder={ __( 'Write caption…' ) }
+								placeholderTextColor={ style.captionPlaceholder.color }
 								onChangeText={ ( newCaption ) => setAttributes( { caption: newCaption } ) }
 								onFocus={ this.props.onFocus }
 							/>

--- a/packages/block-library/src/video/style.native.scss
+++ b/packages/block-library/src/video/style.native.scss
@@ -57,6 +57,10 @@
 	font-family: $default-regular-font;
 }
 
+.captionPlaceholder {
+	color: $gray;
+}
+
 .icon {
 	fill: $gray-dark;
 	width: 100%;


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/996

## Description

Update Video caption placeholder color to match other placeholder text styles.

Note: I had a look at the image caption and it's not using the same component (`RichText` for images, `TextInput` for videos), I wonder if this must be updated in the video block. Also, I guess this part could be factorized.

## How has this been tested?

Manually tested via https://github.com/wordpress-mobile/gutenberg-mobile

## Screenshots <!-- if applicable -->

![out](https://user-images.githubusercontent.com/40213/61696091-fca3ab00-ad34-11e9-9340-4ac3afe8f0df.png)


## Types of changes

Style changes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->


cc @hypest (I can't add you as a reviewer to that PR, I don't have permissions).