### PR TITLE
chore: Update: Use some mixins in button styles instead of media queries.

### DIFF
--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -51,7 +51,7 @@
 		max-width: 290px;
 	}
 
-	@media (min-width: #{ ($break-medium) }) {
+	@include break-medium() {
 		max-width: 260px;
 
 		&-input__suggestions {
@@ -59,7 +59,7 @@
 		}
 
 	}
-	@media (min-width: #{ ($break-large) }) {
+	@include break-large() {
 		max-width: 290px;
 
 		&-input__suggestions {


### PR DESCRIPTION
## Description
Probably soon our mixins will have additional logic e.g: to force mobile styles even if the window is big. It is important that we avoid media queries as much as possible and try to use the mixins.
This PR fixes two direct cases I found where mixins could be used instead of a media query.

## How has this been tested?
I added a button block and verified the link field continued to work as before.
