### PR TITLE
Try making the hover state of nested blocks more visible

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -110,7 +110,7 @@
 			border-left: none;
 			box-shadow: none;
 			pointer-events: none;
-			transition: border-color 0.1s linear, box-shadow 0.1s linear;
+			transition: border-color 0.1s linear, border-style 0.1s linear, box-shadow 0.1s linear;
 			@include reduce-motion("transition");
 
 			// Include a transparent outline for Windows High Contrast mode.
@@ -181,13 +181,29 @@
 		> .block-editor-block-list__block-edit > [data-block] > div > .wp-block-group__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout > .block-editor-block-list__block:not(.is-selected) > .block-editor-block-list__block-edit::before {
 			border: $border-width dashed $dark-opacity-light-800;
 		}
+
+		&.is-hovered > .block-editor-block-list__block-edit::before {
+			border-style: solid;
+			border-color: $dark-opacity-light-700;
+		}
 	}
 
 	// Add extra border to child blocks when they are selected.
-	&.is-selected > .block-editor-block-list__block-edit > [data-block] > div > .block-editor-inner-blocks > .block-editor-block-list__layout > .block-editor-block-list__block:not(.is-selected) > .block-editor-block-list__block-edit::before,
-	&.is-selected > .block-editor-block-list__block-edit > [data-block] > div > .wp-block-cover__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout > .block-editor-block-list__block:not(.is-selected) > .block-editor-block-list__block-edit::before,
-	&.is-selected > .block-editor-block-list__block-edit > [data-block] > div > .wp-block-group__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout > .block-editor-block-list__block:not(.is-selected) > .block-editor-block-list__block-edit::before {
-		border: $border-width dashed $dark-opacity-light-800;
+	&.is-selected {
+
+		> .block-editor-block-list__block-edit > [data-block] > div > .block-editor-inner-blocks > .block-editor-block-list__layout > .block-editor-block-list__block:not(.is-selected),
+		> .block-editor-block-list__block-edit > [data-block] > div > .wp-block-cover__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout > .block-editor-block-list__block:not(.is-selected),
+		> .block-editor-block-list__block-edit > [data-block] > div > .wp-block-group__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout > .block-editor-block-list__block:not(.is-selected) {
+
+			> .block-editor-block-list__block-edit::before {
+				border: $border-width dashed $dark-opacity-light-800;
+			}
+
+			&.is-hovered > .block-editor-block-list__block-edit::before {
+				border-style: solid;
+				border-color: $dark-opacity-light-700;
+			}
+		}
 	}
 }
 

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -190,7 +190,10 @@
 			}
 		}
 
-		&.is-hovered > .block-editor-block-list__block-edit::before {
+		&.is-hovered > .block-editor-block-list__block-edit::before,
+		> .block-editor-block-list__block-edit > [data-block] > div > .block-editor-inner-blocks > .block-editor-block-list__layout > .block-editor-block-list__block.is-hovered:not(.is-selected) > .block-editor-block-list__block-edit::before,
+		> .block-editor-block-list__block-edit > [data-block] > div > .wp-block-cover__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout > .block-editor-block-list__block.is-hovered:not(.is-selected) > .block-editor-block-list__block-edit::before,
+		> .block-editor-block-list__block-edit > [data-block] > div > .wp-block-group__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout > .block-editor-block-list__block.is-hovered:not(.is-selected) > .block-editor-block-list__block-edit::before {
 			border-style: solid;
 			border-color: $dark-opacity-light-500;
 			border-left-color: transparent;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -174,18 +174,31 @@
 
 		> .block-editor-block-list__block-edit::before {
 			border: $border-width dashed $dark-opacity-light-600;
+
+			.is-dark-theme & {
+				border-color: $light-opacity-light-500;
+			}
 		}
 
 		> .block-editor-block-list__block-edit > [data-block] > div > .block-editor-inner-blocks > .block-editor-block-list__layout > .block-editor-block-list__block:not(.is-selected) > .block-editor-block-list__block-edit::before,
 		> .block-editor-block-list__block-edit > [data-block] > div > .wp-block-cover__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout > .block-editor-block-list__block:not(.is-selected) > .block-editor-block-list__block-edit::before,
 		> .block-editor-block-list__block-edit > [data-block] > div > .wp-block-group__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout > .block-editor-block-list__block:not(.is-selected) > .block-editor-block-list__block-edit::before {
 			border: $border-width dashed $dark-opacity-light-600;
+
+			.is-dark-theme & {
+				border-color: $light-opacity-light-500;
+			}
 		}
 
 		&.is-hovered > .block-editor-block-list__block-edit::before {
 			border-style: solid;
 			border-color: $dark-opacity-light-500;
 			border-left-color: transparent;
+
+			.is-dark-theme & {
+				border-color: $light-opacity-light-400;
+				border-left-color: transparent;
+			}
 		}
 	}
 
@@ -198,12 +211,21 @@
 
 			> .block-editor-block-list__block-edit::before {
 				border: $border-width dashed $dark-opacity-light-600;
+
+				.is-dark-theme & {
+					border-color: $light-opacity-light-500;
+				}
 			}
 
 			&.is-hovered > .block-editor-block-list__block-edit::before {
 				border-style: solid;
 				border-color: $dark-opacity-light-500;
 				border-left-color: transparent;
+
+				.is-dark-theme & {
+					border-color: $light-opacity-light-400;
+					border-left-color: transparent;
+				}
 			}
 		}
 	}

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -173,18 +173,19 @@
 	&.has-child-selected {
 
 		> .block-editor-block-list__block-edit::before {
-			border: $border-width dashed $dark-opacity-light-800;
+			border: $border-width dashed $dark-opacity-light-600;
 		}
 
 		> .block-editor-block-list__block-edit > [data-block] > div > .block-editor-inner-blocks > .block-editor-block-list__layout > .block-editor-block-list__block:not(.is-selected) > .block-editor-block-list__block-edit::before,
 		> .block-editor-block-list__block-edit > [data-block] > div > .wp-block-cover__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout > .block-editor-block-list__block:not(.is-selected) > .block-editor-block-list__block-edit::before,
 		> .block-editor-block-list__block-edit > [data-block] > div > .wp-block-group__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout > .block-editor-block-list__block:not(.is-selected) > .block-editor-block-list__block-edit::before {
-			border: $border-width dashed $dark-opacity-light-800;
+			border: $border-width dashed $dark-opacity-light-600;
 		}
 
 		&.is-hovered > .block-editor-block-list__block-edit::before {
 			border-style: solid;
-			border-color: $dark-opacity-light-700;
+			border-color: $dark-opacity-light-500;
+			border-left-color: transparent;
 		}
 	}
 
@@ -196,12 +197,13 @@
 		> .block-editor-block-list__block-edit > [data-block] > div > .wp-block-group__inner-container > .block-editor-inner-blocks > .block-editor-block-list__layout > .block-editor-block-list__block:not(.is-selected) {
 
 			> .block-editor-block-list__block-edit::before {
-				border: $border-width dashed $dark-opacity-light-800;
+				border: $border-width dashed $dark-opacity-light-600;
 			}
 
 			&.is-hovered > .block-editor-block-list__block-edit::before {
 				border-style: solid;
-				border-color: $dark-opacity-light-700;
+				border-color: $dark-opacity-light-500;
+				border-left-color: transparent;
 			}
 		}
 	}


### PR DESCRIPTION
Following up from #14961.

Currently, when you hover over the new dashed borders for nested blocks, nothing happens: 

![old](https://user-images.githubusercontent.com/1202812/62156781-ab1d9200-b2d9-11e9-9940-35a109de0a67.gif)

In the original PR, we briefly discussed [improving upon this by adopting a hover state](https://github.com/WordPress/gutenberg/pull/14961#issuecomment-495361430). This PR implements a similar hover state to the one proposed there, but it uses a `border-style` change instead, which I think is a little more visible than jus the color change. Still could use some iteration though: 

![updated](https://user-images.githubusercontent.com/1202812/62157132-78c06480-b2da-11e9-90cc-b0d90f84b343.gif)

**Todo:** 

- [ ] Make this work for an individual column block when its child is selected. Something's blocking that right now.
- [x] Build in styles for dark mode.