### PR TITLE
FIX > Snackbar | Press Link

### DIFF
--- a/packages/components/src/snackbar/style.scss
+++ b/packages/components/src/snackbar/style.scss
@@ -41,6 +41,12 @@
 			text-decoration: none;
 		}
 	}
+
+	&:focus {
+		background-color: transparent;
+		box-shadow: none;
+		color: $white;
+	}
 }
 
 .components-snackbar__content {


### PR DESCRIPTION
Hallo :) 
**So now I have fixed this Bug with the Snackbar 
Presslink on hover > focus state:**
https://github.com/WordPress/gutenberg/issues/16535 

After correction the _"Open Page Link"_ works fine :) 

**Here one screenshot:** 
![Bildschirmfoto 2019-08-19 um 23 20 37](https://user-images.githubusercontent.com/15845265/63301532-0cce8c00-c2db-11e9-908d-561a50e0537f.png)

When user hover on link the text-decoration is set to none. 