### PR TITLE
Fix: Widgets screen block toolbar overlaps the Block Area accordion

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -8,6 +8,7 @@ import {
 	sortBy,
 	throttle,
 } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -197,6 +198,7 @@ class BlockList extends Component {
 
 	render() {
 		const {
+			className,
 			blockClientIds,
 			rootClientId,
 			isDraggable,
@@ -208,7 +210,12 @@ class BlockList extends Component {
 		} = this.props;
 
 		return (
-			<div className="editor-block-list__layout block-editor-block-list__layout">
+			<div className={
+				classnames(
+					'editor-block-list__layout block-editor-block-list__layout',
+					className
+				)
+			}>
 				{ blockClientIds.map( ( clientId ) => {
 					const isBlockInSelection = hasMultiSelection ?
 						multiSelectedBlockClientIds.includes( clientId ) :

--- a/packages/edit-widgets/src/components/widget-area/index.js
+++ b/packages/edit-widgets/src/components/widget-area/index.js
@@ -84,7 +84,9 @@ function WidgetArea( {
 					</Sidebar.Inspector>
 					<WritingFlow>
 						<ObserveTyping>
-							<BlockList />
+							<BlockList
+								className="edit-widgets-main-block-list"
+							/>
 						</ObserveTyping>
 					</WritingFlow>
 				</BlockEditorProvider>

--- a/packages/edit-widgets/src/components/widget-area/style.scss
+++ b/packages/edit-widgets/src/components/widget-area/style.scss
@@ -2,3 +2,6 @@
 	max-width: $content-width;
 	margin: 0 auto 30px;
 }
+.edit-widgets-main-block-list {
+	padding-top: $block-toolbar-height + 2 * $grid-size;
+}


### PR DESCRIPTION
Fix: https://github.com/WordPress/gutenberg/issues/16602

This PR adds small padding to the block list container for widget areas to make sure the block toolbars don't overlap the block area accordion.

## How has this been tested?
I went to the block widgets screen.
I added a block like an image block and verified the block toolbar does not overlap the block area accordion. 
