### PR TITLE
Check to ensure focus has intentionally left the wrapped component in `withFocusOutside` HOC

### DIFF
--- a/packages/components/src/higher-order/with-focus-outside/index.js
+++ b/packages/components/src/higher-order/with-focus-outside/index.js
@@ -79,8 +79,15 @@ export default createHigherOrderComponent(
 				}
 
 				this.blurCheckTimeout = setTimeout( () => {
-					const eventTargetElIsWithinComponent = this.node.containerRef.current && this.node.containerRef.current.contains( event.target );
-					if ( 'function' === typeof this.node.handleFocusOutside && ! eventTargetElIsWithinComponent ) {
+					// If document is not focused then focus should remain
+					// inside the wrapped component and therefore we cancel
+					// this blur event thereby leaving focus in place.
+					// https://developer.mozilla.org/en-US/docs/Web/API/Document/hasFocus.
+					if ( ! document.hasFocus() ) {
+						event.preventDefault();
+						return;
+					}
+					if ( 'function' === typeof this.node.handleFocusOutside ) {
 						this.node.handleFocusOutside( event );
 					}
 				}, 0 );

--- a/packages/components/src/higher-order/with-focus-outside/index.js
+++ b/packages/components/src/higher-order/with-focus-outside/index.js
@@ -79,7 +79,8 @@ export default createHigherOrderComponent(
 				}
 
 				this.blurCheckTimeout = setTimeout( () => {
-					if ( 'function' === typeof this.node.handleFocusOutside ) {
+					const eventTargetElIsWithinComponent = this.node.containerRef.current && this.node.containerRef.current.contains( event.target );
+					if ( 'function' === typeof this.node.handleFocusOutside && ! eventTargetElIsWithinComponent ) {
 						this.node.handleFocusOutside( event );
 					}
 				}, 0 );


### PR DESCRIPTION
`withFocusOutside` HOC aims to detect when a focus occurs outside of the wrapped compomnent. 

Previously there was no check to see whether the blur event occurred _within_ the wrapped component. 

If it occurs _within_ then we do not want to trigger the `handleFocusOutside` callback because (by definition) the focus has not moved outside the wrapped element.

This may have been a regression introduced by removal of `react-click-outside` in https://github.com/WordPress/gutenberg/pull/16878

## How has this been tested?
Still working on this.

## Types of changes

 Bug fix (non-breaking change which fixes an issue

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
