### PR TITLE
Editor: Move auto-draft status change to the server.

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -29,3 +29,32 @@ function gutenberg_safe_style_css_column_flex_basis( $attr ) {
 	return $attr;
 }
 add_filter( 'safe_style_css', 'gutenberg_safe_style_css_column_flex_basis' );
+
+/**
+ * Filters inserted post data to unset any auto-draft assigned post title. The status
+ * of an auto-draft should be read from its `post_status` and not inferred via its
+ * title. A post with an explicit title should be created with draft status, not
+ * with auto-draft status. It will also update an existing post's status to draft if
+ * currently an auto-draft. This is intended to ensure that a post which is
+ * explicitly updated should no longer be subject to auto-draft purge.
+ *
+ * @see https://core.trac.wordpress.org/ticket/43316#comment:88
+ * @see https://core.trac.wordpress.org/ticket/43316#comment:89
+ *
+ * @param array $data    An array of slashed post data.
+ * @param array $postarr An array of sanitized, but otherwise unmodified post
+ *                        data.
+ *
+ * @return array Filtered post data.
+ */
+function gutenberg_filter_wp_insert_post_data( $data, $postarr ) {
+	if ( 'auto-draft' === $postarr['post_status'] ) {
+		if ( ! empty( $postarr['ID'] ) ) {
+			$data['post_status'] = 'draft';
+		} else {
+			$data['post_title'] = '';
+		}
+	}
+	return $data;
+}
+add_filter( 'wp_insert_post_data', 'gutenberg_filter_wp_insert_post_data', 10, 2 );


### PR DESCRIPTION
Extracted from #16761

## Description

This PR moves auto-draft status changing to the server in preparation for refactoring the editor store to rely entirely on `core/data` entities.

It does this by filtering inserted post data to unset any auto-draft assigned post title. The status of an auto-draft should be read from its `post_status` and not inferred via its title. A post with an explicit title should be created with draft status, not with auto-draft status. It will also update an existing post's status to draft if currently an auto-draft. This is intended to ensure that a post which is explicitly updated should no longer be subject to auto-draft purge.

## How has this been tested?

It was verified that saving still works as expected.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
