### PR TITLE
Raw handling: Fix strikethrough formatting when copy/pasting from Google Docs in Safari

### DIFF
--- a/packages/blocks/src/api/raw-handling/phrasing-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/phrasing-content-reducer.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { includes } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { wrap, replaceTag } from '@wordpress/dom';
@@ -11,6 +16,7 @@ export default function( node, doc ) {
 			fontWeight,
 			fontStyle,
 			textDecorationLine,
+			textDecoration,
 			verticalAlign,
 		} = node.style;
 
@@ -22,7 +28,10 @@ export default function( node, doc ) {
 			wrap( doc.createElement( 'em' ), node );
 		}
 
-		if ( textDecorationLine === 'line-through' ) {
+		// Some DOM implementations (Safari, JSDom) don't support
+		// style.textDecorationLine, so we check style.textDecoration as a
+		// fallback.
+		if ( textDecorationLine === 'line-through' || includes( textDecoration, 'line-through' ) ) {
 			wrap( doc.createElement( 's' ), node );
 		}
 

--- a/test/integration/fixtures/google-docs-out.html
+++ b/test/integration/fixtures/google-docs-out.html
@@ -7,7 +7,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>Formatting test: <strong>bold</strong>, <em>italic</em>, <a href="https://w.org/">link</a>, strikethrough, <sup>superscript</sup>, <sub>subscript</sub>, <strong><em>nested</em></strong>.<br></p>
+<p>Formatting test: <strong>bold</strong>, <em>italic</em>, <a href="https://w.org/">link</a>, <s>strikethrough</s>, <sup>superscript</sup>, <sub>subscript</sub>, <strong><em>nested</em></strong>.<br></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->

--- a/test/integration/fixtures/google-docs-with-comments-out.html
+++ b/test/integration/fixtures/google-docs-with-comments-out.html
@@ -7,7 +7,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>Formatting test: <strong>bold</strong>, <em>italic</em>, <a href="https://w.org/">link</a>, strikethrough, <sup>superscript</sup>, <sub>subscript</sub>, <strong><em>nested</em></strong>.<br></p>
+<p>Formatting test: <strong>bold</strong>, <em>italic</em>, <a href="https://w.org/">link</a>, <s>strikethrough</s>, <sup>superscript</sup>, <sub>subscript</sub>, <strong><em>nested</em></strong>.<br></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/15805.

Copy and pasting text that has strikethrough formatting from Google Docs into Gutenberg was not working in Safari or in JSDOM. 

This is because there's a difference in how browsers set `textDecorationLine`:

```js
const span = document.createElement( 'span' );
span.setAttribute( 'text-decoration: line-through' );
console.log( span.style.textDecorationLine );
```

In Chrome, the output is `'line-through'`. In Safari and JSDOM, the output is `''`.

Since the markup generated by Google Docs sets only `text-decoration` and none of the other `text-decoraton-*` attributes, my fix is to change the raw handler to look at `.textDecoration` instead of `.textDecorationLine`.

#### How to test

Using Safari:

1. Copy some text from Google Docs that includes strikethrough formatting.
2. Create a new post using Gutenberg and add a paragraph block.
3. Paste what you copied.

The strikethrough formatting should remain.