### PR TITLE
block-calendar: Use `400` as a valid `font-weight`

### DIFF
--- a/packages/block-library/src/calendar/style.scss
+++ b/packages/block-library/src/calendar/style.scss
@@ -18,7 +18,7 @@
 	}
 
 	table th {
-		font-weight: 440;
+		font-weight: 400;
 		background: $light-gray-300;
 	}
 


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Reported via [#WP47881](https://core.trac.wordpress.org/ticket/47881):

>W3C CSS Validator results for `.wp-block-calendar table th` in wp-includes/css/dist/block-library/style.min.css?ver=5.2.2:
>
> Value Error : font-weight 440 is not a font-weight
>
> Standart font-weight property: [https://www.w3.org/TR/2018/REC-css-fonts-3-20180920/#font-weight-prop]

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
