### PR TITLE
Add link to fixtures in Testing Overview

### DIFF
--- a/docs/contributors/testing-overview.md
+++ b/docs/contributors/testing-overview.md
@@ -368,7 +368,7 @@ If you're using a different setup, you can provide the base URL, username and pa
 WP_BASE_URL=http://localhost:8888 WP_USERNAME=admin WP_PASSWORD=password npm run test-e2e
 ```
 
-### New Core Blocks
+### Core Block Testing
 
 Every core block is required to have at least one set of fixture files to test the parsing and serialization of that block. See [the e2e tests fixtures readme](/packages/e2e-tests/fixtures/blocks/README.md) for more information and instructions.
 

--- a/docs/contributors/testing-overview.md
+++ b/docs/contributors/testing-overview.md
@@ -370,7 +370,7 @@ WP_BASE_URL=http://localhost:8888 WP_USERNAME=admin WP_PASSWORD=password npm run
 
 ### Core Block Testing
 
-Every core block is required to have at least one set of fixture files to test the parsing and serialization of that block. See [the e2e tests fixtures readme](/packages/e2e-tests/fixtures/blocks/README.md) for more information and instructions.
+Every core block is required to have at least one set of fixture files for its main save function and one for each deprecation. These fixtures test the parsing and serialization of the block. See [the e2e tests fixtures readme](/packages/e2e-tests/fixtures/blocks/README.md) for more information and instructions.
 
 ## PHP Testing
 

--- a/docs/contributors/testing-overview.md
+++ b/docs/contributors/testing-overview.md
@@ -368,6 +368,10 @@ If you're using a different setup, you can provide the base URL, username and pa
 WP_BASE_URL=http://localhost:8888 WP_USERNAME=admin WP_PASSWORD=password npm run test-e2e
 ```
 
+### New Core Blocks
+
+Every core block is required to have at least one set of fixture files to test the parsing and serialization of that block. See [the e2e tests fixtures readme](/packages/e2e-tests/fixtures/blocks/README.md) for more information and instructions.
+
 ## PHP Testing
 
 Tests for PHP use [PHPUnit](https://phpunit.de/) as the testing framework. If you're using the built-in [local environment](/docs/contributors/getting-started.md#local-environment), you can run the PHP tests locally using this command:


### PR DESCRIPTION
## Description

Adds a link to Testing Overview document to the e2e tests fixtures that
are required for each core block.


## How has this been tested?

Documentation, confirm link works as expected.

[View on branch here](https://github.com/WordPress/gutenberg/blob/docs/add-fixtures-testing-link/docs/contributors/testing-overview.md).
