### PR TITLE
Enable declaration-block-no-duplicate-properties style lint rule; Fix existing case.

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -4,7 +4,6 @@
 		"at-rule-empty-line-before": null,
 		"at-rule-no-unknown": null,
 		"comment-empty-line-before": null,
-		"declaration-block-no-duplicate-properties": null,
 		"declaration-property-unit-whitelist": null,
 		"font-weight-notation": null,
 		"max-line-length": null,

--- a/packages/block-library/src/block/edit-panel/editor.scss
+++ b/packages/block-library/src/block/edit-panel/editor.scss
@@ -12,7 +12,6 @@
 	padding: $grid-size $block-padding;
 
 	// Elevate the reusable blocks toolbar above the clickthrough overlay.
-	position: relative;
 	z-index: z-index(".block-editor-block-list__layout .reusable-block-edit-panel");
 
 	// Use opacity to work in various editor styles.


### PR DESCRIPTION
This PR enables rule declaration-block-no-duplicate-properties.
And removes a case where we had a duplicate property.
I don't see a reason for disabling this rule as having a duplicate property in the same block is something we should avoid (just sents useless bytes over the wire).
