### PR TITLE
Extensibility: Add possibility to disable document settings panels registered by plugins

### DIFF
--- a/packages/edit-post/src/components/options-modal/index.js
+++ b/packages/edit-post/src/components/options-modal/index.js
@@ -23,6 +23,7 @@ import {
  */
 import Section from './section';
 import {
+	EnablePluginDocumentSettingPanelOption,
 	EnablePublishSidebarOption,
 	EnableTipsOption,
 	EnablePanelOption,
@@ -48,6 +49,7 @@ export function OptionsModal( { isModalActive, isViewable, closeModal } ) {
 				<EnableTipsOption label={ __( 'Enable Tips' ) } />
 			</Section>
 			<Section title={ __( 'Document Panels' ) }>
+				<EnablePluginDocumentSettingPanelOption.Slot />
 				{ isViewable && (
 					<EnablePanelOption label={ __( 'Permalink' ) } panelName="post-link" />
 				) }

--- a/packages/edit-post/src/components/options-modal/options/enable-plugin-document-setting-panel.js
+++ b/packages/edit-post/src/components/options-modal/options/enable-plugin-document-setting-panel.js
@@ -1,0 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import { createSlotFill } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { EnablePanelOption } from './index';
+
+const { Fill, Slot } = createSlotFill( 'EnablePluginDocumentSettingPanelOption' );
+
+const EnablePluginDocumentSettingPanelOption = ( { label, panelName } ) => (
+	<Fill>
+		<EnablePanelOption
+			label={ label }
+			panelName={ panelName }
+		/>
+	</Fill>
+);
+
+EnablePluginDocumentSettingPanelOption.Slot = Slot;
+
+export default EnablePluginDocumentSettingPanelOption;

--- a/packages/edit-post/src/components/options-modal/options/index.js
+++ b/packages/edit-post/src/components/options-modal/options/index.js
@@ -1,4 +1,5 @@
 export { default as EnableCustomFieldsOption } from './enable-custom-fields';
 export { default as EnablePanelOption } from './enable-panel';
+export { default as EnablePluginDocumentSettingPanelOption } from './enable-plugin-document-setting-panel';
 export { default as EnablePublishSidebarOption } from './enable-publish-sidebar';
 export { default as EnableTipsOption } from './enable-tips';

--- a/packages/edit-post/src/components/options-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/options-modal/test/__snapshots__/index.js.snap
@@ -19,6 +19,7 @@ exports[`OptionsModal should match snapshot when the modal is active 1`] = `
   <Section
     title="Document Panels"
   >
+    <EnablePluginDocumentSettingPanelOptionSlot />
     <WithSelect(PostTaxonomies)
       taxonomyWrapper={[Function]}
     />

--- a/packages/edit-post/src/components/sidebar/plugin-document-setting-panel/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-document-setting-panel/index.js
@@ -10,24 +10,34 @@ import { compose } from '@wordpress/compose';
 import { withPluginContext } from '@wordpress/plugins';
 import { withDispatch, withSelect } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import { EnablePluginDocumentSettingPanelOption } from '../../options-modal/options';
+
 export const { Fill, Slot } = createSlotFill( 'PluginDocumentSettingPanel' );
 
-const PluginDocumentSettingFill = ( { isEnabled, opened, onToggle, className, title, icon, children } ) => {
-	if ( ! isEnabled ) {
-		return null;
-	}
+const PluginDocumentSettingFill = ( { isEnabled, panelName, opened, onToggle, className, title, icon, children } ) => {
 	return (
-		<Fill>
-			<PanelBody
-				className={ className }
-				title={ title }
-				icon={ icon }
-				opened={ opened }
-				onToggle={ onToggle }
-			>
-				{ children }
-			</PanelBody>
-		</Fill>
+		<>
+			<EnablePluginDocumentSettingPanelOption
+				label={ title }
+				panelName={ panelName }
+			/>
+			<Fill>
+				{ isEnabled && (
+					<PanelBody
+						className={ className }
+						title={ title }
+						icon={ icon }
+						opened={ opened }
+						onToggle={ onToggle }
+					>
+						{ children }
+					</PanelBody>
+				) }
+			</Fill>
+		</>
 	);
 };
 
@@ -104,4 +114,5 @@ const PluginDocumentSettingPanel = compose(
 )( PluginDocumentSettingFill );
 
 PluginDocumentSettingPanel.Slot = Slot;
+
 export default PluginDocumentSettingPanel;


### PR DESCRIPTION
## Description
Follow up for #13361. It addresses my own comment https://github.com/WordPress/gutenberg/pull/13361#pullrequestreview-250394347:

> There is also a separate issue which we need to consider in the follow-up - how to expose those registered panels in the Options modal:
> 
> ![Screen Shot 2019-06-17 at 12 02 08](https://user-images.githubusercontent.com/699132/59596336-cc466c80-90f7-11e9-9cd4-818a906ffd1c.png)

This PR introduces internal SlotFill pair to offer a way for users to disable/enable registered Document settings panels by plugins. 

## How has this been tested?

Register a custom document setting panel in the sidebar with the following snippet:

```js
( function() {
	var el = wp.element.createElement;
	var __ = wp.i18n.__;
	var registerPlugin = wp.plugins.registerPlugin;
	var PluginDocumentSettingPanel = wp.editPost.PluginDocumentSettingPanel;

	function MyDocumentSettingPlugin() {
		return el(
			PluginDocumentSettingPanel,
			{
				className: 'my-document-setting-plugin',
				title: 'My Custom Panel 1'
			},
			__( 'My Document Setting Panel 1' )
		);
	}

	registerPlugin( 'my-document-setting-plugin-1', {
		render: MyDocumentSettingPlugin
	} );
} )();
```

In my tests, I registered multiple panels to ensure that it's possible to enable/disable them and everything is rendered in the same order in both the sidebar for Document setting and in the Options modal.

## Screenshots <!-- if applicable -->

![Screen Shot 2019-08-05 at 09 47 05](https://user-images.githubusercontent.com/699132/62447584-00d4bd00-b766-11e9-9eaf-99420556443f.png)

![options-modal](https://user-images.githubusercontent.com/699132/62447816-8a848a80-b766-11e9-82e5-3aef4cfa9185.gif)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
