### PR TITLE
Build: remove global install of latest npm since we want to use the paired node/npm version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ branches:
     - master
 
 before_install:
-  - nvm install --latest-npm
+  - nvm install
 
 env: PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 

--- a/bin/install-node-nvm.sh
+++ b/bin/install-node-nvm.sh
@@ -69,9 +69,6 @@ fi
 echo -e $(status_message "Installing and updating NPM packages..." )
 npm install
 
-# Make sure npm is up-to-date
-npm install npm -g
-
 # There was a bug in NPM that caused changes in package-lock.json. Handle that.
 if [ "$TRAVIS" != "true" ] && ! git diff --no-ext-diff --exit-code package-lock.json >/dev/null; then
 	if ask "$(warning_message "Your package-lock.json changed, which may mean there's an issue with your NPM cache. Would you like to try and automatically clean it up?" )" N 10; then


### PR DESCRIPTION
## Description

When running `./bin/setup-local-env.sh` this tells the node version manager nvm to switch to the current Node LTS line. However we also have a line `npm install npm -g` that also installs the latest npm version (unpaired) and pollutes the local nvm cache. 

For example on a local system with v10.16.3 not installed yet we should see v10.16.3 paired with (npm v6.9.0)

```bash
$ nvm install v10.16.3
Downloading and installing node v10.16.3...
Local cache found: $NVM_DIR/.cache/bin/node-v10.16.3-darwin-x64/node-v10.16.3-darwin-x64.tar.xz
Checksums match! Using existing downloaded archive $NVM_DIR/.cache/bin/node-v10.16.3-darwin-x64/node-v10.16.3-darwin-x64.tar.xz
Now using node v10.16.3 (npm v6.9.0)
```

Now try running `npm install npm -g` and check the nvm versions, we can see that the cache will now always point at the wrong pairing when switching.
```
$ npm install npm -g
/Users/kerryliu/.nvm/versions/node/v10.16.3/bin/npm -> /Users/kerryliu/.nvm/versions/node/v10.16.3/lib/node_modules/npm/bin/npm-cli.js
/Users/kerryliu/.nvm/versions/node/v10.16.3/bin/npx -> /Users/kerryliu/.nvm/versions/node/v10.16.3/lib/node_modules/npm/bin/npx-cli.js
+ npm@6.11.1
added 19 packages from 13 contributors, removed 15 packages and updated 52 packages in 5.647s
$ nvm install v10.16.3
v10.16.3 is already installed.
Now using node v10.16.3 (npm v6.11.1)
```

This PR removes the `npm install npm -g` line so we don't point at edge npm in bin/setup-local script. This also updates travis.yml to not install edge npm.

## Testing Instructions:

- Travis should be green ✅
- Uninstall your cached LTS version: `npm uninstall v10.16.3`
- Run `./bin/setup-loacal-env.sh`, with a missing node version you'll be prompted to nvm install. Verify that the success message says: `Now using node v10.16.3 (npm v6.9.0)`
- Run `./bin/setup-local-env.sh`. Local dev should work as expected. 

```bash
$ ./bin/setup-local-env.sh 
WARNING: Node version does not match the latest long term support version. Please run this command to install and use it:
WARNING: nvm install
WARNING: After that, re-run the setup script to continue.
$ nvm install
Found '/Users/kerryliu/checkouts/gutenberg/.nvmrc' with version <lts/*>
Downloading and installing node v10.16.3...
Local cache found: $NVM_DIR/.cache/bin/node-v10.16.3-darwin-x64/node-v10.16.3-darwin-x64.tar.xz
Checksums match! Using existing downloaded archive $NVM_DIR/.cache/bin/node-v10.16.3-darwin-x64/node-v10.16.3-darwin-x64.tar.xz
Now using node v10.16.3 (npm v6.9.0)
```


