### PR TITLE
Fix: Empty Classic Editor inside innerBlock fatal error

### DIFF
--- a/packages/blocks/src/api/parser.js
+++ b/packages/blocks/src/api/parser.js
@@ -458,6 +458,9 @@ export function createBlockWithFallback( blockNode ) {
 	innerBlocks = innerBlocks.map( createBlockWithFallback );
 
 	// Remove `undefined` innerBlocks.
+	//
+	// This is a temporary fix to prevent unrecoverable TypeErrors when handling unexpectedly
+	// empty freeform block nodes. See https://github.com/WordPress/gutenberg/pull/17164.
 	innerBlocks = innerBlocks.filter( ( innerBlock ) => innerBlock );
 
 	const isFallbackBlock = (

--- a/packages/blocks/src/api/parser.js
+++ b/packages/blocks/src/api/parser.js
@@ -457,6 +457,9 @@ export function createBlockWithFallback( blockNode ) {
 	// Coerce inner blocks from parsed form to canonical form.
 	innerBlocks = innerBlocks.map( createBlockWithFallback );
 
+	// Remove `undefined` innerBlocks.
+	innerBlocks = innerBlocks.filter( ( innerBlock ) => innerBlock );
+
 	const isFallbackBlock = (
 		name === freeformContentFallbackBlock ||
 		name === unregisteredFallbackBlock


### PR DESCRIPTION
## Description
The problem is that the `innerBlocks` array gets `undefined` element if the content parsed is `<!-- wp:freeform /-->`. So the change just removes any `undefined` element in the `innerBlocks`. The merit of this solution is that any previously saved posts with this case will work.

## How has this been tested?
1. Followed the steps provided in #17138.
2. Confirmed that the bug exist.
3. Applied the fix.
4. Re-do step 1.
5. Failed to reproduce the bug.

## Types of changes
Fixes #17138. 

## Checklist:
- [ ] My code is tested.
