### PR TITLE
Add truthy check for the Popover component onClose prop before calling it.

### DIFF
--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -324,7 +324,9 @@ const Popover = ( {
 			onFocusOutside( event );
 			return;
 		} else if ( ! onClickOutside ) {
-			onClose();
+			if ( onClose ) {
+				onClose();
+			}
 			return;
 		}
 


### PR DESCRIPTION
## Description
The Popover component accepts an `onClose` prop which is marked as not required in the [component docs](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/popover#onclose). Though invoking and interacting with this component _without_ the `onClose` prop raises an `Uncaught TypeError`.

i.e.
```
Uncaught TypeError: onClose is not a function
    at Object.handleOnFocusOutside [as onFocusOutside] (index.js?ver=1566273997:45399)
    at PopoverDetectOutside.handleFocusOutside (index.js?ver=1566273997:45012)
    at index.js?ver=1566273997:41965
```

This is because the Popover component attempts to call this prop even when the current value is `undefined`.

This PR introduces a simple truthy to mitigate this.

## How has this been tested?
This was tested locally against the latest `master`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
