### PR TITLE
[RNMobile]: BottomSheet icon color fix.

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/cell.native.js
@@ -151,6 +151,8 @@ class BottomSheetCell extends Component {
 				);
 		};
 
+		const iconStyle = getStyle( styles.icon, styles.iconDark, theme );
+
 		return (
 			<TouchableOpacity
 				accessible={ ! this.state.isEditingValue }
@@ -168,7 +170,7 @@ class BottomSheetCell extends Component {
 					<View style={ styles.cellRowContainer }>
 						{ icon && (
 							<View style={ styles.cellRowContainer }>
-								<Dashicon icon={ icon } size={ 24 } color={ theme === 'dark' && '#C3C4C7' } />
+								<Dashicon icon={ icon } size={ 24 } color={ iconStyle.color } />
 								<View style={ platformStyles.labelIconSeparator } />
 							</View>
 						) }

--- a/packages/components/src/mobile/bottom-sheet/styles.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/styles.native.scss
@@ -134,3 +134,11 @@
 .cellValueRTL {
 	text-align: left;
 }
+
+.icon {
+	color: #7b9ab1;
+}
+
+.iconDark {
+	color: #c3c4c7;
+}


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This PR fixes an issue where on Android, the BottomSheet icons where white (or transparent)

This is by setting both regular and dark color right into the color prop of DashIcon, instead of using DashIcon class for the regular (light) one.

Setting `undefined` or `null` to the `color` prop didn't solve the problem.

`gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1326

To test:
- Run on Android
- Show the BottomSheet
- Check that the icons are visible and gray
