### PR TITLE
Document server functions in block style variations section

### DIFF
--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -53,6 +53,64 @@ wp.domReady( function() {
 } );
 ```
 
+### Server-side registration helper
+
+While the samples provided full allow full control of the style registration client-side scripts, and its enqueuing, they require a considerable amount of code to register a block style.
+
+To simplify the process of registering/unregistering block styles, two server-side functions were implemented: `register_block_style`, and `unregister_block_style`.
+
+#### register_block_style
+
+The `register_block_style` function receives the identifier of the block as the first argument and an array describing properties of the style as the second argument.
+The properties of the style array must include `name` and `label`: 
+ - `name`: The identifier of the style used to compute a CSS class.
+ - `label`: A human-readable label for the style.
+
+Besides the two mandatory properties, the styles properties array  should include a `inline_style`  or a `style_handle` property:
+ - `inline_style`: Contains inline CSS code that registers the CSS class required for the style.
+ - `style_handle`: Contains the handle to an already registered style that should be enqueued in places where block styles are needed.
+
+The following code sample registers a style for the quote block named "Blue Quote", and enqueues an inline style that makes quote blocks with the "Blue Quote" style have blue color:
+
+```php
+register_block_style(
+    'core/quote',
+    array(
+        'name'         => 'blue-quote',
+        'label'        => __( 'Blue Quote' ),
+        'inline_style' => '.wp-block-quote.is-style-blue-quote { color: blue; }',
+    )
+);
+```
+
+Alternatively, if the styles were already registered it is possible to just pass its handle and `register_block_style` function will make sure they are enqued. The following code sample provides an example of this use case:
+
+```php
+(...)
+wp_register_style( 'myguten-style', get_template_directory_uri() . '/custom-style.css' );
+(...)
+
+register_block_style(
+    'core/quote',
+    array(
+        'name'         => 'fancy-quote',
+        'label'        => 'Fancy Quote',
+        'style_handle' => 'myguten-style',
+    )
+);
+```
+#### unregister_block_style
+
+`unregister_block_style` allows unregistering a block style previously registered on the server using `register_block_style`.
+The function registers as the first argument the identifier/name of the block and as second argument the identifier/name of the style.
+
+The following code sample unregisteres the style named 'fancy-quote'  from the quote block:
+```php
+unregister_block_style( 'core/quote', 'fancy-quote' );
+```
+
+**Important:** The function `unregister_block_style`only unregisters styles that were registered on the server using a `register_block_style`. The function does not generate client-side code to unregister a style registered using client-side code.
+
 ### Filters
 
 Extending blocks can involve more than just providing alternative styles, in this case, you can use one of the following filters to extend the block settings.

--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -111,7 +111,7 @@ The following code sample unregisteres the style named 'fancy-quote'  from the q
 unregister_block_style( 'core/quote', 'fancy-quote' );
 ```
 
-**Important:** The function `unregister_block_style`only unregisters styles that were registered on the server using a `register_block_style`. The function does not generate client-side code to unregister a style registered using client-side code.
+**Important:** The function `unregister_block_style` only unregisters styles that were registered on the server using `register_block_style`. The function does not unregister a style registered using client-side code.
 
 ### Filters
 

--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -61,7 +61,7 @@ To simplify the process of registering and unregistering block styles, two serve
 
 #### register_block_style
 
-The `register_block_style` function receives the identifier of the block as the first argument and an array describing properties of the style as the second argument.
+The `register_block_style` function receives the name of the block as the first argument and an array describing properties of the style as the second argument.
 
 The properties of the style array must include `name` and `label`: 
  - `name`: The identifier of the style used to compute a CSS class.

--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -88,7 +88,6 @@ register_block_style(
 Alternatively, if the styles were already registered it is possible to just pass its handle and `register_block_style` function will make sure they are enqued. The following code sample provides an example of this use case:
 
 ```php
-(...)
 wp_register_style( 'myguten-style', get_template_directory_uri() . '/custom-style.css' );
 (...)
 

--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -68,6 +68,7 @@ The properties of the style array must include `name` and `label`:
  - `label`: A human-readable label for the style.
 
 Besides the two mandatory properties, the styles properties array  should include a `inline_style`  or a `style_handle` property:
+
  - `inline_style`: Contains inline CSS code that registers the CSS class required for the style.
  - `style_handle`: Contains the handle to an already registered style that should be enqueued in places where block styles are needed.
 

--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -104,7 +104,8 @@ register_block_style(
 #### unregister_block_style
 
 `unregister_block_style` allows unregistering a block style previously registered on the server using `register_block_style`.
-The function registers as the first argument the identifier/name of the block and as second argument the identifier/name of the style.
+
+The function's first argument is the registered name of the block, and the name of the style as the second argument.
 
 The following code sample unregisteres the style named 'fancy-quote'  from the quote block:
 

--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -100,7 +100,6 @@ register_block_style(
         'style_handle' => 'myguten-style',
     )
 );
-```
 #### unregister_block_style
 
 `unregister_block_style` allows unregistering a block style previously registered on the server using `register_block_style`.

--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -55,7 +55,7 @@ wp.domReady( function() {
 
 ### Server-side registration helper
 
-While the samples provided full allow full control of the style registration client-side scripts, and its enqueuing, they require a considerable amount of code to register a block style.
+While the samples provided do allow full control of block styles, they do require a considerable amount of code.
 
 To simplify the process of registering/unregistering block styles, two server-side functions were implemented: `register_block_style`, and `unregister_block_style`.
 

--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -57,7 +57,7 @@ wp.domReady( function() {
 
 While the samples provided do allow full control of block styles, they do require a considerable amount of code.
 
-To simplify the process of registering/unregistering block styles, two server-side functions were implemented: `register_block_style`, and `unregister_block_style`.
+To simplify the process of registering and unregistering block styles, two server-side functions are also available: `register_block_style`, and `unregister_block_style`.
 
 #### register_block_style
 

--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -67,7 +67,7 @@ The properties of the style array must include `name` and `label`:
  - `name`: The identifier of the style used to compute a CSS class.
  - `label`: A human-readable label for the style.
 
-Besides the two mandatory properties, the styles properties array  should include a `inline_style`  or a `style_handle` property:
+Besides the two mandatory properties, the styles properties array should also include an `inline_style`  or a `style_handle` property:
 
  - `inline_style`: Contains inline CSS code that registers the CSS class required for the style.
  - `style_handle`: Contains the handle to an already registered style that should be enqueued in places where block styles are needed.

--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -102,6 +102,8 @@ register_block_style(
         'style_handle' => 'myguten-style',
     )
 );
+```
+
 #### unregister_block_style
 
 `unregister_block_style` allows unregistering a block style previously registered on the server using `register_block_style`.

--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -107,6 +107,7 @@ register_block_style(
 The function registers as the first argument the identifier/name of the block and as second argument the identifier/name of the style.
 
 The following code sample unregisteres the style named 'fancy-quote'  from the quote block:
+
 ```php
 unregister_block_style( 'core/quote', 'fancy-quote' );
 ```

--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -89,7 +89,8 @@ Alternatively, if the styles were already registered it is possible to just pass
 
 ```php
 wp_register_style( 'myguten-style', get_template_directory_uri() . '/custom-style.css' );
-(...)
+
+// ...
 
 register_block_style(
     'core/quote',

--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -72,7 +72,7 @@ Besides the two mandatory properties, the styles properties array should also in
  - `inline_style`: Contains inline CSS code that registers the CSS class required for the style.
  - `style_handle`: Contains the handle to an already registered style that should be enqueued in places where block styles are needed.
 
-The following code sample registers a style for the quote block named "Blue Quote", and enqueues an inline style that makes quote blocks with the "Blue Quote" style have blue color:
+The following code sample registers a style for the quote block named "Blue Quote", and provides an inline style that makes quote blocks with the "Blue Quote" style have blue color:
 
 ```php
 register_block_style(

--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -62,6 +62,7 @@ To simplify the process of registering and unregistering block styles, two serve
 #### register_block_style
 
 The `register_block_style` function receives the identifier of the block as the first argument and an array describing properties of the style as the second argument.
+
 The properties of the style array must include `name` and `label`: 
  - `name`: The identifier of the style used to compute a CSS class.
  - `label`: A human-readable label for the style.

--- a/docs/designers-developers/developers/filters/block-filters.md
+++ b/docs/designers-developers/developers/filters/block-filters.md
@@ -85,7 +85,9 @@ register_block_style(
 );
 ```
 
-Alternatively, if the styles were already registered it is possible to just pass its handle and `register_block_style` function will make sure they are enqued. The following code sample provides an example of this use case:
+Alternatively, if a stylesheet was already registered which contains the CSS for the style variation, it is possible to just pass the stylesheet's handle so `register_block_style` function will make sure it is enqueue.
+
+The following code sample provides an example of this use case:
 
 ```php
 wp_register_style( 'myguten-style', get_template_directory_uri() . '/custom-style.css' );


### PR DESCRIPTION
This PR documents the server-side functions register_block_style and un register_block_style added in https://github.com/WordPress/gutenberg/pull/16356 inside the block style variations section.
