### PR TITLE
ESLint Plugin: no-unused-vars-before-return: Exempt destructuring only if to multiple properties

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 2.4.0 (Unreleased)
+## Master
+
+### Breaking Changes
+
+- The [`@wordpress/no-unused-vars-before-return` rule](https://github.com/WordPress/gutenberg/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars-before-return.md) has been improved to exempt object destructuring only if destructuring to more than one property.
 
 ### New Features
 

--- a/packages/eslint-plugin/rules/__tests__/no-unused-vars-before-return.js
+++ b/packages/eslint-plugin/rules/__tests__/no-unused-vars-before-return.js
@@ -30,6 +30,17 @@ function example( number ) {
 		{
 			code: `
 function example() {
+	const { foo, bar } = doSomeCostlyOperation();
+	if ( number > 10 ) {
+		return number + bar + 1;
+	}
+
+	return number + foo;
+}`,
+		},
+		{
+			code: `
+function example() {
 	const foo = doSomeCostlyOperation();
 	if ( number > 10 ) {
 		return number + 1;
@@ -45,6 +56,18 @@ function example() {
 			code: `
 function example( number ) {
 	const foo = doSomeCostlyOperation();
+	if ( number > 10 ) {
+		return number + 1;
+	}
+
+	return number + foo;
+}`,
+			errors: [ { message: 'Variables should not be assigned until just prior its first reference. An early return statement may leave this variable unused.' } ],
+		},
+		{
+			code: `
+function example() {
+	const { foo } = doSomeCostlyOperation();
 	if ( number > 10 ) {
 		return number + 1;
 	}

--- a/packages/eslint-plugin/rules/no-unused-vars-before-return.js
+++ b/packages/eslint-plugin/rules/no-unused-vars-before-return.js
@@ -17,6 +17,21 @@ module.exports = {
 		const options = context.options[ 0 ] || {};
 		const { excludePattern } = options;
 
+		/**
+		 * Given an Espree VariableDeclarator node, returns true if the node
+		 * can be exempted from consideration as unused, or false otherwise. A
+		 * node can be exempt if it destructures to multiple variables, since
+		 * those other variables may be used prior to the return statement. A
+		 * future enhancement could validate that they are in-fact referenced.
+		 *
+		 * @param {Object} node Node to test.
+		 *
+		 * @return {boolean} Whether declarator is emempt from consideration.
+		 */
+		function isExemptObjectDestructureDeclarator( node ) {
+			return node.id.type === 'ObjectPattern' && node.id.properties.length > 1;
+		}
+
 		return {
 			ReturnStatement( node ) {
 				let functionScope = context.getScope();
@@ -37,7 +52,7 @@ module.exports = {
 							// Target function calls as "expensive".
 							def.node.init.type === 'CallExpression' &&
 							// Allow unused if part of an object destructuring.
-							def.node.id.type !== 'ObjectPattern' &&
+							! isExemptObjectDestructureDeclarator( def.node ) &&
 							// Only target assignments preceding `return`.
 							def.node.end < node.end
 						);

--- a/packages/eslint-plugin/rules/react-no-unsafe-timeout.js
+++ b/packages/eslint-plugin/rules/react-no-unsafe-timeout.js
@@ -44,8 +44,6 @@ module.exports = {
 	create( context ) {
 		return {
 			'CallExpression[callee.name="setTimeout"]'( node ) {
-				const { references } = context.getScope();
-
 				// If the result of a `setTimeout` call is assigned to a
 				// variable, assume the timer ID is handled by a cancellation.
 				const hasAssignment = (
@@ -74,6 +72,7 @@ module.exports = {
 				// Consider whether `setTimeout` is a reference to the global
 				// by checking references to see if `setTimeout` resolves to a
 				// variable in scope.
+				const { references } = context.getScope();
 				const hasResolvedReference = references.some( ( reference ) => (
 					reference.identifier.name === 'setTimeout' &&
 					!! reference.resolved &&


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/15578#discussion_r308395991

This pull request seeks to apply additional restrictions in the `no-unused-vars-before-return` rule to treat an object destructuring of a single property as being non-exempt from consideration for the rule. This exemption exists only due to complexity in verifying that all properties of the destructuring are referenced prior to the return statement. In the case of destructuring a single property, there is no such complexity.

There was a single violation of this improvement already present in the code, fixed in 44a4ac9.

**Testing Instructions:**

Verify there are no lint errors:

```
npm run lint-js
```

Ensure unit tests pass:

```
npm run test-unit packages/eslint-plugin/rules/__tests__/no-unused-vars-before-return.js
```