### PR TITLE
chore: Remove unused css from ColorPalette component

### DIFF
--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -87,35 +87,6 @@ $color-palette-circle-spacing: 14px;
 	}
 }
 
-.components-color-palette__clear-color .components-color-palette__item {
-	color: $white;
-	background: $white;
-}
-
-.components-color-palette__clear-color-line {
-	display: block;
-	position: absolute;
-	border: 2px solid $alert-red;
-	border-radius: 50%;
-	top: 0;
-	left: 0;
-	bottom: 0;
-	right: 0;
-	&::before {
-		position: absolute;
-		top: 0;
-		left: 0;
-		content: "";
-		width: 100%;
-		height: 100%;
-		border-bottom: 2px solid $alert-red;
-		transform:
-			rotate(45deg)
-			translateY(- $color-palette-circle-size / 2 + 1px)
-			translateX(- 1px);
-	}
-}
-
 .components-color-palette__custom-color {
 	margin-right: $grid-size-large;
 


### PR DESCRIPTION
## Description
This PR removes CSS code from the  ColorPalette component that is not used anywhere.

Searching on all files of the repository for components-color-palette__clear-color and components-color-palette__clear-color-line does not return any occurrences (besides the removed CSS). That means the selector will never be used making the code useless.

If an element used this classes in an indirect way e.g. string concatenation the most probable file to do that would be https://github.com/WordPress/gutenberg//blob/8e18cafdf823c274c8f81ae16ca7b1cbf7f062f3/packages/components/src/color-palette/index.js and manually checking it we can see the classes are not used.

## How has this been tested?
I verified the color pallet component still works as before.

