### PR TITLE
Remove repeating enabled action for checkboxes

### DIFF
--- a/packages/e2e-test-utils/src/disable-pre-publish-checks.js
+++ b/packages/e2e-test-utils/src/disable-pre-publish-checks.js
@@ -7,5 +7,5 @@ import { toggleScreenOption } from './toggle-screen-option';
  * Disables Pre-publish checks.
  */
 export async function disablePrePublishChecks() {
-	await toggleScreenOption( 'Enable Pre-publish Checks', false );
+	await toggleScreenOption( 'Pre-publish Checks', false );
 }

--- a/packages/e2e-test-utils/src/enable-pre-publish-checks.js
+++ b/packages/e2e-test-utils/src/enable-pre-publish-checks.js
@@ -7,5 +7,5 @@ import { toggleScreenOption } from './toggle-screen-option';
  * Enables Pre-publish checks.
  */
 export async function enablePrePublishChecks() {
-	await toggleScreenOption( 'Enable Pre-publish Checks', true );
+	await toggleScreenOption( 'Pre-publish Checks', true );
 }

--- a/packages/e2e-tests/specs/nux.test.js
+++ b/packages/e2e-tests/specs/nux.test.js
@@ -87,7 +87,7 @@ describe( 'New User Experience (NUX)', () => {
 		expect( nuxTipElements ).toHaveLength( 0 );
 	} );
 
-	it( 'should enable tips when the "Enable tips" option is toggled on', async () => {
+	it( 'should enable tips when the "Tips" option is toggled on', async () => {
 		// Start by disabling tips.
 		await page.click( '.nux-dot-tip__disable' );
 
@@ -99,8 +99,8 @@ describe( 'New User Experience (NUX)', () => {
 		let areTipsEnabled = await getTipsEnabled( page );
 		expect( areTipsEnabled ).toEqual( false );
 
-		// Toggle the 'Enable Tips' option to enable.
-		await toggleScreenOption( 'Enable Tips' );
+		// Toggle the 'Tips' option to enable.
+		await toggleScreenOption( 'Tips' );
 
 		// Tips should once again appear.
 		nuxTipElements = await page.$$( '.nux-dot-tip' );

--- a/packages/edit-post/src/components/options-modal/index.js
+++ b/packages/edit-post/src/components/options-modal/index.js
@@ -46,9 +46,9 @@ export function OptionsModal( { isModalActive, isViewable, closeModal } ) {
 			onRequestClose={ closeModal }
 		>
 			<Section title={ __( 'General' ) }>
-				<EnablePublishSidebarOption label={ __( 'Enable Pre-publish Checks' ) } />
-				<EnableTipsOption label={ __( 'Enable Tips' ) } />
-				<EnableFeature feature="showInserterHelpPanel" label={ __( 'Enable Inserter Help Panel' ) } />
+				<EnablePublishSidebarOption label={ __( 'Pre-publish Checks' ) } />
+				<EnableTipsOption label={ __( 'Tips' ) } />
+				<EnableFeature feature="showInserterHelpPanel" label={ __( 'Inserter Help Panel' ) } />
 			</Section>
 			<Section title={ __( 'Document Panels' ) }>
 				<EnablePluginDocumentSettingPanelOption.Slot />

--- a/packages/edit-post/src/components/options-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/options-modal/test/__snapshots__/index.js.snap
@@ -10,14 +10,14 @@ exports[`OptionsModal should match snapshot when the modal is active 1`] = `
     title="General"
   >
     <WithSelect(WithDispatch(IfViewportMatches(BaseOption)))
-      label="Enable Pre-publish Checks"
+      label="Pre-publish Checks"
     />
     <WithSelect(WithDispatch(DeferredOption))
-      label="Enable Tips"
+      label="Tips"
     />
     <WithSelect(WithDispatch(BaseOption))
       feature="showInserterHelpPanel"
-      label="Enable Inserter Help Panel"
+      label="Inserter Help Panel"
     />
   </Section>
   <Section


### PR DESCRIPTION
The word 'enable' is repeated for 3 actions in a row. As it's a checkbox, just saying the action works.

![image](https://user-images.githubusercontent.com/253067/64494203-fedcad00-d281-11e9-9e9c-4ee7cf89e6cf.png)
