### PR TITLE
BlockPreview: add __experimentalOnReady property

### DIFF
--- a/docs/contributors/testing-overview.md
+++ b/docs/contributors/testing-overview.md
@@ -27,7 +27,7 @@ Assuming you've followed the [instructions](/docs/contributors/getting-started.m
 npm test
 ```
 
-Linting is static code analysis used to enforce coding standards and to avoid potential errors. This project uses [ESLint](http://eslint.org/) and [TypeScript's JavaScript type-checking](https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html) to capture these issues. While the above `npm test` will execute both unit tests and code linting, code linting can be verified independently by running `npm run lint`. Some issues can be fixed automatically by running `npm run lint:fix`.
+Linting is static code analysis used to enforce coding standards and to avoid potential errors. This project uses [ESLint](http://eslint.org/) and [TypeScript's JavaScript type-checking](https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html) to capture these issues. While the above `npm test` will execute both unit tests and code linting, code linting can be verified independently by running `npm run lint`. Some JavaScript issues can be fixed automatically by running `npm run lint-js:fix`.
 
 To improve your developer workflow, you should setup an editor linting integration. See the [getting started documentation](/docs/contributors/getting-started.md) for additional information.
 

--- a/packages/block-editor/src/components/block-preview/README.md
+++ b/packages/block-editor/src/components/block-preview/README.md
@@ -34,10 +34,16 @@ Width of the preview container in pixels. Controls at what size the blocks will 
 * **Type** `Function`
 * **Default:** `noop`
 
-Use this callback as an opportunity to know when the preview is ready. The callback will pass the scale factor, offsets position (x, y) and the DOM element reference, if available. Eg:
+Use this callback as an opportunity to know when the preview is ready. The callback will pass, if available:
+
+* `scale`: the scale factor
+* `position`: offsets position (x, y)
+* `previewContainerRef`: DOM element reference
+* `styles`: Online styles applied to the preview container
+
+Eg:
 
 ```es6
-
 <BlockPreview
 	blocks={ blocks }
 	__experimentalOnReady={ ( { scale, previewContainerRef, position } ) => {

--- a/packages/block-editor/src/components/block-preview/README.md
+++ b/packages/block-editor/src/components/block-preview/README.md
@@ -39,7 +39,10 @@ Use this callback as an opportunity to know when the preview is ready. The callb
 ```es6
 
 <BlockPreview
-	__experimentalOnReady={ ( { scale } ) => console.log( `Current preview scale: ${ scale }` )
 	blocks={ blocks }
+	__experimentalOnReady={ ( { scale, previewContainerRef, position } ) => {
+		console.log( `scale ${ scale } applied to the <${ previewContainerRef.current.tagName }> element.` );
+		console.log( `at x: ${ position.x }, y: ${ position.y } position.` );
+	} }
 />
 ```

--- a/packages/block-editor/src/components/block-preview/README.md
+++ b/packages/block-editor/src/components/block-preview/README.md
@@ -30,6 +30,12 @@ Width of the preview container in pixels. Controls at what size the blocks will 
 
 `viewportWidth` can be used to simulate how blocks look on different device sizes or to make sure make sure multiple previews will be rendered with the same scale, regardless of their content.
 
+### __experimentalScalingDelay
+* **Type** `Int`
+* **Default** `100ms`
+
+It defines the delay before to start to calc the scale factor and position of the preview block.
+
 ### `__experimentalOnReady`
 * **Type** `Function`
 * **Default:** `noop`
@@ -39,7 +45,7 @@ Use this callback as an opportunity to know when the preview is ready. The callb
 * `scale`: the scale factor
 * `position`: offsets position (x, y)
 * `previewContainerRef`: DOM element reference
-* `styles`: Online styles applied to the preview container
+* `inlineStyles`: Inline styles applied to the preview container
 
 Eg:
 

--- a/packages/block-editor/src/components/block-preview/README.md
+++ b/packages/block-editor/src/components/block-preview/README.md
@@ -29,3 +29,17 @@ A block instance (object) or a blocks array you would like to render a preview.
 Width of the preview container in pixels. Controls at what size the blocks will be rendered inside the preview.
 
 `viewportWidth` can be used to simulate how blocks look on different device sizes or to make sure make sure multiple previews will be rendered with the same scale, regardless of their content.
+
+### `onReady`
+* **Type** `Function`
+* **Default:** `noop`
+
+Use this callback as an opportunity to know when the preview is ready. The callback will pass the scale factor, offsets position (x, y) and the DOM element reference, if available. Eg:
+
+```es6
+
+<BlockPreview
+	onReady={ ( { scale } ) => console.log( `Current preview scale: ${ scale }` )
+	blocks={ blocks }
+/>
+```

--- a/packages/block-editor/src/components/block-preview/README.md
+++ b/packages/block-editor/src/components/block-preview/README.md
@@ -30,7 +30,7 @@ Width of the preview container in pixels. Controls at what size the blocks will 
 
 `viewportWidth` can be used to simulate how blocks look on different device sizes or to make sure make sure multiple previews will be rendered with the same scale, regardless of their content.
 
-### `onReady`
+### `__experimentalOnReady`
 * **Type** `Function`
 * **Default:** `noop`
 
@@ -39,7 +39,7 @@ Use this callback as an opportunity to know when the preview is ready. The callb
 ```es6
 
 <BlockPreview
-	onReady={ ( { scale } ) => console.log( `Current preview scale: ${ scale }` )
+	__experimentalOnReady={ ( { scale } ) => console.log( `Current preview scale: ${ scale }` )
 	blocks={ blocks }
 />
 ```

--- a/packages/block-editor/src/components/block-preview/README.md
+++ b/packages/block-editor/src/components/block-preview/README.md
@@ -34,7 +34,7 @@ Width of the preview container in pixels. Controls at what size the blocks will 
 * **Type** `Int`
 * **Default** `100ms`
 
-It defines the delay before to start to calc the scale factor and position of the preview block.
+Defines a delay to be applied before calculating the scale factor and position of the preview block.
 
 ### `__experimentalOnReady`
 * **Type** `Function`

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -108,7 +108,7 @@ function ScaledBlockPreview( { blocks, viewportWidth, padding = 0, onReady } ) {
 				previewContainerRef: previewRef,
 				styles: getOnlineStyles( scale, _x, _y, true, viewportWidth ),
 			} );
-		}, 100 );
+		}, 0 );
 
 		// Cleanup
 		return () => {

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -24,12 +24,7 @@ import BlockEditorProvider from '../provider';
 import BlockList from '../block-list';
 import { getBlockPreviewContainerDOMNode } from '../../utils/dom';
 
-function ScaledBlockPreview( {
-	blocks,
-	viewportWidth,
-	padding = 0,
-	__experimentalOnReady,
-} ) {
+function ScaledBlockPreview( { blocks, viewportWidth, padding = 0, onReady } ) {
 	const previewRef = useRef( null );
 
 	const [ isReady, setIsReady ] = useState( false );
@@ -87,7 +82,7 @@ function ScaledBlockPreview( {
 				// Hack: we need  to reset the scaled elements margins
 				previewElement.style.marginTop = '0';
 
-				__experimentalOnReady( {
+				onReady( {
 					scale,
 					position,
 					previewContainerRef: previewRef,
@@ -96,7 +91,8 @@ function ScaledBlockPreview( {
 				const containerElementRect = containerElement.getBoundingClientRect();
 				const scale = containerElementRect.width / viewportWidth;
 				setPreviewScale( scale );
-				__experimentalOnReady( {
+
+				onReady( {
 					scale,
 					previewContainerRef: previewRef,
 				} );
@@ -171,7 +167,7 @@ export function BlockPreview( {
 				blocks={ renderedBlocks }
 				viewportWidth={ viewportWidth }
 				padding={ padding }
-				__experimentalOnReady={ __experimentalOnReady }
+				onReady={ __experimentalOnReady }
 			/>
 		</BlockEditorProvider>
 	);

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -27,7 +27,7 @@ import { getBlockPreviewContainerDOMNode } from '../../utils/dom';
 const getInlineStyles = ( scale, x, y, isReady, width ) => ( {
 	transform: `scale(${ scale })`,
 	visibility: isReady ? 'visible' : 'hidden',
-	left: -x,
+	left: x,
 	top: y,
 	width,
 } );
@@ -56,8 +56,8 @@ function ScaledBlockPreview( {
 
 			// Auxiliary vars used for onReady() callback.
 			let scale,
-				_x = 0,
-				_y = 0;
+				offsetX = 0,
+				offsetY = 0;
 
 			// If we're previewing a single block, scale the preview to fit it.
 			if ( blocks.length === 1 ) {
@@ -80,11 +80,11 @@ function ScaledBlockPreview( {
 
 				scale =
 					containerElementRect.width / scaledElementRect.width || 1;
-				const offsetX =
+				offsetX =
 					-( scaledElementRect.left - containerElementRect.left ) *
 						scale +
 					padding;
-				const offsetY =
+				offsetY =
 					containerElementRect.height >
 					scaledElementRect.height * scale
 						? ( containerElementRect.height -
@@ -93,11 +93,8 @@ function ScaledBlockPreview( {
 						  padding
 						: 0;
 
-				_x = offsetX * scale;
-				_y = offsetY;
-
 				setPreviewScale( scale );
-				setPosition( { x: _x, y: _y } );
+				setPosition( { x: offsetX, y: offsetY } );
 
 				// Hack: we need  to reset the scaled elements margins
 				previewElement.style.marginTop = '0';
@@ -110,12 +107,13 @@ function ScaledBlockPreview( {
 			setIsReady( true );
 			onReady( {
 				scale,
-				position: { x: _x, y: _y },
+				position: { x: offsetX, y: offsetY },
 				previewContainerRef: previewRef,
+
 				inlineStyles: getInlineStyles(
 					scale,
-					_x,
-					_y,
+					offsetX,
+					offsetY,
 					true,
 					viewportWidth
 				),

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { castArray } from 'lodash';
+import { castArray, noop } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -24,7 +24,7 @@ import BlockEditorProvider from '../provider';
 import BlockList from '../block-list';
 import { getBlockPreviewContainerDOMNode } from '../../utils/dom';
 
-function ScaledBlockPreview( { blocks, viewportWidth, padding = 0 } ) {
+function ScaledBlockPreview( { blocks, viewportWidth, onReady, padding = 0 } ) {
 	const previewRef = useRef( null );
 
 	const [ isReady, setIsReady ] = useState( false );
@@ -79,9 +79,17 @@ function ScaledBlockPreview( { blocks, viewportWidth, padding = 0 } ) {
 
 				// Hack: we need  to reset the scaled elements margins
 				previewElement.style.marginTop = '0';
+
+				onReady( {
+					scale,
+					position: { x: offsetX * scale, y: offsetY },
+					ref: previewRef,
+				} );
 			} else {
 				const containerElementRect = containerElement.getBoundingClientRect();
-				setPreviewScale( containerElementRect.width / viewportWidth );
+				const scale = containerElementRect.width / viewportWidth;
+				setPreviewScale( scale );
+				onReady( { scale, ref: previewRef } );
 			}
 
 			setIsReady( true );
@@ -133,6 +141,7 @@ export function BlockPreview( {
 	viewportWidth = 700,
 	padding,
 	settings,
+	onReady = noop,
 } ) {
 	const renderedBlocks = useMemo( () => castArray( blocks ), [ blocks ] );
 	const [ recompute, triggerRecompute ] = useReducer(
@@ -152,6 +161,7 @@ export function BlockPreview( {
 				blocks={ renderedBlocks }
 				viewportWidth={ viewportWidth }
 				padding={ padding }
+				onReady={ onReady }
 			/>
 		</BlockEditorProvider>
 	);

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -79,6 +79,8 @@ function ScaledBlockPreview( {
 						  padding
 						: 0;
 
+				const position = { x: offsetX * scale, y: offsetY };
+
 				setPreviewScale( scale );
 				setPosition( { x: offsetX, y: offsetY } );
 
@@ -87,14 +89,17 @@ function ScaledBlockPreview( {
 
 				__experimentalOnReady( {
 					scale,
-					position: { x: offsetX * scale, y: offsetY },
+					position,
 					previewContainerRef: previewRef,
 				} );
 			} else {
 				const containerElementRect = containerElement.getBoundingClientRect();
 				const scale = containerElementRect.width / viewportWidth;
 				setPreviewScale( scale );
-				__experimentalOnReady( { scale, previewContainerRef: previewRef } );
+				__experimentalOnReady( {
+					scale,
+					previewContainerRef: previewRef,
+				} );
 			}
 
 			setIsReady( true );

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -24,7 +24,12 @@ import BlockEditorProvider from '../provider';
 import BlockList from '../block-list';
 import { getBlockPreviewContainerDOMNode } from '../../utils/dom';
 
-function ScaledBlockPreview( { blocks, viewportWidth, onReady, padding = 0 } ) {
+function ScaledBlockPreview( {
+	blocks,
+	viewportWidth,
+	padding = 0,
+	__experimentalOnReady,
+} ) {
 	const previewRef = useRef( null );
 
 	const [ isReady, setIsReady ] = useState( false );
@@ -80,7 +85,7 @@ function ScaledBlockPreview( { blocks, viewportWidth, onReady, padding = 0 } ) {
 				// Hack: we need  to reset the scaled elements margins
 				previewElement.style.marginTop = '0';
 
-				onReady( {
+				__experimentalOnReady( {
 					scale,
 					position: { x: offsetX * scale, y: offsetY },
 					ref: previewRef,
@@ -89,7 +94,7 @@ function ScaledBlockPreview( { blocks, viewportWidth, onReady, padding = 0 } ) {
 				const containerElementRect = containerElement.getBoundingClientRect();
 				const scale = containerElementRect.width / viewportWidth;
 				setPreviewScale( scale );
-				onReady( { scale, ref: previewRef } );
+				__experimentalOnReady( { scale, ref: previewRef } );
 			}
 
 			setIsReady( true );
@@ -141,7 +146,7 @@ export function BlockPreview( {
 	viewportWidth = 700,
 	padding,
 	settings,
-	onReady = noop,
+	__experimentalOnReady = noop,
 } ) {
 	const renderedBlocks = useMemo( () => castArray( blocks ), [ blocks ] );
 	const [ recompute, triggerRecompute ] = useReducer(
@@ -161,7 +166,7 @@ export function BlockPreview( {
 				blocks={ renderedBlocks }
 				viewportWidth={ viewportWidth }
 				padding={ padding }
-				onReady={ onReady }
+				__experimentalOnReady={ __experimentalOnReady }
 			/>
 		</BlockEditorProvider>
 	);

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -40,6 +40,8 @@ function ScaledBlockPreview( { blocks, viewportWidth, padding = 0, onReady } ) {
 				return;
 			}
 
+			let scale, position;
+
 			// If we're previewing a single block, scale the preview to fit it.
 			if ( blocks.length === 1 ) {
 				const block = blocks[ 0 ];
@@ -59,7 +61,7 @@ function ScaledBlockPreview( { blocks, viewportWidth, padding = 0, onReady } ) {
 				};
 				const scaledElementRect = previewElement.getBoundingClientRect();
 
-				const scale =
+				scale =
 					containerElementRect.width / scaledElementRect.width || 1;
 				const offsetX =
 					-( scaledElementRect.left - containerElementRect.left ) *
@@ -74,31 +76,21 @@ function ScaledBlockPreview( { blocks, viewportWidth, padding = 0, onReady } ) {
 						  padding
 						: 0;
 
-				const position = { x: offsetX * scale, y: offsetY };
+				position = { x: offsetX * scale, y: offsetY };
 
 				setPreviewScale( scale );
 				setPosition( { x: offsetX, y: offsetY } );
 
 				// Hack: we need  to reset the scaled elements margins
 				previewElement.style.marginTop = '0';
-
-				onReady( {
-					scale,
-					position,
-					previewContainerRef: previewRef,
-				} );
 			} else {
 				const containerElementRect = containerElement.getBoundingClientRect();
-				const scale = containerElementRect.width / viewportWidth;
+				scale = containerElementRect.width / viewportWidth;
 				setPreviewScale( scale );
-
-				onReady( {
-					scale,
-					previewContainerRef: previewRef,
-				} );
 			}
 
 			setIsReady( true );
+			onReady( { scale, previewContainerRef: previewRef, position } );
 		}, 100 );
 
 		// Cleanup

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -24,7 +24,7 @@ import BlockEditorProvider from '../provider';
 import BlockList from '../block-list';
 import { getBlockPreviewContainerDOMNode } from '../../utils/dom';
 
-const getOnlineStyles = ( scale, x, y, isReady, width ) => ( {
+const getInlineStyles = ( scale, x, y, isReady, width ) => ( {
 	transform: `scale(${ scale })`,
 	visibility: isReady ? 'visible' : 'hidden',
 	left: -x,
@@ -37,7 +37,7 @@ function ScaledBlockPreview( {
 	viewportWidth,
 	padding = 0,
 	onReady,
-	delay,
+	scalingDelay,
 } ) {
 	const previewRef = useRef( null );
 
@@ -112,9 +112,15 @@ function ScaledBlockPreview( {
 				scale,
 				position: { x: _x, y: _y },
 				previewContainerRef: previewRef,
-				styles: getOnlineStyles( scale, _x, _y, true, viewportWidth ),
+				inlineStyles: getInlineStyles(
+					scale,
+					_x,
+					_y,
+					true,
+					viewportWidth
+				),
 			} );
-		}, delay );
+		}, scalingDelay );
 
 		// Cleanup
 		return () => {
@@ -128,7 +134,7 @@ function ScaledBlockPreview( {
 		return null;
 	}
 
-	const previewStyles = getOnlineStyles(
+	const previewStyles = getInlineStyles(
 		previewScale,
 		x,
 		y,
@@ -163,7 +169,7 @@ export function BlockPreview( {
 	padding,
 	settings,
 	__experimentalOnReady = noop,
-	__experimentalDelay = 100,
+	__experimentalScalingDelay = 100,
 } ) {
 	const renderedBlocks = useMemo( () => castArray( blocks ), [ blocks ] );
 	const [ recompute, triggerRecompute ] = useReducer(
@@ -184,7 +190,7 @@ export function BlockPreview( {
 				viewportWidth={ viewportWidth }
 				padding={ padding }
 				onReady={ __experimentalOnReady }
-				delay={ __experimentalDelay }
+				scalingDelay={ __experimentalScalingDelay }
 			/>
 		</BlockEditorProvider>
 	);

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -24,6 +24,14 @@ import BlockEditorProvider from '../provider';
 import BlockList from '../block-list';
 import { getBlockPreviewContainerDOMNode } from '../../utils/dom';
 
+const getOnlineStyles = ( scale, x, y, isReady, width ) => ( {
+	transform: `scale(${ scale })`,
+	visibility: isReady ? 'visible' : 'hidden',
+	left: -x,
+	top: y,
+	width,
+} );
+
 function ScaledBlockPreview( { blocks, viewportWidth, padding = 0, onReady } ) {
 	const previewRef = useRef( null );
 
@@ -90,7 +98,18 @@ function ScaledBlockPreview( { blocks, viewportWidth, padding = 0, onReady } ) {
 			}
 
 			setIsReady( true );
-			onReady( { scale, previewContainerRef: previewRef, position } );
+			onReady( {
+				scale,
+				position,
+				previewContainerRef: previewRef,
+				styles: getOnlineStyles(
+					scale,
+					position.x,
+					position.y,
+					true,
+					viewportWidth
+				),
+			} );
 		}, 100 );
 
 		// Cleanup
@@ -105,13 +124,13 @@ function ScaledBlockPreview( { blocks, viewportWidth, padding = 0, onReady } ) {
 		return null;
 	}
 
-	const previewStyles = {
-		transform: `scale(${ previewScale })`,
-		visibility: isReady ? 'visible' : 'hidden',
-		left: x,
-		top: y,
-		width: viewportWidth,
-	};
+	const previewStyles = getOnlineStyles(
+		previewScale,
+		x,
+		y,
+		isReady,
+		viewportWidth
+	);
 
 	return (
 		<div

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -88,13 +88,13 @@ function ScaledBlockPreview( {
 				__experimentalOnReady( {
 					scale,
 					position: { x: offsetX * scale, y: offsetY },
-					ref: previewRef,
+					previewContainerRef: previewRef,
 				} );
 			} else {
 				const containerElementRect = containerElement.getBoundingClientRect();
 				const scale = containerElementRect.width / viewportWidth;
 				setPreviewScale( scale );
-				__experimentalOnReady( { scale, ref: previewRef } );
+				__experimentalOnReady( { scale, previewContainerRef: previewRef } );
 			}
 
 			setIsReady( true );

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -32,7 +32,13 @@ const getOnlineStyles = ( scale, x, y, isReady, width ) => ( {
 	width,
 } );
 
-function ScaledBlockPreview( { blocks, viewportWidth, padding = 0, onReady } ) {
+function ScaledBlockPreview( {
+	blocks,
+	viewportWidth,
+	padding = 0,
+	onReady,
+	delay,
+} ) {
 	const previewRef = useRef( null );
 
 	const [ isReady, setIsReady ] = useState( false );
@@ -108,7 +114,7 @@ function ScaledBlockPreview( { blocks, viewportWidth, padding = 0, onReady } ) {
 				previewContainerRef: previewRef,
 				styles: getOnlineStyles( scale, _x, _y, true, viewportWidth ),
 			} );
-		}, 0 );
+		}, delay );
 
 		// Cleanup
 		return () => {
@@ -157,6 +163,7 @@ export function BlockPreview( {
 	padding,
 	settings,
 	__experimentalOnReady = noop,
+	__experimentalDelay = 100,
 } ) {
 	const renderedBlocks = useMemo( () => castArray( blocks ), [ blocks ] );
 	const [ recompute, triggerRecompute ] = useReducer(
@@ -177,6 +184,7 @@ export function BlockPreview( {
 				viewportWidth={ viewportWidth }
 				padding={ padding }
 				onReady={ __experimentalOnReady }
+				delay={ __experimentalDelay }
 			/>
 		</BlockEditorProvider>
 	);

--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -48,7 +48,10 @@ function ScaledBlockPreview( { blocks, viewportWidth, padding = 0, onReady } ) {
 				return;
 			}
 
-			let scale, position;
+			// Auxiliary vars used for onReady() callback.
+			let scale,
+				_x = 0,
+				_y = 0;
 
 			// If we're previewing a single block, scale the preview to fit it.
 			if ( blocks.length === 1 ) {
@@ -84,10 +87,11 @@ function ScaledBlockPreview( { blocks, viewportWidth, padding = 0, onReady } ) {
 						  padding
 						: 0;
 
-				position = { x: offsetX * scale, y: offsetY };
+				_x = offsetX * scale;
+				_y = offsetY;
 
 				setPreviewScale( scale );
-				setPosition( { x: offsetX, y: offsetY } );
+				setPosition( { x: _x, y: _y } );
 
 				// Hack: we need  to reset the scaled elements margins
 				previewElement.style.marginTop = '0';
@@ -100,15 +104,9 @@ function ScaledBlockPreview( { blocks, viewportWidth, padding = 0, onReady } ) {
 			setIsReady( true );
 			onReady( {
 				scale,
-				position,
+				position: { x: _x, y: _y },
 				previewContainerRef: previewRef,
-				styles: getOnlineStyles(
-					scale,
-					position.x,
-					position.y,
-					true,
-					viewportWidth
-				),
+				styles: getOnlineStyles( scale, _x, _y, true, viewportWidth ),
 			} );
 		}, 100 );
 


### PR DESCRIPTION
## Description

This PR adds a new property called **__experimentalOnReady** to the `<BlockPreview />` component, which allows us to know the exact moment when the preview is ready, providing useful data such as the scale factor applied, position and the reference to the DOM element.

It worths to mention that the whole process of previewing contemplates some tricks, pretty common when it needs to interact with the real DOM tree btw, such as adding a timeout (100ms), which sometimes makes it unpredictable and prone to fall in some race conditions if you aren't being careful.

Also, it adds the `__experimentalScalingDelay_` in order to allow set explicitly the delay to take before to start to compute the scale factor. The default value is `100ms`.

## How it works?

```es6
<BlockPreview
	blocks={ blocks }
	__experimentalOnReady={ ( { scale, previewContainerRef, position } ) => {
		console.log( `scale ${ scale } applied to the <${ previewContainerRef.current.tagName }> element.` );
		console.log( `at x: ${ position.x }, y: ${ position.y } position.` );
	} }
/>
```


## How has this been tested?

To test it you can tide a function to this property and confirm that it's called once the preview has been performed, for instance:

```es6
<BlockPreview onReady={ console.log } />
```

Chrome dev console:
![image](https://user-images.githubusercontent.com/77539/65524072-94538000-dec3-11e9-946c-7225d1b41932.png)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
