### PR TITLE
Fix: Button block does not centers on the editor

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -33,10 +33,6 @@ import {
 const { getComputedStyle } = window;
 
 const applyFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
-	if ( node ) {
-		node.classList.add( 'wp-block-button-wrapper' );
-	}
-
 	const { textColor, backgroundColor } = ownProps;
 	const backgroundColorValue = backgroundColor && backgroundColor.color;
 	const textColorValue = textColor && textColor.color;

--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -1,6 +1,10 @@
 .block-editor-block-list__block[data-type="core/button"] {
 	&[data-align="center"] {
 		text-align: center;
+		div[data-block] {
+			margin-left: auto;
+			margin-right: auto;
+		}
 	}
 
 	&[data-align="right"] {
@@ -76,6 +80,7 @@
 	}
 }
 
-.wp-block-button-wrapper {
+// Display "table" is used because the button container should only wrap the content and not takes the full width.
+div[data-type="core/button"] div[data-block] {
 	display: table;
 }


### PR DESCRIPTION
## Description
Fixes: https://github.com/WordPress/gutenberg/issues/17059
Regressed in:https://github.com/WordPress/gutenberg/pull/16873 

In https://github.com/WordPress/gutenberg/pull/16873 we started using a display table for the button block in the editor. As with this display mode, the previews look better. But this introduces a regression as in this mode align-center did not work as expected.
We also relied on withFallbackStyles to directly change the dom and add a class. We should avoid direct dom changes so this PR removes the class addition and uses a more complex CSS selector to avoid the need for that class.
This PR also only applies display table for the previews, as using a display table in normal block operation may be unexpected.

With these changes, the block itself got correctly center aligned but the link UI did not align as expected so a margin for the link UI was added.

## How has this been tested?
I added a button block.
I tried all the alignment options in and verified the result was the expected one in the editor and in the styles preview.