### PR TITLE
RichText 🧹 (clean up, move Autocomplete, remove DOM dependency)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5167,7 +5167,6 @@
 				"@babel/runtime": "^7.4.4",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/data": "file:packages/data",
-				"@wordpress/dom": "file:packages/dom",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/escape-html": "file:packages/escape-html",
 				"@wordpress/hooks": "file:packages/hooks",

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -350,7 +350,7 @@ class RichTextWrapper extends Component {
 			) );
 		}
 
-		return (
+		const content = (
 			<RichText
 				{ ...experimentalProps }
 				value={ adjustedValue }
@@ -359,7 +359,6 @@ class RichTextWrapper extends Component {
 				selectionEnd={ selectionEnd }
 				onSelectionChange={ onSelectionChange }
 				tagName={ tagName }
-				wrapperClassName={ classnames( wrapperClasses, wrapperClassName ) }
 				className={ classnames( classes, className, { 'is-selected': originalIsSelected } ) }
 				placeholder={ placeholder }
 				allowedFormats={ adjustedAllowedFormats }
@@ -404,6 +403,12 @@ class RichTextWrapper extends Component {
 					</>
 				}
 			</RichText>
+		);
+
+		return (
+			<div className={ classnames( wrapperClasses, wrapperClassName ) }>
+				{ content }
+			</div>
 		);
 	}
 }

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -100,7 +100,7 @@ class RichTextWrapper extends Component {
 		}
 	}
 
-	onDelete( { isEmpty: isValueEmpty, isReverse } ) {
+	onDelete( { isReverse, value } ) {
 		const { onMerge, onRemove } = this.props;
 
 		if ( onMerge ) {
@@ -111,7 +111,7 @@ class RichTextWrapper extends Component {
 		// an intentional user interaction distinguishing between Backspace and
 		// Delete to remove the empty field, but also to avoid merge & remove
 		// causing destruction of two fields (merge, then removed merged).
-		if ( onRemove && isValueEmpty && isReverse ) {
+		if ( onRemove && ! isEmpty( value ) && isReverse ) {
 			onRemove( ! isReverse );
 		}
 	}
@@ -467,20 +467,18 @@ const RichTextContainer = compose( [
 ] )( RichTextWrapper );
 
 RichTextContainer.Content = ( { value, tagName: Tag, multiline, ...props } ) => {
-	let html = value;
-
 	// Handle deprecated `children` and `node` sources.
 	if ( Array.isArray( value ) ) {
-		html = children.toHTML( value );
+		value = children.toHTML( value );
 	}
 
 	const MultilineTag = getMultilineTag( multiline );
 
-	if ( ! html && MultilineTag ) {
-		html = `<${ MultilineTag }></${ MultilineTag }>`;
+	if ( ! value && MultilineTag ) {
+		value = `<${ MultilineTag }></${ MultilineTag }>`;
 	}
 
-	const content = <RawHTML>{ html }</RawHTML>;
+	const content = <RawHTML>{ value }</RawHTML>;
 
 	if ( Tag ) {
 		return <Tag { ...omit( props, [ 'format' ] ) }>{ content }</Tag>;
@@ -489,13 +487,8 @@ RichTextContainer.Content = ( { value, tagName: Tag, multiline, ...props } ) => 
 	return content;
 };
 
-RichTextContainer.isEmpty = ( value = '' ) => {
-	// Handle deprecated `children` and `node` sources.
-	if ( Array.isArray( value ) ) {
-		return ! value || value.length === 0;
-	}
-
-	return value.length === 0;
+RichTextContainer.isEmpty = ( value ) => {
+	return ! value || value.length === 0;
 };
 
 RichTextContainer.Content.defaultProps = {

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -42,6 +42,21 @@ import { RemoveBrowserShortcuts } from './remove-browser-shortcuts';
 const wrapperClasses = 'editor-rich-text block-editor-rich-text';
 const classes = 'editor-rich-text__editable block-editor-rich-text__editable';
 
+/**
+ * Get the multiline tag based on the multiline prop.
+ *
+ * @param {?(string|boolean)} multiline The multiline prop.
+ *
+ * @return {?string} The multiline tag.
+ */
+function getMultilineTag( multiline ) {
+	if ( multiline !== true && multiline !== 'p' && multiline !== 'li' ) {
+		return;
+	}
+
+	return multiline === true ? 'p' : multiline;
+}
+
 class RichTextWrapper extends Component {
 	constructor() {
 		super( ...arguments );
@@ -85,7 +100,7 @@ class RichTextWrapper extends Component {
 		}
 	}
 
-	onDelete( { value, isReverse } ) {
+	onDelete( { isEmpty: isValueEmpty, isReverse } ) {
 		const { onMerge, onRemove } = this.props;
 
 		if ( onMerge ) {
@@ -96,13 +111,19 @@ class RichTextWrapper extends Component {
 		// an intentional user interaction distinguishing between Backspace and
 		// Delete to remove the empty field, but also to avoid merge & remove
 		// causing destruction of two fields (merge, then removed merged).
-		if ( onRemove && isEmpty( value ) && isReverse ) {
+		if ( onRemove && isValueEmpty && isReverse ) {
 			onRemove( ! isReverse );
 		}
 	}
 
 	onPaste( { value, onChange, html, plainText, image } ) {
-		const { onReplace, onSplit, tagName, canUserUseUnfilteredHTML } = this.props;
+		const {
+			onReplace,
+			onSplit,
+			tagName,
+			canUserUseUnfilteredHTML,
+			multiline,
+		} = this.props;
 
 		if ( image && ! html ) {
 			const file = image.getAsFile ? image.getAsFile() : image;
@@ -149,7 +170,7 @@ class RichTextWrapper extends Component {
 
 			// If the content should be multiline, we should process text
 			// separated by a line break as separate lines.
-			if ( this.multilineTag ) {
+			if ( multiline ) {
 				valueToInsert = replace( valueToInsert, /\n+/g, LINE_SEPARATOR );
 			}
 
@@ -187,6 +208,7 @@ class RichTextWrapper extends Component {
 		const blocks = [];
 		const [ before, after ] = split( record );
 		const hasPastedBlocks = pastedBlocks.length > 0;
+		const multilineTag = getMultilineTag( multiline );
 
 		// Create a block with the content before the caret if there's no pasted
 		// blocks, or if there are pasted blocks and the value is not empty.
@@ -195,7 +217,7 @@ class RichTextWrapper extends Component {
 		if ( ! hasPastedBlocks || ! isEmpty( before ) ) {
 			blocks.push( onSplit( toHTMLString( {
 				value: before,
-				multilineTag: multiline,
+				multilineTag,
 			} ) ) );
 		}
 
@@ -212,7 +234,7 @@ class RichTextWrapper extends Component {
 		if ( hasPastedBlocks || ! onSplitMiddle || ! isEmpty( after ) ) {
 			blocks.push( onSplit( toHTMLString( {
 				value: after,
-				multilineTag: multiline,
+				multilineTag,
 			} ) ) );
 		}
 
@@ -313,6 +335,7 @@ class RichTextWrapper extends Component {
 			// From experimental filter. To do: pick props instead.
 			...experimentalProps
 		} = this.props;
+		const multilineTag = getMultilineTag( multiline );
 
 		const adjustedAllowedFormats = this.getAllowedFormats();
 		const hasFormats = ! adjustedAllowedFormats || adjustedAllowedFormats.length > 0;
@@ -349,7 +372,7 @@ class RichTextWrapper extends Component {
 				__unstableAutocomplete={ Autocomplete }
 				__unstableAutocompleters={ autocompleters }
 				__unstableOnReplace={ onReplace }
-				__unstableMultiline={ multiline }
+				__unstableMultilineTag={ multilineTag }
 				__unstableIsCaretWithinFormattedText={ isCaretWithinFormattedText }
 				__unstableOnEnterFormattedText={ onEnterFormattedText }
 				__unstableOnExitFormattedText={ onExitFormattedText }
@@ -357,7 +380,7 @@ class RichTextWrapper extends Component {
 			>
 				{ ( { isSelected, value, onChange } ) =>
 					<>
-						{ isSelected && multiline === 'li' && (
+						{ isSelected && multilineTag === 'li' && (
 							<ListEdit
 								onTagNameChange={ onTagNameChange }
 								tagName={ tagName }
@@ -445,16 +468,13 @@ const RichTextContainer = compose( [
 
 RichTextContainer.Content = ( { value, tagName: Tag, multiline, ...props } ) => {
 	let html = value;
-	let MultilineTag;
-
-	if ( multiline === true || multiline === 'p' || multiline === 'li' ) {
-		MultilineTag = multiline === true ? 'p' : multiline;
-	}
 
 	// Handle deprecated `children` and `node` sources.
 	if ( Array.isArray( value ) ) {
 		html = children.toHTML( value );
 	}
+
+	const MultilineTag = getMultilineTag( multiline );
 
 	if ( ! html && MultilineTag ) {
 		html = `<${ MultilineTag }></${ MultilineTag }>`;

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -111,7 +111,7 @@ class RichTextWrapper extends Component {
 		// an intentional user interaction distinguishing between Backspace and
 		// Delete to remove the empty field, but also to avoid merge & remove
 		// causing destruction of two fields (merge, then removed merged).
-		if ( onRemove && ! isEmpty( value ) && isReverse ) {
+		if ( onRemove && isEmpty( value ) && isReverse ) {
 			onRemove( ! isReverse );
 		}
 	}

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -374,7 +374,7 @@ class RichTextWrapper extends Component {
 				__unstableOnExitFormattedText={ onExitFormattedText }
 				__unstableOnCreateUndoLevel={ onCreateUndoLevel }
 			>
-				{ ( { isSelected, value, onChange, children } ) =>
+				{ ( { isSelected, value, onChange, Editable } ) =>
 					<>
 						{ isSelected && multilineTag === 'li' && (
 							<ListEdit
@@ -404,11 +404,11 @@ class RichTextWrapper extends Component {
 							onChange={ onChange }
 						>
 							{ ( { listBoxId, activeId } ) =>
-								children( {
-									'aria-autocomplete': listBoxId ? 'list' : undefined,
-									'aria-owns': listBoxId,
-									'aria-activedescendant': activeId,
-								} )
+								<Editable
+									aria-autocomplete={ listBoxId ? 'list' : undefined }
+									aria-owns={ listBoxId }
+									aria-activedescendant={ activeId }
+								/>
 							}
 						</Autocomplete>
 					</>

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -100,7 +100,7 @@ class RichTextWrapper extends Component {
 		}
 	}
 
-	onDelete( { isReverse, value } ) {
+	onDelete( { value, isReverse } ) {
 		const { onMerge, onRemove } = this.props;
 
 		if ( onMerge ) {

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -24,7 +24,6 @@
 		"@babel/runtime": "^7.4.4",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",
-		"@wordpress/dom": "file:../dom",
 		"@wordpress/element": "file:../element",
 		"@wordpress/escape-html": "file:../escape-html",
 		"@wordpress/hooks": "file:../hooks",

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -893,10 +893,6 @@ class RichText extends Component {
 			placeholder,
 			__unstableIsSelected: isSelected,
 			children,
-			// To do: move autocompletion logic to rich-text.
-			__unstableAutocompleters: autocompleters,
-			__unstableAutocomplete: Autocomplete = ( { children: ch } ) => ch( {} ),
-			__unstableOnReplace: onReplace,
 			allowedFormats,
 			withoutInteractiveFormatting,
 		} = this.props;
@@ -905,20 +901,16 @@ class RichText extends Component {
 		// changes, we replace the relevant element. This is needed because we
 		// prevent Editable component updates.
 		const key = Tagname;
-		const ariaProps = pickAriaProps( this.props );
-		const record = this.record;
 
-		const autoCompleteContent = ( { listBoxId, activeId } ) => (
+		const Content = ( props ) => (
 			<Editable
+				{ ...props }
 				tagName={ Tagname }
 				style={ style }
-				record={ record }
+				record={ this.record }
 				valueToEditableHTML={ this.valueToEditableHTML }
 				aria-label={ placeholder }
-				aria-autocomplete={ listBoxId ? 'list' : undefined }
-				aria-owns={ listBoxId }
-				aria-activedescendant={ activeId }
-				{ ...ariaProps }
+				{ ...pickAriaProps( this.props ) }
 				className={ classnames( 'rich-text', className ) }
 				key={ key }
 				onPaste={ this.onPaste }
@@ -940,31 +932,21 @@ class RichText extends Component {
 			/>
 		);
 
-		const content = (
-			<Autocomplete
-				onReplace={ onReplace }
-				completers={ autocompleters }
-				record={ record }
-				onChange={ this.onChange }
-			>
-				{ autoCompleteContent }
-			</Autocomplete>
-		);
-
 		return (
 			<>
-				{ children && children( {
-					isSelected,
-					value: record,
-					onChange: this.onChange,
-				} ) }
 				{ isSelected && <FormatEdit
 					allowedFormats={ allowedFormats }
 					withoutInteractiveFormatting={ withoutInteractiveFormatting }
-					value={ record }
+					value={ this.record }
 					onChange={ this.onChange }
 				/> }
-				{ content }
+				{ children && children( {
+					isSelected,
+					value: this.record,
+					onChange: this.onChange,
+					children: Content,
+				} ) }
+				{ ! children && <Content /> }
 			</>
 		);
 	}

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -12,7 +12,6 @@ import {
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { isHorizontalEdge } from '@wordpress/dom';
 import { BACKSPACE, DELETE, ENTER, LEFT, RIGHT, SPACE } from '@wordpress/keycodes';
 import { withSelect } from '@wordpress/data';
 import { withSafeTimeout, compose } from '@wordpress/compose';
@@ -85,42 +84,39 @@ function createPrepareEditableTree( props, prefix ) {
 class RichText extends Component {
 	constructor( {
 		value,
-		__unstableMultiline: multiline,
 		selectionStart,
 		selectionEnd,
 	} ) {
 		super( ...arguments );
 
-		if ( multiline === true || multiline === 'p' || multiline === 'li' ) {
-			this.multilineTag = multiline === true ? 'p' : multiline;
-		}
-
-		if ( this.multilineTag === 'li' ) {
-			this.multilineWrapperTags = [ 'ul', 'ol' ];
-		}
-
 		this.onFocus = this.onFocus.bind( this );
 		this.onBlur = this.onBlur.bind( this );
 		this.onChange = this.onChange.bind( this );
-		this.onDeleteKeyDown = this.onDeleteKeyDown.bind( this );
-		this.onKeyDown = this.onKeyDown.bind( this );
+		this.handleDelete = this.handleDelete.bind( this );
+		this.handleEnter = this.handleEnter.bind( this );
+		this.handleSpace = this.handleSpace.bind( this );
+		this.handleHorizontalNavigation = this.handleHorizontalNavigation.bind( this );
 		this.onPaste = this.onPaste.bind( this );
 		this.onCreateUndoLevel = this.onCreateUndoLevel.bind( this );
 		this.onInput = this.onInput.bind( this );
 		this.onCompositionEnd = this.onCompositionEnd.bind( this );
 		this.onSelectionChange = this.onSelectionChange.bind( this );
-		this.getRecord = this.getRecord.bind( this );
 		this.createRecord = this.createRecord.bind( this );
 		this.applyRecord = this.applyRecord.bind( this );
 		this.valueToFormat = this.valueToFormat.bind( this );
 		this.setRef = this.setRef.bind( this );
 		this.valueToEditableHTML = this.valueToEditableHTML.bind( this );
-		this.handleHorizontalNavigation = this.handleHorizontalNavigation.bind( this );
 		this.onPointerDown = this.onPointerDown.bind( this );
 		this.formatToValue = this.formatToValue.bind( this );
 
-		this.state = {};
+		this.onKeyDown = ( event ) => {
+			this.handleDelete( event );
+			this.handleEnter( event );
+			this.handleSpace( event );
+			this.handleHorizontalNavigation( event );
+		};
 
+		this.state = {};
 		this.lastHistoryValue = value;
 
 		// Internal values are updated synchronously, unlike props and state.
@@ -152,34 +148,28 @@ class RichText extends Component {
 		}
 	}
 
-	/**
-	 * Get the current record (value and selection) from props and state.
-	 *
-	 * @return {Object} The current record (value and selection).
-	 */
-	getRecord() {
-		return this.record;
-	}
-
 	createRecord() {
+		const { __unstableMultilineTag: multilineTag } = this.props;
 		const selection = getSelection();
 		const range = selection.rangeCount > 0 ? selection.getRangeAt( 0 ) : null;
 
 		return create( {
 			element: this.editableRef,
 			range,
-			multilineTag: this.multilineTag,
-			multilineWrapperTags: this.multilineWrapperTags,
+			multilineTag,
+			multilineWrapperTags: multilineTag === 'li' ? [ 'ul', 'ol' ] : undefined,
 			__unstableIsEditableTree: true,
 		} );
 	}
 
 	applyRecord( record, { domOnly } = {} ) {
+		const { __unstableMultilineTag: multilineTag } = this.props;
+
 		apply( {
 			value: record,
 			current: this.editableRef,
-			multilineTag: this.multilineTag,
-			multilineWrapperTags: this.multilineWrapperTags,
+			multilineTag,
+			multilineWrapperTags: multilineTag === 'li' ? [ 'ul', 'ol' ] : undefined,
 			prepareEditableTree: createPrepareEditableTree( this.props, 'format_prepare_functions' ),
 			__unstableDomOnly: domOnly,
 			placeholder: this.props.placeholder,
@@ -229,7 +219,7 @@ class RichText extends Component {
 		window.console.log( 'Received HTML:\n\n', html );
 		window.console.log( 'Received plain text:\n\n', plainText );
 
-		const record = this.getRecord();
+		const record = this.record;
 		const transformed = formatTypes.reduce( ( accumlator, { __unstablePasteRule } ) => {
 			// Only allow one transform.
 			if ( __unstablePasteRule && accumlator === record ) {
@@ -340,7 +330,7 @@ class RichText extends Component {
 				inputType.indexOf( 'format' ) === 0 ||
 				INSERTION_INPUT_TYPES_TO_IGNORE.has( inputType )
 			) {
-				this.applyRecord( this.getRecord() );
+				this.applyRecord( this.record );
 				return;
 			}
 		}
@@ -415,43 +405,45 @@ class RichText extends Component {
 		}
 
 		const { start, end } = this.createRecord();
-		const value = this.getRecord();
+		const value = this.record;
 
-		if ( start !== value.start || end !== value.end ) {
-			const {
-				__unstableIsCaretWithinFormattedText: isCaretWithinFormattedText,
-				__unstableOnEnterFormattedText: onEnterFormattedText,
-				__unstableOnExitFormattedText: onExitFormattedText,
-			} = this.props;
-			const newValue = {
-				...value,
-				start,
-				end,
-				// Allow `getActiveFormats` to get new `activeFormats`.
-				activeFormats: undefined,
-			};
+		if ( start === value.start && end === value.end ) {
+			return;
+		}
 
-			const activeFormats = getActiveFormats( newValue );
+		const {
+			__unstableIsCaretWithinFormattedText: isCaretWithinFormattedText,
+			__unstableOnEnterFormattedText: onEnterFormattedText,
+			__unstableOnExitFormattedText: onExitFormattedText,
+		} = this.props;
+		const newValue = {
+			...value,
+			start,
+			end,
+			// Allow `getActiveFormats` to get new `activeFormats`.
+			activeFormats: undefined,
+		};
 
-			// Update the value with the new active formats.
-			newValue.activeFormats = activeFormats;
+		const activeFormats = getActiveFormats( newValue );
 
-			if ( ! isCaretWithinFormattedText && activeFormats.length ) {
-				onEnterFormattedText();
-			} else if ( isCaretWithinFormattedText && ! activeFormats.length ) {
-				onExitFormattedText();
-			}
+		// Update the value with the new active formats.
+		newValue.activeFormats = activeFormats;
 
-			// It is important that the internal value is updated first,
-			// otherwise the value will be wrong on render!
-			this.record = newValue;
-			this.applyRecord( newValue, { domOnly: true } );
-			this.props.onSelectionChange( start, end );
-			this.setState( { activeFormats } );
+		if ( ! isCaretWithinFormattedText && activeFormats.length ) {
+			onEnterFormattedText();
+		} else if ( isCaretWithinFormattedText && ! activeFormats.length ) {
+			onExitFormattedText();
+		}
 
-			if ( activeFormats.length > 0 ) {
-				this.recalculateBoundaryStyle();
-			}
+		// It is important that the internal value is updated first,
+		// otherwise the value will be wrong on render!
+		this.record = newValue;
+		this.applyRecord( newValue, { domOnly: true } );
+		this.props.onSelectionChange( start, end );
+		this.setState( { activeFormats } );
+
+		if ( activeFormats.length > 0 ) {
+			this.recalculateBoundaryStyle();
 		}
 	}
 
@@ -516,112 +508,105 @@ class RichText extends Component {
 	}
 
 	/**
-	 * Handles a delete keyDown event to handle merge or removal for collapsed
-	 * selection where caret is at directional edge: forward for a delete key,
-	 * reverse for a backspace key.
+	 * Handles delete on keydown:
+	 * - outdent list items,
+	 * - delete content if everything is selected,
+	 * - trigger the onDelete prop when selection is uncollapsed and at an edge.
 	 *
-	 * @see https://en.wikipedia.org/wiki/Caret_navigation
-	 *
-	 * @param {KeyboardEvent} event Keydown event.
+	 * @param {SyntheticEvent} event A synthetic keyboard event.
 	 */
-	onDeleteKeyDown( event ) {
-		const { onDelete } = this.props;
-
-		if ( ! onDelete ) {
-			return;
-		}
-
+	handleDelete( event ) {
 		const { keyCode } = event;
-		const isReverse = keyCode === BACKSPACE;
-		const record = this.createRecord();
 
-		// Only process delete if the key press occurs at uncollapsed edge.
-		if ( ! isCollapsed( record ) ) {
+		if ( keyCode !== DELETE && keyCode !== BACKSPACE ) {
 			return;
 		}
 
-		// It is important to consider emptiness because an empty container
-		// will include a padding BR node _after_ the caret, so in a forward
-		// deletion the isHorizontalEdge function will incorrectly interpret the
-		// presence of the BR node as not being at the edge.
-		const isEdge = ( isEmpty( record ) || isHorizontalEdge( this.editableRef, isReverse ) );
+		const { onDelete, __unstableMultilineTag: multilineTag } = this.props;
+		const { start, end, text, activeFormats } = this.record;
+		const isReverse = keyCode === BACKSPACE;
 
-		if ( ! isEdge ) {
+		if ( multilineTag ) {
+			const newValue = removeLineSeparator( this.record, isReverse );
+			if ( newValue ) {
+				this.onChange( newValue );
+				event.preventDefault();
+			}
+		}
+
+		// Always handle full content deletion ourselves.
+		if ( start === 0 && end !== 0 && end === text.length ) {
+			this.onChange( remove( this.record ) );
+			event.preventDefault();
+			return;
+		}
+
+		// Only process delete if the key press occurs at an uncollapsed edge.
+		if (
+			! onDelete ||
+			! isCollapsed( this.record ) ||
+			activeFormats.length ||
+			( isReverse && start !== 0 ) ||
+			( ! isReverse && end !== text.length )
+		) {
+			return;
+		}
+
+		onDelete( { isReverse, isEmpty: isEmpty( this.record ) } );
+		event.preventDefault();
+	}
+
+	/**
+	 * Triggers the `onEnter` prop on keydown.
+	 *
+	 * @param {SyntheticEvent} event A synthetic keyboard event.
+	 */
+	handleEnter( event ) {
+		if ( event.keyCode !== ENTER ) {
 			return;
 		}
 
 		event.preventDefault();
 
-		if ( onDelete ) {
-			onDelete( { isReverse, value: record } );
+		const { onEnter } = this.props;
+
+		if ( ! onEnter ) {
+			return;
 		}
+
+		onEnter( {
+			value: this.removeEditorOnlyFormats( this.createRecord() ),
+			onChange: this.onChange,
+			shiftKey: event.shiftKey,
+		} );
 	}
 
 	/**
-	 * Handles a keydown event.
+	 * Indents list items on space keydown.
 	 *
 	 * @param {SyntheticEvent} event A synthetic keyboard event.
 	 */
-	onKeyDown( event ) {
-		const { keyCode, shiftKey, altKey, metaKey, ctrlKey } = event;
-		const { onEnter } = this.props;
+	handleSpace( event ) {
+		const { tagName, __unstableMultilineTag: multilineTag } = this.props;
 
 		if (
-			// Only override left and right keys without modifiers pressed.
-			! shiftKey && ! altKey && ! metaKey && ! ctrlKey &&
-			( keyCode === LEFT || keyCode === RIGHT )
+			event.keyCode !== SPACE ||
+			multilineTag !== 'li' ||
+			! isCollapsed( this.record )
 		) {
-			this.handleHorizontalNavigation( event );
+			return;
 		}
 
-		// Use the space key in list items (at the start of an item) to indent
-		// the list item.
-		if ( keyCode === SPACE && this.multilineTag === 'li' ) {
-			const value = this.createRecord();
+		const { text, start } = this.record;
+		const characterBefore = text[ start - 1 ];
 
-			if ( isCollapsed( value ) ) {
-				const { text, start } = value;
-				const characterBefore = text[ start - 1 ];
-
-				// The caret must be at the start of a line.
-				if ( ! characterBefore || characterBefore === LINE_SEPARATOR ) {
-					this.onChange( indentListItems( value, { type: this.props.tagName } ) );
-					event.preventDefault();
-				}
-			}
+		// The caret must be at the start of a line.
+		if ( characterBefore && characterBefore !== LINE_SEPARATOR ) {
+			return;
 		}
 
-		if ( keyCode === DELETE || keyCode === BACKSPACE ) {
-			const value = this.createRecord();
-			const { start, end } = value;
-
-			// Always handle full content deletion ourselves.
-			if ( start === 0 && end !== 0 && end === value.text.length ) {
-				this.onChange( remove( value ) );
-				event.preventDefault();
-				return;
-			}
-
-			if ( this.multilineTag ) {
-				const newValue = removeLineSeparator( value, keyCode === BACKSPACE );
-				if ( newValue ) {
-					this.onChange( newValue );
-					event.preventDefault();
-				}
-			}
-
-			this.onDeleteKeyDown( event );
-		} else if ( keyCode === ENTER ) {
-			event.preventDefault();
-
-			if ( onEnter ) {
-				onEnter( {
-					value: this.removeEditorOnlyFormats( this.createRecord() ),
-					onChange: this.onChange,
-					shiftKey: event.shiftKey,
-				} );
-			}
-		}
+		this.onChange( indentListItems( this.record, { type: tagName } ) );
+		event.preventDefault();
 	}
 
 	/**
@@ -632,9 +617,18 @@ class RichText extends Component {
 	 * @param  {SyntheticEvent} event A synthetic keyboard event.
 	 */
 	handleHorizontalNavigation( event ) {
-		const value = this.getRecord();
-		const { text, formats, start, end, activeFormats = [] } = value;
-		const collapsed = isCollapsed( value );
+		const { keyCode, shiftKey, altKey, metaKey, ctrlKey } = event;
+
+		if (
+			// Only override left and right keys without modifiers pressed.
+			shiftKey || altKey || metaKey || ctrlKey ||
+			( keyCode !== LEFT && keyCode !== RIGHT )
+		) {
+			return;
+		}
+
+		const { text, formats, start, end, activeFormats = [] } = this.record;
+		const collapsed = isCollapsed( this.record );
 		// To do: ideally, we should look at visual position instead.
 		const { direction } = getComputedStyle( this.editableRef );
 		const reverseKey = direction === 'rtl' ? RIGHT : LEFT;
@@ -699,17 +693,17 @@ class RichText extends Component {
 
 		if ( newActiveFormatsLength !== activeFormats.length ) {
 			const newActiveFormats = source.slice( 0, newActiveFormatsLength );
-			const newValue = { ...value, activeFormats: newActiveFormats };
+			const newValue = { ...this.record, activeFormats: newActiveFormats };
 			this.record = newValue;
 			this.applyRecord( newValue );
 			this.setState( { activeFormats: newActiveFormats } );
 			return;
 		}
 
-		const newPos = value.start + ( isReverse ? -1 : 1 );
+		const newPos = start + ( isReverse ? -1 : 1 );
 		const newActiveFormats = isReverse ? formatsBefore : formatsAfter;
 		const newValue = {
-			...value,
+			...this.record,
 			start: newPos,
 			end: newPos,
 			activeFormats: newActiveFormats,
@@ -820,26 +814,30 @@ class RichText extends Component {
 	 * @return {Object} An internal rich-text value.
 	 */
 	formatToValue( value ) {
-		if ( this.props.format === 'string' ) {
-			const prepare = createPrepareEditableTree( this.props, 'format_value_functions' );
+		const { format, __unstableMultilineTag: multilineTag } = this.props;
 
-			value = create( {
-				html: value,
-				multilineTag: this.multilineTag,
-				multilineWrapperTags: this.multilineWrapperTags,
-			} );
-			value.formats = prepare( value );
-
+		if ( format !== 'string' ) {
 			return value;
 		}
+
+		const prepare = createPrepareEditableTree( this.props, 'format_value_functions' );
+
+		value = create( {
+			html: value,
+			multilineTag,
+			multilineWrapperTags: multilineTag === 'li' ? [ 'ul', 'ol' ] : undefined,
+		} );
+		value.formats = prepare( value );
 
 		return value;
 	}
 
 	valueToEditableHTML( value ) {
+		const { __unstableMultilineTag: multilineTag } = this.props;
+
 		return toDom( {
 			value,
-			multilineTag: this.multilineTag,
+			multilineTag,
 			prepareEditableTree: createPrepareEditableTree( this.props, 'format_prepare_functions' ),
 			placeholder: this.props.placeholder,
 		} ).body.innerHTML;
@@ -872,16 +870,15 @@ class RichText extends Component {
 	 * @return {*} The external data format, data type depends on props.
 	 */
 	valueToFormat( value ) {
+		const { format, __unstableMultilineTag: multilineTag } = this.props;
+
 		value = this.removeEditorOnlyFormats( value );
 
-		if ( this.props.format === 'string' ) {
-			return toHTMLString( {
-				value,
-				multilineTag: this.multilineTag,
-			} );
+		if ( format !== 'string' ) {
+			return;
 		}
 
-		return value;
+		return toHTMLString( { value, multilineTag } );
 	}
 
 	render() {
@@ -893,6 +890,7 @@ class RichText extends Component {
 			placeholder,
 			__unstableIsSelected: isSelected,
 			children,
+			__unstableMultilineTag: multilineTag,
 			// To do: move autocompletion logic to rich-text.
 			__unstableAutocompleters: autocompleters,
 			__unstableAutocomplete: Autocomplete = ( { children: ch } ) => ch( {} ),
@@ -906,7 +904,7 @@ class RichText extends Component {
 		// prevent Editable component updates.
 		const key = Tagname;
 		const ariaProps = pickAriaProps( this.props );
-		const record = this.getRecord();
+		const record = this.record;
 
 		const autoCompleteContent = ( { listBoxId, activeId } ) => (
 			<>

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -902,7 +902,7 @@ class RichText extends Component {
 		// prevent Editable component updates.
 		const key = Tagname;
 
-		const Content = ( props ) => (
+		const EditableWrapper = ( props ) => (
 			<Editable
 				{ ...props }
 				tagName={ Tagname }
@@ -944,9 +944,9 @@ class RichText extends Component {
 					isSelected,
 					value: this.record,
 					onChange: this.onChange,
-					children: Content,
+					Editable: EditableWrapper,
 				} ) }
-				{ ! children && <Content /> }
+				{ ! children && <EditableWrapper /> }
 			</>
 		);
 	}

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -23,7 +23,6 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
 import FormatEdit from './format-edit';
 import Editable from './editable';
 import { pickAriaProps } from './aria';
-import { isEmpty } from '../is-empty';
 import { create } from '../create';
 import { apply, toDom } from '../to-dom';
 import { toHTMLString } from '../to-html-string';
@@ -890,12 +889,10 @@ class RichText extends Component {
 		const {
 			tagName: Tagname = 'div',
 			style,
-			wrapperClassName,
 			className,
 			placeholder,
 			__unstableIsSelected: isSelected,
 			children,
-			__unstableMultilineTag: multilineTag,
 			// To do: move autocompletion logic to rich-text.
 			__unstableAutocompleters: autocompleters,
 			__unstableAutocomplete: Autocomplete = ( { children: ch } ) => ch( {} ),
@@ -912,43 +909,35 @@ class RichText extends Component {
 		const record = this.record;
 
 		const autoCompleteContent = ( { listBoxId, activeId } ) => (
-			<>
-				<Editable
-					tagName={ Tagname }
-					style={ style }
-					record={ record }
-					valueToEditableHTML={ this.valueToEditableHTML }
-					aria-label={ placeholder }
-					aria-autocomplete={ listBoxId ? 'list' : undefined }
-					aria-owns={ listBoxId }
-					aria-activedescendant={ activeId }
-					{ ...ariaProps }
-					className={ classnames( 'rich-text', className ) }
-					key={ key }
-					onPaste={ this.onPaste }
-					onInput={ this.onInput }
-					onCompositionEnd={ this.onCompositionEnd }
-					onKeyDown={ this.onKeyDown }
-					onFocus={ this.onFocus }
-					onBlur={ this.onBlur }
-					onMouseDown={ this.onPointerDown }
-					onTouchStart={ this.onPointerDown }
-					setRef={ this.setRef }
-					// Selection updates must be done at these events as they
-					// happen before the `selectionchange` event. In some cases,
-					// the `selectionchange` event may not even fire, for
-					// example when the window receives focus again on click.
-					onKeyUp={ this.onSelectionChange }
-					onMouseUp={ this.onSelectionChange }
-					onTouchEnd={ this.onSelectionChange }
-				/>
-				{ isSelected && <FormatEdit
-					allowedFormats={ allowedFormats }
-					withoutInteractiveFormatting={ withoutInteractiveFormatting }
-					value={ record }
-					onChange={ this.onChange }
-				/> }
-			</>
+			<Editable
+				tagName={ Tagname }
+				style={ style }
+				record={ record }
+				valueToEditableHTML={ this.valueToEditableHTML }
+				aria-label={ placeholder }
+				aria-autocomplete={ listBoxId ? 'list' : undefined }
+				aria-owns={ listBoxId }
+				aria-activedescendant={ activeId }
+				{ ...ariaProps }
+				className={ classnames( 'rich-text', className ) }
+				key={ key }
+				onPaste={ this.onPaste }
+				onInput={ this.onInput }
+				onCompositionEnd={ this.onCompositionEnd }
+				onKeyDown={ this.onKeyDown }
+				onFocus={ this.onFocus }
+				onBlur={ this.onBlur }
+				onMouseDown={ this.onPointerDown }
+				onTouchStart={ this.onPointerDown }
+				setRef={ this.setRef }
+				// Selection updates must be done at these events as they
+				// happen before the `selectionchange` event. In some cases,
+				// the `selectionchange` event may not even fire, for
+				// example when the window receives focus again on click.
+				onKeyUp={ this.onSelectionChange }
+				onMouseUp={ this.onSelectionChange }
+				onTouchEnd={ this.onSelectionChange }
+			/>
 		);
 
 		const content = (
@@ -962,19 +951,21 @@ class RichText extends Component {
 			</Autocomplete>
 		);
 
-		if ( ! children ) {
-			return content;
-		}
-
 		return (
-			<div className={ wrapperClassName }>
-				{ children( {
+			<>
+				{ children && children( {
 					isSelected,
 					value: record,
 					onChange: this.onChange,
 				} ) }
+				{ isSelected && <FormatEdit
+					allowedFormats={ allowedFormats }
+					withoutInteractiveFormatting={ withoutInteractiveFormatting }
+					value={ record }
+					onChange={ this.onChange }
+				/> }
 				{ content }
-			</div>
+			</>
 		);
 	}
 }

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -107,6 +107,7 @@ class RichText extends Component {
 		this.valueToEditableHTML = this.valueToEditableHTML.bind( this );
 		this.onPointerDown = this.onPointerDown.bind( this );
 		this.formatToValue = this.formatToValue.bind( this );
+		this.Editable = this.Editable.bind( this );
 
 		this.onKeyDown = ( event ) => {
 			this.handleDelete( event );
@@ -885,24 +886,19 @@ class RichText extends Component {
 		return toHTMLString( { value, multilineTag } );
 	}
 
-	render() {
+	Editable( props ) {
 		const {
 			tagName: Tagname = 'div',
 			style,
 			className,
 			placeholder,
-			__unstableIsSelected: isSelected,
-			children,
-			allowedFormats,
-			withoutInteractiveFormatting,
 		} = this.props;
-
 		// Generating a key that includes `tagName` ensures that if the tag
 		// changes, we replace the relevant element. This is needed because we
 		// prevent Editable component updates.
 		const key = Tagname;
 
-		const EditableWrapper = ( props ) => (
+		return (
 			<Editable
 				{ ...props }
 				tagName={ Tagname }
@@ -931,6 +927,15 @@ class RichText extends Component {
 				onTouchEnd={ this.onSelectionChange }
 			/>
 		);
+	}
+
+	render() {
+		const {
+			__unstableIsSelected: isSelected,
+			children,
+			allowedFormats,
+			withoutInteractiveFormatting,
+		} = this.props;
 
 		return (
 			<>
@@ -944,9 +949,9 @@ class RichText extends Component {
 					isSelected,
 					value: this.record,
 					onChange: this.onChange,
-					Editable: EditableWrapper,
+					Editable: this.Editable,
 				} ) }
-				{ ! children && <EditableWrapper /> }
+				{ ! children && <this.Editable /> }
 			</>
 		);
 	}


### PR DESCRIPTION
_I renamed this branch because @frontdevde had problems pulling Gutenberg because of the emoji in the branch name._

## Description

This PR mostly moves code around.

* Move `Autocomplete` to the `RichText` wrapper with block context.
* Properly convert the `multiline` prop to a `multilineTag`.
* Use the rich text value to determine when to merge. This removes the dependency on the DOM package.
* Split `onKeyDown` in multiple functions.
* Reduce code indentation (in one occasion 5 → 2 tabs).

## How has this been tested?

E2e tests should pass.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->