### PR TITLE
Add mechanism to convert media queries into "element" queries

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -407,6 +407,15 @@ _Type_
 
 -   `Object` 
 
+<a name="transformMediaQueries" href="#transformMediaQueries">#</a> **transformMediaQueries**
+
+Applies a series of CSS rule transforms to convert simple media queries into element queries handled by css-element-queries package.
+Initializes css-element-queries mechanism.
+
+_Parameters_
+
+-   _partialPaths_ `Array`: CSS rules.
+
 <a name="transformStyles" href="#transformStyles">#</a> **transformStyles**
 
 Applies a series of CSS rule transforms to wrap selectors inside a given class and/or rewrite URLs depending on the parameters passed.

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -43,6 +43,7 @@
 		"@wordpress/viewport": "file:../viewport",
 		"@wordpress/wordcount": "file:../wordcount",
 		"classnames": "^2.2.5",
+		"css-element-queries": "^1.2.1",
 		"diff": "^3.5.0",
 		"dom-scroll-into-view": "^1.2.1",
 		"inherits": "^2.0.3",

--- a/packages/block-editor/src/utils/index.js
+++ b/packages/block-editor/src/utils/index.js
@@ -1,1 +1,2 @@
 export { default as transformStyles } from './transform-styles';
+export { default as transformMediaQueries } from './transform-media-queries';

--- a/packages/block-editor/src/utils/transform-media-queries/index.js
+++ b/packages/block-editor/src/utils/transform-media-queries/index.js
@@ -1,0 +1,114 @@
+/**
+ * External dependencies
+ */
+import {
+	filter,
+	get,
+	map,
+	some,
+} from 'lodash';
+import ElementQueries from 'css-element-queries/src/ElementQueries';
+
+/**
+ * Internal dependencies
+ */
+import traverse from '../transform-styles/traverse';
+import wrap from '../transform-styles/transforms/wrap';
+
+const ELEMENT_QUERIES_SELECTOR = '.editor-styles-wrapper';
+
+function parseMediaQueryRule( rule ) {
+	// Make sure there are no multiple media rules.
+	if ( ! rule.media || rule.media.length !== 1 ) {
+		return null;
+	}
+
+	const mediaQueryCondition = rule.media[ 0 ];
+	// Verify if it is a simple media query that could be transformed into an element query.
+	const mediaMatches = mediaQueryCondition.match( /^\(((min|max)-(width|height)):([^\(]*?)\)$/ );
+	if ( ! mediaMatches || ! mediaMatches[ 1 ] || ! mediaMatches[ 4 ] ) {
+		return null;
+	}
+	return {
+		property: mediaMatches[ 1 ].trim(),
+		value: mediaMatches[ 4 ].trim(),
+	};
+}
+
+function getStyleSheetsThatMatchPaths( partialPaths ) {
+	return filter(
+		get( window, [ 'document', 'styleSheets' ], [] ),
+		( styleSheet ) => {
+			return (
+				styleSheet.href &&
+				some(
+					partialPaths,
+					( partialPath ) => {
+						return styleSheet.href.includes( partialPath );
+					}
+				)
+			);
+		}
+	);
+}
+
+function getMediaQueryInnerText( rule ) {
+	return map(
+		rule.cssRules,
+		( { cssText } ) => ( cssText )
+	).join( '\n' );
+}
+
+function getTransformedMediaQuery( rule ) {
+	const parsedMediaQuery = parseMediaQueryRule( rule );
+	if ( ! parsedMediaQuery ) {
+		return;
+	}
+	return traverse(
+		getMediaQueryInnerText( rule ),
+		wrap( `${ ELEMENT_QUERIES_SELECTOR }[${ parsedMediaQuery.property }~="${ parsedMediaQuery.value }"]` )
+	);
+}
+
+/**
+ * Applies a series of CSS rule transforms to convert simple media queries into element queries handled by css-element-queries package.
+ * Initializes css-element-queries mechanism.
+ *
+ * @param {Array} partialPaths CSS rules.
+ */
+export default function transformMediaQueries( partialPaths ) {
+	if ( ! window || ! window.document ) {
+		return;
+	}
+
+	const styleSheets = getStyleSheetsThatMatchPaths( partialPaths );
+
+	const rulesToProcess = [];
+
+	styleSheets.forEach(
+		( styleSheet ) => {
+			for ( let i = 0; i < styleSheet.rules.length; ) {
+				const rule = styleSheet.rules[ i ];
+				const transformedMediaQuery = getTransformedMediaQuery( rule );
+				if ( transformedMediaQuery ) {
+					rulesToProcess.push( transformedMediaQuery );
+					// Remove the stylesheet.
+					styleSheet.removeRule( i );
+				} else {
+					++i;
+				}
+			}
+		}
+	);
+	if ( ! rulesToProcess.length ) {
+		return;
+	}
+
+	const elementQueriesCode = rulesToProcess.join( '\n' );
+
+	const node = document.createElement( 'style' );
+	node.innerHTML = elementQueriesCode;
+	document.body.appendChild( node );
+	ElementQueries.listen();
+	ElementQueries.init();
+}

--- a/packages/edit-widgets/src/components/widget-areas/index.js
+++ b/packages/edit-widgets/src/components/widget-areas/index.js
@@ -1,9 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { useMemo, useState } from '@wordpress/element';
+import { useEffect, useMemo, useState } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
+import { transformMediaQueries } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -11,6 +12,16 @@ import { withSelect } from '@wordpress/data';
 import WidgetArea from '../widget-area';
 
 function WidgetAreas( { areas, blockEditorSettings } ) {
+	useEffect( () => {
+		// Todo: The partial paths should be a setting that includes styles added by the plugins.
+		transformMediaQueries( [
+			'block-editor/style.css',
+			'block-library/style.css',
+			'block-library/theme.css',
+			'block-library/editor.css',
+			'format-library/style.css',
+		] );
+	}, [] );
 	const [ selectedArea, setSelectedArea ] = useState( 0 );
 	const onBlockSelectedInArea = useMemo(
 		() => areas.map( ( value, index ) => ( () => {

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -11,7 +11,7 @@ import { compose } from '@wordpress/compose';
 import { Component } from '@wordpress/element';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { BlockEditorProvider, transformStyles } from '@wordpress/block-editor';
+import { BlockEditorProvider, transformStyles, transformMediaQueries } from '@wordpress/block-editor';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -115,7 +115,15 @@ class EditorProvider extends Component {
 		if ( ! this.props.settings.styles ) {
 			return;
 		}
-
+		// Todo: The partial paths should be a setting that includes styles added by the plugins.
+		transformMediaQueries( [
+			'block-editor/style.css',
+			'editor/style.css',
+			'block-library/style.css',
+			'block-library/theme.css',
+			'block-library/editor.css',
+			'format-library/style.css',
+		] );
 		const updatedStyles = transformStyles( this.props.settings.styles, '.editor-styles-wrapper' );
 
 		map( updatedStyles, ( updatedCSS ) => {


### PR DESCRIPTION
This PR adds a run time mechanism that converts simple media queries e.g: max/min-width/height into element queries that reference the dimensions of .editor-styles-wrapper-container.

We are using https://github.com/marcj/css-element-queries as our element queries "polyfill".

There are some visual regressions in the customizer it happens because although the media queries evaluate as if the viewport was small our components (if/With)ViewportMatches still think the viewport is large.
I will create a separate PR that allows us to simulate widths in these components.

## How has this been tested?
I verified things work as before and there are no visual regressions excluding in the customizer.
I added a rule that changes editor-styles-wrapper width to 550px:
```
.editor-styles-wrapper {
width: 550px;
}
```
In the editor styles.
I added media & text block, I enabled stack on mobile option and I verified the media & text got stacked even though the window continues to have a big size.

