### PR TITLE
Link Format: collapse selection to end after insert

### DIFF
--- a/packages/e2e-tests/specs/editor/various/links.test.js
+++ b/packages/e2e-tests/specs/editor/various/links.test.js
@@ -200,6 +200,9 @@ describe( 'Links', () => {
 
 		// Click on the Submit button
 		await page.keyboard.press( 'Enter' );
+
+		// Reselect the link.
+		await pressKeyWithModifier( 'shiftAlt', 'ArrowLeft' );
 	};
 
 	it( 'can be edited', async () => {
@@ -490,13 +493,6 @@ describe( 'Links', () => {
 		await waitForAutoFocus();
 		await page.keyboard.type( 'w.org' );
 
-		// Insert the link
-		await page.keyboard.press( 'Enter' );
-
-		// Navigate back to the popover
-		await pressKeyWithModifier( 'primary', 'k' );
-		await waitForAutoFocus();
-
 		// Navigate to and toggle the "Open in new tab" checkbox.
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
@@ -508,7 +504,8 @@ describe( 'Links', () => {
 
 		// Close dialog. Expect that "Open in new tab" would have been applied
 		// immediately.
-		await page.keyboard.press( 'Escape' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Enter' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 
@@ -519,9 +516,10 @@ describe( 'Links', () => {
 		//
 		// See: https://github.com/WordPress/gutenberg/pull/15573
 
-		// Collapse selection.
+		// Move caret back into the link.
 		await page.keyboard.press( 'ArrowLeft' );
-		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.press( 'ArrowLeft' );
+
 		// Edit link.
 		await pressKeyWithModifier( 'primary', 'k' );
 		await waitForAutoFocus();
@@ -532,6 +530,10 @@ describe( 'Links', () => {
 		await page.keyboard.press( 'Enter' );
 
 		// Navigate back to the popover
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowLeft' );
+
+		// Navigate back to inputs to verify appears as changed.
 		await pressKeyWithModifier( 'primary', 'k' );
 		await waitForAutoFocus();
 

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -128,7 +128,10 @@ function InlineLinkUI( {
 			);
 			onChange( insert( value, toInsert ) );
 		} else {
-			onChange( applyFormat( value, format ) );
+			const newValue = applyFormat( value, format );
+			newValue.start = newValue.end;
+			newValue.activeFormats = [];
+			onChange( newValue );
 		}
 
 		// Focus should only be shifted back to the formatted segment when the


### PR DESCRIPTION
## Description

Very small code change and change in behaviour.

With change:

<img width="104" alt="Screenshot 2019-08-21 at 14 58 58" src="https://user-images.githubusercontent.com/4710635/63433837-39da8600-c424-11e9-9baf-f77a80261aff.png">

## How has this been tested?

Insert a link.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
