### PR TITLE
RNMobile: Fix crash when viewing HTML on iOS

### DIFF
--- a/packages/edit-post/src/components/layout/index.native.js
+++ b/packages/edit-post/src/components/layout/index.native.js
@@ -101,8 +101,10 @@ class Layout extends Component {
 			mode,
 		} = this.props;
 
+		const isHtmlView = mode === 'text';
+
 		// add a margin view at the bottom for the header
-		const marginBottom = Platform.OS === 'android' ? headerToolbarStyles.container.height : 0;
+		const marginBottom = Platform.OS === 'android' && ! isHtmlView ? headerToolbarStyles.container.height : 0;
 
 		const toolbarKeyboardAvoidingViewStyle = {
 			...styles.toolbarKeyboardAvoidingView,
@@ -114,16 +116,17 @@ class Layout extends Component {
 		return (
 			<SafeAreaView style={ useStyle( styles.container, styles.containerDark, this.props.theme ) } onLayout={ this.onRootViewLayout }>
 				<View style={ useStyle( styles.background, styles.backgroundDark, this.props.theme ) }>
-					{ mode === 'text' ? this.renderHTML() : this.renderVisual() }
+					{ isHtmlView ? this.renderHTML() : this.renderVisual() }
 				</View>
 				<View style={ { flex: 0, flexBasis: marginBottom, height: marginBottom } }>
 				</View>
-				<KeyboardAvoidingView
-					parentHeight={ this.state.rootViewHeight }
-					style={ toolbarKeyboardAvoidingViewStyle }
-				>
-					<Header />
-				</KeyboardAvoidingView>
+				{ ! isHtmlView && (
+					<KeyboardAvoidingView
+						parentHeight={ this.state.rootViewHeight }
+						style={ toolbarKeyboardAvoidingViewStyle }
+					>
+						<Header />
+					</KeyboardAvoidingView> ) }
 			</SafeAreaView>
 		);
 	}

--- a/packages/edit-post/src/components/layout/index.native.js
+++ b/packages/edit-post/src/components/layout/index.native.js
@@ -75,7 +75,7 @@ class Layout extends Component {
 
 	renderHTML() {
 		return (
-			<HTMLTextInput />
+			<HTMLTextInput parentHeight={ this.state.rootViewHeight } />
 		);
 	}
 


### PR DESCRIPTION
## Description
This fixes an error that occurred on iOS when switching to HTML mode and attempting to edit the html: [gutenberg-mobile#1303](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1303). This occurred because during a recent refactor a change was made to [no longer pass a required number prop](https://github.com/WordPress/gutenberg/commit/509da5c5a8788be7ae106fee94d9e9b0bb4fc4e7#diff-3c2c00624c829c2168a35faf5ee6c376L76), which caused subsequent subtraction using that prop to result in `NAN` being used for padding in the HTML view.

## How has this been tested?
Tested on both the demo app and WPiOS. Also verified no regressions on Android.
1. Load iOS App
2. Switch to HTML view
3. Edit HTML
4. Observe no red screen

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
