### PR TITLE
DropdownMenu: Fix shifting menu items

### DIFF
--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -106,5 +106,9 @@
 		&.has-icon {
 			padding-left: 0.5rem;
 		}
+
+		.dashicon {
+			margin-right: 4px;
+		}
 	}
 }


### PR DESCRIPTION
Fix menu items in the More menu from shifting horizontally when selected. This was noticed while testing https://github.com/WordPress/gutenberg/pull/14851.

Before:

![before](https://user-images.githubusercontent.com/612155/62339281-cb8a5e00-b51e-11e9-80f2-66b83cf2dac2.gif)

After:

![after](https://user-images.githubusercontent.com/612155/62339283-cdecb800-b51e-11e9-849a-6a15422ee524.gif)

I'm not really confident that I fixed this the right way. I'm unclear to me whether the margin between the text and icon is supposed to be `4px` per `IconButton`:

https://github.com/WordPress/gutenberg/blob/5b01c97c6943890abb44b2154392ffcccef87b3e/packages/components/src/icon-button/style.scss#L25

Or if it's supposed to be `5px` per `MenuItem`:

https://github.com/WordPress/gutenberg/blob/5b01c97c6943890abb44b2154392ffcccef87b3e/packages/components/src/menu-item/style.scss#L13

 I could really use some of that @jasmussen magic right now! 🙏 