### PR TITLE
Block Editor: Fix undo level inconsistencies.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4885,6 +4885,7 @@
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/data": "file:packages/data",
 				"@wordpress/deprecated": "file:packages/deprecated",
+				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/url": "file:packages/url",
 				"equivalent-key-map": "^0.2.2",
 				"lodash": "^4.17.14",

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -381,7 +381,9 @@ function withPersistentBlockChange( reducer ) {
 		// In comparing against the previous action, consider only those which
 		// would have qualified as one which would have been ignored or not
 		// have resulted in a changed state.
-		lastAction = action;
+		if ( ! isExplicitPersistentChange ) {
+			lastAction = action;
+		}
 
 		return nextState;
 	};

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -381,9 +381,7 @@ function withPersistentBlockChange( reducer ) {
 		// In comparing against the previous action, consider only those which
 		// would have qualified as one which would have been ignored or not
 		// have resulted in a changed state.
-		if ( ! isExplicitPersistentChange ) {
-			lastAction = action;
-		}
+		lastAction = action;
 
 		return nextState;
 	};

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -26,6 +26,7 @@
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/data": "file:../data",
 		"@wordpress/deprecated": "file:../deprecated",
+		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/url": "file:../url",
 		"equivalent-key-map": "^0.2.2",
 		"lodash": "^4.17.14",

--- a/packages/e2e-tests/specs/__snapshots__/undo.test.js.snap
+++ b/packages/e2e-tests/specs/__snapshots__/undo.test.js.snap
@@ -14,6 +14,12 @@ exports[`undo Should undo to expected level intervals 1`] = `
 <!-- /wp:paragraph -->"
 `;
 
+exports[`undo should immediately create an undo level on typing 1`] = `
+"<!-- wp:paragraph -->
+<p>1</p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`undo should undo typing after a pause 1`] = `
 "<!-- wp:paragraph -->
 <p>before pause after pause</p>

--- a/packages/e2e-tests/specs/undo.test.js
+++ b/packages/e2e-tests/specs/undo.test.js
@@ -109,15 +109,6 @@ describe( 'undo', () => {
 		expect( visibleContent ).toBe( 'original' );
 	} );
 
-	it( 'should not create undo level when saving', async () => {
-		await clickBlockAppender();
-		await page.keyboard.type( '1' );
-		await saveDraft();
-		await pressKeyWithModifier( 'primary', 'z' );
-
-		expect( await getEditedPostContent() ).toBe( '' );
-	} );
-
 	it( 'should immediately create an undo level on typing', async () => {
 		await clickBlockAppender();
 

--- a/packages/e2e-tests/specs/undo.test.js
+++ b/packages/e2e-tests/specs/undo.test.js
@@ -117,4 +117,27 @@ describe( 'undo', () => {
 
 		expect( await getEditedPostContent() ).toBe( '' );
 	} );
+
+	it( 'should immediately create an undo level on typing', async () => {
+		await clickBlockAppender();
+
+		await page.keyboard.type( '1' );
+		await saveDraft();
+		await page.reload();
+
+		// Expect undo button to be disabled.
+		expect( await page.$( '.editor-history__undo[aria-disabled="true"]' ) ).not.toBeNull();
+
+		await page.click( '.wp-block-paragraph' );
+
+		await page.keyboard.type( '2' );
+
+		// Expect undo button to be enabled.
+		expect( await page.$( '.editor-history__undo[aria-disabled="true"]' ) ).toBeNull();
+
+		await pressKeyWithModifier( 'primary', 'z' );
+
+		// Expect "1".
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
 } );

--- a/packages/e2e-tests/specs/undo.test.js
+++ b/packages/e2e-tests/specs/undo.test.js
@@ -108,4 +108,13 @@ describe( 'undo', () => {
 		const visibleContent = await page.evaluate( () => document.activeElement.textContent );
 		expect( visibleContent ).toBe( 'original' );
 	} );
+
+	it( 'should not create undo level when saving', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '1' );
+		await saveDraft();
+		await pressKeyWithModifier( 'primary', 'z' );
+
+		expect( await getEditedPostContent() ).toBe( '' );
+	} );
 } );

--- a/packages/e2e-tests/specs/undo.test.js
+++ b/packages/e2e-tests/specs/undo.test.js
@@ -29,6 +29,10 @@ describe( 'undo', () => {
 		await pressKeyWithModifier( 'primary', 'z' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await pressKeyWithModifier( 'primary', 'z' );
+
+		expect( await getEditedPostContent() ).toBe( '' );
 	} );
 
 	it( 'should undo typing after non input change', async () => {
@@ -43,6 +47,10 @@ describe( 'undo', () => {
 		await pressKeyWithModifier( 'primary', 'z' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		await pressKeyWithModifier( 'primary', 'z' );
+
+		expect( await getEditedPostContent() ).toBe( '' );
 	} );
 
 	it( 'Should undo to expected level intervals', async () => {

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -177,7 +177,13 @@ export function* setupEditor( post, edits, template ) {
 	};
 	yield resetEditorBlocks( blocks, { __unstableShouldCreateUndoLevel: false } );
 	yield setupEditorState( post );
-	if ( edits ) {
+	if (
+		edits &&
+		Object.keys( edits ).some(
+			( key ) =>
+				edits[ key ] !== ( has( post, [ key, 'raw' ] ) ? post[ key ].raw : post[ key ] )
+		)
+	) {
 		yield editPost( edits );
 	}
 	yield* __experimentalSubscribeSources();


### PR DESCRIPTION
## Description

This PR fixes a couple of undo level related inconsistencies that surfaced after merging #16932.

In the Block Editor, `withPersistentBlockChange` marks any change to an attribute different than the last, as persistent. However, it considers all actions for this comparison, so an explicit persistence change triggered by a timeout like the one that fires after not typing for a while, would break this "chain of comparison", and the next change would be marked as persistent even if targeted at the same attribute as the one before the explicit persistence change. This resulted in scenarios where typing "Hello", waiting a bit, then typing "World", would result in 4 undo levels instead of 3. Namely, there would be an extra unnecessary undo level in the middle, requiring an extra click to undo. This PR fixes this by ignoring explicit persistence changes when comparing the last two attribute changes.

In the Editor, the decision was made to consider initial edits as dirtying operations that create an undo level and enable saving functionality. For some reason, the server sends an empty initial edit with empty strings for the title, excerpt, and content of new posts. This results in another unnecessary undo level. This PR fixes this by ignoring initial edits that would not change any values of the post.

## How has this been tested?

It was verified that typing two words with a pause in between does not create an undo level and that new posts don't load with an undo level.

## Types of Changes

*Bug Fix:* Stop inserting unnecessary undo levels between words an on empty posts.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
