### PR TITLE
Add: Button Block appender to the widgets screen

### DIFF
--- a/packages/edit-widgets/src/components/widget-area/index.js
+++ b/packages/edit-widgets/src/components/widget-area/index.js
@@ -18,6 +18,7 @@ import {
 	WritingFlow,
 	ObserveTyping,
 	BlockEditorKeyboardShortcuts,
+	ButtonBlockerAppender,
 } from '@wordpress/block-editor';
 import { withDispatch, withSelect } from '@wordpress/data';
 
@@ -91,6 +92,7 @@ function WidgetArea( {
 							<ObserveTyping>
 								<BlockList
 									className="edit-widgets-main-block-list"
+									renderAppender={ ButtonBlockerAppender }
 								/>
 							</ObserveTyping>
 						</WritingFlow>

--- a/packages/edit-widgets/src/components/widget-area/style.scss
+++ b/packages/edit-widgets/src/components/widget-area/style.scss
@@ -17,3 +17,10 @@
 .edit-widgets-main-block-list {
 	padding-top: $block-toolbar-height + 2 * $grid-size;
 }
+
+.edit-widgets-main-block-list > .block-list-appender {
+	padding-top: $panel-padding;
+	// Add a margin equivalent to block side UI so the appender is aligned with the blocks.
+	margin-left: $block-side-ui-width;
+	margin-right: $block-side-ui-width;
+}


### PR DESCRIPTION
## Description
This PR adds the button block appender used the group block and columns to the widget areas.

## How has this been tested?
I went to the widgets screen and verified a button appender was always available.

## Screenshots <!-- if applicable -->
<img width="608" alt="Screenshot 2019-08-08 at 19 39 59" src="https://user-images.githubusercontent.com/11271197/62728796-8e3d3900-ba14-11e9-98cd-b123ab8f50e2.png">

