### PR TITLE
RichText: ignore selection changes during composition

### DIFF
--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -391,14 +391,25 @@ class RichText extends Component {
 	}
 
 	/**
-	 * Handles the `selectionchange` event: sync the selection to local state.
+	 * Syncs the selection to local state. A callback for the `selectionchange`
+	 * native events, `keyup`, `mouseup` and `touchend` synthetic events, and
+	 * animation frames after the `focus` event.
 	 *
-	 * @param {Event} event `selectionchange` event.
+	 * @param {Event|SyntheticEvent|DOMHighResTimeStamp} event
 	 */
 	onSelectionChange( event ) {
 		if (
 			event.type !== 'selectionchange' &&
 			! this.props.__unstableIsSelected
+		) {
+			return;
+		}
+
+		// In case of a keyboard event, ignore selection changes during
+		// composition.
+		if (
+			event.nativeEvent &&
+			event.nativeEvent.isComposing
 		) {
 			return;
 		}


### PR DESCRIPTION
## Description

This PR fixes input composition after #16875. We're checking selection during `keyup` now as well, but we shouldn't do that during input composition as the browser will otherwise fail to compose.

This is done already for the `selectionchange` event:

https://github.com/WordPress/gutenberg/blob/005e0302eba30a24cb4fe64e42cf909a58d4b60e/packages/rich-text/src/component/index.js#L327-L331

Unfortunately I'm not able to write any e2e tests. Puppeteer won't compose characters when given the right sequence of keys, and I'm not succeeding at emulating it. I cannot recreate the internal state and UI that the browser has, and it's this state that gets destroyed if we record any input or selection during composition.

<img width="49" alt="Screenshot 2019-08-08 at 11 51 01" src="https://user-images.githubusercontent.com/4710635/62693445-d0de2180-b9d2-11e9-8d33-dccefa814f96.png">

The line under this backtick means that the browser is composing. Any ideas are welcome here.

## How has this been tested?

This depends a bit on your keyboard layout. For a US/QWERTY layout:

* Press `` Alt+` ``.
* Press `a`.

The result should be `à`.

(Puppeteer ignores `` Alt+` `` here.)

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->