### PR TITLE
Docs: Update CHANGELOG for @wordpress/scripts after Puppeteer upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5037,7 +5037,7 @@
 				"jest-puppeteer": "^4.3.0",
 				"minimist": "^1.2.0",
 				"npm-package-json-lint": "^3.6.0",
-				"puppeteer": "1.19.0",
+				"puppeteer": "^1.19.0",
 				"read-pkg-up": "^1.0.1",
 				"resolve-bin": "^0.4.0",
 				"source-map-loader": "^0.2.4",

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Master
+
+### New Features
+
+- The bundled `puppeteer` dependency has been updated from requiring `1.6.1` to requiring `^1.19.0` ([#16875](https://github.com/WordPress/gutenberg/pull/16875)). It uses Chromium v77 instead of Chromium v69.
+- The bundled `jest-puppeteer` dependency has been updated from requiring `^4.0.0` to requiring `^4.3.0` ([#16875](https://github.com/WordPress/gutenberg/pull/16875)).
+
 ## 3.4.0 (2019-08-05)
 
 ### New Features

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -47,7 +47,7 @@
 		"jest-puppeteer": "^4.3.0",
 		"minimist": "^1.2.0",
 		"npm-package-json-lint": "^3.6.0",
-		"puppeteer": "1.19.0",
+		"puppeteer": "^1.19.0",
 		"read-pkg-up": "^1.0.1",
 		"resolve-bin": "^0.4.0",
 		"source-map-loader": "^0.2.4",


### PR DESCRIPTION
## Description
Follow-up for #16875.

This PR adds the missing CHANGELOG entries for `@wordpress/scripts` package.

In addition, it enables ranged for `puppeteer` dependency so we could update it more often with ease.