### PR TITLE
Try/plugin header toolbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10839,6 +10839,7 @@
 				"@wordpress/primitives": "file:packages/primitives",
 				"@wordpress/url": "file:packages/url",
 				"@wordpress/viewport": "file:packages/viewport",
+				"@wordpress/warning": "file:packages/warning",
 				"classnames": "^2.2.5",
 				"lodash": "^4.17.15",
 				"memize": "^1.1.0",

--- a/packages/edit-post/README.md
+++ b/packages/edit-post/README.md
@@ -159,7 +159,63 @@ _Returns_
 
 <a name="PluginHeaderToolbar" href="#PluginHeaderToolbar">#</a> **PluginHeaderToolbar**
 
-Undocumented declaration.
+Renders a button and association dropdown in the header toolbar
+
+_Usage_
+
+```js
+// Using ES5 syntax
+var el = wp.element.createElement;
+var __ = wp.i18n.__;
+var registerPlugin = wp.plugins.registerPlugin;
+var PluginHeaderToolbar = wp.editPost.PluginDocumentSettingPanel;
+
+function MyHeaderToolbarPlugin() {
+	return el(
+		PluginHeaderToolbar,
+		{
+			className: 'plugin-header-toolbar-button',
+			contentClassName: 'plugin-header-toolbar-content',
+			position: 'bottom left',
+         renderContent: function() { return el( <div>Rendered Content</div>)}
+		},
+	);
+}
+
+registerPlugin( 'my-header-toolbar-plugin', {
+		render: MyHeaderToolbarPlugin
+} );
+```
+
+```jsx
+// Using ESNext syntax
+const { registerPlugin } = wp.plugins;
+const { PluginHeaderToolbar } = wp.editPost;
+
+const MyHeaderToolbarPlugin = () => (
+		<PluginHeaderToolbar
+         className="plugin-header-toolbar-button"
+         classContentName="plugin-header-toolbar-content"
+         position="bottom left"
+         renderContent={() => <div>Rendered Content</div>}
+       />
+);
+
+ registerPlugin( 'my-header-toolbar-plugin', { render: MyDocumentSettingTest } );
+```
+
+_Parameters_
+
+-   _props_ `Object`: Component properties.
+-   _renderContent_ `WPComponent`: The component to render as the UI for the dropdown.
+-   _props.className_ `[string]`: Optional. The class name for the button.
+-   _props.contentClassName_ `[string]`: Optional. The class name of the dropdown item.
+-   _props.position_ `[string]`: Optional. The title of the panel
+-   _props.icon_ `[WPBlockTypeIconRender]`: The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered when the sidebar is pinned to toolbar.
+
+_Returns_
+
+-   `WPComponent`: The component to be rendered.
 
 <a name="PluginMoreMenuItem" href="#PluginMoreMenuItem">#</a> **PluginMoreMenuItem**
 

--- a/packages/edit-post/README.md
+++ b/packages/edit-post/README.md
@@ -157,6 +157,10 @@ _Returns_
 
 -   `WPComponent`: The component to be rendered.
 
+<a name="PluginHeaderToolbar" href="#PluginHeaderToolbar">#</a> **PluginHeaderToolbar**
+
+Undocumented declaration.
+
 <a name="PluginMoreMenuItem" href="#PluginMoreMenuItem">#</a> **PluginMoreMenuItem**
 
 Renders a menu item in `Plugins` group in `More Menu` drop down, and can be used to as a button or link depending on the props provided.

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -50,6 +50,7 @@
 		"@wordpress/primitives": "file:../primitives",
 		"@wordpress/url": "file:../url",
 		"@wordpress/viewport": "file:../viewport",
+		"@wordpress/warning": "file:../warning",
 		"classnames": "^2.2.5",
 		"lodash": "^4.17.15",
 		"memize": "^1.1.0",

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -73,52 +73,36 @@ function HeaderToolbar( { onToggleInserter, isInserterOpen } ) {
 			className="edit-post-header-toolbar"
 			aria-label={ toolbarAriaLabel }
 		>
-			<PluginHeaderToolbar.Slot
-				fillProps={ {
-					hasFixedToolbar,
-					isLargeViewport,
-					displayBlockToolbar,
-				} }
+			<ToolbarItem
+				as={ Button }
+				className="edit-post-header-toolbar__inserter-toggle"
+				isPrimary
+				isPressed={ isInserterOpen }
+				onClick={ onToggleInserter }
+				disabled={ ! isInserterEnabled }
+				icon={ plus }
+				label={ _x(
+					'Add block',
+					'Generic label for block inserter button'
+				) }
 			/>
-			<PluginHeaderToolbar>
-				{ ( fillProps ) => {
-					return (
-						<>
-							<ToolbarItem
-								as={ Button }
-								className="edit-post-header-toolbar__inserter-toggle"
-								isPrimary
-								isPressed={ isInserterOpen }
-								onClick={ onToggleInserter }
-								disabled={ ! isInserterEnabled }
-								icon={ plus }
-								label={ _x(
-									'Add block',
-									'Generic label for block inserter button'
-								) }
-							/>
-							{ fillProps.isLargeViewport && (
-								<ToolbarItem as={ ToolSelector } />
-							) }
-							<ToolbarItem as={ EditorHistoryUndo } />
-							<ToolbarItem as={ EditorHistoryRedo } />
-							<ToolbarItem
-								as={ TableOfContents }
-								hasOutlineItemsDisabled={ isTextModeEnabled }
-							/>
-							<ToolbarItem
-								as={ BlockNavigationDropdown }
-								isDisabled={ isTextModeEnabled }
-							/>
-							{ fillProps.displayBlockToolbar && (
-								<div className="edit-post-header-toolbar__block-toolbar">
-									<BlockToolbar hideDragHandle />
-								</div>
-							) }
-						</>
-					);
-				} }
-			</PluginHeaderToolbar>
+			{ isLargeViewport && <ToolbarItem as={ ToolSelector } /> }
+			<ToolbarItem as={ EditorHistoryUndo } />
+			<ToolbarItem as={ EditorHistoryRedo } />
+			<ToolbarItem
+				as={ TableOfContents }
+				hasOutlineItemsDisabled={ isTextModeEnabled }
+			/>
+			<ToolbarItem
+				as={ BlockNavigationDropdown }
+				isDisabled={ isTextModeEnabled }
+			/>
+			{ isLargeViewport && <PluginHeaderToolbar.Slot /> }
+			{ displayBlockToolbar && (
+				<div className="edit-post-header-toolbar__block-toolbar">
+					<BlockToolbar hideDragHandle />
+				</div>
+			) }
 		</NavigableToolbar>
 	);
 }

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -21,6 +21,11 @@ import {
 } from '@wordpress/components';
 import { plus } from '@wordpress/icons';
 
+/**
+ * Internal dependencies
+ */
+import PluginHeaderToolbar from '../plugin-header-toolbar';
+
 function HeaderToolbar( { onToggleInserter, isInserterOpen } ) {
 	const {
 		hasFixedToolbar,
@@ -68,35 +73,52 @@ function HeaderToolbar( { onToggleInserter, isInserterOpen } ) {
 			className="edit-post-header-toolbar"
 			aria-label={ toolbarAriaLabel }
 		>
-			<ToolbarItem
-				as={ Button }
-				className="edit-post-header-toolbar__inserter-toggle"
-				isPrimary
-				isPressed={ isInserterOpen }
-				onClick={ onToggleInserter }
-				disabled={ ! isInserterEnabled }
-				icon={ plus }
-				label={ _x(
-					'Add block',
-					'Generic label for block inserter button'
-				) }
+			<PluginHeaderToolbar.Slot
+				fillProps={ {
+					hasFixedToolbar,
+					isLargeViewport,
+					displayBlockToolbar,
+				} }
 			/>
-			{ isLargeViewport && <ToolbarItem as={ ToolSelector } /> }
-			<ToolbarItem as={ EditorHistoryUndo } />
-			<ToolbarItem as={ EditorHistoryRedo } />
-			<ToolbarItem
-				as={ TableOfContents }
-				hasOutlineItemsDisabled={ isTextModeEnabled }
-			/>
-			<ToolbarItem
-				as={ BlockNavigationDropdown }
-				isDisabled={ isTextModeEnabled }
-			/>
-			{ displayBlockToolbar && (
-				<div className="edit-post-header-toolbar__block-toolbar">
-					<BlockToolbar hideDragHandle />
-				</div>
-			) }
+			<PluginHeaderToolbar>
+				{ ( fillProps ) => {
+					return (
+						<>
+							<ToolbarItem
+								as={ Button }
+								className="edit-post-header-toolbar__inserter-toggle"
+								isPrimary
+								isPressed={ isInserterOpen }
+								onClick={ onToggleInserter }
+								disabled={ ! isInserterEnabled }
+								icon={ plus }
+								label={ _x(
+									'Add block',
+									'Generic label for block inserter button'
+								) }
+							/>
+							{ fillProps.isLargeViewport && (
+								<ToolbarItem as={ ToolSelector } />
+							) }
+							<ToolbarItem as={ EditorHistoryUndo } />
+							<ToolbarItem as={ EditorHistoryRedo } />
+							<ToolbarItem
+								as={ TableOfContents }
+								hasOutlineItemsDisabled={ isTextModeEnabled }
+							/>
+							<ToolbarItem
+								as={ BlockNavigationDropdown }
+								isDisabled={ isTextModeEnabled }
+							/>
+							{ fillProps.displayBlockToolbar && (
+								<div className="edit-post-header-toolbar__block-toolbar">
+									<BlockToolbar hideDragHandle />
+								</div>
+							) }
+						</>
+					);
+				} }
+			</PluginHeaderToolbar>
 		</NavigableToolbar>
 	);
 }

--- a/packages/edit-post/src/components/header/plugin-header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/plugin-header-toolbar/index.js
@@ -1,11 +1,124 @@
 /**
+ * External dependencies
+ */
+import { isFunction } from 'lodash';
+
+/**
  * WordPress dependencies
  */
-import { createSlotFill } from '@wordpress/components';
+import {
+	createSlotFill,
+	Button,
+	__experimentalToolbarItem as ToolbarItem,
+	Dropdown,
+} from '@wordpress/components';
+import warning from '@wordpress/warning';
+import { plugins as pluginsIcon } from '@wordpress/icons';
+import { compose } from '@wordpress/compose';
+import { withPluginContext } from '@wordpress/plugins';
 
-const { Fill: PluginHeaderToolbar, Slot } = createSlotFill(
-	'PluginHeaderToolbar'
-);
+const { Fill, Slot } = createSlotFill( 'PluginHeaderToolbar' );
+
+const PluginHeaderToolbarFill = ( {
+	icon = pluginsIcon,
+	renderContent = null,
+	className = 'plugin-header-toolbar-button',
+	contentClassName = 'plugin-header-toolbar-content',
+	position = 'bottom right',
+} ) => {
+	if ( null === renderContent || ! isFunction( renderContent ) ) {
+		warning(
+			'PluginHeaderToolbar requires renderContent property to be specified and be a valid function.'
+		);
+		return null;
+	}
+	return (
+		<Fill>
+			<ToolbarItem
+				as={ () => (
+					<Dropdown
+						className={ className }
+						contentClassName={ contentClassName }
+						position={ position }
+						renderToggle={ ( { isOpen, onToggle } ) => (
+							<Button
+								onClick={ onToggle }
+								aria-expanded={ isOpen }
+								icon={ icon }
+							/>
+						) }
+						renderContent={ renderContent }
+					/>
+				) }
+			/>
+		</Fill>
+	);
+};
+
+/**
+ * Renders a button and association dropdown in the header toolbar
+ *
+ * @param {Object} props Component properties.
+ * @param {WPComponent} renderContent                                   The component to render as the UI for the dropdown.
+ * @param {string} [props.className]                                    Optional. The class name for the button.
+ * @param {string} [props.contentClassName]                             Optional. The class name of the dropdown item.
+ * @param {string} [props.position]                                     Optional. The title of the panel
+ * @param {WPBlockTypeIconRender} [props.icon=inherits from the plugin] The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered when the sidebar is pinned to toolbar.
+ *
+ * @example
+ * <caption>ES5</caption>
+ * ```js
+ * // Using ES5 syntax
+ * var el = wp.element.createElement;
+ * var __ = wp.i18n.__;
+ * var registerPlugin = wp.plugins.registerPlugin;
+ * var PluginHeaderToolbar = wp.editPost.PluginDocumentSettingPanel;
+ *
+ * function MyHeaderToolbarPlugin() {
+ * 	return el(
+ * 		PluginHeaderToolbar,
+ * 		{
+ * 			className: 'plugin-header-toolbar-button',
+ * 			contentClassName: 'plugin-header-toolbar-content',
+ * 			position: 'bottom left',
+ *          renderContent: function() { return el( <div>Rendered Content</div>)}
+ * 		},
+ * 	);
+ * }
+ *
+ * registerPlugin( 'my-header-toolbar-plugin', {
+ * 		render: MyHeaderToolbarPlugin
+ * } );
+ * ```
+ *
+ * @example
+ * <caption>ESNext</caption>
+ * ```jsx
+ * // Using ESNext syntax
+ * const { registerPlugin } = wp.plugins;
+ * const { PluginHeaderToolbar } = wp.editPost;
+ *
+ * const MyHeaderToolbarPlugin = () => (
+ * 		<PluginHeaderToolbar
+ *          className="plugin-header-toolbar-button"
+ *          classContentName="plugin-header-toolbar-content"
+ *          position="bottom left"
+ *          renderContent={() => <div>Rendered Content</div>}
+ *        />
+ *	);
+ *
+ *  registerPlugin( 'my-header-toolbar-plugin', { render: MyDocumentSettingTest } );
+ * ```
+ *
+ * @return {WPComponent} The component to be rendered.
+ */
+const PluginHeaderToolbar = compose(
+	withPluginContext( ( context, ownProps ) => {
+		return {
+			icon: ownProps.icon || context.icon,
+		};
+	} )
+)( PluginHeaderToolbarFill );
 
 PluginHeaderToolbar.Slot = Slot;
 

--- a/packages/edit-post/src/components/header/plugin-header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/plugin-header-toolbar/index.js
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies
+ */
+import { createSlotFill } from '@wordpress/components';
+
+const { Fill: PluginHeaderToolbar, Slot } = createSlotFill(
+	'PluginHeaderToolbar'
+);
+
+PluginHeaderToolbar.Slot = Slot;
+
+export default PluginHeaderToolbar;

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -159,4 +159,5 @@ export { default as PluginPostStatusInfo } from './components/sidebar/plugin-pos
 export { default as PluginPrePublishPanel } from './components/sidebar/plugin-pre-publish-panel';
 export { default as PluginSidebar } from './components/sidebar/plugin-sidebar';
 export { default as PluginSidebarMoreMenuItem } from './components/header/plugin-sidebar-more-menu-item';
+export { default as PluginHeaderToolbar } from './components/header/plugin-header-toolbar';
 export { default as __experimentalFullscreenModeClose } from './components/header/fullscreen-mode-close';


### PR DESCRIPTION
## Description
This PR implements SlotFill to render the `<BlockControls />` and additionally exposes a new `PluginHeaderToolbar` SlotFill. This PR addresses #16988.

## How has this been tested?
`npm run test` ran locally.

## Screenshots <!-- if applicable -->

## Types of changes
This PR introduces a change in how the BlockControls are added and should have no other impact. As we are adding the BlockControls immediately after exposing the Slot, any new items added would appear after them.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
