### PR TITLE
Try moving the Modal close button over to the right

### DIFF
--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -90,6 +90,11 @@
 		line-height: 1;
 		margin: 0;
 	}
+
+	.components-icon-button {
+		position: relative;
+		left: $grid-size;
+	}
 }
 
 .components-modal__header-heading-container {


### PR DESCRIPTION
Currently, the modal close button is in right-aligned to the modal content. But because the button has no border by default, the `x` icon button appears misaligned: 

![current-default](https://user-images.githubusercontent.com/1202812/62370718-e6e67080-b500-11e9-9bc7-d446077ca508.jpg)

When hovering over the button, the borders make the intended alignment more clear: 

![current-hover](https://user-images.githubusercontent.com/1202812/62370724-ea79f780-b500-11e9-91ac-8147b2afada6.jpg)

---

This PR tries shifting the button over to the right by `8px` to offset the button padding. This properly aligns the `x` icon with the right side of the content below it: 

![new-default](https://user-images.githubusercontent.com/1202812/62370747-f5cd2300-b500-11e9-83ef-129e2ce2940d.jpg)

On hover, the borders appear, and the intentional misalignment becomes clear, but I don't think this is much of an issue. I'd rather that this appeared misaligned in the hover state than in its default state. 

![new-hover](https://user-images.githubusercontent.com/1202812/62370757-fd8cc780-b500-11e9-8f5d-d9d285b0877f.jpg)