### PR TITLE
Add types of pull_request actions github action should run on

### DIFF
--- a/.github/workflows/pull-request-automation.yml
+++ b/.github/workflows/pull-request-automation.yml
@@ -7,7 +7,6 @@ jobs:
   pull-request-automation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
       # Changing into the action's directory and running `npm install` is much
       # faster than a full project-wide `npm ci`.
       - run: cd packages/project-management-automation && npm install

--- a/.github/workflows/pull-request-automation.yml
+++ b/.github/workflows/pull-request-automation.yml
@@ -1,4 +1,6 @@
-on: pull_request
+on:
+  pull_request:
+    types: [opened, closed]
 name: Pull request automation
 
 jobs:


### PR DESCRIPTION
## Description
Attempts to solve the issue with the Milestone github action using the recommendation in this post:
https://github.community/t5/GitHub-Actions/Action-runs-when-PR-is-created-but-not-when-PR-is-merged/m-p/30514#M455