### PR TITLE
Fix: Duplicate button appears even if the block is not allowed

### DIFF
--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -46,10 +46,15 @@ export default compose( [
 		const { getDefaultBlockName } = select( 'core/blocks' );
 
 		const blocks = getBlocksByClientId( props.clientIds );
-		const canDuplicate = every( blocks, ( block ) => {
-			return !! block && hasBlockSupport( block.name, 'multiple', true );
-		} );
 		const rootClientId = getBlockRootClientId( props.clientIds[ 0 ] );
+		const canDuplicate = every( blocks, ( block ) => {
+			return (
+				!! block &&
+				hasBlockSupport( block.name, 'multiple', true ) &&
+				canInsertBlockType( block.name, rootClientId )
+			);
+		} );
+
 		const canInsertDefaultBlock = canInsertBlockType(
 			getDefaultBlockName(),
 			rootClientId
@@ -83,7 +88,7 @@ export default compose( [
 
 		return {
 			onDuplicate() {
-				if ( isLocked || ! canDuplicate ) {
+				if ( ! canDuplicate ) {
 					return;
 				}
 

--- a/packages/block-editor/src/components/block-settings-menu/index.js
+++ b/packages/block-editor/src/components/block-settings-menu/index.js
@@ -67,7 +67,7 @@ export function BlockSettingsMenu( { clientIds } ) {
 											clientId={ firstBlockClientId }
 										/>
 									) }
-									{ ! isLocked && canDuplicate && (
+									{ canDuplicate && (
 										<MenuItem
 											className="editor-block-settings-menu__control block-editor-block-settings-menu__control"
 											onClick={ flow( onClose, onDuplicate ) }


### PR DESCRIPTION
On master, the duplicate button appears even if the block is not allowed, although clicking on it does nothing.

## How has this been tested?
I added a paragraph block.
I went to the block manager.
I disabled the paragraph block.
I tried to duplicate the paragraph block but verified the button was not available as expected. On master, the button is available but does nothing.

## Screenshots <!-- if applicable -->
![Aug-12-2019 12-12-49](https://user-images.githubusercontent.com/11271197/62861375-3562ee80-bcfb-11e9-9e43-35f69ddd8a5c.gif)
