### PR TITLE
Fix performance tests with the introduction of the navigation mode

### DIFF
--- a/packages/e2e-tests/specs/performance.test.js
+++ b/packages/e2e-tests/specs/performance.test.js
@@ -11,6 +11,7 @@ import {
 	createNewPost,
 	saveDraft,
 	insertBlock,
+	disableNavigationMode,
 } from '@wordpress/e2e-test-utils';
 
 function readFile( filePath ) {
@@ -53,6 +54,7 @@ describe( 'Performance', () => {
 		while ( i-- ) {
 			startTime = new Date();
 			await page.reload( { waitUntil: [ 'domcontentloaded', 'load' ] } );
+			await disableNavigationMode();
 		}
 
 		await insertBlock( 'Paragraph' );


### PR DESCRIPTION
the performance test job was failing since the introduction of the navigation mode since the editor is by default in that mode.