### PR TITLE
WIP: Try vertical arrow key navigation in WritingFlow

### DIFF
--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -210,8 +210,6 @@ class WritingFlow extends Component {
 	}
 
 	getClosestVerticalTabbable( target, isReverse ) {
-		let tabbable;
-
 		// Start searching from the caret position.
 		const caretRect = computeCaretRect();
 		const { left: xPosition } = caretRect || {};
@@ -222,7 +220,7 @@ class WritingFlow extends Component {
 		const startYPosition = ( isReverse ? targetTop : targetBottom ) + verticalIncrement;
 
 		// Make an initial vertical search from the caret's position.
-		tabbable = searchVerticallyForTabbableTextField( xPosition, startYPosition, verticalIncrement );
+		let tabbable = searchVerticallyForTabbableTextField( xPosition, startYPosition, verticalIncrement );
 		if ( tabbable ) {
 			return tabbable;
 		}

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -92,7 +92,7 @@ function searchVerticallyForTabbableTextField( xPosition, yPosition, increment =
 		return;
 	}
 
-	const elements = castArray( elementsFromPoint( xPosition, yPosition ) );
+	const elements = castArray( elementsFromPoint.call( document, xPosition, yPosition ) );
 	const tabbable = find( elements, isTabbableTextField );
 	if ( tabbable ) {
 		return tabbable;

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { overEvery, find, findLast, reverse, first, last } from 'lodash';
+import { overEvery, find, findLast, reverse, first, last, castArray } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -86,9 +86,16 @@ function searchVerticallyForTabbableTextField( xPosition, yPosition, increment =
 		return;
 	}
 
-	const element = document.elementFromPoint( xPosition, yPosition );
-	if ( element && isTabbableTextField( element ) ) {
-		return element;
+	// Prefer elementsFromPoint where supported, but use a fallback otherwise.
+	const elementsFromPoint = document.elementsFromPoint || document.msElementsFromPoint || document.elementFromPoint;
+	if ( ! elementsFromPoint ) {
+		return;
+	}
+
+	const elements = castArray( elementsFromPoint( xPosition, yPosition ) );
+	const tabbable = find( elements, isTabbableTextField );
+	if ( tabbable ) {
+		return tabbable;
 	}
 
 	return searchVerticallyForTabbableTextField( xPosition, yPosition + increment, increment, searches - 1 );

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -233,10 +233,11 @@ class WritingFlow extends Component {
 		}
 
 		// Search around the caret, taking up to 10 steps in either direction horizontally before giving up.
+		const HORIZONTAL_SEARCH_COUNT = 30;
 		const width = targetRight - targetLeft;
-		const horizontalIncrement = width / 10;
+		const horizontalIncrement = width / HORIZONTAL_SEARCH_COUNT;
 
-		for ( let searches = 1; searches <= 10; searches++ ) {
+		for ( let searches = 1; searches <= HORIZONTAL_SEARCH_COUNT; searches++ ) {
 			const positionToRightOfCaret = xPosition + ( horizontalIncrement * searches );
 			if ( positionToRightOfCaret <= targetRight ) {
 				tabbable = searchVerticallyForTabbableTextField( positionToRightOfCaret, startYPosition, verticalIncrement );


### PR DESCRIPTION
## Description
Iteration on #16957, which attempts to bring vertical arrow key navigation to the `WritingFlow` component.

When an up/down arrow key is pressed searches in the relevant direction from the caret until a tabbable text field is found. If none is found, tries searching from the right and left of the caret upwards or downwards until a tabbable is found.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
