### PR TITLE
Fix modal escape key propagation

### DIFF
--- a/packages/components/src/modal/frame.js
+++ b/packages/components/src/modal/frame.js
@@ -2,9 +2,8 @@
  * WordPress dependencies
  */
 import { Component, createRef } from '@wordpress/element';
-import { ESCAPE } from '@wordpress/keycodes';
 import { focus } from '@wordpress/dom';
-import { withGlobalEvents, compose } from '@wordpress/compose';
+import { compose } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -18,7 +17,6 @@ class ModalFrame extends Component {
 		super( ...arguments );
 
 		this.containerRef = createRef();
-		this.handleKeyDown = this.handleKeyDown.bind( this );
 		this.handleFocusOutside = this.handleFocusOutside.bind( this );
 		this.focusFirstTabbable = this.focusFirstTabbable.bind( this );
 	}
@@ -50,31 +48,6 @@ class ModalFrame extends Component {
 	 */
 	handleFocusOutside( event ) {
 		if ( this.props.shouldCloseOnClickOutside ) {
-			this.onRequestClose( event );
-		}
-	}
-
-	/**
-	 * Callback function called when a key is pressed.
-	 *
-	 * @param {KeyboardEvent} event Key down event.
-	 */
-	handleKeyDown( event ) {
-		if ( event.keyCode === ESCAPE ) {
-			this.handleEscapeKeyDown( event );
-		}
-	}
-
-	/**
-	 * Handles a escape key down event.
-	 *
-	 * Calls onRequestClose and prevents default key press behaviour.
-	 *
-	 * @param {Object} event Key down event.
-	 */
-	handleEscapeKeyDown( event ) {
-		if ( this.props.shouldCloseOnEsc ) {
-			event.preventDefault();
 			this.onRequestClose( event );
 		}
 	}
@@ -130,7 +103,4 @@ export default compose( [
 	withFocusReturn,
 	withConstrainedTabbing,
 	withFocusOutside,
-	withGlobalEvents( {
-		keydown: 'handleKeyDown',
-	} ),
 ] )( ModalFrame );

--- a/packages/components/src/modal/frame.js
+++ b/packages/components/src/modal/frame.js
@@ -3,13 +3,10 @@
  */
 import { Component, createRef } from '@wordpress/element';
 import { focus } from '@wordpress/dom';
-import { compose } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
-import withFocusOutside from '../higher-order/with-focus-outside';
-import withFocusReturn from '../higher-order/with-focus-return';
 import withConstrainedTabbing from '../higher-order/with-constrained-tabbing';
 
 class ModalFrame extends Component {
@@ -17,7 +14,6 @@ class ModalFrame extends Component {
 		super( ...arguments );
 
 		this.containerRef = createRef();
-		this.handleFocusOutside = this.handleFocusOutside.bind( this );
 		this.focusFirstTabbable = this.focusFirstTabbable.bind( this );
 	}
 
@@ -38,29 +34,6 @@ class ModalFrame extends Component {
 		const tabbables = focus.tabbable.find( this.containerRef.current );
 		if ( tabbables.length ) {
 			tabbables[ 0 ].focus();
-		}
-	}
-
-	/**
-	 * Callback function called when clicked outside the modal.
-	 *
-	 * @param {Object} event Mouse click event.
-	 */
-	handleFocusOutside( event ) {
-		if ( this.props.shouldCloseOnClickOutside ) {
-			this.onRequestClose( event );
-		}
-	}
-
-	/**
-	 * Calls the onRequestClose callback props when it is available.
-	 *
-	 * @param {Object} event Event object.
-	 */
-	onRequestClose( event ) {
-		const { onRequestClose } = this.props;
-		if ( onRequestClose ) {
-			onRequestClose( event );
 		}
 	}
 
@@ -99,8 +72,4 @@ class ModalFrame extends Component {
 	}
 }
 
-export default compose( [
-	withFocusReturn,
-	withConstrainedTabbing,
-	withFocusOutside,
-] )( ModalFrame );
+export default withConstrainedTabbing( ModalFrame );

--- a/packages/components/src/modal/frame.js
+++ b/packages/components/src/modal/frame.js
@@ -7,28 +7,27 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 
-import { compose } from '@wordpress/compose';
 import { Component, createRef } from '@wordpress/element';
-import { focus } from '@wordpress/dom';
 import { ESCAPE } from '@wordpress/keycodes';
+import { focus } from '@wordpress/dom';
+import { compose } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
-
 import IsolatedEventContainer from '../isolated-event-container';
-import withConstrainedTabbing from '../higher-order/with-constrained-tabbing';
-import withFocusReturn from '../higher-order/with-focus-return';
 import withFocusOutside from '../higher-order/with-focus-outside';
+import withFocusReturn from '../higher-order/with-focus-return';
+import withConstrainedTabbing from '../higher-order/with-constrained-tabbing';
 
 class ModalFrame extends Component {
 	constructor() {
 		super( ...arguments );
 
 		this.containerRef = createRef();
-		this.focusFirstTabbable = this.focusFirstTabbable.bind( this );
-		this.maybeClose = this.maybeClose.bind( this );
+		this.handleKeyDown = this.handleKeyDown.bind( this );
 		this.handleFocusOutside = this.handleFocusOutside.bind( this );
+		this.focusFirstTabbable = this.focusFirstTabbable.bind( this );
 	}
 
 	/**
@@ -57,23 +56,44 @@ class ModalFrame extends Component {
 	 * @param {Object} event Mouse click event.
 	 */
 	handleFocusOutside( event ) {
-		const { onRequestClose, shouldCloseOnClickOutside } = this.props;
-
-		if ( shouldCloseOnClickOutside && onRequestClose ) {
-			onRequestClose( event );
+		if ( this.props.shouldCloseOnClickOutside ) {
+			this.onRequestClose( event );
 		}
 	}
 
 	/**
-	 * Stops proagation of the escape key outside the context of the modal.
+	 * Callback function called when a key is pressed.
 	 *
-	 * @param {Event} event The onKeyDown event.
+	 * @param {KeyboardEvent} event Key down event.
 	 */
-	maybeClose( event ) {
-		const { onRequestClose, shouldCloseOnEsc } = this.props;
+	handleKeyDown( event ) {
+		if ( event.keyCode === ESCAPE ) {
+			this.handleEscapeKeyDown( event );
+		}
+	}
 
-		if ( event.keyCode === ESCAPE && shouldCloseOnEsc && onRequestClose ) {
+	/**
+	 * Handles a escape key down event.
+	 *
+	 * Calls onRequestClose and prevents propagation of the event outside the modal.
+	 *
+	 * @param {Object} event Key down event.
+	 */
+	handleEscapeKeyDown( event ) {
+		if ( this.props.shouldCloseOnEsc ) {
 			event.stopPropagation();
+			this.onRequestClose( event );
+		}
+	}
+
+	/**
+	 * Calls the onRequestClose callback props when it is available.
+	 *
+	 * @param {Object} event Event object.
+	 */
+	onRequestClose( event ) {
+		const { onRequestClose } = this.props;
+		if ( onRequestClose ) {
 			onRequestClose( event );
 		}
 	}
@@ -100,7 +120,7 @@ class ModalFrame extends Component {
 		return (
 			<IsolatedEventContainer
 				className={ classnames( 'components-modal__screen-overlay', overlayClassName ) }
-				onKeyDown={ this.maybeClose }
+				onKeyDown={ this.handleKeyDown }
 			>
 				<div
 					className={ classnames(

--- a/packages/components/src/modal/frame.js
+++ b/packages/components/src/modal/frame.js
@@ -1,13 +1,25 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
+
+import { compose } from '@wordpress/compose';
 import { Component, createRef } from '@wordpress/element';
 import { focus } from '@wordpress/dom';
+import { ESCAPE } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
  */
+
+import IsolatedEventContainer from '../isolated-event-container';
 import withConstrainedTabbing from '../higher-order/with-constrained-tabbing';
+import withFocusReturn from '../higher-order/with-focus-return';
+import withFocusOutside from '../higher-order/with-focus-outside';
 
 class ModalFrame extends Component {
 	constructor() {
@@ -15,6 +27,8 @@ class ModalFrame extends Component {
 
 		this.containerRef = createRef();
 		this.focusFirstTabbable = this.focusFirstTabbable.bind( this );
+		this.maybeClose = this.maybeClose.bind( this );
+		this.handleFocusOutside = this.handleFocusOutside.bind( this );
 	}
 
 	/**
@@ -38,12 +52,40 @@ class ModalFrame extends Component {
 	}
 
 	/**
+	 * Callback function called when clicked outside the modal.
+	 *
+	 * @param {Object} event Mouse click event.
+	 */
+	handleFocusOutside( event ) {
+		const { onRequestClose, shouldCloseOnClickOutside } = this.props;
+
+		if ( shouldCloseOnClickOutside && onRequestClose ) {
+			onRequestClose( event );
+		}
+	}
+
+	/**
+	 * Stops proagation of the escape key outside the context of the modal.
+	 *
+	 * @param {Event} event The onKeyDown event.
+	 */
+	maybeClose( event ) {
+		const { onRequestClose, shouldCloseOnEsc } = this.props;
+
+		if ( event.keyCode === ESCAPE && shouldCloseOnEsc && onRequestClose ) {
+			event.stopPropagation();
+			onRequestClose( event );
+		}
+	}
+
+	/**
 	 * Renders the modal frame element.
 	 *
 	 * @return {WPElement} The modal frame element.
 	 */
 	render() {
 		const {
+			overlayClassName,
 			contentLabel,
 			aria: {
 				describedby,
@@ -56,20 +98,32 @@ class ModalFrame extends Component {
 		} = this.props;
 
 		return (
-			<div
-				className={ className }
-				style={ style }
-				ref={ this.containerRef }
-				role={ role }
-				aria-label={ contentLabel }
-				aria-labelledby={ contentLabel ? null : labelledby }
-				aria-describedby={ describedby }
-				tabIndex="-1"
+			<IsolatedEventContainer
+				className={ classnames( 'components-modal__screen-overlay', overlayClassName ) }
+				onKeyDown={ this.maybeClose }
 			>
-				{ children }
-			</div>
+				<div
+					className={ classnames(
+						'components-modal__frame',
+						className
+					) }
+					style={ style }
+					ref={ this.containerRef }
+					role={ role }
+					aria-label={ contentLabel }
+					aria-labelledby={ contentLabel ? null : labelledby }
+					aria-describedby={ describedby }
+					tabIndex="-1"
+				>
+					{ children }
+				</div>
+			</IsolatedEventContainer>
 		);
 	}
 }
 
-export default withConstrainedTabbing( ModalFrame );
+export default compose( [
+	withFocusReturn,
+	withConstrainedTabbing,
+	withFocusOutside,
+] )( ModalFrame );

--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -1,14 +1,8 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { Component, createPortal } from '@wordpress/element';
-import { compose, withInstanceId } from '@wordpress/compose';
-import { ESCAPE } from '@wordpress/keycodes';
+import { withInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -16,9 +10,6 @@ import { ESCAPE } from '@wordpress/keycodes';
 import ModalFrame from './frame';
 import ModalHeader from './header';
 import * as ariaHelper from './aria-helper';
-import withFocusReturn from '../higher-order/with-focus-return';
-import withFocusOutside from '../higher-order/with-focus-outside';
-import IsolatedEventContainer from '../isolated-event-container';
 
 // Used to count the number of open modals.
 let parentElement,
@@ -27,10 +18,7 @@ let parentElement,
 class Modal extends Component {
 	constructor( props ) {
 		super( props );
-
 		this.prepareDOM();
-		this.maybeClose = this.maybeClose.bind( this );
-		this.handleFocusOutside = this.handleFocusOutside.bind( this );
 	}
 
 	/**
@@ -107,51 +95,12 @@ class Modal extends Component {
 	}
 
 	/**
-	 * Callback function called when clicked outside the modal.
-	 *
-	 * @param {Object} event Mouse click event.
-	 */
-	handleFocusOutside( event ) {
-		if ( this.props.shouldCloseOnClickOutside ) {
-			this.onRequestClose( event );
-		}
-	}
-
-	/**
-	 * Calls the onRequestClose callback props when it is available.
-	 *
-	 * @param {Object} event Event object.
-	 */
-	onRequestClose( event ) {
-		const { onRequestClose } = this.props;
-		if ( onRequestClose ) {
-			onRequestClose( event );
-		}
-	}
-
-	/**
-	 * Stops proagation of the escape key outside the context of the modal.
-	 *
-	 * @param {Event} event The onKeyDown event.
-	 */
-	maybeClose( event ) {
-		const { onRequestClose, shouldCloseOnEsc } = this.props;
-
-		if ( event.keyCode === ESCAPE && shouldCloseOnEsc && onRequestClose ) {
-			event.stopPropagation();
-			onRequestClose( event );
-		}
-	}
-
-	/**
 	 * Renders the modal.
 	 *
 	 * @return {WPElement} The modal element.
 	 */
 	render() {
 		const {
-			overlayClassName,
-			className,
 			onRequestClose,
 			title,
 			icon,
@@ -168,35 +117,26 @@ class Modal extends Component {
 		// Disable reason: this stops mouse events from triggering tooltips and
 		// other elements underneath the modal overlay.
 		return createPortal(
-			<IsolatedEventContainer
-				className={ classnames( 'components-modal__screen-overlay', overlayClassName ) }
-				onKeyDown={ this.maybeClose }
+			<ModalFrame
+				onRequestClose={ onRequestClose }
+				aria={ {
+					labelledby: title ? headingId : null,
+					describedby: aria.describedby,
+				} }
+				{ ...otherProps }
 			>
-				<ModalFrame
-					className={ classnames(
-						'components-modal__frame',
-						className
-					) }
-					onRequestClose={ onRequestClose }
-					aria={ {
-						labelledby: title ? headingId : null,
-						describedby: aria.describedby,
-					} }
-					{ ...otherProps }
-				>
-					<div className={ 'components-modal__content' } tabIndex="0">
-						<ModalHeader
-							closeLabel={ closeButtonLabel }
-							headingId={ headingId }
-							icon={ icon }
-							isDismissable={ isDismissable }
-							onClose={ onRequestClose }
-							title={ title }
-						/>
-						{ children }
-					</div>
-				</ModalFrame>
-			</IsolatedEventContainer>,
+				<div className={ 'components-modal__content' } tabIndex="0">
+					<ModalHeader
+						closeLabel={ closeButtonLabel }
+						headingId={ headingId }
+						icon={ icon }
+						isDismissable={ isDismissable }
+						onClose={ onRequestClose }
+						title={ title }
+					/>
+					{ children }
+				</div>
+			</ModalFrame>,
 			this.node
 		);
 	}
@@ -217,8 +157,4 @@ Modal.defaultProps = {
 	},
 };
 
-export default compose( [
-	withFocusReturn,
-	withInstanceId,
-	withFocusOutside,
-] )( Modal );
+export default withInstanceId( Modal );

--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -109,6 +109,8 @@ class Modal extends Component {
 			aria,
 			instanceId,
 			isDismissable,
+			// Many of the documented props for Modal are passed straight through
+			// to the ModalFrame component and handled there.
 			...otherProps
 		} = this.props;
 

--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -8,6 +8,7 @@ import classnames from 'classnames';
  */
 import { Component, createPortal } from '@wordpress/element';
 import { withInstanceId } from '@wordpress/compose';
+import { ESCAPE } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -26,6 +27,7 @@ class Modal extends Component {
 		super( props );
 
 		this.prepareDOM();
+		this.maybeClose = this.maybeClose.bind( this );
 	}
 
 	/**
@@ -102,6 +104,20 @@ class Modal extends Component {
 	}
 
 	/**
+	 * Stops proagation of the escape key outside the context of the modal.
+	 *
+	 * @param {Event} event The onKeyDown event.
+	 */
+	maybeClose( event ) {
+		const { onRequestClose, shouldCloseOnEsc } = this.props;
+
+		if ( event.keyCode === ESCAPE && shouldCloseOnEsc && onRequestClose ) {
+			event.stopPropagation();
+			onRequestClose( event );
+		}
+	}
+
+	/**
 	 * Renders the modal.
 	 *
 	 * @return {WPElement} The modal element.
@@ -128,6 +144,7 @@ class Modal extends Component {
 		return createPortal(
 			<IsolatedEventContainer
 				className={ classnames( 'components-modal__screen-overlay', overlayClassName ) }
+				onKeyDown={ this.maybeClose }
 			>
 				<ModalFrame
 					className={ classnames(

--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Component, createPortal } from '@wordpress/element';
-import { withInstanceId } from '@wordpress/compose';
+import { compose, withInstanceId } from '@wordpress/compose';
 import { ESCAPE } from '@wordpress/keycodes';
 
 /**
@@ -16,6 +16,8 @@ import { ESCAPE } from '@wordpress/keycodes';
 import ModalFrame from './frame';
 import ModalHeader from './header';
 import * as ariaHelper from './aria-helper';
+import withFocusReturn from '../higher-order/with-focus-return';
+import withFocusOutside from '../higher-order/with-focus-outside';
 import IsolatedEventContainer from '../isolated-event-container';
 
 // Used to count the number of open modals.
@@ -28,6 +30,7 @@ class Modal extends Component {
 
 		this.prepareDOM();
 		this.maybeClose = this.maybeClose.bind( this );
+		this.handleFocusOutside = this.handleFocusOutside.bind( this );
 	}
 
 	/**
@@ -101,6 +104,29 @@ class Modal extends Component {
 	closeLastModal() {
 		document.body.classList.remove( this.props.bodyOpenClassName );
 		ariaHelper.showApp();
+	}
+
+	/**
+	 * Callback function called when clicked outside the modal.
+	 *
+	 * @param {Object} event Mouse click event.
+	 */
+	handleFocusOutside( event ) {
+		if ( this.props.shouldCloseOnClickOutside ) {
+			this.onRequestClose( event );
+		}
+	}
+
+	/**
+	 * Calls the onRequestClose callback props when it is available.
+	 *
+	 * @param {Object} event Event object.
+	 */
+	onRequestClose( event ) {
+		const { onRequestClose } = this.props;
+		if ( onRequestClose ) {
+			onRequestClose( event );
+		}
 	}
 
 	/**
@@ -191,4 +217,8 @@ Modal.defaultProps = {
 	},
 };
 
-export default withInstanceId( Modal );
+export default compose( [
+	withFocusReturn,
+	withInstanceId,
+	withFocusOutside,
+] )( Modal );


### PR DESCRIPTION
## Description
`Modal` components handle an `escape` key down as a global event. Unfortunately this means that the modal cannot stop propagation of an event to the outer context. It can only cancel bubbling to an inner context.

With our current implementation of modals, this hasn't really been an issue. On https://github.com/WordPress/gutenberg/pull/17265 I'm implementing a modal that's launched from a block toolbar, and pressing `esc` to close the modal is triggering navigation mode.

This change in this PR is to stop using a global event and instead use an event on the `IsolatedEventContainer` component. This matches how the `Popover` component is implemented:
https://github.com/WordPress/gutenberg/blob/f198997e2c8e377423beb230ce5283914076d396/packages/components/src/popover/index.js#L390-L399

https://github.com/WordPress/gutenberg/blob/f198997e2c8e377423beb230ce5283914076d396/packages/components/src/popover/index.js#L299-L311

This PR also moves the `IsolatedEventContainer` component into `ModalFrame`. This component is responsible for rendering the overlay behind the modal. Nesting it inside `withFocusReturn` ensures that when the overlay is clicked, focus is returned to the element that opened the modal.

## How has this been tested?
Test that modals:
- Close when pressing escape. Focus should be returned to the element that opened the modal (or as close to the element as possible).
- Close clicking the close button. Focus should be returned to the element that opened the modal (or as close to the element as possible).
- Close when clicking outside. Focus should be returned to the element that opened the modal (or as close to the element as possible).

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
