### PR TITLE
[RNMobile] hide replaceable block when adding block

### DIFF
--- a/packages/block-editor/src/components/block-list/style.native.scss
+++ b/packages/block-editor/src/components/block-list/style.native.scss
@@ -35,7 +35,6 @@
 }
 
 .containerStyleAddHere {
-	flex: 1;
 	flex-direction: row;
 	background-color: $white;
 }


### PR DESCRIPTION
[related gutenberg-mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1262)

## Description
This addresses [gutenberg-mobile/issue#1177](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1177) by hiding a block that would be replaced when the add block bottom sheet is presented.

![hide_block_and mp4](https://user-images.githubusercontent.com/4656348/62567549-5ccc3e00-b859-11e9-8e60-b4c580d6f747.gif)

## Test Scenarios
#### 1. Empty paragraph block
1. Select an empty paragraph block
2. Tap the ➕ to add a new block
3. Observe that the previously selected empty paragraph block is hidden and the Add Block Here (ABH) indicator is in its place
4. Select any block to add
5. Observe that the selected block has taken the place of the ABH indicator and the previously-selected empty paragraph block is still not visible

#### 2. Anything other than an empty paragraph block
1. Select any block _other than_ an empty paragraph block
2. Tap the ➕ to add a new block
3. Observe that the selected block is still visible and the ABH indicator is below it
4. Select any block to add
5. Observe that the selected block has taken the place of the ABH indicator and the previously-selected block is still visible.

#### 3. Block _before_ an empty paragraph block
1. Select any block that is immediately before an empty paragraph block (selected block should not itself be an empty paragraph block) 
2. Tap the ➕ to add a new block
3. Observe that both the selected block and the empty paragraph block following it are still visible.
4. Observe that the Add Block Here (ABH) indicator is between the selected block and the empty paragraph block
4. Select any block to add
5. Observe that the selected block has taken the place of the ABH indicator and both the previously-selected block and the previously-present empty paragraph block are still visible.

#### 4. Add block from Post Title
1. Select the post title _of a non-empty_ post (it's important that this not be a new empty post because of [an outstanding issue](https://github.com/wordpress-mobile/gutenberg-mobile/issues/632#issuecomment-513213114) with inserting blocks from the post title on new posts)
2. Tap the ➕ to add a new block
3. Observe that the ABH indicator is shown at the top of the post, below the post title
4. Select any block to add
5. Observe that the selected block has taken the place of the ABH indicator and is now the top block in the post

## Types of changes
This is a non-breaking change that adds functionality

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
