### PR TITLE
Fix: Some default block appender styles are set on the editpost module

### DIFF
--- a/packages/block-editor/src/components/default-block-appender/style.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.scss
@@ -1,6 +1,17 @@
 .block-editor-default-block-appender {
 	clear: both; // The appender doesn't scale well to sit next to floats, so clear them.
 
+	// Default to centered and content-width, like blocks
+	margin-left: auto;
+	margin-right: auto;
+	position: relative;
+
+	&[data-root-client-id=""] .block-editor-default-block-appender__content:hover {
+		// Outline on root-level default block appender is redundant with the
+		// WritingFlow click redirector.
+		outline: 1px solid transparent;
+	}
+
 	textarea.block-editor-default-block-appender__content { // Needs specificity in order to override input field styles from WP-admin styles.
 		font-family: $editor-font;
 		font-size: $editor-font-size; // It should match the default paragraph size.
@@ -39,6 +50,12 @@
 	.components-drop-zone__content-icon {
 		display: none;
 	}
+}
+
+// Ensure that the height of the first appender, and the one between blocks, is the same as text.
+.block-editor-default-block-appender__content {
+	min-height: $empty-paragraph-height / 2;
+	line-height: $editor-line-height;
 }
 
 // Quick shortcuts, left and right.

--- a/packages/block-library/src/paragraph/editor.scss
+++ b/packages/block-library/src/paragraph/editor.scss
@@ -10,3 +10,8 @@
 		padding-right: $icon-button-size;
 	}
 }
+
+.block-editor-block-list__block[data-type="core/paragraph"] p {
+	min-height: $empty-paragraph-height / 2;
+	line-height: $editor-line-height;
+}

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -90,24 +90,4 @@
 	.block-editor-block-list__layout > .block-editor-block-list__block[data-align="right"]:first-child {
 		margin-top: $block-padding + $block-spacing + $border-width + $border-width + $block-padding;
 	}
-
-	.block-editor-default-block-appender {
-		// Default to centered and content-width, like blocks
-		margin-left: auto;
-		margin-right: auto;
-		position: relative;
-
-		&[data-root-client-id=""] .block-editor-default-block-appender__content:hover {
-			// Outline on root-level default block appender is redundant with the
-			// WritingFlow click redirector.
-			outline: 1px solid transparent;
-		}
-	}
-
-	// Ensure that the height of the first appender, and the one between blocks, is the same as text.
-	.block-editor-block-list__block[data-type="core/paragraph"] p,
-	.block-editor-default-block-appender__content {
-		min-height: $empty-paragraph-height / 2;
-		line-height: $editor-line-height;
-	}
 }


### PR DESCRIPTION
This PR moves styles from the edit-post module into the block editor module. These styles are required for the default block appender work as expected, and that component is part of the block editor module so these styles should be set there.

This problem is affecting the block widgets screen.

Related: https://github.com/WordPress/gutenberg/issues/16601

## How has this been tested?
I enabled the experimental widgets screen in the settings.
I went to the experimental widgets screen.
Deleted all the content in one of the block areas.
I added an image block, and I verified the insert button of the default block appender is visible, in master it is not.