### PR TITLE
A few IE11 fixes

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -419,6 +419,10 @@
 			width: auto;
 			border-bottom: $border-width solid $light-gray-800;
 			bottom: auto;
+
+			@include break-small() {
+				border-bottom: none;
+			}
 		}
 	}
 
@@ -1067,6 +1071,15 @@
 		// RTL note: this rule should not be auto-flipped based on direction.
 		/*rtl:ignore*/
 		float: right;
+
+		// IE11 moves the toolbar to the right because the parent container doesn't expand.
+		// A min-width mitigates this.
+		min-width: 200px;
+
+		// IE11 does not support `position: sticky`.
+		@supports (position: sticky) {
+			min-width: 0;
+		}
 	}
 
 	.block-editor-block-list__block[data-align="left"] &,

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -47,5 +47,11 @@
 }
 
 .block-editor-block-toolbar__slot {
-	display: inline-flex;
+	// Required for IE11.
+	display: inline-block;
+
+	// IE11 doesn't read rules inside this query. They are applied only to modern browsers.
+	@supports (position: sticky) {
+		display: inline-flex;
+	}
 }

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -30,6 +30,9 @@
 
 		// Add a right border to show as separator in the block toolbar.
 		border-right: $border-width solid $light-gray-800;
+
+		// IE11 has thick paddings without this.
+		line-height: 0;
 	}
 
 	// Add a left border and adjust the color for Top Toolbar mode.


### PR DESCRIPTION
This PR tries to improve the situation for IE11, which is currently not that great. 

Fixes #14330.

Fixes #10045.

Addresses parts of #17158.

Fixes probably unreported things too.

Before:

![1](https://user-images.githubusercontent.com/1204802/63762912-fa001c80-c8c3-11e9-87a3-72e5ea531cf9.png)

After the first commit it's no longer thick:

![2](https://user-images.githubusercontent.com/1204802/63762924-02585780-c8c4-11e9-85d0-66e5b7ff949b.png)

After the 2nd commit it's now usable:

![3](https://user-images.githubusercontent.com/1204802/63762951-0be1bf80-c8c4-11e9-8635-d22803cf57dc.png)

And right-floats work:

![4](https://user-images.githubusercontent.com/1204802/63762962-113f0a00-c8c4-11e9-9c63-8765b2a6940c.png)

Please test these if you can and let's get them in :)