### PR TITLE
useReducedMotion hook: guard the reference to window

### DIFF
--- a/packages/compose/src/hooks/use-reduced-motion/index.js
+++ b/packages/compose/src/hooks/use-reduced-motion/index.js
@@ -8,7 +8,9 @@ import useMediaQuery from '../use-media-query';
  *
  * @type {boolean}
  */
-const IS_IE = window.navigator.userAgent.indexOf( 'Trident' ) >= 0;
+const IS_IE =
+	typeof window !== 'undefined' &&
+	window.navigator.userAgent.indexOf( 'Trident' ) >= 0;
 
 /**
  * Hook returning whether the user has a preference for reduced motion.


### PR DESCRIPTION
Fixes a bug where a naked reference to `window` will crash if used in a SSR context where there's no `window`.

Discovered when trying to upgrade Calypso to the latest `@wordpress/compose`.