### PR TITLE
Use darker form field borders

### DIFF
--- a/assets/stylesheets/_mixins.scss
+++ b/assets/stylesheets/_mixins.scss
@@ -179,7 +179,7 @@
 	box-shadow: 0 0 0 transparent;
 	transition: box-shadow 0.1s linear;
 	border-radius: $radius-round-rectangle;
-	border: $border-width solid $dark-gray-150;
+	border: $border-width solid $dark-gray-200;
 	@include reduce-motion("transition");
 }
 

--- a/packages/block-library/src/search/editor.scss
+++ b/packages/block-library/src/search/editor.scss
@@ -1,7 +1,7 @@
 .wp-block-search {
 	.wp-block-search__input {
 		border-radius: $radius-round-rectangle;
-		border: 1px solid $dark-gray-150;
+		border: 1px solid $dark-gray-200;
 		color: $dark-opacity-300;
 		font-family: $default-font;
 		font-size: $default-font-size;


### PR DESCRIPTION
Closes #17199. 

This PR changes our default form field border color from `$dark-gray-150` to `$dark-gray-200`. It's very minor, but ensures more accessible contrast ratios when these borders appear against gray backgrounds in the rest of WP-Admin. More details [in this trac comment](https://core.trac.wordpress.org/ticket/47150#comment:19). 

---

**Before**

<img width="269" alt="current" src="https://user-images.githubusercontent.com/1202812/63706396-4c2a3a80-c7fd-11e9-921a-b40fe7a5cf28.png">

**After**

<img width="266" alt="proposed" src="https://user-images.githubusercontent.com/1202812/63706406-52b8b200-c7fd-11e9-83f7-9889a1d4afe8.png">
