### PR TITLE
Docs: Update helphub links

### DIFF
--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -67,7 +67,7 @@ Alternatively, you can use your own local WordPress environment and clone this r
 
 Next, open a terminal (or if on Windows, a command prompt) and navigate to the repository you cloned. Now type `npm install` to get the dependencies all set up. Then you can type `npm run dev` in your terminal or command prompt to keep the plugin building in the background as you work on it.
 
-WordPress comes with specific [debug systems](https://codex.wordpress.org/Debugging_in_WordPress) designed to simplify the process as well as standardize code across core, plugins and themes. It is possible to use environment variables (`WP_DEBUG` and `SCRIPT_DEBUG`) to update a site's configuration constants located in `wp-config.php` file. Both flags can be disabled at any time by running the following command:
+WordPress comes with specific [debug systems](https://wordpress.org/support/article/debugging-in-wordpress/) designed to simplify the process as well as standardize code across core, plugins and themes. It is possible to use environment variables (`WP_DEBUG` and `SCRIPT_DEBUG`) to update a site's configuration constants located in `wp-config.php` file. Both flags can be disabled at any time by running the following command:
 ```
 SCRIPT_DEBUG=false WP_DEBUG=false ./bin/setup-local-env.sh
 ```

--- a/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
+++ b/packages/edit-post/src/components/header/post-publish-button-or-toggle.js
@@ -32,7 +32,7 @@ export function PostPublishButtonOrToggle( {
 	 * Conditions to show a BUTTON (publish directly) or a TOGGLE (open publish sidebar):
 	 *
 	 * 1) We want to show a BUTTON when the post status is at the _final stage_
-	 * for a particular role (see https://codex.wordpress.org/Post_Status):
+	 * for a particular role (see https://wordpress.org/support/article/post-status/):
 	 *
 	 * - is published
 	 * - is scheduled to be published


### PR DESCRIPTION
## Description
Some linked documentation articles were moved from the Codex into the new HelpHub. This PR updates the links in the docs.