### PR TITLE
[RNMobile] Refactor BlockToolbar follow-up PR

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/index.native.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.native.js
@@ -88,7 +88,7 @@ export default compose( [
 	withDispatch( ( dispatch ) => ( {
 		redo: dispatch( 'core/editor' ).redo,
 		undo: dispatch( 'core/editor' ).undo,
-		clearSelectedBlock: dispatch( 'core/editor' ).clearSelectedBlock,
+		clearSelectedBlock: dispatch( 'core/block-editor' ).clearSelectedBlock,
 	} ) ),
 	withViewportMatch( { isLargeViewport: 'medium' } ),
 ] )( HeaderToolbar );

--- a/packages/edit-post/src/components/header/header-toolbar/index.native.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { ScrollView, Keyboard, Platform, View } from 'react-native';
+import { ScrollView, View } from 'react-native';
 
 /**
  * WordPress dependencies
@@ -31,14 +31,6 @@ function HeaderToolbar( {
 	showKeyboardHideButton,
 	clearSelectedBlock,
 } ) {
-	const hideKeyboard = () => {
-		clearSelectedBlock();
-		if ( Platform.OS === 'android' ) {
-			// Avoiding extra blur calls on iOS but still needed for android.
-			Keyboard.dismiss();
-		}
-	};
-
 	return (
 		<View style={ styles.container }>
 			<ScrollView
@@ -75,7 +67,7 @@ function HeaderToolbar( {
 					<ToolbarButton
 						title={ __( 'Hide keyboard' ) }
 						icon="keyboard-hide"
-						onClick={ hideKeyboard }
+						onClick={ clearSelectedBlock }
 						extraProps={ { hint: __( 'Tap to hide the keyboard' ) } }
 					/>
 				</Toolbar>

--- a/packages/editor/src/components/provider/index.native.js
+++ b/packages/editor/src/components/provider/index.native.js
@@ -160,10 +160,12 @@ export default compose( [
 	} ),
 	withDispatch( ( dispatch ) => {
 		const {
-			clearSelectedBlock,
 			editPost,
 			resetEditorBlocks,
 		} = dispatch( 'core/editor' );
+		const {
+			clearSelectedBlock,
+		} = dispatch( 'core/block-editor' );
 		const {
 			switchEditorMode,
 		} = dispatch( 'core/edit-post' );

--- a/packages/editor/src/components/provider/index.native.js
+++ b/packages/editor/src/components/provider/index.native.js
@@ -118,6 +118,8 @@ class NativeEditorProvider extends Component {
 		const { mode, switchMode } = this.props;
 		// refresh html content first
 		this.serializeToNativeAction();
+		// make sure to blur the selected block and dismiss the keyboard
+		this.props.clearSelectedBlock();
 		switchMode( mode === 'visual' ? 'text' : 'visual' );
 	}
 
@@ -158,6 +160,7 @@ export default compose( [
 	} ),
 	withDispatch( ( dispatch ) => {
 		const {
+			clearSelectedBlock,
 			editPost,
 			resetEditorBlocks,
 		} = dispatch( 'core/editor' );
@@ -166,6 +169,7 @@ export default compose( [
 		} = dispatch( 'core/edit-post' );
 
 		return {
+			clearSelectedBlock,
 			editTitle( title ) {
 				editPost( { title } );
 			},


### PR DESCRIPTION
## Description
This PR fixes some minor issues with https://github.com/WordPress/gutenberg/pull/16677

## How has this been tested?
Tested with https://github.com/wordpress-mobile/gutenberg-mobile/pull/1247

## Types of changes
UX changes:
- Hide keyboard when switching mode
- Do not force hide keyboard on android, as unselecting a block already handles it

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
