### PR TITLE
Fix: changing month or day in post publish date closes the popover.

### DIFF
--- a/packages/components/src/date-time/date.js
+++ b/packages/components/src/date-time/date.js
@@ -26,7 +26,7 @@ class DatePicker extends Component {
 
 	/*
 	* Todo: We should remove this function ASAP.
-	* It is kept because there is focus loose when we click the previous and next month buttons on react dates.
+	* It is kept because focus is lost when we click on the previous and next month buttons.
 	* This focus lose then makes the date picker popover close.
 	* Ideally we should add an upstream commit on react-dates to fix this issue.
 	*/

--- a/packages/components/src/date-time/date.js
+++ b/packages/components/src/date-time/date.js
@@ -7,7 +7,7 @@ import { DayPickerSingleDateController } from 'react-dates';
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, createRef } from '@wordpress/element';
 
 /**
  * Module Constants
@@ -20,6 +20,30 @@ class DatePicker extends Component {
 		super( ...arguments );
 
 		this.onChangeMoment = this.onChangeMoment.bind( this );
+		this.nodeRef = createRef();
+		this.keepFocusInside = this.keepFocusInside.bind( this );
+	}
+
+	/*
+	* Todo: We should remove this function ASAP.
+	* It is kept because there is focus loose when we click the previous and next month buttons on react dates.
+	* This focus lose then makes the date picker popover close.
+	* Ideally we should add an upstream commit on react-dates to fix this issue.
+	*/
+	keepFocusInside() {
+		if ( ! this.nodeRef.current ) {
+			return;
+		}
+		// If focus was lost.
+		if ( ! document.activeElement || ! this.nodeRef.current.contains( document.activeElement ) ) {
+			// Retrieve the focus region div.
+			const focusRegion = this.nodeRef.current.querySelector( '.DayPicker_focusRegion' );
+			if ( ! focusRegion ) {
+				return;
+			}
+			// Keep the focus on focus region.
+			focusRegion.focus();
+		}
 	}
 
 	onChangeMoment( newDate ) {
@@ -56,7 +80,10 @@ class DatePicker extends Component {
 		const momentDate = this.getMomentDate( currentDate );
 
 		return (
-			<div className="components-datetime__date">
+			<div
+				className="components-datetime__date"
+				ref={ this.nodeRef }
+			>
 				<DayPickerSingleDateController
 					date={ momentDate }
 					daySize={ 30 }
@@ -74,6 +101,8 @@ class DatePicker extends Component {
 					isOutsideRange={ ( date ) => {
 						return isInvalidDate && isInvalidDate( date.toDate() );
 					} }
+					onPrevMonthClick={ this.keepFocusInside }
+					onNextMonthClick={ this.keepFocusInside }
 				/>
 			</div>
 		);

--- a/packages/components/src/date-time/date.js
+++ b/packages/components/src/date-time/date.js
@@ -27,7 +27,7 @@ class DatePicker extends Component {
 	/*
 	* Todo: We should remove this function ASAP.
 	* It is kept because focus is lost when we click on the previous and next month buttons.
-	* This focus lose then makes the date picker popover close.
+	* This focus loss closes the date picker popover.
 	* Ideally we should add an upstream commit on react-dates to fix this issue.
 	*/
 	keepFocusInside() {


### PR DESCRIPTION
## Description
Fix: https://github.com/WordPress/gutenberg/issues/17042

Currently, changing the month using previous/next buttons in the date picker closes the popover making it unusable and making post scheduling an arduous task.

The problem happens because when we click previous/next buttons, a focus lose occurs. I did lots of debugging, and I did not found a cause for this in our code. We will need an upstream commit on react-dates. But until then, this PR uses onPrevMonthClick/onNextMonthClick events to force the focus to be inside the focusable region.

## How has this been tested?
I checked that I could change the day or month in the post scheduler, and the popover does not close.