### PR TITLE
Fix: Packages\Url: Trim leading and trailing whitespaces

### DIFF
--- a/packages/url/src/index.js
+++ b/packages/url/src/index.js
@@ -360,6 +360,7 @@ export function removeQueryArgs( url, ...args ) {
  * @return {string} The updated URL.
  */
 export function prependHTTP( url ) {
+	url = url.trim();
 	if ( ! USABLE_HREF_REGEXP.test( url ) && ! EMAIL_REGEXP.test( url ) ) {
 		return 'http://' + url;
 	}

--- a/packages/url/src/test/index.test.js
+++ b/packages/url/src/test/index.test.js
@@ -496,6 +496,18 @@ describe( 'prependHTTP', () => {
 
 		expect( prependHTTP( url ) ).toBe( url );
 	} );
+
+	it( 'should remove leading whitespace before prepending HTTP', () => {
+		const url = ' wordpress.org';
+
+		expect( prependHTTP( url ) ).toBe( 'http://wordpress.org' );
+	} );
+
+	it( 'should not have trailing whitespaces', () => {
+		const url = 'wordpress.org ';
+
+		expect( prependHTTP( url ) ).toBe( 'http://wordpress.org' );
+	} );
 } );
 
 describe( 'safeDecodeURI', () => {


### PR DESCRIPTION
## Description
Trims the trailing and leading whitespaces in the url.

Fixes #17314.

## How has this been tested?
1. Create a new post.
2. Insert a link with different url formats `[ ]` means whitespace.
    - [ ]google.com
    - google.com[ ]
    - http://google.com
    - https://google.com[]
3. URLs above work as expected.

## Types of changes
Bug fix.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. 
