### PR TITLE
Align Gallery block movers with the standard block mover style

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -36,7 +36,7 @@ import { withSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import GalleryImage from './gallery-image';
-import icon from './icon';
+import icon from './icons';
 import { defaultColumnsNumber, pickRelevantMediaFiles } from './shared';
 
 const MAX_COLUMNS = 8;

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -59,6 +59,12 @@ ul.wp-block-gallery {
 		background: $white;
 		border: 1px solid $dark-opacity-light-800;
 		border-radius: $radius-round-rectangle;
+		transition: box-shadow 0.2s ease-out;
+		@include reduce-motion("transition");
+
+		&:hover {
+			box-shadow: $shadow-toolbar;
+		}
 
 		.components-button {
 			color: $dark-opacity-300;

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -63,7 +63,6 @@ ul.wp-block-gallery {
 		.components-button {
 			color: $dark-opacity-300;
 			padding: 2px;
-			width: $icon-button-size-small;
 			height: $icon-button-size-small;
 
 			// Remove hover box shadows, since they clash with the container.

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -56,17 +56,18 @@ ul.wp-block-gallery {
 
 	.is-selected .block-library-gallery-item__move-menu,
 	.is-selected .block-library-gallery-item__inline-menu {
-		background-color: theme(primary);
+		background: $white;
+		border: 1px solid $dark-opacity-light-800;
+		border-radius: $radius-round-rectangle;
 
 		.components-button {
-			color: $white;
+			color: $dark-opacity-300;
 			padding: 2px;
 			width: $icon-button-size-small;
 			height: $icon-button-size-small;
 
-			// Remove hover/focus box shadows, since they clash with the blue background.
-			&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover,
-			&:focus:not(:disabled) {
+			// Remove hover box shadows, since they clash with the container.
+			&:not(:disabled):not([aria-disabled="true"]):not(.is-default):hover {
 				box-shadow: none;
 			}
 
@@ -98,7 +99,7 @@ ul.wp-block-gallery {
 
 .block-library-gallery-item__move-menu,
 .block-library-gallery-item__inline-menu {
-	padding: $grid-size-small;
+	margin: $grid-size;
 	display: inline-flex;
 	z-index: z-index(".block-library-gallery-item__inline-menu");
 

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -14,6 +14,11 @@ import { withSelect } from '@wordpress/data';
 import { RichText } from '@wordpress/block-editor';
 import { isBlobURL } from '@wordpress/blob';
 
+/**
+ * Internal dependencies
+ */
+import { leftArrow, rightArrow } from './icons';
+
 class GalleryImage extends Component {
 	constructor() {
 		super( ...arguments );
@@ -130,7 +135,7 @@ class GalleryImage extends Component {
 				{ href ? <a href={ href }>{ img }</a> : img }
 				<div className="block-library-gallery-item__move-menu">
 					<IconButton
-						icon="arrow-left"
+						icon={ leftArrow }
 						onClick={ isFirstItem ? undefined : onMoveBackward }
 						className="blocks-gallery-item__move-backward"
 						label={ __( 'Move Image Backward' ) }
@@ -138,7 +143,7 @@ class GalleryImage extends Component {
 						disabled={ ! isSelected }
 					/>
 					<IconButton
-						icon="arrow-right"
+						icon={ rightArrow }
 						onClick={ isLastItem ? undefined : onMoveForward }
 						className="blocks-gallery-item__move-forward"
 						label={ __( 'Move Image Forward' ) }

--- a/packages/block-library/src/gallery/icon.js
+++ b/packages/block-library/src/gallery/icon.js
@@ -1,6 +1,0 @@
-/**
- * WordPress dependencies
- */
-import { G, Path, SVG } from '@wordpress/components';
-
-export default <SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><Path fill="none" d="M0 0h24v24H0V0z" /><G><Path d="M20 4v12H8V4h12m0-2H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-8.5 9.67l1.69 2.26 2.48-3.1L19 15H9zM2 6v14c0 1.1.9 2 2 2h14v-2H4V6H2z" /></G></SVG>;

--- a/packages/block-library/src/gallery/icons.js
+++ b/packages/block-library/src/gallery/icons.js
@@ -12,7 +12,7 @@ export const icon = (
 
 export const leftArrow = (
 	<SVG width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
-		<Path d="M5.5 8.70002L11.1 14.4L12.5 12.9L8.3 8.70002L12.5 4.50002L11.1 3.00002L5.5 8.70002Z" />
+		<Path d="M5 8.70002L10.6 14.4L12 12.9L7.8 8.70002L12 4.50002L10.6 3.00002L5 8.70002Z" />
 	</SVG>
 );
 

--- a/packages/block-library/src/gallery/icons.js
+++ b/packages/block-library/src/gallery/icons.js
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies
+ */
+import { G, Path, SVG } from '@wordpress/components';
+
+export const icon = (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+		<Path fill="none" d="M0 0h24v24H0V0z" />
+		<G><Path d="M20 4v12H8V4h12m0-2H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-8.5 9.67l1.69 2.26 2.48-3.1L19 15H9zM2 6v14c0 1.1.9 2 2 2h14v-2H4V6H2z" /></G>
+	</SVG>
+);
+
+export const leftArrow = (
+	<SVG width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+		<Path d="M5.5 8.70002L11.1 14.4L12.5 12.9L8.3 8.70002L12.5 4.50002L11.1 3.00002L5.5 8.70002Z" />
+	</SVG>
+);
+
+export const rightArrow = (
+	<SVG width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+		<Path d="M13 8.7L7.4 3L6 4.5L10.2 8.7L6 12.9L7.4 14.4L13 8.7Z" />
+	</SVG>
+);

--- a/packages/block-library/src/gallery/index.js
+++ b/packages/block-library/src/gallery/index.js
@@ -8,7 +8,7 @@ import { __ } from '@wordpress/i18n';
  */
 import deprecated from './deprecated';
 import edit from './edit';
-import icon from './icon';
+import { icon } from './icons';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';


### PR DESCRIPTION
Followup from #17216.

This PR updates the Gallery block's individual item controls to align with the style used for block movers. As part of that, it switches from using Dashicons for the icons to Material SVGs to match.

**Before**

![Screen Shot 2019-09-03 at 1 33 54 PM](https://user-images.githubusercontent.com/1202812/64195534-b7a08780-ce4f-11e9-9148-c0facc523221.png)

**After**

![Screen Shot 2019-09-03 at 1 33 22 PM](https://user-images.githubusercontent.com/1202812/64195537-ba9b7800-ce4f-11e9-8034-6ba076f04c20.png)
