### PR TITLE
Add supprt for line thickness/Circle size in separator block

### DIFF
--- a/packages/block-library/src/separator/block.json
+++ b/packages/block-library/src/separator/block.json
@@ -7,6 +7,15 @@
 		},
 		"customColor": {
 			"type": "string"
+		},
+		"dotSize": {
+			"type": "number"
+		},
+		"dotSpacing": {
+			"type": "number"
+		},
+		"lineThickness": {
+			"type": "number"
 		}
 	}
 }

--- a/packages/block-library/src/separator/edit.js
+++ b/packages/block-library/src/separator/edit.js
@@ -39,9 +39,9 @@ function SeparatorEdit( { color, setColor, className, attributes, setAttributes 
 					color: color.color,
 					fontSize: dotSize,
 					letterSpacing: dotSpacing || dotSize,
-					paddingLeft: ( isDots ? ( dotSpacing || dotSize ) : '' ),
+					paddingLeft: ( isDots ? ( dotSpacing || dotSize ) : undefined ),
 					borderWidth: lineThickness,
-					height: lineThickness,
+					height: isLine ? lineThickness : undefined,
 				} }
 			/>
 			<InspectorControls>

--- a/packages/block-library/src/separator/edit.js
+++ b/packages/block-library/src/separator/edit.js
@@ -7,14 +7,24 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { HorizontalRule } from '@wordpress/components';
+import { HorizontalRule, RangeControl, PanelBody } from '@wordpress/components';
 import {
 	InspectorControls,
 	withColors,
 	PanelColorSettings,
 } from '@wordpress/block-editor';
 
-function SeparatorEdit( { color, setColor, className } ) {
+/**
+ * Internal dependencies
+ */
+import getActiveStyle from './getActiveStyle';
+import { settings } from './index';
+
+function SeparatorEdit( { color, setColor, className, attributes, setAttributes } ) {
+	const { dotSize, dotSpacing, lineThickness } = attributes;
+	const currentStyle = getActiveStyle( settings.styles, className ).name;
+	const isDots = currentStyle === 'dots';
+	const isLine = currentStyle === 'wide' || currentStyle === 'default';
 	return (
 		<>
 			<HorizontalRule
@@ -27,9 +37,42 @@ function SeparatorEdit( { color, setColor, className } ) {
 				style={ {
 					backgroundColor: color.color,
 					color: color.color,
+					fontSize: dotSize,
+					letterSpacing: dotSpacing || dotSize,
+					paddingLeft: ( isDots ? ( dotSpacing || dotSize ) : '' ),
+					borderWidth: lineThickness,
+					height: lineThickness,
 				} }
 			/>
 			<InspectorControls>
+				{ isDots && <PanelBody title={ __( 'Dots Settings' ) }>
+					<RangeControl
+						label={ __( 'Dot Size' ) }
+						value={ dotSize || 20 }
+						onChange={ ( nextSize ) => {
+							setAttributes( { dotSize: nextSize } );
+						} }
+						allowReset
+					/>
+					<RangeControl
+						label={ __( 'Dot Spacing' ) }
+						value={ dotSpacing || 20 }
+						onChange={ ( nextSize ) => {
+							setAttributes( { dotSpacing: nextSize } );
+						} }
+						allowReset
+					/>
+				</PanelBody> }
+				{ isLine && <PanelBody title={ __( 'Line Settings' ) }>
+					<RangeControl
+						label={ __( 'Line Thickness' ) }
+						value={ lineThickness || 2 }
+						onChange={ ( nextSize ) => {
+							setAttributes( { lineThickness: nextSize } );
+						} }
+						allowReset
+					/>
+				</PanelBody> }
 				<PanelColorSettings
 					title={ __( 'Color Settings' ) }
 					colorSettings={ [

--- a/packages/block-library/src/separator/getActiveStyle.js
+++ b/packages/block-library/src/separator/getActiveStyle.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { find } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import TokenList from '@wordpress/token-list';
+
+export default function getActiveStyle( styles, className ) {
+	for ( const style of new TokenList( className ).values() ) {
+		if ( style.indexOf( 'is-style-' ) === -1 ) {
+			continue;
+		}
+
+		const potentialStyleName = style.substring( 9 );
+		const activeStyle = find( styles, { name: potentialStyleName } );
+		if ( activeStyle ) {
+			return activeStyle;
+		}
+	}
+
+	return find( styles, 'isDefault' );
+}

--- a/packages/block-library/src/separator/save.js
+++ b/packages/block-library/src/separator/save.js
@@ -9,6 +9,11 @@ import classnames from 'classnames';
 import {
 	getColorClassName,
 } from '@wordpress/block-editor';
+/**
+ * Internal dependencies
+ */
+import getActiveStyle from './getActiveStyle';
+import { settings } from './index';
 
 export default function separatorSave( { attributes } ) {
 	const {
@@ -17,7 +22,14 @@ export default function separatorSave( { attributes } ) {
 		dotSize,
 		dotSpacing,
 		lineThickness,
+		className,
 	} = attributes;
+	let { isDots, isLine } = false;
+	if ( className ) {
+		const currentStyle = getActiveStyle( settings.styles, className ).name;
+		isDots = currentStyle === 'dots';
+		isLine = currentStyle === 'wide' || currentStyle === 'default';
+	}
 
 	// the hr support changing color using border-color, since border-color
 	// is not yet supported in the color palette, we use background-color
@@ -37,9 +49,9 @@ export default function separatorSave( { attributes } ) {
 		color: colorClass ? undefined : customColor,
 		fontSize: dotSize || undefined,
 		letterSpacing: dotSpacing || dotSize,
-		paddingLeft: dotSpacing || dotSize,
+		paddingLeft: ( isDots ? ( dotSpacing || dotSize ) : undefined ),
 		borderWidth: lineThickness,
-		height: lineThickness,
+		height: isLine ? lineThickness : undefined,
 	};
 
 	return ( <hr

--- a/packages/block-library/src/separator/save.js
+++ b/packages/block-library/src/separator/save.js
@@ -14,6 +14,9 @@ export default function separatorSave( { attributes } ) {
 	const {
 		color,
 		customColor,
+		dotSize,
+		dotSpacing,
+		lineThickness,
 	} = attributes;
 
 	// the hr support changing color using border-color, since border-color
@@ -32,6 +35,11 @@ export default function separatorSave( { attributes } ) {
 	const separatorStyle = {
 		backgroundColor: backgroundClass ? undefined : customColor,
 		color: colorClass ? undefined : customColor,
+		fontSize: dotSize || undefined,
+		letterSpacing: dotSpacing || dotSize,
+		paddingLeft: dotSpacing || dotSize,
+		borderWidth: lineThickness,
+		height: lineThickness,
 	};
 
 	return ( <hr

--- a/packages/block-library/src/separator/style.scss
+++ b/packages/block-library/src/separator/style.scss
@@ -16,13 +16,13 @@
 		max-width: none;
 		line-height: 1;
 		height: auto;
+		font-size: 20px;
+		letter-spacing: 2em;
+		padding-left: 2em;
 
 		&::before {
 			content: "\00b7 \00b7 \00b7";
 			color: currentColor;
-			font-size: 20px;
-			letter-spacing: 2em;
-			padding-left: 2em;
 			font-family: serif;
 		}
 	}


### PR DESCRIPTION
## Description
follow up to #16784 & #16925
tackles a point from #16483

this PR adds size control to separator block (thickness of line & size of circle)

## How has this been tested?
using Gutenberg starter theme
create separator components in master
switch to this branch
no problems happens


## Screenshots <!-- if applicable -->
![separator:size-control](https://user-images.githubusercontent.com/6165348/62563621-4df68300-b87b-11e9-9e89-826cfcf70d12.gif)


## Problems
- while this doesn't deprecate anything, I'm feeling like it's a bit fragile and need some testing, I've done some testing but I didn't have time to test on other themes.

## Changes
- it moves dots style from the `:before` element to the parent element, for eiser overriding 
- it uses `getActiveStyle` function introduced in `BlockStyles`I just copied & past it since I can't reference it directly and it's not exported.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
