### PR TITLE
Enable customizer legacy widgets only if set

### DIFF
--- a/lib/customizer.php
+++ b/lib/customizer.php
@@ -60,17 +60,17 @@ function gutenberg_customize_register( $wp_customize ) {
 			'gutenberg_widget_blocks',
 			array( 'title' => __( 'Widget Blocks (Experimental)', 'gutenberg' ) )
 		);
-	}
-	$wp_customize->add_control(
-		new WP_Customize_Widget_Blocks_Control(
-			$wp_customize,
-			'gutenberg_widget_blocks',
-			array(
-				'section'  => 'gutenberg_widget_blocks',
-				'settings' => 'gutenberg_widget_blocks',
+		$wp_customize->add_control(
+			new WP_Customize_Widget_Blocks_Control(
+				$wp_customize,
+				'gutenberg_widget_blocks',
+				array(
+					'section'  => 'gutenberg_widget_blocks',
+					'settings' => 'gutenberg_widget_blocks',
+				)
 			)
-		)
-	);
+		);
+	}
 }
 add_action( 'customize_register', 'gutenberg_customize_register' );
 

--- a/lib/customizer.php
+++ b/lib/customizer.php
@@ -55,10 +55,12 @@ function gutenberg_customize_register( $wp_customize ) {
 			'sanitize_callback' => 'gutenberg_customize_sanitize',
 		)
 	);
-	$wp_customize->add_section(
-		'gutenberg_widget_blocks',
-		array( 'title' => __( 'Widget Blocks (Experimental)', 'gutenberg' ) )
-	);
+	if ( get_option( 'gutenberg-experiments' ) && array_key_exists( 'gutenberg-widget-experiments', get_option( 'gutenberg-experiments' ) ) ) {
+		$wp_customize->add_section(
+			'gutenberg_widget_blocks',
+			array( 'title' => __( 'Widget Blocks (Experimental)', 'gutenberg' ) )
+		);
+	}
 	$wp_customize->add_control(
 		new WP_Customize_Widget_Blocks_Control(
 			$wp_customize,

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -69,12 +69,16 @@ function gutenberg_widgets_init( $hook ) {
 		);
 	}
 
+	$experiments_exist        = get_option( 'gutenberg-experiments' );
+	$legacy_widget_experiment = $experiments_exist ? array_key_exists( 'gutenberg-widget-experiments', get_option( 'gutenberg-experiments' ) ) : false;
+
 	$settings = array_merge(
 		array(
-			'disableCustomColors'    => get_theme_support( 'disable-custom-colors' ),
-			'disableCustomFontSizes' => get_theme_support( 'disable-custom-font-sizes' ),
-			'imageSizes'             => $available_image_sizes,
-			'maxUploadFileSize'      => $max_upload_size,
+			'disableCustomColors'                   => get_theme_support( 'disable-custom-colors' ),
+			'disableCustomFontSizes'                => get_theme_support( 'disable-custom-font-sizes' ),
+			'imageSizes'                            => $available_image_sizes,
+			'maxUploadFileSize'                     => $max_upload_size,
+			'__experimentalEnableLegacyWidgetBlock' => $legacy_widget_experiment,
 		),
 		gutenberg_get_legacy_widget_settings()
 	);

--- a/lib/widgets-page.php
+++ b/lib/widgets-page.php
@@ -69,16 +69,12 @@ function gutenberg_widgets_init( $hook ) {
 		);
 	}
 
-	$experiments_exist        = get_option( 'gutenberg-experiments' );
-	$legacy_widget_experiment = $experiments_exist ? array_key_exists( 'gutenberg-widget-experiments', get_option( 'gutenberg-experiments' ) ) : false;
-
 	$settings = array_merge(
 		array(
-			'disableCustomColors'                   => get_theme_support( 'disable-custom-colors' ),
-			'disableCustomFontSizes'                => get_theme_support( 'disable-custom-font-sizes' ),
-			'imageSizes'                            => $available_image_sizes,
-			'maxUploadFileSize'                     => $max_upload_size,
-			'__experimentalEnableLegacyWidgetBlock' => $legacy_widget_experiment,
+			'disableCustomColors'    => get_theme_support( 'disable-custom-colors' ),
+			'disableCustomFontSizes' => get_theme_support( 'disable-custom-font-sizes' ),
+			'imageSizes'             => $available_image_sizes,
+			'maxUploadFileSize'      => $max_upload_size,
 		),
 		gutenberg_get_legacy_widget_settings()
 	);
@@ -101,7 +97,7 @@ function gutenberg_widgets_init( $hook ) {
 				wp.editWidgets.%s( "widgets-editor", %s );
 			} );',
 			$initializer_name,
-			wp_json_encode( $settings )
+			wp_json_encode( gutenberg_experiments_editor_settings( $settings ) )
 		)
 	);
 

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -40,6 +40,9 @@ export function initialize( id, settings ) {
  */
 export function customizerInitialize( id, settings ) {
 	registerCoreBlocks();
+	if ( process.env.GUTENBERG_PHASE === 2 ) {
+		__experimentalRegisterExperimentalCoreBlocks( settings );
+	}
 	render(
 		<CustomizerEditWidgetsInitializer
 			settings={ settings }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Follow-up from #16626 . Hides the legacy widgets section in the customizer if legacy widgets are not enabled in the experiments settings.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Locally, by navigating to "Experiments" under the Gutenberg menu and toggling the "Enable Widgets Screen and Legacy Widget Block" checkbox. "Widget Blocks (Experimental)" section should display in Customizer when setting is enabled and Legacy Widget block should appear in the blocks menu.
						
## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
