### PR TITLE
Paragraph Block with Colour: Underline Links

### DIFF
--- a/packages/block-library/src/paragraph/style.scss
+++ b/packages/block-library/src/paragraph/style.scss
@@ -41,4 +41,5 @@ p.has-background {
 
 p.has-text-color a {
 	color: inherit;
+	text-decoration: underline;
 }


### PR DESCRIPTION
## Description

The two most common ways for a theme to indicate a link are:

- underline the link
- reflect the link with a new colour (this is used by [at least 6500 themes](https://wpdirectory.net/search/01DJ2PT6C58DT0M1N30FATRR3R))

When text colour is changed, that includes for all links inside the paragraph block. Considering the latter option is the most popular and text underlines for individual words aren't supported, I'm wondering if it makes sense to underline any links inside a paragraph block with colour. 

This is simply a proposal, but I'm unable to imagine a scenario where this would have an adverse affect.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I've tested this with various themes and tried to imagine a scenario where this wouldn't be beneficial. In each scenario, it's more clear that a link is present, and more convenient for a user to automatically assume that the link will be underlined. 

## Screenshots <!-- if applicable -->

Theme: Twenty Thirteen

**Before:**
<img width="691" alt="Screenshot 2019-08-12 at 11 56 32" src="https://user-images.githubusercontent.com/43215253/62860494-40684f80-bcf8-11e9-9b53-4e01d31dafa9.png">

**After:**
Whereas now...there is an underline to distinguish the link!

<img width="702" alt="Screenshot 2019-08-12 at 11 56 58" src="https://user-images.githubusercontent.com/43215253/62860537-5aa22d80-bcf8-11e9-8928-ca946374a20a.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Just a minor enhancement which could be deemed unnecessary, it just seems easier than manually having to add underlines every time, when the vast majority of themes would benefit from this

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
