### PR TITLE
Modifies shortcut hierarchy in modal

### DIFF
--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/config.js
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/config.js
@@ -20,13 +20,18 @@ const {
 	ctrlShift,
 } = displayShortcutList;
 
-const globalShortcuts = {
-	title: __( 'Global shortcuts' ),
+const mainShortcut = {
 	shortcuts: [
 		{
 			keyCombination: access( 'h' ),
-			description: __( 'Display this help.' ),
+			description: __( 'Display these keyboard shortcuts.' ),
 		},
+	],
+};
+
+const globalShortcuts = {
+	title: __( 'Global shortcuts' ),
+	shortcuts: [
 		{
 			keyCombination: primary( 's' ),
 			description: __( 'Save your changes.' ),
@@ -148,6 +153,7 @@ const textFormattingShortcuts = {
 };
 
 export default [
+	mainShortcut,
 	globalShortcuts,
 	selectionShortcuts,
 	blockShortcuts,

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/config.js
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/config.js
@@ -21,6 +21,7 @@ const {
 } = displayShortcutList;
 
 const mainShortcut = {
+	className: 'edit-post-keyboard-shortcut-help__main-shortcuts',
 	shortcuts: [
 		{
 			keyCombination: access( 'h' ),

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { castArray } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -64,8 +65,8 @@ const ShortcutList = ( { shortcuts } ) => (
 	</ul>
 );
 
-const ShortcutSection = ( { title, shortcuts } ) => (
-	<section className="edit-post-keyboard-shortcut-help__section">
+const ShortcutSection = ( { title, shortcuts, className } ) => (
+	<section className={ classnames( 'edit-post-keyboard-shortcut-help__section', className ) }>
 		{ !! title && (
 			<h2 className="edit-post-keyboard-shortcut-help__section-title">
 				{ title }

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/index.js
@@ -66,9 +66,11 @@ const ShortcutList = ( { shortcuts } ) => (
 
 const ShortcutSection = ( { title, shortcuts } ) => (
 	<section className="edit-post-keyboard-shortcut-help__section">
-		<h2 className="edit-post-keyboard-shortcut-help__section-title">
-			{ title }
-		</h2>
+		{ !! title && (
+			<h2 className="edit-post-keyboard-shortcut-help__section-title">
+				{ title }
+			</h2>
+		) }
 		<ShortcutList shortcuts={ shortcuts } />
 	</section>
 );

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/style.scss
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/style.scss
@@ -2,6 +2,10 @@
 
 	&__section {
 		margin: 0 0 2rem 0;
+
+		&:nth-child(2) { // Push the shortcut to be flush with top modal header.
+			margin-top: -17px;
+		}
 	}
 
 

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/style.scss
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/style.scss
@@ -5,7 +5,7 @@
 
 	&__main-shortcuts .edit-post-keyboard-shortcut-help__shortcut-list {
 		// Push the shortcut to be flush with top modal header.
-		margin-top: -17px;
+		margin-top: -$panel-padding -$border-width;
 	}
 
 	&__section-title {

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/style.scss
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/style.scss
@@ -1,13 +1,12 @@
 .edit-post-keyboard-shortcut-help {
-
 	&__section {
 		margin: 0 0 2rem 0;
-
-		&:nth-child(2) { // Push the shortcut to be flush with top modal header.
-			margin-top: -17px;
-		}
 	}
 
+	&__main-shortcuts .edit-post-keyboard-shortcut-help__shortcut-list {
+		// Push the shortcut to be flush with top modal header.
+		margin-top: -17px;
+	}
 
 	&__section-title {
 		font-size: 0.9rem;
@@ -35,7 +34,7 @@
 		flex: 1;
 		margin: 0;
 
-		// IE 11 flex item fix - ensure the item does not collapse
+		// IE 11 flex item fix - ensure the item does not collapse.
 		flex-basis: auto;
 	}
 

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/test/__snapshots__/index.js.snap
@@ -17,11 +17,12 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
     title="Keyboard Shortcuts"
   >
     <ShortcutSection
+      className="edit-post-keyboard-shortcut-help__main-shortcuts"
       key="0"
       shortcuts={
         Array [
           Object {
-            "description": "Display this help.",
+            "description": "Display these keyboard shortcuts.",
             "keyCombination": Array [
               "Shift",
               "+",
@@ -30,6 +31,13 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
               "H",
             ],
           },
+        ]
+      }
+    />
+    <ShortcutSection
+      key="1"
+      shortcuts={
+        Array [
           Object {
             "description": "Save your changes.",
             "keyCombination": Array [
@@ -142,7 +150,7 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
       title="Global shortcuts"
     />
     <ShortcutSection
-      key="1"
+      key="2"
       shortcuts={
         Array [
           Object {
@@ -163,7 +171,7 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
       title="Selection shortcuts"
     />
     <ShortcutSection
-      key="2"
+      key="3"
       shortcuts={
         Array [
           Object {
@@ -216,7 +224,7 @@ exports[`KeyboardShortcutHelpModal should match snapshot when the modal is activ
       title="Block shortcuts"
     />
     <ShortcutSection
-      key="3"
+      key="4"
       shortcuts={
         Array [
           Object {


### PR DESCRIPTION
Fixes #16691. Moves the shortcut to open shortcut modal to its own section right under the modal header.

## How has this been tested?
Tested locally.

## Screenshots

**Before:**

![Screen Shot 2019-07-23 at 12 02 03 PM](https://user-images.githubusercontent.com/617986/61739667-c0c31280-ad41-11e9-9b76-1e59653cd14a.png)

**Proposed:**

![Screen Shot 2019-07-23 at 11 57 03 AM](https://user-images.githubusercontent.com/617986/61739686-cb7da780-ad41-11e9-8425-d7cee18cb15c.png)


## Types of changes
CSS changes along with a bit of Javascript in the keyboard-shortcut config file.
Non-breaking change.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
