### PR TITLE
[RNMobile] Fix dismiss keyboard button for the post title

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/index.native.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.native.js
@@ -30,8 +30,8 @@ function HeaderToolbar( {
 	undo,
 	showInserter,
 	showKeyboardHideButton,
-	clearSelectedBlock,
 	theme,
+	onHideKeyboard,
 } ) {
 	const scrollViewRef = useRef( null );
 	const scrollToStart = () => {
@@ -76,7 +76,7 @@ function HeaderToolbar( {
 					<ToolbarButton
 						title={ __( 'Hide keyboard' ) }
 						icon="keyboard-hide"
-						onClick={ clearSelectedBlock }
+						onClick={ onHideKeyboard }
 						extraProps={ { hint: __( 'Tap to hide the keyboard' ) } }
 					/>
 				</Toolbar>
@@ -94,11 +94,19 @@ export default compose( [
 		showInserter: select( 'core/edit-post' ).getEditorMode() === 'visual' && select( 'core/editor' ).getEditorSettings().richEditingEnabled,
 		isTextModeEnabled: select( 'core/edit-post' ).getEditorMode() === 'text',
 	} ) ),
-	withDispatch( ( dispatch ) => ( {
-		redo: dispatch( 'core/editor' ).redo,
-		undo: dispatch( 'core/editor' ).undo,
-		clearSelectedBlock: dispatch( 'core/block-editor' ).clearSelectedBlock,
-	} ) ),
+	withDispatch( ( dispatch ) => {
+		const { clearSelectedBlock } = dispatch( 'core/block-editor' );
+		const { togglePostTitleSelection } = dispatch( 'core/editor' );
+
+		return {
+			redo: dispatch( 'core/editor' ).redo,
+			undo: dispatch( 'core/editor' ).undo,
+			onHideKeyboard() {
+				clearSelectedBlock();
+				togglePostTitleSelection( false );
+			},
+		};
+	} ),
 	withViewportMatch( { isLargeViewport: 'medium' } ),
 	withTheme,
 ] )( HeaderToolbar );


### PR DESCRIPTION
Related [gutenberg-mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1321)

## Description

This fixes an iOS and Android issue with the post title when it is in focus, the option to hide the keyboard wasn't working as expected (it should dismiss the keyboard)

Right now it was only clearing the selected blocks and not the post title so I changed it to dispatch both. If the number of different elements increases another approach should be implemented so it's easy to maintain.

## How has this been tested?
- Open the demo app
- Tap on the Post title
- Tap on the "Hide keyboard option"
- It dismisses the keyboard

## Screenshots

<img width="200" src="https://user-images.githubusercontent.com/4885740/63547976-95dd0180-c52d-11e9-80e4-26ee4e70cf7b.gif" /><img width="200" src="https://user-images.githubusercontent.com/4885740/63547979-983f5b80-c52d-11e9-827e-8163c46546ac.gif" />

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
- [ ] I've included developer documentation if appropriate.
