### PR TITLE
[RNMobile] Activate travis on mobile master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ cache:
 branches:
   only:
     - master
+    - rnmobile/master
 
 before_install:
   - nvm install


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This PR activates Travis CI on `rnmobile/master` branch. This is a temporal change while we still use `rnmobile/master`.

It should be removed before merging back to `master`.

To test:
- Check that Travis CI is triggered on this PR.
