### PR TITLE
Writing Flow/Quote: allow splitting

### DIFF
--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -9,6 +9,7 @@ import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { AlignmentToolbar, BlockControls, RichText } from '@wordpress/block-editor';
 import { BlockQuotation } from '@wordpress/components';
+import { createBlock } from '@wordpress/blocks';
 
 export default function QuoteEdit( { attributes, setAttributes, isSelected, mergeBlocks, onReplace, className } ) {
 	const { align, value, citation } = attributes;
@@ -47,6 +48,16 @@ export default function QuoteEdit( { attributes, setAttributes, isSelected, merg
 					placeholder={
 						// translators: placeholder text used for the quote
 						__( 'Write quote…' )
+					}
+					onReplace={ onReplace }
+					onSplit={ ( piece ) =>
+						createBlock( 'core/quote', {
+							...attributes,
+							value: piece,
+						} )
+					}
+					__unstableOnSplitMiddle={ () =>
+						createBlock( 'core/paragraph' )
 					}
 				/>
 				{ ( ! RichText.isEmpty( citation ) || isSelected ) && (

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -30,17 +30,23 @@ export const settings = {
 	edit,
 	save,
 	merge( attributes, { value, citation } ) {
+		// Quote citations cannot be merged. Pick the second one unless it's
+		// empty.
+		if ( ! citation ) {
+			citation = attributes.citation;
+		}
+
 		if ( ! value || value === '<p></p>' ) {
 			return {
 				...attributes,
-				citation: attributes.citation + citation,
+				citation,
 			};
 		}
 
 		return {
 			...attributes,
 			value: attributes.value + value,
-			citation: attributes.citation + citation,
+			citation,
 		};
 	},
 	deprecated,

--- a/packages/e2e-tests/specs/blocks/__snapshots__/quote.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/quote.test.js.snap
@@ -80,6 +80,62 @@ exports[`Quote can be merged into from a paragraph 1`] = `
 <!-- /wp:quote -->"
 `;
 
+exports[`Quote can be split at the end and merged back 1`] = `
+"<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p>1</p></blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Quote can be split at the end and merged back 2`] = `
+"<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p>1</p><p></p></blockquote>
+<!-- /wp:quote -->"
+`;
+
+exports[`Quote can be split at the end and merged back 3`] = `
+"<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p>1</p></blockquote>
+<!-- /wp:quote -->"
+`;
+
+exports[`Quote can be split in the middle 1`] = `
+"<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p>1</p><cite>c</cite></blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p>2</p><cite>c</cite></blockquote>
+<!-- /wp:quote -->"
+`;
+
+exports[`Quote can be split in the middle 2`] = `
+"<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p>1</p><p></p><cite>c</cite></blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p>2</p><cite>c</cite></blockquote>
+<!-- /wp:quote -->"
+`;
+
+exports[`Quote can be split in the middle 3`] = `
+"<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p>1</p><cite>c</cite></blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p>2</p><cite>c</cite></blockquote>
+<!-- /wp:quote -->"
+`;
+
 exports[`Quote is transformed to a heading and a quote if the quote contains a citation 1`] = `
 "<!-- wp:heading -->
 <h2>one</h2>

--- a/packages/e2e-tests/specs/blocks/__snapshots__/quote.test.js.snap
+++ b/packages/e2e-tests/specs/blocks/__snapshots__/quote.test.js.snap
@@ -102,7 +102,7 @@ exports[`Quote can be split at the end and merged back 3`] = `
 <!-- /wp:quote -->"
 `;
 
-exports[`Quote can be split in the middle 1`] = `
+exports[`Quote can be split in the middle and merged back 1`] = `
 "<!-- wp:quote -->
 <blockquote class=\\"wp-block-quote\\"><p>1</p><cite>c</cite></blockquote>
 <!-- /wp:quote -->
@@ -116,7 +116,7 @@ exports[`Quote can be split in the middle 1`] = `
 <!-- /wp:quote -->"
 `;
 
-exports[`Quote can be split in the middle 2`] = `
+exports[`Quote can be split in the middle and merged back 2`] = `
 "<!-- wp:quote -->
 <blockquote class=\\"wp-block-quote\\"><p>1</p><p></p><cite>c</cite></blockquote>
 <!-- /wp:quote -->
@@ -126,13 +126,19 @@ exports[`Quote can be split in the middle 2`] = `
 <!-- /wp:quote -->"
 `;
 
-exports[`Quote can be split in the middle 3`] = `
+exports[`Quote can be split in the middle and merged back 3`] = `
 "<!-- wp:quote -->
 <blockquote class=\\"wp-block-quote\\"><p>1</p><cite>c</cite></blockquote>
 <!-- /wp:quote -->
 
 <!-- wp:quote -->
 <blockquote class=\\"wp-block-quote\\"><p>2</p><cite>c</cite></blockquote>
+<!-- /wp:quote -->"
+`;
+
+exports[`Quote can be split in the middle and merged back 4`] = `
+"<!-- wp:quote -->
+<blockquote class=\\"wp-block-quote\\"><p>1</p><p>2</p><cite>c</cite></blockquote>
 <!-- /wp:quote -->"
 `;
 

--- a/packages/e2e-tests/specs/blocks/quote.test.js
+++ b/packages/e2e-tests/specs/blocks/quote.test.js
@@ -185,4 +185,50 @@ describe( 'Quote', () => {
 		await page.keyboard.press( 'Backspace' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'can be split at the end and merged back', async () => {
+		await insertBlock( 'Quote' );
+		await page.keyboard.type( '1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
+
+		// Expect empty paragraph outside quote block.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await page.keyboard.press( 'Backspace' );
+
+		// Expect empty paragraph inside quote block.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await page.keyboard.press( 'Backspace' );
+
+		// Expect quote without empty paragraphs.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'can be split in the middle', async () => {
+		await insertBlock( 'Quote' );
+		await page.keyboard.type( '1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '2' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.type( 'c' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.press( 'Enter' );
+
+		// Expect two quote blocks and empty paragraph in the middle.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await page.keyboard.press( 'Backspace' );
+
+		// Expect two quote blocks and empty paragraph in the first quote.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await page.keyboard.press( 'Backspace' );
+
+		// Expect two quote blocks.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );

--- a/packages/e2e-tests/specs/blocks/quote.test.js
+++ b/packages/e2e-tests/specs/blocks/quote.test.js
@@ -206,7 +206,7 @@ describe( 'Quote', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
-	it( 'can be split in the middle', async () => {
+	it( 'can be split in the middle and merged back', async () => {
 		await insertBlock( 'Quote' );
 		await page.keyboard.type( '1' );
 		await page.keyboard.press( 'Enter' );
@@ -229,6 +229,13 @@ describe( 'Quote', () => {
 		await page.keyboard.press( 'Backspace' );
 
 		// Expect two quote blocks.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'Backspace' );
+
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
## Description

Allows the quote block to be split when the caret is at an empty paragraph. This is similar to how list splitting works. The implementation is really simple.

## How has this been tested?

I've added e2e tests.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->