### PR TITLE
Core Data: Return updated record in `saveEntityRecord`.

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -231,6 +231,7 @@ export function* saveEntityRecord(
 	const recordId = record[ entityIdKey ];
 
 	yield { type: 'SAVE_ENTITY_RECORD_START', kind, name, recordId, isAutosave };
+	let updatedRecord;
 	let error;
 	try {
 		const path = `${ entity.baseURL }${ recordId ? '/' + recordId : '' }`;
@@ -260,14 +261,14 @@ export function* saveEntityRecord(
 				}
 				return acc;
 			}, {} );
-			const autosave = yield apiFetch( {
+			updatedRecord = yield apiFetch( {
 				path: `${ path }/autosaves`,
 				method: 'POST',
 				data,
 			} );
-			yield receiveAutosaves( persistedRecord.id, autosave );
+			yield receiveAutosaves( persistedRecord.id, updatedRecord );
 		} else {
-			const updatedRecord = yield apiFetch( {
+			updatedRecord = yield apiFetch( {
 				path,
 				method: recordId ? 'PUT' : 'POST',
 				data: record,
@@ -285,6 +286,8 @@ export function* saveEntityRecord(
 		error,
 		isAutosave,
 	};
+
+	return updatedRecord;
 }
 
 /**

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -21,9 +21,19 @@ describe( 'saveEntityRecord', () => {
 			data: post,
 		} );
 		// Provide response and trigger action
-		const { value: received } = fulfillment.next( { ...post, id: 10 } );
-		expect( received ).toEqual( receiveEntityRecords( 'postType', 'post', { ...post, id: 10 }, undefined, true ) );
+		const updatedRecord = { ...post, id: 10 };
+		const { value: received } = fulfillment.next( updatedRecord );
+		expect( received ).toEqual(
+			receiveEntityRecords(
+				'postType',
+				'post',
+				updatedRecord,
+				undefined,
+				true
+			)
+		);
 		expect( fulfillment.next().value.type ).toBe( 'SAVE_ENTITY_RECORD_FINISH' );
+		expect( fulfillment.next().value ).toBe( updatedRecord );
 	} );
 
 	it( 'triggers a PUT request for an existing record', async () => {


### PR DESCRIPTION
## Description

This PR makes `saveEntityRecord` from `core-data` return the updated record like it did before #16867. Some plugins expect this behavior and the change was not backwards compatible.

## How has this been tested?

A test case was added for this behavior to avoid regressions.

## Types of Changes

*Bug Fix:* Rollback breaking change of not returning the updated record in `saveEntityRecord` from `core-data`.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
