### PR TITLE
i18n: Align "Read more" string with WordPress Core

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -220,7 +220,7 @@ class LatestPostsEdit extends Component {
 										key="html"
 									>
 										{ excerptLength < excerpt.trim().split( ' ' ).length ?
-											excerpt.trim().split( ' ', excerptLength ).join( ' ' ) + ' ... <a href=' + post.link + 'target="_blank" rel="noopener noreferrer">' + __( 'Read More' ) + '</a>' :
+											excerpt.trim().split( ' ', excerptLength ).join( ' ' ) + ' ... <a href=' + post.link + 'target="_blank" rel="noopener noreferrer">' + __( 'Read more' ) + '</a>' :
 											excerpt.trim().split( ' ', excerptLength ).join( ' ' ) }
 									</RawHTML>
 								</div>

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -67,7 +67,7 @@ function render_block_core_latest_posts( $attributes ) {
 				$list_items_markup .= sprintf(
 					'<a href="%1$s">%2$s</a></div>',
 					esc_url( get_permalink( $post ) ),
-					__( 'Read More' )
+					__( 'Read more' )
 				);
 			} else {
 				$list_items_markup .= sprintf(


### PR DESCRIPTION
## Description
WordPress Core does not provide a translation for "Read **M**ore":
https://translate.wordpress.org/projects/wp/dev/en-gb/default/?filters%5Bterm%5D=read+more

Reference: #16665

## How has this been tested?
Tested locally

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
