### PR TITLE
Fix: Clear floats on specific successive blocks that use alignment tool

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -348,7 +348,6 @@
 			border-bottom: $border-width solid $light-gray-800;
 			bottom: auto;
 		}
-
 	}
 
 	// Unlike most explicit left/right alignments, this one should be flipped by the auto-RTL system.

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -348,6 +348,11 @@
 			border-bottom: $border-width solid $light-gray-800;
 			bottom: auto;
 		}
+
+		// Clear floats of centered block when previous sibling block has left/right float.
+		& + .editor-block-list__block[data-align="center"] {
+			clear: both;
+		}
 	}
 
 	// Unlike most explicit left/right alignments, this one should be flipped by the auto-RTL system.

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -349,10 +349,6 @@
 			bottom: auto;
 		}
 
-		// Clear floats of centered block when previous sibling block has left/right float.
-		& + .editor-block-list__block[data-align="center"] {
-			clear: both;
-		}
 	}
 
 	// Unlike most explicit left/right alignments, this one should be flipped by the auto-RTL system.
@@ -414,6 +410,11 @@
 				/*!rtl:end:ignore*/
 			}
 		}
+	}
+
+	// Center
+	&[data-align="center"] {
+		clear: both;
 	}
 
 	// Wide and full-wide


### PR DESCRIPTION
## Description
Rebased PR #13819, fixing conflicts with master.
See https://github.com/WordPress/gutenberg/pull/13819#issuecomment-514984008

Fixes #13819.
Fixes #13784.

## How has this been tested?
In local environment, adding images and floating them around.

## Types of changes
Adds a CSS selector to clear center-aligned images.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
