### PR TITLE
Block Library: Column: Limit width redistribution to adjacent column

### DIFF
--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { forEach, find } from 'lodash';
+import { forEach } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -24,8 +24,8 @@ import { __ } from '@wordpress/i18n';
 import {
 	toWidthPrecision,
 	getColumnWidths,
-	getAdjacentBlock,
-	getEffectiveColumnWidth,
+	getAdjacentBlocks,
+	getRedistributedColumnWidths,
 } from '../columns/utils';
 
 function ColumnEdit( {
@@ -115,17 +115,7 @@ export default compose(
 				// Constrain or expand siblings to account for gain or loss of
 				// total columns area.
 				const columns = getBlocks( getBlockRootClientId( clientId ) );
-				const column = find( columns, { clientId } );
-				const adjacentColumn = getAdjacentBlock( columns, clientId );
-				const adjacentColumnWidth = getEffectiveColumnWidth(
-					adjacentColumn,
-					columns.length
-				);
-				const previousWidth = getEffectiveColumnWidth(
-					column,
-					columns.length
-				);
-				const difference = width - previousWidth;
+				const adjacentColumns = getAdjacentBlocks( columns, clientId );
 
 				// Compute _all_ next column widths, in case the updated column
 				// is in the middle of a set of columns which don't yet have
@@ -134,8 +124,10 @@ export default compose(
 				const nextColumnWidths = {
 					...getColumnWidths( columns, columns.length ),
 					[ clientId ]: toWidthPrecision( width ),
-					[ adjacentColumn.clientId ]: toWidthPrecision(
-						adjacentColumnWidth - difference
+					...getRedistributedColumnWidths(
+						adjacentColumns,
+						100 - width,
+						columns.length
 					),
 				};
 

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -154,7 +154,7 @@ const ColumnsEditContainerWrapper = withDispatch(
 				// Redistribute in consideration of pending block insertion as
 				// constraining the available working width.
 				const widths = getRedistributedColumnWidths(
-					innerBlocks,
+					[ ...innerBlocks ].reverse(),
 					100 - newColumnWidth
 				);
 
@@ -183,7 +183,7 @@ const ColumnsEditContainerWrapper = withDispatch(
 				if ( hasExplicitWidths ) {
 					// Redistribute as if block is already removed.
 					const widths = getRedistributedColumnWidths(
-						innerBlocks,
+						innerBlocks.reverse(),
 						100
 					);
 

--- a/packages/block-library/src/columns/test/utils.js
+++ b/packages/block-library/src/columns/test/utils.js
@@ -3,7 +3,7 @@
  */
 import {
 	toWidthPrecision,
-	getAdjacentBlocks,
+	getAdjacentBlock,
 	getEffectiveColumnWidth,
 	getTotalColumnsWidth,
 	getColumnWidths,
@@ -25,22 +25,22 @@ describe( 'toWidthPrecision', () => {
 	} );
 } );
 
-describe( 'getAdjacentBlocks', () => {
+describe( 'getAdjacentBlock', () => {
 	const blockA = { clientId: 'a' };
 	const blockB = { clientId: 'b' };
 	const blockC = { clientId: 'c' };
 	const blocks = [ blockA, blockB, blockC ];
 
-	it( 'should return blocks after clientId', () => {
-		const result = getAdjacentBlocks( blocks, 'b' );
+	it( 'should return block after clientId', () => {
+		const result = getAdjacentBlock( blocks, 'b' );
 
-		expect( result ).toEqual( [ blockC ] );
+		expect( result ).toBe( blockC );
 	} );
 
-	it( 'should return blocks before clientId if clientId is last', () => {
-		const result = getAdjacentBlocks( blocks, 'c' );
+	it( 'should return block before clientId if clientId is last', () => {
+		const result = getAdjacentBlock( blocks, 'c' );
 
-		expect( result ).toEqual( [ blockA, blockB ] );
+		expect( result ).toBe( blockB );
 	} );
 } );
 

--- a/packages/block-library/src/columns/utils.js
+++ b/packages/block-library/src/columns/utils.js
@@ -23,13 +23,13 @@ export const toWidthPrecision = ( value ) =>
  * @param {WPBlock[]} blocks   Block objects.
  * @param {string}    clientId Client ID to consider for adjacent blocks.
  *
- * @return {WPBlock[]} Adjacent block objects.
+ * @return {WPBlock} Adjacent block object.
  */
-export function getAdjacentBlocks( blocks, clientId ) {
+export function getAdjacentBlock( blocks, clientId ) {
 	const index = findIndex( blocks, { clientId } );
 	const isLastBlock = index === blocks.length - 1;
 
-	return isLastBlock ? blocks.slice( 0, index ) : blocks.slice( index + 1 );
+	return isLastBlock ? blocks[ index - 1 ] : blocks[ index + 1 ];
 }
 
 /**


### PR DESCRIPTION
Closes #16370 (cc @phpbits)

This pull request seeks to improve the behavior of column width assignment to limit impact on other columns, to redistribute width relative only the block immediately adjacent the one being resized, rather than split amongst all other blocks in the set. It is hoped that this should be a more predictable behavior for resizing, particularly when aiming to resize multiple columns.

**Testing Instructions:**

Verify that resizing a column adds or removes width from the column immediately to its right (if the column is the last in the set, it adds or removes from the column to its left).