### PR TITLE
Update the Inspector slots to use the bubblesVirtually slots

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -1,14 +1,12 @@
 /**
- * External dependencies
- */
-import { isEmpty } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { getBlockType, getUnregisteredTypeHandlerName } from '@wordpress/blocks';
-import { PanelBody } from '@wordpress/components';
+import {
+	PanelBody,
+	__experimentalSlotFillConsumer,
+} from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 
 /**
@@ -66,19 +64,21 @@ const BlockInspector = ( {
 					</PanelBody>
 				</div>
 			) }
-			<div><InspectorControls.Slot /></div>
+			<InspectorControls.Slot bubblesVirtually />
 			<div>
-				<InspectorAdvancedControls.Slot>
-					{ ( fills ) => ! isEmpty( fills ) && (
-						<PanelBody
-							className="editor-block-inspector__advanced block-editor-block-inspector__advanced"
-							title={ __( 'Advanced' ) }
-							initialOpen={ false }
-						>
-							{ fills }
-						</PanelBody>
-					) }
-				</InspectorAdvancedControls.Slot>
+				<__experimentalSlotFillConsumer>
+					{ ( { hasFills } ) =>
+						hasFills( InspectorAdvancedControls.slotName ) && (
+							<PanelBody
+								className="editor-block-inspector__advanced block-editor-block-inspector__advanced"
+								title={ __( 'Advanced' ) }
+								initialOpen={ false }
+							>
+								<InspectorAdvancedControls.Slot bubblesVirtually />
+							</PanelBody>
+						)
+					}
+				</__experimentalSlotFillConsumer>
 			</div>
 			<SkipToSelectedBlock key="back" />
 		</div>

--- a/packages/block-editor/src/components/inspector-advanced-controls/index.js
+++ b/packages/block-editor/src/components/inspector-advanced-controls/index.js
@@ -8,10 +8,12 @@ import { createSlotFill } from '@wordpress/components';
  */
 import { ifBlockEditSelected } from '../block-edit/context';
 
-const { Fill, Slot } = createSlotFill( 'InspectorAdvancedControls' );
+const name = 'InspectorAdvancedControls';
+const { Fill, Slot } = createSlotFill( name );
 
 const InspectorAdvancedControls = ifBlockEditSelected( Fill );
 
+InspectorAdvancedControls.slotName = name;
 InspectorAdvancedControls.Slot = Slot;
 
 export default InspectorAdvancedControls;

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -77,6 +77,7 @@ export {
 	Slot,
 	Fill,
 	Provider as SlotFillProvider,
+	Consumer as __experimentalSlotFillConsumer,
 } from './slot-fill';
 
 // Higher-Order Components

--- a/packages/components/src/slot-fill/context.js
+++ b/packages/components/src/slot-fill/context.js
@@ -29,6 +29,7 @@ class SlotFillProvider extends Component {
 		this.unregisterFill = this.unregisterFill.bind( this );
 		this.getSlot = this.getSlot.bind( this );
 		this.getFills = this.getFills.bind( this );
+		this.hasFills = this.hasFills.bind( this );
 		this.subscribe = this.subscribe.bind( this );
 
 		this.slots = {};
@@ -41,6 +42,7 @@ class SlotFillProvider extends Component {
 			unregisterFill: this.unregisterFill,
 			getSlot: this.getSlot,
 			getFills: this.getFills,
+			hasFills: this.hasFills,
 			subscribe: this.subscribe,
 		};
 	}
@@ -103,6 +105,10 @@ class SlotFillProvider extends Component {
 			return [];
 		}
 		return sortBy( this.fills[ name ], 'occurrence' );
+	}
+
+	hasFills( name ) {
+		return this.fills[ name ] && !! this.fills[ name ].length;
 	}
 
 	resetFillOccurrence( name ) {


### PR DESCRIPTION
Continuation of #16421
Closes #9203 

In several occasions, we noticed issues with the default Slot/Fill implementation (the one that copes children from the Fill into the Slot). These issues make it for example impossible to use A Slot inside a Fill. The React context doesn't propagate properly in the regular SlotFill implementation. The "bubblesVirtually" (Portal-based) implementation doesn't suffer from these issues. 

#16421 updated the block toolbar to rely on bubblesVirtually, the current PR expands that work for the inspector slots.

**Testing instructions**

 - Check that the block inspector still works as expected