### PR TITLE
Introduce disableDropZone prop for MediaPlaceholder component.

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/README.md
+++ b/packages/block-editor/src/components/media-placeholder/README.md
@@ -76,8 +76,7 @@ If true, the Drop Zone will not be rendered. Users won't be able to drag & drop 
 ### dropZoneUIOnly
 
 If true, only the Drop Zone will be rendered. No UI controls to upload the media will be shown.
-This prop will take precedence over `disableDropZone`.
-It means, if both the props are supplied with `true` value, the component will still render the Drop Zone.
+The `disableDropZone` prop still takes precedence over `dropZoneUIOnly` – specifying both as true will result in nothing to be rendered.
 
 - Type: `Boolean`
 - Required: No

--- a/packages/block-editor/src/components/media-placeholder/README.md
+++ b/packages/block-editor/src/components/media-placeholder/README.md
@@ -65,6 +65,24 @@ Class name added to the placeholder.
 - Type: `String`
 - Required: No
 
+### disableDropZone
+
+If true, the Drop Zone will not be rendered. Users won't be able to drag & drop any media into the component or the block. The UI controls to upload the media via file, url or the media library would be intact.
+
+- Type: `Boolean`
+- Required: No
+- Default: `false`
+
+### dropZoneUIOnly
+
+If true, only the Drop Zone will be rendered. No UI controls to upload the media will be shown.
+This prop will take precedence over `disableDropZone`.
+It means, if both the props are supplied with `true` value, the component will still render the Drop Zone.
+
+- Type: `Boolean`
+- Required: No
+- Default: `false`
+
 ### icon
 
 Icon to display left of the title. When passed as a `String`, the icon will be resolved as a [Dashicon](https://developer.wordpress.org/resource/dashicons/). Alternatively, you can pass in a `WPComponent` such as `BlockIcon`to render instead.

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -22,10 +22,7 @@ import {
 	withFilters,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import {
-	Component,
-	Fragment,
-} from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 
@@ -229,7 +226,7 @@ export class MediaPlaceholder extends Component {
 		const { disableDropZone, onHTMLDrop = noop } = this.props;
 
 		if ( disableDropZone ) {
-			return <Fragment />;
+			return null;
 		}
 
 		return (

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -22,7 +22,10 @@ import {
 	withFilters,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
+import {
+	Component,
+	Fragment,
+} from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 
@@ -223,7 +226,12 @@ export class MediaPlaceholder extends Component {
 	}
 
 	renderDropZone() {
-		const { onHTMLDrop = noop } = this.props;
+		const { disableDropZone, onHTMLDrop = noop } = this.props;
+
+		if ( disableDropZone ) {
+			return <Fragment />;
+		}
+
 		return (
 			<DropZone
 				onFilesDrop={ this.onFilesUpload }
@@ -286,7 +294,6 @@ export class MediaPlaceholder extends Component {
 			accept,
 			addToGallery,
 			allowedTypes = [],
-			disableDropZone,
 			isAppender,
 			mediaUpload,
 			multiple = false,
@@ -329,7 +336,7 @@ export class MediaPlaceholder extends Component {
 		if ( mediaUpload && isAppender ) {
 			return (
 				<>
-					{ ! disableDropZone && this.renderDropZone() }
+					{ this.renderDropZone() }
 					<FormFileUpload
 						onChange={ this.onUpload }
 						accept={ accept }
@@ -363,7 +370,7 @@ export class MediaPlaceholder extends Component {
 		if ( mediaUpload ) {
 			const content = (
 				<>
-					{ ! disableDropZone && this.renderDropZone() }
+					{ this.renderDropZone() }
 					<FormFileUpload
 						isLarge
 						className={ classnames(

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -286,6 +286,7 @@ export class MediaPlaceholder extends Component {
 			accept,
 			addToGallery,
 			allowedTypes = [],
+			disableDropZone,
 			isAppender,
 			mediaUpload,
 			multiple = false,
@@ -328,7 +329,7 @@ export class MediaPlaceholder extends Component {
 		if ( mediaUpload && isAppender ) {
 			return (
 				<>
-					{ this.renderDropZone() }
+					{ ! disableDropZone && this.renderDropZone() }
 					<FormFileUpload
 						onChange={ this.onUpload }
 						accept={ accept }
@@ -358,10 +359,11 @@ export class MediaPlaceholder extends Component {
 				</>
 			);
 		}
+
 		if ( mediaUpload ) {
 			const content = (
 				<>
-					{ this.renderDropZone() }
+					{ ! disableDropZone && this.renderDropZone() }
 					<FormFileUpload
 						isLarge
 						className={ classnames(
@@ -382,6 +384,7 @@ export class MediaPlaceholder extends Component {
 			);
 			return this.renderPlaceholder( content );
 		}
+
 		return this.renderPlaceholder( mediaLibraryButton );
 	}
 


### PR DESCRIPTION
## Description
Currently, `MediaPlaceholder` does not allow us to disable the drop zone. I work for a newsroom where we do not allow our editors/reporters to drag & drop images into the post, because we have our own media service to handle the images. This PR introduces a component prop which disables the drop zone for `MediaPlaceholder`.

## Types of changes
- A new prop added in `MediaPlaceholder` component.
- Relevant README.md file is also updated to document the use of this prop.
- `dropZoneUIOnly` prop is also documented along with this.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
