### PR TITLE
Bail early in deactivatePlugin if plugin is already inactive

### DIFF
--- a/packages/e2e-test-utils/src/activate-plugin.js
+++ b/packages/e2e-test-utils/src/activate-plugin.js
@@ -15,6 +15,7 @@ export async function activatePlugin( slug ) {
 	await visitAdminPage( 'plugins.php' );
 	const disableLink = await page.$( `tr[data-slug="${ slug }"] .deactivate a` );
 	if ( disableLink ) {
+		await switchUserToTest();
 		return;
 	}
 	await page.click( `tr[data-slug="${ slug }"] .activate a` );

--- a/packages/e2e-test-utils/src/deactivate-plugin.js
+++ b/packages/e2e-test-utils/src/deactivate-plugin.js
@@ -13,6 +13,10 @@ import { visitAdminPage } from './visit-admin-page';
 export async function deactivatePlugin( slug ) {
 	await switchUserToAdmin();
 	await visitAdminPage( 'plugins.php' );
+	const deleteLink = await page.$( `tr[data-slug="${ slug }"] .delete a` );
+	if ( deleteLink ) {
+		return;
+	}
 	await page.click( `tr[data-slug="${ slug }"] .deactivate a` );
 	await page.waitForSelector( `tr[data-slug="${ slug }"] .delete a` );
 	await switchUserToTest();

--- a/packages/e2e-test-utils/src/deactivate-plugin.js
+++ b/packages/e2e-test-utils/src/deactivate-plugin.js
@@ -15,6 +15,7 @@ export async function deactivatePlugin( slug ) {
 	await visitAdminPage( 'plugins.php' );
 	const deleteLink = await page.$( `tr[data-slug="${ slug }"] .delete a` );
 	if ( deleteLink ) {
+		await switchUserToTest();
 		return;
 	}
 	await page.click( `tr[data-slug="${ slug }"] .deactivate a` );


### PR DESCRIPTION
##  Description

Adjusts the `deactivatePlugin` e2e util to bail early if the plugin is already inactive.

Matches behavior with activatePlugin util, which also bails early for already active plugins.

## How has this been tested?

Manual testing by trying to deactivate in inactive plugin.

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
