### PR TITLE
Demo: Publish via full screen modal

### DIFF
--- a/assets/stylesheets/_z-index.scss
+++ b/assets/stylesheets/_z-index.scss
@@ -15,7 +15,6 @@ $z-layers: (
 	".block-editor-inserter__tabs": 1,
 	".block-editor-inserter__tab.is-active": 1,
 	".components-panel__header": 1,
-	".components-modal__header": 10,
 	".edit-post-meta-boxes-area.is-loading::before": 1,
 	".edit-post-meta-boxes-area .spinner": 5,
 	".components-popover__close": 5,

--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -142,7 +142,7 @@ class Modal extends Component {
 					} }
 					{ ...otherProps }
 				>
-					<div className={ 'components-modal__content' } tabIndex="0">
+					<div className="components-modal__content" tabIndex="0">
 						<ModalHeader
 							closeLabel={ closeButtonLabel }
 							headingId={ headingId }

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -5,53 +5,32 @@
 	right: 0;
 	bottom: 0;
 	left: 0;
-	background-color: rgba($black, 0.7);
+	padding: 100px;
+	background: $white;
 	z-index: z-index(".components-modal__screen-overlay");
-
-	// This animates the appearance of the white background.
-	@include edit-post__fade-in-animation();
+	overflow: auto;
 }
 
 // The modal window element.
 .components-modal__frame {
-	// On small screens the content needs to be full width because of limited
-	// space.
-	position: absolute;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0;
-	box-sizing: border-box;
-	margin: 0;
-	border: $border-width solid $light-gray-500;
-	background: $white;
-	box-shadow: $shadow-modal;
-	overflow: auto;
+	max-width: 800px;
+	margin: auto;
 
-	// Show a centered modal on bigger screens.
+	// Animate the modal on bigger screens
 	@include break-small() {
-		top: 50%;
-		right: auto;
-		bottom: auto;
-		left: 50%;
-		min-width: $modal-min-width;
-		max-width: calc(100% - #{ $grid-size-large } - #{ $grid-size-large });
-		max-height: calc(100% - #{ $header-height } - #{ $header-height });
-		transform: translate(-50%, -50%);
-
 		// Animate the modal frame/contents appearing on the page.
-		animation: components-modal__appear-animation 0.1s ease-out;
-		animation-fill-mode: forwards;
+		transform-origin: top center;
+		animation: components-modal__appear-animation 0.2s forwards;
 		@include reduce-motion("animation");
 	}
 }
 
 @keyframes components-modal__appear-animation {
-	from {
-		margin-top: $grid-size * 4;
+	0% {
+		transform: scale(0.1);
 	}
-	to {
-		margin-top: 0;
+	100% {
+		transform: scale(1);
 	}
 }
 
@@ -60,30 +39,17 @@
 // modal screen).
 .components-modal__header {
 	box-sizing: border-box;
-	border-bottom: $border-width solid $light-gray-500;
-	padding: 0 $grid-size-xlarge;
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
 	background: $white;
 	align-items: center;
 	height: $header-height;
-	position: sticky;
-	top: 0;
-	z-index: z-index(".components-modal__header");
-	margin: 0 -#{$grid-size-xlarge} $grid-size-xlarge;
-
-	// Rules inside this query are only run by Microsoft Edge.
-	// Edge has bugs around position: sticky;, so it needs a separate top rule.
-	// See also https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/17555420/.
-	@supports (-ms-ime-align:auto) {
-		position: fixed;
-		width: 100%;
-	}
+	margin-bottom: 2 * $grid-size-xlarge;
 
 	.components-modal__header-heading {
-		font-size: 1rem;
-		font-weight: 600;
+		font-size: 2rem;
+		font-weight: 300;
 	}
 
 	h1 {
@@ -113,12 +79,5 @@
 // Modal contents.
 .components-modal__content {
 	box-sizing: border-box;
-	height: 100%;
 	padding: 0 $grid-size-xlarge $grid-size-xlarge;
-
-	// Rules inside this query are only run by Microsoft Edge.
-	// This is a companion top padding to the fixed rule in line 77.
-	@supports (-ms-ime-align:auto) {
-		padding-top: $header-height;
-	}
 }

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -15,10 +15,22 @@
 	}
 }
 
+// These are two divs rendered by Higher-order components
+// We need their height to be 100% for the verticalcentering
+// of the modal.
+.components-modal__screen-overlay > div,
+.components-modal__screen-overlay > div > div {
+	height: 100%;
+}
+
 // The modal window element.
 .components-modal__frame {
 	max-width: 800px;
+	min-height: 100%;
 	margin: auto;
+	display: grid;
+	align-items: center;
+
 	// Animate the modal frame/contents appearing on the page.
 	transform-origin: top center;
 	animation: components-modal__appear-animation 0.2s forwards;

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -5,24 +5,24 @@
 	right: 0;
 	bottom: 0;
 	left: 0;
-	padding: 100px;
+	padding: 20px;
 	background: $white;
 	z-index: z-index(".components-modal__screen-overlay");
 	overflow: auto;
+
+	@include break-small() {
+		padding: 100px;
+	}
 }
 
 // The modal window element.
 .components-modal__frame {
 	max-width: 800px;
 	margin: auto;
-
-	// Animate the modal on bigger screens
-	@include break-small() {
-		// Animate the modal frame/contents appearing on the page.
-		transform-origin: top center;
-		animation: components-modal__appear-animation 0.2s forwards;
-		@include reduce-motion("animation");
-	}
+	// Animate the modal frame/contents appearing on the page.
+	transform-origin: top center;
+	animation: components-modal__appear-animation 0.2s forwards;
+	@include reduce-motion("animation");
 }
 
 @keyframes components-modal__appear-animation {

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -19,7 +19,7 @@ import {
 	AutosaveMonitor,
 	UnsavedChangesWarning,
 	EditorNotices,
-	PostPublishPanel,
+	PostPublishModal,
 } from '@wordpress/editor';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { PluginArea } from '@wordpress/plugins';
@@ -101,7 +101,7 @@ function Layout( {
 				</div>
 			</div>
 			{ publishSidebarOpened ? (
-				<PostPublishPanel
+				<PostPublishModal
 					{ ...publishLandmarkProps }
 					onClose={ closePublishSidebar }
 					forceIsDirty={ hasActiveMetaboxes }

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -37,6 +37,7 @@ export { default as PostPreviewButton } from './post-preview-button';
 export { default as PostPublishButton } from './post-publish-button';
 export { default as PostPublishButtonLabel } from './post-publish-button/label';
 export { default as PostPublishPanel } from './post-publish-panel';
+export { default as PostPublishModal } from './post-publish-modal';
 export { default as PostSavedState } from './post-saved-state';
 export { default as PostSchedule } from './post-schedule';
 export { default as PostScheduleCheck } from './post-schedule/check';

--- a/packages/editor/src/components/post-publish-modal/index.js
+++ b/packages/editor/src/components/post-publish-modal/index.js
@@ -1,0 +1,166 @@
+/**
+ * External dependencies
+ */
+import { get, omit } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import {
+	Spinner,
+	CheckboxControl,
+	withFocusReturn,
+	withConstrainedTabbing,
+	Modal,
+} from '@wordpress/components';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import PostPublishButton from '../post-publish-button';
+import PostPublishModalPrepublish from './prepublish';
+import PostPublishModalPostpublish from './postpublish';
+
+export class PostPublishModal extends Component {
+	constructor() {
+		super( ...arguments );
+		this.onSubmit = this.onSubmit.bind( this );
+	}
+
+	componentDidUpdate( prevProps ) {
+		// Automatically collapse the publish sidebar when a post
+		// is published and the user makes an edit.
+		if ( prevProps.isPublished && ! this.props.isSaving && this.props.isDirty ) {
+			this.props.onClose();
+		}
+	}
+
+	onSubmit() {
+		const { onClose, hasPublishAction, isPostTypeViewable } = this.props;
+		if ( ! hasPublishAction || ! isPostTypeViewable ) {
+			onClose();
+		}
+	}
+
+	render() {
+		const {
+			forceIsDirty,
+			forceIsSaving,
+			isBeingScheduled,
+			isPublished,
+			isPublishSidebarEnabled,
+			isScheduled,
+			isSaving,
+			onClose,
+			onTogglePublishSidebar,
+			PostPublishExtension,
+			PrePublishExtension,
+			hasPublishAction,
+			...additionalProps
+		} = this.props;
+		const propsForModal = omit( additionalProps, [ 'hasPublishAction', 'isDirty', 'isPostTypeViewable' ] );
+		const isPublishedOrScheduled = isPublished || ( isScheduled && isBeingScheduled );
+		const isPrePublish = ! isPublishedOrScheduled || isSaving;
+		const isPostPublish = isPublishedOrScheduled && ! isSaving;
+
+		let modalTitle;
+		if ( isSaving ) {
+			modalTitle = isScheduled ? __( 'Scheduling' ) : __( 'Publishing' );
+		} else if ( isPrePublish ) {
+			if ( ! hasPublishAction ) {
+				modalTitle = __( 'Are you ready to submit for review?' );
+			} else if ( isBeingScheduled ) {
+				modalTitle = __( 'Are you ready to schedule?' );
+			} else {
+				modalTitle = __( 'Are you ready to publish?' );
+			}
+		} else {
+			modalTitle = isScheduled ? __( 'Scheduled' ) : __( 'Published' );
+		}
+		return (
+			<Modal
+				className="editor-post-publish-modal"
+				title={ modalTitle }
+				closeLabel={ __( 'Close' ) }
+				onRequestClose={ onClose }
+			>
+				<div className="editor-post-publish-modal__content" { ...propsForModal }>
+					{ isPrePublish && (
+						isSaving ?
+							<Spinner /> :
+							<>
+								<PostPublishModalPrepublish>
+									{ PrePublishExtension && <PrePublishExtension /> }
+								</PostPublishModalPrepublish>
+								<CheckboxControl
+									label={ __( 'Always show these pre-publish checks.' ) }
+									checked={ isPublishSidebarEnabled }
+									onChange={ onTogglePublishSidebar }
+								/>
+							</>
+					) }
+
+					{ isPostPublish && (
+						<PostPublishModalPostpublish focusOnMount={ true } >
+							{ PostPublishExtension && <PostPublishExtension /> }
+						</PostPublishModalPostpublish>
+					) }
+
+					{ ! isPostPublish && (
+						<div className="editor-post-publish-modal__header-publish-button">
+							<PostPublishButton focusOnMount={ true } onSubmit={ this.onSubmit } forceIsDirty={ forceIsDirty } forceIsSaving={ forceIsSaving } />
+							<span className="editor-post-publish-modal__spacer"></span>
+						</div>
+					) }
+				</div>
+			</Modal>
+		);
+	}
+}
+
+export default compose( [
+	withSelect( ( select ) => {
+		const { getPostType } = select( 'core' );
+		const {
+			getCurrentPost,
+			getEditedPostAttribute,
+			isCurrentPostPublished,
+			isCurrentPostScheduled,
+			isEditedPostBeingScheduled,
+			isEditedPostDirty,
+			isSavingPost,
+		} = select( 'core/editor' );
+		const { isPublishSidebarEnabled } = select( 'core/editor' );
+		const postType = getPostType( getEditedPostAttribute( 'type' ) );
+
+		return {
+			hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
+			isPostTypeViewable: get( postType, [ 'viewable' ], false ),
+			isBeingScheduled: isEditedPostBeingScheduled(),
+			isDirty: isEditedPostDirty(),
+			isPublished: isCurrentPostPublished(),
+			isPublishSidebarEnabled: isPublishSidebarEnabled(),
+			isSaving: isSavingPost(),
+			isScheduled: isCurrentPostScheduled(),
+		};
+	} ),
+	withDispatch( ( dispatch, { isPublishSidebarEnabled } ) => {
+		const { disablePublishSidebar, enablePublishSidebar } = dispatch( 'core/editor' );
+
+		return {
+			onTogglePublishSidebar: ( ) => {
+				if ( isPublishSidebarEnabled ) {
+					disablePublishSidebar();
+				} else {
+					enablePublishSidebar();
+				}
+			},
+		};
+	} ),
+	withFocusReturn,
+	withConstrainedTabbing,
+] )( PostPublishModal );

--- a/packages/editor/src/components/post-publish-modal/index.js
+++ b/packages/editor/src/components/post-publish-modal/index.js
@@ -14,6 +14,7 @@ import {
 	withFocusReturn,
 	withConstrainedTabbing,
 	Modal,
+	Button,
 } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
@@ -72,14 +73,14 @@ export class PostPublishModal extends Component {
 			modalTitle = isScheduled ? __( 'Scheduling' ) : __( 'Publishing' );
 		} else if ( isPrePublish ) {
 			if ( ! hasPublishAction ) {
-				modalTitle = __( 'Are you ready to submit for review?' );
+				modalTitle = __( 'Ready to submit for review?' );
 			} else if ( isBeingScheduled ) {
-				modalTitle = __( 'Are you ready to schedule?' );
+				modalTitle = __( 'Ready to schedule?' );
 			} else {
-				modalTitle = __( 'Are you ready to publish?' );
+				modalTitle = __( 'Ready to publish?' );
 			}
 		} else {
-			modalTitle = isScheduled ? __( 'Scheduled' ) : __( 'Published' );
+			modalTitle = isScheduled ? __( 'Post Scheduled' ) : __( 'Post Published!' ); //TODO: update Post with Post/Page/Custom type
 		}
 		return (
 			<Modal
@@ -111,8 +112,11 @@ export class PostPublishModal extends Component {
 					) }
 
 					{ ! isPostPublish && (
-						<div className="editor-post-publish-modal__header-publish-button">
-							<PostPublishButton focusOnMount={ true } onSubmit={ this.onSubmit } forceIsDirty={ forceIsDirty } forceIsSaving={ forceIsSaving } />
+						<div className="editor-post-publish-modal__content-publish-controls">
+							<Button isLink isLarge className="editor-post-publish-modal__content-cancel-button">
+								{ __( 'Cancel' ) }
+							</Button>
+							<PostPublishButton className="editor-post-publish-modal__content-cancel-button" focusOnMount={ true } onSubmit={ this.onSubmit } forceIsDirty={ forceIsDirty } forceIsSaving={ forceIsSaving } />
 							<span className="editor-post-publish-modal__spacer"></span>
 						</div>
 					) }

--- a/packages/editor/src/components/post-publish-modal/index.js
+++ b/packages/editor/src/components/post-publish-modal/index.js
@@ -32,14 +32,6 @@ export class PostPublishModal extends Component {
 		this.onSubmit = this.onSubmit.bind( this );
 	}
 
-	componentDidUpdate( prevProps ) {
-		// Automatically collapse the publish sidebar when a post
-		// is published and the user makes an edit.
-		if ( prevProps.isPublished && ! this.props.isSaving && this.props.isDirty ) {
-			this.props.onClose();
-		}
-	}
-
 	onSubmit() {
 		const { onClose, hasPublishAction, isPostTypeViewable } = this.props;
 		if ( ! hasPublishAction || ! isPostTypeViewable ) {

--- a/packages/editor/src/components/post-publish-modal/index.js
+++ b/packages/editor/src/components/post-publish-modal/index.js
@@ -101,7 +101,7 @@ export class PostPublishModal extends Component {
 				<div className="editor-post-publish-modal__content" { ...propsForModal }>
 					{ isPrePublish && (
 						isSaving ?
-							<div className="editor-post-publish-modal-pending">
+							<div className="editor-post-publish-modal__publishing-animation">
 								<Spinner />
 							</div> :
 							<>
@@ -113,16 +113,15 @@ export class PostPublishModal extends Component {
 									checked={ isPublishSidebarEnabled }
 									onChange={ onTogglePublishSidebar }
 								/>
-								<div className="editor-post-publish-modal__content-publish-controls">
+								<div className="editor-post-publish-modal__prepublish-controls">
 									<Button
 										isLink
-										className="editor-post-publish-modal__content-cancel-button"
+										className="editor-post-publish-modal__prepublish-cancel-button"
 										onClick={ onClose }
 									>
 										{ __( 'Cancel' ) }
 									</Button>
-									<PostPublishButton isLarge className="editor-post-publish-modal__content-cancel-button" focusOnMount={ true } onSubmit={ this.onSubmit } forceIsDirty={ forceIsDirty } forceIsSaving={ forceIsSaving } />
-									<span className="editor-post-publish-modal__spacer"></span>
+									<PostPublishButton isLarge className="editor-post-publish-modal__content-publish-button" focusOnMount={ true } onSubmit={ this.onSubmit } forceIsDirty={ forceIsDirty } forceIsSaving={ forceIsSaving } />
 								</div>
 							</>
 					) }

--- a/packages/editor/src/components/post-publish-modal/index.js
+++ b/packages/editor/src/components/post-publish-modal/index.js
@@ -6,7 +6,7 @@ import { get, omit } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import {
 	Spinner,
@@ -61,6 +61,7 @@ export class PostPublishModal extends Component {
 			PostPublishExtension,
 			PrePublishExtension,
 			hasPublishAction,
+			postLabel,
 			...additionalProps
 		} = this.props;
 		const propsForModal = omit( additionalProps, [ 'hasPublishAction', 'isDirty', 'isPostTypeViewable' ] );
@@ -79,8 +80,16 @@ export class PostPublishModal extends Component {
 			} else {
 				modalTitle = __( 'Ready to publish?' );
 			}
+		} else if ( isScheduled ) {
+			modalTitle = sprintf(
+				/* translators: %s: post type singular name */
+				__( '%s Scheduled!' ), postLabel
+			);
 		} else {
-			modalTitle = isScheduled ? __( 'Post Scheduled' ) : __( 'Post Published!' ); //TODO: update Post with Post/Page/Custom type
+			modalTitle = sprintf(
+				/* translators: %s: post type singular name */
+				__( '%s Published!' ), postLabel
+			);
 		}
 		return (
 			<Modal
@@ -102,6 +111,17 @@ export class PostPublishModal extends Component {
 									checked={ isPublishSidebarEnabled }
 									onChange={ onTogglePublishSidebar }
 								/>
+								<div className="editor-post-publish-modal__content-publish-controls">
+									<Button
+										isLink
+										className="editor-post-publish-modal__content-cancel-button"
+										onClick={ onClose }
+									>
+										{ __( 'Cancel' ) }
+									</Button>
+									<PostPublishButton isLarge className="editor-post-publish-modal__content-cancel-button" focusOnMount={ true } onSubmit={ this.onSubmit } forceIsDirty={ forceIsDirty } forceIsSaving={ forceIsSaving } />
+									<span className="editor-post-publish-modal__spacer"></span>
+								</div>
 							</>
 					) }
 
@@ -109,16 +129,6 @@ export class PostPublishModal extends Component {
 						<PostPublishModalPostpublish focusOnMount={ true } >
 							{ PostPublishExtension && <PostPublishExtension /> }
 						</PostPublishModalPostpublish>
-					) }
-
-					{ ! isPostPublish && (
-						<div className="editor-post-publish-modal__content-publish-controls">
-							<Button isLink isLarge className="editor-post-publish-modal__content-cancel-button">
-								{ __( 'Cancel' ) }
-							</Button>
-							<PostPublishButton className="editor-post-publish-modal__content-cancel-button" focusOnMount={ true } onSubmit={ this.onSubmit } forceIsDirty={ forceIsDirty } forceIsSaving={ forceIsSaving } />
-							<span className="editor-post-publish-modal__spacer"></span>
-						</div>
 					) }
 				</div>
 			</Modal>
@@ -150,6 +160,7 @@ export default compose( [
 			isPublishSidebarEnabled: isPublishSidebarEnabled(),
 			isSaving: isSavingPost(),
 			isScheduled: isCurrentPostScheduled(),
+			postLabel: get( postType, [ 'labels', 'singular_name' ] ),
 		};
 	} ),
 	withDispatch( ( dispatch, { isPublishSidebarEnabled } ) => {

--- a/packages/editor/src/components/post-publish-modal/index.js
+++ b/packages/editor/src/components/post-publish-modal/index.js
@@ -101,7 +101,9 @@ export class PostPublishModal extends Component {
 				<div className="editor-post-publish-modal__content" { ...propsForModal }>
 					{ isPrePublish && (
 						isSaving ?
-							<Spinner /> :
+							<div className="editor-post-publish-modal-pending">
+								<Spinner />
+							</div> :
 							<>
 								<PostPublishModalPrepublish>
 									{ PrePublishExtension && <PrePublishExtension /> }

--- a/packages/editor/src/components/post-publish-modal/postpublish.js
+++ b/packages/editor/src/components/post-publish-modal/postpublish.js
@@ -1,0 +1,120 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+
+import { ExternalLink, Button, ClipboardButton } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { Component, createRef } from '@wordpress/element';
+import { withSelect } from '@wordpress/data';
+import { safeDecodeURIComponent } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import PostScheduleLabel from '../post-schedule/label';
+
+class PostPublishModalPostpublish extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			showCopyConfirmation: false,
+		};
+		this.onCopy = this.onCopy.bind( this );
+		this.onSelectInput = this.onSelectInput.bind( this );
+		this.postLink = createRef();
+	}
+
+	componentDidMount() {
+		if ( this.props.focusOnMount ) {
+			this.postLink.current.focus();
+		}
+	}
+
+	componentWillUnmount() {
+		clearTimeout( this.dismissCopyConfirmation );
+	}
+
+	onCopy() {
+		this.setState( {
+			showCopyConfirmation: true,
+		} );
+
+		clearTimeout( this.dismissCopyConfirmation );
+		this.dismissCopyConfirmation = setTimeout( () => {
+			this.setState( {
+				showCopyConfirmation: false,
+			} );
+		}, 4000 );
+	}
+
+	onSelectInput( event ) {
+		event.target.select();
+	}
+
+	render() {
+		const { children, isScheduled, post, postType } = this.props;
+		const postLabel = get( postType, [ 'labels', 'singular_name' ] );
+		const viewPostLabel = get( postType, [ 'labels', 'view_item' ] );
+
+		const postPublishNonLinkHeader = isScheduled ?
+			<>{ __( 'is now scheduled. It will go live on' ) } <PostScheduleLabel />.</> :
+			__( 'is now live.' );
+
+		return (
+			<div className="post-publish-modal__postpublish">
+				<div className="editor-post-publish-modal-panel">
+					<a ref={ this.postLink } href={ post.link }>{ post.title || __( '(no title)' ) }</a> { postPublishNonLinkHeader }
+				</div>
+				<div className="editor-post-publish-modal-panel">
+					{
+						sprintf(
+							/* translators: %s: post type singular name */
+							__( 'Link to your %s:' ), postLabel
+						)
+					}
+					<br />
+					<ExternalLink
+						className="post-publish-modal__postpublish-post-address"
+						href={ safeDecodeURIComponent( post.link ) }
+						target="_blank"
+						ref={ ( linkElement ) => this.linkElement = linkElement }
+					>
+						{ safeDecodeURIComponent( post.link ) }
+						&lrm;
+					</ExternalLink>
+				</div>
+				<div className="editor-post-publish-modal-panel">
+					{ ! isScheduled && (
+						<Button isDefault href={ post.link }>
+							{ viewPostLabel }
+						</Button>
+					) }
+
+					<ClipboardButton
+						isDefault text={ post.link }
+						onCopy={ this.onCopy }
+					>
+						{ this.state.showCopyConfirmation ? __( 'Copied!' ) : __( 'Copy Link' ) }
+					</ClipboardButton>
+				</div>
+				{ children }
+			</div>
+		);
+	}
+}
+
+export default withSelect( ( select ) => {
+	const { getEditedPostAttribute, getCurrentPost, isCurrentPostScheduled } = select( 'core/editor' );
+	const { getPostType } = select( 'core' );
+
+	return {
+		post: getCurrentPost(),
+		postType: getPostType( getEditedPostAttribute( 'type' ) ),
+		isScheduled: isCurrentPostScheduled(),
+	};
+} )( PostPublishModalPostpublish );

--- a/packages/editor/src/components/post-publish-modal/postpublish.js
+++ b/packages/editor/src/components/post-publish-modal/postpublish.js
@@ -51,7 +51,7 @@ class PostPublishModalPostpublish extends Component {
 					{
 						sprintf(
 							/* translators: %s: post type singular name */
-							__( 'Great Work! You\'ve just published your first %s. You can review it here to check for any mistakes, or start on a new %s.' ), postLabel.toLowerCase(), postLabel.toLowerCase()
+							__( 'Great Work! You\'ve just published your first %s. You can review it here to check for any mistakes, or start on a new %s.' ), postLabel, postLabel
 						)
 					}
 				</p>

--- a/packages/editor/src/components/post-publish-modal/postpublish.js
+++ b/packages/editor/src/components/post-publish-modal/postpublish.js
@@ -7,7 +7,7 @@ import { get } from 'lodash';
  * WordPress dependencies
  */
 
-import { ExternalLink, Button, ClipboardButton } from '@wordpress/components';
+import { Button, TextControl, ClipboardButton } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Component, createRef } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
@@ -16,7 +16,7 @@ import { safeDecodeURIComponent } from '@wordpress/url';
 /**
  * Internal dependencies
  */
-import PostScheduleLabel from '../post-schedule/label';
+// import PostScheduleLabel from '../post-schedule/label';
 
 class PostPublishModalPostpublish extends Component {
 	constructor() {
@@ -29,11 +29,11 @@ class PostPublishModalPostpublish extends Component {
 		this.postLink = createRef();
 	}
 
-	componentDidMount() {
-		if ( this.props.focusOnMount ) {
-			this.postLink.current.focus();
-		}
-	}
+	// componentDidMount() {
+	// 	if ( this.props.focusOnMount ) {
+	// 		this.postLink.current.focus();
+	// 	}
+	// }
 
 	componentWillUnmount() {
 		clearTimeout( this.dismissCopyConfirmation );
@@ -61,47 +61,49 @@ class PostPublishModalPostpublish extends Component {
 		const postLabel = get( postType, [ 'labels', 'singular_name' ] );
 		const viewPostLabel = get( postType, [ 'labels', 'view_item' ] );
 
-		const postPublishNonLinkHeader = isScheduled ?
-			<>{ __( 'is now scheduled. It will go live on' ) } <PostScheduleLabel />.</> :
-			__( 'is now live.' );
-
 		return (
 			<div className="post-publish-modal__postpublish">
-				<div className="editor-post-publish-modal-panel">
-					<a ref={ this.postLink } href={ post.link }>{ post.title || __( '(no title)' ) }</a> { postPublishNonLinkHeader }
-				</div>
-				<div className="editor-post-publish-modal-panel">
+				<p className="post-publish-modal__postpublish-post-text">
 					{
 						sprintf(
 							/* translators: %s: post type singular name */
-							__( 'Link to your %s:' ), postLabel
+							__( 'Great Work! You\'ve just published your first %s. You can review it here to check for any mistakes, or start on a new %s.' ), postLabel.toLowerCase(), postLabel.toLowerCase()
 						)
 					}
-					<br />
-					<ExternalLink
-						className="post-publish-modal__postpublish-post-address"
-						href={ safeDecodeURIComponent( post.link ) }
-						target="_blank"
-						ref={ ( linkElement ) => this.linkElement = linkElement }
-					>
-						{ safeDecodeURIComponent( post.link ) }
-						&lrm;
-					</ExternalLink>
-				</div>
-				<div className="editor-post-publish-modal-panel">
-					{ ! isScheduled && (
-						<Button isDefault href={ post.link }>
-							{ viewPostLabel }
-						</Button>
-					) }
-
+				</p>
+				<div className="post-publish-modal__postpublish-post-address">
+					<TextControl
+						disabled
+						className="post-publish-modal__postpublish-post-url"
+						label={
+							sprintf(
+								/* translators: %s: post type singular name */
+								__( 'Link to your %s:' ), postLabel
+							)
+						}
+						value={ safeDecodeURIComponent( post.link ) }
+					/>
 					<ClipboardButton
-						isDefault text={ post.link }
+						isDefault
+						isLarge
+						className="post-publish-modal__postpublish-post-copy"
+						text={ post.link }
 						onCopy={ this.onCopy }
 					>
 						{ this.state.showCopyConfirmation ? __( 'Copied!' ) : __( 'Copy Link' ) }
 					</ClipboardButton>
 				</div>
+				{ ! isScheduled && (
+					<div className="editor-post-publish-modal__content-publish-controls">
+						<Button
+							href={ post.link }
+							isPrimary
+							isLarge
+						>
+							{ viewPostLabel }
+						</Button>
+					</div>
+				) }
 				{ children }
 			</div>
 		);

--- a/packages/editor/src/components/post-publish-modal/postpublish.js
+++ b/packages/editor/src/components/post-publish-modal/postpublish.js
@@ -13,11 +13,6 @@ import { Component, createRef } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 import { safeDecodeURIComponent } from '@wordpress/url';
 
-/**
- * Internal dependencies
- */
-// import PostScheduleLabel from '../post-schedule/label';
-
 class PostPublishModalPostpublish extends Component {
 	constructor() {
 		super( ...arguments );
@@ -25,15 +20,8 @@ class PostPublishModalPostpublish extends Component {
 			showCopyConfirmation: false,
 		};
 		this.onCopy = this.onCopy.bind( this );
-		this.onSelectInput = this.onSelectInput.bind( this );
 		this.postLink = createRef();
 	}
-
-	// componentDidMount() {
-	// 	if ( this.props.focusOnMount ) {
-	// 		this.postLink.current.focus();
-	// 	}
-	// }
 
 	componentWillUnmount() {
 		clearTimeout( this.dismissCopyConfirmation );
@@ -50,10 +38,6 @@ class PostPublishModalPostpublish extends Component {
 				showCopyConfirmation: false,
 			} );
 		}, 4000 );
-	}
-
-	onSelectInput( event ) {
-		event.target.select();
 	}
 
 	render() {

--- a/packages/editor/src/components/post-publish-modal/postpublish.js
+++ b/packages/editor/src/components/post-publish-modal/postpublish.js
@@ -62,8 +62,8 @@ class PostPublishModalPostpublish extends Component {
 		const viewPostLabel = get( postType, [ 'labels', 'view_item' ] );
 
 		return (
-			<div className="post-publish-modal__postpublish">
-				<p className="post-publish-modal__postpublish-post-text">
+			<div className="editor-editor-post-publish-modal__prepublish">
+				<p className="editor-post-publish-modal__postpublish-post-text">
 					{
 						sprintf(
 							/* translators: %s: post type singular name */
@@ -71,10 +71,10 @@ class PostPublishModalPostpublish extends Component {
 						)
 					}
 				</p>
-				<div className="post-publish-modal__postpublish-post-address">
+				<div className="editor-post-publish-modal__postpublish-post-address">
 					<TextControl
 						disabled
-						className="post-publish-modal__postpublish-post-url"
+						className="editor-post-publish-modal__postpublish-post-url"
 						label={
 							sprintf(
 								/* translators: %s: post type singular name */
@@ -86,7 +86,7 @@ class PostPublishModalPostpublish extends Component {
 					<ClipboardButton
 						isDefault
 						isLarge
-						className="post-publish-modal__postpublish-post-copy"
+						className="editor-post-publish-modal__postpublish-post-copy"
 						text={ post.link }
 						onCopy={ this.onCopy }
 					>
@@ -94,7 +94,7 @@ class PostPublishModalPostpublish extends Component {
 					</ClipboardButton>
 				</div>
 				{ ! isScheduled && (
-					<div className="editor-post-publish-modal__content-publish-controls">
+					<div className="editor-post-publish-modal__postpublish-controls">
 						<Button
 							href={ post.link }
 							isPrimary

--- a/packages/editor/src/components/post-publish-modal/prepublish.js
+++ b/packages/editor/src/components/post-publish-modal/prepublish.js
@@ -1,0 +1,102 @@
+/**
+ * External dependencies
+ */
+import { get, find } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+// import { PanelBody } from '@wordpress/components';
+
+import { withSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import PostVisibilityLabel from '../post-visibility/label';
+import PostScheduleLabel from '../post-schedule/label';
+import { visibilityOptions } from '../post-visibility/utils';
+// import PostVisibility from '../post-visibility';
+// import PostSchedule from '../post-schedule';
+// import MaybeTagsPanel from './maybe-tags-panel';
+// import MaybePostFormatPanel from './maybe-post-format-panel';
+
+function PostPublishModalPrepublish( {
+	hasPublishAction,
+	publishDate,
+	isFloating,
+	visibility,
+	children,
+} ) {
+	let prePublishBodyText,
+		prePublishDateText;
+
+	if ( ! hasPublishAction ) {
+		prePublishBodyText = __( 'When you’re ready, submit your work for review, and an Editor will be able to approve it for you.' );
+	} else {
+		prePublishBodyText = __( 'Double-check your settings before publishing.' );
+	}
+
+	if ( isFloating ) {
+		prePublishDateText = __( 'Your work will be published right now.' );
+	} else if ( new Date( publishDate ) < new Date() ) {
+		prePublishDateText = __( 'Your work will be published right now and back-dated.' );
+	} else {
+		prePublishDateText = __( 'Your work will be published at the specified date and time.' );
+	}
+
+	const getVisibilityInfo = () => find( visibilityOptions, { value: visibility } ).info;
+
+	return (
+		<div className="editor-post-publish-modal__prepublish">
+			<p>{ prePublishBodyText }</p>
+			{ hasPublishAction && (
+				<>
+					<div className="editor-post-publish-modal-panel">
+						<div className="editor-post-publish-modal-panel__heading">
+							{ __( 'Visibility:' ) }
+						</div>
+						<div className="editor-post-publish-modal-panel__value">
+							<PostVisibilityLabel />
+						</div>
+						<div className="editor-post-publish-modal__detail">
+							{ getVisibilityInfo( visibility ) }
+						</div>
+					</div>
+					<div className="editor-post-publish-modal-panel">
+						<div className="editor-post-publish-modal-panel__heading">
+							{ __( 'Publish:' ) }
+						</div>
+						<div className="editor-post-publish-modal-panel__value">
+							<PostScheduleLabel />
+						</div>
+						<div className="editor-post-publish-modal__detail">
+							{ prePublishDateText }
+						</div>
+					</div>
+					<div className="editor-post-publish-modal-panel">
+						{ children }
+					</div>
+				</>
+			) }
+		</div>
+	);
+}
+
+export default withSelect(
+	( select ) => {
+		const {
+			getCurrentPost,
+			getEditedPostVisibility,
+			getEditedPostAttribute,
+			isEditedPostDateFloating,
+		} = select( 'core/editor' );
+		return {
+			hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
+			visibility: getEditedPostVisibility(),
+			publishDate: getEditedPostAttribute( 'date' ),
+			isFloating: isEditedPostDateFloating(),
+		};
+	}
+)( PostPublishModalPrepublish );

--- a/packages/editor/src/components/post-publish-modal/prepublish.js
+++ b/packages/editor/src/components/post-publish-modal/prepublish.js
@@ -7,8 +7,6 @@ import { get, find } from 'lodash';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-// import { PanelBody } from '@wordpress/components';
-
 import { withSelect } from '@wordpress/data';
 
 /**
@@ -17,10 +15,6 @@ import { withSelect } from '@wordpress/data';
 import PostVisibilityLabel from '../post-visibility/label';
 import PostScheduleLabel from '../post-schedule/label';
 import { visibilityOptions } from '../post-visibility/utils';
-// import PostVisibility from '../post-visibility';
-// import PostSchedule from '../post-schedule';
-// import MaybeTagsPanel from './maybe-tags-panel';
-// import MaybePostFormatPanel from './maybe-post-format-panel';
 
 function PostPublishModalPrepublish( {
 	hasPublishAction,

--- a/packages/editor/src/components/post-publish-modal/prepublish.js
+++ b/packages/editor/src/components/post-publish-modal/prepublish.js
@@ -6,7 +6,7 @@ import { get, find } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 // import { PanelBody } from '@wordpress/components';
 
 import { withSelect } from '@wordpress/data';
@@ -28,14 +28,19 @@ function PostPublishModalPrepublish( {
 	isFloating,
 	visibility,
 	children,
+	postType,
 } ) {
+	const postLabel = get( postType, [ 'labels', 'singular_name' ] );
 	let prePublishBodyText,
 		prePublishDateText;
 
 	if ( ! hasPublishAction ) {
 		prePublishBodyText = __( 'When you’re ready, submit your work for review, and an Editor will be able to approve it for you.' );
 	} else {
-		prePublishBodyText = __( 'Double-check your settings, then publish your post.' );
+		prePublishBodyText = sprintf(
+			/* translators: %s: post type singular name */
+			__( 'Double-check your settings, then publish your %s.' ), postLabel.toLowerCase()
+		);
 	}
 
 	if ( isFloating ) {
@@ -92,11 +97,13 @@ export default withSelect(
 			getEditedPostAttribute,
 			isEditedPostDateFloating,
 		} = select( 'core/editor' );
+		const { getPostType } = select( 'core' );
 		return {
 			hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
 			visibility: getEditedPostVisibility(),
 			publishDate: getEditedPostAttribute( 'date' ),
 			isFloating: isEditedPostDateFloating(),
+			postType: getPostType( getEditedPostAttribute( 'type' ) ),
 		};
 	}
 )( PostPublishModalPrepublish );

--- a/packages/editor/src/components/post-publish-modal/prepublish.js
+++ b/packages/editor/src/components/post-publish-modal/prepublish.js
@@ -35,7 +35,7 @@ function PostPublishModalPrepublish( {
 	if ( ! hasPublishAction ) {
 		prePublishBodyText = __( 'When you’re ready, submit your work for review, and an Editor will be able to approve it for you.' );
 	} else {
-		prePublishBodyText = __( 'Double-check your settings before publishing.' );
+		prePublishBodyText = __( 'Double-check your settings, then publish your post.' );
 	}
 
 	if ( isFloating ) {
@@ -55,17 +55,6 @@ function PostPublishModalPrepublish( {
 				<>
 					<div className="editor-post-publish-modal-panel">
 						<div className="editor-post-publish-modal-panel__heading">
-							{ __( 'Visibility:' ) }
-						</div>
-						<div className="editor-post-publish-modal-panel__value">
-							<PostVisibilityLabel />
-						</div>
-						<div className="editor-post-publish-modal__detail">
-							{ getVisibilityInfo( visibility ) }
-						</div>
-					</div>
-					<div className="editor-post-publish-modal-panel">
-						<div className="editor-post-publish-modal-panel__heading">
 							{ __( 'Publish:' ) }
 						</div>
 						<div className="editor-post-publish-modal-panel__value">
@@ -73,6 +62,17 @@ function PostPublishModalPrepublish( {
 						</div>
 						<div className="editor-post-publish-modal__detail">
 							{ prePublishDateText }
+						</div>
+					</div>
+					<div className="editor-post-publish-modal-panel">
+						<div className="editor-post-publish-modal-panel__heading">
+							{ __( 'Visibility:' ) }
+						</div>
+						<div className="editor-post-publish-modal-panel__value">
+							<PostVisibilityLabel />
+						</div>
+						<div className="editor-post-publish-modal__detail">
+							{ getVisibilityInfo( visibility ) }
 						</div>
 					</div>
 					<div className="editor-post-publish-modal-panel">

--- a/packages/editor/src/components/post-publish-modal/prepublish.js
+++ b/packages/editor/src/components/post-publish-modal/prepublish.js
@@ -33,7 +33,7 @@ function PostPublishModalPrepublish( {
 	} else {
 		prePublishBodyText = sprintf(
 			/* translators: %s: post type singular name */
-			__( 'Double-check your settings, then publish your %s.' ), postLabel.toLowerCase()
+			__( 'Double-check your settings, then publish your %s.' ), postLabel
 		);
 	}
 

--- a/packages/editor/src/components/post-publish-modal/style.scss
+++ b/packages/editor/src/components/post-publish-modal/style.scss
@@ -1,0 +1,33 @@
+.editor-post-publish-modal {
+	min-width: 600px;
+}
+.editor-post-publish-modal-panel {
+	padding: 16px 0;
+}
+.editor-post-publish-modal-panel__heading {
+	font-size: 13px;
+	line-height: 18px;
+	letter-spacing: -0.006px;
+	color: $dark-gray-300;
+	font-weight: 400;
+}
+
+.editor-post-publish-modal-panel__value {
+	font-size: 21px;
+	line-height: 18px;
+	letter-spacing: -0.006px;
+	color: $dark-gray-800;
+	margin: 4px 0;
+}
+
+.editor-post-publish-modal-panel__detail {
+	font-size: 13px;
+	line-height: 18px;
+	letter-spacing: -0.006px;
+	color: $dark-gray-800;
+	clear: both;
+}
+
+.post-publish-modal__postpublish-post-address .components-text-control__input {
+	width: 80%;
+}

--- a/packages/editor/src/components/post-publish-modal/style.scss
+++ b/packages/editor/src/components/post-publish-modal/style.scss
@@ -1,9 +1,24 @@
 .editor-post-publish-modal {
 	min-width: 600px;
 }
+
+.editor-post-publish-modal .components-modal__header {
+	border-bottom: none;
+	margin-bottom: 12px;
+}
+
+.editor-post-publish-modal .components-modal__header .components-modal__header-heading {
+	font-weight: 400;
+	font-size: 23px;
+	line-height: 18px;
+	text-align: center;
+	letter-spacing: -0.5px;
+}
+
 .editor-post-publish-modal-panel {
 	padding: 16px 0;
 }
+
 .editor-post-publish-modal-panel__heading {
 	font-size: 13px;
 	line-height: 18px;
@@ -30,4 +45,14 @@
 
 .post-publish-modal__postpublish-post-address .components-text-control__input {
 	width: 80%;
+}
+
+.editor-post-publish-modal__content-publish-controls {
+	text-align: right;
+}
+.editor-post-publish-modal__content-cancel-button {
+	margin: 0 3px 0 12px;
+}
+.editor-post-publish-modal__content-publish-button {
+	margin: 0 3px 0 12px;
 }

--- a/packages/editor/src/components/post-publish-modal/style.scss
+++ b/packages/editor/src/components/post-publish-modal/style.scss
@@ -43,16 +43,25 @@
 	clear: both;
 }
 
-.post-publish-modal__postpublish-post-address .components-text-control__input {
-	width: 80%;
+.post-publish-modal__postpublish-post-address {
+	display: flex;
+	align-items: flex-end;
+	padding: 12px 0;
+}
+.post-publish-modal__postpublish-post-url {
+	flex: auto;
+	padding-right: 8px;
+}
+.post-publish-modal__postpublish-post-copy {
+	margin-bottom: 9px;
 }
 
 .editor-post-publish-modal__content-publish-controls {
 	text-align: right;
+	padding: 24px 0 0;
 }
-.editor-post-publish-modal__content-cancel-button {
-	margin: 0 3px 0 12px;
-}
-.editor-post-publish-modal__content-publish-button {
-	margin: 0 3px 0 12px;
+
+.editor-post-publish-modal__content-publish-controls button.is-link,
+.editor-post-publish-modal__content-publish-controls button.is-large {
+	padding: 0 24px 2px;
 }

--- a/packages/editor/src/components/post-publish-modal/style.scss
+++ b/packages/editor/src/components/post-publish-modal/style.scss
@@ -1,5 +1,6 @@
 .editor-post-publish-modal {
 	min-width: 600px;
+	width: 35vw;
 }
 
 .editor-post-publish-modal .components-modal__header {

--- a/packages/editor/src/components/post-publish-modal/style.scss
+++ b/packages/editor/src/components/post-publish-modal/style.scss
@@ -44,6 +44,11 @@
 	clear: both;
 }
 
+.editor-post-publish-modal-pending {
+	display: flex;
+	justify-content: center;
+}
+
 .post-publish-modal__postpublish-post-address {
 	display: flex;
 	align-items: flex-end;

--- a/packages/editor/src/components/post-publish-modal/style.scss
+++ b/packages/editor/src/components/post-publish-modal/style.scss
@@ -3,6 +3,7 @@
 	width: 35vw;
 }
 
+/* Override default modal styles */
 .editor-post-publish-modal .components-modal__header {
 	border-bottom: none;
 	margin-bottom: 12px;
@@ -44,30 +45,40 @@
 	clear: both;
 }
 
-.editor-post-publish-modal-pending {
-	display: flex;
-	justify-content: center;
-}
-
-.post-publish-modal__postpublish-post-address {
-	display: flex;
-	align-items: flex-end;
-	padding: 12px 0;
-}
-.post-publish-modal__postpublish-post-url {
-	flex: auto;
-	padding-right: 8px;
-}
-.post-publish-modal__postpublish-post-copy {
-	margin-bottom: 9px;
-}
-
-.editor-post-publish-modal__content-publish-controls {
+/* Pre-publish Modal Styles */
+.editor-post-publish-modal__prepublish-controls {
 	text-align: right;
 	padding: 24px 0 0;
 }
 
-.editor-post-publish-modal__content-publish-controls button.is-link,
-.editor-post-publish-modal__content-publish-controls button.is-large {
+.editor-post-publish-modal__prepublish-controls .editor-post-publish-modal__prepublish-cancel-button,
+.editor-post-publish-modal__prepublish-controls .editor-post-publish-modal__prepublish-publish-button {
 	padding: 0 24px 2px;
+}
+
+/* Publishing Modal Styles */
+.editor-post-publish-modal__publishing-animation {
+	display: flex;
+	justify-content: center;
+}
+
+/* Post Publish Modal Styles */
+.editor-post-publish-modal__postpublish-post-address {
+	display: flex;
+	align-items: flex-end;
+	padding: 12px 0;
+}
+
+.editor-post-publish-modal__postpublish-post-url {
+	flex: auto;
+	padding-right: 8px;
+}
+
+.editor-post-publish-modal__postpublish-post-copy {
+	margin-bottom: 9px;
+}
+
+.editor-post-publish-modal__postpublish-controls {
+	text-align: right;
+	padding: 24px 0 0;
 }

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -10,6 +10,7 @@
 @import "./components/post-locked-modal/style.scss";
 @import "./components/post-permalink/style.scss";
 @import "./components/post-publish-panel/style.scss";
+@import "./components/post-publish-modal/style.scss";
 @import "./components/post-saved-state/style.scss";
 @import "./components/post-taxonomies/style.scss";
 @import "./components/post-text-editor/style.scss";


### PR DESCRIPTION
**DO NOT MERGE**
## Description
This is a combination of an update to publish via a modal I am working on (#16715) and an alternative modal style change @youknowriad started (#16896) The purpose is to explore what publishing via a full-screen modal could potentially look like, as requested in #7602. 

I wasn't sure the best way to track/share this as it's a combination of two work in progress PRs, and thought this would be the easiest, but if there is another way I'm happy to update.

Screenshot:
![kS5lw4TDIo](https://user-images.githubusercontent.com/6653970/63812587-d86d5800-c8f8-11e9-9000-21a94dd878dc.gif)

