### PR TITLE
Add ability to unregister apiFetch middlewares

### DIFF
--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -49,6 +49,21 @@ function registerMiddleware( middleware ) {
 	middlewares.unshift( middleware );
 }
 
+function unregisterMiddleware( middleware ) {
+	// Change middleware to function that only skips to the next middleware
+	// This prevents bugs that happen when trying to splice multiple middlewares in succession
+	const skip = ( options, next ) => next( options );
+	middlewares.forEach( ( mw, index ) => {
+		if ( mw === middleware ) {
+			middlewares[ index ] = skip;
+		}
+	} );
+}
+
+function getMiddlewares() {
+	return middlewares;
+}
+
 const defaultFetchHandler = ( nextOptions ) => {
 	const { url, path, data, parse = true, ...remainingOptions } = nextOptions;
 	let { body, headers } = nextOptions;
@@ -152,6 +167,8 @@ function apiFetch( options ) {
 }
 
 apiFetch.use = registerMiddleware;
+apiFetch.remove = unregisterMiddleware;
+apiFetch.getMiddlewares = getMiddlewares;
 apiFetch.setFetchHandler = setFetchHandler;
 
 apiFetch.createNonceMiddleware = createNonceMiddleware;

--- a/packages/api-fetch/src/test/index.js
+++ b/packages/api-fetch/src/test/index.js
@@ -198,6 +198,22 @@ describe( 'apiFetch', () => {
 		} );
 	} );
 
+	it( 'should not use unregistred middleware', () => {
+		const customFetchHandler = jest.fn();
+
+		apiFetch.setFetchHandler( customFetchHandler );
+
+		apiFetch.getMiddlewares()
+			.filter( ( mw ) => mw.name === 'userLocaleMiddleware' )
+			.forEach( apiFetch.remove );
+
+		apiFetch( { path: '/random' } );
+
+		expect( customFetchHandler ).toHaveBeenCalledWith( {
+			path: '/random',
+		} );
+	} );
+
 	it( 'should run the last-registered user-defined middleware first', () => {
 		// This could potentially impact other tests in that a lingering
 		// middleware is left. For the purposes of this test, it is sufficient


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Added the ability to remove middlewares from the apiFetch module.
Closes #16805

## How has this been tested?
A testcase has been added and the testsuites ran successfully.

## Types of changes
New feature (non-breaking change which adds functionality)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
