### PR TITLE
Components: Restore default opacity to buttons

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -60,6 +60,7 @@
 			box-shadow: none;
 			text-shadow: 0 1px 0 #fff;
 			transform: none;
+			opacity: 1;
 		}
 	}
 
@@ -109,6 +110,7 @@
 			border-color: color(theme(button) shade(7%));
 			box-shadow: none;
 			text-shadow: none;
+			opacity: 1;
 
 			// This specificity is needed to override alternate color schemes in WP-Admin.
 			&.is-button,
@@ -189,6 +191,7 @@
 	&:disabled,
 	&[aria-disabled="true"] {
 		cursor: default;
+		opacity: 0.3;
 	}
 
 	&:focus:not(:disabled) {

--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -106,12 +106,4 @@
 			padding-left: 0.5rem;
 		}
 	}
-
-	.components-dropdown-menu__menu-item,
-	.components-menu-item__button {
-		&:disabled,
-		&[aria-disabled="true"] {
-			opacity: 0.3;
-		}
-	}
 }


### PR DESCRIPTION
(Partly) extracted: #16761
Related (reverts): #16581
Related (partially reverts): #16103

This pull request seeks to restore default dimmed opacity to buttons, removed as part of #16103. This can be seen for DropdownMenu buttons in #16581, and for the Undo/Redo buttons of a new post.

Before|After
---|---
![Before](https://user-images.githubusercontent.com/1779930/61960361-4e497100-af93-11e9-857f-9cccbbc434a7.png)|![After](https://user-images.githubusercontent.com/1779930/61960309-3671ed00-af93-11e9-9740-f64d3e17f5de.png)

It tries to respect the intention of #16103 by effectively unsetting the default opacity for `isPrimary` and `isDefault` (the "WordPress-styled") button variants, thus not regressing the intention of that pull request.

It's assumed that, since `.components-button` styling otherwise resets all browser-default appearance of a button, there should be _some_ effect to indicate the disabled state of a button, as otherwise (as seen in the "Before" screenshot) they cannot be distinguished from non-disabled buttons.

**Testing Instructions:**

Repeat testing instructions from #16103 

Verify buttons for Undo/Redo for a new post appear as disabled