### PR TITLE
[RNMobile] Prevent always dismissing keyboard when switching away from empty image caption

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -270,6 +270,12 @@ class ImageEdit extends React.Component {
 			);
 		}
 
+		// We still want to render the caption so that the soft keyboard is not forced to close on Android
+		const shouldCaptionDisplay = () => {
+			const isCaptionEmpty = RichText.isEmpty( caption ) > 0;
+			return ! isCaptionEmpty || isSelected;
+		};
+
 		const imageContainerHeight = Dimensions.get( 'window' ).width / IMAGE_ASPECT_RATIO;
 		const getImageComponent = ( openMediaOptions, getMediaOptions ) => (
 			<TouchableWithoutFeedback
@@ -338,40 +344,38 @@ class ImageEdit extends React.Component {
 							);
 						} }
 					/>
-					{ ( ! RichText.isEmpty( caption ) > 0 || isSelected ) && (
-						<View style={ { padding: 12, flex: 1 } }
-							accessible={ true }
-							accessibilityLabel={
-								isEmpty( caption ) ?
-									/* translators: accessibility text. Empty image caption. */
-									__( 'Image caption. Empty' ) :
-									sprintf(
-										/* translators: accessibility text. %s: image caption. */
-										__( 'Image caption. %s' ),
-										caption
-									)
-							}
-							accessibilityRole={ 'button' }
-						>
-							<RichText
-								setRef={ ( ref ) => {
-									this._caption = ref;
-								} }
-								rootTagsToEliminate={ [ 'p' ] }
-								placeholder={ __( 'Write caption…' ) }
-								value={ caption }
-								onChange={ ( newCaption ) => setAttributes( { caption: newCaption } ) }
-								unstableOnFocus={ this.onFocusCaption }
-								onBlur={ this.props.onBlur } // always assign onBlur as props
-								isSelected={ this.state.isCaptionSelected }
-								__unstableMobileNoFocusOnMount
-								fontSize={ 14 }
-								underlineColorAndroid="transparent"
-								textAlign={ 'center' }
-								tagName={ '' }
-							/>
-						</View>
-					) }
+					<View style={ { padding: 12, flex: 1, display: shouldCaptionDisplay() ? 'flex' : 'none' } }
+						accessible={ true }
+						accessibilityLabel={
+							isEmpty( caption ) ?
+							/* translators: accessibility text. Empty image caption. */
+								__( 'Image caption. Empty' ) :
+								sprintf(
+									/* translators: accessibility text. %s: image caption. */
+									__( 'Image caption. %s' ),
+									caption
+								)
+						}
+						accessibilityRole={ 'button' }
+					>
+						<RichText
+							setRef={ ( ref ) => {
+								this._caption = ref;
+							} }
+							rootTagsToEliminate={ [ 'p' ] }
+							placeholder={ __( 'Write caption…' ) }
+							value={ caption }
+							onChange={ ( newCaption ) => setAttributes( { caption: newCaption } ) }
+							unstableOnFocus={ this.onFocusCaption }
+							onBlur={ this.props.onBlur } // always assign onBlur as props
+							isSelected={ this.state.isCaptionSelected }
+							__unstableMobileNoFocusOnMount
+							fontSize={ 14 }
+							underlineColorAndroid="transparent"
+							textAlign={ 'center' }
+							tagName={ '' }
+						/>
+					</View>
 				</View>
 			</TouchableWithoutFeedback>
 		);


### PR DESCRIPTION
Related gutenberg-mobile PR

## Description
This is a bugfix addresses [an issue on Android](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1221) where switching from an empty caption to another text block would cause the keyboard to be dismissed. The issue appears to occur as a result of the caption not being rendered when it is empty, so it was possible to fix the issue by always "rendering" the caption, but setting it's style's display property to "none" when it should not be visible. 

Before | After
--- | ---
![before_keyboard-dismiss mp4](https://user-images.githubusercontent.com/4656348/61905322-d168b980-aef6-11e9-90e8-e08be0cb9d2f.gif) | ![after_keyboard-dismiss mp4](https://user-images.githubusercontent.com/4656348/61905428-0e34b080-aef7-11e9-864d-3e4d106ba61b.gif)

This issue did not occur on iOS and it appears it may be a platform difference (as opposed to an issue with our `RichText` component) because I also observed this same issue when I replaced our `RichText` caption with a `TextInput` component. 

**NOTE: This PR only fixes this issue for image captions. The issue remains for video captions. I am exploring a few different ways of resolving the issue for video captions, and I would like to present that fix in a separate PR.**

## Test steps
1. Open demo app
2. Select image block without a caption
3. Tap on empty caption ("Write caption...")
4. Observe soft keyboard is displayed
5. With the _empty_ image caption, select any other block where you can edit text (paragraph, heading, etc.)
6. Observe that the soft keyboard remains open

I also checked and verified that this change did not seem to mess up TalkBack or VoiceOver support.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
