### PR TITLE
Scripts: Add WordPress folder to the list of ignores in configs

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,1 +1,0 @@
-wordpress

--- a/packages/e2e-tests/jest.config.js
+++ b/packages/e2e-tests/jest.config.js
@@ -10,6 +10,8 @@ module.exports = {
 		'expect-puppeteer',
 	],
 	testPathIgnorePatterns: [
+		'/node_modules/',
+		'/wordpress/',
 		'e2e-tests/specs/performance.test.js',
 	],
 };

--- a/packages/jest-preset-default/CHANGELOG.md
+++ b/packages/jest-preset-default/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Master
+
+### Bug Fixes
+
+- Add `wordpress` folder to the list of ignored paths ([#17296](https://github.com/WordPress/gutenberg/pull/17296)).
+
 ## 5.0.0 (2019-08-29)
 
 ### Breaking Changes

--- a/packages/jest-preset-default/jest-preset.json
+++ b/packages/jest-preset-default/jest-preset.json
@@ -19,6 +19,10 @@
 		"**/test/*.[jt]s",
 		"**/?(*.)test.[jt]s"
 	],
+	"testPathIgnorePatterns": [
+		"/node_modules/",
+		"/wordpress/"
+	],
 	"timers": "fake",
 	"transform": {
 		"^.+\\.[jt]sx?$": "<rootDir>/node_modules/babel-jest"

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Add the new `env` family of scripts [(#17004](https://github.com/WordPress/gutenberg/pull/17004/)).
 
+### Bug Fixes
+
+- Add `wordpress` folder to the list of ignored paths in all applicable config files ([#17296](https://github.com/WordPress/gutenberg/pull/17296)).
+
 ## 4.0.0 (2019-08-29)
 
 ### Breaking Changes

--- a/packages/scripts/config/.eslintignore
+++ b/packages/scripts/config/.eslintignore
@@ -1,2 +1,3 @@
 build
 node_modules
+wordpress

--- a/packages/scripts/config/.npmpackagejsonlintignore
+++ b/packages/scripts/config/.npmpackagejsonlintignore
@@ -1,3 +1,4 @@
 # By default, all `node_modules` are ignored.
 
 build
+wordpress

--- a/packages/scripts/config/.stylelintignore
+++ b/packages/scripts/config/.stylelintignore
@@ -1,3 +1,4 @@
 # By default, all `node_modules` are ignored.
 
 build
+wordpress

--- a/packages/scripts/config/jest-e2e.config.js
+++ b/packages/scripts/config/jest-e2e.config.js
@@ -14,6 +14,10 @@ const jestE2EConfig = {
 		'**/specs/**/*.[jt]s',
 		'**/?(*.)spec.[jt]s',
 	],
+	testPathIgnorePatterns: [
+		'/node_modules/',
+		'/wordpress/',
+	],
 };
 
 if ( ! hasBabelConfig() ) {

--- a/test/native/jest.config.js
+++ b/test/native/jest.config.js
@@ -34,6 +34,7 @@ module.exports = {
 	],
 	testPathIgnorePatterns: [
 		'/node_modules/',
+		'/wordpress/',
 		'/__device-tests__/',
 	],
 	testURL: 'http://localhost/',

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -21,6 +21,7 @@ module.exports = {
 		'/\.git/',
 		'/node_modules/',
 		'/packages/e2e-tests',
+		'/wordpress/',
 		'<rootDir>/.*/build/',
 		'<rootDir>/.*/build-module/',
 		'<rootDir>/.+\.native\.js$',


### PR DESCRIPTION
## Description
Follow-up for #17004 where `wp-scripts env install` adds `wordpress` folder with the local instance of WordPress.

This PR adds this new `wordpress` folder to all recommended configs in `@wordpress/scripts` to ensure that this folder is ignored and doesn't trigger any false alarms. This is quite similar to what happens in Gutenberg with the config overrides:
https://github.com/WordPress/gutenberg/blob/f198997e2c8e377423beb230ce5283914076d396/.eslintignore#L9
https://github.com/WordPress/gutenberg/blob/f198997e2c8e377423beb230ce5283914076d396/.stylelintignore#L1

## Testing

Basically all the following should work as before:

`npm run lint-css`
`npm run lint-js`
`npm run lint-pkg-json`
`npm run test-e2e`
`npm run test-unit`

I did some testing by adding files with failures to the `wordpress` folder.