### PR TITLE
Block library: Refactor Verse block to use class names for text align

### DIFF
--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Master (unreleased)
 
+### Enhancements
+
+- Heading block uses `has-text-align-*` class names rather than inline style for text alignment.
+- Verse block uses `has-text-align-*` class names rather than inline style for text alignment.
+
 ### Bug Fixes
 
 - Fixed insertion of columns in the table block, which now inserts columns for all table sections ([#16410](https://github.com/WordPress/gutenberg/pull/16410))

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -153,10 +153,12 @@
 }
 
 .has-text-align-left {
+	/*rtl:ignore*/
 	text-align: left;
 }
 
 .has-text-align-right {
+	/*rtl:ignore*/
 	text-align: right;
 }
 

--- a/packages/block-library/src/verse/deprecated.js
+++ b/packages/block-library/src/verse/deprecated.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+
+const blockAttributes = {
+	content: {
+		type: 'string',
+		source: 'html',
+		selector: 'pre',
+		default: '',
+	},
+	textAlign: {
+		type: 'string',
+	},
+};
+
+const deprecated = [
+	{
+		attributes: blockAttributes,
+		save( { attributes } ) {
+			const { textAlign, content } = attributes;
+
+			return (
+				<RichText.Content
+					tagName="pre"
+					style={ { textAlign } }
+					value={ content }
+				/>
+			);
+		},
+	},
+];
+
+export default deprecated;

--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -29,9 +34,11 @@ export default function VerseEdit( { attributes, setAttributes, className, merge
 						content: nextContent,
 					} );
 				} }
-				style={ { textAlign } }
 				placeholder={ __( 'Write…' ) }
 				wrapperClassName={ className }
+				className={ classnames( {
+					[ `has-text-align-${ textAlign }` ]: textAlign,
+				} ) }
 				onMerge={ mergeBlocks }
 			/>
 		</>

--- a/packages/block-library/src/verse/index.js
+++ b/packages/block-library/src/verse/index.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import deprecated from './deprecated';
 import edit from './edit';
 import icon from './icon';
 import metadata from './block.json';
@@ -22,11 +23,12 @@ export const settings = {
 	icon,
 	keywords: [ __( 'poetry' ) ],
 	transforms,
-	edit,
-	save,
+	deprecated,
 	merge( attributes, attributesToMerge ) {
 		return {
 			content: attributes.content + attributesToMerge.content,
 		};
 	},
+	edit,
+	save,
 };

--- a/packages/block-library/src/verse/save.js
+++ b/packages/block-library/src/verse/save.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { RichText } from '@wordpress/block-editor';
@@ -6,10 +11,14 @@ import { RichText } from '@wordpress/block-editor';
 export default function save( { attributes } ) {
 	const { textAlign, content } = attributes;
 
+	const className = classnames( {
+		[ `has-text-align-${ textAlign }` ]: textAlign,
+	} );
+
 	return (
 		<RichText.Content
 			tagName="pre"
-			style={ { textAlign } }
+			className={ className }
 			value={ content }
 		/>
 	);

--- a/packages/e2e-tests/fixtures/blocks/core__verse__deprecated.html
+++ b/packages/e2e-tests/fixtures/blocks/core__verse__deprecated.html
@@ -1,0 +1,3 @@
+<!-- wp:verse {"textAlign":"left"} -->
+<pre style="text-align:left" class="wp-block-verse">A <em>verse</em>…<br>And more!</pre>
+<!-- /wp:core/verse -->

--- a/packages/e2e-tests/fixtures/blocks/core__verse__deprecated.json
+++ b/packages/e2e-tests/fixtures/blocks/core__verse__deprecated.json
@@ -1,0 +1,13 @@
+[
+    {
+        "clientId": "_clientId_0",
+        "name": "core/verse",
+        "isValid": true,
+        "attributes": {
+            "content": "A <em>verse</em>…<br>And more!",
+            "textAlign": "left"
+        },
+        "innerBlocks": [],
+        "originalContent": "<pre style=\"text-align:left\" class=\"wp-block-verse\">A <em>verse</em>…<br>And more!</pre>"
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__verse__deprecated.parsed.json
+++ b/packages/e2e-tests/fixtures/blocks/core__verse__deprecated.parsed.json
@@ -1,0 +1,22 @@
+[
+    {
+        "blockName": "core/verse",
+        "attrs": {
+            "textAlign": "left"
+        },
+        "innerBlocks": [],
+        "innerHTML": "\n<pre style=\"text-align:left\" class=\"wp-block-verse\">A <em>verse</em>…<br>And more!</pre>\n",
+        "innerContent": [
+            "\n<pre style=\"text-align:left\" class=\"wp-block-verse\">A <em>verse</em>…<br>And more!</pre>\n"
+        ]
+    },
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
+]

--- a/packages/e2e-tests/fixtures/blocks/core__verse__deprecated.serialized.html
+++ b/packages/e2e-tests/fixtures/blocks/core__verse__deprecated.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:verse {"textAlign":"left"} -->
+<pre class="wp-block-verse has-text-align-left">A <em>verse</em>…<br>And more!</pre>
+<!-- /wp:verse -->


### PR DESCRIPTION
## Description
Related: https://github.com/WordPress/gutenberg/issues/16027, https://github.com/WordPress/gutenberg/issues/15751

This PR follows-up #16035 and fixes #15751.

> Currently the verse block get an inline style after selecting a specific alignment.
> 
> `<pre style="text-align:left" class="wp-block-verse">Content</pre>`
> 
> This is an unexpected behavior and should work like this:
> 
> `<pre class="wp-block-verse alignleft">Content</pre>`
> 
> Without adding the alignment class, I can't set any specific theme side styles for the alignment of verse block.

Before:
```html
<!-- wp:verse {"textAlign":"right"} -->
<pre style="text-align:right" class="wp-block-verse">A <em>verse</em>…<br>And more!</pre>
<!-- /wp:core/verse -->
```

After:
```html
<!-- wp:verse {"textAlign":"right"} -->
<pre class="wp-block-verse has-text-align-right">A <em>verse</em>…<br>And more!</pre>
<!-- /wp:verse -->
```

## How has this been tested?

Using one of the existing branches (`master` probably) add a few Verse blocks and set different text alignments and save your post. Open the same post with this branch and ensure that it still works

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://wordpress.org/gutenberg/handbook/designers-developers/ -->