### PR TITLE
Core Data: Add util for minimally modifying items.

### DIFF
--- a/packages/core-data/src/utils/conservative-map-item.js
+++ b/packages/core-data/src/utils/conservative-map-item.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { isEqual } from 'lodash';
+
+/**
+ * Given the current and next item entity, returns the minimally "modified"
+ * result of the next item, preferring value references from the original item
+ * if equal. If all values match, the original item is returned.
+ *
+ * @param {Object} item     Original item.
+ * @param {Object} nextItem Next item.
+ *
+ * @return {Object} Minimally modified merged item.
+ */
+export default function conservativeMapItem( item, nextItem ) {
+	// Return next item in its entirety if there is no original item.
+	if ( ! item ) {
+		return nextItem;
+	}
+
+	let hasChanges = false;
+	const result = {};
+	for ( const key in nextItem ) {
+		if ( isEqual( item[ key ], nextItem[ key ] ) ) {
+			result[ key ] = item[ key ];
+		} else {
+			hasChanges = true;
+			result[ key ] = nextItem[ key ];
+		}
+	}
+
+	if ( ! hasChanges ) {
+		return item;
+	}
+	return result;
+}

--- a/packages/core-data/src/utils/index.js
+++ b/packages/core-data/src/utils/index.js
@@ -1,3 +1,4 @@
+export { default as conservativeMapItem } from './conservative-map-item';
 export { default as ifMatchingAction } from './if-matching-action';
 export { default as onSubKey } from './on-sub-key';
 export { default as replaceAction } from './replace-action';

--- a/packages/core-data/src/utils/test/conservative-map-item.js
+++ b/packages/core-data/src/utils/test/conservative-map-item.js
@@ -1,0 +1,33 @@
+/**
+ * Internal dependencies
+ */
+import conservativeMapItem from '../conservative-map-item';
+
+describe( 'conservativeMapItem', () => {
+	it( 'Returns the next item if there is no current item to compare with.', () => {
+		const item = undefined;
+		const nextItem = {};
+		const result = conservativeMapItem( item, nextItem );
+
+		expect( result ).toBe( nextItem );
+	} );
+
+	it( 'Returns the original item if all property values are the same, deeply.', () => {
+		const item = { a: [ {} ] };
+		const nextItem = { a: [ {} ] };
+		const result = conservativeMapItem( item, nextItem );
+
+		expect( result ).toBe( item );
+	} );
+
+	it( 'Preserves original references of property values when unchanged, deeply.', () => {
+		const item = { a: [ {} ], b: [ 1 ] };
+		const nextItem = { a: [ {} ], b: [ 2 ] };
+		const result = conservativeMapItem( item, nextItem );
+
+		expect( result ).not.toBe( item );
+		expect( result.a ).toBe( item.a );
+		expect( result.b ).toBe( nextItem.b );
+		expect( result ).toEqual( { a: [ {} ], b: [ 2 ] } );
+	} );
+} );


### PR DESCRIPTION
Extracted from #16761

## Description

This PR adds a utility for minimally modifying items, to the core data package in preparation for refactoring the editor store to rely entirely on `core/data` entities. The utility maps an item to a new item, retaining non primitive value references where possible (where deeply equal). This is necessary so that components that depend on these values don't update unnecessarily.

## How has this been tested?

Unit tests were written and ran to test for expected functionality.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
