### PR TITLE
Use sentence case for tooltips

### DIFF
--- a/packages/block-editor/src/components/block-navigation/dropdown.js
+++ b/packages/block-editor/src/components/block-navigation/dropdown.js
@@ -35,7 +35,7 @@ function BlockNavigationDropdown( { hasBlocks, isDisabled } ) {
 						icon={ MenuIcon }
 						aria-expanded={ isOpen }
 						onClick={ isEnabled ? onToggle : undefined }
-						label={ __( 'Block Navigation' ) }
+						label={ __( 'Block navigation' ) }
 						className="editor-block-navigation block-editor-block-navigation"
 						shortcut={ displayShortcut.access( 'o' ) }
 						aria-disabled={ ! isEnabled }

--- a/packages/block-editor/src/components/block-navigation/index.js
+++ b/packages/block-editor/src/components/block-navigation/index.js
@@ -82,7 +82,7 @@ function BlockNavigation( { rootBlock, rootBlocks, selectedBlockClientId, select
 			role="presentation"
 			className="editor-block-navigation__container block-editor-block-navigation__container"
 		>
-			<p className="editor-block-navigation__label block-editor-block-navigation__label">{ __( 'Block Navigation' ) }</p>
+			<p className="editor-block-navigation__label block-editor-block-navigation__label">{ __( 'Block navigation' ) }</p>
 			{ hasHierarchy && (
 				<BlockNavigationList
 					blocks={ [ rootBlock ] }

--- a/packages/block-editor/src/components/rich-text/format-toolbar/index.js
+++ b/packages/block-editor/src/components/rich-text/format-toolbar/index.js
@@ -26,7 +26,7 @@ const FormatToolbar = () => {
 					{ ( fills ) => fills.length !== 0 &&
 						<DropdownMenu
 							icon={ false }
-							label={ __( 'More Rich Text Controls' ) }
+							label={ __( 'More rich text controls' ) }
 							controls={ orderBy( fills.map( ( [ { props } ] ) => props ), 'title' ) }
 							popoverProps={ POPOVER_PROPS }
 						/>

--- a/packages/block-editor/src/components/url-input/button.js
+++ b/packages/block-editor/src/components/url-input/button.js
@@ -37,7 +37,7 @@ class URLInputButton extends Component {
 	render() {
 		const { url, onChange } = this.props;
 		const { expanded } = this.state;
-		const buttonLabel = url ? __( 'Edit Link' ) : __( 'Insert Link' );
+		const buttonLabel = url ? __( 'Edit link' ) : __( 'Insert link' );
 
 		return (
 			<div className="editor-url-input__button block-editor-url-input__button">

--- a/packages/block-editor/src/components/url-popover/index.js
+++ b/packages/block-editor/src/components/url-popover/index.js
@@ -61,7 +61,7 @@ class URLPopover extends Component {
 							<IconButton
 								className="editor-url-popover__settings-toggle block-editor-url-popover__settings-toggle"
 								icon="arrow-down-alt2"
-								label={ __( 'Link Settings' ) }
+								label={ __( 'Link settings' ) }
 								onClick={ this.toggleSettingsVisibility }
 								aria-expanded={ isSettingsExpanded }
 							/>

--- a/packages/block-editor/src/components/url-popover/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/url-popover/test/__snapshots__/index.js.snap
@@ -19,7 +19,7 @@ exports[`URLPopover matches the snapshot in its default state 1`] = `
         aria-expanded={false}
         className="editor-url-popover__settings-toggle block-editor-url-popover__settings-toggle"
         icon="arrow-down-alt2"
-        label="Link Settings"
+        label="Link settings"
         onClick={[Function]}
       />
     </div>
@@ -46,7 +46,7 @@ exports[`URLPopover matches the snapshot when the settings are toggled open 1`] 
         aria-expanded={true}
         className="editor-url-popover__settings-toggle block-editor-url-popover__settings-toggle"
         icon="arrow-down-alt2"
-        label="Link Settings"
+        label="Link settings"
         onClick={[Function]}
       />
     </div>

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -209,14 +209,14 @@ class ButtonEdit extends Component {
 						borderRadius={ borderRadius }
 						setAttributes={ setAttributes }
 					/>
-					<PanelBody title={ __( 'Link Settings' ) }>
+					<PanelBody title={ __( 'Link settings' ) }>
 						<ToggleControl
-							label={ __( 'Open in New Tab' ) }
+							label={ __( 'Open in new tab' ) }
 							onChange={ this.onToggleOpenInNewTab }
 							checked={ linkTarget === '_blank' }
 						/>
 						<TextControl
-							label={ __( 'Link Rel' ) }
+							label={ __( 'Link rel' ) }
 							value={ rel || '' }
 							onChange={ this.onSetLinkRel }
 						/>

--- a/packages/block-library/src/file/inspector.js
+++ b/packages/block-library/src/file/inspector.js
@@ -23,14 +23,14 @@ export default function FileBlockInspector( {
 	if ( attachmentPage ) {
 		linkDestinationOptions = [
 			{ value: href, label: __( 'Media File' ) },
-			{ value: attachmentPage, label: __( 'Attachment Page' ) },
+			{ value: attachmentPage, label: __( 'Attachment page' ) },
 		];
 	}
 
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody title={ __( 'Text Link Settings' ) }>
+				<PanelBody title={ __( 'Text link settings' ) }>
 					<SelectControl
 						label={ __( 'Link To' ) }
 						value={ textLinkHref }
@@ -38,14 +38,14 @@ export default function FileBlockInspector( {
 						onChange={ changeLinkDestinationOption }
 					/>
 					<ToggleControl
-						label={ __( 'Open in New Tab' ) }
+						label={ __( 'Open in new tab' ) }
 						checked={ openInNewWindow }
 						onChange={ changeOpenInNewWindow }
 					/>
 				</PanelBody>
-				<PanelBody title={ __( 'Download Button Settings' ) }>
+				<PanelBody title={ __( 'Download button settings' ) }>
 					<ToggleControl
-						label={ __( 'Show Download Button' ) }
+						label={ __( 'Show download button' ) }
 						checked={ showDownloadButton }
 						onChange={ changeShowDownloadButton }
 					/>

--- a/packages/block-library/src/gallery/gallery-image.js
+++ b/packages/block-library/src/gallery/gallery-image.js
@@ -133,7 +133,7 @@ class GalleryImage extends Component {
 						icon="arrow-left"
 						onClick={ isFirstItem ? undefined : onMoveBackward }
 						className="blocks-gallery-item__move-backward"
-						label={ __( 'Move Image Backward' ) }
+						label={ __( 'Move image backward' ) }
 						aria-disabled={ isFirstItem }
 						disabled={ ! isSelected }
 					/>
@@ -141,7 +141,7 @@ class GalleryImage extends Component {
 						icon="arrow-right"
 						onClick={ isLastItem ? undefined : onMoveForward }
 						className="blocks-gallery-item__move-forward"
-						label={ __( 'Move Image Forward' ) }
+						label={ __( 'Move image forward' ) }
 						aria-disabled={ isLastItem }
 						disabled={ ! isSelected }
 					/>
@@ -151,7 +151,7 @@ class GalleryImage extends Component {
 						icon="no-alt"
 						onClick={ onRemove }
 						className="blocks-gallery-item__remove"
-						label={ __( 'Remove Image' ) }
+						label={ __( 'Remove image' ) }
 						disabled={ ! isSelected }
 					/>
 				</div>

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -200,7 +200,7 @@ const ImageURLInputUI = ( {
 			<IconButton
 				icon="admin-links"
 				className="components-toolbar__control"
-				label={ url ? __( 'Edit Link' ) : __( 'Insert Link' ) }
+				label={ url ? __( 'Edit link' ) : __( 'Insert link' ) }
 				aria-expanded={ isOpen }
 				onClick={ openLinkUI }
 			/>
@@ -251,7 +251,7 @@ const ImageURLInputUI = ( {
 							/>
 							<IconButton
 								icon="no"
-								label={ __( 'Remove Link' ) }
+								label={ __( 'Remove link' ) }
 								onClick={ onLinkRemove }
 							/>
 						</>

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -161,13 +161,13 @@ class LatestPostsEdit extends Component {
 		const layoutControls = [
 			{
 				icon: 'list-view',
-				title: __( 'List View' ),
+				title: __( 'List view' ),
 				onClick: () => setAttributes( { postLayout: 'list' } ),
 				isActive: postLayout === 'list',
 			},
 			{
 				icon: 'grid-view',
-				title: __( 'Grid View' ),
+				title: __( 'Grid view' ),
 				onClick: () => setAttributes( { postLayout: 'grid' } ),
 				isActive: postLayout === 'grid',
 			},

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -94,13 +94,13 @@ class RSSEdit extends Component {
 			},
 			{
 				icon: 'list-view',
-				title: __( 'List View' ),
+				title: __( 'List view' ),
 				onClick: () => setAttributes( { blockLayout: 'list' } ),
 				isActive: blockLayout === 'list',
 			},
 			{
 				icon: 'grid-view',
-				title: __( 'Grid View' ),
+				title: __( 'Grid view' ),
 				onClick: () => setAttributes( { blockLayout: 'grid' } ),
 				isActive: blockLayout === 'grid',
 			},

--- a/packages/e2e-tests/specs/adding-inline-tokens.test.js
+++ b/packages/e2e-tests/specs/adding-inline-tokens.test.js
@@ -27,8 +27,8 @@ describe( 'adding inline tokens', () => {
 		await clickBlockAppender();
 		await page.keyboard.type( 'a ' );
 
-		await clickBlockToolbarButton( 'More Rich Text Controls' );
-		await clickButton( 'Inline Image' );
+		await clickBlockToolbarButton( 'More rich text controls' );
+		await clickButton( 'Inline image' );
 
 		// Wait for media modal to appear and upload image.
 		await page.waitForSelector( '.media-modal input[type=file]' );

--- a/packages/e2e-tests/specs/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/block-hierarchy-navigation.test.js
@@ -32,7 +32,7 @@ describe( 'Navigating the block hierarchy', () => {
 		await page.keyboard.type( 'First column' );
 
 		// Navigate to the columns blocks.
-		await page.click( '[aria-label="Block Navigation"]' );
+		await page.click( '[aria-label="Block navigation"]' );
 		const columnsBlockMenuItem = ( await page.$x( "//button[contains(@class,'block-editor-block-navigation__item') and contains(text(), 'Columns')]" ) )[ 0 ];
 		await columnsBlockMenuItem.click();
 
@@ -44,7 +44,7 @@ describe( 'Navigating the block hierarchy', () => {
 		await page.keyboard.type( '3' );
 
 		// Navigate to the last column block.
-		await page.click( '[aria-label="Block Navigation"]' );
+		await page.click( '[aria-label="Block navigation"]' );
 		const lastColumnsBlockMenuItem = ( await page.$x(
 			"//button[contains(@class,'block-editor-block-navigation__item') and contains(text(), 'Column')]"
 		) )[ 3 ];

--- a/packages/e2e-tests/specs/blocks/columns.test.js
+++ b/packages/e2e-tests/specs/blocks/columns.test.js
@@ -17,7 +17,7 @@ describe( 'Columns', () => {
 	it( 'restricts all blocks inside the columns block', async () => {
 		await insertBlock( 'Columns' );
 		await page.click( '[aria-label="Two columns; equal split"]' );
-		await page.click( '[aria-label="Block Navigation"]' );
+		await page.click( '[aria-label="Block navigation"]' );
 		const columnBlockMenuItem = ( await page.$x( '//button[contains(concat(" ", @class, " "), " block-editor-block-navigation__item-button ")][text()="Column"]' ) )[ 0 ];
 		await columnBlockMenuItem.click();
 		await openGlobalBlockInserter();

--- a/packages/e2e-tests/specs/links.test.js
+++ b/packages/e2e-tests/specs/links.test.js
@@ -453,7 +453,7 @@ describe( 'Links', () => {
 		}
 
 		// Focus on first paragraph, so the link popover will appear over the subsequent ones
-		await page.click( '[aria-label="Block Navigation"]' );
+		await page.click( '[aria-label="Block navigation"]' );
 		await page.click( '.block-editor-block-navigation__item button' );
 
 		// Select some text
@@ -465,7 +465,7 @@ describe( 'Links', () => {
 		await waitForAutoFocus();
 
 		// Click on the Link Settings button
-		await page.click( 'button[aria-label="Link Settings"]' );
+		await page.click( 'button[aria-label="Link settings"]' );
 
 		// Move mouse over the 'open in new tab' section, then click and drag
 		const settings = await page.$( '.block-editor-url-popover__settings' );

--- a/packages/e2e-tests/specs/plugins/format-api.test.js
+++ b/packages/e2e-tests/specs/plugins/format-api.test.js
@@ -29,7 +29,7 @@ describe( 'Using Format API', () => {
 		await clickBlockAppender();
 		await page.keyboard.type( 'First paragraph' );
 		await pressKeyWithModifier( 'shiftAlt', 'ArrowLeft' );
-		await clickBlockToolbarButton( 'More Rich Text Controls' );
+		await clickBlockToolbarButton( 'More rich text controls' );
 		await clickButton( 'Custom Link' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );

--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -12,7 +12,7 @@ import { computeCaretRect } from '@wordpress/dom';
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 
 const name = 'core/image';
-const title = __( 'Inline Image' );
+const title = __( 'Inline image' );
 
 const stopKeyPropagation = ( event ) => event.stopPropagation();
 

--- a/packages/format-library/src/link/modal.native.js
+++ b/packages/format-library/src/link/modal.native.js
@@ -148,20 +148,20 @@ class ModalLinkUI extends Component {
 				/* eslint-enable jsx-a11y/no-autofocus */ }
 				<BottomSheet.Cell
 					icon={ 'editor-textcolor' }
-					label={ __( 'Link Text' ) }
+					label={ __( 'Link text' ) }
 					value={ text }
-					placeholder={ __( 'Add Link Text' ) }
+					placeholder={ __( 'Add link text' ) }
 					onChangeValue={ this.onChangeText }
 				/>
 				<BottomSheet.SwitchCell
 					icon={ 'external' }
-					label={ __( 'Open in New Tab' ) }
+					label={ __( 'Open in new tab' ) }
 					value={ this.state.opensInNewWindow }
 					onValueChange={ this.onChangeOpensInNewWindow }
 					separatorType={ 'fullWidth' }
 				/>
 				<BottomSheet.Cell
-					label={ __( 'Remove Link' ) }
+					label={ __( 'Remove link' ) }
 					labelStyle={ styles.clearLinkButton }
 					separatorType={ 'none' }
 					onPress={ this.removeLink }


### PR DESCRIPTION
## Description
Fixes #16764 in part. I believe I've found all the tooltip instances that used title case and switched them to sentence case. I have not changed the labels in the popovers yet. I'm thinking that could be another PR to keep things simple. I'm starting to fiddle with a lot of files and it feel uncomfortable.

cc: @gziolo, I'd love to get your eyes on this to make sure I edited the correct files. If there are others I need to edit, let me know.

## How has this been tested?
Locally.

## Screenshots

**Before:**

![61936717-95ccfe80-af8d-11e9-8fb0-c167ab258eb3](https://user-images.githubusercontent.com/617986/64299695-fce7b680-cf2e-11e9-9e4c-b333db895f6d.png)

**After:**

![Screen Shot 2019-09-04 at 4 14 21 PM](https://user-images.githubusercontent.com/617986/64299720-125ce080-cf2f-11e9-8329-bc68b4774704.png)


## Types of changes
Non-breaking change.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
