### PR TITLE
[RNMobile] add RangeControl mobile implementation (slider)

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/index.native.js
@@ -19,6 +19,7 @@ import Button from './button';
 import Cell from './cell';
 import PickerCell from './picker-cell';
 import SwitchCell from './switch-cell';
+import RangeCell from './range-cell';
 import KeyboardAvoidingView from './keyboard-avoiding-view';
 
 class BottomSheet extends Component {
@@ -171,5 +172,6 @@ ThemedBottomSheet.Button = Button;
 ThemedBottomSheet.Cell = Cell;
 ThemedBottomSheet.PickerCell = PickerCell;
 ThemedBottomSheet.SwitchCell = SwitchCell;
+ThemedBottomSheet.RangeCell = RangeCell;
 
 export default ThemedBottomSheet;

--- a/packages/components/src/mobile/bottom-sheet/range-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/range-cell.native.js
@@ -1,0 +1,39 @@
+/**
+ * Internal dependencies
+ */
+import Cell from './cell';
+import Slider from '../slider';
+
+export default function BottomSheetRangeCell( props ) {
+	const {
+		value,
+		onChangeValue,
+		minimumValue = 0,
+		maximumValue = 10,
+		disabled,
+		step = 1,
+		minimumTrackTintColor = '#909090',
+		maximumTrackTintColor = '#909090',
+		thumbTintColor = '#000',
+		...cellProps
+	} = props;
+
+	return (
+		<Cell
+			editable={ false }
+			{ ...cellProps }
+		>
+			<Slider
+				value={ value }
+				disabled={ disabled }
+				step={ step }
+				minimumValue={ minimumValue }
+				maximumValue={ maximumValue }
+				minimumTrackTintColor={ minimumTrackTintColor }
+				maximumTrackTintColor={ maximumTrackTintColor }
+				thumbTintColor={ thumbTintColor }
+				onChangeValue={ onChangeValue }
+			/>
+		</Cell>
+	);
+}

--- a/packages/components/src/mobile/bottom-sheet/range-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/range-cell.native.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { Platform } from 'react-native';
+
+/**
  * Internal dependencies
  */
 import Cell from './cell';
@@ -12,9 +17,9 @@ export default function BottomSheetRangeCell( props ) {
 		maximumValue = 10,
 		disabled,
 		step = 1,
-		minimumTrackTintColor = '#909090',
-		maximumTrackTintColor = '#909090',
-		thumbTintColor = '#000',
+		minimumTrackTintColor = '#00669b',
+		maximumTrackTintColor = Platform.OS === 'ios' ? '#e9eff3' : '#909090',
+		thumbTintColor = Platform.OS === 'ios' ? '#fff' : '#00669b',
 		...cellProps
 	} = props;
 

--- a/packages/components/src/mobile/bottom-sheet/range-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/range-cell.native.js
@@ -12,6 +12,7 @@ import Slider from '../slider';
 export default function BottomSheetRangeCell( props ) {
 	const {
 		value,
+		defaultValue,
 		onChangeValue,
 		minimumValue = 0,
 		maximumValue = 10,
@@ -30,6 +31,7 @@ export default function BottomSheetRangeCell( props ) {
 		>
 			<Slider
 				value={ value }
+				defaultValue={ defaultValue }
 				disabled={ disabled }
 				step={ step }
 				minimumValue={ minimumValue }

--- a/packages/components/src/mobile/slider/index.native.js
+++ b/packages/components/src/mobile/slider/index.native.js
@@ -29,7 +29,7 @@ class Slider extends Component {
 		}
 	}
 
-	handleToggleFocus( validateInput = false ) {
+	handleToggleFocus( validateInput = true ) {
 		const newState = { hasFocus: ! this.state.hasFocus };
 
 		if ( validateInput ) {
@@ -74,7 +74,7 @@ class Slider extends Component {
 		return (
 			<View style={ styles.sliderContainer }>
 				<RNSlider
-					value={ value }
+					value={ this.validateInput( value ) }
 					disabled={ disabled }
 					style={ styles.slider }
 					step={ step }
@@ -89,7 +89,7 @@ class Slider extends Component {
 					style={ [ styles.sliderTextInput, hasFocus ? styles.isSelected : {} ] }
 					onChangeText={ this.handleChange }
 					onFocus={ this.handleToggleFocus }
-					onBlur={ () => this.handleToggleFocus( true ) }
+					onBlur={ this.handleToggleFocus }
 					keyboardType="numeric"
 					value={ `${ sliderValue }` }
 				/>

--- a/packages/components/src/mobile/slider/index.native.js
+++ b/packages/components/src/mobile/slider/index.native.js
@@ -29,8 +29,14 @@ class Slider extends Component {
 		}
 	}
 
-	handleToggleFocus() {
-		this.setState( { hasFocus: ! this.state.hasFocus } );
+	handleToggleFocus( validateInput = false ) {
+		const newState = { hasFocus: ! this.state.hasFocus };
+
+		if ( validateInput ) {
+			newState.sliderValue = this.validateInput( this.state.sliderValue );
+		}
+
+		this.setState( newState );
 	}
 
 	validateInput( text ) {
@@ -46,9 +52,8 @@ class Slider extends Component {
 
 	handleChange( text ) {
 		if ( ! isNaN( Number( text ) ) ) {
-			const newValue = this.validateInput( text );
-			this.props.onChangeValue( newValue );
-			this.setState( { sliderValue: newValue } );
+			this.props.onChangeValue( text );
+			this.setState( { sliderValue: text } );
 		}
 	}
 
@@ -84,7 +89,7 @@ class Slider extends Component {
 					style={ [ styles.sliderTextInput, hasFocus ? styles.isSelected : {} ] }
 					onChangeText={ this.handleChange }
 					onFocus={ this.handleToggleFocus }
-					onBlur={ this.handleToggleFocus }
+					onBlur={ () => this.handleToggleFocus( true ) }
 					keyboardType="numeric"
 					value={ `${ sliderValue }` }
 				/>

--- a/packages/components/src/mobile/slider/index.native.js
+++ b/packages/components/src/mobile/slider/index.native.js
@@ -18,6 +18,7 @@ class Slider extends Component {
 		super( props );
 		this.handleToggleFocus = this.handleToggleFocus.bind( this );
 		this.handleChange = this.handleChange.bind( this );
+		this.handleValueSave = this.handleValueSave.bind( this );
 		this.handleReset = this.handleReset.bind( this );
 
 		const initialValue = this.validateInput( props.value || props.defaultValue || props.minimumValue );
@@ -36,7 +37,8 @@ class Slider extends Component {
 		const newState = { hasFocus: ! this.state.hasFocus };
 
 		if ( validateInput ) {
-			newState.sliderValue = this.validateInput( this.state.sliderValue );
+			const sliderValue = this.validateInput( this.state.sliderValue );
+			this.handleValueSave( sliderValue );
 		}
 
 		this.setState( newState );
@@ -48,12 +50,18 @@ class Slider extends Component {
 			return minimumValue;
 		}
 		if ( typeof text === 'number' ) {
-			return text;
+			return Math.min( Math.max( text, minimumValue ), maximumValue );
 		}
 		return Math.min( Math.max( text.replace( /[^0-9]/g, '' ).replace( /^0+(?=\d)/, '' ), minimumValue ), maximumValue );
 	}
 
 	handleChange( text ) {
+		if ( ! isNaN( Number( text ) ) ) {
+			this.setState( { sliderValue: text } );
+		}
+	}
+
+	handleValueSave( text ) {
 		if ( ! isNaN( Number( text ) ) ) {
 			if ( this.props.onChangeValue ) {
 				this.props.onChangeValue( text );
@@ -63,7 +71,7 @@ class Slider extends Component {
 	}
 
 	handleReset() {
-		this.handleChange( this.props.defaultValue || this.state.initialValue );
+		this.handleValueSave( this.props.defaultValue || this.state.initialValue );
 	}
 
 	render() {
@@ -92,6 +100,7 @@ class Slider extends Component {
 					maximumTrackTintColor={ maximumTrackTintColor }
 					thumbTintColor={ thumbTintColor }
 					onValueChange={ this.handleChange }
+					onSlidingComplete={ this.handleValueSave }
 				/>
 				<TextInput
 					style={ [ styles.sliderTextInput, hasFocus ? styles.isSelected : {} ] }

--- a/packages/components/src/mobile/slider/index.native.js
+++ b/packages/components/src/mobile/slider/index.native.js
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+import { Slider as RNSlider, TextInput, View } from 'react-native';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import styles from './styles.scss';
+
+class Slider extends Component {
+	constructor( props ) {
+		super( props );
+		this.handleToggleFocus = this.handleToggleFocus.bind( this );
+		this.handleChange = this.handleChange.bind( this );
+
+		this.state = { hasFocus: false, sliderValue: props.value || props.minimumValue };
+	}
+
+	componentDidUpdate( ) {
+		const reset = this.props.value === null;
+		if ( reset ) {
+			this.handleChange( this.props.minimumValue );
+		}
+	}
+
+	handleToggleFocus() {
+		this.setState( { hasFocus: ! this.state.hasFocus } );
+	}
+
+	validateInput( text ) {
+		const { minimumValue, maximumValue } = this.props;
+		if ( ! text ) {
+			return minimumValue;
+		}
+		if ( typeof text === 'number' ) {
+			return text;
+		}
+		return Math.min( Math.max( text.replace( /[^0-9]/g, '' ).replace( /^0+(?=\d)/, '' ), minimumValue ), maximumValue );
+	}
+
+	handleChange( text ) {
+		if ( ! isNaN( Number( text ) ) ) {
+			const newValue = this.validateInput( text );
+			this.props.onChangeValue( newValue );
+			this.setState( { sliderValue: newValue } );
+		}
+	}
+
+	render() {
+		const {
+			value,
+			minimumValue,
+			maximumValue,
+			disabled,
+			step,
+			minimumTrackTintColor,
+			maximumTrackTintColor,
+			thumbTintColor,
+		} = this.props;
+
+		const { hasFocus, sliderValue } = this.state;
+
+		return (
+			<View style={ styles.sliderContainer }>
+				<RNSlider
+					value={ value }
+					disabled={ disabled }
+					style={ styles.slider }
+					step={ step }
+					minimumValue={ minimumValue }
+					maximumValue={ maximumValue }
+					minimumTrackTintColor={ minimumTrackTintColor }
+					maximumTrackTintColor={ maximumTrackTintColor }
+					thumbTintColor={ thumbTintColor }
+					onValueChange={ this.handleChange }
+				/>
+				<TextInput
+					style={ [ styles.sliderTextInput, hasFocus ? styles.isSelected : {} ] }
+					onChangeText={ this.handleChange }
+					onFocus={ this.handleToggleFocus }
+					onBlur={ this.handleToggleFocus }
+					keyboardType="numeric"
+					value={ `${ sliderValue }` }
+				/>
+			</View>
+		);
+	}
+}
+
+export default Slider;

--- a/packages/components/src/mobile/slider/index.native.js
+++ b/packages/components/src/mobile/slider/index.native.js
@@ -18,14 +18,17 @@ class Slider extends Component {
 		super( props );
 		this.handleToggleFocus = this.handleToggleFocus.bind( this );
 		this.handleChange = this.handleChange.bind( this );
+		this.handleReset = this.handleReset.bind( this );
 
-		this.state = { hasFocus: false, sliderValue: props.value || props.minimumValue };
+		const initialValue = this.validateInput( props.value || props.defaultValue || props.minimumValue );
+
+		this.state = { hasFocus: false, initialValue, sliderValue: initialValue };
 	}
 
 	componentDidUpdate( ) {
 		const reset = this.props.value === null;
 		if ( reset ) {
-			this.handleChange( this.props.minimumValue );
+			this.handleReset();
 		}
 	}
 
@@ -52,14 +55,19 @@ class Slider extends Component {
 
 	handleChange( text ) {
 		if ( ! isNaN( Number( text ) ) ) {
-			this.props.onChangeValue( text );
+			if ( this.props.onChangeValue ) {
+				this.props.onChangeValue( text );
+			}
 			this.setState( { sliderValue: text } );
 		}
 	}
 
+	handleReset() {
+		this.handleChange( this.props.defaultValue || this.state.initialValue );
+	}
+
 	render() {
 		const {
-			value,
 			minimumValue,
 			maximumValue,
 			disabled,
@@ -74,7 +82,7 @@ class Slider extends Component {
 		return (
 			<View style={ styles.sliderContainer }>
 				<RNSlider
-					value={ this.validateInput( value ) }
+					value={ this.validateInput( sliderValue ) }
 					disabled={ disabled }
 					style={ styles.slider }
 					step={ step }

--- a/packages/components/src/mobile/slider/styles.scss
+++ b/packages/components/src/mobile/slider/styles.scss
@@ -1,0 +1,25 @@
+.sliderContainer {
+	flex: 1;
+	flex-direction: row;
+	align-content: center;
+	justify-content: space-evenly;
+}
+
+.slider {
+	flex-grow: 1;
+}
+
+.sliderTextInput {
+	width: 40px;
+	height: 25px;
+	align-self: center;
+	margin-left: 10px;
+	border-width: 1px;
+	border-radius: 4px;
+	border-color: $dark-gray-150;
+}
+
+.isSelected {
+	border-width: 2px;
+	border-color: $blue-wordpress;
+}

--- a/packages/components/src/mobile/slider/styles.scss
+++ b/packages/components/src/mobile/slider/styles.scss
@@ -17,6 +17,8 @@
 	border-width: 1px;
 	border-radius: 4px;
 	border-color: $dark-gray-150;
+	padding-top: 0;
+	padding-bottom: 0;
 }
 
 .isSelected {


### PR DESCRIPTION
## Description
Add RangeCell component wich is mobile implementation of RangeControl web component (according to #1300 in gutenberg-mobile)

[Related gutenberg-mobile PR #1342](https://github.com/wordpress-mobile/gutenberg-mobile/pull/1342)
[Related gutenberg-mobile issue](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1364)

## How has this been tested?
- Add below range cell implementation inside `InspectorControls` in `edit.native.js` 
<details>
<summary>Usage of BottomSheet.RangeCell </summary>

```
<BottomSheet.RangeCell
icon={ 'admin-settings' }
label={ __( 'Slider' ) }
value={ sliderVal }
defaultValue={ 25 }
minimumValue={ 20 }
maximumValue={ 100 }
separatorType={ 'fullWidth' }
onChangeValue={ this.updateSlider }
/>
```
</details>

- add handler to change slider value
<details>
<summary>Handler to change slider value</summary>

```
updateSlider( newVal ) {
    this.props.setAttributes( { sliderVal: newVal } );
}
```
</details>

- reset `sliderVal` to `null` in `onClearSettings()` function

## Screenshots 
<image  src="https://user-images.githubusercontent.com/21242757/64769036-d6d39f00-d54a-11e9-8cb9-f027a165f02b.png" width="300" />

RangeCell temporally attached to Image block settings
<image  src="https://user-images.githubusercontent.com/21242757/64769277-4f3a6000-d54b-11e9-9b77-e4b521506194.gif" width="300" />

## Types of changes
Add new component (`BottomSheet.RangeCell`) under `BottomSheet` component which is replacement for `RangeControl` component on the web

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
