### PR TITLE
ESLint Plugin: Add rule no-unjustified-disable

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -1,8 +1,13 @@
-## 2.4.0 (Unreleased)
+## Unreleased
+
+### Breaking Changes
+
+- The recommended ruleset now includes `@wordpress/no-unjustified-disable` by default as an error.
 
 ### New Features
 
 - [`@wordpress/no-unused-vars-before-return`](https://github.com/WordPress/gutenberg/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars-before-return.md) now supports an `excludePattern` option to exempt function calls by name.
+- New Rule: [`@wordpress/no-unjustified-disable`](https://github.com/WordPress/gutenberg/blob/master/packages/eslint-plugin/docs/rules/no-unjustified-disable.md)
 
 ### Improvements
 

--- a/packages/eslint-plugin/configs/custom.js
+++ b/packages/eslint-plugin/configs/custom.js
@@ -5,6 +5,7 @@ module.exports = {
 	rules: {
 		'@wordpress/dependency-group': 'error',
 		'@wordpress/gutenberg-phase': 'error',
+		'@wordpress/no-unjustified-disable': 'error',
 		'@wordpress/no-unused-vars-before-return': 'error',
 		'@wordpress/valid-sprintf': 'error',
 		'@wordpress/no-base-control-with-label-without-id': 'error',

--- a/packages/eslint-plugin/docs/rules/no-unjustified-disable.md
+++ b/packages/eslint-plugin/docs/rules/no-unjustified-disable.md
@@ -1,0 +1,29 @@
+# Avoid unjustified disabling of ESLint rules (no-unjustified-disable)
+
+If a developer finds themself in the position to disable an ESLint rule, one of the following should hold true:
+
+- They can provide a reason the rule is not applicable or remediation steps are provided.
+- The rule does not provide value for the development team.
+
+By providing justification for the disabling of a rule, a developer communicates intent to future maintainers who may otherwise not understand the reasons it was done. Such uncertainty can needlessly discourage refactoring or unnecessarily perpetuate the configuration. Good justification can serve as a description for the conditions of its own removal.
+
+If a rule is not valuable, it should not be part of the development team's default configuration.
+
+## Rule details
+
+Examples of **incorrect** code for this rule:
+
+```js
+// eslint-disable-next-line
+var f = foo();
+```
+
+Examples of **correct** code for this rule:
+
+```js
+// Disable reason: The rule is not applicable because remediation steps X, Y,
+// and Z have accounted for the problems otherwise anticipated.
+
+// eslint-disable-next-line
+var f = foo();
+```

--- a/packages/eslint-plugin/rules/__tests__/no-unjustified-disable.js
+++ b/packages/eslint-plugin/rules/__tests__/no-unjustified-disable.js
@@ -1,0 +1,92 @@
+/**
+ * External dependencies
+ */
+import { RuleTester } from 'eslint';
+
+/**
+ * Internal dependencies
+ */
+import rule from '../no-unjustified-disable';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run( 'no-unjustified-disable', rule, {
+	valid: [
+		{
+			code: `
+/* Disable reason: The rule is not applicable because X, Y, Z. */
+/* eslint-disable-next-line */
+var f = foo();`,
+		},
+		{
+			code: `
+// Disable reason: The rule is not applicable because remediation steps X, Y,
+// and Z have accounted for the problems otherwise anticipated.
+
+// eslint-disable-next-line
+var f = foo();`,
+		},
+		{
+			code: `
+/*
+ * Disable reason: The rule is not applicable because remediation steps X, Y,
+ * and Z have accounted for the problems otherwise anticipated.
+ */
+
+// eslint-disable-next-line
+var f = foo();`,
+		},
+	],
+	invalid: [
+		{
+			code: `
+// eslint-disable
+var f = foo();`,
+			errors: [ { message: 'Justify disable with preceding "Disable reason:" comment.' } ],
+			output: `
+// Disable Reason: [Provide justification that the rule is not applicable].
+
+// eslint-disable
+var f = foo();`,
+		},
+		{
+			code: `
+// eslint-disable-next-line
+var f = foo();`,
+			errors: [ { message: 'Justify disable with preceding "Disable reason:" comment.' } ],
+			output: `
+// Disable Reason: [Provide justification that the rule is not applicable].
+
+// eslint-disable-next-line
+var f = foo();`,
+		},
+		{
+			code: `
+/* eslint-disable-next-line */
+var f = foo();`,
+			errors: [ { message: 'Justify disable with preceding "Disable reason:" comment.' } ],
+			output: `
+// Disable Reason: [Provide justification that the rule is not applicable].
+
+/* eslint-disable-next-line */
+var f = foo();`,
+		},
+		{
+			code: `
+/* Disable reason: The rule is not applicable because X, Y, Z. */
+/* eslint-disable-next-line */
+var f = foo();
+/* eslint-disable-next-line */
+var f = foo();`,
+			errors: [ { message: 'Justify disable with preceding "Disable reason:" comment.' } ],
+			output: `
+/* Disable reason: The rule is not applicable because X, Y, Z. */
+/* eslint-disable-next-line */
+var f = foo();
+// Disable Reason: [Provide justification that the rule is not applicable].
+
+/* eslint-disable-next-line */
+var f = foo();`,
+		},
+	],
+} );

--- a/packages/eslint-plugin/rules/no-unjustified-disable.js
+++ b/packages/eslint-plugin/rules/no-unjustified-disable.js
@@ -1,0 +1,79 @@
+/**
+ * Regular expression pattern matching an ESLint disable inline configuration
+ * comment value.
+ *
+ * @type {RegExp}
+ */
+const REGEXP_DISABLE_ESLINT = /^\s*eslint-disable/;
+
+/**
+ * Regular expression pattern matching a disable reason comment value.
+ *
+ * @type {RegExp}
+ */
+const REGEXP_DISABLE_REASON = /^[\s*]*Disable [Rr]eason:/;
+
+module.exports = {
+	meta: {
+		type: 'problem',
+		fixable: true,
+	},
+	create( context ) {
+		function validateCommentNode( node, i, allNodes ) {
+			if ( ! REGEXP_DISABLE_ESLINT.test( node.value ) ) {
+				return;
+			}
+
+			let precedingIndex = i;
+			let precedingComment;
+			while ( ( precedingComment = allNodes[ --precedingIndex ] ) ) {
+				// If exhausted preceding comments, there was no justification.
+				if ( ! precedingComment ) {
+					break;
+				}
+
+				// Working backwards, assume that the preceding comment must be
+				// one or two lines from the disabling, and at most one line
+				// from the previous comment line considered.
+				const { line } = precedingComment.loc.end;
+				if (
+					allNodes[ precedingIndex + 1 ].loc.end.line !== line + 1 &&
+					node.loc.start.line !== line + 2
+				) {
+					break;
+				}
+
+				// Reset consideration if encountering another disable.
+				if ( REGEXP_DISABLE_ESLINT.test( precedingComment.value ) ) {
+					break;
+				}
+
+				// If this point is reached and justification is found, short-
+				// cut the entire validation as successful.
+				if ( REGEXP_DISABLE_REASON.test( precedingComment.value ) ) {
+					return;
+				}
+			}
+
+			context.report( {
+				node,
+				message: 'Justify disable with preceding "Disable reason:" comment.',
+				fix( fixer ) {
+					return fixer.insertTextBefore(
+						node,
+						'// Disable Reason: [Provide justification that the rule is not applicable].\n\n'
+					);
+				},
+			} );
+		}
+
+		return {
+			Program() {
+				context
+					.getSourceCode()
+					.getAllComments()
+					.forEach( validateCommentNode );
+			},
+		};
+	},
+};


### PR DESCRIPTION
This pull request seeks to add a new ESLint rule which enforces that the disabling of an ESLint rule via inline comment configuration must be accompanied by a preceding comment which justifies said disabling, using the "Disable reason:" convention already present in many occurrences in the codebase.

The reason for this rule to exist is explained in the included rule README:

>If a developer finds themself in the position to disable an ESLint rule, one of the following should hold true:
>
>- They can provide a reason the rule is not applicable or remediation steps are provided.
>- The rule does not provide value for the development team.
>
>By providing justification for the disabling of a rule, a developer communicates intent to future maintainers who may otherwise not understand the reasons it was done. Such uncertainty can needlessly discourage refactoring or unnecessarily perpetuate the configuration. Good justification can serve as a description for the conditions of its own removal.
>
>If a rule is not valuable, it should not be part of the development team's default configuration.

**Status:**

The rule itself is considered complete. However, there are a large number (128) of existing problems which must first be addressed.

**Testing Instructions:**

Verify there are no lint errors:

```
npm run lint-js
```

Verify unit tests pass:

```
npm run test-unit packages/eslint-plugin/rules/__tests__/no-unjustified-disable.js
```