### PR TITLE
add overflow support inside block switcher

### DIFF
--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -127,38 +127,41 @@ export class BlockSwitcher extends Component {
 				} }
 				renderContent={ ( { onClose } ) => (
 					<>
-						{ hasBlockStyles &&
-							<PanelBody
-								title={ __( 'Block Styles' ) }
-								initialOpen
-							>
-								<BlockStyles
-									clientId={ blocks[ 0 ].clientId }
-									onSwitch={ onClose }
-									onHoverClassName={ this.onHoverClassName }
-								/>
-							</PanelBody>
+						{ ( hasBlockStyles || possibleBlockTransformations.length !== 0 ) &&
+							<div className="block-editor-block-switcher__container">
+								{ hasBlockStyles &&
+									<PanelBody
+										title={ __( 'Block Styles' ) }
+										initialOpen
+									>
+										<BlockStyles
+											clientId={ blocks[ 0 ].clientId }
+											onSwitch={ onClose }
+											onHoverClassName={ this.onHoverClassName }
+										/>
+									</PanelBody>
+								}
+								{ possibleBlockTransformations.length !== 0 &&
+									<PanelBody
+										title={ __( 'Transform To:' ) }
+										initialOpen
+									>
+										<BlockTypesList
+											items={ possibleBlockTransformations.map( ( destinationBlockType ) => ( {
+												id: destinationBlockType.name,
+												icon: destinationBlockType.icon,
+												title: destinationBlockType.title,
+												hasChildBlocksWithInserterSupport: hasChildBlocksWithInserterSupport( destinationBlockType.name ),
+											} ) ) }
+											onSelect={ ( item ) => {
+												onTransform( blocks, item.id );
+												onClose();
+											} }
+										/>
+									</PanelBody>
+								}
+							</div>
 						}
-						{ possibleBlockTransformations.length !== 0 &&
-							<PanelBody
-								title={ __( 'Transform To:' ) }
-								initialOpen
-							>
-								<BlockTypesList
-									items={ possibleBlockTransformations.map( ( destinationBlockType ) => ( {
-										id: destinationBlockType.name,
-										icon: destinationBlockType.icon,
-										title: destinationBlockType.title,
-										hasChildBlocksWithInserterSupport: hasChildBlocksWithInserterSupport( destinationBlockType.name ),
-									} ) ) }
-									onSelect={ ( item ) => {
-										onTransform( blocks, item.id );
-										onClose();
-									} }
-								/>
-							</PanelBody>
-						}
-
 						{ ( hoveredClassName !== null ) &&
 							<div className="block-editor-block-switcher__preview">
 								<div className="block-editor-block-switcher__preview-title">{ __( 'Preview' ) }</div>

--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -88,15 +88,38 @@
 		@include formatting-button-style__focus();
 	}
 }
-
+// we double the max-width for it to fit both the preview & content
+// but we keep the min width the same for the border to work.
 .components-popover:not(.is-mobile).block-editor-block-switcher__popover .components-popover__content {
 	min-width: 300px;
-	max-width: 340px;
+	max-width: calc(340px * 2);
+	display: flex;
+	background: $white;
+	box-shadow: $shadow-popover;
 }
 
 .block-editor-block-switcher__popover .components-popover__content {
+	.block-editor-block-switcher__container {
+		min-width: 300px;
+		max-width: 340px;
+		width: 50%;
+	}
+
 	@include break-medium {
 		position: relative;
+
+		.block-editor-block-switcher__preview {
+			border-left: $border-width solid $light-gray-500;
+			box-shadow: $shadow-popover;
+			background: $white;
+			width: 300px;
+			height: auto;
+			// sticky helps us keep the preview at the top when scrolling
+			position: sticky;
+			align-self: stretch;
+			// for sticky to work we need top
+			top: 0;
+		}
 	}
 
 	// Hide the bottom border on the last panel so it stacks with the popover.
@@ -113,35 +136,12 @@
 	}
 }
 
-.block-editor-block-switcher__popover:not(.is-mobile) > .components-popover__content {
-	// Reset overflow to allow showing the preview on the left once an item is hovered.
-	overflow-y: visible;
-}
-
 .block-editor-block-switcher__popover .block-editor-block-styles {
 	margin: 0 -3px; // Remove the panel body padding while keeping it for the title.
 }
 
 .block-editor-block-switcher__popover .block-editor-block-types-list {
 	margin: 8px -8px -8px;
-}
-
-.block-editor-block-switcher__preview {
-	border: $border-width solid $light-gray-500;
-	box-shadow: $shadow-popover;
-	background: $white;
-	position: absolute;
-	left: 100%;
-	top: -1px;
-	bottom: -1px;
-	width: 300px;
-	height: auto;
-	padding: 10px;
-	display: none;
-
-	@include break-medium {
-		display: block;
-	}
 }
 
 .block-editor-block-switcher__preview-title {

--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -88,8 +88,7 @@
 		@include formatting-button-style__focus();
 	}
 }
-// we double the max-width for it to fit both the preview & content
-// but we keep the min width the same for the border to work.
+// We double the max-width for it to fit both the preview & content but we keep the min width the same for the border to work.
 .components-popover:not(.is-mobile).block-editor-block-switcher__popover .components-popover__content {
 	min-width: 300px;
 	max-width: calc(340px * 2);
@@ -114,10 +113,10 @@
 			background: $white;
 			width: 300px;
 			height: auto;
-			// sticky helps us keep the preview at the top when scrolling
+			// Sticky helps us keep the preview at the top when scrolling
 			position: sticky;
 			align-self: stretch;
-			// for sticky to work we need top
+			// For sticky to work we need top
 			top: 0;
 		}
 	}


### PR DESCRIPTION
Third time's a charm
closes following issues:
#10905
#16028

replaces PR:
#16824
#16697

fixes some issues with the component popover not having overflow scrolling when the list is long

It adds flexbox support to the component to remove the need for overflow: visible and having problems with long lists of preview options.
![block-preview ](https://user-images.githubusercontent.com/6165348/62781911-ea559b00-bab0-11e9-986f-920c601865cb.gif)
