### PR TITLE
add width control to separator block

### DIFF
--- a/packages/block-library/src/separator/block.json
+++ b/packages/block-library/src/separator/block.json
@@ -7,6 +7,9 @@
 		},
 		"customColor": {
 			"type": "string"
+		},
+		"width": {
+			"type": "number"
 		}
 	}
 }

--- a/packages/block-library/src/separator/edit.js
+++ b/packages/block-library/src/separator/edit.js
@@ -7,14 +7,15 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { HorizontalRule } from '@wordpress/components';
+import { HorizontalRule, RangeControl, PanelBody } from '@wordpress/components';
 import {
 	InspectorControls,
 	withColors,
 	PanelColorSettings,
 } from '@wordpress/block-editor';
 
-function SeparatorEdit( { color, setColor, className } ) {
+function SeparatorEdit( { color, setColor, className, attributes, setAttributes } ) {
+	const { width = 25 } = attributes;
 	return (
 		<>
 			<HorizontalRule
@@ -27,9 +28,23 @@ function SeparatorEdit( { color, setColor, className } ) {
 				style={ {
 					backgroundColor: color.color,
 					color: color.color,
+					width: width + '%',
 				} }
 			/>
 			<InspectorControls>
+				<PanelBody title={ __( 'Separator Settings' ) }>
+					<RangeControl
+						label={ __( 'Percentage width' ) }
+						value={ width || '' }
+						onChange={ ( nextWidth ) => {
+							setAttributes( { width: nextWidth } );
+						} }
+						min={ 1 }
+						max={ 100 }
+						required
+						allowReset
+					/>
+				</PanelBody>
 				<PanelColorSettings
 					title={ __( 'Color Settings' ) }
 					colorSettings={ [

--- a/packages/block-library/src/separator/save.js
+++ b/packages/block-library/src/separator/save.js
@@ -14,6 +14,7 @@ export default function separatorSave( { attributes } ) {
 	const {
 		color,
 		customColor,
+		width,
 	} = attributes;
 
 	// the hr support changing color using border-color, since border-color
@@ -32,6 +33,7 @@ export default function separatorSave( { attributes } ) {
 	const separatorStyle = {
 		backgroundColor: backgroundClass ? undefined : customColor,
 		color: colorClass ? undefined : customColor,
+		width: width ? width + '%' : undefined,
 	};
 
 	return ( <hr

--- a/packages/block-library/src/separator/theme.scss
+++ b/packages/block-library/src/separator/theme.scss
@@ -6,7 +6,7 @@
 
 	// Default, thin style
 	&:not(.is-style-wide):not(.is-style-dots) {
-		max-width: 100px;
+		width: 100px;
 	}
 
 	&.has-background:not(.is-style-dots) {


### PR DESCRIPTION
## Description
follow up to #16784
tackles a point from #16483

this PR adds width control to separator block

## How has this been tested?
create separator components in master
switch to this branch
see if no problems happens


## Screenshots <!-- if applicable -->
![separator-width](https://user-images.githubusercontent.com/6165348/62550487-3eb70b80-b862-11e9-86f2-3d3946c8d7a1.gif)


## Problems
- themes using `max-width` on the hr will have to stop in order for those changes to be visible
- in renders `full-width` useless since that style currently doesn't relay on anything to have it 100%

## Changes
- introduce a new starting width of 25% instead of the 100px.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
