### PR TITLE
[RNMobile] iOS DarkMode toolbar buttons

### DIFF
--- a/packages/components/src/button/index.native.js
+++ b/packages/components/src/button/index.native.js
@@ -94,7 +94,7 @@ export function Button( props ) {
 	const subscriptInactive = getStylesFromColorScheme( styles.subscriptInactive, styles.subscriptInactiveDark );
 
 	const newChildren = Children.map( compact( children ), ( child ) => {
-		return cloneElement( child, { theme: props.theme, active: ariaPressed } );
+		return cloneElement( child, { colorScheme: props.preferredColorScheme, active: ariaPressed } );
 	} );
 
 	return (

--- a/packages/components/src/button/index.native.js
+++ b/packages/components/src/button/index.native.js
@@ -8,11 +8,7 @@ import { compact } from 'lodash';
  * WordPress dependencies
  */
 import { Children, cloneElement } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
-import { withTheme } from '../mobile/dark-mode';
+import { withPreferredColorScheme } from '@wordpress/compose';
 
 const isAndroid = Platform.OS === 'android';
 const marginBottom = isAndroid ? -0.5 : 0;
@@ -71,7 +67,7 @@ export function Button( props ) {
 		disabled,
 		hint,
 		fixedRatio = true,
-		useStyle,
+		getStylesFromColorScheme,
 		'aria-disabled': ariaDisabled,
 		'aria-label': ariaLabel,
 		'aria-pressed': ariaPressed,
@@ -95,7 +91,7 @@ export function Button( props ) {
 		states.push( 'disabled' );
 	}
 
-	const subscriptInactive = useStyle( styles.subscriptInactive, styles.subscriptInactiveDark );
+	const subscriptInactive = getStylesFromColorScheme( styles.subscriptInactive, styles.subscriptInactiveDark );
 
 	const newChildren = Children.map( compact( children ), ( child ) => {
 		return cloneElement( child, { theme: props.theme, active: ariaPressed } );
@@ -123,4 +119,4 @@ export function Button( props ) {
 	);
 }
 
-export default withTheme( Button );
+export default withPreferredColorScheme( Button );

--- a/packages/components/src/button/index.native.js
+++ b/packages/components/src/button/index.native.js
@@ -2,6 +2,17 @@
  * External dependencies
  */
 import { StyleSheet, TouchableOpacity, Text, View, Platform } from 'react-native';
+import { compact } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Children, cloneElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { withTheme } from '../mobile/dark-mode';
 
 const isAndroid = Platform.OS === 'android';
 const marginBottom = isAndroid ? -0.5 : 0;
@@ -40,6 +51,9 @@ const styles = StyleSheet.create( {
 		marginLeft,
 		marginBottom,
 	},
+	subscriptInactiveDark: {
+		color: '#a7aaad', // $gray_20
+	},
 	subscriptActive: {
 		color: 'white',
 		fontWeight: 'bold',
@@ -50,13 +64,14 @@ const styles = StyleSheet.create( {
 	},
 } );
 
-export default function Button( props ) {
+export function Button( props ) {
 	const {
 		children,
 		onClick,
 		disabled,
 		hint,
 		fixedRatio = true,
+		useStyle,
 		'aria-disabled': ariaDisabled,
 		'aria-label': ariaLabel,
 		'aria-pressed': ariaPressed,
@@ -66,7 +81,7 @@ export default function Button( props ) {
 	const isDisabled = ariaDisabled || disabled;
 
 	const buttonViewStyle = {
-		opacity: isDisabled ? 0.2 : 1,
+		opacity: isDisabled ? 0.3 : 1,
 		...( fixedRatio && styles.fixedRatio ),
 		...( ariaPressed ? styles.buttonActive : styles.buttonInactive ),
 	};
@@ -79,6 +94,12 @@ export default function Button( props ) {
 	if ( isDisabled ) {
 		states.push( 'disabled' );
 	}
+
+	const subscriptInactive = useStyle( styles.subscriptInactive, styles.subscriptInactiveDark );
+
+	const newChildren = Children.map( compact( children ), ( child ) => {
+		return cloneElement( child, { theme: props.theme, active: ariaPressed } );
+	} );
 
 	return (
 		<TouchableOpacity
@@ -94,10 +115,12 @@ export default function Button( props ) {
 		>
 			<View style={ buttonViewStyle }>
 				<View style={ { flexDirection: 'row' } }>
-					{ children }
-					{ subscript && ( <Text style={ ariaPressed ? styles.subscriptActive : styles.subscriptInactive }>{ subscript }</Text> ) }
+					{ newChildren }
+					{ subscript && ( <Text style={ ariaPressed ? styles.subscriptActive : subscriptInactive }>{ subscript }</Text> ) }
 				</View>
 			</View>
 		</TouchableOpacity>
 	);
 }
+
+export default withTheme( Button );

--- a/packages/components/src/icon-button/index.js
+++ b/packages/components/src/icon-button/index.js
@@ -27,7 +27,6 @@ function IconButton( props, ref ) {
 		labelPosition,
 		...additionalProps
 	} = props;
-	const { 'aria-pressed': ariaPressed } = additionalProps;
 	const classes = classnames( 'components-icon-button', className, {
 		'has-text': children,
 	} );
@@ -56,7 +55,7 @@ function IconButton( props, ref ) {
 			className={ classes }
 			ref={ ref }
 		>
-			<Icon icon={ icon } ariaPressed={ ariaPressed } />
+			<Icon icon={ icon } />
 			{ children }
 		</Button>
 	);

--- a/packages/components/src/primitives/svg/index.native.js
+++ b/packages/components/src/primitives/svg/index.native.js
@@ -17,10 +17,10 @@ export {
 } from 'react-native-svg';
 
 export const SVG = ( props ) => {
-	const theme = props.theme || 'light';
+	const colorScheme = props.colorScheme || 'light';
 	const stylesFromClasses = ( props.className || '' ).split( ' ' ).map( ( element ) => styles[ element ] ).filter( Boolean );
-	const stylesFromAriaPressed = props.active ? styles[ 'is-active' ] : styles[ 'components-toolbar__control-' + theme ];
-	const styleValues = Object.assign( {}, props.style, stylesFromAriaPressed, ...stylesFromClasses );
+	const defaultStyle = props.active ? styles[ 'is-active' ] : styles[ 'components-toolbar__control-' + colorScheme ];
+	const styleValues = Object.assign( {}, props.style, defaultStyle, ...stylesFromClasses );
 
 	const safeProps = { ...props, style: styleValues };
 

--- a/packages/components/src/primitives/svg/index.native.js
+++ b/packages/components/src/primitives/svg/index.native.js
@@ -17,8 +17,9 @@ export {
 } from 'react-native-svg';
 
 export const SVG = ( props ) => {
+	const theme = props.theme || 'light';
 	const stylesFromClasses = ( props.className || '' ).split( ' ' ).map( ( element ) => styles[ element ] ).filter( Boolean );
-	const stylesFromAriaPressed = props.ariaPressed ? styles[ 'is-active' ] : styles[ 'components-toolbar__control' ];
+	const stylesFromAriaPressed = props.active ? styles[ 'is-active' ] : styles[ 'components-toolbar__control-' + theme ];
 	const styleValues = Object.assign( {}, props.style, stylesFromAriaPressed, ...stylesFromClasses );
 
 	const safeProps = { ...props, style: styleValues };

--- a/packages/components/src/primitives/svg/style.native.scss
+++ b/packages/components/src/primitives/svg/style.native.scss
@@ -1,6 +1,12 @@
-.dashicon,
-.components-toolbar__control {
+.dashicon-light,
+.components-toolbar__control-light {
 	color: #7b9ab1;
+	fill: currentColor;
+}
+
+.dashicon-dark,
+.components-toolbar__control-dark {
+	color: $gray_20;
 	fill: currentColor;
 }
 

--- a/packages/components/src/toolbar/style.native.scss
+++ b/packages/components/src/toolbar/style.native.scss
@@ -7,5 +7,5 @@
 }
 
 .containerDark {
-	border-color: #515459;
+	border-color: #525354;
 }


### PR DESCRIPTION
`gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1357
## Description
<!-- Please describe what you have changed or added -->
This PR allow us to add different styles to DashIcons inside IconButton component depending on the the style theme (Dark/Light mode).

It also enhance the DarkMode theme for Toolbar buttons (and the toolbar separator)

With this change, is not needed to send `ariaPressed` prop from `IconButton`. This is a change that [was requested](https://github.com/WordPress/gutenberg/pull/13977#issuecomment-468731745) long ago, (even though we still are sending it button states).

A second idea is to send styles directly to DashIcon from the Button, to avoid having to declare styles for every new class. I'm not sure if this is something we want to change though.

As always any moment is welcome! 

![toolbar](https://user-images.githubusercontent.com/9772967/64407508-bf953d00-d084-11e9-9b51-22f68544e3dd.png)

To test:
- Run the example app with Xcode 11 beta
- Check that the toolbar colors are correct on the toolbar (following the screenshots)
- Check that the rest of the icons in the app shows properly
  - In particular the BottomSheet icons (Add link / Image settings)
- Check that the icon Subscript is colored properly (Numbers on H1, H2, etc...)

