### PR TITLE
MobileUpload and MobilePlaceholder unify props

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/README.md
+++ b/packages/block-editor/src/components/media-placeholder/README.md
@@ -37,6 +37,7 @@ This property is similar to the `allowedTypes` property. The difference is the f
 
 - Type: `String`
 - Required: No
+- Platform: Web
 
 ### addToGallery
 
@@ -46,6 +47,7 @@ If false the gallery media modal opens in the edit mode where the user can edit 
 - Type: `Boolean`
 - Required: No
 - Default: `false`
+- Platform: Web
 
 ### allowedTypes
 
@@ -57,6 +59,7 @@ This property is similar to the `accept` property. The difference is the format 
 
 - Type: `Array`
 - Required: No
+- Platform: Web | Mobile
 
 ### className
 
@@ -64,6 +67,7 @@ Class name added to the placeholder.
 
 - Type: `String`
 - Required: No
+- Platform: Web
 
 ### icon
 
@@ -71,6 +75,7 @@ Icon to display left of the title. When passed as a `String`, the icon will be r
 
 - Type: `String|WPComponent`
 - Required: No
+- Platform: Web | Mobile
 
 ### isAppender
 
@@ -80,6 +85,7 @@ If false the default placeholder style is used.
 - Type: `Boolean`
 - Required: No
 - Default: `false`
+- Platform: Web
 
 ### labels
 
@@ -87,7 +93,7 @@ An object that can contain a `title` and `instructions` properties. These proper
 
 - Type: `Object`
 - Required: No
-
+- Platform: Web | Mobile
 
 ### multiple
 
@@ -96,6 +102,7 @@ Whether to allow multiple selection of files or not.
 - Type: `Boolean`
 - Required: No
 - Default: `false`
+- Platform: Web
 
 ### onError
 
@@ -103,6 +110,7 @@ Callback called when an upload error happens.
 
 - Type: `Function`
 - Required: No
+- Platform: Web
 
 ### onSelect
 
@@ -111,6 +119,7 @@ The call back receives an array with the new files. Each element of the collecti
 
 - Type: `Function`
 - Required: Yes
+- Platform: Web | Mobile
 
 ### value
 
@@ -118,6 +127,7 @@ Media ID (or media IDs if multiple is true) to be selected by default when openi
 
 - Type: `Number|Array`
 - Required: No
+- Platform: Web
 
 
 ## Extend

--- a/packages/block-editor/src/components/media-placeholder/index.native.js
+++ b/packages/block-editor/src/components/media-placeholder/index.native.js
@@ -48,8 +48,8 @@ function MediaPlaceholder( props ) {
 
 	return (
 		<MediaUpload
-			allowedTypes={ [ mediaType ] }
-			onSelect={ onSelectURL }
+			allowedTypes={ allowedTypes }
+			onSelect={ onSelect }
 			render={ ( { open, getMediaOptions } ) => {
 				return (
 					<TouchableWithoutFeedback

--- a/packages/block-editor/src/components/media-placeholder/index.native.js
+++ b/packages/block-editor/src/components/media-placeholder/index.native.js
@@ -65,7 +65,7 @@ function MediaPlaceholder( props ) {
 							open();
 						} }
 					>
-						<View style={ [ styles.emptyStateContainer ] }>
+						<View style={ styles.emptyStateContainer }>
 							{ getMediaOptions() }
 							<View style={ styles.modalIcon }>
 								{ icon }

--- a/packages/block-editor/src/components/media-placeholder/index.native.js
+++ b/packages/block-editor/src/components/media-placeholder/index.native.js
@@ -15,7 +15,7 @@ import { MediaUpload, MEDIA_TYPE_IMAGE, MEDIA_TYPE_VIDEO } from '@wordpress/bloc
 import styles from './styles.scss';
 
 function MediaPlaceholder( props ) {
-	const { allowedTypes, labels = {}, icon, onSelect, isAppender } = props;
+	const { allowedTypes, labels = {}, icon, onSelect } = props;
 
 	const isImage = MEDIA_TYPE_IMAGE === allowedTypes[ 0 ];
 	const isVideo = MEDIA_TYPE_VIDEO === allowedTypes[ 0 ];
@@ -65,7 +65,7 @@ function MediaPlaceholder( props ) {
 							open();
 						} }
 					>
-						<View style={ [ styles.emptyStateContainer, isAppender && styles.isAppender ] }>
+						<View style={ [ styles.emptyStateContainer ] }>
 							{ getMediaOptions() }
 							<View style={ styles.modalIcon }>
 								{ icon }

--- a/packages/block-editor/src/components/media-placeholder/index.native.js
+++ b/packages/block-editor/src/components/media-placeholder/index.native.js
@@ -15,10 +15,10 @@ import { MediaUpload, MEDIA_TYPE_IMAGE, MEDIA_TYPE_VIDEO } from '@wordpress/bloc
 import styles from './styles.scss';
 
 function MediaPlaceholder( props ) {
-	const { mediaType, labels = {}, icon, onSelectURL } = props;
+	const { allowedTypes, labels = {}, icon, onSelect, isAppender } = props;
 
-	const isImage = MEDIA_TYPE_IMAGE === mediaType;
-	const isVideo = MEDIA_TYPE_VIDEO === mediaType;
+	const isImage = MEDIA_TYPE_IMAGE === allowedTypes[ 0 ];
+	const isVideo = MEDIA_TYPE_VIDEO === allowedTypes[ 0 ];
 
 	let placeholderTitle = labels.title;
 	if ( placeholderTitle === undefined ) {
@@ -65,7 +65,7 @@ function MediaPlaceholder( props ) {
 							open();
 						} }
 					>
-						<View style={ styles.emptyStateContainer }>
+						<View style={ [ styles.emptyStateContainer, isAppender && styles.isAppender ] }>
 							{ getMediaOptions() }
 							<View style={ styles.modalIcon }>
 								{ icon }

--- a/packages/block-editor/src/components/media-placeholder/index.native.js
+++ b/packages/block-editor/src/components/media-placeholder/index.native.js
@@ -48,8 +48,8 @@ function MediaPlaceholder( props ) {
 
 	return (
 		<MediaUpload
-			mediaType={ mediaType }
-			onSelectURL={ onSelectURL }
+			allowedTypes={ [ mediaType ] }
+			onSelect={ onSelectURL }
 			render={ ( { open, getMediaOptions } ) => {
 				return (
 					<TouchableWithoutFeedback

--- a/packages/block-editor/src/components/media-placeholder/styles.native.scss
+++ b/packages/block-editor/src/components/media-placeholder/styles.native.scss
@@ -33,3 +33,9 @@
 	align-items: center;
 	fill: $gray-dark;
 }
+
+.isAppender {
+	border: $border-width dashed $dark-gray-150;
+	background-color: $gray-light;
+	height: auto;
+}

--- a/packages/block-editor/src/components/media-placeholder/styles.native.scss
+++ b/packages/block-editor/src/components/media-placeholder/styles.native.scss
@@ -33,9 +33,3 @@
 	align-items: center;
 	fill: $gray-dark;
 }
-
-.isAppender {
-	border: $border-width dashed $dark-gray-150;
-	background-color: $gray-light;
-	height: auto;
-}

--- a/packages/block-editor/src/components/media-upload/README.md
+++ b/packages/block-editor/src/components/media-upload/README.md
@@ -63,6 +63,7 @@ If allowedTypes is unset all mime types should be allowed.
 
 - Type: `Array`
 - Required: No
+- Platform: Web | Mobile
 
 ### multiple
 
@@ -71,6 +72,7 @@ Whether to allow multiple selections or not.
 - Type: `Boolean`
 - Required: No
 - Default: false
+- Platform: Web
 
 ### value
 
@@ -78,6 +80,7 @@ Media ID (or media IDs if multiple is true) to be selected by default when openi
 
 - Type: `Number|Array`
 - Required: No
+- Platform: Web
 
 ### onSelect
 
@@ -85,6 +88,7 @@ Callback called when the media modal is closed, the selected media are passed as
 
 - Type: `Function`
 - Required: Yes
+- Platform: Web | Mobile
 
 ### title
 
@@ -93,6 +97,7 @@ Title displayed in the media modal.
 - Type: `String`
 - Required: No
 - Default: `Select or Upload Media`
+- Platform: Web
 
 ### modalClass
 
@@ -100,7 +105,7 @@ CSS class added to the media modal frame.
 
 - Type: `String`
 - Required: No
-
+- Platform: Web
 
 ### addToGallery
 
@@ -111,6 +116,7 @@ Only applies if `gallery === true`.
 - Type: `Boolean`
 - Required: No
 - Default: `false`
+- Platform: Web
 
 ### gallery
 
@@ -119,6 +125,7 @@ If true, the component will initiate all the states required to represent a gall
 - Type: `Boolean`
 - Required: No
 - Default: `false`
+- Platform: Web
 
 ## render
 
@@ -126,6 +133,7 @@ A callback invoked to render the Button opening the media library.
 
 - Type: `Function`
 - Required: Yes
+- Platform: Web | Mobile
 
 The first argument of the callback is an object containing the following properties:
 

--- a/packages/block-editor/src/components/media-upload/index.native.js
+++ b/packages/block-editor/src/components/media-upload/index.native.js
@@ -79,7 +79,7 @@ export class MediaUpload extends React.Component {
 		const { allowedTypes, onSelect } = this.props;
 		requestFunction( allowedTypes, ( mediaId, mediaUrl ) => {
 			if ( mediaId ) {
-				onSelect( mediaId, mediaUrl );
+				onSelect( { mediaId, mediaUrl } );
 			}
 		} );
 	}

--- a/packages/block-editor/src/components/media-upload/index.native.js
+++ b/packages/block-editor/src/components/media-upload/index.native.js
@@ -26,7 +26,8 @@ export const OPTION_TAKE_PHOTO = __( 'Take a Photo' );
 
 export class MediaUpload extends React.Component {
 	getTakeMediaLabel() {
-		const { mediaType } = this.props;
+		const { allowedTypes } = this.props;
+		const mediaType = allowedTypes[ 0 ];
 
 		if ( mediaType === MEDIA_TYPE_IMAGE ) {
 			return OPTION_TAKE_PHOTO;
@@ -44,7 +45,8 @@ export class MediaUpload extends React.Component {
 	}
 
 	getChooseFromDeviceIcon() {
-		const { mediaType } = this.props;
+		const { allowedTypes } = this.props;
+		const mediaType = allowedTypes[ 0 ];
 
 		if ( mediaType === MEDIA_TYPE_IMAGE ) {
 			return 'format-image';
@@ -61,58 +63,44 @@ export class MediaUpload extends React.Component {
 		return 'wordpress-alt';
 	}
 
+	onPickerPresent = () => {
+		if ( this.picker ) {
+			this.picker.presentPicker();
+		}
+	};
+
+	onPickerSelect = ( requestFunction ) => {
+		const { allowedTypes, onSelect } = this.props;
+		requestFunction( allowedTypes, ( mediaId, mediaUrl ) => {
+			if ( mediaId ) {
+				onSelect( mediaId, mediaUrl );
+			}
+		} );
+	}
+
+	onPickerChange = ( value ) => {
+		if ( value === MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_CHOOSE_FROM_DEVICE ) {
+			this.onPickerSelect( requestMediaPickFromDeviceLibrary );
+		} else if ( value === MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_TAKE_MEDIA ) {
+			this.onPickerSelect( requestMediaPickFromDeviceCamera );
+		} else if ( value === MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_WORD_PRESS_LIBRARY ) {
+			this.onPickerSelect( requestMediaPickFromMediaLibrary );
+		}
+	}
+
 	render() {
-		const { mediaType } = this.props;
-
-		const onMediaLibraryButtonPressed = () => {
-			requestMediaPickFromMediaLibrary( [ mediaType ], ( mediaId, mediaUrl ) => {
-				if ( mediaId ) {
-					this.props.onSelectURL( mediaId, mediaUrl );
-				}
-			} );
-		};
-
-		const onMediaUploadButtonPressed = () => {
-			requestMediaPickFromDeviceLibrary( [ mediaType ], ( mediaId, mediaUrl ) => {
-				if ( mediaId ) {
-					this.props.onSelectURL( mediaId, mediaUrl );
-				}
-			} );
-		};
-
-		const onMediaCaptureButtonPressed = () => {
-			requestMediaPickFromDeviceCamera( [ mediaType ], ( mediaId, mediaUrl ) => {
-				if ( mediaId ) {
-					this.props.onSelectURL( mediaId, mediaUrl );
-				}
-			} );
-		};
-
 		const mediaOptions = this.getMediaOptionsItems();
-
-		let picker;
-
-		const onPickerPresent = () => {
-			picker.presentPicker();
-		};
 
 		const getMediaOptions = () => (
 			<Picker
 				hideCancelButton={ true }
-				ref={ ( instance ) => picker = instance }
+				ref={ ( instance ) => this.picker = instance }
 				options={ mediaOptions }
-				onChange={ ( value ) => {
-					if ( value === MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_CHOOSE_FROM_DEVICE ) {
-						onMediaUploadButtonPressed();
-					} else if ( value === MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_TAKE_MEDIA ) {
-						onMediaCaptureButtonPressed();
-					} else if ( value === MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_WORD_PRESS_LIBRARY ) {
-						onMediaLibraryButtonPressed();
-					}
-				} }
+				onChange={ this.onPickerChange }
 			/>
 		);
-		return this.props.render( { open: onPickerPresent, getMediaOptions } );
+
+		return this.props.render( { open: this.onPickerPresent, getMediaOptions } );
 	}
 }
 

--- a/packages/block-editor/src/components/media-upload/index.native.js
+++ b/packages/block-editor/src/components/media-upload/index.native.js
@@ -25,6 +25,12 @@ export const OPTION_TAKE_VIDEO = __( 'Take a Video' );
 export const OPTION_TAKE_PHOTO = __( 'Take a Photo' );
 
 export class MediaUpload extends React.Component {
+	constructor( props ) {
+		super( props );
+		this.onPickerPresent = this.onPickerPresent.bind( this );
+		this.onPickerChange = this.onPickerChange.bind( this );
+		this.onPickerSelect = this.onPickerSelect.bind( this );
+	}
 	getTakeMediaLabel() {
 		const { allowedTypes } = this.props;
 		const mediaType = allowedTypes[ 0 ];
@@ -63,13 +69,13 @@ export class MediaUpload extends React.Component {
 		return 'wordpress-alt';
 	}
 
-	onPickerPresent = () => {
+	onPickerPresent() {
 		if ( this.picker ) {
 			this.picker.presentPicker();
 		}
-	};
+	}
 
-	onPickerSelect = ( requestFunction ) => {
+	onPickerSelect( requestFunction ) {
 		const { allowedTypes, onSelect } = this.props;
 		requestFunction( allowedTypes, ( mediaId, mediaUrl ) => {
 			if ( mediaId ) {
@@ -78,7 +84,7 @@ export class MediaUpload extends React.Component {
 		} );
 	}
 
-	onPickerChange = ( value ) => {
+	onPickerChange( value ) {
 		if ( value === MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_CHOOSE_FROM_DEVICE ) {
 			this.onPickerSelect( requestMediaPickFromDeviceLibrary );
 		} else if ( value === MEDIA_UPLOAD_BOTTOM_SHEET_VALUE_TAKE_MEDIA ) {

--- a/packages/block-editor/src/components/media-upload/test/index.native.js
+++ b/packages/block-editor/src/components/media-upload/test/index.native.js
@@ -29,14 +29,14 @@ const MEDIA_ID = 123;
 describe( 'MediaUpload component', () => {
 	it( 'renders without crashing', () => {
 		const wrapper = shallow(
-			<MediaUpload render={ () => {} } />
+			<MediaUpload allowedTypes={ [] } render={ () => {} } />
 		);
 		expect( wrapper ).toBeTruthy();
 	} );
 
 	it( 'opens media options picker', () => {
 		const wrapper = shallow(
-			<MediaUpload render={ ( { open, getMediaOptions } ) => {
+			<MediaUpload allowedTypes={ [] } render={ ( { open, getMediaOptions } ) => {
 				return (
 					<TouchableWithoutFeedback onPress={ open }>
 						{ getMediaOptions() }
@@ -51,7 +51,7 @@ describe( 'MediaUpload component', () => {
 		const expectOptionForMediaType = ( mediaType, expectedOption ) => {
 			const wrapper = shallow(
 				<MediaUpload
-					mediaType={ mediaType }
+					allowedTypes={ [ mediaType ] }
 					render={ ( { open, getMediaOptions } ) => {
 						return (
 							<TouchableWithoutFeedback onPress={ open }>
@@ -72,12 +72,12 @@ describe( 'MediaUpload component', () => {
 			callback( MEDIA_ID, MEDIA_URL );
 		} );
 
-		const onSelectURL = jest.fn();
+		const onSelect = jest.fn();
 
 		const wrapper = shallow(
 			<MediaUpload
-				mediaType={ MEDIA_TYPE_VIDEO }
-				onSelectURL={ onSelectURL }
+				allowedTypes={ [ MEDIA_TYPE_VIDEO ] }
+				onSelect={ onSelect }
 				render={ ( { open, getMediaOptions } ) => {
 					return (
 						<TouchableWithoutFeedback onPress={ open }>
@@ -89,8 +89,8 @@ describe( 'MediaUpload component', () => {
 		wrapper.find( 'Picker' ).simulate( 'change', option );
 		expect( requestFunction ).toHaveBeenCalledTimes( 1 );
 
-		expect( onSelectURL ).toHaveBeenCalledTimes( 1 );
-		expect( onSelectURL ).toHaveBeenCalledWith( MEDIA_ID, MEDIA_URL );
+		expect( onSelect ).toHaveBeenCalledTimes( 1 );
+		expect( onSelect ).toHaveBeenCalledWith( MEDIA_ID, MEDIA_URL );
 	};
 
 	it( 'can select media from device library', () => {

--- a/packages/block-editor/src/components/media-upload/test/index.native.js
+++ b/packages/block-editor/src/components/media-upload/test/index.native.js
@@ -87,10 +87,12 @@ describe( 'MediaUpload component', () => {
 				} } />
 		);
 		wrapper.find( 'Picker' ).simulate( 'change', option );
+		const media = { mediaId: MEDIA_ID, mediaUrl: MEDIA_URL };
+
 		expect( requestFunction ).toHaveBeenCalledTimes( 1 );
 
 		expect( onSelect ).toHaveBeenCalledTimes( 1 );
-		expect( onSelect ).toHaveBeenCalledWith( MEDIA_ID, MEDIA_URL );
+		expect( onSelect ).toHaveBeenCalledWith( media );
 	};
 
 	it( 'can select media from device library', () => {

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -260,8 +260,8 @@ class ImageEdit extends React.Component {
 			return (
 				<View style={ { flex: 1 } } >
 					<MediaPlaceholder
-						mediaType={ MEDIA_TYPE_IMAGE }
-						onSelectURL={ this.onSelectMediaUploadOption }
+						allowedTypes={ [ MEDIA_TYPE_IMAGE ] }
+						onSelect={ this.onSelectMediaUploadOption }
 						icon={ this.getIcon( false ) }
 						onFocus={ this.props.onFocus }
 					/>

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -358,8 +358,8 @@ class ImageEdit extends React.Component {
 		);
 
 		return (
-			<MediaUpload mediaType={ MEDIA_TYPE_IMAGE }
-				onSelectURL={ this.onSelectMediaUploadOption }
+			<MediaUpload allowedTypes={ [ MEDIA_TYPE_IMAGE ] }
+				onSelect={ this.onSelectMediaUploadOption }
 				render={ ( { open, getMediaOptions } ) => {
 					return getImageComponent( open, getMediaOptions );
 				} }

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -175,7 +175,7 @@ class ImageEdit extends React.Component {
 		} );
 	}
 
-	onSelectMediaUploadOption( mediaId, mediaUrl ) {
+	onSelectMediaUploadOption( { mediaId, mediaUrl } ) {
 		const { setAttributes } = this.props;
 		setAttributes( { url: mediaUrl, id: mediaId } );
 	}

--- a/packages/block-library/src/video/edit.native.js
+++ b/packages/block-library/src/video/edit.native.js
@@ -182,7 +182,7 @@ class VideoEdit extends React.Component {
 				<View style={ { flex: 1 } } >
 					<MediaPlaceholder
 						mediaType={ MEDIA_TYPE_VIDEO }
-						onSelectURL={ this.onSelectMediaUploadOption }
+						onSelect={ this.onSelectMediaUploadOption }
 						icon={ this.getIcon( false, true ) }
 						onFocus={ this.props.onFocus }
 					/>

--- a/packages/block-library/src/video/edit.native.js
+++ b/packages/block-library/src/video/edit.native.js
@@ -160,8 +160,8 @@ class VideoEdit extends React.Component {
 		const { videoContainerHeight } = this.state;
 
 		const toolbarEditButton = (
-			<MediaUpload mediaType={ MEDIA_TYPE_VIDEO }
-				onSelectURL={ this.onSelectMediaUploadOption }
+			<MediaUpload allowedTypes={ [ MEDIA_TYPE_VIDEO ] }
+				onSelect={ this.onSelectMediaUploadOption }
 				render={ ( { open, getMediaOptions } ) => {
 					return (
 						<Toolbar>

--- a/packages/block-library/src/video/edit.native.js
+++ b/packages/block-library/src/video/edit.native.js
@@ -133,7 +133,7 @@ class VideoEdit extends React.Component {
 		this.setState( { isUploadInProgress: false } );
 	}
 
-	onSelectMediaUploadOption( mediaId, mediaUrl ) {
+	onSelectMediaUploadOption( { mediaId, mediaUrl } ) {
 		const { setAttributes } = this.props;
 		setAttributes( { id: mediaId, src: mediaUrl } );
 	}


### PR DESCRIPTION
## Description
This PR unifies web and mobile props for MediaUpload and MediaPlaceholder components. It is the first iteration where we do not support `multiple` select images/videos.

See https://github.com/wordpress-mobile/gutenberg-mobile/issues/1298 and https://github.com/wordpress-mobile/gutenberg-mobile/issues/1299

## How has this been tested?
Tested manually on web and mobile (local gutenber, Wordpress-iOS, Wordpress-Android):
- added image/video block to the page from the device, saved and checked if media is uploaded and rendered properly (Wordpress-iOS, Wordpress-Android)
- added image/video block to the page from Wordpress Media Library

All unit and e2e tests passed
All UI tests passed on Wordpress-iOS

## Screenshots <!-- if applicable -->

## Types of changes
Change props for mobile implementation of MobileUpload and MobilePlaceholder component.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
