### PR TITLE
Remove the forced gray scale from the category icons

### DIFF
--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -117,7 +117,6 @@
 
 .components-panel__icon {
 	color: $dark-gray-500;
-	filter: grayscale(1) !important;
 	margin: -2px 0 -2px 6px;
 }
 


### PR DESCRIPTION
revert #16163

#16163 was an attempt to reduce the cognitive load from the category icons in the inserter but we got some feedback that it makes it a bit harder to recognize block sources without these colors.

A11y wise, the loss of color contrast can affect the visibility of some icons;

cc @mapk @mtias 