### PR TITLE
Add featured images to Latest Posts block

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -687,7 +687,7 @@ add_filter( 'block_editor_preload_paths', 'gutenberg_extend_block_editor_preload
  */
 function gutenberg_extend_settings_image_dimensions( $settings ) {
 	$image_dimensions = array();
-	$all_sizes = wp_get_registered_image_subsizes();
+	$all_sizes        = wp_get_registered_image_subsizes();
 	foreach ( $settings['imageSizes'] as $size ) {
 		$key = $size['slug'];
 		if ( isset( $all_sizes[ $key ] ) ) {

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -677,3 +677,24 @@ function gutenberg_extend_block_editor_preload_paths( $preload_paths, $post ) {
 	return $preload_paths;
 }
 add_filter( 'block_editor_preload_paths', 'gutenberg_extend_block_editor_preload_paths', 10, 2 );
+
+/**
+ * Extends block editor settings to include a list of image dimensions per size.
+ *
+ * @param array $settings Default editor settings.
+ *
+ * @return array Filtered editor settings.
+ */
+function gutenberg_extend_settings_image_dimensions( $settings ) {
+	$image_dimensions = array();
+	$all_sizes = wp_get_registered_image_subsizes();
+	foreach ( $settings['imageSizes'] as $size ) {
+		$key = $size['slug'];
+		if ( isset( $all_sizes[ $key ] ) ) {
+			$image_dimensions[ $key ] = $all_sizes[ $key ];
+		}
+	}
+	$settings['imageDimensions'] = $image_dimensions;
+	return $settings;
+}
+add_filter( 'block_editor_settings', 'gutenberg_extend_settings_image_dimensions' );

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isUndefined, map, pickBy } from 'lodash';
+import { get, isUndefined, map, pickBy } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -329,7 +329,8 @@ class LatestPostsEdit extends Component {
 							'';
 
 						const imageSourceUrl = getFeaturedMediaSourceUrl(
-							post.featured_media
+							post.featured_media,
+							imageSizeSlug
 						);
 						const imageClasses = classnames( [
 							'wp-block-latest-posts__featured-image',
@@ -443,12 +444,18 @@ export default withSelect( ( select, props ) => {
 			label: name,
 		} ) ),
 		// @todo get size dynamically based on size selected.
-		getFeaturedMediaSourceUrl( featuredImageId ) {
+		getFeaturedMediaSourceUrl( featuredImageId, sizeSlug ) {
 			if ( featuredImageId ) {
-				const media = getMedia( featuredImageId );
-				if ( media ) {
-					return media.source_url;
+				const image = getMedia( featuredImageId );
+				const url = get(
+					image,
+					[ 'media_details', 'sizes', sizeSlug, 'source_url' ],
+					null
+				);
+				if ( ! url ) {
+					return get( image, 'source_url', null );
 				}
+				return url;
 			}
 			return null;
 		},

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -102,14 +102,14 @@ class LatestPostsEdit extends Component {
 			categories,
 			postsToShow,
 			excerptLength,
-			imageAlign,
-			imageSizeSlug,
-			imageSizeWidth,
-			imageSizeHeight,
+			featuredImageAlign,
+			featuredImageSizeSlug,
+			featuredImageSizeWidth,
+			featuredImageSizeHeight,
 		} = attributes;
 
 		const [ imageWidth, imageHeight ] = getImageDimensionsFromSlug(
-			imageSizeSlug
+			featuredImageSizeSlug
 		);
 
 		const inspectorControls = (
@@ -166,7 +166,7 @@ class LatestPostsEdit extends Component {
 
 				<PanelBody title={ __( 'Featured Image Settings' ) }>
 					<ToggleControl
-						label={ __( 'Disaply featured image' ) }
+						label={ __( 'Display featured image' ) }
 						checked={ displayFeaturedImage }
 						onChange={ ( value ) =>
 							setAttributes( { displayFeaturedImage: value } )
@@ -178,24 +178,26 @@ class LatestPostsEdit extends Component {
 								onChange={ ( value ) => {
 									const newAttrs = {};
 									if ( value.hasOwnProperty( 'width' ) ) {
-										newAttrs.imageSizeWidth = value.width;
+										newAttrs.featuredImageSizeWidth =
+											value.width;
 									}
 									if ( value.hasOwnProperty( 'height' ) ) {
-										newAttrs.imageSizeHeight = value.height;
+										newAttrs.featuredImageSizeHeight =
+											value.height;
 									}
 									setAttributes( newAttrs );
 								} }
-								slug={ imageSizeSlug }
-								width={ imageSizeWidth }
-								height={ imageSizeHeight }
+								slug={ featuredImageSizeSlug }
+								width={ featuredImageSizeWidth }
+								height={ featuredImageSizeHeight }
 								imageWidth={ imageWidth }
 								imageHeight={ imageHeight }
 								imageSizeOptions={ imageSizeOptions }
 								onChangeImage={ ( value ) =>
 									setAttributes( {
-										imageSizeSlug: value,
-										imageSizeWidth: undefined,
-										imageSizeHeight: undefined,
+										featuredImageSizeSlug: value,
+										featuredImageSizeWidth: undefined,
+										featuredImageSizeHeight: undefined,
 									} )
 								}
 							/>
@@ -204,9 +206,11 @@ class LatestPostsEdit extends Component {
 									{ __( 'Image Alignment' ) }
 								</BaseControl.VisualLabel>
 								<BlockAlignmentToolbar
-									value={ imageAlign }
+									value={ featuredImageAlign }
 									onChange={ ( value ) =>
-										setAttributes( { imageAlign: value } )
+										setAttributes( {
+											featuredImageAlign: value,
+										} )
 									}
 									controls={ [ 'left', 'center', 'right' ] }
 									isCollapsed={ false }
@@ -330,12 +334,12 @@ class LatestPostsEdit extends Component {
 
 						const imageSourceUrl = getFeaturedMediaSourceUrl(
 							post.featured_media,
-							imageSizeSlug
+							featuredImageSizeSlug
 						);
-						const imageClasses = classnames( [
-							'wp-block-latest-posts__featured-image',
-							imageAlign && `align${ imageAlign }`,
-						] );
+						const imageClasses = classnames( {
+							'wp-block-latest-posts__featured-image': true,
+							[ `align${ featuredImageAlign }` ]: !! featuredImageAlign,
+						} );
 
 						return (
 							<li key={ i }>
@@ -346,8 +350,8 @@ class LatestPostsEdit extends Component {
 												src={ imageSourceUrl }
 												alt=""
 												style={ {
-													maxWidth: imageSizeWidth,
-													maxHeight: imageSizeHeight,
+													maxWidth: featuredImageSizeWidth,
+													maxHeight: featuredImageSizeHeight,
 												} }
 											/>
 										) }

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -172,6 +172,18 @@ function register_block_core_latest_posts() {
 					'type'    => 'string',
 					'default' => false,
 				),
+				'imageSizeSlug'           => array(
+					'type'    => 'string',
+					'default' => 'thumbnail',
+				),
+				'imageSizeWidth'          => array(
+					'type'    => 'number',
+					'default' => null,
+				),
+				'imageSizeHeight'         => array(
+					'type'    => 'number',
+					'default' => null,
+				),
 			),
 			'render_callback' => 'render_block_core_latest_posts',
 		)

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -164,6 +164,14 @@ function register_block_core_latest_posts() {
 					'type'    => 'string',
 					'default' => 'date',
 				),
+				'displayFeaturedImage'    => array(
+					'type'    => 'boolean',
+					'default' => false,
+				),
+				'imageAlign'              => array(
+					'type'    => 'string',
+					'default' => false,
+				),
 			),
 			'render_callback' => 'render_block_core_latest_posts',
 		)

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -34,16 +34,16 @@ function render_block_core_latest_posts( $attributes ) {
 
 		if ( $attributes['displayFeaturedImage'] && has_post_thumbnail( $post ) ) {
 			$image_style = '';
-			if ( isset( $attributes['imageSizeWidth'] ) ) {
-				$image_style .= sprintf( 'max-width:%spx;', $attributes['imageSizeWidth'] );
+			if ( isset( $attributes['featuredImageSizeWidth'] ) ) {
+				$image_style .= sprintf( 'max-width:%spx;', $attributes['featuredImageSizeWidth'] );
 			}
-			if ( isset( $attributes['imageSizeHeight'] ) ) {
-				$image_style .= sprintf( 'max-height:%spx;', $attributes['imageSizeHeight'] );
+			if ( isset( $attributes['featuredImageSizeHeight'] ) ) {
+				$image_style .= sprintf( 'max-height:%spx;', $attributes['featuredImageSizeHeight'] );
 			}
 
 			$image_classes = 'wp-block-latest-posts__featured-image';
-			if ( isset( $attributes['imageAlign'] ) ) {
-				$image_classes .= ' align' . $attributes['imageAlign'];
+			if ( isset( $attributes['featuredImageAlign'] ) ) {
+				$image_classes .= ' align' . $attributes['featuredImageAlign'];
 			}
 
 			$list_items_markup .= sprintf(
@@ -51,7 +51,7 @@ function render_block_core_latest_posts( $attributes ) {
 				$image_classes,
 				get_the_post_thumbnail(
 					$post,
-					$attributes['imageSizeSlug'],
+					$attributes['featuredImageSizeSlug'],
 					array(
 						'style' => $image_style,
 					)
@@ -197,19 +197,19 @@ function register_block_core_latest_posts() {
 					'type'    => 'boolean',
 					'default' => false,
 				),
-				'imageAlign'              => array(
+				'featuredImageAlign'      => array(
 					'type' => 'string',
 					'enum' => array( 'left', 'center', 'right' ),
 				),
-				'imageSizeSlug'           => array(
+				'featuredImageSizeSlug'   => array(
 					'type'    => 'string',
 					'default' => 'thumbnail',
 				),
-				'imageSizeWidth'          => array(
+				'featuredImageSizeWidth'  => array(
 					'type'    => 'number',
 					'default' => null,
 				),
-				'imageSizeHeight'         => array(
+				'featuredImageSizeHeight' => array(
 					'type'    => 'number',
 					'default' => null,
 				),

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -169,8 +169,8 @@ function register_block_core_latest_posts() {
 					'default' => false,
 				),
 				'imageAlign'              => array(
-					'type'    => 'string',
-					'default' => false,
+					'type' => 'string',
+					'enum' => array( 'left', 'center', 'right' ),
 				),
 				'imageSizeSlug'           => array(
 					'type'    => 'string',

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -32,7 +32,7 @@ function render_block_core_latest_posts( $attributes ) {
 	foreach ( $recent_posts as $post ) {
 		$list_items_markup .= '<li>';
 
-		if ( $attributes['displayFeaturedImage'] && has_post_thumbnail( $post )  ) {
+		if ( $attributes['displayFeaturedImage'] && has_post_thumbnail( $post ) ) {
 			$image_style = '';
 			if ( isset( $attributes['imageSizeWidth'] ) ) {
 				$image_style .= sprintf( 'max-width:%spx;', $attributes['imageSizeWidth'] );

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -30,12 +30,41 @@ function render_block_core_latest_posts( $attributes ) {
 	$list_items_markup = '';
 
 	foreach ( $recent_posts as $post ) {
+		$list_items_markup .= '<li>';
+
+		if ( $attributes['displayFeaturedImage'] && has_post_thumbnail( $post )  ) {
+			$image_style = '';
+			if ( isset( $attributes['imageSizeWidth'] ) ) {
+				$image_style .= sprintf( 'max-width:%spx;', $attributes['imageSizeWidth'] );
+			}
+			if ( isset( $attributes['imageSizeHeight'] ) ) {
+				$image_style .= sprintf( 'max-height:%spx;', $attributes['imageSizeHeight'] );
+			}
+
+			$image_classes = 'wp-block-latest-posts__featured-image';
+			if ( isset( $attributes['imageAlign'] ) ) {
+				$image_classes .= ' align' . $attributes['imageAlign'];
+			}
+
+			$list_items_markup .= sprintf(
+				'<div class="%1$s">%2$s</div>',
+				$image_classes,
+				get_the_post_thumbnail(
+					$post,
+					$attributes['imageSizeSlug'],
+					array(
+						'style' => $image_style,
+					)
+				)
+			);
+		}
+
 		$title = get_the_title( $post );
 		if ( ! $title ) {
 			$title = __( '(no title)' );
 		}
 		$list_items_markup .= sprintf(
-			'<li><a href="%1$s">%2$s</a>',
+			'<a href="%1$s">%2$s</a>',
 			esc_url( get_permalink( $post ) ),
 			$title
 		);

--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -46,6 +46,10 @@
 }
 
 .wp-block-latest-posts__featured-image {
+	img {
+		height: auto;
+		width: auto;
+	}
 	&.alignleft {
 		/*rtl:ignore*/
 		margin-right: 1em;

--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -9,6 +9,10 @@
 	}
 	&.wp-block-latest-posts__list {
 		list-style: none;
+
+		li {
+			clear: both;
+		}
 	}
 	&.is-grid {
 		display: flex;
@@ -39,4 +43,19 @@
 .wp-block-latest-posts__post-excerpt {
 	margin-top: $grid-size;
 	margin-bottom: $grid-size-large;
+}
+
+.wp-block-latest-posts__featured-image {
+	&.alignleft {
+		/*rtl:ignore*/
+		margin-right: 1em;
+	}
+	&.alignright {
+		/*rtl:ignore*/
+		margin-left: 1em;
+	}
+	&.aligncenter {
+		margin-bottom: 1em;
+		text-align: center;
+	}
 }

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -106,6 +106,7 @@ class EditorProvider extends Component {
 				'hasFixedToolbar',
 				'hasPermissionsToManageWidgets',
 				'imageSizes',
+				'imageDimensions',
 				'isRTL',
 				'maxWidth',
 				'styles',


### PR DESCRIPTION
## Description

See #1594. This PR builds on #17148 to add featured image to the Latest Posts block. It uses that new `ImageSizeControl` control and adds an alignment control for image alignment.

## Screenshots

Editor

![Screen Shot 2020-01-29 at 5 07 34 PM](https://user-images.githubusercontent.com/541093/73401813-e2d1ba80-42b9-11ea-92b1-8f200783dbe3.png)

Sidebar

![Screen Shot 2020-01-29 at 5 07 39 PM](https://user-images.githubusercontent.com/541093/73401814-e2d1ba80-42b9-11ea-8796-2d3dac26f8f7.png)

Front end

![Screen Shot 2020-01-29 at 5 08 10 PM](https://user-images.githubusercontent.com/541093/73401860-fa10a800-42b9-11ea-8fe6-d1bdf022a5b3.png)

## Still To Do

- [x] Need to figure out a solution for the image sizes issue– the ImageSizeControl component expects `imageHeight` & `imageWidth`, which function as a basis for the resizing. For a single image, this is literally the width & height of that particular image. For this block, we can use the site defaults for  each image size? — This seems to work just fine ✅
- [x] Selecting a different "image size" right now does nothing to change the image, so we also need to update that.  — Done 27eb6675e0e54ec64232ea60a010c8dd2595d476  ✅
- [x] And finally, we need to add the images into the frontend render. — Done c785f737fda5d099f6f741fcbfe522173fc2705b ✅

## To Test

- Make sure you have some posts with various sized featured images
- Add the Latest Posts block
- Toggle the "Display featured image" setting
- Try out the various sizes & alignment, make sure it works as you'd expect
