### PR TITLE
Chore: Upgrade ESLint to the latest version (6.1.0)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -104,7 +104,6 @@ module.exports = {
 				};
 			} ),
 		} ],
-		'jest/valid-describe': 'off',
 	},
 	overrides: [
 		{

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -104,6 +104,7 @@ module.exports = {
 				};
 			} ),
 		} ],
+		'jest/valid-describe': 'off',
 	},
 	overrides: [
 		{

--- a/package-lock.json
+++ b/package-lock.json
@@ -10491,9 +10491,9 @@
 			}
 		},
 		"es6-promise": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+			"integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
 			"dev": true
 		},
 		"es6-promisify": {
@@ -10517,9 +10517,9 @@
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"escodegen": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
-			"integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.10.0.tgz",
+			"integrity": "sha512-fjUOf8johsv23WuIKdNQU4P9t9jhQ4Qzx6pC2uW890OloK3Zs1ZAoCNpg/2larNF501jLl3UNy0kIRcF6VI22g==",
 			"dev": true,
 			"requires": {
 				"esprima": "^3.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
 			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-			"dev": true,
 			"requires": {
 				"@babel/highlight": "^7.0.0"
 			}
@@ -134,17 +133,6 @@
 				"@babel/helper-split-export-declaration": "^7.4.4"
 			}
 		},
-		"@babel/helper-define-map": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.4.tgz",
-			"integrity": "sha512-IX3Ln8gLhZpSuqHJSnTNBWGDE9kdkTEWl21A/K7PQ00tseBwbqCHTvNLHSBd9M0R5rER4h5Rsvj9vw0R5SieBg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/types": "^7.4.4",
-				"lodash": "^4.17.11"
-			}
-		},
 		"@babel/helper-explode-assignable-expression": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
@@ -170,7 +158,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
 			"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}
@@ -311,7 +298,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
 			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
@@ -573,19 +559,130 @@
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.4.tgz",
-			"integrity": "sha512-/e44eFLImEGIpL9qPxSRat13I5QNRgBLu2hOQJCF7VLy/otSM/sypV1+XaIw5+502RX/+6YaSAPmldk+nhHDPw==",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz",
+			"integrity": "sha512-U2htCNK/6e9K7jGyJ++1p5XRU+LJjrwtoiVn9SzRlDT2KubcZ11OOwy3s24TjHxPgxNwonCYP7U2K51uVYCMDg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.0.0",
-				"@babel/helper-define-map": "^7.4.4",
+				"@babel/helper-define-map": "^7.5.5",
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/helper-optimise-call-expression": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.4.4",
+				"@babel/helper-replace-supers": "^7.5.5",
 				"@babel/helper-split-export-declaration": "^7.4.4",
 				"globals": "^11.1.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+					"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
+					"integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.5.5",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"@babel/helper-define-map": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz",
+					"integrity": "sha512-fTfxx7i0B5NJqvUOBBGREnrqbTxRh7zinBANpZXAVDlsZxYdclDp467G1sQ8VZYMnAURY3RpBUAgOYT9GfzHBg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/types": "^7.5.5",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
+					"integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.5.5"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
+					"integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.5.5",
+						"@babel/helper-optimise-call-expression": "^7.0.0",
+						"@babel/traverse": "^7.5.5",
+						"@babel/types": "^7.5.5"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
+					"integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+					"dev": true
+				},
+				"@babel/traverse": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
+					"integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.5.5",
+						"@babel/helper-function-name": "^7.1.0",
+						"@babel/helper-split-export-declaration": "^7.4.4",
+						"@babel/parser": "^7.5.5",
+						"@babel/types": "^7.5.5",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.5.5",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+					"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/plugin-transform-computed-properties": {
@@ -1161,10 +1258,16 @@
 						"ms": "^2.1.1"
 					}
 				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
 				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				}
 			}
@@ -1173,7 +1276,6 @@
 			"version": "7.4.4",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
 			"integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
-			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
 				"lodash": "^4.17.11",
@@ -4858,23 +4960,6 @@
 				"eslint-plugin-react-hooks": "^1.6.1",
 				"globals": "^12.0.0",
 				"requireindex": "^1.2.0"
-			},
-			"dependencies": {
-				"globals": {
-					"version": "12.0.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-12.0.0.tgz",
-					"integrity": "sha512-c9xoi32iDwlETiyYfO0pd3M8GcEuytJinSoqq7k3fz4H8p2p31NyfKr7JVd7Y0QvmtWcWXcwqW4L33eeDYgh1A==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.6.0"
-					}
-				},
-				"type-fest": {
-					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-					"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-					"dev": true
-				}
 			}
 		},
 		"@wordpress/format-library": {
@@ -5400,7 +5485,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
 			"requires": {
 				"color-convert": "^1.9.0"
 			}
@@ -5604,12 +5688,53 @@
 			"dev": true
 		},
 		"array.prototype.find": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
-			"integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.0.tgz",
+			"integrity": "sha512-Wn41+K1yuO5p7wRZDl7890c3xvv5UBrfVXTVIe28rSQb6LS0fZMDrQB6PAcxQFRFy6vJTLDc3A2+3CjQdzVKRg==",
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.7.0"
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.13.0"
+			},
+			"dependencies": {
+				"define-properties": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+					"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+					"requires": {
+						"object-keys": "^1.0.12"
+					}
+				},
+				"es-abstract": {
+					"version": "1.13.0",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+					"integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+					"requires": {
+						"es-to-primitive": "^1.2.0",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"is-callable": "^1.1.4",
+						"is-regex": "^1.0.4",
+						"object-keys": "^1.0.12"
+					}
+				},
+				"es-to-primitive": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+					"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+					"requires": {
+						"is-callable": "^1.1.4",
+						"is-date-object": "^1.0.1",
+						"is-symbol": "^1.0.2"
+					}
+				},
+				"is-symbol": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+					"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+					"requires": {
+						"has-symbols": "^1.0.0"
+					}
+				}
 			}
 		},
 		"array.prototype.flat": {
@@ -7081,7 +7206,6 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -8036,7 +8160,6 @@
 			"version": "1.9.2",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
 			"integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
-			"dev": true,
 			"requires": {
 				"color-name": "1.1.1"
 			}
@@ -8044,8 +8167,7 @@
 		"color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
-			"integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
-			"dev": true
+			"integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
 		},
 		"color-string": {
 			"version": "0.3.0",
@@ -10369,9 +10491,9 @@
 			}
 		},
 		"es6-promise": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-			"integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
 			"dev": true
 		},
 		"es6-promisify": {
@@ -10392,13 +10514,12 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"escodegen": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.10.0.tgz",
-			"integrity": "sha512-fjUOf8johsv23WuIKdNQU4P9t9jhQ4Qzx6pC2uW890OloK3Zs1ZAoCNpg/2larNF501jLl3UNy0kIRcF6VI22g==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
+			"integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
 			"dev": true,
 			"requires": {
 				"esprima": "^3.1.3",
@@ -10583,6 +10704,12 @@
 							}
 						}
 					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
 				},
 				"ignore": {
 					"version": "4.0.6",
@@ -10915,8 +11042,7 @@
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-			"dev": true
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
 		},
 		"etag": {
 			"version": "1.8.1",
@@ -12920,10 +13046,21 @@
 			"dev": true
 		},
 		"globals": {
-			"version": "11.12.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-			"dev": true
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-12.0.0.tgz",
+			"integrity": "sha512-c9xoi32iDwlETiyYfO0pd3M8GcEuytJinSoqq7k3fz4H8p2p31NyfKr7JVd7Y0QvmtWcWXcwqW4L33eeDYgh1A==",
+			"dev": true,
+			"requires": {
+				"type-fest": "^0.6.0"
+			},
+			"dependencies": {
+				"type-fest": {
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+					"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+					"dev": true
+				}
+			}
 		},
 		"globby": {
 			"version": "9.2.0",
@@ -13136,8 +13273,7 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
 		"has-symbols": {
 			"version": "1.0.0",
@@ -19705,6 +19841,12 @@
 						"ms": "^2.1.1"
 					}
 				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
 				"json5": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
@@ -20431,7 +20573,6 @@
 					"version": "7.1.0",
 					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
 					"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
-					"dev": true,
 					"requires": {
 						"@babel/helper-get-function-arity": "^7.0.0",
 						"@babel/template": "^7.1.0",
@@ -20465,42 +20606,22 @@
 				"@babel/parser": {
 					"version": "7.2.3",
 					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.2.3.tgz",
-					"integrity": "sha512-0LyEcVlfCoFmci8mXx8A5oIkpkOgyo8dRHtxBnK9RRBwxO2+JZPNsqtVEZQ7mJFPxnXF9lfmU24mHOPI0qnlkA==",
-					"dev": true
+					"integrity": "sha512-0LyEcVlfCoFmci8mXx8A5oIkpkOgyo8dRHtxBnK9RRBwxO2+JZPNsqtVEZQ7mJFPxnXF9lfmU24mHOPI0qnlkA=="
 				},
 				"@babel/template": {
 					"version": "7.2.2",
 					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
 					"integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
 						"@babel/parser": "^7.2.2",
 						"@babel/types": "^7.2.2"
 					}
 				},
-				"@babel/traverse": {
-					"version": "7.2.3",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
-					"integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/generator": "^7.2.2",
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-split-export-declaration": "^7.0.0",
-						"@babel/parser": "^7.2.3",
-						"@babel/types": "^7.2.2",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.10"
-					}
-				},
 				"@babel/types": {
 					"version": "7.2.2",
 					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.2.2.tgz",
 					"integrity": "sha512-fKCuD6UFUMkR541eDWL+2ih/xFZBXPOg/7EQFeTluMDebfqR4jrpaCjLhkWlQS4hT6nRa2PMEgXKbRB5/H2fpg==",
-					"dev": true,
 					"requires": {
 						"esutils": "^2.0.2",
 						"lodash": "^4.17.10",
@@ -24639,7 +24760,6 @@
 			"version": "5.4.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
@@ -25187,8 +25307,7 @@
 		"to-fast-properties": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-			"dev": true
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
 		},
 		"to-object-path": {
 			"version": "0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4169,6 +4169,12 @@
 				"@types/istanbul-lib-report": "*"
 			}
 		},
+		"@types/json-schema": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
+			"integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
+			"dev": true
+		},
 		"@types/minimatch": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -4225,6 +4231,47 @@
 			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.12.tgz",
 			"integrity": "sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==",
 			"dev": true
+		},
+		"@typescript-eslint/experimental-utils": {
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
+			"integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
+			"dev": true,
+			"requires": {
+				"@types/json-schema": "^7.0.3",
+				"@typescript-eslint/typescript-estree": "1.13.0",
+				"eslint-scope": "^4.0.0"
+			},
+			"dependencies": {
+				"eslint-scope": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+					"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+					"dev": true,
+					"requires": {
+						"esrecurse": "^4.1.0",
+						"estraverse": "^4.1.1"
+					}
+				}
+			}
+		},
+		"@typescript-eslint/typescript-estree": {
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
+			"integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
+			"dev": true,
+			"requires": {
+				"lodash.unescape": "4.0.1",
+				"semver": "5.5.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+					"dev": true
+				}
+			}
 		},
 		"@webassemblyjs/ast": {
 			"version": "1.4.3",
@@ -4804,11 +4851,11 @@
 			"version": "file:packages/eslint-plugin",
 			"dev": true,
 			"requires": {
-				"babel-eslint": "^10.0.1",
+				"babel-eslint": "^10.0.2",
 				"eslint-plugin-jsdoc": "^15.8.0",
-				"eslint-plugin-jsx-a11y": "^6.2.1",
-				"eslint-plugin-react": "^7.12.4",
-				"eslint-plugin-react-hooks": "^1.6.0",
+				"eslint-plugin-jsx-a11y": "^6.2.3",
+				"eslint-plugin-react": "^7.14.3",
+				"eslint-plugin-react-hooks": "^1.6.1",
 				"globals": "^12.0.0",
 				"requireindex": "^1.2.0"
 			},
@@ -5032,7 +5079,7 @@
 				"chalk": "^2.4.1",
 				"check-node-version": "^3.1.1",
 				"cross-spawn": "^5.1.0",
-				"eslint": "^5.16.0",
+				"eslint": "^6.1.0",
 				"jest": "^24.7.1",
 				"jest-puppeteer": "^4.3.0",
 				"minimist": "^1.2.0",
@@ -5774,9 +5821,9 @@
 			}
 		},
 		"babel-eslint": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.1.tgz",
-			"integrity": "sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==",
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.2.tgz",
+			"integrity": "sha512-UdsurWPtgiPgpJ06ryUnuaSXC2s0WoSZnQmEpbAH65XZSdwowgN5MvyP7e88nW07FYXv72erVtpBkxyDVKhH1Q==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
@@ -9413,9 +9460,9 @@
 			"dev": true
 		},
 		"damerau-levenshtein": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
-			"integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ=",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz",
+			"integrity": "sha512-CBCRqFnpu715iPmw1KrdOrzRqbdFwQTwAWyyyYS42+iAgHCuXZ+/TdMgQkUENPomxEz9z1BEzuQU2Xw0kUuAgA==",
 			"dev": true
 		},
 		"dargs": {
@@ -10371,53 +10418,54 @@
 			}
 		},
 		"eslint": {
-			"version": "5.16.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
-			"integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-6.1.0.tgz",
+			"integrity": "sha512-QhrbdRD7ofuV09IuE2ySWBz0FyXCq0rriLTZXZqaWSI79CVtHVRdkFuFTViiqzZhkCgfOh9USpriuGN2gIpZDQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"ajv": "^6.9.1",
+				"ajv": "^6.10.0",
 				"chalk": "^2.1.0",
 				"cross-spawn": "^6.0.5",
 				"debug": "^4.0.1",
 				"doctrine": "^3.0.0",
-				"eslint-scope": "^4.0.3",
+				"eslint-scope": "^5.0.0",
 				"eslint-utils": "^1.3.1",
 				"eslint-visitor-keys": "^1.0.0",
-				"espree": "^5.0.1",
+				"espree": "^6.0.0",
 				"esquery": "^1.0.1",
 				"esutils": "^2.0.2",
 				"file-entry-cache": "^5.0.1",
 				"functional-red-black-tree": "^1.0.1",
-				"glob": "^7.1.2",
+				"glob-parent": "^5.0.0",
 				"globals": "^11.7.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
-				"inquirer": "^6.2.2",
-				"js-yaml": "^3.13.0",
+				"inquirer": "^6.4.1",
+				"is-glob": "^4.0.0",
+				"js-yaml": "^3.13.1",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.3.0",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.14",
 				"minimatch": "^3.0.4",
 				"mkdirp": "^0.5.1",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.8.2",
-				"path-is-inside": "^1.0.2",
 				"progress": "^2.0.0",
 				"regexpp": "^2.0.1",
-				"semver": "^5.5.1",
-				"strip-ansi": "^4.0.0",
-				"strip-json-comments": "^2.0.1",
+				"semver": "^6.1.2",
+				"strip-ansi": "^5.2.0",
+				"strip-json-comments": "^3.0.1",
 				"table": "^5.2.3",
-				"text-table": "^0.2.0"
+				"text-table": "^0.2.0",
+				"v8-compile-cache": "^2.0.3"
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "6.1.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-					"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
+					"integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
 					"dev": true
 				},
 				"acorn-jsx": {
@@ -10427,9 +10475,9 @@
 					"dev": true
 				},
 				"ajv": {
-					"version": "6.10.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-					"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+					"version": "6.10.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+					"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^2.0.1",
@@ -10461,6 +10509,14 @@
 						"semver": "^5.5.0",
 						"shebang-command": "^1.2.0",
 						"which": "^1.2.9"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "5.7.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+							"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+							"dev": true
+						}
 					}
 				},
 				"debug": {
@@ -10482,9 +10538,9 @@
 					}
 				},
 				"eslint-scope": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
-					"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+					"integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
 					"dev": true,
 					"requires": {
 						"esrecurse": "^4.1.0",
@@ -10492,9 +10548,9 @@
 					}
 				},
 				"espree": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
-					"integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/espree/-/espree-6.0.0.tgz",
+					"integrity": "sha512-lJvCS6YbCn3ImT3yKkPe0+tJ+mH6ljhGNjHQH9mRtiO6gjhVAOhVXW1yjnwqGwTkK3bGbye+hb00nFNmu0l/1Q==",
 					"dev": true,
 					"requires": {
 						"acorn": "^6.0.7",
@@ -10508,24 +10564,24 @@
 					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
 					"dev": true
 				},
-				"file-entry-cache": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-					"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+				"glob-parent": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
+					"integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
 					"dev": true,
 					"requires": {
-						"flat-cache": "^2.0.1"
-					}
-				},
-				"flat-cache": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
-					"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
-					"dev": true,
-					"requires": {
-						"flatted": "^2.0.0",
-						"rimraf": "2.6.3",
-						"write": "1.0.3"
+						"is-glob": "^4.0.1"
+					},
+					"dependencies": {
+						"is-glob": {
+							"version": "4.0.1",
+							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+							"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+							"dev": true,
+							"requires": {
+								"is-extglob": "^2.1.1"
+							}
+						}
 					}
 				},
 				"ignore": {
@@ -10535,9 +10591,9 @@
 					"dev": true
 				},
 				"inquirer": {
-					"version": "6.3.1",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.3.1.tgz",
-					"integrity": "sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==",
+					"version": "6.5.0",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
+					"integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
 					"dev": true,
 					"requires": {
 						"ansi-escapes": "^3.2.0",
@@ -10546,7 +10602,7 @@
 						"cli-width": "^2.0.0",
 						"external-editor": "^3.0.3",
 						"figures": "^2.0.0",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.12",
 						"mute-stream": "0.0.7",
 						"run-async": "^2.2.0",
 						"rxjs": "^6.4.0",
@@ -10565,15 +10621,6 @@
 								"escape-string-regexp": "^1.0.5",
 								"supports-color": "^5.3.0"
 							}
-						},
-						"strip-ansi": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^4.1.0"
-							}
 						}
 					}
 				},
@@ -10584,49 +10631,24 @@
 					"dev": true
 				},
 				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				},
-				"rimraf": {
-					"version": "2.6.3",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					},
-					"dependencies": {
-						"glob": {
-							"version": "7.1.3",
-							"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-							"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-							"dev": true,
-							"requires": {
-								"fs.realpath": "^1.0.0",
-								"inflight": "^1.0.4",
-								"inherits": "2",
-								"minimatch": "^3.0.4",
-								"once": "^1.3.0",
-								"path-is-absolute": "^1.0.0"
-							}
-						}
-					}
-				},
 				"rxjs": {
-					"version": "6.5.1",
-					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.1.tgz",
-					"integrity": "sha512-y0j31WJc83wPu31vS1VlAFW5JGrnGC+j+TtGAa1fRQphy48+fDYiDmX8tjGloToEsMkxnouOg/1IzXGKkJnZMg==",
+					"version": "6.5.2",
+					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+					"integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
 					"dev": true,
 					"requires": {
 						"tslib": "^1.9.0"
 					}
 				},
 				"semver": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				},
 				"slice-ansi": {
@@ -10640,14 +10662,29 @@
 						"is-fullwidth-code-point": "^2.0.0"
 					}
 				},
-				"table": {
-					"version": "5.2.3",
-					"resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
-					"integrity": "sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==",
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"dev": true,
 					"requires": {
-						"ajv": "^6.9.1",
-						"lodash": "^4.17.11",
+						"ansi-regex": "^4.1.0"
+					}
+				},
+				"strip-json-comments": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+					"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+					"dev": true
+				},
+				"table": {
+					"version": "5.4.5",
+					"resolved": "https://registry.npmjs.org/table/-/table-5.4.5.tgz",
+					"integrity": "sha512-oGa2Hl7CQjfoaogtrOHEJroOcYILTx7BZWLGsJIlzoWmB2zmguhNfPJZsWPKYek/MgCxfco54gEi31d1uN2hFA==",
+					"dev": true,
+					"requires": {
+						"ajv": "^6.10.2",
+						"lodash": "^4.17.14",
 						"slice-ansi": "^2.1.0",
 						"string-width": "^3.0.0"
 					},
@@ -10662,34 +10699,25 @@
 								"is-fullwidth-code-point": "^2.0.0",
 								"strip-ansi": "^5.1.0"
 							}
-						},
-						"strip-ansi": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^4.1.0"
-							}
 						}
 					}
 				},
-				"write": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
-					"integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
-					"dev": true,
-					"requires": {
-						"mkdirp": "^0.5.1"
-					}
+				"v8-compile-cache": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+					"integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+					"dev": true
 				}
 			}
 		},
 		"eslint-plugin-jest": {
-			"version": "21.5.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-21.5.0.tgz",
-			"integrity": "sha512-4fxfe2RcqzU+IVNQL5n4pqibLcUhKKxihYsA510+6kC/FTdGInszDDHgO4ntBzPWu8mcHAvKJLs8o3AQw6eHTg==",
-			"dev": true
+			"version": "22.14.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.14.1.tgz",
+			"integrity": "sha512-mpLjhADl+HjagrlaGNx95HIji089S18DhnU/Ee8P8VP+dhEnuEzb43BXEaRmDgQ7BiSUPcSCvt1ydtgPkjOF/Q==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/experimental-utils": "^1.13.0"
+			}
 		},
 		"eslint-plugin-jsdoc": {
 			"version": "15.8.0",
@@ -10730,11 +10758,12 @@
 			}
 		},
 		"eslint-plugin-jsx-a11y": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.1.tgz",
-			"integrity": "sha512-cjN2ObWrRz0TTw7vEcGQrx+YltMvZoOEx4hWU8eEERDnBIU00OTq7Vr+jA7DFKxiwLNv4tTh5Pq2GUNEa8b6+w==",
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz",
+			"integrity": "sha512-CawzfGt9w83tyuVekn0GDPU9ytYtxyxyFZ3aSWROmnRRFQFT2BiPJd7jvRdzNDi6oLWaS2asMeYSNMjWTV4eNg==",
 			"dev": true,
 			"requires": {
+				"@babel/runtime": "^7.4.5",
 				"aria-query": "^3.0.0",
 				"array-includes": "^3.0.3",
 				"ast-types-flow": "^0.0.7",
@@ -10742,24 +10771,59 @@
 				"damerau-levenshtein": "^1.0.4",
 				"emoji-regex": "^7.0.2",
 				"has": "^1.0.3",
-				"jsx-ast-utils": "^2.0.1"
+				"jsx-ast-utils": "^2.2.1"
 			}
 		},
 		"eslint-plugin-react": {
-			"version": "7.12.4",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz",
-			"integrity": "sha512-1puHJkXJY+oS1t467MjbqjvX53uQ05HXwjqDgdbGBqf5j9eeydI54G3KwiJmWciQ0HTBacIKw2jgwSBSH3yfgQ==",
+			"version": "7.14.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
+			"integrity": "sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==",
 			"dev": true,
 			"requires": {
 				"array-includes": "^3.0.3",
 				"doctrine": "^2.1.0",
 				"has": "^1.0.3",
-				"jsx-ast-utils": "^2.0.1",
+				"jsx-ast-utils": "^2.1.0",
+				"object.entries": "^1.1.0",
 				"object.fromentries": "^2.0.0",
-				"prop-types": "^15.6.2",
-				"resolve": "^1.9.0"
+				"object.values": "^1.1.0",
+				"prop-types": "^15.7.2",
+				"resolve": "^1.10.1"
 			},
 			"dependencies": {
+				"define-properties": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+					"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+					"dev": true,
+					"requires": {
+						"object-keys": "^1.0.12"
+					}
+				},
+				"object.entries": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+					"integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+					"dev": true,
+					"requires": {
+						"define-properties": "^1.1.3",
+						"es-abstract": "^1.12.0",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3"
+					}
+				},
+				"object.values": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
+					"integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+					"dev": true,
+					"requires": {
+						"define-properties": "^1.1.3",
+						"es-abstract": "^1.12.0",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3"
+					}
+				},
 				"path-parse": {
 					"version": "1.0.6",
 					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
@@ -10767,9 +10831,9 @@
 					"dev": true
 				},
 				"resolve": {
-					"version": "1.10.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-					"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+					"version": "1.12.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+					"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
 					"dev": true,
 					"requires": {
 						"path-parse": "^1.0.6"
@@ -10778,9 +10842,9 @@
 			}
 		},
 		"eslint-plugin-react-hooks": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.0.tgz",
-			"integrity": "sha512-lHBVRIaz5ibnIgNG07JNiAuBUeKhEf8l4etNx5vfAEwqQ5tcuK3jV9yjmopPgQDagQb7HwIuQVsE3IVcGrRnag==",
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.1.tgz",
+			"integrity": "sha512-wHhmGJyVuijnYIJXZJHDUF2WM+rJYTjulUTqF9k61d3BTk8etydz+M4dXUVH7M76ZRS85rqBTCx0Es/lLsrjnA==",
 			"dev": true
 		},
 		"eslint-scope": {
@@ -10794,10 +10858,13 @@
 			}
 		},
 		"eslint-utils": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-			"integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-			"dev": true
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
+			"integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+			"dev": true,
+			"requires": {
+				"eslint-visitor-keys": "^1.0.0"
+			}
 		},
 		"eslint-visitor-keys": {
 			"version": "1.0.0",
@@ -11369,6 +11436,15 @@
 				"escape-string-regexp": "^1.0.5"
 			}
 		},
+		"file-entry-cache": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+			"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+			"dev": true,
+			"requires": {
+				"flat-cache": "^2.0.1"
+			}
+		},
 		"fileset": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
@@ -11587,6 +11663,42 @@
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
 					"integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
 					"dev": true
+				}
+			}
+		},
+		"flat-cache": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+			"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+			"dev": true,
+			"requires": {
+				"flatted": "^2.0.0",
+				"rimraf": "2.6.3",
+				"write": "1.0.3"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.4",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
 				}
 			}
 		},
@@ -12808,9 +12920,9 @@
 			"dev": true
 		},
 		"globals": {
-			"version": "11.7.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-			"integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
 			"dev": true
 		},
 		"globby": {
@@ -13347,9 +13459,9 @@
 			"dev": true
 		},
 		"import-fresh": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
-			"integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
+			"integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
 			"dev": true,
 			"requires": {
 				"parent-module": "^1.0.0",
@@ -15692,12 +15804,13 @@
 			}
 		},
 		"jsx-ast-utils": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
-			"integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz",
+			"integrity": "sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==",
 			"dev": true,
 			"requires": {
-				"array-includes": "^3.0.3"
+				"array-includes": "^3.0.3",
+				"object.assign": "^4.1.0"
 			}
 		},
 		"kind-of": {
@@ -16187,6 +16300,12 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
 			"integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
+			"dev": true
+		},
+		"lodash.unescape": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+			"integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
 			"dev": true
 		},
 		"lodash.uniq": {
@@ -19637,20 +19756,12 @@
 			}
 		},
 		"parent-module": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
-			"integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
 			"dev": true,
 			"requires": {
 				"callsites": "^3.0.0"
-			},
-			"dependencies": {
-				"callsites": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
-					"integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
-					"dev": true
-				}
 			}
 		},
 		"parse-asn1": {
@@ -26621,6 +26732,15 @@
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 			"dev": true
+		},
+		"write": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+			"integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+			"dev": true,
+			"requires": {
+				"mkdirp": "^0.5.1"
+			}
 		},
 		"write-file-atomic": {
 			"version": "2.4.3",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
 		"deep-freeze": "0.0.1",
 		"doctrine": "2.1.0",
 		"enzyme": "3.9.0",
-		"eslint-plugin-jest": "21.5.0",
+		"eslint-plugin-jest": "22.14.1",
 		"espree": "4.0.0",
 		"fast-glob": "2.2.7",
 		"fbjs": "0.8.17",

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -486,7 +486,7 @@ function BlockListBlock( {
 	//  jsx-a11y/no-static-element-interactions:
 	//   - Each block can be selected by clicking on it
 
-	/* eslint-disable jsx-a11y/mouse-events-have-key-events, jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
+	/* eslint-disable jsx-a11y/mouse-events-have-key-events, jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 
 	return (
 		<IgnoreNestedEvents
@@ -618,7 +618,7 @@ function BlockListBlock( {
 			) }
 		</IgnoreNestedEvents>
 	);
-	/* eslint-enable jsx-a11y/mouse-events-have-key-events, jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
+	/* eslint-enable jsx-a11y/mouse-events-have-key-events, jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 }
 
 const applyWithSelect = withSelect(

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -151,7 +151,7 @@ class AudioEdit extends Component {
 			);
 		}
 
-		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
+		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 		return (
 			<>
 				<BlockControls>
@@ -210,7 +210,7 @@ class AudioEdit extends Component {
 				</figure>
 			</>
 		);
-		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
+		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 	}
 }
 export default compose( [

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -778,7 +778,7 @@ export class ImageEdit extends Component {
 		);
 
 		// Disable reason: Each block can be selected by clicking on it
-		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
+		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 		return (
 			<>
 				{ controls }
@@ -924,7 +924,7 @@ export class ImageEdit extends Component {
 				{ mediaPlaceholder }
 			</>
 		);
-		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
+		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 	}
 }
 

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -198,7 +198,7 @@ class VideoEdit extends Component {
 		}
 		const videoPosterDescription = `video-block__poster-image-description-${ instanceId }`;
 
-		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
+		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 		return (
 			<>
 				<BlockControls>
@@ -314,7 +314,7 @@ class VideoEdit extends Component {
 				</figure>
 			</>
 		);
-		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
+		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 	}
 }
 

--- a/packages/block-serialization-default-parser/test/index.js
+++ b/packages/block-serialization-default-parser/test/index.js
@@ -14,6 +14,6 @@ import { jsTester, phpTester } from '@wordpress/block-serialization-spec-parser/
  */
 import { parse } from '../src';
 
-describe( 'block-serialization-default-parser-js', jsTester( parse ) );
+describe( 'block-serialization-default-parser-js', jsTester( parse ) ); // eslint-disable-line jest/valid-describe
 
 phpTester( 'block-serialization-default-parser-php', path.join( __dirname, 'test-parser.php' ) );

--- a/packages/block-serialization-spec-parser/shared-tests.js
+++ b/packages/block-serialization-spec-parser/shared-tests.js
@@ -176,7 +176,7 @@ const hasPHP = 'test' === process.env.NODE_ENV ? ( () => {
 // skipping if `php` isn't available to us, such as in local dev without it
 // skipping preserves snapshots while commenting out or simply
 // not injecting the tests prompts `jest` to remove "obsolete snapshots"
-// eslint-disable-next-line jest/no-disabled-tests
+// eslint-disable-next-line jest/no-disabled-tests, jest/valid-describe
 const makeTest = hasPHP ? ( ...args ) => describe( ...args ) : ( ...args ) => describe.skip( ...args );
 
 export const phpTester = ( name, filename ) => makeTest(

--- a/packages/block-serialization-spec-parser/test/index.js
+++ b/packages/block-serialization-spec-parser/test/index.js
@@ -9,6 +9,6 @@ import path from 'path';
 import { parse } from '../';
 import { jsTester, phpTester } from '../shared-tests';
 
-describe( 'block-serialization-spec-parser-js', jsTester( parse ) );
+describe( 'block-serialization-spec-parser-js', jsTester( parse ) ); // eslint-disable-line jest/valid-describe
 
 phpTester( 'block-serialization-spec-parser-php', path.join( __dirname, 'test-parser.php' ) );

--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -1,5 +1,3 @@
-/* eslint-disable react/forbid-elements2 */
-
 /**
  * External dependencies
  */

--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -446,7 +446,7 @@ export class Autocomplete extends Component {
 		const activeId = isExpanded ? `components-autocomplete-item-${ instanceId }-${ selectedKey }` : null;
 
 		// Disable reason: Clicking the editor should reset the autocomplete when the menu is suppressed
-		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
+		/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 		return (
 			<div
 				ref={ this.bindNode }
@@ -487,7 +487,7 @@ export class Autocomplete extends Component {
 				) }
 			</div>
 		);
-		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
+		/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 	}
 }
 

--- a/packages/components/src/higher-order/navigate-regions/index.js
+++ b/packages/components/src/higher-order/navigate-regions/index.js
@@ -61,7 +61,7 @@ export default createHigherOrderComponent(
 				} );
 
 				// Disable reason: Clicking the editor should dismiss the regions focus style
-				/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
+				/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 				return (
 					<div ref={ this.bindContainer } className={ className } onClick={ this.onClick }>
 						<KeyboardShortcuts
@@ -76,7 +76,7 @@ export default createHigherOrderComponent(
 						<WrappedComponent { ...this.props } />
 					</div>
 				);
-				/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/onclick-has-role, jsx-a11y/click-events-have-key-events */
+				/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 			}
 		};
 	}, 'navigateRegions'

--- a/packages/components/src/higher-order/with-spoken-messages/test/index.js
+++ b/packages/components/src/higher-order/with-spoken-messages/test/index.js
@@ -21,7 +21,7 @@ describe( 'withSpokenMessages', () => {
 		render( <DumpComponent /> );
 
 		// Unrendered element.
-		expect( testSpeak ).toBeCalledWith( true );
-		expect( testDebouncedSpeak ).toBeCalledWith( true );
+		expect( testSpeak ).toHaveBeenCalledWith( true );
+		expect( testDebouncedSpeak ).toHaveBeenCalledWith( true );
 	} );
 } );

--- a/packages/components/src/slot-fill/test/slot.js
+++ b/packages/components/src/slot-fill/test/slot.js
@@ -210,8 +210,9 @@ describe( 'Slot', () => {
 		expect( testRenderer.toJSON() ).toMatchSnapshot();
 	} );
 
-	[ false, true ].forEach( ( bubblesVirtually ) => {
-		describe( 'bubblesVirtually ' + bubblesVirtually, () => {
+	describe.each( [ false, true ] )(
+		'bubblesVirtually %p',
+		( bubblesVirtually ) => {
 			it( 'should subsume another slot by the same name', () => {
 				const testRenderer = ReactTestRenderer.create(
 					<Provider>
@@ -251,6 +252,6 @@ describe( 'Slot', () => {
 
 				expect( testRenderer.getInstance().slots ).toHaveProperty( 'egg' );
 			} );
-		} );
-	} );
+		}
+	);
 } );

--- a/packages/data/src/components/with-dispatch/test/index.js
+++ b/packages/data/src/components/with-dispatch/test/index.js
@@ -35,7 +35,7 @@ describe( 'withDispatch', () => {
 			return {
 				increment: () => {
 					const actionReturnedFromDispatch = Promise.resolve( _dispatch( 'counter' ).increment( count ) );
-					expect( actionReturnedFromDispatch ).resolves.toEqual(
+					return expect( actionReturnedFromDispatch ).resolves.toEqual(
 						{
 							type: 'increment',
 							count,
@@ -166,7 +166,7 @@ describe( 'withDispatch', () => {
 					const actionReturnedFromDispatch = Promise.resolve(
 						_dispatch( 'counter' ).update( innerCount + 1 )
 					);
-					expect( actionReturnedFromDispatch ).resolves.toEqual( {
+					return expect( actionReturnedFromDispatch ).resolves.toEqual( {
 						type: 'update',
 						count: innerCount + 1,
 					} );

--- a/packages/data/src/namespace-store/test/index.js
+++ b/packages/data/src/namespace-store/test/index.js
@@ -36,7 +36,7 @@ describe( 'controls', () => {
 			} );
 
 			registry.dispatch( 'store2' ).action2();
-			expect( action1 ).toHaveBeeenCalled();
+			expect( action1 ).toHaveBeenCalled();
 		} );
 	} );
 

--- a/packages/data/src/namespace-store/test/index.js
+++ b/packages/data/src/namespace-store/test/index.js
@@ -36,7 +36,7 @@ describe( 'controls', () => {
 			} );
 
 			registry.dispatch( 'store2' ).action2();
-			expect( action1 ).toBeCalled();
+			expect( action1 ).toHaveBeeenCalled();
 		} );
 	} );
 

--- a/packages/data/src/namespace-store/test/index.js
+++ b/packages/data/src/namespace-store/test/index.js
@@ -107,8 +107,7 @@ describe( 'controls', () => {
 			expect( registry.select( 'store' ).getItems.hasResolver ).toBe( false );
 		} );
 	} );
-	describe( 'various action types have expected response and resolve as ' +
-		'expected with controls middleware', () => {
+	describe( 'various action types have expected response and resolve as expected with controls middleware', () => {
 		const actions = {
 			*withPromise() {
 				yield { type: 'SOME_ACTION' };
@@ -164,8 +163,7 @@ describe( 'controls', () => {
 				.toEqual( { type: 'NORMAL' } );
 		} );
 	} );
-	describe( 'action type resolves as expected with just promise ' +
-		'middleware', () => {
+	describe( 'action type resolves as expected with just promise middleware', () => {
 		const actions = {
 			normal: () => ( { type: 'NORMAL' } ),
 			withPromiseAndAction: () => new Promise(

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -438,10 +438,10 @@ describe( 'createRegistry', () => {
 			} );
 
 			expect( registry.select( 'reducer1' ).selector1() ).toEqual( 'result1' );
-			expect( selector1 ).toBeCalledWith( store.getState() );
+			expect( selector1 ).toHaveBeenCalledWith( store.getState() );
 
 			expect( registry.select( 'reducer1' ).selector2() ).toEqual( 'result2' );
-			expect( selector2 ).toBeCalledWith( store.getState() );
+			expect( selector2 ).toHaveBeenCalledWith( store.getState() );
 		} );
 
 		it( 'should run the registry selectors properly', () => {

--- a/packages/e2e-tests/specs/navigable-toolbar.test.js
+++ b/packages/e2e-tests/specs/navigable-toolbar.test.js
@@ -22,20 +22,18 @@ describe.each( [ [ 'unified', true ], [ 'contextual', false ] ] )(
 			!! document.activeElement.closest( '.block-editor-block-toolbar' )
 		) );
 
-		describe( label, () => {
-			it( 'navigates in and out of toolbar by keyboard (Alt+F10, Escape)', async () => {
-				// Assumes new post focus starts in title. Create first new
-				// block by ArrowDown.
-				await page.keyboard.press( 'ArrowDown' );
+		it( 'navigates in and out of toolbar by keyboard (Alt+F10, Escape)', async () => {
+			// Assumes new post focus starts in title. Create first new
+			// block by ArrowDown.
+			await page.keyboard.press( 'ArrowDown' );
 
-				// [TEMPORARY]: A new paragraph is not technically a block yet
-				// until starting to type within it.
-				await page.keyboard.type( 'Example' );
+			// [TEMPORARY]: A new paragraph is not technically a block yet
+			// until starting to type within it.
+			await page.keyboard.type( 'Example' );
 
-				// Upward
-				await pressKeyWithModifier( 'alt', 'F10' );
-				expect( await isInBlockToolbar() ).toBe( true );
-			} );
+			// Upward
+			await pressKeyWithModifier( 'alt', 'F10' );
+			expect( await isInBlockToolbar() ).toBe( true );
 		} );
 	}
 );

--- a/packages/e2e-tests/specs/navigable-toolbar.test.js
+++ b/packages/e2e-tests/specs/navigable-toolbar.test.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { forEach } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { createNewPost, pressKeyWithModifier } from '@wordpress/e2e-test-utils';

--- a/packages/e2e-tests/specs/navigable-toolbar.test.js
+++ b/packages/e2e-tests/specs/navigable-toolbar.test.js
@@ -8,11 +8,9 @@ import { forEach } from 'lodash';
  */
 import { createNewPost, pressKeyWithModifier } from '@wordpress/e2e-test-utils';
 
-describe( 'block toolbar', () => {
-	forEach( {
-		unified: true,
-		contextual: false,
-	}, ( isUnifiedToolbar, label ) => {
+describe.each( [ [ 'unified', true ], [ 'contextual', false ] ] )(
+	'block toolbar (%s: %p)',
+	( label, isUnifiedToolbar ) => {
 		beforeEach( async () => {
 			await createNewPost();
 
@@ -44,5 +42,6 @@ describe( 'block toolbar', () => {
 				expect( await isInBlockToolbar() ).toBe( true );
 			} );
 		} );
-	} );
-} );
+	}
+);
+

--- a/packages/e2e-tests/specs/navigable-toolbar.test.js
+++ b/packages/e2e-tests/specs/navigable-toolbar.test.js
@@ -18,9 +18,14 @@ describe.each( [ [ 'unified', true ], [ 'contextual', false ] ] )(
 			}, isUnifiedToolbar );
 		} );
 
-		const isInBlockToolbar = () => page.evaluate( () => (
-			!! document.activeElement.closest( '.block-editor-block-toolbar' )
-		) );
+		const isInBlockToolbar = () => page.evaluate( ( _isUnifiedToolbar ) => {
+			if ( _isUnifiedToolbar ) {
+				return !! document.activeElement
+					.closest( '.edit-post-header-toolbar' )
+					.querySelector( '.block-editor-block-toolbar' );
+			}
+			return !! document.activeElement.closest( '.block-editor-block-toolbar' );
+		}, isUnifiedToolbar );
 
 		it( 'navigates in and out of toolbar by keyboard (Alt+F10, Escape)', async () => {
 			// Assumes new post focus starts in title. Create first new

--- a/packages/e2e-tests/specs/publishing.test.js
+++ b/packages/e2e-tests/specs/publishing.test.js
@@ -12,9 +12,11 @@ import {
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Publishing', () => {
-	[ 'post', 'page' ].forEach( ( postType ) => {
-		let werePrePublishChecksEnabled;
-		describe( `a ${ postType }`, () => {
+	describe.each( [ 'post', 'page' ] )(
+		'a %s',
+		( postType ) => {
+			let werePrePublishChecksEnabled;
+
 			beforeEach( async () => {
 				await createNewPost( postType );
 				werePrePublishChecksEnabled = await arePrePublishChecksEnabled();
@@ -43,12 +45,14 @@ describe( 'Publishing', () => {
 				// The post-publishing panel is not visible anymore.
 				expect( await page.$( '.editor-post-publish-panel' ) ).toBeNull();
 			} );
-		} );
-	} );
+		}
+	);
 
-	[ 'post', 'page' ].forEach( ( postType ) => {
-		let werePrePublishChecksEnabled;
-		describe( `a ${ postType } with pre-publish checks disabled`, () => {
+	describe.each( [ 'post', 'page' ] )(
+		'a %s with pre-publish checks disabled',
+		( postType ) => {
+			let werePrePublishChecksEnabled;
+
 			beforeEach( async () => {
 				await createNewPost( postType );
 				werePrePublishChecksEnabled = await arePrePublishChecksEnabled();
@@ -75,12 +79,14 @@ describe( 'Publishing', () => {
 				// The post-publishing panel should have been not shown.
 				expect( await page.$( '.editor-post-publish-panel' ) ).toBeNull();
 			} );
-		} );
-	} );
+		}
+	);
 
-	[ 'post', 'page' ].forEach( ( postType ) => {
-		let werePrePublishChecksEnabled;
-		describe( `a ${ postType } in small viewports`, () => {
+	describe.each( [ 'post', 'page' ] )(
+		'a %s in small viewports',
+		( postType ) => {
+			let werePrePublishChecksEnabled;
+
 			beforeEach( async () => {
 				await createNewPost( postType );
 				werePrePublishChecksEnabled = await arePrePublishChecksEnabled();
@@ -101,6 +107,6 @@ describe( 'Publishing', () => {
 				expect( await page.$( '.editor-post-publish-panel__toggle' ) ).not.toBeNull();
 				expect( await page.$( '.editor-post-publish-button' ) ).toBeNull();
 			} );
-		} );
-	} );
+		}
+	);
 } );

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -436,8 +436,7 @@ describe( 'Post generator actions', () => {
 			} );
 		};
 
-		describe( 'yields with expected responses when edited post is not ' +
-			'saveable', () => {
+		describe( 'yields with expected responses when edited post is not saveable', () => {
 			it( 'yields action for selecting if edited post is saveable', () => {
 				reset( false );
 				const { value } = fulfillment.next();
@@ -451,8 +450,7 @@ describe( 'Post generator actions', () => {
 				expect( value ).toBeUndefined();
 			} );
 		} );
-		describe( 'yields with expected responses for when not autosaving ' +
-			'and edited post is new', () => {
+		describe( 'yields with expected responses for when not autosaving and edited post is new', () => {
 			beforeEach( () => {
 				isAutosave = false;
 				isEditedPostNew = true;
@@ -469,8 +467,7 @@ describe( 'Post generator actions', () => {
 			} );
 		} );
 
-		describe( 'yields with expected responses for when not autosaving ' +
-			'and edited post is not new', () => {
+		describe( 'yields with expected responses for when not autosaving and edited post is not new', () => {
 			beforeEach( () => {
 				isAutosave = false;
 				isEditedPostNew = false;
@@ -486,8 +483,7 @@ describe( 'Post generator actions', () => {
 				fetchSuccessConditions.forEach( testRunRoutine );
 			} );
 		} );
-		describe( 'yields with expected responses for when autosaving is true ' +
-			'and edited post is not new', () => {
+		describe( 'yields with expected responses for when autosaving is true and edited post is not new', () => {
 			beforeEach( () => {
 				isAutosave = true;
 				isEditedPostNew = false;

--- a/packages/eslint-plugin/configs/jsdoc.js
+++ b/packages/eslint-plugin/configs/jsdoc.js
@@ -16,7 +16,7 @@ module.exports = {
 		},
 	},
 	rules: {
-		'jsdoc/no-undefined-types': [ 'warning', {
+		'jsdoc/no-undefined-types': [ 'warn', {
 			// Required to reference browser types because we don't have the `browser` environment enabled for the project.
 			// Here we filter out all browser globals that don't begin with an uppercase letter because those
 			// generally refer to window-level event listeners and are not a valid type to reference (e.g. `onclick`).

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -24,11 +24,11 @@
 	],
 	"main": "index.js",
 	"dependencies": {
-		"babel-eslint": "^10.0.1",
+		"babel-eslint": "^10.0.2",
 		"eslint-plugin-jsdoc": "^15.8.0",
-		"eslint-plugin-jsx-a11y": "^6.2.1",
-		"eslint-plugin-react": "^7.12.4",
-		"eslint-plugin-react-hooks": "^1.6.0",
+		"eslint-plugin-jsx-a11y": "^6.2.3",
+		"eslint-plugin-react": "^7.14.3",
+		"eslint-plugin-react-hooks": "^1.6.1",
 		"globals": "^12.0.0",
 		"requireindex": "^1.2.0"
 	},

--- a/packages/jest-console/src/matchers.js
+++ b/packages/jest-console/src/matchers.js
@@ -9,7 +9,7 @@ import { isEqual, reduce, some } from 'lodash';
  */
 import supportedMatchers from './supported-matchers';
 
-const createToBeCalledMatcher = ( matcherName, methodName ) =>
+const createToHaveBeenCalledMatcher = ( matcherName, methodName ) =>
 	( received ) => {
 		const spy = received[ methodName ];
 		const calls = spy.mock.calls;
@@ -33,7 +33,7 @@ const createToBeCalledMatcher = ( matcherName, methodName ) =>
 		};
 	};
 
-const createToBeCalledWithMatcher = ( matcherName, methodName ) =>
+const createToHaveBeenCalledWith = ( matcherName, methodName ) =>
 	( received, ...expected ) => {
 		const spy = received[ methodName ];
 		const calls = spy.mock.calls;
@@ -69,8 +69,8 @@ expect.extend(
 
 		return {
 			...result,
-			[ matcherName ]: createToBeCalledMatcher( `.${ matcherName }`, methodName ),
-			[ matcherNameWith ]: createToBeCalledWithMatcher( `.${ matcherNameWith }`, methodName ),
+			[ matcherName ]: createToHaveBeenCalledMatcher( `.${ matcherName }`, methodName ),
+			[ matcherNameWith ]: createToHaveBeenCalledWith( `.${ matcherNameWith }`, methodName ),
 		};
 	}, {} )
 );

--- a/packages/jest-console/src/test/index.test.js
+++ b/packages/jest-console/src/test/index.test.js
@@ -1,89 +1,77 @@
 /* eslint-disable no-console */
 
 /**
- * External dependencies
- */
-import { forEach } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import '../matchers';
 
 describe( 'jest-console', () => {
-	forEach(
-		{
-			error: 'toHaveErrored',
-			info: 'toHaveInformed',
-			log: 'toHaveLogged',
-			warn: 'toHaveWarned',
-		},
-		( matcherName, methodName ) => {
-			describe( `console.${ methodName }`, () => {
-				const matcherNameWith = `${ matcherName }With`;
-				const message = `This is ${ methodName }!`;
+	describe.each( [ [ 'error', 'toHaveErrored' ], [ 'info', 'toHaveInformed' ], [ 'log', 'toHaveLogged' ], [ 'warn', 'toHaveWarned' ] ] )(
+		'console.%s',
+		( methodName, matcherName ) => {
+			const matcherNameWith = `${ matcherName }With`;
+			const message = `This is ${ methodName }!`;
 
-				test( `${ matcherName } works`, () => {
-					console[ methodName ]( message );
+			test( `${ matcherName } works`, () => {
+				console[ methodName ]( message );
 
-					expect( console )[ matcherName ]();
+				expect( console )[ matcherName ]();
+			} );
+
+			test( `${ matcherName } works when not called`, () => {
+				expect( console ).not[ matcherName ]();
+				expect(
+					() => expect( console )[ matcherName ]()
+				).toThrow( 'Expected mock function to be called.' );
+			} );
+
+			test( `${ matcherNameWith } works with arguments that match`, () => {
+				console[ methodName ]( message );
+
+				expect( console )[ matcherNameWith ]( message );
+			} );
+
+			test( `${ matcherNameWith } works when not called`, () => {
+				expect( console ).not[ matcherNameWith ]( message );
+				expect(
+					() => expect( console )[ matcherNameWith ]( message )
+				).toThrow( /Expected mock function to be called with:.*but it was called with:/s );
+			} );
+
+			test( `${ matcherNameWith } works with many arguments that do not match`, () => {
+				console[ methodName ]( 'Unknown message.' );
+				console[ methodName ]( message, 'Unknown param.' );
+
+				expect( console ).not[ matcherNameWith ]( message );
+				expect(
+					() => expect( console )[ matcherNameWith ]( message )
+				).toThrow( /Expected mock function to be called with:.*but it was called with:.*Unknown param./s );
+			} );
+
+			test( 'assertions number gets incremented after every matcher call', () => {
+				const spy = console[ methodName ];
+
+				expect( spy.assertionsNumber ).toBe( 0 );
+
+				console[ methodName ]( message );
+
+				expect( console )[ matcherName ]();
+				expect( spy.assertionsNumber ).toBe( 1 );
+
+				expect( console )[ matcherNameWith ]( message );
+				expect( spy.assertionsNumber ).toBe( 2 );
+			} );
+
+			describe( 'lifecycle', () => {
+				beforeAll( () => {
+					// This is a difficult one to test, since the matcher's
+					// own lifecycle is defined to run before ours. Infer
+					// that we're being watched by testing the console
+					// method as being a spy.
+					expect( console[ methodName ].assertionsNumber ).toBeGreaterThanOrEqual( 0 );
 				} );
 
-				test( `${ matcherName } works when not called`, () => {
-					expect( console ).not[ matcherName ]();
-					expect(
-						() => expect( console )[ matcherName ]()
-					).toThrow( 'Expected mock function to be called.' );
-				} );
-
-				test( `${ matcherNameWith } works with arguments that match`, () => {
-					console[ methodName ]( message );
-
-					expect( console )[ matcherNameWith ]( message );
-				} );
-
-				test( `${ matcherNameWith } works when not called`, () => {
-					expect( console ).not[ matcherNameWith ]( message );
-					expect(
-						() => expect( console )[ matcherNameWith ]( message )
-					).toThrow( /Expected mock function to be called with:.*but it was called with:/s );
-				} );
-
-				test( `${ matcherNameWith } works with many arguments that do not match`, () => {
-					console[ methodName ]( 'Unknown message.' );
-					console[ methodName ]( message, 'Unknown param.' );
-
-					expect( console ).not[ matcherNameWith ]( message );
-					expect(
-						() => expect( console )[ matcherNameWith ]( message )
-					).toThrow( /Expected mock function to be called with:.*but it was called with:.*Unknown param./s );
-				} );
-
-				test( 'assertions number gets incremented after every matcher call', () => {
-					const spy = console[ methodName ];
-
-					expect( spy.assertionsNumber ).toBe( 0 );
-
-					console[ methodName ]( message );
-
-					expect( console )[ matcherName ]();
-					expect( spy.assertionsNumber ).toBe( 1 );
-
-					expect( console )[ matcherNameWith ]( message );
-					expect( spy.assertionsNumber ).toBe( 2 );
-				} );
-
-				describe( 'lifecycle', () => {
-					beforeAll( () => {
-						// This is a difficult one to test, since the matcher's
-						// own lifecycle is defined to run before ours. Infer
-						// that we're being watched by testing the console
-						// method as being a spy.
-						expect( console[ methodName ].assertionsNumber ).toBeGreaterThanOrEqual( 0 );
-					} );
-
-					it( 'captures logging in lifecycle', () => {} );
-				} );
+				it( 'captures logging in lifecycle', () => {} );
 			} );
 		}
 	);

--- a/packages/jest-console/src/test/index.test.js
+++ b/packages/jest-console/src/test/index.test.js
@@ -33,7 +33,7 @@ describe( 'jest-console', () => {
 					expect( console ).not[ matcherName ]();
 					expect(
 						() => expect( console )[ matcherName ]()
-					).toThrowError( 'Expected mock function to be called.' );
+					).toThrow( 'Expected mock function to be called.' );
 				} );
 
 				test( `${ matcherNameWith } works with arguments that match`, () => {
@@ -46,7 +46,7 @@ describe( 'jest-console', () => {
 					expect( console ).not[ matcherNameWith ]( message );
 					expect(
 						() => expect( console )[ matcherNameWith ]( message )
-					).toThrowError( /Expected mock function to be called with:.*but it was called with:/s );
+					).toThrow( /Expected mock function to be called with:.*but it was called with:/s );
 				} );
 
 				test( `${ matcherNameWith } works with many arguments that do not match`, () => {
@@ -56,7 +56,7 @@ describe( 'jest-console', () => {
 					expect( console ).not[ matcherNameWith ]( message );
 					expect(
 						() => expect( console )[ matcherNameWith ]( message )
-					).toThrowError( /Expected mock function to be called with:.*but it was called with:.*Unknown param./s );
+					).toThrow( /Expected mock function to be called with:.*but it was called with:.*Unknown param./s );
 				} );
 
 				test( 'assertions number gets incremented after every matcher call', () => {

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - The bundled `puppeteer` dependency has been updated from requiring `1.6.1` to requiring `^1.19.0` ([#16875](https://github.com/WordPress/gutenberg/pull/16875)). It uses Chromium v77 instead of Chromium v69.
 - The bundled `jest-puppeteer` dependency has been updated from requiring `^4.0.0` to requiring `^4.3.0` ([#16875](https://github.com/WordPress/gutenberg/pull/16875)).
+- The bundled `eslint` dependency has been updated from requiring `^5.16.0` to requiring `^6.1.0`.
 
 ## 3.4.0 (2019-08-05)
 
@@ -26,7 +27,7 @@
 
 ## 3.2.0 (2019-05-21)
 
-### New Feature
+### New Features
 
 - Leverage `@wordpress/dependency-extraction-webpack-plugin` plugin to extract WordPress
   dependencies.

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -42,7 +42,7 @@
 		"chalk": "^2.4.1",
 		"check-node-version": "^3.1.1",
 		"cross-spawn": "^5.1.0",
-		"eslint": "^5.16.0",
+		"eslint": "^6.1.0",
 		"jest": "^24.7.1",
 		"jest-puppeteer": "^4.3.0",
 		"minimist": "^1.2.0",

--- a/packages/scripts/scripts/test-e2e.js
+++ b/packages/scripts/scripts/test-e2e.js
@@ -12,6 +12,7 @@ process.on( 'unhandledRejection', ( err ) => {
 /**
  * External dependencies
  */
+/* eslint-disable jest/no-jest-import */
 const jest = require( 'jest' );
 
 /**

--- a/packages/scripts/scripts/test-unit-jest.js
+++ b/packages/scripts/scripts/test-unit-jest.js
@@ -12,6 +12,7 @@ process.on( 'unhandledRejection', ( err ) => {
 /**
  * External dependencies
  */
+/* eslint-disable jest/no-jest-import */
 const jest = require( 'jest' );
 
 /**


### PR DESCRIPTION
## Description

This PR updates ESLInt to the latest version: `6.1.0`. This is a major version bump.

In addition, it updates the following packages which are related to ESLint:
- `babel-eslint`: "^10.0.2",
- `eslint-plugin-jsx-a11y`: "^6.2.3"
- `eslint-plugin-react`: "^7.14.3" (minor version bump)
- `eslint-plugin-react-hooks`: "^1.6.1"

There was also this major version upgrade:
- `eslint-plugin-jest`: "22.14.1"

I had to disable `jest/valid-describe` rule because we often create dynamic `describe` calls and this rule doesn't like it. Well, it's not flexible enough in my opinion.


## How has this been tested?
`npm run lint-js`
`npm run test-unit`
