### PR TITLE
Fix: Block toolbar appears above sidebar on medium viewports

### DIFF
--- a/assets/stylesheets/_z-index.scss
+++ b/assets/stylesheets/_z-index.scss
@@ -46,24 +46,24 @@ $z-layers: (
 	".block-editor-block-list__block-edit .reusable-block-edit-panel *": 1,
 
 	// Show drop zone above most standard content, but below any overlays
-	".components-drop-zone": 100,
-	".components-drop-zone__content": 110,
+	".components-drop-zone": 40,
+	".components-drop-zone__content": 50,
 
 	// The block mover for floats should overlap the controls of adjacent blocks.
-	".block-editor-block-list__block {core/image aligned left or right}": 81,
+	".block-editor-block-list__block {core/image aligned left or right}": 21,
 
 	// Small screen inner blocks overlay must be displayed above drop zone,
 	// settings menu, and movers.
-	".block-editor-inner-blocks.has-overlay::after": 120,
+	".block-editor-inner-blocks.has-overlay::after": 60,
 
 	// The toolbar, when contextual, should be above any adjacent nested block click overlays.
-	".block-editor-block-list__layout .reusable-block-edit-panel": 121,
-	".block-editor-block-contextual-toolbar": 121,
-	".editor-inner-blocks .block-editor-block-list__breadcrumb": 122,
+	".block-editor-block-list__layout .reusable-block-edit-panel": 61,
+	".block-editor-block-contextual-toolbar": 61,
+	".editor-inner-blocks .block-editor-block-list__breadcrumb": 62,
 
 	// The block mover, particularly in nested contexts,
 	// should overlap most block content.
-	".block-editor-block-list__block.is-{selected,hovered} .block-editor-block-mover": 121,
+	".block-editor-block-list__block.is-{selected,hovered} .block-editor-block-mover": 61,
 
 	// Show sidebar above wp-admin navigation bar for mobile viewports:
 	// #wpadminbar { z-index: 99999 }


### PR DESCRIPTION
## Description
The `.edit-post-sidebar {greater than small}` z index is 90 so it is bellow some wp admin UI.
The block movers z-index, dropzone, and other block related UI range between 100 to 122.
This causes a problem on medium screens block related UI appears above the block sidebar making the sidebar hard to use. It is also possible to drag things and to the sidebar and trigger upload actions.

This PR decreases the block related UI elements by 60 so the values are lower than the sidebar z-index of 90.

## How has this been tested?
I set a screen width of 768.
I created some blocks and made the toolbar and block movers visible.
I opened the sidebar and verified the block UI is not visible.
I tried to drag a file to the sidebar and verified the drop zone indication did not appear.

## Screenshots <!-- if applicable -->
Before:
<img width="572" alt="Screenshot 2019-08-20 at 17 27 06" src="https://user-images.githubusercontent.com/11271197/63366251-3a661480-c371-11e9-8ed2-d6b80ec85938.png">
![Aug-20-2019 17-29-00](https://user-images.githubusercontent.com/11271197/63366284-44881300-c371-11e9-9b55-3636c0f83bad.gif)


