### PR TITLE
Fix: Widget blocks screen does not include legacy widgets and navigation

### DIFF
--- a/lib/load.php
+++ b/lib/load.php
@@ -33,7 +33,9 @@ require dirname( __FILE__ ) . '/class-wp-block-styles-registry.php';
 require dirname( __FILE__ ) . '/blocks.php';
 require dirname( __FILE__ ) . '/client-assets.php';
 require dirname( __FILE__ ) . '/demo.php';
+// experiments-page eeeds to be required before widgets, widgets-page, and customizer.
+require dirname( __FILE__ ) . '/experiments-page.php';
 require dirname( __FILE__ ) . '/widgets.php';
 require dirname( __FILE__ ) . '/widgets-page.php';
-require dirname( __FILE__ ) . '/experiments-page.php';
+
 require dirname( __FILE__ ) . '/customizer.php';

--- a/lib/widgets.php
+++ b/lib/widgets.php
@@ -142,7 +142,7 @@ function gutenberg_get_legacy_widget_settings() {
 	$settings['hasPermissionsToManageWidgets'] = $has_permissions_to_manage_widgets;
 	$settings['availableLegacyWidgets']        = $available_legacy_widgets;
 
-	return $settings;
+	return gutenberg_experiments_editor_settings( $settings );
 }
 
 /**


### PR DESCRIPTION
In https://github.com/WordPress/gutenberg/pull/16626/files we introduced a settings page that enabling and disabling the legacy widgets and the navigation menu block.

These settings don't affect the widget blocks screen. So legacy widgets and navigation blocks are never enabled on the widget blocks screen.

This PR fixes this problem.
