### PR TITLE
Table block: Removes the `word-break:break-all;` from the table cells

### DIFF
--- a/packages/block-library/src/table/editor.scss
+++ b/packages/block-library/src/table/editor.scss
@@ -12,7 +12,7 @@
 
 		td,
 		th {
-			overflow-wrap: break-word;
+			word-break: break-word;
 		}
 	}
 

--- a/packages/block-library/src/table/editor.scss
+++ b/packages/block-library/src/table/editor.scss
@@ -9,10 +9,6 @@
 			// Ensure the table element is not full-width when aligned.
 			width: auto;
 		}
-		td,
-		th {
-			word-break: break-all;
-		}
 	}
 
 	&[data-align="center"] {

--- a/packages/block-library/src/table/editor.scss
+++ b/packages/block-library/src/table/editor.scss
@@ -9,6 +9,11 @@
 			// Ensure the table element is not full-width when aligned.
 			width: auto;
 		}
+
+		td,
+		th {
+			overflow-wrap: break-word;
+		}
 	}
 
 	&[data-align="center"] {

--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -34,7 +34,7 @@
 
 		td,
 		th {
-			overflow-wrap: break-word;
+			word-break: break-word;
 		}
 	}
 

--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -17,7 +17,7 @@
 
 		td,
 		th {
-			overflow-wrap: break-word;
+			word-break: break-word;
 		}
 	}
 

--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -14,11 +14,6 @@
 	.has-fixed-layout {
 		table-layout: fixed;
 		width: 100%;
-
-		td,
-		th {
-			word-break: break-all;
-		}
 	}
 
 	&.alignleft,
@@ -31,12 +26,6 @@
 		// Table cannot be 100% width if it is aligned, so set
 		// width as auto.
 		width: auto;
-
-		td,
-		th {
-			// Aligned tables shouldn't scroll horizontally so we need their contents to wrap.
-			word-break: break-all;
-		}
 	}
 
 	.has-subtle-light-gray-background-color {

--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -14,6 +14,11 @@
 	.has-fixed-layout {
 		table-layout: fixed;
 		width: 100%;
+
+		td,
+		th {
+			overflow-wrap: break-word;
+		}
 	}
 
 	&.alignleft,
@@ -26,6 +31,11 @@
 		// Table cannot be 100% width if it is aligned, so set
 		// width as auto.
 		width: auto;
+
+		td,
+		th {
+			overflow-wrap: break-word;
+		}
 	}
 
 	.has-subtle-light-gray-background-color {


### PR DESCRIPTION
Fixes #16740. Removes the word-break:break-all; from the CSS for the Table cells.

## How has this been tested?
Locally.

## Screenshots

**BEFORE:**

![Screen Shot 2019-07-24 at 10 06 56 AM](https://user-images.githubusercontent.com/617986/61814685-6be4d200-adfd-11e9-8765-e784fc98698e.png)

**AFTER:**

![table-breaks](https://user-images.githubusercontent.com/617986/61814706-769f6700-adfd-11e9-92ae-c17c313ce673.gif)


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
