### PR TITLE
Try: Fix MacOS auto-hiding scrollbars disappearing.

### DIFF
--- a/packages/a11y/src/addContainer.js
+++ b/packages/a11y/src/addContainer.js
@@ -20,8 +20,8 @@ const addContainer = function( ariaLive ) {
 		'width: 1px;' +
 		'overflow: hidden;' +
 		'clip: rect(1px, 1px, 1px, 1px);' +
-		'-webkit-clip-path: inset(50%);' +
-		'clip-path: inset(50%);' +
+		//'-webkit-clip-path: inset(50%);' +
+		//'clip-path: inset(50%);' +
 		'border: 0;' +
 		'word-wrap: normal !important;'
 	) );


### PR DESCRIPTION
DO NOT MERGE. This is a work in progress and needs discussion first.

This PR fixes #16966.

However it does so by some weird Voodoo. For whatever reason, the clip-path attached to screen-reader-text is causing the silly MacOS auto-hiding scrollbars to disappear entirely. But only in Chrome (and Chromium based Edge), and only when there are adjacent elements with specific styles.

This is a pretty exotic issue, and basically it hinges on TWO types of CSS properties being used in the body of the scrolling container. There has to be both an element that uses `position: sticky;`— like the block toolbars, and there has to be an element that uses `clip-path` — like the screen-reader text.

This is clearly a Chromium issue, so I have reported it here: https://bugs.chromium.org/p/chromium/issues/detail?id=997607

In the mean time, removing the clip-path from screen-reader text fixes it for us. However this is a hack that's frustrating to do, and although I can't see any negative effects of removing it (it appears to just be an extra effort to make sure the screen-reader text is not visible), it definitely needs a thorough testing and sanity check before we consider merging it. 