### PR TITLE
Add placeholder to the Button Block

### DIFF
--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -42,6 +42,9 @@
 			"source": "attribute",
 			"selector": "a",
 			"attribute": "rel"
+		},
+		"placeholder": {
+			"type": "string"
 		}
 	}
 }

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -104,6 +104,7 @@ class ButtonEdit extends Component {
 			title,
 			linkTarget,
 			rel,
+			placeholder,
 		} = attributes;
 
 		const linkId = `wp-block-button__inline-link-${ instanceId }`;
@@ -111,7 +112,7 @@ class ButtonEdit extends Component {
 		return (
 			<div className={ className } title={ title } ref={ this.bindRef }>
 				<RichText
-					placeholder={ __( 'Add text…' ) }
+					placeholder={ placeholder || __( 'Add text…' ) }
 					value={ text }
 					onChange={ ( value ) => setAttributes( { text: value } ) }
 					withoutInteractiveFormatting


### PR DESCRIPTION
## Description
Adds a new attribute `placeholder` for the core/button block. This allows block developers and template makers to add initial instructions, just like it is already possible with core/heading and `core/paragraph`.

I think this change doesn't need any kind of block deprecation - it adds a new attribute and has no effect on the resulting markup. This would be good to confirm during the review.

Fixes: #16618 

## How has this been tested?
I have tested by manually updating the content source to include the placeholder attribute.

Example content: 

```html
<!-- wp:button {"placeholder":"Add Primary Button…"} -->
<div class="wp-block-button"><a class="wp-block-button__link"></a></div>
<!-- /wp:button -->
```

## Screenshots

Code above should render in the editor as:

<img width="428" alt="Screenshot 2019-07-27 at 08 09 40" src="https://user-images.githubusercontent.com/156676/61996216-cf157500-b046-11e9-945c-70080d6b6817.png">

## Types of changes

New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
