### PR TITLE
Fix featured image modal

### DIFF
--- a/=10.0.0
+++ b/=10.0.0
@@ -1,0 +1,3 @@
+Found '/Users/anthony.burchell/wpe/the52test/wp-content/plugins/gutenberg/.nvmrc' with version <lts/*>
+Downloading and installing node v10.16.3...
+Now using node v10.16.3 (npm v6.9.0)

--- a/=10.0.0
+++ b/=10.0.0
@@ -1,3 +1,0 @@
-Found '/Users/anthony.burchell/wpe/the52test/wp-content/plugins/gutenberg/.nvmrc' with version <lts/*>
-Downloading and installing node v10.16.3...
-Now using node v10.16.3 (npm v6.9.0)

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -50,6 +50,7 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 					<MediaUpload
 						title={ postLabel.featured_image || DEFAULT_FEATURE_IMAGE_LABEL }
 						onSelect={ onUpdateImage }
+						unstableFeaturedImageFlow
 						allowedTypes={ ALLOWED_MEDIA_TYPES }
 						modalClass={ ! featuredImageId ? 'editor-post-featured-image__media-modal' : 'editor-post-featured-image__media-modal' }
 						render={ ( { open } ) => (
@@ -77,6 +78,7 @@ function PostFeaturedImage( { currentPostId, featuredImageId, onUpdateImage, onR
 						<MediaUpload
 							title={ postLabel.featured_image || DEFAULT_FEATURE_IMAGE_LABEL }
 							onSelect={ onUpdateImage }
+							unstableFeaturedImageFlow
 							allowedTypes={ ALLOWED_MEDIA_TYPES }
 							modalClass="editor-post-featured-image__media-modal"
 							render={ ( { open } ) => (

--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -11,6 +11,30 @@ import { __ } from '@wordpress/i18n';
 
 const { wp } = window;
 
+const getFeaturedImageMediaFrame = () => {
+	return wp.media.view.MediaFrame.Select.extend( {
+
+		featuredImageToolbar: function( toolbar ) {
+			this.createSelectToolbar( toolbar, {
+				text:  wp.media.view.l10n.setFeaturedImage,
+				state: this.options.state
+			});
+		},
+
+		/**
+		 * Create the default states.
+		 *
+		 * @return {void}
+		 */
+		createStates: function createStates() {
+			this.states.add( [
+				this.on( 'toolbar:create:featured-image', this.featuredImageToolbar, this ),
+				new wp.media.controller.FeaturedImage(),
+			] );
+		},
+	} );
+};
+
 // Getter for the sake of unit tests.
 const getGalleryDetailsMediaFrame = () => {
 	/**
@@ -79,6 +103,7 @@ class MediaUpload extends Component {
 	constructor( {
 		allowedTypes,
 		gallery = false,
+		unstableFeaturedImageFlow = false,
 		modalClass,
 		multiple = false,
 		title = __( 'Select or Upload Media' ),
@@ -109,6 +134,22 @@ class MediaUpload extends Component {
 
 		if ( modalClass ) {
 			this.frame.$el.addClass( modalClass );
+		}
+
+		if ( unstableFeaturedImageFlow ) {
+			const featuredImageFrame = getFeaturedImageMediaFrame();
+			const attachments = getAttachmentsCollection( this.props.value );
+			const selection = new wp.media.model.Selection( attachments.models, {
+				props: attachments.props.toJSON(),
+			} );
+			this.frame = new featuredImageFrame( {
+				mimeType: allowedTypes,
+				state: 'featured-image',
+				multiple,
+				selection,
+				editing: ( this.props.value ) ? true : false,
+			} );
+			wp.media.frame = this.frame;
 		}
 
 		this.initializeListeners();

--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -142,19 +142,7 @@ class MediaUpload extends Component {
 		}
 
 		if ( unstableFeaturedImageFlow ) {
-			const featuredImageFrame = getFeaturedImageMediaFrame();
-			const attachments = getAttachmentsCollection( this.props.value );
-			const selection = new wp.media.model.Selection( attachments.models, {
-				props: attachments.props.toJSON(),
-			} );
-			this.frame = new featuredImageFrame( {
-				mimeType: allowedTypes,
-				state: 'featured-image',
-				multiple,
-				selection,
-				editing: ( this.props.value ) ? true : false,
-			} );
-			wp.media.frame = this.frame;
+			this.buildAndSetFeatureImageFrame();
 		}
 
 		this.initializeListeners();
@@ -211,6 +199,22 @@ class MediaUpload extends Component {
 		} );
 		wp.media.frame = this.frame;
 		this.initializeListeners();
+	}
+
+	buildAndSetFeatureImageFrame() {
+		const featuredImageFrame = getFeaturedImageMediaFrame();
+		const attachments = getAttachmentsCollection( this.props.value );
+		const selection = new wp.media.model.Selection( attachments.models, {
+			props: attachments.props.toJSON(),
+		} );
+		this.frame = new featuredImageFrame( {
+			mimeType: this.props.allowedTypes,
+			state: 'featured-image',
+			multiple: this.props.multiple,
+			selection,
+			editing: ( this.props.value ) ? true : false,
+		} );
+		wp.media.frame = this.frame;
 	}
 
 	componentWillUnmount() {

--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -14,11 +14,17 @@ const { wp } = window;
 const getFeaturedImageMediaFrame = () => {
 	return wp.media.view.MediaFrame.Select.extend( {
 
-		featuredImageToolbar: function( toolbar ) {
+		/**
+		 * Enables the Set Featured Image Button.
+		 *
+		 * @param {Object} toolbar toolbar for featured image state
+		 * @return {void}
+		 */
+		featuredImageToolbar( toolbar ) {
 			this.createSelectToolbar( toolbar, {
-				text:  wp.media.view.l10n.setFeaturedImage,
-				state: this.options.state
-			});
+				text: wp.media.view.l10n.setFeaturedImage,
+				state: this.options.state,
+			} );
 		},
 
 		/**

--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -13,7 +13,6 @@ const { wp } = window;
 
 const getFeaturedImageMediaFrame = () => {
 	return wp.media.view.MediaFrame.Select.extend( {
-
 		/**
 		 * Enables the Set Featured Image Button.
 		 *
@@ -33,8 +32,8 @@ const getFeaturedImageMediaFrame = () => {
 		 * @return {void}
 		 */
 		createStates: function createStates() {
+			this.on( 'toolbar:create:featured-image', this.featuredImageToolbar, this );
 			this.states.add( [
-				this.on( 'toolbar:create:featured-image', this.featuredImageToolbar, this ),
 				new wp.media.controller.FeaturedImage(),
 			] );
 		},


### PR DESCRIPTION
## Description
This is to match the backbone featured image frames expected in the editor. This allows a user to select images with filters of `mine` and `uploaded to post` which was previously missing in the existing Gutenberg featured image frame.


## How has this been tested?
Much of the discussion that lead to this pull request can be referenced here: https://github.com/WordPress/gutenberg/pull/10810

<img width="1081" alt="Screen Shot 2019-09-11 at 6 29 51 PM" src="https://user-images.githubusercontent.com/11888980/64742545-320d7f00-d4c2-11e9-91d0-4fcc90c513f8.png">


Issue this fixes:
#8748
