### PR TITLE
Fix some problems in enableExperimentalFeatures e2e util function

### DIFF
--- a/packages/e2e-test-utils/src/enable-experimental-features.js
+++ b/packages/e2e-test-utils/src/enable-experimental-features.js
@@ -21,7 +21,14 @@ export async function enableExperimentalFeatures( features ) {
 
 	await Promise.all( features.map( async ( feature ) => {
 		await page.waitForSelector( feature );
-		await page.click( feature );
-		await page.click( '#submit' );
+		const checkedSelector = `${ feature }[checked=checked]`;
+		const isChecked = !! ( await page.$( checkedSelector ) );
+		if ( ! isChecked ) {
+			await page.click( feature );
+		}
 	} ) );
+	await Promise.all( [
+		page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+		page.click( '#submit' ),
+	] );
 }


### PR DESCRIPTION
Make enableExperimentalFeatures wait for the request to complete and don't disable already enabled features.

Introduced in https://github.com/WordPress/gutenberg/pull/16626

## Description
End 2 end tests are failing a lot of times and according to the debugging I did, it seems these fails are caused by the problems referred above.

## How has this been tested?
Executed the end 2 end tests several times and verified they pass.
