### PR TITLE
Clean up Gallery block move/remove UI

### DIFF
--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -19,7 +19,7 @@ ul.wp-block-gallery {
 		outline: none;
 	}
 
-	.is-selected {
+	> .is-selected {
 		outline: 4px solid theme(primary);
 	}
 

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -64,6 +64,12 @@ ul.wp-block-gallery {
 			width: $icon-button-size-small;
 			height: $icon-button-size-small;
 
+			// Remove hover/focus box shadows, since they clash with the blue background.
+			&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover,
+			&:focus:not(:disabled) {
+				box-shadow: none;
+			}
+
 			@include break-small() {
 				// Use smaller buttons to fit when there are many columns.
 				.columns-7 &,

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -60,12 +60,24 @@ ul.wp-block-gallery {
 
 		.components-button {
 			color: $white;
+			padding: 2px;
+			width: $icon-button-size-small;
+			height: $icon-button-size-small;
+
+			@include break-small() {
+				// Use smaller buttons to fit when there are many columns.
+				.columns-7 &,
+				.columns-8 & {
+					padding: 0;
+					width: inherit;
+					height: inherit;
+				}
+			}
 		}
 
 		.components-button:focus {
 			color: inherit;
 		}
-
 	}
 
 	.block-editor-rich-text figcaption {
@@ -80,12 +92,20 @@ ul.wp-block-gallery {
 
 .block-library-gallery-item__move-menu,
 .block-library-gallery-item__inline-menu {
-	padding: 2px;
+	padding: $grid-size-small;
 	display: inline-flex;
 	z-index: z-index(".block-library-gallery-item__inline-menu");
 
 	.components-button {
 		color: transparent;
+	}
+
+	@include break-small() {
+		// Use smaller buttons to fit when there are many columns.
+		.columns-7 &,
+		.columns-8 & {
+			padding: $grid-size-small / 2;
+		}
 	}
 }
 

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -19,11 +19,11 @@ ul.wp-block-gallery {
 		outline: none;
 	}
 
-	> .is-selected {
+	figure.is-selected {
 		outline: 4px solid theme(primary);
 	}
 
-	.is-transient img {
+	figure.is-transient img {
 		opacity: 0.3;
 	}
 


### PR DESCRIPTION
This PR tidies up a couple small visual bugs with the Gallery block's individual image controls. It also switches the buttons to appear larger when possible. This is helpful (especially on mobile) to create a more visible hit area for these previously-tiny controls.

## 1. Button size improvements: 

**Before**

![Screen Shot 2019-07-29 at 9 25 00 AM](https://user-images.githubusercontent.com/1202812/62054411-8812b580-b1e7-11e9-9cb7-ebed50f0688f.png)

**After**

![Screen Shot 2019-07-29 at 9 24 18 AM](https://user-images.githubusercontent.com/1202812/62054418-8b0da600-b1e7-11e9-930b-086270f58555.png)

The buttons increase from 20 to 24px. Note that on larger screens, these buttons will shrink back down if there are more than 7 columns present. Is to prevent overlap: 

![number-of-columns](https://user-images.githubusercontent.com/1202812/62054465-a37dc080-b1e7-11e9-82a8-41c9732db39e.gif)

## 2. Clean up extra `is-selected` border on the caption field.

I'm not sure when this made its first appearance, but I believe it's unintentional? 

**Before**

![Screen Shot 2019-07-29 at 10 03 14 AM](https://user-images.githubusercontent.com/1202812/62054697-1f780880-b1e8-11e9-85a9-375d5eb0d423.png)


**After**

![Screen Shot 2019-07-29 at 9 48 00 AM](https://user-images.githubusercontent.com/1202812/62054554-cf00ab00-b1e7-11e9-8b21-82746340797a.png)

## 3. Removes box shadow from move/remove controls on hover and focus

These borders weren't working against the blue background.

**Before**

![Screen Shot 2019-07-29 at 9 56 47 AM](https://user-images.githubusercontent.com/1202812/62054659-00797680-b1e8-11e9-8f0c-6feedaa8fc48.png)

**After**

![Screen Shot 2019-07-29 at 9 56 26 AM](https://user-images.githubusercontent.com/1202812/62054667-05d6c100-b1e8-11e9-9a70-0c5fd976c179.png)
