### PR TITLE
Docs(block-api/block-registration/): Minor layout fixes

### DIFF
--- a/docs/designers-developers/developers/block-api/block-registration.md
+++ b/docs/designers-developers/developers/block-api/block-registration.md
@@ -55,6 +55,7 @@ description: __( 'Block showing a Book card.' )
 Blocks are grouped into categories to help users browse and discover them.
 
 The core provided categories are:
+
 * common
 * formatting
 * layout
@@ -85,11 +86,10 @@ icon: <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="no
 **Note:** Custom SVG icons are automatically wrapped in the [`wp.components.SVG` component](/packages/components/src/primitives/svg/) to add accessibility attributes (`aria-hidden`, `role`, and `focusable`).
 
 An object can also be passed as icon, in this case, icon, as specified above, should be included in the src property.
-Besides src the object can contain background and foreground colors, this colors will appear with the icon
-when they are applicable e.g.: in the inserter.
+
+Besides src the object can contain background and foreground colors, this colors will appear with the icon when they are applicable e.g.: in the inserter.
 
 ```js
-
 icon: {
 	// Specifying a background color to appear with the icon e.g.: in the inserter.
 	background: '#7e70af',
@@ -174,7 +174,7 @@ attributes: {
 
 Transforms provide rules for what a block can be transformed from and what it can be transformed to. A block can be transformed from another block, a shortcode, a regular expression, a file or a raw DOM node.
 
-For example, a Paragraph block can be transformed into a Heading block. This uses the `createBlock` function from the [`wp-blocks` package](/packages/blocks/README.md#createBlock)
+For example, a Paragraph block can be transformed into a Heading block. This uses the `createBlock` function from the [`wp-blocks` package](/packages/blocks/README.md#createBlock).
 
 {% codetabs %}
 {% ES5 %}


### PR DESCRIPTION
## Description
Line 58: Added blank line so that list will show.
Lines 88-90: Fixed a random line break after "icon" and added a blank line in between "property." and "Besides".
Line 93: Removed a blank line that was causing a br tag to show in the code box.
Line 177: Add period after the "wp-blocks package" link.

## How has this been tested?
N/A

## Screenshots
![block-registration-extra-br-tag](https://user-images.githubusercontent.com/11235561/64371270-29163c80-cfee-11e9-817c-5cf4e8b5d58f.png)

## Types of changes
Minor documentation layout changes.

## Checklist:
N/A