### PR TITLE
Fix pasting content into inner blocks

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -225,6 +225,17 @@ const withBlockCache = ( reducer ) => ( state = {}, action ) => {
 	}
 	newState.cache = state.cache ? state.cache : {};
 
+	/**
+	 * For each clientId provided, traverses up parents, adding the provided clientIds
+	 * and each parent's clientId to the returned array.
+	 *
+	 * When calling this function consider that it uses the old state, so any state
+	 * modifications made by the `reducer` will not be present.
+	 *
+	 * @param {Array} clientIds an Array of block clientIds.
+	 *
+	 * @return {Array} The provided clientIds and all of their parent clientIds.
+	 */
 	const getBlocksWithParentsClientIds = ( clientIds ) => {
 		return clientIds.reduce( ( result, clientId ) => {
 			let current = clientId;

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -267,7 +267,7 @@ const withBlockCache = ( reducer ) => ( state = {}, action ) => {
 			newState.cache = {
 				...omit( newState.cache, action.replacedClientIds ),
 				...fillKeysWithEmptyObject(
-					getBlocksWithParentsClientIds( keys( flattenBlocks( action.blocks ) ) ),
+					getBlocksWithParentsClientIds( action.replacedClientIds )
 				),
 			};
 			break;

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -275,11 +275,12 @@ const withBlockCache = ( reducer ) => ( state = {}, action ) => {
 			};
 			break;
 		case 'REPLACE_BLOCKS_AUGMENTED_WITH_CHILDREN':
+			const parentClientIds = fillKeysWithEmptyObject( getBlocksWithParentsClientIds( action.replacedClientIds ) );
+
 			newState.cache = {
 				...omit( newState.cache, action.replacedClientIds ),
-				...fillKeysWithEmptyObject(
-					getBlocksWithParentsClientIds( action.replacedClientIds )
-				),
+				...omit( parentClientIds, action.replacedClientIds ),
+				...fillKeysWithEmptyObject( keys( flattenBlocks( action.blocks ) ) ),
 			};
 			break;
 		case 'REMOVE_BLOCKS_AUGMENTED_WITH_CHILDREN':

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -759,21 +759,29 @@ describe( 'state', () => {
 				blocks: [ wrapperBlock ],
 			} );
 
+			const originalWrapperBlockCacheKey = original.cache[ wrapperBlock.clientId ];
+
 			const state = blocks( original, {
 				type: 'REPLACE_BLOCKS',
 				clientIds: [ nestedBlock.clientId ],
 				blocks: [ replacementBlock ],
 			} );
 
+			const newWrapperBlockCacheKey = state.cache[ wrapperBlock.clientId ];
+
+			expect( newWrapperBlockCacheKey ).not.toBe( originalWrapperBlockCacheKey );
+
 			expect( state.order ).toEqual( {
 				'': [ wrapperBlock.clientId ],
 				[ wrapperBlock.clientId ]: [ replacementBlock.clientId ],
 				[ replacementBlock.clientId ]: [],
 			} );
+
 			expect( state.parents ).toEqual( {
 				[ wrapperBlock.clientId ]: '',
 				[ replacementBlock.clientId ]: wrapperBlock.clientId,
 			} );
+
 			expect( state.cache ).toEqual( {
 				[ wrapperBlock.clientId ]: {},
 				[ replacementBlock.clientId ]: {},


### PR DESCRIPTION
Fixes #16645

## Description

Resolves an issue where content pasted into inner blocks is not saved correctly.

The issue was caused by a small caching error introduced in https://github.com/WordPress/gutenberg/pull/16407. 

When pasting content into an empty paragraph, a block replacement is triggered. When this action was being carried out in an inner block, cached parent blocks were not being invalidated.

This is the code that attempts to invalidate parents of a replaced block:
https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/store/reducer.js#L269-L271

The issue is that `getBlocksWithParentsClientIds` is called with the incorrect clientId. `getBlocksWithParentsClientIds` operates on the old state rather than the new state, so it needs to be called with the block that's about to be removed rather than the block that's about to be added: https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/store/reducer.js#L228-L237

This PR resolves the issue.
<!-- Please describe what you have changed or added -->

## How has this been tested?
Updated the relevant unit test to ensure the parent block is invalidated.

Manual testing:
1. Add Columns block.
2. Copy and paste text from another website into each of the columns.
3. Save the document and preview it.
4. Observe that the text isn't showing on the frontend.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
