### PR TITLE
ESLint Plugin: Exempt React hooks from no-unused-vars-before-return

### DIFF
--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -35,7 +35,6 @@ function FontSizePicker( {
 	value,
 	withSlider = false,
 } ) {
-	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
 	const [ currentSelectValue, setCurrentSelectValue ] = useState( getSelectValueFromFontSize( fontSizes, value ) );
 
 	if ( disableCustomFontSizes && ! fontSizes.length ) {

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.4.0 (Unreleased)
+
+### New Features
+
+- [`@wordpress/no-unused-vars-before-return`](https://github.com/WordPress/gutenberg/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars-before-return.md) now supports an `excludePattern` option to exempt function calls by name.
+
 ## 2.3.0 (2019-06-12)
 
 ### Bug Fix

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - [`@wordpress/no-unused-vars-before-return`](https://github.com/WordPress/gutenberg/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars-before-return.md) now supports an `excludePattern` option to exempt function calls by name.
 
+### Improvements
+
+- The recommended `react` configuration specifies an option to [`@wordpress/no-unused-vars-before-return`](https://github.com/WordPress/gutenberg/blob/master/packages/eslint-plugin/docs/rules/react-unused-vars-before-return.md) to exempt React hooks usage, by convention of hooks beginning with "use" prefix.
+
 ## 2.3.0 (2019-06-12)
 
 ### Bug Fix

--- a/packages/eslint-plugin/configs/react.js
+++ b/packages/eslint-plugin/configs/react.js
@@ -12,6 +12,9 @@ module.exports = {
 		'react-hooks',
 	],
 	rules: {
+		'@wordpress/no-unused-vars-before-return': [ 'error', {
+			excludePattern: '^use',
+		} ],
 		'react/display-name': 'off',
 		'react/jsx-curly-spacing': [ 'error', {
 			when: 'always',

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -2,8 +2,8 @@ module.exports = {
 	parser: 'babel-eslint',
 	extends: [
 		require.resolve( './jsx-a11y.js' ),
-		require.resolve( './react.js' ),
 		require.resolve( './custom.js' ),
+		require.resolve( './react.js' ),
 		require.resolve( './esnext.js' ),
 	],
 	env: {

--- a/packages/eslint-plugin/docs/rules/no-unused-vars-before-return.md
+++ b/packages/eslint-plugin/docs/rules/no-unused-vars-before-return.md
@@ -29,3 +29,9 @@ function example( number ) {
 	return number + foo;
 }
 ```
+
+## Options
+
+This rule accepts a single options argument:
+
+- Set the `excludePattern` option to a regular expression string to exempt specific function calls by name.

--- a/packages/eslint-plugin/rules/__tests__/no-unused-vars-before-return.js
+++ b/packages/eslint-plugin/rules/__tests__/no-unused-vars-before-return.js
@@ -27,6 +27,18 @@ function example( number ) {
 	return number + foo;
 }`,
 		},
+		{
+			code: `
+function example() {
+	const foo = doSomeCostlyOperation();
+	if ( number > 10 ) {
+		return number + 1;
+	}
+
+	return number + foo;
+}`,
+			options: [ { excludePattern: '^do' } ],
+		},
 	],
 	invalid: [
 		{
@@ -39,6 +51,19 @@ function example( number ) {
 
 	return number + foo;
 }`,
+			errors: [ { message: 'Variables should not be assigned until just prior its first reference. An early return statement may leave this variable unused.' } ],
+		},
+		{
+			code: `
+function example() {
+	const foo = doSomeCostlyOperation();
+	if ( number > 10 ) {
+		return number + 1;
+	}
+
+	return number + foo;
+}`,
+			options: [ { excludePattern: '^run' } ],
 			errors: [ { message: 'Variables should not be assigned until just prior its first reference. An early return statement may leave this variable unused.' } ],
 		},
 	],

--- a/packages/eslint-plugin/rules/no-unused-vars-before-return.js
+++ b/packages/eslint-plugin/rules/no-unused-vars-before-return.js
@@ -1,9 +1,22 @@
 module.exports = {
 	meta: {
 		type: 'problem',
-		schema: [],
+		schema: [
+			{
+				type: 'object',
+				properties: {
+					excludePattern: {
+						type: 'string',
+					},
+				},
+				additionalProperties: false,
+			},
+		],
 	},
 	create( context ) {
+		const options = context.options[ 0 ] || {};
+		const { excludePattern } = options;
+
 		return {
 			ReturnStatement( node ) {
 				let functionScope = context.getScope();
@@ -32,6 +45,13 @@ module.exports = {
 
 					if ( ! declaratorCandidate ) {
 						continue;
+					}
+
+					if (
+						excludePattern !== undefined &&
+						new RegExp( excludePattern ).test( declaratorCandidate.node.init.callee.name )
+					) {
+						return;
 					}
 
 					// The first entry in `references` is the declaration


### PR DESCRIPTION
This pull request seeks to improve interoperability between our custom [`@wordpress/no-unused-vars-before-return`](https://github.com/WordPress/gutenberg/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars-before-return.md) and React Hooks. Since hooks [must appear in a deterministic order](https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level), they occasionally must break this rule.

The implementation here adds a new `excludePattern` to the rule, which is then used by the default React configuration to exclude function calls prefixed with the [`use` convention](https://reactjs.org/docs/hooks-custom.html#extracting-a-custom-hook).

**Testing Instructions:**

Verify there are no lint errors:

```
npm run lint-js
```

Verify that implementing a variable assignment where the variable is used after a return path does not trigger the `@wordpress/no-unused-vars-before-return` rule.