### PR TITLE
Add notice of disabled blocks to block inserter when no results are found

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -375,9 +375,8 @@ export class InserterMenu extends Component {
 										}
 										<br />
 										<Button
-											isButton
 											isDefault
-											className="editor-inserter__block-manager-button block-editor-inserter__block-manager-button"
+											className="block-editor-inserter__block-manager-button"
 											onClick={ () => openModal( 'edit-post/manage-blocks' ) }
 										>
 											{ __( 'Manage Blocks' ) }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -7,7 +7,7 @@ import {
 	findIndex,
 	flow,
 	groupBy,
-	isArray,
+	size,
 	isEmpty,
 	map,
 	some,
@@ -359,8 +359,8 @@ export class InserterMenu extends Component {
 						) }
 						{ isEmpty( suggestedItems ) && isEmpty( reusableItems ) && isEmpty( itemsPerCategory ) && (
 							<p className="editor-inserter__no-results block-editor-inserter__no-results">
-								{ numberOfHiddenBlocks ? __( 'No active blocks found.' ) : __( 'No blocks found.' ) }
-								{ !! numberOfHiddenBlocks && (
+								{ numberOfHiddenBlocks > 0 ? __( 'No active blocks found.' ) : __( 'No blocks found.' ) }
+								{ numberOfHiddenBlocks > 0 && (
 									<>
 										<br />
 										{
@@ -469,7 +469,7 @@ export default compose(
 		}
 		const destinationRootBlockName = getBlockName( destinationRootClientId );
 		const hiddenBlockTypes = getPreference( 'hiddenBlockTypes' );
-		const numberOfHiddenBlocks = isArray( hiddenBlockTypes ) && hiddenBlockTypes.length;
+		const numberOfHiddenBlocks = size( hiddenBlockTypes );
 
 		return {
 			rootChildBlocks: getChildBlockNames( destinationRootBlockName ),

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -123,9 +123,13 @@ $block-inserter-search-height: 38px;
 }
 
 .block-editor-inserter__no-results {
-	font-style: italic;
 	padding: 24px;
 	text-align: center;
+	line-height: 1.75;
+}
+
+.block-editor-inserter__block-manager-button {
+	margin-top: 24px;
 }
 
 .block-editor-inserter__child-blocks {


### PR DESCRIPTION
Fixes #17235.
(Also potentially fixes part of #15121)

## Description
If blocks are disabled when a search in the inserter comes up empty, it will now display a message with the number of disabled blocks and include a button that will open the block manager. If no blocks are disabled, the existing messaging will be used.

## How has this been tested?
Open the block manager and disable some blocks.
Open the inserter, type until no matching blocks are found, see new messaging.
Open Block manager and re-enable all blocks
Open the inserter, type until no matching blocks are found, see existing messaging.

## Screenshots
![Edit_Post_‹_WordPress_Develop_—_WordPress](https://user-images.githubusercontent.com/6653970/64300436-b86a1400-cf4a-11e9-9e1e-0f64e67f244e.png)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
