### PR TITLE
Added button for displaying author name in 'Latest Posts' blog.

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -41,6 +41,7 @@ class LatestPostsEdit extends Component {
 		super( ...arguments );
 		this.state = {
 			categoriesList: [],
+			usersList: [],
 		};
 	}
 
@@ -61,6 +62,22 @@ class LatestPostsEdit extends Component {
 				}
 			}
 		);
+		//Users List
+		this.fetchRequest = apiFetch( {
+			path: addQueryArgs( `/wp/v2/users` ),
+		} ).then(
+			( usersList ) => {
+				if ( this.isStillMounted ) {
+					this.setState( { usersList } );
+				}
+			}
+		).catch(
+			() => {
+				if ( this.isStillMounted ) {
+					this.setState( { usersList: [] } );
+				}
+			}
+		);
 	}
 
 	componentWillUnmount() {
@@ -69,8 +86,8 @@ class LatestPostsEdit extends Component {
 
 	render() {
 		const { attributes, setAttributes, latestPosts } = this.props;
-		const { categoriesList } = this.state;
-		const { displayPostContentRadio, displayPostContent, displayPostDate, postLayout, columns, order, orderBy, categories, postsToShow, excerptLength } = attributes;
+		const { categoriesList, usersList } = this.state;
+		const { displayPostContentRadio, displayPostContent, displayPostDate, displayPostAuthor, postLayout, columns, order, orderBy, categories, postsToShow, excerptLength } = attributes;
 
 		const inspectorControls = (
 			<InspectorControls>
@@ -107,6 +124,11 @@ class LatestPostsEdit extends Component {
 						label={ __( 'Display post date' ) }
 						checked={ displayPostDate }
 						onChange={ ( value ) => setAttributes( { displayPostDate: value } ) }
+					/>
+					<ToggleControl
+						label={ __( 'Display post author' ) }
+						checked={ displayPostAuthor }
+						onChange={ ( value ) => setAttributes( { displayPostAuthor: value } ) }
 					/>
 				</PanelBody>
 
@@ -186,6 +208,7 @@ class LatestPostsEdit extends Component {
 						'wp-block-latest-posts__list': true,
 						'is-grid': postLayout === 'grid',
 						'has-dates': displayPostDate,
+						'has-author': displayPostAuthor,
 						[ `columns-${ columns }` ]: postLayout === 'grid',
 					} ) }
 				>
@@ -213,6 +236,11 @@ class LatestPostsEdit extends Component {
 									<time dateTime={ format( 'c', post.date_gmt ) } className="wp-block-latest-posts__post-date">
 										{ dateI18n( dateFormat, post.date_gmt ) }
 									</time>
+								}
+								{ displayPostAuthor && usersList[i].name &&
+									<span className="wp-block-latest-posts__post-author">
+								 		by { usersList[i].name }	
+									</span>
 								}
 								{ displayPostContent && displayPostContentRadio === 'excerpt' &&
 								<div className="wp-block-latest-posts__post-excerpt">

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -50,6 +50,15 @@ function render_block_core_latest_posts( $attributes ) {
 			);
 		}
 
+		if ( isset( $attributes['displayPostAuthor'] ) && $attributes['displayPostAuthor'] ) {
+			$recent_author = get_user_by( 'ID', $post->post_author );
+			$author_display_name = 'by ' . $recent_author->display_name;
+			$list_items_markup .= sprintf(
+				'<span class="wp-block-latest-posts__post-author">%1$s</span>',
+				esc_html( $author_display_name )
+			);		
+		}
+
 		if ( isset( $attributes['displayPostContent'] ) && $attributes['displayPostContent']
 			&& isset( $attributes['displayPostContentRadio'] ) && 'excerpt' === $attributes['displayPostContentRadio'] ) {
 			$post_excerpt = $post->post_excerpt;
@@ -104,6 +113,10 @@ function render_block_core_latest_posts( $attributes ) {
 		$class .= ' has-dates';
 	}
 
+	if ( isset( $attributes['displayPostAuthor'] ) && $attributes['displayPostAuthor'] ) {
+		$class .= ' has-author';
+	}
+
 	if ( isset( $attributes['className'] ) ) {
 		$class .= ' ' . $attributes['className'];
 	}
@@ -152,6 +165,10 @@ function register_block_core_latest_posts() {
 					'default' => 55,
 				),
 				'displayPostDate'         => array(
+					'type'    => 'boolean',
+					'default' => false,
+				),
+				'displayPostAuthor'         => array(
 					'type'    => 'boolean',
 					'default' => false,
 				),

--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -30,7 +30,8 @@
 	}
 }
 
-.wp-block-latest-posts__post-date {
+.wp-block-latest-posts__post-date,
+.wp-block-latest-posts__post-author {
 	display: block;
 	color: $dark-gray-300;
 	font-size: $default-font-size;


### PR DESCRIPTION
Fixes #17681.

Files modified:
- packages/block-library/src/latest-posts/edit.js
- packages/block-library/src/latest-posts/index.php
- packages/block-library/src/latest-posts/style.scss

## Description
A toggle button to display the name of post's author has been added in 'Latest posts' blog.

## How has this been tested?
Tested locally and it works as expected.

## Screenshots <!-- if applicable -->
![added-display-author-name-button](https://user-images.githubusercontent.com/53076388/63586590-3fb89e80-c5bf-11e9-8bc3-83b943300cc1.png)

## Types of changes
New feature in 'Latest posts' blog to display Author name of post.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
