### PR TITLE
Custom Fields: Update test snapshot with the new checkbox implementation

### DIFF
--- a/packages/edit-post/src/components/options-modal/options/test/__snapshots__/enable-custom-fields.js.snap
+++ b/packages/edit-post/src/components/options-modal/options/test/__snapshots__/enable-custom-fields.js.snap
@@ -21,7 +21,22 @@ exports[`EnableCustomFieldsOption renders a checked checkbox and a confirmation 
       <label
         className="components-checkbox-control__label"
         htmlFor="inspector-checkbox-control-3"
-      />
+      >
+        <svg
+          aria-hidden="true"
+          className="dashicon dashicons-yes components-checkbox-control__checked"
+          focusable="false"
+          height={20}
+          role="img"
+          viewBox="0 0 20 20"
+          width={20}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M14.83 4.89l1.34.94-5.81 8.38H9.02L5.78 9.67l1.34-1.25 2.57 2.4z"
+          />
+        </svg>
+      </label>
     </div>
   </div>
   <p
@@ -61,7 +76,22 @@ exports[`EnableCustomFieldsOption renders a checked checkbox when custom fields 
       <label
         className="components-checkbox-control__label"
         htmlFor="inspector-checkbox-control-0"
-      />
+      >
+        <svg
+          aria-hidden="true"
+          className="dashicon dashicons-yes components-checkbox-control__checked"
+          focusable="false"
+          height={20}
+          role="img"
+          viewBox="0 0 20 20"
+          width={20}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M14.83 4.89l1.34.94-5.81 8.38H9.02L5.78 9.67l1.34-1.25 2.57 2.4z"
+          />
+        </svg>
+      </label>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Description

I have merged my PR #15688 onto master where it got an updated implementation of checkboxes from #16551 and that unfortunately broke test snapshots. This PR updates them.

My original PR should have been rebased before merging, despite the merge looking clean. Rebasing would have surfaced this. 

Failed merge: https://travis-ci.com/WordPress/gutenberg/builds/122051161?utm_medium=notification&utm_source=email

## How has this been tested?

Tested by running unit tests 😉`npm run test-unit`
