### PR TITLE
[RNMobile] Add rounded corners on media placeholder and unsupported blocks

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/styles.native.scss
+++ b/packages/block-editor/src/components/media-placeholder/styles.native.scss
@@ -9,6 +9,10 @@
 	padding-right: 12;
 	padding-top: 12;
 	padding-bottom: 12;
+	border-top-left-radius: 4;
+	border-top-right-radius: 4;
+	border-bottom-left-radius: 4;
+	border-bottom-right-radius: 4;
 }
 
 .emptyStateTitle {

--- a/packages/block-editor/src/components/media-placeholder/styles.native.scss
+++ b/packages/block-editor/src/components/media-placeholder/styles.native.scss
@@ -4,7 +4,7 @@
 	flex-direction: column;
 	align-items: center;
 	justify-content: center;
-	background-color: $gray-light;
+	background-color: $gray-lighten-30;
 	padding-left: 12;
 	padding-right: 12;
 	padding-top: 12;

--- a/packages/block-editor/src/components/warning/style.native.scss
+++ b/packages/block-editor/src/components/warning/style.native.scss
@@ -6,6 +6,10 @@
 	padding-bottom: 24;
 	padding-left: 8;
 	padding-right: 8;
+	border-top-left-radius: 4;
+	border-top-right-radius: 4;
+	border-bottom-left-radius: 4;
+	border-bottom-right-radius: 4;
 	align-items: center;
 	justify-content: center;
 }

--- a/packages/block-library/src/missing/style.native.scss
+++ b/packages/block-library/src/missing/style.native.scss
@@ -6,6 +6,10 @@
 	padding-bottom: 24;
 	padding-left: 8;
 	padding-right: 8;
+	border-top-left-radius: 4;
+	border-top-right-radius: 4;
+	border-bottom-left-radius: 4;
+	border-bottom-right-radius: 4;
 	align-items: center;
 	justify-content: center;
 }


### PR DESCRIPTION
## Description

Fix https://github.com/wordpress-mobile/gutenberg-mobile/issues/999

I had a look at other places this could be changed, by searching for components with a gray background color:

```sh
$ find . -iname "*native*.*" -exec grep -H background-col {} \; 2> /dev/null | grep "gr[ae]y"
./gutenberg/packages/block-library/src/video/style.native.scss:	background-color: $gray-lighten-30;
./gutenberg/packages/block-library/src/missing/style.native.scss:	background-color: #e9eff3; // grey lighten 30
./gutenberg/packages/block-library/src/image/styles.native.scss:	background-color: $gray-lighten-30;
./gutenberg/packages/block-library/src/image/styles.native.scss:	background-color: $gray-lighten-30;
./gutenberg/packages/block-library/src/more/editor.native.scss:	background-color: $gray-lighten-20;
./gutenberg/packages/block-library/src/nextpage/editor.native.scss:	background-color: $gray-lighten-20;
./gutenberg/packages/components/src/mobile/bottom-sheet/styles.native.scss:	background-color: $light-gray-400;
./gutenberg/packages/components/src/mobile/bottom-sheet/styles.native.scss:	background-color: $light-gray-400;
./gutenberg/packages/components/src/mobile/bottom-sheet/styles.native.scss:	background-color: $light-gray-400;
./gutenberg/packages/block-editor/src/components/block-list/block.native.scss:	background-color: $gray;
./gutenberg/packages/block-editor/src/components/media-placeholder/styles.native.scss:	background-color: $gray-light;
./gutenberg/packages/block-editor/src/components/inserter/style.native.scss:	background-color: $gray-light; //#f3f6f8
./gutenberg/packages/block-editor/src/components/warning/style.native.scss:	background-color: $gray-lighten-30;
```

Then I manually opened these style sheets to check if they were used in some sort of a container, and it seem only one more need to be updated: `block-editor/src/components/warning/`, so I did the change there as well.

Rounded corners were added to the following components:
- `block-editor/src/components/media-placeholder/` - used to display placeholder on image/video blocks
- `block-editor/src/components/warning/` - used to show a warning when a block is not valid.
- `block-library/src/missing/` - used to show a placeholder when the block is not supported.

## How has this been tested?

I tested the changes in the gutenberg-mobile repository.

## Screenshots <!-- if applicable -->

![out](https://user-images.githubusercontent.com/40213/61783910-fed73980-ae08-11e9-9d76-e51394e3d53c.png)

With the fix applied:
![Screenshot_1563960758](https://user-images.githubusercontent.com/40213/61784252-ae141080-ae09-11e9-9284-2765bd2498ca.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->

cc @iamthomasbishop  @hypest 