### PR TITLE
[RNMobile] Fix focus title on new posts regression

### DIFF
--- a/packages/edit-post/src/editor.native.js
+++ b/packages/edit-post/src/editor.native.js
@@ -3,6 +3,7 @@
  */
 import memize from 'memize';
 import { size, map, without } from 'lodash';
+import { subscribeSetFocusOnTitle } from 'react-native-gutenberg-bridge';
 
 /**
  * WordPress dependencies
@@ -31,6 +32,8 @@ class Editor extends Component {
 		this.getEditorSettings = memize( this.getEditorSettings, {
 			maxSize: 1,
 		} );
+
+		this.setTitleRef = this.setTitleRef.bind( this );
 	}
 
 	getEditorSettings(
@@ -64,6 +67,24 @@ class Editor extends Component {
 		}
 
 		return settings;
+	}
+
+	componentDidMount() {
+		this.subscriptionParentSetFocusOnTitle = subscribeSetFocusOnTitle( () => {
+			if ( this.postTitleRef ) {
+				this.postTitleRef.focus();
+			}
+		} );
+	}
+
+	componentWillUnmount() {
+		if ( this.subscriptionParentSetFocusOnTitle ) {
+			this.subscriptionParentSetFocusOnTitle.remove();
+		}
+	}
+
+	setTitleRef( titleRef ) {
+		this.postTitleRef = titleRef;
 	}
 
 	render() {

--- a/packages/editor/src/components/provider/index.native.js
+++ b/packages/editor/src/components/provider/index.native.js
@@ -5,7 +5,6 @@ import RNReactNativeGutenbergBridge, {
 	subscribeParentGetHtml,
 	subscribeParentToggleHTMLMode,
 	subscribeUpdateHtml,
-	subscribeSetFocusOnTitle,
 	subscribeSetTitle,
 } from 'react-native-gutenberg-bridge';
 
@@ -28,8 +27,6 @@ class NativeEditorProvider extends Component {
 
 		// Keep a local reference to `post` to detect changes
 		this.post = props.post;
-
-		this.setTitleRef = this.setTitleRef.bind( this );
 	}
 
 	componentDidMount() {
@@ -47,12 +44,6 @@ class NativeEditorProvider extends Component {
 
 		this.subscriptionParentUpdateHtml = subscribeUpdateHtml( ( payload ) => {
 			this.updateHtmlAction( payload.html );
-		} );
-
-		this.subscriptionParentSetFocusOnTitle = subscribeSetFocusOnTitle( () => {
-			if ( this.postTitleRef ) {
-				this.postTitleRef.focus();
-			}
 		} );
 	}
 
@@ -72,10 +63,6 @@ class NativeEditorProvider extends Component {
 		if ( this.subscriptionParentUpdateHtml ) {
 			this.subscriptionParentUpdateHtml.remove();
 		}
-
-		if ( this.subscriptionParentSetFocusOnTitle ) {
-			this.subscriptionParentSetFocusOnTitle.remove();
-		}
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -85,10 +72,6 @@ class NativeEditorProvider extends Component {
 			const unsupportedBlockNames = blocks.filter( isUnsupportedBlock ).map( ( block ) => block.attributes.originalName );
 			RNReactNativeGutenbergBridge.editorDidMount( unsupportedBlockNames );
 		}
-	}
-
-	setTitleRef( titleRef ) {
-		this.postTitleRef = titleRef;
 	}
 
 	serializeToNativeAction() {


### PR DESCRIPTION
This PR fixes a regression where the event "setTitleFocus" was not handled properly on the JS side. This had the effect that the Title was not set to focus on new (empty) posts.

`gutenberg-mobile` side PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1324
`WPiOS PR`: https://github.com/wordpress-mobile/WordPress-iOS/pull/12379

To test:
- Checkout the WPiOS PR.
- Open a new gutenberg post (no need to run metro).
- Check that the PostTitle is automatically focused.

The UI Tests on the WPiOS branch should also be passing now.