### PR TITLE
Do not override post template innerblocks with placeholder content (#16881)

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -31,6 +31,7 @@ import {
 } from '@wordpress/block-editor';
 import { Component, createRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -96,6 +97,7 @@ class CoverEdit extends Component {
 			noticeUI,
 			overlayColor,
 			setOverlayColor,
+			innerBlockCount,
 		} = this.props;
 		const {
 			backgroundType,
@@ -297,7 +299,7 @@ class CoverEdit extends Component {
 					) }
 					<div className="wp-block-cover__inner-container">
 						<InnerBlocks
-							template={ INNER_BLOCKS_TEMPLATE }
+							template={ innerBlockCount === 0 ? INNER_BLOCKS_TEMPLATE : null }
 						/>
 					</div>
 				</div>
@@ -372,4 +374,7 @@ class CoverEdit extends Component {
 export default compose( [
 	withColors( { overlayColor: 'background-color' } ),
 	withNotices,
+	withSelect( ( select, { clientId } ) => ( {
+		innerBlockCount: select( 'core/block-editor' ).getBlockCount( clientId ),
+	} ) ),
 ] )( CoverEdit );

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -25,6 +25,9 @@ import {
 	ExternalLink,
 	FocalPointPicker,
 } from '@wordpress/components';
+import { compose } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
+
 /**
  * Internal dependencies
  */
@@ -125,6 +128,7 @@ class MediaTextEdit extends Component {
 			isSelected,
 			setAttributes,
 			setBackgroundColor,
+			innerBlockCount,
 		} = this.props;
 		const {
 			isStackedOnMobile,
@@ -232,7 +236,7 @@ class MediaTextEdit extends Component {
 				<div className={ classNames } style={ style } >
 					{ this.renderMediaArea() }
 					<InnerBlocks
-						template={ TEMPLATE }
+						template={ innerBlockCount === 0 ? TEMPLATE : null }
 						templateInsertUpdatesSelection={ false }
 					/>
 				</div>
@@ -241,4 +245,9 @@ class MediaTextEdit extends Component {
 	}
 }
 
-export default withColors( 'backgroundColor' )( MediaTextEdit );
+export default compose( [
+	withColors( 'backgroundColor' ),
+	withSelect( ( select, { clientId } ) => ( {
+		innerBlockCount: select( 'core/block-editor' ).getBlockCount( clientId ),
+	} ) ),
+] )( MediaTextEdit );


### PR DESCRIPTION
## Description

Fixed Media & Text and Cover block placeholder content overriding innerblocks defined in post type templates.

I'm quite unfamiliar with the Gutenberg codebase so I did this by looking at the Columns block for inspiration and went with a solution that checks if the block has any existing innerblocks before defining it's own template.

## How has this been tested?

I tested this by running it on the site I'm building which defines:

```
            'template_lock' => 'all',
            'template' => [
                ['core/media-text',
                    [
                        'mediaPosition' => 'right',
                        'mediaId' => 80,
                        'mediaType' => 'image',
                        'imageFill' => false,
                        'mediaUrl' => 'http://localhost/app/uploads/2019/07/thumb-1463-product-primary-desktop.png',
                        'className' => 'is-style-hero',
                        'backgroundMediaId' => 89,
                        'backgroundMediaUrl' => 'http://localhost/app/uploads/2019/07/mutti-polpa-zoom-copy.jpg',
                    ], [
                        ['core/heading', ['align' => 'right', 'level' => 1, 'placeholder' => __('Product name', 'mutti')]],
                        ['core/heading', ['align' => 'right', 'level' => 4, 'placeholder' => __('Descriptive product name', 'mutti')]],
                        ['core/paragraph', ['align' => 'right', 'placeholder' => __('A short description about the product and why it is unique.', 'mutti')]],
                    ],
                ],
```

This patch fixes the problem and still applies the placeholder content if I add a new block through the editor.

## Types of changes
Bugfix/New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
