### PR TITLE
Editor: Optimize common dependencies bail-out

### DIFF
--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -55,6 +55,11 @@ const lastBlockSourceDependenciesByRegistry = new WeakMap;
  */
 function* getBlocksWithSourcedAttributes( blocks ) {
 	const registry = yield getRegistry();
+	if ( ! lastBlockSourceDependenciesByRegistry.has( registry ) ) {
+		return blocks;
+	}
+
+	const blockSourceDependencies = lastBlockSourceDependenciesByRegistry.get( registry );
 
 	let workingBlocks = blocks;
 	for ( let i = 0; i < blocks.length; i++ ) {
@@ -66,11 +71,6 @@ function* getBlocksWithSourcedAttributes( blocks ) {
 				continue;
 			}
 
-			if ( ! lastBlockSourceDependenciesByRegistry.has( registry ) ) {
-				continue;
-			}
-
-			const blockSourceDependencies = lastBlockSourceDependenciesByRegistry.get( registry );
 			if ( ! blockSourceDependencies.has( sources[ schema.source ] ) ) {
 				continue;
 			}
@@ -136,13 +136,13 @@ function* resetLastBlockSourceDependencies( sourcesToUpdate = Object.values( sou
 	}
 
 	const registry = yield getRegistry();
+	if ( ! lastBlockSourceDependenciesByRegistry.has( registry ) ) {
+		lastBlockSourceDependenciesByRegistry.set( registry, new WeakMap );
+	}
+
+	const lastBlockSourceDependencies = lastBlockSourceDependenciesByRegistry.get( registry );
 
 	for ( const source of sourcesToUpdate ) {
-		if ( ! lastBlockSourceDependenciesByRegistry.has( registry ) ) {
-			lastBlockSourceDependenciesByRegistry.set( registry, new WeakMap );
-		}
-
-		const lastBlockSourceDependencies = lastBlockSourceDependenciesByRegistry.get( registry );
 		const dependencies = yield* source.getDependencies();
 		lastBlockSourceDependencies.set( source, dependencies );
 	}


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/16402#discussion_r303558680, https://github.com/WordPress/gutenberg/pull/16402#discussion_r303559645

This pull request seeks to apply a minor optimization to the block sources behavior implemented in #16402 to avoid repeated validation of common data access within loops to sources and blocks applications. It's unlikely this has a significant impact, but these loops are both called for every change to a block in a post (e.g. each keypress).

**Testing Instructions:**

Repeat testing instructions from #16402.