### PR TITLE
Testing: Whitelist specific files for PHPCS

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -25,10 +25,12 @@
 	<arg value="ps"/>
 	<arg name="extensions" value="php"/>
 
+	<file>./bin</file>
+	<file>./gutenberg.php</file>
 	<file>./lib</file>
 	<file>./packages</file>
 	<file>./phpunit</file>
-	<file>./gutenberg.php</file>
+	<file>./post-content.php</file>
 
 	<!-- Exclude generated files -->
 	<exclude-pattern>./packages/block-serialization-spec-parser/parser.php</exclude-pattern>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -25,15 +25,13 @@
 	<arg value="ps"/>
 	<arg name="extensions" value="php"/>
 
-	<file>.</file>
-
-	<!-- Exclude 3rd party libraries -->
-	<exclude-pattern>./node_modules</exclude-pattern>
-	<exclude-pattern>./vendor</exclude-pattern>
+	<file>./lib</file>
+	<file>./packages</file>
+	<file>./phpunit</file>
+	<file>./gutenberg.php</file>
 
 	<!-- Exclude generated files -->
 	<exclude-pattern>./packages/block-serialization-spec-parser/parser.php</exclude-pattern>
-	<exclude-pattern>./build</exclude-pattern>
 
 	<!-- These special comments are markers for the build process -->
 	<rule ref="Squiz.Commenting.InlineComment.WrongStyle">


### PR DESCRIPTION
Related: #16753

This pull request seeks to improve the PHPCS linting to avoid testing files in folders for local development. It can often be the case, either with Parcel (playground) or Docker local `./wordpress` files, that the `npm run lint-php` file times out due to attempts to recurse deeply into these folder structures.

We could exclude more files as done in #16753, but I chose not to because the locations of PHP files are well-known and limited, and because I'm not convinced (with testing from `-v` verbose output of the `phpcs` command) that the exclusions were actually effective.

**Testing Instructions:**

Verify lint passes:

```
npm run lint-php
```