### PR TITLE
Editor: Clear post password when switching to public visibility.

### DIFF
--- a/packages/editor/src/components/post-visibility/index.js
+++ b/packages/editor/src/components/post-visibility/index.js
@@ -139,12 +139,8 @@ export default compose( [
 		const { savePost, editPost } = dispatch( 'core/editor' );
 		return {
 			onSave: savePost,
-			onUpdateVisibility( status, password ) {
-				const edits = { status };
-				if ( password !== undefined ) {
-					edits.password = password;
-				}
-				editPost( edits );
+			onUpdateVisibility( status, password = '' ) {
+				editPost( { status, password } );
 			},
 		};
 	} ),


### PR DESCRIPTION
Fixes #17247

## Description

#17210 Fixed an issue where the password was being set to null when there wasn't any. Null was not persisted by the API so the edit would keep the post dirty indefinitely. This was removed, but that introduced the issue that the password would not be cleared when switching from password protected to public visibility.

This PR fixes both issues by clearing the password with an empty string, which is persisted by the API, and correctly clears the password.

## How has this been tested?

It was verified that it is possible to switch between visibilities as expected.

## Types of Changes

*Bug Fix:* Correctly clear post password when switching to public visibility.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
