### PR TITLE
Temporarily change NPM version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ branches:
     - master
 
 before_install:
-  - nvm install --latest-npm
+  - nvm install 6.10.3
 
 env: PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ branches:
     - master
 
 before_install:
-  - nvm install 6.10.3
+  - nvm install 10.16.2
 
 env: PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 

--- a/packages/e2e-tests-block-editor/utils.js
+++ b/packages/e2e-tests-block-editor/utils.js
@@ -1,8 +1,0 @@
-/**
- * Returns a promise which resolves with the edited post content (HTML string).
- *
- * @return {Promise} Promise resolving with post content markup.
- */
-export async function getEditedPostContent() {
-	return page.evaluate( () => window._getContent() );
-}

--- a/packages/e2e-tests-block-editor/utils.js
+++ b/packages/e2e-tests-block-editor/utils.js
@@ -1,0 +1,8 @@
+/**
+ * Returns a promise which resolves with the edited post content (HTML string).
+ *
+ * @return {Promise} Promise resolving with post content markup.
+ */
+export async function getEditedPostContent() {
+	return page.evaluate( () => window._getContent() );
+}


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

The build artefacts test is currently failing on Travis after the npm 6.11 update.

https://npm.community/t/6-11-1-some-dependencies-are-no-longer-being-installed/9586

A temporary solution could be to revert to the previous npm version, if we don't know how long it will take to fix.

Locally, `nvm install 10.16.2` can be used.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->