### PR TITLE
Test: Collapse passed tests in Travis.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7653,11 +7653,713 @@
 			"version": "file:packages/jest-preset-default",
 			"dev": true,
 			"requires": {
+				"@jest/reporters": "^24.8.0",
 				"@wordpress/jest-console": "file:packages/jest-console",
 				"babel-jest": "^24.7.1",
 				"enzyme": "^3.9.0",
 				"enzyme-adapter-react-16": "^1.10.0",
 				"enzyme-to-json": "^3.3.5"
+			},
+			"dependencies": {
+				"@jest/environment": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.8.0.tgz",
+					"integrity": "sha512-vlGt2HLg7qM+vtBrSkjDxk9K0YtRBi7HfRFaDxoRtyi+DyVChzhF20duvpdAnKVBV6W5tym8jm0U9EfXbDk1tw==",
+					"dev": true,
+					"requires": {
+						"@jest/fake-timers": "^24.8.0",
+						"@jest/transform": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"jest-mock": "^24.8.0"
+					}
+				},
+				"@jest/fake-timers": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.8.0.tgz",
+					"integrity": "sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.8.0",
+						"jest-message-util": "^24.8.0",
+						"jest-mock": "^24.8.0"
+					}
+				},
+				"@jest/reporters": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.8.0.tgz",
+					"integrity": "sha512-eZ9TyUYpyIIXfYCrw0UHUWUvE35vx5I92HGMgS93Pv7du+GHIzl+/vh8Qj9MCWFK/4TqyttVBPakWMOfZRIfxw==",
+					"dev": true,
+					"requires": {
+						"@jest/environment": "^24.8.0",
+						"@jest/test-result": "^24.8.0",
+						"@jest/transform": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"chalk": "^2.0.1",
+						"exit": "^0.1.2",
+						"glob": "^7.1.2",
+						"istanbul-lib-coverage": "^2.0.2",
+						"istanbul-lib-instrument": "^3.0.1",
+						"istanbul-lib-report": "^2.0.4",
+						"istanbul-lib-source-maps": "^3.0.1",
+						"istanbul-reports": "^2.1.1",
+						"jest-haste-map": "^24.8.0",
+						"jest-resolve": "^24.8.0",
+						"jest-runtime": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"jest-worker": "^24.6.0",
+						"node-notifier": "^5.2.1",
+						"slash": "^2.0.0",
+						"source-map": "^0.6.0",
+						"string-length": "^2.0.0"
+					}
+				},
+				"@jest/test-result": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.8.0.tgz",
+					"integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
+					"dev": true,
+					"requires": {
+						"@jest/console": "^24.7.1",
+						"@jest/types": "^24.8.0",
+						"@types/istanbul-lib-coverage": "^2.0.0"
+					}
+				},
+				"@jest/test-sequencer": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.8.0.tgz",
+					"integrity": "sha512-OzL/2yHyPdCHXEzhoBuq37CE99nkme15eHkAzXRVqthreWZamEMA0WoetwstsQBCXABhczpK03JNbc4L01vvLg==",
+					"dev": true,
+					"requires": {
+						"@jest/test-result": "^24.8.0",
+						"jest-haste-map": "^24.8.0",
+						"jest-runner": "^24.8.0",
+						"jest-runtime": "^24.8.0"
+					}
+				},
+				"@jest/transform": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.8.0.tgz",
+					"integrity": "sha512-xBMfFUP7TortCs0O+Xtez2W7Zu1PLH9bvJgtraN1CDST6LBM/eTOZ9SfwS/lvV8yOfcDpFmwf9bq5cYbXvqsvA==",
+					"dev": true,
+					"requires": {
+						"@babel/core": "^7.1.0",
+						"@jest/types": "^24.8.0",
+						"babel-plugin-istanbul": "^5.1.0",
+						"chalk": "^2.0.1",
+						"convert-source-map": "^1.4.0",
+						"fast-json-stable-stringify": "^2.0.0",
+						"graceful-fs": "^4.1.15",
+						"jest-haste-map": "^24.8.0",
+						"jest-regex-util": "^24.3.0",
+						"jest-util": "^24.8.0",
+						"micromatch": "^3.1.10",
+						"realpath-native": "^1.1.0",
+						"slash": "^2.0.0",
+						"source-map": "^0.6.1",
+						"write-file-atomic": "2.4.1"
+					}
+				},
+				"@jest/types": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.8.0.tgz",
+					"integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^1.1.1",
+						"@types/yargs": "^12.0.9"
+					}
+				},
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				},
+				"ci-info": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+					"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+					"dev": true
+				},
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"execa": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^6.0.0",
+						"get-stream": "^4.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					}
+				},
+				"expect": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/expect/-/expect-24.8.0.tgz",
+					"integrity": "sha512-/zYvP8iMDrzaaxHVa724eJBCKqSHmO0FA7EDkBiRHxg6OipmMn1fN+C8T9L9K8yr7UONkOifu6+LLH+z76CnaA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.8.0",
+						"ansi-styles": "^3.2.0",
+						"jest-get-type": "^24.8.0",
+						"jest-matcher-utils": "^24.8.0",
+						"jest-message-util": "^24.8.0",
+						"jest-regex-util": "^24.3.0"
+					}
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
+					"integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
+					"dev": true
+				},
+				"invert-kv": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+					"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+					"dev": true
+				},
+				"is-ci": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+					"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+					"dev": true,
+					"requires": {
+						"ci-info": "^2.0.0"
+					}
+				},
+				"jest-config": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.8.0.tgz",
+					"integrity": "sha512-Czl3Nn2uEzVGsOeaewGWoDPD8GStxCpAe0zOYs2x2l0fZAgPbCr3uwUkgNKV3LwE13VXythM946cd5rdGkkBZw==",
+					"dev": true,
+					"requires": {
+						"@babel/core": "^7.1.0",
+						"@jest/test-sequencer": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"babel-jest": "^24.8.0",
+						"chalk": "^2.0.1",
+						"glob": "^7.1.1",
+						"jest-environment-jsdom": "^24.8.0",
+						"jest-environment-node": "^24.8.0",
+						"jest-get-type": "^24.8.0",
+						"jest-jasmine2": "^24.8.0",
+						"jest-regex-util": "^24.3.0",
+						"jest-resolve": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"jest-validate": "^24.8.0",
+						"micromatch": "^3.1.10",
+						"pretty-format": "^24.8.0",
+						"realpath-native": "^1.1.0"
+					}
+				},
+				"jest-diff": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.8.0.tgz",
+					"integrity": "sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"diff-sequences": "^24.3.0",
+						"jest-get-type": "^24.8.0",
+						"pretty-format": "^24.8.0"
+					}
+				},
+				"jest-each": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.8.0.tgz",
+					"integrity": "sha512-NrwK9gaL5+XgrgoCsd9svsoWdVkK4gnvyhcpzd6m487tXHqIdYeykgq3MKI1u4I+5Zf0tofr70at9dWJDeb+BA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.8.0",
+						"chalk": "^2.0.1",
+						"jest-get-type": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"pretty-format": "^24.8.0"
+					}
+				},
+				"jest-environment-jsdom": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.8.0.tgz",
+					"integrity": "sha512-qbvgLmR7PpwjoFjM/sbuqHJt/NCkviuq9vus9NBn/76hhSidO+Z6Bn9tU8friecegbJL8gzZQEMZBQlFWDCwAQ==",
+					"dev": true,
+					"requires": {
+						"@jest/environment": "^24.8.0",
+						"@jest/fake-timers": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"jest-mock": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"jsdom": "^11.5.1"
+					}
+				},
+				"jest-environment-node": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.8.0.tgz",
+					"integrity": "sha512-vIGUEScd1cdDgR6sqn2M08sJTRLQp6Dk/eIkCeO4PFHxZMOgy+uYLPMC4ix3PEfM5Au/x3uQ/5Tl0DpXXZsJ/Q==",
+					"dev": true,
+					"requires": {
+						"@jest/environment": "^24.8.0",
+						"@jest/fake-timers": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"jest-mock": "^24.8.0",
+						"jest-util": "^24.8.0"
+					}
+				},
+				"jest-get-type": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.8.0.tgz",
+					"integrity": "sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ==",
+					"dev": true
+				},
+				"jest-haste-map": {
+					"version": "24.8.1",
+					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.1.tgz",
+					"integrity": "sha512-SwaxMGVdAZk3ernAx2Uv2sorA7jm3Kx+lR0grp6rMmnY06Kn/urtKx1LPN2mGTea4fCT38impYT28FfcLUhX0g==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.8.0",
+						"anymatch": "^2.0.0",
+						"fb-watchman": "^2.0.0",
+						"fsevents": "^1.2.7",
+						"graceful-fs": "^4.1.15",
+						"invariant": "^2.2.4",
+						"jest-serializer": "^24.4.0",
+						"jest-util": "^24.8.0",
+						"jest-worker": "^24.6.0",
+						"micromatch": "^3.1.10",
+						"sane": "^4.0.3",
+						"walker": "^1.0.7"
+					}
+				},
+				"jest-jasmine2": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.8.0.tgz",
+					"integrity": "sha512-cEky88npEE5LKd5jPpTdDCLvKkdyklnaRycBXL6GNmpxe41F0WN44+i7lpQKa/hcbXaQ+rc9RMaM4dsebrYong==",
+					"dev": true,
+					"requires": {
+						"@babel/traverse": "^7.1.0",
+						"@jest/environment": "^24.8.0",
+						"@jest/test-result": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"chalk": "^2.0.1",
+						"co": "^4.6.0",
+						"expect": "^24.8.0",
+						"is-generator-fn": "^2.0.0",
+						"jest-each": "^24.8.0",
+						"jest-matcher-utils": "^24.8.0",
+						"jest-message-util": "^24.8.0",
+						"jest-runtime": "^24.8.0",
+						"jest-snapshot": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"pretty-format": "^24.8.0",
+						"throat": "^4.0.0"
+					}
+				},
+				"jest-leak-detector": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.8.0.tgz",
+					"integrity": "sha512-cG0yRSK8A831LN8lIHxI3AblB40uhv0z+SsQdW3GoMMVcK+sJwrIIyax5tu3eHHNJ8Fu6IMDpnLda2jhn2pD/g==",
+					"dev": true,
+					"requires": {
+						"pretty-format": "^24.8.0"
+					}
+				},
+				"jest-matcher-utils": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz",
+					"integrity": "sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"jest-diff": "^24.8.0",
+						"jest-get-type": "^24.8.0",
+						"pretty-format": "^24.8.0"
+					}
+				},
+				"jest-message-util": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.8.0.tgz",
+					"integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@jest/test-result": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"@types/stack-utils": "^1.0.1",
+						"chalk": "^2.0.1",
+						"micromatch": "^3.1.10",
+						"slash": "^2.0.0",
+						"stack-utils": "^1.0.1"
+					}
+				},
+				"jest-mock": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.8.0.tgz",
+					"integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.8.0"
+					}
+				},
+				"jest-resolve": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.8.0.tgz",
+					"integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.8.0",
+						"browser-resolve": "^1.11.3",
+						"chalk": "^2.0.1",
+						"jest-pnp-resolver": "^1.2.1",
+						"realpath-native": "^1.1.0"
+					}
+				},
+				"jest-runner": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.8.0.tgz",
+					"integrity": "sha512-utFqC5BaA3JmznbissSs95X1ZF+d+4WuOWwpM9+Ak356YtMhHE/GXUondZdcyAAOTBEsRGAgH/0TwLzfI9h7ow==",
+					"dev": true,
+					"requires": {
+						"@jest/console": "^24.7.1",
+						"@jest/environment": "^24.8.0",
+						"@jest/test-result": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"chalk": "^2.4.2",
+						"exit": "^0.1.2",
+						"graceful-fs": "^4.1.15",
+						"jest-config": "^24.8.0",
+						"jest-docblock": "^24.3.0",
+						"jest-haste-map": "^24.8.0",
+						"jest-jasmine2": "^24.8.0",
+						"jest-leak-detector": "^24.8.0",
+						"jest-message-util": "^24.8.0",
+						"jest-resolve": "^24.8.0",
+						"jest-runtime": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"jest-worker": "^24.6.0",
+						"source-map-support": "^0.5.6",
+						"throat": "^4.0.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "2.4.2",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						}
+					}
+				},
+				"jest-runtime": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.8.0.tgz",
+					"integrity": "sha512-Mq0aIXhvO/3bX44ccT+czU1/57IgOMyy80oM0XR/nyD5zgBcesF84BPabZi39pJVA6UXw+fY2Q1N+4BiVUBWOA==",
+					"dev": true,
+					"requires": {
+						"@jest/console": "^24.7.1",
+						"@jest/environment": "^24.8.0",
+						"@jest/source-map": "^24.3.0",
+						"@jest/transform": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"@types/yargs": "^12.0.2",
+						"chalk": "^2.0.1",
+						"exit": "^0.1.2",
+						"glob": "^7.1.3",
+						"graceful-fs": "^4.1.15",
+						"jest-config": "^24.8.0",
+						"jest-haste-map": "^24.8.0",
+						"jest-message-util": "^24.8.0",
+						"jest-mock": "^24.8.0",
+						"jest-regex-util": "^24.3.0",
+						"jest-resolve": "^24.8.0",
+						"jest-snapshot": "^24.8.0",
+						"jest-util": "^24.8.0",
+						"jest-validate": "^24.8.0",
+						"realpath-native": "^1.1.0",
+						"slash": "^2.0.0",
+						"strip-bom": "^3.0.0",
+						"yargs": "^12.0.2"
+					},
+					"dependencies": {
+						"glob": {
+							"version": "7.1.4",
+							"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+							"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+							"dev": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						}
+					}
+				},
+				"jest-snapshot": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.8.0.tgz",
+					"integrity": "sha512-5ehtWoc8oU9/cAPe6fez6QofVJLBKyqkY2+TlKTOf0VllBB/mqUNdARdcjlZrs9F1Cv+/HKoCS/BknT0+tmfPg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.0.0",
+						"@jest/types": "^24.8.0",
+						"chalk": "^2.0.1",
+						"expect": "^24.8.0",
+						"jest-diff": "^24.8.0",
+						"jest-matcher-utils": "^24.8.0",
+						"jest-message-util": "^24.8.0",
+						"jest-resolve": "^24.8.0",
+						"mkdirp": "^0.5.1",
+						"natural-compare": "^1.4.0",
+						"pretty-format": "^24.8.0",
+						"semver": "^5.5.0"
+					}
+				},
+				"jest-util": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.8.0.tgz",
+					"integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
+					"dev": true,
+					"requires": {
+						"@jest/console": "^24.7.1",
+						"@jest/fake-timers": "^24.8.0",
+						"@jest/source-map": "^24.3.0",
+						"@jest/test-result": "^24.8.0",
+						"@jest/types": "^24.8.0",
+						"callsites": "^3.0.0",
+						"chalk": "^2.0.1",
+						"graceful-fs": "^4.1.15",
+						"is-ci": "^2.0.0",
+						"mkdirp": "^0.5.1",
+						"slash": "^2.0.0",
+						"source-map": "^0.6.0"
+					}
+				},
+				"jest-validate": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.8.0.tgz",
+					"integrity": "sha512-+/N7VOEMW1Vzsrk3UWBDYTExTPwf68tavEPKDnJzrC6UlHtUDU/fuEdXqFoHzv9XnQ+zW6X3qMZhJ3YexfeLDA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.8.0",
+						"camelcase": "^5.0.0",
+						"chalk": "^2.0.1",
+						"jest-get-type": "^24.8.0",
+						"leven": "^2.1.0",
+						"pretty-format": "^24.8.0"
+					}
+				},
+				"lcid": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+					"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+					"dev": true,
+					"requires": {
+						"invert-kv": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"mem": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+					"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+					"dev": true,
+					"requires": {
+						"map-age-cleaner": "^0.1.1",
+						"mimic-fn": "^2.0.0",
+						"p-is-promise": "^2.0.0"
+					}
+				},
+				"mimic-fn": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+					"dev": true
+				},
+				"os-locale": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+					"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+					"dev": true,
+					"requires": {
+						"execa": "^1.0.0",
+						"lcid": "^2.0.0",
+						"mem": "^4.0.0"
+					}
+				},
+				"p-is-promise": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+					"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+					"dev": true
+				},
+				"p-limit": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"pretty-format": {
+					"version": "24.8.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.8.0.tgz",
+					"integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.8.0",
+						"ansi-regex": "^4.0.0",
+						"ansi-styles": "^3.2.0",
+						"react-is": "^16.8.4"
+					}
+				},
+				"pump": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+					"dev": true,
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				},
+				"slash": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+					"dev": true
+				},
+				"write-file-atomic": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
+					"integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"signal-exit": "^3.0.2"
+					}
+				},
+				"yargs": {
+					"version": "12.0.5",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+					"dev": true,
+					"requires": {
+						"cliui": "^4.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^3.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1 || ^4.0.0",
+						"yargs-parser": "^11.1.1"
+					}
+				},
+				"yargs-parser": {
+					"version": "11.1.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+					"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
 			}
 		},
 		"@wordpress/jest-puppeteer-axe": {

--- a/packages/jest-preset-default/jest-preset.json
+++ b/packages/jest-preset-default/jest-preset.json
@@ -27,5 +27,6 @@
 	"transform": {
 		"^.+\\.[jt]sx?$": "<rootDir>/node_modules/babel-jest"
 	},
-	"verbose": true
+	"verbose": true,
+	"reporters": [ "../../../@wordpress/jest-preset-default/scripts/travis-fold-passes-reporter.js" ]
 }

--- a/packages/jest-preset-default/package.json
+++ b/packages/jest-preset-default/package.json
@@ -31,6 +31,7 @@
 	],
 	"main": "index.js",
 	"dependencies": {
+		"@jest/reporters": "^24.8.0",
 		"@wordpress/jest-console": "file:../jest-console",
 		"babel-jest": "^24.7.1",
 		"enzyme": "^3.9.0",

--- a/packages/jest-preset-default/scripts/travis-fold-passes-reporter.js
+++ b/packages/jest-preset-default/scripts/travis-fold-passes-reporter.js
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+const { DefaultReporter } = require( '@jest/reporters' );
+
+class TravisFoldPassesReporter extends DefaultReporter {
+	constructor( ...args ) {
+		super( ...args );
+		this.foldedTestResults = [];
+	}
+
+	flushFoldedTestResults() {
+		if ( this.foldedTestResults.length > 0 ) {
+			this.log( 'travis_fold:start:TravisFoldPassesReporter' );
+			this.log(
+				`...${ this.foldedTestResults.length } passing test${
+					this.foldedTestResults.length === 1 ? '' : 's'
+				}.`
+			);
+			this.foldedTestResults.forEach( ( args ) => super.onTestResult( ...args ) );
+			this.log( 'travis_fold:end:TravisFoldPassesReporter' );
+			this.foldedTestResults = [];
+		}
+	}
+
+	onTestResult( ...args ) {
+		if ( args[ 1 ].numFailingTests === 0 && ! args[ 1 ].failureMessage ) {
+			this.foldedTestResults.push( args );
+		} else {
+			this.flushFoldedTestResults();
+			super.onTestResult( ...args );
+		}
+	}
+
+	onRunComplete( ...args ) {
+		this.flushFoldedTestResults();
+		super.onRunComplete( ...args );
+	}
+}
+
+module.exports =
+	'TRAVIS' in process.env && 'CI' in process.env ?
+		TravisFoldPassesReporter :
+		DefaultReporter;

--- a/packages/jest-preset-default/scripts/travis-fold-passes-reporter.js
+++ b/packages/jest-preset-default/scripts/travis-fold-passes-reporter.js
@@ -1,30 +1,33 @@
 /**
  * External dependencies
  */
-const { DefaultReporter } = require( '@jest/reporters' );
+const { VerboseReporter } = require( '@jest/reporters' );
 
-class TravisFoldPassesReporter extends DefaultReporter {
+class TravisFoldPassesReporter extends VerboseReporter {
 	constructor( ...args ) {
 		super( ...args );
 		this.foldedTestResults = [];
 	}
 
 	flushFoldedTestResults() {
-		if ( this.foldedTestResults.length > 0 ) {
-			this.log( 'travis_fold:start:TravisFoldPassesReporter' );
-			this.log(
-				`...${ this.foldedTestResults.length } passing test${
-					this.foldedTestResults.length === 1 ? '' : 's'
-				}.`
-			);
-			this.foldedTestResults.forEach( ( args ) => super.onTestResult( ...args ) );
-			this.log( 'travis_fold:end:TravisFoldPassesReporter' );
-			this.foldedTestResults = [];
+		if ( ! this.foldedTestResults.length ) {
+			return;
 		}
+
+		this.log( 'travis_fold:start:TravisFoldPassesReporter' );
+		this.log(
+			`...${ this.foldedTestResults.length } passing test${
+				this.foldedTestResults.length === 1 ? '' : 's'
+			}.`
+		);
+		this.foldedTestResults.forEach( ( args ) => super.onTestResult( ...args ) );
+		this.log( 'travis_fold:end:TravisFoldPassesReporter' );
+		this.foldedTestResults = [];
 	}
 
 	onTestResult( ...args ) {
-		if ( args[ 1 ].numFailingTests === 0 && ! args[ 1 ].failureMessage ) {
+		const testResult = args[ 1 ];
+		if ( testResult.numFailingTests === 0 && ! testResult.failureMessage ) {
 			this.foldedTestResults.push( args );
 		} else {
 			this.flushFoldedTestResults();
@@ -41,4 +44,4 @@ class TravisFoldPassesReporter extends DefaultReporter {
 module.exports =
 	'TRAVIS' in process.env && 'CI' in process.env ?
 		TravisFoldPassesReporter :
-		DefaultReporter;
+		VerboseReporter;

--- a/packages/jest-preset-default/scripts/travis-fold-passes-reporter.js
+++ b/packages/jest-preset-default/scripts/travis-fold-passes-reporter.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-const { VerboseReporter } = require( '@jest/reporters' );
+const { VerboseReporter, DefaultReporter } = require( '@jest/reporters' );
 
 class TravisFoldPassesReporter extends VerboseReporter {
 	constructor( ...args ) {
@@ -44,4 +44,11 @@ class TravisFoldPassesReporter extends VerboseReporter {
 module.exports =
 	'TRAVIS' in process.env && 'CI' in process.env ?
 		TravisFoldPassesReporter :
-		VerboseReporter;
+		class VerboseOrDefaultReporter {
+			constructor( globalConfig, ...args ) {
+				return new ( globalConfig.verbose ? VerboseReporter : DefaultReporter )(
+					globalConfig,
+					...args
+				);
+			}
+		};


### PR DESCRIPTION
Closes #16744 

## Description

This PR replaces the default jest reporter with a subclass that folds passed tests when running in Travis CI.

## How has this been tested?

Tests were run locally and the default reporter was used. Now we need to verify the new reporter works as expected in Travis.

## Types of Changes

*Build Tooling:* Collapse passed tests in Travis.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
