### PR TITLE
Fix issue with defaults not being applied for dynamic blocks

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -94,8 +94,8 @@ function gutenberg_provide_render_callback_with_block_object( $pre_render, $bloc
 	if ( $is_dynamic ) {
 		$global_post = $post;
 
-		$block_type->prepare_attributes_for_render( $block['attrs'] );
-		$block_content = (string) call_user_func( $block_type->render_callback, $block['attrs'], $block_content, $block );
+		$prepared_attributes = $block_type->prepare_attributes_for_render( $block['attrs'] );
+		$block_content       = (string) call_user_func( $block_type->render_callback, $prepared_attributes, $block_content, $block );
 
 		$post = $global_post;
 	}

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -15,8 +15,9 @@
 function render_block_core_search( $attributes ) {
 	static $instance_id = 0;
 
-	$input_id     = 'wp-block-search__input-' . ++$instance_id;
-	$label_markup = '';
+	$input_id      = 'wp-block-search__input-' . ++$instance_id;
+	$label_markup  = '';
+	$button_markup = '';
 
 	if ( ! empty( $attributes['label'] ) ) {
 		$label_markup = sprintf(


### PR DESCRIPTION
## Description
https://github.com/WordPress/gutenberg/pull/16796 introduced a regression where default attributes for dynamic blocks stopped working. This change resolves that issue.

Also fixes https://github.com/WordPress/gutenberg/issues/15487.

## How has this been tested?
I looked into adding an e2e test. It's a definite possibility to test a block like the `Search` block, but we'd need to produce a snapshot comparing against the rendered version of a post rather than the raw version like we do for static blocks.

For now, manual testing steps:

1. Create a new post, add a search block
2. Preview the post
3. Expect that the search block should render correctly in the post

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->
### Before
![Screen Shot 2019-09-05 at 6 02 59 pm](https://user-images.githubusercontent.com/677833/64332757-b31ecf00-d007-11e9-86fd-2612a5bc3a5d.png)

### After
![Screen Shot 2019-09-05 at 6 02 22 pm](https://user-images.githubusercontent.com/677833/64332765-b87c1980-d007-11e9-9ed9-ba833eb7e124.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
