### PR TITLE
Block Editor: Try making block drop zones a bit wider.

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -604,7 +604,7 @@
 	.block-editor-block-drop-zone {
 		top: -4px;
 		bottom: -3px;
-		margin: 0 $block-padding;
+		margin: 0 -10%;
 	}
 
 	// Hide appender shortcuts in nested blocks.


### PR DESCRIPTION
## Description

This PR explores making block drop zones a bit wider than blocks themselves to make drag and drop block reordering easier and more fluid.

Currently, you have to move your mouse towards the center after initiating a drag so that your cursor hovers over drop zones, and this is a bit awkward, specially because it's intuitive for LTR users to drag blocks through the left margin of a document.

## How has this been tested?

Block drop zones were tested and they work as expected.

## Screenshots

<img width="988" alt="Screen Shot 2019-08-05 at 5 14 29 PM" src="https://user-images.githubusercontent.com/19157096/62495652-90995c00-b7a4-11e9-9b21-5b3e211045de.png">

## Types of Changes

*New Feature:* Block drop zones were widened a little to make drag and drop reordering more fluid.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
