### PR TITLE
Revise margins for notices in the notice list

### DIFF
--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -65,7 +65,7 @@
 	z-index: z-index(".components-notice-list");
 
 	.components-notice__content {
-		margin-top: $grid-size;
-		margin-bottom: $grid-size;
+		margin-top: 1em;
+		margin-bottom: 1em;
 	}
 }


### PR DESCRIPTION
Looks like #16589 may have introduced a slight regression in the size/alignment of content inside of Notices that appear at the top of the screen. The notices appear too short, and the close button is misaligned. I'm not sure why this looked fine when we merged #16589, but doesn't work now: 

<img width="953" alt="Screen Shot 2019-08-01 at 11 12 33 AM" src="https://user-images.githubusercontent.com/1202812/62305172-69adf380-b44d-11e9-80bc-05dbb1c1757e.png">

In any case, this PR switches back to using `1em` margins on the top and bottom of `.components-notice__content` to even that out: 

<img width="954" alt="Screen Shot 2019-08-01 at 11 10 23 AM" src="https://user-images.githubusercontent.com/1202812/62305266-95c97480-b44d-11e9-9b9a-615f5a67a0ae.png">

It only applies this to notices when they're inside of  `.components-notice-list`, so it should have no negative effect on notices that appear inline, elsewhere. (Thus preserving the original intent of #16589).