### PR TITLE
[RNMobile] Fix loss of center alignment in image captions on Android

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -368,6 +368,7 @@ class ImageEdit extends React.Component {
 								fontSize={ 14 }
 								underlineColorAndroid="transparent"
 								textAlign={ 'center' }
+								tagName={ '' }
 							/>
 						</View>
 					) }


### PR DESCRIPTION
This PR is related to [WordPress/gutenberg-mobile#1243](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1243).

## Description

Addresses an issue where an unwanted `<div>` tag was added to image captions because the `defaultProps` for `RichText` specified a div tagName. This was causing the loss of center alignment on image captions in mobile.

### Background

In order to implement quote blocks, `RichText` [was given a default "div" `tagName`](https://github.com/WordPress/gutenberg/pull/15482/files#diff-4828a21853e899e5a36faecfa96d83e8R886). This created a problem on Android because AztecEditor-Android [creates a `HiddenHtmlSpan` out of `div` tags](https://github.com/wordpress-mobile/AztecEditor-Android/blob/ee83fa8f21b2f60d0b3ca147ecb9e4747898e60a/aztec/src/main/kotlin/org/wordpress/aztec/AztecTagHandler.kt#L87), and because `HiddenHtmlSpan`s extend `IAztecParagraphStyle` [they default to "normal" text alignment](https://github.com/wordpress-mobile/AztecEditor-Android/blob/09be48692d78c212b552b0730f8a2e7e30644b57/aztec/src/main/kotlin/org/wordpress/aztec/spans/IAztecParagraphStyle.kt#L16). This overrides the center gravity that is set on the native EditText as a result of the text-align prop being set [from the image block](https://github.com/WordPress/gutenberg/blob/b06c3cebaf001c4be26e848179d455c7de6db7eb/packages/block-library/src/image/edit.native.js#L370). 

This problem exhibited itself in the loss of center alignment anytime RichText sent html with `div` tags to native for rendering on a view with center alignment (i.e., the image caption). Explicitly setting the image block's `tagName` to be an empty string prevents the default "div" tagName from being applied. It would be nice to address this on the native layer (so that div tags didn't override the view's gravity), but any fix at that level would have been very invasive.

## Test steps
### From [gutenberg-mobile Issue 1070](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1070)
1. Select an image block from the demo content in the demo app
2. Add some text in the caption. Notice that the text is centered as expected.
3. Select all caption text and tap on the "Bold" toolbar button
4. Verify that the image caption remains horizontally centered.

Before | After
--- | ---
![Screen Shot 2019-07-23 at 1 53 39 PM](https://user-images.githubusercontent.com/4656348/61735132-50bc8880-ad51-11e9-86e4-84c2db5d50ba.png) | ![Screen Shot 2019-07-23 at 1 45 25 PM](https://user-images.githubusercontent.com/4656348/61734570-28805a00-ad50-11e9-983d-a982a8fee0d9.png)

### From [gutenberg-mobile Issue 1113](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1113)
1. Add this snipped to gutenberg-mobile sample app:
```
<!-- wp:image {"align":"center"} -->
<div class="wp-block-image"><figure class="aligncenter"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="Beautiful landscape"/><figcaption>Give it a try.<br> Press the "wide" button on the image toolbar.</figcaption></figure></div>
<!-- /wp:image -->
```
2. Run the example app.
3. Verify that the image caption is horizontally centered.

Before | After
--- | ---
![Screen Shot 2019-07-23 at 1 52 29 PM](https://user-images.githubusercontent.com/4656348/61735051-22d74400-ad51-11e9-9094-d6afdc1b5c1e.png) | ![Screen Shot 2019-07-23 at 1 55 23 PM](https://user-images.githubusercontent.com/4656348/61735269-9e38f580-ad51-11e9-871a-661f86a56f95.png)

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
