### PR TITLE
Fix: Fixture generation documentation.

### DIFF
--- a/packages/e2e-tests/fixtures/blocks/README.md
+++ b/packages/e2e-tests/fixtures/blocks/README.md
@@ -38,12 +38,12 @@ When adding a new test, it's only necessary to create file (1) above, then
 there is a command you can run to generate (2) through (4):
 
 ```sh
-GENERATE_MISSING_FIXTURES=y npm run test-unit test/integration/full-content/full-content.spec.js
+GENERATE_MISSING_FIXTURES=y npm run test-unit test/integration/full-content/full-content.test.js
 ```
 
 However, when using this command, please be sure to manually verify that the
 contents of the `.json` and `.serialized.html` files are as expected.
 
 See the
-[`full-content.spec.js`](../full-content.spec.js)
+[`full-content.test.js`](../../../../test/integration/full-content/full-content.test.js)
 test file for the code that runs these tests.


### PR DESCRIPTION
## Description
This PR fixes a command a link in the fixture generation documentation.
## How has this been tested?
I deleted the following files:
```
packages/e2e-tests/fixtures/blocks/core__gallery__columns.json
packages/e2e-tests/fixtures/blocks/core__gallery__columns.parsed.json
packages/e2e-tests/fixtures/blocks/core__gallery__columns.serialized.html
```

I executed the following command:
```
GENERATE_MISSING_FIXTURES=y npm run test-unit test/integration/full-content/full-content.test.js
```
I verified the deleted files were regenerated.
I went to the following URL:
https://github.com/WordPress/gutenberg/blob/f34f58d5ff4abb58fa5fa643785aaf602d1d3e5d/packages/e2e-tests/fixtures/blocks/README.md

I pressed the `full-content.spec.js` link and I verified I did not get a 404 error.

