### PR TITLE
Fix: UI: Post Publish Panel overlaps the user profile dropdown menu

### DIFF
--- a/assets/stylesheets/_z-index.scss
+++ b/assets/stylesheets/_z-index.scss
@@ -67,6 +67,9 @@ $z-layers: (
 	".edit-post-sidebar": 100000,
 	".edit-widgets-sidebar": 100000,
 	".edit-post-layout .edit-post-post-publish-panel": 100001,
+	// For larger views, the wp-admin navbar dropdown should be at top of
+	// the Publish Post sidebar.
+	".edit-post-layout .edit-post-post-publish-panel-break-medium": 99998,
 
 	// Show sidebar in greater than small viewports above editor related elements
 	// but bellow #adminmenuback { z-index: 100 }

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -155,6 +155,7 @@
 	overflow: auto;
 
 	@include break-medium() {
+		z-index: z-index(".edit-post-layout .edit-post-post-publish-panel-break-medium");
 		top: $admin-bar-height;
 		left: auto;
 		width: $sidebar-width;


### PR DESCRIPTION
## Description
The changes would make `.edit-post-layout .editor-post-publish-panel` use a z-index of `100001` up until viewport = 782px (mobile) then z-index of `99998` for larger viewport which would fix the problem since the user profile dropdown menu `(#wpadminbar)` has a z-index of `99999`.

## How has this been tested?
Reproduced the steps mentioned in the issue and confirmed that the changes fixed the issue. I tested in both viewports greater and less than 782px.

Tested in:
OS: macOS
Browser: Chrome

## Screenshots
<img width="1680" alt="Screen Shot 2019-08-17 at 8 01 15 PM" src="https://user-images.githubusercontent.com/5747475/63211471-12d13b00-c12a-11e9-98c2-f248869927d8.png">

<img width="1124" alt="Screen Shot 2019-08-17 at 8 02 12 PM" src="https://user-images.githubusercontent.com/5747475/63211476-2086c080-c12a-11e9-8ad5-1868da0c2af1.png">

## Types of changes
Fixes #16859.

## Checklist:
- [x] My code is tested.
