### PR TITLE
[RNMobile] Reset toolbar scroll on content change

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/index.native.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.native.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useRef } from 'react';
 import { ScrollView, View } from 'react-native';
 
 /**
@@ -31,9 +32,16 @@ function HeaderToolbar( {
 	showKeyboardHideButton,
 	clearSelectedBlock,
 } ) {
+	const scrollViewRef = useRef( null );
+	const scrollToStart = () => {
+		scrollViewRef.current.scrollTo( { x: 0 } );
+	};
+
 	return (
 		<View style={ styles.container }>
 			<ScrollView
+				ref={ scrollViewRef }
+				onContentSizeChange={ scrollToStart }
 				horizontal={ true }
 				showsHorizontalScrollIndicator={ false }
 				keyboardShouldPersistTaps="always"


### PR DESCRIPTION
[related gutenberg-mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1270)

## Description
On Android, when switching between blocks, the scroll position of the toolbar would never reset ([gutenberg-mobile#934](https://github.com/wordpress-mobile/gutenberg-mobile/issues/934)). This is a problem when you have a block with many toolbar buttons selected and you have scrolled so that the right-most part of the toolbar is visible. When switching to a block with fewer buttons, the scroll position would be maintained and you would see a partially empty scrollbar with some of the buttons not visible off the left of the screen.

This PR addresses this issue by resetting the scroll position of the toolbar anytime the toolbar's content changes.

## Screenshots

In the gifs below note that in the after gif the ➕ for adding a new block is only visible after switching back to the paragraph block in the `After` gif.

Before | After 
---- | ----
![before mp4](https://user-images.githubusercontent.com/4656348/62644178-89468f80-b917-11e9-9688-3b89f5650848.gif) | ![after](https://user-images.githubusercontent.com/4656348/62644800-ec84f180-b918-11e9-8405-6320a841cfc8.gif)

## Test steps

1. Select Heading block
2. Scroll to right side of toolbar so the strikethrough button is visible
3. Select a paragraph block
4. Observe that toolbar's scroll position has reset and the ➕ button for adding a new block is visible.

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
