### PR TITLE
Hide appender on BlockPreviews via checking for null component in BlockListAppender

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { last, isNull } from 'lodash';
+import { last } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -27,15 +27,19 @@ function BlockListAppender( {
 		return null;
 	}
 
-	// A render prop has been provided
-	// and it is not a component that return `null`
-	// then use it to render the appender.
-	if ( CustomAppender && ! isNull( CustomAppender ) ) {
+	// If a render prop has been provided
+	// use it to render the appender.
+	if ( CustomAppender ) {
 		return (
 			<div className="block-list-appender">
 				<CustomAppender />
 			</div>
 		);
+	}
+
+	// a false value means, don't render any appender.
+	if ( CustomAppender === false ) {
+		return null;
 	}
 
 	// Render the default block appender when renderAppender has not been

--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { last } from 'lodash';
+import { last, isNull } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -27,8 +27,10 @@ function BlockListAppender( {
 		return null;
 	}
 
-	// A render prop has been provided, use it to render the appender.
-	if ( CustomAppender ) {
+	// A render prop has been provided
+	// and it is not a component that return `null`
+	// then use it to render the appender.
+	if ( CustomAppender && ! isNull( CustomAppender ) ) {
 		return (
 			<div className="block-list-appender">
 				<CustomAppender />

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -43,7 +43,7 @@ export function BlockPreviewContent( { blocks, settings } ) {
 				value={ castArray( blocks ) }
 				settings={ settings }
 			>
-				<BlockList />
+				<BlockList renderAppender={ () => null } />
 			</BlockEditorProvider>
 		</Disabled>
 	);

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -43,7 +43,7 @@ export function BlockPreviewContent( { blocks, settings } ) {
 				value={ castArray( blocks ) }
 				settings={ settings }
 			>
-				<BlockList renderAppender={ () => null } />
+				<BlockList renderAppender={ false } />
 			</BlockEditorProvider>
 		</Disabled>
 	);

--- a/packages/block-editor/src/components/inner-blocks/README.md
+++ b/packages/block-editor/src/components/inner-blocks/README.md
@@ -177,8 +177,8 @@ If locking is not set in an `InnerBlocks` area: the locking of the parent `Inner
 If the block is a top level block: the locking of the Custom Post Type is used.
 
 ### `renderAppender`
-* **Type:** `Function`
-* **Default:** - `undefined`. When `renderAppender` is not specific the `<DefaultBlockAppender>` component is as a default. It automatically inserts whichever block is configured as the default block via `wp.blocks.setDefaultBlockName` (typically `paragraph`).
+* **Type:** `Function|false`
+* **Default:** - `undefined`. When `renderAppender` is not specific the `<DefaultBlockAppender>` component is as a default. It automatically inserts whichever block is configured as the default block via `wp.blocks.setDefaultBlockName` (typically `paragraph`). If a `false` value is provider, no appender is rendered.
 
 A 'render prop' function that can be used to customize the block's appender.
 


### PR DESCRIPTION
Previously if a `null` component was passed to the `BlockList` component it would still render an empty `<div className="block-list-appender">` element. This because we didn't check for `null` before rendering.

This is useful because we sometimes want to disable the rendering of the Block appender UI. For example in block previews.

Required for https://github.com/WordPress/gutenberg/pull/16873



## How has this been tested?
* Insert quote Block with content
* Switch style of Block
* Inspect the Block Preview of the Style. See no `<div className="block-list-appender">` component.



## Types of changes
* Bug fix (non-breaking change which fixes an issue) 
* New feature (non-breaking change which adds functionality)


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
