### PR TITLE
Deprecated: Output an informational message for deprecation when no version provided

### DIFF
--- a/packages/deprecated/CHANGELOG.md
+++ b/packages/deprecated/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### Breaking Change
+
+- When there is no `options.version` param provided `deprecated` method outputs an informational message to the Web Console rather than warns as previously.
+
 ## 2.0.4 (2019-01-03)
 
 ## 2.0.0 (2018-09-05)

--- a/packages/deprecated/CHANGELOG.md
+++ b/packages/deprecated/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Master
 
-### Breaking Change
+### Bug Fix
 
-- When there is no `options.version` param provided `deprecated` method outputs an informational message to the Web Console rather than warns as previously.
+- When there is no `options.version` param provided `deprecated` method warns with more relaxed tone.
 
 ## 2.0.4 (2019-01-03)
 

--- a/packages/deprecated/src/index.js
+++ b/packages/deprecated/src/index.js
@@ -46,7 +46,7 @@ export default function deprecated( feature, options = {} ) {
 	} = options;
 
 	const pluginMessage = plugin ? ` from ${ plugin }` : '';
-	const versionMessage = version ? ` and will be removed${ pluginMessage } in ${ version }` : '';
+	const versionMessage = version ? ` and will be removed${ pluginMessage } in version ${ version }` : '';
 	const useInsteadMessage = alternative ? ` Please use ${ alternative } instead.` : '';
 	const linkMessage = link ? ` See: ${ link }` : '';
 	const hintMessage = hint ? ` Note: ${ hint }` : '';
@@ -71,13 +71,8 @@ export default function deprecated( feature, options = {} ) {
 	 */
 	doAction( 'deprecated', feature, options, message );
 
-	if ( version ) {
-		// eslint-disable-next-line no-console
-		console.warn( message );
-	} else {
-		// eslint-disable-next-line no-console
-		console.info( message );
-	}
+	// eslint-disable-next-line no-console
+	console.warn( message );
 
 	logged[ message ] = true;
 }

--- a/packages/deprecated/src/index.js
+++ b/packages/deprecated/src/index.js
@@ -46,11 +46,11 @@ export default function deprecated( feature, options = {} ) {
 	} = options;
 
 	const pluginMessage = plugin ? ` from ${ plugin }` : '';
-	const versionMessage = version ? `${ pluginMessage } in ${ version }` : '';
+	const versionMessage = version ? ` and will be removed${ pluginMessage } in ${ version }` : '';
 	const useInsteadMessage = alternative ? ` Please use ${ alternative } instead.` : '';
 	const linkMessage = link ? ` See: ${ link }` : '';
 	const hintMessage = hint ? ` Note: ${ hint }` : '';
-	const message = `${ feature } is deprecated and will be removed${ versionMessage }.${ useInsteadMessage }${ linkMessage }${ hintMessage }`;
+	const message = `${ feature } is deprecated${ versionMessage }.${ useInsteadMessage }${ linkMessage }${ hintMessage }`;
 
 	// Skip if already logged.
 	if ( message in logged ) {
@@ -71,8 +71,13 @@ export default function deprecated( feature, options = {} ) {
 	 */
 	doAction( 'deprecated', feature, options, message );
 
-	// eslint-disable-next-line no-console
-	console.warn( message );
+	if ( version ) {
+		// eslint-disable-next-line no-console
+		console.warn( message );
+	} else {
+		// eslint-disable-next-line no-console
+		console.info( message );
+	}
 
 	logged[ message ] = true;
 }

--- a/packages/deprecated/src/test/index.js
+++ b/packages/deprecated/src/test/index.js
@@ -18,8 +18,8 @@ describe( 'deprecated', () => {
 	it( 'should show a deprecation warning', () => {
 		deprecated( 'Eating meat' );
 
-		expect( console ).toHaveWarnedWith(
-			'Eating meat is deprecated and will be removed.'
+		expect( console ).toHaveInformedWith(
+			'Eating meat is deprecated.'
 		);
 	} );
 
@@ -81,15 +81,15 @@ describe( 'deprecated', () => {
 		deprecated( 'Eating meat' );
 		deprecated( 'Eating meat' );
 
-		expect( console ).toHaveWarned();
+		expect( console ).toHaveInformed();
 		// eslint-disable-next-line no-console
-		expect( console.warn ).toHaveBeenCalledTimes( 1 );
+		expect( console.info ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'should do an action', () => {
 		deprecated( 'turkey', { alternative: 'tofurky' } );
 
-		expect( console ).toHaveWarned();
+		expect( console ).toHaveInformed();
 		expect( didAction( 'deprecated' ) ).toBeTruthy();
 	} );
 } );

--- a/packages/deprecated/src/test/index.js
+++ b/packages/deprecated/src/test/index.js
@@ -24,56 +24,56 @@ describe( 'deprecated', () => {
 	} );
 
 	it( 'should show a deprecation warning with a version', () => {
-		deprecated( 'Eating meat', { version: 'the future' } );
+		deprecated( 'Eating meat', { version: '2020.01.01' } );
 
 		expect( console ).toHaveWarnedWith(
-			'Eating meat is deprecated and will be removed in version the future.'
+			'Eating meat is deprecated and will be removed in version 2020.01.01.'
 		);
 	} );
 
 	it( 'should show a deprecation warning with an alternative', () => {
-		deprecated( 'Eating meat', { version: 'the future', alternative: 'vegetables' } );
+		deprecated( 'Eating meat', { version: '2020.01.01', alternative: 'vegetables' } );
 
 		expect( console ).toHaveWarnedWith(
-			'Eating meat is deprecated and will be removed in version the future. Please use vegetables instead.'
+			'Eating meat is deprecated and will be removed in version 2020.01.01. Please use vegetables instead.'
 		);
 	} );
 
 	it( 'should show a deprecation warning with an alternative specific to a plugin', () => {
 		deprecated( 'Eating meat', {
-			version: 'the future',
+			version: '2020.01.01',
 			alternative: 'vegetables',
 			plugin: 'the earth',
 		} );
 
 		expect( console ).toHaveWarnedWith(
-			'Eating meat is deprecated and will be removed from the earth in version the future. Please use vegetables instead.'
+			'Eating meat is deprecated and will be removed from the earth in version 2020.01.01. Please use vegetables instead.'
 		);
 	} );
 
 	it( 'should show a deprecation warning with a link', () => {
 		deprecated( 'Eating meat', {
-			version: 'the future',
+			version: '2020.01.01',
 			alternative: 'vegetables',
 			plugin: 'the earth',
 			link: 'https://en.wikipedia.org/wiki/Vegetarianism',
 		} );
 
 		expect( console ).toHaveWarnedWith(
-			'Eating meat is deprecated and will be removed from the earth in version the future. Please use vegetables instead. See: https://en.wikipedia.org/wiki/Vegetarianism'
+			'Eating meat is deprecated and will be removed from the earth in version 2020.01.01. Please use vegetables instead. See: https://en.wikipedia.org/wiki/Vegetarianism'
 		);
 	} );
 
 	it( 'should show a deprecation warning with a hint', () => {
 		deprecated( 'Eating meat', {
-			version: 'the future',
+			version: '2020.01.01',
 			alternative: 'vegetables',
 			plugin: 'the earth',
 			hint: 'You may find it beneficial to transition gradually.',
 		} );
 
 		expect( console ).toHaveWarnedWith(
-			'Eating meat is deprecated and will be removed from the earth in version the future. Please use vegetables instead. Note: You may find it beneficial to transition gradually.'
+			'Eating meat is deprecated and will be removed from the earth in version 2020.01.01. Please use vegetables instead. Note: You may find it beneficial to transition gradually.'
 		);
 	} );
 

--- a/packages/deprecated/src/test/index.js
+++ b/packages/deprecated/src/test/index.js
@@ -18,7 +18,7 @@ describe( 'deprecated', () => {
 	it( 'should show a deprecation warning', () => {
 		deprecated( 'Eating meat' );
 
-		expect( console ).toHaveInformedWith(
+		expect( console ).toHaveWarnedWith(
 			'Eating meat is deprecated.'
 		);
 	} );
@@ -27,7 +27,7 @@ describe( 'deprecated', () => {
 		deprecated( 'Eating meat', { version: 'the future' } );
 
 		expect( console ).toHaveWarnedWith(
-			'Eating meat is deprecated and will be removed in the future.'
+			'Eating meat is deprecated and will be removed in version the future.'
 		);
 	} );
 
@@ -35,7 +35,7 @@ describe( 'deprecated', () => {
 		deprecated( 'Eating meat', { version: 'the future', alternative: 'vegetables' } );
 
 		expect( console ).toHaveWarnedWith(
-			'Eating meat is deprecated and will be removed in the future. Please use vegetables instead.'
+			'Eating meat is deprecated and will be removed in version the future. Please use vegetables instead.'
 		);
 	} );
 
@@ -47,7 +47,7 @@ describe( 'deprecated', () => {
 		} );
 
 		expect( console ).toHaveWarnedWith(
-			'Eating meat is deprecated and will be removed from the earth in the future. Please use vegetables instead.'
+			'Eating meat is deprecated and will be removed from the earth in version the future. Please use vegetables instead.'
 		);
 	} );
 
@@ -60,7 +60,7 @@ describe( 'deprecated', () => {
 		} );
 
 		expect( console ).toHaveWarnedWith(
-			'Eating meat is deprecated and will be removed from the earth in the future. Please use vegetables instead. See: https://en.wikipedia.org/wiki/Vegetarianism'
+			'Eating meat is deprecated and will be removed from the earth in version the future. Please use vegetables instead. See: https://en.wikipedia.org/wiki/Vegetarianism'
 		);
 	} );
 
@@ -73,7 +73,7 @@ describe( 'deprecated', () => {
 		} );
 
 		expect( console ).toHaveWarnedWith(
-			'Eating meat is deprecated and will be removed from the earth in the future. Please use vegetables instead. Note: You may find it beneficial to transition gradually.'
+			'Eating meat is deprecated and will be removed from the earth in version the future. Please use vegetables instead. Note: You may find it beneficial to transition gradually.'
 		);
 	} );
 
@@ -81,15 +81,15 @@ describe( 'deprecated', () => {
 		deprecated( 'Eating meat' );
 		deprecated( 'Eating meat' );
 
-		expect( console ).toHaveInformed();
+		expect( console ).toHaveWarned();
 		// eslint-disable-next-line no-console
-		expect( console.info ).toHaveBeenCalledTimes( 1 );
+		expect( console.warn ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'should do an action', () => {
 		deprecated( 'turkey', { alternative: 'tofurky' } );
 
-		expect( console ).toHaveInformed();
+		expect( console ).toHaveWarned();
 		expect( didAction( 'deprecated' ) ).toBeTruthy();
 	} );
 } );


### PR DESCRIPTION
## Description

When there is no `options.version` param provided `deprecated` method outputs more relaxed warning message to the Web Console.

The fact that we warn when there is no clear path for removing deprecation is very confusing in my opinion. The change proposed tries to make it less dramatic for 3rd party developers. The idea is that when there is no version provided we are going to support deprecated version forever according to [Deprecations document](https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/backward-compatibility/deprecations.md). As soon as we decide to remove it, we should specify the target version for removal and it will automatically make the message stronger. 

### Before

![Screen Shot 2019-07-26 at 18 27 32](https://user-images.githubusercontent.com/699132/61966503-0d714c80-afd3-11e9-85a5-8212ef009213.png)
![Screen Shot 2019-07-26 at 18 24 49](https://user-images.githubusercontent.com/699132/61966445-eb77ca00-afd2-11e9-853b-87ad6f17a2c4.png)


### After


![Screen Shot 2019-07-31 at 14 03 47](https://user-images.githubusercontent.com/699132/62210423-6c9cdb80-b39c-11e9-9b0c-97571c188697.png)
![Screen Shot 2019-07-31 at 14 05 42](https://user-images.githubusercontent.com/699132/62210424-6d357200-b39c-11e9-8e85-82bbe1489945.png)
