### PR TITLE
Fix: Group  side menu option hide/show logic

### DIFF
--- a/packages/editor/src/components/convert-to-group-buttons/convert-button.js
+++ b/packages/editor/src/components/convert-to-group-buttons/convert-button.js
@@ -51,6 +51,7 @@ export function ConvertToGroupButton( {
 export default compose( [
 	withSelect( ( select, { clientIds } ) => {
 		const {
+			getBlockRootClientId,
 			getBlocksByClientId,
 			canInsertBlockType,
 		} = select( 'core/block-editor' );
@@ -61,7 +62,11 @@ export default compose( [
 
 		const groupingBlockName = getGroupingBlockName();
 
-		const groupingBlockAvailable = canInsertBlockType( groupingBlockName );
+		const rootClientId = clientIds && clientIds.length > 0 ?
+			getBlockRootClientId( clientIds[ 0 ] ) :
+			undefined;
+
+		const groupingBlockAvailable = canInsertBlockType( groupingBlockName, rootClientId );
 
 		const blocksSelection = getBlocksByClientId( clientIds );
 


### PR DESCRIPTION
The "Group" option that appears on the block side menu correctly checked if the Group block can be inserted using canInsertBlockType but did not pass the rootBlockId. This caused bugs when in nested blocks where the group block can not be used the option to group still appears.

## How has this been tested?
I added a Columns block with some columns inside.
I selected the column block and verified the "Group" side menu option does not appear (on master it appears but fails to do the action because a group is not allowed inside columns.