### PR TITLE
Remove: Child blocks from block manager

### DIFF
--- a/packages/edit-post/src/components/manage-blocks-modal/manager.js
+++ b/packages/edit-post/src/components/manage-blocks-modal/manager.js
@@ -30,7 +30,8 @@ function BlockManager( {
 	// value reference on each call.
 	blockTypes = blockTypes.filter( ( blockType ) => (
 		hasBlockSupport( blockType, 'inserter', true ) &&
-		( ! search || isMatchingSearchTerm( blockType, search ) )
+		( ! search || isMatchingSearchTerm( blockType, search ) ) &&
+		! blockType.parent
 	) );
 
 	return (


### PR DESCRIPTION
## Description
Part of: https://github.com/WordPress/gutenberg/issues/15121

This PR makes sure child blocks don't appear in the block manager, so we are consistent with the inserter currently they don't appear on the inserter by default.

## How has this been tested?
I pasted the following code block in the browser console: https://gist.github.com/jorgefilipecosta/60a0bf242e8c7c18805618558268315d

I verified the Test Child block was not available in the block manager (on master it is).
