### PR TITLE
Fix paste after focus

### DIFF
--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -303,7 +303,7 @@ class RichText extends Component {
 
 		// Update selection as soon as possible, which is at the next animation
 		// frame. The event listener for selection changes may be added too late
-		// at this point, but this focus event is still too early to calcutate
+		// at this point, but this focus event is still too early to calculate
 		// the selection.
 		this.rafId = window.requestAnimationFrame( this.onSelectionChange );
 

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -132,6 +132,7 @@ class RichText extends Component {
 
 	componentWillUnmount() {
 		document.removeEventListener( 'selectionchange', this.onSelectionChange );
+		window.cancelAnimationFrame( this.rafId );
 	}
 
 	setRef( node ) {
@@ -287,7 +288,7 @@ class RichText extends Component {
 		this.recalculateBoundaryStyle();
 
 		// We know for certain that on focus, the old selection is invalid. It
-		// will be recalculated on `selectionchange`.
+		// will be recalculated on the next animation frame.
 		const index = undefined;
 		const activeFormats = undefined;
 
@@ -299,6 +300,12 @@ class RichText extends Component {
 		};
 		this.props.onSelectionChange( index, index );
 		this.setState( { activeFormats } );
+
+		// Update selection as soon as possible, which is at the next animation
+		// frame. The event listener for selection changes may be added too late
+		// at this point, but this focus event is still too early to calcutate
+		// the selection.
+		this.rafId = window.requestAnimationFrame( this.onSelectionChange );
 
 		document.addEventListener( 'selectionchange', this.onSelectionChange );
 	}


### PR DESCRIPTION
## Description

Fixes #15724.

This is a small fix for the bug that duplicates the rich text contents after pasting in a rich text instance that just received focus.

## How has this been tested?

Copy a small amount of text.
Open the Gutenberg demo content.
Place the caret at the end of the first paragraph.
Move selection out of the window: e.g. place the caret in the address bar.
Place the caret again at the end of the first paragraph.
Now paste the text.
No content should be duplicated.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->