### PR TITLE
Add: Block editor keyboard shortcuts to the widget screen and the playground

### DIFF
--- a/packages/edit-widgets/src/components/widget-area/index.js
+++ b/packages/edit-widgets/src/components/widget-area/index.js
@@ -17,6 +17,7 @@ import {
 	Inserter as BlockInserter,
 	WritingFlow,
 	ObserveTyping,
+	BlockEditorKeyboardShortcuts,
 } from '@wordpress/block-editor';
 import { withDispatch, withSelect } from '@wordpress/data';
 
@@ -71,9 +72,12 @@ function WidgetArea( {
 					settings={ settings }
 				>
 					{ isSelectedArea && (
-						<Inserter>
-							<BlockInserter />
-						</Inserter>
+						<>
+							<Inserter>
+								<BlockInserter />
+							</Inserter>
+							<BlockEditorKeyboardShortcuts />
+						</>
 					) }
 					<SelectionObserver
 						isSelectedArea={ isSelectedArea }

--- a/playground/src/index.js
+++ b/playground/src/index.js
@@ -5,6 +5,7 @@ import '@wordpress/editor'; // This shouldn't be necessary
 
 import { render, useState, Fragment } from '@wordpress/element';
 import {
+	BlockEditorKeyboardShortcuts,
 	BlockEditorProvider,
 	BlockList,
 	WritingFlow,
@@ -49,6 +50,7 @@ function App() {
 							onChange={ updateBlocks }
 						>
 							<div className="editor-styles-wrapper">
+								<BlockEditorKeyboardShortcuts />
 								<WritingFlow>
 									<ObserveTyping>
 										<BlockList />


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/16954

This PR adds the block editor keyboard shortcuts that allow for example selecting all blocks or deleting them to the widgets screen and the playground.


## How has this been tested?
I went to the widgets screen I multi-selected some blocks, I verified pressing delete key removes the blocks. I went to the widgets screen I pressed cmd + A multiple times and I verified all the blocks were selected.
I repeated the same tests on the playground.

