### PR TITLE
Add disable support to PostStatus settings panel

### DIFF
--- a/packages/e2e-tests/specs/sidebar.test.js
+++ b/packages/e2e-tests/specs/sidebar.test.js
@@ -115,6 +115,7 @@ describe( 'Sidebar', () => {
 		expect( await findSidebarPanelWithTitle( 'Featured Image' ) ).toBeDefined();
 		expect( await findSidebarPanelWithTitle( 'Excerpt' ) ).toBeDefined();
 		expect( await findSidebarPanelWithTitle( 'Discussion' ) ).toBeDefined();
+		expect( await findSidebarPanelWithTitle( 'Status & Visibility' ) ).toBeDefined();
 
 		await page.evaluate( () => {
 			const { removeEditorPanel } = wp.data.dispatch( 'core/edit-post' );

--- a/packages/e2e-tests/specs/sidebar.test.js
+++ b/packages/e2e-tests/specs/sidebar.test.js
@@ -124,6 +124,7 @@ describe( 'Sidebar', () => {
 			removeEditorPanel( 'featured-image' );
 			removeEditorPanel( 'post-excerpt' );
 			removeEditorPanel( 'discussion-panel' );
+			removeEditorPanel( 'post-status' );
 		} );
 
 		expect( await findSidebarPanelWithTitle( 'Categories' ) ).toBeUndefined();
@@ -131,5 +132,6 @@ describe( 'Sidebar', () => {
 		expect( await findSidebarPanelWithTitle( 'Featured Image' ) ).toBeUndefined();
 		expect( await findSidebarPanelWithTitle( 'Excerpt' ) ).toBeUndefined();
 		expect( await findSidebarPanelWithTitle( 'Discussion' ) ).toBeUndefined();
+		expect( await findSidebarPanelWithTitle( 'Status & Visibility' ) ).toBeUndefined();
 	} );
 } );

--- a/packages/edit-post/src/components/sidebar/post-status/index.js
+++ b/packages/edit-post/src/components/sidebar/post-status/index.js
@@ -46,13 +46,15 @@ function PostStatus( { isOpened, onTogglePanel } ) {
 
 export default compose( [
 	withSelect( ( select ) => {
-		const { isEditorPanelEnabled, isEditorPanelOpened } = select( 'core/edit-post' );
+		// We use isEditorPanelRemoved to hide the panel if it was programatically removed. We do
+		// not use isEditorPanelEnabled since this panel should not be disabled through the UI.
+		const { isEditorPanelRemoved, isEditorPanelOpened } = select( 'core/edit-post' );
 		return {
-			isEnabled: isEditorPanelEnabled( PANEL_NAME ),
+			isRemoved: isEditorPanelRemoved( PANEL_NAME ),
 			isOpened: isEditorPanelOpened( PANEL_NAME ),
 		};
 	} ),
-	ifCondition( ( { isEnabled } ) => isEnabled ),
+	ifCondition( ( { isRemoved } ) => isRemoved ),
 	withDispatch( ( dispatch ) => ( {
 		onTogglePanel() {
 			return dispatch( 'core/edit-post' ).toggleEditorPanelOpened( PANEL_NAME );

--- a/packages/edit-post/src/components/sidebar/post-status/index.js
+++ b/packages/edit-post/src/components/sidebar/post-status/index.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { PanelBody } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { compose, ifCondition } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -45,9 +45,14 @@ function PostStatus( { isOpened, onTogglePanel } ) {
 }
 
 export default compose( [
-	withSelect( ( select ) => ( {
-		isOpened: select( 'core/edit-post' ).isEditorPanelOpened( PANEL_NAME ),
-	} ) ),
+	withSelect( ( select ) => {
+		const { isEditorPanelEnabled, isEditorPanelOpened } = select( 'core/edit-post' );
+		return {
+			isEnabled: isEditorPanelEnabled( PANEL_NAME ),
+			isOpened: isEditorPanelOpened( PANEL_NAME ),
+		};
+	} ),
+	ifCondition( ( { isEnabled } ) => isEnabled ),
 	withDispatch( ( dispatch ) => ( {
 		onTogglePanel() {
 			return dispatch( 'core/edit-post' ).toggleEditorPanelOpened( PANEL_NAME );

--- a/packages/edit-post/src/components/sidebar/post-status/index.js
+++ b/packages/edit-post/src/components/sidebar/post-status/index.js
@@ -54,7 +54,7 @@ export default compose( [
 			isOpened: isEditorPanelOpened( PANEL_NAME ),
 		};
 	} ),
-	ifCondition( ( { isRemoved } ) => isRemoved ),
+	ifCondition( ( { isRemoved } ) => ! isRemoved ),
 	withDispatch( ( dispatch ) => ( {
 		onTogglePanel() {
 			return dispatch( 'core/edit-post' ).toggleEditorPanelOpened( PANEL_NAME );


### PR DESCRIPTION
While many other panels support the isEditorPanelEnabled option, the `PostStatus` panel does not.  In my own project, I was trying to use `dispatch('core/edit-post').removeEditorPanel( 'post-status' );` to remove this panel in a particular context. I realized that it wasn't working and found that the component did not respect the setting.

Note: I have a PR up here which is the context of finding this bug: https://github.com/Automattic/wp-calypso/pull/35643

## Description
-  If the 'post-status' panel is not enabled, the component now returns null. Previously, it always returned the full Panel regardless of whether it was enabled. I used the prior art of the featured-image panel to make these changes.

## How has this been tested?
1. I tested this fix with my own project and `removeEditorPanel( 'post-status' );` now works correctly from a JS context. (This was using Gutenberg master on the Gutenberg docker setup.)
2. I tried `wp.data.dispatch('core/edit-post').removeEditorPanel( 'post-status' );` from the console on a normal post (outside of my project), and it works correctly. I would recommend this option in order to test this branch.

## Types of changes
- Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
