### PR TITLE
Try an alternative modal style

### DIFF
--- a/assets/stylesheets/_z-index.scss
+++ b/assets/stylesheets/_z-index.scss
@@ -15,6 +15,7 @@ $z-layers: (
 	".block-editor-inserter__tabs": 1,
 	".block-editor-inserter__tab.is-active": 1,
 	".components-panel__header": 1,
+	".components-modal__header": 10,
 	".edit-post-meta-boxes-area.is-loading::before": 1,
 	".edit-post-meta-boxes-area .spinner": 5,
 	".components-popover__close": 5,

--- a/assets/stylesheets/_z-index.scss
+++ b/assets/stylesheets/_z-index.scss
@@ -15,7 +15,6 @@ $z-layers: (
 	".block-editor-inserter__tabs": 1,
 	".block-editor-inserter__tab.is-active": 1,
 	".components-panel__header": 1,
-	".components-modal__header": 10,
 	".edit-post-meta-boxes-area.is-loading::before": 1,
 	".edit-post-meta-boxes-area .spinner": 5,
 	".components-popover__close": 5,

--- a/packages/components/src/modal/header.js
+++ b/packages/components/src/modal/header.js
@@ -30,6 +30,7 @@ const ModalHeader = ( { icon, title, onClose, closeLabel, headingId, isDismissab
 			</div>
 			{ isDismissable &&
 				<IconButton
+					className="components-modal-header__close"
 					onClick={ onClose }
 					icon="no-alt"
 					label={ label }

--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -142,7 +142,7 @@ class Modal extends Component {
 					} }
 					{ ...otherProps }
 				>
-					<div className={ 'components-modal__content' } tabIndex="0">
+					<div className="components-modal__content" tabIndex="0">
 						<ModalHeader
 							closeLabel={ closeButtonLabel }
 							headingId={ headingId }

--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -118,6 +118,7 @@ class Modal extends Component {
 			aria,
 			instanceId,
 			isDismissable,
+			isDialog,
 			...otherProps
 		} = this.props;
 
@@ -128,7 +129,10 @@ class Modal extends Component {
 		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		return createPortal(
 			<IsolatedEventContainer
-				className={ classnames( 'components-modal__screen-overlay', overlayClassName ) }
+				className={ classnames( 'components-modal__screen-overlay', overlayClassName, {
+					'is-dialog': isDialog,
+					'is-full-screen': ! isDialog,
+				} ) }
 			>
 				<ModalFrame
 					className={ classnames(

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -5,53 +5,32 @@
 	right: 0;
 	bottom: 0;
 	left: 0;
-	background-color: rgba($black, 0.7);
+	padding: 100px;
+	background: $white;
 	z-index: z-index(".components-modal__screen-overlay");
-
-	// This animates the appearance of the white background.
-	@include edit-post__fade-in-animation();
+	overflow: auto;
 }
 
 // The modal window element.
 .components-modal__frame {
-	// On small screens the content needs to be full width because of limited
-	// space.
-	position: absolute;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0;
-	box-sizing: border-box;
-	margin: 0;
-	border: $border-width solid $light-gray-500;
-	background: $white;
-	box-shadow: $shadow-modal;
-	overflow: auto;
+	max-width: 800px;
+	margin: auto;
 
-	// Show a centered modal on bigger screens.
+	// Animate the modal on bigger screens
 	@include break-small() {
-		top: 50%;
-		right: auto;
-		bottom: auto;
-		left: 50%;
-		min-width: $modal-min-width;
-		max-width: calc(100% - #{ $grid-size-large } - #{ $grid-size-large });
-		max-height: calc(100% - #{ $header-height } - #{ $header-height });
-		transform: translate(-50%, -50%);
-
 		// Animate the modal frame/contents appearing on the page.
-		animation: components-modal__appear-animation 0.1s ease-out;
-		animation-fill-mode: forwards;
+		transform-origin: top center;
+		animation: components-modal__appear-animation 0.2s forwards;
 		@include reduce-motion("animation");
 	}
 }
 
 @keyframes components-modal__appear-animation {
-	from {
-		margin-top: $grid-size * 4;
+	0% {
+		transform: scale(0.1);
 	}
-	to {
-		margin-top: 0;
+	100% {
+		transform: scale(1);
 	}
 }
 
@@ -60,30 +39,17 @@
 // modal screen).
 .components-modal__header {
 	box-sizing: border-box;
-	border-bottom: $border-width solid $light-gray-500;
-	padding: 0 $grid-size-xlarge;
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
 	background: $white;
 	align-items: center;
 	height: $header-height;
-	position: sticky;
-	top: 0;
-	z-index: z-index(".components-modal__header");
-	margin: 0 -#{$grid-size-xlarge} $grid-size-xlarge;
-
-	// Rules inside this query are only run by Microsoft Edge.
-	// Edge has bugs around position: sticky;, so it needs a separate top rule.
-	// See also https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/17555420/.
-	@supports (-ms-ime-align:auto) {
-		position: fixed;
-		width: 100%;
-	}
+	margin-bottom: 2 * $grid-size-xlarge;
 
 	.components-modal__header-heading {
-		font-size: 1rem;
-		font-weight: 600;
+		font-size: 2rem;
+		font-weight: 300;
 	}
 
 	h1 {
@@ -113,12 +79,5 @@
 // Modal contents.
 .components-modal__content {
 	box-sizing: border-box;
-	height: 100%;
 	padding: 0 $grid-size-xlarge $grid-size-xlarge;
-
-	// Rules inside this query are only run by Microsoft Edge.
-	// This is a companion top padding to the fixed rule in line 77.
-	@supports (-ms-ime-align:auto) {
-		padding-top: $header-height;
-	}
 }

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -15,10 +15,22 @@
 	}
 }
 
+// These are two divs rendered by Higher-order components
+// We need their height to be 100% for the verticalcentering
+// of the modal.
+.components-modal__screen-overlay > div,
+.components-modal__screen-overlay > div > div {
+	height: 100%;
+}
+
 // The modal window element.
 .components-modal__frame {
 	max-width: 800px;
+	min-height: 100%;
 	margin: auto;
+	display: grid;
+	align-items: center;
+
 	// Animate the modal frame/contents appearing on the page.
 	transform-origin: top center;
 	animation: components-modal__appear-animation 0.2s forwards;

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -5,24 +5,24 @@
 	right: 0;
 	bottom: 0;
 	left: 0;
-	padding: 100px;
+	padding: 20px;
 	background: $white;
 	z-index: z-index(".components-modal__screen-overlay");
 	overflow: auto;
+
+	@include break-small() {
+		padding: 100px;
+	}
 }
 
 // The modal window element.
 .components-modal__frame {
 	max-width: 800px;
 	margin: auto;
-
-	// Animate the modal on bigger screens
-	@include break-small() {
-		// Animate the modal frame/contents appearing on the page.
-		transform-origin: top center;
-		animation: components-modal__appear-animation 0.2s forwards;
-		@include reduce-motion("animation");
-	}
+	// Animate the modal frame/contents appearing on the page.
+	transform-origin: top center;
+	animation: components-modal__appear-animation 0.2s forwards;
+	@include reduce-motion("animation");
 }
 
 @keyframes components-modal__appear-animation {

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -5,26 +5,36 @@
 	right: 0;
 	bottom: 0;
 	left: 0;
-	padding: 20px;
-	background: $white;
 	z-index: z-index(".components-modal__screen-overlay");
-	overflow: auto;
 
-	@include break-small() {
-		padding: 100px;
+	&.is-full-screen {
+		padding: 20px;
+		background: $white;
+		overflow: auto;
+
+		@include break-small() {
+			padding: 100px;
+		}
+
+		// These are two divs rendered by Higher-order components
+		// We need their height to be 100% for the verticalcentering
+		// of the modal.
+		& > div,
+		& > div > div {
+			height: 100%;
+		}
+	}
+
+	&.is-dialog {
+		// This animates the appearance of the background.
+		@include edit-post__fade-in-animation();
+
+		background-color: rgba($black, 0.7);
 	}
 }
 
-// These are two divs rendered by Higher-order components
-// We need their height to be 100% for the verticalcentering
-// of the modal.
-.components-modal__screen-overlay > div,
-.components-modal__screen-overlay > div > div {
-	height: 100%;
-}
-
 // The modal window element.
-.components-modal__frame {
+.components-modal__screen-overlay.is-full-screen .components-modal__frame {
 	max-width: 800px;
 	min-height: 100%;
 	margin: auto;
@@ -33,16 +43,39 @@
 
 	// Animate the modal frame/contents appearing on the page.
 	transform-origin: top center;
-	animation: components-modal__appear-animation 0.2s forwards;
+	animation: components-modal__appear-scale-animation 0.2s forwards;
 	@include reduce-motion("animation");
 }
 
-@keyframes components-modal__appear-animation {
-	0% {
-		transform: scale(0.1);
-	}
-	100% {
-		transform: scale(1);
+.components-modal__screen-overlay.is-dialog .components-modal__frame {
+	// On small screens the content needs to be full width because of limited
+	// space.
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	box-sizing: border-box;
+	margin: 0;
+	border: $border-width solid $light-gray-500;
+	background: $white;
+	box-shadow: $shadow-modal;
+	overflow: auto;
+
+	// Show a centered modal on bigger screens.
+	@include break-small() {
+		top: 50%;
+		right: auto;
+		bottom: auto;
+		left: 50%;
+		min-width: $modal-min-width;
+		max-width: calc(100% - #{ $grid-size-large } - #{ $grid-size-large });
+		max-height: calc(100% - #{ $header-height } - #{ $header-height });
+		transform: translate(-50%, -50%);
+		// Animate the modal frame/contents appearing on the page.
+		animation: components-modal__appear-slide-animation 0.1s ease-out;
+		animation-fill-mode: forwards;
+		@include reduce-motion("animation");
 	}
 }
 
@@ -59,15 +92,38 @@
 	height: $header-height;
 	margin-bottom: 2 * $grid-size-xlarge;
 
-	.components-modal__header-heading {
-		font-size: 2rem;
-		font-weight: 300;
+	.components-modal__screen-overlay.is-dialog & {
+		border-bottom: $border-width solid $light-gray-500;
+		padding: 0 $grid-size-xlarge;
+
+		position: sticky;
+		top: 0;
+		z-index: z-index(".components-modal__header");
+		margin: 0 -#{$grid-size-xlarge} $grid-size-xlarge;
+
+		// Rules inside this query are only run by Microsoft Edge.
+		// Edge has bugs around position: sticky;, so it needs a separate top rule.
+		// See also https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/17555420/.
+		@supports (-ms-ime-align:auto) {
+			position: fixed;
+			width: 100%;
+		}
 	}
 
 	h1 {
 		line-height: 1;
 		margin: 0;
 	}
+}
+
+.components-modal__screen-overlay.is-dialog .components-modal__header-heading {
+	font-size: 1rem;
+	font-weight: 600;
+}
+
+.components-modal__screen-overlay.is-full-screen .components-modal__header-heading {
+	font-size: 2rem;
+	font-weight: 300;
 }
 
 .components-modal__header-heading-container {
@@ -92,4 +148,36 @@
 .components-modal__content {
 	box-sizing: border-box;
 	padding: 0 $grid-size-xlarge $grid-size-xlarge;
+
+	.components-modal__screen-overlay.is-dialog & {
+		height: 100%;
+
+		// Rules inside this query are only run by Microsoft Edge.
+		// This is a companion top padding to the fixed rule in line 77.
+		@supports (-ms-ime-align:auto) {
+			padding-top: $header-height;
+		}
+	}
+}
+
+.components-modal__screen-overlay.is-full-screen .components-modal-header__close svg {
+	transform: scale(1.5);
+}
+
+@keyframes components-modal__appear-scale-animation {
+	from {
+		transform: scale(0.1);
+	}
+	to {
+		transform: scale(1);
+	}
+}
+
+@keyframes components-modal__appear-slide-animation {
+	from {
+		margin-top: $grid-size * 4;
+	}
+	to {
+		margin-top: 0;
+	}
 }

--- a/packages/edit-post/src/components/keyboard-shortcut-help-modal/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcut-help-modal/index.js
@@ -88,6 +88,7 @@ export function KeyboardShortcutHelpModal( { isModalActive, toggleModal } ) {
 					title={ __( 'Keyboard Shortcuts' ) }
 					closeLabel={ __( 'Close' ) }
 					onRequestClose={ toggleModal }
+					isDialog
 				>
 					{ shortcutConfig.map( ( config, index ) => (
 						<ShortcutSection key={ index } { ...config } />


### PR DESCRIPTION
This is basically a design change to modals. I've been using several websites that rely on full-screen modals and I believe it's a better design because when a modal is opened, the user should only focus on that modal, there's no point of having a dark overlay to hide the remaining part of the screen.

It also matches the a11y behavior pretty well since when a modal is opened, the remaining part of the screen is disabled entirely

**Testing instructions**

  - Try opening the block manager, the options or the keyboard shortcuts modals.