### PR TITLE
Block Editor: Merge block wrapper props by reassignment

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -412,10 +412,9 @@ function BlockListBlock( {
 	);
 
 	// Determine whether the block has props to apply to the wrapper.
-	let blockWrapperProps = wrapperProps;
 	if ( blockType.getEditWrapperProps ) {
-		blockWrapperProps = {
-			...blockWrapperProps,
+		wrapperProps = {
+			...wrapperProps,
 			...blockType.getEditWrapperProps( attributes ),
 		};
 	}
@@ -470,7 +469,7 @@ function BlockListBlock( {
 			aria-label={ blockLabel }
 			childHandledEvents={ [ 'onDragStart', 'onMouseDown' ] }
 			tagName={ animated.div }
-			{ ...blockWrapperProps }
+			{ ...wrapperProps }
 			style={
 				wrapperProps && wrapperProps.style ?
 					{


### PR DESCRIPTION
Related (regression): https://github.com/WordPress/gutenberg/pull/16750/files#r308873571

This pull request seeks to resolve an issue where column widths are not visibly displayed in the editor. See https://github.com/WordPress/gutenberg/pull/16750/files#r308873571 for additional context.

**Testing Instructions:**

Repeat testing instructions from #16750

Verify column widths are shown as assigned.