### PR TITLE
Notice: Update dismiss button to match other Gutenberg UI

### DIFF
--- a/packages/components/src/notice/index.js
+++ b/packages/components/src/notice/index.js
@@ -69,7 +69,7 @@ function Notice( {
 			{ isDismissible && (
 				<IconButton
 					className="components-notice__dismiss"
-					icon="no"
+					icon="no-alt"
 					label={ __( 'Dismiss this notice' ) }
 					onClick={ onRemove }
 					tooltip={ false }

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -45,7 +45,7 @@
 	position: absolute;
 	top: 0;
 	right: 0;
-	color: $dark-gray-300;
+	color: $dark-gray-500;
 
 	&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover,
 	&:not(:disabled):not([aria-disabled="true"]):not(.is-default):active,

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -50,7 +50,7 @@
 	&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover,
 	&:not(:disabled):not([aria-disabled="true"]):not(.is-default):active,
 	&:not(:disabled):not([aria-disabled="true"]):focus {
-		color: $alert-red;
+		color: $dark-gray-900;
 		background-color: transparent;
 	}
 


### PR DESCRIPTION
Currently the dismiss button in the Notice component is a little non-standard: 

- It uses the `no` dashicon, instead of `no-alt` (which is used in our modal and sidebar panel close buttons)
- It is `$dark-gray-300` by default (instead of the usual `$dark-gray-500`), and is red on hover, regardless of the type of notification.

This PR updates those to be more consistent. 

## Screenshots

**Before:** 

_Notice dismiss icon alongside the panel close icon:_
![gutenberg test_wp-admin_post-new php (2)](https://user-images.githubusercontent.com/1202812/62550504-5a0d2100-b838-11e9-8a23-14fd332fa7f9.png)

_Hovers:_
![close-old](https://user-images.githubusercontent.com/1202812/62550519-61342f00-b838-11e9-9555-aafeac9cd618.gif)


**After:**

_Notice dismiss icon alongside the panel close icon:_
![gutenberg test_wp-admin_post-new php (1)](https://user-images.githubusercontent.com/1202812/62550537-685b3d00-b838-11e9-809d-0a353530ed7d.png)

_Hovers:_
![close-new](https://user-images.githubusercontent.com/1202812/62550550-6db88780-b838-11e9-8a3a-1cc5ea9a95c9.gif)


## Testing

Pasting this into your console should produce all 4 standard dismissible notices. 

```
wp.data.dispatch('core/notices').createNotice(
	'',
	'Default',
	{
		isDismissible: true,
	}
);
wp.data.dispatch('core/notices').createNotice(
	'warning',
	'Warning',
	{
		isDismissible: true,
	}
);
wp.data.dispatch('core/notices').createNotice(
	'success',
	'Success',
	{
		isDismissible: true,
	}
);
wp.data.dispatch('core/notices').createNotice(
	'error',
	'Error',
	{
		isDismissible: true,
	}
);
```