### PR TITLE
Accessibility: Move focus back to the modal dialog to More Menu when it was used to get there

### DIFF
--- a/packages/components/src/dropdown/index.js
+++ b/packages/components/src/dropdown/index.js
@@ -49,10 +49,14 @@ class Dropdown extends Component {
 	 * Closes the dropdown if a focus leaves the dropdown wrapper. This is
 	 * intentionally distinct from `onClose` since focus loss from the popover
 	 * is expected to occur when using the Dropdown's toggle button, in which
-	 * case the correct behavior is to keep the dropdown closed.
+	 * case the correct behavior is to keep the dropdown closed. The same applies
+	 * in case when focus is moved to the modal dialog.
 	 */
 	closeIfFocusOutside() {
-		if ( ! this.containerRef.current.contains( document.activeElement ) ) {
+		if (
+			! this.containerRef.current.contains( document.activeElement ) &&
+			! document.activeElement.closest( '[role="dialog"]' )
+		) {
 			this.close();
 		}
 	}

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -473,6 +473,10 @@ running the test is not already the admin user).
 Switches the current user to whichever user we should be
 running the tests as (if we're not already that user).
 
+<a name="toggleMoreMenu" href="#toggleMoreMenu">#</a> **toggleMoreMenu**
+
+Toggles the More Menu.
+
 <a name="toggleScreenOption" href="#toggleScreenOption">#</a> **toggleScreenOption**
 
 Toggles the screen option with the given label.

--- a/packages/e2e-test-utils/src/click-on-more-menu-item.js
+++ b/packages/e2e-test-utils/src/click-on-more-menu-item.js
@@ -4,14 +4,17 @@
 import { first } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import { toggleMoreMenu } from './toggle-more-menu';
+
+/**
  * Clicks on More Menu item, searches for the button with the text provided and clicks it.
  *
  * @param {string} buttonLabel The label to search the button for.
  */
 export async function clickOnMoreMenuItem( buttonLabel ) {
-	await expect( page ).toClick(
-		'.edit-post-more-menu [aria-label="More tools & options"]'
-	);
+	await toggleMoreMenu();
 	const moreMenuContainerSelector =
 		'//*[contains(concat(" ", @class, " "), " edit-post-more-menu__content ")]';
 	let elementToClick = first( await page.$x(

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -46,6 +46,7 @@ export { switchEditorModeTo } from './switch-editor-mode-to';
 export { disableNavigationMode } from './keyboard-mode';
 export { switchUserToAdmin } from './switch-user-to-admin';
 export { switchUserToTest } from './switch-user-to-test';
+export { toggleMoreMenu } from './toggle-more-menu';
 export { toggleScreenOption } from './toggle-screen-option';
 export { transformBlockTo } from './transform-block-to';
 export { uninstallPlugin } from './uninstall-plugin';

--- a/packages/e2e-test-utils/src/switch-editor-mode-to.js
+++ b/packages/e2e-test-utils/src/switch-editor-mode-to.js
@@ -1,14 +1,21 @@
 /**
+ * Internal dependencies
+ */
+import { toggleMoreMenu } from './toggle-more-menu';
+
+/**
  * Switches editor mode.
  *
  * @param {string} mode String editor mode.
  */
 export async function switchEditorModeTo( mode ) {
-	await page.click(
-		'.edit-post-more-menu [aria-label="More tools & options"]'
-	);
+	await toggleMoreMenu();
 	const [ button ] = await page.$x(
 		`//button[contains(text(), '${ mode } Editor')]`
 	);
 	await button.click( 'button' );
+	await toggleMoreMenu();
+	if ( mode === 'Code' ) {
+		await page.waitForSelector( '.editor-post-text-editor' );
+	}
 }

--- a/packages/e2e-test-utils/src/toggle-more-menu.js
+++ b/packages/e2e-test-utils/src/toggle-more-menu.js
@@ -1,0 +1,8 @@
+/**
+ * Toggles the More Menu.
+ */
+export async function toggleMoreMenu() {
+	await expect( page ).toClick(
+		'.edit-post-more-menu [aria-label="More tools & options"]'
+	);
+}

--- a/packages/e2e-test-utils/src/toggle-screen-option.js
+++ b/packages/e2e-test-utils/src/toggle-screen-option.js
@@ -1,7 +1,9 @@
 /**
  * Internal dependencies
  */
+import { clickOnCloseModalButton } from './click-on-close-modal-button';
 import { clickOnMoreMenuItem } from './click-on-more-menu-item';
+import { toggleMoreMenu } from './toggle-more-menu';
 
 /**
  * Toggles the screen option with the given label.
@@ -22,5 +24,6 @@ export async function toggleScreenOption( label, shouldBeChecked = undefined ) {
 		await handle.click();
 	}
 
-	await page.click( 'button[aria-label="Close dialog"]' );
+	await clickOnCloseModalButton();
+	await toggleMoreMenu();
 }

--- a/packages/e2e-tests/specs/adding-blocks.test.js
+++ b/packages/e2e-tests/specs/adding-blocks.test.js
@@ -6,6 +6,7 @@ import {
 	insertBlock,
 	getEditedPostContent,
 	pressKeyTimes,
+	switchEditorModeTo,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'adding blocks', () => {
@@ -96,10 +97,7 @@ describe( 'adding blocks', () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'Second paragraph' );
 
-		// Switch to Text Mode to check HTML Output
-		await page.click( '.edit-post-more-menu [aria-label="More tools & options"]' );
-		const codeEditorButton = ( await page.$x( "//button[contains(text(), 'Code Editor')]" ) )[ 0 ];
-		await codeEditorButton.click( 'button' );
+		await switchEditorModeTo( 'Code' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );

--- a/packages/e2e-tests/specs/editor-modes.test.js
+++ b/packages/e2e-tests/specs/editor-modes.test.js
@@ -97,11 +97,7 @@ describe( 'Editing modes (visual/HTML)', () => {
 		let blockInspectorTab = await page.$( '.edit-post-sidebar__panel-tab.is-active[data-label="Block"]' );
 		expect( blockInspectorTab ).not.toBeNull();
 
-		// Switch to Code Editor and hide More Menu
 		await switchEditorModeTo( 'Code' );
-		await page.click(
-			'.edit-post-more-menu [aria-label="More tools & options"]'
-		);
 
 		// The Block inspector should not be active anymore
 		blockInspectorTab = await page.$( '.edit-post-sidebar__panel-tab.is-active[data-label="Block"]' );

--- a/packages/e2e-tests/specs/fullscreen-mode.test.js
+++ b/packages/e2e-tests/specs/fullscreen-mode.test.js
@@ -4,6 +4,7 @@
 import {
 	createNewPost,
 	clickOnMoreMenuItem,
+	toggleMoreMenu,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Fullscreen Mode', () => {
@@ -13,6 +14,7 @@ describe( 'Fullscreen Mode', () => {
 
 	it( 'should open the fullscreen mode from the more menu', async () => {
 		await clickOnMoreMenuItem( 'Fullscreen Mode' );
+		await toggleMoreMenu();
 
 		const isFullscreenEnabled = await page.$eval( 'body', ( body ) => {
 			return body.classList.contains( 'is-fullscreen-mode' );

--- a/packages/e2e-tests/specs/plugins/allowed-blocks.test.js
+++ b/packages/e2e-tests/specs/plugins/allowed-blocks.test.js
@@ -3,6 +3,7 @@
  */
 import {
 	activatePlugin,
+	clickOnMoreMenuItem,
 	createNewPost,
 	deactivatePlugin,
 	searchForBlock,
@@ -40,15 +41,9 @@ describe( 'Allowed Blocks Filter', () => {
 	} );
 
 	it( 'should remove not allowed blocks from the block manager', async () => {
-		const BLOCK_LABEL_SELECTOR = '.edit-post-manage-blocks-modal__checklist-item .components-checkbox-control__label';
-		await page.click(
-			'.edit-post-more-menu [aria-label="More tools & options"]'
-		);
-		const [ button ] = await page.$x(
-			`//button[contains(text(), 'Block Manager')]`
-		);
-		await button.click( 'button' );
+		await clickOnMoreMenuItem( 'Block Manager' );
 
+		const BLOCK_LABEL_SELECTOR = '.edit-post-manage-blocks-modal__checklist-item .components-checkbox-control__label';
 		await page.waitForSelector( BLOCK_LABEL_SELECTOR );
 		const blocks = await page.evaluate(
 			( selector ) => {

--- a/packages/e2e-tests/specs/plugins/container-blocks.test.js
+++ b/packages/e2e-tests/specs/plugins/container-blocks.test.js
@@ -31,7 +31,6 @@ describe( 'InnerBlocks Template Sync', () => {
 		`;
 		await insertBlock( blockName );
 		await switchEditorModeTo( 'Code' );
-		await page.waitForSelector( '.editor-post-text-editor' );
 		await page.$eval( '.editor-post-text-editor', ( element, _paragraph, _blockSlug ) => {
 			const blockDelimiter = `<!-- /wp:${ _blockSlug } -->`;
 			element.value = element.value.replace( blockDelimiter, `${ _paragraph }${ blockDelimiter }` );

--- a/packages/e2e-tests/specs/preview.test.js
+++ b/packages/e2e-tests/specs/preview.test.js
@@ -8,6 +8,7 @@ import { parse } from 'url';
  * WordPress dependencies
  */
 import {
+	clickOnCloseModalButton,
 	createNewPost,
 	createURL,
 	publishPost,
@@ -78,7 +79,7 @@ async function toggleCustomFieldsOption( shouldBeChecked ) {
 		return;
 	}
 
-	await page.click( '.edit-post-options-modal button[aria-label="Close dialog"]' );
+	await clickOnCloseModalButton( '.edit-post-options-modal' );
 }
 
 describe( 'Preview', () => {

--- a/packages/edit-post/src/components/header/more-menu/index.js
+++ b/packages/edit-post/src/components/header/more-menu/index.js
@@ -36,7 +36,7 @@ const MoreMenu = () => (
 				<PluginMoreMenuGroup.Slot fillProps={ { onClose } } />
 				<ToolsMoreMenuGroup.Slot fillProps={ { onClose } } />
 				<MenuGroup>
-					<OptionsMenuItem onSelect={ onClose } />
+					<OptionsMenuItem />
 				</MenuGroup>
 			</>
 		) }

--- a/packages/edit-post/src/components/header/options-menu-item/index.js
+++ b/packages/edit-post/src/components/header/options-menu-item/index.js
@@ -5,11 +5,10 @@ import { withDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { MenuItem } from '@wordpress/components';
 
-export function OptionsMenuItem( { openModal, onSelect } ) {
+export function OptionsMenuItem( { openModal } ) {
 	return (
 		<MenuItem
 			onClick={ () => {
-				onSelect();
 				openModal( 'edit-post/options' );
 			} }
 		>

--- a/packages/edit-post/src/plugins/keyboard-shortcuts-help-menu-item/index.js
+++ b/packages/edit-post/src/plugins/keyboard-shortcuts-help-menu-item/index.js
@@ -6,11 +6,10 @@ import { withDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { displayShortcut } from '@wordpress/keycodes';
 
-export function KeyboardShortcutsHelpMenuItem( { openModal, onSelect } ) {
+export function KeyboardShortcutsHelpMenuItem( { openModal } ) {
 	return (
 		<MenuItem
 			onClick={ () => {
-				onSelect();
 				openModal( 'edit-post/keyboard-shortcut-help' );
 			} }
 			shortcut={ displayShortcut.access( 'h' ) }

--- a/packages/edit-post/src/plugins/manage-blocks-menu-item/index.js
+++ b/packages/edit-post/src/plugins/manage-blocks-menu-item/index.js
@@ -1,22 +1,16 @@
 /**
- * External dependencies
- */
-import { flow } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { MenuItem } from '@wordpress/components';
 import { withDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
-export function ManageBlocksMenuItem( { onSelect, openModal } ) {
+export function ManageBlocksMenuItem( { openModal } ) {
 	return (
 		<MenuItem
-			onClick={ flow( [
-				onSelect,
-				() => openModal( 'edit-post/manage-blocks' ),
-			] ) }
+			onClick={ () => {
+				openModal( 'edit-post/manage-blocks' );
+			} }
 		>
 			{ __( 'Block Manager' ) }
 		</MenuItem>


### PR DESCRIPTION
## Description

Related: #15321 (it's probably the fix).

> When the "Keyboard Shortcuts" and "Options" dialogs are dismissed,
the keyboard focus is reset to the top of the page. This may be
confusing or inconvenient for users, who would expect the focus to
return to the last element they were focused on.

This PR changes the behavior of More Menu in terms of maintaining focus. When a dialog is opened from one of the menu items, then we no longer close More Menu. Instead, we keep it opened and move focus back to the More Menu when the dialog is closed.

### Known issue

~When I mouse-click outside of the modal dialog then More Menu remains opened. This is because Modal dialog prevents all events to be propagated below the overlay layer. We need to find a fix for it, @youknowriad any hints?~ - this is resolved now

## How has this been tested?

1. Open More Menu.
2. Click on the Block Manager menu item (or anything else).
3. Close the dialog by clicking on the close button.
4. Focus should return to the item in More Menu.
5. Repeat steps 2-4 but this time click outside of the modal dialog instead..
6. Repeat using keyboard-only navigation (space to select an item and `esc` to close the dialog.

See also the screencast.

## Screenshots <!-- if applicable -->
![focus-more-menu-dialog](https://user-images.githubusercontent.com/699132/62704049-ccbdfe00-b9ea-11e9-8e01-9d60677ead04.gif)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
