### PR TITLE
Guard block component against zombie state bug

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -775,6 +775,8 @@ export default compose(
 	withViewportMatch( { isLargeViewport: 'medium' } ),
 	applyWithSelect,
 	applyWithDispatch,
+	// block is sometimes not mounted at the right time, causing it be undefined
+	// see issue for more info https://github.com/WordPress/gutenberg/issues/17013
 	ifCondition( ( { block } ) => !! block ),
 	withFilters( 'editor.BlockListBlock' )
 )( BlockListBlock );

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -29,7 +29,7 @@ import {
 	withSelect,
 } from '@wordpress/data';
 import { withViewportMatch } from '@wordpress/viewport';
-import { compose, pure } from '@wordpress/compose';
+import { compose, pure, ifCondition } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -775,5 +775,6 @@ export default compose(
 	withViewportMatch( { isLargeViewport: 'medium' } ),
 	applyWithSelect,
 	applyWithDispatch,
+	ifCondition( ( { block } ) => !! block ),
 	withFilters( 'editor.BlockListBlock' )
 )( BlockListBlock );


### PR DESCRIPTION
fixes #17013
implements this fix by @nerrad 
https://github.com/WordPress/gutenberg/issues/17013#issuecomment-521237613
![gif that shows a paragraph being transformed to a heading in the cover component](https://user-images.githubusercontent.com/6165348/63295506-b9514380-c2c4-11e9-974e-e5484719933d.gif)
