### PR TITLE
Block Editor: Disable click-through on desktop.

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import { withViewportMatch } from '@wordpress/viewport'; // Temporary click-through disable on desktop.
 import { Component } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { synchronizeBlocksWithTemplate, withBlockContentContext } from '@wordpress/blocks';
@@ -101,6 +102,7 @@ class InnerBlocks extends Component {
 
 	render() {
 		const {
+			isSmallScreen, // Temporary click-through disable on desktop.
 			clientId,
 			hasOverlay,
 			renderAppender,
@@ -114,7 +116,7 @@ class InnerBlocks extends Component {
 		const isPlaceholder = template === null && !! templateOptions;
 
 		const classes = classnames( 'editor-inner-blocks block-editor-inner-blocks', {
-			'has-overlay': hasOverlay && ! isPlaceholder,
+			'has-overlay': isSmallScreen && ( hasOverlay && ! isPlaceholder ), // Temporary click-through disable on desktop.
 		} );
 
 		return (
@@ -137,6 +139,7 @@ class InnerBlocks extends Component {
 }
 
 InnerBlocks = compose( [
+	withViewportMatch( { isSmallScreen: '< medium' } ), // Temporary click-through disable on desktop.
 	withBlockEditContext( ( context ) => pick( context, [ 'clientId' ] ) ),
 	withSelect( ( select, ownProps ) => {
 		const {


### PR DESCRIPTION
## Description

This PR disables inner block click-through on large, `>= medium`, viewports.

As expressed in #16888 and #17088, click-through degrades the experience on larger viewports. If the viewport is large enough to click on block paddings, we don't need the click-through behavior to edit inner blocks, so it adds unnecessary friction.

That said, we could revisit the feature in another form for a future release.

## How has this been tested?

It was verified that click-through is disabled on large, `>= medium`, viewports.

## Types of Changes

*New Feature:* Disable click-through on larger viewports where just clicking on paddings is viable and requiring multiple clicks to edit inner blocks degrades the experience.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
