### PR TITLE
Remove edit gallery toolbar button

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -9,19 +9,15 @@ import { filter, forEach, map, find, every } from 'lodash';
  */
 import { compose } from '@wordpress/compose';
 import {
-	IconButton,
 	PanelBody,
 	RangeControl,
 	SelectControl,
 	ToggleControl,
-	Toolbar,
 	withNotices,
 } from '@wordpress/components';
 import {
-	BlockControls,
 	BlockIcon,
 	MediaPlaceholder,
-	MediaUpload,
 	InspectorControls,
 } from '@wordpress/block-editor';
 import { Component } from '@wordpress/element';
@@ -243,30 +239,6 @@ class GalleryEdit extends Component {
 
 		const hasImages = !! images.length;
 
-		const controls = (
-			<BlockControls>
-				{ hasImages && (
-					<Toolbar>
-						<MediaUpload
-							onSelect={ this.onSelectImages }
-							allowedTypes={ ALLOWED_MEDIA_TYPES }
-							multiple
-							gallery
-							value={ images.map( ( img ) => img.id ) }
-							render={ ( { open } ) => (
-								<IconButton
-									className="components-toolbar__control"
-									label={ __( 'Edit gallery' ) }
-									icon="edit"
-									onClick={ open }
-								/>
-							) }
-						/>
-					</Toolbar>
-				) }
-			</BlockControls>
-		);
-
 		const mediaPlaceholder = (
 			<MediaPlaceholder
 				addToGallery={ hasImages }
@@ -289,17 +261,11 @@ class GalleryEdit extends Component {
 		);
 
 		if ( ! hasImages ) {
-			return (
-				<>
-					{ controls }
-					{ mediaPlaceholder }
-				</>
-			);
+			return mediaPlaceholder;
 		}
 
 		return (
 			<>
-				{ controls }
 				<InspectorControls>
 					<PanelBody title={ __( 'Gallery Settings' ) }>
 						{ images.length > 1 && <RangeControl


### PR DESCRIPTION
## Description
This PR follows the suggestion discussed on https://github.com/WordPress/gutenberg/pull/16548#issuecomment-511702401 and removes the edit gallery button from the gallery block.

## How has this been tested?
I created a gallery I added some images and I verified the edit gallery button does not appear on the block toolbar.
