### PR TITLE
Fix: Flipped color picker in RTL

### DIFF
--- a/packages/components/src/color-picker/style.scss
+++ b/packages/components/src/color-picker/style.scss
@@ -97,6 +97,7 @@
 	overflow: hidden;
 }
 .components-color-picker__saturation-white {
+	/*rtl:ignore*/
 	background: linear-gradient(to right, #fff, rgba(255, 255, 255, 0));
 }
 .components-color-picker__saturation-black {
@@ -151,10 +152,12 @@
 	padding: 0 2px;
 }
 .components-color-picker__hue-gradient {
+	/*rtl:ignore*/
 	background: linear-gradient(to right, #f00 0%, #ff0 17%, #0f0 33%, #0ff 50%, #00f 67%, #f0f 83%, #f00 100%);
 }
 .components-color-picker__hue-pointer,
 .components-color-picker__alpha-pointer {
+	/*rtl:ignore*/
 	left: 0;
 	width: 14px;
 	height: 14px;
@@ -207,6 +210,8 @@
 }
 .components-color-picker__inputs-fields {
 	display: flex;
+	/*rtl:ignore*/
+	direction: ltr;
 
 	.components-base-control__field {
 		margin: 0 4px;


### PR DESCRIPTION
## Description
fixes #17321
implements @hamedmoody [solution](https://gist.github.com/hamedmoody/ec00422cd80a0df39791945481d54f21)

didn't implement this part since it's unrelated
```css
div[data-type='core/paragraph'] .editor-block-toolbar.block-editor-block-toolbar div:nth-child(2) {
    direction: ltr;
}
```

## How has this been tested?
* switch to RTL
* start setting a color
* see that the color you're setting is the same as you selected.

## Screenshots <!-- if applicable -->
![backgroundcolor](https://user-images.githubusercontent.com/6165348/64520078-46e4e980-d2ed-11e9-9bb5-23e4d39a9560.gif)

