### PR TITLE
Update: Latest Posts Block: Use (no title) instead of (Untitled) for …

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -206,7 +206,7 @@ class LatestPostsEdit extends Component {
 											{ titleTrimmed }
 										</RawHTML>
 									) :
-										__( '(Untitled)' )
+										__( '(no title)' )
 									}
 								</a>
 								{ displayPostDate && post.date_gmt &&

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -34,7 +34,7 @@ function render_block_core_latest_posts( $attributes ) {
 	foreach ( $recent_posts as $post ) {
 		$title = get_the_title( $post );
 		if ( ! $title ) {
-			$title = __( '(Untitled)' );
+			$title = __( '(no title)' );
 		}
 		$list_items_markup .= sprintf(
 			'<li><a href="%1$s">%2$s</a>',

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -32,7 +32,7 @@ function render_block_core_rss( $attributes ) {
 	foreach ( $rss_items as $item ) {
 		$title = esc_html( trim( strip_tags( $item->get_title() ) ) );
 		if ( empty( $title ) ) {
-			$title = __( '(Untitled)' );
+			$title = __( '(no title)' );
 		}
 		$link = $item->get_link();
 		$link = esc_url( $link );


### PR DESCRIPTION
## Description
Use "(no title)" instead of "(Untitled)" as title of untitled posts.

## How has this been tested?
I tested the "Latest Posts" block in both pages and posts while in "Gutenberg Editor" mode and in the actual published post.

## Type of changes
Fixes #9695

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
