### PR TITLE
Accessibility: Fix the issue when focus is moved to the post title from More Menu

### DIFF
--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -136,7 +136,7 @@ class PostTitle extends Component {
 									right away, without needing to click anything.
 								*/
 								/* eslint-disable jsx-a11y/no-autofocus */
-								autoFocus={ isCleanNewPost }
+								autoFocus={ document.body === document.activeElement && isCleanNewPost }
 								/* eslint-enable jsx-a11y/no-autofocus */
 							/>
 						</KeyboardShortcuts>


### PR DESCRIPTION
## Description
Last bug fix which finally resolves #15501. Most of the work has been merged with #14851.

> Clicking on "Code Editor" or "Visual Editor" should not move focus to the post title.

The proposed solution checks whether the focus is currently at the body element which reflects the behavior when the post is initially loaded. This happens in addition to the check whether the post is empty.

We might also alternatively completely remove the autofocus behavior from the title `textarea` field. I'm happy to refine the logic if this is the preferred way.

## How has this been tested?

1. Open a new post.
2. Open More Menu.
3. Clicking on "Code Editor" or "Visual Editor" should not move focus to the post title.

## Screenshots <!-- if applicable -->

![title-auto-focus](https://user-images.githubusercontent.com/699132/62353114-282f4e00-b50a-11e9-930e-2cd40afa62cb.gif)


## Types of changes
Bugfix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
