### PR TITLE
Try solid block movers

### DIFF
--- a/assets/stylesheets/_variables.scss
+++ b/assets/stylesheets/_variables.scss
@@ -57,7 +57,7 @@ $resize-handler-container-size: $resize-handler-size + ($grid-size-small * 2); /
 $block-left-border-width: $border-width * 3;
 $block-padding: 14px; // Space between block footprint and focus boundaries. These are drawn outside the block footprint, and do not affect the size.
 $block-spacing: 4px; // Vertical space between blocks.
-$block-side-ui-width: 28px; // Width of the movers/drag handle UI.
+$block-side-ui-width: 24px; // Width of the movers/drag handle UI.
 $block-side-ui-clearance: 2px; // Space between movers/drag handle UI, and block.
 $block-container-side-padding: $block-side-ui-width + $block-padding + 2 * $block-side-ui-clearance; // Total space left and right of the block footprint.
 $block-bg-padding--v: $block-padding + $block-spacing + $block-side-ui-clearance; // padding for Blocks with a background color (eg: paragraph or group)

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -495,7 +495,7 @@
 		&.is-multi-selected > .block-editor-block-mover,
 		> .block-editor-block-list__block-edit > .block-editor-block-mover {
 			// This moves the menu up by the height of the button + border + padding.
-			top: -$block-side-ui-width - $block-padding - $block-side-ui-clearance;
+			top: -$block-side-ui-width - $block-padding + $border-width;
 			bottom: auto;
 			min-height: 0;
 			height: auto;
@@ -548,7 +548,7 @@
 		// Position mover
 		&.is-multi-selected > .block-editor-block-mover,
 		> .block-editor-block-list__block-edit > .block-editor-block-mover {
-			left: -$block-padding + $border-width;
+			left: -$block-padding - $block-left-border-width;
 		}
 	}
 

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -550,6 +550,11 @@
 		> .block-editor-block-list__block-edit > .block-editor-block-mover {
 			left: -$block-padding - $block-left-border-width;
 		}
+
+		// Move the controls up so they don't interfere with the breadcrumb on hover.
+		&.is-hovered > .block-editor-block-list__block-edit > .block-editor-block-mover {
+			top: -$block-side-ui-width - $block-padding - $border-width - ($block-side-ui-clearance * 2);
+		}
 	}
 
 	// Full-wide

--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -5,16 +5,6 @@
 	&.is-visible {
 		@include edit-post__fade-in-animation;
 	}
-
-	// 24px is the smallest size of a good pressable button.
-	// With 3 pieces of side UI, that comes to a total of 72px.
-	// To vertically center against a 56px paragraph, move upwards 72px - 56px / 2.
-	// Don't do this for wide, fullwide, or mobile.
-	@include break-small() {
-		.block-editor-block-list__block:not([data-align="wide"]):not([data-align="full"]) & {
-			margin-top: -$grid-size;
-		}
-	}
 }
 
 // Mover icon buttons.
@@ -24,6 +14,9 @@
 	justify-content: center;
 	cursor: pointer;
 	padding: 0;
+	border-radius: 0;
+	transition: background-color 0.1s ease-out;
+	@include reduce-motion("transition");
 
 	// Carefully adjust the size of the side UI to fit one paragraph of text (56px).
 	width: $block-side-ui-width;
@@ -36,21 +29,49 @@
 	}
 
 	// Use opacity to work in various editor styles
+	background-color: $dark-opacity-light-500;
 	color: $dark-opacity-300;
 
 	.is-dark-theme & {
-		color: $light-opacity-300;
+		background-color: $light-opacity-light-400;
+		color: $light-opacity-900;
 	}
 
-	// Nested movers have a background, so don't invert the colors there.
-	.is-dark-theme .wp-block .wp-block &,
-	.wp-block .is-dark-theme .wp-block & {
-		color: $dark-opacity-300;
+	.is-selected & {
+		background-color: $dark-gray-500;
+		color: $light-gray-500;
+
+		.is-dark-theme & {
+			background-color: $light-opacity-light-400;
+			color: $light-opacity-400;
+		}
+	}
+
+	&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover,
+	&:focus:not(:disabled) {
+		background-color: $dark-opacity-light-500;
+		box-shadow: none;
+
+		.is-selected & {
+			background-color: $dark-gray-500;
+			color: $white;
+		}
+
+		.is-dark-theme & {
+			background-color: $light-opacity-light-400;
+			color: $white;
+		}
+
+		.is-dark-theme .is-selected & {
+			background-color: $light-gray-600;
+			color: $dark-gray-900;
+		}
 	}
 
 	&[aria-disabled="true"] {
 		cursor: default;
 		pointer-events: none;
+		opacity: 1;
 		color: $dark-opacity-light-300; // Use opacity to work in various editor styles.
 
 		.is-dark-theme & {
@@ -63,7 +84,7 @@
 	cursor: move; // Fallback for IE/Edge < 14
 	cursor: grab;
 	fill: currentColor;
-	border-radius: $radius-round-rectangle;
+	border-radius: 0;
 
 	&,
 	&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover,
@@ -72,11 +93,13 @@
 		box-shadow: none;
 		background: none;
 
-		// Use opacity to work in various editor styles.
-		color: $dark-opacity-500;
+		// Use opacity to work in various editor styles
+		background-color: $dark-opacity-light-500;
+		color: $dark-opacity-300;
 
 		.is-dark-theme & {
-			color: $light-opacity-500;
+			background-color: $light-opacity-light-400;
+			color: $light-opacity-900;
 		}
 
 		// Nested movers have a background, so don't invert the colors there.


### PR DESCRIPTION
Closes #16580.

This PR implements the idea shared by @richtabor in #16580: it gives the block movers a solid color background, and hangs them off the side of the thick left block border.

I'm not totally sure about this yet — it makes the mover controls really prominent, and I'm not sure that's right. I think it could still use some iteration. 

**Hover:** 

![Screen Shot 2019-08-07 at 2 19 56 PM](https://user-images.githubusercontent.com/1202812/62647840-7768ea80-b91f-11e9-96c3-6cb6ef8a6adf.png)

**Select:**

![Screen Shot 2019-08-07 at 2 20 04 PM](https://user-images.githubusercontent.com/1202812/62647842-7a63db00-b91f-11e9-88fd-9eeba8e9421e.png)

---

Still todo: 

- [ ] Build in a more prominent focus state.
- [ ] Come out with a better plan for how these work with breadcrumbs. Things look [a little disjointed](https://cloudup.com/cW_GWfYuaYX) for standard blocks, and [even worse](https://cloudup.com/cUSlAldAkV1) for wide/full-aligned blocks. 
- [ ] Double check to make sure the changed `$block-side-ui-width` variable didn't have any unintended effects. It appears to be used in many places. 