### PR TITLE
Try: Fix cropped focus ring in block library

### DIFF
--- a/packages/block-editor/src/components/block-types-list/style.scss
+++ b/packages/block-editor/src/components/block-types-list/style.scss
@@ -1,6 +1,8 @@
 .block-editor-block-types-list {
 	list-style: none;
-	padding: 4px 0;
+	padding: 4px;
+	margin-left: -4px;
+	margin-right: -4px;
 	overflow: hidden;
 	display: flex;
 	flex-wrap: wrap;


### PR DESCRIPTION
Maybe fixes #17094 and maybe fixes #17168 too.

There's focus ring on blocks in the block library and the switcher. These are cropped when blocks are near the edges, due to an overflow: hidden;. This PR attempts to fix that with a deadpan negative margin. Will it work? This is where YOU come in!

Before:

<img width="337" alt="63598879-72966e80-c58e-11e9-8a61-8d870dc60e39" src="https://user-images.githubusercontent.com/1204802/63777505-8110bd00-c8e3-11e9-9cea-19d0e9771923.png">

After:

![Screenshot 2019-08-27 at 15 56 45](https://user-images.githubusercontent.com/1204802/63777512-82da8080-c8e3-11e9-9bd9-d0a5c54c22b2.png)
