### PR TITLE
Try attached container for the block movers. 

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -667,10 +667,6 @@
 	> .block-editor-block-list__block-edit > .block-editor-block-mover {
 		position: absolute;
 		width: $block-side-ui-width + $block-side-ui-clearance;
-
-		// Stretch to fill half of the available space to increase hoverable area.
-		height: 100%;
-		max-height: $block-side-ui-width * 4;
 	}
 
 	// Position depending on whether selected or not.
@@ -696,7 +692,7 @@
 		padding-right: $block-side-ui-clearance;
 
 		// Position for top level blocks.
-		left: -$block-side-ui-width - $block-side-ui-clearance - $block-padding - $border-width;
+		left: -$block-side-ui-width - $block-side-ui-clearance - $block-padding - $border-width - $grid-size;
 
 		// Hide on mobile, as mobile has a separate solution.
 		display: none;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -692,7 +692,7 @@
 		padding-right: $block-side-ui-clearance;
 
 		// Position for top level blocks.
-		left: -$block-side-ui-width - $block-side-ui-clearance - $block-padding - $border-width - $grid-size;
+		left: -$block-side-ui-width - $block-side-ui-clearance - $block-padding - $block-left-border-width;
 
 		// Hide on mobile, as mobile has a separate solution.
 		display: none;

--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -1,9 +1,25 @@
 .block-editor-block-mover {
 	min-height: $empty-paragraph-height;
 	opacity: 0;
+	background: $white;
+	border: 1px solid $dark-opacity-light-800;
+	border-radius: $icon-button-size-small * 3 + $grid-size-small; // Creates a pill shape
+	height: ($icon-button-size-small * 3) + ( $grid-size-small * 1.5);
+	padding-top: $grid-size-small / 2;
+	padding-bottom: $grid-size-small / 2;
+	transition: box-shadow 0.2s ease-out;
+	@include reduce-motion("transition");
+
+	.is-dark-theme & {
+		border-color: $light-opacity-light-800;
+	}
 
 	&.is-visible {
 		@include edit-post__fade-in-animation;
+	}
+
+	&:hover {
+		box-shadow: $shadow-toolbar;
 	}
 
 	// 24px is the smallest size of a good pressable button.
@@ -24,6 +40,8 @@
 	justify-content: center;
 	cursor: pointer;
 	padding: 0;
+	border: none;
+	box-shadow: none;
 
 	// Carefully adjust the size of the side UI to fit one paragraph of text (56px).
 	width: $block-side-ui-width;
@@ -46,6 +64,12 @@
 	.is-dark-theme .wp-block .wp-block &,
 	.wp-block .is-dark-theme .wp-block & {
 		color: $dark-opacity-300;
+	}
+
+	&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover,
+	&:focus:not(:disabled) {
+		background-color: transparent;
+		box-shadow: none;
 	}
 
 	&[aria-disabled="true"] {

--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -2,33 +2,23 @@
 	min-height: $empty-paragraph-height;
 	opacity: 0;
 	background: $white;
-	border: 1px solid $dark-opacity-light-800;
-	border-radius: $icon-button-size-small * 3 + $grid-size-small; // Creates a pill shape
 	height: ($icon-button-size-small * 3) + ( $grid-size-small * 1.5);
 	padding-top: $grid-size-small / 2;
 	padding-bottom: $grid-size-small / 2;
-	transition: box-shadow 0.2s ease-out;
-	@include reduce-motion("transition");
-
-	.is-dark-theme & {
-		border-color: $light-opacity-light-800;
-	}
 
 	&.is-visible {
 		@include edit-post__fade-in-animation;
 	}
 
-	&:hover {
-		box-shadow: $shadow-toolbar;
-	}
-
-	// 24px is the smallest size of a good pressable button.
-	// With 3 pieces of side UI, that comes to a total of 72px.
-	// To vertically center against a 56px paragraph, move upwards 72px - 56px / 2.
-	// Don't do this for wide, fullwide, or mobile.
 	@include break-small() {
 		.block-editor-block-list__block:not([data-align="wide"]):not([data-align="full"]) & {
-			margin-top: -$grid-size;
+			border: 1px solid $dark-opacity-light-800;
+			border-right: none;
+			margin-top: $border-width;
+
+			.is-dark-theme & {
+				border-color: $light-opacity-light-800;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Alternate to #17216. As proposed in https://github.com/WordPress/gutenberg/issues/16580#issuecomment-519704818. 

Still a little buggy, but this is a rough first implementation of adding an attached block container around the block movers: 

<img width="681" alt="Screen Shot 2019-08-28 at 9 28 38 AM" src="https://user-images.githubusercontent.com/1202812/63860116-89fe9e80-c976-11e9-8fc8-ed6e57431381.png">

- [ ] Needs revised focus states
- [ ] Needs to be revised so that it works on short blocks (like one-line paragraphs)
- [ ] Needs to include a treatment for wide/full blocks