### PR TITLE
Add a rounded corners block style to the Image and Gallery blocks

### DIFF
--- a/packages/block-library/src/gallery/index.js
+++ b/packages/block-library/src/gallery/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -25,6 +25,10 @@ export const settings = {
 	supports: {
 		align: true,
 	},
+	styles: [
+		{ name: 'default', label: _x( 'Default', 'block style' ), isDefault: true },
+		{ name: 'rounded-corners', label: _x( 'Rounded Corners', 'block style' ) },
+	],
 	transforms,
 	edit,
 	save,

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -147,4 +147,17 @@
 			justify-content: center;
 		}
 	}
+
+	// Rounded corners block style
+	&.is-style-rounded-corners {
+
+		img {
+			border-radius: $grid-size;
+		}
+
+		figcaption {
+			border-bottom-right-radius: $grid-size;
+			border-bottom-left-radius: $grid-size;
+		}
+	}
 }

--- a/packages/block-library/src/image/index.js
+++ b/packages/block-library/src/image/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -24,6 +24,10 @@ export const settings = {
 	keywords: [
 		'img', // "img" is not translated as it is intended to reflect the HTML <img> tag.
 		__( 'photo' ),
+	],
+	styles: [
+		{ name: 'default', label: _x( 'Default', 'block style' ), isDefault: true },
+		{ name: 'rounded-corners', label: _x( 'Rounded Corners', 'block style' ) },
 	],
 	transforms,
 	getEditWrapperProps( attributes ) {

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -59,6 +59,7 @@
 		margin-right: auto;
 	}
 
+	// Rounded corners block style
 	&.is-style-rounded-corners img {
 		border-radius: $grid-size;
 	}

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -58,4 +58,8 @@
 		margin-left: auto;
 		margin-right: auto;
 	}
+
+	&.is-style-rounded-corners img {
+		border-radius: $grid-size;
+	}
 }


### PR DESCRIPTION
This PR adds a simple "Rounded Corners" block style to the Image and Gallery blocks. This seems like something we might as well include, separately from the effort in #16130. I went with `8px` rounded corners since those seemed visibly rounded at a glance. 

---

**Image Block**

![Screen Shot 2019-08-07 at 3 24 36 PM](https://user-images.githubusercontent.com/1202812/62651646-7e93f680-b927-11e9-82a8-0c2d7dd07bca.png)

![Screen Shot 2019-08-07 at 3 25 29 PM](https://user-images.githubusercontent.com/1202812/62651750-b438df80-b927-11e9-99b4-e0f55eb8be6f.png)

---

**Gallery Block**

![Screen Shot 2019-08-07 at 3 24 28 PM](https://user-images.githubusercontent.com/1202812/62651659-8489d780-b927-11e9-82a2-69e5fe5a06ca.png)

![Screen Shot 2019-08-07 at 3 25 58 PM](https://user-images.githubusercontent.com/1202812/62651760-b9962a00-b927-11e9-9f6b-fd359177b320.png)