### PR TITLE
Editor: Avoid passing event object to save button onSave prop

### DIFF
--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -103,7 +103,7 @@ export class PostSavedState extends Component {
 				<IconButton
 					className="editor-post-save-draft"
 					label={ label }
-					onClick={ onSave }
+					onClick={ () => onSave() }
 					shortcut={ displayShortcut.primary( 's' ) }
 					icon="cloud-upload"
 				/>
@@ -113,7 +113,7 @@ export class PostSavedState extends Component {
 		return (
 			<Button
 				className="editor-post-save-draft"
-				onClick={ onSave }
+				onClick={ () => onSave() }
 				shortcut={ displayShortcut.primary( 's' ) }
 				isTertiary
 			>

--- a/packages/editor/src/components/post-saved-state/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-saved-state/test/__snapshots__/index.js.snap
@@ -6,7 +6,7 @@ exports[`PostSavedState should return Save button if edits to be saved 1`] = `
 <ForwardRef(Button)
   className="editor-post-save-draft"
   isTertiary={true}
-  onClick={[MockFunction]}
+  onClick={[Function]}
   shortcut="Ctrl+S"
 >
   Save Draft

--- a/packages/editor/src/components/post-saved-state/test/index.js
+++ b/packages/editor/src/components/post-saved-state/test/index.js
@@ -66,7 +66,9 @@ describe( 'PostSavedState', () => {
 		);
 
 		expect( wrapper ).toMatchSnapshot();
-		wrapper.simulate( 'click' );
+		wrapper.simulate( 'click', {} );
 		expect( saveSpy ).toHaveBeenCalled();
+		// Regression: Verify the event object is not passed to prop callback.
+		expect( saveSpy.mock.calls[ 0 ] ).toEqual( [] );
 	} );
 } );


### PR DESCRIPTION
Extracted from #16761

This pull request seeks to remove inadvertent arguments passing to `PostSavedState` `onSave` prop. Without these changes, the `event` object of the mouse click on "Save Draft" is interpreted as the [`options` argument of `savePost`](https://github.com/WordPress/gutenberg/blob/32b7b341885c6e5d9b710bfe4ed64123d3e23a9d/packages/editor/src/store/actions.js#L434).

**Testing Instructions:**

Ensure unit tests pass:

```
npm run test-unit packages/editor/components/post-saved-state/test/index.js
```

Verify there are no regressions in using the "Save Draft" button to save a post.