### PR TITLE
Add keyboard shortcut styling to "/" in default tip in the inserter modal

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -406,7 +406,7 @@ export class InserterMenu extends Component {
 									{ __(
 										'While writing, you can press'
 									) }
-									<kbd className="edit-post-keyboard-shortcut-help__shortcut-key">/</kbd>
+									<kbd>/</kbd>
 									{ __(
 										' to quickly insert new blocks.'
 									) }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -404,7 +404,11 @@ export class InserterMenu extends Component {
 								</div>
 								<Tip>
 									{ __(
-										'While writing, you can press "/" to quickly insert new blocks.'
+										'While writing, you can press'
+									) }
+									<kbd className="edit-post-keyboard-shortcut-help__shortcut-key">/</kbd>
+									{ __(
+										' to quickly insert new blocks.'
 									) }
 								</Tip>
 							</div>

--- a/packages/components/src/tip/style.scss
+++ b/packages/components/src/tip/style.scss
@@ -12,4 +12,8 @@
 	p {
 		margin: 0;
 	}
+
+	kbd {
+		font-weight: 600;
+	}
 }

--- a/packages/components/src/tip/style.scss
+++ b/packages/components/src/tip/style.scss
@@ -15,5 +15,8 @@
 
 	kbd {
 		font-weight: 600;
+		padding: 0.25rem 0.5rem;
+		border-radius: 8%;
+		margin: 0 0.2rem 0 0.2rem;
 	}
 }


### PR DESCRIPTION
Closes #17111 

This PR adds keyboard shortcut styling to the "/" in the default tip in the inserter modal.

**Before:**
<img width="397" alt="63377650-7e035300-c35e-11e9-9af5-6383f554b1fc" src="https://user-images.githubusercontent.com/3276087/63805395-f4640000-c8de-11e9-9a25-698c00c1d9ac.png">

**After:**
<img width="710" alt="Screen Shot 2019-08-27 at 3 11 01 PM" src="https://user-images.githubusercontent.com/3276087/63805411-fded6800-c8de-11e9-8251-ec1f2c19dbb8.png">