### PR TITLE
Reduce the padding around the sibling inserter icon

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -865,7 +865,7 @@
 		background: $white;
 		height: $block-padding * 2;
 		width: $block-padding * 2;
-		padding: 4px;
+		padding: $grid-size-small;
 
 		&:not(:disabled):not([aria-disabled="true"]):hover {
 			box-shadow: none;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -860,12 +860,12 @@
 
 	// Show a clickable plus.
 	.block-editor-inserter__toggle {
-		margin-top: -8px;
 		border-radius: 50%;
 		color: $blue-medium-focus;
 		background: $white;
-		height: $block-padding * 2 + 8px;
-		width: $block-padding * 2 + 8px;
+		height: $block-padding * 2;
+		width: $block-padding * 2;
+		padding: 4px;
 
 		&:not(:disabled):not([aria-disabled="true"]):hover {
 			box-shadow: none;


### PR DESCRIPTION
 This PR is so the icon doesn't interfere with other UI elements. Kind of fixes #16646. I wanted to try a delay on the Inserter, but animating the `display` attribute isn't possible with just CSS. I think that's why the Inserter uses the `opacity` attribute instead, but `opacity` still takes up space even when `opacity` is set to `0`. This results in an element that still covers other UI elements.

Basically, I changed the padding around the `+` icon. It's not the most robust solution, so I'm open to alternatives. 

## How has this been tested?
Tested locally.

## Screenshots

**This PR**

![inserter-new](https://user-images.githubusercontent.com/617986/63479650-e5df9980-c443-11e9-950a-68f2330d74ea.gif)


**Master branch**

![inserter-old](https://user-images.githubusercontent.com/617986/63479679-f6900f80-c443-11e9-8d04-677bb53bc3ba.gif)


## Types of changes
Minor CSS change.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
