### PR TITLE
Framework: Ignore more transient directories for lint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,8 +1,11 @@
+.cache
 build
 build-module
 node_modules
-packages/e2e-tests/plugins
-vendor
 packages/block-serialization-spec-parser/parser.js
+packages/e2e-tests/plugins
+playground/dist
+vendor
+wordpress
 
 !.eslintrc.js


### PR DESCRIPTION
This pull request seeks to include additional directories in `.eslintignore` to further align between this file and [`.gitignore`](https://github.com/WordPress/gutenberg/blob/master/.gitignore). Without these changes, there can be significant time wasted recursing into folders not intended to be scanned for ESLint violations.

**Testing Instructions:**

Verify lint passes:

```
npm run lint-js
```

For good measure, you may also verify that an intentionally-introduced lint error fails as expected.