### PR TITLE
Implement new block-directory package 

### DIFF
--- a/docs/manifest-devhub.json
+++ b/docs/manifest-devhub.json
@@ -1086,6 +1086,12 @@
 		"parent": "packages"
 	},
 	{
+		"title": "@wordpress/block-directory",
+		"slug": "packages-block-directory",
+		"markdown_source": "../packages/block-directory/README.md",
+		"parent": "packages"
+	},
+	{
 		"title": "@wordpress/block-editor",
 		"slug": "packages-block-editor",
 		"markdown_source": "../packages/block-editor/README.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4678,6 +4678,20 @@
 				"@babel/runtime": "^7.4.4"
 			}
 		},
+		"@wordpress/block-directory": {
+			"version": "file:packages/block-directory",
+			"requires": {
+				"@wordpress/api-fetch": "file:packages/api-fetch",
+				"@wordpress/block-editor": "file:packages/block-editor",
+				"@wordpress/blocks": "file:packages/blocks",
+				"@wordpress/components": "file:packages/components",
+				"@wordpress/compose": "file:packages/compose",
+				"@wordpress/data": "file:packages/data",
+				"@wordpress/element": "file:packages/element",
+				"@wordpress/i18n": "file:packages/i18n",
+				"lodash": "^4.17.14"
+			}
+		},
 		"@wordpress/block-editor": {
 			"version": "file:packages/block-editor",
 			"requires": {
@@ -5005,6 +5019,8 @@
 				"@babel/runtime": "^7.4.4",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/autop": "file:packages/autop",
+				"@wordpress/blob": "file:packages/blob",
+				"@wordpress/block-directory": "file:packages/block-directory",
 				"@wordpress/block-editor": "file:packages/block-editor",
 				"@wordpress/blocks": "file:packages/blocks",
 				"@wordpress/components": "file:packages/components",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"@wordpress/api-fetch": "file:packages/api-fetch",
 		"@wordpress/autop": "file:packages/autop",
 		"@wordpress/blob": "file:packages/blob",
+		"@wordpress/block-directory": "file:packages/block-directory",
 		"@wordpress/block-editor": "file:packages/block-editor",
 		"@wordpress/block-library": "file:packages/block-library",
 		"@wordpress/block-serialization-default-parser": "file:packages/block-serialization-default-parser",

--- a/packages/block-directory/.npmrc
+++ b/packages/block-directory/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/block-directory/CHANGELOG.md
+++ b/packages/block-directory/CHANGELOG.md
@@ -1,0 +1,3 @@
+## Master
+
+-   Initial release.

--- a/packages/block-directory/README.md
+++ b/packages/block-directory/README.md
@@ -1,0 +1,17 @@
+# Block directory
+
+Package used to extend editor with block directory features to search and install blocks.
+
+> This package is meant to be used only with WordPress core. Feel free to use it in your own project but please keep in mind that it might never get fully documented.
+
+## Installation
+
+Install the module
+
+```bash
+npm install @wordpress/block-directory --save
+```
+
+_This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for ES2015+ such as lower versions of IE then using [core-js](https://github.com/zloirock/core-js) or [@babel/polyfill](https://babeljs.io/docs/en/next/babel-polyfill) will add support for these methods. Learn more about it in [Babel docs](https://babeljs.io/docs/en/next/caveats)._
+
+<br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/block-directory/package.json
+++ b/packages/block-directory/package.json
@@ -1,0 +1,36 @@
+{
+	"name": "@wordpress/block-directory",
+	"version": "1.0.0-alpha.0",
+	"description": "Extend editor with block directory features to search, download and install blocks.",
+	"author": "The WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress",		
+		"block directory"
+	],
+	"homepage": "https://github.com/WordPress/gutenberg/tree/master/packages/block-directory/README.md",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/gutenberg.git",
+		"directory": "packages/block-directory"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/gutenberg/issues"
+	},
+	"main": "build/index.js",
+	"module": "build-module/index.js",
+	"dependencies": {
+		"@wordpress/api-fetch": "file:../api-fetch",
+		"@wordpress/block-editor": "file:../block-editor",
+		"@wordpress/blocks": "file:../blocks",
+		"@wordpress/components": "file:../components",
+		"@wordpress/compose": "file:../compose",
+		"@wordpress/data": "file:../data",
+		"@wordpress/element": "file:../element",
+		"@wordpress/i18n": "file:../i18n",
+		"lodash": "^4.17.14"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/block-directory/src/components/block-ratings/index.js
+++ b/packages/block-directory/src/components/block-ratings/index.js
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { _n, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import Stars from './stars';
+
+export const BlockRatings = ( { rating, ratingCount } ) => (
+	<div className="block-directory-block-ratings">
+		<Stars rating={ rating } />
+		<span
+			className="block-directory-block-ratings__rating-count"
+			aria-label={
+				// translators: %d: number of ratings (number).
+				sprintf( _n( '%d total rating', '%d total ratings', ratingCount ), ratingCount )
+			}
+		>
+			({ ratingCount })
+		</span>
+	</div>
+);
+
+export default BlockRatings;

--- a/packages/block-directory/src/components/block-ratings/stars.js
+++ b/packages/block-directory/src/components/block-ratings/stars.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { times } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Icon } from '@wordpress/components';
+
+function Stars( {
+	rating,
+} ) {
+	const stars = Math.round( rating / 0.5 ) * 0.5;
+
+	const fullStarCount = Math.floor( rating );
+	const halfStarCount = Math.ceil( rating - fullStarCount );
+	const emptyStarCount = 5 - ( fullStarCount + halfStarCount );
+
+	return (
+		<div aria-label={ sprintf( __( '%s out of 5 stars', stars ), stars ) }>
+			{ times( fullStarCount, ( i ) => <Icon key={ `full_stars_${ i }` } icon="star-filled" size={ 16 } /> ) }
+			{ times( halfStarCount, ( i ) => <Icon key={ `half_stars_${ i }` } icon="star-half" size={ 16 } /> ) }
+			{ times( emptyStarCount, ( i ) => <Icon key={ `empty_stars_${ i }` } icon="star-empty" size={ 16 } /> ) }
+		</div>
+	);
+}
+
+export default Stars;

--- a/packages/block-directory/src/components/block-ratings/style.scss
+++ b/packages/block-directory/src/components/block-ratings/style.scss
@@ -1,0 +1,19 @@
+.block-directory-block-ratings {
+	display: flex;
+	> div {
+		line-height: 1;
+		display: flex;
+	}
+	.dashicons {
+		font-size: ms(-2);
+		width: 1.1em;
+	}
+	.block-directory-block-ratings__rating-count {
+		color: $dark-gray-400;
+		font-size: ms(-2);
+	}
+
+	[class*="dashicons-star-"] {
+		color: #ffb900;
+	}
+}

--- a/packages/block-directory/src/components/downloadable-block-author-info/index.js
+++ b/packages/block-directory/src/components/downloadable-block-author-info/index.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import { Fragment } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+
+function DownloadableBlockAuthorInfo( { author, authorBlockCount, authorBlockRating } ) {
+	return (
+		<Fragment>
+			<span className="block-directory-downloadable-block-author-info__content-author">
+				{ sprintf( __( 'Authored by %s' ), author ) }
+			</span>
+			<span className="block-directory-downloadable-block-author-info__content">
+				{ sprintf( _n( 'This author has %d block, with an average rating of %d.', 'This author has %d blocks, with an average rating of %d.', authorBlockCount, authorBlockRating ), authorBlockCount, authorBlockRating ) }
+			</span>
+		</Fragment>
+	);
+}
+
+export default DownloadableBlockAuthorInfo;

--- a/packages/block-directory/src/components/downloadable-block-author-info/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-author-info/style.scss
@@ -1,0 +1,9 @@
+.block-directory-downloadable-block-author-info__content {
+	color: $dark-gray-400;
+	margin-bottom: 4px;
+}
+
+.block-directory-downloadable-block-author-info__content-author {
+	margin-bottom: 4px;
+	font-size: 14px;
+}

--- a/packages/block-directory/src/components/downloadable-block-header/index.js
+++ b/packages/block-directory/src/components/downloadable-block-header/index.js
@@ -1,0 +1,43 @@
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { BlockIcon } from '@wordpress/block-editor';
+import BlockRatings from '../block-ratings';
+
+function DownloadableBlockHeader( { icon, title, rating, ratingCount, onClick } ) {
+	return (
+		<div className="block-directory-downloadable-block-header__row">
+			{
+				icon.match( /\.(jpeg|jpg|gif|png)/ ) !== null ?
+					<img src={ icon } alt="block icon" /> :
+					<span >
+						<BlockIcon icon={ icon } showColors />
+					</span>
+			}
+
+			<div className="block-directory-downloadable-block-header__column">
+				<span role="heading" className="block-directory-downloadable-block-header__title" >
+					{ title }
+				</span>
+				<BlockRatings rating={ rating } ratingCount={ ratingCount } />
+			</div>
+			<Button
+				isDefault
+				onClick={ ( event ) => {
+					event.preventDefault();
+					onClick();
+				} }
+			>
+				{ __( 'Add' ) }
+			</Button>
+		</div>
+	);
+}
+
+export default DownloadableBlockHeader;

--- a/packages/block-directory/src/components/downloadable-block-header/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-header/style.scss
@@ -1,0 +1,29 @@
+.block-directory-downloadable-block-header__row {
+	display: flex;
+	flex-grow: 1;
+
+	.block-editor-block-icon {
+		width: 36px;
+		height: 36px;
+		font-size: 36px;
+		background-color: $light-gray-300;
+	}
+
+	img {
+		width: 36px;
+		height: 36px;
+	}
+
+	.block-directory-downloadable-block-header__column {
+		display: flex;
+		flex-direction: column;
+		flex-grow: 1;
+		.block-directory-downloadable-block-header__title {
+			font-weight: 600;
+			margin-left: 12px;
+		}
+		.block-directory-block-ratings {
+			margin-left: 12px;
+		}
+	}
+}

--- a/packages/block-directory/src/components/downloadable-block-info/index.js
+++ b/packages/block-directory/src/components/downloadable-block-info/index.js
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { Fragment } from '@wordpress/element';
+import { Icon } from '@wordpress/components';
+import { __, _n, sprintf } from '@wordpress/i18n';
+
+function DownloadableBlockInfo( { description, activeInstalls, humanizedUpdated } ) {
+	return (
+		<Fragment>
+			<span className="block-directory-downloadable-block-info__content">
+				{ description }
+			</span>
+			<div className="block-directory-downloadable-block-info__row">
+				<div className="block-directory-downloadable-block-info__column">
+					<Icon icon="chart-line"></Icon>{ sprintf( _n( '%d active installation', '%d active installations', activeInstalls ), activeInstalls ) }
+				</div>
+				<div className="block-directory-downloadable-block-info__column">
+					<Icon icon="update"></Icon><span aria-label={ sprintf( __( 'Updated %s' ), humanizedUpdated ) }>{ humanizedUpdated }</span>
+				</div>
+			</div>
+		</Fragment>
+	);
+}
+
+export default DownloadableBlockInfo;

--- a/packages/block-directory/src/components/downloadable-block-info/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-info/style.scss
@@ -1,0 +1,24 @@
+.block-directory-downloadable-block-info__content {
+	font-size: 14px;
+}
+
+.block-directory-downloadable-block-info__row {
+	display: flex;
+	justify-content: space-between;
+	color: $dark-gray-400;
+	margin-top: 8px;
+
+	.block-directory-downloadable-block-info__column {
+		display: flex;
+		align-items: flex-start;
+
+		.dashicon {
+			font-size: 16px;
+			margin-right: 4px;
+		}
+
+		.dashicons-chart-line {
+			font-weight: 900;
+		}
+	}
+}

--- a/packages/block-directory/src/components/downloadable-block-list-item/index.js
+++ b/packages/block-directory/src/components/downloadable-block-list-item/index.js
@@ -1,0 +1,56 @@
+/**
+ * Internal dependencies
+ */
+import DownloadableBlockHeader from '../downloadable-block-header';
+import DownloadableBlockAuthorInfo from '../downloadable-block-author-info';
+import DownloadableBlockInfo from '../downloadable-block-info';
+
+function DownloadableBlockListItem( {
+	item,
+	onClick,
+} ) {
+	const {
+		icon,
+		title,
+		description,
+		rating,
+		activeInstalls,
+		ratingCount,
+		author,
+		humanizedUpdated,
+		authorBlockCount,
+		authorBlockRating,
+	} = item;
+
+	return (
+		<li className="block-directory-downloadable-block-list-item">
+			<article className="block-directory-downloadable-block-list-item__panel">
+				<header className="block-directory-downloadable-block-list-item__header">
+					<DownloadableBlockHeader
+						icon={ icon }
+						onClick={ onClick }
+						title={ title }
+						rating={ rating }
+						ratingCount={ ratingCount }
+					/>
+				</header>
+				<section className="block-directory-downloadable-block-list-item__body">
+					<DownloadableBlockInfo
+						activeInstalls={ activeInstalls }
+						description={ description }
+						humanizedUpdated={ humanizedUpdated }
+					/>
+				</section>
+				<footer className="block-directory-downloadable-block-list-item__footer">
+					<DownloadableBlockAuthorInfo
+						author={ author }
+						authorBlockCount={ authorBlockCount }
+						authorBlockRating={ authorBlockRating }
+					/>
+				</footer>
+			</article>
+		</li>
+	);
+}
+
+export default DownloadableBlockListItem;

--- a/packages/block-directory/src/components/downloadable-block-list-item/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-list-item/style.scss
@@ -1,0 +1,48 @@
+.block-directory-downloadable-block-list-item {
+	width: 100%;
+	padding: 0;
+	margin: 0 0 12px;
+	display: flex;
+	flex-direction: row;
+	font-size: $default-font-size;
+	color: $dark-gray-700;
+	align-items: flex-start;
+	justify-content: center;
+	background: transparent;
+	word-break: break-word;
+	border-radius: $radius-round-rectangle;
+	border: $border-width solid $light-gray-500;
+	transition: all 0.05s ease-in-out;
+	@include reduce-motion("transition");
+	position: relative;
+	text-align: left;
+}
+
+.block-directory-downloadable-block-list-item__panel {
+	display: flex;
+	flex-grow: 1;
+	flex-direction: column;
+}
+
+.block-directory-downloadable-block-list-item__header {
+	display: flex;
+	flex-direction: column;
+	padding: 12px 12px 0;
+}
+
+.block-directory-downloadable-block-list-item__body {
+	display: flex;
+	flex-direction: column;
+	padding: 12px;
+}
+
+.block-directory-downloadable-block-list-item__footer {
+	display: flex;
+	flex-direction: column;
+	padding: 12px;
+	background-color: $light-gray-200;
+}
+
+.block-directory-downloadable-block-list-item__content {
+	color: $dark-gray-400;
+}

--- a/packages/block-directory/src/components/downloadable-blocks-list/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-list/index.js
@@ -1,0 +1,115 @@
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { getBlockMenuDefaultClassName, unregisterBlockType } from '@wordpress/blocks';
+import { withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import DownloadableBlockListItem from '../downloadable-block-list-item';
+
+const DOWNLOAD_ERROR_NOTICE_ID = 'block-download-error';
+const INSTALL_ERROR_NOTICE_ID = 'block-install-error';
+
+function DownloadableBlocksList( { items, onHover = noop, children, downloadAndInstallBlock } ) {
+	return (
+		/*
+		 * Disable reason: The `list` ARIA role is redundant but
+		 * Safari+VoiceOver won't announce the list otherwise.
+		 */
+		/* eslint-disable jsx-a11y/no-redundant-roles */
+		<ul role="list" className="block-directory-downloadable-blocks-list">
+			{ items && items.map( ( item ) =>
+				<DownloadableBlockListItem
+					key={ item.id }
+					className={ getBlockMenuDefaultClassName( item.id ) }
+					icons={ item.icons }
+					onClick={ () => {
+						downloadAndInstallBlock( item );
+						onHover( null );
+					} }
+					onFocus={ () => onHover( item ) }
+					onMouseEnter={ () => onHover( item ) }
+					onMouseLeave={ () => onHover( null ) }
+					onBlur={ () => onHover( null ) }
+					isDisabled={ item.isDisabled }
+					item={ item }
+				/>
+			) }
+			{ children }
+		</ul>
+		/* eslint-enable jsx-a11y/no-redundant-roles */
+	);
+}
+
+export default compose(
+	withDispatch( ( dispatch, props ) => {
+		const { installBlock, downloadBlock } = dispatch( 'core/block-directory' );
+		const { createErrorNotice, removeNotice } = dispatch( 'core/notices' );
+		const { removeBlocks } = dispatch( 'core/block-editor' );
+		const { onSelect } = props;
+
+		return {
+			downloadAndInstallBlock: ( item ) => {
+				const onDownloadError = () => {
+					createErrorNotice(
+						__( 'Block previews can\'t load.' ),
+						{
+							id: DOWNLOAD_ERROR_NOTICE_ID,
+							actions: [
+								{
+									label: __( 'Retry' ),
+									onClick: () => {
+										removeNotice( DOWNLOAD_ERROR_NOTICE_ID );
+										downloadBlock( item, onSuccess, onDownloadError );
+									},
+								},
+							],
+						} );
+				};
+
+				const onSuccess = () => {
+					const createdBlock = onSelect( item );
+
+					const onInstallBlockError = () => {
+						createErrorNotice(
+							__( 'Block previews can\'t install.' ),
+							{
+								id: INSTALL_ERROR_NOTICE_ID,
+								actions: [
+									{
+										label: __( 'Retry' ),
+										onClick: () => {
+											removeNotice( INSTALL_ERROR_NOTICE_ID );
+											installBlock( item, noop, onInstallBlockError );
+										},
+									},
+									{
+										label: __( 'Remove' ),
+										onClick: () => {
+											removeNotice( INSTALL_ERROR_NOTICE_ID );
+											removeBlocks( createdBlock.clientId );
+											unregisterBlockType( item.name );
+										},
+									},
+								],
+							}
+						);
+					};
+
+					installBlock( item, noop, onInstallBlockError );
+				};
+
+				downloadBlock( item, onSuccess, onDownloadError );
+			},
+		};
+	} ),
+)( DownloadableBlocksList );

--- a/packages/block-directory/src/components/downloadable-blocks-list/style.scss
+++ b/packages/block-directory/src/components/downloadable-blocks-list/style.scss
@@ -1,0 +1,7 @@
+.block-directory-downloadable-blocks-list {
+	list-style: none;
+	padding: 2px 0;
+	overflow: hidden;
+	display: flex;
+	flex-wrap: wrap;
+}

--- a/packages/block-directory/src/components/downloadable-blocks-panel/index.js
+++ b/packages/block-directory/src/components/downloadable-blocks-panel/index.js
@@ -1,0 +1,78 @@
+/**
+ * WordPress dependencies
+ */
+import { Fragment } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { Spinner, withSpokenMessages } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import DownloadableBlocksList from '../downloadable-blocks-list';
+
+function DownloadableBlocksPanel( { downloadableItems, onSelect, onHover, hasPermission, isLoading, isWaiting, debouncedSpeak } ) {
+	if ( ! hasPermission ) {
+		debouncedSpeak( __( 'Please contact your site administrator to install new blocks.' ) );
+		return (
+			<p className="block-directory-downloadable-blocks-panel__description has-no-results">
+				{ __( 'No blocks found in your library.' ) }
+				<br />
+				{ __( 'Please contact your site administrator to install new blocks.' ) }
+			</p>
+		);
+	}
+
+	if ( isLoading || isWaiting ) {
+		return (
+			<p className="block-directory-downloadable-blocks-panel__description has-no-results">
+				<Spinner />
+			</p>
+		);
+	}
+
+	if ( ! downloadableItems.length ) {
+		return (
+			<p className="block-directory-downloadable-blocks-panel__description has-no-results">
+				{ __( 'No blocks found in your library.' ) }
+			</p>
+		);
+	}
+
+	const resultsFoundMessage = sprintf(
+		_n( 'We did find %d block available for download.', 'We did find %d blocks available.', downloadableItems.length ),
+		downloadableItems.length
+	);
+
+	debouncedSpeak( resultsFoundMessage );
+	return (
+		<Fragment>
+			<p className="block-directory-downloadable-blocks-panel__description">
+				{ __( 'No blocks found in your library. We did find these blocks available for download:' ) }
+			</p>
+			<DownloadableBlocksList items={ downloadableItems } onSelect={ onSelect } onHover={ onHover } />
+		</Fragment>
+	);
+}
+
+export default compose( [
+	withSpokenMessages,
+	withSelect( ( select, { filterValue } ) => {
+		const {
+			getDownloadableBlocks,
+			hasInstallBlocksPermission,
+			isRequestingDownloadableBlocks,
+		} = select( 'core/block-directory' );
+
+		const hasPermission = hasInstallBlocksPermission();
+		const downloadableItems = hasPermission ? getDownloadableBlocks( filterValue ) : [];
+		const isLoading = isRequestingDownloadableBlocks();
+
+		return {
+			downloadableItems,
+			hasPermission,
+			isLoading,
+		};
+	} ),
+] )( DownloadableBlocksPanel );

--- a/packages/block-directory/src/components/downloadable-blocks-panel/style.scss
+++ b/packages/block-directory/src/components/downloadable-blocks-panel/style.scss
@@ -1,0 +1,19 @@
+
+.block-directory-downloadable-blocks-panel__description {
+	font-style: italic;
+	padding: 0;
+	margin-top: 0;
+	text-align: left;
+	color: $dark-gray-400;
+}
+
+.block-directory-downloadable-blocks-panel__description.has-no-results {
+	font-style: normal;
+	padding: 0;
+	margin-top: 100px;
+	text-align: center;
+	color: $dark-gray-400;
+	.components-spinner {
+		float: inherit;
+	}
+}

--- a/packages/block-directory/src/index.js
+++ b/packages/block-directory/src/index.js
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import './store';
+
+export { default as DownloadableBlocksPanel } from './components/downloadable-blocks-panel';

--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -1,0 +1,148 @@
+/**
+ * WordPress dependencies
+ */
+import { getBlockTypes } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { apiFetch, loadAssets } from './controls';
+
+/**
+ * Returns an action object used in signalling that the downloadable blocks have been requested and is loading.
+ *
+ * @return {Object} Action object.
+ */
+export function fetchDownloadableBlocks() {
+	return { type: 'FETCH_DOWNLOADABLE_BLOCKS' };
+}
+
+/**
+ * Returns an action object used in signalling that the downloadable blocks have been updated.
+ *
+ * @param {Array} downloadableBlocks Downloadable blocks.
+ * @param {string} filterValue Search string.
+ *
+ * @return {Object} Action object.
+ */
+export function receiveDownloadableBlocks( downloadableBlocks, filterValue ) {
+	return { type: 'RECEIVE_DOWNLOADABLE_BLOCKS', downloadableBlocks, filterValue };
+}
+
+/**
+ * Returns an action object used in signalling that the user does not have permission to install blocks.
+ *
+ @param {boolean} hasPermission User has permission to install blocks.
+ *
+ * @return {Object} Action object.
+ */
+export function setInstallBlocksPermission( hasPermission ) {
+	return { type: 'SET_INSTALL_BLOCKS_PERMISSION', hasPermission };
+}
+
+/**
+ * Action triggered to download block assets.
+ *
+ * @param {Object} item The selected block item
+ * @param {Function} onSuccess The callback function when the action has succeeded.
+ * @param {Function} onError The callback function when the action has failed.
+ */
+export function* downloadBlock( item, onSuccess, onError ) {
+	try {
+		if ( ! item.assets.length ) {
+			throw new Error( 'Block has no assets' );
+		}
+
+		yield loadAssets( item.assets );
+		const registeredBlocks = getBlockTypes();
+		if ( registeredBlocks.length ) {
+			onSuccess( item );
+		} else {
+			throw new Error( 'Unable to get block types' );
+		}
+	} catch ( error ) {
+		yield onError( error );
+	}
+}
+
+/**
+ * Action triggered to install a block plugin.
+ *
+ * @param {string} item The block item returned by search.
+ * @param {Function} onSuccess The callback function when the action has succeeded.
+ * @param {Function} onError The callback function when the action has failed.
+ *
+ */
+export function* installBlock( { id, name }, onSuccess, onError ) {
+	try {
+		const response = yield apiFetch( {
+			path: '__experimental/block-directory/install',
+			data: {
+				slug: id,
+			},
+			method: 'POST',
+		} );
+		if ( response.success === false ) {
+			throw new Error( response.errorMessage );
+		}
+		yield addInstalledBlockType( { id, name } );
+		onSuccess();
+	} catch ( error ) {
+		onError( error );
+	}
+}
+
+/**
+ * Action triggered to uninstall a block plugin.
+ *
+ * @param {string} item The block item returned by search.
+ * @param {Function} onSuccess The callback function when the action has succeeded.
+ * @param {Function} onError The callback function when the action has failed.
+ *
+ */
+export function* uninstallBlock( { id, name }, onSuccess, onError ) {
+	try {
+		const response = yield apiFetch( {
+			path: '__experimental/block-directory/uninstall',
+			data: {
+				slug: id,
+			},
+			method: 'DELETE',
+		} );
+		if ( response.success === false ) {
+			throw new Error( response.errorMessage );
+		}
+		yield removeInstalledBlockType( { id, name } );
+		onSuccess();
+	} catch ( error ) {
+		onError( error );
+	}
+}
+
+/**
+ * Returns an action object used to add a newly installed block type.
+ *
+ * @param {string} item The block item with the block id and name.
+ *
+ * @return {Object} Action object.
+ */
+export function addInstalledBlockType( item ) {
+	return {
+		type: 'ADD_INSTALLED_BLOCK_TYPE',
+		item,
+	};
+}
+
+/**
+ * Returns an action object used to remove a newly installed block type.
+ *
+ * @param {string} item The block item with the block id and name.
+ *
+ * @return {Object} Action object.
+ */
+export function removeInstalledBlockType( item ) {
+	return {
+		type: 'REMOVE_INSTALLED_BLOCK_TYPE',
+		item,
+	};
+}

--- a/packages/block-directory/src/store/controls.js
+++ b/packages/block-directory/src/store/controls.js
@@ -1,0 +1,149 @@
+/**
+ * External dependencies
+ */
+import { forEach } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { createRegistryControl } from '@wordpress/data';
+import wpApiFetch from '@wordpress/api-fetch';
+
+/**
+ * Calls a selector using the current state.
+ *
+ * @param {string} storeName    Store name.
+ * @param {string} selectorName Selector name.
+ * @param  {Array} args         Selector arguments.
+ *
+ * @return {Object} control descriptor.
+ */
+export function select( storeName, selectorName, ...args ) {
+	return {
+		type: 'SELECT',
+		storeName,
+		selectorName,
+		args,
+	};
+}
+
+/**
+ * Calls a dispatcher using the current state.
+ *
+ * @param {string} storeName      Store name.
+ * @param {string} dispatcherName Dispatcher name.
+ * @param  {Array} args           Selector arguments.
+ *
+ * @return {Object} control descriptor.
+ */
+export function dispatch( storeName, dispatcherName, ...args ) {
+	return {
+		type: 'DISPATCH',
+		storeName,
+		dispatcherName,
+		args,
+	};
+}
+
+/**
+ * Trigger an API Fetch request.
+ *
+ * @param {Object} request API Fetch Request Object.
+ * @return {Object} control descriptor.
+ */
+export function apiFetch( request ) {
+	return {
+		type: 'API_FETCH',
+		request,
+	};
+}
+
+/**
+ * Loads JavaScript
+ * @param {Array} asset the url for the JavaScript.
+ * @param {Function} onLoad callback function on success.
+ * @param {Function} onError callback funciton on failure.
+ */
+const loadScript = ( asset, onLoad, onError ) => {
+	if ( ! asset ) {
+		return;
+	}
+	const existing = document.querySelector( `script[src="${ asset.src }"]` );
+	if ( existing ) {
+		existing.parentNode.removeChild( existing );
+	}
+	const script = document.createElement( 'script' );
+	script.src = typeof asset === 'string' ? asset : asset.src;
+	script.onload = onLoad;
+	script.onerror = onError;
+	document.body.appendChild( script );
+};
+
+/**
+ * Loads CSS file.
+ * @param {*} asset the url for the CSS file.
+ */
+const loadStyle = ( asset ) => {
+	if ( ! asset ) {
+		return;
+	}
+	const link = document.createElement( 'link' );
+	link.rel = 'stylesheet';
+	link.href = typeof asset === 'string' ? asset : asset.src;
+	document.body.appendChild( link );
+};
+
+/**
+ * Load the asset files for a block
+ * @param {Array} assets A collection of URL for the assets
+ * @param {Function} onLoad callback function on success.
+ * @param {Function} onError callback funciton on failure.
+ * @return {Object} control descriptor.
+ */
+export function* loadAssets( assets, onLoad, onError ) {
+	return {
+		type: 'LOAD_ASSETS',
+		assets,
+		onLoad,
+		onError,
+	};
+}
+
+const controls = {
+	SELECT: createRegistryControl( ( registry ) => ( { storeName, selectorName, args } ) => {
+		return registry.select( storeName )[ selectorName ]( ...args );
+	} ),
+	DISPATCH: createRegistryControl( ( registry ) => ( { storeName, dispatcherName, args } ) => {
+		return registry.dispatch( storeName )[ dispatcherName ]( ...args );
+	} ),
+	API_FETCH( { request } ) {
+		return wpApiFetch( { ... request } );
+	},
+	LOAD_ASSETS( { assets } ) {
+		return new Promise( ( resolve, reject ) => {
+			if ( typeof assets === 'object' && assets.constructor === Array ) {
+				let scriptsCount = 0;
+				forEach( assets, ( asset ) => {
+					if ( asset.match( /\.js$/ ) !== null ) {
+						scriptsCount++;
+						loadScript( asset, () => {
+							scriptsCount--;
+							if ( scriptsCount === 0 ) {
+								return resolve( scriptsCount );
+							}
+						}, reject );
+					} else {
+						loadStyle( asset );
+					}
+				} );
+			} else {
+				loadScript( assets.editor_script, () => {
+					return resolve( 0 );
+				}, reject );
+				loadStyle( assets.style );
+			}
+		} );
+	},
+};
+
+export default controls;

--- a/packages/block-directory/src/store/index.js
+++ b/packages/block-directory/src/store/index.js
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { registerStore } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import reducer from './reducer';
+import * as selectors from './selectors';
+import * as actions from './actions';
+import resolvers from './resolvers';
+import controls from './controls';
+
+/**
+ * Module Constants
+ */
+const MODULE_KEY = 'core/block-directory';
+
+/**
+ * Block editor data store configuration.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/master/packages/data/README.md#registerStore
+ *
+ * @type {Object}
+ */
+export const storeConfig = {
+	reducer,
+	selectors,
+	actions,
+	controls,
+	resolvers,
+};
+
+const store = registerStore( MODULE_KEY, {
+	...storeConfig,
+} );
+
+export default store;

--- a/packages/block-directory/src/store/reducer.js
+++ b/packages/block-directory/src/store/reducer.js
@@ -1,0 +1,59 @@
+/**
+ * WordPress dependencies
+ */
+import { combineReducers } from '@wordpress/data';
+
+/**
+ * Reducer returning an array of downloadable blocks.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export const downloadableBlocks = ( state = {
+	results: {},
+	hasPermission: true,
+	filterValue: undefined,
+	isRequestingDownloadableBlocks: true,
+	installedBlockTypes: [],
+}, action ) => {
+	switch ( action.type ) {
+		case 'FETCH_DOWNLOADABLE_BLOCKS' :
+			return {
+				...state,
+				isRequestingDownloadableBlocks: true,
+			};
+		case 'RECEIVE_DOWNLOADABLE_BLOCKS' :
+			return {
+				...state,
+				results: Object.assign( {}, state.results, {
+					[ action.filterValue ]: action.downloadableBlocks,
+				} ),
+				hasPermission: true,
+				isRequestingDownloadableBlocks: false,
+			};
+		case 'SET_INSTALL_BLOCKS_PERMISSION' :
+			return {
+				...state,
+				items: action.hasPermission ? state.items : [],
+				hasPermission: action.hasPermission,
+			};
+		case 'ADD_INSTALLED_BLOCK_TYPE' :
+			return {
+				...state,
+				installedBlockTypes: [ ...state.installedBlockTypes, action.item ],
+			};
+
+		case 'REMOVE_INSTALLED_BLOCK_TYPE' :
+			return {
+				...state,
+				installedBlockTypes: state.installedBlockTypes.filter( ( blockType ) => blockType.name !== action.item.name ),
+			};
+	}
+	return state;
+};
+
+export default combineReducers( {
+	downloadableBlocks,
+} );

--- a/packages/block-directory/src/store/resolvers.js
+++ b/packages/block-directory/src/store/resolvers.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { camelCase, mapKeys } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { apiFetch } from './controls';
+import { fetchDownloadableBlocks, receiveDownloadableBlocks, setInstallBlocksPermission } from './actions';
+
+export default {
+	* getDownloadableBlocks( filterValue ) {
+		if ( ! filterValue ) {
+			return;
+		}
+
+		try {
+			yield fetchDownloadableBlocks( filterValue );
+			const results = yield apiFetch( {
+				path: `__experimental/block-directory/search?term=${ filterValue }`,
+			} );
+			const blocks = results.map( ( result ) => mapKeys( result, ( value, key ) => {
+				return camelCase( key );
+			} ) );
+
+			yield receiveDownloadableBlocks( blocks, filterValue );
+		} catch ( error ) {
+			if ( error.code === 'rest_user_cannot_view' ) {
+				yield setInstallBlocksPermission( false );
+			}
+		}
+	},
+	* hasInstallBlocksPermission() {
+		try {
+			yield apiFetch( {
+				path: `__experimental/block-directory/search?term=${ '' }`,
+			} );
+			yield setInstallBlocksPermission( true );
+		} catch ( error ) {
+			if ( error.code === 'rest_user_cannot_view' ) {
+				yield setInstallBlocksPermission( false );
+			}
+		}
+	},
+};

--- a/packages/block-directory/src/store/selectors.js
+++ b/packages/block-directory/src/store/selectors.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Returns true if application is requesting for downloable blocks.
+ *
+ * @param {Object} state       Global application state.
+ *
+ * @return {Array} Downloadable blocks
+ */
+export function isRequestingDownloadableBlocks( state ) {
+	return state.downloadableBlocks.isRequestingDownloadableBlocks;
+}
+
+/**
+ * Returns the available uninstalled blocks
+ *
+ * @param {Object} state       Global application state.
+ * @param {string} filterValue Search string.
+ *
+ * @return {Array} Downloadable blocks
+ */
+export function getDownloadableBlocks( state, filterValue ) {
+	if ( ! state.downloadableBlocks.results[ filterValue ] ) {
+		return [];
+	}
+	return state.downloadableBlocks.results[ filterValue ];
+}
+
+/**
+ * Returns true if user has permission to install blocks.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {boolean} User has permission to install blocks.
+ */
+export function hasInstallBlocksPermission( state ) {
+	return state.downloadableBlocks.hasPermission;
+}
+
+/**
+ * Returns the block types that have been installed on the server.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {Array} Block type items.
+ */
+export function getInstalledBlockTypes( state ) {
+	return get( state, [ 'downloadableBlocks', 'installedBlockTypes' ], [] );
+}

--- a/packages/block-directory/src/style.scss
+++ b/packages/block-directory/src/style.scss
@@ -1,0 +1,7 @@
+@import "./components/downloadable-block-header/style.scss";
+@import "./components/downloadable-block-info/style.scss";
+@import "./components/downloadable-block-author-info/style.scss";
+@import "./components/downloadable-block-list-item/style.scss";
+@import "./components/downloadable-blocks-list/style.scss";
+@import "./components/downloadable-blocks-panel/style.scss";
+@import "./components/block-ratings/style.scss";


### PR DESCRIPTION
Implement new block-directory package to discover blocks and seamlessly install them.

## Description
This introduce a new package `block-directory` in gutenberg.

## How has this been tested?
Tested locally.
Tested for accessibility.
Tested in a staging environment.

## Screenshots <!-- if applicable -->
![screencast 2019-08-29 11-38-53](https://user-images.githubusercontent.com/5370495/63899673-e387cb80-ca51-11e9-8af3-7348625645cb.gif)

## Types of changes
New feature (non-breaking change which adds functionality)
This PR is a split of #16524 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
