### PR TITLE
fix(editor): remove nonexistent `getBlockDependantsCacheBust` selector reference

### DIFF
--- a/docs/designers-developers/developers/data/data-core-editor.md
+++ b/docs/designers-developers/developers/data/data-core-editor.md
@@ -118,12 +118,6 @@ _Related_
 
 -   getBlockCount in core/block-editor store.
 
-<a name="getBlockDependantsCacheBust" href="#getBlockDependantsCacheBust">#</a> **getBlockDependantsCacheBust**
-
-_Related_
-
--   getBlockDependantsCacheBust in core/block-editor store.
-
 <a name="getBlockHierarchyRootClientId" href="#getBlockHierarchyRootClientId">#</a> **getBlockHierarchyRootClientId**
 
 _Related_

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1169,11 +1169,6 @@ function getBlockEditorSelector( name ) {
 }
 
 /**
- * @see getBlockDependantsCacheBust in core/block-editor store.
- */
-export const getBlockDependantsCacheBust = getBlockEditorSelector( 'getBlockDependantsCacheBust' );
-
-/**
  * @see getBlockName in core/block-editor store.
  */
 export const getBlockName = getBlockEditorSelector( 'getBlockName' );


### PR DESCRIPTION
## Description

This PR removes a selector reference from `core/editor` that references a deleted selector in `core/block-editor`

## How has this been tested?

Unit tests still pass.

## Screenshots <!-- if applicable -->

N/A

## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->