### PR TITLE
Fixes missing default funcs as props in `BlockEditorProvider`

### DIFF
--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
@@ -87,8 +92,8 @@ class BlockEditorProvider extends Component {
 
 		this.unsubscribe = registry.subscribe( () => {
 			const {
-				onChange,
-				onInput,
+				onChange = noop,
+				onInput = noop,
 			} = this.props;
 
 			const newBlocks = getBlocks();


### PR DESCRIPTION
The component assumes that the `onChange` and `onInput` props are always present. However, there are times where this may **_not_** be the case such as when the `BlockPreview` component uses the provider to render the previews. In such cases `onChange` is called but is `undefined` which causes an error to be thrown.

To avoid this we provide lodash `noop` as defaults for both “change” props.

An example of when an error is thrown can be seen in this PR

https://github.com/Automattic/wp-calypso/pull/35333

## Questions

* Should we test for `isFunction` as well?
* Is `noop` a good default?
* Should I also fix the React Native version? Who do I need to ping about this?

## How has this been tested?

Running this branch against https://github.com/Automattic/wp-calypso/pull/35333 causes the error related to `onChange` to disappear. 

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
