### PR TITLE
Fix: Image Block: Update media link when image is replaced

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -357,7 +357,7 @@ export class ImageEdit extends Component {
 			isEditing: false,
 		} );
 
-		const { id, url, alt, caption } = this.props.attributes;
+		const { id, url, alt, caption, linkDestination } = this.props.attributes;
 
 		let mediaAttributes = pickRelevantMediaFiles( media );
 
@@ -383,6 +383,12 @@ export class ImageEdit extends Component {
 		} else {
 			// Keep the same url when selecting the same file, so "Image Size" option is not changed.
 			additionalAttributes = { url };
+		}
+
+		// Check if the image is linked to it's media.
+		if ( linkDestination === LINK_DESTINATION_MEDIA ) {
+			// Update the media link.
+			mediaAttributes.href = media.url;
 		}
 
 		this.props.setAttributes( {


### PR DESCRIPTION
## Description
Update the Media Link in the image block when the image is replaced.

## How has this been tested?
1. Confirmed the bug by following the steps provided in #17119.
2. Applied the changes / additions.
3. No longer able to reproduce the bug.

## Types of changes
Fixes #17119. 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. 
