### PR TITLE
Fix core/column not having templateLock inherited from posttype template

### DIFF
--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -90,10 +90,14 @@ export default compose(
 
 		const parentColumnsId = getBlockRootClientId( clientId );
 		const parentOfColumnsId = getBlockRootClientId( parentColumnsId );
+		const columnsParentLock = parentOfColumnsId
+			? getTemplateLock( parentOfColumnsId )
+			: getTemplateLock();
 
 		return {
 			hasChildBlocks: getBlockOrder( clientId ).length > 0,
-			columnsParentLock: getTemplateLock( parentOfColumnsId ),
+			columnsParentLock:
+				columnsParentLock !== undefined ? columnsParentLock : false,
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps, registry ) => {

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -23,6 +23,7 @@ function ColumnEdit( {
 	setAttributes,
 	updateAlignment,
 	hasChildBlocks,
+	parentLock,
 } ) {
 	const { verticalAlignment, width } = attributes;
 
@@ -60,7 +61,7 @@ function ColumnEdit( {
 				</PanelBody>
 			</InspectorControls>
 			<InnerBlocks
-				templateLock={ false }
+				templateLock={ parentLock }
 				renderAppender={
 					hasChildBlocks
 						? undefined
@@ -79,10 +80,18 @@ function ColumnEdit( {
 export default compose(
 	withSelect( ( select, ownProps ) => {
 		const { clientId } = ownProps;
-		const { getBlockOrder } = select( 'core/block-editor' );
+		const { getBlockOrder, getBlockRootClientId, getTemplateLock } = select(
+			'core/block-editor'
+		);
+
+		// Retrieve the parent of the Columns Block.
+		const rootParentClientId = getBlockRootClientId(
+			getBlockRootClientId( clientId )
+		);
 
 		return {
 			hasChildBlocks: getBlockOrder( clientId ).length > 0,
+			parentLock: getTemplateLock( rootParentClientId ),
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps, registry ) => {

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -23,7 +23,7 @@ function ColumnEdit( {
 	setAttributes,
 	updateAlignment,
 	hasChildBlocks,
-	parentLock,
+	columnsParentLock,
 } ) {
 	const { verticalAlignment, width } = attributes;
 
@@ -61,7 +61,11 @@ function ColumnEdit( {
 				</PanelBody>
 			</InspectorControls>
 			<InnerBlocks
-				templateLock={ parentLock }
+				// It is safe to set an "inherited" locking explicitly because no
+				// template is set on the column. If a template was set and parent lock
+				// was equal to "all" the local template set would be forced and other
+				// templates passed e.g via CPT would be ignored.
+				templateLock={ columnsParentLock }
 				renderAppender={
 					hasChildBlocks
 						? undefined
@@ -84,14 +88,12 @@ export default compose(
 			'core/block-editor'
 		);
 
-		// Retrieve the parent of the Columns Block.
-		const rootParentClientId = getBlockRootClientId(
-			getBlockRootClientId( clientId )
-		);
+		const parentColumnsId = getBlockRootClientId( clientId );
+		const parentOfColumnsId = getBlockRootClientId( parentColumnsId );
 
 		return {
 			hasChildBlocks: getBlockOrder( clientId ).length > 0,
-			parentLock: getTemplateLock( rootParentClientId ),
+			columnsParentLock: getTemplateLock( parentOfColumnsId ),
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps, registry ) => {


### PR DESCRIPTION
## Description

See https://github.com/WordPress/gutenberg/issues/17262 although this only fixes the inconsistency, not the issues expected behavior which I personally disagree with.

Basically `core/column` sets the `templateLock` to `false` to override the parent `core/columns` blocks `all`. This however doesn't take into account the post type templateLock.

This PR inherits the templateLock from the parent of the parent `core/columns` block.

## How has this been tested?

Added a locked post type template with a column block and verified it's not possible to add child blocks. On an unlocked post type template, it is still possible to add.

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
