### PR TITLE
Fix incorrect nesting of buttons within a button

### DIFF
--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -111,15 +111,18 @@ export class PostPublishButton extends Component {
 		const componentProps = isToggle ? toggleProps : buttonProps;
 		const componentChildren = isToggle ? toggleChildren : buttonChildren;
 		return (
-			<Button
-				ref={ this.buttonNode }
-				{ ...componentProps }
-			>
-				{ componentChildren }
+			<div>
+				<Button
+					ref={ this.buttonNode }
+					{ ...componentProps }
+				>
+					{ componentChildren }
+				</Button>
+				{ /* Todo: Remove the wrapping div when DotTips are removed. */ }
 				<DotTip tipId="core/editor.publish">
 					{ __( 'Finished writing? That’s great, let’s get this published right now. Just click “Publish” and you’re good to go.' ) }
 				</DotTip>
-			</Button>
+			</div>
 		);
 	}
 }

--- a/packages/editor/src/components/post-publish-button/test/index.js
+++ b/packages/editor/src/components/post-publish-button/test/index.js
@@ -4,6 +4,11 @@
 import { shallow } from 'enzyme';
 
 /**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+
+/**
  * Internal dependencies
  */
 import { PostPublishButton } from '../';
@@ -19,7 +24,7 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			expect( wrapper.prop( 'aria-disabled' ) ).toBe( true );
+			expect( wrapper.find( Button ).prop( 'aria-disabled' ) ).toBe( true );
 		} );
 
 		it( 'should be true if forceIsSaving is true', () => {
@@ -31,7 +36,7 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			expect( wrapper.prop( 'aria-disabled' ) ).toBe( true );
+			expect( wrapper.find( Button ).prop( 'aria-disabled' ) ).toBe( true );
 		} );
 
 		it( 'should be true if post is not publishable and not forceIsDirty', () => {
@@ -43,7 +48,7 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			expect( wrapper.prop( 'aria-disabled' ) ).toBe( true );
+			expect( wrapper.find( Button ).prop( 'aria-disabled' ) ).toBe( true );
 		} );
 
 		it( 'should be true if post is not saveable', () => {
@@ -54,7 +59,7 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			expect( wrapper.prop( 'aria-disabled' ) ).toBe( true );
+			expect( wrapper.find( Button ).prop( 'aria-disabled' ) ).toBe( true );
 		} );
 
 		it( 'should be true if post saving is locked', () => {
@@ -66,7 +71,7 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			expect( wrapper.prop( 'aria-disabled' ) ).toBe( true );
+			expect( wrapper.find( Button ).prop( 'aria-disabled' ) ).toBe( true );
 		} );
 
 		it( 'should be false if post is saveable but not publishable and forceIsDirty is true', () => {
@@ -78,7 +83,7 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			expect( wrapper.prop( 'aria-disabled' ) ).toBe( false );
+			expect( wrapper.find( Button ).prop( 'aria-disabled' ) ).toBe( false );
 		} );
 
 		it( 'should be false if post is publishave and saveable', () => {
@@ -89,7 +94,7 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			expect( wrapper.prop( 'aria-disabled' ) ).toBe( false );
+			expect( wrapper.find( Button ).prop( 'aria-disabled' ) ).toBe( false );
 		} );
 	} );
 
@@ -107,7 +112,7 @@ describe( 'PostPublishButton', () => {
 				/>
 			);
 
-			wrapper.simulate( 'click' );
+			wrapper.find( Button ).simulate( 'click' );
 
 			expect( onStatusChange ).toHaveBeenCalledWith( 'pending' );
 		} );
@@ -125,7 +130,7 @@ describe( 'PostPublishButton', () => {
 					isPublishable={ true } />
 			);
 
-			wrapper.simulate( 'click' );
+			wrapper.find( Button ).simulate( 'click' );
 
 			expect( onStatusChange ).toHaveBeenCalledWith( 'future' );
 		} );
@@ -143,7 +148,7 @@ describe( 'PostPublishButton', () => {
 					isPublishable={ true } />
 			);
 
-			wrapper.simulate( 'click' );
+			wrapper.find( Button ).simulate( 'click' );
 
 			expect( onStatusChange ).toHaveBeenCalledWith( 'private' );
 		} );
@@ -160,7 +165,7 @@ describe( 'PostPublishButton', () => {
 					isPublishable={ true } />
 			);
 
-			wrapper.simulate( 'click' );
+			wrapper.find( Button ).simulate( 'click' );
 
 			expect( onStatusChange ).toHaveBeenCalledWith( 'publish' );
 		} );
@@ -179,7 +184,7 @@ describe( 'PostPublishButton', () => {
 					isPublishable={ true } />
 			);
 
-			wrapper.simulate( 'click' );
+			wrapper.find( Button ).simulate( 'click' );
 
 			expect( onStatusChange ).toHaveBeenCalledWith( 'publish' );
 			expect( onSave ).toHaveBeenCalled();
@@ -194,6 +199,6 @@ describe( 'PostPublishButton', () => {
 			/>
 		);
 
-		expect( wrapper.find( 'ForwardRef(Button)' ).prop( 'isBusy' ) ).toBe( true );
+		expect( wrapper.find( Button ).prop( 'isBusy' ) ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
## Description
Fixes #9033.

The `DotTip` component renders buttons, so nesting it within another button was causing invalid DOM nesting. This PR makes the `DotTip` and the `Button` siblings and both children of a new parent `div` element. `DotTip` requires this parent `div` element to position itself in the right place.

Since https://github.com/WordPress/gutenberg/issues/16315#issuecomment-523174068 proposes to remove `DotTip`s at some point, I've left a comment to ensure the wrapping div is removed when that work is carried out.

## Screenshots
![Screen Shot 2019-09-05 at 5 07 55 pm](https://user-images.githubusercontent.com/677833/64328417-faa15d00-cfff-11e9-937b-9df209f37682.png)

## How has this been tested?
1. Go the editor options and enable Tips.
2. For the first three tips, click on 'See Next Tip'
3. When the forth tip appears ('Finished Writing?'), check the console in the dev tools.
4. Confirm that a `Warning: validateDOMNesting(...): <button> cannot appear as a descendant of <button>.` message does not appear in the console.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
