### PR TITLE
Editor: Introduce a new dynamic templates mode and add basic post title and content blocks.

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -53,6 +53,8 @@ function gutenberg_reregister_core_block_types() {
 		'social-link.php'     => gutenberg_get_registered_social_link_blocks(),
 		'tag-cloud.php'       => 'core/tag-cloud',
 		'site-title.php'      => 'core/site-title',
+		'post-title.php'      => 'core/post-title',
+		'post-content.php'    => 'core/post-content',
 	);
 
 	$registry = WP_Block_Type_Registry::get_instance();

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -177,14 +177,14 @@ function gutenberg_strip_php_suffix( $template_file ) {
 }
 
 /**
- * Extends default editor settings to add the right template ID.
+ * Extends default editor settings to add the right template ID and enable editing modes.
  *
  * @param array $settings Default editor settings.
  *
  * @return array Filtered editor settings.
  */
 function gutenberg_template_loader_filter_block_editor_settings( $settings ) {
-	global $_wp_current_template_post;
+	global $wp_query, $_wp_current_template_post;
 
 	// Run template resolution manually to trigger our override filters.
 	$tag_templates = array(
@@ -208,6 +208,8 @@ function gutenberg_template_loader_filter_block_editor_settings( $settings ) {
 	);
 	$template      = false;
 	// Loop through each of the template conditionals, and find the appropriate template file.
+	$post = get_post();
+	$wp_query->parse_query( 'p=' . $post->ID . '&preview=true' );
 	foreach ( $tag_templates as $tag => $template_getter ) {
 		if ( call_user_func( $tag ) ) {
 			$template = call_user_func( $template_getter );
@@ -225,7 +227,8 @@ function gutenberg_template_loader_filter_block_editor_settings( $settings ) {
 	}
 	$template = apply_filters( 'template_include', $template );
 
-	$settings['templateId'] = $_wp_current_template_post->ID;
+	$settings['templateId']  = $_wp_current_template_post->ID;
+	$settings['editingMode'] = 'post-content';
 	return $settings;
 }
 add_filter( 'block_editor_settings', 'gutenberg_template_loader_filter_block_editor_settings' );

--- a/lib/template-loader.php
+++ b/lib/template-loader.php
@@ -175,3 +175,57 @@ function gutenberg_viewport_meta_tag() {
 function gutenberg_strip_php_suffix( $template_file ) {
 	return preg_replace( '/\.php$/', '', $template_file );
 }
+
+/**
+ * Extends default editor settings to add the right template ID.
+ *
+ * @param array $settings Default editor settings.
+ *
+ * @return array Filtered editor settings.
+ */
+function gutenberg_template_loader_filter_block_editor_settings( $settings ) {
+	global $_wp_current_template_post;
+
+	// Run template resolution manually to trigger our override filters.
+	$tag_templates = array(
+		'is_embed'             => 'get_embed_template',
+		'is_404'               => 'get_404_template',
+		'is_search'            => 'get_search_template',
+		'is_front_page'        => 'get_front_page_template',
+		'is_home'              => 'get_home_template',
+		'is_privacy_policy'    => 'get_privacy_policy_template',
+		'is_post_type_archive' => 'get_post_type_archive_template',
+		'is_tax'               => 'get_taxonomy_template',
+		'is_attachment'        => 'get_attachment_template',
+		'is_single'            => 'get_single_template',
+		'is_page'              => 'get_page_template',
+		'is_singular'          => 'get_singular_template',
+		'is_category'          => 'get_category_template',
+		'is_tag'               => 'get_tag_template',
+		'is_author'            => 'get_author_template',
+		'is_date'              => 'get_date_template',
+		'is_archive'           => 'get_archive_template',
+	);
+	$template      = false;
+	// Loop through each of the template conditionals, and find the appropriate template file.
+	foreach ( $tag_templates as $tag => $template_getter ) {
+		if ( call_user_func( $tag ) ) {
+			$template = call_user_func( $template_getter );
+		}
+
+		if ( $template ) {
+			if ( 'is_attachment' === $tag ) {
+				remove_filter( 'the_content', 'prepend_attachment' );
+			}
+			break;
+		}
+	}
+	if ( ! $template ) {
+		$template = get_index_template();
+	}
+	$template = apply_filters( 'template_include', $template );
+
+	$settings['templateId'] = $_wp_current_template_post->ID;
+	return $settings;
+}
+add_filter( 'block_editor_settings', 'gutenberg_template_loader_filter_block_editor_settings' );

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -31,7 +31,7 @@ $z-layers: (
 	".wp-block-cover__inner-container": 1, // InnerBlocks area inside cover image block
 	".wp-block-cover.has-background-dim::before": 1, // Overlay area inside block cover need to be higher than the video background.
 	".wp-block-cover__video-background": 0, // Video background inside cover block.
-	".wp-block-site-title__save-button": 1,
+	".wp-block-custom-entity__save-button": 1,
 
 	// Active pill button
 	".components-button.is-button {:focus or .is-primary}": 1,

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -36,7 +36,6 @@
 @import "./text-columns/editor.scss";
 @import "./verse/editor.scss";
 @import "./video/editor.scss";
-@import "./site-title/editor.scss";
 
 /**
  * Import styles from internal editor components used by the blocks.
@@ -56,4 +55,11 @@
 .editor-styles-wrapper [data-block] {
 	margin-top: $default-block-margin;
 	margin-bottom: $default-block-margin;
+}
+
+.wp-block-custom-entity__save-button {
+	position: absolute;
+	right: 0;
+	top: 0;
+	z-index: z-index(".wp-block-custom-entity__save-button");
 }

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -64,6 +64,8 @@ import * as socialLink from './social-link';
 
 // Full Site Editing Blocks
 import * as siteTitle from './site-title';
+import * as postTitle from './post-title';
+import * as postContent from './post-content';
 
 /**
  * Function to register an individual block.
@@ -182,7 +184,9 @@ export const __experimentalRegisterExperimentalCoreBlocks =
 				...socialLink.sites,
 
 				// Register Full Site Editing Blocks.
-				...( __experimentalEnableFullSiteEditing ? [ siteTitle ] : [] ),
+				...( __experimentalEnableFullSiteEditing ?
+					[ siteTitle, postTitle, postContent ] :
+					[] ),
 			].forEach( registerBlock );
 		} :
 		undefined;

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -1,4 +1,4 @@
 {
 	"name": "core/post-content",
-	"category": "theme"
+	"category": "layout"
 }

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -1,0 +1,4 @@
+{
+	"name": "core/post-content",
+	"category": "theme"
+}

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -1,7 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { useEntityProp, useEntitySaving } from '@wordpress/core-data';
+import {
+	useEntityProp,
+	__experimentalUseEntitySaving,
+} from '@wordpress/core-data';
 import { useMemo, useCallback } from '@wordpress/element';
 import { parse } from '@wordpress/blocks';
 import { Button } from '@wordpress/components';
@@ -20,7 +23,7 @@ export default function PostContentEdit() {
 		'post',
 		'blocks'
 	);
-	const [ isDirty, isSaving, save ] = useEntitySaving(
+	const [ isDirty, isSaving, save ] = __experimentalUseEntitySaving(
 		'postType',
 		'post',
 		'content'

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -39,15 +39,17 @@ export default function PostContentEdit() {
 			>
 				{ __( 'Update' ) }
 			</Button>
-			<InnerBlocks
-				value={ blocks }
-				onChange={ setBlocks }
-				onInput={ useCallback( () => {
-					setContent( ( { blocks: blocksForSerialization = [] } ) =>
-						serializeBlocks( blocksForSerialization )
-					);
-				}, [] ) }
-			/>
+			<div className="entry-content">
+				<InnerBlocks
+					value={ blocks }
+					onChange={ setBlocks }
+					onInput={ useCallback( () => {
+						setContent( ( { blocks: blocksForSerialization = [] } ) =>
+							serializeBlocks( blocksForSerialization )
+						);
+					}, [] ) }
+				/>
+			</div>
 		</>
 	);
 }

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -1,0 +1,53 @@
+/**
+ * WordPress dependencies
+ */
+import { useEntityProp, useEntitySaving } from '@wordpress/core-data';
+import { useMemo, useCallback } from '@wordpress/element';
+import { parse } from '@wordpress/blocks';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { InnerBlocks } from '@wordpress/block-editor';
+import { serializeBlocks } from '@wordpress/editor';
+
+export default function PostContentEdit() {
+	const [ content, setContent ] = useEntityProp( 'postType', 'post', 'content' );
+	const initialBlocks = useMemo( () => {
+		const parsedContent = parse( content );
+		return parsedContent.length ? parsedContent : undefined;
+	}, [] );
+	const [ blocks = initialBlocks, setBlocks ] = useEntityProp(
+		'postType',
+		'post',
+		'blocks'
+	);
+	const [ isDirty, isSaving, save ] = useEntitySaving(
+		'postType',
+		'post',
+		'content'
+	);
+	return (
+		<>
+			<Button
+				isPrimary
+				className="wp-block-custom-entity__save-button"
+				disabled={ ! isDirty || ! content }
+				isBusy={ isSaving }
+				onClick={ useCallback( () => {
+					setContent( content( { blocks } ) );
+					save();
+				}, [ content, blocks ] ) }
+			>
+				{ __( 'Update' ) }
+			</Button>
+			<InnerBlocks
+				value={ blocks }
+				onChange={ setBlocks }
+				onInput={ useCallback( () => {
+					setContent( ( { blocks: blocksForSerialization = [] } ) =>
+						serializeBlocks( blocksForSerialization )
+					);
+				}, [] ) }
+			/>
+		</>
+	);
+}

--- a/packages/block-library/src/post-content/icon.js
+++ b/packages/block-library/src/post-content/icon.js
@@ -1,0 +1,11 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/components';
+
+export default (
+	<SVG xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path fill="none" d="M0 0h24v24H0V0z" />
+		<Path d="M3 15h18v-2H3v2zm0 4h18v-2H3v2zm0-8h18V9H3v2zm0-6v2h18V5H3z" />
+	</SVG>
+);

--- a/packages/block-library/src/post-content/index.js
+++ b/packages/block-library/src/post-content/index.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import icon from './icon';
+import edit from './edit';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	title: __( 'Post Content' ),
+	icon,
+	edit,
+};

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Server-side rendering of the `core/post-content` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `core/post-content` block on the server.
+ *
+ * @return string Returns the filtered post content of the current post.
+ */
+function render_block_core_post_content() {
+	rewind_posts();
+	the_post();
+	return apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', get_the_content() ) );
+}
+
+/**
+ * Registers the `core/post-content` block on the server.
+ */
+function register_block_core_post_content() {
+	register_block_type(
+		'core/post-content',
+		array(
+			'render_callback' => 'render_block_core_post_content',
+		)
+	);
+}
+add_action( 'init', 'register_block_core_post_content' );

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -11,8 +11,11 @@
  * @return string Returns the filtered post content of the current post.
  */
 function render_block_core_post_content() {
-	rewind_posts();
-	the_post();
+	if ( ! in_the_loop() ) {
+		rewind_posts();
+		the_post();
+	}
+
 	return apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', get_the_content() ) );
 }
 

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -11,6 +11,11 @@
  * @return string Returns the filtered post content of the current post.
  */
 function render_block_core_post_content() {
+	// TODO: Without this temporary fix, an infinite loop can occur.
+	if ( is_admin() || defined( 'REST_REQUEST' ) ) {
+		return '';
+	}
+
 	if ( ! in_the_loop() ) {
 		rewind_posts();
 		the_post();

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -16,7 +16,7 @@ function render_block_core_post_content() {
 		the_post();
 	}
 
-	return apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', get_the_content() ) );
+	return '<div class="entry-content">' . apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', get_the_content() ) ) . '</div>';
 }
 
 /**

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -1,0 +1,4 @@
+{
+	"name": "core/post-title",
+	"category": "theme"
+}

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -1,4 +1,4 @@
 {
 	"name": "core/post-title",
-	"category": "theme"
+	"category": "layout"
 }

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -2,9 +2,11 @@
  * WordPress dependencies
  */
 import {
+	useEntityId,
 	useEntityProp,
 	__experimentalUseEntitySaving,
 } from '@wordpress/core-data';
+import { useCallback } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/block-editor';
@@ -12,14 +14,19 @@ import { cleanForSlug } from '@wordpress/editor';
 
 const saveProps = [ 'title', 'slug' ];
 export default function PostTitleEdit() {
-	const [ title, setTitle ] = useEntityProp( 'postType', 'post', 'title' );
+	const postId = useEntityId( 'postType', 'post' );
+	const [ title, _setTitle ] = useEntityProp( 'postType', 'post', 'title' );
 	const [ , setSlug ] = useEntityProp( 'postType', 'post', 'slug' );
 	const [ isDirty, isSaving, save ] = __experimentalUseEntitySaving(
 		'postType',
 		'post',
 		saveProps
 	);
-	return (
+	const setTitle = useCallback( ( value ) => {
+		_setTitle( value );
+		setSlug( cleanForSlug( value ) );
+	}, [] );
+	return postId ? (
 		<>
 			<Button
 				isPrimary
@@ -34,12 +41,11 @@ export default function PostTitleEdit() {
 				tagName="h1"
 				placeholder={ __( 'Title' ) }
 				value={ title }
-				onChange={ ( value ) => {
-					setTitle( value );
-					setSlug( cleanForSlug( value ) );
-				} }
+				onChange={ setTitle }
 				allowedFormats={ [] }
 			/>
 		</>
+	) : (
+		'Post Title Placeholder'
 	);
 }

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -1,7 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { useEntityProp, useEntitySaving } from '@wordpress/core-data';
+import {
+	useEntityProp,
+	__experimentalUseEntitySaving,
+} from '@wordpress/core-data';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { RichText } from '@wordpress/block-editor';
@@ -11,7 +14,7 @@ const saveProps = [ 'title', 'slug' ];
 export default function PostTitleEdit() {
 	const [ title, setTitle ] = useEntityProp( 'postType', 'post', 'title' );
 	const [ , setSlug ] = useEntityProp( 'postType', 'post', 'slug' );
-	const [ isDirty, isSaving, save ] = useEntitySaving(
+	const [ isDirty, isSaving, save ] = __experimentalUseEntitySaving(
 		'postType',
 		'post',
 		saveProps
@@ -29,13 +32,13 @@ export default function PostTitleEdit() {
 			</Button>
 			<RichText
 				tagName="h1"
-				formattingControls={ [] }
 				placeholder={ __( 'Title' ) }
 				value={ title }
 				onChange={ ( value ) => {
 					setTitle( value );
 					setSlug( cleanForSlug( value ) );
 				} }
+				allowedFormats={ [] }
 			/>
 		</>
 	);

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { useEntityProp, useEntitySaving } from '@wordpress/core-data';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { RichText } from '@wordpress/block-editor';
+import { cleanForSlug } from '@wordpress/editor';
+
+const saveProps = [ 'title', 'slug' ];
+export default function PostTitleEdit() {
+	const [ title, setTitle ] = useEntityProp( 'postType', 'post', 'title' );
+	const [ , setSlug ] = useEntityProp( 'postType', 'post', 'slug' );
+	const [ isDirty, isSaving, save ] = useEntitySaving(
+		'postType',
+		'post',
+		saveProps
+	);
+	return (
+		<>
+			<Button
+				isPrimary
+				className="wp-block-custom-entity__save-button"
+				disabled={ ! isDirty || ! title }
+				isBusy={ isSaving }
+				onClick={ save }
+			>
+				{ __( 'Update' ) }
+			</Button>
+			<RichText
+				tagName="h1"
+				formattingControls={ [] }
+				placeholder={ __( 'Title' ) }
+				value={ title }
+				onChange={ ( value ) => {
+					setTitle( value );
+					setSlug( cleanForSlug( value ) );
+				} }
+			/>
+		</>
+	);
+}

--- a/packages/block-library/src/post-title/icon.js
+++ b/packages/block-library/src/post-title/icon.js
@@ -1,0 +1,11 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/components';
+
+export default (
+	<SVG xmlns="https://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path fill="none" d="M0 0h24v24H0V0z" />
+		<Path d="M5 4v3h5.5v12h3V7H19V4H5z" />
+	</SVG>
+);

--- a/packages/block-library/src/post-title/index.js
+++ b/packages/block-library/src/post-title/index.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import icon from './icon';
+import edit from './edit';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	title: __( 'Post Title' ),
+	icon,
+	edit,
+};

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Server-side rendering of the `core/post-title` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `core/post-title` block on the server.
+ *
+ * @return string Returns the filtered post title for the current post wrapped inside "h1" tags.
+ */
+function render_block_core_post_title() {
+	rewind_posts();
+	the_post();
+	return the_title( '<h1>', '</h1>', false );
+}
+
+/**
+ * Registers the `core/post-title` block on the server.
+ */
+function register_block_core_post_title() {
+	register_block_type(
+		'core/post-title',
+		array(
+			'render_callback' => 'render_block_core_post_title',
+		)
+	);
+}
+add_action( 'init', 'register_block_core_post_title' );

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -11,8 +11,11 @@
  * @return string Returns the filtered post title for the current post wrapped inside "h1" tags.
  */
 function render_block_core_post_title() {
-	rewind_posts();
-	the_post();
+	if ( ! in_the_loop() ) {
+		rewind_posts();
+		the_post();
+	}
+
 	return the_title( '<h1>', '</h1>', false );
 }
 

--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -20,7 +20,7 @@ export default function SiteTitleEdit() {
 		<>
 			<Button
 				isPrimary
-				className="wp-block-site-title__save-button"
+				className="wp-block-custom-entity__save-button"
 				disabled={ ! isDirty || ! title }
 				isBusy={ isSaving }
 				onClick={ save }

--- a/packages/block-library/src/site-title/editor.scss
+++ b/packages/block-library/src/site-title/editor.scss
@@ -1,6 +1,0 @@
-.wp-block-site-title__save-button {
-	position: absolute;
-	right: 0;
-	top: 0;
-	z-index: z-index(".wp-block-site-title__save-button");
-}

--- a/packages/edit-post/src/components/browser-url/index.js
+++ b/packages/edit-post/src/components/browser-url/index.js
@@ -42,8 +42,8 @@ export class BrowserURL extends Component {
 	}
 
 	componentDidMount() {
-		const { isTemplate, postId } = this.props;
-		if ( isTemplate ) {
+		const { editingMode, postId } = this.props;
+		if ( editingMode === 'template' ) {
 			this.setBrowserURL( postId );
 		}
 	}
@@ -100,13 +100,13 @@ export class BrowserURL extends Component {
 
 export default withSelect( ( select ) => {
 	const { getEditorSettings, getCurrentPost } = select( 'core/editor' );
-	const { postId, templateId } = getEditorSettings();
+	const { postId, editingMode } = getEditorSettings();
 	const { status, type } = getCurrentPost();
 
 	return {
 		postId,
 		postStatus: status,
 		postType: type,
-		isTemplate: templateId !== undefined,
+		editingMode,
 	};
 } )( BrowserURL );

--- a/packages/edit-post/src/components/browser-url/index.js
+++ b/packages/edit-post/src/components/browser-url/index.js
@@ -41,6 +41,13 @@ export class BrowserURL extends Component {
 		};
 	}
 
+	componentDidMount() {
+		const { isTemplate, postId } = this.props;
+		if ( isTemplate ) {
+			this.setBrowserURL( postId );
+		}
+	}
+
 	componentDidUpdate( prevProps ) {
 		const { postId, postStatus, postType } = this.props;
 		const { historyId } = this.state;
@@ -92,12 +99,14 @@ export class BrowserURL extends Component {
 }
 
 export default withSelect( ( select ) => {
-	const { getCurrentPost } = select( 'core/editor' );
-	const { id, status, type } = getCurrentPost();
+	const { getEditorSettings, getCurrentPost } = select( 'core/editor' );
+	const { postId, templateId } = getEditorSettings();
+	const { status, type } = getCurrentPost();
 
 	return {
-		postId: id,
+		postId,
 		postStatus: status,
 		postType: type,
+		isTemplate: templateId !== undefined,
 	};
 } )( BrowserURL );

--- a/packages/edit-post/src/components/header/header-toolbar/index.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.js
@@ -16,6 +16,7 @@ import {
 	TableOfContents,
 	EditorHistoryRedo,
 	EditorHistoryUndo,
+	SwitchEditingMode,
 } from '@wordpress/editor';
 
 function HeaderToolbar( { hasFixedToolbar, isLargeViewport, showInserter, isTextModeEnabled } ) {
@@ -40,6 +41,7 @@ function HeaderToolbar( { hasFixedToolbar, isLargeViewport, showInserter, isText
 			<EditorHistoryRedo />
 			<TableOfContents hasOutlineItemsDisabled={ isTextModeEnabled } />
 			<BlockNavigationDropdown isDisabled={ isTextModeEnabled } />
+			<SwitchEditingMode />
 			{ hasFixedToolbar && isLargeViewport && (
 				<div className="edit-post-header-toolbar__block-toolbar">
 					<BlockToolbar />

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -56,7 +56,7 @@ function Layout( {
 	isSaving,
 	isMobileViewport,
 	isRichEditingEnabled,
-	isTemplate,
+	editingMode,
 } ) {
 	const sidebarIsOpened = editorSidebarOpened || pluginSidebarOpened || publishSidebarOpened;
 
@@ -93,7 +93,7 @@ function Layout( {
 				<ManageBlocksModal />
 				<OptionsModal />
 				{ ( mode === 'text' || ! isRichEditingEnabled ) && <TextEditor /> }
-				{ isRichEditingEnabled && mode === 'visual' && <VisualEditor noTitle={ isTemplate } /> }
+				{ isRichEditingEnabled && mode === 'visual' && <VisualEditor noTitle={ editingMode === 'template' } /> }
 				<div className="edit-post-layout__metaboxes">
 					<MetaBoxes location="normal" />
 				</div>
@@ -146,7 +146,7 @@ export default compose(
 		hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
 		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
 		isRichEditingEnabled: select( 'core/editor' ).getEditorSettings().richEditingEnabled,
-		isTemplate: select( 'core/editor' ).getEditorSettings().templateId !== undefined,
+		editingMode: select( 'core/editor' ).getEditorSettings().editingMode,
 	} ) ),
 	withDispatch( ( dispatch ) => {
 		const { closePublishSidebar, togglePublishSidebar } = dispatch( 'core/edit-post' );

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -56,6 +56,7 @@ function Layout( {
 	isSaving,
 	isMobileViewport,
 	isRichEditingEnabled,
+	isTemplate,
 } ) {
 	const sidebarIsOpened = editorSidebarOpened || pluginSidebarOpened || publishSidebarOpened;
 
@@ -92,7 +93,7 @@ function Layout( {
 				<ManageBlocksModal />
 				<OptionsModal />
 				{ ( mode === 'text' || ! isRichEditingEnabled ) && <TextEditor /> }
-				{ isRichEditingEnabled && mode === 'visual' && <VisualEditor /> }
+				{ isRichEditingEnabled && mode === 'visual' && <VisualEditor noTitle={ isTemplate } /> }
 				<div className="edit-post-layout__metaboxes">
 					<MetaBoxes location="normal" />
 				</div>
@@ -145,6 +146,7 @@ export default compose(
 		hasActiveMetaboxes: select( 'core/edit-post' ).hasMetaBoxes(),
 		isSaving: select( 'core/edit-post' ).isSavingMetaBoxes(),
 		isRichEditingEnabled: select( 'core/editor' ).getEditorSettings().richEditingEnabled,
+		isTemplate: select( 'core/editor' ).getEditorSettings().templateId !== undefined,
 	} ) ),
 	withDispatch( ( dispatch ) => {
 		const { closePublishSidebar, togglePublishSidebar } = dispatch( 'core/edit-post' );

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -23,7 +23,7 @@ import {
 import BlockInspectorButton from './block-inspector-button';
 import PluginBlockSettingsMenuGroup from '../block-settings-menu/plugin-block-settings-menu-group';
 
-function VisualEditor() {
+function VisualEditor( { noTitle } ) {
 	return (
 		<BlockSelectionClearer className="edit-post-visual-editor editor-styles-wrapper">
 			<VisualEditorGlobalKeyboardShortcuts />
@@ -32,7 +32,7 @@ function VisualEditor() {
 				<WritingFlow>
 					<ObserveTyping>
 						<CopyHandler>
-							<PostTitle />
+							{ ! noTitle && <PostTitle /> }
 							<BlockList />
 						</CopyHandler>
 					</ObserveTyping>

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -44,6 +44,8 @@ class Editor extends Component {
 		preferredStyleVariations,
 		__experimentalLocalAutosaveInterval,
 		updatePreferredStyleVariations,
+		postId,
+		postType,
 	) {
 		settings = {
 			...settings,
@@ -55,6 +57,8 @@ class Editor extends Component {
 			focusMode,
 			showInserterHelpPanel,
 			__experimentalLocalAutosaveInterval,
+			postId,
+			postType,
 		};
 
 		// Omit hidden block types if exists and non-empty.
@@ -83,7 +87,9 @@ class Editor extends Component {
 			hasFixedToolbar,
 			focusMode,
 			post,
+			template,
 			postId,
+			postType,
 			initialEdits,
 			onError,
 			hiddenBlockTypes,
@@ -95,7 +101,7 @@ class Editor extends Component {
 			...props
 		} = this.props;
 
-		if ( ! post ) {
+		if ( ! post || ( settings.templateId !== undefined && ! template ) ) {
 			return null;
 		}
 
@@ -109,6 +115,8 @@ class Editor extends Component {
 			preferredStyleVariations,
 			__experimentalLocalAutosaveInterval,
 			updatePreferredStyleVariations,
+			postId,
+			postType
 		);
 
 		return (
@@ -119,6 +127,7 @@ class Editor extends Component {
 							<EditorProvider
 								settings={ editorSettings }
 								post={ post }
+								template={ template }
 								initialEdits={ initialEdits }
 								useSubRegistry={ false }
 								{ ...props }
@@ -139,7 +148,7 @@ class Editor extends Component {
 }
 
 export default compose( [
-	withSelect( ( select, { postId, postType } ) => {
+	withSelect( ( select, { postId, postType, settings } ) => {
 		const { isFeatureActive, getPreference } = select( 'core/edit-post' );
 		const { getEntityRecord } = select( 'core' );
 		const { getBlockTypes } = select( 'core/blocks' );
@@ -149,6 +158,10 @@ export default compose( [
 			hasFixedToolbar: isFeatureActive( 'fixedToolbar' ),
 			focusMode: isFeatureActive( 'focusMode' ),
 			post: getEntityRecord( 'postType', postType, postId ),
+			template:
+				settings.templateId === undefined ?
+					undefined :
+					getEntityRecord( 'postType', 'wp_template', settings.templateId ),
 			preferredStyleVariations: getPreference( 'preferredStyleVariations' ),
 			hiddenBlockTypes: getPreference( 'hiddenBlockTypes' ),
 			blockTypes: getBlockTypes(),

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -57,6 +57,7 @@ export { default as PostTypeSupportCheck } from './post-type-support-check';
 export { default as PostVisibility } from './post-visibility';
 export { default as PostVisibilityLabel } from './post-visibility/label';
 export { default as PostVisibilityCheck } from './post-visibility/check';
+export { default as SwitchEditingMode } from './switch-editing-mode';
 export { default as TableOfContents } from './table-of-contents';
 export { default as UnsavedChangesWarning } from './unsaved-changes-warning';
 export { default as WordCount } from './word-count';

--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -208,13 +208,14 @@ export default compose( [
 			isEditedPostSaveable,
 			isEditedPostAutosaveable,
 			getEditedPostPreviewLink,
+			getEditorSettings,
 		} = select( 'core/editor' );
 		const {
 			getPostType,
 		} = select( 'core' );
-
-		const previewLink = getEditedPostPreviewLink();
-		const postType = getPostType( getEditedPostAttribute( 'type' ) );
+		const { postId, postType: _postType } = getEditorSettings();
+		const previewLink = getEditedPostPreviewLink( postId, _postType );
+		const postType = getPostType( _postType );
 
 		return {
 			postId: getCurrentPostId(),

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -60,9 +60,13 @@ class EditorProvider extends Component {
 
 		props.updatePostLock( props.settings.postLock );
 		props.setupEditor(
-			props.template || props.post,
-			props.template ? undefined : props.initialEdits,
-			props.template ? undefined : props.settings.template
+			props.settings.editingMode === 'template' ? props.template : props.post,
+			props.settings.editingMode === 'template' ?
+				undefined :
+				props.initialEdits,
+			props.settings.editingMode === 'template' ?
+				undefined :
+				props.settings.template
 		);
 
 		if ( props.settings.autosave ) {
@@ -160,6 +164,18 @@ class EditorProvider extends Component {
 				unregisterBlockType( blockType.name );
 			} );
 		}
+
+		if ( this.props.editingMode !== prevProps.editingMode ) {
+			this.props.setupEditor(
+				this.props.editingMode === 'template' ?
+					this.props.template :
+					this.props.post,
+				this.props.editingMode === 'template' ?
+					undefined :
+					this.props.initialEdits,
+				this.props.editingMode === 'template' ? undefined : this.props.template
+			);
+		}
 	}
 
 	componentWillUnmount() {
@@ -222,6 +238,7 @@ export default compose( [
 			__unstableIsEditorReady: isEditorReady,
 			getEditorBlocks,
 			__experimentalGetReusableBlocks,
+			getEditorSettings,
 		} = select( 'core/editor' );
 		const { canUser } = select( 'core' );
 		const { getInstalledBlockTypes } = select( 'core/block-directory' );
@@ -236,6 +253,7 @@ export default compose( [
 			reusableBlocks: __experimentalGetReusableBlocks(),
 			hasUploadPermissions: defaultTo( canUser( 'create', 'media' ), true ),
 			downloadableBlocksToUninstall,
+			editingMode: getEditorSettings().editingMode,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -59,7 +59,11 @@ class EditorProvider extends Component {
 		}
 
 		props.updatePostLock( props.settings.postLock );
-		props.setupEditor( props.post, props.initialEdits, props.settings.template );
+		props.setupEditor(
+			props.template || props.post,
+			props.template ? undefined : props.initialEdits,
+			props.template ? undefined : props.settings.template
+		);
 
 		if ( props.settings.autosave ) {
 			props.createWarningNotice(

--- a/packages/editor/src/components/switch-editing-mode/index.js
+++ b/packages/editor/src/components/switch-editing-mode/index.js
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
+import { IconButton } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+export default function SwitchEditingMode() {
+	const { editingMode } = useSelect(
+		( select ) => select( 'core/editor' ).getEditorSettings(),
+		[]
+	);
+	const { updateEditorSettings } = useDispatch( 'core/editor' );
+	const toggleEditingMode = useCallback(
+		() =>
+			updateEditorSettings( {
+				editingMode: editingMode === 'template' ? 'post-content' : 'template',
+			} ),
+		[ editingMode ]
+	);
+	return (
+		editingMode !== undefined && (
+			<IconButton
+				icon="welcome-widgets-menus"
+				onClick={ toggleEditingMode }
+				label={ __( 'Toggle Template Mode' ) }
+			/>
+		)
+	);
+}

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -745,11 +745,16 @@ export function isPreviewingPost( state ) {
 /**
  * Returns the post preview link
  *
- * @param {Object} state Global application state.
+ * @param {Object} state    Global application state.
+ * @param {number} postId   Optional post ID override.
+ * @param {string} postType Optional post type override.
  *
  * @return {string?} Preview Link.
  */
-export function getEditedPostPreviewLink( state ) {
+export function getEditedPostPreviewLink( state, postId, postType ) {
+	if ( postId && postType ) {
+		state = { ...state, postId, postType };
+	}
 	if ( state.saving.pending || isSavingPost( state ) ) {
 		return;
 	}

--- a/packages/editor/src/utils/index.js
+++ b/packages/editor/src/utils/index.js
@@ -5,3 +5,5 @@ import mediaUpload from './media-upload';
 
 export { mediaUpload };
 export { cleanForSlug } from './url.js';
+
+export { default as serializeBlocks } from '../store/utils/serialize-blocks';


### PR DESCRIPTION
Depends on #17207

## Description

This PR implements a new custom post type for implementing a dynamic template hierarchy like in #4659. Then it makes a few changes to the editor store to load in a "template mode" when it detects that the current post has an attached template.

It also brings in the post title and post content blocks of #16565, but using the new declarative APIs introduced in #17153 and #17207.

All of this new functionality is enabled only when you enable the full site editing experiment in the experiments tab. This way we can iterate it on it, until it's ship-able.

If you try the experiment on this branch, you should see posts load in template mode where you can edit the top level template, the post title and content blocks, preview the post, etc, etc. Blocks have their own save buttons for now, until we design all the different save flows we should have and how they should interact with each other.

## How has this been tested?

It hasn't :grimacing:

## Screenshots

<img width="1179" alt="Screen Shot 2019-08-29 at 4 14 04 PM" src="https://user-images.githubusercontent.com/19157096/63982633-1349ca00-ca78-11e9-891c-5e4c63789368.png">

## Types of Changes

*New Feature:* Introduce a new dynamic templates mode and add basic post title and content blocks.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
