### PR TITLE
Fix:Image Block: Hide 'noreferrer' and 'noopener' in Link Rel

### DIFF
--- a/packages/block-library/src/image/constants.js
+++ b/packages/block-library/src/image/constants.js
@@ -3,6 +3,6 @@ export const LINK_DESTINATION_NONE = 'none';
 export const LINK_DESTINATION_MEDIA = 'media';
 export const LINK_DESTINATION_ATTACHMENT = 'attachment';
 export const LINK_DESTINATION_CUSTOM = 'custom';
-export const NEW_TAB_REL = 'noreferrer noopener';
+export const NEW_TAB_REL = [ 'noreferrer', 'noopener' ];
 export const ALLOWED_MEDIA_TYPES = [ 'image' ];
 export const DEFAULT_SIZE_SLUG = 'large';

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -10,6 +10,7 @@ import {
 	last,
 	omit,
 	pick,
+	each,
 } from 'lodash';
 
 /**
@@ -83,6 +84,7 @@ import {
 	LINK_DESTINATION_MEDIA,
 	LINK_DESTINATION_ATTACHMENT,
 	LINK_DESTINATION_CUSTOM,
+	NEW_TAB_REL,
 	ALLOWED_MEDIA_TYPES,
 	DEFAULT_SIZE_SLUG,
 } from './constants';
@@ -335,6 +337,30 @@ export class ImageEdit extends Component {
 		}
 	}
 
+	removeNewTabRel( currentRel ) {
+		let newRel = currentRel;
+
+		if ( currentRel !== undefined && ! isEmpty( newRel ) ) {
+			if ( ! isEmpty( newRel ) ) {
+				each( NEW_TAB_REL, function( relVal ) {
+					const regExp = new RegExp( '\\b' + relVal + '\\b', 'gi' );
+					newRel = newRel.replace( regExp, '' );
+				} );
+
+				// Only trim if NEW_TAB_REL values was replaced.
+				if ( newRel !== currentRel ) {
+					newRel = newRel.trim();
+				}
+
+				if ( isEmpty( newRel ) ) {
+					newRel = undefined;
+				}
+			}
+		}
+
+		return newRel;
+	}
+
 	onUploadError( message ) {
 		const { noticeOperations } = this.props;
 		noticeOperations.removeAllNotices();
@@ -585,6 +611,7 @@ export class ImageEdit extends Component {
 			sizeSlug,
 		} = attributes;
 
+		const cleanRel = this.removeNewTabRel( rel );
 		const isExternal = isExternalImage( id, url );
 		const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
 		const controls = (
@@ -617,18 +644,18 @@ export class ImageEdit extends Component {
 											onChange={ this.onSetNewTab }
 											checked={ linkTarget === '_blank' } />
 										<TextControl
+											label={ __( 'Link Rel' ) }
+											value={ cleanRel || '' }
+											onChange={ this.onSetLinkRel }
+											onKeyPress={ stopPropagation }
+											onKeyDown={ stopPropagationRelevantKeys }
+										/>
+										<TextControl
 											label={ __( 'Link CSS Class' ) }
 											value={ linkClass || '' }
 											onKeyPress={ stopPropagation }
 											onKeyDown={ stopPropagationRelevantKeys }
 											onChange={ this.onSetLinkClass }
-										/>
-										<TextControl
-											label={ __( 'Link Rel' ) }
-											value={ rel || '' }
-											onChange={ this.onSetLinkRel }
-											onKeyPress={ stopPropagation }
-											onKeyDown={ stopPropagationRelevantKeys }
 										/>
 									</>
 								}

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -10,7 +10,6 @@ import {
 	last,
 	omit,
 	pick,
-	each,
 } from 'lodash';
 
 /**
@@ -73,7 +72,7 @@ import { speak } from '@wordpress/a11y';
 import { createUpgradedEmbedBlock } from '../embed/util';
 import icon from './icon';
 import ImageSize from './image-size';
-import { getUpdatedLinkTargetSettings } from './utils';
+import { getUpdatedLinkTargetSettings, removeNewTabRel } from './utils';
 
 /**
  * Module constants
@@ -84,7 +83,6 @@ import {
 	LINK_DESTINATION_MEDIA,
 	LINK_DESTINATION_ATTACHMENT,
 	LINK_DESTINATION_CUSTOM,
-	NEW_TAB_REL,
 	ALLOWED_MEDIA_TYPES,
 	DEFAULT_SIZE_SLUG,
 } from './constants';
@@ -337,30 +335,6 @@ export class ImageEdit extends Component {
 		}
 	}
 
-	removeNewTabRel( currentRel ) {
-		let newRel = currentRel;
-
-		if ( currentRel !== undefined && ! isEmpty( newRel ) ) {
-			if ( ! isEmpty( newRel ) ) {
-				each( NEW_TAB_REL, function( relVal ) {
-					const regExp = new RegExp( '\\b' + relVal + '\\b', 'gi' );
-					newRel = newRel.replace( regExp, '' );
-				} );
-
-				// Only trim if NEW_TAB_REL values was replaced.
-				if ( newRel !== currentRel ) {
-					newRel = newRel.trim();
-				}
-
-				if ( isEmpty( newRel ) ) {
-					newRel = undefined;
-				}
-			}
-		}
-
-		return newRel;
-	}
-
 	onUploadError( message ) {
 		const { noticeOperations } = this.props;
 		noticeOperations.removeAllNotices();
@@ -611,7 +585,7 @@ export class ImageEdit extends Component {
 			sizeSlug,
 		} = attributes;
 
-		const cleanRel = this.removeNewTabRel( rel );
+		const cleanRel = removeNewTabRel( rel );
 		const isExternal = isExternalImage( id, url );
 		const editImageIcon = ( <SVG width={ 20 } height={ 20 } viewBox="0 0 20 20"><Rect x={ 11 } y={ 3 } width={ 7 } height={ 5 } rx={ 1 } /><Rect x={ 2 } y={ 12 } width={ 7 } height={ 5 } rx={ 1 } /><Path d="M13,12h1a3,3,0,0,1-3,3v2a5,5,0,0,0,5-5h1L15,9Z" /><Path d="M4,8H3l2,3L7,8H6A3,3,0,0,1,9,5V3A5,5,0,0,0,4,8Z" /></SVG> );
 		const controls = (

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -24,7 +25,7 @@ export default function save( { attributes } ) {
 		sizeSlug,
 	} = attributes;
 
-	const newRel = RichText.isEmpty( rel ) ? undefined : rel;
+	const newRel = isEmpty( rel ) ? undefined : rel;
 
 	const classes = classnames( {
 		[ `align${ align }` ]: align,

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -24,6 +24,8 @@ export default function save( { attributes } ) {
 		sizeSlug,
 	} = attributes;
 
+	const newRel = RichText.isEmpty( rel ) ? undefined : rel;
+
 	const classes = classnames( {
 		[ `align${ align }` ]: align,
 		[ `size-${ sizeSlug }` ]: sizeSlug,
@@ -47,7 +49,7 @@ export default function save( { attributes } ) {
 					className={ linkClass }
 					href={ href }
 					target={ linkTarget }
-					rel={ rel }
+					rel={ newRel }
 				>
 					{ image }
 				</a>

--- a/packages/block-library/src/image/utils.js
+++ b/packages/block-library/src/image/utils.js
@@ -1,4 +1,12 @@
 /**
+ * External dependencies
+ */
+import {
+	isEmpty,
+	each,
+} from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { NEW_TAB_REL } from './constants';
@@ -10,6 +18,30 @@ export function calculatePreferedImageSize( image, container ) {
 	const width = exceedMaxWidth ? maxWidth : image.width;
 	const height = exceedMaxWidth ? maxWidth * ratio : image.height;
 	return { width, height };
+}
+
+export function removeNewTabRel( currentRel ) {
+	let newRel = currentRel;
+
+	if ( currentRel !== undefined && ! isEmpty( newRel ) ) {
+		if ( ! isEmpty( newRel ) ) {
+			each( NEW_TAB_REL, function( relVal ) {
+				const regExp = new RegExp( '\\b' + relVal + '\\b', 'gi' );
+				newRel = newRel.replace( regExp, '' );
+			} );
+
+			// Only trim if NEW_TAB_REL values was replaced.
+			if ( newRel !== currentRel ) {
+				newRel = newRel.trim();
+			}
+
+			if ( isEmpty( newRel ) ) {
+				newRel = undefined;
+			}
+		}
+	}
+
+	return newRel;
 }
 
 /**
@@ -24,11 +56,11 @@ export function calculatePreferedImageSize( image, container ) {
 export function getUpdatedLinkTargetSettings( value, { rel } ) {
 	const linkTarget = value ? '_blank' : undefined;
 
-	let updatedRel = rel;
-	if ( linkTarget && ! rel ) {
-		updatedRel = NEW_TAB_REL;
-	} else if ( ! linkTarget && rel === NEW_TAB_REL ) {
+	let updatedRel;
+	if ( ! linkTarget && ! rel ) {
 		updatedRel = undefined;
+	} else {
+		updatedRel = removeNewTabRel( rel );
 	}
 
 	return {


### PR DESCRIPTION
## Description
1. Hide the 'noreferrer' and 'noopener' in Link Rel field if "Open in New Tab" is toggled on.
2. Do not display empty rel attribute in frontend.
3. Move the Link Rel field below the "Open in New Tab" toggle.

## How has this been tested?
Followed the steps in #15915.

## Types of changes
Fixes #15915.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style.