### PR TITLE
Social Links: Change default state to WordPress link instead of mail

### DIFF
--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -17,12 +17,12 @@ const ALLOWED_BLOCKS = Object.keys( socialList ).map( ( site ) => {
 
 // Template contains the links that show when start.
 const TEMPLATE = [
+	[ 'core/social-link-wordpress', { url: 'https://wordpress.org' } ],
 	[ 'core/social-link-facebook' ],
 	[ 'core/social-link-twitter' ],
 	[ 'core/social-link-instagram' ],
 	[ 'core/social-link-linkedin' ],
 	[ 'core/social-link-youtube' ],
-	[ 'core/social-link-mail', { url: 'mailto:' } ],
 ];
 
 export const SocialLinksEdit = function( { className } ) {


### PR DESCRIPTION
## Description

Per discussion in #17362 switch default link to WordPress instead of mail.
If unchanged, this will insert a valid link, whereas the mail link unchanged when be an invalid link.

The purpose of including a link prefilled is so the block does not "disappear" when unselected.

## How has this been tested?

Confirm WordPress icon shows and is properly linked to https://wordpress.org/

## Types of changes

Switches template for default state of the social-links/edit.js function.


## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
