### PR TITLE
Move fade animation to the Animate component

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -22,7 +22,7 @@ import {
 	isUnmodifiedDefaultBlock,
 	getUnregisteredTypeHandlerName,
 } from '@wordpress/blocks';
-import { KeyboardShortcuts, withFilters } from '@wordpress/components';
+import { Animate, KeyboardShortcuts, withFilters } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	withDispatch,
@@ -588,13 +588,17 @@ function BlockListBlock( {
 				</IgnoreNestedEvents>
 			</div>
 			{ showInserterShortcuts && (
-				<div className="editor-block-list__side-inserter block-editor-block-list__side-inserter">
-					<InserterWithShortcuts
-						clientId={ clientId }
-						rootClientId={ rootClientId }
-						onToggle={ selectOnOpen }
-					/>
-				</div>
+				<Animate type="fade-in">
+					{ ( { className: animateClassName } ) =>
+						<div className={ classnames( 'editor-block-list__side-inserter', 'block-editor-block-list__side-inserter', animateClassName ) }>
+							<InserterWithShortcuts
+								clientId={ clientId }
+								rootClientId={ rootClientId }
+								onToggle={ selectOnOpen }
+							/>
+						</div>
+					}
+				</Animate>
 			) }
 			{ showEmptyBlockSideInserter && (
 				<div className="editor-block-list__empty-block-inserter block-editor-block-list__empty-block-inserter">

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -351,10 +351,6 @@
 		animation: none;
 	}
 
-	.block-editor-block-list__side-inserter {
-		@include edit-post__fade-in-animation;
-	}
-
 	// Reusable blocks
 	&.is-reusable > .block-editor-block-list__block-edit::before {
 		border: $border-width dashed $dark-opacity-light-500;

--- a/packages/block-editor/src/components/block-mover/index.js
+++ b/packages/block-editor/src/components/block-mover/index.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton } from '@wordpress/components';
+import { Animate, IconButton } from '@wordpress/components';
 import { getBlockType } from '@wordpress/blocks';
 import { Component } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -56,61 +56,65 @@ export class BlockMover extends Component {
 		// to an unfocused state (body as active element) without firing blur on,
 		// the rendering parent, leaving it unable to react to focus out.
 		return (
-			<div className={ classnames( 'editor-block-mover block-editor-block-mover', { 'is-visible': isFocused || ! isHidden } ) }>
-				<IconButton
-					className="editor-block-mover__control block-editor-block-mover__control"
-					onClick={ isFirst ? null : onMoveUp }
-					icon={ upArrow }
-					label={ __( 'Move up' ) }
-					aria-describedby={ `block-editor-block-mover__up-description-${ instanceId }` }
-					aria-disabled={ isFirst }
-					onFocus={ this.onFocus }
-					onBlur={ this.onBlur }
-				/>
-				<IconDragHandle
-					className="editor-block-mover__control block-editor-block-mover__control"
-					icon={ dragHandle }
-					clientId={ clientIds }
-					blockElementId={ blockElementId }
-					isVisible={ isDraggable }
-					onDragStart={ onDragStart }
-					onDragEnd={ onDragEnd }
-				/>
-				<IconButton
-					className="editor-block-mover__control block-editor-block-mover__control"
-					onClick={ isLast ? null : onMoveDown }
-					icon={ downArrow }
-					label={ __( 'Move down' ) }
-					aria-describedby={ `block-editor-block-mover__down-description-${ instanceId }` }
-					aria-disabled={ isLast }
-					onFocus={ this.onFocus }
-					onBlur={ this.onBlur }
-				/>
-				<span id={ `block-editor-block-mover__up-description-${ instanceId }` } className="editor-block-mover__description block-editor-block-mover__description">
-					{
-						getBlockMoverDescription(
-							blocksCount,
-							blockType && blockType.title,
-							firstIndex,
-							isFirst,
-							isLast,
-							-1,
-						)
-					}
-				</span>
-				<span id={ `block-editor-block-mover__down-description-${ instanceId }` } className="editor-block-mover__description block-editor-block-mover__description">
-					{
-						getBlockMoverDescription(
-							blocksCount,
-							blockType && blockType.title,
-							firstIndex,
-							isFirst,
-							isLast,
-							1,
-						)
-					}
-				</span>
-			</div>
+			<Animate type={ isFocused || ! isHidden ? 'fade-in' : null }>
+				{ ( { className: animateClassName } ) =>
+					<div className={ classnames( 'editor-block-mover block-editor-block-mover', { 'is-visible': isFocused || ! isHidden }, animateClassName ) }>
+						<IconButton
+							className="editor-block-mover__control block-editor-block-mover__control"
+							onClick={ isFirst ? null : onMoveUp }
+							icon={ upArrow }
+							label={ __( 'Move up' ) }
+							aria-describedby={ `block-editor-block-mover__up-description-${ instanceId }` }
+							aria-disabled={ isFirst }
+							onFocus={ this.onFocus }
+							onBlur={ this.onBlur }
+						/>
+						<IconDragHandle
+							className="editor-block-mover__control block-editor-block-mover__control"
+							icon={ dragHandle }
+							clientId={ clientIds }
+							blockElementId={ blockElementId }
+							isVisible={ isDraggable }
+							onDragStart={ onDragStart }
+							onDragEnd={ onDragEnd }
+						/>
+						<IconButton
+							className="editor-block-mover__control block-editor-block-mover__control"
+							onClick={ isLast ? null : onMoveDown }
+							icon={ downArrow }
+							label={ __( 'Move down' ) }
+							aria-describedby={ `block-editor-block-mover__down-description-${ instanceId }` }
+							aria-disabled={ isLast }
+							onFocus={ this.onFocus }
+							onBlur={ this.onBlur }
+						/>
+						<span id={ `block-editor-block-mover__up-description-${ instanceId }` } className="editor-block-mover__description block-editor-block-mover__description">
+							{
+								getBlockMoverDescription(
+									blocksCount,
+									blockType && blockType.title,
+									firstIndex,
+									isFirst,
+									isLast,
+									-1,
+								)
+							}
+						</span>
+						<span id={ `block-editor-block-mover__down-description-${ instanceId }` } className="editor-block-mover__description block-editor-block-mover__description">
+							{
+								getBlockMoverDescription(
+									blocksCount,
+									blockType && blockType.title,
+									firstIndex,
+									isFirst,
+									isLast,
+									1,
+								)
+							}
+						</span>
+					</div>
+				}
+			</Animate>
 		);
 	}
 }

--- a/packages/block-editor/src/components/block-mover/index.js
+++ b/packages/block-editor/src/components/block-mover/index.js
@@ -57,7 +57,7 @@ export class BlockMover extends Component {
 		// the rendering parent, leaving it unable to react to focus out.
 		return (
 			<Animate type={ isFocused || ! isHidden ? 'fade-in' : null }>
-				{ ( { className: animateClassName } ) =>
+				{ ( { className: animateClassName } ) => (
 					<div className={ classnames( 'editor-block-mover block-editor-block-mover', { 'is-visible': isFocused || ! isHidden }, animateClassName ) }>
 						<IconButton
 							className="editor-block-mover__control block-editor-block-mover__control"
@@ -113,7 +113,7 @@ export class BlockMover extends Component {
 							}
 						</span>
 					</div>
-				}
+				) }
 			</Animate>
 		);
 	}

--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -2,10 +2,6 @@
 	min-height: $empty-paragraph-height;
 	opacity: 0;
 
-	&.is-visible {
-		@include edit-post__fade-in-animation;
-	}
-
 	// 24px is the smallest size of a good pressable button.
 	// With 3 pieces of side UI, that comes to a total of 72px.
 	// To vertically center against a 56px paragraph, move upwards 72px - 56px / 2.

--- a/packages/block-editor/src/components/default-block-appender/style.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.scss
@@ -40,12 +40,6 @@
 		}
 	}
 
-	&:hover {
-		.block-editor-inserter-with-shortcuts {
-			@include edit-post__fade-in-animation;
-		}
-	}
-
 	// Dropzone.
 	.components-drop-zone__content-icon {
 		display: none;

--- a/packages/block-editor/src/components/inserter-with-shortcuts/index.js
+++ b/packages/block-editor/src/components/inserter-with-shortcuts/index.js
@@ -2,13 +2,14 @@
  * External dependencies
  */
 import { filter, isEmpty } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
  */
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { compose } from '@wordpress/compose';
-import { IconButton } from '@wordpress/components';
+import { Animate, IconButton } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { withDispatch, withSelect } from '@wordpress/data';
 
@@ -30,20 +31,24 @@ function InserterWithShortcuts( { items, isLocked, onInsert } ) {
 	} ).slice( 0, 3 );
 
 	return (
-		<div className="editor-inserter-with-shortcuts block-editor-inserter-with-shortcuts">
-			{ itemsWithoutDefaultBlock.map( ( item ) => (
-				<IconButton
-					key={ item.id }
-					className="editor-inserter-with-shortcuts__block block-editor-inserter-with-shortcuts__block"
-					onClick={ () => onInsert( item ) }
-					// translators: %s: block title/name to be added
-					label={ sprintf( __( 'Add %s' ), item.title ) }
-					icon={ (
-						<BlockIcon icon={ item.icon } />
-					) }
-				/>
-			) ) }
-		</div>
+		<Animate type="fade-in">
+			{ ( { className: animateClassName } ) => (
+				<div className={ classnames( 'editor-inserter-with-shortcuts block-editor-inserter-with-shortcuts', animateClassName ) }>
+					{ itemsWithoutDefaultBlock.map( ( item ) => (
+						<IconButton
+							key={ item.id }
+							className="editor-inserter-with-shortcuts__block block-editor-inserter-with-shortcuts__block"
+							onClick={ () => onInsert( item ) }
+							// translators: %s: block title/name to be added
+							label={ sprintf( __( 'Add %s' ), item.title ) }
+							icon={ (
+								<BlockIcon icon={ item.icon } />
+							) }
+						/>
+					) ) }
+				</div>
+			) }
+		</Animate>
 	);
 }
 

--- a/packages/components/src/animate/index.js
+++ b/packages/components/src/animate/index.js
@@ -30,6 +30,14 @@ function Animate( { type, options = {}, children } ) {
 		} );
 	}
 
+	if ( type === 'fade-in' ) {
+		return children( {
+			className: classnames(
+				'components-animate__fade-in',
+			),
+		} );
+	}
+
 	return children( {} );
 }
 

--- a/packages/components/src/animate/style.scss
+++ b/packages/components/src/animate/style.scss
@@ -43,3 +43,18 @@
 		transform: translateX(0%);
 	}
 }
+
+.components-animate__fade-in {
+	animation: components-animate__fade-in 0.2s ease-out 0s;
+	animation-fill-mode: forwards;
+	@include reduce-motion("animation");
+}
+
+@keyframes components-animate__fade-in {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}


### PR DESCRIPTION
Once #17106 is merged in, this PR will handle the final migration of animations from `_animations.scss` into the Animate component. Moving these into the Animate component will allow the animations to be much more self-contained, and prevent us from separately declaring the keyframe declarations in each environment where they need to be used. 

Some of these are a bit beyond my expertise, so if anyone else wants to pitch in, please feel free to push directly to this PR (and thank you in advance! 🙌)!

## Tasks

- [x] Add a new `fade-in` animation to the Animate component
- [x] Update `block-movers` to use the new animation
- [x] Update `inserter-with-shortcuts` to use the new animation
- [ ] Update `inserter` help panel to use the new animation
- [ ] Update `modal` to use the new animation
- [ ] Update `fullscreen-mode` to use the new animation
- [ ] Delete the `_animations.scss` file, and stop it from being included in all other SCSS files. 
- [ ] Remove keyframes from `packages/edit-widgets/src/style.scss`, `playground/src/style.scss`, and `packages/edit-post/src/style.scss`
- [ ] Update documentation

_(If it ends up making sense to break these out into separate PRs, we can do that)_