### PR TITLE
Block Preview: remove resetting CSS styles

### DIFF
--- a/packages/block-editor/src/components/block-preview/style.scss
+++ b/packages/block-editor/src/components/block-preview/style.scss
@@ -34,11 +34,6 @@
 	overflow: visible;
 	min-height: auto;
 
-	.block-editor-block-list__layout,
-	.block-editor-block-list__block {
-		padding: 0;
-	}
-
 	.editor-block-list__block-edit [data-block] {
 		margin: 0;
 	}


### PR DESCRIPTION
## Description
This PR removes a CSS defined in the `<BlockPreview />` component because:

1) It applies the styles straight to the block `.block-editor-block-list__layout` and `.block-editor-block-list__block` into the preview window, which implies that if it is not suitable for use where the preview is used it will be a headache to be able to eliminate it.

2) It doesn't seem to be needed.

## Background

The CSS code which is removed in this PR is the following:

```scss
	.block-editor-block-list__layout,
	.block-editor-block-list__block {
		padding: 0;
	}
```

In some way, [we already are aware of this potential issue](https://github.com/WordPress/gutenberg/pull/15561/files#r284314288).

It applies padding 0 to all blocks into the preview element (`.block-editor-block-preview__content`). It will be a problem If for some reason this change is affecting what we want to preview.
We've been in similar situations where we needed to tweak the width of the element. In those cases, we use to use margin: 100%, margin: auto, etc. which is not great either.

So what I propose is applying these kinds of CSS but nesting under a context class. For instance, if the preview needs some tweaks when it's used in the block styles, then set them using something like the following:

```scss
.block-editor-block-styles {
	.block-editor-block-list__layout,
	.block-editor-block-list__block {
		padding: 0;
	}
}
```

In a similar way, we can apply custom styles for the preview in the block switcher, etc.

One point against this approach is that we need to apply these styles in all the places that are necessary. But we can't make a general rule if we are not completely sure that it won't break anything.

## Testing

I've created a post whit many blocks and testing if the preview is working as expected after this change. Let me share some screenshots:

![image](https://user-images.githubusercontent.com/77539/63716428-658eaf00-c81c-11e9-81b2-75104a91e581.png)

![image](https://user-images.githubusercontent.com/77539/63716465-7b9c6f80-c81c-11e9-8fa1-c245975dbf71.png)

![image](https://user-images.githubusercontent.com/77539/63716479-8525d780-c81c-11e9-9a1b-a5a99128cd3c.png)



## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
