### PR TITLE
Adds prop to enable hiding of the Block Appender within BlockList

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -205,6 +205,7 @@ class BlockList extends Component {
 			hasMultiSelection,
 			renderAppender,
 			enableAnimation,
+			showAppender = true,
 		} = this.props;
 
 		return (
@@ -237,10 +238,13 @@ class BlockList extends Component {
 					);
 				} ) }
 
-				<BlockListAppender
-					rootClientId={ rootClientId }
-					renderAppender={ renderAppender }
-				/>
+				{ showAppender && (
+
+					<BlockListAppender
+						rootClientId={ rootClientId }
+						renderAppender={ renderAppender }
+					/>
+				) }
 			</div>
 		);
 	}


### PR DESCRIPTION
It is occasionally useful to be able to hide the `BlockListAppender` component within the `BlockList` component.

An example is when rendering a preview into the `BlockPreviewContent` component. In such a case you don't want to display the appender as it is not relevant in a (non-editing) preview context.

This PR introduces a prop to allow developers to selectively enable/disable the appender.

Relates to https://github.com/WordPress/gutenberg/pull/16873

## How has this been tested?

On your local machine (only!):
* Merge this PR into https://github.com/WordPress/gutenberg/pull/16873
* Add the `showAppender` prop to the `BlockPreviewContent` component rendering of `BlockList` within `packages/block-editor/src/components/block-preview/index.js` 
* Inspect the DOM of the _preview_
* See no block appender has been rendered.
* Toggle the value of the prop to see the inverse state.

## Types of changes
New feature (non-breaking change which adds functionality).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
