### PR TITLE
Add a div with editor-styles-wrapper class to the widgets screen block list

### DIFF
--- a/packages/edit-widgets/src/components/widget-area/index.js
+++ b/packages/edit-widgets/src/components/widget-area/index.js
@@ -86,13 +86,15 @@ function WidgetArea( {
 					<Sidebar.Inspector>
 						<BlockInspector showNoBlockSelectedMessage={ false } />
 					</Sidebar.Inspector>
-					<WritingFlow>
-						<ObserveTyping>
-							<BlockList
-								className="edit-widgets-main-block-list"
-							/>
-						</ObserveTyping>
-					</WritingFlow>
+					<div className="editor-styles-wrapper">
+						<WritingFlow>
+							<ObserveTyping>
+								<BlockList
+									className="edit-widgets-main-block-list"
+								/>
+							</ObserveTyping>
+						</WritingFlow>
+					</div>
 				</BlockEditorProvider>
 			</PanelBody>
 		</Panel>


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/16992

Internally we use the class editor-styles-wrapper for some block styles, e.g., the blocks top and bottom margins.
This PR adds this missing wrapper to the widgets screen.


## How has this been tested?
I verified that with these changes, blocks don't overlap each other on the widget screen.
I added a group block (where it is possible to see block margins) and verified nested blocks on widget screen, and standard post editor bewave similarly and don't overlap each other.