### PR TITLE
ESLint plugin: Enable `wp` global by default in the `recommended` config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,9 @@ module.exports = {
 		'plugin:@wordpress/eslint-plugin/recommended',
 		'plugin:jest/recommended',
 	],
+	globals: {
+		wp: 'off',
+	},
 	rules: {
 		'@wordpress/react-no-unsafe-timeout': 'error',
 		'no-restricted-syntax': [
@@ -112,9 +115,9 @@ module.exports = {
 				browser: true,
 			},
 			globals: {
-				browser: true,
-				page: true,
-				wp: true,
+				browser: 'readonly',
+				page: 'readonly',
+				wp: 'readonly',
 			},
 		},
 	],

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### New Features
 
 - New Rule: [`@wordpress/no-unguarded-get-range-at`](https://github.com/WordPress/gutenberg/blob/master/packages/eslint-plugin/docs/rules/no-unguarded-get-range-at.md)
+- Enable `wp` global by default in the `recommended` config.
 
 ## 2.4.0 (2019-08-05)
 

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -13,5 +13,6 @@ module.exports = {
 	globals: {
 		window: true,
 		document: true,
+		wp: 'readonly',
 	},
 };


### PR DESCRIPTION
## Description

Related PR where I encountered this issue: https://github.com/WordPress/gutenberg-examples/pull/83.

It's perfectly fine to use `wp` globals when developing plugins as presented below:

```js
/* global wp */
const { __ } = wp.i18n;
const { registerBlockType } = wp.blocks;
```

However, the recommended ESLing config considers this as an error so the only way to make it happy is to silence it. This PR tries to fix this issue which is extremely inconvenient for those using `@wordpress/scripts` with the default configuration.

In Gutenberg, it's still something that we want to avoid, so I updated the local config accordingly.

## How has this been tested?
`npm run lint-js` should error when `wp` global is used in Gutenberg.

You can add `const { registerBlockType } = wp.blocks;` anywhere in the source code to validate it.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
