### PR TITLE
Framework: Restrict combineReducers usage to data module

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -58,6 +58,10 @@ module.exports = {
 				message: 'Use ellipsis character (…) in place of three dots',
 			},
 			{
+				selector: 'ImportDeclaration[source.value="redux"] Identifier.imported[name="combineReducers"]',
+				message: 'Use `combineReducers` from `@wordpress/data`',
+			},
+			{
 				selector: 'ImportDeclaration[source.value="lodash"] Identifier.imported[name="memoize"]',
 				message: 'Use memize instead of Lodash’s memoize',
 			},

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'redux';
 import { keyBy, map, flowRight } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { combineReducers } from '@wordpress/data';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
This pull request seeks to replace a reference to Redux's `combineReducers` in `@wordpress/core-data` with the equivalent utility exported from `@wordpress/data`. In so doing, it includes a new project-level ESLint syntax restriction to enforce this usage. The proposed benefit of this change is to ensure consistency, leverage performance benefits from #11255, and avoid bundling multiple copies of a `combineReducers` utility. Furthermore, the `core-data` package never defined an explicit dependency on `redux` and thus was only incidentally able to be built without errors.

**Testing Instructions:**

Ensure unit tests pass:

```
npm run test-unit
```

Ensure lint passes:

```
npm run lint-js
```