### PR TITLE
Fix: Image Block: Add protocol to custom link

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -62,7 +62,7 @@ import {
 	useRef,
 } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { getPath } from '@wordpress/url';
+import { getPath, prependHTTP } from '@wordpress/url';
 import { withViewportMatch } from '@wordpress/viewport';
 import { speak } from '@wordpress/a11y';
 
@@ -178,7 +178,14 @@ const ImageURLInputUI = ( {
 	const onSubmitLinkChange = useCallback( () => {
 		return ( event ) => {
 			if ( urlInput ) {
-				onChangeUrl( urlInput );
+				let imageUrl = urlInput;
+
+				// Append HTTP protocol to custom link.
+				if ( linkDestination === LINK_DESTINATION_CUSTOM ) {
+					imageUrl = prependHTTP( urlInput );
+				}
+
+				onChangeUrl( imageUrl );
 			}
 			stopEditLink();
 			setUrlInput( null );


### PR DESCRIPTION
## Description
Append HTTP protocol to custom link set in Image Block.

## How has this been tested?
1. Create a post.
2. Insert an Image Block and select image from library.
3. In the Toolbar click "Insert Link" icon.
4. Enter an address. (Tested addresses with http, https, as well as without e.g. google.com.)
5. Click the "external link" icon besides the custom link. (It will redirect you to the custom URL instead of a relative URL).
6. Save the post and view it in the frontend.
7. Click the image. (It will now redirect you to the custom URL instead of a relative URL).

## Worth consideration
The change uses `prependHTTP` which will always prepend `HTTP`. It might be worth considering prepending `HTTPS` instead.

## Types of changes
Fixes #17155.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
