### PR TITLE
RichText: Fall back to setTimeout if no requestIdleCallback

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -38,7 +38,10 @@ import FormatToolbar from './format-toolbar';
 import { withBlockEditContext } from '../block-edit/context';
 import { RemoveBrowserShortcuts } from './remove-browser-shortcuts';
 
-const requestIdleCallback = window.requestIdleCallback ? window.requestIdleCallback : window.requestAnimationFrame;
+const requestIdleCallback = window.requestIdleCallback ||
+	function fallbackRequestIdleCallback( fn ) {
+		window.setTimeout( fn, 100 );
+	};
 
 const wrapperClasses = 'editor-rich-text block-editor-rich-text';
 const classes = 'editor-rich-text__editable block-editor-rich-text__editable';

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -38,6 +38,8 @@ import FormatToolbar from './format-toolbar';
 import { withBlockEditContext } from '../block-edit/context';
 import { RemoveBrowserShortcuts } from './remove-browser-shortcuts';
 
+const requestIdleCallback = window.requestIdleCallback ? window.requestIdleCallback : window.requestAnimationFrame;
+
 const wrapperClasses = 'editor-rich-text block-editor-rich-text';
 const classes = 'editor-rich-text__editable block-editor-rich-text__editable';
 
@@ -301,7 +303,7 @@ class RichTextWrapper extends Component {
 	 * ensure all selection changes have been recorded.
 	 */
 	markAutomaticChange() {
-		window.requestIdleCallback( () => {
+		requestIdleCallback( () => {
 			this.props.markAutomaticChange();
 		} );
 	}


### PR DESCRIPTION
## Description

See https://github.com/WordPress/gutenberg/pull/14776#discussion_r317968149. If `window.requestIdleCallback` isn't available, fall back to ~`window.requestAnimationFrame`~ `window.setTimeout`. This approach is also used in `priority-queue`:

https://github.com/WordPress/gutenberg/blob/9c58193621b4bb913bcc6991426c1e9b97dcc9f7/packages/priority-queue/src/index.js#L1

## How has this been tested?

Make sure the behaviour introduced in #14776 is preserved both in environments that provide `requestIdleCallback` (e.g. Firefox) and those that don't (Safari).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->