### PR TITLE
FormTokenField: Automatically add token on blur if there is valid content

### DIFF
--- a/packages/components/src/form-token-field/index.js
+++ b/packages/components/src/form-token-field/index.js
@@ -104,7 +104,7 @@ class FormTokenField extends Component {
 
 	onBlur() {
 		if ( this.inputHasValidValue() ) {
-			this.setState( { isActive: false } );
+			this.setState( { isActive: false }, this.addCurrentToken );
 		} else {
 			this.setState( initialState );
 		}


### PR DESCRIPTION
## Description

This PR adds functionality that adds the current input value as a new token on blur. 

`FormTokenField` was originally build with a feature that retains the input content that user wrote in the input (but doesn't add it as tag). See:

<img src="https://user-images.githubusercontent.com/156676/62255265-3cac0300-b3b1-11e9-9975-daf5c083694e.gif" width="300" />

This works great in theory but it turns out that it's super easy to move focus from the token input into the block editor and that will switch the context of the sidebar - making the tag input disappear (and forget the content next time it is opened). This is displayed in #16788 

What would be the best solution? I like an explicit confirmation of tags (enter, comma) but losing the content is very easy and maybe something we should try to prevent.

I remember working on this component previously and we've had long discussion about the label "Separate with commas or the Enter key." which leaves one situation open to interpretation: "if I'm only adding a single token, I don't need any separator". Adding the token on blur would solve that problem too.

Fixes #16788

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
