### PR TITLE
RichText: Fix intermittent test failure

### DIFF
--- a/packages/e2e-tests/specs/rich-text.test.js
+++ b/packages/e2e-tests/specs/rich-text.test.js
@@ -239,6 +239,8 @@ describe( 'RichText', () => {
 			activeElement.blur();
 			activeElement.focus();
 		} );
+		// Wait for the next animation frame, see the focus event listener in
+		// RichText.
 		await page.evaluate( () => new Promise( window.requestAnimationFrame ) );
 		await pressKeyWithModifier( 'primary', 'b' );
 		await page.keyboard.type( '2' );

--- a/packages/e2e-tests/specs/rich-text.test.js
+++ b/packages/e2e-tests/specs/rich-text.test.js
@@ -239,6 +239,7 @@ describe( 'RichText', () => {
 			activeElement.blur();
 			activeElement.focus();
 		} );
+		await page.evaluate( () => new Promise( window.requestAnimationFrame ) );
 		await pressKeyWithModifier( 'primary', 'b' );
 		await page.keyboard.type( '2' );
 		await pressKeyWithModifier( 'primary', 'b' );


### PR DESCRIPTION
## Description

After #16875, this fixes one of the new e2e tests that sometimes fails.

The problem is that we don't wait for the next animation frame:

https://github.com/WordPress/gutenberg/blob/005e0302eba30a24cb4fe64e42cf909a58d4b60e/packages/rich-text/src/component/index.js#L308

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
