### PR TITLE
Add: Disabled block count in the block manager

### DIFF
--- a/packages/edit-post/src/components/manage-blocks-modal/manager.js
+++ b/packages/edit-post/src/components/manage-blocks-modal/manager.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter } from 'lodash';
+import { filter, isArray } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -9,7 +9,7 @@ import { filter } from 'lodash';
 import { withSelect } from '@wordpress/data';
 import { compose, withState } from '@wordpress/compose';
 import { TextControl } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -23,6 +23,7 @@ function BlockManager( {
 	categories,
 	hasBlockSupport,
 	isMatchingSearchTerm,
+	numberOfHiddenBlocks,
 } ) {
 	// Filtering occurs here (as opposed to `withSelect`) to avoid wasted
 	// wasted renders by consequence of `Array#filter` producing a new
@@ -43,6 +44,20 @@ function BlockManager( {
 				} ) }
 				className="edit-post-manage-blocks-modal__search"
 			/>
+			{ !! numberOfHiddenBlocks && (
+				<div className="edit-post-manage-blocks-modal__disabled-blocks-count">
+					{
+						sprintf(
+							_n(
+								'%1$d block is disabled.',
+								'%1$d blocks are disabled.',
+								numberOfHiddenBlocks
+							),
+							numberOfHiddenBlocks
+						)
+					}
+				</div>
+			) }
 			<div
 				tabIndex="0"
 				role="region"
@@ -77,12 +92,16 @@ export default compose( [
 			hasBlockSupport,
 			isMatchingSearchTerm,
 		} = select( 'core/blocks' );
+		const { getPreference } = select( 'core/edit-post' );
+		const hiddenBlockTypes = getPreference( 'hiddenBlockTypes' );
+		const numberOfHiddenBlocks = isArray( hiddenBlockTypes ) && hiddenBlockTypes.length;
 
 		return {
 			blockTypes: getBlockTypes(),
 			categories: getCategories(),
 			hasBlockSupport,
 			isMatchingSearchTerm,
+			numberOfHiddenBlocks,
 		};
 	} ),
 ] )( BlockManager );

--- a/packages/edit-post/src/components/manage-blocks-modal/style.scss
+++ b/packages/edit-post/src/components/manage-blocks-modal/style.scss
@@ -45,6 +45,17 @@
 	}
 }
 
+.edit-post-manage-blocks-modal__disabled-blocks-count {
+	border-top: 1px solid $light-gray-500;
+	margin-left: -$grid-size-xlarge;
+	margin-right: -$grid-size-xlarge;
+	padding-top: 0.6rem;
+	padding-bottom: 0.6rem;
+	padding-left: $grid-size-xlarge;
+	padding-right: $grid-size-xlarge;
+	background-color: $light-gray-200;
+}
+
 .edit-post-manage-blocks-modal__category {
 	margin: 0 0 2rem 0;
 }


### PR DESCRIPTION
## Description
Part of: https://github.com/WordPress/gutenberg/issues/15121

This PR adds a disabled block count to the block manager.
## How has this been tested?
I opened the block manager with no disabled blocks and verified no count appears.
I opened the block manager with one disabled block and verified the message "1 block is disabled." appears.
I opened the block manager with eleven disabled blocks and verified the message "11 blocks are disabled." appears.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/11271197/63339469-df1a2f00-c33c-11e9-830b-bdda35f9b397.png)


![image](https://user-images.githubusercontent.com/11271197/63339474-e0e3f280-c33c-11e9-9907-7d49a045b76d.png)

