### PR TITLE
Improved rich text placeholder

### DIFF
--- a/docs/designers-developers/developers/richtext.md
+++ b/docs/designers-developers/developers/richtext.md
@@ -49,7 +49,6 @@ wp.blocks.registerBlockType( /* ... */, {
 				props.setAttributes( { content: content } ); // Store updated content as a block attribute
 			},
 			placeholder: __( 'Heading...' ), // Display this text before any content has been added by the user
-			keepPlaceholderOnFocus: true // Keep the placeholder text showing even when the field is focused (leave this property off to remove placeholder content on focus)
 		} );
 	},
 
@@ -85,7 +84,6 @@ registerBlockType( /* ... */, {
 				formattingControls={ [ 'bold', 'italic' ] } // Allow the content to be made bold or italic, but do not allow other formatting options
 				onChange={ ( content ) => setAttributes( { content } ) } // Store updated content as a block attribute
 				placeholder={ __( 'Heading...' ) } // Display this text before any content has been added by the user
-				keepPlaceholderOnFocus // Keep the placeholder text showing even when the field is focused (leave this property off to remove placeholder content on focus)
 			/>
 		);
 	},

--- a/packages/block-editor/src/components/rich-text/README.md
+++ b/packages/block-editor/src/components/rich-text/README.md
@@ -53,10 +53,6 @@ Render a rich [`contenteditable` input](https://developer.mozilla.org/en-US/docs
 
 *Optional.* Whether to show the input is selected or not in order to show the formatting controls. By default it renders the controls when the block is selected.
 
-### `keepPlaceholderOnFocus: Boolean`
-
-*Optional.* By default, the placeholder will hide as soon as the editable field receives focus. With this setting it can be be kept while the field is focussed and empty.
-
 ### `autocompleters: Array<Completer>`
 
 *Optional.* A list of autocompleters to use instead of the default.

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -337,7 +337,7 @@ class RichTextWrapper extends Component {
 				onSelectionChange={ onSelectionChange }
 				tagName={ tagName }
 				wrapperClassName={ classnames( wrapperClasses, wrapperClassName ) }
-				className={ classnames( classes, className ) }
+				className={ classnames( classes, className, { 'is-selected': originalIsSelected } ) }
 				placeholder={ placeholder }
 				allowedFormats={ adjustedAllowedFormats }
 				withoutInteractiveFormatting={ withoutInteractiveFormatting }

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -293,7 +293,6 @@ class RichTextWrapper extends Component {
 			isSelected: originalIsSelected,
 			onCreateUndoLevel,
 			placeholder,
-			keepPlaceholderOnFocus,
 			// eslint-disable-next-line no-unused-vars
 			allowedFormats,
 			withoutInteractiveFormatting,
@@ -340,7 +339,6 @@ class RichTextWrapper extends Component {
 				wrapperClassName={ classnames( wrapperClasses, wrapperClassName ) }
 				className={ classnames( classes, className ) }
 				placeholder={ placeholder }
-				keepPlaceholderOnFocus={ keepPlaceholderOnFocus }
 				allowedFormats={ adjustedAllowedFormats }
 				withoutInteractiveFormatting={ withoutInteractiveFormatting }
 				onEnter={ this.onEnter }

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -49,7 +49,6 @@ function RichTextWraper( {
 	isSelected: originalIsSelected,
 	onCreateUndoLevel,
 	placeholder,
-	keepPlaceholderOnFocus,
 	// From experimental filter.
 	...experimentalProps
 } ) {
@@ -68,7 +67,6 @@ function RichTextWraper( {
 			wrapperClassName={ classnames( wrapperClasses, wrapperClassName ) }
 			className={ classnames( classes, className ) }
 			placeholder={ placeholder }
-			keepPlaceholderOnFocus={ keepPlaceholderOnFocus }
 			__unstableIsSelected={ originalIsSelected }
 			//__unstablePatterns={ getPatterns() }
 			//__unstableEnterPatterns={ getEnterPatterns() }

--- a/packages/block-editor/src/components/rich-text/style.scss
+++ b/packages/block-editor/src/components/rich-text/style.scss
@@ -43,7 +43,7 @@
 	}
 
 	// Could be unset for individual rich text instances.
-	&:focus [data-rich-text-placeholder]::after {
+	&.is-selected [data-rich-text-placeholder]::after {
 		display: none;
 	}
 }

--- a/packages/block-editor/src/components/rich-text/style.scss
+++ b/packages/block-editor/src/components/rich-text/style.scss
@@ -34,37 +34,24 @@
 		}
 	}
 
-	&[data-is-placeholder-visible="true"] {
-		position: absolute;
-		top: 0;
-		width: 100%;
-		margin-top: 0;
-
-		& > p {
-			margin-top: 0;
-		}
-
-		// Ensure that if placeholder wraps (mobile/nested contexts) the clickable area is full-height.
-		height: 100%;
-	}
-
-	// Placeholder text.
-	& + .block-editor-rich-text__editable {
+	[data-rich-text-placeholder]::after {
+		content: attr(data-rich-text-placeholder);
 		pointer-events: none;
-
 		// Use opacity to work in various editor styles.
 		// We don't specify the color here, because blocks or editor styles might provide their own.
-		&,
-		p {
-			opacity: 0.62;
-		}
+		opacity: 0.62;
 	}
 
-	// Captions may have lighter (gray) text, or be shown on a range of different background luminosites.
-	// To ensure legibility, we increase the default placeholder opacity to ensure contrast.
-	&[data-is-placeholder-visible="true"] + figcaption.block-editor-rich-text__editable {
-		opacity: 0.8;
+	// Could be unset for individual rich text instances.
+	&:focus [data-rich-text-placeholder]::after {
+		display: none;
 	}
+}
+
+// Captions may have lighter (gray) text, or be shown on a range of different background luminosites.
+// To ensure legibility, we increase the default placeholder opacity to ensure contrast.
+figcaption.block-editor-rich-text__editable [data-rich-text-placeholder]::before {
+	opacity: 0.8;
 }
 
 .block-editor-rich-text__inline-toolbar {

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -127,7 +127,6 @@ class ButtonEdit extends Component {
 						backgroundColor: backgroundColor.color,
 						color: textColor.color,
 					} }
-					keepPlaceholderOnFocus
 				/>
 				<BaseControl
 					label={ __( 'Link' ) }

--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -22,7 +22,7 @@
 	}
 
 	// Make placeholder text white unless custom colors or outline versions are chosen.
-	&:not(.has-text-color):not(.is-style-outline) .block-editor-rich-text__editable[data-is-placeholder-visible="true"] + .block-editor-rich-text__editable {
+	&:not(.has-text-color):not(.is-style-outline) [data-rich-text-placeholder]::after {
 		color: $white;
 	}
 
@@ -36,28 +36,13 @@
 	}
 
 	// Increase placeholder opacity to meet contrast ratios.
-	.block-editor-rich-text__editable[data-is-placeholder-visible="true"] + .block-editor-rich-text__editable {
+	[data-rich-text-placeholder]::after {
 		opacity: 0.8;
-	}
-
-	// Make placeholder disappear on focus to make focus-state visible.
-	.block-editor-rich-text__editable[data-is-placeholder-visible="true"]:focus + .block-editor-rich-text__editable {
-		opacity: 0;
-	}
-
-	// Align cursor to left when placeholder is active.
-	.block-editor-rich-text__editable[data-is-placeholder-visible="true"] {
-		text-align: left;
 	}
 
 	// Don't let the placeholder text wrap in the variation preview.
 	.block-editor-block-preview__content & {
 		max-width: 100%;
-
-		// Polish the empty placeholder text for the button in variation previews.
-		.block-editor-rich-text__editable[data-is-placeholder-visible="true"] {
-			height: auto;
-		}
 
 		.wp-block-button__link {
 			max-width: 100%;
@@ -69,11 +54,6 @@
 			white-space: nowrap !important;
 			text-overflow: ellipsis;
 		}
-	}
-
-	// Limit width of the text field if empty
-	.wp-block-button__link[data-is-placeholder-visible="true"] {
-		max-width: 150px;
 	}
 }
 

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -212,7 +212,6 @@ class FileEdit extends Component {
 							tagName="div" // must be block-level or else cursor disappears
 							value={ fileName }
 							placeholder={ __( 'Write file name…' ) }
-							keepPlaceholderOnFocus
 							withoutInteractiveFormatting
 							onChange={ ( text ) => setAttributes( { fileName: text } ) }
 						/>
@@ -225,7 +224,6 @@ class FileEdit extends Component {
 									value={ downloadButtonText }
 									withoutInteractiveFormatting
 									placeholder={ __( 'Add text…' ) }
-									keepPlaceholderOnFocus
 									onChange={ ( text ) => setAttributes( { downloadButtonText: text } ) }
 								/>
 							</div>

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -69,6 +69,9 @@ ul.wp-block-gallery {
 	}
 
 	.block-editor-rich-text figcaption {
+		position: relative;
+		overflow: hidden;
+
 		a {
 			color: $white;
 		}

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -35,11 +35,6 @@ ul.wp-block-gallery {
 		overflow-y: auto;
 	}
 
-	.block-editor-rich-text figcaption:not([data-is-placeholder-visible="true"]) {
-		position: relative;
-		overflow: hidden;
-	}
-
 	.is-selected .block-editor-rich-text {
 		// IE calculates this incorrectly, so leave it to modern browsers.
 		@supports (position: sticky) {

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -157,7 +157,7 @@ class GalleryImage extends Component {
 				</div>
 				<RichText
 					tagName="figcaption"
-					placeholder={ isSelected ? __( 'Write caption…' ) : null }
+					placeholder={ __( 'Write caption…' ) }
 					value={ caption }
 					isSelected={ this.state.captionSelected }
 					onChange={ ( newCaption ) => setAttributes( { caption: newCaption } ) }

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -157,7 +157,7 @@ class GalleryImage extends Component {
 				</div>
 				<RichText
 					tagName="figcaption"
-					placeholder={ __( 'Write caption…' ) }
+					placeholder={ isSelected ? __( 'Write caption…' ) : null }
 					value={ caption }
 					isSelected={ this.state.captionSelected }
 					onChange={ ( newCaption ) => setAttributes( { caption: newCaption } ) }

--- a/packages/block-library/src/paragraph/editor.scss
+++ b/packages/block-library/src/paragraph/editor.scss
@@ -1,7 +1,7 @@
 // Specific to the empty paragraph placeholder:
 // when shown on mobile and in nested contexts, one or more icons show up on the right.
 // This padding makes sure it doesn't overlap text.
-.block-editor-rich-text__editable.wp-block-paragraph:not(:focus) [data-rich-text-placeholder]::after {
+.block-editor-rich-text__editable.wp-block-paragraph:not(.is-selected) [data-rich-text-placeholder]::after {
 	display: inline-block;
 	padding-right: $icon-button-size * 3;
 

--- a/packages/block-library/src/paragraph/editor.scss
+++ b/packages/block-library/src/paragraph/editor.scss
@@ -1,7 +1,8 @@
 // Specific to the empty paragraph placeholder:
 // when shown on mobile and in nested contexts, one or more icons show up on the right.
 // This padding makes sure it doesn't overlap text.
-.block-editor-rich-text__editable[data-is-placeholder-visible="true"] + .block-editor-rich-text__editable.wp-block-paragraph {
+.block-editor-rich-text__editable.wp-block-paragraph:not(:focus) [data-rich-text-placeholder]::after {
+	display: inline-block;
 	padding-right: $icon-button-size * 3;
 
 	// In nested contexts only one icon shows up.

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -13,7 +13,6 @@ export default function SearchEdit( { className, attributes, setAttributes } ) {
 				wrapperClassName="wp-block-search__label"
 				aria-label={ __( 'Label text' ) }
 				placeholder={ __( 'Add label…' ) }
-				keepPlaceholderOnFocus
 				withoutInteractiveFormatting
 				value={ label }
 				onChange={ ( html ) => setAttributes( { label: html } ) }
@@ -33,7 +32,6 @@ export default function SearchEdit( { className, attributes, setAttributes } ) {
 				className="wp-block-search__button-rich-text"
 				aria-label={ __( 'Button text' ) }
 				placeholder={ __( 'Add button text…' ) }
-				keepPlaceholderOnFocus
 				withoutInteractiveFormatting
 				value={ buttonText }
 				onChange={ ( html ) => setAttributes( { buttonText: html } ) }

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -105,7 +105,7 @@
 	}
 
 	// Ensure that the height of the first appender, and the one between blocks, is the same as text.
-	.block-editor-block-list__block[data-type="core/paragraph"] p[data-is-placeholder-visible="true"] + p,
+	.block-editor-block-list__block[data-type="core/paragraph"] p,
 	.block-editor-default-block-appender__content {
 		min-height: $empty-paragraph-height / 2;
 		line-height: $editor-line-height;

--- a/packages/edit-widgets/src/components/customizer-edit-widgets-initializer/style.scss
+++ b/packages/edit-widgets/src/components/customizer-edit-widgets-initializer/style.scss
@@ -11,8 +11,4 @@
 	.block-editor-block-list__empty-block-inserter {
 		left: -18px;
 	}
-
-	.block-editor-rich-text__editable[data-is-placeholder-visible="true"] + .block-editor-rich-text__editable.wp-block-paragraph {
-		padding: 0;
-	}
 }

--- a/packages/rich-text/src/component/editable.js
+++ b/packages/rich-text/src/component/editable.js
@@ -81,8 +81,6 @@ function applyInternetExplorerInputFix( editorNode ) {
 	};
 }
 
-const IS_PLACEHOLDER_VISIBLE_ATTR_NAME = 'data-is-placeholder-visible';
-
 /**
  * Whether or not the user agent is Internet Explorer.
  *
@@ -106,8 +104,6 @@ export default class Editable extends Component {
 	// update the attributes on the wrapper nodes here. `componentDidUpdate`
 	// will never be called.
 	shouldComponentUpdate( nextProps ) {
-		this.configureIsPlaceholderVisible( nextProps.isPlaceholderVisible );
-
 		if ( ! isEqual( this.props.style, nextProps.style ) ) {
 			this.editorNode.setAttribute( 'style', '' );
 			Object.assign( this.editorNode.style, {
@@ -127,13 +123,6 @@ export default class Editable extends Component {
 			this.editorNode.setAttribute( key, nextProps[ key ] ) );
 
 		return false;
-	}
-
-	configureIsPlaceholderVisible( isPlaceholderVisible ) {
-		const isPlaceholderVisibleString = String( !! isPlaceholderVisible );
-		if ( this.editorNode.getAttribute( IS_PLACEHOLDER_VISIBLE_ATTR_NAME ) !== isPlaceholderVisibleString ) {
-			this.editorNode.setAttribute( IS_PLACEHOLDER_VISIBLE_ATTR_NAME, isPlaceholderVisibleString );
-		}
 	}
 
 	bindEditorNode( editorNode ) {
@@ -158,7 +147,6 @@ export default class Editable extends Component {
 			record,
 			valueToEditableHTML,
 			className,
-			isPlaceholderVisible,
 			...remainingProps
 		} = this.props;
 
@@ -190,7 +178,6 @@ export default class Editable extends Component {
 			'aria-multiline': true,
 			className,
 			contentEditable: true,
-			[ IS_PLACEHOLDER_VISIBLE_ATTR_NAME ]: isPlaceholderVisible,
 			ref: this.bindEditorNode,
 			style: {
 				...style,

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -726,6 +726,7 @@ class RichText extends Component {
 			value,
 			selectionStart,
 			selectionEnd,
+			placeholder,
 			__unstableIsSelected: isSelected,
 		} = this.props;
 
@@ -752,6 +753,10 @@ class RichText extends Component {
 		// Check if any format props changed.
 		shouldReapply = shouldReapply ||
 			! isShallowEqual( prepareProps, prevPrepareProps );
+
+		// Rerender if the placeholder changed.
+		shouldReapply = shouldReapply ||
+			placeholder !== prevProps.placeholder;
 
 		const { activeFormats = [] } = this.record;
 

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -181,6 +181,7 @@ class RichText extends Component {
 			multilineWrapperTags: this.multilineWrapperTags,
 			prepareEditableTree: createPrepareEditableTree( this.props, 'format_prepare_functions' ),
 			__unstableDomOnly: domOnly,
+			placeholder: this.props.placeholder,
 		} );
 	}
 
@@ -808,6 +809,7 @@ class RichText extends Component {
 			value,
 			multilineTag: this.multilineTag,
 			prepareEditableTree: createPrepareEditableTree( this.props, 'format_prepare_functions' ),
+			placeholder: this.props.placeholder,
 		} ).body.innerHTML;
 	}
 
@@ -857,7 +859,6 @@ class RichText extends Component {
 			wrapperClassName,
 			className,
 			placeholder,
-			keepPlaceholderOnFocus = false,
 			__unstableIsSelected: isSelected,
 			children,
 			// To do: move autocompletion logic to rich-text.
@@ -872,10 +873,8 @@ class RichText extends Component {
 		// changes, we replace the relevant element. This is needed because we
 		// prevent Editable component updates.
 		const key = Tagname;
-		const MultilineTag = this.multilineTag;
 		const ariaProps = pickAriaProps( this.props );
 		const record = this.getRecord();
-		const isPlaceholderVisible = placeholder && ( ! isSelected || keepPlaceholderOnFocus ) && isEmpty( record );
 
 		const autoCompleteContent = ( { listBoxId, activeId } ) => (
 			<>
@@ -884,7 +883,6 @@ class RichText extends Component {
 					style={ style }
 					record={ record }
 					valueToEditableHTML={ this.valueToEditableHTML }
-					isPlaceholderVisible={ isPlaceholderVisible }
 					aria-label={ placeholder }
 					aria-autocomplete={ listBoxId ? 'list' : undefined }
 					aria-owns={ listBoxId }
@@ -902,14 +900,6 @@ class RichText extends Component {
 					onTouchStart={ this.onPointerDown }
 					setRef={ this.setRef }
 				/>
-				{ isPlaceholderVisible &&
-					<Tagname
-						className={ classnames( 'rich-text', className ) }
-						style={ style }
-					>
-						{ MultilineTag ? <MultilineTag>{ placeholder }</MultilineTag> : placeholder }
-					</Tagname>
-				}
 				{ isSelected && <FormatEdit
 					allowedFormats={ allowedFormats }
 					withoutInteractiveFormatting={ withoutInteractiveFormatting }

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -333,11 +333,12 @@ function createFromElement( {
 			continue;
 		}
 
-		if (
-			isEditableTree &&
-			type === 'br' &&
-			! node.getAttribute( 'data-rich-text-line-break' )
-		) {
+		if ( isEditableTree && (
+			// Ignore any placeholders.
+			node.getAttribute( 'data-rich-text-placeholder' ) ||
+			// Ignore any line breaks that are not inserted by us.
+			( type === 'br' && ! node.getAttribute( 'data-rich-text-line-break' ) )
+		) ) {
 			accumulateSelection( accumulator, node, range, createEmptyValue() );
 			continue;
 		}

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -118,6 +118,7 @@ export function toDom( {
 	multilineTag,
 	prepareEditableTree,
 	isEditableTree = true,
+	placeholder,
 } ) {
 	let startPath = [];
 	let endPath = [];
@@ -147,6 +148,7 @@ export function toDom( {
 			endPath = createPathToNode( pointer, body, [ pointer.nodeValue.length ] );
 		},
 		isEditableTree,
+		placeholder,
 	} );
 
 	return {
@@ -172,12 +174,14 @@ export function apply( {
 	multilineTag,
 	prepareEditableTree,
 	__unstableDomOnly,
+	placeholder,
 } ) {
 	// Construct a new element tree in memory.
 	const { body, selection } = toDom( {
 		value,
 		multilineTag,
 		prepareEditableTree,
+		placeholder,
 	} );
 
 	applyValue( body, current );

--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -84,6 +84,7 @@ export function toTree( {
 	onStartIndex,
 	onEndIndex,
 	isEditableTree,
+	placeholder,
 } ) {
 	const { formats, replacements, text, start, end } = value;
 	const formatsLength = formats.length + 1;
@@ -248,6 +249,15 @@ export function toTree( {
 
 		if ( shouldInsertPadding && i === text.length ) {
 			append( getParent( pointer ), ZWNBSP );
+
+			if ( placeholder && text.length === 0 ) {
+				append( getParent( pointer ), {
+					type: 'span',
+					attributes: {
+						'data-rich-text-placeholder': placeholder,
+					},
+				} );
+			}
 		}
 
 		lastCharacterFormats = characterFormats;


### PR DESCRIPTION
## Description

This small PR improves the currently clunky placeholder text for rich text instances.

The way placeholders are currently implemented is by "shadowing" the whole rich text element.

* This may sometimes result in styles being duplicated (when using `:before` or `:after`). See the double line?

<img width="402" alt="Screenshot 2019-07-24 at 16 15 43" src="https://user-images.githubusercontent.com/4710635/61801017-5dfb7500-ae2e-11e9-97ac-5c11cb73c95f.png">

* Sometimes it needs style adjustments for multi-line instances (see removal of `p` handling).
* It requires a wrapper tag with relative positioning.

When placeholders were first implemented, we used `:before`, but we cannot do that as themes may use pseudo elements for styling.

What I propose here is to insert a placeholder `span` element whenever then content is empty. This way the styling is _always_ correct. It's as if the text is just there. This implementation requires less code, and it feel a lot "cleaner".

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
