### PR TITLE
Try to figure out which is the right LinkDestination value for an image

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -147,7 +147,7 @@ export class ImageEdit extends Component {
 		// user has changed the default linkDestination value (none) and
 		// the user edits a post created with a different linkDestination
 		// default value.
-		if ( !this.state.isEditing ) {
+		if ( ! this.state.isEditing ) {
 			if (
 				attributes.href &&
 				attributes.linkDestination === LINK_DESTINATION_NONE
@@ -160,7 +160,7 @@ export class ImageEdit extends Component {
 					attributes.linkDestination = LINK_DESTINATION_CUSTOM;
 				}
 			} else if (
-				!attributes.href &&
+				! attributes.href &&
 				attributes.linkDestination !== LINK_DESTINATION_NONE
 			) {
 				attributes.linkDestination = LINK_DESTINATION_NONE;
@@ -251,7 +251,7 @@ export class ImageEdit extends Component {
 			...additionalAttributes,
 			...linkAttributes,
 			width: undefined,
-			height: undefined
+			height: undefined,
 		} );
 
 		this.setState( {
@@ -261,11 +261,11 @@ export class ImageEdit extends Component {
 
 	onSetLinkDestination( value ) {
 		this.props.setAttributes(
-			this.buildLinkAttributes(value, this.props.attributes, this.props.image)
+			this.buildLinkAttributes( value, this.props.attributes, this.props.image )
 		);
 	}
 
-	buildLinkAttributes(value, attributes, image) {
+	buildLinkAttributes( value, attributes, image ) {
 		let href;
 
 		if ( value === LINK_DESTINATION_NONE ) {

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -273,7 +273,7 @@ export class ImageEdit extends Component {
 		} else if ( value === LINK_DESTINATION_MEDIA ) {
 			href = ( image && image.source_url ) || attributes.url;
 		} else if ( value === LINK_DESTINATION_ATTACHMENT ) {
-			href = image && image.link;
+			href = ( image && image.link ) || attributes.link;
 		} else {
 			href = attributes.href;
 		}
@@ -285,13 +285,21 @@ export class ImageEdit extends Component {
 	}
 
 	onSelectURL( newURL ) {
-		const { url } = this.props.attributes;
+		const { url, linkDestination } = this.props.attributes;
+		let newLinkDestination = linkDestination;
+
+		// Images from URL doesn't have an attachment link
+		if ( linkDestination === LINK_DESTINATION_ATTACHMENT ) {
+			newLinkDestination = LINK_DESTINATION_NONE;
+		}
 
 		if ( newURL !== url ) {
 			this.props.setAttributes( {
 				url: newURL,
+				href: linkDestination === LINK_DESTINATION_MEDIA ? newURL : null,
 				id: undefined,
 				sizeSlug: DEFAULT_SIZE_SLUG,
+				linkDestination: newLinkDestination,
 			} );
 		}
 	}


### PR DESCRIPTION
I want to always link the images in my posts to its source url. This way, users can click on the thumbnail and see the image full size. In Gutenberg's image block, the default setting is not to link the images, so I have to manually change the LinkDestination select for each image I insert in the posts.

Users can change the default value of LinkDestination with a plugin and some JavaScript like this:

       function modifyImageLinkDestinationDefault( settings, name ) {

           // Override core default value for LinkDestination and change it to media 
           if ( name == "core/image" ) {
                // Set image block default destination.
                settings.attributes.linkDestination.default = "media";
            }

            return settings;
        }

        // Add settings filter to block registration.
        wp.hooks.addFilter(
            "blocks.registerBlockType",
            "my-plugin/modify-image-link-destination-default",
            modifyImageLinkDestinationDefault
        );
The actual code of the Gutenberg's image block doesn't work well when it finds old posts with no LinkDestination attribute, as no attribute means default value, but the new default value isn't the same as the old one.

Description
I've added code to the componentDidMount method of the image block to figure out which is the right value for the LinkDestination attribute based on the innerHTML. This work is based on @SeanDS pull request #13797 and closes issue #13749.

How has this been tested?
I used the latest development release of Gutenberg (cloned at 313974f), and WordPress 5.1, using docker images. I used the plugin showed above to change the default link target to media. I added several images with different LinkDestination values and I edited again after disabling the plugin.

This change doesn't affect other areas of the code.

Types of changes
Bug fix (non-breaking change which fixes an issue)

Checklist:
[ X] My code is tested.
[ X] My code follows the WordPress code style.
[ X] My code follows the accessibility standards.
[ X] My code has proper inline documentation.
[ X] I've included developer documentation if appropriate.