### PR TITLE
Project management automation: Fix 'add first time contributor label'

### DIFF
--- a/packages/project-management-automation/lib/add-first-time-contributor-label.js
+++ b/packages/project-management-automation/lib/add-first-time-contributor-label.js
@@ -17,12 +17,12 @@ async function addFirstTimeContributorLabel( payload, octokit ) {
 
 	debug( `add-first-time-contributor-label: Searching for commits in ${ owner }/${ repo } by @${ author }` );
 
-	const { total_count: totalCount } = await octokit.search.commits( {
+	const { data: { total_count: totalCount } } = await octokit.search.commits( {
 		q: `repo:${ owner }/${ repo }+author:${ author }`,
 	} );
 
 	if ( totalCount !== 0 ) {
-		debug( 'add-first-time-contributor-label: Commits found. Aborting' );
+		debug( `add-first-time-contributor-label: ${ totalCount } commits found. Aborting` );
 		return;
 	}
 

--- a/packages/project-management-automation/lib/test/add-first-time-contributor-label.js
+++ b/packages/project-management-automation/lib/test/add-first-time-contributor-label.js
@@ -22,7 +22,11 @@ describe( 'addFirstTimeContributorLabel', () => {
 	it( 'does nothing if the user has commits', async () => {
 		const octokit = {
 			search: {
-				commits: jest.fn( () => Promise.resolve( { total_count: 100 } ) ),
+				commits: jest.fn( () => Promise.resolve( {
+					data: {
+						total_count: 100,
+					},
+				} ) ),
 			},
 			issues: {
 				addLabels: jest.fn(),
@@ -40,7 +44,11 @@ describe( 'addFirstTimeContributorLabel', () => {
 	it( 'adds the label if the user does not have commits', async () => {
 		const octokit = {
 			search: {
-				commits: jest.fn( () => Promise.resolve( { total_count: 0 } ) ),
+				commits: jest.fn( () => Promise.resolve( {
+					data: {
+						total_count: 0,
+					},
+				} ) ),
 			},
 			issues: {
 				addLabels: jest.fn(),


### PR DESCRIPTION
Octokit returns the search result count as `data.total_count`, not `total_count`.

I confirmed this in my local Node REPL:

```
$ node
> let { GitHub } = require( '@actions/github' )
> let octokit = new GitHub( 'INSERT_PERSONAL_ACCESS_TOKEN_HERE' )
> octokit.search.commits( { q: 'repo:WordPress/gutenberg+author:geriux' } ).then( ( result ) => console.log( result ) )
```