### PR TITLE
Show Height control in Cover if we only selected an image

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -329,16 +329,6 @@ class CoverEdit extends Component {
 									onChange={ ( value ) => setAttributes( { focalPoint: value } ) }
 								/>
 							) }
-							<CoverHeightInput
-								value={ temporaryMinHeight || minHeight }
-								onChange={
-									( value ) => {
-										setAttributes( {
-											minHeight: value,
-										} );
-									}
-								}
-							/>
 							<PanelRow>
 								<Button
 									isDefault
@@ -361,28 +351,16 @@ class CoverEdit extends Component {
 					{ ( url || overlayColor.color ) && (
 						<>
 							<PanelBody title={ __( 'Dimensions' ) }>
-								<BaseControl label={ __( 'Height in pixels' ) } id={ inputId }>
-									<input
-										type="number"
-										id={ inputId }
-										onChange={ ( event ) => {
-											let coverMinHeight = parseInt( event.target.value, 10 );
-											this.setState( { coverMinHeight } );
-											if ( isNaN( coverMinHeight ) ) {
-											// Set cover min height to default size and input box to empty string
-												this.setState( { coverMinHeight: COVER_DEFAULT_HEIGHT } );
-												coverMinHeight = COVER_DEFAULT_HEIGHT;
-											} else if ( coverMinHeight < COVER_MIN_HEIGHT ) {
-											// Set cover min height to minimum size
-												coverMinHeight = COVER_MIN_HEIGHT;
-											}
-											setAttributes( { minHeight: coverMinHeight } );
-										} }
-										value={ this.state.coverMinHeight || minHeight }
-										min={ COVER_MIN_HEIGHT }
-										step="10"
-									/>
-								</BaseControl>
+								<CoverHeightInput
+									value={ temporaryMinHeight || minHeight }
+									onChange={
+										( value ) => {
+											setAttributes( {
+												minHeight: value,
+											} );
+										}
+									}
+								/>
 							</PanelBody>
 							<PanelColorSettings
 								title={ __( 'Overlay' ) }

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -360,7 +360,7 @@ class CoverEdit extends Component {
 					) }
 					{ ( url || overlayColor.color ) && (
 						<>
-							<PanelBody title={ __( 'Size' ) }>
+							<PanelBody title={ __( 'Dimensions' ) }>
 								<BaseControl label={ __( 'Height in pixels' ) } id={ inputId }>
 									<input
 										type="number"

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -359,27 +359,53 @@ class CoverEdit extends Component {
 						</PanelBody>
 					) }
 					{ ( url || overlayColor.color ) && (
-						<PanelColorSettings
-							title={ __( 'Overlay' ) }
-							initialOpen={ true }
-							colorSettings={ [ {
-								value: overlayColor.color,
-								onChange: setOverlayColor,
-								label: __( 'Overlay Color' ),
-							} ] }
-						>
-							{ !! url && (
-								<RangeControl
-									label={ __( 'Background Opacity' ) }
-									value={ dimRatio }
-									onChange={ setDimRatio }
-									min={ 0 }
-									max={ 100 }
-									step={ 10 }
-									required
-								/>
-							) }
-						</PanelColorSettings>
+						<>
+							<PanelBody title={ __( 'Size' ) }>
+								<BaseControl label={ __( 'Height in pixels' ) } id={ inputId }>
+									<input
+										type="number"
+										id={ inputId }
+										onChange={ ( event ) => {
+											let coverMinHeight = parseInt( event.target.value, 10 );
+											this.setState( { coverMinHeight } );
+											if ( isNaN( coverMinHeight ) ) {
+											// Set cover min height to default size and input box to empty string
+												this.setState( { coverMinHeight: COVER_DEFAULT_HEIGHT } );
+												coverMinHeight = COVER_DEFAULT_HEIGHT;
+											} else if ( coverMinHeight < COVER_MIN_HEIGHT ) {
+											// Set cover min height to minimum size
+												coverMinHeight = COVER_MIN_HEIGHT;
+											}
+											setAttributes( { minHeight: coverMinHeight } );
+										} }
+										value={ this.state.coverMinHeight || minHeight }
+										min={ COVER_MIN_HEIGHT }
+										step="10"
+									/>
+								</BaseControl>
+							</PanelBody>
+							<PanelColorSettings
+								title={ __( 'Overlay' ) }
+								initialOpen={ true }
+								colorSettings={ [ {
+									value: overlayColor.color,
+									onChange: setOverlayColor,
+									label: __( 'Overlay Color' ),
+								} ] }
+							>
+								{ !! url && (
+									<RangeControl
+										label={ __( 'Background Opacity' ) }
+										value={ dimRatio }
+										onChange={ setDimRatio }
+										min={ 0 }
+										max={ 100 }
+										step={ 10 }
+										required
+									/>
+								) }
+							</PanelColorSettings>
+						</>
 					) }
 				</InspectorControls>
 			</>


### PR DESCRIPTION
## Description
fixes https://github.com/WordPress/gutenberg/issues/17258

This PR takes the height control and put it in its own panel, it didn't make much sense to keep it with the media settings since it has nothing to do with media, since we can control the size with only the color, so a new panel "Dimensions" is here

## How has this been tested?
* create a cover
* set a color only
* see the Dimensions panel in the sidebar

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/6165348/64489506-dd60ce80-d24b-11e9-8d82-85de21b78ab4.png)