### PR TITLE
Fixed typo

### DIFF
--- a/docs/designers-developers/developers/slotfills/plugin-more-menu-item.md
+++ b/docs/designers-developers/developers/slotfills/plugin-more-menu-item.md
@@ -6,7 +6,7 @@ This slot will add a new item to the More Tools & Options section.
 
 ```js
 const { registerPlugin } = wp.plugins;
-const { PluginMoreMenuItem,} = wp.editPost;
+const { PluginMoreMenuItem } = wp.editPost;
 
 const MyButtonMoreMenuItemTest = () => (
 	<PluginMoreMenuItem


### PR DESCRIPTION
Fixes #16809 

Removes unnecessary comma after 'PluginMoreyMenuItem'.
