### PR TITLE
Components: Stop using `react-click-outside` as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3848,7 +3848,6 @@
 				"moment": "^2.22.1",
 				"mousetrap": "^1.6.2",
 				"re-resizable": "^5.0.1",
-				"react-click-outside": "^3.0.0",
 				"react-dates": "^17.1.1",
 				"react-spring": "^8.0.20",
 				"rememo": "^3.0.0",
@@ -20730,21 +20729,6 @@
 				"autosize": "^4.0.0",
 				"line-height": "^0.3.1",
 				"prop-types": "^15.5.6"
-			}
-		},
-		"react-click-outside": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/react-click-outside/-/react-click-outside-3.0.1.tgz",
-			"integrity": "sha512-d0KWFvBt+esoZUF15rL2UBB7jkeAqLU8L/Ny35oLK6fW6mIbOv/ChD+ExF4sR9PD26kVx+9hNfD0FTIqRZEyRQ==",
-			"requires": {
-				"hoist-non-react-statics": "^2.1.1"
-			},
-			"dependencies": {
-				"hoist-non-react-statics": {
-					"version": "2.5.5",
-					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-					"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-				}
 			}
 		},
 		"react-dates": {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - The `Dropdown` component has been refactored to focus changes using the `Popover` component's `onFocusOutside` prop.
 - The `MenuItem` component will now always use an `IconButton`. This prevents a focus loss when clicking a menu item.
+- Package no longer depends on external `react-click-outside` library.
 
 ## 8.0.0 (2019-06-12)
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -42,7 +42,6 @@
 		"moment": "^2.22.1",
 		"mousetrap": "^1.6.2",
 		"re-resizable": "^5.0.1",
-		"react-click-outside": "^3.0.0",
 		"react-dates": "^17.1.1",
 		"react-spring": "^8.0.20",
 		"rememo": "^3.0.0",

--- a/packages/components/src/modal/frame.js
+++ b/packages/components/src/modal/frame.js
@@ -7,13 +7,9 @@ import { focus } from '@wordpress/dom';
 import { withGlobalEvents, compose } from '@wordpress/compose';
 
 /**
- * External dependencies
- */
-import clickOutside from 'react-click-outside';
-
-/**
  * Internal dependencies
  */
+import withFocusOutside from '../higher-order/with-focus-outside';
 import withFocusReturn from '../higher-order/with-focus-return';
 import withConstrainedTabbing from '../higher-order/with-constrained-tabbing';
 
@@ -23,7 +19,7 @@ class ModalFrame extends Component {
 
 		this.containerRef = createRef();
 		this.handleKeyDown = this.handleKeyDown.bind( this );
-		this.handleClickOutside = this.handleClickOutside.bind( this );
+		this.handleFocusOutside = this.handleFocusOutside.bind( this );
 		this.focusFirstTabbable = this.focusFirstTabbable.bind( this );
 	}
 
@@ -52,7 +48,7 @@ class ModalFrame extends Component {
 	 *
 	 * @param {Object} event Mouse click event.
 	 */
-	handleClickOutside( event ) {
+	handleFocusOutside( event ) {
 		if ( this.props.shouldCloseOnClickOutside ) {
 			this.onRequestClose( event );
 		}
@@ -133,7 +129,7 @@ class ModalFrame extends Component {
 export default compose( [
 	withFocusReturn,
 	withConstrainedTabbing,
-	clickOutside,
+	withFocusOutside,
 	withGlobalEvents( {
 		keydown: 'handleKeyDown',
 	} ),


### PR DESCRIPTION
## Description
Follow-up for #14851.

This PR addresses [my comment](https://github.com/WordPress/gutenberg/pull/14851/files#r273979181) from one of the PRs merged this week:

> Unrelated question to this PR. Can we also refactor `Modal` component to stop using `react-click-outside`?

This allows us to get rid of `react-click-outside` dependency from the repository in favor of our own HOC `withFocusOutside`.

## How has this been tested?
Open one of the modals from More Menu:
- Block Manager
- Keyboard Shortcuts
- Options

Make sure it closes when you mouse-click outside of the modal. 

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
