### PR TITLE
Ensure withFocusReturn's context props are not passed to wrappedElement

### DIFF
--- a/packages/components/src/higher-order/with-focus-return/index.js
+++ b/packages/components/src/higher-order/with-focus-return/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { stubTrue, without } from 'lodash';
+import { stubTrue, without, omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -88,7 +88,7 @@ function withFocusReturn( options ) {
 
 				const stack = [
 					...without(
-						this.props.focusHistory,
+						this.props.focus.focusHistory,
 						...ownFocusedElements
 					),
 					activeElementOnMount,
@@ -109,7 +109,7 @@ function withFocusReturn( options ) {
 						onFocus={ this.setIsFocusedTrue }
 						onBlur={ this.setIsFocusedFalse }
 					>
-						<WrappedComponent { ...this.props } />
+						<WrappedComponent { ...this.props.childProps } />
 					</div>
 				);
 			}
@@ -117,7 +117,7 @@ function withFocusReturn( options ) {
 
 		return ( props ) => (
 			<Consumer>
-				{ ( context ) => <FocusReturn { ...props } { ...context } /> }
+				{ ( context ) => <FocusReturn childProps={ props } focus={ context } /> }
 			</Consumer>
 		);
 	};

--- a/packages/components/src/higher-order/with-focus-return/index.js
+++ b/packages/components/src/higher-order/with-focus-return/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { stubTrue, without, omit } from 'lodash';
+import { stubTrue, without } from 'lodash';
 
 /**
  * WordPress dependencies

--- a/packages/components/src/higher-order/with-focus-return/test/index.js
+++ b/packages/components/src/higher-order/with-focus-return/test/index.js
@@ -51,11 +51,18 @@ describe( 'withFocusReturn()', () => {
 			expect( wrappedElementShallow.children[ 0 ].type ).toBe( 'textarea' );
 		} );
 
-		it( 'should pass additional props through to the wrapped element', () => {
+		it( 'should pass own props through to the wrapped element', () => {
 			const renderedComposite = renderer.create( <Composite test="test" /> );
 			const wrappedElement = renderedComposite.root.findByType( Test );
 			// Ensure that the wrapped Test element has the appropriate props.
 			expect( wrappedElement.props.test ).toBe( 'test' );
+		} );
+
+		it( 'should not pass any withFocusReturn context props through to the wrapped element', () => {
+			const renderedComposite = renderer.create( <Composite test="test" /> );
+			const wrappedElement = renderedComposite.root.findByType( Test );
+			// Ensure that the wrapped Test element has the appropriate props.
+			expect( wrappedElement.props.focusHistory ).toBeUndefined();
 		} );
 
 		it( 'should not switch focus back to the bound focus element', () => {


### PR DESCRIPTION
Related #17342.

## Description
The `withFocusReturn` HOC was passing through an additional prop `focusHistory` to its wrapped component. It receives this prop from its context provider.

In most cases this wasn't an issue, the additional prop is ignored. However, some components, like `Button` pass all props straight through to a DOM element, and when those components are wrapped with `withFocusReturn` the result is a react warning about invalid prop types:

```
["Warning: React does not recognize the `focusHistory` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `focushistory` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
        in div (created by PostPublishPanel)
        in PostPublishPanel (created by WithConstrainedTabbing(PostPublishPanel))
        in div (created by WithConstrainedTabbing(PostPublishPanel))
        in WithConstrainedTabbing(PostPublishPanel) (created by FocusReturn)
```

This PR splits the props passed through to `FocusReturn` so that props received from context and props intended for the child are kept separate. Only `childProps` are passed to the wrapped component.

## How has this been tested?
Added a unit test.

Also searched the codebase to ensure `focusHistory` isn't used by wrapped components.
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
