### PR TITLE
Block Editor: Only show block movers when block is selected.

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -368,7 +368,7 @@ function BlockListBlock( {
 		! isEmptyDefaultBlock;
 	// We render block movers and block settings to keep them tabbale even if hidden
 	const shouldRenderMovers =
-		( isSelected || hoverArea === ( isRTL ? 'right' : 'left' ) ) &&
+		isSelected &&
 		! showEmptyBlockSideInserter &&
 		! isPartOfMultiSelection &&
 		! isTypingWithinBlock;


### PR DESCRIPTION
Fixes #16681 

## Description

Avoids block movers overlapping when there are certain combinations of blocks, block selections, and/or hovers, by only showing them when a block is selected and not on hover.

## How has this been tested?

Blocks were hovered and it was verified that the movers were not showing.

## Screenshots

<img width="719" alt="Screen Shot 2019-07-24 at 4 36 30 PM" src="https://user-images.githubusercontent.com/19157096/61830758-9b153680-ae31-11e9-8f11-c5fb53e45f26.png">

## Types of Changes

*Bug Fix:* Only show block movers when block is selected.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
