### PR TITLE
Project management automation: Fix 'add milestone'

### DIFF
--- a/packages/project-management-automation/lib/add-milestone.js
+++ b/packages/project-management-automation/lib/add-milestone.js
@@ -31,7 +31,7 @@ async function addMilestone( payload, octokit ) {
 
 	debug( 'add-milestone: Fetching current milestone' );
 
-	const { milestone } = await octokit.issues.get( {
+	const { data: { milestone } } = await octokit.issues.get( {
 		owner: payload.repository.owner.login,
 		repo: payload.repository.name,
 		issue_number: payload.pull_request.number,
@@ -44,13 +44,13 @@ async function addMilestone( payload, octokit ) {
 
 	debug( 'add-milestone: Fetching `package.json` contents' );
 
-	const { content } = await octokit.repos.getContents( {
+	const { data: { content, encoding } } = await octokit.repos.getContents( {
 		owner: payload.repository.owner.login,
 		repo: payload.repository.name,
 		path: 'package.json',
 	} );
 
-	const { version } = JSON.parse( content );
+	const { version } = JSON.parse( Buffer.from( content, encoding ).toString() );
 
 	let [ major, minor ] = version.split( '.' ).map( Number );
 
@@ -81,7 +81,7 @@ async function addMilestone( payload, octokit ) {
 
 	debug( 'add-milestone: Fetching all milestones' );
 
-	const milestones = await octokit.issues.listMilestonesForRepo( {
+	const { data: milestones } = await octokit.issues.listMilestonesForRepo( {
 		owner: payload.repository.owner.login,
 		repo: payload.repository.name,
 	} );

--- a/packages/project-management-automation/lib/test/add-milestone.js
+++ b/packages/project-management-automation/lib/test/add-milestone.js
@@ -80,7 +80,9 @@ describe( 'addFirstTimeContributorLabel', () => {
 		const octokit = {
 			issues: {
 				get: jest.fn( () => Promise.resolve( {
-					milestone: 'Gutenberg 6.4',
+					data: {
+						milestone: 'Gutenberg 6.4',
+					},
 				} ) ),
 				createMilestone: jest.fn(),
 				listMilestonesForRepo: jest.fn(),
@@ -123,21 +125,28 @@ describe( 'addFirstTimeContributorLabel', () => {
 		const octokit = {
 			issues: {
 				get: jest.fn( () => Promise.resolve( {
-					milestone: null,
+					data: {
+						milestone: null,
+					},
 				} ) ),
 				createMilestone: jest.fn(),
-				listMilestonesForRepo: jest.fn( () => Promise.resolve( [
-					{ title: 'Gutenberg 6.2', number: 10 },
-					{ title: 'Gutenberg 6.3', number: 11 },
-					{ title: 'Gutenberg 6.4', number: 12 },
-				] ) ),
+				listMilestonesForRepo: jest.fn( () => Promise.resolve( {
+					data: [
+						{ title: 'Gutenberg 6.2', number: 10 },
+						{ title: 'Gutenberg 6.3', number: 11 },
+						{ title: 'Gutenberg 6.4', number: 12 },
+					],
+				} ) ),
 				update: jest.fn(),
 			},
 			repos: {
 				getContents: jest.fn( () => Promise.resolve( {
-					content: JSON.stringify( {
-						version: '6.3.0',
-					} ),
+					data: {
+						content: Buffer.from( JSON.stringify( {
+							version: '6.3.0',
+						} ) ).toString( 'base64' ),
+						encoding: 'base64',
+					},
 				} ) ),
 			},
 		};
@@ -191,21 +200,28 @@ describe( 'addFirstTimeContributorLabel', () => {
 		const octokit = {
 			issues: {
 				get: jest.fn( () => Promise.resolve( {
-					milestone: null,
+					data: {
+						milestone: null,
+					},
 				} ) ),
 				createMilestone: jest.fn(),
-				listMilestonesForRepo: jest.fn( () => Promise.resolve( [
-					{ title: 'Gutenberg 6.8', number: 10 },
-					{ title: 'Gutenberg 6.9', number: 11 },
-					{ title: 'Gutenberg 7.0', number: 12 },
-				] ) ),
+				listMilestonesForRepo: jest.fn( () => Promise.resolve( {
+					data: [
+						{ title: 'Gutenberg 6.8', number: 10 },
+						{ title: 'Gutenberg 6.9', number: 11 },
+						{ title: 'Gutenberg 7.0', number: 12 },
+					],
+				} ) ),
 				update: jest.fn(),
 			},
 			repos: {
 				getContents: jest.fn( () => Promise.resolve( {
-					content: JSON.stringify( {
-						version: '6.9.0',
-					} ),
+					data: {
+						content: Buffer.from( JSON.stringify( {
+							version: '6.9.0',
+						} ) ).toString( 'base64' ),
+						encoding: 'base64',
+					},
 				} ) ),
 			},
 		};


### PR DESCRIPTION
Octokit returns **all** resources wrapped in a `data` key, e.g. `data.milestone` instead of `milestone`. Also, `octokit.repos.getContents()` returns a base64 encoded string.

(I'm a big idiot who didn't read https://octokit.github.io/rest.js/#usage!)

Confirmed this by using my local Node REPL:

```
$ node
> let { GitHub } = require( '@actions/github' )
> let octokit = new GitHub( 'INSERT_PERSONAL_ACCESS_TOKEN_HERE' )
> octokit.issues.get( { owner: 'WordPress', repo: 'gutenberg', issue_number: 17156 } ).then( r => result = r )
> result.data.milestone
null
> octokit.repos.getContents( { owner: 'WordPress', repo: 'gutenberg', path: 'package.json' } ).then( r => result = r )
> JSON.parse( Buffer.from( result.data.content, result.data.encoding ).toString() ).version
'6.3.0'
> octokit.issues.listMilestonesForRepo( { owner: 'WordPress', repo: 'gutenberg' } ).then( r => result = r )
> result.data[0].title
'Future'
```