### PR TITLE
Chore: Run npm audit fix to update reported `eslint-utils` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11280,9 +11280,9 @@
 			}
 		},
 		"eslint-utils": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
-			"integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+			"integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
 			"dev": true,
 			"requires": {
 				"eslint-visitor-keys": "^1.0.0"


### PR DESCRIPTION
## Description
Executed `npm audit fix` to get rid of vulnerabilities:

Before
```
found 3 vulnerabilities (1 high, 2 critical) in 1988725 scanned packages
  run `npm audit fix` to fix 2 of them.
  1 vulnerability requires manual review. See the full report for details.
```

After

```
found 1 high severity vulnerability in 1988725 scanned packages
  1 vulnerability requires manual review. See the full report for details.
```

We still need to update Parcel but it is used only for the playground so isn't as much important as the other one.