### PR TITLE
Add navigator for nav block

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -122,6 +122,10 @@ Undocumented declaration.
 
 Undocumented declaration.
 
+<a name="BlockNavigationList" href="#BlockNavigationList">#</a> **BlockNavigationList**
+
+Undocumented declaration.
+
 <a name="BlockPreview" href="#BlockPreview">#</a> **BlockPreview**
 
 BlockPreview renders a preview of a block or array of blocks.

--- a/packages/block-editor/src/components/block-navigation/index.js
+++ b/packages/block-editor/src/components/block-navigation/index.js
@@ -1,69 +1,20 @@
 /**
  * External dependencies
  */
-import { map, noop } from 'lodash';
-import classnames from 'classnames';
+import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { withSelect, withDispatch } from '@wordpress/data';
-import { Button, NavigableMenu } from '@wordpress/components';
-import { getBlockType } from '@wordpress/blocks';
+import { NavigableMenu } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import BlockIcon from '../block-icon';
-
-function BlockNavigationList( {
-	blocks,
-	selectedBlockClientId,
-	selectBlock,
-	showNestedBlocks,
-} ) {
-	return (
-		/*
-		 * Disable reason: The `list` ARIA role is redundant but
-		 * Safari+VoiceOver won't announce the list otherwise.
-		 */
-		/* eslint-disable jsx-a11y/no-redundant-roles */
-		<ul className="editor-block-navigation__list block-editor-block-navigation__list" role="list">
-			{ map( blocks, ( block ) => {
-				const blockType = getBlockType( block.name );
-				const isSelected = block.clientId === selectedBlockClientId;
-
-				return (
-					<li key={ block.clientId }>
-						<div className="editor-block-navigation__item block-editor-block-navigation__item">
-							<Button
-								className={ classnames( 'editor-block-navigation__item-button block-editor-block-navigation__item-button', {
-									'is-selected': isSelected,
-								} ) }
-								onClick={ () => selectBlock( block.clientId ) }
-							>
-								<BlockIcon icon={ blockType.icon } showColors />
-								{ blockType.title }
-								{ isSelected && <span className="screen-reader-text">{ __( '(selected block)' ) }</span> }
-							</Button>
-						</div>
-						{ showNestedBlocks && !! block.innerBlocks && !! block.innerBlocks.length && (
-							<BlockNavigationList
-								blocks={ block.innerBlocks }
-								selectedBlockClientId={ selectedBlockClientId }
-								selectBlock={ selectBlock }
-								showNestedBlocks
-							/>
-						) }
-					</li>
-				);
-			} ) }
-		</ul>
-		/* eslint-enable jsx-a11y/no-redundant-roles */
-	);
-}
+import BlockNavigationList from './list';
 
 function BlockNavigation( { rootBlock, rootBlocks, selectedBlockClientId, selectBlock } ) {
 	if ( ! rootBlocks || rootBlocks.length === 0 ) {

--- a/packages/block-editor/src/components/block-navigation/list.js
+++ b/packages/block-editor/src/components/block-navigation/list.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { map } from 'lodash';
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { getBlockType } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import BlockIcon from '../block-icon';
+
+export default function BlockNavigationList( {
+	blocks,
+	selectedBlockClientId,
+	selectBlock,
+	showNestedBlocks,
+} ) {
+	return (
+		/*
+		 * Disable reason: The `list` ARIA role is redundant but
+		 * Safari+VoiceOver won't announce the list otherwise.
+		 */
+		/* eslint-disable jsx-a11y/no-redundant-roles */
+		<ul className="editor-block-navigation__list block-editor-block-navigation__list" role="list">
+			{ map( blocks, ( block ) => {
+				const blockType = getBlockType( block.name );
+				const isSelected = block.clientId === selectedBlockClientId;
+
+				return (
+					<li key={ block.clientId }>
+						<div className="editor-block-navigation__item block-editor-block-navigation__item">
+							<Button
+								className={ classnames( 'editor-block-navigation__item-button block-editor-block-navigation__item-button', {
+									'is-selected': isSelected,
+								} ) }
+								onClick={ () => selectBlock( block.clientId ) }
+							>
+								<BlockIcon icon={ blockType.icon } showColors />
+								{ blockType.title }
+								{ isSelected && <span className="screen-reader-text">{ __( '(selected block)' ) }</span> }
+							</Button>
+						</div>
+						{ showNestedBlocks && !! block.innerBlocks && !! block.innerBlocks.length && (
+							<BlockNavigationList
+								blocks={ block.innerBlocks }
+								selectedBlockClientId={ selectedBlockClientId }
+								selectBlock={ selectBlock }
+								showNestedBlocks
+							/>
+						) }
+					</li>
+				);
+			} ) }
+		</ul>
+		/* eslint-enable jsx-a11y/no-redundant-roles */
+	);
+}

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -12,6 +12,7 @@ export { default as BlockEdit } from './block-edit';
 export { default as BlockFormatControls } from './block-format-controls';
 export { default as BlockIcon } from './block-icon';
 export { default as BlockNavigationDropdown } from './block-navigation/dropdown';
+export { default as BlockNavigationList } from './block-navigation/list';
 export { default as BlockVerticalAlignmentToolbar } from './block-vertical-alignment-toolbar';
 export { default as ButtonBlockerAppender } from './button-block-appender';
 export { default as ColorPalette } from './color-palette';

--- a/packages/block-library/src/navigation-menu/block-navigator.js
+++ b/packages/block-library/src/navigation-menu/block-navigator.js
@@ -1,0 +1,75 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	Fragment,
+	useState,
+} from '@wordpress/element';
+import {
+	useSelect,
+	useDispatch,
+} from '@wordpress/data';
+import {
+	BlockNavigationList,
+} from '@wordpress/block-editor';
+import {
+	IconButton,
+	SVG,
+	Path,
+	Modal,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const NavigatorIcon = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20">
+		<Path d="M5 5H3v2h2V5zm3 8h11v-2H8v2zm9-8H6v2h11V5zM7 11H5v2h2v-2zm0 8h2v-2H7v2zm3-2v2h11v-2H10z" />
+	</SVG>
+);
+
+export default function BlockNavigator( { clientId } ) {
+	const [ isNavigationListOpen, setIsNavigationListOpen ] = useState( false );
+
+	const {
+		block,
+		selectedBlockClientId,
+	} = useSelect( ( select ) => {
+		const {
+			getSelectedBlockClientId,
+			getBlock,
+		} = select( 'core/block-editor' );
+
+		return {
+			block: getBlock( clientId ),
+			selectedBlockClientId: getSelectedBlockClientId(),
+		};
+	}, [ clientId ] );
+
+	const {
+		selectBlock,
+	} = useDispatch( 'core/block-editor' );
+
+	return (
+		<Fragment>
+			{ isNavigationListOpen && (
+				<Modal
+					title={ __( 'Block Navigator' ) }
+					closeLabel={ __( 'Close' ) }
+					onRequestClose={ () => setIsNavigationListOpen( false ) }
+				>
+					<BlockNavigationList
+						blocks={ [ block ] }
+						selectedBlockClientId={ selectedBlockClientId }
+						selectBlock={ selectBlock }
+						showNestedBlocks
+					/>
+				</Modal>
+			) }
+			<IconButton
+				className="components-toolbar__control"
+				label={ __( 'Open block navigator' ) }
+				onClick={ () => setIsNavigationListOpen( true ) }
+				icon={ NavigatorIcon }
+			/>
+		</Fragment>
+	);
+}

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -26,15 +26,16 @@ function NavigationMenu( {
 	setAttributes,
 	clientId,
 } ) {
-	const { NavigatorToolbarButton, NavigatorModal } = useBlockNavigator( clientId );
+	const { navigatorToolbarButton, navigatorModal } = useBlockNavigator( clientId );
 
 	return (
 		<Fragment>
 			<BlockControls>
 				<Toolbar>
-					<NavigatorToolbarButton />
+					{ navigatorToolbarButton }
 				</Toolbar>
 			</BlockControls>
+			{ navigatorModal }
 			<InspectorControls>
 				<PanelBody
 					title={ __( 'Menu Settings' ) }
@@ -49,7 +50,6 @@ function NavigationMenu( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<NavigatorModal />
 			<div className="wp-block-navigation-menu">
 				<InnerBlocks
 					allowedBlocks={ [ 'core/navigation-menu-item' ] }

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -13,36 +13,24 @@ import {
 	CheckboxControl,
 	PanelBody,
 	Toolbar,
-	IconButton,
-	SVG,
-	Path,
 } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { __ } from '@wordpress/i18n';
-
-const NavigatorIcon = (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20">
-		<Path d="M5 5H3v2h2V5zm3 8h11v-2H8v2zm9-8H6v2h11V5zM7 11H5v2h2v-2zm0 8h2v-2H7v2zm3-2v2h11v-2H10z" />
-	</SVG>
-);
+import BlockNavigator from './block-navigator';
 
 function NavigationMenu( {
 	attributes,
 	setAttributes,
+	clientId,
 } ) {
 	return (
 		<Fragment>
 			<BlockControls>
 				<Toolbar>
-					<IconButton
-						className="components-toolbar__control"
-						label={ __( 'View navigator' ) }
-						onClick={ () => {} }
-						icon={ NavigatorIcon }
-					/>
+					<BlockNavigator clientId={ clientId } />
 				</Toolbar>
 			</BlockControls>
 			<InspectorControls>

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -19,18 +19,20 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import BlockNavigator from './block-navigator';
+import useBlockNavigator from './use-block-navigator';
 
 function NavigationMenu( {
 	attributes,
 	setAttributes,
 	clientId,
 } ) {
+	const { NavigatorToolbarButton, NavigatorModal } = useBlockNavigator( clientId );
+
 	return (
 		<Fragment>
 			<BlockControls>
 				<Toolbar>
-					<BlockNavigator clientId={ clientId } />
+					<NavigatorToolbarButton />
 				</Toolbar>
 			</BlockControls>
 			<InspectorControls>
@@ -47,6 +49,7 @@ function NavigationMenu( {
 					/>
 				</PanelBody>
 			</InspectorControls>
+			<NavigatorModal />
 			<div className="wp-block-navigation-menu">
 				<InnerBlocks
 					allowedBlocks={ [ 'core/navigation-menu-item' ] }

--- a/packages/block-library/src/navigation-menu/edit.js
+++ b/packages/block-library/src/navigation-menu/edit.js
@@ -7,10 +7,15 @@ import {
 import {
 	InnerBlocks,
 	InspectorControls,
+	BlockControls,
 } from '@wordpress/block-editor';
 import {
 	CheckboxControl,
 	PanelBody,
+	Toolbar,
+	IconButton,
+	SVG,
+	Path,
 } from '@wordpress/components';
 
 /**
@@ -18,12 +23,28 @@ import {
  */
 import { __ } from '@wordpress/i18n';
 
+const NavigatorIcon = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20">
+		<Path d="M5 5H3v2h2V5zm3 8h11v-2H8v2zm9-8H6v2h11V5zM7 11H5v2h2v-2zm0 8h2v-2H7v2zm3-2v2h11v-2H10z" />
+	</SVG>
+);
+
 function NavigationMenu( {
 	attributes,
 	setAttributes,
 } ) {
 	return (
 		<Fragment>
+			<BlockControls>
+				<Toolbar>
+					<IconButton
+						className="components-toolbar__control"
+						label={ __( 'View navigator' ) }
+						onClick={ () => {} }
+						icon={ NavigatorIcon }
+					/>
+				</Toolbar>
+			</BlockControls>
 			<InspectorControls>
 				<PanelBody
 					title={ __( 'Menu Settings' ) }

--- a/packages/block-library/src/navigation-menu/use-block-navigator.js
+++ b/packages/block-library/src/navigation-menu/use-block-navigator.js
@@ -47,30 +47,7 @@ export default function useBlockNavigator( clientId ) {
 		selectBlock,
 	} = useDispatch( 'core/block-editor' );
 
-	const NavigatorModal = () => {
-		if ( ! isNavigationListOpen ) {
-			return null;
-		}
-
-		return (
-			<Modal
-				title={ __( 'Block Navigator' ) }
-				closeLabel={ __( 'Close' ) }
-				onRequestClose={ () => {
-					setIsNavigationListOpen( false );
-				} }
-			>
-				<BlockNavigationList
-					blocks={ [ block ] }
-					selectedBlockClientId={ selectedBlockClientId }
-					selectBlock={ selectBlock }
-					showNestedBlocks
-				/>
-			</Modal>
-		);
-	};
-
-	const NavigatorToolbarButton = () => (
+	const navigatorToolbarButton = (
 		<IconButton
 			className="components-toolbar__control"
 			label={ __( 'Open block navigator' ) }
@@ -79,8 +56,25 @@ export default function useBlockNavigator( clientId ) {
 		/>
 	);
 
+	const navigatorModal = isNavigationListOpen && (
+		<Modal
+			title={ __( 'Block Navigator' ) }
+			closeLabel={ __( 'Close' ) }
+			onRequestClose={ () => {
+				setIsNavigationListOpen( false );
+			} }
+		>
+			<BlockNavigationList
+				blocks={ [ block ] }
+				selectedBlockClientId={ selectedBlockClientId }
+				selectBlock={ selectBlock }
+				showNestedBlocks
+			/>
+		</Modal>
+	);
+
 	return {
-		NavigatorModal,
-		NavigatorToolbarButton,
+		navigatorToolbarButton,
+		navigatorModal,
 	};
 }

--- a/packages/block-library/src/navigation-menu/use-block-navigator.js
+++ b/packages/block-library/src/navigation-menu/use-block-navigator.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import {
-	Fragment,
 	useState,
 } from '@wordpress/element';
 import {
@@ -26,7 +25,7 @@ const NavigatorIcon = (
 	</SVG>
 );
 
-export default function BlockNavigator( { clientId } ) {
+export default function useBlockNavigator( clientId ) {
 	const [ isNavigationListOpen, setIsNavigationListOpen ] = useState( false );
 
 	const {
@@ -48,28 +47,40 @@ export default function BlockNavigator( { clientId } ) {
 		selectBlock,
 	} = useDispatch( 'core/block-editor' );
 
-	return (
-		<Fragment>
-			{ isNavigationListOpen && (
-				<Modal
-					title={ __( 'Block Navigator' ) }
-					closeLabel={ __( 'Close' ) }
-					onRequestClose={ () => setIsNavigationListOpen( false ) }
-				>
-					<BlockNavigationList
-						blocks={ [ block ] }
-						selectedBlockClientId={ selectedBlockClientId }
-						selectBlock={ selectBlock }
-						showNestedBlocks
-					/>
-				</Modal>
-			) }
-			<IconButton
-				className="components-toolbar__control"
-				label={ __( 'Open block navigator' ) }
-				onClick={ () => setIsNavigationListOpen( true ) }
-				icon={ NavigatorIcon }
-			/>
-		</Fragment>
+	const NavigatorModal = () => {
+		if ( ! isNavigationListOpen ) {
+			return null;
+		}
+
+		return (
+			<Modal
+				title={ __( 'Block Navigator' ) }
+				closeLabel={ __( 'Close' ) }
+				onRequestClose={ () => {
+					setIsNavigationListOpen( false );
+				} }
+			>
+				<BlockNavigationList
+					blocks={ [ block ] }
+					selectedBlockClientId={ selectedBlockClientId }
+					selectBlock={ selectBlock }
+					showNestedBlocks
+				/>
+			</Modal>
+		);
+	};
+
+	const NavigatorToolbarButton = () => (
+		<IconButton
+			className="components-toolbar__control"
+			label={ __( 'Open block navigator' ) }
+			onClick={ () => setIsNavigationListOpen( true ) }
+			icon={ NavigatorIcon }
+		/>
 	);
+
+	return {
+		NavigatorModal,
+		NavigatorToolbarButton,
+	};
 }


### PR DESCRIPTION
## Description
Fixes #16812, adds Block Navigation to the Navigation Block.

I've called it 'Block Navigator', but the name clash seems like a little issue that might need to be resolved.

Changes:
- Extract and export `BlockNavigationList` as a component from `@wordpress/block-editor`
- Add new `BlockNavigatorModal` component in the navigation block's folder and integrate.

## How has this been tested?
Manual testing
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
![Screen Shot 2019-08-30 at 1 51 42 pm](https://user-images.githubusercontent.com/677833/63996177-7f3a3a00-cb2d-11e9-8a8a-94d8e5ab425b.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
