### PR TITLE
Block Editor: Interpret adjacent block selection from insertion point

### DIFF
--- a/docs/designers-developers/developers/data/data-core-block-editor.md
+++ b/docs/designers-developers/developers/data/data-core-block-editor.md
@@ -1031,7 +1031,7 @@ reflects a reverse selection.
 _Parameters_
 
 -   _clientId_ `string`: Block client ID.
--   _initialPosition_ `?number`: Optional initial position. Pass as -1 to reflect reverse selection.
+-   _initialPosition_ `?WPBlockInitialPosition`: Optional initial position.
 
 _Returns_
 
@@ -1061,6 +1061,7 @@ clientId should be selected.
 _Parameters_
 
 -   _clientId_ `string`: Block client ID.
+-   _initialPosition_ `?WPBlockInitialPosition`: Optional initial position.
 
 <a name="selectPreviousBlock" href="#selectPreviousBlock">#</a> **selectPreviousBlock**
 
@@ -1070,6 +1071,7 @@ clientId should be selected.
 _Parameters_
 
 -   _clientId_ `string`: Block client ID.
+-   _initialPosition_ `?WPBlockInitialPosition`: Optional initial position.
 
 <a name="setTemplateValidity" href="#setTemplateValidity">#</a> **setTemplateValidity**
 

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -224,7 +224,10 @@ function BlockListBlock( {
 
 		// If reversed (e.g. merge via backspace), use the last in the set of
 		// tabbables.
-		const isReverse = -1 === initialPosition || initialPosition.isReverse;
+		const { isReverse, caretRect } = {
+			isReverse: initialPosition === -1,
+			...initialPosition,
+		};
 		const target = ( isReverse ? last : first )( textInputs );
 
 		if ( ! target ) {
@@ -232,7 +235,7 @@ function BlockListBlock( {
 			return;
 		}
 
-		placeCaretAtVerticalEdge( target, isReverse, initialPosition.caretRect );
+		placeCaretAtVerticalEdge( target, isReverse, caretRect );
 	};
 
 	// Focus the selected block's wrapper or inner input on mount and update

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -12,7 +12,7 @@ import { useRef, useEffect, useState } from '@wordpress/element';
 import {
 	focus,
 	isTextField,
-	placeCaretAtHorizontalEdge,
+	placeCaretAtVerticalEdge,
 } from '@wordpress/dom';
 import { BACKSPACE, DELETE, ENTER } from '@wordpress/keycodes';
 import {
@@ -224,7 +224,7 @@ function BlockListBlock( {
 
 		// If reversed (e.g. merge via backspace), use the last in the set of
 		// tabbables.
-		const isReverse = -1 === initialPosition;
+		const isReverse = -1 === initialPosition || initialPosition.isReverse;
 		const target = ( isReverse ? last : first )( textInputs );
 
 		if ( ! target ) {
@@ -232,7 +232,7 @@ function BlockListBlock( {
 			return;
 		}
 
-		placeCaretAtHorizontalEdge( target, isReverse );
+		placeCaretAtVerticalEdge( target, isReverse, initialPosition.caretRect );
 	};
 
 	// Focus the selected block's wrapper or inner input on mount and update

--- a/packages/block-editor/src/components/block-list/insertion-point.js
+++ b/packages/block-editor/src/components/block-list/insertion-point.js
@@ -6,93 +6,73 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
-import { withSelect } from '@wordpress/data';
+import { useState, useCallback } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import Inserter from '../inserter';
 
-class BlockInsertionPoint extends Component {
-	constructor() {
-		super( ...arguments );
-		this.state = {
-			isInserterFocused: false,
-		};
+function BlockInsertionPoint( { rootClientId, clientId } ) {
+	const [ isInserterFocused, setIsInserterFocused ] = useState( false );
 
-		this.onBlurInserter = this.onBlurInserter.bind( this );
-		this.onFocusInserter = this.onFocusInserter.bind( this );
-	}
-
-	onFocusInserter( event ) {
+	const onFocusInserter = useCallback( ( event ) => {
 		// Stop propagation of the focus event to avoid selecting the current
 		// block while inserting a new block, as it is not relevant to sibling
 		// insertion and conflicts with contextual toolbar placement.
 		event.stopPropagation();
 
-		this.setState( {
-			isInserterFocused: true,
-		} );
-	}
+		setIsInserterFocused( true );
+	}, [] );
 
-	onBlurInserter() {
-		this.setState( {
-			isInserterFocused: false,
-		} );
-	}
+	const onBlurInserter = useCallback( () => setIsInserterFocused( false ), [] );
 
-	render() {
-		const { isInserterFocused } = this.state;
+	const { showInsertionPoint } = useSelect( ( select ) => {
 		const {
-			showInsertionPoint,
-			rootClientId,
-			clientId,
-		} = this.props;
+			getBlockIndex,
+			getBlockInsertionPoint,
+			isBlockInsertionPointVisible,
+		} = select( 'core/block-editor' );
+		const blockIndex = getBlockIndex( clientId, rootClientId );
+		const insertionPoint = getBlockInsertionPoint();
+		return {
+			showInsertionPoint: (
+				isBlockInsertionPointVisible() &&
+				insertionPoint.index === blockIndex &&
+				insertionPoint.rootClientId === rootClientId
+			),
+		};
+	}, [ clientId, rootClientId ] );
 
-		return (
-			<div className="editor-block-list__insertion-point block-editor-block-list__insertion-point">
-				{ showInsertionPoint && (
-					<div className="editor-block-list__insertion-point-indicator block-editor-block-list__insertion-point-indicator" />
-				) }
-				<div
-					onFocus={ this.onFocusInserter }
-					onBlur={ this.onBlurInserter }
-					// While ideally it would be enough to capture the
-					// bubbling focus event from the Inserter, due to the
-					// characteristics of click focusing of `button`s in
-					// Firefox and Safari, it is not reliable.
-					//
-					// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
-					tabIndex={ -1 }
-					className={
-						classnames( 'editor-block-list__insertion-point-inserter block-editor-block-list__insertion-point-inserter', {
-							'is-visible': isInserterFocused,
-						} )
-					}
-				>
-					<Inserter
-						rootClientId={ rootClientId }
-						clientId={ clientId }
-					/>
-				</div>
+	return (
+		<div className="editor-block-list__insertion-point block-editor-block-list__insertion-point">
+			{ showInsertionPoint && (
+				<div className="editor-block-list__insertion-point-indicator block-editor-block-list__insertion-point-indicator" />
+			) }
+			<div
+				onFocus={ onFocusInserter }
+				onBlur={ onBlurInserter }
+				// While ideally it would be enough to capture the
+				// bubbling focus event from the Inserter, due to the
+				// characteristics of click focusing of `button`s in
+				// Firefox and Safari, it is not reliable.
+				//
+				// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
+				tabIndex={ -1 }
+				className={
+					classnames( 'editor-block-list__insertion-point-inserter block-editor-block-list__insertion-point-inserter', {
+						'is-visible': isInserterFocused,
+					} )
+				}
+			>
+				<Inserter
+					rootClientId={ rootClientId }
+					clientId={ clientId }
+				/>
 			</div>
-		);
-	}
-}
-export default withSelect( ( select, { clientId, rootClientId } ) => {
-	const {
-		getBlockIndex,
-		getBlockInsertionPoint,
-		isBlockInsertionPointVisible,
-	} = select( 'core/block-editor' );
-	const blockIndex = getBlockIndex( clientId, rootClientId );
-	const insertionPoint = getBlockInsertionPoint();
-	const showInsertionPoint = (
-		isBlockInsertionPointVisible() &&
-		insertionPoint.index === blockIndex &&
-		insertionPoint.rootClientId === rootClientId
+		</div>
 	);
+}
 
-	return { showInsertionPoint };
-} )( BlockInsertionPoint );
+export default BlockInsertionPoint;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -849,11 +849,16 @@
 // This is the edge-to-edge hover area that contains the plus.
 .block-editor-block-list__block {
 	> .block-editor-block-list__insertion-point {
+		display: flex;
+		align-items: center;
+
+		cursor: text;
+
 		position: absolute;
 		top: -$block-padding - $block-spacing / 2;
 
 		// Matches the whole empty space between two blocks.
-		height: $block-padding * 2;
+		height: $block-padding * 2 + $block-spacing;
 		bottom: auto;
 
 		// Go edge to edge on mobile.

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -14,6 +14,17 @@ import { getDefaultBlockName, createBlock } from '@wordpress/blocks';
 import { select } from './controls';
 
 /**
+ * Value describing a selected block's initial position, either a number as the
+ * offset (-1 for reverse), or an object of properties `isReverse`, `caretRect`.
+ *
+ * @typedef {(number|Object)} WPBlockInitialPosition
+ *
+ * @property {boolean} isReverse Whether initial position should be placed at
+ *                               the end of the selected block.
+ * @property {DOMRect} caretRect Rect describing offset of initial position.
+ */
+
+/**
  * Generator which will yield a default block insert action if there
  * are no other blocks at the root of the editor. This generator should be used
  * in actions which may result in no blocks remaining in the editor (removal,
@@ -104,9 +115,8 @@ export function updateBlock( clientId, updates ) {
  * value reflecting its selection directionality. An initialPosition of -1
  * reflects a reverse selection.
  *
- * @param {string}  clientId        Block client ID.
- * @param {?number} initialPosition Optional initial position. Pass as -1 to
- *                                  reflect reverse selection.
+ * @param {string}                  clientId        Block client ID.
+ * @param {?WPBlockInitialPosition} initialPosition Optional initial position.
  *
  * @return {Object} Action object.
  */
@@ -122,9 +132,10 @@ export function selectBlock( clientId, initialPosition = null ) {
  * Yields action objects used in signalling that the block preceding the given
  * clientId should be selected.
  *
- * @param {string} clientId Block client ID.
+ * @param {string}                  clientId        Block client ID.
+ * @param {?WPBlockInitialPosition} initialPosition Optional initial position.
  */
-export function* selectPreviousBlock( clientId ) {
+export function* selectPreviousBlock( clientId, initialPosition = -1 ) {
 	const previousBlockClientId = yield select(
 		'core/block-editor',
 		'getPreviousBlockClientId',
@@ -132,7 +143,7 @@ export function* selectPreviousBlock( clientId ) {
 	);
 
 	if ( previousBlockClientId ) {
-		yield selectBlock( previousBlockClientId, -1 );
+		yield selectBlock( previousBlockClientId, initialPosition );
 	}
 }
 
@@ -140,9 +151,10 @@ export function* selectPreviousBlock( clientId ) {
  * Yields action objects used in signalling that the block following the given
  * clientId should be selected.
  *
- * @param {string} clientId Block client ID.
+ * @param {string}                  clientId        Block client ID.
+ * @param {?WPBlockInitialPosition} initialPosition Optional initial position.
  */
-export function* selectNextBlock( clientId ) {
+export function* selectNextBlock( clientId, initialPosition ) {
 	const nextBlockClientId = yield select(
 		'core/block-editor',
 		'getNextBlockClientId',
@@ -150,7 +162,7 @@ export function* selectNextBlock( clientId ) {
 	);
 
 	if ( nextBlockClientId ) {
-		yield selectBlock( nextBlockClientId );
+		yield selectBlock( nextBlockClientId, initialPosition );
 	}
 }
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -27,6 +27,10 @@ import {
 	hasChildBlocksWithInserterSupport,
 } from '@wordpress/blocks';
 
+/**
+ * @typedef {import('./actions').WPBlockInitialPosition} WPBlockInitialPosition
+ */
+
 // Module constants
 
 /**
@@ -523,7 +527,7 @@ export function getNextBlockClientId( state, startClientId ) {
  *
  * @param {Object} state Global application state.
  *
- * @return {?Object} Selected block.
+ * @return {?WPBlockInitialPosition} Initial position.
  */
 export function getSelectedBlocksInitialCaretPosition( state ) {
 	const { start, end } = state.blockSelection;


### PR DESCRIPTION
This pull request seeks to experiment with an approach to reduce "dead zones" between blocks. Currently, it can be difficult to select paragraphs using the mouse due to margins between the blocks. The margins are a result of default spacing between blocks and to provide a space for the sibling inserter to be displayed.

Before|After
---|---
![before](https://user-images.githubusercontent.com/1779930/62149663-40188f00-b2ca-11e9-8f89-599c74501927.gif)|![after](https://user-images.githubusercontent.com/1779930/62149661-40188f00-b2ca-11e9-88ed-0a206cbccba5.gif)

**Implementation Notes:**

Ideally, this would be handled taking advantage of the browser's default treatment of padding for an input field, where the input field should be considered the paragraph (as if it were extended to the bounds of the block). Unfortunately, this is made prohibitively difficult by the complexities of the block styling in handling margins (and margin collapses), inner blocks, and the need to support activation of the sibling inserter.

Instead, this takes the next best approach: It interprets clicks on the sibling inserter as intent to select the following or preceding block.

This required expanding support for the `selectBlock` `initialPosition` argument to support an X-offset of the selection (similar as to what's done in the `WritingFlow` component to preserve the horizontal offset).

This works fairly well, but is not perfect; notably, if the block is already selected, clicking within the sibling inserter will not reposition the caret. There may be an alternative approach to explore here.

**Testing Instructions:**

Verify that there is no dead zone between blocks.

Verify there are no regressions of the use of the sibling inserter.