### PR TITLE
[RNMobile] Fix crash when adding separator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ branches:
     - master
 
 before_install:
-  - nvm install --latest-npm
+  - nvm install
 
 env: PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 

--- a/bin/install-node-nvm.sh
+++ b/bin/install-node-nvm.sh
@@ -69,9 +69,6 @@ fi
 echo -e $(status_message "Installing and updating NPM packages..." )
 npm install
 
-# Make sure npm is up-to-date
-npm install npm -g
-
 # There was a bug in NPM that caused changes in package-lock.json. Handle that.
 if [ "$TRAVIS" != "true" ] && ! git diff --no-ext-diff --exit-code package-lock.json >/dev/null; then
 	if ask "$(warning_message "Your package-lock.json changed, which may mean there's an issue with your NPM cache. Would you like to try and automatically clean it up?" )" N 10; then

--- a/packages/block-library/src/separator/edit.js
+++ b/packages/block-library/src/separator/edit.js
@@ -6,13 +6,12 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { HorizontalRule } from '@wordpress/components';
-import {
-	InspectorControls,
-	withColors,
-	PanelColorSettings,
-} from '@wordpress/block-editor';
+import { withColors } from '@wordpress/block-editor';
+/**
+ * Internal dependencies
+ */
+import SeparatorSettings from './separator-settings';
 
 function SeparatorEdit( { color, setColor, className } ) {
 	return (
@@ -29,19 +28,10 @@ function SeparatorEdit( { color, setColor, className } ) {
 					color: color.color,
 				} }
 			/>
-			<InspectorControls>
-				<PanelColorSettings
-					title={ __( 'Color Settings' ) }
-					colorSettings={ [
-						{
-							value: color.color,
-							onChange: setColor,
-							label: __( 'Color' ),
-						},
-					] }
-				>
-				</PanelColorSettings>
-			</InspectorControls>
+			<SeparatorSettings
+				color={ color }
+				setColor={ setColor }
+			/>
 		</>
 	);
 }

--- a/packages/block-library/src/separator/separator-settings.js
+++ b/packages/block-library/src/separator/separator-settings.js
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	InspectorControls,
+	PanelColorSettings,
+} from '@wordpress/block-editor';
+
+const SeparatorSettings = ( { color, setColor } ) => (
+	<InspectorControls>
+		<PanelColorSettings
+			title={ __( 'Color Settings' ) }
+			colorSettings={ [
+				{
+					value: color.color,
+					onChange: setColor,
+					label: __( 'Color' ),
+				},
+			] }
+		>
+		</PanelColorSettings>
+	</InspectorControls>
+);
+
+export default SeparatorSettings;

--- a/packages/block-library/src/separator/separator-settings.native.js
+++ b/packages/block-library/src/separator/separator-settings.native.js
@@ -1,0 +1,3 @@
+// Mobile has no separator settings at this time, so render nothing
+const SeparatorSettings = () => null;
+export default SeparatorSettings;


### PR DESCRIPTION
## Description
This PR addresses [an issue](issue/1307_fix-separator-crash) where the mobile app would crash anytime a separator block was added. The issue arose as a result of a recent change to [add color options to the separator block on the web](https://github.com/WordPress/gutenberg/pull/16784), which involved [adding a `PanelColorSettings` component to `separator/edit.js`](https://github.com/WordPress/gutenberg/pull/16784/files#diff-5f165bd7fda27ae68e9884becd035489R33). Mobile also uses `separator/edit.js`, but it does not have the `PanelColorSettings` component. This PR fixes that by extracting the new settings into a separate `SeparatorSettings` component, and just having the `.native.js` file return `null` for that component.

This PR is targetting the `rnmobile/release-1.11.0` branch. That branch will then be merged back into develop in a separate PR following the 1.11.0 release.

## How has this been tested?
### Mobile
* Opened app, added a separator block, and verified the app was not crashing
### Web
* Verified color settings are available
* Verfied that changing the color settings resulted in a visible change in the post preview

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
