### PR TITLE
add color support to separator block

### DIFF
--- a/packages/block-library/src/separator/block.json
+++ b/packages/block-library/src/separator/block.json
@@ -1,4 +1,12 @@
 {
 	"name": "core/separator",
-	"category": "layout"
+	"category": "layout",
+	"attributes": {
+		"color": {
+			"type": "string"
+		},
+		"customColor": {
+			"type": "string"
+		}
+	}
 }

--- a/packages/block-library/src/separator/edit.js
+++ b/packages/block-library/src/separator/edit.js
@@ -1,8 +1,72 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
-import { HorizontalRule } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
-export default function SeparatorEdit( { className } ) {
-	return <HorizontalRule className={ className } />;
+import {
+	Component,
+} from '@wordpress/element';
+
+import {
+	compose,
+	withInstanceId,
+} from '@wordpress/compose';
+
+import {
+	HorizontalRule,
+} from '@wordpress/components';
+
+import {
+	InspectorControls,
+	withColors,
+	PanelColorSettings,
+} from '@wordpress/block-editor';
+
+class SeparatorEdit extends Component {
+	render() {
+		const {
+			backgroundColor,
+			setBackgroundColor,
+			className,
+		} = this.props;
+		return (
+			<div>
+				<HorizontalRule
+					className={ classnames(
+						className, {
+							'has-background': backgroundColor.color,
+							[ backgroundColor.class ]: backgroundColor.class,
+						}
+					) }
+					style={ {
+						borderColor: backgroundColor.color,
+						color: backgroundColor.color,
+					} }
+				/>
+				<InspectorControls>
+					<PanelColorSettings
+						title={ __( 'Color Settings' ) }
+						colorSettings={ [
+							{
+								value: backgroundColor.color,
+								onChange: setBackgroundColor,
+								label: __( 'Background Color' ),
+							},
+						] }
+					>
+					</PanelColorSettings>
+				</InspectorControls>
+			</div>
+		);
+	}
 }
+
+export default compose( [
+	withInstanceId,
+	withColors( 'backgroundColor', { textColor: 'color' } ),
+] )( SeparatorEdit );

--- a/packages/block-library/src/separator/edit.js
+++ b/packages/block-library/src/separator/edit.js
@@ -25,7 +25,7 @@ function SeparatorEdit( { color, setColor, className } ) {
 					}
 				) }
 				style={ {
-					borderColor: color.color,
+					backgroundColor: color.color,
 					color: color.color,
 				} }
 			/>

--- a/packages/block-library/src/separator/edit.js
+++ b/packages/block-library/src/separator/edit.js
@@ -7,66 +7,43 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-
-import {
-	Component,
-} from '@wordpress/element';
-
-import {
-	compose,
-	withInstanceId,
-} from '@wordpress/compose';
-
-import {
-	HorizontalRule,
-} from '@wordpress/components';
-
+import { HorizontalRule } from '@wordpress/components';
 import {
 	InspectorControls,
 	withColors,
 	PanelColorSettings,
 } from '@wordpress/block-editor';
 
-class SeparatorEdit extends Component {
-	render() {
-		const {
-			backgroundColor,
-			setBackgroundColor,
-			className,
-		} = this.props;
-		return (
-			<div>
-				<HorizontalRule
-					className={ classnames(
-						className, {
-							'has-background': backgroundColor.color,
-							[ backgroundColor.class ]: backgroundColor.class,
-						}
-					) }
-					style={ {
-						borderColor: backgroundColor.color,
-						color: backgroundColor.color,
-					} }
-				/>
-				<InspectorControls>
-					<PanelColorSettings
-						title={ __( 'Color Settings' ) }
-						colorSettings={ [
-							{
-								value: backgroundColor.color,
-								onChange: setBackgroundColor,
-								label: __( 'Background Color' ),
-							},
-						] }
-					>
-					</PanelColorSettings>
-				</InspectorControls>
-			</div>
-		);
-	}
+function SeparatorEdit( { color, setColor, className } ) {
+	return (
+		<>
+			<HorizontalRule
+				className={ classnames(
+					className, {
+						'has-background': color.color,
+						[ color.class ]: color.class,
+					}
+				) }
+				style={ {
+					borderColor: color.color,
+					color: color.color,
+				} }
+			/>
+			<InspectorControls>
+				<PanelColorSettings
+					title={ __( 'Color Settings' ) }
+					colorSettings={ [
+						{
+							value: color.color,
+							onChange: setColor,
+							label: __( 'Color' ),
+						},
+					] }
+				>
+				</PanelColorSettings>
+			</InspectorControls>
+		</>
+	);
 }
 
-export default compose( [
-	withInstanceId,
-	withColors( 'backgroundColor', { textColor: 'color' } ),
-] )( SeparatorEdit );
+export default withColors( 'color', { textColor: 'color' } )( SeparatorEdit );

--- a/packages/block-library/src/separator/save.js
+++ b/packages/block-library/src/separator/save.js
@@ -10,27 +10,32 @@ import {
 	getColorClassName,
 } from '@wordpress/block-editor';
 
-export default function save( { attributes } ) {
+export default function separatorSave( { attributes } ) {
 	const {
-		backgroundColor,
-		customBackgroundColor,
+		color,
+		customColor,
 	} = attributes;
 
-	const backgroundClass = getColorClassName( 'background-color', backgroundColor );
-	const textClass = getColorClassName( 'color', backgroundColor );
+	// the hr support changing color using border-color, since border-color
+	// is not yet supported in the color palette, we use background-color
+	const backgroundClass = getColorClassName( 'background-color', color );
+	// the dots styles uses text for the dots, to change those dots color is
+	// using color, not backgroundColor
+	const colorClass = getColorClassName( 'color', color );
 
 	const separatorClasses = classnames( {
-		'has-text-color has-background': backgroundColor || customBackgroundColor,
+		'has-text-color has-background': color || customColor,
 		[ backgroundClass ]: backgroundClass,
-		[ textClass ]: textClass,
+		[ colorClass ]: colorClass,
 	} );
 
 	const separatorStyle = {
-		backgroundColor: backgroundClass ? undefined : customBackgroundColor,
-		color: textClass ? undefined : customBackgroundColor,
+		backgroundColor: backgroundClass ? undefined : customColor,
+		color: colorClass ? undefined : customColor,
 	};
-	return <hr
+
+	return ( <hr
 		className={ separatorClasses }
 		style={ separatorStyle }
-	/>;
+	/> );
 }

--- a/packages/block-library/src/separator/save.js
+++ b/packages/block-library/src/separator/save.js
@@ -17,14 +17,17 @@ export default function save( { attributes } ) {
 	} = attributes;
 
 	const backgroundClass = getColorClassName( 'background-color', backgroundColor );
+	const textClass = getColorClassName( 'color', backgroundColor );
 
 	const separatorClasses = classnames( {
-		'has-background': backgroundColor || customBackgroundColor,
+		'has-text-color has-background': backgroundColor || customBackgroundColor,
 		[ backgroundClass ]: backgroundClass,
+		[ textClass ]: textClass,
 	} );
 
 	const separatorStyle = {
 		backgroundColor: backgroundClass ? undefined : customBackgroundColor,
+		color: textClass ? undefined : customBackgroundColor,
 	};
 	return <hr
 		className={ separatorClasses }

--- a/packages/block-library/src/separator/save.js
+++ b/packages/block-library/src/separator/save.js
@@ -1,3 +1,33 @@
-export default function save() {
-	return <hr />;
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	getColorClassName,
+} from '@wordpress/block-editor';
+
+export default function save( { attributes } ) {
+	const {
+		backgroundColor,
+		customBackgroundColor,
+	} = attributes;
+
+	const backgroundClass = getColorClassName( 'background-color', backgroundColor );
+
+	const separatorClasses = classnames( {
+		'has-background': backgroundColor || customBackgroundColor,
+		[ backgroundClass ]: backgroundClass,
+	} );
+
+	const separatorStyle = {
+		backgroundColor: backgroundClass ? undefined : customBackgroundColor,
+	};
+	return <hr
+		className={ separatorClasses }
+		style={ separatorStyle }
+	/>;
 }

--- a/packages/block-library/src/separator/style.scss
+++ b/packages/block-library/src/separator/style.scss
@@ -8,8 +8,9 @@
 
 	// Dots style
 	&.is-style-dots {
-		background: none !important; // Override any background themes often set on the hr tag for this style.
-		// also override the color set on the editor
+		// Override any background themes often set on the hr tag for this style.
+		// also override the color set in the editor since it's intented for normal HR
+		background: none !important;
 		border: none;
 		text-align: center;
 		max-width: none;

--- a/packages/block-library/src/separator/style.scss
+++ b/packages/block-library/src/separator/style.scss
@@ -8,7 +8,8 @@
 
 	// Dots style
 	&.is-style-dots {
-		background: none; // Override any background themes often set on the hr tag for this style.
+		background: none !important; // Override any background themes often set on the hr tag for this style.
+		// also override the color set on the editor
 		border: none;
 		text-align: center;
 		max-width: none;

--- a/packages/block-library/src/separator/style.scss
+++ b/packages/block-library/src/separator/style.scss
@@ -17,7 +17,7 @@
 
 		&::before {
 			content: "\00b7 \00b7 \00b7";
-			color: $dark-gray-900;
+			color: currentColor;
 			font-size: 20px;
 			letter-spacing: 2em;
 			padding-left: 2em;

--- a/packages/block-library/src/separator/theme.scss
+++ b/packages/block-library/src/separator/theme.scss
@@ -1,6 +1,5 @@
 .wp-block-separator {
 	border: none;
-	border-bottom: 2px solid $dark-gray-100;
 	margin-left: auto;
 	margin-right: auto;
 

--- a/packages/block-library/src/separator/theme.scss
+++ b/packages/block-library/src/separator/theme.scss
@@ -2,6 +2,7 @@
 	border: none;
 	margin-left: auto;
 	margin-right: auto;
+	height: 1px;
 
 	// Default, thin style
 	&:not(.is-style-wide):not(.is-style-dots) {

--- a/packages/block-library/src/separator/theme.scss
+++ b/packages/block-library/src/separator/theme.scss
@@ -1,11 +1,20 @@
 .wp-block-separator {
 	border: none;
+	border-bottom: 2px solid $dark-gray-100;
 	margin-left: auto;
 	margin-right: auto;
-	height: 1px;
 
 	// Default, thin style
 	&:not(.is-style-wide):not(.is-style-dots) {
 		max-width: 100px;
+	}
+
+	&.has-background:not(.is-style-dots) {
+		border-bottom: none;
+		height: 1px;
+	}
+
+	&.has-background:not(.is-style-wide):not(.is-style-dots) {
+		height: 2px;
 	}
 }


### PR DESCRIPTION
tackles a point from #16483 

it adds color support to the Separator block.

worth mentioning, the color won't be honored if the theme already defined a color, this is the case for the Dots, not the line, I can extend it to honor the theme color in the case of the line HR but it will require printing direct CSS or that the theme style is defined it using `!important`.

so, this is what is happening

* line HR color is overriding the theme style (unless the theme uses `!important`)
* the Dots are respecting the theme style (since they use currentColor)

you will see this case in 2019 in which they define a color for the dots 

my suggestion is to unify the experience, but this will cause a slight problem.

the Dots are defined using `:before`, in order to unify the experience, we have to do this inside React rather then using `:before` but it will break compantility with anything that is already targeting the :before, like 2019 