### PR TITLE
[RNMobile] Fix MaxListenersExceededWarning caused by dark-mode event emitter

### DIFF
--- a/packages/components/src/mobile/dark-mode/index.native.js
+++ b/packages/components/src/mobile/dark-mode/index.native.js
@@ -4,6 +4,8 @@
 import { eventEmitter, initialMode } from 'react-native-dark-mode';
 import React from 'react';
 
+eventEmitter.setMaxListeners( 150 );
+
 export function useStyle( light, dark, theme ) {
 	const finalDark = {
 		...light,

--- a/packages/components/src/mobile/dark-mode/index.native.js
+++ b/packages/components/src/mobile/dark-mode/index.native.js
@@ -24,6 +24,8 @@ export function withTheme( WrappedComponent ) {
 		constructor( props ) {
 			super( props );
 
+			this.onModeChanged = this.onModeChanged.bind( this );
+
 			this.state = {
 				mode: initialMode,
 			};

--- a/packages/components/src/mobile/dark-mode/index.native.js
+++ b/packages/components/src/mobile/dark-mode/index.native.js
@@ -29,10 +29,16 @@ export function withTheme( WrappedComponent ) {
 			};
 		}
 
+		onModeChanged( newMode ) {
+			this.setState( { mode: newMode } );
+		}
+
 		componentDidMount() {
-			eventEmitter.on( 'currentModeChanged', ( newMode ) => {
-				this.setState( { mode: newMode } );
-			} );
+			this.subscription = eventEmitter.on( 'currentModeChanged', this.onModeChanged );
+		}
+
+		componentWillUnmount() {
+			eventEmitter.removeListener( 'currentModeChanged', this.onModeChanged );
 		}
 
 		render() {

--- a/packages/components/src/mobile/dark-mode/index.native.js
+++ b/packages/components/src/mobile/dark-mode/index.native.js
@@ -40,7 +40,10 @@ export function withTheme( WrappedComponent ) {
 		}
 
 		componentWillUnmount() {
-			eventEmitter.removeListener( 'currentModeChanged', this.onModeChanged );
+			// Conditional needed to pass UI Tests on CI
+			if ( eventEmitter.removeListener ) {
+				eventEmitter.removeListener( 'currentModeChanged', this.onModeChanged );
+			}
 		}
 
 		render() {

--- a/packages/components/src/mobile/dark-mode/index.native.js
+++ b/packages/components/src/mobile/dark-mode/index.native.js
@@ -4,7 +4,10 @@
 import { eventEmitter, initialMode } from 'react-native-dark-mode';
 import React from 'react';
 
-eventEmitter.setMaxListeners( 150 );
+// This was failing on CI
+if ( eventEmitter.setMaxListeners ) {
+	eventEmitter.setMaxListeners( 150 );
+}
 
 export function useStyle( light, dark, theme ) {
 	const finalDark = {


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

`gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1325

This PR fixes a warning caused by RNDarkMode event emitter:

```
axListenersExceededWarning: Possible EventEmitter memory leak detected. 11 currentModeChanged listeners added. Use emitter.setMaxListeners() to increase limit
```

To test:
- Run the demo app.
- Check that the warning does not appear.
