### PR TITLE
Project Management: Update aduth's code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,86 +4,86 @@
 /docs/designers-developers/designers            @youknowriad @chrisvanpatten @mkaz @ajitbohra
 
 # Data
-/packages/api-fetch                             @youknowriad @aduth @nerrad @mmtr
-/packages/core-data                             @youknowriad @aduth @nerrad
-/packages/data                                  @youknowriad @aduth @nerrad @coderkevin
-/packages/redux-routine                         @youknowriad @aduth @nerrad
+/packages/api-fetch                             @youknowriad @nerrad @mmtr
+/packages/core-data                             @youknowriad @nerrad
+/packages/data                                  @youknowriad @nerrad @coderkevin
+/packages/redux-routine                         @youknowriad @nerrad
 
 # Blocks
 /packages/block-library                         @youknowriad @gziolo @Soean @ajitbohra @jorgefilipecosta @talldan
 
 # Editor
-/packages/annotations                           @youknowriad @aduth @atimmer @ellatrix
+/packages/annotations                           @youknowriad @atimmer @ellatrix
 /packages/autop                                 @youknowriad @aduth
 /packages/block-editor                          @youknowriad @talldan @ellatrix
-/packages/block-serialization-spec-parser       @youknowriad @aduth @dmsnell
-/packages/block-serialization-default-parser    @youknowriad @aduth @dmsnell
-/packages/blocks                                @youknowriad @gziolo @aduth @ellatrix
+/packages/block-serialization-spec-parser       @youknowriad @dmsnell
+/packages/block-serialization-default-parser    @youknowriad @dmsnell
+/packages/blocks                                @youknowriad @gziolo @ellatrix
 /packages/edit-post                             @youknowriad @talldan
 /packages/editor                                @youknowriad @talldan
-/packages/list-reusable-blocks                  @youknowriad @aduth @noisysocks
+/packages/list-reusable-blocks                  @youknowriad @noisysocks
 /packages/shortcode                             @youknowriad @aduth
 
 # Widgets
 /packages/edit-widgets                          @youknowriad
 
 # Tooling
-/bin                                            @youknowriad @aduth @ntwb @nerrad @ajitbohra
-/bin/update-readmes.js                          @youknowriad @aduth @ntwb @nerrad @ajitbohra @nosolosw
+/bin                                            @youknowriad @ntwb @nerrad @ajitbohra
+/bin/update-readmes.js                          @youknowriad @ntwb @nerrad @ajitbohra @nosolosw
 /docs/tool                                      @youknowriad @chrisvanpatten @ajitbohra @nosolosw
-/packages/babel-plugin-import-jsx-pragma        @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
-/packages/babel-plugin-makepot                  @youknowriad @aduth @ntwb @nerrad @ajitbohra
-/packages/babel-preset-default                  @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
-/packages/browserslist-config                   @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
-/packages/custom-templated-path-webpack-plugin  @youknowriad @aduth @ntwb @nerrad @ajitbohra
+/packages/babel-plugin-import-jsx-pragma        @youknowriad @gziolo @ntwb @nerrad @ajitbohra
+/packages/babel-plugin-makepot                  @youknowriad @ntwb @nerrad @ajitbohra
+/packages/babel-preset-default                  @youknowriad @gziolo @ntwb @nerrad @ajitbohra
+/packages/browserslist-config                   @youknowriad @gziolo @ntwb @nerrad @ajitbohra
+/packages/custom-templated-path-webpack-plugin  @youknowriad @ntwb @nerrad @ajitbohra
 /packages/docgen                                @nosolosw
-/packages/e2e-test-utils                        @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
-/packages/e2e-tests                             @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra @talldan
-/packages/eslint-plugin                         @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
-/packages/jest-console                          @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
-/packages/jest-preset-default                   @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
-/packages/jest-puppeteer-axe                    @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
-/packages/library-export-default-webpack-plugin @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
-/packages/npm-package-json-lint-config          @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra
-/packages/postcss-themes                        @youknowriad @aduth @ntwb @nerrad @ajitbohra
-/packages/scripts                               @youknowriad @gziolo @aduth @ntwb @nerrad @ajitbohra @nosolosw
+/packages/e2e-test-utils                        @youknowriad @gziolo @ntwb @nerrad @ajitbohra
+/packages/e2e-tests                             @youknowriad @gziolo @ntwb @nerrad @ajitbohra @talldan
+/packages/eslint-plugin                         @youknowriad @gziolo @ntwb @nerrad @ajitbohra
+/packages/jest-console                          @youknowriad @gziolo @ntwb @nerrad @ajitbohra
+/packages/jest-preset-default                   @youknowriad @gziolo @ntwb @nerrad @ajitbohra
+/packages/jest-puppeteer-axe                    @youknowriad @gziolo @ntwb @nerrad @ajitbohra
+/packages/library-export-default-webpack-plugin @youknowriad @gziolo @ntwb @nerrad @ajitbohra
+/packages/npm-package-json-lint-config          @youknowriad @gziolo @ntwb @nerrad @ajitbohra
+/packages/postcss-themes                        @youknowriad @ntwb @nerrad @ajitbohra
+/packages/scripts                               @youknowriad @gziolo @ntwb @nerrad @ajitbohra @nosolosw
 
 # UI Components
-/packages/components                            @youknowriad @gziolo @aduth @ajitbohra @jaymanpandya @jorgefilipecosta @talldan @chrisvanpatten
-/packages/compose                               @youknowriad @gziolo @aduth @ajitbohra @jaymanpandya @jorgefilipecosta @talldan
-/packages/element                               @youknowriad @gziolo @aduth @ajitbohra @jaymanpandya @jorgefilipecosta @talldan
-/packages/notices                               @youknowriad @aduth @ajitbohra @jaymanpandya @jorgefilipecosta @talldan
-/packages/nux                                   @youknowriad @aduth @ajitbohra @jaymanpandya @jorgefilipecosta @talldan @noisysocks
-/packages/viewport                              @youknowriad @aduth @ajitbohra @jaymanpandya @jorgefilipecosta @talldan
+/packages/components                            @youknowriad @gziolo @ajitbohra @jaymanpandya @jorgefilipecosta @talldan @chrisvanpatten
+/packages/compose                               @youknowriad @gziolo @ajitbohra @jaymanpandya @jorgefilipecosta @talldan
+/packages/element                               @youknowriad @gziolo @ajitbohra @jaymanpandya @jorgefilipecosta @talldan
+/packages/notices                               @youknowriad @ajitbohra @jaymanpandya @jorgefilipecosta @talldan
+/packages/nux                                   @youknowriad @ajitbohra @jaymanpandya @jorgefilipecosta @talldan @noisysocks
+/packages/viewport                              @youknowriad @ajitbohra @jaymanpandya @jorgefilipecosta @talldan
 
 # Utilities
 /packages/a11y                                  @youknowriad @aduth
 /packages/blob                                  @youknowriad @aduth
 /packages/date                                  @youknowriad @aduth
 /packages/deprecated                            @youknowriad @aduth
-/packages/dom                                   @youknowriad @aduth @ellatrix
+/packages/dom                                   @youknowriad @ellatrix
 /packages/dom-ready                             @youknowriad @aduth
 /packages/escape-html                           @youknowriad @aduth
 /packages/html-entities                         @youknowriad @aduth
-/packages/i18n                                  @youknowriad @aduth @swissspidy
+/packages/i18n                                  @youknowriad @swissspidy
 /packages/is-shallow-equal                      @youknowriad @aduth
-/packages/keycodes                              @youknowriad @aduth @talldan @ellatrix
+/packages/keycodes                              @youknowriad @talldan @ellatrix
 /packages/priority-queue                        @youknowriad @aduth
 /packages/token-list                            @youknowriad @aduth
-/packages/url                                   @youknowriad @aduth @talldan
+/packages/url                                   @youknowriad @talldan
 /packages/wordcount                             @youknowriad @aduth
 
 # Extensibility
-/packages/hooks                                 @youknowriad @gziolo @aduth @adamsilverstein
-/packages/plugins                               @youknowriad @gziolo @aduth @adamsilverstein
+/packages/hooks                                 @youknowriad @gziolo @adamsilverstein
+/packages/plugins                               @youknowriad @gziolo @adamsilverstein
 
 # Rich Text
-/packages/format-library                        @youknowriad @aduth @ellatrix @jorgefilipecosta @daniloercoli @sergioestevao @etoledom
-/packages/rich-text                             @youknowriad @aduth @ellatrix @jorgefilipecosta @daniloercoli @sergioestevao @etoledom
-/packages/block-editor/src/components/rich-text @youknowriad @aduth @ellatrix @jorgefilipecosta @daniloercoli @sergioestevao @etoledom
+/packages/format-library                        @youknowriad @ellatrix @jorgefilipecosta @daniloercoli @sergioestevao @etoledom
+/packages/rich-text                             @youknowriad @ellatrix @jorgefilipecosta @daniloercoli @sergioestevao @etoledom
+/packages/block-editor/src/components/rich-text @youknowriad @ellatrix @jorgefilipecosta @daniloercoli @sergioestevao @etoledom
 
 # PHP
-/lib                                            @youknowriad @aduth @timothybjacobs
+/lib                                            @youknowriad @timothybjacobs
 
 # Native (Unowned)
 *.native.js                                     @ghost


### PR DESCRIPTION
I will be taking an extended leave from active Gutenberg development, and have herein included revisions to remove myself from code ownership notifications until my return.