### PR TITLE
Revert "Build: remove global install of latest npm since we want to use the paired node/npm version"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ env:
     - INSTALL_WORDPRESS: true
 
 before_install:
-  - nvm install
+  - nvm install --latest-npm
   - |
     if [[ "$INSTALL_WORDPRESS" = "true" ]]; then
       # Upgrade docker-compose.


### PR DESCRIPTION
The Gutenberg project intentionally uses latest `npm` releases. I'd still recommend avoiding this to have a little less excitement with other project releases, but happy to prep this PR if folks are okay with it.

### Testing Instructions
- ✅Travis is green
- Run `nvm uninstall v10.16.3`
- Run `./bin/setup-local-env.sh`
- We see an updated prompt to transparently run ` nvm install --latest-npm`

```
$ ./bin/setup-local-env.sh 
WARNING: Node version does not match the latest long term support version. Please run this command to install and use it:
WARNING: nvm install --latest-npm
WARNING: After that, re-run the setup script to continue.
```
- Running this command, we see that we download the active node LTS with latest npm:
- Switching node versions will see this cached pairing.
```
$  nvm install --latest-npm
Found '/Users/kerryliu/checkouts/gutenberg/.nvmrc' with version <lts/*>
v10.16.3 is already installed.
Now using node v10.16.3 (npm v6.9.0)
Attempting to upgrade to the latest working version of npm...
* Installing latest `npm`; if this does not work on your node version, please report a bug!
/Users/kerryliu/.nvm/versions/node/v10.16.3/bin/npm -> /Users/kerryliu/.nvm/versions/node/v10.16.3/lib/node_modules/npm/bin/npm-cli.js
/Users/kerryliu/.nvm/versions/node/v10.16.3/bin/npx -> /Users/kerryliu/.nvm/versions/node/v10.16.3/lib/node_modules/npm/bin/npx-cli.js
+ npm@6.11.2
added 19 packages from 13 contributors, removed 15 packages and updated 53 packages in 6.584s
* npm upgraded to: v6.11.2
```

Reverts WordPress/gutenberg#17134