### PR TITLE
Expose BlockPreview component

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -122,6 +122,10 @@ Undocumented declaration.
 
 Undocumented declaration.
 
+<a name="BlockPreview" href="#BlockPreview">#</a> **BlockPreview**
+
+Undocumented declaration.
+
 <a name="BlockSelectionClearer" href="#BlockSelectionClearer">#</a> **BlockSelectionClearer**
 
 Undocumented declaration.

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -124,7 +124,15 @@ Undocumented declaration.
 
 <a name="BlockPreview" href="#BlockPreview">#</a> **BlockPreview**
 
-Undocumented declaration.
+BlockPreview renders a preview given an array of blocks.
+
+_Parameters_
+
+-   _props_ `Object`: Component props.
+
+_Returns_
+
+-   `WPElement`: Rendered element.
 
 <a name="BlockSelectionClearer" href="#BlockSelectionClearer">#</a> **BlockSelectionClearer**
 

--- a/packages/block-editor/src/components/block-preview/README.md
+++ b/packages/block-editor/src/components/block-preview/README.md
@@ -1,0 +1,46 @@
+BlockPreview
+============
+
+`<BlockPreview />` allows you to preview any arbitrary HTML and CSS content, with a perfectly scaled thumbnail.
+
+## Usage
+
+Render the component passing in the required props:
+
+```jsx
+<BlockPreview
+	blocks={ blocks }
+	srcWidth={ 400 }
+	srcHeight={ 300 }
+
+/>
+```
+
+## A note on source dimensions
+
+Please note that `srcWidth` and `srcHeight` refer to the _unscaled dimensions_ of what you mean to preview. 
+
+Think of the preview as a big source image, say 800x600 that's scaled down. So if the HTML you mean to preview looks good at 800x600, those are your source dimensionss. 
+
+A calculated `transform: scale( ...  )` value will be assigned to the thumbnail, so that it fits your _destination_ dimensions, which you set in CSS.
+
+
+## Props
+
+### `blocks`
+* **Type:** `array|object`
+* **Default:** `undefined`
+
+A block instance (object) or a blocks array you would like to render a preview.
+
+### `srcWidth`
+* **Type:** `Integer`
+* **Default:** `400`
+
+The unscaled dimension of the Block you are looking to preview. For example, if the Block looks good at `700x450` then you should set this value to `750`. See also `A note on source dimensions` above.
+
+### `srcHeight`
+* **Type:** `Integer`
+* **Default:** `300`
+
+The unscaled dimension of the Block you are looking to preview. For example, if the Block looks good at `700x450` then you should set this value to `450`. See also `A note on source dimensions` above.

--- a/packages/block-editor/src/components/block-preview/README.md
+++ b/packages/block-editor/src/components/block-preview/README.md
@@ -1,7 +1,7 @@
 BlockPreview
 ============
 
-`<BlockPreview />` allows you to preview any arbitrary HTML and CSS content, with a perfectly scaled thumbnail.
+`<BlockPreview />` allows you to preview blocks.
 
 ## Usage
 
@@ -10,20 +10,9 @@ Render the component passing in the required props:
 ```jsx
 <BlockPreview
 	blocks={ blocks }
-	srcWidth={ 400 }
-	srcHeight={ 300 }
-
+	isScaled={ false }
 />
 ```
-
-## A note on source dimensions
-
-Please note that `srcWidth` and `srcHeight` refer to the _unscaled dimensions_ of what you mean to preview. 
-
-Think of the preview as a big source image, say 800x600 that's scaled down. So if the HTML you mean to preview looks good at 800x600, those are your source dimensionss. 
-
-A calculated `transform: scale( ...  )` value will be assigned to the thumbnail, so that it fits your _destination_ dimensions, which you set in CSS.
-
 
 ## Props
 
@@ -33,14 +22,8 @@ A calculated `transform: scale( ...  )` value will be assigned to the thumbnail,
 
 A block instance (object) or a blocks array you would like to render a preview.
 
-### `srcWidth`
-* **Type:** `Integer`
-* **Default:** `400`
+### `isScaled`
+* **Type:** `Boolean`
+* **Default:** `false`
 
-The unscaled dimension of the Block you are looking to preview. For example, if the Block looks good at `700x450` then you should set this value to `750`. See also `A note on source dimensions` above.
-
-### `srcHeight`
-* **Type:** `Integer`
-* **Default:** `300`
-
-The unscaled dimension of the Block you are looking to preview. For example, if the Block looks good at `700x450` then you should set this value to `450`. See also `A note on source dimensions` above.
+Use this if you need to render previews in smaller areas, like block thumbnails.

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -16,13 +16,6 @@ import { withSelect } from '@wordpress/data';
 import BlockEditorProvider from '../provider';
 import BlockList from '../block-list';
 
-/**
- * Block Preview Component: It renders a preview given a block name and attributes.
- *
- * @param {Object} props Component props.
- *
- * @return {WPElement} Rendered element.
- */
 export function BlockPreview( { blocks, settings, className, isScaled } ) {
 	if ( ! blocks ) {
 		return null;
@@ -51,6 +44,13 @@ export function BlockPreview( { blocks, settings, className, isScaled } ) {
 	);
 }
 
+/**
+ * BlockPreview renders a preview given an array of blocks.
+ *
+ * @param {Object} props Component props.
+ *
+ * @return {WPElement} Rendered element.
+ */
 export default withSelect( ( select ) => {
 	return {
 		settings: select( 'core/block-editor' ).getSettings(),

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -23,7 +23,7 @@ import BlockList from '../block-list';
  *
  * @return {WPElement} Rendered element.
  */
-function BlockPreview( { blocks, settings, className, isScaled } ) {
+export function BlockPreview( { blocks, settings, className, isScaled } ) {
 	if ( ! blocks ) {
 		return null;
 	}

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -45,6 +45,7 @@ export { default as BlockEditorKeyboardShortcuts } from './block-editor-keyboard
 export { default as BlockInspector } from './block-inspector';
 export { default as BlockList } from './block-list';
 export { default as BlockMover } from './block-mover';
+export { default as BlockPreview } from './block-preview';
 export { default as BlockSelectionClearer } from './block-selection-clearer';
 export { default as BlockSettingsMenu } from './block-settings-menu';
 export { default as BlockTitle } from './block-title';


### PR DESCRIPTION
## Description
This PR exposes the `BlockPreview` component in order to make it available to be consumed by other plugins.

This branch has been created from `update/unify-block-preview-components`

## How has this been tested?
A simple way to confirm whether the function is being exposed is trying to get it from the console of your dev browser. Type `wp.blockEditor` and look up the `BlockPreview` among the other components. Without these changes, the `BlockPreview` shouldn't be there.

![image](https://user-images.githubusercontent.com/77539/62210014-807f1800-b371-11e9-9781-f28d2f00aa3d.png)

## Types of changes
Expose the `BlockPreview` component.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
