### PR TITLE
Try adding a subtle animation to innerblock selection when padding is added. 

### DIFF
--- a/assets/stylesheets/_animations.scss
+++ b/assets/stylesheets/_animations.scss
@@ -7,3 +7,9 @@
 	animation-fill-mode: forwards;
 	@include reduce-motion("animation");
 }
+
+@mixin edit-post__inner-blocks-padding-animation($speed: 0.1s, $delay: 0s) {
+	animation: edit-post__inner-blocks-padding-animation $speed ease-out $delay;
+	animation-fill-mode: forwards;
+	@include reduce-motion("animation");
+}

--- a/assets/stylesheets/_animations.scss
+++ b/assets/stylesheets/_animations.scss
@@ -13,3 +13,9 @@
 	animation-fill-mode: forwards;
 	@include reduce-motion("animation");
 }
+
+@mixin edit-post__inner-blocks-padding-negative-animation($speed: 0.1s, $delay: 0s) {
+	animation: edit-post__inner-blocks-padding-negative-animation $speed ease-out $delay;
+	animation-fill-mode: forwards;
+	@include reduce-motion("animation");
+}

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -190,6 +190,7 @@ div.block-core-columns.is-vertically-aligned-bottom {
 .block-editor-block-list__layout .block-editor-block-list__block[data-type="core/column"].is-selected > .block-editor-block-list__block-edit > [data-block] > div > .block-editor-inner-blocks,
 .block-editor-block-list__layout .block-editor-block-list__block[data-type="core/column"].has-child-selected > .block-editor-block-list__block-edit > [data-block] > div > .block-editor-inner-blocks {
 	padding: $block-padding;
+	@include edit-post__inner-blocks-padding-animation();
 
 	// Negate this padding for the placeholder.
 	> .components-placeholder {

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -197,4 +197,10 @@ div.block-core-columns.is-vertically-aligned-bottom {
 		margin: -$block-padding;
 		width: calc(100% + #{$block-padding * 2});
 	}
+
+	// Negate the animation for the appender and placeholders.
+	> .block-editor-block-list__layout > .block-list-appender,
+	> .components-placeholder {
+		@include edit-post__inner-blocks-padding-negative-animation();
+	}
 }

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -93,6 +93,11 @@
 	> .wp-block-group__inner-container > .block-editor-inner-blocks {
 		padding: $block-padding;
 		@include edit-post__inner-blocks-padding-animation();
+
+		// Negate the animation for the appender.
+		> .block-editor-block-list__layout > .block-list-appender {
+			@include edit-post__inner-blocks-padding-negative-animation();
+		}
 	}
 
 	&:not(.has-background) > .wp-block-group__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout {

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -92,6 +92,7 @@
 
 	> .wp-block-group__inner-container > .block-editor-inner-blocks {
 		padding: $block-padding;
+		@include edit-post__inner-blocks-padding-animation();
 	}
 
 	&:not(.has-background) > .wp-block-group__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout {

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -51,6 +51,15 @@
 	}
 }
 
+@keyframes edit-post__inner-blocks-padding-animation {
+	from {
+		transform: scale(1.01);
+	}
+	to {
+		transform: scale(1);
+	}
+}
+
 // In order to use mix-blend-mode, this element needs to have an explicitly set background-color
 // We scope it to .wp-toolbar to be wp-admin only, to prevent bleed into other implementations
 html.wp-toolbar {

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -60,6 +60,16 @@
 	}
 }
 
+// This negates the animation above, and is used on child elements that don't require animation.
+@keyframes edit-post__inner-blocks-padding-negative-animation {
+	from {
+		transform: scale(0.99);
+	}
+	to {
+		transform: scale(1);
+	}
+}
+
 // In order to use mix-blend-mode, this element needs to have an explicitly set background-color
 // We scope it to .wp-toolbar to be wp-admin only, to prevent bleed into other implementations
 html.wp-toolbar {


### PR DESCRIPTION
When it's necessary to prevent overlap, #14961 adds some additional padding to `.editor-inner-blocks`. This additional padding is currently only provided for the Group block, and for the Columns block. 

In that issue, we discussed [adopting a very subtle `scale()` animation](https://github.com/WordPress/gutenberg/pull/14961#issuecomment-484643248) so that the addition of that extra space wasn't so jarring. This PR implements that animation. 

**Before:** 

![select-not-animated](https://user-images.githubusercontent.com/1202812/62147913-91268400-b2c6-11e9-9db2-38dbbb7ba434.gif)

**After:** _(The GIF is slowed down to make the animation more visible)_

![select-animated](https://user-images.githubusercontent.com/1202812/62147817-65a39980-b2c6-11e9-8c99-81863e4d1c5a.gif)

---

This seems pretty subtle, and helps make this smoother by just a little bit. The only issue I'm seeing is that it is unnecessarily applied to placeholders as well: 

![placeholder](https://user-images.githubusercontent.com/1202812/62148303-6f79cc80-b2c7-11e9-85fa-a4a8889d9eca.gif)

I don't think there's a way to turn this off, without the addition of a `has-placeholder` class on the parent block to hook into. This [seemed like it might be a possibility](https://github.com/WordPress/gutenberg/pull/14961#issuecomment-507391881) during an earlier discussion. 
