### PR TITLE
Fix: InnerBlocks should only force the template on directly set lockings

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -35,18 +35,11 @@ class InnerBlocks extends Component {
 		this.updateNestedSettings();
 	}
 
-	getTemplateLock() {
-		const {
-			templateLock,
-			parentLock,
-		} = this.props;
-		return templateLock === undefined ? parentLock : templateLock;
-	}
-
 	componentDidMount() {
-		const { innerBlocks } = this.props.block;
-		// only synchronize innerBlocks with template if innerBlocks are empty or a locking all exists
-		if ( innerBlocks.length === 0 || this.getTemplateLock() === 'all' ) {
+		const { templateLock, block } = this.props;
+		const { innerBlocks } = block;
+		// Only synchronize innerBlocks with template if innerBlocks are empty or a locking all exists directly on the block.
+		if ( innerBlocks.length === 0 || templateLock === 'all' ) {
 			this.synchronizeBlocksWithTemplate();
 		}
 
@@ -58,12 +51,12 @@ class InnerBlocks extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { template, block } = this.props;
+		const { template, block, templateLock } = this.props;
 		const { innerBlocks } = block;
 
 		this.updateNestedSettings();
-		// only synchronize innerBlocks with template if innerBlocks are empty or a locking all exists
-		if ( innerBlocks.length === 0 || this.getTemplateLock() === 'all' ) {
+		// Only synchronize innerBlocks with template if innerBlocks are empty or a locking all exists directly on the block.
+		if ( innerBlocks.length === 0 || templateLock === 'all' ) {
 			const hasTemplateChanged = ! isEqual( template, prevProps.template );
 			if ( hasTemplateChanged ) {
 				this.synchronizeBlocksWithTemplate();
@@ -92,11 +85,13 @@ class InnerBlocks extends Component {
 			blockListSettings,
 			allowedBlocks,
 			updateNestedSettings,
+			templateLock,
+			parentLock,
 		} = this.props;
 
 		const newSettings = {
 			allowedBlocks,
-			templateLock: this.getTemplateLock(),
+			templateLock: templateLock === undefined ? parentLock : templateLock,
 		};
 
 		if ( ! isShallowEqual( blockListSettings, newSettings ) ) {


### PR DESCRIPTION
Supersedes: https://github.com/WordPress/gutenberg/pull/16882

Currently, InnerBlocks forces the template when locking is all even if the locking is inherited.
This logic is not correct, because if block used in a template contains another template, the inner blocks for that block set on the parent template will be ignored as the child will inherit the locking all and the template of the child will start to be forced.

This PR updates the InnerBlocks logic to only force the template if the locking all is directly set and not inherited. In cases, the locking all is inherited it should be the template of the parent managing the inner blocks.


## How has this been tested?
I pasted the following code in functions.php:
```

register_post_type(
	'locked-all-post',
	array(
		'public'        => true,
		'label'         => 'Locked All Post',
		'show_in_rest'  => true,
		'template' => [
			['core/media-text',
				[
					'mediaPosition' => 'right',
					'mediaId' => 80,
					'mediaType' => 'image',
					'imageFill' => false,
					'mediaUrl' => 'http://localhost/app/uploads/2019/07/thumb-1463-product-primary-desktop.png',
					'className' => 'is-style-hero',
					'backgroundMediaId' => 89,
					'backgroundMediaUrl' => 'http://localhost/app/uploads/2019/07/mutti-polpa-zoom-copy.jpg',
				], [
					['core/heading', ['align' => 'right', 'level' => 1, 'placeholder' => __('Product name', 'mutti')]],
					['core/heading', ['align' => 'right', 'level' => 4, 'placeholder' => __('Descriptive product name', 'mutti')]],
					['core/paragraph', ['align' => 'right', 'placeholder' => __('A short description about the product and why it is unique.', 'mutti')]],
				],
			],
			['core/cover',
				[
					'url' => 'http://yah.local/wp-content/uploads/2019/08/Jul-14-2019-13-21-12-16.gif',
				],
				[
					['core/heading', ['align' => 'right', 'level' => 1, 'placeholder' => __('Product name', 'mutti')]],
				],
			]
	],
		'template_lock' => 'all',
	)
);

```

I created a new Locked All Post and I verified the InnerBlocks set for media-text and cover appear as expected.


Props to @oxyc for bringing this issue for our attention and proposing an initial fix for the media text-specific case.