### PR TITLE
[RNMobile] Recover border color on focused blocks

### DIFF
--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -131,7 +131,7 @@ class BlockListBlock extends Component {
 					>
 						{ isValid && this.getBlockForType() }
 						{ ! isValid &&
-						<BlockInvalidWarning blockTitle={ title } icon={ icon } />
+							<BlockInvalidWarning blockTitle={ title } icon={ icon } />
 						}
 					</View>
 					{ isSelected && <BlockMobileToolbar clientId={ clientId } /> }

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -140,7 +140,7 @@ export class BlockList extends Component {
 						rootClientId={ this.props.rootClientId }
 						onCaretVerticalPositionChange={ this.onCaretVerticalPositionChange }
 						borderStyle={ this.blockHolderBorderStyle() }
-						focusedBorderColor={ blockHolderFocusedStyle }
+						focusedBorderColor={ blockHolderFocusedStyle.borderColor }
 					/> ) }
 			</ReadableContentView>
 		);

--- a/packages/edit-post/src/components/layout/index.native.js
+++ b/packages/edit-post/src/components/layout/index.native.js
@@ -118,8 +118,7 @@ class Layout extends Component {
 				<View style={ useStyle( styles.background, styles.backgroundDark, this.props.theme ) }>
 					{ isHtmlView ? this.renderHTML() : this.renderVisual() }
 				</View>
-				<View style={ { flex: 0, flexBasis: marginBottom, height: marginBottom } }>
-				</View>
+				<View style={ { flex: 0, flexBasis: marginBottom, height: marginBottom } } />
 				{ ! isHtmlView && (
 					<KeyboardAvoidingView
 						parentHeight={ this.state.rootViewHeight }


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Small PR that fixes an issue where the border color for focused blocks were not being shown.

`gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1339

![border](https://user-images.githubusercontent.com/9772967/64008078-adac1b00-cb15-11e9-8fdb-6cebfaee2575.png)

cc @pinarol - I couldn't reproduce the black lines problem anymore. I saw it yesterday though 🤔 
cc @iamthomasbishop - I couldn't reproduce the icons grey color issue either. The ones in the screenshots are the correct ones, right?


