### PR TITLE
Components: Add ImageSizeControl component

### DIFF
--- a/packages/block-editor/src/components/image-size-control/README.md
+++ b/packages/block-editor/src/components/image-size-control/README.md
@@ -1,0 +1,108 @@
+# ImageSizeControl
+
+Allow users to control the width & height of an image.
+
+## Usage
+
+Render a ImageSizeControl.
+
+```jsx
+import { ImageSizeControl } from '@wordpress/components';
+import { withState } from '@wordpress/compose';
+
+const MyImageSizeControl = withState( {
+	width: null,
+	height: null,
+} )( ( { width, height, setState } ) => {
+	// In this example, we have one image with a fixed size of 600x600.
+	const imageWidth = 600;
+	const imageHeight = 600;
+
+	return (
+		<ImageSizeControl
+			onChange={ ( value ) => setState( value ) }
+			width={ width }
+			height={ height }
+			imageWidth={ imageWidth }
+			imageHeight={ imageHeight }
+		/>
+	);
+} );
+```
+
+## Props
+
+The component accepts the following props:
+
+### slug
+
+The currently-selected image size slug (`thumbnail`, `large`, etc). This is used by the parent component to get the specific image, which is used to populate `imageHeight` & `imageWidth`. This is not required, but necessary when `imageSizeOptions` is used.
+
+- Type: `string`
+- Required: No
+
+### height
+
+The height of the image when displayed.
+
+- Type: `number`
+- Required: No
+
+### width
+
+The width of the image when displayed.
+
+- Type: `number`
+- Required: No
+
+### onChange
+
+The function called when the image size changes. It is passed an object with `{ width, height }` (potentially just one if only one dimension changed).
+
+- Type: `Function`
+- Required: Yes
+
+### onChangeImage
+
+The function called when a new image size is selected. It is passed the `slug` as an argument. This is not required, but necessary when `imageSizeOptions` is used.
+
+- Type: `Function`
+- Required: No
+
+### imageSizeOptions
+
+An array of image size slugs and labels. Should be of the format:
+
+```js
+[
+	{ value: 'thumbnail', label: 'Thumbnail' },
+	{ value: 'medium', label: 'Medium' },
+	...
+]
+```
+
+If not provided, the "Image Size" dropdown is not displayed.
+
+- Type: `array`
+- Required: No
+
+### isResizable
+
+A boolean control for showing the resize fields "Image Dimensions". Set this to false if you want images to always be the fixed size of the selected image.
+
+- Type: `boolean`
+- Required: No
+
+### imageWidth
+
+The width of the currently selected image, used for calculating the percentage sizes. This will likely be updated when the image size slug changes, but does not control the image display (that's the `width` prop).
+
+- Type: `number`
+- Required: Yes
+
+### imageHeight
+
+The height of the currently selected image, used for calculating the percentage sizes. This will likely be updated when the image size slug changes, but does not control the image display (that's the `height` prop).
+
+- Type: `number`
+- Required: Yes

--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -87,7 +87,7 @@ class ImageSizeControl extends Component {
 											key={ scale }
 											isSmall
 											isPrimary={ isCurrent }
-											aria-pressed={ isCurrent }
+											isPressed={ isCurrent }
 											onClick={ this.updateDimensions( scaledWidth, scaledHeight ) }
 										>
 											{ scale }%

--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -19,22 +19,7 @@ class ImageSizeControl extends Component {
 	constructor( props ) {
 		super( props );
 
-		this.updateImage = this.updateImage.bind( this );
-		this.updateWidth = this.updateWidth.bind( this );
-		this.updateHeight = this.updateHeight.bind( this );
 		this.updateDimensions = this.updateDimensions.bind( this );
-	}
-
-	updateImage( slug ) {
-		this.props.onChangeImage( slug );
-	}
-
-	updateWidth( width ) {
-		this.props.onChange( { width: parseInt( width, 10 ) } );
-	}
-
-	updateHeight( height ) {
-		this.props.onChange( { height: parseInt( height, 10 ) } );
 	}
 
 	updateDimensions( width = undefined, height = undefined ) {
@@ -52,6 +37,8 @@ class ImageSizeControl extends Component {
 			slug,
 			width,
 			height,
+			onChange,
+			onChangeImage,
 		} = this.props;
 
 		return (
@@ -61,7 +48,7 @@ class ImageSizeControl extends Component {
 						label={ __( 'Image Size' ) }
 						value={ slug }
 						options={ imageSizeOptions }
-						onChange={ this.updateImage }
+						onChange={ onChangeImage }
 					/>
 				) }
 				{ isResizable && (
@@ -76,7 +63,7 @@ class ImageSizeControl extends Component {
 								label={ __( 'Width' ) }
 								value={ width || imageWidth || '' }
 								min={ 1 }
-								onChange={ this.updateWidth }
+								onChange={ ( value ) => onChange( { width: parseInt( value, 10 ) } ) }
 							/>
 							<TextControl
 								type="number"
@@ -84,7 +71,7 @@ class ImageSizeControl extends Component {
 								label={ __( 'Height' ) }
 								value={ height || imageHeight || '' }
 								min={ 1 }
-								onChange={ this.updateHeight }
+								onChange={ ( value ) => onChange( { height: parseInt( value, 10 ) } ) }
 							/>
 						</div>
 						<div className="block-editor-image-size-control__row">

--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -32,7 +32,7 @@ class ImageSizeControl extends Component {
 		const {
 			imageWidth,
 			imageHeight,
-			imageSizeOptions,
+			imageSizeOptions = [],
 			isResizable = true,
 			slug,
 			width,

--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -1,0 +1,125 @@
+/**
+ * External dependencies
+ */
+import { isEmpty } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button, ButtonGroup, SelectControl, TextControl } from '@wordpress/components';
+import { Component } from '@wordpress/element';
+
+class ImageSizeControl extends Component {
+	/**
+	 * Run additional operations during component initialization.
+	 *
+	 * @param {Object} props
+	 */
+	constructor( props ) {
+		super( props );
+
+		this.updateImage = this.updateImage.bind( this );
+		this.updateWidth = this.updateWidth.bind( this );
+		this.updateHeight = this.updateHeight.bind( this );
+		this.updateDimensions = this.updateDimensions.bind( this );
+	}
+
+	updateImage( slug ) {
+		this.props.onChangeImage( slug );
+	}
+
+	updateWidth( width ) {
+		this.props.onChange( { width: parseInt( width, 10 ) } );
+	}
+
+	updateHeight( height ) {
+		this.props.onChange( { height: parseInt( height, 10 ) } );
+	}
+
+	updateDimensions( width = undefined, height = undefined ) {
+		return () => {
+			this.props.onChange( { width, height } );
+		};
+	}
+
+	render() {
+		const {
+			imageWidth,
+			imageHeight,
+			imageSizeOptions,
+			isResizable = true,
+			slug,
+			width,
+			height,
+		} = this.props;
+
+		return (
+			<>
+				{ ! isEmpty( imageSizeOptions ) && (
+					<SelectControl
+						label={ __( 'Image Size' ) }
+						value={ slug }
+						options={ imageSizeOptions }
+						onChange={ this.updateImage }
+					/>
+				) }
+				{ isResizable && (
+					<div className="block-editor-image-size-control">
+						<p className="block-editor-image-size-control__row">
+							{ __( 'Image Dimensions' ) }
+						</p>
+						<div className="block-editor-image-size-control__row">
+							<TextControl
+								type="number"
+								className="block-editor-image-size-control__width"
+								label={ __( 'Width' ) }
+								value={ width || imageWidth || '' }
+								min={ 1 }
+								onChange={ this.updateWidth }
+							/>
+							<TextControl
+								type="number"
+								className="block-editor-image-size-control__height"
+								label={ __( 'Height' ) }
+								value={ height || imageHeight || '' }
+								min={ 1 }
+								onChange={ this.updateHeight }
+							/>
+						</div>
+						<div className="block-editor-image-size-control__row">
+							<ButtonGroup aria-label={ __( 'Image Size' ) }>
+								{ [ 25, 50, 75, 100 ].map( ( scale ) => {
+									const scaledWidth = Math.round( imageWidth * ( scale / 100 ) );
+									const scaledHeight = Math.round( imageHeight * ( scale / 100 ) );
+
+									const isCurrent = width === scaledWidth && height === scaledHeight;
+
+									return (
+										<Button
+											key={ scale }
+											isSmall
+											isPrimary={ isCurrent }
+											aria-pressed={ isCurrent }
+											onClick={ this.updateDimensions( scaledWidth, scaledHeight ) }
+										>
+											{ scale }%
+										</Button>
+									);
+								} ) }
+							</ButtonGroup>
+							<Button
+								isSmall
+								onClick={ this.updateDimensions( imageWidth, imageHeight ) }
+							>
+								{ __( 'Reset' ) }
+							</Button>
+						</div>
+					</div>
+				) }
+			</>
+		);
+	}
+}
+
+export default ImageSizeControl;

--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty } from 'lodash';
+import { isEmpty, noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -38,7 +38,7 @@ class ImageSizeControl extends Component {
 			width,
 			height,
 			onChange,
-			onChangeImage,
+			onChangeImage = noop,
 		} = this.props;
 
 		return (
@@ -97,7 +97,7 @@ class ImageSizeControl extends Component {
 							</ButtonGroup>
 							<Button
 								isSmall
-								onClick={ this.updateDimensions( imageWidth, imageHeight ) }
+								onClick={ this.updateDimensions() }
 							>
 								{ __( 'Reset' ) }
 							</Button>

--- a/packages/block-editor/src/components/image-size-control/style.scss
+++ b/packages/block-editor/src/components/image-size-control/style.scss
@@ -1,0 +1,26 @@
+.block-editor-image-size-control {
+	margin-bottom: 1em;
+
+	.block-editor-image-size-control__row {
+		display: flex;
+		justify-content: space-between;
+
+		.block-editor-image-size-control__width,
+		.block-editor-image-size-control__height {
+			margin-bottom: 0.5em;
+
+			// Fix the text and placeholder text being misaligned in Safari
+			input {
+				line-height: 1.25;
+			}
+		}
+
+		.block-editor-image-size-control__width {
+			margin-right: 5px;
+		}
+
+		.block-editor-image-size-control__height {
+			margin-left: 5px;
+		}
+	}
+}

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -5,6 +5,7 @@
 export * from './colors';
 export * from './gradients';
 export * from './font-sizes';
+export { default as __experimentalImageSizeControl } from './image-size-control';
 export { default as AlignmentToolbar } from './alignment-toolbar';
 export { default as Autocomplete } from './autocomplete';
 export { default as BlockAlignmentToolbar } from './block-alignment-toolbar';

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -5,7 +5,6 @@
 export * from './colors';
 export * from './gradients';
 export * from './font-sizes';
-export { default as __experimentalImageSizeControl } from './image-size-control';
 export { default as AlignmentToolbar } from './alignment-toolbar';
 export { default as Autocomplete } from './autocomplete';
 export { default as BlockAlignmentToolbar } from './block-alignment-toolbar';
@@ -27,6 +26,7 @@ export { default as __experimentalGradientPickerControl } from './gradient-picke
 export { default as __experimentalGradientPickerPanel } from './gradient-picker/panel';
 export { default as __experimentalColorGradientControl } from './colors-gradients/control';
 export { default as __experimentalPanelColorGradientSettings } from './colors-gradients/panel-color-gradient-settings';
+export { default as __experimentalImageSizeControl } from './image-size-control';
 export { default as InnerBlocks } from './inner-blocks';
 export { default as InspectorAdvancedControls } from './inspector-advanced-controls';
 export { default as InspectorControls } from './inspector-controls';

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -21,6 +21,7 @@
 @import "./components/contrast-checker/style.scss";
 @import "./components/default-block-appender/style.scss";
 @import "./components/link-control/style.scss";
+@import "./components/image-size-control/style.scss";
 @import "./components/inner-blocks/style.scss";
 @import "./components/inserter/style.scss";
 @import "./components/inserter-list-item/style.scss";

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -4,7 +4,6 @@
 import classnames from 'classnames';
 import {
 	get,
-	isEmpty,
 	filter,
 	map,
 	last,
@@ -17,12 +16,9 @@ import {
  */
 import { getBlobByURL, isBlobURL, revokeBlobURL } from '@wordpress/blob';
 import {
-	Button,
-	ButtonGroup,
 	ExternalLink,
 	PanelBody,
 	ResizableBox,
-	SelectControl,
 	Spinner,
 	TextareaControl,
 	TextControl,
@@ -35,6 +31,7 @@ import {
 	BlockAlignmentToolbar,
 	BlockControls,
 	BlockIcon,
+	ImageSizeControl,
 	InspectorControls,
 	InspectorAdvancedControls,
 	MediaPlaceholder,
@@ -104,9 +101,6 @@ export class ImageEdit extends Component {
 		this.onSelectImage = this.onSelectImage.bind( this );
 		this.onSelectURL = this.onSelectURL.bind( this );
 		this.updateImage = this.updateImage.bind( this );
-		this.updateWidth = this.updateWidth.bind( this );
-		this.updateHeight = this.updateHeight.bind( this );
-		this.updateDimensions = this.updateDimensions.bind( this );
 		this.onSetHref = this.onSetHref.bind( this );
 		this.onSetTitle = this.onSetTitle.bind( this );
 		this.getFilename = this.getFilename.bind( this );
@@ -297,20 +291,6 @@ export class ImageEdit extends Component {
 		} );
 	}
 
-	updateWidth( width ) {
-		this.props.setAttributes( { width: parseInt( width, 10 ) } );
-	}
-
-	updateHeight( height ) {
-		this.props.setAttributes( { height: parseInt( height, 10 ) } );
-	}
-
-	updateDimensions( width = undefined, height = undefined ) {
-		return () => {
-			this.props.setAttributes( { width, height } );
-		};
-	}
-
 	getFilename( url ) {
 		const path = getPath( url );
 		if ( path ) {
@@ -451,67 +431,17 @@ export class ImageEdit extends Component {
 								</>
 							}
 						/>
-						{ ! isEmpty( imageSizeOptions ) && (
-							<SelectControl
-								label={ __( 'Image Size' ) }
-								value={ sizeSlug }
-								options={ imageSizeOptions }
-								onChange={ this.updateImage }
-							/>
-						) }
-						{ isResizable && (
-							<div className="block-library-image__dimensions">
-								<p className="block-library-image__dimensions__row">
-									{ __( 'Image Dimensions' ) }
-								</p>
-								<div className="block-library-image__dimensions__row">
-									<TextControl
-										type="number"
-										className="block-library-image__dimensions__width"
-										label={ __( 'Width' ) }
-										value={ width || imageWidth || '' }
-										min={ 1 }
-										onChange={ this.updateWidth }
-									/>
-									<TextControl
-										type="number"
-										className="block-library-image__dimensions__height"
-										label={ __( 'Height' ) }
-										value={ height || imageHeight || '' }
-										min={ 1 }
-										onChange={ this.updateHeight }
-									/>
-								</div>
-								<div className="block-library-image__dimensions__row">
-									<ButtonGroup aria-label={ __( 'Image Size' ) }>
-										{ [ 25, 50, 75, 100 ].map( ( scale ) => {
-											const scaledWidth = Math.round( imageWidth * ( scale / 100 ) );
-											const scaledHeight = Math.round( imageHeight * ( scale / 100 ) );
-
-											const isCurrent = width === scaledWidth && height === scaledHeight;
-
-											return (
-												<Button
-													key={ scale }
-													isSmall
-													isPrimary={ isCurrent }
-													isPressed={ isCurrent }
-													onClick={ this.updateDimensions( scaledWidth, scaledHeight ) }
-												>
-													{ scale }%
-												</Button>
-											);
-										} ) }
-									</ButtonGroup>
-									<Button
-										isSmall
-										onClick={ this.updateDimensions() }
-									>
-										{ __( 'Reset' ) }
-									</Button>
-								</div>
-							</div>
-						) }
+						<ImageSizeControl
+							onChangeImage={ this.updateImage }
+							onChange={ ( value ) => setAttributes( value ) }
+							slug={ sizeSlug }
+							width={ width }
+							height={ height }
+							imageSizeOptions={ imageSizeOptions }
+							isResizable={ isResizable }
+							imageWidth={ imageWidth }
+							imageHeight={ imageHeight }
+						/>
 					</PanelBody>
 				</InspectorControls>
 				<InspectorAdvancedControls>

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -31,12 +31,12 @@ import {
 	BlockAlignmentToolbar,
 	BlockControls,
 	BlockIcon,
-	ImageSizeControl,
 	InspectorControls,
 	InspectorAdvancedControls,
 	MediaPlaceholder,
 	MediaReplaceFlow,
 	RichText,
+	__experimentalImageSizeControl as ImageSizeControl,
 	__experimentalImageURLInputUI as ImageURLInputUI,
 } from '@wordpress/block-editor';
 import {

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -52,33 +52,6 @@
 	}
 }
 
-.edit-post-sidebar .block-library-image__dimensions {
-	margin-bottom: 1em;
-
-	.block-library-image__dimensions__row {
-		display: flex;
-		justify-content: space-between;
-
-		.block-library-image__dimensions__width,
-		.block-library-image__dimensions__height {
-			margin-bottom: 0.5em;
-
-			// Fix the text and placeholder text being misaligned in Safari
-			input {
-				line-height: 1.25;
-			}
-		}
-
-		.block-library-image__dimensions__width {
-			margin-right: 5px;
-		}
-
-		.block-library-image__dimensions__height {
-			margin-left: 5px;
-		}
-	}
-}
-
 .block-editor-block-list__block[data-type="core/image"] .block-editor-block-toolbar .block-editor-url-input__button-modal {
 	position: absolute;
 	left: 0;


### PR DESCRIPTION
Pull out the image size controls from the image block into a standalone component. This also updates the Image block to use this new component. The new component allows for selecting the source image size (if provided), and then adjusting the size from there – so you can pick the thumbnail, which sets the image size as 150x150, and then you can change the dimensions from there. The image block fetches each image's data directly, so it sets the source image height & width based on the real image size.

The idea is that this now-shared component can be used by the latest posts block to control featured images (and any plugins that add images).

**To test**

- Add an image block
- Change the sizes
- The preview and rendered frontend should all be updated as expected

There should be no functionality change here.