### PR TITLE
Fix(eslint-plugin): misc bugfixes related to recent jsdoc changes

### DIFF
--- a/docs/designers-developers/developers/data/data-core.md
+++ b/docs/designers-developers/developers/data/data-core.md
@@ -373,7 +373,7 @@ _Parameters_
 
 _Returns_
 
--   `booleans`: Is the preview for the URL an oEmbed link fallback.
+-   `boolean`: Is the preview for the URL an oEmbed link fallback.
 
 <a name="isRequestingEmbedPreview" href="#isRequestingEmbedPreview">#</a> **isRequestingEmbedPreview**
 

--- a/packages/block-editor/src/components/inserter/index.native.js
+++ b/packages/block-editor/src/components/inserter/index.native.js
@@ -45,6 +45,7 @@ class Inserter extends Component {
 	/**
 	 * Render callback to display Dropdown toggle element.
 	 *
+	 * @param {Object}   options
 	 * @param {Function} options.onToggle Callback to invoke when toggle is
 	 *                                    pressed.
 	 * @param {boolean}  options.isOpen   Whether dropdown is currently open.
@@ -63,6 +64,7 @@ class Inserter extends Component {
 	/**
 	 * Render callback to display Dropdown content element.
 	 *
+	 * @param {Object}   options
 	 * @param {Function} options.onClose Callback to invoke when dropdown is
 	 *                                   closed.
 	 *

--- a/packages/components/src/tooltip/index.js
+++ b/packages/components/src/tooltip/index.js
@@ -117,7 +117,7 @@ class Tooltip extends Component {
 	 * Creates an event callback to handle assignment of the `isInMouseDown`
 	 * instance property in response to a `mousedown` or `mouseup` event.
 	 *
-	 * @param {booelan} isMouseDown Whether handler is to be created for the
+	 * @param {boolean} isMouseDown Whether handler is to be created for the
 	 *                              `mousedown` event, as opposed to `mouseup`.
 	 *
 	 * @return {Function} Event callback handler.

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -584,7 +584,7 @@ _Parameters_
 
 _Returns_
 
--   `booleans`: Is the preview for the URL an oEmbed link fallback.
+-   `boolean`: Is the preview for the URL an oEmbed link fallback.
 
 <a name="isRequestingEmbedPreview" href="#isRequestingEmbedPreview">#</a> **isRequestingEmbedPreview**
 

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -355,7 +355,7 @@ export function getEmbedPreview( state, url ) {
  * @param {Object} state    Data state.
  * @param {string} url      Embedded URL.
  *
- * @return {booleans} Is the preview for the URL an oEmbed link fallback.
+ * @return {boolean} Is the preview for the URL an oEmbed link fallback.
  */
 export function isPreviewEmbedFallback( state, url ) {
 	const preview = state.embedPreviews[ url ];

--- a/packages/eslint-plugin/configs/es5.js
+++ b/packages/eslint-plugin/configs/es5.js
@@ -1,4 +1,7 @@
 module.exports = {
+	extends: [
+		require.resolve( './jsdoc.js' ),
+	],
 	rules: {
 		'array-bracket-spacing': [ 'error', 'always' ],
 		'array-callback-return': 'error',

--- a/packages/eslint-plugin/configs/jsdoc.js
+++ b/packages/eslint-plugin/configs/jsdoc.js
@@ -1,5 +1,33 @@
 const globals = require( 'globals' );
 
+/**
+ * Helpful utilities that are globally defined and known to the TypeScript compiler.
+ *
+ * @see http://www.typescriptlang.org/docs/handbook/utility-types.html
+ */
+const typescriptUtilityTypes = [
+	'ArrayLike',
+	'Exclude',
+	'Extract',
+	'InstanceType',
+	'Iterable',
+	'IterableIterator',
+	'NonNullable',
+	'Omit',
+	'Partial',
+	'Pick',
+	'PromiseLike',
+	'Readonly',
+	'Readonly',
+	'ReadonlyArray',
+	'ReadonlyMap',
+	'ReadonlySet',
+	'Record',
+	'Required',
+	'ReturnType',
+	'ThisType',
+];
+
 module.exports = {
 	extends: [
 		'plugin:jsdoc/recommended',
@@ -17,10 +45,14 @@ module.exports = {
 	},
 	rules: {
 		'jsdoc/no-undefined-types': [ 'warn', {
-			// Required to reference browser types because we don't have the `browser` environment enabled for the project.
-			// Here we filter out all browser globals that don't begin with an uppercase letter because those
-			// generally refer to window-level event listeners and are not a valid type to reference (e.g. `onclick`).
-			definedTypes: Object.keys( globals.browser ).filter( ( k ) => /^[A-Z]/.test( k ) ),
+			definedTypes: [
+				// Required to reference browser types because we don't have the `browser` environment enabled for the project.
+				// Here we filter out all browser globals that don't begin with an uppercase letter because those
+				// generally refer to window-level event listeners and are not a valid type to reference (e.g. `onclick`).
+				...Object.keys( globals.browser ).filter( ( k ) => /^[A-Z]/.test( k ) ),
+				...typescriptUtilityTypes,
+				'void',
+			],
 		} ],
 		'jsdoc/require-jsdoc': 'off',
 		'jsdoc/require-param-description': 'off',

--- a/packages/eslint-plugin/configs/jsdoc.js
+++ b/packages/eslint-plugin/configs/jsdoc.js
@@ -18,7 +18,6 @@ const typescriptUtilityTypes = [
 	'Pick',
 	'PromiseLike',
 	'Readonly',
-	'Readonly',
 	'ReadonlyArray',
 	'ReadonlyMap',
 	'ReadonlySet',

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -5,7 +5,6 @@ module.exports = {
 		require.resolve( './custom.js' ),
 		require.resolve( './react.js' ),
 		require.resolve( './esnext.js' ),
-		require.resolve( './jsdoc.js' ),
 	],
 	env: {
 		node: true,

--- a/packages/token-list/src/index.js
+++ b/packages/token-list/src/index.js
@@ -76,7 +76,7 @@ export default class TokenList {
 	 *
 	 * @see https://dom.spec.whatwg.org/#domtokenlist
 	 *
-	 * @return {Generator} TokenList iterator.
+	 * @return {IterableIterator<string>} TokenList iterator.
 	 */
 	* [ Symbol.iterator ]() {
 		return yield* this._valueAsArray;


### PR DESCRIPTION
## Description

This PR does the following:

- addresses an issue brought up by @gziolo related to how es5 configurations were being skipped over with jsdoc being at the top-level. https://github.com/WordPress/gutenberg/pull/16869#discussion_r311490658
- adds in a few helpful TypeScript-defined helper types that are nice to have available for JSDoc in some cases.
- adds in the missing `void` type since it appears that's defined in `globals` and we're filtering it out.
- fixes a few misc scattered JSDoc issues that are indeed errors and easily fixable.

## How has this been tested?

Lints still run and pass. However, there are quite a bit more warnings that are currently showing up. I don't think these warnings are a big deal for now. They'll get handled when I get around to fixing up that package. The warnings are all valid.

## Types of changes

Code quality / Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->