### PR TITLE
Make `Disabled` component truly disable child interactivity

### DIFF
--- a/packages/components/src/disabled/README.md
+++ b/packages/components/src/disabled/README.md
@@ -2,6 +2,10 @@
 
 Disabled is a component which disables interaction with descendant tabbable or focusable DOM elements. Pointer interaction, keyboard focus/tab and events are disabled.
 
+## A note on Accessibility
+
+Usage of this component should be implemented with caution. If the component being disabled is still intenteded to be perceivable then, when using this component, you must provide a suitable alternative presentation for users of assitive technologies.
+
 ## Usage
 
 Assuming you have a form component, you can disable all form inputs by wrapping the form with `<Disabled>`.

--- a/packages/components/src/disabled/README.md
+++ b/packages/components/src/disabled/README.md
@@ -1,6 +1,8 @@
 # Disabled
 
-Disabled is a component which disables descendant tabbable elements and prevents pointer interaction.
+Disabled is a component which disables descendant tabbable form input elements and prevents pointer interaction.
+
+Note: by default this component does not prevent tabbing to anchor elements. If this is required then you may utilise the `onDisable` prop to manually disable individual elements on a per node basis.
 
 ## Usage
 

--- a/packages/components/src/disabled/README.md
+++ b/packages/components/src/disabled/README.md
@@ -1,8 +1,6 @@
 # Disabled
 
-Disabled is a component which disables descendant tabbable form input elements and prevents pointer interaction.
-
-Note: by default this component does not prevent tabbing to anchor elements. If this is required then you may utilise the `onDisable` prop to manually disable individual elements on a per node basis.
+Disabled is a component which disables interaction with descendant tabbable or focusable DOM elements. Pointer interaction, keyboard focus/tab and events are disabled.
 
 ## Usage
 

--- a/packages/components/src/disabled/index.js
+++ b/packages/components/src/disabled/index.js
@@ -78,9 +78,12 @@ class Disabled extends Component {
 	disable() {
 		const {
 			eligibleNodeNames = DISABLED_ELIGIBLE_NODE_NAMES,
+			includeScrollable = false,
 		} = this.props;
 
-		const focusableNodes = focus.focusable.find( this.node );
+		const focusableNodes = focus.focusable.find( this.node, {
+			includeScrollable, // opt in to find all focusable elements
+		} );
 
 		focusableNodes.forEach( ( focusable ) => {
 			// Disable all nodes from being tabbable order
@@ -98,12 +101,9 @@ class Disabled extends Component {
 			if ( focusable.hasAttribute( 'href' ) ) {
 				focusable.removeAttribute( 'href' );
 			}
-		} );
 
-		// In FF the `<RichText>` node becomes focusable (presumanly via scripting).
-		// We manually disable this via tabindex also
-		const blockEditorEdgeCaseFocusable = '.block-editor-rich-text';
-		this.node.querySelectorAll( blockEditorEdgeCaseFocusable ).forEach( ( rc ) => rc.setAttribute( 'tabindex', '-1' ) );
+			focusable.setAttribute( 'data-focus-removed', 'true' );
+		} );
 	}
 
 	render() {

--- a/packages/components/src/disabled/index.js
+++ b/packages/components/src/disabled/index.js
@@ -68,7 +68,6 @@ class Disabled extends Component {
 	catchEvents( e ) {
 		if ( this.node && this.node.contains( e.target ) ) {
 			e.preventDefault();
-			e.stopPropagation();
 		}
 	}
 

--- a/packages/components/src/disabled/index.js
+++ b/packages/components/src/disabled/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { includes, debounce } from 'lodash';
+import { includes, debounce, noop } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -64,8 +64,15 @@ class Disabled extends Component {
 	}
 
 	disable() {
-		focus.focusable.find( this.node ).forEach( ( focusable ) => {
-			if ( includes( DISABLED_ELIGIBLE_NODE_NAMES, focusable.nodeName ) ) {
+		const {
+			onDisable = noop,
+			eligibleNodeNames = DISABLED_ELIGIBLE_NODE_NAMES,
+		} = this.props;
+
+		const focusableNodes = focus.focusable.find( this.node );
+
+		focusableNodes.forEach( ( focusable ) => {
+			if ( includes( eligibleNodeNames, focusable.nodeName ) ) {
 				focusable.setAttribute( 'disabled', '' );
 			}
 
@@ -77,6 +84,8 @@ class Disabled extends Component {
 				focusable.setAttribute( 'contenteditable', 'false' );
 			}
 		} );
+
+		onDisable( focusableNodes );
 	}
 
 	render() {

--- a/packages/components/src/disabled/index.js
+++ b/packages/components/src/disabled/index.js
@@ -37,6 +37,7 @@ class Disabled extends Component {
 
 		this.bindNode = this.bindNode.bind( this );
 		this.disable = this.disable.bind( this );
+		this.catchEvents = this.catchEvents.bind( this );
 
 		// Debounce re-disable since disabling process itself will incur
 		// additional mutations which should be ignored.
@@ -52,11 +53,21 @@ class Disabled extends Component {
 			attributes: true,
 			subtree: true,
 		} );
+
+		this.node.addEventListener( 'click', this.catchEvents );
+		this.node.addEventListener( 'focus', this.catchEvents );
 	}
 
 	componentWillUnmount() {
 		this.observer.disconnect();
 		this.debouncedDisable.cancel();
+		this.node.removeEventListener( 'click', this.catchEvents );
+		this.node.removeEventListener( 'focus', this.catchEvents );
+	}
+
+	catchEvents( e ) {
+		e.preventDefault();
+		e.stopPropagation();
 	}
 
 	bindNode( node ) {
@@ -76,13 +87,17 @@ class Disabled extends Component {
 				focusable.setAttribute( 'disabled', '' );
 			}
 
-			if ( focusable.hasAttribute( 'tabindex' ) ) {
-				focusable.removeAttribute( 'tabindex' );
-			}
-
 			if ( focusable.hasAttribute( 'contenteditable' ) ) {
 				focusable.setAttribute( 'contenteditable', 'false' );
 			}
+
+			// Make it impossible to focus or tab to `<a>` or `<area>` els
+			if ( focusable.hasAttribute( 'href' ) ) {
+				focusable.removeAttribute( 'href' );
+			}
+
+			// Disable all nodes from being tabbable order
+			focusable.setAttribute( 'tabindex', '-1' );
 		} );
 
 		onDisable( focusableNodes );

--- a/packages/components/src/disabled/index.js
+++ b/packages/components/src/disabled/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { includes, debounce, noop } from 'lodash';
+import { includes, debounce } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -76,7 +76,6 @@ class Disabled extends Component {
 
 	disable() {
 		const {
-			onDisable = noop,
 			eligibleNodeNames = DISABLED_ELIGIBLE_NODE_NAMES,
 		} = this.props;
 
@@ -99,8 +98,6 @@ class Disabled extends Component {
 			// Disable all nodes from being tabbable order
 			focusable.setAttribute( 'tabindex', '-1' );
 		} );
-
-		onDisable( focusableNodes );
 	}
 
 	render() {

--- a/packages/components/src/disabled/test/index.js
+++ b/packages/components/src/disabled/test/index.js
@@ -6,7 +6,7 @@ import TestUtils from 'react-dom/test-utils';
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -56,17 +56,27 @@ describe( 'Disabled', () => {
 		window.MutationObserver = MutationObserver;
 	} );
 
-	const Form = () => <form><input /><div contentEditable tabIndex="0" /></form>;
+	const ChildComponentStub = () => (
+		<Fragment>
+			<a href="https://wordpress.org">Link</a>
+			<iframe title="Dummy iframe" src="https://github.com/WordPress/gutenberg" />
+			<form><input /><div contentEditable tabIndex="0" /></form>
+		</Fragment>
+	);
 
-	it( 'will disable all fields', () => {
-		const wrapper = TestUtils.renderIntoDocument( <Disabled><Form /></Disabled> );
+	it( 'will disable all interactive elements', () => {
+		const wrapper = TestUtils.renderIntoDocument( <Disabled><ChildComponentStub /></Disabled> );
 
 		const input = TestUtils.findRenderedDOMComponentWithTag( wrapper, 'input' );
+		const anchorLink = TestUtils.findRenderedDOMComponentWithTag( wrapper, 'a' );
+		const iframe = TestUtils.findRenderedDOMComponentWithTag( wrapper, 'iframe' );
 		const div = TestUtils.scryRenderedDOMComponentsWithTag( wrapper, 'div' )[ 1 ];
 
 		expect( input.hasAttribute( 'disabled' ) ).toBe( true );
 		expect( div.getAttribute( 'contenteditable' ) ).toBe( 'false' );
-		expect( div.hasAttribute( 'tabindex' ) ).toBe( false );
+		expect( div.getAttribute( 'tabindex' ) ).toEqual( '-1' );
+		expect( iframe.getAttribute( 'tabindex' ) ).toEqual( '-1' );
+		expect( anchorLink.hasAttribute( 'href' ) ).toBe( false );
 		expect( div.hasAttribute( 'disabled' ) ).toBe( false );
 	} );
 
@@ -84,8 +94,8 @@ describe( 'Disabled', () => {
 
 			render() {
 				return this.state.isDisabled ?
-					<Disabled><Form /></Disabled> :
-					<Form />;
+					<Disabled><ChildComponentStub /></Disabled> :
+					<ChildComponentStub />;
 			}
 		}
 
@@ -94,10 +104,13 @@ describe( 'Disabled', () => {
 
 		const input = TestUtils.findRenderedDOMComponentWithTag( wrapper, 'input' );
 		const div = TestUtils.findRenderedDOMComponentWithTag( wrapper, 'div' );
+		const anchorLink = TestUtils.findRenderedDOMComponentWithTag( wrapper, 'a' );
 
 		expect( input.hasAttribute( 'disabled' ) ).toBe( false );
 		expect( div.getAttribute( 'contenteditable' ) ).toBe( 'true' );
 		expect( div.hasAttribute( 'tabindex' ) ).toBe( true );
+		expect( div.hasAttribute( 'tabindex' ) ).not.toEqual( '-1' );
+		expect( anchorLink.hasAttribute( 'href' ) ).toBe( true );
 	} );
 
 	// Ideally, we'd have two more test cases here:

--- a/packages/dom/src/focusable.js
+++ b/packages/dom/src/focusable.js
@@ -100,7 +100,7 @@ export function find( context, options = {
 	// and may result in poor performance.
 	// see https://html.spec.whatwg.org/multipage/interaction.html#focusable-area.
 	if ( options.includeScrollable ) {
-		const allChildren = context.querySelectorAll( '*' );
+		const allChildren = context.getElementsByTagName( '*' );
 		const scrollableContainers = [ ...allChildren ].filter( ( el ) => {
 			const hasScroll = el.clientHeight <= el.scrollHeight;
 


### PR DESCRIPTION
Currently the `Disabled` component is somewhat confusing and inflexible.

1. The `README` doesn't mention it only disables _form_ elements.
2. There is no way to extend the component to disable other types of focusable elements.

This PR 

* extends the component to disable all interactivity within the child components (specifically ability to tab to or `focus` elements)
* adds an `onDisable` callback which accepts the  detected `focusable` elements and allows developers to choose to disable other types of focusable elements.

This ~is intentionally implemented to be fully backwards compatible and doesn't break any existing implementations. It is purely~ may cause knock-on effects for components which wish to retain the current/older "only disable form elements" functionality. 

## How has this been tested?
Unit tests.


## Types of changes
New feature (breaking change which adds functionality).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
