### PR TITLE
Add phpcs rule to detect unused variables; Fix existing issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
 		"squizlabs/php_codesniffer": "^3.4.2",
 		"phpcompatibility/php-compatibility": "^9.2.0",
-		"wp-coding-standards/wpcs": "^2.1.1"
+		"wp-coding-standards/wpcs": "^2.1.1",
+		"sirbrillig/phpcs-variable-analysis": "^2.7"
 	},
 	"require": {
 		"composer/installers": "~1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "14e6f0898af5e07bd8ff8b2bc6172712",
+    "content-hash": "f802871495ce4d7ed5928e17524d0cdb",
     "packages": [
         {
             "name": "composer/installers",
@@ -251,6 +251,54 @@
                 "standards"
             ],
             "time": "2019-06-27T19:58:56+00:00"
+        },
+        {
+            "name": "sirbrillig/phpcs-variable-analysis",
+            "version": "v2.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
+                "reference": "1b1b2b503a19bb56fa75f4a2d959b12c8ed28c12"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/1b1b2b503a19bb56fa75f4a2d959b12c8ed28c12",
+                "reference": "1b1b2b503a19bb56fa75f4a2d959b12c8ed28c12",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "limedeck/phpunit-detailed-printer": "^3.1",
+                "phpstan/phpstan": "^0.11.8",
+                "phpunit/phpunit": "^6.5",
+                "sirbrillig/phpcs-import-detection": "^1.1",
+                "squizlabs/php_codesniffer": "^3.1"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "VariableAnalysis\\": "VariableAnalysis/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Payton Swick",
+                    "email": "payton@foolord.com"
+                },
+                {
+                    "name": "Sam Graham",
+                    "email": "php-codesniffer-variableanalysis@illusori.co.uk"
+                }
+            ],
+            "description": "A PHPCS sniff to detect problems with variables.",
+            "time": "2019-06-24T23:57:11+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -110,6 +110,7 @@ function gutenberg_build_files_notice() {
  * @since 1.5.0
  */
 function gutenberg_pre_init() {
+	global $wp_version;
 	if ( defined( 'GUTENBERG_DEVELOPMENT_MODE' ) && GUTENBERG_DEVELOPMENT_MODE && ! file_exists( dirname( __FILE__ ) . '/build/blocks' ) ) {
 		add_action( 'admin_notices', 'gutenberg_build_files_notice' );
 		return;

--- a/lib/class-wp-rest-block-directory-controller.php
+++ b/lib/class-wp-rest-block-directory-controller.php
@@ -71,10 +71,9 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|bool True if the request has permission, WP_Error object otherwise.
 	 */
-	public function permissions_check( $request ) {
+	public function permissions_check() {
 		if ( ! current_user_can( 'install_plugins' ) || ! current_user_can( 'activate_plugins' ) ) {
 			return new WP_Error(
 				'rest_user_cannot_view',
@@ -221,8 +220,8 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 
 		include( ABSPATH . WPINC . '/version.php' );
 
-		$url      = 'http://api.wordpress.org/plugins/info/1.2/';
-		$url      = add_query_arg(
+		$url = 'http://api.wordpress.org/plugins/info/1.2/';
+		$url = add_query_arg(
 			array(
 				'action'              => 'query_plugins',
 				'request[block]'      => $search_string,
@@ -231,11 +230,12 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 			),
 			$url
 		);
-		$http_url = $url;
-		$ssl      = wp_http_supports( array( 'ssl' ) );
+		$ssl = wp_http_supports( array( 'ssl' ) );
 		if ( $ssl ) {
 			$url = set_url_scheme( $url, 'https' );
 		}
+
+		global $wp_version;
 		$http_args = array(
 			'timeout'    => 15,
 			'user-agent' => 'WordPress/' . $wp_version . '; ' . home_url( '/' ),

--- a/lib/class-wp-rest-widget-areas-controller.php
+++ b/lib/class-wp-rest-widget-areas-controller.php
@@ -52,12 +52,6 @@ class WP_REST_Widget_Areas_Controller extends WP_REST_Controller {
 			'validate_callback' => 'Experimental_WP_Widget_Blocks_Manager::is_valid_sidabar_id',
 		);
 
-		$content_argument = array(
-			'description' => __( 'Sidebar content.', 'gutenberg' ),
-			'type'        => 'string',
-			'required'    => true,
-		);
-
 		register_rest_route(
 			$this->namespace,
 			'/' . $this->rest_base . '/(?P<id>.+)',
@@ -141,6 +135,9 @@ class WP_REST_Widget_Areas_Controller extends WP_REST_Controller {
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|bool True if the request has read access, WP_Error object otherwise.
+	 *
+	 * This function is overloading a function defined in WP_REST_Controller so it should have the same parameters.
+	 * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 	 */
 	public function get_items_permissions_check( $request ) {
 		if ( ! current_user_can( 'edit_theme_options' ) ) {
@@ -152,6 +149,7 @@ class WP_REST_Widget_Areas_Controller extends WP_REST_Controller {
 
 		return true;
 	}
+	/* phpcs:enable */
 
 	/**
 	 * Retrieves all widget areas.
@@ -192,6 +190,9 @@ class WP_REST_Widget_Areas_Controller extends WP_REST_Controller {
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|bool True if the request has access to update the item, error object otherwise.
+	 *
+	 * This function is overloading a function defined in WP_REST_Controller so it should have the same parameters.
+	 * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 	 */
 	public function update_item_permissions_check( $request ) {
 		if ( ! current_user_can( 'edit_theme_options' ) ) {
@@ -203,6 +204,7 @@ class WP_REST_Widget_Areas_Controller extends WP_REST_Controller {
 
 		return true;
 	}
+	/* phpcs:enable */
 
 	/**
 	 * Updates a single widget area.

--- a/lib/class-wp-rest-widget-updater-controller.php
+++ b/lib/class-wp-rest-widget-updater-controller.php
@@ -85,8 +85,6 @@ class WP_REST_Widget_Updater_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function compute_new_widget( $request ) {
-		$url_params = $request->get_url_params();
-
 		$widget = $request->get_param( 'identifier' );
 
 		global $wp_widget_factory;

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -240,7 +240,6 @@ function gutenberg_register_scripts_and_styles() {
 	//
 	// See: https://core.trac.wordpress.org/ticket/46107 .
 	// See: https://github.com/WordPress/gutenberg/pull/13451 .
-	global $wp_scripts;
 	if ( isset( $wp_scripts->registered['wp-api-fetch'] ) ) {
 		$wp_scripts->registered['wp-api-fetch']->deps[] = 'wp-hooks';
 	}

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -9,10 +9,8 @@
  * The main entry point for the Gutenberg experiments page.
  *
  * @since 6.3.0
- *
- * @param string $page The page name the function is being called for, `'gutenberg_customizer'` for the Customizer.
  */
-function the_gutenberg_experiments( $page = 'gutenberg_page_gutenberg-experiments' ) {
+function the_gutenberg_experiments() {
 	?>
 	<div
 		id="experiments-editor"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -10,6 +10,11 @@
 	<rule ref="WordPress.WP.I18n"/>
 	<config name="text_domain" value="gutenberg,default"/>
 
+	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis">
+		<properties>
+			<property name="allowUnusedParametersBeforeUsed" value="true"/>
+		</properties>
+	</rule>
 	<rule ref="WordPress.CodeAnalysis.EmptyStatement"/>
 
 	<rule ref="PEAR.Functions.FunctionCallSignature">


### PR DESCRIPTION
## Description
This PR adds a PHP rule to detect unused PHP variables. And fixes the problems detected by this rule.

The fact we have many existing problems is a small proof that this rule is useful.

## How has this been tested?
I executed `composer lint`.
I verified no lint error were detected.

