### PR TITLE
Fix the double scrollbar appearing in full screen mode

### DIFF
--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -5,6 +5,7 @@
 
 .edit-post-layout {
 	position: relative;
+	box-sizing: border-box;
 
 	// Beyond the mobile breakpoint, the editor bar is fixed, so make room for it eabove the layout content.
 	@include break-small {


### PR DESCRIPTION
Fix regression introduced by https://github.com/WordPress/gutenberg/pull/16856

The fact that "border-box: sizing" is not applied consistently now across all the elements cause this unnecessary scrollbar to show up in the full-screen mode.