### PR TITLE
Compat: Remove filter that unsets auto-draft titles.

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -31,36 +31,6 @@ function gutenberg_safe_style_css_column_flex_basis( $attr ) {
 add_filter( 'safe_style_css', 'gutenberg_safe_style_css_column_flex_basis' );
 
 /**
- * Filters inserted post data to unset any auto-draft assigned post title. The status
- * of an auto-draft should be read from its `post_status` and not inferred via its
- * title. A post with an explicit title should be created with draft status, not
- * with auto-draft status. It will also update an existing post's status to draft if
- * currently an auto-draft. This is intended to ensure that a post which is
- * explicitly updated should no longer be subject to auto-draft purge.
- *
- * @see https://core.trac.wordpress.org/ticket/43316#comment:88
- * @see https://core.trac.wordpress.org/ticket/43316#comment:89
- *
- * @param array $data    An array of slashed post data.
- * @param array $postarr An array of sanitized, but otherwise unmodified post
- *                        data.
- *
- * @return array Filtered post data.
- */
-function gutenberg_filter_wp_insert_post_data( $data, $postarr ) {
-	if ( 'auto-draft' === $postarr['post_status'] ) {
-		if ( ! empty( $postarr['ID'] ) ) {
-			$data['post_status'] = 'draft';
-		} else {
-			$data['post_title'] = '';
-		}
-	}
-	return $data;
-}
-add_filter( 'wp_insert_post_data', 'gutenberg_filter_wp_insert_post_data', 10, 2 );
-
-
-/**
  * Shim that hooks into `pre_render_block` so as to override `render_block`
  * with a function that passes `render_callback` the block object as the
  * argument.

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -71,9 +71,11 @@ export function addEntities( entities ) {
 export function receiveEntityRecords( kind, name, records, query, invalidateCache = false ) {
 	// Auto drafts should not have titles, but some plugins rely on them so we can't filter this
 	// on the server.
-	records = castArray( records ).map( ( record ) =>
-		record.status === 'auto-draft' ? { ...record, title: '' } : record
-	);
+	if ( kind === 'postType' ) {
+		records = castArray( records ).map( ( record ) =>
+			record.status === 'auto-draft' ? { ...record, title: '' } : record
+		);
+	}
 	let action;
 	if ( query ) {
 		action = receiveQueriedItems( records, query );
@@ -312,7 +314,11 @@ export function* saveEntityRecord(
 			// Auto drafts should be converted to drafts on explicit saves,
 			// but some plugins break with this behavior so we can't filter it on the server.
 			let data = record;
-			if ( persistedRecord.status === 'auto-draft' && ! data.status ) {
+			if (
+				kind === 'postType' &&
+				persistedRecord.status === 'auto-draft' &&
+				! data.status
+			) {
 				data = { ...data, status: 'draft' };
 			}
 			updatedRecord = yield apiFetch( {

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -69,6 +69,11 @@ export function addEntities( entities ) {
  * @return {Object} Action object.
  */
 export function receiveEntityRecords( kind, name, records, query, invalidateCache = false ) {
+	// Auto drafts should not have titles, but some plugins rely on them so we can't filter this
+	// on the server.
+	records = castArray( records ).map( ( record ) =>
+		record.status === 'auto-draft' ? { ...record, title: '' } : record
+	);
 	let action;
 	if ( query ) {
 		action = receiveQueriedItems( records, query );
@@ -235,18 +240,18 @@ export function* saveEntityRecord(
 	let error;
 	try {
 		const path = `${ entity.baseURL }${ recordId ? '/' + recordId : '' }`;
+		const persistedRecord = yield select(
+			'getRawEntityRecord',
+			kind,
+			name,
+			recordId
+		);
 
 		if ( isAutosave ) {
 			// Most of this autosave logic is very specific to posts.
 			// This is fine for now as it is the only supported autosave,
 			// but ideally this should all be handled in the back end,
 			// so the client just sends and receives objects.
-			const persistedRecord = yield select(
-				'getRawEntityRecord',
-				kind,
-				name,
-				recordId
-			);
 			const currentUser = yield select( 'getCurrentUser' );
 			const currentUserId = currentUser ? currentUser.id : undefined;
 			const autosavePost = yield select(
@@ -304,10 +309,16 @@ export function* saveEntityRecord(
 				yield receiveAutosaves( persistedRecord.id, updatedRecord );
 			}
 		} else {
+			// Auto drafts should be converted to drafts on explicit saves,
+			// but some plugins break with this behavior so we can't filter it on the server.
+			let data = record;
+			if ( persistedRecord.status === 'auto-draft' && ! data.status ) {
+				data = { ...data, status: 'draft' };
+			}
 			updatedRecord = yield apiFetch( {
 				path,
 				method: recordId ? 'PUT' : 'POST',
-				data: record,
+				data,
 			} );
 			yield receiveEntityRecords( kind, name, updatedRecord, undefined, true );
 		}

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -14,7 +14,8 @@ describe( 'saveEntityRecord', () => {
 		expect( fulfillment.next( entities ).value.type ).toBe(
 			'SAVE_ENTITY_RECORD_START'
 		);
-		const { value: apiFetchAction } = fulfillment.next();
+		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
+		const { value: apiFetchAction } = fulfillment.next( {} );
 		expect( apiFetchAction.request ).toEqual( {
 			path: '/wp/v2/posts',
 			method: 'POST',
@@ -46,7 +47,8 @@ describe( 'saveEntityRecord', () => {
 		expect( fulfillment.next( entities ).value.type ).toBe(
 			'SAVE_ENTITY_RECORD_START'
 		);
-		const { value: apiFetchAction } = fulfillment.next();
+		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
+		const { value: apiFetchAction } = fulfillment.next( {} );
 		expect( apiFetchAction.request ).toEqual( {
 			path: '/wp/v2/posts/10',
 			method: 'PUT',
@@ -68,7 +70,8 @@ describe( 'saveEntityRecord', () => {
 		expect( fulfillment.next( entities ).value.type ).toBe(
 			'SAVE_ENTITY_RECORD_START'
 		);
-		const { value: apiFetchAction } = fulfillment.next();
+		expect( fulfillment.next().value.type ).toBe( 'SELECT' );
+		const { value: apiFetchAction } = fulfillment.next( {} );
 		expect( apiFetchAction.request ).toEqual( {
 			path: '/wp/v2/types/page',
 			method: 'PUT',


### PR DESCRIPTION
Reverts #16814 

Resolves #17241 

## Description

This PR removes a filter that unsets auto-draft titles that was creating plugin compatibility issues and replaces it with client side code.

## How has this been tested?

The test suites were ran and verified to still pass.

## Types of Changes

*Bug Fix:* Don't unset auto-draft titles, because some plugins rely on it.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
