### PR TITLE
Polish Social Links block

### DIFF
--- a/packages/block-library/src/social-link/editor.scss
+++ b/packages/block-library/src/social-link/editor.scss
@@ -8,24 +8,3 @@
 	padding-left: 16px;
 	padding-right: 16px;
 }
-
-// The following two rules have their classes doubled to increase specificity.
-.has-child-selected .wp-social-link__is-incomplete.wp-social-link__is-incomplete,
-.is-selected .wp-social-link__is-incomplete.wp-social-link__is-incomplete {
-	background-color: $dark-gray-150;
-}
-
-.has-child-selected .is-style-logos-only .wp-social-link__is-incomplete.wp-social-link__is-incomplete,
-.is-selected .is-style-logos-only .wp-social-link__is-incomplete.wp-social-link__is-incomplete {
-	color: $dark-gray-150;
-	background-color: transparent;
-}
-
-
-[data-type*="core/social-link-"].is-selected .wp-social-link, // Matches the selected social logo block.
-.wp-social-link:focus {
-	box-shadow: 0 0 0 1px $white, 0 0 0 3px $blue-medium-500;
-
-	// Windows High Contrast mode will show this outline, but not the box-shadow.
-	outline: 2px solid transparent;
-}

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -1,7 +1,7 @@
 
 .wp-block-social-links div.editor-url-input {
 	display: inline-block;
-	margin-left: 8px;
+	margin-left: $grid-size;
 }
 
 .wp-block-social-links .editor-block-list__layout {
@@ -96,7 +96,7 @@
 	transform-origin: center center;
 }
 
-[data-type="core/social-links"]:not(.is-selected):not(.has-child-selected):not(.is-hovered) {
+[data-type="core/social-links"]:not(.is-selected):not(.has-child-selected) {
 	.wp-social-link__is-incomplete {
 		opacity: 0;
 		transform: scale(0);
@@ -106,8 +106,21 @@
 	}
 }
 
-[data-type="core/social-links"]:not(.is-selected):not(.has-child-selected) {
-	.wp-social-link__is-incomplete {
-		opacity: 0.6;
+// Unconfigured placeholder links are semitransparent.
+.wp-social-link.wp-social-link__is-incomplete {
+	opacity: 0.5;
+
+	&:hover,
+	&:focus {
+		opacity: 1;
 	}
+}
+
+[data-type="core/social-links"] .wp-block.is-selected .wp-social-link,
+.wp-social-link:focus {
+	opacity: 1;
+	box-shadow: 0 0 0 1px $white, 0 0 0 3px $blue-medium-500;
+
+	// Windows High Contrast mode will show this outline, but not the box-shadow.
+	outline: 2px solid transparent;
 }

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -1,12 +1,14 @@
+// Editor specific styles for Social Links.
+.wp-block-social-links {
+	div.editor-url-input {
+		display: inline-block;
+		margin-left: $grid-size;
+	}
 
-.wp-block-social-links div.editor-url-input {
-	display: inline-block;
-	margin-left: $grid-size;
-}
-
-.wp-block-social-links .editor-block-list__layout {
-	display: flex;
-	justify-content: flex-start;
+	.editor-block-list__layout {
+		display: flex;
+		justify-content: flex-start;
+	}
 }
 
 // Reduce the paddings, margins, and UI of inner-blocks.
@@ -45,12 +47,13 @@
 
 	// Hide the breadcrumb.
 	// Hide the mover.
+	// Hide the sibling inserter.
+	.block-editor-block-list__insertion-point,
 	.block-editor-block-list__breadcrumb,
 	.block-editor-block-mover.block-editor-block-mover { // Needs specificity.
 		display: none;
 	}
 }
-
 
 // Polish the Appender.
 .wp-block-social-links .block-list-appender {
@@ -109,17 +112,20 @@
 // Unconfigured placeholder links are semitransparent.
 .wp-social-link.wp-social-link__is-incomplete {
 	opacity: 0.5;
-
-	&:hover,
-	&:focus {
-		opacity: 1;
-	}
 }
 
-[data-type="core/social-links"] .wp-block.is-selected .wp-social-link,
-.wp-social-link:focus {
+.wp-block-social-links .is-selected .wp-social-link__is-incomplete,
+.wp-social-link.wp-social-link__is-incomplete:hover,
+.wp-social-link.wp-social-link__is-incomplete:focus {
 	opacity: 1;
-	box-shadow: 0 0 0 1px $white, 0 0 0 3px $blue-medium-500;
+}
+
+
+// Focus styles for the button inside the child block.
+// The child block itself has a more generic focus style, see line 55.
+[data-type="core/social-links"] .wp-social-link:focus { // This needs specificity.
+	opacity: 1;
+	box-shadow: 0 0 0 2px $white, 0 0 0 4px $blue-medium-focus;
 
 	// Windows High Contrast mode will show this outline, but not the box-shadow.
 	outline: 2px solid transparent;

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -14,33 +14,46 @@
 // Reduce the paddings, margins, and UI of inner-blocks.
 // @todo: eventually we may add a feature that lets a parent container absorb the block UI of a child block.
 // When that happens, leverage that instead of the following overrides.
-.wp-block-social-links {
+[data-type="core/social-links"] {
 	// 1. Reset margins on immediate innerblocks container.
-	> .block-editor-inner-blocks > .block-editor-block-list__layout {
+	.wp-block-social-links > .block-editor-inner-blocks > .block-editor-block-list__layout {
 		margin-left: 0;
 		margin-right: 0;
 	}
 
 	// 2. Remove paddings on subsequent immediate children.
-	> .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block {
+	.wp-block-social-links > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block {
 		width: auto;
 		padding-left: 0;
 		padding-right: 0;
 	}
 
 	// 3. Remove margins on subsequent Edit container.
-	> .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block > .block-editor-block-list__block-edit {
+	.wp-block-social-links > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block > .block-editor-block-list__block-edit {
 		margin-left: 0;
 		margin-right: 0;
 	}
 
-	// 4. Hide the block outlines.
-	> .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block > .block-editor-block-list__block-edit::before {
-		content: none;
+	// 4. Minimize the block outlines.
+	.wp-block-social-links > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block > .block-editor-block-list__block-edit::before {
+		border-right: none;
+		border-top: none;
+		border-bottom: none;
 	}
 
-	// 5. Remove vertical margins on subsequent block container.
-	> .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block > .block-editor-block-list__block-edit > [data-block] {
+	.wp-block-social-links > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block.is-hovered:not(.is-navigate-mode) > .block-editor-block-list__block-edit::before {
+		box-shadow: none;
+	}
+
+	// 5. Remove the dashed outlines for child blocks.
+	&.is-hovered .wp-block-social-links .block-editor-block-list__block-edit::before,
+	&.is-selected .wp-block-social-links .block-editor-block-list__block-edit::before,
+	&.has-child-selected .wp-block-social-links .block-editor-block-list__block-edit::before {
+		border-color: transparent !important; // !important used to keep the selector from growing any more complex.
+	}
+
+	// 6. Remove vertical margins on subsequent block container.
+	.wp-block-social-links > .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block > .block-editor-block-list__block-edit > [data-block] {
 		margin-top: 0;
 		margin-bottom: 0;
 	}
@@ -48,9 +61,9 @@
 	// Hide the breadcrumb.
 	// Hide the mover.
 	// Hide the sibling inserter.
-	.block-editor-block-list__insertion-point,
-	.block-editor-block-list__breadcrumb,
-	.block-editor-block-mover.block-editor-block-mover { // Needs specificity.
+	.wp-block-social-links .block-editor-block-list__insertion-point,
+	.wp-block-social-links .block-editor-block-list__breadcrumb,
+	.wp-block-social-links .block-editor-block-mover.block-editor-block-mover { // Needs specificity.
 		display: none;
 	}
 }

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -10,7 +10,7 @@
 	width: 36px;
 	height: 36px;
 	border-radius: 36px; // This makes it pill-shaped instead of oval, in cases where the image fed is not perfectly sized.
-	margin-right: $grid-size;
+	margin-right: 8px;
 	transition: transform 0.1s ease;
 
 	a {


### PR DESCRIPTION
This PR aims to address recent feedback, and fixes #17362. In doing so it also addresses some initial feedback from #17267, namey to provide a generic "block selected" style.

Specifically this PR:

- Removes the gray placeholder color, which was intended to provide a "disabled state" for social links that had not been configured.
- It addresses hover issues reported
- While I'm here, it refines the code a little bit, adds comments here and there
- It hides the sibling inserter. Same argument as removing the mover controls, it will be explored separately in context of general child block improvements. 
- It makes the focus style for the selected logo button thicker and darker.
- The opacity changes that indicate unconfigured blocks are simplified to always provide full opacity on hover or select.
- It restores and tweaks the "child block selected" outlines, but in a version that is still simpler than the full thing. This will likely benefit from further polish as we seek to make these child block improvements generalized in #17267.
- It hides the "dashed outlines for child blocks" as that clashes with their neutralized margins.


Before:

![before](https://user-images.githubusercontent.com/1204802/64516740-48afac80-d2ef-11e9-9103-8220ca347d9f.gif)

After:

![after](https://user-images.githubusercontent.com/1204802/64516632-156d1d80-d2ef-11e9-8fef-74f5f183a997.gif)

