### PR TITLE
Added an extension slot for inserter menu.

### DIFF
--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -41,6 +41,7 @@ export { default as withColorContext } from './color-palette/with-color-context'
 
 export { default as __experimentalBlockSettingsMenuFirstItem } from './block-settings-menu/block-settings-menu-first-item';
 export { default as __experimentalBlockSettingsMenuPluginsExtension } from './block-settings-menu/block-settings-menu-plugins-extension';
+export { default as __experimentalInserterMenuExtension } from './inserter-menu-extension';
 export { default as BlockEditorKeyboardShortcuts } from './block-editor-keyboard-shortcuts';
 export { default as BlockInspector } from './block-inspector';
 export { default as BlockList } from './block-list';

--- a/packages/block-editor/src/components/inserter-menu-extension/index.js
+++ b/packages/block-editor/src/components/inserter-menu-extension/index.js
@@ -1,0 +1,10 @@
+/**
+ * WordPress dependencies
+ */
+import { createSlotFill } from '@wordpress/components';
+
+const { Fill: __experimentalInserterMenuExtension, Slot } = createSlotFill( '__experimentalInserterMenuExtension' );
+
+__experimentalInserterMenuExtension.Slot = Slot;
+
+export default __experimentalInserterMenuExtension;

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -47,6 +47,7 @@ import BlockPreview from '../block-preview';
 import BlockTypesList from '../block-types-list';
 import BlockCard from '../block-card';
 import ChildBlocks from './child-blocks';
+import __experimentalInserterMenuExtension from '../inserter-menu-extension';
 
 const MAX_SUGGESTED_ITEMS = 9;
 
@@ -263,6 +264,7 @@ export class InserterMenu extends Component {
 			suggestedItems,
 		} = this.state;
 		const isPanelOpen = ( panel ) => openPanels.indexOf( panel ) !== -1;
+		const isMenuEmpty = isEmpty( suggestedItems ) && isEmpty( reusableItems ) && isEmpty( itemsPerCategory );
 		const hoveredItemBlockType = hoveredItem ? getBlockType( hoveredItem.name ) : null;
 
 		// Disable reason (no-autofocus): The inserter menu is a modal display, not one which
@@ -355,9 +357,26 @@ export class InserterMenu extends Component {
 								</a>
 							</PanelBody>
 						) }
-						{ isEmpty( suggestedItems ) && isEmpty( reusableItems ) && isEmpty( itemsPerCategory ) && (
-							<p className="editor-inserter__no-results block-editor-inserter__no-results">{ __( 'No blocks found.' ) }</p>
-						) }
+						<__experimentalInserterMenuExtension.Slot
+							fillProps={ {
+								onSelect,
+								onHover: this.onHover,
+								filterValue: this.state.filterValue,
+								isMenuEmpty,
+							} }
+						>
+							{ ( fills ) => {
+								if ( fills.length ) {
+									return fills;
+								}
+								if ( isMenuEmpty ) {
+									return (
+										<p className="editor-inserter__no-results block-editor-inserter__no-results">{ __( 'No blocks found.' ) }</p>
+									);
+								}
+								return null;
+							} }
+						</__experimentalInserterMenuExtension.Slot>
 					</div>
 				</div>
 


### PR DESCRIPTION
## Description
Added an extension slot for inserter menu.
When the `slot` is filled, the empty state (isMenuEmpty is true) should be handle by the `fills`.
When the `slot` is not filled, the empty state behaves the same as before. It shows "No blocks found".
<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested locally

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature (non-breaking change which adds functionality)
This PR is a split of #16524

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
