### PR TITLE
Show colors for InserterWithShortcuts block icons

### DIFF
--- a/packages/block-editor/src/components/inserter-with-shortcuts/index.js
+++ b/packages/block-editor/src/components/inserter-with-shortcuts/index.js
@@ -39,7 +39,7 @@ function InserterWithShortcuts( { items, isLocked, onInsert } ) {
 					// translators: %s: block title/name to be added
 					label={ sprintf( __( 'Add %s' ), item.title ) }
 					icon={ (
-						<BlockIcon icon={ item.icon } />
+						<BlockIcon icon={ item.icon } showColors />
 					) }
 				/>
 			) ) }


### PR DESCRIPTION
## Description
![image](https://user-images.githubusercontent.com/3616980/63862978-c699bc80-c9ad-11e9-8025-610b8426d75e.png)
`<InserterWithShortcuts />` shows block icons without colors when they are defined using a Dashicon and the `foreground`/`background` properties. In the screenshot above, different blocks from WooCommerce Blocks are displayed in different colors depending on how their icons are defined. The _Featured Product_ block (star icon) has its icon [defined](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/assets/js/blocks/featured-product/index.js#L22) as a Dashicon so its shown gray, while the other blocks, are using [SVG icons](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/assets/js/blocks/reviews/reviews-by-product/index.js#L22) so they appear purple.

I'm not sure if showing icons without colors was intentional or if it's a bug, but I couldn't find any prior discussion were a decision was taken, so I decided to create the PR directly.

## How has this been tested?
Verifying icons show the correct colors in the inserter.

## Screenshots
Screenshots from WooCommerce Blocks 2.4:
_Before:_
![image_360](https://user-images.githubusercontent.com/3616980/63862267-99004380-c9ac-11e9-98d4-2ca70e8f537b.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/63862047-43c43200-c9ac-11e9-836b-50da24f11895.png)

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
