### PR TITLE
RichText: fix backspace for IE

### DIFF
--- a/packages/rich-text/src/component/editable.js
+++ b/packages/rich-text/src/component/editable.js
@@ -7,86 +7,11 @@ import { isEqual } from 'lodash';
  * WordPress dependencies
  */
 import { Component, createElement } from '@wordpress/element';
-import { BACKSPACE, DELETE } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
  */
 import { diffAriaProps } from './aria';
-
-/**
- * Browser dependencies
- */
-
-const { userAgent } = window.navigator;
-
-/**
- * Applies a fix that provides `input` events for contenteditable in Internet Explorer.
- *
- * @param {Element} editorNode The root editor node.
- *
- * @return {Function} A function to remove the fix (for cleanup).
- */
-function applyInternetExplorerInputFix( editorNode ) {
-	/**
-	 * Dispatches `input` events in response to `textinput` events.
-	 *
-	 * IE provides a `textinput` event that is similar to an `input` event,
-	 * and we use it to manually dispatch an `input` event.
-	 * `textinput` is dispatched for text entry but for not deletions.
-	 *
-	 * @param {Event} textInputEvent An Internet Explorer `textinput` event.
-	 */
-	function mapTextInputEvent( textInputEvent ) {
-		textInputEvent.stopImmediatePropagation();
-
-		const inputEvent = document.createEvent( 'Event' );
-		inputEvent.initEvent( 'input', true, false );
-		inputEvent.data = textInputEvent.data;
-		textInputEvent.target.dispatchEvent( inputEvent );
-	}
-
-	/**
-	 * Dispatches `input` events in response to Delete and Backspace keyup.
-	 *
-	 * It would be better dispatch an `input` event after each deleting
-	 * `keydown` because the DOM is updated after each, but it is challenging
-	 * to determine the right time to dispatch `input` since propagation of
-	 * `keydown` can be stopped at any point.
-	 *
-	 * It's easier to listen for `keyup` in the capture phase and dispatch
-	 * `input` before `keyup` propagates further. It's not perfect, but should
-	 * be good enough.
-	 *
-	 * @param {KeyboardEvent} keyUp
-	 * @param {Node}          keyUp.target  The event target.
-	 * @param {number}        keyUp.keyCode The key code.
-	 */
-	function mapDeletionKeyUpEvents( { target, keyCode } ) {
-		const isDeletion = BACKSPACE === keyCode || DELETE === keyCode;
-
-		if ( isDeletion && editorNode.contains( target ) ) {
-			const inputEvent = document.createEvent( 'Event' );
-			inputEvent.initEvent( 'input', true, false );
-			inputEvent.data = null;
-			target.dispatchEvent( inputEvent );
-		}
-	}
-
-	editorNode.addEventListener( 'textinput', mapTextInputEvent );
-	document.addEventListener( 'keyup', mapDeletionKeyUpEvents, true );
-	return function removeInternetExplorerInputFix() {
-		editorNode.removeEventListener( 'textinput', mapTextInputEvent );
-		document.removeEventListener( 'keyup', mapDeletionKeyUpEvents, true );
-	};
-}
-
-/**
- * Whether or not the user agent is Internet Explorer.
- *
- * @type {boolean}
- */
-const IS_IE = userAgent.indexOf( 'Trident' ) >= 0;
 
 export default class Editable extends Component {
 	constructor() {
@@ -136,16 +61,6 @@ export default class Editable extends Component {
 	bindEditorNode( editorNode ) {
 		this.editorNode = editorNode;
 		this.props.setRef( editorNode );
-
-		if ( IS_IE ) {
-			if ( editorNode ) {
-				// Mounting:
-				this.removeInternetExplorerInputFix = applyInternetExplorerInputFix( editorNode );
-			} else {
-				// Unmounting:
-				this.removeInternetExplorerInputFix();
-			}
-		}
 	}
 
 	render() {

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -418,8 +418,15 @@ class RichText extends Component {
 			return;
 		}
 
-		const { start, end } = this.createRecord();
+		const { start, end, text } = this.createRecord();
 		const value = this.record;
+
+		// Fallback mechanism for IE11, which doesn't support the input event.
+		// Any input results in a selection change.
+		if ( text !== value.text ) {
+			this.onInput();
+			return;
+		}
 
 		if ( start === value.start && end === value.end ) {
 			return;


### PR DESCRIPTION
## Description

Fixes #15945. The approach is as follows: call `onInput` when selection changes and then content has changed as well. Input always results in a selection change, so it's a good way to detect input in browsers that don't support the input event, such as IE.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
