### PR TITLE
Fix: Gallery placeholder icon does not appear

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -37,7 +37,7 @@ import { withSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import GalleryImage from './gallery-image';
-import icon from './icons';
+import { icon } from './icons';
 import { defaultColumnsNumber, pickRelevantMediaFiles } from './shared';
 
 const MAX_COLUMNS = 8;


### PR DESCRIPTION
## Description
In https://github.com/WordPress/gutenberg/pull/17316 we added new icons to the icon file and removed the fault export but we did not update the import on the edit file and it still wrongly imported the default export.

This PR fixes the import on the gallery edit file.

## How has this been tested?
I verified that the gallery icon appears on the media placeholder.
