### PR TITLE
Try a pill-shaped block mover

### DIFF
--- a/assets/stylesheets/_z-index.scss
+++ b/assets/stylesheets/_z-index.scss
@@ -32,9 +32,6 @@ $z-layers: (
 	".wp-block-cover.has-background-dim::before": 1, // Overlay area inside block cover need to be higher than the video background.
 	".wp-block-cover__video-background": 0, // Video background inside cover block.
 
-	// Side UI active buttons
-	".block-editor-block-mover__control": 1,
-
 	// Active pill button
 	".components-button.is-button {:focus or .is-primary}": 1,
 

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -404,7 +404,7 @@ function BlockListBlock( {
 	// We render block movers and block settings to keep them tabbale even if hidden
 	const shouldRenderMovers =
 		! isNavigationMode &&
-		( isSelected || hoverArea === ( isRTL ? 'right' : 'left' ) ) &&
+		isSelected &&
 		! showEmptyBlockSideInserter &&
 		! isPartOfMultiSelection &&
 		! isTypingWithinBlock;

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -404,7 +404,7 @@ function BlockListBlock( {
 	// We render block movers and block settings to keep them tabbale even if hidden
 	const shouldRenderMovers =
 		! isNavigationMode &&
-		isSelected &&
+		( isSelected || hoverArea === ( isRTL ? 'right' : 'left' ) ) &&
 		! showEmptyBlockSideInserter &&
 		! isPartOfMultiSelection &&
 		! isTypingWithinBlock;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -495,7 +495,7 @@
 		&.is-multi-selected > .block-editor-block-mover,
 		> .block-editor-block-list__block-edit > .block-editor-block-mover {
 			// This moves the menu up by the height of the button + border + padding.
-			top: -$block-side-ui-width - $block-padding - $block-side-ui-clearance;
+			top: -$block-side-ui-width - $block-padding - $block-side-ui-clearance - ( $border-width * 2 );
 			bottom: auto;
 			min-height: 0;
 			height: auto;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -667,10 +667,6 @@
 	> .block-editor-block-list__block-edit > .block-editor-block-mover {
 		position: absolute;
 		width: $block-side-ui-width + $block-side-ui-clearance;
-
-		// Stretch to fill half of the available space to increase hoverable area.
-		height: 100%;
-		max-height: $block-side-ui-width * 4;
 	}
 
 	// Position depending on whether selected or not.
@@ -696,7 +692,7 @@
 		padding-right: $block-side-ui-clearance;
 
 		// Position for top level blocks.
-		left: -$block-side-ui-width - $block-side-ui-clearance - $block-padding - $border-width;
+		left: -$block-side-ui-width - $block-side-ui-clearance - $block-padding - $border-width - $grid-size;
 
 		// Hide on mobile, as mobile has a separate solution.
 		display: none;

--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -1,25 +1,18 @@
 .block-editor-block-mover {
 	min-height: $empty-paragraph-height;
 	opacity: 0;
-	background: $white;
-	border: 1px solid $dark-opacity-light-800;
-	border-radius: $icon-button-size-small * 3 + $grid-size-small; // Creates a pill shape
+	background: $dark-opacity-600;
+	border-radius: $radius-round-rectangle;
 	height: ($icon-button-size-small * 3) + ( $grid-size-small * 1.5);
 	padding-top: $grid-size-small / 2;
 	padding-bottom: $grid-size-small / 2;
-	transition: box-shadow 0.2s ease-out;
-	@include reduce-motion("transition");
 
 	.is-dark-theme & {
-		border-color: $light-opacity-light-800;
+		background: $light-opacity-600;
 	}
 
 	&.is-visible {
 		@include edit-post__fade-in-animation;
-	}
-
-	&:hover {
-		box-shadow: $shadow-toolbar;
 	}
 
 	// 24px is the smallest size of a good pressable button.
@@ -53,26 +46,30 @@
 		padding: #{ ($block-side-ui-width - $icon-button-size-small) / 2 } #{ ($block-side-ui-width - 18px) / 2 }; // This makes the SVG fill the whole available area, without scaling the artwork.
 	}
 
-	// Use opacity to work in various editor styles
-	color: $dark-opacity-300;
+	color: $light-gray-500;
 
 	.is-dark-theme & {
-		color: $light-opacity-300;
+		color: $dark-gray-500;
 	}
 
 	&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover,
 	&:focus:not(:disabled) {
 		background-color: transparent;
 		box-shadow: none;
+		color: $white;
+
+		.is-dark-theme & {
+			color: $dark-gray-900;
+		}
 	}
 
 	&[aria-disabled="true"] {
 		cursor: default;
 		pointer-events: none;
-		color: $dark-opacity-light-300; // Use opacity to work in various editor styles.
+		color: $light-gray-800;
 
 		.is-dark-theme & {
-			color: $light-opacity-light-300;
+			color: $dark-gray-800;
 		}
 	}
 }
@@ -89,18 +86,10 @@
 	&:not(:disabled):not([aria-disabled="true"]):not(.is-default):focus {
 		box-shadow: none;
 		background: none;
-
-		// Use opacity to work in various editor styles.
-		color: $dark-opacity-500;
+		color: $light-gray-500;
 
 		.is-dark-theme & {
-			color: $light-opacity-500;
-		}
-
-		// Nested movers have a background, so don't invert the colors there.
-		.is-dark-theme .wp-block .wp-block &,
-		.wp-block .is-dark-theme .wp-block & {
-			color: $dark-opacity-500;
+			color: $dark-gray-500;
 		}
 	}
 

--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -1,18 +1,25 @@
 .block-editor-block-mover {
 	min-height: $empty-paragraph-height;
 	opacity: 0;
-	background: $dark-opacity-600;
-	border-radius: $radius-round-rectangle;
+	background: $white;
+	border: 1px solid $dark-opacity-light-800;
+	border-radius: $icon-button-size-small * 3 + $grid-size-small; // Creates a pill shape
 	height: ($icon-button-size-small * 3) + ( $grid-size-small * 1.5);
 	padding-top: $grid-size-small / 2;
 	padding-bottom: $grid-size-small / 2;
+	transition: box-shadow 0.2s ease-out;
+	@include reduce-motion("transition");
 
 	.is-dark-theme & {
-		background: $light-opacity-600;
+		border-color: $light-opacity-light-800;
 	}
 
 	&.is-visible {
 		@include edit-post__fade-in-animation;
+	}
+
+	&:hover {
+		box-shadow: $shadow-toolbar;
 	}
 
 	// 24px is the smallest size of a good pressable button.
@@ -46,30 +53,26 @@
 		padding: #{ ($block-side-ui-width - $icon-button-size-small) / 2 } #{ ($block-side-ui-width - 18px) / 2 }; // This makes the SVG fill the whole available area, without scaling the artwork.
 	}
 
-	color: $light-gray-500;
+	// Use opacity to work in various editor styles
+	color: $dark-opacity-300;
 
 	.is-dark-theme & {
-		color: $dark-gray-500;
+		color: $light-opacity-300;
 	}
 
 	&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover,
 	&:focus:not(:disabled) {
 		background-color: transparent;
 		box-shadow: none;
-		color: $white;
-
-		.is-dark-theme & {
-			color: $dark-gray-900;
-		}
 	}
 
 	&[aria-disabled="true"] {
 		cursor: default;
 		pointer-events: none;
-		color: $light-gray-800;
+		color: $dark-opacity-light-300; // Use opacity to work in various editor styles.
 
 		.is-dark-theme & {
-			color: $dark-gray-800;
+			color: $light-opacity-light-300;
 		}
 	}
 }
@@ -86,10 +89,18 @@
 	&:not(:disabled):not([aria-disabled="true"]):not(.is-default):focus {
 		box-shadow: none;
 		background: none;
-		color: $light-gray-500;
+
+		// Use opacity to work in various editor styles.
+		color: $dark-opacity-500;
 
 		.is-dark-theme & {
-			color: $dark-gray-500;
+			color: $light-opacity-500;
+		}
+
+		// Nested movers have a background, so don't invert the colors there.
+		.is-dark-theme .wp-block .wp-block &,
+		.wp-block .is-dark-theme .wp-block & {
+			color: $dark-opacity-500;
 		}
 	}
 

--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -60,12 +60,6 @@
 		color: $light-opacity-300;
 	}
 
-	// Nested movers have a background, so don't invert the colors there.
-	.is-dark-theme .wp-block .wp-block &,
-	.wp-block .is-dark-theme .wp-block & {
-		color: $dark-opacity-300;
-	}
-
 	&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover,
 	&:focus:not(:disabled) {
 		background-color: transparent;
@@ -117,28 +111,4 @@
 
 .block-editor-block-mover__description {
 	display: none;
-}
-
-// Apply a background in nested contexts, only on desktop.
-.block-editor-block-mover__control-drag-handle:not(:disabled):not([aria-disabled="true"]):not(.is-default),
-.block-editor-block-mover__control {
-	@include break-small() {
-		.block-editor-block-list__layout [data-align="right"] &,
-		.block-editor-block-list__layout [data-align="left"] &,
-		.block-editor-block-list__layout .block-editor-block-list__layout & {
-			background: $white;
-			box-shadow: inset 0 0 0 1px $light-gray-500;
-
-			&:nth-child(-n+2) {
-				margin-bottom: -1px;
-			}
-
-			&:hover,
-			&:active,
-			&:focus {
-				// Buttons are stacked with overlapping border to look like a unit, so elevate on interactions.
-				z-index: z-index(".block-editor-block-mover__control");
-			}
-		}
-	}
 }

--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -1,9 +1,25 @@
 .block-editor-block-mover {
 	min-height: $empty-paragraph-height;
 	opacity: 0;
+	background: $white;
+	border: 1px solid $dark-opacity-light-800;
+	border-radius: $icon-button-size-small * 3 + $grid-size-small; // Creates a pill shape
+	height: ($icon-button-size-small * 3) + ( $grid-size-small * 1.5);
+	padding-top: $grid-size-small / 2;
+	padding-bottom: $grid-size-small / 2;
+	transition: box-shadow 0.2s ease-out;
+	@include reduce-motion("transition");
+
+	.is-dark-theme & {
+		border-color: $light-opacity-light-800;
+	}
 
 	&.is-visible {
 		@include edit-post__fade-in-animation;
+	}
+
+	&:hover {
+		box-shadow: $shadow-toolbar;
 	}
 
 	// 24px is the smallest size of a good pressable button.
@@ -24,6 +40,8 @@
 	justify-content: center;
 	cursor: pointer;
 	padding: 0;
+	border: none;
+	box-shadow: none;
 
 	// Carefully adjust the size of the side UI to fit one paragraph of text (56px).
 	width: $block-side-ui-width;
@@ -46,6 +64,12 @@
 	.is-dark-theme .wp-block .wp-block &,
 	.wp-block .is-dark-theme .wp-block & {
 		color: $dark-opacity-300;
+	}
+
+	&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover,
+	&:focus:not(:disabled) {
+		background-color: transparent;
+		box-shadow: none;
 	}
 
 	&[aria-disabled="true"] {

--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -1,32 +1,26 @@
 .block-editor-block-mover {
-	min-height: $empty-paragraph-height;
-	opacity: 0;
-	background: $white;
-	border: 1px solid $dark-opacity-light-800;
-	border-radius: $radius-round-rectangle;
-	height: ($icon-button-size-small * 3) + ( $grid-size-small * 1.5);
-	padding-top: $grid-size-small / 2;
-	padding-bottom: $grid-size-small / 2;
-	transition: box-shadow 0.2s ease-out;
-	@include reduce-motion("transition");
 
-	.is-dark-theme & {
-		border-color: $light-opacity-light-800;
-	}
-
-	&.is-visible {
-		@include edit-post__fade-in-animation;
-	}
-
-	&:hover {
-		box-shadow: $shadow-toolbar;
-	}
-
-	// 24px is the smallest size of a good pressable button.
-	// With 3 pieces of side UI, that comes to a total of 72px.
-	// To vertically center against a 56px paragraph, move upwards 72px - 56px / 2.
-	// Don't do this for wide, fullwide, or mobile.
 	@include break-small() {
+		min-height: $empty-paragraph-height;
+		opacity: 0;
+		background: $white;
+		border: 1px solid $dark-opacity-light-800;
+		border-radius: $radius-round-rectangle;
+		transition: box-shadow 0.2s ease-out;
+		@include reduce-motion("transition");
+
+		&.is-visible {
+			@include edit-post__fade-in-animation;
+		}
+
+		&:hover {
+			box-shadow: $shadow-toolbar;
+		}
+
+		// 24px is the smallest size of a good pressable button.
+		// With 3 pieces of side UI, that comes to a total of 72px.
+		// To vertically center against a 56px paragraph, move upwards 72px - 56px / 2.
+		// Don't do this for wide, fullwide, or mobile.
 		.block-editor-block-list__block:not([data-align="wide"]):not([data-align="full"]) & {
 			margin-top: -$grid-size;
 		}
@@ -53,35 +47,31 @@
 		padding: #{ ($block-side-ui-width - $icon-button-size-small) / 2 } #{ ($block-side-ui-width - 18px) / 2 }; // This makes the SVG fill the whole available area, without scaling the artwork.
 	}
 
-	// Use opacity to work in various editor styles
-	color: $dark-opacity-300;
-
-	.is-dark-theme & {
-		color: $light-opacity-300;
-	}
-
-	&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover,
-	&:focus:not(:disabled) {
-		background-color: transparent;
-		box-shadow: none;
-	}
-
 	&[aria-disabled="true"] {
 		cursor: default;
 		pointer-events: none;
-		color: $dark-opacity-light-300; // Use opacity to work in various editor styles.
+		color: $dark-opacity-300;
+	}
 
-		.is-dark-theme & {
-			color: $light-opacity-light-300;
+	@include break-small() {
+		color: $dark-opacity-300;
+
+		&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover {
+			background-color: transparent;
+			box-shadow: none;
+		}
+
+		&:focus:not(:disabled) {
+			background-color: transparent;
 		}
 	}
+
 }
 
 .block-editor-block-mover__control-drag-handle {
 	cursor: move; // Fallback for IE/Edge < 14
 	cursor: grab;
 	fill: currentColor;
-	border-radius: $radius-round-rectangle;
 
 	&,
 	&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover,
@@ -89,19 +79,7 @@
 	&:not(:disabled):not([aria-disabled="true"]):not(.is-default):focus {
 		box-shadow: none;
 		background: none;
-
-		// Use opacity to work in various editor styles.
 		color: $dark-opacity-500;
-
-		.is-dark-theme & {
-			color: $light-opacity-500;
-		}
-
-		// Nested movers have a background, so don't invert the colors there.
-		.is-dark-theme .wp-block .wp-block &,
-		.wp-block .is-dark-theme .wp-block & {
-			color: $dark-opacity-500;
-		}
 	}
 
 	&:not(:disabled):not([aria-disabled="true"]):not(.is-default):active {

--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -3,7 +3,7 @@
 	opacity: 0;
 	background: $white;
 	border: 1px solid $dark-opacity-light-800;
-	border-radius: $icon-button-size-small * 3 + $grid-size-small; // Creates a pill shape
+	border-radius: $radius-round-rectangle;
 	height: ($icon-button-size-small * 3) + ( $grid-size-small * 1.5);
 	padding-top: $grid-size-small / 2;
 	padding-bottom: $grid-size-small / 2;


### PR DESCRIPTION
This PR tries out a rounded, pill-style container for the block movers. As proposed in https://github.com/WordPress/gutenberg/issues/16580#issuecomment-519521871. 

![new](https://user-images.githubusercontent.com/1202812/63777518-3aa26a80-c8b1-11e9-94cc-567d590e2148.gif)

Still needs some cleanup, as well as revised focus states, but it should serve as a decent proof-of-concept. 