### PR TITLE
fix(scripts): Use the SCSS shared stylelint-config-wordpress config

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -6,6 +6,10 @@
 - The bundled `jest-puppeteer` dependency has been updated from requiring `^4.0.0` to requiring `^4.3.0` ([#16875](https://github.com/WordPress/gutenberg/pull/16875)).
 - The bundled `eslint` dependency has been updated from requiring `^5.16.0` to requiring `^6.1.0`.
 
+### Bug Fix
+
+- Use the SCSS shared stylelint configuration so that both CSS and SCSS stylelint rules are used ([#](https://github.com/WordPress/gutenberg/pull/))
+
 ## 3.4.0 (2019-08-05)
 
 ### New Features

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fix
 
-- Use the SCSS shared stylelint configuration so that both CSS and SCSS stylelint rules are used ([#](https://github.com/WordPress/gutenberg/pull/))
+- Use the SCSS shared `stylelint-config-wordpress` config so that both CSS and SCSS rules are used ([#17060](https://github.com/WordPress/gutenberg/pull/17060))
 
 ## 3.4.0 (2019-08-05)
 

--- a/packages/scripts/config/.stylelintrc.json
+++ b/packages/scripts/config/.stylelintrc.json
@@ -1,3 +1,3 @@
 {
-	"extends": "stylelint-config-wordpress"
+	"extends": "stylelint-config-wordpress/scss"
 }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

When using the `lint-style` `wp-scripts` command the SCSS rules from `stylelint-config-wordpress` are not used, this results in lint errors being displayed when linting SCSS files.

> `"lint:css": "wp-scripts lint-style",`

By updating the config to use the `stylelint-config-wordpress/scss` shared config then both CSS and SCSS files are linted correctly.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Download a valid SCSS file, e.g. [scss-valid.scss](https://raw.githubusercontent.com/WordPress-Coding-Standards/stylelint-config-wordpress/master/__tests__/scss-valid.scss) and run the `lint-style` script against the `scss-valid.scss` file:

> `./node_modules/.bin/wp-scripts lint-style 'scss-valid.scss'`

If successful there should be no errors displayed.

If unsuccessful the following errors will be displayed:
```shell
scss-valid.scss
  3:1  ✖  Unexpected unknown at-rule "@function"   at-rule-no-unknown               
  5:2  ✖  Unexpected unknown at-rule "@return"     at-rule-no-unknown               
  8:1  ✖  Unexpected unknown at-rule "@mixin"      at-rule-no-unknown               
 19:1  ✖  Unexpected unknown at-rule "@if"         at-rule-no-unknown               
 21:2  ✖  Expected newline after "}"               block-closing-brace-newline-after
 21:3  ✖  Expected empty line before at-rule       at-rule-empty-line-before        
 21:3  ✖  Unexpected unknown at-rule "@else"       at-rule-no-unknown               
 30:2  ✖  Unexpected unknown at-rule "@include"    at-rule-no-unknown               
 31:2  ✖  Unexpected unknown at-rule "@include"    at-rule-no-unknown
```
## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
