### PR TITLE
Clean up toolbar position for wide full blocks

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -526,7 +526,7 @@
 
 		// Align block toolbar to floated content.
 		// Extra specificity is needed to avoid applying this to innerblocks.
-		@include break-mobile() {
+		@include break-small() {
 			> .editor-block-list__block-edit > .block-editor-block-contextual-toolbar > .block-editor-block-toolbar {
 				/*!rtl:begin:ignore*/
 				left: $block-side-ui-width * 3 + ($grid-size-small * 1.5);

--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -35,7 +35,7 @@
 		&[data-align="wide"] > .block-editor-block-list__block-edit > .block-editor-block-contextual-toolbar,
 		&[data-align="full"] > .block-editor-block-list__block-edit > .block-editor-block-contextual-toolbar {
 			height: 0; // This collapses the container to an invisible element without margin.
-			width: calc(100% - 1px); // -1px to account for inner element left: 1px value causing overflow-x scrollbars
+			width: calc(100% - #{$block-side-ui-width * 3} - #{$grid-size-small * 1.5}); // -90px to account for inner element left position value causing overflow-x scrollbars
 			margin-left: 0;
 			margin-right: 0;
 			text-align: center;
@@ -43,6 +43,10 @@
 			// This is necessary because otherwise the mere presence of the toolbar can push down content.
 			// Pairs with relative rule on line 49.
 			float: left;
+
+			@include break-xlarge() {
+				width: calc(100% - #{$block-padding * 2} + #{$border-width * 2}); // On the largest screens, line the toolbar up with standard-aligned block controls.
+			}
 
 			.block-editor-block-toolbar {
 				max-width: $content-width;


### PR DESCRIPTION
This cleans up a few bugs all related to the toolbar position for wide and full blocks. 

1. Eliminates the need for a horizontal scrollbar on screens between 600-782px wide.
2. Corrects toolbar position on screens above 1080px.
3. Corrects toolbar controls position on screens between 480-600px wide.

---

## 1. Eliminate the need for a horizontal scrollbar on screens between 600-782px wide

Closes #17137

This PR temoves the scrollbar that was showing up when selecting a full-width block in between the `600-782px` breakpoints. We needed the toolbar's `width` value to negate its child's position value [as defined here](https://github.com/WordPress/gutenberg/blob/87da09e96550ca87a35daae401fd21d5261812e9/packages/block-editor/src/components/block-list/style.scss#L529-L535).

_Before (Horizontal scrollbar is visible):_ 

<img width="719" alt="Screen Shot 2019-08-26 at 9 37 05 AM" src="https://user-images.githubusercontent.com/1202812/63694731-17aa8480-c7e5-11e9-9a0b-7232a718e429.png">

_After (Horizontal scrollbar is not visible):_

<img width="719" alt="Screen Shot 2019-08-26 at 9 34 34 AM" src="https://user-images.githubusercontent.com/1202812/63694577-c00c1900-c7e4-11e9-82f4-dce0a75ebcb5.png">

---

## 2. Correct toolbar position on screens above 1080px

This PR also adds new breakpoint overriding that rule, ensuring that the wide/full toolbars line up with those for standard blocks on large screens: 

_Before:_

![before](https://user-images.githubusercontent.com/1202812/63695028-be8f2080-c7e5-11e9-915c-a594e30c14e6.gif)

_After:_

![after](https://user-images.githubusercontent.com/1202812/63695034-c2bb3e00-c7e5-11e9-8414-72922ba7caf3.gif)

---

## Correct toolbar controls position on screens between 480-600px wide

_Before:_

<img width="550" alt="Screen Shot 2019-08-26 at 9 46 00 AM" src="https://user-images.githubusercontent.com/1202812/63695290-5856cd80-c7e6-11e9-9bc9-c872da41a483.png">

_After:_

<img width="550" alt="Screen Shot 2019-08-26 at 9 45 43 AM" src="https://user-images.githubusercontent.com/1202812/63695296-5b51be00-c7e6-11e9-8605-7968eebae9ff.png">