### PR TITLE
don't use hardcoded values for separator styles

### DIFF
--- a/packages/block-library/src/separator/style.scss
+++ b/packages/block-library/src/separator/style.scss
@@ -20,7 +20,7 @@
 		&::before {
 			content: "\00b7 \00b7 \00b7";
 			color: currentColor;
-			font-size: 20px;
+			font-size: 1.5em;
 			letter-spacing: 2em;
 			padding-left: 2em;
 			font-family: serif;

--- a/packages/block-library/src/separator/theme.scss
+++ b/packages/block-library/src/separator/theme.scss
@@ -1,8 +1,9 @@
 .wp-block-separator {
 	border: none;
-	border-bottom: 2px solid $dark-gray-100;
+	border-bottom: 2px solid currentColor;
 	margin-left: auto;
 	margin-right: auto;
+	opacity: .4;
 
 	// Default, thin style
 	&:not(.is-style-wide):not(.is-style-dots) {


### PR DESCRIPTION
## Description
Avoid using hardcoded styles for separators.
This is a part of #16782, I'll try to push separate PRs per block so they can be examined and discussed separately.

## Types of changes
* Changed hardcoded font-size value from `px` to `em`
* Changed `$dark-gray-100` color to `currentColor` with an opacity of `.4` which is pretty close on white backgrounds.

The above changes make things work properly regardless of font-size used on the site, and regardless of whether the site uses a light or dark background color.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
