### PR TITLE
Fix: Close "Block Styles" section on transformBlockTo e2e test helper.

### DIFF
--- a/packages/e2e-test-utils/src/transform-block-to.js
+++ b/packages/e2e-test-utils/src/transform-block-to.js
@@ -7,6 +7,14 @@ export async function transformBlockTo( name ) {
 	await page.mouse.move( 200, 300, { steps: 10 } );
 	await page.mouse.move( 250, 350, { steps: 10 } );
 	await page.click( '.block-editor-block-switcher__toggle' );
+	// Close the "Block Styles" section if it is open.
+	// Having the section open may make the transform buttons hidden on the testing resolution.
+	const closeBlockStylesButton = await page.$x(
+		'//div[contains(@class,"block-editor-block-switcher__popover")]//button[contains(text(),"Block Styles")][@aria-expanded="true"]'
+	);
+	if ( closeBlockStylesButton.length > 0 ) {
+		await closeBlockStylesButton[ 0 ].click();
+	}
 	const insertButton = ( await page.$x(
 		`//button//span[contains(text(), '${ name }')]`
 	) )[ 0 ];


### PR DESCRIPTION
## Description
In pr https://github.com/WordPress/gutenberg/pull/16113, the end to end tests are failing, because, during a transform test a button is not visible in the test screen height (that PR increases the height of block style buttons). This PR fixes the problem by first closing the "Block Styles" button. This change replicates the same a human user would have to do to press the transform button in that screen resolution.

## How has this been tested?
Merge https://github.com/WordPress/gutenberg/pull/16113 temporarily in this branch and verify end to end transform tests pass:
`npm run test-e2e packages/e2e-tests/specs/block-transforms.test.js`