### PR TITLE
Fix image flickering & focus lose on resizing 

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -575,7 +575,6 @@ export class ImageEdit extends Component {
 			className,
 			maxWidth,
 			noticeUI,
-			toggleSelection,
 			isRTL,
 		} = this.props;
 		const {
@@ -892,15 +891,11 @@ export class ImageEdit extends Component {
 											bottom: true,
 											left: showLeftHandle,
 										} }
-										onResizeStart={ () => {
-											toggleSelection( false );
-										} }
 										onResizeStop={ ( event, direction, elt, delta ) => {
 											setAttributes( {
 												width: parseInt( currentWidth + delta.width, 10 ),
 												height: parseInt( currentHeight + delta.height, 10 ),
 											} );
-											toggleSelection( true );
 										} }
 									>
 										{ img }


### PR DESCRIPTION
## Description
fixes https://github.com/WordPress/gutenberg/issues/17174
fixes https://github.com/WordPress/gutenberg/issues/15420
handles problem in this comment https://github.com/WordPress/gutenberg/pull/16475#issuecomment-524457509

it deletes the selection toggling on the image on resize start & resize end

