### PR TITLE
Add table block keyboard navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4656,6 +4656,7 @@
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/date": "file:packages/date",
 				"@wordpress/deprecated": "file:packages/deprecated",
+				"@wordpress/dom": "file:packages/dom",
 				"@wordpress/editor": "file:packages/editor",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/i18n": "file:packages/i18n",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -34,6 +34,7 @@
 		"@wordpress/data": "file:../data",
 		"@wordpress/date": "file:../date",
 		"@wordpress/deprecated": "file:../deprecated",
+		"@wordpress/dom": "file:../dom",
 		"@wordpress/editor": "file:../editor",
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -32,7 +32,7 @@ import {
  */
 import {
 	createTable,
-	updateSelectedCell,
+	updateSelectedCellAttributes,
 	getCellAttribute,
 	insertRow,
 	deleteRow,
@@ -182,7 +182,7 @@ export class TableEdit extends Component {
 
 		const { attributes, setAttributes } = this.props;
 
-		setAttributes( updateSelectedCell(
+		setAttributes( updateSelectedCellAttributes(
 			attributes,
 			selectedCell,
 			( cellAttributes ) => ( { ...cellAttributes, content } ),
@@ -209,7 +209,7 @@ export class TableEdit extends Component {
 		};
 
 		const { attributes, setAttributes } = this.props;
-		const newAttributes = updateSelectedCell(
+		const newAttributes = updateSelectedCellAttributes(
 			attributes,
 			columnSelection,
 			( cellAttributes ) => ( { ...cellAttributes, align } ),
@@ -599,7 +599,6 @@ export class TableEdit extends Component {
 						className={ tableClasses }
 						tableState={ attributes }
 						selectedCell={ selectedCell }
-						onNavigation={ ( cellLocation ) => this.updateSelectedCell( cellLocation ) }
 					>
 						<Section name="head" rows={ head } />
 						<Section name="body" rows={ body } />

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -43,6 +43,7 @@ import {
 	isCellSelected,
 } from './state';
 import icon from './icon';
+import NavigableTable from './navigable-table';
 
 const BACKGROUND_COLORS = [
 	{
@@ -110,6 +111,7 @@ export class TableEdit extends Component {
 		this.onToggleFooterSection = this.onToggleFooterSection.bind( this );
 		this.onChangeColumnAlignment = this.onChangeColumnAlignment.bind( this );
 		this.getCellAlignment = this.getCellAlignment.bind( this );
+		this.updateSelectedCell = this.updateSelectedCell.bind( this );
 
 		this.state = {
 			initialRowCount: 2,
@@ -354,22 +356,18 @@ export class TableEdit extends Component {
 	}
 
 	/**
-	 * Creates an onFocus handler for a specified cell.
+	 * Update the cell selection
 	 *
 	 * @param {Object} cellLocation Object with `section`, `rowIndex`, and
 	 *                              `columnIndex` properties.
-	 *
-	 * @return {Function} Function to call on focus.
 	 */
-	createOnFocus( cellLocation ) {
-		return () => {
-			this.setState( {
-				selectedCell: {
-					...cellLocation,
-					type: 'cell',
-				},
-			} );
-		};
+	updateSelectedCell( cellLocation ) {
+		this.setState( {
+			selectedCell: {
+				...cellLocation,
+				type: 'cell',
+			},
+		} );
 	}
 
 	/**
@@ -473,7 +471,7 @@ export class TableEdit extends Component {
 										className={ richTextClassName }
 										value={ content }
 										onChange={ this.onChange }
-										unstableOnFocus={ this.createOnFocus( cellLocation ) }
+										unstableOnFocus={ () => this.updateSelectedCell( cellLocation ) }
 									/>
 								</CellTag>
 							);
@@ -500,7 +498,11 @@ export class TableEdit extends Component {
 			backgroundColor,
 			setBackgroundColor,
 		} = this.props;
-		const { initialRowCount, initialColumnCount } = this.state;
+		const {
+			initialRowCount,
+			initialColumnCount,
+			selectedCell,
+		} = this.state;
 		const { hasFixedLayout, head, body, foot } = attributes;
 		const isEmpty = isEmptyTableSection( head ) && isEmptyTableSection( body ) && isEmptyTableSection( foot );
 		const Section = this.renderSection;
@@ -593,11 +595,16 @@ export class TableEdit extends Component {
 					/>
 				</InspectorControls>
 				<figure className={ className }>
-					<table className={ tableClasses }>
+					<NavigableTable
+						className={ tableClasses }
+						tableState={ attributes }
+						selectedCell={ selectedCell }
+						onNavigation={ ( cellLocation ) => this.updateSelectedCell( cellLocation ) }
+					>
 						<Section name="head" rows={ head } />
 						<Section name="body" rows={ body } />
 						<Section name="foot" rows={ foot } />
-					</table>
+					</NavigableTable>
 				</figure>
 			</>
 		);

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -265,7 +265,6 @@ export class TableEdit extends Component {
 		const { attributes, setAttributes } = this.props;
 		const { sectionName, rowIndex } = selectedCell;
 
-		this.setState( { selectedCell: null } );
 		setAttributes( insertRow( attributes, {
 			sectionName,
 			rowIndex: rowIndex + delta,
@@ -299,7 +298,6 @@ export class TableEdit extends Component {
 		const { attributes, setAttributes } = this.props;
 		const { sectionName, rowIndex } = selectedCell;
 
-		this.setState( { selectedCell: null } );
 		setAttributes( deleteRow( attributes, { sectionName, rowIndex } ) );
 	}
 
@@ -318,7 +316,6 @@ export class TableEdit extends Component {
 		const { attributes, setAttributes } = this.props;
 		const { columnIndex } = selectedCell;
 
-		this.setState( { selectedCell: null } );
 		setAttributes( insertColumn( attributes, {
 			columnIndex: columnIndex + delta,
 		} ) );
@@ -351,7 +348,6 @@ export class TableEdit extends Component {
 		const { attributes, setAttributes } = this.props;
 		const { sectionName, columnIndex } = selectedCell;
 
-		this.setState( { selectedCell: null } );
 		setAttributes( deleteColumn( attributes, { sectionName, columnIndex } ) );
 	}
 
@@ -469,6 +465,7 @@ export class TableEdit extends Component {
 								>
 									<RichText
 										className={ richTextClassName }
+										tabIndex={ isSelected ? 0 : -1 }
 										value={ content }
 										onChange={ this.onChange }
 										unstableOnFocus={ () => this.updateSelectedCell( cellLocation ) }
@@ -480,15 +477,6 @@ export class TableEdit extends Component {
 				) ) }
 			</Tag>
 		);
-	}
-
-	componentDidUpdate() {
-		const { isSelected } = this.props;
-		const { selectedCell } = this.state;
-
-		if ( ! isSelected && selectedCell ) {
-			this.setState( { selectedCell: null } );
-		}
 	}
 
 	render() {

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -111,7 +111,7 @@ export class TableEdit extends Component {
 		this.onToggleFooterSection = this.onToggleFooterSection.bind( this );
 		this.onChangeColumnAlignment = this.onChangeColumnAlignment.bind( this );
 		this.getCellAlignment = this.getCellAlignment.bind( this );
-		this.updateSelectedCell = this.updateSelectedCell.bind( this );
+		this.createOnFocus = this.createOnFocus.bind( this );
 
 		this.state = {
 			initialRowCount: 2,
@@ -352,18 +352,22 @@ export class TableEdit extends Component {
 	}
 
 	/**
-	 * Update the cell selection
+	 * Creates an onFocus handler for a specified cell.
 	 *
 	 * @param {Object} cellLocation Object with `section`, `rowIndex`, and
 	 *                              `columnIndex` properties.
+	 *
+	 * @return {Function} Function to call on focus.
 	 */
-	updateSelectedCell( cellLocation ) {
-		this.setState( {
-			selectedCell: {
-				...cellLocation,
-				type: 'cell',
-			},
-		} );
+	createOnFocus( cellLocation ) {
+		return () => {
+			this.setState( {
+				selectedCell: {
+					...cellLocation,
+					type: 'cell',
+				},
+			} );
+		};
 	}
 
 	/**
@@ -480,7 +484,7 @@ export class TableEdit extends Component {
 										tabIndex={ tabIndex }
 										value={ content }
 										onChange={ this.onChange }
-										unstableOnFocus={ () => this.updateSelectedCell( cellLocation ) }
+										unstableOnFocus={ this.createOnFocus( cellLocation ) }
 									/>
 								</CellTag>
 							);

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -449,6 +449,18 @@ export class TableEdit extends Component {
 							} );
 							const richTextClassName = 'wp-block-table__cell-content';
 
+							// Table implements a roving tabIndex. If there are no selected cells,
+							// don't set a tabIndex so that table can be tabbed into normally.
+							// If there is a selected cell, only that cell has is tabbable so that
+							// the user can easily navigate in and out of a table and maintain
+							// cell selection when navigating to the toolbar.
+							// For more info see:
+							// https://www.w3.org/TR/wai-aria-practices/examples/grid/dataGrids.html
+							let tabIndex;
+							if ( selectedCell ) {
+								tabIndex = isSelected ? 0 : -1;
+							}
+
 							return (
 								<CellTag
 									key={ columnIndex }
@@ -465,7 +477,7 @@ export class TableEdit extends Component {
 								>
 									<RichText
 										className={ richTextClassName }
-										tabIndex={ isSelected ? 0 : -1 }
+										tabIndex={ tabIndex }
 										value={ content }
 										onChange={ this.onChange }
 										unstableOnFocus={ () => this.updateSelectedCell( cellLocation ) }

--- a/packages/block-library/src/table/navigable-table.js
+++ b/packages/block-library/src/table/navigable-table.js
@@ -8,7 +8,7 @@ import {
 	placeCaretAtHorizontalEdge,
 } from '@wordpress/dom';
 import { useRef } from '@wordpress/element';
-import { UP, DOWN, LEFT, RIGHT, isKeyboardModifierEvent } from '@wordpress/keycodes';
+import { UP, DOWN, LEFT, RIGHT, HOME, END, isKeyboardModifierEvent } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -22,9 +22,11 @@ import {
 	getLastCellInColumn,
 	getFirstCellInRow,
 	getLastCellInRow,
+	getFirstCellInTable,
+	getLastCellInTable,
 } from './state';
 
-function getNextCellLocation( tableState, selectedCell, { isPrimary, isUp, isDown, isLeft, isRight } ) {
+function getNextCellLocation( tableState, selectedCell, { isPrimary, isUp, isDown, isLeft, isRight, isHome, isEnd } ) {
 	if ( isUp ) {
 		if ( isPrimary ) {
 			return getFirstCellInColumn( tableState, selectedCell );
@@ -52,6 +54,18 @@ function getNextCellLocation( tableState, selectedCell, { isPrimary, isUp, isDow
 		}
 
 		return getCellToRight( tableState, selectedCell );
+	}
+	if ( isHome ) {
+		if ( isPrimary ) {
+			return getFirstCellInTable( tableState );
+		}
+		return getFirstCellInRow( selectedCell );
+	}
+	if ( isEnd ) {
+		if ( isPrimary ) {
+			return getLastCellInTable( tableState );
+		}
+		return getLastCellInRow( tableState, selectedCell );
 	}
 }
 
@@ -87,7 +101,9 @@ export default function NavigableTable( { children, className, tableState, selec
 		const isDown = keyCode === DOWN;
 		const isLeft = keyCode === LEFT;
 		const isRight = keyCode === RIGHT;
-		const isHorizontal = isLeft || isRight;
+		const isHome = keyCode === HOME;
+		const isEnd = keyCode === END;
+		const isHorizontal = isLeft || isRight || isHome || isEnd;
 		const isVertical = isUp || isDown;
 		const isNav = isHorizontal || isVertical;
 
@@ -103,7 +119,7 @@ export default function NavigableTable( { children, className, tableState, selec
 		}
 
 		const isAtEdge = isVertical ? isVerticalEdge : isHorizontalEdge;
-		const isReverse = isUp || isLeft;
+		const isReverse = isUp || isLeft || isHome;
 		const isCaretAtEdgeOfField = isAtEdge( target, isReverse );
 
 		if ( ! isCaretAtEdgeOfField ) {
@@ -114,7 +130,7 @@ export default function NavigableTable( { children, className, tableState, selec
 		event.preventDefault();
 
 		const isPrimary = isKeyboardModifierEvent.primary( event );
-		const nextCellLocation = getNextCellLocation( tableState, selectedCell, { isPrimary, isUp, isDown, isLeft, isRight } );
+		const nextCellLocation = getNextCellLocation( tableState, selectedCell, { isPrimary, isUp, isDown, isLeft, isRight, isHome, isEnd } );
 
 		if ( ! nextCellLocation ) {
 			return;

--- a/packages/block-library/src/table/navigable-table.js
+++ b/packages/block-library/src/table/navigable-table.js
@@ -65,7 +65,7 @@ function getCellContentEditableElement( tableElement, { sectionName, rowIndex, c
 		return;
 	}
 
-	return rowElement.querySelectorAll( 'tr,td *[contenteditable="true"]' )[ columnIndex ];
+	return rowElement.querySelectorAll( '*[contenteditable="true"]' )[ columnIndex ];
 }
 
 export default function NavigableTable( { children, className, tableState, selectedCell, onNavigation } ) {

--- a/packages/block-library/src/table/navigable-table.js
+++ b/packages/block-library/src/table/navigable-table.js
@@ -8,7 +8,7 @@ import {
 	placeCaretAtHorizontalEdge,
 } from '@wordpress/dom';
 import { useRef } from '@wordpress/element';
-import { UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
+import { UP, DOWN, LEFT, RIGHT, isKeyboardModifierEvent } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -18,19 +18,39 @@ import {
 	getCellBelow,
 	getCellToLeft,
 	getCellToRight,
+	getFirstCellInColumn,
+	getLastCellInColumn,
+	getFirstCellInRow,
+	getLastCellInRow,
 } from './state';
 
-function getNextCellLocation( tableState, selectedCell, { isUp, isDown, isLeft, isRight } ) {
+function getNextCellLocation( tableState, selectedCell, { isPrimary, isUp, isDown, isLeft, isRight } ) {
 	if ( isUp ) {
+		if ( isPrimary ) {
+			return getFirstCellInColumn( tableState, selectedCell );
+		}
+
 		return getCellAbove( tableState, selectedCell );
 	}
 	if ( isDown ) {
+		if ( isPrimary ) {
+			return getLastCellInColumn( tableState, selectedCell );
+		}
+
 		return getCellBelow( tableState, selectedCell );
 	}
 	if ( isLeft ) {
+		if ( isPrimary ) {
+			return getFirstCellInRow( selectedCell );
+		}
+
 		return getCellToLeft( selectedCell );
 	}
 	if ( isRight ) {
+		if ( isPrimary ) {
+			return getLastCellInRow( tableState, selectedCell );
+		}
+
 		return getCellToRight( tableState, selectedCell );
 	}
 }
@@ -92,7 +112,9 @@ export default function NavigableTable( { children, className, tableState, selec
 
 		event.stopPropagation();
 		event.preventDefault();
-		const nextCellLocation = getNextCellLocation( tableState, selectedCell, { isUp, isDown, isLeft, isRight } );
+
+		const isPrimary = isKeyboardModifierEvent.primary( event );
+		const nextCellLocation = getNextCellLocation( tableState, selectedCell, { isPrimary, isUp, isDown, isLeft, isRight } );
 
 		if ( ! nextCellLocation ) {
 			return;

--- a/packages/block-library/src/table/navigable-table.js
+++ b/packages/block-library/src/table/navigable-table.js
@@ -58,6 +58,7 @@ export default function NavigableTable( { children, className, tableState, selec
 
 		const { keyCode, target } = event;
 
+		//
 		if ( ! isTextField( target ) ) {
 			return;
 		}
@@ -70,7 +71,14 @@ export default function NavigableTable( { children, className, tableState, selec
 		const isVertical = isUp || isDown;
 		const isNav = isHorizontal || isVertical;
 
+		// The user hasn't pressed a navigation key, abort early.
 		if ( ! isNav ) {
+			return;
+		}
+
+		// Abort if navigation has already been handled (e.g. RichText inline
+		// boundaries).
+		if ( event.nativeEvent.defaultPrevented ) {
 			return;
 		}
 

--- a/packages/block-library/src/table/navigable-table.js
+++ b/packages/block-library/src/table/navigable-table.js
@@ -1,0 +1,118 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	isTextField,
+	isHorizontalEdge,
+	isVerticalEdge,
+	placeCaretAtHorizontalEdge,
+} from '@wordpress/dom';
+import { useRef } from '@wordpress/element';
+import { UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getCellAbove,
+	getCellBelow,
+	getCellToLeft,
+	getCellToRight,
+} from './state';
+
+function getNextCellLocation( tableState, selectedCell, { isUp, isDown, isLeft, isRight } ) {
+	if ( isUp ) {
+		return getCellAbove( tableState, selectedCell );
+	}
+	if ( isDown ) {
+		return getCellBelow( tableState, selectedCell );
+	}
+	if ( isLeft ) {
+		return getCellToLeft( selectedCell );
+	}
+	if ( isRight ) {
+		return getCellToRight( tableState, selectedCell );
+	}
+}
+
+function getCellContentEditableElement( tableElement, { sectionName, rowIndex, columnIndex } ) {
+	if ( ! tableElement ) {
+		return;
+	}
+	const rowElement = tableElement.querySelectorAll( `t${ sectionName } tr` )[ rowIndex ];
+
+	if ( ! rowElement ) {
+		return;
+	}
+
+	return rowElement.querySelectorAll( 'tr,td *[contenteditable="true"]' )[ columnIndex ];
+}
+
+export default function NavigableTable( { children, className, tableState, selectedCell, onNavigation } ) {
+	const tableRef = useRef();
+
+	const handleKeyDown = ( event ) => {
+		if ( ! selectedCell ) {
+			return;
+		}
+
+		const { keyCode, target } = event;
+
+		if ( ! isTextField( target ) ) {
+			return;
+		}
+
+		const isUp = keyCode === UP;
+		const isDown = keyCode === DOWN;
+		const isLeft = keyCode === LEFT;
+		const isRight = keyCode === RIGHT;
+		const isHorizontal = isLeft || isRight;
+		const isVertical = isUp || isDown;
+		const isNav = isHorizontal || isVertical;
+
+		if ( ! isNav ) {
+			return;
+		}
+
+		const isAtEdge = isVertical ? isVerticalEdge : isHorizontalEdge;
+		const isReverse = isUp || isLeft;
+		const isCaretAtEdgeOfField = isAtEdge( target, isReverse );
+
+		if ( ! isCaretAtEdgeOfField ) {
+			return;
+		}
+
+		event.stopPropagation();
+		event.preventDefault();
+		const nextCellLocation = getNextCellLocation( tableState, selectedCell, { isUp, isDown, isLeft, isRight } );
+
+		if ( ! nextCellLocation ) {
+			return;
+		}
+
+		const contentEditableElement = getCellContentEditableElement( tableRef.current, nextCellLocation );
+
+		if ( ! contentEditableElement ) {
+			return;
+		}
+
+		placeCaretAtHorizontalEdge( contentEditableElement, isReverse );
+		onNavigation( nextCellLocation );
+	};
+
+	// Disable reason: Wrapper itself is non-interactive, but must capture
+	// bubbling events from children to determine focus transition intents.
+	/* eslint-disable jsx-a11y/no-static-element-interactions */
+	/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+	return (
+		<table
+			ref={ tableRef }
+			className={ className }
+			onKeyDown={ handleKeyDown }
+		>
+			{ children }
+		</table>
+	);
+	/* eslint-enable jsx-a11y/no-static-element-interactions */
+	/* eslint-enable jsx-a11y/no-noninteractive-element-interactions */
+}

--- a/packages/block-library/src/table/navigable-table.js
+++ b/packages/block-library/src/table/navigable-table.js
@@ -82,7 +82,7 @@ function getCellContentEditableElement( tableElement, { sectionName, rowIndex, c
 	return rowElement.querySelectorAll( '*[contenteditable="true"]' )[ columnIndex ];
 }
 
-export default function NavigableTable( { children, className, tableState, selectedCell, onNavigation } ) {
+export default function NavigableTable( { children, className, tableState, selectedCell } ) {
 	const tableRef = useRef();
 
 	const handleKeyDown = ( event ) => {
@@ -143,7 +143,6 @@ export default function NavigableTable( { children, className, tableState, selec
 		}
 
 		placeCaretAtHorizontalEdge( contentEditableElement, isReverse );
-		onNavigation( nextCellLocation );
 	};
 
 	// Disable reason: Wrapper itself is non-interactive, but must capture

--- a/packages/block-library/src/table/navigable-table.js
+++ b/packages/block-library/src/table/navigable-table.js
@@ -14,58 +14,58 @@ import { UP, DOWN, LEFT, RIGHT, HOME, END, isKeyboardModifierEvent } from '@word
  * Internal dependencies
  */
 import {
-	getCellAbove,
-	getCellBelow,
-	getCellToLeft,
-	getCellToRight,
-	getFirstCellInColumn,
-	getLastCellInColumn,
-	getFirstCellInRow,
-	getLastCellInRow,
-	getFirstCellInTable,
-	getLastCellInTable,
+	getLocationOfCellAbove,
+	getLocationOfCellBelow,
+	getLocationOfCellToLeft,
+	getLocationOfCellToRight,
+	getLocationOfFirstCellInColumn,
+	getLocationOfLastCellInColumn,
+	getLocationOfFirstCellInRow,
+	getLocationOfLastCellInRow,
+	getLocationOfFirstCellInTable,
+	getLocationOfLastCellInTable,
 } from './state';
 
 function getNextCellLocation( tableState, selectedCell, { isPrimary, isUp, isDown, isLeft, isRight, isHome, isEnd } ) {
 	if ( isUp ) {
 		if ( isPrimary ) {
-			return getFirstCellInColumn( tableState, selectedCell );
+			return getLocationOfFirstCellInColumn( tableState, selectedCell );
 		}
 
-		return getCellAbove( tableState, selectedCell );
+		return getLocationOfCellAbove( tableState, selectedCell );
 	}
 	if ( isDown ) {
 		if ( isPrimary ) {
-			return getLastCellInColumn( tableState, selectedCell );
+			return getLocationOfLastCellInColumn( tableState, selectedCell );
 		}
 
-		return getCellBelow( tableState, selectedCell );
+		return getLocationOfCellBelow( tableState, selectedCell );
 	}
 	if ( isLeft ) {
 		if ( isPrimary ) {
-			return getFirstCellInRow( selectedCell );
+			return getLocationOfFirstCellInRow( selectedCell );
 		}
 
-		return getCellToLeft( selectedCell );
+		return getLocationOfCellToLeft( selectedCell );
 	}
 	if ( isRight ) {
 		if ( isPrimary ) {
-			return getLastCellInRow( tableState, selectedCell );
+			return getLocationOfLastCellInRow( tableState, selectedCell );
 		}
 
-		return getCellToRight( tableState, selectedCell );
+		return getLocationOfCellToRight( tableState, selectedCell );
 	}
 	if ( isHome ) {
 		if ( isPrimary ) {
-			return getFirstCellInTable( tableState );
+			return getLocationOfFirstCellInTable( tableState );
 		}
-		return getFirstCellInRow( selectedCell );
+		return getLocationOfFirstCellInRow( selectedCell );
 	}
 	if ( isEnd ) {
 		if ( isPrimary ) {
-			return getLastCellInTable( tableState );
+			return getLocationOfLastCellInTable( tableState );
 		}
-		return getLastCellInRow( tableState, selectedCell );
+		return getLocationOfLastCellInRow( tableState, selectedCell );
 	}
 }
 

--- a/packages/block-library/src/table/state.js
+++ b/packages/block-library/src/table/state.js
@@ -28,6 +28,14 @@ export function createTable( {
 	};
 }
 
+export function getRow( state, { sectionName, rowIndex } ) {
+	return get( state, [ sectionName, rowIndex ] );
+}
+
+export function getCell( state, { sectionName, rowIndex, columnIndex } ) {
+	return get( state, [ sectionName, rowIndex, 'cells', columnIndex ] );
+}
+
 /**
  * Returns the first row in the table.
  *
@@ -35,16 +43,45 @@ export function createTable( {
  *
  * @return {Object} The first table row.
  */
-export function getFirstRow( state ) {
+export function getFirstRowLocation( state ) {
+	let firstSectionName;
+
 	if ( ! isEmptyTableSection( state.head ) ) {
-		return state.head[ 0 ];
+		firstSectionName = 'head';
+	} else if ( ! isEmptyTableSection( state.body ) ) {
+		firstSectionName = 'body';
+	} else if ( ! isEmptyTableSection( state.foot ) ) {
+		firstSectionName = 'foot';
 	}
-	if ( ! isEmptyTableSection( state.body ) ) {
-		return state.body[ 0 ];
-	}
+
+	return {
+		sectionName: firstSectionName,
+		rowIndex: 0,
+	};
+}
+
+/**
+ * Returns the first row in the table.
+ *
+ * @param {Object} state Current table state.
+ *
+ * @return {Object} The first table row.
+ */
+export function getLastRowLocation( state ) {
+	let lastSectionName;
+
 	if ( ! isEmptyTableSection( state.foot ) ) {
-		return state.foot[ 0 ];
+		lastSectionName = 'foot';
+	} else if ( ! isEmptyTableSection( state.body ) ) {
+		lastSectionName = 'body';
+	} else if ( ! isEmptyTableSection( state.head ) ) {
+		lastSectionName = 'head';
 	}
+
+	return {
+		sectionName: lastSectionName,
+		rowIndex: state[ lastSectionName ].length - 1,
+	};
 }
 
 /**
@@ -153,7 +190,7 @@ export function insertRow( state, {
 	rowIndex,
 	columnCount,
 } ) {
-	const firstRow = getFirstRow( state );
+	const firstRow = getRow( state, getFirstRowLocation( state ) );
 	const cellCount = columnCount === undefined ? get( firstRow, [ 'cells', 'length' ] ) : columnCount;
 
 	// Bail early if the function cannot determine how many cells to add.
@@ -447,37 +484,23 @@ export function getCellToLeft( cellLocation ) {
 	} : undefined;
 }
 
-export function getFirstCellInColumn( state, cellLocation ) {
-	let firstSectionName;
-	if ( ! isEmptyTableSection( state.head ) ) {
-		firstSectionName = 'head';
-	} else if ( ! isEmptyTableSection( state.body ) ) {
-		firstSectionName = 'body';
-	} else if ( ! isEmptyTableSection( state.foot ) ) {
-		firstSectionName = 'foot';
-	}
+export function getFirstCellInColumn( state, { columnIndex } ) {
+	const { sectionName, rowIndex } = getFirstRowLocation( state );
 
 	return {
-		...cellLocation,
-		sectionName: firstSectionName,
-		rowIndex: 0,
+		sectionName,
+		rowIndex,
+		columnIndex,
 	};
 }
 
-export function getLastCellInColumn( state, cellLocation ) {
-	let lastSectionName;
-	if ( ! isEmptyTableSection( state.foot ) ) {
-		lastSectionName = 'foot';
-	} else if ( ! isEmptyTableSection( state.body ) ) {
-		lastSectionName = 'body';
-	} else if ( ! isEmptyTableSection( state.head ) ) {
-		lastSectionName = 'head';
-	}
+export function getLastCellInColumn( state, { columnIndex } ) {
+	const { sectionName, rowIndex } = getLastRowLocation( state );
 
 	return {
-		...cellLocation,
-		sectionName: lastSectionName,
-		rowIndex: state[ lastSectionName ].length - 1,
+		sectionName,
+		rowIndex,
+		columnIndex,
 	};
 }
 
@@ -500,4 +523,24 @@ export function getLastCellInRow( state, cellLocation ) {
 		...cellLocation,
 		columnIndex: columnCount - 1,
 	} : undefined;
+}
+
+export function getFirstCellInTable( state ) {
+	const { sectionName, rowIndex } = getFirstRowLocation( state );
+
+	return {
+		sectionName,
+		rowIndex,
+		columnIndex: 0,
+	};
+}
+
+export function getLastCellInTable( state ) {
+	const { sectionName, rowIndex } = getLastRowLocation( state );
+
+	return {
+		sectionName,
+		rowIndex,
+		columnIndex: get( state, [ sectionName, rowIndex, 'cells', 'length' ] ) - 1,
+	};
 }

--- a/packages/block-library/src/table/state.js
+++ b/packages/block-library/src/table/state.js
@@ -347,7 +347,7 @@ export function getCellAbove( state, cellLocation ) {
 		const lastRowOfPreviousSection = previousSection.length - 1;
 
 		return {
-			section: previousSectionName,
+			sectionName: previousSectionName,
 			rowIndex: lastRowOfPreviousSection,
 			columnIndex,
 		};
@@ -396,7 +396,7 @@ export function getCellBelow( state, cellLocation ) {
 		}
 
 		return {
-			section: nextSectionName,
+			sectionName: nextSectionName,
 			rowIndex: 0,
 			columnIndex,
 		};

--- a/packages/block-library/src/table/state.js
+++ b/packages/block-library/src/table/state.js
@@ -111,7 +111,7 @@ export function getCellAttribute( state, cellLocation, attributeName ) {
  *
  * @return {Object} New table state including the updated cells.
  */
-export function updateSelectedCell( state, selection, updateCell ) {
+export function updateSelectedCellAttributes( state, selection, updateCell ) {
 	if ( ! selection ) {
 		return state;
 	}

--- a/packages/block-library/src/table/state.js
+++ b/packages/block-library/src/table/state.js
@@ -309,3 +309,140 @@ export function isEmptyTableSection( section ) {
 export function isEmptyRow( row ) {
 	return ! ( row.cells && row.cells.length );
 }
+
+/**
+ * Returns the location of the cell above.
+ *
+ * @param {Object} state        The table state.
+ * @param {Object} cellLocation The cell location (section, rowIndex, columnIndex).
+ *
+ * @return {?Object} The location of the cell above this one or undefined
+ *                   if this cell is at the table perimeter.
+ */
+export function getCellAbove( state, cellLocation ) {
+	const { sectionName, rowIndex, columnIndex } = cellLocation;
+	const isFirstRow = rowIndex === 0;
+
+	// This is the first row of the first section, return undefined early.
+	if ( sectionName === 'head' && isFirstRow ) {
+		return;
+	}
+
+	// Handle getting the cell from the next section.
+	if ( isFirstRow ) {
+		const previousSectionName = sectionName === 'foot' ? 'body' : 'head';
+		const previousSection = state[ previousSectionName ];
+
+		// There is no previous section, return undefined early.
+		if ( isEmptyTableSection( previousSection ) ) {
+			return;
+		}
+
+		// The previous section doesn't have as many columns, return undefined early.
+		const columnCount = previousSection[ 0 ].cells.length;
+		if ( columnIndex > columnCount - 1 ) {
+			return;
+		}
+
+		const lastRowOfPreviousSection = previousSection.length - 1;
+
+		return {
+			section: previousSectionName,
+			rowIndex: lastRowOfPreviousSection,
+			columnIndex,
+		};
+	}
+
+	return {
+		...cellLocation,
+		rowIndex: rowIndex - 1,
+	};
+}
+
+/**
+ * Returns the location of the cell below.
+ *
+ * @param {Object} state        The table state.
+ * @param {Object} cellLocation The cell location (section, rowIndex, columnIndex).
+ *
+ * @return {?Object} The location of the cell below this one or undefined
+ *                   if this cell is at the table perimeter.
+ */
+export function getCellBelow( state, cellLocation ) {
+	const { sectionName, rowIndex, columnIndex } = cellLocation;
+	const section = state[ sectionName ];
+	const rowCount = section.length;
+	const isLastRow = rowIndex === rowCount - 1;
+
+	// This is the last row of the last section, return undefined early.
+	if ( sectionName === 'foot' && isLastRow ) {
+		return;
+	}
+
+	// Handle getting the cell from the next section.
+	if ( isLastRow ) {
+		const nextSectionName = sectionName === 'head' ? 'body' : 'foot';
+		const nextSection = state[ nextSectionName ];
+
+		// There is no next section, return undefined early.
+		if ( isEmptyTableSection( nextSection ) ) {
+			return;
+		}
+
+		// The next section doesn't have as many columns, return undefined early.
+		const columnCount = nextSection[ 0 ].cells.length;
+		if ( columnIndex > columnCount - 1 ) {
+			return;
+		}
+
+		return {
+			section: nextSectionName,
+			rowIndex: 0,
+			columnIndex,
+		};
+	}
+
+	return {
+		...cellLocation,
+		rowIndex: rowIndex + 1,
+	};
+}
+
+/**
+ * Returns the location of the cell to the right.
+ *
+ * @param {Object} state        The table state.
+ * @param {Object} cellLocation The cell location (section, rowIndex, columnIndex).
+ *
+ * @return {?Object} The location of the cell to the right of this one or undefined
+ *                   if this cell is at the table perimeter.
+ */
+export function getCellToRight( state, cellLocation ) {
+	const { sectionName, rowIndex, columnIndex } = cellLocation;
+	const section = state[ sectionName ];
+	const columnCount = section[ rowIndex ].cells.length;
+	const hasCellToRight = columnIndex < columnCount - 1;
+
+	return hasCellToRight ? {
+		...cellLocation,
+		columnIndex: columnIndex + 1,
+	} : undefined;
+}
+
+/**
+ * Returns the location of the cell to the left.
+ *
+ * @param {Object} cellLocation The cell location (section, rowIndex, columnIndex).
+ *
+ * @return {?Object} The location of the cell to the left of this one or undefined
+ *                   if this cell is at the table perimeter.
+ */
+export function getCellToLeft( cellLocation ) {
+	const { columnIndex } = cellLocation;
+	const hasCellToLeft = columnIndex > 0;
+
+	return hasCellToLeft ? {
+		...cellLocation,
+		columnIndex: columnIndex - 1,
+	} : undefined;
+}

--- a/packages/block-library/src/table/state.js
+++ b/packages/block-library/src/table/state.js
@@ -446,3 +446,58 @@ export function getCellToLeft( cellLocation ) {
 		columnIndex: columnIndex - 1,
 	} : undefined;
 }
+
+export function getFirstCellInColumn( state, cellLocation ) {
+	let firstSectionName;
+	if ( ! isEmptyTableSection( state.head ) ) {
+		firstSectionName = 'head';
+	} else if ( ! isEmptyTableSection( state.body ) ) {
+		firstSectionName = 'body';
+	} else if ( ! isEmptyTableSection( state.foot ) ) {
+		firstSectionName = 'foot';
+	}
+
+	return {
+		...cellLocation,
+		sectionName: firstSectionName,
+		rowIndex: 0,
+	};
+}
+
+export function getLastCellInColumn( state, cellLocation ) {
+	let lastSectionName;
+	if ( ! isEmptyTableSection( state.foot ) ) {
+		lastSectionName = 'foot';
+	} else if ( ! isEmptyTableSection( state.body ) ) {
+		lastSectionName = 'body';
+	} else if ( ! isEmptyTableSection( state.head ) ) {
+		lastSectionName = 'head';
+	}
+
+	return {
+		...cellLocation,
+		sectionName: lastSectionName,
+		rowIndex: state[ lastSectionName ].length - 1,
+	};
+}
+
+export function getFirstCellInRow( cellLocation ) {
+	const { columnIndex } = cellLocation;
+	const hasCellsToLeft = columnIndex > 0;
+
+	return hasCellsToLeft ? {
+		...cellLocation,
+		columnIndex: 0,
+	} : undefined;
+}
+
+export function getLastCellInRow( state, cellLocation ) {
+	const { sectionName, rowIndex, columnIndex } = cellLocation;
+	const columnCount = get( state, [ sectionName, rowIndex, 'cells', 'length' ] );
+	const hasCellsToRight = columnIndex < columnCount - 1;
+
+	return hasCellsToRight ? {
+		...cellLocation,
+		columnIndex: columnCount - 1,
+	} : undefined;
+}

--- a/packages/block-library/src/table/state.js
+++ b/packages/block-library/src/table/state.js
@@ -294,8 +294,8 @@ export function isEmptyRow( row ) {
 /**
  * Return the row referenced by the location object.
  *
- * @param {Object} state 				   The table state.
- * @param {Object} rowLocation 			   The row location.
+ * @param {Object} state                   The table state.
+ * @param {Object} rowLocation             The row location.
  * @param {string} rowLocation.sectionName The table section that the row belongs to.
  * @param {number} rowLocation.rowIndex    The index of the row within the section.
  *
@@ -356,8 +356,8 @@ export function getLocationOfLastRow( state ) {
 /**
  * Returns the location of the cell above.
  *
- * @param {Object} state        			The table state.
- * @param {Object} cellLocation 			The cell location.
+ * @param {Object} state                    The table state.
+ * @param {Object} cellLocation             The cell location.
  * @param {string} cellLocation.sectionName The table section that the cell belongs to.
  * @param {number} cellLocation.rowIndex    The row index for the cell within the section.
  * @param {number} cellLocation.columnIndex The column index for the cell.
@@ -411,8 +411,8 @@ export function getLocationOfCellAbove( state, { sectionName, rowIndex, columnIn
 /**
  * Returns the location of the cell below.
  *
- * @param {Object} state        			The table state.
- * @param {Object} cellLocation 			The cell location.
+ * @param {Object} state                    The table state.
+ * @param {Object} cellLocation             The cell location.
  * @param {string} cellLocation.sectionName The table section that the cell belongs to.
  * @param {number} cellLocation.rowIndex    The row index for the cell within the section.
  * @param {number} cellLocation.columnIndex The column index for the cell.
@@ -466,8 +466,8 @@ export function getLocationOfCellBelow( state, { sectionName, rowIndex, columnIn
 /**
  * Returns the location of the cell to the right.
  *
- * @param {Object} state        			The table state.
- * @param {Object} cellLocation 			The cell location.
+ * @param {Object} state                    The table state.
+ * @param {Object} cellLocation             The cell location.
  * @param {string} cellLocation.sectionName The table section that the cell belongs to.
  * @param {number} cellLocation.rowIndex    The row index for the cell within the section.
  * @param {number} cellLocation.columnIndex The column index for the cell.
@@ -489,7 +489,7 @@ export function getLocationOfCellToRight( state, { sectionName, rowIndex, column
 /**
  * Returns the location of the cell to the left.
  *
- * @param {Object} cellLocation 			The cell location.
+ * @param {Object} cellLocation             The cell location.
  * @param {string} cellLocation.sectionName The table section that the cell belongs to.
  * @param {number} cellLocation.rowIndex    The row index for the cell within the section.
  * @param {number} cellLocation.columnIndex The column index for the cell.
@@ -509,8 +509,8 @@ export function getLocationOfCellToLeft( cellLocation ) {
 /**
  * Returns the location of the first cell in the column.
  *
- * @param {Object} state        			The table state.
- * @param {Object} cellLocation 			The cell location.
+ * @param {Object} state                    The table state.
+ * @param {Object} cellLocation             The cell location.
  * @param {number} cellLocation.columnIndex The column index for the cell.
  *
  * @return {?Object} The location of the first cell in the column or `undefined` if there isn't one.
@@ -530,8 +530,8 @@ export function getLocationOfFirstCellInColumn( state, { columnIndex } ) {
 /**
  * Returns the location of the last cell in the column.
  *
- * @param {Object} state        			The table state.
- * @param {Object} cellLocation 			The cell location.
+ * @param {Object} state                    The table state.
+ * @param {Object} cellLocation             The cell location.
  * @param {number} cellLocation.columnIndex The column index for the cell.
  *
  * @return {?Object} The location of the last cell in the column or `undefined` if there isn't one.
@@ -551,7 +551,7 @@ export function getLocationOfLastCellInColumn( state, { columnIndex } ) {
 /**
  * Returns the location of the first cell in the row.
  *
- * @param {Object} cellLocation 			The cell location.
+ * @param {Object} cellLocation             The cell location.
  * @param {string} cellLocation.sectionName The table section that the cell belongs to.
  * @param {number} cellLocation.rowIndex    The row index for the cell within the section.
  *
@@ -568,8 +568,8 @@ export function getLocationOfFirstCellInRow( { sectionName, rowIndex } ) {
 /**
  * Returns the location of the last cell in the row.
  *
- * @param {Object} state        			The table state.
- * @param {Object} cellLocation 			The cell location.
+ * @param {Object} state                    The table state.
+ * @param {Object} cellLocation             The cell location.
  * @param {string} cellLocation.sectionName The table section that the cell belongs to.
  * @param {number} cellLocation.rowIndex    The row index for the cell within the section.
  *

--- a/packages/block-library/src/table/test/state.js
+++ b/packages/block-library/src/table/test/state.js
@@ -18,7 +18,7 @@ import {
 	isEmptyTableSection,
 	isEmptyRow,
 	isCellSelected,
-	updateSelectedCell,
+	updateSelectedCellAttributes,
 	getCellAbove,
 	getCellBelow,
 	getCellToLeft,
@@ -1213,21 +1213,21 @@ describe( 'isCellSelected', () => {
 	} );
 } );
 
-describe( 'updateSelectedCell', () => {
+describe( 'updateSelectedCellAttributes', () => {
 	it( 'returns an unchanged table state if there is no selection', () => {
-		const updated = updateSelectedCell( table, undefined, ( cell ) => ( { ...cell, content: 'test' } ) );
+		const updated = updateSelectedCellAttributes( table, undefined, ( cell ) => ( { ...cell, content: 'test' } ) );
 		expect( table ).toEqual( updated );
 	} );
 
 	it( 'returns an unchanged table state if the selection is outside the bounds of the table', () => {
 		const cellSelection = { type: 'cell', sectionName: 'body', rowIndex: 100, columnIndex: 100 };
-		const updated = updateSelectedCell( table, cellSelection, ( cell ) => ( { ...cell, content: 'test' } ) );
+		const updated = updateSelectedCellAttributes( table, cellSelection, ( cell ) => ( { ...cell, content: 'test' } ) );
 		expect( table ).toEqual( updated );
 	} );
 
 	it( 'updates only the individual cell when the selection type is `cell`', () => {
 		const cellSelection = { type: 'cell', sectionName: 'body', rowIndex: 0, columnIndex: 0 };
-		const updated = updateSelectedCell( table, cellSelection, ( cell ) => ( { ...cell, content: 'test' } ) );
+		const updated = updateSelectedCellAttributes( table, cellSelection, ( cell ) => ( { ...cell, content: 'test' } ) );
 
 		expect( updated ).toEqual( {
 			body: [
@@ -1247,7 +1247,7 @@ describe( 'updateSelectedCell', () => {
 
 	it( 'updates every cell in the column when the selection type is `column`', () => {
 		const cellSelection = { type: 'column', columnIndex: 1 };
-		const updated = updateSelectedCell( table, cellSelection, ( cell ) => ( { ...cell, content: 'test' } ) );
+		const updated = updateSelectedCellAttributes( table, cellSelection, ( cell ) => ( { ...cell, content: 'test' } ) );
 
 		expect( updated ).toEqual( {
 			body: [

--- a/packages/block-library/src/table/test/state.js
+++ b/packages/block-library/src/table/test/state.js
@@ -19,6 +19,10 @@ import {
 	isEmptyRow,
 	isCellSelected,
 	updateSelectedCell,
+	getCellAbove,
+	getCellBelow,
+	getCellToLeft,
+	getCellToRight,
 } from '../state';
 
 const table = deepFreeze( {
@@ -69,6 +73,63 @@ const tableWithFoot = deepFreeze( {
 			cells: [
 				{
 					content: 'test',
+					tag: 'td',
+				},
+			],
+		},
+	],
+} );
+
+const tableWithHeadAndFoot = deepFreeze( {
+	head: [
+		{
+			cells: [
+				{
+					content: '',
+					tag: 'th',
+				},
+				{
+					content: '',
+					tag: 'th',
+				},
+			],
+		},
+	],
+	body: [
+		{
+			cells: [
+				{
+					content: '',
+					tag: 'td',
+				},
+				{
+					content: '',
+					tag: 'td',
+				},
+			],
+		},
+		{
+			cells: [
+				{
+					content: '',
+					tag: 'td',
+				},
+				{
+					content: '',
+					tag: 'td',
+				},
+			],
+		},
+	],
+	foot: [
+		{
+			cells: [
+				{
+					content: '',
+					tag: 'td',
+				},
+				{
+					content: '',
 					tag: 'td',
 				},
 			],
@@ -1209,6 +1270,114 @@ describe( 'updateSelectedCell', () => {
 					],
 				},
 			],
+		} );
+	} );
+} );
+
+describe( 'getCellAbove', () => {
+	it( `returns undefined for the first row of 'head' section`, () => {
+		const cellLocation = { sectionName: 'head', rowIndex: 0, columnIndex: 0 };
+		expect( getCellAbove( tableWithHeadAndFoot, cellLocation ) ).toBeUndefined();
+	} );
+
+	it( `returns undefined for the first row of 'body' section if the 'head' section is empty`, () => {
+		const cellLocation = { sectionName: 'body', rowIndex: 0, columnIndex: 0 };
+		expect( getCellAbove( table, cellLocation ) ).toBeUndefined();
+	} );
+
+	it( `returns undefined if the row above does not have as many cells`, () => {
+		const cellLocation = { sectionName: 'body', rowIndex: 1, columnIndex: 2 };
+		expect( getCellAbove( table, cellLocation ) ).toBeUndefined();
+	} );
+
+	it( `returns the location for the row above in the same section when that row exists`, () => {
+		const cellLocation = { sectionName: 'body', rowIndex: 1, columnIndex: 0 };
+		expect( getCellAbove( table, cellLocation ) ).toEqual( { section: 'body', rowIndex: 0, columnIndex: 0 } );
+	} );
+
+	it( `returns the location for the row above in the previous section when that row exists`, () => {
+		const bodyCellLocation = { sectionName: 'body', rowIndex: 0, columnIndex: 0 };
+		const footCellLocation = { sectionName: 'foot', rowIndex: 0, columnIndex: 0 };
+
+		expect( getCellAbove( tableWithHeadAndFoot, bodyCellLocation ) ).toEqual( {
+			sectionName: 'head',
+			rowIndex: 0,
+			columnIndex: 0,
+		} );
+		expect( getCellAbove( tableWithHeadAndFoot, footCellLocation ) ).toEqual( {
+			sectionName: 'body',
+			rowIndex: 1,
+			columnIndex: 0,
+		} );
+	} );
+} );
+
+describe( 'getCellBelow', () => {
+	it( `returns undefined for the last row of 'foot' section`, () => {
+		const cellLocation = { sectionName: 'foot', rowIndex: 0, columnIndex: 0 };
+		expect( getCellBelow( tableWithHeadAndFoot, cellLocation ) ).toBeUndefined();
+	} );
+
+	it( `returns undefined for the last row of 'body' section if the 'foot' section is empty`, () => {
+		const cellLocation = { sectionName: 'body', rowIndex: 1, columnIndex: 0 };
+		expect( getCellBelow( table, cellLocation ) ).toBeUndefined();
+	} );
+
+	it( `returns undefined if the row below does not have as many cells`, () => {
+		const cellLocation = { sectionName: 'body', rowIndex: 0, columnIndex: 2 };
+		expect( getCellBelow( table, cellLocation ) ).toBeUndefined();
+	} );
+
+	it( `returns the location for the row below in the same section when that row exists`, () => {
+		const cellLocation = { sectionName: 'body', rowIndex: 0, columnIndex: 0 };
+		expect( getCellBelow( table, cellLocation ) ).toEqual( { section: 'body', rowIndex: 1, columnIndex: 0 } );
+	} );
+
+	it( `returns the location for the row below in the next section when that row exists`, () => {
+		const bodyCellLocation = { sectionName: 'head', rowIndex: 0, columnIndex: 0 };
+		expect( getCellBelow( tableWithHeadAndFoot, bodyCellLocation ) ).toEqual( {
+			section: 'body',
+			rowIndex: 0,
+			columnIndex: 0,
+		} );
+
+		const footCellLocation = { sectionName: 'body', rowIndex: 1, columnIndex: 0 };
+		expect( getCellBelow( tableWithHeadAndFoot, footCellLocation ) ).toEqual( {
+			section: 'foot',
+			rowIndex: 0,
+			columnIndex: 0,
+		} );
+	} );
+} );
+
+describe( 'getCellToRight', () => {
+	it( 'returns undefined if there is no cell to the right', () => {
+		const cellLocation = { sectionName: 'body', rowIndex: 0, columnIndex: 1 };
+		expect( getCellToRight( table, cellLocation ) ).toBeUndefined();
+	} );
+
+	it( 'returns the location of the cell to the right if it exists', () => {
+		const cellLocation = { sectionName: 'body', rowIndex: 0, columnIndex: 0 };
+		expect( getCellToRight( table, cellLocation ) ).toEqual( {
+			section: 'body',
+			rowIndex: 0,
+			columnIndex: 1,
+		} );
+	} );
+} );
+
+describe( 'getCellToLeft', () => {
+	it( 'returns undefined if there is no cell to the left', () => {
+		const cellLocation = { sectionName: 'body', rowIndex: 0, columnIndex: 0 };
+		expect( getCellToLeft( cellLocation ) ).toBeUndefined();
+	} );
+
+	it( 'returns the location of the cell to the left if it exists', () => {
+		const cellLocation = { sectionName: 'body', rowIndex: 0, columnIndex: 1 };
+		expect( getCellToLeft( cellLocation ) ).toEqual( {
+			section: 'body',
+			rowIndex: 0,
+			columnIndex: 0,
 		} );
 	} );
 } );

--- a/packages/e2e-tests/specs/blocks/__snapshots__/table.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/table.test.js.snap
@@ -36,6 +36,18 @@ exports[`Table allows header and footer rows to be switched on and off 2`] = `
 <!-- /wp:table -->"
 `;
 
+exports[`Table allows keyboard navigation between table cells using arrow keys 1`] = `
+"<!-- wp:table -->
+<figure class=\\"wp-block-table\\"><table class=\\"\\"><tbody><tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td></tr><tr><td></td><td>B2</td><td>C2</td><td></td></tr><tr><td></td><td></td><td></td><td></td></tr><tr><td>A4</td><td></td><td></td><td>D4</td></tr></tbody></table></figure>
+<!-- /wp:table -->"
+`;
+
+exports[`Table allows keyboard navigation between table cells using the HOME and END keys 1`] = `
+"<!-- wp:table -->
+<figure class=\\"wp-block-table\\"><table class=\\"\\"><tbody><tr><td>A1</td><td></td><td></td><td></td></tr><tr><td>A2</td><td></td><td></td><td>D2</td></tr><tr><td></td><td></td><td></td><td></td></tr><tr><td></td><td></td><td></td><td>D4</td></tr></tbody></table></figure>
+<!-- /wp:table -->"
+`;
+
 exports[`Table allows text to by typed into cells 1`] = `
 "<!-- wp:table -->
 <figure class=\\"wp-block-table\\"><table class=\\"\\"><tbody><tr><td>This</td><td>is</td></tr><tr><td>table</td><td>block</td></tr></tbody></table></figure>

--- a/packages/e2e-tests/specs/blocks/table.test.js
+++ b/packages/e2e-tests/specs/blocks/table.test.js
@@ -74,15 +74,16 @@ describe( 'Table', () => {
 		await page.keyboard.type( 'This' );
 
 		// Tab to the next cell and add some text.
-		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.type( 'is' );
 
 		// Tab to the next cell and add some text.
-		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'ArrowLeft' );
 		await page.keyboard.type( 'table' );
 
 		// Tab to the next cell and add some text.
-		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.type( 'block' );
 
 		// Expect the post to have the correct written content inside the table.

--- a/packages/e2e-tests/specs/blocks/table.test.js
+++ b/packages/e2e-tests/specs/blocks/table.test.js
@@ -12,6 +12,8 @@ import {
 	createNewPost,
 	getEditedPostContent,
 	insertBlock,
+	pressKeyTimes,
+	pressKeyWithModifier,
 } from '@wordpress/e2e-test-utils';
 
 const createButtonLabel = 'Create Table';
@@ -231,6 +233,83 @@ describe( 'Table', () => {
 		await page.keyboard.type( 'Second cell.' );
 
 		// Expect that the snapshot shows the text in the second cell.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'allows keyboard navigation between table cells using arrow keys', async () => {
+		await insertBlock( 'Table' );
+
+		// Modify the row and column count and create the table.
+		await pressKeyTimes( 'Tab', 5 );
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.type( '4' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.type( '4' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Space' );
+
+		// Tab into the first cell.
+		await page.keyboard.press( 'Tab' );
+
+		// Navigate and type spreadsheet-style cell locations.
+		// First use normal arrow keys in the middle of the table.
+		await pressKeyTimes( 'ArrowRight', 2 );
+		await page.keyboard.type( 'C1' );
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.type( 'C2' );
+		await pressKeyTimes( 'ArrowLeft', 3 );
+		await page.keyboard.type( 'B2' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.type( 'B1' );
+
+		// Next use Cmd/Ctrl with arrow keys to navigate to the corners of the table.
+		await pressKeyWithModifier( 'primary', 'ArrowRight' );
+		await page.keyboard.type( 'D1' );
+		await pressKeyWithModifier( 'primary', 'ArrowDown' );
+		await page.keyboard.type( 'D4' );
+		await pressKeyTimes( 'ArrowLeft', 2 );
+		await pressKeyWithModifier( 'primary', 'ArrowLeft' );
+		await page.keyboard.type( 'A4' );
+		await pressKeyWithModifier( 'primary', 'ArrowUp' );
+		await page.keyboard.type( 'A1' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'allows keyboard navigation between table cells using the HOME and END keys', async () => {
+		await insertBlock( 'Table' );
+
+		// Modify the row and column count and create the table.
+		await pressKeyTimes( 'Tab', 5 );
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.type( '4' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Backspace' );
+		await page.keyboard.type( '4' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Space' );
+
+		// Tab into the first cell.
+		await page.keyboard.press( 'Tab' );
+
+		// Navigate and type spreadsheet-style cell locations.
+		// Navigate to the start and end of the second row.
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'Home' );
+		await page.keyboard.type( 'A2' );
+		await page.keyboard.press( 'End' );
+		await page.keyboard.type( 'D2' );
+
+		// Move the caret to the start of the cell.
+		await pressKeyTimes( 'ArrowLeft', 2 );
+
+		// Navigate to the first and last cells in the table.
+		await pressKeyWithModifier( 'primary', 'Home' );
+		await page.keyboard.type( 'A1' );
+		await pressKeyWithModifier( 'primary', 'End' );
+		await page.keyboard.type( 'D4' );
+
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 } );

--- a/packages/keycodes/README.md
+++ b/packages/keycodes/README.md
@@ -103,6 +103,17 @@ _Type_
 
 -   `Object` Keyed map of functions to match events.
 
+<a name="isKeyboardModifierEvent" href="#isKeyboardModifierEvent">#</a> **isKeyboardModifierEvent**
+
+An object that contains functions to check if a keyboard event involves a
+particular modifier key being pressed.
+E.g. isKeyboardEvent.primary( event ) will return true if the event
+signals pressing ⌘ on a Mac.
+
+_Type_
+
+-   `Object` Keyed map of functions to match events.
+
 <a name="LEFT" href="#LEFT">#</a> **LEFT**
 
 Keycode for LEFT key.

--- a/packages/keycodes/README.md
+++ b/packages/keycodes/README.md
@@ -80,6 +80,10 @@ _Type_
 
 Keycode for DOWN key.
 
+<a name="END" href="#END">#</a> **END**
+
+Keycode for SPACE key.
+
 <a name="ENTER" href="#ENTER">#</a> **ENTER**
 
 Keycode for ENTER key.
@@ -91,6 +95,10 @@ Keycode for ESCAPE key.
 <a name="F10" href="#F10">#</a> **F10**
 
 Keycode for F10 key.
+
+<a name="HOME" href="#HOME">#</a> **HOME**
+
+Keycode for SPACE key.
 
 <a name="isKeyboardEvent" href="#isKeyboardEvent">#</a> **isKeyboardEvent**
 

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -194,6 +194,22 @@ export const shortcutAriaLabel = mapValues( modifiers, ( modifier ) => {
 } );
 
 /**
+ * An object that contains functions to check if a keyboard event involves a
+ * particular modifier key being pressed.
+ * E.g. isKeyboardEvent.primary( event ) will return true if the event
+ * signals pressing ⌘ on a Mac.
+ *
+ * @type {Object} Keyed map of functions to match events.
+ */
+export const isKeyboardModifierEvent = mapValues( modifiers, ( getModifiers ) => {
+	return ( event, _isApple = isAppleOS ) => {
+		const mods = getModifiers( _isApple );
+
+		return mods.every( ( key ) => event[ `${ key }Key` ] );
+	};
+} );
+
+/**
  * An object that contains functions to check if a keyboard event matches a
  * predefined shortcut combination.
  * E.g. isKeyboardEvent.primary( event, 'm' ) will return true if the event
@@ -216,3 +232,4 @@ export const isKeyboardEvent = mapValues( modifiers, ( getModifiers ) => {
 		return event.key === character;
 	};
 } );
+

--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -45,6 +45,14 @@ export const ESCAPE = 27;
  */
 export const SPACE = 32;
 /**
+ * Keycode for SPACE key.
+ */
+export const END = 35;
+/**
+ * Keycode for SPACE key.
+ */
+export const HOME = 36;
+/**
  * Keycode for LEFT key.
  */
 export const LEFT = 37;

--- a/packages/keycodes/src/test/index.js
+++ b/packages/keycodes/src/test/index.js
@@ -7,6 +7,7 @@ import {
 	rawShortcut,
 	shortcutAriaLabel,
 	isKeyboardEvent,
+	isKeyboardModifierEvent,
 } from '../';
 
 const isAppleOSFalse = () => false;
@@ -464,6 +465,249 @@ describe( 'isKeyboardEvent', () => {
 			expect.assertions( 3 );
 			const attachNode = attachEventListeners( ( event ) => {
 				expect( isKeyboardEvent.primary( event, 'm', isAppleOSTrue ) ).toBe( true );
+			} );
+
+			keyPress( attachNode, {
+				metaKey: true,
+				altKey: true,
+				key: 'm',
+			} );
+		} );
+	} );
+} );
+
+describe( 'isKeyboardModifierEvent', () => {
+	afterEach( () => {
+		while ( document.body.firstChild ) {
+			document.body.removeChild( document.body.firstChild );
+		}
+	} );
+
+	function keyPress( target, modifiers = {} ) {
+		[ 'keydown', 'keypress', 'keyup' ].forEach( ( eventName ) => {
+			const event = new window.Event( eventName, { bubbles: true } );
+			Object.assign( event, modifiers );
+			target.dispatchEvent( event );
+		} );
+	}
+
+	function attachEventListeners( eventHandler ) {
+		const attachNode = document.createElement( 'div' );
+		document.body.appendChild( attachNode );
+
+		[ 'keydown', 'keypress', 'keyup' ].forEach( ( eventName ) => {
+			attachNode.addEventListener( eventName, eventHandler );
+		} );
+
+		return attachNode;
+	}
+
+	describe( 'primary', () => {
+		it( 'should identify modifier key when Ctrl is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
+				expect( isKeyboardModifierEvent.primary( event, isAppleOSFalse ) ).toBe( true );
+			} );
+
+			keyPress( attachNode, {
+				ctrlKey: true,
+				key: 'Ctrl',
+			} );
+		} );
+
+		it( 'should identify modifier key when ⌘ is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
+				expect( isKeyboardModifierEvent.primary( event, isAppleOSTrue ) ).toBe( true );
+			} );
+
+			keyPress( attachNode, {
+				metaKey: true,
+				key: 'Meta',
+			} );
+		} );
+
+		it( 'should identify modifier key when Ctrl + M is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
+				expect( isKeyboardModifierEvent.primary( event, isAppleOSFalse ) ).toBe( true );
+			} );
+
+			keyPress( attachNode, {
+				ctrlKey: true,
+				key: 'm',
+			} );
+		} );
+
+		it( 'should identify modifier key when ⌘M is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
+				expect( isKeyboardModifierEvent.primary( event, isAppleOSTrue ) ).toBe( true );
+			} );
+
+			keyPress( attachNode, {
+				metaKey: true,
+				key: 'm',
+			} );
+		} );
+	} );
+
+	describe( 'primaryShift', () => {
+		it( 'should identify modifier key when Shift + Ctrl is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
+				expect( isKeyboardModifierEvent.primary( event, isAppleOSFalse ) ).toBe( true );
+			} );
+
+			keyPress( attachNode, {
+				ctrlKey: true,
+				shiftKey: true,
+				key: 'Ctrl',
+			} );
+		} );
+
+		it( 'should identify modifier key when ⇧⌘ is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
+				expect( isKeyboardModifierEvent.primary( event, isAppleOSTrue ) ).toBe( true );
+			} );
+
+			keyPress( attachNode, {
+				metaKey: true,
+				shiftKey: true,
+				key: 'Meta',
+			} );
+		} );
+
+		it( 'should identify modifier key when Shift + Ctrl + M is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
+				expect( isKeyboardModifierEvent.primary( event, isAppleOSFalse ) ).toBe( true );
+			} );
+
+			keyPress( attachNode, {
+				ctrlKey: true,
+				shiftKey: true,
+				key: 'm',
+			} );
+		} );
+
+		it( 'should identify modifier key when ⇧⌘M is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
+				expect( isKeyboardModifierEvent.primary( event, isAppleOSTrue ) ).toBe( true );
+			} );
+
+			keyPress( attachNode, {
+				metaKey: true,
+				shiftKey: true,
+				key: 'm',
+			} );
+		} );
+	} );
+
+	describe( 'secondary', () => {
+		it( 'should identify modifier key when Shift + Alt + Ctrl is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
+				expect( isKeyboardModifierEvent.primary( event, isAppleOSFalse ) ).toBe( true );
+			} );
+
+			keyPress( attachNode, {
+				ctrlKey: true,
+				shiftKey: true,
+				altKey: true,
+				key: 'Ctrl',
+			} );
+		} );
+
+		it( 'should identify modifier key when ⇧⌥⌘ is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
+				expect( isKeyboardModifierEvent.primary( event, isAppleOSTrue ) ).toBe( true );
+			} );
+
+			keyPress( attachNode, {
+				metaKey: true,
+				shiftKey: true,
+				altKey: true,
+				key: 'Meta',
+			} );
+		} );
+
+		it( 'should identify modifier key when Shift + Ctrl + ALt + M is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
+				expect( isKeyboardModifierEvent.primary( event, isAppleOSFalse ) ).toBe( true );
+			} );
+
+			keyPress( attachNode, {
+				ctrlKey: true,
+				shiftKey: true,
+				altKey: true,
+				key: 'm',
+			} );
+		} );
+
+		it( 'should identify modifier key when ⇧⌥⌘M is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
+				expect( isKeyboardModifierEvent.primary( event, isAppleOSTrue ) ).toBe( true );
+			} );
+
+			keyPress( attachNode, {
+				metaKey: true,
+				shiftKey: true,
+				altKey: true,
+				key: 'm',
+			} );
+		} );
+	} );
+
+	describe( 'access', () => {
+		it( 'should identify modifier key when Alt + Ctrl is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
+				expect( isKeyboardModifierEvent.primary( event, isAppleOSFalse ) ).toBe( true );
+			} );
+
+			keyPress( attachNode, {
+				ctrlKey: true,
+				altKey: true,
+				key: 'Ctrl',
+			} );
+		} );
+
+		it( 'should identify modifier key when ⌥⌘ is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
+				expect( isKeyboardModifierEvent.primary( event, isAppleOSTrue ) ).toBe( true );
+			} );
+
+			keyPress( attachNode, {
+				metaKey: true,
+				altKey: true,
+				key: 'Meta',
+			} );
+		} );
+
+		it( 'should identify modifier key when Ctrl + ALt + M is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
+				expect( isKeyboardModifierEvent.primary( event, isAppleOSFalse ) ).toBe( true );
+			} );
+
+			keyPress( attachNode, {
+				ctrlKey: true,
+				altKey: true,
+				key: 'm',
+			} );
+		} );
+
+		it( 'should identify modifier key when ⌥⌘M is pressed', () => {
+			expect.assertions( 3 );
+			const attachNode = attachEventListeners( ( event ) => {
+				expect( isKeyboardModifierEvent.primary( event, isAppleOSTrue ) ).toBe( true );
 			} );
 
 			keyPress( attachNode, {

--- a/packages/rich-text/src/component/editable.js
+++ b/packages/rich-text/src/component/editable.js
@@ -116,6 +116,10 @@ export default class Editable extends Component {
 			this.editorNode.className = nextProps.className;
 		}
 
+		if ( ! isEqual( this.props.tabIndex, nextProps.tabIndex ) ) {
+			this.editorNode.tabIndex = nextProps.tabIndex;
+		}
+
 		const { removedKeys, updatedKeys } = diffAriaProps( this.props, nextProps );
 		removedKeys.forEach( ( key ) =>
 			this.editorNode.removeAttribute( key ) );

--- a/packages/rich-text/src/component/editable.js
+++ b/packages/rich-text/src/component/editable.js
@@ -116,7 +116,7 @@ export default class Editable extends Component {
 			this.editorNode.className = nextProps.className;
 		}
 
-		if ( ! isEqual( this.props.tabIndex, nextProps.tabIndex ) ) {
+		if ( this.props.tabIndex !== nextProps.tabIndex ) {
 			this.editorNode.tabIndex = nextProps.tabIndex;
 		}
 

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -888,6 +888,7 @@ class RichText extends Component {
 			__unstableOnReplace: onReplace,
 			allowedFormats,
 			withoutInteractiveFormatting,
+			tabIndex,
 		} = this.props;
 
 		// Generating a key that includes `tagName` ensures that if the tag
@@ -904,6 +905,7 @@ class RichText extends Component {
 					style={ style }
 					record={ record }
 					valueToEditableHTML={ this.valueToEditableHTML }
+					tabIndex={ tabIndex }
 					aria-label={ placeholder }
 					aria-autocomplete={ listBoxId ? 'list' : undefined }
 					aria-owns={ listBoxId }


### PR DESCRIPTION
Status: This is blocked by https://github.com/WordPress/gutenberg/pull/17084, which will move some of the functionality from this PR to a `WritingFlow`.

## Description
This PR implements improved keyboard navigation within the table block. Previously only tab could be used to navigate cells.

This PR implements the following changes:
- Arrow keys are now used to navigate cells along with `HOME` and `END`. The `Cmd`/`Ctrl` modifiers can be used to go directly to the start/end of a column, row, or the entire table (when used with `HOME` and `END`)
![table-arrow-nav](https://user-images.githubusercontent.com/677833/62997097-a17b5900-be99-11e9-9c8c-ee19a465f761.gif)

- Tab / Shift+Tab is now used to navigate directly to from an individual cell within the table. A user is able to navigate to a cell using arrow keys, shift tab to the toolbar to make some changes to the table, then tab back to the last selected cell. Previously this was quite hard to achieve as tabbing to the toolbar also changed the selected cell.
![table-tab](https://user-images.githubusercontent.com/677833/62997102-a4764980-be99-11e9-96b0-c3f48e6fdc6e.gif)

The implementation follows the described behaviours here and uses a roving tabIndex:
https://www.w3.org/TR/wai-aria-practices/examples/grid/dataGrids.html

The changes here open up the possibilities for other future enhancements to the table block:
- Multi-cell selection using the keyboard (holding down shift with navigation keys).
- Merging of cells (`colspan`/`rowspan`), which will require multi-selection.
- The improvements to keyboard usage also help considerably with implementing column/row selection (#16493), which is why I switched to working on this first.

## How has this been tested?
Added e2e and unit tests

Manual testing:
1. Add a table block
2. Toggle on the header and footer.
3. Use cursor keys to navigate around. Ensure all cells are navigable.
4. Type some text.
5. Use cursor keys to navigate through the cell with text.
6. Use HOME and END to navigate to the start and end of the row.
7. Use Cmd/Ctrl with arrow keys and HOME and END
8. Use shift tab and tab to navigate out of the table and back in to the last selected cell.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
