### PR TITLE
Show block anchor attribute in Block Navigation

### DIFF
--- a/packages/block-editor/src/components/block-navigation/index.js
+++ b/packages/block-editor/src/components/block-navigation/index.js
@@ -46,6 +46,7 @@ function BlockNavigationList( {
 							>
 								<BlockIcon icon={ blockType.icon } showColors />
 								{ blockType.title }
+								{ block.attributes.anchor && <span className="block-editor-block-navigation__item-anchor-name">{ block.attributes.anchor }</span> }
 								{ isSelected && <span className="screen-reader-text">{ __( '(selected block)' ) }</span> }
 							</Button>
 						</div>

--- a/packages/block-editor/src/components/block-navigation/index.js
+++ b/packages/block-editor/src/components/block-navigation/index.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
  */
 import { withSelect, withDispatch } from '@wordpress/data';
 import { Button, NavigableMenu } from '@wordpress/components';
-import { getBlockType } from '@wordpress/blocks';
+import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 
@@ -34,6 +34,7 @@ function BlockNavigationList( {
 			{ map( blocks, ( block ) => {
 				const blockType = getBlockType( block.name );
 				const isSelected = block.clientId === selectedBlockClientId;
+				const hasAnchor = hasBlockSupport( block.name, 'anchor' );
 
 				return (
 					<li key={ block.clientId }>
@@ -46,7 +47,7 @@ function BlockNavigationList( {
 							>
 								<BlockIcon icon={ blockType.icon } showColors />
 								{ blockType.title }
-								{ block.attributes.anchor && <span className="block-editor-block-navigation__item-anchor-name">{ block.attributes.anchor }</span> }
+								{ hasAnchor && <span className="block-editor-block-navigation__item-anchor-name">{ block.attributes.anchor }</span> }
 								{ isSelected && <span className="screen-reader-text">{ __( '(selected block)' ) }</span> }
 							</Button>
 						</div>

--- a/packages/block-editor/src/components/block-navigation/index.js
+++ b/packages/block-editor/src/components/block-navigation/index.js
@@ -47,7 +47,11 @@ function BlockNavigationList( {
 							>
 								<BlockIcon icon={ blockType.icon } showColors />
 								{ blockType.title }
-								{ hasAnchor && <span className="block-editor-block-navigation__item-anchor-name">{ block.attributes.anchor }</span> }
+								{
+									hasAnchor &&
+									block.attributes.anchor &&
+									<span className="block-editor-block-navigation__item-anchor-name">{ block.attributes.anchor }</span>
+								}
 								{ isSelected && <span className="screen-reader-text">{ __( '(selected block)' ) }</span> }
 							</Button>
 						</div>

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -72,6 +72,7 @@ $tree-item-height: 36px;
 	}
 
 	& > .block-editor-block-navigation__item-anchor-name {
+		color: $blue-medium-600;
 		margin-left: auto;
 		font-style: italic;
 		white-space: nowrap;

--- a/packages/block-editor/src/components/block-navigation/style.scss
+++ b/packages/block-editor/src/components/block-navigation/style.scss
@@ -71,6 +71,20 @@ $tree-item-height: 36px;
 		margin-right: 6px;
 	}
 
+	& > .block-editor-block-navigation__item-anchor-name {
+		margin-left: auto;
+		font-style: italic;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: 8em;
+		padding-right: 6px;
+
+		&::before {
+			content: "#";
+		}
+	}
+
 	&:hover:not(:disabled):not([aria-disabled="true"]) {
 		@include menu-style__hover;
 	}


### PR DESCRIPTION
## Description
Added showing the block anchor ID in the block navigation.

Long anchor IDs is a potential issue that's up for discussion. At the moment I've hidden the overflow.

Fixes #16307.

## How has this been tested?
Developed and tested within the provided dockerized Wordpress.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/16200219/62795177-ade06a00-bac5-11e9-9a38-08f704f70b11.png)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
