### PR TITLE
Fix toolbar bottom inset for iPhone X devices

### DIFF
--- a/packages/edit-post/src/components/layout/index.native.js
+++ b/packages/edit-post/src/components/layout/index.native.js
@@ -108,6 +108,7 @@ class Layout extends Component {
 			...styles.toolbarKeyboardAvoidingView,
 			left: this.state.safeAreaInsets.left,
 			right: this.state.safeAreaInsets.right,
+			bottom: this.state.safeAreaInsets.bottom,
 		};
 
 		return (


### PR DESCRIPTION
## Description
Addresses https://github.com/WordPress/gutenberg/pull/16677#issuecomment-519089648

## How has this been tested?
Tested with Gutenberg mobile PR https://github.com/wordpress-mobile/gutenberg-mobile/pull/1273

## Types of changes
Layout changes for native mobile

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
