### PR TITLE
[Tiny PR] Paste: do not force blocks for empty rich text

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -138,12 +138,11 @@ class RichTextWrapper extends Component {
 				mode: 'BLOCKS',
 				tagName,
 			} );
-			const shouldReplace = onReplace && isEmpty( value );
 
 			// Allows us to ask for this information when we get a report.
 			window.console.log( 'Received item:\n\n', file );
 
-			if ( shouldReplace ) {
+			if ( onReplace && isEmpty( value ) ) {
 				onReplace( content );
 			} else {
 				this.onSplit( value, content );
@@ -152,21 +151,10 @@ class RichTextWrapper extends Component {
 			return;
 		}
 
-		const canReplace = onReplace && isEmpty( value );
-		const canSplit = onReplace && onSplit;
-
-		let mode = 'INLINE';
-
-		if ( canReplace ) {
-			mode = 'BLOCKS';
-		} else if ( canSplit ) {
-			mode = 'AUTO';
-		}
-
 		const content = pasteHandler( {
 			HTML: html,
 			plainText,
-			mode,
+			mode: onReplace && onSplit ? 'AUTO' : 'INLINE',
 			tagName,
 			canUserUseUnfilteredHTML,
 		} );
@@ -182,7 +170,7 @@ class RichTextWrapper extends Component {
 
 			onChange( insert( value, valueToInsert ) );
 		} else if ( content.length > 0 ) {
-			if ( canReplace ) {
+			if ( onReplace && isEmpty( value ) ) {
 				onReplace( content );
 			} else {
 				this.onSplit( value, content );

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -28,6 +28,7 @@ import {
 import { withFilters, IsolatedEventContainer } from '@wordpress/components';
 import { createBlobURL } from '@wordpress/blob';
 import deprecated from '@wordpress/deprecated';
+import { isURL } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -129,6 +130,7 @@ class RichTextWrapper extends Component {
 			tagName,
 			canUserUseUnfilteredHTML,
 			multiline,
+			__unstableEmbedURLOnPaste,
 		} = this.props;
 
 		if ( image && ! html ) {
@@ -151,10 +153,20 @@ class RichTextWrapper extends Component {
 			return;
 		}
 
+		let mode = onReplace && onSplit ? 'AUTO' : 'INLINE';
+
+		if (
+			__unstableEmbedURLOnPaste &&
+			isEmpty( value ) &&
+			isURL( plainText.trim() )
+		) {
+			mode = 'BLOCKS';
+		}
+
 		const content = pasteHandler( {
 			HTML: html,
 			plainText,
-			mode: onReplace && onSplit ? 'AUTO' : 'INLINE',
+			mode,
 			tagName,
 			canUserUseUnfilteredHTML,
 		} );

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -195,6 +195,7 @@ class ParagraphBlock extends Component {
 					onRemove={ onReplace ? () => onReplace( [] ) : undefined }
 					aria-label={ content ? __( 'Paragraph block' ) : __( 'Empty block; start writing or type forward slash to choose a block' ) }
 					placeholder={ placeholder || __( 'Start writing or type / to choose a block' ) }
+					__unstableEmbedURLOnPaste
 				/>
 			</>
 		);


### PR DESCRIPTION
## Description

Fixes #16990. There's probably similar older issues.
Also blocks introducing caption splitting as you wouldn't be able to paste in an empty caption.

Reverts some of #3326, introduced 2 years ago for embedding on URL paste. I've solved that problem differently here.

## How has this been tested?

See #16990. Create an empty heading. Copy paste a piece of the URL in the address bar. Expect a heading with the pasted text. On master it would be converted to a paragraph.
Paste an embeddable URL in an empty paragraph. It should be converted to an embed block.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
