### PR TITLE
Block library: When pressing enter on empty line new Paragraph blocks is crated

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { omit } from 'lodash';
+import { castArray, omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -64,9 +64,10 @@ class RichTextWrapper extends Component {
 			} );
 
 			if ( transformation ) {
-				onReplace( [
+				onReplace( castArray(
 					transformation.transform( { content: value.text } ),
-				] );
+				) );
+				return;
 			}
 		}
 

--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -13,7 +13,7 @@ import {
 	AlignmentToolbar,
 } from '@wordpress/block-editor';
 
-export default function VerseEdit( { attributes, setAttributes, className, mergeBlocks } ) {
+export default function VerseEdit( { attributes, setAttributes, className, mergeBlocks, onReplace } ) {
 	const { textAlign, content } = attributes;
 
 	return (
@@ -40,6 +40,7 @@ export default function VerseEdit( { attributes, setAttributes, className, merge
 					[ `has-text-align-${ textAlign }` ]: textAlign,
 				} ) }
 				onMerge={ mergeBlocks }
+				onReplace={ onReplace }
 			/>
 		</>
 	);

--- a/packages/block-library/src/verse/tranforms.js
+++ b/packages/block-library/src/verse/tranforms.js
@@ -6,6 +6,16 @@ import { createBlock } from '@wordpress/blocks';
 const transforms = {
 	from: [
 		{
+			type: 'enter',
+			regExp: /\n$/,
+			transform: ( { content } ) => [
+				createBlock( 'core/verse', {
+					content: content.replace( /\n$/, '' ),
+				} ),
+				createBlock( 'core/paragraph' ),
+			],
+		},
+		{
 			type: 'block',
 			blocks: [ 'core/paragraph' ],
 			transform: ( attributes ) =>


### PR DESCRIPTION
## Description
This is an experiment. I have no idea if the solution is the most expected but it does what I want.

This PR mirrors the behavior of List block where pressing enter on empty line removes it and it creates new Paragraph block and moves focus there. I'd love to have it replicated for the following blocks:
- Image (caption)
- Quote (cite)
- Pullquote (cite)
- Preformatted
- Verse

This is how List block works in `master`:
![list-split-empty-line](https://user-images.githubusercontent.com/699132/62370369-36916000-b532-11e9-922c-6fd00c5b07ba.gif)



## How has this been tested?
- Add Verse block and start typing.
- Press `enter` key, a new line should be created.
- Press `enter` key again, this new line should be removed, new Paragraph block added and focus should move there.

## Screenshots <!-- if applicable -->

![verse-split-empty-line](https://user-images.githubusercontent.com/699132/62369721-d0580d80-b530-11e9-9e53-4a17a7c59bbf.gif)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
