### PR TITLE
Apply box-sizing border-box properly to the notices components

### DIFF
--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -66,6 +66,7 @@
 .components-notice-list {
 	// The notice should never be wider than the viewport, or the close button might be hidden. Especially relevant at high zoom levels. Related to https://core.trac.wordpress.org/ticket/47603#ticket.
 	max-width: 100vw;
+	box-sizing: border-box;
 	z-index: z-index(".components-notice-list");
 
 	.components-notice__content {

--- a/packages/components/src/snackbar/style.scss
+++ b/packages/components/src/snackbar/style.scss
@@ -8,6 +8,7 @@
 	padding: 16px 24px;
 	width: 100%;
 	max-width: 600px;
+	box-sizing: border-box;
 	cursor: pointer;
 
 	@include break-small() {
@@ -54,6 +55,7 @@
 	position: absolute;
 	z-index: z-index(".components-snackbar-list");
 	width: 100%;
+	box-sizing: border-box;
 }
 
 .components-snackbar-list__notice-container {


### PR DESCRIPTION
closes #17045
regressed in #16856 

Instead of restoring the CSS reset, I opted to use a more "portable" fix making the styles of the notices components independent from any global reset by adding the "border-box" box-sizing where needed.