### PR TITLE
Fully disable animation style if enableAnimations is false.

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -261,7 +261,11 @@ function BlockListBlock( {
 	}, [ isFirstMultiSelected ] );
 
 	// Block Reordering animation
-	const animationStyle = useMovingAnimation( wrapper, isSelected || isPartOfMultiSelection, enableAnimation, animateOnChange );
+	// useMovingAnimation uses hooks and requires being called even with disabled animations.
+	let animationStyle = useMovingAnimation( wrapper, isSelected || isPartOfMultiSelection, enableAnimation, animateOnChange );
+
+	// Dismiss animation style if animations are disabled.
+	animationStyle = enableAnimation ? animationStyle : {};
 
 	// Focus the breadcrumb if the wrapper is focused on navigation mode.
 	// Focus the first editable or the wrapper if edit mode.

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -261,11 +261,7 @@ function BlockListBlock( {
 	}, [ isFirstMultiSelected ] );
 
 	// Block Reordering animation
-	// useMovingAnimation uses hooks and requires being called even with disabled animations.
-	let animationStyle = useMovingAnimation( wrapper, isSelected || isPartOfMultiSelection, enableAnimation, animateOnChange );
-
-	// Dismiss animation style if animations are disabled.
-	animationStyle = enableAnimation ? animationStyle : {};
+	const animationStyle = useMovingAnimation( wrapper, isSelected || isPartOfMultiSelection, enableAnimation, animateOnChange );
 
 	// Focus the breadcrumb if the wrapper is focused on navigation mode.
 	// Focus the first editable or the wrapper if edit mode.

--- a/packages/block-editor/src/components/block-list/moving-animation.js
+++ b/packages/block-editor/src/components/block-list/moving-animation.js
@@ -75,23 +75,26 @@ function useMovingAnimation( ref, isSelected, enableAnimation, triggerAnimationO
 		immediate: prefersReducedMotion,
 	} );
 
-	return {
-		transformOrigin: 'center',
-		transform: interpolate(
-			[
-				animationProps.x,
-				animationProps.y,
-			],
-			( x, y ) => x === 0 && y === 0 ? undefined : `translate3d(${ x }px,${ y }px,0)`
-		),
-		zIndex: interpolate(
-			[
-				animationProps.x,
-				animationProps.y,
-			],
-			( x, y ) => ! isSelected || ( x === 0 && y === 0 ) ? undefined : `1`
-		),
-	};
+	// Dismiss animations if disabled.
+	return prefersReducedMotion ?
+		{} :
+		{
+			transformOrigin: 'center',
+			transform: interpolate(
+				[
+					animationProps.x,
+					animationProps.y,
+				],
+				( x, y ) => x === 0 && y === 0 ? undefined : `translate3d(${ x }px,${ y }px,0)`
+			),
+			zIndex: interpolate(
+				[
+					animationProps.x,
+					animationProps.y,
+				],
+				( x, y ) => ! isSelected || ( x === 0 && y === 0 ) ? undefined : `1`
+			),
+		};
 }
 
 export default useMovingAnimation;


### PR DESCRIPTION
## Description
`useMovingAnimation` accepts `enableAnimation` as param, however, the animation styling is applied eventually to the block wrapper even if `enableAnimation` is set to `false`. With `enableAnimation` set to `false`, `transform` is set to `undefined`, also `transformOrigin` is always set.

This can potentially override existing `transform` coming from `wrapperProps.style` via a filter for example.

## How has this been tested?
Functional testing making sure that the block animations remain as they are by default.
Also tested that when setting `enableAnimations` to `false` the animation related styles are not applied.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
