### PR TITLE
Editor: Fix post visibility null password edits.

### DIFF
--- a/packages/editor/src/components/post-visibility/index.js
+++ b/packages/editor/src/components/post-visibility/index.js
@@ -139,8 +139,12 @@ export default compose( [
 		const { savePost, editPost } = dispatch( 'core/editor' );
 		return {
 			onSave: savePost,
-			onUpdateVisibility( status, password = null ) {
-				editPost( { status, password } );
+			onUpdateVisibility( status, password ) {
+				const edits = { status };
+				if ( password !== undefined ) {
+					edits.password = password;
+				}
+				editPost( edits );
 			},
 		};
 	} ),


### PR DESCRIPTION
Fixes #17209

## Description

This PR fixes the issue described in #17209.

The cause was that an old component incorrectly sets the post's password to `null` when publishing a post as private without a password. The API does not persist that edit so it would not clear after the response.

## How has this been tested?

The expected behavior in #17209 was verified to occur.

## Types of Changes

*Bug Fix:* Stop the post visibility component from setting passwords to `null` when publishing private posts.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
