### PR TITLE
Update github action exit codes

### DIFF
--- a/.github/actions/assign-fixed-issues/entrypoint.sh
+++ b/.github/actions/assign-fixed-issues/entrypoint.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
 set -e
 
-# 1. Find the issues that this PR 'fixes'.
+# 1. Proceed only when acting on an opened pull request.
+
+action=$(jq -r '.action' $GITHUB_EVENT_PATH)
+
+if [ "$action" != 'closed' ]; then
+	echo "Action '$action' not a close action. Aborting."
+	exit 0;
+fi
+
+# 2. Find the issues that this PR 'fixes'.
 
 issues=$(
 	jq -r '.pull_request.body' $GITHUB_EVENT_PATH | perl -nle 'print $1 while /
@@ -18,15 +27,15 @@ if [ -z "$issues" ]; then
 	exit 0
 fi
 
-# 2. Grab the author of the PR.
+# 3. Grab the author of the PR.
 
 author=$(jq -r '.pull_request.user.login' $GITHUB_EVENT_PATH)
 
-# 3. Loop through each 'fixed' issue.
+# 4. Loop through each 'fixed' issue.
 
 for issue in $issues; do
 
-	# 3a. Add the author as an asignee to the issue. This fails if the author is
+	# 4a. Add the author as an asignee to the issue. This fails if the author is
 	#     already assigned, which is expected and ignored.
 
 	curl \

--- a/.github/actions/assign-fixed-issues/entrypoint.sh
+++ b/.github/actions/assign-fixed-issues/entrypoint.sh
@@ -15,7 +15,7 @@ issues=$(
 
 if [ -z "$issues" ]; then
 	echo "Pull request does not 'fix' any issues. Aborting."
-	exit 78
+	exit 0
 fi
 
 # 2. Grab the author of the PR.

--- a/.github/actions/first-time-contributor/entrypoint.sh
+++ b/.github/actions/first-time-contributor/entrypoint.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 set -e
 
-# 1. Get the author and pr number for the pull request.
+# 1. Proceed only when acting on an opened pull request.
+action=$(jq -r '.action' $GITHUB_EVENT_PATH)
+
+if [ "$action" != 'opened' ]; then
+	echo "Action '$action' not a close action. Aborting."
+	exit 0;
+fi
+
+# 2. Get the author and pr number for the pull request.
 author=$(jq -r '.pull_request.user.login' $GITHUB_EVENT_PATH)
 pr_number=$(jq -r '.number' $GITHUB_EVENT_PATH)
 
@@ -10,7 +18,7 @@ if [ "$pr_number" = "null" ] || [ "$author" = "null" ]; then
 	exit 0
 fi
 
-# 2. Fetch the author's commit count for the repo to determine if they're a first-time contributor.
+# 3. Fetch the author's commit count for the repo to determine if they're a first-time contributor.
 commit_count=$(
 	curl \
 		--silent \
@@ -19,13 +27,13 @@ commit_count=$(
 		| jq -r '.total_count'
 )
 
-# 3. If the response has a commit count of zero, exit early, the author is not a first time contributor.
+# 4. If the response has a commit count of zero, exit early, the author is not a first time contributor.
 if [ "$commit_count" != "0" ]; then
 	echo "Pull request #$pr_number was not created by a first-time contributor ($author)."
 	exit 0
 fi
 
-# 4. Assign the 'First Time Contributor' label.
+# 5. Assign the 'First Time Contributor' label.
 curl \
 	--silent \
 	-X POST \

--- a/.github/actions/first-time-contributor/entrypoint.sh
+++ b/.github/actions/first-time-contributor/entrypoint.sh
@@ -7,7 +7,7 @@ pr_number=$(jq -r '.number' $GITHUB_EVENT_PATH)
 
 if [ "$pr_number" = "null" ] || [ "$author" = "null" ]; then
 	echo "Could not find PR number or author. $pr_number / $author"
-	exit 78
+	exit 0
 fi
 
 # 2. Fetch the author's commit count for the repo to determine if they're a first-time contributor.
@@ -22,7 +22,7 @@ commit_count=$(
 # 3. If the response has a commit count of zero, exit early, the author is not a first time contributor.
 if [ "$commit_count" != "0" ]; then
 	echo "Pull request #$pr_number was not created by a first-time contributor ($author)."
-	exit 78
+	exit 0
 fi
 
 # 4. Assign the 'First Time Contributor' label.

--- a/.github/actions/milestone-it/entrypoint.sh
+++ b/.github/actions/milestone-it/entrypoint.sh
@@ -7,21 +7,21 @@ action=$(jq -r '.action' $GITHUB_EVENT_PATH)
 
 if [ "$action" != 'closed' ]; then
 	echo "Action '$action' not a close action. Aborting."
-	exit 78;
+	exit 0;
 fi
 
 merged=$(jq -r '.pull_request.merged' $GITHUB_EVENT_PATH)
 
 if [ "$merged" != 'true' ]; then
 	echo "Pull request closed without merge. Aborting."
-	exit 78;
+	exit 0;
 fi
 
 base=$(jq -r '.pull_request.base.ref' $GITHUB_EVENT_PATH)
 
 if [ "$base" != 'master' ]; then
 	echo 'Milestones apply only to master merge. Aborting.'
-	exit 78;
+	exit 0;
 fi
 
 # 2. Determine if milestone already exists (don't replace one which has already
@@ -39,7 +39,7 @@ current_milestone=$(
 
 if [ "$current_milestone" != 'null' ]; then
 	echo 'Milestone already applied. Aborting.'
-	exit 78;
+	exit 0;
 fi
 
 # 3. Read current version.

--- a/.github/workflows/pull_request-add-the-first-time-contributor-label-to-prs-opened-by-first-time-contributors.yml
+++ b/.github/workflows/pull_request-add-the-first-time-contributor-label-to-prs-opened-by-first-time-contributors.yml
@@ -1,15 +1,11 @@
 on: pull_request
-name: Add the First-time Contributor label to PRs opened by first-time contributors
+name: Add the First-time Contributor label
 jobs:
   filterOpened:
     name: Filter opened
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Filter opened
-      uses: actions/bin/filter@0dbb077f64d0ec1068a644d25c71b1db66148a24
-      with:
-        args: action opened
     - name: First Time Contributor
       uses: ./.github/actions/first-time-contributor
       env:

--- a/.github/workflows/pull_request-assign-fixed-issues-when-pull-request-opened.yml
+++ b/.github/workflows/pull_request-assign-fixed-issues-when-pull-request-opened.yml
@@ -6,10 +6,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Filter opened
-      uses: actions/bin/filter@0dbb077f64d0ec1068a644d25c71b1db66148a24
-      with:
-        args: action opened
     - name: Assign Fixed Issues
       uses: ./.github/actions/assign-fixed-issues
       env:


### PR DESCRIPTION
## Description
Github actions used to support an exit code of `78` to indicate that an action is neutral (has no effect, but any subsequent actions shouldn't run):
https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#exit-codes-and-statuses

It looks like neutral exit code have been dropped from the new version of actions, they need to return `0` to indicate success, or will show as a big red ❌against PRs:
https://help.github.com/en/articles/virtual-environments-for-github-actions#exit-codes-and-statuses

## How has this been tested?
This PR should hopefully have a green check for each action ✅
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->


## Types of changes
<!-- What types of changes does your code introduce?  -->
Task
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
