### PR TITLE
Trim inserter help panel copy

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -382,17 +382,12 @@ export class InserterMenu extends Component {
 									<div className="block-editor-inserter__menu-help-panel-title">Content Blocks</div>
 									<p>
 										{ __(
-											'Welcome to the wonderful world of blocks! Blocks are the basis of all content within the editor. '
+											'There are blocks for all sorts of content: insert text, images, videos, and lots more.'
 										) }
 									</p>
 									<p>
 										{ __(
-											'There are blocks available for all kinds of content: insert text, headings, images, lists, videos, tables, and lots more.'
-										) }
-									</p>
-									<p>
-										{ __(
-											'Browse through the library to learn more about what each block does.'
+											'Browse the library to learn about what each block does.'
 										) }
 									</p>
 								</div>

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -382,7 +382,7 @@ export class InserterMenu extends Component {
 									<div className="block-editor-inserter__menu-help-panel-title">Content Blocks</div>
 									<p>
 										{ __(
-											'There are blocks for all sorts of content: insert text, images, videos, and lots more.'
+											'Insert blocks for all kinds of content: text, images, videos, and lots more.'
 										) }
 									</p>
 									<p>

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -382,18 +382,18 @@ export class InserterMenu extends Component {
 									<div className="block-editor-inserter__menu-help-panel-title">Content Blocks</div>
 									<p>
 										{ __(
-											'Insert blocks for all kinds of content: text, images, videos, and lots more.'
+											'Add blocks for all kinds of content: text, images, videos, and lots more.'
 										) }
 									</p>
 									<p>
 										{ __(
-											'Browse the library to learn about what each block does.'
+											'Browse the library to learn what each block does.'
 										) }
 									</p>
 								</div>
 								<Tip>
 									{ __(
-										'While writing, you can press "/" to quickly insert new blocks.'
+										'While writing, you can press "/" to quickly add new blocks.'
 									) }
 								</Tip>
 							</div>


### PR DESCRIPTION
This PR does a quick trim of the inserter panel's copy. Three paragraphs is a lot to read, and I think we can say the same thing with less text. 

We'll have other opportunities for more in-depth education (https://github.com/WordPress/gutenberg/issues/16315#issuecomment-516112054 for instance), but since this text be seen frequently, it makes sense to keep it light. 

---

**Before:** 

<img width="814" alt="Screen Shot 2019-08-20 at 11 41 47 AM" src="https://user-images.githubusercontent.com/1202812/63362334-a7f94d00-c33f-11e9-9b77-1f0b0332e614.png">

> Welcome to the wonderful world of blocks! Blocks are the basis of all content within the editor.
> 
> There are blocks available for all kinds of content: insert text, headings, images, lists, videos, tables, and lots more.
> 
> Browse through the library to learn more about what each block does.

**After:**

<img width="814" alt="Screen Shot 2019-08-20 at 11 46 11 AM" src="https://user-images.githubusercontent.com/1202812/63362643-2ce46680-c340-11e9-86c5-941eb3479e0c.png">

> Insert blocks for all kinds of content: text, images, videos, and lots more.
> 
> Browse the library to learn about what each block does.