### PR TITLE
Block Editor: Implement new colors hook.

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -450,10 +450,6 @@ _Related_
 
 Undocumented declaration.
 
-<a name="useColors" href="#useColors">#</a> **useColors**
-
-Undocumented declaration.
-
 <a name="Warning" href="#Warning">#</a> **Warning**
 
 Undocumented declaration.

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -446,6 +446,14 @@ _Related_
 
 -   <https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/url-popover/README.md>
 
+<a name="useBlockEditContext" href="#useBlockEditContext">#</a> **useBlockEditContext**
+
+Undocumented declaration.
+
+<a name="useColors" href="#useColors">#</a> **useColors**
+
+Undocumented declaration.
+
 <a name="Warning" href="#Warning">#</a> **Warning**
 
 Undocumented declaration.

--- a/packages/block-editor/src/components/block-edit/context.js
+++ b/packages/block-editor/src/components/block-edit/context.js
@@ -6,18 +6,22 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { createContext } from '@wordpress/element';
+import { createContext, useContext } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
 
-const { Consumer, Provider } = createContext( {
+const Context = createContext( {
 	name: '',
 	isSelected: false,
 	focusedElement: null,
 	setFocusedElement: noop,
 	clientId: null,
 } );
+const { Provider, Consumer } = Context;
 
 export { Provider as BlockEditContextProvider };
+export function useBlockEditContext() {
+	return useContext( Context );
+}
 
 /**
  * A Higher Order Component used to inject BlockEdit context to the

--- a/packages/block-editor/src/components/block-edit/index.js
+++ b/packages/block-editor/src/components/block-edit/index.js
@@ -27,13 +27,13 @@ class BlockEdit extends Component {
 		);
 	}
 
-	propsToContext( name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, attributes, setAttributes ) {
-		return { name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, attributes, setAttributes };
+	propsToContext( name, isSelected, clientId, onFocus, onCaretVerticalPositionChange ) {
+		return { name, isSelected, clientId, onFocus, onCaretVerticalPositionChange };
 	}
 
 	render() {
-		const { name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, attributes, setAttributes } = this.props;
-		const value = this.propsToContext( name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, attributes, setAttributes );
+		const { name, isSelected, clientId, onFocus, onCaretVerticalPositionChange } = this.props;
+		const value = this.propsToContext( name, isSelected, clientId, onFocus, onCaretVerticalPositionChange );
 
 		return (
 			<BlockEditContextProvider value={ value }>

--- a/packages/block-editor/src/components/block-edit/index.js
+++ b/packages/block-editor/src/components/block-edit/index.js
@@ -12,7 +12,7 @@ import { Component } from '@wordpress/element';
  * Internal dependencies
  */
 import Edit from './edit';
-import { BlockEditContextProvider } from './context';
+import { BlockEditContextProvider, useBlockEditContext } from './context';
 
 class BlockEdit extends Component {
 	constructor() {
@@ -27,13 +27,13 @@ class BlockEdit extends Component {
 		);
 	}
 
-	propsToContext( name, isSelected, clientId, onFocus, onCaretVerticalPositionChange ) {
-		return { name, isSelected, clientId, onFocus, onCaretVerticalPositionChange };
+	propsToContext( name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, attributes, setAttributes ) {
+		return { name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, attributes, setAttributes };
 	}
 
 	render() {
-		const { name, isSelected, clientId, onFocus, onCaretVerticalPositionChange } = this.props;
-		const value = this.propsToContext( name, isSelected, clientId, onFocus, onCaretVerticalPositionChange );
+		const { name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, attributes, setAttributes } = this.props;
+		const value = this.propsToContext( name, isSelected, clientId, onFocus, onCaretVerticalPositionChange, attributes, setAttributes );
 
 		return (
 			<BlockEditContextProvider value={ value }>
@@ -44,3 +44,4 @@ class BlockEdit extends Component {
 }
 
 export default BlockEdit;
+export { useBlockEditContext };

--- a/packages/block-editor/src/components/colors/index.js
+++ b/packages/block-editor/src/components/colors/index.js
@@ -7,4 +7,4 @@ export {
 	createCustomColorsHOC,
 	default as withColors,
 } from './with-colors';
-export { default as useColors } from './use-colors';
+export { default as __experimentalUseColors } from './use-colors';

--- a/packages/block-editor/src/components/colors/index.js
+++ b/packages/block-editor/src/components/colors/index.js
@@ -7,3 +7,4 @@ export {
 	createCustomColorsHOC,
 	default as withColors,
 } from './with-colors';
+export { default as useColors } from './use-colors';

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -39,10 +39,10 @@ const ColorPanel = ( {
 		{ ...colorPanelProps }
 	>
 		{ contrastCheckerProps &&
-			components.map( ( Component ) => (
+			components.map( ( Component, index ) => (
 				<ContrastChecker
 					key={ Component.displayName }
-					textColor={ Component.color }
+					textColor={ colorSettings[ index ].value }
 					{ ...contrastCheckerProps }
 				/>
 			) ) }
@@ -170,7 +170,9 @@ export default function __experimentalUseColors(
 
 			const newSettingIndex =
 				colorSettings.push( {
-					value: color,
+					value: _color ?
+						_color.color :
+						attributes[ camelCase( `custom ${ name }` ) ],
 					onChange: acc[ componentName ].setColor,
 					label: panelLabel,
 					colors,

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -89,8 +89,8 @@ export default function __experimentalUseColors(
 	const createComponent = useMemo(
 		() =>
 			memoize(
-				( attribute, color, colorValue, customColor ) => ( { children } ) =>
-					// Clone children, setting the style attribute from the color configuration,
+				( property, color, colorValue, customColor ) => ( { children } ) =>
+					// Clone children, setting the style property from the color configuration,
 					// if not already set explicitly through props.
 					Children.map( children, ( child ) => {
 						let className = child.props.className;
@@ -98,11 +98,11 @@ export default function __experimentalUseColors(
 						if ( color ) {
 							className = `${ child.props.className } has-${ kebabCase(
 								color
-							) }-${ kebabCase( attribute ) }`;
-							style = { [ attribute ]: colorValue, ...child.props.style };
+							) }-${ kebabCase( property ) }`;
+							style = { [ property ]: colorValue, ...child.props.style };
 						} else if ( customColor ) {
-							className = `${ child.props.className } has-${ kebabCase( attribute ) }`;
-							style = { [ attribute ]: customColor, ...child.props.style };
+							className = `${ child.props.className } has-${ kebabCase( property ) }`;
+							style = { [ property ]: customColor, ...child.props.style };
 						}
 						return cloneElement( child, {
 							className,
@@ -143,7 +143,7 @@ export default function __experimentalUseColors(
 			}
 			const {
 				name, // E.g. 'backgroundColor'.
-				attribute = name, // E.g. 'backgroundColor'.
+				property = name, // E.g. 'backgroundColor'.
 
 				panelLabel = startCase( name ), // E.g. 'Background Color'.
 				componentName = panelLabel.replace( /\s/g, '' ), // E.g. 'BackgroundColor'.
@@ -159,7 +159,7 @@ export default function __experimentalUseColors(
 			// when they are used as props for other components.
 			const _color = colors.find( ( __color ) => __color.slug === color );
 			acc[ componentName ] = createComponent(
-				attribute,
+				property,
 				color,
 				_color && _color.color,
 				attributes[ camelCase( `custom ${ name }` ) ]

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -15,22 +15,43 @@ import { useMemo, Children, cloneElement } from '@wordpress/element';
  */
 import InspectorControls from '../inspector-controls';
 import PanelColorSettings from '../panel-color-settings';
+import ContrastChecker from '../contrast-checker';
 import { useBlockEditContext } from '../block-edit';
 
-const InspectorControlsColorPanel = ( { title, colorSettings } ) => (
+const InspectorControlsColorPanel = ( {
+	title,
+	colorSettings,
+	contrastCheckerProps,
+	components,
+	panelChildren,
+} ) => (
 	<InspectorControls>
 		<PanelColorSettings
 			title={ title }
 			initialOpen={ false }
 			colorSettings={ colorSettings }
-		/>
+		>
+			{ contrastCheckerProps &&
+				components.map( ( Component ) => (
+					<ContrastChecker
+						key={ Component.displayName }
+						textColor={ Component.color }
+						{ ...contrastCheckerProps }
+					/>
+				) ) }
+			{ typeof panelChildren === 'function' ?
+				panelChildren( components ) :
+				panelChildren }
+		</PanelColorSettings>
 	</InspectorControls>
 );
 
 export default function useColors(
 	colorConfigs,
-	deps = [],
-	panelTitle = __( 'Color Settings' )
+	{ panelTitle = __( 'Color Settings' ), contrastCheckerProps, panelChildren } = {
+		panelTitle: __( 'Color Settings' ),
+	},
+	deps = []
 ) {
 	const { attributes, setAttributes } = useBlockEditContext();
 
@@ -83,6 +104,7 @@ export default function useColors(
 			// We memoize the non-primitives to avoid unnecessary updates
 			// when they are used as props for other components.
 			acc[ componentName ] = createComponent( attribute, color );
+			acc[ componentName ].displayName = componentName;
 			acc[ componentName ].color = color;
 			acc[ componentName ].setColor = createSetColor( name );
 
@@ -101,6 +123,9 @@ export default function useColors(
 				<InspectorControlsColorPanel
 					title={ panelTitle }
 					colorSettings={ colorSettings }
+					contrastCheckerProps={ contrastCheckerProps }
+					components={ Object.values( components ) }
+					panelChildren={ panelChildren }
 				/>
 			),
 		};

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import memoize from 'memize';
-import { startCase } from 'lodash';
+import { kebabCase, startCase } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -22,6 +22,9 @@ const createComponent = memoize( ( attribute, color ) => ( { children } ) =>
 	// if not already set explicitly through props.
 	Children.map( children, ( child ) =>
 		cloneElement( child, {
+			className: color ?
+				`${ child.props.className } has-${ kebabCase( attribute ) }` :
+				child.props.className,
 			style: { [ attribute ]: color, ...child.props.style },
 		} )
 	)

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -8,7 +8,13 @@ import { kebabCase, startCase } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useMemo, Children, cloneElement } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import {
+	useCallback,
+	useMemo,
+	Children,
+	cloneElement,
+} from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -63,7 +69,16 @@ export default function __experimentalUseColors(
 	},
 	deps = []
 ) {
-	const { attributes, setAttributes } = useBlockEditContext();
+	const { clientId } = useBlockEditContext();
+	const attributes = useSelect(
+		( select ) => select( 'core/block-editor' ).getBlockAttributes( clientId ),
+		[ clientId ]
+	);
+	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
+	const setAttributes = useCallback(
+		( newAttributes ) => updateBlockAttributes( clientId, newAttributes ),
+		[ updateBlockAttributes, clientId ]
+	);
 
 	const createComponent = useMemo(
 		() =>

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -13,36 +13,39 @@ import { useMemo, Children, cloneElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import InspectorControls from '../inspector-controls';
 import PanelColorSettings from '../panel-color-settings';
 import ContrastChecker from '../contrast-checker';
+import InspectorControls from '../inspector-controls';
 import { useBlockEditContext } from '../block-edit';
 
-const InspectorControlsColorPanel = ( {
+const ColorPanel = ( {
 	title,
 	colorSettings,
 	contrastCheckerProps,
 	components,
 	panelChildren,
 } ) => (
+	<PanelColorSettings
+		title={ title }
+		initialOpen={ false }
+		colorSettings={ colorSettings }
+	>
+		{ contrastCheckerProps &&
+			components.map( ( Component ) => (
+				<ContrastChecker
+					key={ Component.displayName }
+					textColor={ Component.color }
+					{ ...contrastCheckerProps }
+				/>
+			) ) }
+		{ typeof panelChildren === 'function' ?
+			panelChildren( components ) :
+			panelChildren }
+	</PanelColorSettings>
+);
+const InspectorControlsColorPanel = ( props ) => (
 	<InspectorControls>
-		<PanelColorSettings
-			title={ title }
-			initialOpen={ false }
-			colorSettings={ colorSettings }
-		>
-			{ contrastCheckerProps &&
-				components.map( ( Component ) => (
-					<ContrastChecker
-						key={ Component.displayName }
-						textColor={ Component.color }
-						{ ...contrastCheckerProps }
-					/>
-				) ) }
-			{ typeof panelChildren === 'function' ?
-				panelChildren( components ) :
-				panelChildren }
-		</PanelColorSettings>
+		<ColorPanel { ...props } />
 	</InspectorControls>
 );
 
@@ -117,16 +120,18 @@ export default function useColors(
 			return acc;
 		}, {} );
 
+		const colorPanelProps = {
+			title: panelTitle,
+			colorSettings,
+			contrastCheckerProps,
+			components: Object.values( components ),
+			panelChildren,
+		};
 		return {
 			...components,
+			ColorPanel: <ColorPanel { ...colorPanelProps } />,
 			InspectorControlsColorPanel: (
-				<InspectorControlsColorPanel
-					title={ panelTitle }
-					colorSettings={ colorSettings }
-					contrastCheckerProps={ contrastCheckerProps }
-					components={ Object.values( components ) }
-					panelChildren={ panelChildren }
-				/>
+				<InspectorControlsColorPanel { ...colorPanelProps } />
 			),
 		};
 	}, [ attributes, setAttributes, ...deps ] );

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -49,7 +49,7 @@ const InspectorControlsColorPanel = ( props ) => (
 	</InspectorControls>
 );
 
-export default function useColors(
+export default function __experimentalUseColors(
 	colorConfigs,
 	{ panelTitle = __( 'Color Settings' ), contrastCheckerProps, panelChildren } = {
 		panelTitle: __( 'Color Settings' ),

--- a/packages/block-editor/src/components/colors/use-colors.js
+++ b/packages/block-editor/src/components/colors/use-colors.js
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+import memoize from 'memize';
+import { startCase } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Children, cloneElement, useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import InspectorControls from '../inspector-controls';
+import PanelColorSettings from '../panel-color-settings';
+import { useBlockEditContext } from '../block-edit';
+
+const createComponent = memoize( ( attribute, color ) => ( { children } ) =>
+	// Clone children, setting the style attribute from the color configuration,
+	// if not already set explicitly through props.
+	Children.map( children, ( child ) =>
+		cloneElement( child, {
+			style: { [ attribute ]: color, ...child.props.style },
+		} )
+	)
+);
+
+const createSetColor = memoize( ( setAttributes, name ) => ( newColor ) =>
+	setAttributes( { [ name ]: newColor } )
+);
+
+const InspectorControlsColorPanel = ( { title, colorSettings } ) => (
+	<InspectorControls>
+		<PanelColorSettings
+			title={ title }
+			initialOpen={ false }
+			colorSettings={ colorSettings }
+		/>
+	</InspectorControls>
+);
+
+export default function useColors(
+	colorConfigs,
+	deps = [],
+	panelTitle = __( 'Color Settings' )
+) {
+	const { attributes, setAttributes } = useBlockEditContext();
+
+	return useMemo( () => {
+		const colorSettings = [];
+
+		const components = colorConfigs.reduce( ( acc, colorConfig ) => {
+			if ( typeof colorConfig === 'string' ) {
+				colorConfig = { name: colorConfig };
+			}
+			const {
+				name, // E.g. 'backgroundColor'.
+				attribute = name, // E.g. 'backgroundColor'.
+
+				panelLabel = startCase( name ), // E.g. 'Background Color'.
+				componentName = panelLabel.replace( /\s/g, '' ), // E.g. 'BackgroundColor'.
+
+				color = colorConfig.color,
+			} = {
+				...colorConfig,
+				color: attributes[ colorConfig.name ],
+			};
+
+			// We memoize the non-primitives to avoid unnecessary updates
+			// when they are used as props for other components.
+			acc[ componentName ] = createComponent( attribute, color );
+			acc[ componentName ].color = color;
+			acc[ componentName ].setColor = createSetColor( setAttributes, name );
+
+			colorSettings.push( {
+				value: color,
+				onChange: acc[ componentName ].setColor,
+				label: panelLabel,
+			} );
+
+			return acc;
+		}, {} );
+
+		return {
+			...components,
+			InspectorControlsColorPanel: (
+				<InspectorControlsColorPanel
+					title={ panelTitle }
+					colorSettings={ colorSettings }
+				/>
+			),
+		};
+	}, [ attributes, setAttributes, ...deps ] );
+}

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -8,7 +8,7 @@ export { default as AlignmentToolbar } from './alignment-toolbar';
 export { default as Autocomplete } from './autocomplete';
 export { default as BlockAlignmentToolbar } from './block-alignment-toolbar';
 export { default as BlockControls } from './block-controls';
-export { default as BlockEdit } from './block-edit';
+export { default as BlockEdit, useBlockEditContext } from './block-edit';
 export { default as BlockFormatControls } from './block-format-controls';
 export { default as BlockIcon } from './block-icon';
 export { default as BlockNavigationDropdown } from './block-navigation/dropdown';

--- a/packages/block-editor/src/components/index.native.js
+++ b/packages/block-editor/src/components/index.native.js
@@ -1,6 +1,6 @@
 // Block Creation Components
 export { default as BlockControls } from './block-controls';
-export { default as BlockEdit } from './block-edit';
+export { default as BlockEdit, useBlockEditContext } from './block-edit';
 export { default as BlockFormatControls } from './block-format-controls';
 export { default as BlockIcon } from './block-icon';
 export { default as BlockVerticalAlignmentToolbar } from './block-vertical-alignment-toolbar';

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -12,7 +12,7 @@ import HeadingToolbar from './heading-toolbar';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PanelBody } from '@wordpress/components';
+import { PanelBody, withFallbackStyles } from '@wordpress/components';
 import { createBlock } from '@wordpress/blocks';
 import {
 	AlignmentToolbar,
@@ -22,7 +22,13 @@ import {
 	__experimentalUseColors,
 } from '@wordpress/block-editor';
 
+/**
+ * Browser dependencies
+ */
+const { getComputedStyle } = window;
+
 function HeadingEdit( {
+	backgroundColor,
 	attributes,
 	setAttributes,
 	mergeBlocks,
@@ -32,7 +38,7 @@ function HeadingEdit( {
 	const { TextColor, InspectorControlsColorPanel } = __experimentalUseColors(
 		[ { name: 'textColor', attribute: 'color' } ],
 		{
-			contrastCheckerProps: { backgroundColor: 'white', isLargeText: true },
+			contrastCheckerProps: { backgroundColor, isLargeText: true },
 		},
 		[]
 	);
@@ -84,4 +90,11 @@ function HeadingEdit( {
 	);
 }
 
-export default HeadingEdit;
+export default withFallbackStyles( ( node ) => {
+	let backgroundColor = getComputedStyle( node ).backgroundColor;
+	while ( backgroundColor === 'rgba(0, 0, 0, 0)' && node.parentNode ) {
+		node = node.parentNode;
+		backgroundColor = getComputedStyle( node ).backgroundColor;
+	}
+	return { backgroundColor };
+} )( HeadingEdit );

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -36,7 +36,7 @@ function HeadingEdit( {
 	className,
 } ) {
 	const { TextColor, InspectorControlsColorPanel } = __experimentalUseColors(
-		[ { name: 'textColor', attribute: 'color' } ],
+		[ { name: 'textColor', property: 'color' } ],
 		{
 			contrastCheckerProps: { backgroundColor, isLargeText: true },
 		},

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -76,7 +76,6 @@ function HeadingEdit( {
 					onRemove={ () => onReplace( [] ) }
 					className={ classnames( className, {
 						[ `has-text-align-${ align }` ]: align,
-						'has-text-color': TextColor.color,
 					} ) }
 					placeholder={ placeholder || __( 'Write heading…' ) }
 				/>

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -19,7 +19,7 @@ import {
 	BlockControls,
 	InspectorControls,
 	RichText,
-	useColors,
+	__experimentalUseColors,
 } from '@wordpress/block-editor';
 
 function HeadingEdit( {
@@ -29,7 +29,7 @@ function HeadingEdit( {
 	onReplace,
 	className,
 } ) {
-	const { TextColor, InspectorControlsColorPanel } = useColors(
+	const { TextColor, InspectorControlsColorPanel } = __experimentalUseColors(
 		[ { name: 'textColor', attribute: 'color' } ],
 		{
 			contrastCheckerProps: { backgroundColor: 'white', isLargeText: true },

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -29,7 +29,13 @@ function HeadingEdit( {
 	onReplace,
 	className,
 } ) {
-	const { TextColor, InspectorControlsColorPanel } = useColors( [ { name: 'textColor', attribute: 'color' } ], [] );
+	const { TextColor, InspectorControlsColorPanel } = useColors(
+		[ { name: 'textColor', attribute: 'color' } ],
+		{
+			contrastCheckerProps: { backgroundColor: 'white', isLargeText: true },
+		},
+		[]
+	);
 
 	const { align, content, level, placeholder } = attributes;
 	const tagName = 'h' + level;

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -13,38 +13,14 @@ import HeadingToolbar from './heading-toolbar';
  */
 import { __ } from '@wordpress/i18n';
 import { PanelBody } from '@wordpress/components';
-import { compose } from '@wordpress/compose';
 import { createBlock } from '@wordpress/blocks';
 import {
 	AlignmentToolbar,
 	BlockControls,
 	InspectorControls,
 	RichText,
-	withColors,
-	PanelColorSettings,
+	useColors,
 } from '@wordpress/block-editor';
-import { memo } from '@wordpress/element';
-
-const HeadingColorUI = memo(
-	function( {
-		textColorValue,
-		setTextColor,
-	} ) {
-		return (
-			<PanelColorSettings
-				title={ __( 'Color Settings' ) }
-				initialOpen={ false }
-				colorSettings={ [
-					{
-						value: textColorValue,
-						onChange: setTextColor,
-						label: __( 'Text Color' ),
-					},
-				] }
-			/>
-		);
-	}
-);
 
 function HeadingEdit( {
 	attributes,
@@ -52,9 +28,9 @@ function HeadingEdit( {
 	mergeBlocks,
 	onReplace,
 	className,
-	textColor,
-	setTextColor,
 } ) {
+	const { TextColor, InspectorControlsColorPanel } = useColors( [ { name: 'textColor', attribute: 'color' } ], [] );
+
 	const { align, content, level, placeholder } = attributes;
 	const tagName = 'h' + level;
 
@@ -71,43 +47,36 @@ function HeadingEdit( {
 					<p>{ __( 'Level' ) }</p>
 					<HeadingToolbar isCollapsed={ false } minLevel={ 1 } maxLevel={ 7 } selectedLevel={ level } onChange={ ( newLevel ) => setAttributes( { level: newLevel } ) } />
 				</PanelBody>
-				<HeadingColorUI
-					setTextColor={ setTextColor }
-					textColorValue={ textColor.color }
-				/>
 			</InspectorControls>
-			<RichText
-				identifier="content"
-				tagName={ tagName }
-				value={ content }
-				onChange={ ( value ) => setAttributes( { content: value } ) }
-				onMerge={ mergeBlocks }
-				onSplit={ ( value ) => {
-					if ( ! value ) {
-						return createBlock( 'core/paragraph' );
-					}
+			{ InspectorControlsColorPanel }
+			<TextColor>
+				<RichText
+					identifier="content"
+					tagName={ tagName }
+					value={ content }
+					onChange={ ( value ) => setAttributes( { content: value } ) }
+					onMerge={ mergeBlocks }
+					onSplit={ ( value ) => {
+						if ( ! value ) {
+							return createBlock( 'core/paragraph' );
+						}
 
-					return createBlock( 'core/heading', {
-						...attributes,
-						content: value,
-					} );
-				} }
-				onReplace={ onReplace }
-				onRemove={ () => onReplace( [] ) }
-				className={ classnames( className, {
-					[ `has-text-align-${ align }` ]: align,
-					'has-text-color': textColor.color,
-					[ textColor.class ]: textColor.class,
-				} ) }
-				placeholder={ placeholder || __( 'Write heading…' ) }
-				style={ {
-					color: textColor.color,
-				} }
-			/>
+						return createBlock( 'core/heading', {
+							...attributes,
+							content: value,
+						} );
+					} }
+					onReplace={ onReplace }
+					onRemove={ () => onReplace( [] ) }
+					className={ classnames( className, {
+						[ `has-text-align-${ align }` ]: align,
+						'has-text-color': TextColor.color,
+					} ) }
+					placeholder={ placeholder || __( 'Write heading…' ) }
+				/>
+			</TextColor>
 		</>
 	);
 }
 
-export default compose( [
-	withColors( 'backgroundColor', { textColor: 'color' } ),
-] )( HeadingEdit );
+export default HeadingEdit;

--- a/packages/block-library/src/heading/save.js
+++ b/packages/block-library/src/heading/save.js
@@ -34,7 +34,7 @@ export default function save( { attributes } ) {
 			className={ className ? className : undefined }
 			tagName={ tagName }
 			style={ {
-				color: textClass ? undefined : customTextColor,
+				color: textColor,
 			} }
 			value={ content }
 		/>

--- a/packages/block-library/src/heading/save.js
+++ b/packages/block-library/src/heading/save.js
@@ -34,7 +34,7 @@ export default function save( { attributes } ) {
 			className={ className ? className : undefined }
 			tagName={ tagName }
 			style={ {
-				color: textColor,
+				color: textClass ? undefined : customTextColor,
 			} }
 			value={ content }
 		/>


### PR DESCRIPTION
Relates to #15450

## Description

This PR continues to explore a new way to share Common Block Code using React hooks, see #16229 for prior art.

More specifically, it combines the functionality of the `withColors` HOC and `PanelColorSettings` with `InspectorControls` into an easy to use `useColors` hook.

To be able to reference the block edit context from within hooks, e.g. `attributes` and `setAttributes`, a few changes were made in `@wordpress/block-editor`'s `block-edit` and a `useBlockEditContext` hook was introduced.

The new colors hook takes an array of color configuration objects for its first parameter. These objects draw inspiration from `colorTypes` in the HOC counterpart, but are easier to reason about, and support a few extra properties:

- `name`: The name of the color.
*E.g. `'backgroundColor'`.*

- `attribute`: The name of the corresponding CSS attribute in camel-case. Defaults to `name`.
*E.g. `'backgroundColor'`.*

- `panelLabel`: The color setting's label in the inspector panel. Defaults to `startCase( name )`.
*E.g. `'Background Color'`.*

- `componentName`: The name of the returned component for wrapping children with color. Defaults to `panelLabel.replace( /\s/g, '' )`.
*E.g. `'BackgroundColor'`.*

- `color`: An initial value for the color when one isn't set.
*E.g. `'#fcba03'`.*

The second parameter is an optional hooks dependency array for cases where you have closures in your configuration objects, and the third is an optional string to overwrite the default panel title, `__( 'Color Settings' )`.

The hook will return a color component for each configuration object and a single inspector controls panel preconfigured for all the configuration objects passed. If you want to break up your colors into multiple panels, you can just break up your array of configuration objects into different calls to the hook as each call will return a different inspector controls panel.

Color components merge all of their top level children's style props with the relevant attribute and its current value, giving preference to current props. E.g. `style: { color: attributes.textColor, ...style }`. They also have static properties `color` and `setColor`, for directly reading and setting the color's value respectively.

Here's a simple example:

```jsx
const MyColorfulHeadings = ( { attributes: { textColor }, setAttributes } ) => {
	const { TextColor, InspectorControlsColorPanel } = useColors(
		[ { name: 'textColor', attribute: 'color' } ],
		[]
	);

	TextColor.color; // `textColor`
	TextColor.setColor; // `( newColor ) => setAttributes( { textColor: newColor } )`

	return (
		<>
			{ /* This sets up the panel in the inspector. */ }
			{ InspectorControlsColorPanel }

			<TextColor>
				{ /* Color is applied to all children here. */ }
				<h1>Heading</h1>
				<h2>Heading</h2>
				{ /* Custom components work too! */ }
				<RichText />
			</TextColor>
		</>
	);
};
```

A real life example can be seen in this commit, https://github.com/WordPress/gutenberg/commit/aaf3e642b66ece33ebd2c582f095b09931ad6642, where I swap the HOC usage for the new hook in the heading block's edit function. Of course, if we decide to land a change like that, we would need to add a block `deprecated` entry and modify the new block `save` appropriately. It might make more sense to just use the new hook going forwards, but we should also consider that the current HOC breaks validation in a couple of ways. Namely, when settings are not available during validation, #16489, and when settings change.

New tests and documentation should be written once the approach is validated.

## How has this been tested?

The color functionality of the heading block's edit mode was tested and it worked as expected.

Once the approach is validated, proper tests need to be written.

## Types of Changes

*New Feature:* Add a new `useColors` hook to `@wordpress/block-editor` for making it easier to build blocks with color functionality.

*New Feature:* Add a new `useBlockEditContext` hook to `@wordpress/block-editor` for enabling the development of hooks that access block edit context, e.g. `attributes` and `setAttributes`.

## Checklist:

- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
