### PR TITLE
Fix race condition in block moving animation.

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -252,7 +252,7 @@ function BlockListBlock( {
 	}, [ isFirstMultiSelected ] );
 
 	// Block Reordering animation
-	const style = useMovingAnimation( wrapper, isSelected || isPartOfMultiSelection, enableAnimation, animateOnChange );
+	const animationStyle = useMovingAnimation( wrapper, isSelected || isPartOfMultiSelection, enableAnimation, animateOnChange );
 
 	// Other event handlers
 
@@ -466,8 +466,15 @@ function BlockListBlock( {
 			aria-label={ blockLabel }
 			childHandledEvents={ [ 'onDragStart', 'onMouseDown' ] }
 			tagName={ animated.div }
-			style={ style }
 			{ ...blockWrapperProps }
+			style={
+				wrapperProps && wrapperProps.style ?
+					{
+						...wrapperProps.style,
+						...animationStyle,
+					} :
+					animationStyle
+			}
 		>
 			{ shouldShowInsertionPoint && (
 				<BlockInsertionPoint

--- a/packages/block-editor/src/components/block-list/moving-animation.js
+++ b/packages/block-editor/src/components/block-list/moving-animation.js
@@ -6,7 +6,7 @@ import { useSpring, interpolate } from 'react-spring/web.cjs';
 /**
  * WordPress dependencies
  */
-import { useState, useLayoutEffect } from '@wordpress/element';
+import { useState, useLayoutEffect, useReducer } from '@wordpress/element';
 import { useReducedMotion } from '@wordpress/compose';
 
 /**
@@ -29,10 +29,17 @@ import { useReducedMotion } from '@wordpress/compose';
  */
 function useMovingAnimation( ref, isSelected, enableAnimation, triggerAnimationOnChange ) {
 	const prefersReducedMotion = useReducedMotion() || ! enableAnimation;
-	const [ resetAnimation, setResetAnimation ] = useState( false );
+	const [ triggeredAnimation, triggerAnimation ] = useReducer( ( state = 0 ) => state + 1 );
+	const [ finishedAnimation, endAnimation ] = useReducer( ( state = 0 ) => state + 1 );
 	const [ transform, setTransform ] = useState( { x: 0, y: 0 } );
 
 	const previous = ref.current ? ref.current.getBoundingClientRect() : null;
+
+	useLayoutEffect( () => {
+		if ( triggeredAnimation ) {
+			endAnimation();
+		}
+	}, [ triggeredAnimation ] );
 	useLayoutEffect( () => {
 		if ( prefersReducedMotion ) {
 			return;
@@ -46,21 +53,16 @@ function useMovingAnimation( ref, isSelected, enableAnimation, triggerAnimationO
 		ref.current.style.transform = newTransform.x === 0 && newTransform.y === 0 ?
 			undefined :
 			`translate3d(${ newTransform.x }px,${ newTransform.y }px,0)`;
-		setResetAnimation( true );
+		triggerAnimation();
 		setTransform( newTransform );
 	}, [ triggerAnimationOnChange ] );
-	useLayoutEffect( () => {
-		if ( resetAnimation ) {
-			setResetAnimation( false );
-		}
-	}, [ resetAnimation ] );
 	const animationProps = useSpring( {
 		from: transform,
 		to: {
 			x: 0,
 			y: 0,
 		},
-		reset: resetAnimation,
+		reset: triggeredAnimation !== finishedAnimation,
 		config: { mass: 5, tension: 2000, friction: 200 },
 		immediate: prefersReducedMotion,
 	} );

--- a/packages/block-editor/src/components/block-list/moving-animation.js
+++ b/packages/block-editor/src/components/block-list/moving-animation.js
@@ -10,6 +10,14 @@ import { useState, useLayoutEffect, useReducer } from '@wordpress/element';
 import { useReducedMotion } from '@wordpress/compose';
 
 /**
+ * Simple reducer used to increment a counter.
+ *
+ * @param {number} state  Previous counter value.
+ * @return {number} New state value.
+ */
+const counterReducer = ( state ) => state + 1;
+
+/**
  * Hook used to compute the styles required to move a div into a new position.
  *
  * The way this animation works is the following:
@@ -29,8 +37,8 @@ import { useReducedMotion } from '@wordpress/compose';
  */
 function useMovingAnimation( ref, isSelected, enableAnimation, triggerAnimationOnChange ) {
 	const prefersReducedMotion = useReducedMotion() || ! enableAnimation;
-	const [ triggeredAnimation, triggerAnimation ] = useReducer( ( state = 0 ) => state + 1 );
-	const [ finishedAnimation, endAnimation ] = useReducer( ( state = 0 ) => state + 1 );
+	const [ triggeredAnimation, triggerAnimation ] = useReducer( counterReducer, 0 );
+	const [ finishedAnimation, endAnimation ] = useReducer( counterReducer, 0 );
 	const [ transform, setTransform ] = useState( { x: 0, y: 0 } );
 
 	const previous = ref.current ? ref.current.getBoundingClientRect() : null;


### PR DESCRIPTION
The block animations introduced in the previous release can suffer from some issues:

 - Sometimes on very quick rerenders, the animation stops in the middle causing the blocks to overflow each other.
 - The `style` prop that can be provided by third-party plugins is not rendered anymore.

closes #16540