### PR TITLE
Scripts: Add section about updating package after new releases

### DIFF
--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -1,14 +1,16 @@
 # Scripts
 
-Collection of reusable scripts for WordPress development. For convenience, every tool provided in this package comes with a recommended configuration.
+This is a collection of reusable scripts tailored for WordPress development. For convenience, every tool provided in this package comes with an integrated recommended configuration.
 
-Command-line interfaces help to turn working with an app into a pleasant experience, but it is still not enough to keep it easy to maintain in the long run. Developers are left on their own to keep all configurations and dependent tools up to date. This problem multiplies when they own more than one project which shares the same setup. Fortunately, there is a pattern that can simplify maintainers life – reusable scripts. This idea boils down to moving all the necessary configurations and scripts to one single tool dependency. In most cases, it should be possible to accomplish all tasks using the default settings, but some customization is allowed, too. With all that in place updating all projects should become a very straightforward task.
+When working seamlessly, sophisticated command-line interfaces help to turn work with a project into a more pleasant experience. However, it’s a misleading assumption that developers can easily pick the proper tools in the first place and then ensure that they play along with each other, including all their extensions. Besides, it’s still not enough because developers are left on their own to keep all configurations and dependent tools up to date. This problem multiplies when they support more than one project which shares the same setup.
+
+Fortunately, there is a pattern that can simplify maintainers life – reusable scripts. The idea boils down to moving all the necessary configurations and scripts to one single tool dependency. In most cases, it should be possible to accomplish all tasks using the default settings, but some customization is allowed, too. With all that in place, updating all projects should become a very straightforward task.
 
 _This package is inspired by [react-scripts](https://www.npmjs.com/package/react-scripts) and [kcd-scripts](https://www.npmjs.com/package/kcd-scripts)._
 
 ## Installation
 
-Install the module
+You only need to install one npm module:
 
 ```bash
 npm install @wordpress/scripts --save-dev
@@ -16,7 +18,7 @@ npm install @wordpress/scripts --save-dev
 
 ## Setup
 
-This is a CLI and exposes a binary called `wp-scripts` so you can call it directly. However this module is designed to be configured using the `scripts` section in the `package.json` file of your project.
+This package offers a command-line interface and exposes a binary called `wp-scripts` so you can call it directly with `npx` – an npm package runner. However, this module is designed to be configured using the `scripts` section in the `package.json` file of your project. This comprehensive example demonstrates the most of the capabilities included.
 
 _Example:_
 
@@ -37,6 +39,14 @@ _Example:_
 ```
 
 It might also be a good idea to get familiar with the [JavaScript Build Setup tutorial](/docs/designers-developers/developers/tutorials/javascript/js-build-setup.md) for setting up a development environment to use ESNext syntax. It gives a very in-depth explanation of how to use the [build](#build) and [start](#start) scripts.
+
+## Updating to New Release
+
+To update an existing project to a new version of `@wordpress/scripts`, open the [changelog](/packages/scripts/CHANGELOG.md), find the version you’re currently on (check `package.json` in the top-level directory of your project), and apply the migration instructions for the newer versions.
+
+In most cases bumping the `@wordpress/scripts` version in `package.json` and running `npm install` in the root folder of your project should be enough, but it’s good to check the [changelog](/packages/scripts/CHANGELOG.md) for potential breaking changes.
+
+We commit to keeping the breaking changes minimal so you can upgrade `@wordpress/scripts` as seamless as possible.
 
 ## Available Scripts
 
@@ -281,7 +291,7 @@ It uses [Jest](https://jestjs.io/) behind the scenes and you are able to use all
 
 ## Advanced Usage
 
-In general, this package should be used with the set of recommended config files. While it is possible to override every single config file provided, if you have to do it, it means that your use case is more complex than anticipated. If that happens, it would be better to avoid using the whole abstraction layer and set up your project with full control over tooling used.
+In general, this package should be used with the set of recommended config files. While it’s possible to override every single config file provided, if you have to do it, it means that your use case is far more complicated than anticipated. If that happens, it would be better to avoid using the whole abstraction layer and set up your project with full control over tooling used.
 
 ### Webpack config
 

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -52,7 +52,7 @@ We commit to keeping the breaking changes minimal so you can upgrade `@wordpress
 
 ### `build`
 
-Transforms your code according the configuration provided so it's ready for production and optimized for the best performance. The entry point for your project's code should be located in `src/index.js`. The output generated will be written to `build/index.js`. This script exits after producing a single build. For incremental builds, better suited for development, see the [start](#start) script.
+Transforms your code according the configuration provided so it’s ready for production and optimized for the best performance. The entry point for your project’s code should be located in `src/index.js`. The output generated will be written to `build/index.js`. This script exits after producing a single build. For incremental builds, better suited for development, see the [start](#start) script.
 
 _Example:_
 
@@ -72,7 +72,7 @@ This is how you execute the script with presented setup:
 
 #### Advanced information
 
-This script uses [webpack](https://webpack.js.org/) behind the scenes. It'll look for a webpack config in the top-level directory of your package and will use it if it finds one. If none is found, it'll use the default config provided by `@wordpress/scripts` packages. Learn more in the [Advanced Usage](#advanced-usage) section.
+This script uses [webpack](https://webpack.js.org/) behind the scenes. It’ll look for a webpack config in the top-level directory of your package and will use it if it finds one. If none is found, it’ll use the default config provided by `@wordpress/scripts` packages. Learn more in the [Advanced Usage](#advanced-usage) section.
 
 ### `check-engines`
 
@@ -98,7 +98,7 @@ It uses [check-node-version](https://www.npmjs.com/package/check-node-version) b
 
 ### `check-licenses`
 
-Validates that all dependencies of a project are compatible with the project's own license.
+Validates that all dependencies of a project are compatible with the project’s own license.
 
 _Example:_
 
@@ -115,7 +115,7 @@ _Flags_:
 - `--prod` (or `--production`): When present, validates only `dependencies` and not `devDependencies`
 - `--dev` (or `--development`): When present, validates only `devDependencies` and not `dependencies`
 - `--gpl2`: Validates against [GPLv2 license compatibility](https://www.gnu.org/licenses/license-list.en.html)
-- `--ignore=a,b,c`: A comma-separated set of package names to ignore for validation. This is intended to be used primarily in cases where a dependency's `license` field is malformed. It's assumed that any `ignored` package argument would be manually vetted for compatibility by the project owner.
+- `--ignore=a,b,c`: A comma-separated set of package names to ignore for validation. This is intended to be used primarily in cases where a dependency’s `license` field is malformed. It’s assumed that any `ignored` package argument would be manually vetted for compatibility by the project owner.
 
 ### `lint-js`
 
@@ -134,8 +134,8 @@ _Example:_
 
 This is how you execute the script with presented setup:
 
-* `npm run lint:js` - lints JavaScript files in the entire project's directories.
-* `npm run lint:js:src` - lints JavaScript files in the project's `src` subfolder's directories.
+* `npm run lint:js` - lints JavaScript files in the entire project’s directories.
+* `npm run lint:js:src` - lints JavaScript files in the project’s `src` subfolder’s directories.
 
 When you run commands similar to the `npm run lint:js:src` example above, you can provide a file, a directory, or `glob` syntax or any combination of them. See [more examples](https://eslint.org/docs/user-guide/command-line-interface).
 
@@ -162,8 +162,8 @@ _Example:_
 
 This is how you execute those scripts using the presented setup:
 
-* `npm run lint:pkg-json` - lints `package.json` file in the entire project's directories.
-* `npm run lint:pkg-json:src` - lints `package.json` file in the project's `src` subfolder's directories.
+* `npm run lint:pkg-json` - lints `package.json` file in the entire project’s directories.
+* `npm run lint:pkg-json:src` - lints `package.json` file in the project’s `src` subfolder’s directories.
 
 When you run commands similar to the `npm run lint:pkg-json:src` example above, you can provide one or multiple directories to scan as well. See [more examples](https://github.com/tclindner/npm-package-json-lint/blob/HEAD/README.md#examples).
 
@@ -190,8 +190,8 @@ _Example:_
 
 This is how you execute the script with presented setup:
 
-* `npm run lint:style` - lints CSS and SCSS files in the entire project's directories.
-* `npm run lint:css:src` - lints only CSS files in the project's `src` subfolder's directories.
+* `npm run lint:style` - lints CSS and SCSS files in the entire project’s directories.
+* `npm run lint:css:src` - lints only CSS files in the project’s `src` subfolder’s directories.
 
 When you run commands similar to the `npm run lint:css:src` example above, be sure to include the quotation marks around file globs. This ensures that you can use the powers of [globby](https://github.com/sindresorhus/globby) (like the `**` globstar) regardless of your shell. See [more examples](https://github.com/stylelint/stylelint/blob/HEAD/docs/user-guide/cli.md#examples).
 
@@ -203,7 +203,7 @@ It uses [stylelint](https://github.com/stylelint/stylelint) with the [stylelint-
 
 ### `start`
 
-Transforms your code according the configuration provided so it's ready for development. The script will automatically rebuild if you make changes to the code, and you will see the build errors in the console. The entry point for your project's code should be located in `src/index.js`. The output generated will be written to `build/index.js`. For single builds, better suited for production, see the [build](#build) script.
+Transforms your code according the configuration provided so it’s ready for development. The script will automatically rebuild if you make changes to the code, and you will see the build errors in the console. The entry point for your project’s code should be located in `src/index.js`. The output generated will be written to `build/index.js`. For single builds, better suited for production, see the [build](#build) script.
 
 _Example:_
 
@@ -223,7 +223,7 @@ This is how you execute the script with presented setup:
 
 #### Advanced information
 
-This script uses [webpack](https://webpack.js.org/) behind the scenes. It'll look for a webpack config in the top-level directory of your package and will use it if it finds one. If none is found, it'll use the default config provided by `@wordpress/scripts` packages. Learn more in the [Advanced Usage](#advanced-usage) section.
+This script uses [webpack](https://webpack.js.org/) behind the scenes. It’ll look for a webpack config in the top-level directory of your package and will use it if it finds one. If none is found, it’ll use the default config provided by `@wordpress/scripts` packages. Learn more in the [Advanced Usage](#advanced-usage) section.
 
 ### `test-e2e`
 
@@ -338,5 +338,5 @@ module.exports = {
   }
 };
 ```
-If you follow this approach, please, be aware that future versions of this package may change what webpack and Babel plugins we bundle, default configs, etc. Should those changes be necessary, they will be registered in the [package's CHANGELOG](https://github.com/WordPress/gutenberg/blob/master/packages/scripts/CHANGELOG.md), so make sure to read it before upgrading.
+If you follow this approach, please, be aware that future versions of this package may change what webpack and Babel plugins we bundle, default configs, etc. Should those changes be necessary, they will be registered in the [package’s CHANGELOG](https://github.com/WordPress/gutenberg/blob/master/packages/scripts/CHANGELOG.md), so make sure to read it before upgrading.
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>


### PR DESCRIPTION
## Description
This PR adds a new section explaining how to update `@wordpress/scripts` package after new releases. I noticed that `create-react-app` has this section in their repository I thought that we should include it as well. See https://create-react-app.dev/docs/updating-to-new-releases for reference. I mostly included the same instructions.

It also contains some editorial changes to make things clearer.

You can preview the updated version here:
https://github.com/WordPress/gutenberg/blob/6c7ff15f2742b9dc405b82c42d38c7fd74ffa3bd/packages/scripts/README.md