### PR TITLE
Set a constant namespace for module sourcemaps

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,6 +39,7 @@ module.exports = {
 		return memo;
 	}, {} ),
 	output: {
+		devtoolNamespace: 'wp',
 		filename: './build/[basename]/index.js',
 		path: __dirname,
 		library: [ 'wp', '[name]' ],


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
At the moment, sourcemap namespaces are generated with the value from [output.library](https://github.com/WordPress/gutenberg/blob/master/webpack.config.js#L44), which becomes: `webpack://wp.[name]`. Firefox is unable to retrieve the sourcemaps because it is an invalid URL, for example:

```
Source map error: TypeError: Invalid URL: webpack://wp.[name]/webpack/bootstrap
Resource URL: http://localhost:8888/wp-content/plugins/gutenberg/build/components/index.js?ver=1565639281
Source Map URL: index.js.map
```

This PR sets the namespace to `wp`, so the URL becomes `webpack://wp`

_N.B._: Chrome is not affected.